### PR TITLE
Fixes minor error in spelling of stitch

### DIFF
--- a/tools/cmgen/src/Cubemap.cpp
+++ b/tools/cmgen/src/Cubemap.cpp
@@ -97,7 +97,7 @@ Cubemap::Address Cubemap::getAddressFor(const double3& r) {
 void Cubemap::makeSeamless() {
     Geometry geometry = mGeometry;
     size_t dim = getDimensions();
-    auto stich = [ & ](void* dst, size_t incDst, void const* src, ssize_t incSrc) {
+    auto stitch = [ & ](void* dst, size_t incDst, void const* src, ssize_t incSrc) {
         for (size_t i = 0; i < dim; ++i) {
             *(Texel*)dst = *(Texel*)src;
             dst = ((uint8_t*)dst + incDst);
@@ -110,36 +110,36 @@ void Cubemap::makeSeamless() {
 
     if (geometry == Geometry::HORIZONTAL_CROSS ||
         geometry == Geometry::VERTICAL_CROSS) {
-        stich(  getImageForFace(Face::NX).getPixelRef(0, dim), bpp,
+        stitch(  getImageForFace(Face::NX).getPixelRef(0, dim), bpp,
                 getImageForFace(Face::NY).getPixelRef(0, dim - 1), -bpr);
 
-        stich(  getImageForFace(Face::PY).getPixelRef(dim, 0), bpr,
+        stitch(  getImageForFace(Face::PY).getPixelRef(dim, 0), bpr,
                 getImageForFace(Face::PX).getPixelRef(dim - 1, 0), -bpp);
 
-        stich(  getImageForFace(Face::PX).getPixelRef(0, dim), bpp,
+        stitch(  getImageForFace(Face::PX).getPixelRef(0, dim), bpp,
                 getImageForFace(Face::NY).getPixelRef(dim - 1, 0), bpr);
 
-        stich(  getImageForFace(Face::NY).getPixelRef(dim, 0), bpr,
+        stitch(  getImageForFace(Face::NY).getPixelRef(dim, 0), bpr,
                 getImageForFace(Face::PX).getPixelRef(0, dim - 1), bpp);
 
         if (geometry == Geometry::HORIZONTAL_CROSS) { // horizontal cross
-            stich(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
+            stitch(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
                     getImageForFace(Face::NY).getPixelRef(dim - 1, dim - 1), -bpp);
 
-            stich(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
+            stitch(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
                     getImageForFace(Face::NX).getPixelRef(0, 0), bpr);
 
-            stich(  getImageForFace(Face::NY).getPixelRef(0, dim), bpp,
+            stitch(  getImageForFace(Face::NY).getPixelRef(0, dim), bpp,
                     getImageForFace(Face::NZ).getPixelRef(dim - 1, dim - 1), -bpp);
 
         } else {
-            stich(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
+            stitch(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
                     getImageForFace(Face::PY).getPixelRef(0, dim - 1), bpp);
 
-            stich(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
+            stitch(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
                     getImageForFace(Face::PX).getPixelRef(dim - 1, dim - 1), -bpr);
 
-            stich(  getImageForFace(Face::PX).getPixelRef(dim, 0), bpr,
+            stitch(  getImageForFace(Face::PX).getPixelRef(dim, 0), bpr,
                     getImageForFace(Face::NZ).getPixelRef(dim - 1, dim - 1), -bpr);
         }
     }


### PR DESCRIPTION
Fixes a minor error in the spelling of `stitch`, it was spelled as `stich`, in `cmgen`.