### PR TITLE
WebGL demos now decode PNG in C.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,7 @@ endif()
 set (FILAMENT_SAMPLES_BINARY_DIR ${PROJECT_BINARY_DIR}/samples)
 
 if (WEBGL)
+    add_subdirectory(${EXTERNAL}/stb/tnt)
     add_subdirectory(${FILAMENT}/samples/web)
 endif()
 

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -77,27 +77,21 @@ add_custom_command(
     DEPENDS filamesh)
 
 # Next build two cubemaps:
-#  (1) single miplevel of blurry skybox (png)
-#  (2) all miplevels for the IBL (rgbm)
+#  (1) single miplevel of blurry skybox
+#  (2) all miplevels for the IBL
 
 set(source_envmap "${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/environments/syferfontein_18d_clear_2k.hdr")
 
 foreach(FACE nx ny nz px py pz)
-    set(target_skybox ${target_skybox} public/syferfontein_18d_clear_2k/${FACE}.png)
+    set(target_skybox ${target_skybox} public/syferfontein_18d_clear_2k/${FACE}.rgbm)
     foreach(MIP 0 1 2 3 4 5 6 7 8)
         set(target_envmap ${target_envmap} public/syferfontein_18d_clear_2k/m${MIP}_${FACE}.rgbm)
     endforeach()
 endforeach()
 
 add_custom_command(
-    OUTPUT ${target_envmap}
-    COMMAND cmgen -x public --format=rgbm --size=256 ${source_envmap} 
-    MAIN_DEPENDENCY ${source_envmap}
-    DEPENDS cmgen)
-
-add_custom_command(
-    OUTPUT ${target_skybox}
-    COMMAND cmgen -x public --format=png --size=512 --extract-blur=0.1 ${source_envmap} 
+    OUTPUT ${target_skybox} ${target_envmap}
+    COMMAND cmgen -x public --format=rgbm --size=512 --extract-blur=0.1 ${source_envmap}
     MAIN_DEPENDENCY ${source_envmap}
     DEPENDS cmgen)
 
@@ -126,7 +120,7 @@ function(add_demo NAME)
             filaweb.h
             filaweb.cpp)
     add_dependencies(${NAME} sample_materials sample_assets)
-    target_link_libraries(${NAME} PRIVATE filament math filamat utils)
+    target_link_libraries(${NAME} PRIVATE filament math utils stb)
 
     # Copy the generated js and wasm files into the public folder, as well as the app-specific
     # manually-written HTML file.


### PR DESCRIPTION
This removes the trick of drawing to a 2D canvas. It corrupted the alpha in RGBM images, which caused subtle banding in the Suzanne reflection. Moreover it added complexity to the demo code.

This commit will increase the pre-zipped WASM size by 17k, but I think it's worth it.

This also removes one of the cmgen passes in the WebGL build; we were using PNG instead of RGBM for the skybox to work around the banding issue that this fixes.