### PR TITLE
Add option USE_EXTERNAL_GLES3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ project(TNT)
 
 option(ENABLE_JAVA "Compile Java projects, requires a JDK and the JAVA_HOME env var" ON)
 
+option(USE_EXTERNAL_GLES3 "Experimental: Compile filament against OpenGL ES 3" OFF)
+
 # ==================================================================================================
 # OS specific
 # ==================================================================================================
@@ -93,6 +95,10 @@ if (WIN32)
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function")
+
+if (USE_EXTERNAL_GLES3)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EXTERNAL_GLES3")
+endif()
 
 if (WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_USE_MATH_DEFINES=1")

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -162,7 +162,9 @@ endif()
 # OS specific
 # ==================================================================================================
 # Here set the architecture specific sources
-if (ANDROID)
+if (USE_EXTERNAL_GLES3)
+    # Experimental feature; clients provide their own Context Manager.
+elseif (ANDROID)
     list(APPEND SRCS src/driver/opengl/ContextManagerEGL.cpp)
 elseif (APPLE)
     list(APPEND SRCS src/driver/opengl/ContextManagerCocoa.mm)

--- a/filament/src/driver/ExternalContext.cpp
+++ b/filament/src/driver/ExternalContext.cpp
@@ -17,27 +17,37 @@
 #include <filament/driver/ExternalContext.h>
 
 #if defined(ANDROID)
-    #include "driver/opengl/ContextManagerEGL.h"
+    #ifndef USE_EXTERNAL_GLES3
+        #include "driver/opengl/ContextManagerEGL.h"
+    #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "driver/vulkan/ContextManagerVkAndroid.h"
     #endif
 #elif defined(__APPLE__)
-    #include "driver/opengl/ContextManagerCocoa.h"
+    #ifndef USE_EXTERNAL_GLES3
+        #include "driver/opengl/ContextManagerCocoa.h"
+    #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "driver/vulkan/ContextManagerVkCocoa.h"
     #endif
 #elif defined(__linux__)
-    #include "driver/opengl/ContextManagerGLX.h"
+    #ifndef USE_EXTERNAL_GLES3
+        #include "driver/opengl/ContextManagerGLX.h"
+    #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "driver/vulkan/ContextManagerVkLinux.h"
     #endif
 #elif defined(WIN32)
-    #include "driver/opengl/ContextManagerWGL.h"
+    #ifndef USE_EXTERNAL_GLES3
+        #include "driver/opengl/ContextManagerWGL.h"
+    #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "driver/vulkan/ContextManagerVkWindows.h"
     #endif
 #else
-    #include "driver/opengl/ContextManagerDummy.h"
+    #ifndef USE_EXTERNAL_GLES3
+        #include "driver/opengl/ContextManagerDummy.h"
+    #endif
 #endif
 
 namespace filament {
@@ -72,7 +82,9 @@ ExternalContext* ExternalContext::create(Backend* backend) noexcept {
             return nullptr;
         #endif
     }
-    #if defined(ANDROID)
+    #if defined(USE_EXTERNAL_GLES3)
+        return nullptr;
+    #elif defined(ANDROID)
         return new ContextManagerEGL();
     #elif defined(__APPLE__)
         return new ContextManagerCocoa();

--- a/filament/src/driver/opengl/gl_headers.cpp
+++ b/filament/src/driver/opengl/gl_headers.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(USE_EXTERNAL_GLES3)
 
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>

--- a/filament/src/driver/opengl/gl_headers.h
+++ b/filament/src/driver/opengl/gl_headers.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DRIVER_GL_HEADERS_H
 #define TNT_FILAMENT_DRIVER_GL_HEADERS_H
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(USE_EXTERNAL_GLES3)
 
     #include <GLES3/gl31.h>
     #include <GLES2/gl2ext.h>


### PR DESCRIPTION
Causes gl_headers to use GLES, even on desktop.
Causes all ContextManagers to be elided;
users are expected to provide their own.