### PR TITLE
Fix forward declaration type. 

### DIFF
--- a/libs/filaflat/include/filaflat/MaterialParser.h
+++ b/libs/filaflat/include/filaflat/MaterialParser.h
@@ -38,7 +38,7 @@ namespace filaflat {
 class ChunkContainer;
 class ShaderBuilder;
 
-class MaterialParserDetails;
+struct MaterialParserDetails;
 
 class UTILS_PUBLIC MaterialParser {
 public:

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -45,7 +45,7 @@ using PostProcessCallBack = std::function<bool(
         std::string* /* outputGlsl */,
         std::vector<uint32_t>* /* outputSpirv */ )>;
 
-class MaterialInfo;
+struct MaterialInfo;
 
 class UTILS_PUBLIC MaterialBuilderBase {
 public:


### PR DESCRIPTION
`MaterialParserDetails` and `MaterialInfo` are structs.