### PR TITLE
WGL: Match pixel formats across HDC and HGLRC

### DIFF
--- a/filament/src/driver/opengl/ContextManagerWGL.cpp
+++ b/filament/src/driver/opengl/ContextManagerWGL.cpp
@@ -33,7 +33,7 @@ namespace filament {
 using namespace driver;
 
 std::unique_ptr<Driver> ContextManagerWGL::createDriver(void* const sharedGLContext) noexcept {
-    PIXELFORMATDESCRIPTOR pfd = {
+    mPfd = {
         sizeof(PIXELFORMATDESCRIPTOR),
         1,
         PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,    // Flags
@@ -66,8 +66,8 @@ std::unique_ptr<Driver> ContextManagerWGL::createDriver(void* const sharedGLCont
         goto error;
     }
 
-    int pixelFormat = ChoosePixelFormat(whdc, &pfd);
-    SetPixelFormat(whdc, pixelFormat, &pfd);
+    int pixelFormat = ChoosePixelFormat(whdc, &mPfd);
+    SetPixelFormat(whdc, pixelFormat, &mPfd);
 
     // We need a tmp context to retrieve and call wglCreateContextAttribsARB.
     HGLRC tempContext = wglCreateContext(whdc);
@@ -128,6 +128,10 @@ ExternalContext::SwapChain* ContextManagerWGL::createSwapChain(void* nativeWindo
     HDC hdc = (HDC) nativeWindow;
     ASSERT_POSTCONDITION_NON_FATAL(hdc,
             "Unable to create the SwapChain (nativeWindow = %p)", nativeWindow);
+
+	// We have to match pixel formats across the HDC and HGLRC (mContext)
+    int pixelFormat = ChoosePixelFormat(hdc, &mPfd);
+    SetPixelFormat(hdc, pixelFormat, &mPfd);
 
     SwapChain* swapChain = (SwapChain *)hdc;
     return swapChain;

--- a/filament/src/driver/opengl/ContextManagerWGL.h
+++ b/filament/src/driver/opengl/ContextManagerWGL.h
@@ -58,6 +58,7 @@ private:
     HGLRC mContext = NULL;
     HWND mHWnd = NULL;
     HDC mWhdc = NULL;
+    PIXELFORMATDESCRIPTOR mPfd = {};
 };
 
 using ContextManager = filament::ContextManagerWGL;


### PR DESCRIPTION
`wglMakeCurrent` requires the pixel format match between the HGLRC and HDC. Previously, the pixel format of the HDC wasn't explicitly set, and on most implementations, this leads to a failure.

I decided to stash off the PFD, and use that re-query the pixel format index from the WGL layer. The PFD and pixel format index are both required in order to call `SetPixelFormat`.

Alternative solutions:
* Stash off the pixel format index. This saves a call to `ChoosePixelFormat` in `ContextManagerWGL::createSwapChain`. _Technically_, the index is dependent on the HDC as well, and the HDC does change between calls to `ChoosePixelFormat`. However, I can't imagine any implementation deciding to change their pixel format indices across HDCs sourced from similar windows (dangerous assumption)
* Make the PFD static to the file. Fine for now, but perhaps there is flexibility desired in the future.

Tested against material_sandbox, two different Windows PCs with different GPU vendors.