### PR TITLE
Exclude comments from brace parsing in vertex/fragment blocks

### DIFF
--- a/tools/matc/src/matc/JsonishLexeme.h
+++ b/tools/matc/src/matc/JsonishLexeme.h
@@ -63,7 +63,7 @@ public:
         }
         const char *start = (*mStart == '"') ? mStart + 1 : mStart;
         const char *end = (*mEnd == '"') ? mEnd - 1 : mEnd;
-        return JsonLexeme(mType, start, end, mLineNumber, mPosition);
+        return { mType, start, end, mLineNumber, mPosition };
     }
 
 };

--- a/tools/matc/src/matc/Lexer.h
+++ b/tools/matc/src/matc/Lexer.h
@@ -27,7 +27,7 @@ namespace matc {
 template <class T>
 class Lexer {
 public:
-    virtual ~Lexer() {}
+    virtual ~Lexer() = default;
 
     void lex(const char* text, size_t size, size_t lineOffset = 1) {
         mCursor = text;
@@ -101,15 +101,14 @@ protected:
     // this method was called. This method can return false if it wishes lexing to stop.
     virtual bool readLexeme() noexcept = 0;
 
-    inline void skipWhiteSpace() {
+    void skipWhiteSpace() {
         while (mCursor < mEnd && isWhiteSpaceCharacter(*mCursor)) {
             consume();
         }
 
         // If a comment marker is detected "//", skip until the next return
         // carriage is encountered.
-        if (hasMore() && *mCursor == '/' && mCursor < (mEnd - 1)
-                && *(mCursor+1) == '/') {
+        if (hasMore() && *mCursor == '/' && mCursor < (mEnd - 1) && *(mCursor + 1) == '/') {
             skipUntilEndOfLine();
             skipWhiteSpace();
         }
@@ -120,7 +119,7 @@ protected:
     std::vector<T> mLexemes;
 
     size_t mLineCounter = 1;
-    size_t mLinePosition;
+    size_t mLinePosition = 0;
 };
 }
 

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -87,20 +87,20 @@ bool MaterialCompiler::processMaterial(const MaterialLexeme& jsonLexeme,
 bool MaterialCompiler::processVertexShader(const MaterialLexeme& lexeme,
         MaterialBuilder& builder) const noexcept {
 
-    MaterialLexeme trimedLexeme = lexeme.trimBlockMarkers();
-    std::string shaderStr = trimedLexeme.getStringValue();
+    MaterialLexeme trimmedLexeme = lexeme.trimBlockMarkers();
+    std::string shaderStr = trimmedLexeme.getStringValue();
 
-    builder.materialVertex(shaderStr.c_str(), trimedLexeme.getLine() + 1);
+    builder.materialVertex(shaderStr.c_str(), trimmedLexeme.getLine() + 1);
     return true;
 }
 
 bool MaterialCompiler::processFragmentShader(const MaterialLexeme& lexeme,
         MaterialBuilder& builder) const noexcept {
 
-    MaterialLexeme trimedLexeme = lexeme.trimBlockMarkers();
-    std::string shaderStr = trimedLexeme.getStringValue();
+    MaterialLexeme trimmedLexeme = lexeme.trimBlockMarkers();
+    std::string shaderStr = trimmedLexeme.getStringValue();
 
-    builder.material(shaderStr.c_str(), trimedLexeme.getLine() + 1);
+    builder.material(shaderStr.c_str(), trimmedLexeme.getLine() + 1);
     return true;
 }
 
@@ -175,7 +175,7 @@ bool MaterialCompiler::processFragmentShaderJSON(const JsonishValue* value,
     return true;
 }
 
-bool MaterialCompiler::ignoreLexemeJSON(const JsonishValue* value,
+bool MaterialCompiler::ignoreLexemeJSON(const JsonishValue*,
         filamat::MaterialBuilder& builder) const noexcept {
     return true;
 }
@@ -189,18 +189,18 @@ static bool reflectParameters(const MaterialBuilder& builder) {
     for (uint8_t i = 0; i < count; i++) {
         const MaterialBuilder::Parameter& parameter = parameters[i];
         std::cout << "    {" << std::endl;
-        std::cout << "      \"name\": \"" << parameter.name.c_str() << "\"," << std::endl;
+        std::cout << R"(      "name": ")" << parameter.name.c_str() << "\"," << std::endl;
         if (parameter.isSampler) {
-            std::cout << "      \"type\": \"" <<
+            std::cout << R"(      "type": ")" <<
                       Enums::toString(parameter.samplerType) << "\"," << std::endl;
-            std::cout << "      \"format\": \"" <<
+            std::cout << R"(      "format": ")" <<
                       Enums::toString(parameter.samplerFormat) << "\"," << std::endl;
-            std::cout << "      \"precision\": \"" <<
+            std::cout << R"(      "precision": ")" <<
                       Enums::toString(parameter.samplerPrecision) << "\"" << std::endl;
         } else {
-            std::cout << "      \"type\": \"" <<
+            std::cout << R"(      "type": ")" <<
                       Enums::toString(parameter.uniformType) << "\"," << std::endl;
-            std::cout << "      \"size\": \"" << parameter.size << "\"" << std::endl;
+            std::cout << R"(      "size": ")" << parameter.size << "\"" << std::endl;
         }
         std::cout << "    }";
         if (i < count - 1) std::cout << ",";
@@ -232,20 +232,17 @@ bool MaterialCompiler::isValidJsonStart(const char* buffer, size_t size) const n
     }
 
     // boolean true
-    if (c == 't' && (end - buffer) > 3 && strncmp(buffer, "true", 4)) {
+    if (c == 't' && (end - buffer) > 3 && strncmp(buffer, "true", 4) != 0) {
         return true;
     }
 
     // boolean false
-    if (c == 'f' && (end - buffer) > 4 && strncmp(buffer, "false", 5)) {
+    if (c == 'f' && (end - buffer) > 4 && strncmp(buffer, "false", 5) != 0) {
         return true;
     }
 
     // null literal
-    if (c == 'n' && (end - buffer) > 3 && strncmp(buffer, "null", 5)) {
-        return true;
-    }
-    return false;
+    return c == 'n' && (end - buffer) > 3 && strncmp(buffer, "null", 5) != 0;
 }
 
 bool MaterialCompiler::run(const Config& config) {

--- a/tools/matc/src/matc/MaterialCompiler.h
+++ b/tools/matc/src/matc/MaterialCompiler.h
@@ -36,7 +36,7 @@ class JsonishValue;
 class MaterialCompiler final: public Compiler {
 public:
     MaterialCompiler();
-    ~MaterialCompiler();
+    ~MaterialCompiler() override;
 
     bool run(const Config& config) override;
     bool checkParameters(const Config& config) override;

--- a/tools/matc/src/matc/MaterialLexeme.h
+++ b/tools/matc/src/matc/MaterialLexeme.h
@@ -29,20 +29,12 @@ enum MaterialType {
 
 class MaterialLexeme final: public Lexeme<MaterialType> {
 public:
-    static const char* getTypeString(MaterialType type) {
-        switch (type) {
-            case BLOCK: return "BLOCK";
-            case IDENTIFIER: return "IDENTIFIER";
-            case UNKNOWN: return "UNKNOWN";
-        }
-    }
-
     MaterialLexeme(MaterialType type, const char* start, const char* end, size_t line, size_t pos) :
             Lexeme(type, start, end, line, pos) {
     }
 
     MaterialLexeme trimBlockMarkers() const {
-        return MaterialLexeme(mType, mStart + 1, mEnd - 1, mLineNumber, mPosition);
+        return { mType, mStart + 1, mEnd - 1, mLineNumber, mPosition };
     }
 };
 

--- a/tools/matc/src/matc/MaterialLexer.cpp
+++ b/tools/matc/src/matc/MaterialLexer.cpp
@@ -20,22 +20,26 @@ namespace matc {
 
 void MaterialLexer::readBlock() noexcept {
     size_t braceCount = 0;
-     while(hasMore()) {
+     while (hasMore()) {
+         skipWhiteSpace();
+
          if (*mCursor == '{') {
              braceCount++;
          }  else if (*mCursor == '}') {
              braceCount--;
          }
+
          if (braceCount == 0) {
              consume();
              break;
          }
+
          consume();
      }
 }
 
 void MaterialLexer::readIdentifier() noexcept {
-    while(hasMore() && isAphaNumericCharacter(*mCursor)) {
+    while (hasMore() && isAphaNumericCharacter(*mCursor)) {
         consume();
     }
 }
@@ -45,8 +49,7 @@ void MaterialLexer::readUnknown() noexcept {
 }
 
 bool MaterialLexer::peek(MaterialType* type) const noexcept {
-    if (!hasMore())
-        return false;
+    if (!hasMore()) return false;
 
     char c = *mCursor;
     if (isAlphaCharacter(c)) {
@@ -56,6 +59,7 @@ bool MaterialLexer::peek(MaterialType* type) const noexcept {
     } else {
         *type = MaterialType::UNKNOWN;
     }
+
     return true;
 }
 
@@ -72,16 +76,15 @@ bool MaterialLexer::readLexeme() noexcept {
     size_t line = getLine();
     size_t cursor = getCursor();
     switch (nextMaterialType) {
-        case MaterialType::BLOCK :     readBlock();       break;
-        case MaterialType::IDENTIFIER: readIdentifier();  break;
-        case MaterialType::UNKNOWN:    readUnknown();     break;
-        default  :
+        case MaterialType::BLOCK :     readBlock();      break;
+        case MaterialType::IDENTIFIER: readIdentifier(); break;
+        case MaterialType::UNKNOWN:    readUnknown();    break;
+        default:
             break;
     }
-    mLexemes.push_back(MaterialLexeme(
-            nextMaterialType, lexemeStart, mCursor - 1, line, cursor));
+    mLexemes.emplace_back(nextMaterialType, lexemeStart, mCursor - 1, line, cursor);
 
-    return (nextMaterialType != UNKNOWN);
+    return nextMaterialType != UNKNOWN;
 }
 
 } // namespace matc


### PR DESCRIPTION
If a comment contained an opening brace { but not the matching
closing one, matc would not count braces properly and not find
the proper end of a vertex/fragment block.

This change also cleans up the code a bit.

Fixes #159 