### PR TITLE
libs/image: fix structure-packing pragma warning

### DIFF
--- a/libs/image/src/ImageDecoder.cpp
+++ b/libs/image/src/ImageDecoder.cpp
@@ -496,7 +496,7 @@ Image PSDDecoder::decode() {
         uint16_t depth;
         uint16_t mode;
     };
-    #pragma pop()
+    #pragma pack(pop)
 
     static const uint16_t kColorModeRGB = 3;
     static const uint16_t kCompressionRAW = 0;


### PR DESCRIPTION
When compiling with clang on Linux, the following warning is generated:

```
../../libs/image/src/ImageDecoder.cpp:487:13: warning: unterminated '#pragma pack (push, ...)' at end of file [-Wpragma-pack]
    #pragma pack(push, 1)
            ^
```

According to [1], the correct pragma to pop the packing state from the internal stack is "#pragma pack(pop)" rather than "#pragma pop()" which is used currently. This PR replaces "#pragma pop()" with "#pragma pack(pop)".

[1] http://gcc.gnu.org/onlinedocs/gcc-4.2.3/gcc/Structure_002dPacking-Pragmas.html