### PR TITLE
WebGL samples should pass free callback to BufferDescriptor.

### DIFF
--- a/libs/filagui/src/ImGuiHelper.cpp
+++ b/libs/filagui/src/ImGuiHelper.cpp
@@ -284,7 +284,9 @@ void ImGuiHelper::populateVertexData(size_t bufferIndex, size_t vbSizeInBytes, v
     memcpy(vbFilamentData, vbImguiData, nVbBytes);
     mVertexBuffers[bufferIndex]->setBufferAt(*mEngine, 0,
             VertexBuffer::BufferDescriptor(vbFilamentData, nVbBytes,
-            (VertexBuffer::BufferDescriptor::Callback) free));
+                [](void* buffer, size_t size, void* user) {
+                    free(buffer);
+                }, /* user = */ nullptr));
 
     // Create a new index buffer if the size isn't large enough, then copy the ImGui data into
     // a staging area since Filament's render thread might consume the data at any time.
@@ -298,7 +300,9 @@ void ImGuiHelper::populateVertexData(size_t bufferIndex, size_t vbSizeInBytes, v
     memcpy(ibFilamentData, ibImguiData, nIbBytes);
     mIndexBuffers[bufferIndex]->setBuffer(*mEngine,
             IndexBuffer::BufferDescriptor(ibFilamentData, nIbBytes,
-            (IndexBuffer::BufferDescriptor::Callback) free));
+                [](void* buffer, size_t size, void* user) {
+                    free(buffer);
+                }, /* user = */ nullptr));
 }
 
 void ImGuiHelper::syncThreads() {

--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -179,8 +179,10 @@ SkyLight getSkyLight(Engine& engine, const char* name) {
         offsets.nz = faceSize * 5;
         Texture::PixelBufferDescriptor buffer(
                 malloc(faceSize * 6), faceSize * 6,
-                Texture::Format::RGBM, Texture::Type::UBYTE);
-                // (Texture::PixelBufferDescriptor::Callback) &free // TODO: why does this crash?
+                Texture::Format::RGBM, Texture::Type::UBYTE,
+                [](void* buffer, size_t size, void* user) {
+                    free(buffer);
+                }, /* user = */ nullptr);
         uint8_t* pixels = static_cast<uint8_t*>(buffer.buffer);
         auto& px = asset.envFaces[i++];
         auto& nx = asset.envFaces[i++];
@@ -229,8 +231,10 @@ SkyLight getSkyLight(Engine& engine, const char* name) {
         offsets.nz = faceSize * 5;
         Texture::PixelBufferDescriptor buffer(
                 malloc(faceSize * 6), faceSize * 6,
-                Texture::Format::RGBA, Texture::Type::UBYTE);
-                // (Texture::PixelBufferDescriptor::Callback) &free // TODO: why does this crash?
+                Texture::Format::RGBA, Texture::Type::UBYTE,
+                [](void* buffer, size_t size, void* user) {
+                    free(buffer);
+                }, /* user = */ nullptr);
         uint8_t* pixels = static_cast<uint8_t*>(buffer.buffer);
         i = 0;
         auto& px = asset.skyFaces[i++];


### PR DESCRIPTION
Unfortunately the trick of passing the address to stdlib "free" causes
a crash in WebGL, so we need to wrap these in lambda.