### PR TITLE
use pointers instead of std::array<>::iterator

### DIFF
--- a/libs/utils/include/utils/RangeSet.h
+++ b/libs/utils/include/utils/RangeSet.h
@@ -60,9 +60,9 @@ private:
     class vector {
         std::array<TYPE, RANGE_COUNT> mElements;
         uint32_t mSize = 0;
-        using iterator       = typename std::array<TYPE, CAPACITY>::iterator;
-        using const_iterator = typename std::array<TYPE, CAPACITY>::const_iterator;
         using value_type     = typename std::array<TYPE, CAPACITY>::value_type;
+        using iterator       = value_type*;
+        using const_iterator = value_type const*;
 
     public:
         bool empty() const noexcept { return size() == 0; }
@@ -70,11 +70,11 @@ private:
         size_t capacity() const noexcept { return CAPACITY; }
         value_type *data() { return mElements.data(); }
         value_type const *data() const { return mElements.data(); }
-        iterator begin() { return mElements.begin(); }
+        iterator begin() { return mElements.data(); }
         iterator end() { return begin() + mSize; }
-        const_iterator begin() const { return mElements.begin(); }
+        const_iterator begin() const { return mElements.data(); }
         const_iterator end() const { return begin() + mSize; }
-        const_iterator cbegin() const { return mElements.cbegin(); }
+        const_iterator cbegin() const { return mElements.data(); }
         const_iterator cend() const { return cbegin() + mSize; }
         value_type const& operator[](size_t i) const noexcept { return mElements[i]; }
         value_type& operator[](size_t i)  noexcept { return mElements[i]; }


### PR DESCRIPTION
some STL implementations assert when iterators are
out of range (even without dereferencing).

Fixes #94 