### PR TITLE
Add new demo for WebGL called "sandbox".

### DIFF
--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_SAMPLES_MATERIAL_SANDBOX_H
+#define TNT_FILAMENT_SAMPLES_MATERIAL_SANDBOX_H
+
+#include <math/vec3.h>
+
+#include <utils/Entity.h>
+#include <utils/EntityManager.h>
+
+#include <filament/Color.h>
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+
+static constexpr uint8_t MATERIAL_UNLIT_PACKAGE[] = {
+    #include "generated/material/sandboxUnlit.inc"
+};
+
+static constexpr uint8_t MATERIAL_LIT_PACKAGE[] = {
+    #include "generated/material/sandboxLit.inc"
+};
+
+static constexpr uint8_t MATERIAL_LIT_FADE_PACKAGE[] = {
+    #include "generated/material/sandboxLitFade.inc"
+};
+
+static constexpr uint8_t MATERIAL_LIT_TRANSPARENT_PACKAGE[] = {
+    #include "generated/material/sandboxLitTransparent.inc"
+};
+
+static constexpr uint8_t MATERIAL_SUBSURFACE_PACKAGE[] = {
+    #include "generated/material/sandboxSubsurface.inc"
+};
+
+static constexpr uint8_t MATERIAL_CLOTH_PACKAGE[] = {
+    #include "generated/material/sandboxCloth.inc"
+};
+
+constexpr uint8_t MATERIAL_MODEL_UNLIT =       0;
+constexpr uint8_t MATERIAL_MODEL_LIT =         1;
+constexpr uint8_t MATERIAL_MODEL_SUBSURFACE =  2;
+constexpr uint8_t MATERIAL_MODEL_CLOTH =       3;
+
+constexpr uint8_t MATERIAL_UNLIT =       0;
+constexpr uint8_t MATERIAL_LIT =         1;
+constexpr uint8_t MATERIAL_SUBSURFACE =  2;
+constexpr uint8_t MATERIAL_CLOTH =       3;
+constexpr uint8_t MATERIAL_TRANSPARENT = 4;
+constexpr uint8_t MATERIAL_FADE =        5;
+constexpr uint8_t MATERIAL_COUNT =       6;
+
+constexpr uint8_t BLENDING_OPAQUE      = 0;
+constexpr uint8_t BLENDING_TRANSPARENT = 1;
+constexpr uint8_t BLENDING_FADE        = 2;
+
+struct SandboxParameters {
+    const filament::Material* material[MATERIAL_COUNT];
+    filament::MaterialInstance* materialInstance[MATERIAL_COUNT];
+    filament::sRGBColor color = {0.69f, 0.69f, 0.69f};
+    float alpha = 1.0f;
+    float roughness = 0.6f;
+    float metallic = 0.0f;
+    float reflectance = 0.5f;
+    float clearCoat = 0.0f;
+    float clearCoatRoughness = 0.0f;
+    float anisotropy = 0.0f;
+    float thickness = 1.0f;
+    float subsurfacePower = 12.234f;
+    filament::sRGBColor subsurfaceColor = {0.0f};
+    filament::sRGBColor sheenColor = {0.83f, 0.0f, 0.0f};
+    int currentMaterialModel = MATERIAL_MODEL_LIT;
+    int currentBlending = BLENDING_OPAQUE;
+    bool castShadows = true;
+    filament::sRGBColor lightColor = {0.98f, 0.92f, 0.89f};
+    float lightIntensity = 110000.0f;
+    math::float3 lightDirection = {0.6f, -1.0f, -0.8f};
+    float iblIntensity = 30000.0f;
+    float iblRotation = 0.0f;
+    float sunHaloSize = 10.0f;
+    float sunHaloFalloff = 80.0f;
+    float sunAngularRadius = 1.9f;
+    bool directionalLightEnabled = true;
+    utils::Entity light;
+    bool hasDirectionalLight = true;
+};
+
+inline void createInstances(SandboxParameters& params, filament::Engine& engine) {
+    using namespace filament;
+    using namespace utils;
+    params.material[MATERIAL_UNLIT] = Material::Builder()
+            .package((void*) MATERIAL_UNLIT_PACKAGE, sizeof(MATERIAL_UNLIT_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_UNLIT] =
+            params.material[MATERIAL_UNLIT]->createInstance();
+
+    params.material[MATERIAL_LIT] = Material::Builder()
+            .package((void*) MATERIAL_LIT_PACKAGE, sizeof(MATERIAL_LIT_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_LIT] =
+            params.material[MATERIAL_LIT]->createInstance();
+
+    params.material[MATERIAL_TRANSPARENT] = Material::Builder()
+            .package((void*) MATERIAL_LIT_TRANSPARENT_PACKAGE,
+                    sizeof(MATERIAL_LIT_TRANSPARENT_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_TRANSPARENT] =
+            params.material[MATERIAL_TRANSPARENT]->createInstance();
+
+    params.material[MATERIAL_FADE] = Material::Builder()
+            .package((void*) MATERIAL_LIT_FADE_PACKAGE, sizeof(MATERIAL_LIT_FADE_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_FADE] =
+            params.material[MATERIAL_FADE]->createInstance();
+
+    params.material[MATERIAL_SUBSURFACE] = Material::Builder()
+            .package((void*) MATERIAL_SUBSURFACE_PACKAGE, sizeof(MATERIAL_SUBSURFACE_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_SUBSURFACE] =
+            params.material[MATERIAL_SUBSURFACE]->createInstance();
+
+    params.material[MATERIAL_CLOTH] = Material::Builder()
+            .package((void*) MATERIAL_CLOTH_PACKAGE, sizeof(MATERIAL_CLOTH_PACKAGE))
+            .build(engine);
+    params.materialInstance[MATERIAL_CLOTH] =
+            params.material[MATERIAL_CLOTH]->createInstance();
+
+    params.light = EntityManager::get().create();
+    LightManager::Builder(LightManager::Type::SUN)
+            .color(Color::toLinear<ACCURATE>(params.lightColor))
+            .intensity(params.lightIntensity)
+            .direction(params.lightDirection)
+            .castShadows(true)
+            .sunAngularRadius(params.sunAngularRadius)
+            .sunHaloSize(params.sunHaloSize)
+            .sunHaloFalloff(params.sunHaloFalloff)
+            .build(engine, params.light);
+}
+
+inline filament::MaterialInstance* updateInstances(SandboxParameters& params,
+        filament::Engine& engine) {
+    using namespace filament;
+    int material = params.currentMaterialModel;
+    if (material == MATERIAL_MODEL_LIT) {
+        if (params.currentBlending == BLENDING_TRANSPARENT) material = MATERIAL_TRANSPARENT;
+        if (params.currentBlending == BLENDING_FADE) material = MATERIAL_FADE;
+    }
+    MaterialInstance* materialInstance = params.materialInstance[material];
+    if (params.currentMaterialModel == MATERIAL_MODEL_UNLIT) {
+        materialInstance->setParameter("baseColor", RgbType::sRGB, params.color);
+    }
+    if (params.currentMaterialModel == MATERIAL_MODEL_LIT) {
+        materialInstance->setParameter("baseColor", RgbType::sRGB, params.color);
+        materialInstance->setParameter("roughness", params.roughness);
+        materialInstance->setParameter("metallic", params.metallic);
+        materialInstance->setParameter("reflectance", params.reflectance);
+        materialInstance->setParameter("clearCoat", params.clearCoat);
+        materialInstance->setParameter("clearCoatRoughness", params.clearCoatRoughness);
+        materialInstance->setParameter("anisotropy", params.anisotropy);
+        if (params.currentBlending != BLENDING_OPAQUE) {
+            materialInstance->setParameter("alpha", params.alpha);
+        }
+    }
+    if (params.currentMaterialModel == MATERIAL_MODEL_SUBSURFACE) {
+        materialInstance->setParameter("baseColor", RgbType::sRGB, params.color);
+        materialInstance->setParameter("roughness", params.roughness);
+        materialInstance->setParameter("metallic", params.metallic);
+        materialInstance->setParameter("reflectance", params.reflectance);
+        materialInstance->setParameter("thickness", params.thickness);
+        materialInstance->setParameter("subsurfacePower", params.subsurfacePower);
+        materialInstance->setParameter("subsurfaceColor", RgbType::sRGB, params.subsurfaceColor);
+    }
+    if (params.currentMaterialModel == MATERIAL_MODEL_CLOTH) {
+        materialInstance->setParameter("baseColor", RgbType::sRGB, params.color);
+        materialInstance->setParameter("roughness", params.roughness);
+        materialInstance->setParameter("sheenColor", RgbType::sRGB, params.sheenColor);
+        materialInstance->setParameter("subsurfaceColor", RgbType::sRGB, params.subsurfaceColor);
+    }
+
+    auto& lcm = engine.getLightManager();
+    auto lightInstance = lcm.getInstance(params.light);
+    lcm.setColor(lightInstance, params.lightColor);
+    lcm.setIntensity(lightInstance, params.lightIntensity);
+    lcm.setDirection(lightInstance, params.lightDirection);
+    lcm.setSunAngularRadius(lightInstance, params.sunAngularRadius);
+    lcm.setSunHaloSize(lightInstance, params.sunHaloSize);
+    lcm.setSunHaloFalloff(lightInstance, params.sunHaloFalloff);
+    return materialInstance;
+}
+
+#endif // TNT_FILAMENT_SAMPLES_MATERIAL_SANDBOX_H

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -147,3 +147,4 @@ endfunction()
 
 add_demo(suzanne)
 add_demo(triangle)
+add_demo(sandbox)

--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -58,7 +58,7 @@ Asset getCubemap(const char* name);
 
 struct SkyLight {
     math::float3 bands[9];
-    filament::IndirectLight const* indirectLight;
+    filament::IndirectLight* indirectLight;
     filament::Skybox* skybox;
 };
 

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -35,8 +35,8 @@ function maybe_launch() {
     if (assets_ready && context_ready) {
         _launch();
         canvas_resize();
+        window.addEventListener("resize", canvas_resize);
         let canvas = document.getElementById('filament-canvas');
-        canvas.addEventListener("resize", canvas_resize);
         canvas.addEventListener("wheel", canvas_mouse);
         canvas.addEventListener("pointermove", canvas_mouse);
         canvas.addEventListener("pointerdown", canvas_mouse);

--- a/samples/web/sandbox.cpp
+++ b/samples/web/sandbox.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filament/DebugRegistry.h>
+#include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
+#include <filament/LightManager.h>
+#include <filament/Material.h>
+#include <filament/MaterialInstance.h>
+#include <filament/RenderableManager.h>
+#include <filament/Scene.h>
+#include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
+#include <filament/View.h>
+
+#include <math/vec3.h>
+
+#include <utils/Entity.h>
+
+#include <imgui.h>
+
+#include "filamesh.h"
+#include "filaweb.h"
+#include "../material_sandbox.h"
+
+using namespace filament;
+using namespace filagui;
+using namespace math;
+using namespace utils;
+
+using MagFilter = TextureSampler::MagFilter;
+using WrapMode = TextureSampler::WrapMode;
+using Format = Texture::InternalFormat;
+
+struct SandboxApp {
+    Filamesh filamesh;
+    Camera* cam;
+    SandboxParameters params;
+    filaweb::SkyLight skylight;
+    Scene* scene;
+};
+
+static SandboxApp app;
+
+void setup(Engine* engine, View* view, Scene* scene) {
+    app.scene = scene;
+
+    // Create material.
+    createInstances(app.params, *engine);
+
+    // Move raw asset data from JavaScript to C++ static storage. Their held data will be freed via
+    // BufferDescriptor callbacks after Filament creates the corresponding GPU objects.
+    static auto mesh = filaweb::getRawFile("mesh");
+
+    // Create mesh.
+    const uint8_t* mdata = mesh.data.get();
+    const auto destructor = [](void* buffer, size_t size, void* user) {
+        auto asset = (filaweb::Asset*) user;
+        asset->data.reset();
+    };
+    MaterialInstance* materialInstance = app.params.materialInstance[MATERIAL_LIT];
+    app.filamesh = decodeMesh(*engine, mdata, 0, materialInstance, destructor, &mesh);
+    scene->addEntity(app.filamesh->renderable);
+
+    // Create the sun.
+    scene->addEntity(app.params.light);
+
+    // Create skybox and image-based light source.
+    app.skylight = filaweb::getSkyLight(*engine, "pillars_2k");
+    scene->setIndirectLight(app.skylight.indirectLight);
+    scene->setSkybox(app.skylight.skybox);
+
+    const math::float3 center {0, 1.05, -1};
+    const math::float3 eye {0, 1, 0};
+
+    app.cam = engine->createCamera();
+    app.cam->setExposure(16.0f, 1 / 125.0f, 100.0f);
+    app.cam->lookAt(eye, center);
+    view->setCamera(app.cam);
+    view->setClearColor({0.1, 0.125, 0.25, 1.0});
+};
+
+void animate(Engine* engine, View* view, double now) {
+    static double previous = now;
+
+    // Adjust camera on every frame in case window size changes.
+    using Fov = Camera::Fov;
+    const uint32_t width = view->getViewport().width;
+    const uint32_t height = view->getViewport().height;
+    double ratio = double(width) / height;
+    app.cam->setProjection(45.0, ratio, 0.1, 50.0, ratio < 1 ? Fov::HORIZONTAL : Fov::VERTICAL);
+
+    // Spin the object.
+    auto& tcm = engine->getTransformManager();
+    tcm.setTransform(tcm.getInstance(app.filamesh->renderable),
+        mat4f{mat3f{1.0}, float3{0.0f, 0.0f, -5.0f}} *
+        mat4f::rotate(now, math::float3{0, 1, 0}));
+};
+
+void ui(Engine* engine, View* view) {
+    auto& params = app.params;
+    ImGui::SetNextWindowSize(ImVec2(0.0f, 0.0f));
+    ImGui::Begin("Parameters");
+    {
+        if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen)) {
+            ImGui::Combo("model", &params.currentMaterialModel,
+                    "unlit\0lit\0subsurface\0cloth\0\0");
+
+            if (params.currentMaterialModel == MATERIAL_MODEL_LIT) {
+                ImGui::Combo("blending", &params.currentBlending,
+                        "opaque\0transparent\0fade\0\0");
+            }
+
+            ImGui::ColorEdit3("baseColor", &params.color.r);
+
+            if (params.currentMaterialModel > MATERIAL_MODEL_UNLIT) {
+                if (params.currentBlending == BLENDING_TRANSPARENT ||
+                        params.currentBlending == BLENDING_FADE) {
+                    ImGui::SliderFloat("alpha", &params.alpha, 0.0f, 1.0f);
+                }
+                ImGui::SliderFloat("roughness", &params.roughness, 0.0f, 1.0f);
+                if (params.currentMaterialModel != MATERIAL_MODEL_CLOTH) {
+                    ImGui::SliderFloat("metallic", &params.metallic, 0.0f, 1.0f);
+                    ImGui::SliderFloat("reflectance", &params.reflectance, 0.0f, 1.0f);
+                }
+                if (params.currentMaterialModel != MATERIAL_MODEL_CLOTH &&
+                        params.currentMaterialModel != MATERIAL_MODEL_SUBSURFACE) {
+                    ImGui::SliderFloat("clearCoat", &params.clearCoat, 0.0f, 1.0f);
+                    ImGui::SliderFloat("clearCoatRoughness", &params.clearCoatRoughness, 0.0f, 1.0f);
+                    ImGui::SliderFloat("anisotropy", &params.anisotropy, -1.0f, 1.0f);
+                }
+                if (params.currentMaterialModel == MATERIAL_MODEL_SUBSURFACE) {
+                    ImGui::SliderFloat("thickness", &params.thickness, 0.0f, 1.0f);
+                    ImGui::SliderFloat("subsurfacePower", &params.subsurfacePower, 1.0f, 24.0f);
+                    ImGui::ColorEdit3("subsurfaceColor", &params.subsurfaceColor.r);
+                }
+                if (params.currentMaterialModel == MATERIAL_MODEL_CLOTH) {
+                    ImGui::ColorEdit3("sheenColor", &params.sheenColor.r);
+                    ImGui::ColorEdit3("subsurfaceColor", &params.subsurfaceColor.r);
+                }
+            }
+        }
+
+        if (ImGui::CollapsingHeader("Object")) {
+            ImGui::Checkbox("castShadows", &params.castShadows);
+        }
+
+        if (ImGui::CollapsingHeader("Light")) {
+            ImGui::Checkbox("enabled", &params.directionalLightEnabled);
+            ImGui::ColorEdit3("color", &params.lightColor.r);
+            ImGui::SliderFloat("lux", &params.lightIntensity, 0.0f, 150000.0f);
+            ImGui::SliderFloat3("direction", &params.lightDirection.x, -1.0f, 1.0f);
+            ImGui::SliderFloat("sunSize", &params.sunAngularRadius, 0.1f, 10.0f);
+            ImGui::SliderFloat("haloSize", &params.sunHaloSize, 1.01f, 40.0f);
+            ImGui::SliderFloat("haloFalloff", &params.sunHaloFalloff, 0.0f, 2048.0f);
+            ImGui::SliderFloat("ibl", &params.iblIntensity, 0.0f, 50000.0f);
+            ImGui::SliderAngle("ibl rotation", &params.iblRotation);
+        }
+    }
+    ImGui::End();
+
+    MaterialInstance* materialInstance = updateInstances(params, *engine);
+
+    auto& rcm = engine->getRenderableManager();
+    auto instance = rcm.getInstance(app.filamesh->renderable);
+    for (size_t i = 0; i < rcm.getPrimitiveCount(instance); i++) {
+        rcm.setMaterialInstanceAt(instance, i, materialInstance);
+    }
+    rcm.setCastShadows(instance, params.castShadows);
+
+    if (params.directionalLightEnabled && !params.hasDirectionalLight) {
+        app.scene->addEntity(params.light);
+        params.hasDirectionalLight = true;
+    } else if (!params.directionalLightEnabled && params.hasDirectionalLight) {
+        app.scene->remove(params.light);
+        params.hasDirectionalLight = false;
+    }
+
+    app.skylight.indirectLight->setIntensity(params.iblIntensity);
+    app.skylight.indirectLight->setRotation(
+            mat3f::rotate(params.iblRotation, float3{ 0, 1, 0 }));
+}
+
+// This is called only after the JavaScript layer has created a WebGL 2.0 context and all assets
+// have been downloaded.
+extern "C" void launch() {
+    filaweb::Application::get()->run(setup, animate, ui);
+}
+
+// The main() entry point is implicitly called after JIT compilation, but potentially before the
+// WebGL context has been created or assets have finished loading.
+int main() { }
+

--- a/samples/web/sandbox.html
+++ b/samples/web/sandbox.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Triangle</title>
+    <title>Sandbox</title>
     <link href="favicon.png" rel="icon" type="image/x-icon"/>
     <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
     <style>
@@ -19,10 +19,13 @@
 </head>
 <body>
     <canvas id="filament-canvas"></canvas>
-    <script src="triangle.js"></script>
+    <script src="sandbox.js"></script>
     <script src="filaweb.js"></script>
     <script>
-    load({});
+    load({
+        'mesh':       load_rawfile('shaderball/mesh.filamesh'),
+        'pillars_2k': load_cubemap('pillars_2k/', 9)
+    });
     </script>
 </body>
 </html>

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Suzanne</title>
     <link href="favicon.png" rel="icon" type="image/x-icon"/>
-    <meta name="viewport" content="width=device-width,user-scalable=no">
+    <meta name="viewport" content="width=device-width,user-scalable=no,initial-scale=1">
     <style>
     body {
         margin: 0;
@@ -12,8 +12,8 @@
     }
     #filament-canvas {
         touch-action: none;
-        width: 100vw;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
     }
     </style>
 </head>


### PR DESCRIPTION
**Please note: this refactors the existing `material_sandbox` native demo, GitHub collapses large diffs.**

This adds a new demo that leverages ImGui. It looks very similar to the
existing material_sandbox demo we have for desktop, with a few
differences:

    1. Does not use FilamentApp.
    2. Does not draw a shadow plane.
    3. Does not use a TrueType font in ImGui. (improves load time)
    4. Does not allow the user to spin the model. (will fix soon)

We now have a triumvirate of web demos with a progression in complexity:

    1. triangle
    2. suzanne
    3. sandbox

This is a sufficient set of WebGL samples for now, at least until we
finish creating a proper JavaScript API.

This CL factors out some of the common code with the native sandbox
demo, but keeps the UI definition separate since the web demo has some
minor differences (e.g., there is no shadow plane yet).

Note that using viewport units for height was wrong; it caused a bad
aspect ratio on Android while the URL bar was visible. This is explained
in an article:

https://developers.google.com/web/updates/2016/12/url-bar-resizing