### PR TITLE
option to reorder the froxel info for better cpu cache utilization

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -129,14 +129,14 @@ public:
         math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
         math::float3 lightDirection;
-        float padding1;
+        uint32_t fParamsX; // stride-x
 
         math::float3 shadowBias; // constant bias, normal bias, unused
         float oneOverFroxelDimensionY;
 
         math::float4 zParams; // froxel Z parameters
 
-        math::uint2 fParams; // froxelCountX, froxelCountX * froxelCountY
+        math::uint2 fParams; // stride-y, stride-z
         math::float2 origin; // viewport left, viewport bottom
 
         float oneOverFroxelDimensionX;

--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -117,6 +117,7 @@ public:
     size_t getFroxelCountX() const noexcept { return mFroxelCountX; }
     size_t getFroxelCountY() const noexcept { return mFroxelCountY; }
     size_t getFroxelCountZ() const noexcept { return mFroxelCountZ; }
+    size_t getFroxelCount() const noexcept { return mFroxelCount; }
 
     // update Records and Froxels texture with lights data. this is thread-safe.
     void froxelizeLights(FEngine& engine, math::mat4f const& viewMatrix,
@@ -124,7 +125,8 @@ public:
 
     void updateUniforms(UniformBuffer& u) {
         u.setUniform(offsetof(FEngine::PerViewUib, zParams), mParamsZ);
-        u.setUniform(offsetof(FEngine::PerViewUib, fParams), mParamsF);
+        u.setUniform(offsetof(FEngine::PerViewUib, fParams), mParamsF.yz);
+        u.setUniform(offsetof(FEngine::PerViewUib, fParamsX), mParamsF.x);
         u.setUniform(offsetof(FEngine::PerViewUib, oneOverFroxelDimensionX), mOneOverDimension.x);
         u.setUniform(offsetof(FEngine::PerViewUib, oneOverFroxelDimensionY), mOneOverDimension.y);
     }
@@ -224,6 +226,7 @@ private:
     uint16_t mFroxelCountX = 0;
     uint16_t mFroxelCountY = 0;
     uint16_t mFroxelCountZ = 0;
+    uint16_t mFroxelCount = 0;
     math::uint2 mFroxelDimension = {};
 
     math::mat4f mProjection;
@@ -238,7 +241,7 @@ private:
     // needed for update()
     Viewport mViewport;
     math::float4 mParamsZ = {};
-    math::uint4 mParamsF = {};
+    math::uint3 mParamsF = {};
     float mNear = 0.0f;        // camera near
     float mZLightFar = FEngine::CONFIG_Z_LIGHT_FAR;
     float mZLightNear = FEngine::CONFIG_Z_LIGHT_NEAR;  // light near (first slice)

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -43,7 +43,7 @@ UniformInterfaceBlock& UibGenerator::getPerViewUib() noexcept  {
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
-            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT)
+            .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)
             // shadow
             .add("shadowBias",              1, UniformInterfaceBlock::Type::FLOAT3)
             .add("oneOverFroxelDimensionY", 1, UniformInterfaceBlock::Type::FLOAT)


### PR DESCRIPTION
This changes the layout of the froxels data
structure in the GPU so that the major axis
is the Z axis instead of X. The idea is that
within a given screen-space tile, we have a high
probability to access froxels at the same x/y
but different z.

This is turned off right now, as it requires
a change that breaks existing compiled materials.