### PR TITLE
Tungsten: introduce handling for varying dimensionality

### DIFF
--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
@@ -16,4 +16,7 @@
 
 package com.google.android.filament.tungsten.compiler
 
-class Expression(val symbol: String)
+class Expression(
+    val symbol: String,
+    val dimensions: Int
+)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
@@ -27,9 +27,7 @@ open class Expression(
     val rgb get() = conform(3)
     val rgba get() = conform(4)
 
-    override fun toString(): String {
-        return symbol
-    }
+    override fun toString() = symbol
 
     private fun conform(components: Int): Expression {
         if (dimensions == components) return this
@@ -66,13 +64,9 @@ private fun createFloatLiteral(dimensions: Int): String {
 class Literal(dimensions: Int) : Expression(
         dimensions = dimensions, symbol = createFloatLiteral(dimensions)) {
 
-    override fun shorten(components: Int): Expression {
-        return Literal(dimensions = components)
-    }
+    override fun shorten(components: Int) = Literal(dimensions = components)
 
-    override fun lengthen(components: Int): Expression {
-        return Literal(dimensions = components)
-    }
+    override fun lengthen(components: Int) = Literal(dimensions = components)
 }
 
 /**

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
@@ -16,7 +16,74 @@
 
 package com.google.android.filament.tungsten.compiler
 
-class Expression(
-    val symbol: String,
-    val dimensions: Int
-)
+// TODO: support other data types- expression assumes a float vector
+
+open class Expression(
+    open val symbol: String,
+    open val dimensions: Int
+) {
+    val r get() = conform(1)
+    val rg get() = conform(2)
+    val rgb get() = conform(3)
+    val rgba get() = conform(4)
+
+    override fun toString(): String {
+        return symbol
+    }
+
+    private fun conform(components: Int): Expression {
+        if (dimensions == components) return this
+        return if (dimensions > components) {
+            shorten(components)
+        } else {
+            lengthen(components)
+        }
+    }
+
+    open fun lengthen(components: Int): Expression {
+        val componentsToAdd = components - dimensions
+        val extraComponents = ", 0.0".repeat(componentsToAdd)
+        return Expression(symbol = "float$components($symbol$extraComponents)",
+                dimensions = components)
+    }
+
+    open fun shorten(components: Int): Expression {
+        val swizzle = when (components) {
+            1 -> ".r"
+            2 -> ".rg"
+            3 -> ".rgb"
+            else -> ""
+        }
+        return Expression(symbol = "$symbol$swizzle", dimensions = components)
+    }
+}
+
+private fun createFloatLiteral(dimensions: Int): String {
+    val zeroes = "0.0, ".repeat(maxOf(dimensions - 1, 0)) + "0.0"
+    return "float$dimensions($zeroes)"
+}
+
+class Literal(dimensions: Int) : Expression(
+        dimensions = dimensions, symbol = createFloatLiteral(dimensions)) {
+
+    override fun shorten(components: Int): Expression {
+        return Literal(dimensions = components)
+    }
+
+    override fun lengthen(components: Int): Expression {
+        return Literal(dimensions = components)
+    }
+}
+
+/**
+ * Make two expressions the same dimensionality by trimming the higher dimension expression.
+ */
+fun trim(a: Expression, b: Expression): Pair<Expression, Expression> {
+    if (a.dimensions == b.dimensions) return Pair(a, b)
+    val dimensions = Math.min(a.dimensions, b.dimensions)
+    return if (a.dimensions < b.dimensions) {
+        Pair(a, b.shorten(dimensions))
+    } else {
+        Pair(a.shorten(dimensions), b)
+    }
+}

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -18,6 +18,7 @@ package com.google.android.filament.tungsten.compiler;
 
 import com.google.android.filament.tungsten.model.Graph;
 import com.google.android.filament.tungsten.model.Node;
+import com.google.android.filament.tungsten.model.Slot;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -42,7 +43,7 @@ public final class GraphCompiler {
 
     private final @NotNull Graph mGraph;
     private final @NotNull Node mRootNode;
-    private final Map<Node.OutputSlot, Expression> mCompiledVariableMap = new HashMap<>();
+    private final Map<Slot, Expression> mCompiledVariableMap = new HashMap<>();
 
     public GraphCompiler(@NotNull Graph graph) {
         mGraph = graph;
@@ -65,8 +66,7 @@ public final class GraphCompiler {
      * @return null, if the InputSlot is not connected to any OutputSlot, otherwise an Expression.
      */
     @Nullable
-    // todo: rename to compileAndRetrieveExpression
-    public Expression compileAndRetrieveVariable(@NotNull Node.InputSlot slot) {
+    public Expression compileAndRetrieveExpression(@NotNull Node.InputSlot slot) {
         Node.OutputSlot outputSlot = mGraph.getOutputSlotConnectedToInput(slot);
         if (outputSlot == null) {
             return null;
@@ -95,8 +95,7 @@ public final class GraphCompiler {
         return compiledExpression;
     }
 
-    public void setExpressionForOutputSlot(@NotNull Node.OutputSlot slot,
-            @NotNull Expression expression) {
+    public void setExpressionForSlot(@NotNull Slot slot, @NotNull Expression expression) {
         mCompiledVariableMap.put(slot, expression);
     }
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -65,6 +65,7 @@ public final class GraphCompiler {
      * @return null, if the InputSlot is not connected to any OutputSlot, otherwise an Expression.
      */
     @Nullable
+    // todo: rename to compileAndRetrieveExpression
     public Expression compileAndRetrieveVariable(@NotNull Node.InputSlot slot) {
         Node.OutputSlot outputSlot = mGraph.getOutputSlotConnectedToInput(slot);
         if (outputSlot == null) {

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/NodeRegistry.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/NodeRegistry.kt
@@ -19,6 +19,7 @@ package com.google.android.filament.tungsten.compiler
 import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
 import com.google.android.filament.tungsten.model.createAdderNode
+import com.google.android.filament.tungsten.model.createFloat2ConstantNode
 import com.google.android.filament.tungsten.model.createFloat3ConstantNode
 import com.google.android.filament.tungsten.model.createFloat3ParameterNode
 import com.google.android.filament.tungsten.model.createShaderNode
@@ -43,7 +44,8 @@ class NodeRegistry : INodeFactory {
     init {
         mNodes = listOf(
                 NodeEntry("Add", "adder", createAdderNode),
-                NodeEntry("Constant", "float3Constant", createFloat3ConstantNode),
+                NodeEntry("Constant float2", "float2Constant", createFloat2ConstantNode),
+                NodeEntry("Constant float3", "float3Constant", createFloat3ConstantNode),
                 NodeEntry("Float3 parameter", "float3Parameter", createFloat3ParameterNode),
                 NodeEntry("Shader", "shader", createShaderNode)
         )

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
@@ -31,7 +31,7 @@ private val adderNodeCompile = fun(node: Node, compiler: GraphCompiler): Node {
     val temp = compiler.getNewTemporaryVariableName("adder")
     compiler.addCodeToMaterialFunctionBody("float3 $temp = $aExpression + $bExpression;\n")
 
-    compiler.setExpressionForOutputSlot(outputSlot, Expression(temp))
+    compiler.setExpressionForOutputSlot(outputSlot, Expression(temp, 3))
 
     return node
 }
@@ -65,7 +65,7 @@ private val constantFloat3NodeCompile = fun(node: Node, compiler: GraphCompiler)
     compiler.addCodeToMaterialFunctionBody(
             "float3 $outputVariable = float3(${color.x}, ${color.y}, ${color.z});\n")
 
-    compiler.setExpressionForOutputSlot(outputSlot, Expression(outputVariable))
+    compiler.setExpressionForOutputSlot(outputSlot, Expression(outputVariable, 3))
     return node
 }
 
@@ -73,7 +73,7 @@ private val float3ParameterNodeCompile = fun(node: Node, compiler: GraphCompiler
     val parameter = compiler.addParameter("float3", "float3Parameter")
     compiler.associateParameterWithProperty(parameter, node.getPropertyHandle("value"))
     compiler.setExpressionForOutputSlot(node.getOutputSlot("result"),
-            Expression("materialParams.${parameter.name}"))
+            Expression("materialParams.${parameter.name}", 3))
     return node
 }
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
@@ -85,6 +85,21 @@ private val float3ParameterNodeCompile = fun(node: Node, compiler: GraphCompiler
     compiler.associateParameterWithProperty(parameter, node.getPropertyHandle("value"))
     compiler.setExpressionForSlot(node.getOutputSlot("result"),
             Expression("materialParams.${parameter.name}", 3))
+
+    return node
+}
+
+private val constantFloat2NodeCompile = fun(node: Node, compiler: GraphCompiler): Node {
+    val outputSlot = node.getOutputSlot("result")
+
+    val color = (node.properties[0].value as Float3)
+
+    val outputVariable = compiler.getNewTemporaryVariableName("float2Constant")
+    compiler.addCodeToMaterialFunctionBody(
+            "float2 $outputVariable = float2(${color.x}, ${color.y});\n")
+
+    compiler.setExpressionForSlot(outputSlot, Expression(outputVariable, 2))
+
     return node
 }
 
@@ -115,6 +130,16 @@ val createFloat3ParameterNode = fun(id: NodeId): Node {
         compileFunction = float3ParameterNodeCompile,
         outputSlots = listOf("result"),
         properties = listOf(Property("value", Float3(), PropertyType.MATERIAL_PARAMETER))
+    )
+}
+
+val createFloat2ConstantNode = fun(id: NodeId): Node {
+    return Node(
+            id = id,
+            type = "float2Constant",
+            compileFunction = constantFloat2NodeCompile,
+            outputSlots = listOf("result"),
+            properties = listOf(Property("value", Float3()))
     )
 }
 

--- a/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/ExpressionTest.kt
+++ b/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/ExpressionTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament.tungsten.compiler
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExpressionTest {
+
+    @Test
+    fun `toString returns the symbol`() {
+        assertEquals("float3(1.0, 2.0, 3.0)", Expression("float3(1.0, 2.0, 3.0)", 3).toString())
+    }
+
+    @Test
+    fun `swizzle to a lower dimension`() {
+        assertEquals("exp.rg", "${Expression("exp", 4).rg}")
+    }
+
+    @Test
+    fun `swizzle to a higher dimension`() {
+        assertEquals("float4(exp, 0.0, 0.0)", "${Expression("exp", 2).rgba}")
+    }
+
+    @Test
+    fun `swizzling a literal returns a new literal`() {
+        assertEquals("float2(0.0, 0.0)", "${Literal(4).rg}")
+        assertEquals("float3(0.0, 0.0, 0.0)", "${Literal(1).rgb}")
+    }
+}


### PR DESCRIPTION
The Adder node can now add `float` vectors of different lengths by trimming them to the same dimensionality. We can change this behavior in the future, or introduce different nodes (like a "mix" node) that address differing vector lengths in different ways.