### PR TITLE
froxelization fixes

### DIFF
--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -305,7 +305,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
     const CameraInfo& camera = mViewingCameraInfo;
     FScene* const scene = mScene;
 
-    scene->prepareLights(camera);
+    scene->prepareLights(camera, arena);
 
     // here the array of visible lights has been shrunk to CONFIG_MAX_LIGHT_COUNT
     auto const& lightData = scene->getLightData();

--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -143,8 +143,8 @@ public:
         };
     };
     // This depends on the maximum number of lights (currently 255),and can't be more than 16 bits.
-    static_assert(CONFIG_MAX_LIGHT_COUNT <= std::numeric_limits<uint16_t>::max(), "can't have more than 65535 lights");
-    using RecordBufferType = std::conditional_t<CONFIG_MAX_LIGHT_COUNT <= std::numeric_limits<uint8_t>::max(), uint8_t, uint16_t>;
+    static_assert(CONFIG_MAX_LIGHT_INDEX <= std::numeric_limits<uint16_t>::max(), "can't have more than 65536 lights");
+    using RecordBufferType = std::conditional_t<CONFIG_MAX_LIGHT_INDEX <= std::numeric_limits<uint8_t>::max(), uint8_t, uint16_t>;
     const utils::Slice<FroxelEntry>& getFroxelBufferUser() const { return mFroxelBufferUser; }
     const utils::Slice<RecordBufferType>& getRecordBufferUser() const { return mRecordBufferUser; }
 
@@ -155,7 +155,8 @@ private:
     };
 
     struct LightRecord {
-        utils::bitset256 lights;
+        using bitset = utils::bitset<uint64_t, (CONFIG_MAX_LIGHT_COUNT + 63) / 64>;
+        bitset lights;
     };
 
     struct LightParams {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -25,6 +25,8 @@
 #include "details/Culler.h"
 #include "details/GpuLightBuffer.h"
 
+#include "Allocators.h"
+
 #include <filament/Box.h>
 #include <filament/Scene.h>
 
@@ -81,7 +83,7 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(const math::mat4f& worldOriginTansform);
-    void prepareLights(const CameraInfo& camera) noexcept;
+    void prepareLights(const CameraInfo& camera, ArenaScope& arena) noexcept;
     void computeBounds(Aabb& castersBox, Aabb& receiversBox, uint32_t visibleLayers) const noexcept;
 
     /*

--- a/libs/filabridge/include/filament/EngineEnums.h
+++ b/libs/filabridge/include/filament/EngineEnums.h
@@ -52,8 +52,9 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
 constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8;   // FIXME: should match Driver::MAX_ATTRIBUTE_BUFFER_COUNT
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
-// Values <= 255, use less CPU and GPU resources.
-constexpr size_t CONFIG_MAX_LIGHT_COUNT = 255;
+// Values <= 256, use less CPU and GPU resources.
+constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
+constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // 256 is enough, but we could use 512 if needed


### PR DESCRIPTION
- fix froxelization with more than 255 lights
- fix stack corruption when the scene has more than 255 lights
