### PR TITLE
Set max number of lights to 255 instead of 256

### DIFF
--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -142,8 +142,9 @@ public:
             };
         };
     };
-    // This depends on the maximum number of lights (currently 256),and can't be more than 16 bits.
-    using RecordBufferType = std::conditional_t<CONFIG_MAX_LIGHT_COUNT <= 255, uint8_t, uint16_t>;
+    // This depends on the maximum number of lights (currently 255),and can't be more than 16 bits.
+    static_assert(CONFIG_MAX_LIGHT_COUNT <= std::numeric_limits<uint16_t>::max(), "can't have more than 65535 lights");
+    using RecordBufferType = std::conditional_t<CONFIG_MAX_LIGHT_COUNT <= std::numeric_limits<uint8_t>::max(), uint8_t, uint16_t>;
     const utils::Slice<FroxelEntry>& getFroxelBufferUser() const { return mFroxelBufferUser; }
     const utils::Slice<RecordBufferType>& getRecordBufferUser() const { return mRecordBufferUser; }
 

--- a/libs/filabridge/include/filament/EngineEnums.h
+++ b/libs/filabridge/include/filament/EngineEnums.h
@@ -44,7 +44,7 @@ namespace BindingPoints {
     constexpr uint8_t POST_PROCESS            = 4;    // samplers for the post process pass
     constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                   = 6;
-};
+}
 
 static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
         "Dynamically sized sampler buffer must be the last binding point.");
@@ -52,7 +52,8 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
 constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8;   // FIXME: should match Driver::MAX_ATTRIBUTE_BUFFER_COUNT
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
-constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
+// Values <= 255, use less CPU and GPU resources.
+constexpr size_t CONFIG_MAX_LIGHT_COUNT = 255;
 
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // 256 is enough, but we could use 512 if needed


### PR DESCRIPTION
This always was the intention because internally 
it uses 8-bits buffers instead of 16-bits. One of
our temporary buffer goes from 4 MiB to 2 MiB.
This got mistakenly changed to 256 recently.