### PR TITLE
importance sampling option for IBL

### DIFF
--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -96,6 +96,8 @@ IndirectLight* IndirectLight::Builder::build(Engine& engine) {
             return nullptr;
         }
         if (IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING) {
+            // FIXME: this doesn't work because IBLs are encoded as RGBM with a gamma of 0.5
+            // this produces mipmap levels that are too dark
             mImpl->mReflectionsMap->generateMipmaps(engine);
         }
     }

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -23,6 +23,9 @@
 
 #include <utils/Panic.h>
 
+#define IBL_INTEGRATION_PREFILTERED_CUBEMAP         0
+#define IBL_INTEGRATION_IMPORTANCE_SAMPLING         1
+#define IBL_INTEGRATION                             IBL_INTEGRATION_PREFILTERED_CUBEMAP
 
 using namespace math;
 
@@ -91,6 +94,9 @@ IndirectLight* IndirectLight::Builder::build(Engine& engine) {
                 mImpl->mReflectionsMap->getLevels() == 1,
                 "reflection map must be 256x256 and have 9 mipmap levels")) {
             return nullptr;
+        }
+        if (IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING) {
+            mImpl->mReflectionsMap->generateMipmaps(engine);
         }
     }
 


### PR DESCRIPTION
This will be useful for testing and can be
enabled at compile time by setting
IBL_INTEGRATION to IBL_INTEGRATION_IMPORTANCE_SAMPLING
in *both* indirectLight.cpp and light_indirect.fs

BUGS: clearcoat and subsurface won’t
work well when this is enabled since the prefiltered
cubemap is not available and, we don’t evaluate
those lobes with importance sampling (yet).
Additionally, anisotropy can’t work with our
prefiltered importance sampling, so it still uses
the emulation by bending the normal.