### PR TITLE
Add missing include to math/mat3.h

### DIFF
--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -21,6 +21,7 @@
 #include <math/TMatHelpers.h>
 #include <math/vec3.h>
 
+#include <limits.h>
 #include <stdint.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
`CHAR_BIT` is defined in `limits.h`