### PR TITLE
Enhance CMake compiler check on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,11 +61,22 @@ set(TOOLS ${CMAKE_SOURCE_DIR}/tools)
 # ==================================================================================================
 # Compiler check
 # ==================================================================================================
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    message(FATAL_ERROR
-            "The GCC compiler is not supported, please use clang for both C and C++. "
-            "Please refer to README.md for more information.")
-    return()
+set(MIN_CLANG_VERSION "5.0")
+
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_C_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
+        message(SEND_ERROR "Detected C compiler Clang ${CMAKE_C_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
+    endif()
+else()
+    message(SEND_ERROR "Detected C compiler ${CMAKE_C_COMPILER_ID} is unsupported")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
+        message(SEND_ERROR "Detected CXX compiler Clang ${CMAKE_CXX_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
+    endif()
+else()
+    message(SEND_ERROR "Detected CXX compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
 endif()
 
 # Detect use of the clang-cl.exe frontend, which does not support all of clangs normal options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,18 +65,18 @@ set(MIN_CLANG_VERSION "5.0")
 
 if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     if (CMAKE_C_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
-        message(SEND_ERROR "Detected C compiler Clang ${CMAKE_C_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
+        message(FATAL_ERROR "Detected C compiler Clang ${CMAKE_C_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
     endif()
 else()
-    message(SEND_ERROR "Detected C compiler ${CMAKE_C_COMPILER_ID} is unsupported")
+    message(FATAL_ERROR "Detected C compiler ${CMAKE_C_COMPILER_ID} is unsupported")
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
-        message(SEND_ERROR "Detected CXX compiler Clang ${CMAKE_CXX_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
+        message(FATAL_ERROR "Detected CXX compiler Clang ${CMAKE_CXX_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
     endif()
 else()
-    message(SEND_ERROR "Detected CXX compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
+    message(FATAL_ERROR "Detected CXX compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
 endif()
 
 # Detect use of the clang-cl.exe frontend, which does not support all of clangs normal options


### PR DESCRIPTION
Somehow I missed the specified compiler version in the docs. Maybe I forgot about it by the time I got to the platform-specific requirements. Maybe I just can't read. Not sure what the problem was, but it would be nice for CMake to catch that sort of mistake.

This commit adds a warning for compilers that don't meet the project's minimum requirements. There is already an explicit check for GNU, but this will catch Clang versions that are too low as well as any non-GNU, non-Clang compilers.

The check is Linux-only as I have only built Filament on Linux and I'm not sure if this check would apply to Windows or OSX. The message is warning rather than an error to minimize the impact of false-positives caused by differing compiler names or version numbers. In particular, forks of clang may be compatible but have different names or numbers.

I know the contribution guidelines suggest I should open an issue before submitting a PR, but I figured this was a small enough change that it was probably unnecessary. I'm guessing the process was set up to avoid wasted development effort on rejected designs, but if there's some other reason I should be opening an issue first, I'd be happy to go back and do that.