### PR TITLE
Fix pathing issues on Windows

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -91,7 +91,8 @@ install(FILES ${DIST_HDRS} DESTINATION include/${TARGET})
 # ==================================================================================================
 # Test executables
 # ==================================================================================================
-add_executable(test_${TARGET}
+
+set(TEST_SRCS
         test/test_algorithm.cpp
         test/test_Allocators.cpp
         test/test_bitset.cpp
@@ -102,11 +103,16 @@ add_executable(test_${TARGET}
         test/test_JobSystem.cpp
         test/test_StructureOfArrays.cpp
         test/test_utils_main.cpp
-        test/test_Zip2Iterator.cpp)
+        test/test_Zip2Iterator.cpp
+)
 
-# The Path tests are platform-specific, and fail on Windows
-if (NOT WIN32)
-    list(APPEND SRCS test/test_Path.cpp)
+# The Path tests are platform-specific
+if (WIN32)
+    list(APPEND TEST_SRCS test/test_WinPath.cpp)
+else()
+    list(APPEND TEST_SRCS test/test_Path.cpp)
 endif()
+
+add_executable(test_${TARGET} ${TEST_SRCS})
 
 target_link_libraries(test_${TARGET} PRIVATE gtest utils tsl math)

--- a/libs/utils/include/utils/Path.h
+++ b/libs/utils/include/utils/Path.h
@@ -154,9 +154,7 @@ public:
      * @return true if this abstract pathname is not empty
      *         and starts with a leading '/', false otherwise
      */
-    bool isAbsolute() const {
-        return !isEmpty() && m_path.front() == '/';
-    }
+    bool isAbsolute() const;
 
     /**
      * Splits this object's abstract pathname in a vector of file

--- a/libs/utils/src/Path.cpp
+++ b/libs/utils/src/Path.cpp
@@ -104,6 +104,13 @@ Path Path::getAbsolutePath() const {
     return getCurrentDirectory().concat(*this);
 }
 
+
+#if !defined(WIN32)
+bool Path::isAbsolute() const {
+    return !isEmpty() && m_path.front() == '/';
+}
+#endif
+
 Path Path::getParent() const {
     if (isEmpty()) return "";
 

--- a/libs/utils/src/Path.cpp
+++ b/libs/utils/src/Path.cpp
@@ -179,24 +179,24 @@ std::vector<std::string> Path::split() const {
     return segments;
 }
 
-#if !defined(WIN32)
 std::string Path::getCanonicalPath(const std::string& path) {
     if (path.empty()) return "";
 
     std::vector<std::string> segments;
 
     // If the path starts with a / we must preserve it
-    bool starts_with_slash = path.front() == '/';
+    bool starts_with_slash = path.front() == SEPARATOR;
     // If the path does not end with a / we need to remove the
     // extra / added by the join process
-    bool ends_with_slash = path.back() == '/';
+    bool ends_with_slash = path.back() == SEPARATOR;
 
     size_t current;
     ssize_t next = -1;
 
     do {
         current = size_t(next + 1);
-        next = path.find_first_of("/", current);
+        // Handle both Unix and Windows style separators
+        next = path.find_first_of("/\\", current);
 
         std::string segment(path.substr(current, next - current));
         size_t size = segment.length();
@@ -230,11 +230,11 @@ std::string Path::getCanonicalPath(const std::string& path) {
     // the end that might need to be removed
     std::stringstream clean_path;
     std::copy(segments.begin(), segments.end(),
-            std::ostream_iterator<std::string>(clean_path, "/"));
+            std::ostream_iterator<std::string>(clean_path, SEPARATOR_STR));
     std::string new_path = clean_path.str();
 
     if (starts_with_slash && new_path.empty()) {
-        new_path = "/";
+        new_path = SEPARATOR_STR;
     }
 
     if (!ends_with_slash && new_path.length() > 1) {
@@ -243,7 +243,6 @@ std::string Path::getCanonicalPath(const std::string& path) {
 
     return new_path;
 }
-#endif
 
 bool Path::mkdirRecursive() const {
     if (isEmpty()) {

--- a/libs/utils/src/win32/Path.cpp
+++ b/libs/utils/src/win32/Path.cpp
@@ -63,4 +63,8 @@ std::vector<Path> Path::listContents() const {
     return directory_contents;
 }
 
+bool Path::isAbsolute() const {
+    return !PathIsRelative(m_path.c_str());
+}
+
 } // namespace utils

--- a/libs/utils/src/win32/Path.cpp
+++ b/libs/utils/src/win32/Path.cpp
@@ -63,12 +63,4 @@ std::vector<Path> Path::listContents() const {
     return directory_contents;
 }
 
-std::string Path::getCanonicalPath(const std::string& path) {
-    if (path.empty()) return "";
-
-    char canonized[MAX_PATH];
-    PathCanonicalize(canonized, path.c_str());
-    return canonized;
-}
-
 } // namespace utils

--- a/libs/utils/test/test_WinPath.cpp
+++ b/libs/utils/test/test_WinPath.cpp
@@ -116,4 +116,53 @@ TEST(WinPathTest, Split) {
     EXPECT_EQ("foo", segments[2]);
     EXPECT_EQ("blue", segments[3]);
     EXPECT_EQ("bin", segments[4]);
+
+    segments = Path("C:\\out\\foo/blue\\bin/").split();
+    EXPECT_EQ(5, segments.size());
+    EXPECT_EQ("C:", segments[0]);
+    EXPECT_EQ("out", segments[1]);
+    EXPECT_EQ("foo", segments[2]);
+    EXPECT_EQ("blue", segments[3]);
+    EXPECT_EQ("bin", segments[4]);
+}
+
+TEST(WinPathTest, Concatenate) {
+    Path root("C:\\Volumes\\Replicant\\blue");
+
+    Path r;
+    r = root.concat("");
+    EXPECT_EQ("C:\\Volumes\\Replicant\\blue", r.getPath());
+
+    r = root.concat("C:\\out\\bin");
+    EXPECT_EQ("C:\\out\\bin", r.getPath());
+
+    r = root.concat("out\\bin");
+    EXPECT_EQ("C:\\Volumes\\Replicant\\blue\\out\\bin", r.getPath());
+
+    r = root.concat(".");
+    EXPECT_EQ("C:\\Volumes\\Replicant\\blue", r.getPath());
+
+    r = root.concat("..");
+    EXPECT_EQ("C:\\Volumes\\Replicant", r.getPath());
+
+    r = root.concat("C:\\");
+    EXPECT_EQ("C:\\", r.getPath());
+
+    r = root.concat("..\\remote-blue");
+    EXPECT_EQ("C:\\Volumes\\Replicant\\remote-blue", r.getPath());
+
+    r = root.concat("..\\remote-blue");
+    EXPECT_EQ(r, root + Path("../remote-blue"));
+    EXPECT_EQ(r, root + "../remote-blue");
+
+    r = "C:\\out\\bin";
+    r.concatToSelf("../bin");
+    EXPECT_EQ("C:\\out\\bin", r.getPath());
+
+    r += "./resources";
+    EXPECT_EQ("C:\\out\\bin\\resources", r.getPath());
+
+    // Unix-style separators work too
+    r = root.concat("out/bin/foo/bar");
+    EXPECT_EQ("C:\\Volumes\\Replicant\\blue\\out\\bin\\foo\\bar", r.getPath());
 }

--- a/libs/utils/test/test_WinPath.cpp
+++ b/libs/utils/test/test_WinPath.cpp
@@ -76,3 +76,18 @@ TEST(PathTest, Sanitization) {
     r = Path::getCanonicalPath("..\\..\\bin");
     EXPECT_EQ("..\\..\\bin", r);
 }
+
+TEST(PathTest, AbsolutePath) {
+    Path cwd = Path::getCurrentDirectory();
+
+    Path p;
+    p = Path("C:\\out\\blue\\bin");
+    EXPECT_TRUE(p.isAbsolute());
+
+    p = p.getAbsolutePath();
+    EXPECT_EQ("C:\\out\\blue\\bin", p.getPath());
+
+    p = Path("../bin").getAbsolutePath();
+    EXPECT_NE(cwd, p);
+    EXPECT_TRUE(p.isAbsolute());
+}

--- a/libs/utils/test/test_WinPath.cpp
+++ b/libs/utils/test/test_WinPath.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits.h>
+#include <gtest/gtest.h>
+
+#include <utils/Path.h>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#ifndef PATH_MAX    // should be in <limits.h>
+#define PATH_MAX    4096
+#endif
+
+using namespace utils;
+
+TEST(PathTest, Sanitization) {
+    std::string r;
+
+    // An empty path remains empty
+    r = Path::getCanonicalPath("");
+    EXPECT_EQ("", r);
+
+    // A single / is preserved
+    r = Path::getCanonicalPath("\\");
+    EXPECT_EQ("\\", r);
+
+    // Unix style paths are converted to Windows style
+    r = Path::getCanonicalPath("out/./././bin/foo/../../bar");
+    EXPECT_EQ("out\\bar", r);
+
+    // A mix of Unix style paths and Windows style
+    r = Path::getCanonicalPath("out/.\\././bin/foo\\../..\\bar");
+    EXPECT_EQ("out\\bar", r);
+
+    // Disk designation
+    r = Path::getCanonicalPath("C:\\out\\bin");
+    EXPECT_EQ("C:\\out\\bin", r);
+
+    // Collapse .. with disk designation
+    r = Path::getCanonicalPath("C:\\out\\bin\\..\\foo");
+    EXPECT_EQ("C:\\out\\foo", r);
+
+    // Collapse multiple .. with disk designation
+    r = Path::getCanonicalPath("C:\\out\\bin\\..\\..\\foo");
+    EXPECT_EQ("C:\\foo", r);
+
+    // Collapse . with disk designation
+    r = Path::getCanonicalPath("C:\\out\\.\\foo");
+    EXPECT_EQ("C:\\out\\foo", r);
+
+    // Collapse multiple . with disk designation
+    r = Path::getCanonicalPath("C:\\out\\.\\.\\foo");
+    EXPECT_EQ("C:\\out\\foo", r);
+
+    // Collapse multiple . and .. with disk designation
+    r = Path::getCanonicalPath("C:\\out\\bin\\.\\..\\..\\foo");
+    EXPECT_EQ("C:\\foo", r);
+
+    // make sure it works with several ../
+    r = Path::getCanonicalPath("..\\..\\bin");
+    EXPECT_EQ("..\\..\\bin", r);
+}

--- a/libs/utils/test/test_WinPath.cpp
+++ b/libs/utils/test/test_WinPath.cpp
@@ -29,7 +29,7 @@
 
 using namespace utils;
 
-TEST(PathTest, Sanitization) {
+TEST(WinPathTest, Sanitization) {
     std::string r;
 
     // An empty path remains empty
@@ -77,7 +77,7 @@ TEST(PathTest, Sanitization) {
     EXPECT_EQ("..\\..\\bin", r);
 }
 
-TEST(PathTest, AbsolutePath) {
+TEST(WinPathTest, AbsolutePath) {
     Path cwd = Path::getCurrentDirectory();
 
     Path p;
@@ -90,4 +90,30 @@ TEST(PathTest, AbsolutePath) {
     p = Path("../bin").getAbsolutePath();
     EXPECT_NE(cwd, p);
     EXPECT_TRUE(p.isAbsolute());
+}
+
+TEST(WinPathTest, Split) {
+    std::vector<std::string> segments;
+
+    segments = Path("").split();
+    EXPECT_EQ(0, segments.size());
+
+    segments = Path("\\").split();
+    EXPECT_EQ(1, segments.size());
+    EXPECT_EQ("\\", segments[0]);
+
+    segments = Path("\\out\\blue\\bin").split();
+    EXPECT_EQ(4, segments.size());
+    EXPECT_EQ("\\", segments[0]);
+    EXPECT_EQ("out", segments[1]);
+    EXPECT_EQ("blue", segments[2]);
+    EXPECT_EQ("bin", segments[3]);
+
+    segments = Path("/out\\foo/blue\\bin/").split();
+    EXPECT_EQ(5, segments.size());
+    EXPECT_EQ("\\", segments[0]);
+    EXPECT_EQ("out", segments[1]);
+    EXPECT_EQ("foo", segments[2]);
+    EXPECT_EQ("blue", segments[3]);
+    EXPECT_EQ("bin", segments[4]);
 }

--- a/libs/utils/test/test_WinPath.cpp
+++ b/libs/utils/test/test_WinPath.cpp
@@ -49,6 +49,10 @@ TEST(WinPathTest, Sanitization) {
     EXPECT_EQ("out\\bar", r);
 
     // Disk designation
+    r = Path::getCanonicalPath("C:\\");
+    EXPECT_EQ("C:\\", r);
+
+    // Disk designation
     r = Path::getCanonicalPath("C:\\out\\bin");
     EXPECT_EQ("C:\\out\\bin", r);
 
@@ -102,6 +106,10 @@ TEST(WinPathTest, Split) {
     EXPECT_EQ(1, segments.size());
     EXPECT_EQ("\\", segments[0]);
 
+    segments = Path("C:\\").split();
+    EXPECT_EQ(1, segments.size());
+    EXPECT_EQ("C:\\", segments[0]);
+
     segments = Path("\\out\\blue\\bin").split();
     EXPECT_EQ(4, segments.size());
     EXPECT_EQ("\\", segments[0]);
@@ -119,7 +127,7 @@ TEST(WinPathTest, Split) {
 
     segments = Path("C:\\out\\foo/blue\\bin/").split();
     EXPECT_EQ(5, segments.size());
-    EXPECT_EQ("C:", segments[0]);
+    EXPECT_EQ("C:\\", segments[0]);
     EXPECT_EQ("out", segments[1]);
     EXPECT_EQ("foo", segments[2]);
     EXPECT_EQ("blue", segments[3]);
@@ -165,4 +173,39 @@ TEST(WinPathTest, Concatenate) {
     // Unix-style separators work too
     r = root.concat("out/bin/foo/bar");
     EXPECT_EQ("C:\\Volumes\\Replicant\\blue\\out\\bin\\foo\\bar", r.getPath());
+}
+
+TEST(PathTest, GetParent) {
+    std::string r;
+    Path p("C:\\out\\bin");
+    r = p.getParent();
+    EXPECT_EQ("C:\\out\\", r);
+
+    p = "C:\\out\\bin\\";
+    r = p.getParent();
+    EXPECT_EQ("C:\\out\\", r);
+
+    p = "out\\bin";
+    r = p.getParent();
+    EXPECT_EQ("out\\", r);
+
+    p = "out\\bin\\";
+    r = p.getParent();
+    EXPECT_EQ("out\\", r);
+
+    p = "out";
+    r = p.getParent();
+    EXPECT_EQ("", r);
+
+    p = "C:\\out";
+    r = p.getParent();
+    EXPECT_EQ("C:\\", r);
+
+    p = "";
+    r = p.getParent();
+    EXPECT_EQ("", r);
+
+    p = "C:\\";
+    r = p.getParent();
+    EXPECT_EQ("C:\\", r);
 }


### PR DESCRIPTION
Fix `Path::split`, `Path::isAbsolute`, `Path::getParent`, and `getCanonicalPath` on Windows.

Fixes #13 
Fixes #14

Some edge-case windows pathing may still not work:
- "drive relative" paths: "C:tmp.txt"
- UNC paths (network paths): "\\foo\\bar" (will be collapsed to \foo\bar, which may resolve to a different location than expected)
- "absolute paths": "\foo\bar" (may or may not resolve to drive root)