### PR TITLE
Fix filaweb bug with detecting PNG vs KTX.

### DIFF
--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -47,6 +47,7 @@ struct Asset {
     std::unique_ptr<Asset> envShCoeffs;
     std::unique_ptr<Asset[]> envFaces;
     std::unique_ptr<Asset[]> skyFaces;
+    char url[256];
 };
 
 Asset getRawFile(const char* name);

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -86,7 +86,7 @@ function load_rawfile(url) {
         fetch(url).then(resp => {
             resp.arrayBuffer().then(filedata => success({
                 kind: 'rawfile',
-                name: url,
+                url: url,
                 data: new Uint8Array(filedata)
             }));
         });

--- a/samples/web/suzanne.cpp
+++ b/samples/web/suzanne.cpp
@@ -185,6 +185,7 @@ void setup(Engine* engine, View* view, Scene* scene) {
     scene->setSkybox(skylight.skybox);
     skylight.indirectLight->setRotation(
             mat3f::rotate(M_PI, float3{ 0, 1, 0 }));
+    skylight.indirectLight->setIntensity(100000);
 
     app.cam = engine->createCamera();
     app.cam->setExposure(16.0f, 1 / 125.0f, 100.0f);


### PR DESCRIPTION
To determine PNG vs KTX, we were looking at the file extension of the asset name rather than the actual file path (which is a URL).

Also, le singe était trop sombre, so I added a call to setIntensity.