### PR TITLE
Fix ambiguities with translate() and scale()

### DIFF
--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -51,7 +51,7 @@ namespace filament {
  *
  *  // set its transform
  *  auto i = tcm.getInstance(object);
- *  tcm.setTransform(i, mat4f::translate(0, 0, -1));
+ *  tcm.setTransform(i, mat4f::translate({ 0, 0, -1 }));
  *
  *  // destroy the transform component
  *  tcm.destroy(object);

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -454,7 +454,7 @@ mat4f ShadowMap::applyLISPSM(CameraInfo const& camera, float dzn, float dzf, mat
         };
 
         const mat4f Wp = warpFrustum(nopt, nopt + d);
-        const mat4f Wv = mat4f::translate(float4{ -p, 1 });
+        const mat4f Wv = mat4f::translate(-p);
         W = Wp * Wv;
     }
     return W;

--- a/libs/math/include/math/TMatHelpers.h
+++ b/libs/math/include/math/TMatHelpers.h
@@ -432,18 +432,6 @@ public:
         return static_cast<BASE<T>&>(*this)[col][row];
     }
 
-    template <typename VEC>
-    static BASE<T> translate(const VEC& t) {
-        BASE<T> r;
-        r[BASE<T>::NUM_COLS-1] = t;
-        return r;
-    }
-
-    template <typename VEC>
-    static constexpr BASE<T> scale(const VEC& s) {
-        return BASE<T>(s);
-    }
-
     friend inline BASE<T> MATH_PURE abs(BASE<T> m) {
         for (size_t col = 0; col < BASE<T>::NUM_COLS; ++col) {
             m[col] = abs(m[col]);

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -252,6 +252,18 @@ public:
         }
         return result != 0;
     }
+
+    template <typename A>
+    static constexpr TMat22 translate(A t) {
+        TMat22 r;
+        r[1] = TVec2<T>{ t, 1 };
+        return r;
+    }
+
+    template <typename A>
+    static constexpr TMat22 scale(A s) {
+        return TMat22{ TVec2<T>{ s, 1 } };
+    }
 };
 
 // ----------------------------------------------------------------------------------------

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -266,6 +266,30 @@ public:
      */
     static constexpr TQuaternion<T> packTangentFrame(const TMat33& m,
             size_t storageSize = sizeof(int16_t));
+
+    template <typename A>
+    static constexpr TMat33 translate(const TVec2<A>& t) {
+        TMat33 r;
+        r[2] = TVec3<T>{ t, 1 };
+        return r;
+    }
+
+    template <typename A>
+    static constexpr TMat33 translate(A t) {
+        TMat33 r;
+        r[2] = TVec3<T>{ t, t, 1 };
+        return r;
+    }
+
+    template <typename A>
+    static constexpr TMat33 scale(const TVec2<A>& s) {
+        return TMat33{ TVec3<T>{ s, 1 } };
+    }
+
+    template <typename A>
+    static constexpr TMat33 scale(A s) {
+        return TMat33{ TVec3<T>{ s, s, 1 } };
+    }
 };
 
 // ----------------------------------------------------------------------------------------

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -318,6 +318,30 @@ public:
     inline constexpr TMat33<T> upperLeft() const {
         return TMat33<T>(m_value[0].xyz, m_value[1].xyz, m_value[2].xyz);
     }
+
+    template <typename A>
+    static constexpr TMat44 translate(const TVec3<A>& t) {
+        TMat44 r;
+        r[3] = TVec4<T>{ t, 1 };
+        return r;
+    }
+
+    template <typename A>
+    static constexpr TMat44 translate(A t) {
+        TMat44 r;
+        r[3] = TVec4<T>{ t, t, t, 1 };
+        return r;
+    }
+
+    template <typename A>
+    static constexpr TMat44 scale(const TVec3<A>& s) {
+        return TMat44{ TVec4<T>{ s, 1 } };
+    }
+
+    template <typename A>
+    static constexpr TMat44 scale(A s) {
+        return TMat44{ TVec4<T>{ s, s, s, 1 } };
+    }
 };
 
 // ----------------------------------------------------------------------------------------

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -516,9 +516,10 @@ do {                                                            \
 TYPED_TEST(MatTestT, Translation4) {
     typedef ::math::details::TMat44<TypeParam> M44T;
     typedef ::math::details::TVec4<TypeParam> V4T;
+    typedef ::math::details::TVec3<TypeParam> V3T;
 
-    V4T translateBy(-7.3, 1.1, 14.4, 0.0);
-    V4T translation(translateBy[0], translateBy[1], translateBy[2], 1.0);
+    V3T translateBy(-7.3, 1.1, 14.4);
+    V3T translation(translateBy[0], translateBy[1], translateBy[2]);
     M44T translation_matrix = M44T::translate(translation);
 
     V4T p1(9.9, 3.1, 41.1, 1.0);
@@ -526,10 +527,38 @@ TYPED_TEST(MatTestT, Translation4) {
     V4T p3(0, 0, 0, 1);
     V4T p4(-1000, -1000, 1000, 1.0);
 
-    EXPECT_VEC_EQ(translation_matrix * p1, translateBy + p1);
-    EXPECT_VEC_EQ(translation_matrix * p2, translateBy + p2);
-    EXPECT_VEC_EQ(translation_matrix * p3, translateBy + p3);
-    EXPECT_VEC_EQ(translation_matrix * p4, translateBy + p4);
+    EXPECT_VEC_EQ((translation_matrix * p1).xyz, translateBy + p1.xyz);
+    EXPECT_VEC_EQ((translation_matrix * p2).xyz, translateBy + p2.xyz);
+    EXPECT_VEC_EQ((translation_matrix * p3).xyz, translateBy + p3.xyz);
+    EXPECT_VEC_EQ((translation_matrix * p4).xyz, translateBy + p4.xyz);
+
+    translation_matrix = M44T::translate(2.7);
+    EXPECT_VEC_EQ((translation_matrix * p1).xyz, V3T{2.7} + p1.xyz);
+}
+
+//------------------------------------------------------------------------------
+// Test some scale stuff.
+TYPED_TEST(MatTestT, Scale4) {
+    typedef ::math::details::TMat44<TypeParam> M44T;
+    typedef ::math::details::TVec4<TypeParam> V4T;
+    typedef ::math::details::TVec3<TypeParam> V3T;
+
+    V3T scaleBy(2.0, 3.0, 4.0);
+    V3T scale(scaleBy[0], scaleBy[1], scaleBy[2]);
+    M44T scale_matrix = M44T::scale(scale);
+
+    V4T p1(9.9, 3.1, 41.1, 1.0);
+    V4T p2(-18.0, 0.0, 1.77, 1.0);
+    V4T p3(0, 0, 0, 1);
+    V4T p4(-1000, -1000, 1000, 1.0);
+
+    EXPECT_VEC_EQ((scale_matrix * p1).xyz, scaleBy * p1.xyz);
+    EXPECT_VEC_EQ((scale_matrix * p2).xyz, scaleBy * p2.xyz);
+    EXPECT_VEC_EQ((scale_matrix * p3).xyz, scaleBy * p3.xyz);
+    EXPECT_VEC_EQ((scale_matrix * p4).xyz, scaleBy * p4.xyz);
+
+    scale_matrix = M44T::scale(3.0);
+    EXPECT_VEC_EQ((scale_matrix * p1).xyz, V3T{3.0} * p1.xyz);
 }
 
 //------------------------------------------------------------------------------
@@ -594,6 +623,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
 
     typedef ::math::details::TMat44<TypeParam> M44T;
     typedef ::math::details::TVec4<TypeParam> V4T;
+    typedef ::math::details::TVec3<TypeParam> V3T;
     typedef ::math::details::TQuaternion<TypeParam> QuatT;
 
     std::default_random_engine generator(112233);
@@ -602,7 +632,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
 
     for (size_t i = 0; i < 100; ++i) {
         M44T r = M44T::eulerZYX(rand_gen(), rand_gen(), rand_gen());
-        M44T t = M44T::translate(V4T(rand_gen(), rand_gen(), rand_gen(), 1));
+        M44T t = M44T::translate(V3T(rand_gen(), rand_gen(), rand_gen()));
         QuatT qr = r.toQuaternion();
         M44T tr = t * r;
         QuatT qtr = tr.toQuaternion();
@@ -614,7 +644,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
     }
 
     M44T r = M44T::eulerZYX(1, 2, 3);
-    M44T t = M44T::translate(V4T(20, -15, 2, 1));
+    M44T t = M44T::translate(V3T(20, -15, 2));
     QuatT qr = r.toQuaternion();
     M44T tr = t * r;
     QuatT qtr = tr.toQuaternion();

--- a/samples/app/CameraManipulator.cpp
+++ b/samples/app/CameraManipulator.cpp
@@ -116,7 +116,7 @@ void CameraManipulator::updateCameraTransform() {
         mat4 rotate_z  = mat4::rotate(mRotation.z, double3(0, 0, 1));
         mat4 rotate_x  = mat4::rotate(mRotation.x, double3(1, 0, 0));
         mat4 rotate_y  = mat4::rotate(mRotation.y, double3(0, 1, 0));
-        mat4 translate = mat4::translate(double4(mTranslation, 1));
+        mat4 translate = mat4::translate(mTranslation);
         mat4 view = translate * (rotate_y * rotate_x * rotate_z);
         mCamera->setModelMatrix(mat4f(view));
         if (mCameraChanged) {

--- a/samples/app/Cube.cpp
+++ b/samples/app/Cube.cpp
@@ -121,7 +121,7 @@ void Cube::mapFrustum(filament::Engine& engine, math::mat4 const& transform) {
 
 
 void Cube::mapAabb(filament::Engine& engine, filament::Box const& box) {
-    mat4 p = mat4::translate(double4{ box.center, 1 }) * mat4::scale(double4{ box.halfExtent, 1 });
+    mat4 p = mat4::translate(box.center) * mat4::scale(box.halfExtent);
     return mapFrustum(engine, p);
 }
 

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -299,7 +299,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         slog.d << "light count = " << n << io::endl;
 
         Entity discoBall = em.create();
-        tcm.create(discoBall, {}, mat4f::translate(float4{ 0, 3, -14, 1 }));
+        tcm.create(discoBall, {}, mat4f::translate(float3{ 0, 3, -14 }));
         auto parent = tcm.getInstance(discoBall);
 
         for (size_t i = 0, c = n; i < c; i++) {
@@ -404,7 +404,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         scene->addEntity(planeRenderable);
 
         tcm.setTransform(tcm.getInstance(planeRenderable),
-                math::mat4f::translate(float4{0, -1, -4, 1}));
+                math::mat4f::translate(float3{0, -1, -4}));
     }
 }
 #pragma clang diagnostic pop
@@ -434,7 +434,7 @@ int main(int argc, char* argv[]) {
         filamentApp.animate([lastTime](filament::Engine* engine, filament::View*, double now) mutable {
             auto& tcm = engine->getTransformManager();
             tcm.setTransform(tcm.getInstance(g_discoBallEntity),
-                    mat4f::translate(float4{ 0, 2, -4, 1 }) *
+                    mat4f::translate(float3{ 0, 2, -4, }) *
                     mat4f::rotate(g_discoAngle, float3{ 0, 1, 0 })
             );
             if (lastTime != 0) {

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -368,7 +368,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
         scene->addEntity(planeRenderable);
 
         tcm.setTransform(tcm.getInstance(planeRenderable),
-                math::mat4f::translate(float4{0, -1, -4, 1}));
+                math::mat4f::translate(float3{0, -1, -4}));
     }
 }
 

--- a/samples/vk_shadowtest.cpp
+++ b/samples/vk_shadowtest.cpp
@@ -172,7 +172,7 @@ static GroundPlane createGroundPlane(Engine* engine) {
         .build(*engine, renderable);
 
     auto& tcm = engine->getTransformManager();
-    tcm.setTransform(tcm.getInstance(renderable), mat4f::translate(float4{0, -1, -4, 1}));
+    tcm.setTransform(tcm.getInstance(renderable), mat4f::translate(float3{0, -1, -4}));
     return {
         .vb = vertexBuffer,
         .ib = indexBuffer,


### PR DESCRIPTION
These two functions expect a vector of the same size as the
matrix's storage vectors (float4 for a mat4f for instance) which
has two major issues:

- The vector must end with 1 for homogeneous coordinates to work
- Passing a single scalar (mat4f::scale(0.5)) creates a matrix
  whose diagonal is set to that scalar, thus breaking homogeneous
  coordinates

With this change scale and translate expect a vector who dimensionality
is 1 less that of the matrix's underlying storage vectors. i.e. a float3
for mat4f.