### PR TITLE
Update VkMemAlloc and fix its usage.

### DIFF
--- a/filament/src/driver/vulkan/VulkanBuffer.cpp
+++ b/filament/src/driver/vulkan/VulkanBuffer.cpp
@@ -48,6 +48,7 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
     memcpy(mapped, cpuData, numBytes);
     vmaUnmapMemory(mContext.allocator, stage->memory);
+    vmaFlushAllocation(mContext.allocator, stage->memory, byteOffset, numBytes);
 
     // Create and submit a one-off command buffer to allow uploading outside a frame.
     VkCommandBuffer cmdbuffer;

--- a/filament/src/driver/vulkan/VulkanDriverImpl.cpp
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.cpp
@@ -21,7 +21,9 @@
 #pragma clang diagnostic ignored "-Wundef"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#pragma clang diagnostic ignored "-Wtautological-compare"
 #define VMA_IMPLEMENTATION
+#include <cstdio>
 #include "vk_mem_alloc.h"
 #pragma clang diagnostic pop
 

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -343,6 +343,7 @@ void VulkanUniformBuffer::loadFromCpu(const void* cpuData, uint32_t numBytes) {
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
     memcpy(mapped, cpuData, numBytes);
     vmaUnmapMemory(mContext.allocator, stage->memory);
+    vmaFlushAllocation(mContext.allocator, stage->memory, 0, numBytes);
 
     // Create and submit a one-off command buffer to allow uploading outside a frame.
     VkCommandBuffer cmdbuffer;
@@ -497,6 +498,7 @@ void VulkanTexture::load2DImage(PixelBufferDescriptor&& data, uint32_t width, ui
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
     memcpy(mapped, cpuData, numBytes);
     vmaUnmapMemory(mContext.allocator, stage->memory);
+    vmaFlushAllocation(mContext.allocator, stage->memory, 0, numBytes);
 
     // Create a copy-to-device functor because we might need to defer it.
     auto copyToDevice = [this, stage, width, height, miplevel] (VkCommandBuffer cmd) {
@@ -529,6 +531,7 @@ void VulkanTexture::loadCubeImage(PixelBufferDescriptor&& data,  const FaceOffse
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
     memcpy(mapped, cpuData, numBytes);
     vmaUnmapMemory(mContext.allocator, stage->memory);
+    vmaFlushAllocation(mContext.allocator, stage->memory, 0, numBytes);
 
     // Create a copy-to-device functor because we might need to defer it.
     auto copyToDevice = [this, faceOffsets, stage, miplevel] (VkCommandBuffer cmd) {

--- a/filament/src/driver/vulkan/VulkanStagePool.cpp
+++ b/filament/src/driver/vulkan/VulkanStagePool.cpp
@@ -45,7 +45,7 @@ VulkanStage const* VulkanStagePool::acquireStage(uint32_t numBytes) noexcept {
         .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
     };
     VmaAllocationCreateInfo allocInfo {
-        .usage = VMA_MEMORY_USAGE_CPU_TO_GPU
+        .usage = VMA_MEMORY_USAGE_CPU_ONLY
     };
     vmaCreateBuffer(mContext.allocator, &bufferInfo, &allocInfo, &stage->buffer, &stage->memory, 0);
     return stage;

--- a/third_party/vkmemalloc/README.md
+++ b/third_party/vkmemalloc/README.md
@@ -41,6 +41,7 @@ Additional features:
 - Configuration: Fill optional members of CreateInfo structure to provide custom CPU memory allocator, pointers to Vulkan functions and other parameters.
 - Customization: Predefine appropriate macros to provide your own implementation of all external facilities used by the library, from assert, mutex, and atomic, to vector and linked list. 
 - Support for memory mapping, reference-counted internally. Support for persistently mapped memory: Just allocate with appropriate flag and you get access to mapped pointer.
+- Support for non-coherent memory. Functions that flush/invalidate memory. nonCoherentAtomSize is respected automatically.
 - Custom memory pools: Create a pool with desired parameters (e.g. fixed or limited maximum size) and allocate memory out of it.
 - Support for VK_KHR_dedicated_allocation extension: Just enable it and it will be used automatically by the library.
 - Defragmentation: Call one function and let the library move data around to free some memory blocks and make your allocations better compacted.
@@ -49,6 +50,8 @@ Additional features:
 - Debug annotations: Associate string with name or opaque pointer to your own data with every allocation.
 - JSON dump: Obtain a string in JSON format with detailed map of internal state, including list of allocations and gaps between them.
 - Convert this JSON dump into a picture to visualize your memory. See [tools/VmaDumpVis](tools/VmaDumpVis/README.md).
+- Debugging incorrect memory usage: Enable initialization of all allocated memory with a bit pattern to detect usage of uninitialized or freed memory. Enable validation of a magic number before and after every allocation to detect out-of-bounds memory corruption.
+- Record and replay sequence of calls to library functions to a file to check correctness, measure performance, and gather statistics.
 
 # Prequisites
 
@@ -98,5 +101,4 @@ See **[Documentation](https://gpuopen-librariesandsdks.github.io/VulkanMemoryAll
 
 - **[Awesome Vulkan](https://github.com/vinjn/awesome-vulkan)** - a curated list of awesome Vulkan libraries, debuggers and resources.
 - **[PyVMA](https://github.com/realitix/pyvma)** - Python wrapper for this library. Author: Jean-Sébastien B. (@realitix). License: Apache 2.0.
-- **[vma_sample_sdl](https://github.com/rextimmy/vma_sample_sdl)** - SDL port of the sample app of this library (with the goal of running it on multiple platforms, including MacOS). Author: @rextimmy. License: MIT.
 - **[vulkan-malloc](https://github.com/dylanede/vulkan-malloc)** - Vulkan memory allocation library for Rust. Based on version 1 of this library. Author: Dylan Ede (@dylanede). License: MIT / Apache 2.0.

--- a/third_party/vkmemalloc/src/Tests.cpp
+++ b/third_party/vkmemalloc/src/Tests.cpp
@@ -558,12 +558,12 @@ VkResult MainTest(Result& outResult, const Config& config)
     return res;
 }
 
-static void SaveAllocatorStatsToFile(VmaAllocator alloc, const wchar_t* filePath)
+static void SaveAllocatorStatsToFile(const wchar_t* filePath)
 {
     char* stats;
-    vmaBuildStatsString(alloc, &stats, VK_TRUE);
+    vmaBuildStatsString(g_hAllocator, &stats, VK_TRUE);
     SaveFile(filePath, stats, strlen(stats));
-    vmaFreeStatsString(alloc, stats);
+    vmaFreeStatsString(g_hAllocator, stats);
 }
 
 struct AllocInfo
@@ -982,7 +982,7 @@ void TestDefragmentationFull()
     for(size_t i = 0; i < allocations.size(); ++i)
         ValidateAllocationData(allocations[i]);
 
-    SaveAllocatorStatsToFile(g_hAllocator, L"Before.csv");
+    SaveAllocatorStatsToFile(L"Before.csv");
 
     {
         std::vector<VmaAllocation> vmaAllocations(allocations.size());
@@ -1033,7 +1033,7 @@ void TestDefragmentationFull()
 
             wchar_t fileName[MAX_PATH];
             swprintf(fileName, MAX_PATH, L"After_%02u.csv", defragIndex);
-            SaveAllocatorStatsToFile(g_hAllocator, fileName);
+            SaveAllocatorStatsToFile(fileName);
         }
     }
 
@@ -1322,6 +1322,72 @@ void TestHeapSizeLimit()
     vmaDestroyAllocator(hAllocator);
 }
 
+#if VMA_DEBUG_MARGIN
+static void TestDebugMargin()
+{
+    if(VMA_DEBUG_MARGIN == 0)
+    {
+        return;
+    }
+
+    VkBufferCreateInfo bufInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+    bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    
+    VmaAllocationCreateInfo allocCreateInfo = {};
+    allocCreateInfo.usage = VMA_MEMORY_USAGE_CPU_ONLY;
+
+    // Create few buffers of different size.
+    const size_t BUF_COUNT = 10;
+    BufferInfo buffers[BUF_COUNT];
+    VmaAllocationInfo allocInfo[BUF_COUNT];
+    for(size_t i = 0; i < 10; ++i)
+    {
+        bufInfo.size = (VkDeviceSize)(i + 1) * 64;
+        // Last one will be mapped.
+        allocCreateInfo.flags = (i == BUF_COUNT - 1) ? VMA_ALLOCATION_CREATE_MAPPED_BIT : 0;
+
+        VkResult res = vmaCreateBuffer(g_hAllocator, &bufInfo, &allocCreateInfo, &buffers[i].Buffer, &buffers[i].Allocation, &allocInfo[i]);
+        assert(res == VK_SUCCESS);
+        // Margin is preserved also at the beginning of a block.
+        assert(allocInfo[i].offset >= VMA_DEBUG_MARGIN);
+
+        if(i == BUF_COUNT - 1)
+        {
+            // Fill with data.
+            assert(allocInfo[i].pMappedData != nullptr);
+            // Uncomment this "+ 1" to overwrite past end of allocation and check corruption detection.
+            memset(allocInfo[i].pMappedData, 0xFF, bufInfo.size /* + 1 */);
+        }
+    }
+
+    // Check if their offsets preserve margin between them.
+    std::sort(allocInfo, allocInfo + BUF_COUNT, [](const VmaAllocationInfo& lhs, const VmaAllocationInfo& rhs) -> bool
+    {
+        if(lhs.deviceMemory != rhs.deviceMemory)
+        {
+            return lhs.deviceMemory < rhs.deviceMemory;
+        }
+        return lhs.offset < rhs.offset;
+    });
+    for(size_t i = 1; i < BUF_COUNT; ++i)
+    {
+        if(allocInfo[i].deviceMemory == allocInfo[i - 1].deviceMemory)
+        {
+            assert(allocInfo[i].offset >= allocInfo[i - 1].offset + VMA_DEBUG_MARGIN);
+        }
+    }
+
+    VkResult res = vmaCheckCorruption(g_hAllocator, UINT32_MAX);
+    assert(res == VK_SUCCESS);
+
+    // Destroy all buffers.
+    for(size_t i = BUF_COUNT; i--; )
+    {
+        vmaDestroyBuffer(g_hAllocator, buffers[i].Buffer, buffers[i].Allocation);
+    }
+}
+#endif
+
 static void TestPool_SameSize()
 {
     const VkDeviceSize BUF_SIZE = 1024 * 1024;
@@ -1585,7 +1651,116 @@ static void TestPool_SameSize()
 
     items.clear();
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // Test for allocation too large for pool
+
+    {
+        VmaAllocationCreateInfo allocCreateInfo = {};
+        allocCreateInfo.pool = pool;
+
+        VkMemoryRequirements memReq;
+        memReq.memoryTypeBits = UINT32_MAX;
+        memReq.alignment = 1;
+        memReq.size = poolCreateInfo.blockSize + 4;
+        
+        VmaAllocation alloc = nullptr;
+        res = vmaAllocateMemory(g_hAllocator, &memReq, &allocCreateInfo, &alloc, nullptr);
+        assert(res == VK_ERROR_OUT_OF_DEVICE_MEMORY && alloc == nullptr);
+    }
+
     vmaDestroyPool(g_hAllocator, pool);
+}
+
+static bool ValidatePattern(const void* pMemory, size_t size, uint8_t pattern)
+{
+    const uint8_t* pBytes = (const uint8_t*)pMemory;
+    for(size_t i = 0; i < size; ++i)
+    {
+        if(pBytes[i] != pattern)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void TestAllocationsInitialization()
+{
+    VkResult res;
+
+    const size_t BUF_SIZE = 1024;
+
+    // Create pool.
+
+    VkBufferCreateInfo bufInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+    bufInfo.size = BUF_SIZE;
+    bufInfo.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+
+    VmaAllocationCreateInfo dummyBufAllocCreateInfo = {};
+    dummyBufAllocCreateInfo.usage = VMA_MEMORY_USAGE_CPU_ONLY;
+
+    VmaPoolCreateInfo poolCreateInfo = {};
+    poolCreateInfo.blockSize = BUF_SIZE * 10;
+    poolCreateInfo.minBlockCount = 1; // To keep memory alive while pool exists.
+    poolCreateInfo.maxBlockCount = 1;
+    res = vmaFindMemoryTypeIndexForBufferInfo(g_hAllocator, &bufInfo, &dummyBufAllocCreateInfo, &poolCreateInfo.memoryTypeIndex);
+    assert(res == VK_SUCCESS);
+
+    VmaAllocationCreateInfo bufAllocCreateInfo = {};
+    res = vmaCreatePool(g_hAllocator, &poolCreateInfo, &bufAllocCreateInfo.pool);
+    assert(res == VK_SUCCESS);
+
+    // Create one persistently mapped buffer to keep memory of this block mapped,
+    // so that pointer to mapped data will remain (more or less...) valid even
+    // after destruction of other allocations.
+    
+    bufAllocCreateInfo.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    VkBuffer firstBuf;
+    VmaAllocation firstAlloc;
+    res = vmaCreateBuffer(g_hAllocator, &bufInfo, &bufAllocCreateInfo, &firstBuf, &firstAlloc, nullptr);
+    assert(res == VK_SUCCESS);
+
+    // Test buffers.
+
+    for(uint32_t i = 0; i < 2; ++i)
+    {
+        const bool persistentlyMapped = i == 0;
+        bufAllocCreateInfo.flags = persistentlyMapped ? VMA_ALLOCATION_CREATE_MAPPED_BIT : 0;
+        VkBuffer buf;
+        VmaAllocation alloc;
+        VmaAllocationInfo allocInfo;
+        res = vmaCreateBuffer(g_hAllocator, &bufInfo, &bufAllocCreateInfo, &buf, &alloc, &allocInfo);
+        assert(res == VK_SUCCESS);
+
+        void* pMappedData;
+        if(!persistentlyMapped)
+        {
+            res = vmaMapMemory(g_hAllocator, alloc, &pMappedData);
+            assert(res == VK_SUCCESS);
+        }
+        else
+        {
+            pMappedData = allocInfo.pMappedData;
+        }
+
+        // Validate initialized content
+        bool valid = ValidatePattern(pMappedData, BUF_SIZE, 0xDC);
+        assert(valid);
+
+        if(!persistentlyMapped)
+        {
+            vmaUnmapMemory(g_hAllocator, alloc);
+        }
+
+        vmaDestroyBuffer(g_hAllocator, buf, alloc);
+
+        // Validate freed content
+        valid = ValidatePattern(pMappedData, BUF_SIZE, 0xEF);
+        assert(valid);
+    }
+
+    vmaDestroyBuffer(g_hAllocator, firstBuf, firstAlloc);
+    vmaDestroyPool(g_hAllocator, bufAllocCreateInfo.pool);
 }
 
 static void TestPool_Benchmark(
@@ -2936,11 +3111,20 @@ void Test()
 {
     wprintf(L"TESTING:\n");
 
+    // TEMP tests
+
     // # Simple tests
 
     TestBasics();
+#if VMA_DEBUG_MARGIN
+    TestDebugMargin();
+#else
     TestPool_SameSize();
     TestHeapSizeLimit();
+#endif
+#if VMA_DEBUG_INITIALIZE_ALLOCATIONS
+    TestAllocationsInitialization();
+#endif
     TestMapping();
     TestMappingMultithreaded();
     TestDefragmentationSimple();

--- a/third_party/vkmemalloc/src/VmaReplay/Common.cpp
+++ b/third_party/vkmemalloc/src/VmaReplay/Common.cpp
@@ -1,0 +1,670 @@
+#include "Common.h"
+
+////////////////////////////////////////////////////////////////////////////////
+// LineSplit class
+
+bool LineSplit::GetNextLine(StrRange& out)
+{
+    if(m_NextLineBeg < m_NumBytes)
+    {
+        out.beg = m_Data + m_NextLineBeg;
+        size_t currLineEnd = m_NextLineBeg;
+        while(currLineEnd < m_NumBytes && m_Data[currLineEnd] != '\n')
+            ++currLineEnd;
+        out.end = m_Data + currLineEnd;
+        m_NextLineBeg = currLineEnd + 1; // Past '\n'
+        ++m_NextLineIndex;
+        return true;
+    }
+    else
+        return false;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CsvSplit class
+
+void CsvSplit::Set(const StrRange& line, size_t maxCount)
+{
+    assert(maxCount <= RANGE_COUNT_MAX);
+    m_Line = line;
+    const size_t strLen = line.length();
+    size_t rangeIndex = 0;
+    size_t charIndex = 0;
+    while(charIndex < strLen && rangeIndex < maxCount)
+    {
+        m_Ranges[rangeIndex * 2] = charIndex;
+        while(charIndex < strLen && (rangeIndex + 1 == maxCount || m_Line.beg[charIndex] != ','))
+            ++charIndex;
+        m_Ranges[rangeIndex * 2 + 1] = charIndex;
+        ++rangeIndex;
+        ++charIndex; // Past ','
+    }
+    m_Count = rangeIndex;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// class CmdLineParser
+
+bool CmdLineParser::ReadNextArg(std::string *OutArg)
+{
+	if (m_argv != NULL)
+	{
+		if (m_ArgIndex >= (size_t)m_argc) return false;
+
+		*OutArg = m_argv[m_ArgIndex];
+		m_ArgIndex++;
+		return true;
+	}
+	else
+	{
+		if (m_ArgIndex >= m_CmdLineLength) return false;
+		
+		OutArg->clear();
+		bool InsideQuotes = false;
+		while (m_ArgIndex < m_CmdLineLength)
+		{
+			char Ch = m_CmdLine[m_ArgIndex];
+			if (Ch == '\\')
+			{
+				bool FollowedByQuote = false;
+				size_t BackslashCount = 1;
+				size_t TmpIndex = m_ArgIndex + 1;
+				while (TmpIndex < m_CmdLineLength)
+				{
+					char TmpCh = m_CmdLine[TmpIndex];
+					if (TmpCh == '\\')
+					{
+						BackslashCount++;
+						TmpIndex++;
+					}
+					else if (TmpCh == '"')
+					{
+						FollowedByQuote = true;
+						break;
+					}
+					else
+						break;
+				}
+
+				if (FollowedByQuote)
+				{
+					if (BackslashCount % 2 == 0)
+					{
+						for (size_t i = 0; i < BackslashCount / 2; i++)
+							*OutArg += '\\';
+						m_ArgIndex += BackslashCount + 1;
+						InsideQuotes = !InsideQuotes;
+					}
+					else
+					{
+						for (size_t i = 0; i < BackslashCount / 2; i++)
+							*OutArg += '\\';
+						*OutArg += '"';
+						m_ArgIndex += BackslashCount + 1;
+					}
+				}
+				else
+				{
+					for (size_t i = 0; i < BackslashCount; i++)
+						*OutArg += '\\';
+					m_ArgIndex += BackslashCount;
+				}
+			}
+			else if (Ch == '"')
+			{
+				InsideQuotes = !InsideQuotes;
+				m_ArgIndex++;
+			}
+			else if (isspace(Ch))
+			{
+				if (InsideQuotes)
+				{
+					*OutArg += Ch;
+					m_ArgIndex++;
+				}
+				else
+				{
+					m_ArgIndex++;
+					break;
+				}
+			}
+			else
+			{
+				*OutArg += Ch;
+				m_ArgIndex++;
+			}
+		}
+
+		while (m_ArgIndex < m_CmdLineLength && isspace(m_CmdLine[m_ArgIndex]))
+			m_ArgIndex++;
+
+		return true;
+	}
+}
+
+CmdLineParser::SHORT_OPT * CmdLineParser::FindShortOpt(char Opt)
+{
+	for (size_t i = 0; i < m_ShortOpts.size(); i++)
+		if (m_ShortOpts[i].Opt == Opt)
+			return &m_ShortOpts[i];
+	return NULL;
+}
+
+CmdLineParser::LONG_OPT * CmdLineParser::FindLongOpt(const std::string &Opt)
+{
+	for (size_t i = 0; i < m_LongOpts.size(); i++)
+		if (m_LongOpts[i].Opt == Opt)
+			return &m_LongOpts[i];
+	return NULL;
+}
+
+CmdLineParser::CmdLineParser(int argc, char **argv) :
+	m_argv(argv),
+	m_CmdLine(NULL),
+	m_argc(argc),
+	m_CmdLineLength(0),
+	m_ArgIndex(1),
+	m_InsideMultioption(false),
+	m_LastArgIndex(0),
+	m_LastOptId(0)
+{
+	assert(argc > 0);
+	assert(argv != NULL);
+}
+
+CmdLineParser::CmdLineParser(const char *CmdLine) :
+	m_argv(NULL),
+	m_CmdLine(CmdLine),
+	m_argc(0),
+	m_ArgIndex(0),
+	m_InsideMultioption(false),
+	m_LastArgIndex(0),
+	m_LastOptId(0)
+{
+	assert(CmdLine != NULL);
+
+	m_CmdLineLength = strlen(m_CmdLine);
+
+	while (m_ArgIndex < m_CmdLineLength && isspace(m_CmdLine[m_ArgIndex]))
+		m_ArgIndex++;
+}
+
+void CmdLineParser::RegisterOpt(uint32_t Id, char Opt, bool Parameter)
+{
+	assert(Opt != '\0');
+
+	m_ShortOpts.push_back(SHORT_OPT(Id, Opt, Parameter));
+}
+
+void CmdLineParser::RegisterOpt(uint32_t Id, const std::string &Opt, bool Parameter)
+{
+	assert(!Opt.empty());
+	
+	m_LongOpts.push_back(LONG_OPT(Id, Opt, Parameter));
+}
+
+CmdLineParser::RESULT CmdLineParser::ReadNext()
+{
+	if (m_InsideMultioption)
+	{
+		assert(m_LastArgIndex < m_LastArg.length());
+		SHORT_OPT *so = FindShortOpt(m_LastArg[m_LastArgIndex]);
+		if (so == NULL)
+		{
+			m_LastOptId = 0;
+			m_LastParameter.clear();
+			return CmdLineParser::RESULT_ERROR;
+		}
+		if (so->Parameter)
+		{
+			if (m_LastArg.length() == m_LastArgIndex+1)
+			{
+				if (!ReadNextArg(&m_LastParameter))
+				{
+					m_LastOptId = 0;
+					m_LastParameter.clear();
+					return CmdLineParser::RESULT_ERROR;
+				}
+				m_InsideMultioption = false;
+				m_LastOptId = so->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+			else if (m_LastArg[m_LastArgIndex+1] == '=')
+			{
+				m_InsideMultioption = false;
+				m_LastParameter = m_LastArg.substr(m_LastArgIndex+2);
+				m_LastOptId = so->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+			else
+			{
+				m_InsideMultioption = false;
+				m_LastParameter = m_LastArg.substr(m_LastArgIndex+1);
+				m_LastOptId = so->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+		}
+		else
+		{
+			if (m_LastArg.length() == m_LastArgIndex+1)
+			{
+				m_InsideMultioption = false;
+				m_LastParameter.clear();
+				m_LastOptId = so->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+			else
+			{
+				m_LastArgIndex++;
+
+				m_LastParameter.clear();
+				m_LastOptId = so->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+		}
+	}
+	else
+	{
+		if (!ReadNextArg(&m_LastArg))
+		{
+			m_LastParameter.clear();
+			m_LastOptId = 0;
+			return CmdLineParser::RESULT_END;
+		}
+		
+		if (!m_LastArg.empty() && m_LastArg[0] == '-')
+		{
+			if (m_LastArg.length() > 1 && m_LastArg[1] == '-')
+			{
+				size_t EqualIndex = m_LastArg.find('=', 2);
+				if (EqualIndex != std::string::npos)
+				{
+					LONG_OPT *lo = FindLongOpt(m_LastArg.substr(2, EqualIndex-2));
+					if (lo == NULL || lo->Parameter == false)
+					{
+						m_LastOptId = 0;
+						m_LastParameter.clear();
+						return CmdLineParser::RESULT_ERROR;
+					}
+					m_LastParameter = m_LastArg.substr(EqualIndex+1);
+					m_LastOptId = lo->Id;
+					return CmdLineParser::RESULT_OPT;
+				}
+				else
+				{
+					LONG_OPT *lo = FindLongOpt(m_LastArg.substr(2));
+					if (lo == NULL)
+					{
+						m_LastOptId = 0;
+						m_LastParameter.clear();
+						return CmdLineParser::RESULT_ERROR;
+					}
+					if (lo->Parameter)
+					{
+						if (!ReadNextArg(&m_LastParameter))
+						{
+							m_LastOptId = 0;
+							m_LastParameter.clear();
+							return CmdLineParser::RESULT_ERROR;
+						}
+					}
+					else
+						m_LastParameter.clear();
+					m_LastOptId = lo->Id;
+					return CmdLineParser::RESULT_OPT;
+				}
+			}
+			else
+			{
+				if (m_LastArg.length() < 2)
+				{
+					m_LastOptId = 0;
+					m_LastParameter.clear();
+					return CmdLineParser::RESULT_ERROR;
+				}
+				SHORT_OPT *so = FindShortOpt(m_LastArg[1]);
+				if (so == NULL)
+				{
+					m_LastOptId = 0;
+					m_LastParameter.clear();
+					return CmdLineParser::RESULT_ERROR;
+				}
+				if (so->Parameter)
+				{
+					if (m_LastArg.length() == 2)
+					{
+						if (!ReadNextArg(&m_LastParameter))
+						{
+							m_LastOptId = 0;
+							m_LastParameter.clear();
+							return CmdLineParser::RESULT_ERROR;
+						}
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+					else if (m_LastArg[2] == '=')
+					{
+						m_LastParameter = m_LastArg.substr(3);
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+					else
+					{
+						m_LastParameter = m_LastArg.substr(2);
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+				}
+				else
+				{
+					if (m_LastArg.length() == 2)
+					{
+						m_LastParameter.clear();
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+					else
+					{
+						m_InsideMultioption = true;
+						m_LastArgIndex = 2;
+
+						m_LastParameter.clear();
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+				}
+			}
+		}
+		else if (!m_LastArg.empty() && m_LastArg[0] == '/')
+		{
+			size_t EqualIndex = m_LastArg.find('=', 1);
+			if (EqualIndex != std::string::npos)
+			{
+				if (EqualIndex == 2)
+				{
+					SHORT_OPT *so = FindShortOpt(m_LastArg[1]);
+					if (so != NULL)
+					{
+						if (so->Parameter == false)	
+						{
+							m_LastOptId = 0;
+							m_LastParameter.clear();
+							return CmdLineParser::RESULT_ERROR;
+						}
+						m_LastParameter = m_LastArg.substr(EqualIndex+1);
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+				}
+				LONG_OPT *lo = FindLongOpt(m_LastArg.substr(1, EqualIndex-1));
+				if (lo == NULL || lo->Parameter == false)
+				{
+					m_LastOptId = 0;
+					m_LastParameter.clear();
+					return CmdLineParser::RESULT_ERROR;
+				}
+				m_LastParameter = m_LastArg.substr(EqualIndex+1);
+				m_LastOptId = lo->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+			else
+			{
+				if (m_LastArg.length() == 2)
+				{
+					SHORT_OPT *so = FindShortOpt(m_LastArg[1]);
+					if (so != NULL)
+					{
+						if (so->Parameter)
+						{
+							if (!ReadNextArg(&m_LastParameter))
+							{
+								m_LastOptId = 0;
+								m_LastParameter.clear();
+								return CmdLineParser::RESULT_ERROR;
+							}
+						}
+						else
+							m_LastParameter.clear();
+						m_LastOptId = so->Id;
+						return CmdLineParser::RESULT_OPT;
+					}
+				}
+				LONG_OPT *lo = FindLongOpt(m_LastArg.substr(1));
+				if (lo == NULL)
+				{
+					m_LastOptId = 0;
+					m_LastParameter.clear();
+					return CmdLineParser::RESULT_ERROR;
+				}
+				if (lo->Parameter)
+				{
+					if (!ReadNextArg(&m_LastParameter))
+					{
+						m_LastOptId = 0;
+						m_LastParameter.clear();
+						return CmdLineParser::RESULT_ERROR;
+					}
+				}
+				else
+					m_LastParameter.clear();
+				m_LastOptId = lo->Id;
+				return CmdLineParser::RESULT_OPT;
+			}
+		}
+		else
+		{
+			m_LastOptId = 0;
+			m_LastParameter = m_LastArg;
+			return CmdLineParser::RESULT_PARAMETER;
+		}
+	}
+}
+
+uint32_t CmdLineParser::GetOptId()
+{
+	return m_LastOptId;
+}
+
+const std::string & CmdLineParser::GetParameter()
+{
+	return m_LastParameter;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Glolals
+
+/*
+
+void SetConsoleColor(CONSOLE_COLOR color)
+{
+    WORD attr = 0;
+    switch(color)
+    {
+    case CONSOLE_COLOR::INFO:
+        attr = FOREGROUND_INTENSITY;;
+        break;
+    case CONSOLE_COLOR::NORMAL:
+        attr = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
+        break;
+    case CONSOLE_COLOR::WARNING:
+        attr = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+        break;
+    case CONSOLE_COLOR::ERROR_:
+        attr = FOREGROUND_RED | FOREGROUND_INTENSITY;
+        break;
+    default:
+        assert(0);
+    }
+
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    SetConsoleTextAttribute(out, attr);
+}
+
+void PrintMessage(CONSOLE_COLOR color, const char* msg)
+{
+    if(color != CONSOLE_COLOR::NORMAL)
+        SetConsoleColor(color);
+    
+    printf("%s\n", msg);
+    
+    if (color != CONSOLE_COLOR::NORMAL)
+        SetConsoleColor(CONSOLE_COLOR::NORMAL);
+}
+
+void PrintMessage(CONSOLE_COLOR color, const wchar_t* msg)
+{
+    if(color != CONSOLE_COLOR::NORMAL)
+        SetConsoleColor(color);
+    
+    wprintf(L"%s\n", msg);
+    
+    if (color != CONSOLE_COLOR::NORMAL)
+        SetConsoleColor(CONSOLE_COLOR::NORMAL);
+}
+
+static const size_t CONSOLE_SMALL_BUF_SIZE = 256;
+
+void PrintMessageV(CONSOLE_COLOR color, const char* format, va_list argList)
+{
+	size_t dstLen = (size_t)::_vscprintf(format, argList);
+	if(dstLen)
+	{
+		bool useSmallBuf = dstLen < CONSOLE_SMALL_BUF_SIZE;
+		char smallBuf[CONSOLE_SMALL_BUF_SIZE];
+		std::vector<char> bigBuf(useSmallBuf ? 0 : dstLen + 1);
+		char* bufPtr = useSmallBuf ? smallBuf : bigBuf.data();
+		::vsprintf_s(bufPtr, dstLen + 1, format, argList);
+		PrintMessage(color, bufPtr);
+	}
+}
+
+void PrintMessageV(CONSOLE_COLOR color, const wchar_t* format, va_list argList)
+{
+	size_t dstLen = (size_t)::_vcwprintf(format, argList);
+	if(dstLen)
+	{
+		bool useSmallBuf = dstLen < CONSOLE_SMALL_BUF_SIZE;
+		wchar_t smallBuf[CONSOLE_SMALL_BUF_SIZE];
+		std::vector<wchar_t> bigBuf(useSmallBuf ? 0 : dstLen + 1);
+		wchar_t* bufPtr = useSmallBuf ? smallBuf : bigBuf.data();
+		::vswprintf_s(bufPtr, dstLen + 1, format, argList);
+		PrintMessage(color, bufPtr);
+	}
+}
+
+void PrintMessageF(CONSOLE_COLOR color, const char* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(color, format, argList);
+	va_end(argList);
+}
+
+void PrintMessageF(CONSOLE_COLOR color, const wchar_t* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(color, format, argList);
+	va_end(argList);
+}
+
+void PrintWarningF(const char* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(CONSOLE_COLOR::WARNING, format, argList);
+	va_end(argList);
+}
+
+void PrintWarningF(const wchar_t* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(CONSOLE_COLOR::WARNING, format, argList);
+	va_end(argList);
+}
+
+void PrintErrorF(const char* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(CONSOLE_COLOR::WARNING, format, argList);
+	va_end(argList);
+}
+
+void PrintErrorF(const wchar_t* format, ...)
+{
+	va_list argList;
+	va_start(argList, format);
+	PrintMessageV(CONSOLE_COLOR::WARNING, format, argList);
+	va_end(argList);
+}
+*/
+
+void SecondsToFriendlyStr(float seconds, std::string& out)
+{
+    if(seconds == 0.f)
+    {
+        out = "0";
+        return;
+    }
+
+    if (seconds < 0.f)
+	{
+		out = "-";
+        seconds = -seconds;
+	}
+	else
+	{
+		out.clear();
+	}
+
+	char s[32];
+
+    // #.### ns
+    if(seconds < 1e-6)
+    {
+        sprintf_s(s, "%.3f ns", seconds * 1e9);
+        out += s;
+    }
+    // #.### us
+    else if(seconds < 1e-3)
+    {
+        sprintf_s(s, "%.3f us", seconds * 1e6);
+        out += s;
+    }
+    // #.### ms
+    else if(seconds < 1.f)
+    {
+        sprintf_s(s, "%.3f ms", seconds * 1e3);
+        out += s;
+    }
+    // #.### s
+    else if(seconds < 60.f)
+    {
+        sprintf_s(s, "%.3f s", seconds);
+        out += s;
+    }
+    else
+    {
+	    uint64_t seconds_u = (uint64_t)seconds;
+	    // "#:## min"
+	    if (seconds_u < 3600)
+	    {
+		    uint64_t minutes = seconds_u / 60;
+		    seconds_u -= minutes * 60;
+            sprintf_s(s, "%llu:%02llu min", minutes, seconds_u);
+            out += s;
+	    }
+	    // "#:##:## h"
+	    else
+	    {
+		    uint64_t minutes = seconds_u / 60;
+            seconds_u -= minutes * 60;
+		    uint64_t hours = minutes / 60;
+		    minutes -= hours * 60;
+            sprintf_s(s, "%llu:%02llu:%02llu h", hours, minutes, seconds_u);
+            out += s;
+	    }
+    }
+}

--- a/third_party/vkmemalloc/src/VmaReplay/Common.h
+++ b/third_party/vkmemalloc/src/VmaReplay/Common.h
@@ -1,0 +1,391 @@
+#pragma once
+
+#include "VmaUsage.h"
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <memory>
+#include <algorithm>
+#include <numeric>
+#include <array>
+#include <type_traits>
+#include <utility>
+#include <chrono>
+#include <string>
+#include <limits>
+
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+#include <cstdarg>
+
+typedef std::chrono::high_resolution_clock::time_point time_point;
+typedef std::chrono::high_resolution_clock::duration duration;
+
+inline float ToFloatSeconds(duration d)
+{
+    return std::chrono::duration_cast<std::chrono::duration<float>>(d).count();
+}
+
+void SecondsToFriendlyStr(float seconds, std::string& out);
+
+template <typename T>
+T ceil_div(T x, T y)
+{
+    return (x+y-1) / y;
+}
+
+template <typename T>
+inline T align_up(T val, T align)
+{
+    return (val + align - 1) / align * align;
+}
+
+struct StrRange
+{
+    const char* beg;
+    const char* end;
+
+    StrRange() { }
+    StrRange(const char* beg, const char* end) : beg(beg), end(end) { }
+    explicit StrRange(const char* sz) : beg(sz), end(sz + strlen(sz)) { }
+    explicit StrRange(const std::string& s) : beg(s.data()), end(s.data() + s.length()) { }
+
+    size_t length() const { return end - beg; }
+    void to_str(std::string& out) const { out.assign(beg, end); }
+};
+
+inline bool StrRangeEq(const StrRange& lhs, const char* rhsSz)
+{
+    const size_t rhsLen = strlen(rhsSz);
+    return rhsLen == lhs.length() &&
+        memcmp(lhs.beg, rhsSz, rhsLen) == 0;
+}
+
+inline bool StrRangeToUint(const StrRange& s, uint32_t& out)
+{
+    char* end = (char*)s.end;
+    out = (uint32_t)strtoul(s.beg, &end, 10);
+    return end == s.end;
+}
+inline bool StrRangeToUint(const StrRange& s, uint64_t& out)
+{
+    char* end = (char*)s.end;
+    out = (uint64_t)strtoull(s.beg, &end, 10);
+    return end == s.end;
+}
+inline bool StrRangeToPtr(const StrRange& s, uint64_t& out)
+{
+    char* end = (char*)s.end;
+    out = (uint64_t)strtoull(s.beg, &end, 16);
+    return end == s.end;
+}
+inline bool StrRangeToFloat(const StrRange& s, float& out)
+{
+    char* end = (char*)s.end;
+    out = strtof(s.beg, &end);
+    return end == s.end;
+}
+inline bool StrRangeToBool(const StrRange& s, bool& out)
+{
+    if(s.end - s.beg == 1)
+    {
+        if(*s.beg == '1')
+        {
+            out = true;
+        }
+        else if(*s.beg == '0')
+        {
+            out = false;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    return true;
+}
+
+class LineSplit
+{
+public:
+    LineSplit(const char* data, size_t numBytes) :
+        m_Data(data),
+        m_NumBytes(numBytes),
+        m_NextLineBeg(0),
+        m_NextLineIndex(0)
+    {
+    }
+
+    bool GetNextLine(StrRange& out);
+    size_t GetNextLineIndex() const { return m_NextLineIndex; }
+
+private:
+    const char* const m_Data;
+    const size_t m_NumBytes;
+    size_t m_NextLineBeg;
+    size_t m_NextLineIndex;
+};
+
+class CsvSplit
+{
+public:
+    static const size_t RANGE_COUNT_MAX = 32;
+
+    void Set(const StrRange& line, size_t maxCount = RANGE_COUNT_MAX);
+
+    const StrRange& GetLine() const { return m_Line; }
+
+    size_t GetCount() const { return m_Count; }
+    StrRange GetRange(size_t index) const 
+    {
+        return StrRange {
+            m_Line.beg + m_Ranges[index * 2],
+            m_Line.beg + m_Ranges[index * 2 + 1] };
+    }
+
+private:
+    StrRange m_Line = { nullptr, nullptr };
+    size_t m_Count = 0;
+    size_t m_Ranges[RANGE_COUNT_MAX * 2]; // Pairs of begin-end.
+};
+
+class CmdLineParser
+{
+public:
+	enum RESULT
+	{
+		RESULT_OPT,
+		RESULT_PARAMETER,
+		RESULT_END,
+		RESULT_ERROR,
+	};
+
+	CmdLineParser(int argc, char **argv);
+	CmdLineParser(const char *CmdLine);
+	
+    void RegisterOpt(uint32_t Id, char Opt, bool Parameter);
+	void RegisterOpt(uint32_t Id, const std::string &Opt, bool Parameter);
+	
+    RESULT ReadNext();
+	uint32_t GetOptId();
+	const std::string & GetParameter();
+
+private:
+	struct SHORT_OPT
+	{
+		uint32_t Id;
+		char Opt;
+		bool Parameter;
+
+		SHORT_OPT(uint32_t Id, char Opt, bool Parameter) : Id(Id), Opt(Opt), Parameter(Parameter) { }
+	};
+
+	struct LONG_OPT
+	{
+		uint32_t Id;
+		std::string Opt;
+		bool Parameter;
+
+		LONG_OPT(uint32_t Id, std::string Opt, bool Parameter) : Id(Id), Opt(Opt), Parameter(Parameter) { }
+	};
+
+	char **m_argv;
+	const char *m_CmdLine;
+	int m_argc;
+	size_t m_CmdLineLength;
+	size_t m_ArgIndex;
+
+	bool ReadNextArg(std::string *OutArg);
+
+	std::vector<SHORT_OPT> m_ShortOpts;
+	std::vector<LONG_OPT> m_LongOpts;
+
+	SHORT_OPT * FindShortOpt(char Opt);
+	LONG_OPT * FindLongOpt(const std::string &Opt);
+
+	bool m_InsideMultioption;
+	std::string m_LastArg;
+	size_t m_LastArgIndex;
+	uint32_t m_LastOptId;
+	std::string m_LastParameter;
+};
+
+/*
+Parses and stores a sequence of ranges.
+
+Upper range is inclusive.
+
+Examples:
+
+    "1" -> [ {1, 1} ]
+    "1,10" -> [ {1, 1}, {10, 10} ]
+    "2-6" -> [ {2, 6} ]
+    "-8" -> [ {MIN, 8} ]
+    "12-" -> [ {12, MAX} ]
+    "1-10,12,15-" -> [ {1, 10}, {12, 12}, {15, MAX} ]
+
+TODO: Optimize it: Do sorting and merging while parsing. Do binary search while
+reading.
+*/
+template<typename T>
+class RangeSequence
+{
+public:
+    typedef std::pair<T, T> RangeType;
+
+    void Clear() { m_Ranges.clear(); }
+    bool Parse(const StrRange& str);
+
+    bool IsEmpty() const { return m_Ranges.empty(); }
+    size_t GetCount() const { return m_Ranges.size(); }
+    const RangeType* GetRanges() const { return m_Ranges.data(); }
+
+    bool Includes(T number) const;
+    
+private:
+    std::vector<RangeType> m_Ranges;
+};
+
+template<typename T>
+bool RangeSequence<T>::Parse(const StrRange& str)
+{
+    m_Ranges.clear();
+
+    StrRange currRange = { str.beg, str.beg };
+    while(currRange.beg < str.end)
+    {
+        currRange.end = currRange.beg + 1;
+        // Find next ',' or the end.
+        while(currRange.end < str.end && *currRange.end != ',')
+        {
+            ++currRange.end;
+        }
+
+        // Find '-' within this range.
+        const char* hyphenPos = currRange.beg;
+        while(hyphenPos < currRange.end && *hyphenPos != '-')
+        {
+            ++hyphenPos;
+        }
+
+        // No hyphen - single number like '10'.
+        if(hyphenPos == currRange.end)
+        {
+            RangeType range;
+            if(!StrRangeToUint(currRange, range.first))
+            {
+                return false;
+            }
+            range.second = range.first;
+            m_Ranges.push_back(range);
+        }
+        // Hyphen at the end, like '10-'.
+        else if(hyphenPos + 1 == currRange.end)
+        {
+            const StrRange numberRange = { currRange.beg, hyphenPos };
+            RangeType range;
+            if(!StrRangeToUint(numberRange, range.first))
+            {
+                return false;
+            }
+            range.second = std::numeric_limits<T>::max();
+            m_Ranges.push_back(range);
+        }
+        // Hyphen at the beginning, like "-10".
+        else if(hyphenPos == currRange.beg)
+        {
+            const StrRange numberRange = { currRange.beg + 1, currRange.end };
+            RangeType range;
+            range.first = std::numeric_limits<T>::min();
+            if(!StrRangeToUint(numberRange, range.second))
+            {
+                return false;
+            }
+            m_Ranges.push_back(range);
+        }
+        // Hyphen in the middle, like "1-10".
+        else
+        {
+            const StrRange numberRange1 = { currRange.beg, hyphenPos };
+            const StrRange numberRange2 = { hyphenPos + 1, currRange.end };
+            RangeType range;
+            if(!StrRangeToUint(numberRange1, range.first) ||
+                !StrRangeToUint(numberRange2, range.second) ||
+                range.second < range.first)
+            {
+                return false;
+            }
+            m_Ranges.push_back(range);
+        }
+
+        // Skip ','
+        currRange.beg = currRange.end + 1;
+    }
+
+    return true;
+}
+
+template<typename T>
+bool RangeSequence<T>::Includes(T number) const
+{
+    for(const auto& it : m_Ranges)
+    {
+        if(number >= it.first && number <= it.second)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+class RandomNumberGenerator
+{
+public:
+    RandomNumberGenerator() : m_Value{GetTickCount()} {}
+    RandomNumberGenerator(uint32_t seed) : m_Value{seed} { }
+    void Seed(uint32_t seed) { m_Value = seed; }
+    uint32_t Generate() { return GenerateFast() ^ (GenerateFast() >> 7); }
+
+private:
+    uint32_t m_Value;
+    uint32_t GenerateFast() { return m_Value = (m_Value * 196314165 + 907633515); }
+};
+
+enum class CONSOLE_COLOR
+{
+    INFO,
+    NORMAL,
+    WARNING,
+    ERROR_,
+    COUNT
+};
+
+void SetConsoleColor(CONSOLE_COLOR color);
+
+void PrintMessage(CONSOLE_COLOR color, const char* msg);
+void PrintMessage(CONSOLE_COLOR color, const wchar_t* msg);
+
+inline void Print(const char* msg) { PrintMessage(CONSOLE_COLOR::NORMAL, msg); }
+inline void Print(const wchar_t* msg) { PrintMessage(CONSOLE_COLOR::NORMAL, msg); }
+inline void PrintWarning(const char* msg) { PrintMessage(CONSOLE_COLOR::WARNING, msg); }
+inline void PrintWarning(const wchar_t* msg) { PrintMessage(CONSOLE_COLOR::WARNING, msg); }
+inline void PrintError(const char* msg) { PrintMessage(CONSOLE_COLOR::ERROR_, msg); }
+inline void PrintError(const wchar_t* msg) { PrintMessage(CONSOLE_COLOR::ERROR_, msg); }
+
+void PrintMessageV(CONSOLE_COLOR color, const char* format, va_list argList);
+void PrintMessageV(CONSOLE_COLOR color, const wchar_t* format, va_list argList);
+void PrintMessageF(CONSOLE_COLOR color, const char* format, ...);
+void PrintMessageF(CONSOLE_COLOR color, const wchar_t* format, ...);
+void PrintWarningF(const char* format, ...);
+void PrintWarningF(const wchar_t* format, ...);
+void PrintErrorF(const char* format, ...);
+void PrintErrorF(const wchar_t* format, ...);
+*/

--- a/third_party/vkmemalloc/src/VmaReplay/VmaReplay.cpp
+++ b/third_party/vkmemalloc/src/VmaReplay/VmaReplay.cpp
@@ -1,0 +1,3000 @@
+//
+// Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "VmaUsage.h"
+#include "Common.h"
+#include <unordered_map>
+
+static const int RESULT_EXCEPTION          = -1000;
+static const int RESULT_ERROR_COMMAND_LINE = -1;
+static const int RESULT_ERROR_SOURCE_FILE  = -2;
+static const int RESULT_ERROR_FORMAT       = -3;
+static const int RESULT_ERROR_VULKAN       = -4;
+
+enum CMD_LINE_OPT
+{
+    CMD_LINE_OPT_VERBOSITY,
+    CMD_LINE_OPT_ITERATIONS,
+    CMD_LINE_OPT_LINES,
+    CMD_LINE_OPT_PHYSICAL_DEVICE,
+    CMD_LINE_OPT_USER_DATA,
+    CMD_LINE_OPT_VK_KHR_DEDICATED_ALLOCATION,
+    CMD_LINE_OPT_VK_LAYER_LUNARG_STANDARD_VALIDATION,
+    CMD_LINE_OPT_MEM_STATS,
+    CMD_LINE_OPT_DUMP_STATS_AFTER_LINE,
+    CMD_LINE_OPT_DUMP_DETAILED_STATS_AFTER_LINE,
+};
+
+static enum class VERBOSITY
+{
+    MINIMUM = 0,
+    DEFAULT,
+    MAXIMUM,
+    COUNT,
+} g_Verbosity = VERBOSITY::DEFAULT;
+
+enum class VULKAN_EXTENSION_REQUEST
+{
+    DISABLED,
+    ENABLED,
+    DEFAULT
+};
+
+enum class OBJECT_TYPE { BUFFER, IMAGE };
+
+enum class VMA_FUNCTION
+{
+    CreatePool,
+    DestroyPool,
+    SetAllocationUserData,
+    CreateBuffer,
+    DestroyBuffer,
+    CreateImage,
+    DestroyImage,
+    FreeMemory,
+    CreateLostAllocation,
+    AllocateMemory,
+    AllocateMemoryForBuffer,
+    AllocateMemoryForImage,
+    MapMemory,
+    UnmapMemory,
+    FlushAllocation,
+    InvalidateAllocation,
+    TouchAllocation,
+    GetAllocationInfo,
+    MakePoolAllocationsLost,
+    Count
+};
+static const char* VMA_FUNCTION_NAMES[] = {
+    "vmaCreatePool",
+    "vmaDestroyPool",
+    "vmaSetAllocationUserData",
+    "vmaCreateBuffer",
+    "vmaDestroyBuffer",
+    "vmaCreateImage",
+    "vmaDestroyImage",
+    "vmaFreeMemory",
+    "vmaCreateLostAllocation",
+    "vmaAllocateMemory",
+    "vmaAllocateMemoryForBuffer",
+    "vmaAllocateMemoryForImage",
+    "vmaMapMemory",
+    "vmaUnmapMemory",
+    "vmaFlushAllocation",
+    "vmaInvalidateAllocation",
+    "vmaTouchAllocation",
+    "vmaGetAllocationInfo",
+    "vmaMakePoolAllocationsLost",
+};
+static_assert(
+    _countof(VMA_FUNCTION_NAMES) == (size_t)VMA_FUNCTION::Count,
+    "VMA_FUNCTION_NAMES array doesn't match VMA_FUNCTION enum.");
+
+// Set this to false to disable deleting leaked VmaAllocation, VmaPool objects
+// and let VMA report asserts about them.
+static const bool CLEANUP_LEAKED_OBJECTS = true;
+
+static std::string g_FilePath;
+// Most significant 16 bits are major version, least significant 16 bits are minor version.
+static uint32_t g_FileVersion;
+
+inline uint32_t MakeVersion(uint32_t major, uint32_t minor) { return (major << 16) | minor; }
+inline uint32_t GetVersionMajor(uint32_t version) { return version >> 16; }
+inline uint32_t GetVersionMinor(uint32_t version) { return version & 0xFFFF; }
+
+static size_t g_IterationCount = 1;
+static uint32_t g_PhysicalDeviceIndex = 0;
+static RangeSequence<size_t> g_LineRanges;
+static bool g_UserDataEnabled = true;
+static bool g_MemStatsEnabled = false;
+VULKAN_EXTENSION_REQUEST g_VK_KHR_dedicated_allocation_request = VULKAN_EXTENSION_REQUEST::DEFAULT;
+VULKAN_EXTENSION_REQUEST g_VK_LAYER_LUNARG_standard_validation = VULKAN_EXTENSION_REQUEST::DEFAULT;
+
+struct StatsAfterLineEntry
+{
+    size_t line;
+    bool detailed;
+
+    bool operator<(const StatsAfterLineEntry& rhs) const { return line < rhs.line; }
+    bool operator==(const StatsAfterLineEntry& rhs) const { return line == rhs.line; }
+};
+static std::vector<StatsAfterLineEntry> g_DumpStatsAfterLine;
+static size_t g_DumpStatsAfterLineNextIndex = 0;
+
+static bool ValidateFileVersion()
+{
+    if(GetVersionMajor(g_FileVersion) == 1 &&
+        GetVersionMinor(g_FileVersion) <= 3)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+static bool ParseFileVersion(const StrRange& s)
+{
+    CsvSplit csvSplit;
+    csvSplit.Set(s, 2);
+    uint32_t major, minor;
+    if(csvSplit.GetCount() == 2 &&
+        StrRangeToUint(csvSplit.GetRange(0), major) &&
+        StrRangeToUint(csvSplit.GetRange(1), minor))
+    {
+        g_FileVersion = (major << 16) | minor;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// class Statistics
+
+class Statistics
+{
+public:
+    static uint32_t BufferUsageToClass(uint32_t usage);
+    static uint32_t ImageUsageToClass(uint32_t usage);
+
+    Statistics();
+    void Init(uint32_t memHeapCount, uint32_t memTypeCount);
+    void PrintMemStats() const;
+
+    const size_t* GetFunctionCallCount() const { return m_FunctionCallCount; }
+    size_t GetImageCreationCount(uint32_t imgClass) const { return m_ImageCreationCount[imgClass]; }
+    size_t GetLinearImageCreationCount() const { return m_LinearImageCreationCount; }
+    size_t GetBufferCreationCount(uint32_t bufClass) const { return m_BufferCreationCount[bufClass]; }
+    size_t GetAllocationCreationCount() const { return m_AllocationCreationCount; }
+    size_t GetPoolCreationCount() const { return m_PoolCreationCount; }
+
+    void RegisterFunctionCall(VMA_FUNCTION func);
+    void RegisterCreateImage(uint32_t usage, uint32_t tiling);
+    void RegisterCreateBuffer(uint32_t usage);
+    void RegisterCreatePool();
+    void RegisterCreateAllocation();
+
+    void UpdateMemStats(const VmaStats& currStats);
+
+private:
+    uint32_t m_MemHeapCount = 0;
+    uint32_t m_MemTypeCount = 0;
+
+    size_t m_FunctionCallCount[(size_t)VMA_FUNCTION::Count] = {};
+    size_t m_ImageCreationCount[4] = { };
+    size_t m_LinearImageCreationCount = 0;
+    size_t m_BufferCreationCount[4] = { };
+    size_t m_AllocationCreationCount = 0; // Also includes buffers and images, and lost allocations.
+    size_t m_PoolCreationCount = 0;
+    
+    // Structure similar to VmaStatInfo, but not the same.
+    struct MemStatInfo
+    {
+        uint32_t blockCount;
+        uint32_t allocationCount;
+        uint32_t unusedRangeCount;
+        VkDeviceSize usedBytes;
+        VkDeviceSize unusedBytes;
+        VkDeviceSize totalBytes;
+    };
+    struct MemStats
+    {
+        MemStatInfo memoryType[VK_MAX_MEMORY_TYPES];
+        MemStatInfo memoryHeap[VK_MAX_MEMORY_HEAPS];
+        MemStatInfo total;
+    } m_PeakMemStats;
+
+    void UpdateMemStatInfo(MemStatInfo& inoutPeakInfo, const VmaStatInfo& currInfo);
+    static void PrintMemStatInfo(const MemStatInfo& info);
+};
+
+uint32_t Statistics::BufferUsageToClass(uint32_t usage)
+{
+    // Buffer is used as source of data for fixed-function stage of graphics pipeline.
+    // It's indirect, vertex, or index buffer.
+    if ((usage & (VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT |
+        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+        VK_BUFFER_USAGE_INDEX_BUFFER_BIT)) != 0)
+    {
+        return 0;
+    }
+    // Buffer is accessed by shaders for load/store/atomic.
+    // Aka "UAV"
+    else if ((usage & (VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+        VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)) != 0)
+    {
+        return 1;
+    }
+    // Buffer is accessed by shaders for reading uniform data.
+    // Aka "constant buffer"
+    else if ((usage & (VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
+    VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)) != 0)
+    {
+        return 2;
+    }
+    // Any other type of buffer.
+    // Notice that VK_BUFFER_USAGE_TRANSFER_SRC_BIT and VK_BUFFER_USAGE_TRANSFER_DST_BIT
+    // flags are intentionally ignored.
+    else
+    {
+        return 3;
+    }
+}
+
+uint32_t Statistics::ImageUsageToClass(uint32_t usage)
+{
+    // Image is used as depth/stencil "texture/surface".
+    if ((usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0)
+    {
+        return 0;
+    }
+    // Image is used as other type of attachment.
+    // Aka "render target"
+    else if ((usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+        VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT |
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) != 0)
+    {
+        return 1;
+    }
+    // Image is accessed by shaders for sampling.
+    // Aka "texture"
+    else if ((usage & VK_IMAGE_USAGE_SAMPLED_BIT) != 0)
+    {
+        return 2;
+    }
+    // Any other type of image.
+    // Notice that VK_IMAGE_USAGE_TRANSFER_SRC_BIT and VK_IMAGE_USAGE_TRANSFER_DST_BIT
+    // flags are intentionally ignored.
+    else
+    {
+        return 3;
+    }
+}
+
+Statistics::Statistics()
+{
+    ZeroMemory(&m_PeakMemStats, sizeof(m_PeakMemStats));
+}
+
+void Statistics::Init(uint32_t memHeapCount, uint32_t memTypeCount)
+{
+    m_MemHeapCount = memHeapCount;
+    m_MemTypeCount = memTypeCount;
+}
+
+void Statistics::PrintMemStats() const
+{
+    printf("Memory statistics:\n");
+
+    printf("    Total:\n");
+    PrintMemStatInfo(m_PeakMemStats.total);
+
+    for(uint32_t i = 0; i < m_MemHeapCount; ++i)
+    {
+        const MemStatInfo& info = m_PeakMemStats.memoryHeap[i];
+        if(info.blockCount > 0 || info.totalBytes > 0)
+        {
+            printf("    Heap %u:\n", i);
+            PrintMemStatInfo(info);
+        }
+    }
+
+    for(uint32_t i = 0; i < m_MemTypeCount; ++i)
+    {
+        const MemStatInfo& info = m_PeakMemStats.memoryType[i];
+        if(info.blockCount > 0 || info.totalBytes > 0)
+        {
+            printf("    Type %u:\n", i);
+            PrintMemStatInfo(info);
+        }
+    }
+}
+
+void Statistics::RegisterFunctionCall(VMA_FUNCTION func)
+{
+    ++m_FunctionCallCount[(size_t)func];
+}
+
+void Statistics::RegisterCreateImage(uint32_t usage, uint32_t tiling)
+{
+    if(tiling == VK_IMAGE_TILING_LINEAR)
+        ++m_LinearImageCreationCount;
+    else
+    {
+        const uint32_t imgClass = ImageUsageToClass(usage);
+        ++m_ImageCreationCount[imgClass];
+    }
+
+    ++m_AllocationCreationCount;
+}
+
+void Statistics::RegisterCreateBuffer(uint32_t usage)
+{
+    const uint32_t bufClass = BufferUsageToClass(usage);
+    ++m_BufferCreationCount[bufClass];
+
+    ++m_AllocationCreationCount;
+}
+
+void Statistics::RegisterCreatePool()
+{
+    ++m_PoolCreationCount;
+}
+
+void Statistics::RegisterCreateAllocation()
+{
+    ++m_AllocationCreationCount;
+}
+
+void Statistics::UpdateMemStats(const VmaStats& currStats)
+{
+    UpdateMemStatInfo(m_PeakMemStats.total, currStats.total);
+    
+    for(uint32_t i = 0; i < m_MemHeapCount; ++i)
+    {
+        UpdateMemStatInfo(m_PeakMemStats.memoryHeap[i], currStats.memoryHeap[i]);
+    }
+
+    for(uint32_t i = 0; i < m_MemTypeCount; ++i)
+    {
+        UpdateMemStatInfo(m_PeakMemStats.memoryType[i], currStats.memoryType[i]);
+    }
+}
+
+void Statistics::UpdateMemStatInfo(MemStatInfo& inoutPeakInfo, const VmaStatInfo& currInfo)
+{
+#define SET_PEAK(inoutDst, src) \
+    if((src) > (inoutDst)) \
+    { \
+        (inoutDst) = (src); \
+    }
+
+    SET_PEAK(inoutPeakInfo.blockCount, currInfo.blockCount);
+    SET_PEAK(inoutPeakInfo.allocationCount, currInfo.allocationCount);
+    SET_PEAK(inoutPeakInfo.unusedRangeCount, currInfo.unusedRangeCount);
+    SET_PEAK(inoutPeakInfo.usedBytes, currInfo.usedBytes);
+    SET_PEAK(inoutPeakInfo.unusedBytes, currInfo.unusedBytes);
+    SET_PEAK(inoutPeakInfo.totalBytes, currInfo.usedBytes + currInfo.unusedBytes);
+
+#undef SET_PEAK
+}
+
+void Statistics::PrintMemStatInfo(const MemStatInfo& info)
+{
+    printf("        Peak blocks %u, allocations %u, unused ranges %u\n",
+        info.blockCount,
+        info.allocationCount,
+        info.unusedRangeCount);
+    printf("        Peak total bytes %llu, used bytes %llu, unused bytes %llu\n",
+        info.totalBytes,
+        info.usedBytes,
+        info.unusedBytes);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// class ConfigurationParser
+
+class ConfigurationParser
+{
+public:
+    ConfigurationParser();
+    
+    bool Parse(LineSplit& lineSplit);
+
+    void Compare(
+        const VkPhysicalDeviceProperties& currDevProps,
+        const VkPhysicalDeviceMemoryProperties& currMemProps,
+        bool currDedicatedAllocationExtensionEnabled);
+
+private:
+    enum class OPTION
+    {
+        PhysicalDevice_apiVersion,
+        PhysicalDevice_driverVersion,
+        PhysicalDevice_vendorID,
+        PhysicalDevice_deviceID,
+        PhysicalDevice_deviceType,
+        PhysicalDevice_deviceName,
+        PhysicalDeviceLimits_maxMemoryAllocationCount,
+        PhysicalDeviceLimits_bufferImageGranularity,
+        PhysicalDeviceLimits_nonCoherentAtomSize,
+        Extension_VK_KHR_dedicated_allocation,
+        Macro_VMA_DEBUG_ALWAYS_DEDICATED_MEMORY,
+        Macro_VMA_DEBUG_ALIGNMENT,
+        Macro_VMA_DEBUG_MARGIN,
+        Macro_VMA_DEBUG_INITIALIZE_ALLOCATIONS,
+        Macro_VMA_DEBUG_DETECT_CORRUPTION,
+        Macro_VMA_DEBUG_GLOBAL_MUTEX,
+        Macro_VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY,
+        Macro_VMA_SMALL_HEAP_MAX_SIZE,
+        Macro_VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE,
+        Count
+    };
+
+    std::vector<bool> m_OptionSet;
+    std::vector<std::string> m_OptionValue;
+    VkPhysicalDeviceMemoryProperties m_MemProps;
+
+    bool m_WarningHeaderPrinted = false;
+
+    void SetOption(
+        size_t lineNumber,
+        OPTION option,
+        const StrRange& str);
+    void EnsureWarningHeader();
+    void CompareOption(VERBOSITY minVerbosity, const char* name,
+        OPTION option, uint32_t currValue);
+    void CompareOption(VERBOSITY minVerbosity, const char* name,
+        OPTION option, uint64_t currValue);
+    void CompareOption(VERBOSITY minVerbosity, const char* name,
+        OPTION option, bool currValue);
+    void CompareOption(VERBOSITY minVerbosity, const char* name,
+        OPTION option, const char* currValue);
+    void CompareMemProps(
+        const VkPhysicalDeviceMemoryProperties& currMemProps);
+};
+
+ConfigurationParser::ConfigurationParser() :
+    m_OptionSet((size_t)OPTION::Count),
+    m_OptionValue((size_t)OPTION::Count)
+{
+    ZeroMemory(&m_MemProps, sizeof(m_MemProps));
+}
+
+bool ConfigurationParser::Parse(LineSplit& lineSplit)
+{
+    for(auto& it : m_OptionSet)
+    {
+        it = false;
+    }
+    for(auto& it : m_OptionValue)
+    {
+        it.clear();
+    }
+
+    StrRange line;
+
+    if(!lineSplit.GetNextLine(line) && !StrRangeEq(line, "Config,Begin"))
+    {
+        return false;
+    }
+
+    CsvSplit csvSplit;
+    while(lineSplit.GetNextLine(line))
+    {
+        if(StrRangeEq(line, "Config,End"))
+        {
+            break;
+        }
+
+        const size_t currLineNumber = lineSplit.GetNextLineIndex();
+
+        csvSplit.Set(line);
+        if(csvSplit.GetCount() == 0)
+        {
+            return false;
+        }
+
+        const StrRange optionName = csvSplit.GetRange(0);
+        if(StrRangeEq(optionName, "PhysicalDevice"))
+        {
+            if(csvSplit.GetCount() >= 3)
+            {
+                const StrRange subOptionName = csvSplit.GetRange(1);
+                if(StrRangeEq(subOptionName, "apiVersion"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_apiVersion, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "driverVersion"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_driverVersion, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "vendorID"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_vendorID, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "deviceID"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_deviceID, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "deviceType"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_deviceType, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "deviceName"))
+                    SetOption(currLineNumber, OPTION::PhysicalDevice_deviceName, StrRange(csvSplit.GetRange(2).beg, line.end));
+                else
+                    printf("Line %zu: Unrecognized configuration option.\n", currLineNumber);
+            }
+            else
+                printf("Line %zu: Too few columns.\n", currLineNumber);
+        }
+        else if(StrRangeEq(optionName, "PhysicalDeviceLimits"))
+        {
+            if(csvSplit.GetCount() >= 3)
+            {
+                const StrRange subOptionName = csvSplit.GetRange(1);
+                if(StrRangeEq(subOptionName, "maxMemoryAllocationCount"))
+                    SetOption(currLineNumber, OPTION::PhysicalDeviceLimits_maxMemoryAllocationCount, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "bufferImageGranularity"))
+                    SetOption(currLineNumber, OPTION::PhysicalDeviceLimits_bufferImageGranularity, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "nonCoherentAtomSize"))
+                    SetOption(currLineNumber, OPTION::PhysicalDeviceLimits_nonCoherentAtomSize, csvSplit.GetRange(2));
+                else
+                    printf("Line %zu: Unrecognized configuration option.\n", currLineNumber);
+            }
+            else
+                printf("Line %zu: Too few columns.\n", currLineNumber);
+        }
+        else if(StrRangeEq(optionName, "Extension"))
+        {
+            if(csvSplit.GetCount() >= 3)
+            {
+                const StrRange subOptionName = csvSplit.GetRange(1);
+                if(StrRangeEq(subOptionName, "VK_KHR_dedicated_allocation"))
+                    SetOption(currLineNumber, OPTION::Extension_VK_KHR_dedicated_allocation, csvSplit.GetRange(2));
+                else
+                    printf("Line %zu: Unrecognized configuration option.\n", currLineNumber);
+            }
+            else
+                printf("Line %zu: Too few columns.\n", currLineNumber);
+        }
+        else if(StrRangeEq(optionName, "Macro"))
+        {
+            if(csvSplit.GetCount() >= 3)
+            {
+                const StrRange subOptionName = csvSplit.GetRange(1);
+                if(StrRangeEq(subOptionName, "VMA_DEBUG_ALWAYS_DEDICATED_MEMORY"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_ALWAYS_DEDICATED_MEMORY, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_ALIGNMENT"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_ALIGNMENT, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_MARGIN"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_MARGIN, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_INITIALIZE_ALLOCATIONS"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_INITIALIZE_ALLOCATIONS, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_DETECT_CORRUPTION"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_DETECT_CORRUPTION, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_GLOBAL_MUTEX"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_GLOBAL_MUTEX, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEBUG_MIN_BUFFER_IMAGE_GRANULARITY, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_SMALL_HEAP_MAX_SIZE"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_SMALL_HEAP_MAX_SIZE, csvSplit.GetRange(2));
+                else if(StrRangeEq(subOptionName, "VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE"))
+                    SetOption(currLineNumber, OPTION::Macro_VMA_DEFAULT_LARGE_HEAP_BLOCK_SIZE, csvSplit.GetRange(2));
+                else
+                    printf("Line %zu: Unrecognized configuration option.\n", currLineNumber);
+            }
+            else
+                printf("Line %zu: Too few columns.\n", currLineNumber);
+        }
+        else if(StrRangeEq(optionName, "PhysicalDeviceMemory"))
+        {
+            uint32_t value = 0;
+            if(csvSplit.GetCount() == 3 && StrRangeEq(csvSplit.GetRange(1), "HeapCount") &&
+                StrRangeToUint(csvSplit.GetRange(2), value))
+            {
+                m_MemProps.memoryHeapCount = value;
+            }
+            else if(csvSplit.GetCount() == 3 && StrRangeEq(csvSplit.GetRange(1), "TypeCount") &&
+                StrRangeToUint(csvSplit.GetRange(2), value))
+            {
+                m_MemProps.memoryTypeCount = value;
+            }
+            else if(csvSplit.GetCount() == 5 && StrRangeEq(csvSplit.GetRange(1), "Heap") &&
+                StrRangeToUint(csvSplit.GetRange(2), value) &&
+                value < m_MemProps.memoryHeapCount)
+            {
+                if(StrRangeEq(csvSplit.GetRange(3), "size") &&
+                    StrRangeToUint(csvSplit.GetRange(4), m_MemProps.memoryHeaps[value].size))
+                {
+                     // Parsed.
+                }
+                else if(StrRangeEq(csvSplit.GetRange(3), "flags") &&
+                    StrRangeToUint(csvSplit.GetRange(4), m_MemProps.memoryHeaps[value].flags))
+                {
+                     // Parsed.
+                }
+                else
+                    printf("Line %zu: Invalid configuration option.\n", currLineNumber);
+            }
+            else if(csvSplit.GetCount() == 5 && StrRangeEq(csvSplit.GetRange(1), "Type") &&
+                StrRangeToUint(csvSplit.GetRange(2), value) &&
+                value < m_MemProps.memoryTypeCount)
+            {
+                if(StrRangeEq(csvSplit.GetRange(3), "heapIndex") &&
+                    StrRangeToUint(csvSplit.GetRange(4), m_MemProps.memoryTypes[value].heapIndex))
+                {
+                     // Parsed.
+                }
+                else if(StrRangeEq(csvSplit.GetRange(3), "propertyFlags") &&
+                    StrRangeToUint(csvSplit.GetRange(4), m_MemProps.memoryTypes[value].propertyFlags))
+                {
+                     // Parsed.
+                }
+                else
+                    printf("Line %zu: Invalid configuration option.\n", currLineNumber);
+            }
+            else
+                printf("Line %zu: Invalid configuration option.\n", currLineNumber);
+        }
+        else
+            printf("Line %zu: Unrecognized configuration option.\n", currLineNumber);
+    }
+
+    return true;
+}
+
+void ConfigurationParser::Compare(
+    const VkPhysicalDeviceProperties& currDevProps,
+    const VkPhysicalDeviceMemoryProperties& currMemProps,
+    bool currDedicatedAllocationExtensionEnabled)
+{
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice apiVersion",
+        OPTION::PhysicalDevice_apiVersion, currDevProps.apiVersion);
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice driverVersion",
+        OPTION::PhysicalDevice_driverVersion, currDevProps.driverVersion);
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice vendorID",
+        OPTION::PhysicalDevice_vendorID, currDevProps.vendorID);
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice deviceID",
+        OPTION::PhysicalDevice_deviceID, currDevProps.deviceID);
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice deviceType",
+        OPTION::PhysicalDevice_deviceType, (uint32_t)currDevProps.deviceType);
+    CompareOption(VERBOSITY::MAXIMUM, "PhysicalDevice deviceName",
+        OPTION::PhysicalDevice_deviceName, currDevProps.deviceName);
+
+    CompareOption(VERBOSITY::DEFAULT, "PhysicalDeviceLimits maxMemoryAllocationCount",
+        OPTION::PhysicalDeviceLimits_maxMemoryAllocationCount, currDevProps.limits.maxMemoryAllocationCount);
+    CompareOption(VERBOSITY::DEFAULT, "PhysicalDeviceLimits bufferImageGranularity",
+        OPTION::PhysicalDeviceLimits_bufferImageGranularity, currDevProps.limits.bufferImageGranularity);
+    CompareOption(VERBOSITY::DEFAULT, "PhysicalDeviceLimits nonCoherentAtomSize",
+        OPTION::PhysicalDeviceLimits_nonCoherentAtomSize, currDevProps.limits.nonCoherentAtomSize);
+    CompareOption(VERBOSITY::DEFAULT, "Extension VK_KHR_dedicated_allocation",
+        OPTION::Extension_VK_KHR_dedicated_allocation, currDedicatedAllocationExtensionEnabled);
+
+    CompareMemProps(currMemProps);
+}
+
+void ConfigurationParser::SetOption(
+    size_t lineNumber,
+    OPTION option,
+    const StrRange& str)
+{
+    if(m_OptionSet[(size_t)option])
+    {
+        printf("Line %zu: Option already specified.\n" ,lineNumber);
+    }
+
+    m_OptionSet[(size_t)option] = true;
+
+    std::string val;
+    str.to_str(val);
+    m_OptionValue[(size_t)option] = std::move(val);
+}
+
+void ConfigurationParser::EnsureWarningHeader()
+{
+    if(!m_WarningHeaderPrinted)
+    {
+        printf("WARNING: Following configuration parameters don't match:\n");
+        m_WarningHeaderPrinted = true;
+    }
+}
+
+void ConfigurationParser::CompareOption(VERBOSITY minVerbosity, const char* name,
+    OPTION option, uint32_t currValue)
+{
+    if(m_OptionSet[(size_t)option] &&
+        g_Verbosity >= minVerbosity)
+    {
+        uint32_t origValue;
+        if(StrRangeToUint(StrRange(m_OptionValue[(size_t)option]), origValue))
+        {
+            if(origValue != currValue)
+            {
+                EnsureWarningHeader();
+                printf("    %s: original %u, current %u\n", name, origValue, currValue);
+            }
+        }
+    }
+}
+
+void ConfigurationParser::CompareOption(VERBOSITY minVerbosity, const char* name,
+    OPTION option, uint64_t currValue)
+{
+    if(m_OptionSet[(size_t)option] &&
+        g_Verbosity >= minVerbosity)
+    {
+        uint64_t origValue;
+        if(StrRangeToUint(StrRange(m_OptionValue[(size_t)option]), origValue))
+        {
+            if(origValue != currValue)
+            {
+                EnsureWarningHeader();
+                printf("    %s: original %llu, current %llu\n", name, origValue, currValue);
+            }
+        }
+    }
+}
+
+void ConfigurationParser::CompareOption(VERBOSITY minVerbosity, const char* name,
+    OPTION option, bool currValue)
+{
+    if(m_OptionSet[(size_t)option] &&
+        g_Verbosity >= minVerbosity)
+    {
+        bool origValue;
+        if(StrRangeToBool(StrRange(m_OptionValue[(size_t)option]), origValue))
+        {
+            if(origValue != currValue)
+            {
+                EnsureWarningHeader();
+                printf("    %s: original %u, current %u\n", name,
+                    origValue ? 1 : 0,
+                    currValue ? 1 : 0);
+            }
+        }
+    }
+}
+
+void ConfigurationParser::CompareOption(VERBOSITY minVerbosity, const char* name,
+    OPTION option, const char* currValue)
+{
+    if(m_OptionSet[(size_t)option] &&
+        g_Verbosity >= minVerbosity)
+    {
+        const std::string& origValue = m_OptionValue[(size_t)option];
+        if(origValue != currValue)
+        {
+            EnsureWarningHeader();
+            printf("    %s: original \"%s\", current \"%s\"\n", name, origValue.c_str(), currValue);
+        }
+    }
+}
+
+void ConfigurationParser::CompareMemProps(
+    const VkPhysicalDeviceMemoryProperties& currMemProps)
+{
+    if(g_Verbosity < VERBOSITY::DEFAULT)
+    {
+        return;
+    }
+
+    bool memoryMatch =
+        currMemProps.memoryHeapCount == m_MemProps.memoryHeapCount &&
+        currMemProps.memoryTypeCount == m_MemProps.memoryTypeCount;
+
+    for(uint32_t i = 0; memoryMatch && i < currMemProps.memoryHeapCount; ++i)
+    {
+        memoryMatch =
+            currMemProps.memoryHeaps[i].flags == m_MemProps.memoryHeaps[i].flags;
+    }
+    for(uint32_t i = 0; memoryMatch && i < currMemProps.memoryTypeCount; ++i)
+    {
+        memoryMatch =
+            currMemProps.memoryTypes[i].heapIndex == m_MemProps.memoryTypes[i].heapIndex &&
+            currMemProps.memoryTypes[i].propertyFlags == m_MemProps.memoryTypes[i].propertyFlags;
+    }
+
+    if(memoryMatch && g_Verbosity == VERBOSITY::MAXIMUM)
+    {
+        bool memorySizeMatch = true;
+        for(uint32_t i = 0; memorySizeMatch && i < currMemProps.memoryHeapCount; ++i)
+        {
+            memorySizeMatch =
+                currMemProps.memoryHeaps[i].size == m_MemProps.memoryHeaps[i].size;
+        }
+
+        if(!memorySizeMatch)
+        {
+            printf("WARNING: Sizes of original memory heaps are different from current ones.\n");
+        }
+    }
+    else
+    {
+        printf("WARNING: Layout of original memory heaps and types is different from current one.\n");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// class Player
+
+static const char* const VALIDATION_LAYER_NAME = "VK_LAYER_LUNARG_standard_validation";
+
+static bool g_MemoryAliasingWarningEnabled = true;
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL MyDebugReportCallback(
+    VkDebugReportFlagsEXT flags,
+    VkDebugReportObjectTypeEXT objectType,
+    uint64_t object,
+    size_t location,
+    int32_t messageCode,
+    const char* pLayerPrefix,
+    const char* pMessage,
+    void* pUserData)
+{
+    // "Non-linear image 0xebc91 is aliased with linear buffer 0xeb8e4 which may indicate a bug."
+    if(!g_MemoryAliasingWarningEnabled && flags == VK_DEBUG_REPORT_WARNING_BIT_EXT &&
+        (strstr(pMessage, " is aliased with non-linear ") || strstr(pMessage, " is aliased with linear ")))
+    {
+        return VK_FALSE;
+    }
+
+    // Ignoring because when VK_KHR_dedicated_allocation extension is enabled,
+    // vkGetBufferMemoryRequirements2KHR function is used instead, while Validation
+    // Layer seems to be unaware of it.
+    if (strstr(pMessage, "but vkGetBufferMemoryRequirements() has not been called on that buffer") != nullptr)
+    {
+        return VK_FALSE;
+    }
+    if (strstr(pMessage, "but vkGetImageMemoryRequirements() has not been called on that image") != nullptr)
+    {
+        return VK_FALSE;
+    }
+    
+    /*
+    "Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if this memory is used by the device. Only GENERAL or PREINITIALIZED should be used."
+    Ignoring because we map entire VkDeviceMemory blocks, where different types of
+    images and buffers may end up together, especially on GPUs with unified memory
+    like Intel.
+    */
+    if(strstr(pMessage, "Mapping an image with layout") != nullptr &&
+        strstr(pMessage, "can result in undefined behavior if this memory is used by the device") != nullptr)
+    {
+        return VK_FALSE;
+    }
+
+    printf("%s \xBA %s\n", pLayerPrefix, pMessage);
+
+    return VK_FALSE;
+}
+
+static bool IsLayerSupported(const VkLayerProperties* pProps, size_t propCount, const char* pLayerName)
+{
+    const VkLayerProperties* propsEnd = pProps + propCount;
+    return std::find_if(
+        pProps,
+        propsEnd,
+        [pLayerName](const VkLayerProperties& prop) -> bool {
+            return strcmp(pLayerName, prop.layerName) == 0;
+        }) != propsEnd;
+}
+
+static const size_t FIRST_PARAM_INDEX = 4;
+
+static void InitVulkanFeatures(
+    VkPhysicalDeviceFeatures& outFeatures,
+    const VkPhysicalDeviceFeatures& supportedFeatures)
+{
+    ZeroMemory(&outFeatures, sizeof(outFeatures));
+
+    // Enable something what may interact with memory/buffer/image support.
+
+    outFeatures.fullDrawIndexUint32 = supportedFeatures.fullDrawIndexUint32;
+    outFeatures.imageCubeArray = supportedFeatures.imageCubeArray;
+    outFeatures.geometryShader = supportedFeatures.geometryShader;
+    outFeatures.tessellationShader = supportedFeatures.tessellationShader;
+    outFeatures.multiDrawIndirect = supportedFeatures.multiDrawIndirect;
+    outFeatures.textureCompressionETC2 = supportedFeatures.textureCompressionETC2;
+    outFeatures.textureCompressionASTC_LDR = supportedFeatures.textureCompressionASTC_LDR;
+    outFeatures.textureCompressionBC = supportedFeatures.textureCompressionBC;
+}
+
+class Player
+{
+public:
+    Player();
+    int Init();
+    ~Player();
+
+    void ApplyConfig(ConfigurationParser& configParser);
+    void ExecuteLine(size_t lineNumber, const StrRange& line);
+    void DumpStats(const char* fileNameFormat, size_t lineNumber, bool detailed);
+
+    void PrintStats();
+
+private:
+    static const size_t MAX_WARNINGS_TO_SHOW = 64;
+
+    size_t m_WarningCount = 0;
+    bool m_AllocateForBufferImageWarningIssued = false;
+
+    VkInstance m_VulkanInstance = VK_NULL_HANDLE;
+    VkPhysicalDevice m_PhysicalDevice = VK_NULL_HANDLE;
+    uint32_t m_GraphicsQueueFamilyIndex = UINT_MAX;
+    VkDevice m_Device = VK_NULL_HANDLE;
+    VmaAllocator m_Allocator = VK_NULL_HANDLE;
+    bool m_DedicatedAllocationEnabled = false;
+    const VkPhysicalDeviceProperties* m_DevProps = nullptr;
+    const VkPhysicalDeviceMemoryProperties* m_MemProps = nullptr;
+
+    PFN_vkCreateDebugReportCallbackEXT m_pvkCreateDebugReportCallbackEXT;
+    PFN_vkDebugReportMessageEXT m_pvkDebugReportMessageEXT;
+    PFN_vkDestroyDebugReportCallbackEXT m_pvkDestroyDebugReportCallbackEXT;
+    VkDebugReportCallbackEXT m_hCallback;
+
+    uint32_t m_VmaFrameIndex = 0;
+
+    // Any of these handles null can mean it was created in original but couldn't be created now.
+    struct Pool
+    {
+        VmaPool pool;
+    };
+    struct Allocation
+    {
+        uint32_t allocationFlags;
+        VmaAllocation allocation;
+        VkBuffer buffer;
+        VkImage image;
+    };
+    std::unordered_map<uint64_t, Pool> m_Pools;
+    std::unordered_map<uint64_t, Allocation> m_Allocations;
+
+    struct Thread
+    {
+        uint32_t callCount;
+    };
+    std::unordered_map<uint32_t, Thread> m_Threads;
+
+    // Copy of column [1] from previously parsed line.
+    std::string m_LastLineTimeStr;
+    Statistics m_Stats;
+
+    std::vector<char> m_UserDataTmpStr;
+
+    void Destroy(const Allocation& alloc);
+
+    // Finds VmaPool bu original pointer.
+    // If origPool = null, returns true and outPool = null.
+    // If failed, prints warning, returns false and outPool = null.
+    bool FindPool(size_t lineNumber, uint64_t origPool, VmaPool& outPool);
+    // If allocation with that origPtr already exists, prints warning and replaces it.
+    void AddAllocation(size_t lineNumber, uint64_t origPtr, VkResult res, const char* functionName, Allocation&& allocDesc);
+
+    // Increments warning counter. Returns true if warning message should be printed.
+    bool IssueWarning();
+
+    int InitVulkan();
+    void FinalizeVulkan();
+    void RegisterDebugCallbacks();
+
+    // If parmeter count doesn't match, issues warning and returns false.
+    bool ValidateFunctionParameterCount(size_t lineNumber, const CsvSplit& csvSplit, size_t expectedParamCount, bool lastUnbound);
+
+    // If failed, prints warning, returns false, and sets allocCreateInfo.pUserData to null.
+    bool PrepareUserData(size_t lineNumber, uint32_t allocCreateFlags, const StrRange& userDataColumn, const StrRange& wholeLine, void*& outUserData);
+
+    void UpdateMemStats();
+
+    void ExecuteCreatePool(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteDestroyPool(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteSetAllocationUserData(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteCreateBuffer(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteDestroyBuffer(size_t lineNumber, const CsvSplit& csvSplit) { m_Stats.RegisterFunctionCall(VMA_FUNCTION::DestroyBuffer); DestroyAllocation(lineNumber, csvSplit); }
+    void ExecuteCreateImage(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteDestroyImage(size_t lineNumber, const CsvSplit& csvSplit) { m_Stats.RegisterFunctionCall(VMA_FUNCTION::DestroyImage); DestroyAllocation(lineNumber, csvSplit); }
+    void ExecuteFreeMemory(size_t lineNumber, const CsvSplit& csvSplit) { m_Stats.RegisterFunctionCall(VMA_FUNCTION::FreeMemory); DestroyAllocation(lineNumber, csvSplit); }
+    void ExecuteCreateLostAllocation(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteAllocateMemory(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteAllocateMemoryForBufferOrImage(size_t lineNumber, const CsvSplit& csvSplit, OBJECT_TYPE objType);
+    void ExecuteMapMemory(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteUnmapMemory(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteFlushAllocation(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteInvalidateAllocation(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteTouchAllocation(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteGetAllocationInfo(size_t lineNumber, const CsvSplit& csvSplit);
+    void ExecuteMakePoolAllocationsLost(size_t lineNumber, const CsvSplit& csvSplit);
+
+    void DestroyAllocation(size_t lineNumber, const CsvSplit& csvSplit);
+};
+
+Player::Player()
+{
+}
+
+int Player::Init()
+{
+    int result = InitVulkan();
+    
+    if(result == 0)
+    {
+        m_Stats.Init(m_MemProps->memoryHeapCount, m_MemProps->memoryTypeCount);
+        UpdateMemStats();
+    }
+    
+    return result;
+}
+
+Player::~Player()
+{
+    FinalizeVulkan();
+
+    if(g_Verbosity < VERBOSITY::MAXIMUM && m_WarningCount > MAX_WARNINGS_TO_SHOW)
+        printf("WARNING: %zu more warnings not shown.\n", m_WarningCount - MAX_WARNINGS_TO_SHOW);
+}
+
+void Player::ApplyConfig(ConfigurationParser& configParser)
+{
+    configParser.Compare(*m_DevProps, *m_MemProps, m_DedicatedAllocationEnabled);
+}
+
+void Player::ExecuteLine(size_t lineNumber, const StrRange& line)
+{
+    CsvSplit csvSplit;
+    csvSplit.Set(line);
+
+    if(csvSplit.GetCount() >= FIRST_PARAM_INDEX)
+    {
+        // Check thread ID.
+        uint32_t threadId;
+        if(StrRangeToUint(csvSplit.GetRange(0), threadId))
+        {
+            const auto it = m_Threads.find(threadId);
+            if(it != m_Threads.end())
+            {
+                ++it->second.callCount;
+            }
+            else
+            {
+                Thread threadInfo{};
+                threadInfo.callCount = 1;
+                m_Threads[threadId] = threadInfo;
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Incorrect thread ID.\n", lineNumber);
+            }
+        }
+
+        // Save time.
+        csvSplit.GetRange(1).to_str(m_LastLineTimeStr);
+
+        // Update VMA current frame index.
+        StrRange frameIndexStr = csvSplit.GetRange(2);
+        uint32_t frameIndex;
+        if(StrRangeToUint(frameIndexStr, frameIndex))
+        {
+            if(frameIndex != m_VmaFrameIndex)
+            {
+                vmaSetCurrentFrameIndex(m_Allocator, frameIndex);
+                m_VmaFrameIndex = frameIndex;
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Incorrect frame index.\n", lineNumber);
+            }
+        }
+
+        StrRange functionName = csvSplit.GetRange(3);
+
+        if(StrRangeEq(functionName, "vmaCreateAllocator"))
+        {
+            if(ValidateFunctionParameterCount(lineNumber, csvSplit, 0, false))
+            {
+                // Nothing.
+            }
+        }
+        else if(StrRangeEq(functionName, "vmaDestroyAllocator"))
+        {
+            if(ValidateFunctionParameterCount(lineNumber, csvSplit, 0, false))
+            {
+                // Nothing.
+            }
+        }
+        else if(StrRangeEq(functionName, "vmaCreatePool"))
+            ExecuteCreatePool(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaDestroyPool"))
+            ExecuteDestroyPool(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaSetAllocationUserData"))
+            ExecuteSetAllocationUserData(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaCreateBuffer"))
+            ExecuteCreateBuffer(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaDestroyBuffer"))
+            ExecuteDestroyBuffer(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaCreateImage"))
+            ExecuteCreateImage(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaDestroyImage"))
+            ExecuteDestroyImage(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaFreeMemory"))
+            ExecuteFreeMemory(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaCreateLostAllocation"))
+            ExecuteCreateLostAllocation(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaAllocateMemory"))
+            ExecuteAllocateMemory(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaAllocateMemoryForBuffer"))
+            ExecuteAllocateMemoryForBufferOrImage(lineNumber, csvSplit, OBJECT_TYPE::BUFFER);
+        else if(StrRangeEq(functionName, "vmaAllocateMemoryForImage"))
+            ExecuteAllocateMemoryForBufferOrImage(lineNumber, csvSplit, OBJECT_TYPE::IMAGE);
+        else if(StrRangeEq(functionName, "vmaMapMemory"))
+            ExecuteMapMemory(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaUnmapMemory"))
+            ExecuteUnmapMemory(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaFlushAllocation"))
+            ExecuteFlushAllocation(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaInvalidateAllocation"))
+            ExecuteInvalidateAllocation(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaTouchAllocation"))
+            ExecuteTouchAllocation(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaGetAllocationInfo"))
+            ExecuteGetAllocationInfo(lineNumber, csvSplit);
+        else if(StrRangeEq(functionName, "vmaMakePoolAllocationsLost"))
+            ExecuteMakePoolAllocationsLost(lineNumber, csvSplit);
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Unknown function.\n", lineNumber);
+            }
+        }
+    }
+    else
+    {
+        if(IssueWarning())
+        {
+            printf("Line %zu: Too few columns.\n", lineNumber);
+        }
+    }
+}
+
+void Player::DumpStats(const char* fileNameFormat, size_t lineNumber, bool detailed)
+{
+    char* pStatsString = nullptr;
+    vmaBuildStatsString(m_Allocator, &pStatsString, detailed ? VK_TRUE : VK_FALSE);
+
+    char fileName[MAX_PATH];
+    sprintf_s(fileName, fileNameFormat, lineNumber);
+
+    FILE* file = nullptr;
+    errno_t err = fopen_s(&file, fileName, "wb");
+    if(err == 0)
+    {
+        fwrite(pStatsString, 1, strlen(pStatsString), file);
+        fclose(file);
+    }
+    else
+    {
+        printf("ERROR: Failed to write file: %s\n", fileName);
+    }
+
+    vmaFreeStatsString(m_Allocator, pStatsString);
+}
+
+void Player::Destroy(const Allocation& alloc)
+{
+    if(alloc.buffer)
+    {
+        assert(alloc.image == VK_NULL_HANDLE);
+        vmaDestroyBuffer(m_Allocator, alloc.buffer, alloc.allocation);
+    }
+    else if(alloc.image)
+    {
+        vmaDestroyImage(m_Allocator, alloc.image, alloc.allocation);
+    }
+    else
+        vmaFreeMemory(m_Allocator, alloc.allocation);
+}
+
+bool Player::FindPool(size_t lineNumber, uint64_t origPool, VmaPool& outPool)
+{
+    outPool = VK_NULL_HANDLE;
+
+    if(origPool != 0)
+    {
+        const auto poolIt = m_Pools.find(origPool);
+        if(poolIt != m_Pools.end())
+        {
+            outPool = poolIt->second.pool;
+            return true;
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Pool %llX not found.\n", lineNumber, origPool);
+            }
+        }
+    }
+
+    return true;
+}
+
+void Player::AddAllocation(size_t lineNumber, uint64_t origPtr, VkResult res, const char* functionName, Allocation&& allocDesc)
+{
+    if(origPtr)
+    {
+        if(res == VK_SUCCESS)
+        {
+            // Originally succeeded, currently succeeded.
+            // Just save pointer (done below).
+        }
+        else
+        {
+            // Originally succeeded, currently failed.
+            // Print warning. Save null pointer.
+            if(IssueWarning())
+            {
+                printf("Line %zu: %s failed (%d), while originally succeeded.\n", lineNumber, functionName, res);
+            }
+        }
+
+        const auto existingIt = m_Allocations.find(origPtr);
+        if(existingIt != m_Allocations.end())
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Allocation %llX already exists.\n", lineNumber, origPtr);
+            }
+        }
+        m_Allocations[origPtr] = std::move(allocDesc);
+    }
+    else
+    {
+        if(res == VK_SUCCESS)
+        {
+            // Originally failed, currently succeeded.
+            // Print warning, destroy the object.
+            if(IssueWarning())
+            {
+                printf("Line %zu: %s succeeded, originally failed.\n", lineNumber, functionName);
+            }
+
+            Destroy(allocDesc);
+        }
+        else
+        {
+            // Originally failed, currently failed.
+            // Print warning.
+            if(IssueWarning())
+            {
+                printf("Line %zu: %s failed (%d), originally also failed.\n", lineNumber, functionName, res);
+            }
+        }
+    }
+}
+
+bool Player::IssueWarning()
+{
+    if(g_Verbosity < VERBOSITY::MAXIMUM)
+    {
+        return m_WarningCount++ < MAX_WARNINGS_TO_SHOW;
+    }
+    else
+    {
+        ++m_WarningCount;
+        return true;
+    }
+}
+
+int Player::InitVulkan()
+{
+    if(g_Verbosity == VERBOSITY::MAXIMUM)
+    {
+        printf("Initializing Vulkan...\n");
+    }
+
+    uint32_t instanceLayerPropCount = 0;
+    VkResult res = vkEnumerateInstanceLayerProperties(&instanceLayerPropCount, nullptr);
+    assert(res == VK_SUCCESS);
+
+    std::vector<VkLayerProperties> instanceLayerProps(instanceLayerPropCount);
+    if(instanceLayerPropCount > 0)
+    {
+        res = vkEnumerateInstanceLayerProperties(&instanceLayerPropCount, instanceLayerProps.data());
+        assert(res == VK_SUCCESS);
+    }
+
+    const bool validationLayersAvailable =
+        IsLayerSupported(instanceLayerProps.data(), instanceLayerProps.size(), VALIDATION_LAYER_NAME);
+
+    bool validationLayersEnabled = false;
+    switch(g_VK_LAYER_LUNARG_standard_validation)
+    {
+    case VULKAN_EXTENSION_REQUEST::DISABLED:
+        break;
+    case VULKAN_EXTENSION_REQUEST::DEFAULT:
+        validationLayersEnabled = validationLayersAvailable;
+        break;
+    case VULKAN_EXTENSION_REQUEST::ENABLED:
+        validationLayersEnabled = validationLayersAvailable;
+        if(!validationLayersAvailable)
+        {
+            printf("WARNING: %s layer cannot be enabled.\n", VALIDATION_LAYER_NAME);
+        }
+        break;
+    default: assert(0);
+    }
+
+    std::vector<const char*> instanceExtensions;
+    //instanceExtensions.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
+    //instanceExtensions.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
+
+    std::vector<const char*> instanceLayers;
+    if(validationLayersEnabled)
+    {
+        instanceLayers.push_back(VALIDATION_LAYER_NAME);
+        instanceExtensions.push_back("VK_EXT_debug_report");
+    }
+
+    VkApplicationInfo appInfo = { VK_STRUCTURE_TYPE_APPLICATION_INFO };
+    appInfo.pApplicationName = "VmaReplay";
+    appInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    appInfo.pEngineName = "Vulkan Memory Allocator";
+    appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    appInfo.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo instInfo = { VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
+    instInfo.pApplicationInfo = &appInfo;
+    instInfo.enabledExtensionCount = (uint32_t)instanceExtensions.size();
+    instInfo.ppEnabledExtensionNames = instanceExtensions.data();
+    instInfo.enabledLayerCount = (uint32_t)instanceLayers.size();
+    instInfo.ppEnabledLayerNames = instanceLayers.data();
+
+    res = vkCreateInstance(&instInfo, NULL, &m_VulkanInstance);
+    if(res != VK_SUCCESS)
+    {
+        printf("ERROR: vkCreateInstance failed (%d)\n", res);
+        return RESULT_ERROR_VULKAN;
+    }
+
+    if(validationLayersEnabled)
+    {
+        RegisterDebugCallbacks();
+    }
+
+    // Find physical device
+
+    uint32_t physicalDeviceCount = 0;
+    res = vkEnumeratePhysicalDevices(m_VulkanInstance, &physicalDeviceCount, nullptr);
+    assert(res == VK_SUCCESS);
+    if(physicalDeviceCount == 0)
+    {
+        printf("ERROR: No Vulkan physical devices found.\n");
+        return RESULT_ERROR_VULKAN;
+    }
+
+    std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
+    res = vkEnumeratePhysicalDevices(m_VulkanInstance, &physicalDeviceCount, physicalDevices.data());
+    assert(res == VK_SUCCESS);
+
+    if(g_PhysicalDeviceIndex >= physicalDeviceCount)
+    {
+        printf("ERROR: Incorrect Vulkan physical device index %u. System has %u physical devices.\n",
+            g_PhysicalDeviceIndex,
+            physicalDeviceCount);
+        return RESULT_ERROR_VULKAN;
+    }
+
+    m_PhysicalDevice = physicalDevices[0];
+
+    // Find queue family index
+
+    uint32_t queueFamilyCount = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(m_PhysicalDevice, &queueFamilyCount, nullptr);
+    if(queueFamilyCount)
+    {
+        std::vector<VkQueueFamilyProperties> queueFamilies(queueFamilyCount);
+        vkGetPhysicalDeviceQueueFamilyProperties(m_PhysicalDevice, &queueFamilyCount, queueFamilies.data());
+        for(uint32_t i = 0; i < queueFamilyCount; ++i)
+        {
+            if(queueFamilies[i].queueCount > 0 &&
+                (queueFamilies[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) != 0)
+            {
+                m_GraphicsQueueFamilyIndex = i;
+                break;
+            }
+        }
+    }
+    if(m_GraphicsQueueFamilyIndex == UINT_MAX)
+    {
+        printf("ERROR: Couldn't find graphics queue.\n");
+        return RESULT_ERROR_VULKAN;
+    }
+
+    VkPhysicalDeviceFeatures supportedFeatures;
+    vkGetPhysicalDeviceFeatures(m_PhysicalDevice, &supportedFeatures);
+
+    // Create logical device
+
+    const float queuePriority = 1.f;
+
+    VkDeviceQueueCreateInfo deviceQueueCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO };
+    deviceQueueCreateInfo.queueFamilyIndex = m_GraphicsQueueFamilyIndex;
+    deviceQueueCreateInfo.queueCount = 1;
+    deviceQueueCreateInfo.pQueuePriorities = &queuePriority;
+
+    // Enable something what may interact with memory/buffer/image support.
+    VkPhysicalDeviceFeatures enabledFeatures;
+    InitVulkanFeatures(enabledFeatures, supportedFeatures);
+
+    bool VK_KHR_get_memory_requirements2_available = false;
+    bool VK_KHR_dedicated_allocation_available = false;
+
+    // Determine list of device extensions to enable.
+    std::vector<const char*> enabledDeviceExtensions;
+    //enabledDeviceExtensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    {
+        uint32_t propertyCount = 0;
+        res = vkEnumerateDeviceExtensionProperties(m_PhysicalDevice, nullptr, &propertyCount, nullptr);
+        assert(res == VK_SUCCESS);
+
+        if(propertyCount)
+        {
+            std::vector<VkExtensionProperties> properties{propertyCount};
+            res = vkEnumerateDeviceExtensionProperties(m_PhysicalDevice, nullptr, &propertyCount, properties.data());
+            assert(res == VK_SUCCESS);
+
+            for(uint32_t i = 0; i < propertyCount; ++i)
+            {
+                if(strcmp(properties[i].extensionName, VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME) == 0)
+                {
+                    VK_KHR_get_memory_requirements2_available = true;
+                }
+                else if(strcmp(properties[i].extensionName, VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME) == 0)
+                {
+                    VK_KHR_dedicated_allocation_available = true;
+                }
+            }
+        }
+    }
+
+    const bool dedicatedAllocationAvailable =
+        VK_KHR_get_memory_requirements2_available && VK_KHR_dedicated_allocation_available;
+
+    switch(g_VK_KHR_dedicated_allocation_request)
+    {
+    case VULKAN_EXTENSION_REQUEST::DISABLED:
+        break;
+    case VULKAN_EXTENSION_REQUEST::DEFAULT:
+        m_DedicatedAllocationEnabled = dedicatedAllocationAvailable;
+        break;
+    case VULKAN_EXTENSION_REQUEST::ENABLED:
+        m_DedicatedAllocationEnabled = dedicatedAllocationAvailable;
+        if(!dedicatedAllocationAvailable)
+        {
+            printf("WARNING: VK_KHR_dedicated_allocation extension cannot be enabled.\n");
+        }
+        break;
+    default: assert(0);
+    }
+
+    if(m_DedicatedAllocationEnabled)
+    {
+        enabledDeviceExtensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+        enabledDeviceExtensions.push_back(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+    }
+
+    VkDeviceCreateInfo deviceCreateInfo = { VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };
+    deviceCreateInfo.enabledExtensionCount = (uint32_t)enabledDeviceExtensions.size();
+    deviceCreateInfo.ppEnabledExtensionNames = !enabledDeviceExtensions.empty() ? enabledDeviceExtensions.data() : nullptr;
+    deviceCreateInfo.queueCreateInfoCount = 1;
+    deviceCreateInfo.pQueueCreateInfos = &deviceQueueCreateInfo;
+    deviceCreateInfo.pEnabledFeatures = &enabledFeatures;
+
+    res = vkCreateDevice(m_PhysicalDevice, &deviceCreateInfo, nullptr, &m_Device);
+    if(res != VK_SUCCESS)
+    {
+        printf("ERROR: vkCreateDevice failed (%d)\n", res);
+        return RESULT_ERROR_VULKAN;
+    }
+
+    // Create memory allocator
+
+    VmaAllocatorCreateInfo allocatorInfo = {};
+    allocatorInfo.physicalDevice = m_PhysicalDevice;
+    allocatorInfo.device = m_Device;
+    allocatorInfo.flags = VMA_ALLOCATOR_CREATE_EXTERNALLY_SYNCHRONIZED_BIT;
+
+    if(m_DedicatedAllocationEnabled)
+    {
+        allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
+    }
+
+    res = vmaCreateAllocator(&allocatorInfo, &m_Allocator);
+    if(res != VK_SUCCESS)
+    {
+        printf("ERROR: vmaCreateAllocator failed (%d)\n", res);
+        return RESULT_ERROR_VULKAN;
+    }
+
+    vmaGetPhysicalDeviceProperties(m_Allocator, &m_DevProps);
+    vmaGetMemoryProperties(m_Allocator, &m_MemProps);
+
+    return 0;
+}
+
+void Player::FinalizeVulkan()
+{
+    if(!m_Allocations.empty())
+    {
+        printf("WARNING: Allocations not destroyed: %zu.\n", m_Allocations.size());
+
+        if(CLEANUP_LEAKED_OBJECTS)
+        {
+            for(const auto it : m_Allocations)
+            {
+                Destroy(it.second);
+            }
+        }
+
+        m_Allocations.clear();
+    }
+
+    if(!m_Pools.empty())
+    {
+        printf("WARNING: Custom pools not destroyed: %zu.\n", m_Pools.size());
+
+        if(CLEANUP_LEAKED_OBJECTS)
+        {
+            for(const auto it : m_Pools)
+            {
+                vmaDestroyPool(m_Allocator, it.second.pool);
+            }
+        }
+
+        m_Pools.clear();
+    }
+
+    vkDeviceWaitIdle(m_Device);
+
+    if(m_Allocator != VK_NULL_HANDLE)
+    {
+        vmaDestroyAllocator(m_Allocator);
+        m_Allocator = nullptr;
+    }
+
+    if(m_Device != VK_NULL_HANDLE)
+    {
+        vkDestroyDevice(m_Device, nullptr);
+        m_Device = nullptr;
+    }
+
+    if(m_pvkDestroyDebugReportCallbackEXT && m_hCallback != VK_NULL_HANDLE)
+    {
+        m_pvkDestroyDebugReportCallbackEXT(m_VulkanInstance, m_hCallback, nullptr);
+        m_hCallback = VK_NULL_HANDLE;
+    }
+
+    if(m_VulkanInstance != VK_NULL_HANDLE)
+    {
+        vkDestroyInstance(m_VulkanInstance, NULL);
+        m_VulkanInstance = VK_NULL_HANDLE;
+    }
+}
+
+void Player::RegisterDebugCallbacks()
+{
+    m_pvkCreateDebugReportCallbackEXT =
+        reinterpret_cast<PFN_vkCreateDebugReportCallbackEXT>
+            (vkGetInstanceProcAddr(m_VulkanInstance, "vkCreateDebugReportCallbackEXT"));
+    m_pvkDebugReportMessageEXT =
+        reinterpret_cast<PFN_vkDebugReportMessageEXT>
+            (vkGetInstanceProcAddr(m_VulkanInstance, "vkDebugReportMessageEXT"));
+    m_pvkDestroyDebugReportCallbackEXT =
+        reinterpret_cast<PFN_vkDestroyDebugReportCallbackEXT>
+            (vkGetInstanceProcAddr(m_VulkanInstance, "vkDestroyDebugReportCallbackEXT"));
+    assert(m_pvkCreateDebugReportCallbackEXT);
+    assert(m_pvkDebugReportMessageEXT);
+    assert(m_pvkDestroyDebugReportCallbackEXT);
+
+    VkDebugReportCallbackCreateInfoEXT callbackCreateInfo = { VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT };
+    callbackCreateInfo.flags = //VK_DEBUG_REPORT_INFORMATION_BIT_EXT |
+        VK_DEBUG_REPORT_ERROR_BIT_EXT |
+        VK_DEBUG_REPORT_WARNING_BIT_EXT |
+        VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT /*|
+        VK_DEBUG_REPORT_DEBUG_BIT_EXT*/;
+    callbackCreateInfo.pfnCallback = &MyDebugReportCallback;
+
+    VkResult res = m_pvkCreateDebugReportCallbackEXT(m_VulkanInstance, &callbackCreateInfo, nullptr, &m_hCallback);
+    assert(res == VK_SUCCESS);
+}
+
+void Player::PrintStats()
+{
+    if(g_Verbosity == VERBOSITY::MINIMUM)
+    {
+        return;
+    }
+
+    printf("Statistics:\n");
+    if(m_Stats.GetAllocationCreationCount() > 0)
+    {
+        printf("    Total allocations created: %zu\n", m_Stats.GetAllocationCreationCount());
+    }
+
+    // Buffers
+    const size_t bufferCreationCount =
+        m_Stats.GetBufferCreationCount(0) +
+        m_Stats.GetBufferCreationCount(1) +
+        m_Stats.GetBufferCreationCount(2) +
+        m_Stats.GetBufferCreationCount(3);
+    if(bufferCreationCount > 0)
+    {
+        printf("    Total buffers created: %zu\n", bufferCreationCount);
+        if(g_Verbosity == VERBOSITY::MAXIMUM)
+        {
+            printf("        Class 0 (indirect/vertex/index): %zu\n", m_Stats.GetBufferCreationCount(0));
+            printf("        Class 1 (storage): %zu\n", m_Stats.GetBufferCreationCount(1));
+            printf("        Class 2 (uniform): %zu\n", m_Stats.GetBufferCreationCount(2));
+            printf("        Class 3 (other): %zu\n", m_Stats.GetBufferCreationCount(3));
+        }
+    }
+    
+    // Images
+    const size_t imageCreationCount =
+        m_Stats.GetImageCreationCount(0) +
+        m_Stats.GetImageCreationCount(1) +
+        m_Stats.GetImageCreationCount(2) +
+        m_Stats.GetImageCreationCount(3) +
+        m_Stats.GetLinearImageCreationCount();
+    if(imageCreationCount > 0)
+    {
+        printf("    Total images created: %zu\n", imageCreationCount);
+        if(g_Verbosity == VERBOSITY::MAXIMUM)
+        {
+            printf("        Class 0 (depth/stencil): %zu\n", m_Stats.GetImageCreationCount(0));
+            printf("        Class 1 (attachment): %zu\n", m_Stats.GetImageCreationCount(1));
+            printf("        Class 2 (sampled): %zu\n", m_Stats.GetImageCreationCount(2));
+            printf("        Class 3 (other): %zu\n", m_Stats.GetImageCreationCount(3));
+            if(m_Stats.GetLinearImageCreationCount() > 0)
+            {
+                printf("        LINEAR tiling: %zu\n", m_Stats.GetLinearImageCreationCount());
+            }
+        }
+    }
+    
+    if(m_Stats.GetPoolCreationCount() > 0)
+    {
+        printf("    Total custom pools created: %zu\n", m_Stats.GetPoolCreationCount());
+    }
+
+    float lastTime;
+    if(!m_LastLineTimeStr.empty() && StrRangeToFloat(StrRange(m_LastLineTimeStr), lastTime))
+    {
+        std::string origTimeStr;
+        SecondsToFriendlyStr(lastTime, origTimeStr);
+        printf("    Original recording time: %s\n", origTimeStr.c_str());
+    }
+
+    // Thread statistics.
+    const size_t threadCount = m_Threads.size();
+    if(threadCount > 1)
+    {
+        uint32_t threadCallCountMax = 0;
+        uint32_t threadCallCountSum = 0;
+        for(const auto& it : m_Threads)
+        {
+            threadCallCountMax = std::max(threadCallCountMax, it.second.callCount);
+            threadCallCountSum += it.second.callCount;
+        }
+        printf("    Threads making calls to VMA: %zu\n", threadCount);
+        printf("        %.2f%% calls from most active thread.\n",
+            (float)threadCallCountMax * 100.f / (float)threadCallCountSum);
+    }
+    else
+    {
+        printf("    VMA used from only one thread.\n");
+    }
+
+    // Function call count
+    if(g_Verbosity == VERBOSITY::MAXIMUM)
+    {
+        printf("    Function call count:\n");
+        const size_t* const functionCallCount = m_Stats.GetFunctionCallCount();
+        for(size_t i = 0; i < (size_t)VMA_FUNCTION::Count; ++i)
+        {
+            if(functionCallCount[i] > 0)
+            {
+                printf("        %s %zu\n", VMA_FUNCTION_NAMES[i], functionCallCount[i]);
+            }
+        }
+    }
+
+    if(g_MemStatsEnabled)
+    {
+        m_Stats.PrintMemStats();
+    }
+}
+
+bool Player::ValidateFunctionParameterCount(size_t lineNumber, const CsvSplit& csvSplit, size_t expectedParamCount, bool lastUnbound)
+{
+    bool ok;
+    if(lastUnbound)
+        ok = csvSplit.GetCount() >= FIRST_PARAM_INDEX + expectedParamCount - 1;
+    else
+        ok = csvSplit.GetCount() == FIRST_PARAM_INDEX + expectedParamCount;
+
+    if(!ok)
+    {
+        if(IssueWarning())
+        {
+            printf("Line %zu: Incorrect number of function parameters.\n", lineNumber);
+        }
+    }
+
+    return ok;
+}
+
+bool Player::PrepareUserData(size_t lineNumber, uint32_t allocCreateFlags, const StrRange& userDataColumn, const StrRange& wholeLine, void*& outUserData)
+{
+    if(!g_UserDataEnabled)
+    {
+        outUserData = nullptr;
+        return true;
+    }
+
+    // String
+    if((allocCreateFlags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0)
+    {
+        const size_t len = wholeLine.end - userDataColumn.beg;
+        m_UserDataTmpStr.resize(len + 1);
+        memcpy(m_UserDataTmpStr.data(), userDataColumn.beg, len);
+        m_UserDataTmpStr[len] = '\0';
+        outUserData = m_UserDataTmpStr.data();
+        return true;
+    }
+    // Pointer
+    else
+    {
+        uint64_t pUserData = 0;
+        if(StrRangeToPtr(userDataColumn, pUserData))
+        {
+            outUserData = (void*)(uintptr_t)pUserData;
+            return true;
+        }
+    }
+
+    if(IssueWarning())
+    {
+        printf("Line %zu: Invalid pUserData.\n", lineNumber);
+    }
+    outUserData = 0;
+    return false;
+}
+
+void Player::UpdateMemStats()
+{
+    if(!g_MemStatsEnabled)
+    {
+        return;
+    }
+
+    VmaStats stats;
+    vmaCalculateStats(m_Allocator, &stats);
+    m_Stats.UpdateMemStats(stats);
+}
+
+void Player::ExecuteCreatePool(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::CreatePool);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 7, false))
+    {
+        VmaPoolCreateInfo poolCreateInfo = {};
+        uint64_t origPtr = 0;
+
+        if(StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX), poolCreateInfo.memoryTypeIndex) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), poolCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), poolCreateInfo.blockSize) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 3), poolCreateInfo.minBlockCount) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 4), poolCreateInfo.maxBlockCount) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 5), poolCreateInfo.frameInUseCount) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 6), origPtr))
+        {
+            m_Stats.RegisterCreatePool();
+
+            Pool poolDesc = {};
+            VkResult res = vmaCreatePool(m_Allocator, &poolCreateInfo, &poolDesc.pool);
+
+            if(origPtr)
+            {
+                if(res == VK_SUCCESS)
+                {
+                    // Originally succeeded, currently succeeded.
+                    // Just save pointer (done below).
+                }
+                else
+                {
+                    // Originally succeeded, currently failed.
+                    // Print warning. Save null pointer.
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: vmaCreatePool failed (%d), while originally succeeded.\n", lineNumber, res);
+                    }
+               }
+
+                const auto existingIt = m_Pools.find(origPtr);
+                if(existingIt != m_Pools.end())
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Pool %llX already exists.\n", lineNumber, origPtr);
+                    }
+                }
+                m_Pools[origPtr] = poolDesc;
+            }
+            else
+            {
+                if(res == VK_SUCCESS)
+                {
+                    // Originally failed, currently succeeded.
+                    // Print warning, destroy the pool.
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: vmaCreatePool succeeded, originally failed.\n", lineNumber);
+                    }
+
+                    vmaDestroyPool(m_Allocator, poolDesc.pool);
+                }
+                else
+                {
+                    // Originally failed, currently failed.
+                    // Print warning.
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: vmaCreatePool failed (%d), originally also failed.\n", lineNumber, res);
+                    }
+                }
+            }
+
+            UpdateMemStats();
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaCreatePool.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteDestroyPool(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::DestroyPool);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Pools.find(origPtr);
+                if(it != m_Pools.end())
+                {
+                    vmaDestroyPool(m_Allocator, it->second.pool);
+                    UpdateMemStats();
+                    m_Pools.erase(it);
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Pool %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaDestroyPool.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteSetAllocationUserData(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::SetAllocationUserData);
+
+    if(!g_UserDataEnabled)
+    {
+        return;
+    }
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 2, true))
+    {
+        uint64_t origPtr = 0;
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            const auto it = m_Allocations.find(origPtr);
+            if(it != m_Allocations.end())
+            {
+                void* pUserData = nullptr;
+                if(csvSplit.GetCount() > FIRST_PARAM_INDEX + 1)
+                {
+                    PrepareUserData(
+                        lineNumber,
+                        it->second.allocationFlags,
+                        csvSplit.GetRange(FIRST_PARAM_INDEX + 1),
+                        csvSplit.GetLine(),
+                        pUserData);
+                }
+
+                vmaSetAllocationUserData(m_Allocator, it->second.allocation, pUserData);
+            }
+            else
+            {
+                if(IssueWarning())
+                {
+                    printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaSetAllocationUserData.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteCreateBuffer(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::CreateBuffer);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 12, true))
+    {
+        VkBufferCreateInfo bufCreateInfo = { VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO };
+        VmaAllocationCreateInfo allocCreateInfo = {};
+        uint64_t origPool = 0;
+        uint64_t origPtr = 0;
+
+        if(StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX), bufCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), bufCreateInfo.size) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), bufCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 3), (uint32_t&)bufCreateInfo.sharingMode) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 4), allocCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 5), (uint32_t&)allocCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 6), allocCreateInfo.requiredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 7), allocCreateInfo.preferredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 8), allocCreateInfo.memoryTypeBits) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 9), origPool) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 10), origPtr))
+        {
+            FindPool(lineNumber, origPool, allocCreateInfo.pool);
+
+            if(csvSplit.GetCount() > FIRST_PARAM_INDEX + 11)
+            {
+                PrepareUserData(
+                    lineNumber,
+                    allocCreateInfo.flags,
+                    csvSplit.GetRange(FIRST_PARAM_INDEX + 11),
+                    csvSplit.GetLine(),
+                    allocCreateInfo.pUserData);
+            }
+
+            m_Stats.RegisterCreateBuffer(bufCreateInfo.usage);
+
+            Allocation allocDesc = { };
+            allocDesc.allocationFlags = allocCreateInfo.flags;
+            VkResult res = vmaCreateBuffer(m_Allocator, &bufCreateInfo, &allocCreateInfo, &allocDesc.buffer, &allocDesc.allocation, nullptr);
+            UpdateMemStats();
+            AddAllocation(lineNumber, origPtr, res, "vmaCreateBuffer", std::move(allocDesc));
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaCreateBuffer.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::DestroyAllocation(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origAllocPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origAllocPtr))
+        {
+            if(origAllocPtr != 0)
+            {
+                const auto it = m_Allocations.find(origAllocPtr);
+                if(it != m_Allocations.end())
+                {
+                    Destroy(it->second);
+                    UpdateMemStats();
+                    m_Allocations.erase(it);
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Allocation %llX not found.\n", lineNumber, origAllocPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaDestroyBuffer.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteCreateImage(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::CreateImage);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 21, true))
+    {
+        VkImageCreateInfo imageCreateInfo = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+        VmaAllocationCreateInfo allocCreateInfo = {};
+        uint64_t origPool = 0;
+        uint64_t origPtr = 0;
+
+        if(StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX), imageCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), (uint32_t&)imageCreateInfo.imageType) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), (uint32_t&)imageCreateInfo.format) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 3), imageCreateInfo.extent.width) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 4), imageCreateInfo.extent.height) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 5), imageCreateInfo.extent.depth) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 6), imageCreateInfo.mipLevels) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 7), imageCreateInfo.arrayLayers) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 8), (uint32_t&)imageCreateInfo.samples) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 9), (uint32_t&)imageCreateInfo.tiling) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 10), imageCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 11), (uint32_t&)imageCreateInfo.sharingMode) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 12), (uint32_t&)imageCreateInfo.initialLayout) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 13), allocCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 14), (uint32_t&)allocCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 15), allocCreateInfo.requiredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 16), allocCreateInfo.preferredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 17), allocCreateInfo.memoryTypeBits) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 18), origPool) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 19), origPtr))
+        {
+            FindPool(lineNumber, origPool, allocCreateInfo.pool);
+
+            if(csvSplit.GetCount() > FIRST_PARAM_INDEX + 20)
+            {
+                PrepareUserData(
+                    lineNumber,
+                    allocCreateInfo.flags,
+                    csvSplit.GetRange(FIRST_PARAM_INDEX + 20),
+                    csvSplit.GetLine(),
+                    allocCreateInfo.pUserData);
+            }
+
+            m_Stats.RegisterCreateImage(imageCreateInfo.usage, imageCreateInfo.tiling);
+
+            Allocation allocDesc = {};
+            allocDesc.allocationFlags = allocCreateInfo.flags;
+            VkResult res = vmaCreateImage(m_Allocator, &imageCreateInfo, &allocCreateInfo, &allocDesc.image, &allocDesc.allocation, nullptr);
+            UpdateMemStats();
+            AddAllocation(lineNumber, origPtr, res, "vmaCreateImage", std::move(allocDesc));
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaCreateImage.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteCreateLostAllocation(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::CreateLostAllocation);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            Allocation allocDesc = {};
+            vmaCreateLostAllocation(m_Allocator, &allocDesc.allocation);
+            UpdateMemStats();
+            m_Stats.RegisterCreateAllocation();
+
+            AddAllocation(lineNumber, origPtr, VK_SUCCESS, "vmaCreateLostAllocation", std::move(allocDesc));
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaCreateLostAllocation.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteAllocateMemory(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::AllocateMemory);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 11, true))
+    {
+        VkMemoryRequirements memReq = {};
+        VmaAllocationCreateInfo allocCreateInfo = {};
+        uint64_t origPool = 0;
+        uint64_t origPtr = 0;
+
+        if(StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX), memReq.size) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), memReq.alignment) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), memReq.memoryTypeBits) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 3), allocCreateInfo.flags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 4), (uint32_t&)allocCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 5), allocCreateInfo.requiredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 6), allocCreateInfo.preferredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 7), allocCreateInfo.memoryTypeBits) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 8), origPool) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 9), origPtr))
+        {
+            FindPool(lineNumber, origPool, allocCreateInfo.pool);
+
+            if(csvSplit.GetCount() > FIRST_PARAM_INDEX + 10)
+            {
+                PrepareUserData(
+                    lineNumber,
+                    allocCreateInfo.flags,
+                    csvSplit.GetRange(FIRST_PARAM_INDEX + 10),
+                    csvSplit.GetLine(),
+                    allocCreateInfo.pUserData);
+            }
+
+            UpdateMemStats();
+            m_Stats.RegisterCreateAllocation();
+
+            Allocation allocDesc = {};
+            allocDesc.allocationFlags = allocCreateInfo.flags;
+            VkResult res = vmaAllocateMemory(m_Allocator, &memReq, &allocCreateInfo, &allocDesc.allocation, nullptr);
+            AddAllocation(lineNumber, origPtr, res, "vmaAllocateMemory", std::move(allocDesc));
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaAllocateMemory.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteAllocateMemoryForBufferOrImage(size_t lineNumber, const CsvSplit& csvSplit, OBJECT_TYPE objType)
+{
+    switch(objType)
+    {
+    case OBJECT_TYPE::BUFFER:
+        m_Stats.RegisterFunctionCall(VMA_FUNCTION::AllocateMemoryForBuffer);
+        break;
+    case OBJECT_TYPE::IMAGE:
+        m_Stats.RegisterFunctionCall(VMA_FUNCTION::AllocateMemoryForImage);
+        break;
+    default: assert(0);
+    }
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 13, true))
+    {
+        VkMemoryRequirements memReq = {};
+        VmaAllocationCreateInfo allocCreateInfo = {};
+        bool requiresDedicatedAllocation = false;
+        bool prefersDedicatedAllocation = false;
+        uint64_t origPool = 0;
+        uint64_t origPtr = 0;
+
+        if(StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX), memReq.size) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), memReq.alignment) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), memReq.memoryTypeBits) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 3), allocCreateInfo.flags) &&
+            StrRangeToBool(csvSplit.GetRange(FIRST_PARAM_INDEX + 4), requiresDedicatedAllocation) &&
+            StrRangeToBool(csvSplit.GetRange(FIRST_PARAM_INDEX + 5), prefersDedicatedAllocation) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 6), (uint32_t&)allocCreateInfo.usage) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 7), allocCreateInfo.requiredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 8), allocCreateInfo.preferredFlags) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 9), allocCreateInfo.memoryTypeBits) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 10), origPool) &&
+            StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX + 11), origPtr))
+        {
+            FindPool(lineNumber, origPool, allocCreateInfo.pool);
+
+            if(csvSplit.GetCount() > FIRST_PARAM_INDEX + 12)
+            {
+                PrepareUserData(
+                    lineNumber,
+                    allocCreateInfo.flags,
+                    csvSplit.GetRange(FIRST_PARAM_INDEX + 12),
+                    csvSplit.GetLine(),
+                    allocCreateInfo.pUserData);
+            }
+
+            if(requiresDedicatedAllocation || prefersDedicatedAllocation)
+            {
+                allocCreateInfo.flags |= VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+            }
+
+            if(!m_AllocateForBufferImageWarningIssued)
+            {
+                if(IssueWarning())
+                {
+                    printf("Line %zu: vmaAllocateMemoryForBuffer or vmaAllocateMemoryForImage cannot be replayed accurately. Using vmaCreateAllocation instead.\n", lineNumber);
+                }
+                m_AllocateForBufferImageWarningIssued = true;
+            }
+
+            UpdateMemStats();
+            m_Stats.RegisterCreateAllocation();
+
+            Allocation allocDesc = {};
+            allocDesc.allocationFlags = allocCreateInfo.flags;
+            VkResult res = vmaAllocateMemory(m_Allocator, &memReq, &allocCreateInfo, &allocDesc.allocation, nullptr);
+            AddAllocation(lineNumber, origPtr, res, "vmaAllocateMemory (called as vmaAllocateMemoryForBuffer or vmaAllocateMemoryForImage)", std::move(allocDesc));
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaAllocateMemoryForBuffer or vmaAllocateMemoryForImage.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteMapMemory(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::MapMemory);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Allocations.find(origPtr);
+                if(it != m_Allocations.end())
+                {
+                    if(it->second.allocation)
+                    {
+                        void* pData;
+                        VkResult res = vmaMapMemory(m_Allocator, it->second.allocation, &pData);
+                        if(res != VK_SUCCESS)
+                        {
+                            printf("Line %zu: vmaMapMemory failed (%d)\n", lineNumber, res);
+                        }
+                    }
+                    else
+                    {
+                        if(IssueWarning())
+                        {
+                            printf("Line %zu: Cannot call vmaMapMemory - allocation is null.\n", lineNumber);
+                        }
+                    }
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaMapMemory.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteUnmapMemory(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::UnmapMemory);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Allocations.find(origPtr);
+                if(it != m_Allocations.end())
+                {
+                    if(it->second.allocation)
+                    {
+                        vmaUnmapMemory(m_Allocator, it->second.allocation);
+                    }
+                    else
+                    {
+                        if(IssueWarning())
+                        {
+                            printf("Line %zu: Cannot call vmaUnmapMemory - allocation is null.\n", lineNumber);
+                        }
+                    }
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaMapMemory.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteFlushAllocation(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::FlushAllocation);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 3, false))
+    {
+        uint64_t origPtr = 0;
+        uint64_t offset = 0;
+        uint64_t size = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), offset) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), size))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Allocations.find(origPtr);
+                if(it != m_Allocations.end())
+                {
+                    if(it->second.allocation)
+                    {
+                        vmaFlushAllocation(m_Allocator, it->second.allocation, offset, size);
+                    }
+                    else
+                    {
+                        if(IssueWarning())
+                        {
+                            printf("Line %zu: Cannot call vmaFlushAllocation - allocation is null.\n", lineNumber);
+                        }
+                    }
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaFlushAllocation.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteInvalidateAllocation(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::InvalidateAllocation);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 3, false))
+    {
+        uint64_t origPtr = 0;
+        uint64_t offset = 0;
+        uint64_t size = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 1), offset) &&
+            StrRangeToUint(csvSplit.GetRange(FIRST_PARAM_INDEX + 2), size))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Allocations.find(origPtr);
+                if(it != m_Allocations.end())
+                {
+                    if(it->second.allocation)
+                    {
+                        vmaInvalidateAllocation(m_Allocator, it->second.allocation, offset, size);
+                    }
+                    else
+                    {
+                        if(IssueWarning())
+                        {
+                            printf("Line %zu: Cannot call vmaInvalidateAllocation - allocation is null.\n", lineNumber);
+                        }
+                    }
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaInvalidateAllocation.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteTouchAllocation(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::TouchAllocation);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            const auto it = m_Allocations.find(origPtr);
+            if(it != m_Allocations.end())
+            {
+                if(it->second.allocation)
+                {
+                    vmaTouchAllocation(m_Allocator, it->second.allocation);
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Cannot call vmaTouchAllocation - allocation is null.\n", lineNumber);
+                    }
+                }
+            }
+            else
+            {
+                if(IssueWarning())
+                {
+                    printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaTouchAllocation.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteGetAllocationInfo(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::GetAllocationInfo);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            const auto it = m_Allocations.find(origPtr);
+            if(it != m_Allocations.end())
+            {
+                if(it->second.allocation)
+                {
+                    VmaAllocationInfo allocInfo;
+                    vmaGetAllocationInfo(m_Allocator, it->second.allocation, &allocInfo);
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Cannot call vmaGetAllocationInfo - allocation is null.\n", lineNumber);
+                    }
+                }
+            }
+            else
+            {
+                if(IssueWarning())
+                {
+                    printf("Line %zu: Allocation %llX not found.\n", lineNumber, origPtr);
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaGetAllocationInfo.\n", lineNumber);
+            }
+        }
+    }
+}
+
+void Player::ExecuteMakePoolAllocationsLost(size_t lineNumber, const CsvSplit& csvSplit)
+{
+    m_Stats.RegisterFunctionCall(VMA_FUNCTION::MakePoolAllocationsLost);
+
+    if(ValidateFunctionParameterCount(lineNumber, csvSplit, 1, false))
+    {
+        uint64_t origPtr = 0;
+
+        if(StrRangeToPtr(csvSplit.GetRange(FIRST_PARAM_INDEX), origPtr))
+        {
+            if(origPtr != 0)
+            {
+                const auto it = m_Pools.find(origPtr);
+                if(it != m_Pools.end())
+                {
+                    vmaMakePoolAllocationsLost(m_Allocator, it->second.pool, nullptr);
+                    UpdateMemStats();
+                }
+                else
+                {
+                    if(IssueWarning())
+                    {
+                        printf("Line %zu: Pool %llX not found.\n", lineNumber, origPtr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            if(IssueWarning())
+            {
+                printf("Line %zu: Invalid parameters for vmaMakePoolAllocationsLost.\n", lineNumber);
+            }
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Main functions
+
+static void PrintCommandLineSyntax()
+{
+    printf(
+        "Command line syntax:\n"
+        "    VmaReplay [Options] <SrcFile.csv>\n"
+        "Available options:\n"
+        "    -v <Number> - Verbosity level:\n"
+        "        0 - Minimum verbosity. Prints only warnings and errors.\n"
+        "        1 - Default verbosity. Prints important messages and statistics.\n"
+        "        2 - Maximum verbosity. Prints a lot of information.\n"
+        "    -i <Number> - Repeat playback given number of times (iterations)\n"
+        "        Default is 1. Vulkan is reinitialized with every iteration.\n"
+        "    --MemStats <Value> - 0 to disable or 1 to enable memory statistics.\n"
+        "        Default is 0. Enabling it may negatively impact playback performance.\n"
+        "    --DumpStatsAfterLine <Line> - Dump VMA statistics to JSON file after specified source file line finishes execution.\n"
+        "        File is written to current directory with name: VmaReplay_Line####.json.\n"
+        "        This parameter can be repeated.\n"
+        "    --DumpDetailedStatsAfterLine <Line> - Like command above, but includes detailed map.\n"
+        "    --Lines <Ranges> - Replay only limited set of lines from file\n"
+        "        Ranges is comma-separated list of ranges, e.g. \"-10,15,18-25,31-\".\n"
+        "    --PhysicalDevice <Index> - Choice of Vulkan physical device. Default: 0.\n"
+        "    --UserData <Value> - 0 to disable or 1 to enable setting pUserData during playback.\n"
+        "        Default is 1. Affects both creation of buffers and images, as well as calls to vmaSetAllocationUserData.\n"
+        "    --VK_LAYER_LUNARG_standard_validation <Value> - 0 to disable or 1 to enable validation layers.\n"
+        "        By default the layers are silently enabled if available.\n"
+        "    --VK_KHR_dedicated_allocation <Value> - 0 to disable or 1 to enable this extension.\n"
+        "        By default the extension is silently enabled if available.\n"
+    );
+}
+
+static int ProcessFile(size_t iterationIndex, const char* data, size_t numBytes, duration& outDuration)
+{
+    outDuration = duration::max();
+
+    const bool useLineRanges = !g_LineRanges.IsEmpty();
+    const bool useDumpStatsAfterLine = !g_DumpStatsAfterLine.empty();
+
+    LineSplit lineSplit(data, numBytes);
+    StrRange line;
+
+    if(!lineSplit.GetNextLine(line) ||
+        !StrRangeEq(line, "Vulkan Memory Allocator,Calls recording"))
+    {
+        printf("ERROR: Incorrect file format.\n");
+        return RESULT_ERROR_FORMAT;
+    }
+
+    if(!lineSplit.GetNextLine(line) || !ParseFileVersion(line) || !ValidateFileVersion())
+    {
+        printf("ERROR: Incorrect file format version.\n");
+        return RESULT_ERROR_FORMAT;
+    }
+
+    if(g_Verbosity == VERBOSITY::MAXIMUM)
+    {
+        printf("Format version: %u,%u\n",
+            GetVersionMajor(g_FileVersion),
+            GetVersionMinor(g_FileVersion));
+    }
+
+    // Parse configuration
+    const bool configEnabled = g_FileVersion >= MakeVersion(1, 3);
+    ConfigurationParser configParser;
+    if(configEnabled)
+    {
+        if(!configParser.Parse(lineSplit))
+        {
+            return RESULT_ERROR_FORMAT;
+        }
+    }
+
+    Player player;
+    int result = player.Init();
+
+    if(configEnabled)
+    {
+        player.ApplyConfig(configParser);
+    }
+
+    size_t executedLineCount = 0;
+    if(result == 0)
+    {
+        if(g_Verbosity > VERBOSITY::MINIMUM)
+        {
+            if(useLineRanges)
+            {
+                printf("Playing #%zu (limited range of lines)...\n", iterationIndex + 1);
+            }
+            else
+            {
+                printf("Playing #%zu...\n", iterationIndex + 1);
+            }
+        }
+
+        const time_point timeBeg = std::chrono::high_resolution_clock::now();
+
+        while(lineSplit.GetNextLine(line))
+        {
+            const size_t currLineNumber = lineSplit.GetNextLineIndex();
+
+            bool execute = true;
+            if(useLineRanges)
+            {
+                execute = g_LineRanges.Includes(currLineNumber);
+            }
+
+            if(execute)
+            {
+                player.ExecuteLine(currLineNumber, line);
+                ++executedLineCount;
+            }
+
+            while(useDumpStatsAfterLine &&
+                g_DumpStatsAfterLineNextIndex < g_DumpStatsAfterLine.size() &&
+                currLineNumber >= g_DumpStatsAfterLine[g_DumpStatsAfterLineNextIndex].line)
+            {
+                const size_t requestedLine = g_DumpStatsAfterLine[g_DumpStatsAfterLineNextIndex].line;
+                const bool detailed = g_DumpStatsAfterLine[g_DumpStatsAfterLineNextIndex].detailed;
+                
+                if(g_Verbosity == VERBOSITY::MAXIMUM)
+                {
+                    printf("Dumping %sstats after line %zu actual line %zu...\n",
+                        detailed ? "detailed " : "",
+                        requestedLine,
+                        currLineNumber);
+                }
+
+                player.DumpStats("VmaReplay_Line%04zu.json", requestedLine, detailed);
+                
+                ++g_DumpStatsAfterLineNextIndex;
+            }
+        }
+
+        const duration playDuration = std::chrono::high_resolution_clock::now() - timeBeg;
+        outDuration = playDuration;
+
+        // End stats.
+        if(g_Verbosity > VERBOSITY::MINIMUM)
+        {
+            std::string playDurationStr;
+            SecondsToFriendlyStr(ToFloatSeconds(playDuration), playDurationStr);
+
+            printf("Done.\n");
+            printf("Playback took: %s\n", playDurationStr.c_str());
+        }
+        if(g_Verbosity == VERBOSITY::MAXIMUM)
+        {
+            printf("File lines: %zu\n", lineSplit.GetNextLineIndex());
+            printf("Executed %zu file lines\n", executedLineCount);
+        }
+
+        player.PrintStats();
+    }
+
+    return result;
+}
+
+static int ProcessFile()
+{
+    if(g_Verbosity > VERBOSITY::MINIMUM)
+    {
+        printf("Loading file \"%s\"...\n", g_FilePath.c_str());
+    }
+    int result = 0;
+
+    FILE* file = nullptr;
+    const errno_t err = fopen_s(&file, g_FilePath.c_str(), "rb");
+    if(err == 0)
+    {
+        _fseeki64(file, 0, SEEK_END);
+        const size_t fileSize = (size_t)_ftelli64(file);
+        _fseeki64(file, 0, SEEK_SET);
+
+        if(fileSize > 0)
+        {
+            std::vector<char> fileContents(fileSize);
+            fread(fileContents.data(), 1, fileSize, file);
+
+            // Begin stats.
+            if(g_Verbosity == VERBOSITY::MAXIMUM)
+            {
+                printf("File size: %zu B\n", fileSize);
+            }
+
+            duration durationSum = duration::zero();
+            for(size_t i = 0; i < g_IterationCount; ++i)
+            {
+                duration currDuration;
+                ProcessFile(i, fileContents.data(), fileContents.size(), currDuration);
+                durationSum += currDuration;
+            }
+
+            if(g_IterationCount > 1)
+            {
+                std::string playDurationStr;
+                SecondsToFriendlyStr(ToFloatSeconds(durationSum / g_IterationCount), playDurationStr);
+                printf("Average playback time from %zu iterations: %s\n", g_IterationCount, playDurationStr.c_str());
+            }
+        }
+        else
+        {
+            printf("ERROR: Source file is empty.\n");
+            result = RESULT_ERROR_SOURCE_FILE;
+        }
+
+        fclose(file);
+    }
+    else
+    {
+        printf("ERROR: Couldn't open file (%i).\n", err);
+        result = RESULT_ERROR_SOURCE_FILE;
+    }
+
+    return result;
+}
+
+static int main2(int argc, char** argv)
+{
+    CmdLineParser cmdLineParser(argc, argv);
+
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_VERBOSITY, 'v', true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_ITERATIONS, 'i', true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_LINES, "Lines", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_PHYSICAL_DEVICE, "PhysicalDevice", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_USER_DATA, "UserData", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_VK_KHR_DEDICATED_ALLOCATION, "VK_KHR_dedicated_allocation", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_VK_LAYER_LUNARG_STANDARD_VALIDATION, VALIDATION_LAYER_NAME, true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_MEM_STATS, "MemStats", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_DUMP_STATS_AFTER_LINE, "DumpStatsAfterLine", true);
+    cmdLineParser.RegisterOpt(CMD_LINE_OPT_DUMP_DETAILED_STATS_AFTER_LINE, "DumpDetailedStatsAfterLine", true);
+
+    CmdLineParser::RESULT res;
+    while((res = cmdLineParser.ReadNext()) != CmdLineParser::RESULT_END)
+    {
+        switch(res)
+        {
+        case CmdLineParser::RESULT_OPT:
+            switch(cmdLineParser.GetOptId())
+            {
+            case CMD_LINE_OPT_VERBOSITY:
+                {
+                    uint32_t verbosityVal = UINT32_MAX;
+                    if(StrRangeToUint(StrRange(cmdLineParser.GetParameter()), verbosityVal) &&
+                        verbosityVal < (uint32_t)VERBOSITY::COUNT)
+                    {
+                        g_Verbosity = (VERBOSITY)verbosityVal;
+                    }
+                    else
+                    {
+                        PrintCommandLineSyntax();
+                        return RESULT_ERROR_COMMAND_LINE;
+                    }
+                }
+                break;
+            case CMD_LINE_OPT_ITERATIONS:
+                if(!StrRangeToUint(StrRange(cmdLineParser.GetParameter()), g_IterationCount))
+                {
+                    PrintCommandLineSyntax();
+                    return RESULT_ERROR_COMMAND_LINE;
+                }
+                break;
+            case CMD_LINE_OPT_LINES:
+                if(!g_LineRanges.Parse(StrRange(cmdLineParser.GetParameter())))
+                {
+                    PrintCommandLineSyntax();
+                    return RESULT_ERROR_COMMAND_LINE;
+                }
+                break;
+            case CMD_LINE_OPT_PHYSICAL_DEVICE:
+                if(!StrRangeToUint(StrRange(cmdLineParser.GetParameter()), g_PhysicalDeviceIndex))
+                {
+                    PrintCommandLineSyntax();
+                    return RESULT_ERROR_COMMAND_LINE;
+                }
+                break;
+            case CMD_LINE_OPT_USER_DATA:
+                if(!StrRangeToBool(StrRange(cmdLineParser.GetParameter()), g_UserDataEnabled))
+                {
+                    PrintCommandLineSyntax();
+                    return RESULT_ERROR_COMMAND_LINE;
+                }
+                break;
+            case CMD_LINE_OPT_VK_KHR_DEDICATED_ALLOCATION:
+                {
+                    bool newValue;
+                    if(StrRangeToBool(StrRange(cmdLineParser.GetParameter()), newValue))
+                    {
+                        g_VK_KHR_dedicated_allocation_request = newValue ?
+                            VULKAN_EXTENSION_REQUEST::ENABLED :
+                            VULKAN_EXTENSION_REQUEST::DISABLED;
+                    }
+                    else
+                    {
+                        PrintCommandLineSyntax();
+                        return RESULT_ERROR_COMMAND_LINE;
+                    }
+                }
+                break;
+            case CMD_LINE_OPT_VK_LAYER_LUNARG_STANDARD_VALIDATION:
+                {
+                    bool newValue;
+                    if(StrRangeToBool(StrRange(cmdLineParser.GetParameter()), newValue))
+                    {
+                        g_VK_LAYER_LUNARG_standard_validation = newValue ?
+                            VULKAN_EXTENSION_REQUEST::ENABLED :
+                            VULKAN_EXTENSION_REQUEST::DISABLED;
+                    }
+                    else
+                    {
+                        PrintCommandLineSyntax();
+                        return RESULT_ERROR_COMMAND_LINE;
+                    }
+                }
+                break;
+            case CMD_LINE_OPT_MEM_STATS:
+                if(!StrRangeToBool(StrRange(cmdLineParser.GetParameter()), g_MemStatsEnabled))
+                {
+                    PrintCommandLineSyntax();
+                    return RESULT_ERROR_COMMAND_LINE;
+                }
+                break;
+            case CMD_LINE_OPT_DUMP_STATS_AFTER_LINE:
+            case CMD_LINE_OPT_DUMP_DETAILED_STATS_AFTER_LINE:
+                {
+                    size_t line;
+                    if(StrRangeToUint(StrRange(cmdLineParser.GetParameter()), line))
+                    {
+                        const bool detailed =
+                            cmdLineParser.GetOptId() == CMD_LINE_OPT_DUMP_DETAILED_STATS_AFTER_LINE;
+                        g_DumpStatsAfterLine.push_back({line, detailed});
+                    }
+                    else
+                    {
+                        PrintCommandLineSyntax();
+                        return RESULT_ERROR_COMMAND_LINE;
+                    }
+                }
+                break;
+            default:
+                assert(0);
+            }
+            break;
+        case CmdLineParser::RESULT_PARAMETER:
+            if(g_FilePath.empty())
+            {
+                g_FilePath = cmdLineParser.GetParameter();
+            }
+            else
+            {
+                PrintCommandLineSyntax();
+                return RESULT_ERROR_COMMAND_LINE;
+            }
+            break;
+        case CmdLineParser::RESULT_ERROR:
+            PrintCommandLineSyntax();
+            return RESULT_ERROR_COMMAND_LINE;
+            break;
+        default:
+            assert(0);
+        }
+    }
+
+    // Postprocess command line parameters.
+
+    if(g_FilePath.empty())
+    {
+        PrintCommandLineSyntax();
+        return RESULT_ERROR_COMMAND_LINE;
+    }
+
+    // Sort g_DumpStatsAfterLine and make unique.
+    std::sort(g_DumpStatsAfterLine.begin(), g_DumpStatsAfterLine.end());
+    g_DumpStatsAfterLine.erase(
+        std::unique(g_DumpStatsAfterLine.begin(), g_DumpStatsAfterLine.end()),
+        g_DumpStatsAfterLine.end());
+
+    return ProcessFile();
+}
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        return main2(argc, argv);
+    }
+    catch(const std::exception& e)
+    {
+        printf("ERROR: %s\n", e.what());
+        return RESULT_EXCEPTION;
+    }
+    catch(...)
+    {
+        printf("UNKNOWN ERROR\n");
+        return RESULT_EXCEPTION;
+    }
+}

--- a/third_party/vkmemalloc/src/VmaReplay/VmaUsage.cpp
+++ b/third_party/vkmemalloc/src/VmaReplay/VmaUsage.cpp
@@ -1,0 +1,2 @@
+#define VMA_IMPLEMENTATION
+#include "VmaUsage.h"

--- a/third_party/vkmemalloc/src/VmaReplay/VmaUsage.h
+++ b/third_party/vkmemalloc/src/VmaReplay/VmaUsage.h
@@ -1,7 +1,4 @@
-#ifndef VMA_USAGE_H_
-#define VMA_USAGE_H_
-
-#ifdef _WIN32
+#pragma once
 
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
@@ -9,12 +6,6 @@
 #define VK_USE_PLATFORM_WIN32_KHR
 
 #include <vulkan/vulkan.h>
-
-/*
-In every place where you want to use Vulkan Memory Allocator, define appropriate
-macros if you want to configure the library and then include its header to
-include all public interface declarations. Example:
-*/
 
 //#define VMA_USE_STL_CONTAINERS 1
 
@@ -25,22 +16,12 @@ include all public interface declarations. Example:
 //#define VMA_DEBUG_MARGIN 16
 //#define VMA_DEBUG_DETECT_CORRUPTION 1
 //#define VMA_DEBUG_INITIALIZE_ALLOCATIONS 1
-//#define VMA_RECORDING_ENABLED 0
 
 #pragma warning(push, 4)
 #pragma warning(disable: 4127) // conditional expression is constant
 #pragma warning(disable: 4100) // unreferenced formal parameter
 #pragma warning(disable: 4189) // local variable is initialized but not referenced
 
-#include "vk_mem_alloc.h"
+#include "../vk_mem_alloc.h"
 
 #pragma warning(pop)
-
-#else // #ifdef _WIN32
-
-#include <vulkan/vulkan.h>
-#include "vk_mem_alloc.h"
-
-#endif // #ifdef _WIN32
-
-#endif

--- a/third_party/vkmemalloc/src/VulkanSample.cpp
+++ b/third_party/vkmemalloc/src/VulkanSample.cpp
@@ -190,6 +190,18 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MyDebugReportCallback(
     {
         return VK_FALSE;
     }
+
+    /*
+    "Mapping an image with layout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL can result in undefined behavior if this memory is used by the device. Only GENERAL or PREINITIALIZED should be used."
+    Ignoring because we map entire VkDeviceMemory blocks, where different types of
+    images and buffers may end up together, especially on GPUs with unified memory
+    like Intel.
+    */
+    if(strstr(pMessage, "Mapping an image with layout") != nullptr &&
+        strstr(pMessage, "can result in undefined behavior if this memory is used by the device") != nullptr)
+    {
+        return VK_FALSE;
+    }
     
     switch(flags)
     {
@@ -573,7 +585,7 @@ static void CreateTexture(uint32_t sizeX, uint32_t sizeY)
 
 struct UniformBufferObject
 {
-    mathfu::vec4_packed ModelViewProj[4];
+    mat4 ModelViewProj;
 };
 
 static void RegisterDebugCallbacks()
@@ -1573,18 +1585,16 @@ static void DrawFrame()
         VK_PIPELINE_BIND_POINT_GRAPHICS,
         g_hPipeline);
 
-    mathfu::mat4 view = mathfu::mat4::LookAt(
-        mathfu::kZeros3f,
-        mathfu::vec3(0.f, -2.f, 4.f),
-        mathfu::kAxisY3f);
-    mathfu::mat4 proj = mathfu::mat4::Perspective(
+    mat4 view = mat4::LookAt(
+        vec3(0.f, 0.f, 0.f),
+        vec3(0.f, -2.f, 4.f),
+        vec3(0.f, 1.f, 0.f));
+    mat4 proj = mat4::Perspective(
         1.0471975511966f, // 60 degrees
         (float)g_Extent.width / (float)g_Extent.height,
         0.1f,
-        1000.f,
-        -1.f);
-    //proj[1][1] *= -1.f;
-    mathfu::mat4 viewProj = proj * view;
+        1000.f);
+    mat4 viewProj = view * proj;
 
     vkCmdBindDescriptorSets(
         hCommandBuffer,
@@ -1596,17 +1606,11 @@ static void DrawFrame()
         0,
         nullptr);
 
-    float rotationAngle = (float)GetTickCount() * 0.001f * (float)M_PI * 0.2f;
-    mathfu::mat3 model_3 = mathfu::mat3::RotationY(rotationAngle);
-    mathfu::mat4 model_4 = mathfu::mat4(
-        model_3(0, 0), model_3(0, 1), model_3(0, 2), 0.f,
-        model_3(1, 0), model_3(1, 1), model_3(1, 2), 0.f,
-        model_3(2, 0), model_3(2, 1), model_3(2, 2), 0.f,
-        0.f, 0.f, 0.f, 1.f);
-    mathfu::mat4 modelViewProj = viewProj * model_4;
+    float rotationAngle = (float)GetTickCount() * 0.001f * (float)PI * 0.2f;
+    mat4 model = mat4::RotationY(rotationAngle);
 
     UniformBufferObject ubo = {};
-    modelViewProj.Pack(ubo.ModelViewProj);
+    ubo.ModelViewProj = model * viewProj;
     vkCmdPushConstants(hCommandBuffer, g_hPipelineLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(UniformBufferObject), &ubo);
 
     VkBuffer vertexBuffers[] = { g_hVertexBuffer };

--- a/third_party/vkmemalloc/tnt/README
+++ b/third_party/vkmemalloc/tnt/README
@@ -1,7 +1,8 @@
 This folder was created as follows:
 
-curl -L -O https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/8a5ba7.zip
-unzip 8a5ba7.zip
+curl -L -O https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/62c009.zip
+unzip 62c009.zip
 mv VulkanMemoryAllocator-* vkmemalloc
 cd vkmemalloc
 rm -rf bin docs media premake third_party tools
+rsync -r ./ ~/github/filament/third_party/vkmemalloc/ --delete --exclude tnt


### PR DESCRIPTION
This implements the following suggestions from Adam Sawicki:

(1) Update VkMemAlloc to dev branch.
(2) Use VMA_MEMORY_USAGE_CPU_ONLY in the stage pool.
(2) Add vmaFlush after every vmaUnmap.

We also considered removing Map / Unmap in favor of persistent mapping
via VMA_ALLOCATION_CREATE_MAPPED_BIT, but decided to be conservative
until we have a chance to rethink our UBO update strategy.

Closes #19