### PR TITLE
Fix continuous web builds by skipping unit tests.

### DIFF
--- a/build/web/build.sh
+++ b/build/web/build.sh
@@ -16,4 +16,4 @@ source `dirname $0`/ci-common.sh
 source `dirname $0`/../common/build-common.sh
 
 pushd `dirname $0`/../.. > /dev/null
-./build.sh -p webgl -c $RUN_TESTS $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE
+./build.sh -p webgl -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE


### PR DESCRIPTION
We do not build unit tests for the web build, so we should skip them.