### PR TITLE
Fix binding of integer attributes

### DIFF
--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -84,7 +84,7 @@ public:
             uint8_t stride = 0;
             uint8_t buffer = 0;
             AttributeType type = AttributeType::FLOAT4;
-            bool normalized = false;
+            uint8_t flags = 0x0; // See Driver::Attribute
         };
     };
 

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -33,6 +33,10 @@ struct VertexBuffer::BuilderDetails {
     uint8_t mBufferCount = 0;
 };
 
+static bool hasIntegerTarget(VertexAttribute attribute) {
+    return attribute == BONE_INDICES;
+}
+
 using BuilderType = VertexBuffer;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
@@ -81,6 +85,9 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         entry.offset = byteOffset;
         entry.stride = byteStride;
         entry.type = attributeType;
+        if (hasIntegerTarget(attribute)) {
+            entry.flags |= Driver::Attribute::FLAG_INTEGER_TARGET;
+        }
         mImpl->mDeclaredAttributes.set(attribute);
     }
     return *this;
@@ -89,7 +96,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
 VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribute) noexcept {
     if (size_t(attribute) < MAX_ATTRIBUTE_BUFFERS_COUNT) {
         AttributeData& entry = mImpl->mAttributes[attribute];
-        entry.normalized = true;
+        entry.flags |= Driver::Attribute::FLAG_NORMALIZED;
     }
     return *this;
 }
@@ -132,8 +139,8 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
             attributeArray[i].offset = attributes[i].offset;
             attributeArray[i].stride = attributes[i].stride;
             attributeArray[i].buffer = attributes[i].buffer;
-            attributeArray[i].type = attributes[i].type;
-            attributeArray[i].normalized = attributes[i].normalized;
+            attributeArray[i].type   = attributes[i].type;
+            attributeArray[i].flags  = attributes[i].flags;
         }
     }
 

--- a/filament/src/driver/Driver.h
+++ b/filament/src/driver/Driver.h
@@ -100,11 +100,13 @@ public:
     using StreamHandle          = Handle<HwStream>;
 
     struct Attribute {
+        static constexpr uint8_t FLAG_NORMALIZED     = 0x1;
+        static constexpr uint8_t FLAG_INTEGER_TARGET = 0x2;
         uint32_t offset = 0;
         uint8_t stride = 0;
         uint8_t buffer = 0xFF;
         ElementType type = ElementType::BYTE;
-        bool normalized = false;
+        uint8_t flags = 0x0;
     };
 
     using AttributeArray = std::array<Attribute, MAX_ATTRIBUTE_BUFFER_COUNT>;

--- a/filament/src/driver/DriverBase.h
+++ b/filament/src/driver/DriverBase.h
@@ -48,7 +48,7 @@ struct HwBase {
 struct HwVertexBuffer : public HwBase {
     static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = Driver::MAX_ATTRIBUTE_BUFFER_COUNT;
 
-    Driver::AttributeArray attributes;    // 8*6
+    Driver::AttributeArray attributes;    // 8*8
     uint32_t vertexCount;                 //   4
     uint8_t bufferCount;                  //   1
     uint8_t attributeCount;               //   1

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1773,12 +1773,20 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
                 uint8_t bi = eb->attributes[i].buffer;
                 assert(bi != 0xFF);
                 bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[bi]);
-                glVertexAttribPointer(GLuint(i),
-                        getComponentCount(eb->attributes[i].type),
-                        getComponentType(eb->attributes[i].type),
-                        getNormalization(eb->attributes[i].normalized),
-                        eb->attributes[i].stride,
-                        (void*)uintptr_t(eb->attributes[i].offset));
+                if (UTILS_UNLIKELY(eb->attributes[i].flags & Attribute::FLAG_INTEGER_TARGET)) {
+                    glVertexAttribIPointer(GLuint(i),
+                            getComponentCount(eb->attributes[i].type),
+                            getComponentType(eb->attributes[i].type),
+                            eb->attributes[i].stride,
+                            (void*) uintptr_t(eb->attributes[i].offset));
+                } else {
+                    glVertexAttribPointer(GLuint(i),
+                            getComponentCount(eb->attributes[i].type),
+                            getComponentType(eb->attributes[i].type),
+                            getNormalization(eb->attributes[i].flags & Attribute::FLAG_NORMALIZED),
+                            eb->attributes[i].stride,
+                            (void*) uintptr_t(eb->attributes[i].offset));
+                }
 
                 enableVertexAttribArray(GLuint(i));
             } else {

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -667,7 +667,7 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
         varray.attributes[bufferIndex] = {
             .location = attribIndex, // matches the GLSL layout specifier
             .binding = bufferIndex,  // matches the position within vkCmdBindVertexBuffers
-            .format = getVkFormat(attrib.type, attrib.normalized),
+            .format = getVkFormat(attrib.type, attrib.flags & Driver::Attribute::FLAG_NORMALIZED),
             .offset = 0
         };
         varray.buffers[bufferIndex] = {

--- a/libs/filabridge/include/filament/EngineEnums.h
+++ b/libs/filabridge/include/filament/EngineEnums.h
@@ -21,13 +21,15 @@
 
 namespace filament {
 
+// Update hasIntegerTarget() in VertexBuffer when adding an attribute that will
+// be read as integers in the shaders
 enum VertexAttribute : uint8_t {
     POSITION        = 0, // XYZ position (float3)
     TANGENTS        = 1, // tangent, bitangent and normal, encoded as a quaternion (float4)
     COLOR           = 2, // vertex color (float4)
     UV0             = 3, // texture coordinates (float2)
     UV1             = 4, // texture coordinates (float2)
-    BONE_INDICES    = 5, // indices of 4 bones (uvec4)
+    BONE_INDICES    = 5, // indices of 4 bones, as unsigned integers (uvec4)
     BONE_WEIGHTS    = 6, // weights of the 4 bones (normalized float4)
 };
 

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -77,10 +77,10 @@ struct RenderPassParams {
     };
     static constexpr uint8_t DEPENDENCY_BY_REGION = 1; // see "framebuffer-local" in Vulkan spec.
     // Viewport (16 bytes)
-    int32_t left;
-    int32_t bottom;
-    uint32_t width;
-    uint32_t height;
+    int32_t left = 0;
+    int32_t bottom = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
     // Clear values (32 bytes)
     math::float4 clearColor = {};
     double clearDepth = 1.0;


### PR DESCRIPTION
According to the spec, an attribute declared as an integer (ivec* or uvec* in the shaders) but be bound using `glVertexAttribIPointer` instead of `glVertexAttribPointer`. This means we were not binding bone indices correctly for GPU skinning. This issue was hidden by lenient drivers, particularly on Android.