### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR to enable embedding of filament as a subdirectory in a larger CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,16 @@ endif()
 #  Paths
 # ==================================================================================================
 # Where our external libs are
-set(EXTERNAL ${CMAKE_SOURCE_DIR}/third_party)
+set(EXTERNAL ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
 
 # Where our libraries are
-set(LIBRARIES ${CMAKE_SOURCE_DIR}/libs)
+set(LIBRARIES ${CMAKE_CURRENT_SOURCE_DIR}/libs)
 
 # Where our filament code is
-set(FILAMENT ${CMAKE_SOURCE_DIR})
+set(FILAMENT ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Where our tools are
-set(TOOLS ${CMAKE_SOURCE_DIR}/tools)
+set(TOOLS ${CMAKE_CURRENT_SOURCE_DIR}/tools)
 
 # ==================================================================================================
 # Compiler check


### PR DESCRIPTION
When trying to use filament as a subproject in a larger project, I stumbled on a problem that the variables changed in this diff would not get the right path.

This comes from that when using the CMake function add_subdirectory, all build artifacts are prefixed with the directory name.

This commit should not change the behavior of the filament build system if it is built stand alone.