### PR TITLE
Fix cmgen cross cubmap input

### DIFF
--- a/libs/imageio/src/ImageDecoder.cpp
+++ b/libs/imageio/src/ImageDecoder.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 /*
  * Copyright (C) 2015 The Android Open Source Project
  *
@@ -290,7 +292,7 @@ Image PNGDecoder::decode() {
         uint32_t height = png_get_image_height(mPNG, mInfo);
         size_t rowBytes = png_get_rowbytes(mPNG, mInfo);
 
-        imageData.reset(new uint8_t[height * rowBytes]);
+        imageData = std::make_unique<uint8_t[]>(height * rowBytes);
         std::unique_ptr<png_bytep[]> rowPointers(new png_bytep[height]);
         for (size_t y = 0 ; y < height ; y++) {
             rowPointers[y] = &imageData[y * rowBytes];
@@ -369,8 +371,7 @@ HDRDecoder::HDRDecoder(std::istream& stream)
     : mStream(stream), mStreamStartPos(stream.tellg()) {
 }
 
-HDRDecoder::~HDRDecoder() {
-}
+HDRDecoder::~HDRDecoder() = default;
 
 Image HDRDecoder::decode() {
     try {
@@ -480,8 +481,7 @@ PSDDecoder::PSDDecoder(std::istream& stream)
         : mStream(stream), mStreamStartPos(stream.tellg()) {
 }
 
-PSDDecoder::~PSDDecoder() {
-}
+PSDDecoder::~PSDDecoder() = default;
 
 Image PSDDecoder::decode() {
     #pragma pack(push, 1)
@@ -593,8 +593,7 @@ EXRDecoder::EXRDecoder(std::istream& stream, const std::string& sourceName)
         : mStream(stream), mStreamStartPos(stream.tellg()), mSourceName(sourceName) {
 }
 
-EXRDecoder::~EXRDecoder() {
-}
+EXRDecoder::~EXRDecoder() = default;
 
 Image EXRDecoder::decode() {
     try {

--- a/tools/cmgen/src/CubemapUtils.h
+++ b/tools/cmgen/src/CubemapUtils.h
@@ -60,7 +60,10 @@ public:
     static std::string getFaceName(Cubemap::Face face);
 
     // Create a cubemap object and its backing Image
-    static Cubemap create(image::Image& image, size_t dim);
+    static Cubemap create(image::Image& image, size_t dim, bool horizontal = true);
+
+    // Copy an image
+    static void copyImage(image::Image& dst, const image::Image& src);
 
     // Sets a Cubemap faces from a cross image
     static void setAllFacesFromCross(Cubemap& cm, const image::Image& image);
@@ -73,7 +76,7 @@ public:
 
 private:
     static void setFaceFromCross(Cubemap& cm, Cubemap::Face face, const image::Image& image);
-    static image::Image createCubemapImage(size_t dim);
+    static image::Image createCubemapImage(size_t dim, bool horizontal = true);
 };
 
 // -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes bug #45 
cmgen always expects the backing store of cubmaps to have an extra line and column, which wasn't the case when the input was not equirectangular.