### PR TITLE
Specify a MIN_FILTER for render target textures

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -887,6 +887,10 @@ void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
     bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t, t->gl.targetIndex);
     activeTexture(MAX_TEXTURE_UNITS - 1);
 
+    // The default min filtering is GL_NEAREST_MIPMAP_LINEAR, but allocated
+    // textures don't have mipmaps.
+    glTexParameteri(t->gl.target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+
     switch (t->gl.target) {
         case GL_TEXTURE_2D:
         case GL_TEXTURE_CUBE_MAP:


### PR DESCRIPTION
Previously when rendering with Swiftshader, enabling the postprocessing
pipeline would result in nothing being rendered to the screen.

I narrowed down the issue due to Swiftshader not considering the
postProcess_colorBuffer sampler as complete.  This occurs because the
default min filter for textures is GL_NEAREST_MIPMAP_LINEAR, which
requires mipmaps, and the render target texture doesn't include those,
so Swiftshader doesn't consider the texture to be complete when it's
binding it to a sampler, resulting in it failing to bind.

The OpenGL ES 3.1 spec is vague around this area, see section 8.16.1,
which states that if the sampler min filter requires mipmaps and the
texture doesn't include them the sampler may be considered incomplete,
but it doesn't say what happens if the texture is incomplete by itself
and complete after the sampler min filter overrides the texture min
filter.

Since the language is vague, and the current behavior is arguably
incorrect, update OpenGLDriver::textureStorage to explicitly specify a
min filter so that render target textures are considered complete
standalone.