### PR TITLE
Prep for WebGL on Kokoro.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -212,6 +212,16 @@ function build_webgl_with_target {
             ../..
         ${BUILD_COMMAND} ${BUILD_TARGETS}
     fi
+
+    if [ -d "samples/web/public" ]; then
+        if [ "$ISSUE_ARCHIVES" == "true" ]; then
+            echo "Generating out/filament-${LC_TARGET}-web.tgz..."
+            cd samples/web/public
+            tar -czvf ../../../../filament-${LC_TARGET}-web.tgz .
+            cd -
+        fi
+    fi
+
     cd ../..
 }
 

--- a/build/web/build.sh
+++ b/build/web/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Usage: the first argument selects the build type:
+# - release, to build release only
+# - debug, to build debug only
+# - continuous, to build release and debug
+# - presubmit, for presubmit builds
+#
+# The default is release
+
+set -e
+set -x
+
+source `dirname $0`/../common/ci-common.sh
+source `dirname $0`/ci-common.sh
+source `dirname $0`/../common/build-common.sh
+
+pushd `dirname $0`/../.. > /dev/null
+./build.sh -p webgl -c $RUN_TESTS $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE

--- a/build/web/ci-common.sh
+++ b/build/web/ci-common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+curl -OL https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
+unzip -q ninja-mac.zip
+chmod +x ninja
+export PATH="$PWD:$PATH"
+
+curl -L https://github.com/juj/emsdk/archive/0d8576c.zip > emsdk.zip
+unzip emsdk.zip
+mv emsdk-* emsdk
+emsdk/emsdk update
+emsdk/emsdk install sdk-1.38.11-64bit
+emsdk/emsdk activate sdk-1.38.11-64bit
+export EMSDK="$PWD/emsdk"

--- a/build/web/common.cfg
+++ b/build/web/common.cfg
@@ -1,0 +1,9 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+action {
+  define_artifacts {
+    regex: "github/filament/out/*.tgz"
+    strip_prefix: "github/filament/out"
+    regex: "**/*sponge_log.xml"
+  }
+}

--- a/build/web/continuous.cfg
+++ b/build/web/continuous.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "filament/build/web/build.sh"

--- a/build/web/presubmit.cfg
+++ b/build/web/presubmit.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "filament/build/web/build.sh"

--- a/build/web/release.cfg
+++ b/build/web/release.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "filament/build/web/build.sh"


### PR DESCRIPTION
This is identical to the mac build except that it uses the `/web/` path and it installs the emscripten SDK in `ci-common.sh`