### PR TITLE
make we our indices to the hammersley sequence are within range

### DIFF
--- a/tools/cmgen/src/CubemapIBL.cpp
+++ b/tools/cmgen/src/CubemapIBL.cpp
@@ -126,8 +126,7 @@ void CubemapIBL::roughnessFilter(Cubemap& dst,
     // our goal is to use maxNumSamples for which NoL is > 0
     // to achieve this, we might have to try more samples than
     // maxNumSamples
-    size_t sampleIndex = 0;
-    for (size_t sample = 0 ; sample < maxNumSamples; ) {
+    for (size_t sampleIndex = 0, sample = 0 ; sampleIndex < maxNumSamples; sampleIndex++) {
         /*
          *       (sampling)
          *            L         H (never calculated below)
@@ -200,8 +199,6 @@ void CubemapIBL::roughnessFilter(Cubemap& dst,
             cache.push_back({ L, brdf_NoL, lerp, l0, l1 });
             sample++;
         }
-
-        sampleIndex++;
     }
 
     std::for_each(cache.begin(), cache.end(), [weight](CacheEntry& entry){


### PR DESCRIPTION
fix #87 

We just skip samples that have a dot(N,L)<0 which 
means we’re “loosing” some samples. However,
this happens higher levels of the mipmap chain,
and since we’re increasing significantly the 
number of samples as the level increases, this
doesn’t end-up being a problem.