### PR TITLE
cmgen and mipgen should return an error code upon failure.

### DIFF
--- a/libs/imageio/include/imageio/ImageDecoder.h
+++ b/libs/imageio/include/imageio/ImageDecoder.h
@@ -31,6 +31,7 @@ public:
         SRGB
     };
 
+    // Returns linear floating-point data, or a non-valid image if an error occured.
     static LinearImage decode(std::istream& stream, const std::string& sourceName,
             ColorSpace sourceSpace = ColorSpace::SRGB);
 

--- a/libs/imageio/include/imageio/ImageEncoder.h
+++ b/libs/imageio/include/imageio/ImageEncoder.h
@@ -42,8 +42,8 @@ public:
                     // Default: 16 bit
     };
 
-    // the encode function only expects images that store pixels as floats
-    static void encode(std::ostream& stream, Format format, const LinearImage& image,
+    // Consumes linear floating-point data, returns false if unable to encode.
+    static bool encode(std::ostream& stream, Format format, const LinearImage& image,
             const std::string& compression, const std::string& destName);
 
     static Format chooseFormat(const std::string& name, bool forceLinear = false);
@@ -51,7 +51,7 @@ public:
 
     class Encoder {
     public:
-        virtual void encode(const LinearImage& image) = 0;
+        virtual bool encode(const LinearImage& image) = 0;
         virtual ~Encoder() = default;
     };
 };

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -886,5 +886,7 @@ static void saveImage(const std::string& path, ImageEncoder::Format format, cons
         memcpy(dst, src, w * 12);
     }
 
-    ImageEncoder::encode(outputStream, format, linearImage, compression, path);
+    if (!ImageEncoder::encode(outputStream, format, linearImage, compression, path)) {
+        exit(1);
+    }
 }

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
     LinearImage sourceImage = ImageDecoder::decode(inputStream, inputPath.getPath());
     if (!sourceImage.isValid()) {
         cerr << "Unable to open image: " << inputPath.getPath() << endl;
-        exit(1);
+        return 1;
     }
 
     puts("Generating miplevels...");
@@ -210,16 +210,20 @@ int main(int argc, char* argv[]) {
         int result = snprintf(path, sizeof(path), outputPattern.c_str(), mip++);
         if (result < 0 || result >= sizeof(path)) {
             cerr << "Output pattern is too long." << endl;
-            exit(1);
+            return 1;
         }
         ofstream outputStream(path, ios::binary | ios::trunc);
         if (!outputStream) {
             cerr << "The output file cannot be opened: " << path << endl;
         } else {
-            ImageEncoder::encode(outputStream, g_format, image, g_compression, path);
+            if (!ImageEncoder::encode(outputStream, g_format, image, g_compression, path)) {
+                cerr << "An error occurred while encoding the image." << endl;
+                return 1;
+            }
             outputStream.close();
             if (!outputStream) {
                 cerr << "An error occurred while writing the output file: " << path << endl;
+                return 1;
             }
         }
     }
@@ -236,7 +240,7 @@ int main(int argc, char* argv[]) {
         int result = snprintf(tag, sizeof(tag), pattern, inputPath.c_str(), width, height);
         if (result < 0 || result >= sizeof(tag)) {
             cerr << "Output pattern is too long." << endl;
-            exit(1);
+            return 1;
         }
         html << tag << std::endl;
         for (auto image: miplevels) {
@@ -244,7 +248,7 @@ int main(int argc, char* argv[]) {
             result = snprintf(tag, sizeof(tag), pattern, path, width, height);
             if (result < 0 || result >= sizeof(tag)) {
                 cerr << "Output pattern is too long." << endl;
-                exit(1);
+                return 1;
             }
             html << tag << std::endl;
         }


### PR DESCRIPTION
These tools can be used in an asset pipeline; build scripts should not
be required to parse stdout in order to determine success.