### PR TITLE
Properly initialize VulkanBinder::mDescriptorKey

### DIFF
--- a/filament/src/driver/vulkan/VulkanBinder.cpp
+++ b/filament/src/driver/vulkan/VulkanBinder.cpp
@@ -56,6 +56,8 @@ VulkanBinder::VulkanBinder() : mDefaultRasterState(createDefaultRasterState()) {
     mShaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     mShaderStages[1].pName = "main";
     resetBindings();
+
+	mDescriptorKey = {};
 }
 
 VulkanBinder::~VulkanBinder() {

--- a/filament/src/driver/vulkan/VulkanBinder.cpp
+++ b/filament/src/driver/vulkan/VulkanBinder.cpp
@@ -57,7 +57,7 @@ VulkanBinder::VulkanBinder() : mDefaultRasterState(createDefaultRasterState()) {
     mShaderStages[1].pName = "main";
     resetBindings();
 
-	mDescriptorKey = {};
+    mDescriptorKey = {};
 }
 
 VulkanBinder::~VulkanBinder() {


### PR DESCRIPTION
Previously, the contents of mDescriptorKey were not being initialized during VulkanBinder construction. This could leads to bugs, such as getOrCreateDescriptor finding false entries inside the DescriptorKey::uniformBuffers or DescriptorKey::samplers arrays.

I found the issue on Win10 Vulkan.  Both the AMD ICD and VK_LAYER_LUNARG_standard_validation layer complained about issues that manifested in vkUpdateDescriptorSets.