### PR TITLE
Tungsten: improvements to shader node

### DIFF
--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/CompiledGraph.kt
@@ -27,5 +27,11 @@ data class CompiledGraph(
     val parameterMap: Map<Node.PropertyHandle, Parameter>,
 
     // Maps a Slot to its corresponding Expression
-    val expressionMap: Map<Slot, Expression>
+    val expressionMap: Map<Slot, Expression>,
+
+    /**
+     * Nodes can change during compilation. This maps from Nodes in the graph pre-compilation to
+     * equivalent nodes post-compilation.
+     */
+    val oldToNewNodeMap: Map<Node, Node>
 )

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
@@ -29,7 +29,7 @@ open class Expression(
 
     override fun toString() = symbol
 
-    private fun conform(components: Int): Expression {
+    fun conform(components: Int): Expression {
         if (dimensions == components) return this
         return if (dimensions > components) {
             shorten(components)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/Expression.kt
@@ -58,7 +58,8 @@ open class Expression(
 
 private fun createFloatLiteral(dimensions: Int): String {
     val zeroes = "0.0, ".repeat(maxOf(dimensions - 1, 0)) + "0.0"
-    return "float$dimensions($zeroes)"
+    val typeName = if (dimensions > 1) "float$dimensions" else "float"
+    return "$typeName($zeroes)"
 }
 
 class Literal(dimensions: Int) : Expression(

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphCompiler.java
@@ -20,6 +20,7 @@ import com.google.android.filament.tungsten.model.Graph;
 import com.google.android.filament.tungsten.model.Node;
 import com.google.android.filament.tungsten.model.Slot;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -37,6 +38,7 @@ public final class GraphCompiler {
 
     private StringBuilder mMaterialFunctionBodyBuilder = new StringBuilder();
     private final List<String> mRequiredAttributes = new ArrayList<>();
+    private String mShadingModel = "unlit";
     private final List<Parameter> mParameters = new ArrayList<>();
     private final Map<String, Integer> mParameterNumberMap = new HashMap<>();
     private final Map<Node.PropertyHandle, Parameter> mPropertyParameterMap = new HashMap<>();
@@ -49,6 +51,8 @@ public final class GraphCompiler {
     private final Set<Node> mUncompiledNodes;
     private boolean mShouldAppendCode = true;
     private final Map<Node, Node> mOldToNewNodeMap = new HashMap<>();
+    private final List<String> validShadingModels =
+            Arrays.asList("lit", "unlit", "cloth", "subsurface");
 
     public GraphCompiler(@NotNull Graph graph) {
         mGraph = graph;
@@ -73,8 +77,8 @@ public final class GraphCompiler {
         String fragmentSection = GraphFormatter.formatFragmentSection(mGlobalFunctions.values(),
                 mMaterialFunctionBodyBuilder.toString());
         String materialDefinition =
-                GraphFormatter.formatMaterialSection(mRequiredAttributes, mParameters)
-                + fragmentSection;
+                GraphFormatter.formatMaterialSection(mRequiredAttributes, mParameters,
+                mShadingModel) + fragmentSection;
         return new CompiledGraph(materialDefinition, mPropertyParameterMap, mCompiledVariableMap,
                 mOldToNewNodeMap);
     }
@@ -132,6 +136,12 @@ public final class GraphCompiler {
     public void requireAttribute(String requirement) {
         if (!mRequiredAttributes.contains(requirement)) {
             mRequiredAttributes.add(requirement);
+        }
+    }
+
+    public void setShadingModel(String shadingModel) {
+        if (validShadingModels.contains(shadingModel)) {
+            mShadingModel = shadingModel;
         }
     }
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphFormatter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/compiler/GraphFormatter.java
@@ -45,7 +45,7 @@ final class GraphFormatter {
     }
 
     static String formatMaterialSection(Collection<String> attributes,
-            Collection<Parameter> parameters) {
+            Collection<Parameter> parameters, String shadingModel) {
         StringBuilder builder = new StringBuilder();
         for (String attribute : attributes) {
             builder.append(indent(attribute, BODY_CODE_INDENT_AMOUNT)).append("\n");
@@ -58,7 +58,7 @@ final class GraphFormatter {
                 + "    requires : [\n"
                 + attributeText
                 + "    ],\n"
-                + "    shadingModel : unlit\n"
+                + "    shadingModel : \"" + shadingModel + "\"\n"
                 + "}\n"
                 + "\n";
     }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
@@ -48,7 +48,7 @@ data class Node(
     val outputSlots: List<String> = emptyList(),
     val inputSlots: List<String> = emptyList(),
 
-    val properties: List<Property> = emptyList()
+    val properties: List<Property<*>> = emptyList()
 ) {
 
     data class InputSlot(val nodeId: NodeId, val name: String) : Slot()
@@ -157,7 +157,7 @@ data class Graph(
         return this
     }
 
-    fun graphByChangingProperty(property: Node.PropertyHandle, value: Property): Graph {
+    fun graphByChangingProperty(property: Node.PropertyHandle, value: Property<*>): Graph {
         val node = nodeMap[property.nodeId] ?: return this
         val newProperties = node.properties.map {
             p -> if (p.name == property.name) value else p

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
@@ -71,6 +71,9 @@ data class Node(
     fun getInputSlot(name: String) = InputSlot(id, name)
 
     fun getOutputSlot(name: String) = OutputSlot(id, name)
+
+    fun nodeBySettingInputSlots(newInputs: List<String>) =
+            if (inputSlots === newInputs) this else copy(inputSlots = newInputs)
 }
 
 class ConnectionMapper {

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Graph.kt
@@ -150,12 +150,8 @@ data class Graph(
     fun graphByAddingNodeAtLocation(node: Node, x: Float, y: Float) =
             this.copy(nodes = nodes + node.copy(x = x, y = y))
 
-    fun graphByReplacingNode(oldNode: Node, newNode: Node): Graph {
-        if (nodes.contains(oldNode)) {
-            return this.copy(nodes = nodes - oldNode + newNode)
-        }
-        return this
-    }
+    fun graphByReplacingNode(oldNode: Node, newNode: Node) =
+            graphByReplacingNodes(mapOf(oldNode to newNode))
 
     fun graphByChangingProperty(property: Node.PropertyHandle, value: Property<*>): Graph {
         val node = nodeMap[property.nodeId] ?: return this
@@ -167,6 +163,11 @@ data class Graph(
 
     fun graphByMovingNode(node: Node, x: Float, y: Float) =
             graphByReplacingNode(node, node.copy(x = x, y = y))
+
+    fun graphByReplacingNodes(nodeMap: Map<Node, Node>): Graph {
+        val newNodes = nodes.map { n -> nodeMap[n] ?: n }
+        return this.copy(nodes = newNodes)
+    }
 
     fun graphByFormingConnection(connection: Connection) =
             this.copy(connections = connections + connection)

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
@@ -20,6 +20,8 @@ import com.google.android.filament.tungsten.compiler.GraphCompiler
 import com.google.android.filament.tungsten.compiler.Expression
 import com.google.android.filament.tungsten.compiler.Literal
 import com.google.android.filament.tungsten.compiler.trim
+import com.google.android.filament.tungsten.properties.ColorChooser
+import com.google.android.filament.tungsten.properties.MultipleChoice
 
 private val adderNodeCompile = fun(node: Node, compiler: GraphCompiler): Node {
     val outputSlot = node.getOutputSlot("result")
@@ -119,7 +121,10 @@ val createFloat3ConstantNode = fun(id: NodeId): Node {
         type = "float3Constant",
         compileFunction = constantFloat3NodeCompile,
         outputSlots = listOf("result"),
-        properties = listOf(Property("value", Float3()))
+        properties = listOf(Property(
+            name = "value",
+            value = Float3(),
+            editorFactory = ::ColorChooser))
     )
 }
 
@@ -129,17 +134,24 @@ val createFloat3ParameterNode = fun(id: NodeId): Node {
         type = "float3Parameter",
         compileFunction = float3ParameterNodeCompile,
         outputSlots = listOf("result"),
-        properties = listOf(Property("value", Float3(), PropertyType.MATERIAL_PARAMETER))
+        properties = listOf(Property(
+            name = "value",
+            value = Float3(),
+            type = PropertyType.MATERIAL_PARAMETER,
+            editorFactory = ::ColorChooser))
     )
 }
 
 val createFloat2ConstantNode = fun(id: NodeId): Node {
     return Node(
-            id = id,
-            type = "float2Constant",
-            compileFunction = constantFloat2NodeCompile,
-            outputSlots = listOf("result"),
-            properties = listOf(Property("value", Float3()))
+        id = id,
+        type = "float2Constant",
+        compileFunction = constantFloat2NodeCompile,
+        outputSlots = listOf("result"),
+        properties = listOf(Property(
+            name = "value",
+            value = Float3(),
+            editorFactory = ::ColorChooser))
     )
 }
 
@@ -149,7 +161,10 @@ val createShaderNode = fun(id: NodeId): Node {
         type = "shader",
         compileFunction = shaderNodeCompile,
         inputSlots = listOf("baseColor", "emissive"),
-        properties = listOf(Property("materialModel", StringValue("unlit"))))
+        properties = listOf(Property(
+            name = "materialModel",
+            value = StringValue("unlit"),
+            editorFactory = { MultipleChoice(it, listOf("lit", "unlit")) })))
 }
 
 object GraphInitializer {

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Nodes.kt
@@ -148,7 +148,8 @@ val createShaderNode = fun(id: NodeId): Node {
         id = id,
         type = "shader",
         compileFunction = shaderNodeCompile,
-        inputSlots = listOf("baseColor", "metallic", "roughness"))
+        inputSlots = listOf("baseColor", "emissive"),
+        properties = listOf(Property("materialModel", StringValue("unlit"))))
 }
 
 object GraphInitializer {

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Properties.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/Properties.kt
@@ -20,7 +20,7 @@ import com.google.android.filament.MaterialInstance
 
 sealed class PropertyValue {
 
-    abstract fun applyToMaterialInstance(materialInstance: MaterialInstance, name: String)
+    open fun applyToMaterialInstance(materialInstance: MaterialInstance, name: String) { }
 
     /**
      * Serialize this value into a Kotlin List, Map, String, or Number
@@ -46,6 +46,16 @@ data class Float3(val x: Float = 0.0f, val y: Float = 0.0f, val z: Float = 0.0f)
         val (x, y, z) = value
         if (x !is Number || y !is Number || z !is Number) return this
         return Float3(x.toFloat(), y.toFloat(), z.toFloat())
+    }
+}
+
+data class StringValue(val value: String) : PropertyValue() {
+
+    override fun serialize() = value
+
+    override fun deserialize(value: Any): PropertyValue {
+        if (value !is String) return this
+        return StringValue(value)
     }
 }
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/model/serialization/GraphSerializer.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/model/serialization/GraphSerializer.kt
@@ -20,6 +20,7 @@ import com.google.android.filament.tungsten.model.Connection
 import com.google.android.filament.tungsten.model.Graph
 import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
+import com.google.android.filament.tungsten.model.copyPropertyWithValue
 import java.awt.Point
 
 /**
@@ -76,8 +77,9 @@ object GraphSerializer {
             // Allow properties specified in the serialized data to override default properties
             // of the node.
             val overridenProperties = newNode.properties.map { p ->
-                val override = n.properties?.get(p.name)
-                if (override != null) p.copy(value = p.value.deserialize(override)) else p
+                val override = n.properties?.get(p.name) ?: p
+                val newValue = p.value.deserialize(override)
+                copyPropertyWithValue(p, newValue)
             }
             newNode.copy(
                     x = position.x.toFloat(),

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/IPropertiesPresenter.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/IPropertiesPresenter.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.google.android.filament.tungsten.properties;
+package com.google.android.filament.tungsten.properties
 
-import com.google.android.filament.tungsten.model.Node;
-import com.google.android.filament.tungsten.model.Property;
+import com.google.android.filament.tungsten.model.Node
+import com.google.android.filament.tungsten.model.Property
 
-public interface IPropertiesPresenter {
+interface IPropertiesPresenter {
 
-    void propertyChanged(Node.PropertyHandle handle, Property property);
+    fun propertyChanged(handle: Node.PropertyHandle, property: Property<*>)
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
@@ -19,6 +19,7 @@ package com.google.android.filament.tungsten.properties
 import com.google.android.filament.tungsten.model.Float3
 import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
+import com.google.android.filament.tungsten.model.StringValue
 import javax.swing.JPanel
 
 class PropertiesPanel : JPanel() {
@@ -64,6 +65,7 @@ class PropertiesPanel : JPanel() {
                 when (property.value) {
                     // Each PropertyValue type has a 1:1 mapping to a PropertyEditor
                     is Float3 -> ColorChooser(property.value)
+                    is StringValue -> MultipleChoice(property.value, listOf("one", "two", "three"))
                 }
             }
         }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertiesPanel.kt
@@ -16,10 +16,9 @@
 
 package com.google.android.filament.tungsten.properties
 
-import com.google.android.filament.tungsten.model.Float3
 import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
-import com.google.android.filament.tungsten.model.StringValue
+import com.google.android.filament.tungsten.model.copyPropertyWithValue
 import javax.swing.JPanel
 
 class PropertiesPanel : JPanel() {
@@ -47,7 +46,7 @@ class PropertiesPanel : JPanel() {
             editor.setValue(property.value)
             editor.valueChanged = { newValue ->
                 p.propertyChanged(node.getPropertyHandle(property.name),
-                        property.copy(value = newValue))
+                        copyPropertyWithValue(property, newValue))
             }
             add(editor.component)
         }
@@ -61,13 +60,7 @@ class PropertiesPanel : JPanel() {
      */
     private fun createEditorsForNode(node: Node) {
         editorCache.computeIfAbsent(node.id) { _ ->
-            node.properties.map { property ->
-                when (property.value) {
-                    // Each PropertyValue type has a 1:1 mapping to a PropertyEditor
-                    is Float3 -> ColorChooser(property.value)
-                    is StringValue -> MultipleChoice(property.value, listOf("one", "two", "three"))
-                }
-            }
+            node.properties.map { it.callEditorFactory() }
         }
     }
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertyEditors.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/properties/PropertyEditors.kt
@@ -18,15 +18,17 @@ package com.google.android.filament.tungsten.properties
 
 import com.google.android.filament.tungsten.model.Float3
 import com.google.android.filament.tungsten.model.PropertyValue
+import com.google.android.filament.tungsten.model.StringValue
 import java.awt.Color
 import javax.swing.JColorChooser
+import javax.swing.JComboBox
 import javax.swing.JComponent
 import kotlin.math.roundToInt
 
 sealed class PropertyEditor {
 
     abstract val component: JComponent
-    var valueChanged: (newValue: Float3) -> Unit = { }
+    var valueChanged: (newValue: PropertyValue) -> Unit = { }
 
     abstract fun setValue(v: PropertyValue)
 }
@@ -51,5 +53,21 @@ internal class ColorChooser(value: Float3) : PropertyEditor() {
                     z = component.color.blue / 255.0f)
             valueChanged(newValue)
         }
+    }
+}
+
+internal class MultipleChoice(value: StringValue, choices: List<String>) : PropertyEditor() {
+
+    override val component: JComboBox<String> = JComboBox<String>(choices.toTypedArray())
+
+    init {
+        component.addActionListener {
+            valueChanged(StringValue(component.selectedItem as String))
+        }
+    }
+
+    override fun setValue(v: PropertyValue) {
+        val newValue = v as? StringValue ?: return
+        component.selectedItem = newValue.value
     }
 }

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphPresenter.java
@@ -195,13 +195,16 @@ public class GraphPresenter implements IPropertiesPresenter {
         mCompiledGraph = compiler.compileGraph();
         mMaterialSource.setText(mCompiledGraph.getMaterialDefinition());
 
-        // Update the model with the newly compiled expression map.
-        mModel.getAndUpdate(
-                graph -> graph.graphBySettingExpressionMap(mCompiledGraph.getExpressionMap()));
-        mGraphView.render(mModel.get());
-
         CompletableFuture<Material> futureMaterial = mMaterialManager
                 .compileMaterial(mCompiledGraph.getMaterialDefinition());
+
+        // Update the model with the newly compiled expression map and replace any modified nodes.
+        mModel.getAndUpdate(
+                graph -> graph
+                    .graphBySettingExpressionMap(mCompiledGraph.getExpressionMap())
+                    .graphByReplacingNodes(mCompiledGraph.getOldToNewNodeMap()));
+
+        mGraphView.render(mModel.get());
 
         serializeAndSave();
 

--- a/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphViews.kt
+++ b/tools/tungsten/core/src/com/google/android/filament/tungsten/ui/GraphViews.kt
@@ -88,12 +88,10 @@ internal data class NodeView(
 
     override val children = inputSlots + outputSlots
 
-    init {
-        width = NODE_WIDTH
-        height = NODE_HEIGHT
-    }
-
     override fun layout() {
+        width = NODE_WIDTH
+        height = maxOf((inputSlots.size + outputSlots.size) * SLOT_HEIGHT + 2 * SLOT_MARGIN,
+                NODE_HEIGHT)
         inputSlots.forEachIndexed { index, slot ->
             slot.x = SLOT_MARGIN
             slot.y = SLOT_MARGIN + index * SLOT_HEIGHT
@@ -111,12 +109,12 @@ internal data class NodeView(
     override fun render(g2d: Graphics2D) {
         if (isSelected) {
             g2d.color = ColorScheme.nodeSelected
-            g2d.fillRoundRect(0, 0, NODE_WIDTH.toInt(), NODE_HEIGHT.toInt(), ARC_RADIUS, ARC_RADIUS)
+            g2d.fillRoundRect(0, 0, width.toInt(), height.toInt(), ARC_RADIUS, ARC_RADIUS)
         }
         g2d.color = ColorScheme.nodeBackground
         g2d.fillRoundRect(BORDER_THICKNESS, BORDER_THICKNESS,
-                (NODE_WIDTH - 2 * BORDER_THICKNESS).toInt(),
-                (NODE_HEIGHT - 2 * BORDER_THICKNESS).toInt(), ARC_RADIUS, ARC_RADIUS)
+                (width - 2 * BORDER_THICKNESS).toInt(),
+                (height - 2 * BORDER_THICKNESS).toInt(), ARC_RADIUS, ARC_RADIUS)
     }
 }
 

--- a/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/ExpressionTest.kt
+++ b/tools/tungsten/core/test/com/google/android/filament/tungsten/compiler/ExpressionTest.kt
@@ -41,4 +41,9 @@ class ExpressionTest {
         assertEquals("float2(0.0, 0.0)", "${Literal(4).rg}")
         assertEquals("float3(0.0, 0.0, 0.0)", "${Literal(1).rgb}")
     }
+
+    @Test
+    fun `create a float literal of dimension 1`() {
+        assertEquals("float(0.0)", "${Literal(1).r}")
+    }
 }

--- a/tools/tungsten/core/test/com/google/android/filament/tungsten/model/serialization/GraphSerializerTest.kt
+++ b/tools/tungsten/core/test/com/google/android/filament/tungsten/model/serialization/GraphSerializerTest.kt
@@ -21,6 +21,8 @@ import com.google.android.filament.tungsten.model.Graph
 import com.google.android.filament.tungsten.model.Node
 import com.google.android.filament.tungsten.model.NodeId
 import com.google.android.filament.tungsten.model.Property
+import com.google.android.filament.tungsten.model.copyPropertyWithValue
+import com.google.android.filament.tungsten.properties.ColorChooser
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -104,7 +106,7 @@ class GraphSerializerTest {
                 nodes = listOf(node),
                 rootNodeId = 0
         ).graphByChangingProperty(node.getPropertyHandle("mockProperty"),
-                Property("mockProperty", Float3(1.0f, 1.0f, 1.0f)))
+                copyPropertyWithValue(mockProperty, Float3(1.0f, 2.0f, 3.0f)))
 
         val serialized = GraphSerializer.serialize(graph, emptyMap())
         val (deserialized, _) = GraphSerializer.deserialize(serialized, mockNodeFactory)
@@ -112,11 +114,17 @@ class GraphSerializerTest {
         assertEquals(graph, deserialized)
     }
 
+    private val mockProperty = Property(
+        name = "mockProperty",
+        value = Float3(),
+        editorFactory = ::ColorChooser
+    )
+
     private fun createMockNode(id: NodeId) = Node(
-                id = id,
-                type = "node",
-                inputSlots = listOf("input"),
-                outputSlots = listOf("output"),
-                properties = listOf(Property("mockProperty", Float3()))
-        )
+        id = id,
+        type = "node",
+        inputSlots = listOf("input"),
+        outputSlots = listOf("output"),
+        properties = listOf(mockProperty)
+    )
 }


### PR DESCRIPTION
The root node can switch between unlit and lit material models, which also affects the input slots it allows. Still need to add a few more material inputs, and additional shading models (cloth and subsurface).

![tungsten_shadingmodel](https://user-images.githubusercontent.com/5298046/45185381-d63d5580-b1de-11e8-832e-978459fcfee0.gif)