### PR TITLE
Fix error

### DIFF
--- a/libs/utils/src/Profiler.cpp
+++ b/libs/utils/src/Profiler.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <algorithm>
+#include <memory>
 
 #if defined(__linux__)
 


### PR DESCRIPTION
`libs\utils\src\Profiler.cpp(61): error : no member named 'uninitialized_fill' in namespace 'std'`