### PR TITLE
Allow macOS developers to optionally use an SDK version of Vulkan.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,11 +253,13 @@ endif()
 # "bluevk" and "samples" targets.
 # ==================================================================================================
 
-find_library(Vulkan_LIBRARY NAMES vulkan HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/macOS/lib")
-if (Vulkan_LIBRARY)
-    set(Vulkan_FOUND ON)
-    message(STATUS "Found Vulkan library in SDK: ${Vulkan_LIBRARY}.")
-    add_definitions(-DFILAMENT_VKLIBRARY_PATH=\"${Vulkan_LIBRARY}\")
+if (FILAMENT_SUPPORTS_VULKAN AND APPLE)
+    find_library(Vulkan_LIBRARY NAMES vulkan HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/macOS/lib")
+    if (Vulkan_LIBRARY)
+        set(Vulkan_FOUND ON)
+        message(STATUS "Found Vulkan library in SDK: ${Vulkan_LIBRARY}.")
+        add_definitions(-DFILAMENT_VKLIBRARY_PATH=\"${Vulkan_LIBRARY}\")
+    endif()
 endif()
 
 # ==================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,19 @@ else()
 endif()
 
 # ==================================================================================================
+# Try to find Vulkan if the SDK is installed, otherwise fall back to the bundled version.
+# This needs to stay in our top-level CMakeLists because it sets up variables that are used by the
+# "bluevk" and "samples" targets.
+# ==================================================================================================
+
+find_library(Vulkan_LIBRARY NAMES vulkan HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/macOS/lib")
+if (Vulkan_LIBRARY)
+    set(Vulkan_FOUND ON)
+    message(STATUS "Found Vulkan library in SDK: ${Vulkan_LIBRARY}.")
+    add_definitions(-DFILAMENT_VKLIBRARY_PATH=\"${Vulkan_LIBRARY}\")
+endif()
+
+# ==================================================================================================
 # Sub-projects
 # ==================================================================================================
 # Common to all platforms

--- a/libs/bluevk/src/BlueVKDarwin.cpp
+++ b/libs/bluevk/src/BlueVKDarwin.cpp
@@ -28,12 +28,18 @@ static const char* VKLIBRARY_PATH = "libvulkan.1.dylib";
 static void* module = nullptr;
 
 bool loadLibrary() {
+
+#ifndef FILAMENT_VKLIBRARY_PATH
     // Rather than looking in the working directory, look for the dylib in the same folder that the
     // executable lives in. This allows MacOS users to run Vulkan-based Filament apps from anywhere.
     const Path executableFolder = Path::getCurrentExecutable().getParent();
     const Path dylibPath = executableFolder.concat(VKLIBRARY_PATH);
     const Path jsonPath = executableFolder.concat("MoltenVK_icd.json");
     setenv("VK_ICD_FILENAMES", jsonPath.c_str(), 1);
+#else
+    const Path dylibPath = FILAMENT_VKLIBRARY_PATH;
+#endif
+
     module = dlopen(dylibPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     return module != nullptr;
 }

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -156,7 +156,8 @@ endif()
 # Copy the MoltenVK dylibs and JSON on MacOS
 # ==================================================================================================
 
-if (APPLE)
+if (APPLE AND NOT Vulkan_LIBRARY)
+    message(STATUS "No Vulkan SDK was found, using prebuilt MoltenVK.")
     set(MOLTENVK_DIR "../third_party/moltenvk")
     configure_file(
             ${MOLTENVK_DIR}/libvulkan.1.dylib


### PR DESCRIPTION
This looks for VULKAN_SDK at build time, and if present it tells
Filament to use the `libvulkan.1.dylib` that's located there. Otherwise
it falls back to our old loading strategy, which uses a bundled version
of MoltenVK that allows us to avoid requiring installation of the
LunarG SDK.

I tried this out an it works for me...

Closes issue #238.