### PR TITLE
Fix bad skybox color in web demo.

### DIFF
--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -215,7 +215,7 @@ SkyLight getSkyLight(Engine& engine, const char* name) {
         .width(size)
         .height(size)
         .levels(1)
-        .format(Texture::InternalFormat::RGBA8)
+        .format(Texture::InternalFormat::RGBM)
         .sampler(Texture::Sampler::SAMPLER_CUBEMAP)
         .build(engine);
     {


### PR DESCRIPTION
In a previous CL today, I changed the skybox to RGBM but forgot to
change the format. Thanks Romain for catching this.