### PR TITLE
Tungsten: prep for material parameters editing

### DIFF
--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
@@ -16,7 +16,12 @@
 
 package com.google.android.filament.tungsten.compiler
 
+import com.google.android.filament.tungsten.model.Node
+
 data class CompiledGraph(
     // The Filament material definition that is fed into matc
-    val materialDefinition: String
+    val materialDefinition: String,
+
+    // Maps a Node's property to the associated material parameter it controls
+    val parameterMap: Map<Node.PropertyHandle, Parameter>
 )

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-package com.google.android.filament.tungsten.compiler;
+package com.google.android.filament.tungsten.compiler
 
-class Parameter {
-
-    final String type;
-    final String name;
-
-    Parameter(String type, String name) {
-        this.type = type;
-        this.name = name;
-    }
-}
+data class CompiledGraph(
+    // The Filament material definition that is fed into matc
+    val materialDefinition: String
+)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -32,10 +32,10 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class GraphCompiler {
 
-    private int mTextureNumber = 1;
     private StringBuilder mMaterialFunctionBodyBuilder = new StringBuilder();
     private final List<String> mRequiredAttributes = new ArrayList<>();
     private final List<Parameter> mParameters = new ArrayList<>();
+    private final Map<String, Integer> mParameterNumberMap = new HashMap<>();
     private final LinkedHashMap<String, String> mGlobalFunctions = new LinkedHashMap<>();
     private final Map<String, Integer> mVariableNameMap = new HashMap<>();
 
@@ -111,18 +111,18 @@ public final class GraphCompiler {
     }
 
     /**
-     * Called by a NodeModel subclass to add a new material parameter.
+     * Called by a node's compile function to add a new material parameter.
      * The parameter will be added to the material source's "parameters" section.
      *
      * @param type The type of parameter
-     * @return A String representing the name of the parameter variable that the node should use
-     * in its source.
+     * @return A String with the unique name of the parameter that the node should use in code.
      */
-    public String addParameter(String type) {
-        String parameterName = allocateNewParameterName();
-        mParameters.add(new Parameter(type, parameterName));
-        // todo: Handle parameters other than sampler parameters
-        return "materialParams_" + parameterName;
+    @NotNull
+    public Parameter addParameter(@NotNull String type, @NotNull String name) {
+        String parameterName = allocateNewParameterName(name);
+        Parameter parameter = new Parameter(type, parameterName);
+        mParameters.add(parameter);
+        return parameter;
     }
 
     /**
@@ -184,7 +184,16 @@ public final class GraphCompiler {
         provideFunctionDefinition(symbolName, String.format(format, args));
     }
 
-    private String allocateNewParameterName() {
-        return "texture" + mTextureNumber++;
+    /**
+     * Appends an integer to a parameter name to ensure globally-unique names.
+     */
+    private String allocateNewParameterName(String name) {
+        Integer parameterNumber =
+                mParameterNumberMap.computeIfPresent(name, (s, integer) -> integer + 1);
+        if (parameterNumber == null) {
+            parameterNumber = 0;
+            mParameterNumberMap.putIfAbsent(name, parameterNumber);
+        }
+        return name + parameterNumber;
     }
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -16,7 +16,6 @@
 
 package com.google.android.filament.tungsten.compiler;
 
-import com.google.android.filament.tungsten.model.Connection;
 import com.google.android.filament.tungsten.model.Graph;
 import com.google.android.filament.tungsten.model.Node;
 import java.util.ArrayList;
@@ -42,7 +41,6 @@ public final class GraphCompiler {
 
     private final @NotNull Graph mGraph;
     private final @NotNull Node mRootNode;
-    private final Map<Node.InputSlot, Connection> mConnectionMap = new HashMap<>();
     private final Map<Node.OutputSlot, Expression> mCompiledVariableMap = new HashMap<>();
 
     public GraphCompiler(@NotNull Graph graph) {
@@ -51,12 +49,14 @@ public final class GraphCompiler {
     }
 
     @NotNull
-    public String compileGraph() {
+    public CompiledGraph compileGraph() {
         mRootNode.getCompileFunction().invoke(mRootNode, this);
         String fragmentSection = GraphFormatter.formatFragmentSection(mGlobalFunctions.values(),
                 mMaterialFunctionBodyBuilder.toString());
-        return GraphFormatter.formatMaterialSection(mRequiredAttributes, mParameters)
-                + fragmentSection;
+        String materialDefinition =
+                GraphFormatter.formatMaterialSection(mRequiredAttributes, mParameters) +
+                        fragmentSection;
+        return new CompiledGraph(materialDefinition);
     }
 
     /**

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -36,6 +36,7 @@ public final class GraphCompiler {
     private final List<String> mRequiredAttributes = new ArrayList<>();
     private final List<Parameter> mParameters = new ArrayList<>();
     private final Map<String, Integer> mParameterNumberMap = new HashMap<>();
+    private final Map<Node.PropertyHandle, Parameter> mPropertyParameterMap = new HashMap<>();
     private final LinkedHashMap<String, String> mGlobalFunctions = new LinkedHashMap<>();
     private final Map<String, Integer> mVariableNameMap = new HashMap<>();
 
@@ -56,7 +57,7 @@ public final class GraphCompiler {
         String materialDefinition =
                 GraphFormatter.formatMaterialSection(mRequiredAttributes, mParameters) +
                         fragmentSection;
-        return new CompiledGraph(materialDefinition);
+        return new CompiledGraph(materialDefinition, mPropertyParameterMap);
     }
 
     /**
@@ -123,6 +124,16 @@ public final class GraphCompiler {
         Parameter parameter = new Parameter(type, parameterName);
         mParameters.add(parameter);
         return parameter;
+    }
+
+    /**
+    * Associates a material parameter with a Node's property. After the graph is compiled, this
+    * mapping between parameters and properties is returned so that adjustments to a property
+    * can affect the appropriate material parameter.
+    */
+    public void associateParameterWithProperty(@NotNull Parameter parameter,
+            @NotNull Node.PropertyHandle property) {
+        mPropertyParameterMap.put(property, parameter);
     }
 
     /**

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphFormatter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphFormatter.java
@@ -99,8 +99,8 @@ final class GraphFormatter {
 
     private static String formatParameterSource(Parameter p) {
         return indent("{\n"
-                + "    type : " + p.type + ",\n"
-                + "    name : " + p.name + "\n"
+                + "    type : " + p.getType() + ",\n"
+                + "    name : " + p.getName() + "\n"
                 + "}", 4);
     }
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Parameter.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Parameter.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament.tungsten.compiler
+
+data class Parameter(val type: String, val name: String)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
@@ -63,6 +63,10 @@ data class Node(
         }
     }
 
+    data class PropertyHandle(val nodeId: NodeId, val name: String)
+
+    fun getPropertyHandle(name: String) = PropertyHandle(id, name)
+
     fun getInputSlot(name: String) = InputSlot(id, name)
 
     fun getOutputSlot(name: String) = OutputSlot(id, name)
@@ -119,6 +123,9 @@ data class Graph(
 
     fun getNodeWithId(id: NodeId) = nodeMap[id]
 
+    fun getNodeProperty(property: Node.PropertyHandle) =
+            nodeMap[property.nodeId]?.properties?.find { p -> p.name == property.name }
+
     fun getOutputSlotConnectedToInput(slot: Node.InputSlot) = connectionMap[slot]
 
     fun isNodeSelected(node: Node) = selection.contains(node.id)
@@ -146,10 +153,10 @@ data class Graph(
         return this
     }
 
-    fun graphByChangingProperty(id: NodeId, propertyName: String, value: PropertyValue): Graph {
-        val node = nodeMap[id] ?: return this
+    fun graphByChangingProperty(property: Node.PropertyHandle, value: Property): Graph {
+        val node = nodeMap[property.nodeId] ?: return this
         val newProperties = node.properties.map {
-            p -> if (p.name == propertyName) Property(propertyName, value) else p
+            p -> if (p.name == property.name) value else p
         }
         return graphByReplacingNode(node, node.copy(properties = newProperties))
     }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/IPropertiesPresenter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/IPropertiesPresenter.java
@@ -16,9 +16,10 @@
 
 package com.google.android.filament.tungsten.properties;
 
-import com.google.android.filament.tungsten.model.PropertyValue;
+import com.google.android.filament.tungsten.model.Node;
+import com.google.android.filament.tungsten.model.Property;
 
 public interface IPropertiesPresenter {
 
-    void propertyChanged(int nodeId, String propertyName, PropertyValue value);
+    void propertyChanged(Node.PropertyHandle handle, Property property);
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
@@ -45,7 +45,8 @@ class PropertiesPanel : JPanel() {
         for ((property, editor) in node.properties.zip(editors)) {
             editor.setValue(property.value)
             editor.valueChanged = { newValue ->
-                p.propertyChanged(node.id, property.name, newValue)
+                p.propertyChanged(node.getPropertyHandle(property.name),
+                        property.copy(value = newValue))
             }
             add(editor.component)
         }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
@@ -158,7 +158,7 @@ public class GraphPresenter implements IPropertiesPresenter {
             return;
         }
         GraphCompiler compiler = new GraphCompiler(mModel);
-        mCompiledGraph = compiler.compileGraph();
+        mCompiledGraph = compiler.compileGraph().getMaterialDefinition();
         mMaterialSource.setText(mCompiledGraph);
 
         CompletableFuture<Material> futureMaterial = mMaterialManager

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
@@ -25,7 +25,7 @@ import com.google.android.filament.tungsten.model.Connection;
 import com.google.android.filament.tungsten.model.Graph;
 import com.google.android.filament.tungsten.model.GraphInitializer;
 import com.google.android.filament.tungsten.model.Node;
-import com.google.android.filament.tungsten.model.PropertyValue;
+import com.google.android.filament.tungsten.model.Property;
 import com.google.android.filament.tungsten.model.serialization.GraphFile;
 import com.google.android.filament.tungsten.model.serialization.GraphSerializer;
 import com.google.android.filament.tungsten.model.serialization.JsonDeserializer;
@@ -112,8 +112,8 @@ public class GraphPresenter implements IPropertiesPresenter {
      * Action from the view that lets us know a NodeProperty's value has changed.
      */
     @Override
-    public void propertyChanged(int nodeId, String propertyName, PropertyValue value) {
-        mModel = mModel.graphByChangingProperty(nodeId, propertyName, value);
+    public void propertyChanged(Node.PropertyHandle handle, Property property) {
+        mModel = mModel.graphByChangingProperty(handle, property);
         mGraphView.render(mModel);
         mPropertiesPanel.showPropertiesForNode(mModel.getSelectedNodes().get(0));
         recompileGraph();

--- a/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/GraphCompilerTest.kt
+++ b/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/GraphCompilerTest.kt
@@ -17,9 +17,11 @@
 package com.google.android.filament.tungsten.compiler
 
 import com.google.android.filament.tungsten.model.Graph
+import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.createAdderNode
 import com.google.android.filament.tungsten.model.createFloat3ConstantNode
 import com.google.android.filament.tungsten.model.createShaderNode
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class GraphCompilerTest {
@@ -56,4 +58,16 @@ class GraphCompilerTest {
         val compiler = GraphCompiler(graph)
         compiler.compileGraph()
     }
+
+    @Test
+    fun `multiple material parameters have unique names`() {
+        val compiler = GraphCompiler(createMockGraph())
+        val first = compiler.addParameter("float3", "parameter")
+        val second = compiler.addParameter("float3", "parameter")
+        assertNotEquals(first, second)
+    }
+
+    private fun createMockGraph() = Graph(
+            nodes = listOf(Node(id = 0, type = "node")),
+            rootNodeId = 0)
 }


### PR DESCRIPTION
- `GraphCompiler.compile` now returns an instance of `CompiledGraph` that contains the material definition along with a mapping from node properties to material parameters.
- Introduce PropertyHandles- a way to uniquely reference a single property in a graph. This simplifies logic for handling property updates, and in a future CL, with material parameter updating.