### PR TITLE
Huge speed up for WebGL debug builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,15 @@ function(list_licenses OUTPUT MODULES)
 endfunction(list_licenses)
 
 # ==================================================================================================
+# Configuration for CMAKE_CROSSCOMPILING.
+# ==================================================================================================
+if (WEBGL)
+    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-Release.cmake)
+else()
+    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
+endif()
+
+# ==================================================================================================
 # Sub-projects
 # ==================================================================================================
 # Common to all platforms
@@ -306,5 +315,5 @@ endif()
 
 # Generate exported executables for cross-compiled builds (Android and WebGL)
 if (NOT CMAKE_CROSSCOMPILING)
-    export(TARGETS matc cmgen filamesh FILE ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
+    export(TARGETS matc cmgen filamesh FILE ${IMPORT_EXECUTABLES})
 endif()

--- a/build.sh
+++ b/build.sh
@@ -226,11 +226,14 @@ function build_webgl_with_target {
 }
 
 function build_webgl {
-    # Supress intermediate desktop tools install
-    OLD_INSTALL_COMMAND=${INSTALL_COMMAND}
-    INSTALL_COMMAND=
+    # For the host tools, supress install and always use Release.
+    OLD_INSTALL_COMMAND=${INSTALL_COMMAND}; INSTALL_COMMAND=
+    OLD_ISSUE_DEBUG_BUILD=${ISSUE_DEBUG_BUILD}; ISSUE_DEBUG_BUILD=false
+    OLD_ISSUE_RELEASE_BUILD=${ISSUE_RELEASE_BUILD}; ISSUE_RELEASE_BUILD=true
     build_desktop "${HOST_TOOLS}"
     INSTALL_COMMAND=${OLD_INSTALL_COMMAND}
+    ISSUE_DEBUG_BUILD=${OLD_ISSUE_DEBUG_BUILD}
+    ISSUE_RELEASE_BUILD=${OLD_ISSUE_RELEASE_BUILD}
 
     if [ "$ISSUE_DEBUG_BUILD" == "true" ]; then
         build_webgl_with_target "Debug"

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -218,7 +218,6 @@ endif()
 # ==================================================================================================
 
 if (CMAKE_CROSSCOMPILING)
-    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
     include(${IMPORT_EXECUTABLES})
 endif()
 

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -18,7 +18,6 @@ set(SRCS
 # ==================================================================================================
 
 if (CMAKE_CROSSCOMPILING)
-    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
     include(${IMPORT_EXECUTABLES})
 endif()
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -21,7 +21,6 @@ set(MATERIAL_SRCS
         materials/transparentColor.mat)
 
 if (CMAKE_CROSSCOMPILING)
-    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
     include(${IMPORT_EXECUTABLES})
 endif()
 

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -10,8 +10,6 @@ set(MATERIAL_SRCS
         ../materials/bakedColor.mat)
 
 if (CMAKE_CROSSCOMPILING)
-    set(IMPORT_EXECUTABLES ${FILAMENT}/${IMPORT_EXECUTABLES_DIR})
-    set(IMPORT_EXECUTABLES ${IMPORT_EXECUTABLES}/ImportExecutables-${CMAKE_BUILD_TYPE}.cmake)
     include(${IMPORT_EXECUTABLES})
 endif()
 


### PR DESCRIPTION
The WebGL build invokes cmgen for samples, which takes several minutes
in debug configuration. Let's use a release build for the host tools,
regardless of the build configuration for the target architecture.