### PR TITLE
Tungsten: add material parameters editing

### DIFF
--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/Filament.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/Filament.java
@@ -125,6 +125,10 @@ public final class Filament {
         mFilamentThread.start();
     }
 
+    public void assertIsFilamentThread() {
+        assert Thread.currentThread().equals(mFilamentThread);
+    }
+
     private void drainJobQueue() {
         while (!mJobQueue.isEmpty()) {
             Task task = mJobQueue.poll();

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/NodeRegistry.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/NodeRegistry.kt
@@ -20,6 +20,7 @@ import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
 import com.google.android.filament.tungsten.model.createAdderNode
 import com.google.android.filament.tungsten.model.createFloat3ConstantNode
+import com.google.android.filament.tungsten.model.createFloat3ParameterNode
 import com.google.android.filament.tungsten.model.createShaderNode
 import com.google.android.filament.tungsten.model.serialization.INodeFactory
 
@@ -43,6 +44,7 @@ class NodeRegistry : INodeFactory {
         mNodes = listOf(
                 NodeEntry("Add", "adder", createAdderNode),
                 NodeEntry("Constant", "float3Constant", createFloat3ConstantNode),
+                NodeEntry("Float3 parameter", "float3Parameter", createFloat3ParameterNode),
                 NodeEntry("Shader", "shader", createShaderNode)
         )
         nodeLabelsForMenu = mNodes

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
@@ -69,6 +69,14 @@ private val constantFloat3NodeCompile = fun(node: Node, compiler: GraphCompiler)
     return node
 }
 
+private val float3ParameterNodeCompile = fun(node: Node, compiler: GraphCompiler): Node {
+    val parameter = compiler.addParameter("float3", "float3Parameter")
+    compiler.associateParameterWithProperty(parameter, node.getPropertyHandle("value"))
+    compiler.setExpressionForOutputSlot(node.getOutputSlot("result"),
+            Expression("materialParams.${parameter.name}"))
+    return node
+}
+
 val createAdderNode = fun(id: NodeId): Node {
     return Node(
         id = id,
@@ -86,6 +94,16 @@ val createFloat3ConstantNode = fun(id: NodeId): Node {
         compileFunction = constantFloat3NodeCompile,
         outputSlots = listOf("result"),
         properties = listOf(Property("value", Float3()))
+    )
+}
+
+val createFloat3ParameterNode = fun(id: NodeId): Node {
+    return Node(
+        id = id,
+        type = "float3Parameter",
+        compileFunction = float3ParameterNodeCompile,
+        outputSlots = listOf("result"),
+        properties = listOf(Property("value", Float3(), PropertyType.MATERIAL_PARAMETER))
     )
 }
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Properties.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Properties.kt
@@ -16,8 +16,27 @@
 
 package com.google.android.filament.tungsten.model
 
-sealed class PropertyValue
+import com.google.android.filament.MaterialInstance
 
-data class Float3(val x: Float = 0.0f, val y: Float = 0.0f, val z: Float = 0.0f) : PropertyValue()
+sealed class PropertyValue {
 
-data class Property(val name: String, val value: PropertyValue)
+    abstract fun applyToMaterialInstance(materialInstance: MaterialInstance, name: String)
+}
+
+data class Float3(val x: Float = 0.0f, val y: Float = 0.0f, val z: Float = 0.0f) : PropertyValue() {
+
+    override fun applyToMaterialInstance(materialInstance: MaterialInstance, name: String) {
+        materialInstance.setParameter(name, x, y, z)
+    }
+}
+
+enum class PropertyType {
+    GRAPH_PROPERTY,
+    MATERIAL_PARAMETER
+}
+
+data class Property(
+    val name: String,
+    val value: PropertyValue,
+    val type: PropertyType = PropertyType.GRAPH_PROPERTY
+)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
@@ -60,10 +60,10 @@ class PropertiesPanel : JPanel() {
      */
     private fun createEditorsForNode(node: Node) {
         editorCache.computeIfAbsent(node.id) { _ ->
-            node.properties.map { (_, value) ->
-                when (value) {
+            node.properties.map { property ->
+                when (property.value) {
                     // Each PropertyValue type has a 1:1 mapping to a PropertyEditor
-                    is Float3 -> ColorChooser(value)
+                    is Float3 -> ColorChooser(property.value)
                 }
             }
         }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/TungstenPanel.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/TungstenPanel.java
@@ -18,7 +18,6 @@ package com.google.android.filament.tungsten.ui;
 
 import com.google.android.filament.tungsten.MaterialManager;
 import com.google.android.filament.tungsten.compiler.NodeRegistry;
-import com.google.android.filament.tungsten.model.Graph;
 import com.google.android.filament.tungsten.properties.PropertiesPanel;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -42,7 +41,6 @@ public class TungstenPanel extends JPanel {
         JTextArea materialSource = new JTextArea();
         materialSource.setEditable(false);
 
-        Graph model = new Graph();
         MaterialGraphComponent materialGraph = new MaterialGraphComponent();
 
         PropertiesPanel propertiesPanel = new PropertiesPanel();
@@ -56,7 +54,7 @@ public class TungstenPanel extends JPanel {
         editor.addTab("Graph", materialGraph);
         editor.addTab("Source", materialSource);
 
-        GraphPresenter presenter = new GraphPresenter(model, materialGraph, mPreviewMeshPanel,
+        GraphPresenter presenter = new GraphPresenter(materialGraph, mPreviewMeshPanel,
                 materialSource, propertiesPanel, materialManager, file);
         materialGraph.setPresenter(presenter);
         propertiesPanel.setPresenter(presenter);


### PR DESCRIPTION
Node property can now influence a material parameter. Model is now stored in `GraphPresenter` as an `AtomicReference<Graph>` because it is read from the `Filament` thread and written to from the `UI` thread.