### PR TITLE
Compile shaders in a separate static library

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ In addition your distribution might require:
 Then invoke `cmake`:
 
 ```
-$ mkdir out/cmake-build-release
-$ cd out/cmake-build-release
+$ mkdir out/cmake-release
+$ cd out/cmake-release
 $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release/filament ../..
 ```
 
@@ -214,8 +214,8 @@ Your Linux distribution might default to `gcc` instead of `clang`, if that's the
 `cmake` with the following command:
 
 ```
-$ mkdir out/cmake-build-release
-$ cd out/cmake-build-release
+$ mkdir out/cmake-release
+$ cd out/cmake-release
 # Or use a specific version of clang, for instance /usr/bin/clang-5.0
 $ CC=/usr/bin/clang CXX=/usr/bin/clang++ \
     cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release/filament ../..
@@ -257,8 +257,8 @@ export JAVA_HOME="$(/usr/libexec/java_home)"
 Then run `cmake` and `ninja` to trigger a build:
 
 ```
-$ mkdir out/cmake-build-release
-$ cd out/cmake-build-release
+$ mkdir out/cmake-release
+$ cd out/cmake-release
 $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release/filament ../..
 $ ninja
 ```
@@ -282,8 +282,8 @@ Open an VS2015 x64 Native Tools terminal (click the start button, type "x64 nati
 
 Create a working directory:
 ```
-> mkdir out/cmake-build-release
-> cd out/cmake-build-release
+> mkdir out/cmake-release
+> cd out/cmake-release
 ```
 
 Create the msBuild project:

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -144,8 +144,7 @@ set(PRIVATE_HDRS
         src/PrecompiledMaterials.h
         src/RenderPass.h
         src/RenderTargetPool.h
-        src/upcast.h
-        ../libs/filamat/src/shaders/Shaders.h)
+        src/upcast.h)
 
 set(MATERIAL_SRCS
         src/materials/defaultMaterial.mat

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -145,7 +145,7 @@ set(PRIVATE_HDRS
         src/RenderPass.h
         src/RenderTargetPool.h
         src/upcast.h
-)
+        ../libs/filamat/src/shaders/Shaders.h)
 
 set(MATERIAL_SRCS
         src/materials/defaultMaterial.mat

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -7,8 +7,24 @@ set(PUBLIC_HDR_DIR include)
 # ==================================================================================================
 # Sources and headers
 # ==================================================================================================
-file(GLOB_RECURSE HDRS include/filamat/*.h)
-file(GLOB_RECURSE PRIVATE_HDRS src/*.h)
+set(HDRS
+        include/filamat/MaterialBuilder.h
+        include/filamat/Package.h)
+
+set(PRIVATE_HDRS
+        src/eiff/BlobDictionary.h
+        src/eiff/Chunk.h
+        src/eiff/ChunkContainer.h
+        src/eiff/DictionaryGlslChunk.h
+        src/eiff/DictionarySpirvChunk.h
+        src/eiff/Flattener.h
+        src/eiff/GlslChunk.h
+        src/eiff/LineDictionary.h
+        src/eiff/MaterialGlslChunk.h
+        src/eiff/MaterialInterfaceBlockChunk.h
+        src/eiff/MaterialSpirvChunk.h
+        src/eiff/ShaderEntry.h
+        src/eiff/SimpleFieldChunk.h)
 
 set(SRCS
         src/eiff/BlobDictionary.cpp
@@ -34,9 +50,7 @@ include_directories(${CMAKE_BINARY_DIR})
 add_library(${TARGET} STATIC ${HDRS} ${PRIVATE_HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
-target_link_libraries(${TARGET} filabridge filaflat utils)
-
-add_dependencies(${TARGET} shaders)
+target_link_libraries(${TARGET} shaders filabridge filaflat utils)
 
 # ==================================================================================================
 # Compiler flags

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -24,7 +24,8 @@ set(PRIVATE_HDRS
         src/eiff/MaterialInterfaceBlockChunk.h
         src/eiff/MaterialSpirvChunk.h
         src/eiff/ShaderEntry.h
-        src/eiff/SimpleFieldChunk.h)
+        src/eiff/SimpleFieldChunk.h
+        src/shaders/Shaders.h)
 
 set(SRCS
         src/eiff/BlobDictionary.cpp

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -16,6 +16,8 @@
 
 #include "CodeGenerator.h"
 
+#include "Shaders.h"
+
 #include <cctype>
 #include <iomanip>
 
@@ -32,7 +34,7 @@ std::ostream& CodeGenerator::generateSeparator(std::ostream& out) const {
 }
 
 std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
-        BlendingMode blendingMode, bool hasExternalSamplers) const {
+        bool hasExternalSamplers) const {
     assert(mShaderModel != ShaderModel::UNKNOWN);
     switch (mShaderModel) {
         case ShaderModel::UNKNOWN:
@@ -76,9 +78,7 @@ std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
         out << "invariant gl_Position;\n";
     }
 
-    out <<
-        #include "generated/shaders/common_types.fs"
-            ;
+    out << filament::shaders::common_types_fs;
 
     out << "\n";
     return out;
@@ -112,16 +112,10 @@ std::ostream& CodeGenerator::generateEpilog(std::ostream& out) const {
 
 std::ostream& CodeGenerator::generateShaderMain(std::ostream& out, ShaderType type) const {
     if (type == ShaderType::VERTEX) {
-        out <<
-        #include "generated/shaders/shadowing.vs"
-                ;
-        out <<
-        #include "generated/shaders/main.vs"
-                ;
+        out << filament::shaders::shadowing_vs;
+        out << filament::shaders::main_vs;
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/main.fs"
-                ;
+        out << filament::shaders::main_fs;
     }
     return out;
 }
@@ -129,33 +123,21 @@ std::ostream& CodeGenerator::generateShaderMain(std::ostream& out, ShaderType ty
 std::ostream& CodeGenerator::generatePostProcessMain(std::ostream& out,
         ShaderType type, filament::PostProcessStage variant) const {
     if (type == ShaderType::VERTEX) {
-        out <<
-            #include "generated/shaders/post_process.vs"
-                ;
+        out << filament::shaders::post_process_vs;
     } else if (type == ShaderType::FRAGMENT) {
         switch (variant) {
             case PostProcessStage::TONE_MAPPING_OPAQUE:
             case PostProcessStage::TONE_MAPPING_TRANSLUCENT:
-                out <<
-                    #include "generated/shaders/tone_mapping.fs"
-                        ;
-                out <<
-                    #include "generated/shaders/conversion_functions.fs"
-                        ;
-                out <<
-                    #include "generated/shaders/dithering.fs"
-                        ;
+                out << filament::shaders::tone_mapping_fs;
+                out << filament::shaders::conversion_functions_fs;
+                out << filament::shaders::dithering_fs;
                 break;
             case PostProcessStage::ANTI_ALIASING_OPAQUE:
             case PostProcessStage::ANTI_ALIASING_TRANSLUCENT:
-                out <<
-                    #include "generated/shaders/fxaa.fs"
-                        ;
+                out << filament::shaders::fxaa_fs;
                 break;
         }
-        out <<
-            #include "generated/shaders/post_process.fs"
-                ;
+        out << filament::shaders::post_process_fs;
     }
     return out;
 }
@@ -221,26 +203,18 @@ std::ostream& CodeGenerator::generateVariables(std::ostream& out, ShaderType typ
             generateDefine(out, "LOCATION_BONE_WEIGHTS", uint32_t(VertexAttribute::BONE_WEIGHTS));
         }
 
-        out <<
-        #include "generated/shaders/variables.vs"
-                ;
+        out << filament::shaders::variables_vs;
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/variables.fs"
-                ;
+        out << filament::shaders::variables_fs;
     }
     return out;
 }
 
 std::ostream& CodeGenerator::generateDepthShaderMain(std::ostream& out, ShaderType type) const {
     if (type == ShaderType::VERTEX) {
-        out <<
-        #include "generated/shaders/depth_main.vs"
-                ;
+        out << filament::shaders::depth_main_vs;
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/depth_main.fs"
-                ;
+        out << filament::shaders::depth_main_fs;
     }
     return out;
 }
@@ -272,7 +246,7 @@ std::ostream& CodeGenerator::generateUniforms(std::ostream& out, ShaderType shad
 
     out << "\nlayout(";
     if (mTargetApi == TargetApi::VULKAN) {
-        const uint32_t bindingIndex = (uint32_t) binding; // avoid char output
+        uint32_t bindingIndex = (uint32_t) binding; // avoid char output
         out << "binding = " << bindingIndex << ", ";
     }
     out << "std140) uniform " << blockName.c_str() << " {\n";
@@ -293,8 +267,8 @@ std::ostream& CodeGenerator::generateUniforms(std::ostream& out, ShaderType shad
     return out;
 }
 
-std::ostream& CodeGenerator::generateSamplers(std::ostream& out, ShaderType shaderType,
-        uint8_t firstBinding, const SamplerInterfaceBlock& sib) const {
+std::ostream& CodeGenerator::generateSamplers(
+        std::ostream& out, uint8_t firstBinding, const SamplerInterfaceBlock& sib) const {
     auto const& infos = sib.getSamplerInfoList();
     if (infos.empty()) {
         return out;
@@ -365,43 +339,29 @@ std::ostream& CodeGenerator::generateMaterialProperty(std::ostream& out,
 }
 
 std::ostream& CodeGenerator::generateCommon(std::ostream& out, ShaderType type) const {
-    out <<
-    #include "generated/shaders/common_math.fs"
-            ;
+    out << filament::shaders::common_math_fs;
     if (type == ShaderType::VERTEX) {
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/common_graphics.fs"
-                ;
+        out << filament::shaders::common_graphics_fs;
     }
     return out;
 }
 
 std::ostream& CodeGenerator::generateCommonMaterial(std::ostream& out, ShaderType type) const {
     if (type == ShaderType::VERTEX) {
-        out <<
-            #include "generated/shaders/common_material.vs"
-                ;
+        out << filament::shaders::common_material_vs;
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-            #include "generated/shaders/common_material.fs"
-                ;
+        out << filament::shaders::common_material_fs;
     }
     return out;
 }
 
 std::ostream& CodeGenerator::generateGetters(std::ostream& out, ShaderType type) const {
-    out <<
-    #include "generated/shaders/common_getters.fs"
-            ;
+    out << filament::shaders::common_getters_fs;
     if (type == ShaderType::VERTEX) {
-        out <<
-        #include "generated/shaders/getters.vs"
-                ;
+        out << filament::shaders::getters_vs;
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/getters.fs"
-                ;
+        out << filament::shaders::getters_fs;
     }
     return out;
 }
@@ -409,9 +369,7 @@ std::ostream& CodeGenerator::generateGetters(std::ostream& out, ShaderType type)
 std::ostream& CodeGenerator::generateParameters(std::ostream& out, ShaderType type) const {
     if (type == ShaderType::VERTEX) {
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/shading_parameters.fs"
-                ;
+        out << filament::shaders::shading_parameters_fs;
     }
     return out;
 }
@@ -420,58 +378,38 @@ std::ostream& CodeGenerator::generateShaderLit(std::ostream& out, ShaderType typ
         filament::Variant variant, filament::Shading shading) const {
     if (type == ShaderType::VERTEX) {
     } else if (type == ShaderType::FRAGMENT) {
-        out <<
-        #include "generated/shaders/common_lighting.fs"
-                ;
+        out << filament::shaders::common_lighting_fs;
         if (variant.hasShadowReceiver()) {
-            out <<
-            #include "generated/shaders/shadowing.fs"
-                    ;
+            out << filament::shaders::shadowing_fs;
         }
 
-        out <<
-        #include "generated/shaders/brdf.fs"
-                ;
+        out << filament::shaders::brdf_fs;
         switch (shading) {
             case Shading::UNLIT:
                 assert("Lit shader generated with unlit shading model");
                 break;
             case Shading::LIT:
-                out <<
-                #include "generated/shaders/shading_model_standard.fs"
-                        ;
+                out << filament::shaders::shading_model_standard_fs;
                 break;
             case Shading::SUBSURFACE:
-                out <<
-                    #include "generated/shaders/shading_model_subsurface.fs"
-                        ;
+                out << filament::shaders::shading_model_subsurface_fs;
                 break;
             case Shading::CLOTH:
-                out <<
-                    #include "generated/shaders/shading_model_cloth.fs"
-                        ;
+                out << filament::shaders::shading_model_cloth_fs;
                 break;
         }
 
         if (shading != Shading::UNLIT) {
-            out <<
-            #include "generated/shaders/light_indirect.fs"
-                    ;
+            out << filament::shaders::light_indirect_fs;
         }
         if (variant.hasDirectionalLighting()) {
-            out <<
-            #include "generated/shaders/light_directional.fs"
-                    ;
+            out << filament::shaders::light_directional_fs;
         }
         if (variant.hasDynamicLighting()) {
-            out <<
-            #include "generated/shaders/light_punctual.fs"
-                    ;
+            out << filament::shaders::light_punctual_fs;
         }
 
-        out <<
-        #include "generated/shaders/shading_lit.fs"
-                ;
+        out << filament::shaders::shading_lit_fs;
     }
     return out;
 }
@@ -482,14 +420,10 @@ std::ostream& CodeGenerator::generateShaderUnlit(std::ostream& out, ShaderType t
     } else if (type == ShaderType::FRAGMENT) {
         if (hasShadowMultiplier) {
             if (variant.hasShadowReceiver()) {
-                out <<
-                    #include "generated/shaders/shadowing.fs"
-                        ;
+                out << filament::shaders::shadowing_fs;
             }
         }
-        out <<
-        #include "generated/shaders/shading_unlit.fs"
-                ;
+        out << filament::shaders::shading_unlit_fs;
     }
     return out;
 }
@@ -559,7 +493,6 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
                     case SamplerFormat::SHADOW: return "sampler2DShadow";   // should not happen
                 }
             }
-            break;
         case SamplerType::SAMPLER_CUBEMAP:
             assert(!multisample);
             switch (format) {
@@ -568,7 +501,6 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
                 case SamplerFormat::FLOAT:  return "samplerCube";
                 case SamplerFormat::SHADOW: return "samplerCubeShadow";
             }
-            break;
         case SamplerType::SAMPLER_EXTERNAL:
             assert(!multisample);
             assert(format != SamplerFormat::SHADOW);
@@ -576,7 +508,6 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
             // are created via VK_ANDROID_external_memory_android_hardware_buffer, but they are
             // backed by VkImage just like a normal texture, and sampled from normally.
             return (mTargetApi == TargetApi::VULKAN) ? "sampler2D" : "samplerExternalOES";
-            break;
     }
 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -53,9 +53,7 @@ public:
     std::ostream& generateSeparator(std::ostream& out) const;
 
     // generate prolog for the given shader
-    std::ostream& generateProlog(std::ostream& out, ShaderType type,
-            filament::BlendingMode blendingMode = filament::BlendingMode::OPAQUE,
-            bool hasExternalSamplers = false) const;
+    std::ostream& generateProlog(std::ostream& out, ShaderType type, bool hasExternalSamplers) const;
 
     std::ostream& generateEpilog(std::ostream& out) const;
 
@@ -92,8 +90,8 @@ public:
             const filament::UniformInterfaceBlock& uib) const;
 
     // generate samplers
-    std::ostream& generateSamplers(std::ostream& out, ShaderType type, uint8_t firstBinding,
-            const filament::SamplerInterfaceBlock& sib) const;
+    std::ostream& generateSamplers(
+        std::ostream& out, uint8_t firstBinding, const filament::SamplerInterfaceBlock& sib) const;
 
     // generate material properties getters
     std::ostream& generateMaterialProperty(std::ostream& out,

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -148,7 +148,7 @@ const std::string ShaderGenerator::createVertexProgram(filament::driver::ShaderM
     const bool lit = material.isLit;
     const filament::Variant variant(variantKey);
 
-    cg.generateProlog(vs, ShaderType::VERTEX, material.blendingMode, material.hasExternalSamplers);
+    cg.generateProlog(vs, ShaderType::VERTEX, material.hasExternalSamplers);
 
     if (cg.getShaderModel() >= filament::driver::ShaderModel::GL_CORE_41) {
         // TODO: find a better way to set this, esp. on mobile
@@ -193,7 +193,6 @@ const std::string ShaderGenerator::createVertexProgram(filament::driver::ShaderM
     cg.generateSeparator(vs);
     // TODO: should we generate per-view SIB in the vertex shader?
     cg.generateSamplers(vs,
-            ShaderType::VERTEX,
             material.samplerBindings.getBlockOffset(BindingPoints::PER_MATERIAL_INSTANCE),
             material.sib);
 
@@ -237,8 +236,7 @@ const std::string ShaderGenerator::createFragmentProgram(filament::driver::Shade
     const filament::Variant variant(variantKey);
 
     std::stringstream fs;
-    cg.generateProlog(fs, ShaderType::FRAGMENT,
-            material.blendingMode, material.hasExternalSamplers);
+    cg.generateProlog(fs, ShaderType::FRAGMENT, material.hasExternalSamplers);
 
     cg.generateDefine(fs, "IBL_USE_RGBM", filament::CONFIG_IBL_RGBM);
     cg.generateDefine(fs, "IBL_MAX_MIP_LEVEL", std::log2f(filament::CONFIG_IBL_SIZE));
@@ -292,11 +290,10 @@ const std::string ShaderGenerator::createFragmentProgram(filament::driver::Shade
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_MATERIAL_INSTANCE, material.uib);
     cg.generateSeparator(fs);
-    cg.generateSamplers(fs, ShaderType::FRAGMENT,
+    cg.generateSamplers(fs,
             material.samplerBindings.getBlockOffset(BindingPoints::PER_VIEW),
             SibGenerator::getPerViewSib());
     cg.generateSamplers(fs,
-            ShaderType::FRAGMENT,
             material.samplerBindings.getBlockOffset(BindingPoints::PER_MATERIAL_INSTANCE),
             material.sib);
 
@@ -340,7 +337,7 @@ const std::string ShaderPostProcessGenerator::createPostProcessVertexProgram(
         filament::PostProcessStage variant, uint8_t firstSampler) noexcept {
     const CodeGenerator cg(sm, ta);
     std::stringstream vs;
-    cg.generateProlog(vs, ShaderType::VERTEX);
+    cg.generateProlog(vs, ShaderType::VERTEX, false);
     cg.generateDefine(vs, "LOCATION_POSITION", uint32_t(VertexAttribute::POSITION));
     generatePostProcessStageDefines(vs, cg, variant);
 
@@ -348,7 +345,7 @@ const std::string ShaderPostProcessGenerator::createPostProcessVertexProgram(
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
-    cg.generateSamplers(vs, ShaderType::VERTEX,
+    cg.generateSamplers(vs,
             firstSampler, SibGenerator::getPostProcessSib());
 
     cg.generateCommon(vs, ShaderType::VERTEX);
@@ -362,14 +359,14 @@ const std::string ShaderPostProcessGenerator::createPostProcessFragmentProgram(
         filament::PostProcessStage variant, uint8_t firstSampler) noexcept {
     const CodeGenerator cg(sm, ta);
     std::stringstream fs;
-    cg.generateProlog(fs, ShaderType::FRAGMENT);
+    cg.generateProlog(fs, ShaderType::FRAGMENT, false);
     generatePostProcessStageDefines(fs, cg, variant);
 
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
-    cg.generateSamplers(fs, ShaderType::FRAGMENT,
+    cg.generateSamplers(fs,
             firstSampler, SibGenerator::getPostProcessSib());
 
     cg.generateCommon(fs, ShaderType::FRAGMENT);

--- a/libs/filamat/src/shaders/Shaders.h
+++ b/libs/filamat/src/shaders/Shaders.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMANT_SHADERS_H
+#define TNT_FILAMANT_SHADERS_H
+
+namespace filament {
+namespace shaders {
+
+extern const char brdf_fs[];
+extern const char common_getters_fs[];
+extern const char common_graphics_fs[];
+extern const char common_lighting_fs[];
+extern const char common_material_fs[];
+extern const char common_material_vs[];
+extern const char common_math_fs[];
+extern const char common_types_fs[];
+extern const char conversion_functions_fs[];
+extern const char depth_main_fs[];
+extern const char depth_main_vs[];
+extern const char dithering_fs[];
+extern const char fxaa_fs[];
+extern const char getters_fs[];
+extern const char getters_vs[];
+extern const char light_directional_fs[];
+extern const char light_indirect_fs[];
+extern const char light_punctual_fs[];
+extern const char main_fs[];
+extern const char main_vs[];
+extern const char post_process_fs[];
+extern const char post_process_vs[];
+extern const char shading_lit_fs[];
+extern const char shading_model_cloth_fs[];
+extern const char shading_model_standard_fs[];
+extern const char shading_model_subsurface_fs[];
+extern const char shading_parameters_fs[];
+extern const char shading_unlit_fs[];
+extern const char shadowing_fs[];
+extern const char shadowing_vs[];
+extern const char tone_mapping_fs[];
+extern const char variables_fs[];
+extern const char variables_vs[];
+
+}
+}
+
+#endif //TNT_FILAMAT_SHADERS_H

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -65,18 +65,26 @@ endif()
 
 foreach (shader_file ${SHADERS})
     get_filename_component(localname "${shader_file}" NAME)
-    get_filename_component(fullname "${shader_file}" ABSOLUTE)
+    get_filename_component(filename  "${localname}"   NAME_WE)
+    get_filename_component(extension "${localname}"   EXT)
+    get_filename_component(fullname  "${shader_file}" ABSOLUTE)
+
+    string(SUBSTRING "${extension}" 1 -1 extension)
 
     if (WIN32)
        string(REPLACE "/" "\\" fullname ${fullname})
     endif()
 
-    set(output_path "${GENERATION_ROOT}/generated/shaders/${localname}")
+    set(output_path "${GENERATION_ROOT}/generated/shaders/${localname}.cpp")
     add_custom_command(
             OUTPUT ${output_path}
-            COMMAND echo "R${DOUBLEQUOTE}FILAMENT__${OPENP}" > ${output_path}
+            COMMAND echo "namespace filament {" > ${output_path}
+            COMMAND echo "namespace shaders {" >> ${output_path}
+            COMMAND echo "extern const char ${filename}_${extension}[] = R${DOUBLEQUOTE}FILAMENT__${OPENP}" >> ${output_path}
             COMMAND ${CAT_COMMAND} \"${fullname}\" >> \"${output_path}\"
-            COMMAND echo "${CLOSEP}FILAMENT__${DOUBLEQUOTE}" >> ${output_path}
+            COMMAND echo "${CLOSEP}FILAMENT__${DOUBLEQUOTE}\;" >> ${output_path}
+            COMMAND echo "} // namespace shaders" >> ${output_path}
+            COMMAND echo "} // namespace filament" >> ${output_path}
             DEPENDS ${shader_file}
             COMMENT "Processing shader ${shader_file}"
     )
@@ -87,4 +95,4 @@ endforeach()
 # ==================================================================================================
 # Include and target definitions
 # ==================================================================================================
-add_custom_target(${TARGET} DEPENDS ${SHADER_LIST} ${SHADERS})
+add_library(${TARGET} STATIC ${SHADER_LIST} ${SHADERS})


### PR DESCRIPTION
Each shader string is now part of a separate .o file, which should make recompiling `filamat`/`matc` a tad more enjoyable.