### PR TITLE
Refactor code a bit to make usage of DriverAPI more explicit

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -542,7 +542,7 @@ void FRenderer::ColorPass::renderColorPass(FEngine& engine, JobSystem& js,
 
     // start the froxelization immediately, it has no dependencies
     JobSystem::Job* jobFroxelize = js.createJob(nullptr,
-            [view](JobSystem&, JobSystem::Job*) { view->froxelize(); });
+            [&engine, view](JobSystem&, JobSystem::Job*) { view->froxelize(engine); });
     js.run(jobFroxelize);
 
     CameraInfo const& cameraInfo = view->getCameraInfo();

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -24,12 +24,11 @@
 namespace filament {
 namespace details {
 
-void FRenderPrimitive::init(FEngine& engine,
+void FRenderPrimitive::init(driver::DriverApi& driver,
         const RenderableManager::Builder::Entry& entry) noexcept {
 
     assert(entry.materialInstance);
 
-    FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createRenderPrimitive();
     mMaterialInstance = upcast(entry.materialInstance);
     mBlendOrder = entry.blendOrder;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -139,7 +139,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView* view) {
         return;
     }
 
-    view->prepare(engine, arena, svp);
+    view->prepare(engine, driver, arena, svp);
     // TODO: froxelization could actually start now, instead of in ColorPass::renderColorPass()
 
     /*

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -85,7 +85,7 @@ void FView::terminate(FEngine& engine) {
     driverApi.destroyUniformBuffer(mPerViewUbh);
     driverApi.destroySamplerBuffer(mPerViewSbh);
     mDirectionalShadowMap.terminate(driverApi);
-    mFroxelizer.terminate();
+    mFroxelizer.terminate(driverApi);
 }
 
 void FView::setViewport(Viewport const& viewport) noexcept {
@@ -256,9 +256,8 @@ bool FView::isSkyboxVisible() const noexcept {
     return skybox != nullptr && (skybox->getLayerMask() & mVisibleLayers);
 }
 
-void FView::prepareShadowing(FEngine& engine,
-        FScene::RenderableSoa& renderableData,
-        FScene::LightSoa const& lightData) noexcept {
+void FView::prepareShadowing(FEngine& engine, driver::DriverApi& driver,
+        FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept {
     SYSTRACE_CALL();
 
     // setup shadow mapping
@@ -281,7 +280,7 @@ void FView::prepareShadowing(FEngine& engine,
             prepareVisibleShadowCasters(engine.getJobSystem(), renderableData, frustum);
 
             // allocates shadowmap driver resources
-            shadowMap.prepare(engine.getDriverApi(), getUs());
+            shadowMap.prepare(driver, getUs());
 
             mat4f const& lightFromWorldMatrix = shadowMap.getLightSpaceMatrix();
             u.setUniform(offsetof(FEngine::PerViewUib, lightFromWorldMatrix), lightFromWorldMatrix);
@@ -298,8 +297,8 @@ void FView::prepareShadowing(FEngine& engine,
     }
 }
 
-void FView::prepareLighting(
-        FEngine& engine, FEngine::DriverApi& driver, ArenaScope& arena, Viewport const& viewport) noexcept {
+void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaScope& arena,
+        Viewport const& viewport) noexcept {
     SYSTRACE_CALL();
 
     UniformBuffer& u = getUb();
@@ -379,9 +378,9 @@ void FView::prepareLighting(
     }
 }
 
-void FView::prepare(FEngine& engine, ArenaScope& arena, Viewport const& viewport) noexcept {
+void FView::prepare(FEngine& engine, driver::DriverApi& driver, ArenaScope& arena,
+        Viewport const& viewport) noexcept {
     JobSystem& js = engine.getJobSystem();
-    FEngine::DriverApi& driver = engine.getDriverApi();
 
     /*
      * Prepare the scene -- this is where we gather all the objects added to the scene,
@@ -459,7 +458,7 @@ void FView::prepare(FEngine& engine, ArenaScope& arena, Viewport const& viewport
      * (this will set the VISIBLE_SHADOW_CASTER bit)
      */
 
-    prepareShadowing(engine, renderableData, scene->getLightData());
+    prepareShadowing(engine, driver, renderableData, scene->getLightData());
 
     /*
      * partition the array of renderable w.r.t their visibility:
@@ -586,12 +585,12 @@ void FView::prepareCamera(const CameraInfo& camera, const Viewport& viewport) co
     u.setUniform(offsetof(FEngine::PerViewUib, cameraPosition), float3{camera.getPosition()});
 }
 
-void FView::froxelize() const noexcept {
+void FView::froxelize(FEngine& engine) const noexcept {
     SYSTRACE_CALL();
 
     if (mHasDynamicLighting) {
         // froxelize lights
-        mFroxelizer.froxelizeLights(mViewingCameraInfo.view, mScene->getLightData());
+        mFroxelizer.froxelizeLights(engine, mViewingCameraInfo.view, mScene->getLightData());
     }
 }
 
@@ -700,7 +699,7 @@ void FView::prepareVisibleLights(FLightManager& lcm, utils::JobSystem&, FScene::
         }
     }
 
-    // Parition array such that all visible lights appear first
+    // Partition array such that all visible lights appear first
     UTILS_UNUSED_IN_RELEASE auto last =
             std::partition(lightData.begin() + FScene::DIRECTIONAL_LIGHTS_COUNT, lightData.end(),
                     [](auto const& it) {
@@ -712,8 +711,7 @@ void FView::prepareVisibleLights(FLightManager& lcm, utils::JobSystem&, FScene::
     mHasDynamicLighting = visibleLightCount > FScene::DIRECTIONAL_LIGHTS_COUNT;
 }
 
-void FView::updatePrimitivesLod(
-        FEngine& engine, const CameraInfo&,
+void FView::updatePrimitivesLod(FEngine& engine, const CameraInfo&,
         FScene::RenderableSoa& renderableData, Range visibles) noexcept {
     FRenderableManager const& rcm = engine.getRenderableManager();
     for (uint32_t index : visibles) {

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -241,7 +241,8 @@ FRenderableManager::~FRenderableManager() {
     assert(mManager.getComponentCount() == 0);
 }
 
-void FRenderableManager::create(const RenderableManager::Builder& UTILS_RESTRICT builder, Entity entity) {
+void FRenderableManager::create(
+        const RenderableManager::Builder& UTILS_RESTRICT builder, Entity entity) {
     FEngine& engine = mEngine;
     auto& manager = mManager;
     FEngine::DriverApi& driver = engine.getDriverApi();
@@ -269,7 +270,7 @@ void FRenderableManager::create(const RenderableManager::Builder& UTILS_RESTRICT
         Builder::Entry const * const entries = builder->mEntries;
         FRenderPrimitive* rp = new FRenderPrimitive[builder->mEntriesCount];
         for (size_t i = 0, c = builder->mEntriesCount; i < c; ++i) {
-            rp[i].init(engine, entries[i]);
+            rp[i].init(driver, entries[i]);
         }
         setPrimitives(ci, { rp, size_type(builder->mEntriesCount) });
 

--- a/filament/src/details/Froxel.h
+++ b/filament/src/details/Froxel.h
@@ -78,7 +78,7 @@ public:
     explicit FroxelData(FEngine& engine);
     ~FroxelData();
 
-    void terminate() noexcept;
+    void terminate(driver::DriverApi& driverApi) noexcept;
 
     // gpu buffer containing records. valid after construction.
     GPUBuffer const& getRecordBuffer() const noexcept { return mRecordsBuffer; }
@@ -100,8 +100,7 @@ public:
      *
      * return true if updateUniforms() needs to be called
      */
-    bool prepare(
-            FEngine::DriverApi& driverApi, ArenaScope& arena, Viewport const& viewport,
+    bool prepare(driver::DriverApi& driverApi, ArenaScope& arena, Viewport const& viewport,
             const math::mat4f& projection, float projectionNear, float projectionFar) noexcept;
 
     Froxel getFroxelAt(size_t x, size_t y, size_t z) const noexcept;
@@ -110,7 +109,8 @@ public:
     size_t getFroxelCountZ() const noexcept { return mFroxelCountZ; }
 
     // update Records and Froxels texture with lights data. this is thread-safe.
-    void froxelizeLights(math::mat4f const& viewMatrix, const FScene::LightSoa& lightData) noexcept;
+    void froxelizeLights(FEngine& engine, math::mat4f const& viewMatrix,
+            const FScene::LightSoa& lightData) noexcept;
 
     void updateUniforms(UniformBuffer& u) {
         u.setUniform(offsetof(FEngine::PerViewUib, zParams), mParamsZ);
@@ -162,10 +162,8 @@ private:
     void setProjection(const math::mat4f& projection, float near, float far) noexcept;
     bool update() noexcept;
 
-    void froxelizeLoop(
-            utils::Slice<uint16_t>& froxelsList,
-            utils::Slice<FroxelRunEntry> froxelsListIndices,
-            math::mat4f const& viewMatrix,
+    void froxelizeLoop(FEngine& engine, utils::Slice<uint16_t>& froxelsList,
+            utils::Slice<FroxelRunEntry> froxelsListIndices, const math::mat4f& viewMatrix,
             const FScene::LightSoa& lightData) noexcept;
 
     void froxelizePointAndSpotLight(
@@ -197,8 +195,6 @@ private:
 
 
     // internal state dependant on the viewport and needed for froxelizing
-    FEngine& mEngine;
-
     LinearAllocatorArena mArena;                    // ~256 KiB
 
     float* mDistancesZ = nullptr;                   // max 2.1 MiB (actual: resolution dependant)

--- a/filament/src/details/RenderPrimitive.h
+++ b/filament/src/details/RenderPrimitive.h
@@ -37,7 +37,7 @@ class FRenderPrimitive {
 public:
     FRenderPrimitive() noexcept = default;
 
-    void init(FEngine& engine, const RenderableManager::Builder::Entry& entry) noexcept;
+    void init(driver::DriverApi& driver, const RenderableManager::Builder::Entry& entry) noexcept;
 
     void set(FEngine& engine, RenderableManager::PrimitiveType type,
             FVertexBuffer* vertices, FIndexBuffer* indices, size_t offset,

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -61,7 +61,8 @@ public:
 
     void terminate(FEngine& engine);
 
-    void prepare(FEngine& engine, ArenaScope& arena, Viewport const& viewport) noexcept;
+    void prepare(FEngine& engine, driver::DriverApi& driver, ArenaScope& arena,
+            Viewport const& viewport) noexcept;
 
     void setScene(FScene* scene) { mScene = scene; }
     FScene const* getScene() const noexcept { return mScene; }
@@ -113,11 +114,11 @@ public:
     }
 
     void prepareCamera(const CameraInfo& camera, const Viewport& viewport) const noexcept;
-    void prepareShadowing(
-            FEngine& engine, FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept;
+    void prepareShadowing(FEngine& engine, driver::DriverApi& driver,
+            FScene::RenderableSoa& renderableData, FScene::LightSoa const& lightData) noexcept;
     void prepareLighting(
             FEngine& engine, FEngine::DriverApi& driver, ArenaScope& arena, Viewport const& viewport) noexcept;
-    void froxelize() const noexcept;
+    void froxelize(FEngine& engine) const noexcept;
     void commitUniforms(driver::DriverApi& driverApi) const noexcept;
     void commitFroxels(driver::DriverApi& driverApi) const noexcept;
 

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -516,7 +516,7 @@ TEST(FilamentTest, FroxelData) {
     //tileSize *= 0.25f;
     //froxelData.froxelizePointLight(p, vec4f{ 0, 0, -5, tileSize*tileSize });
 
-    froxelData.terminate();
+    froxelData.terminate(engine->getDriverApi());
     engine->shutdown();
     delete engine;
 }


### PR DESCRIPTION
Because DriverAPI is not thread-safe, it’s better
to make its usage more explicit — so it’s now
passed as argument of all methods that need it.

also pass Engine as parameter in internal classes
that made little use of it (i.e. no point in
storing it if we can just pass it a sa parameter).

Change-Id: I9142959437ed3d8c8ecb7bcd030ea55d9c8ef352