### PR TITLE
Fix three bugs that caused bad normals with Suzanne.

### DIFF
--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -84,7 +84,7 @@ function(add_ktxfiles SOURCE TARGET EXTRA_ARGS)
 endfunction()
 
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo.ktx" "")
-add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal.ktx" "--kernel=NORMALS")
+add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal.ktx" "--kernel=NORMALS;--linear")
 add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness.ktx" "--grayscale")
 add_ktxfiles("assets/models/monkey/metallic.png" "monkey/metallic.ktx" "--grayscale")
 add_ktxfiles("assets/models/monkey/ao.png" "monkey/ao.ktx" "--grayscale")

--- a/samples/web/suzanne.cpp
+++ b/samples/web/suzanne.cpp
@@ -57,7 +57,7 @@ static constexpr uint8_t MATERIAL_LIT_PACKAGE[] = {
 
 static SuzanneApp app;
 
-static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, string name,
+static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, string name, bool linear,
         TextureSampler const &sampler) {
 
     const auto destructor = [](void* buffer, size_t size, void* user) {
@@ -80,8 +80,8 @@ static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, strin
     switch (asset.channels) {
         case 1: internalFormat = Format::R8; break;
         case 2: internalFormat = Format::RG8; break;
-        case 3: internalFormat = Format::SRGB8; break;
-        case 4: internalFormat = Format::SRGB8_A8; break;
+        case 3: internalFormat = linear ? Format::RGB8 : Format::SRGB8; break;
+        case 4: internalFormat = linear ? Format::RGBA8 : Format::SRGB8_A8; break;
     }
 
     auto texture = Texture::Builder()
@@ -126,15 +126,15 @@ void setup(Engine* engine, View* view, Scene* scene) {
 
     // Create textures.
     TextureSampler sampler(MagFilter::LINEAR, WrapMode::CLAMP_TO_EDGE);
-    auto setTexture = [engine, sampler] (filaweb::Asset& asset, const char* name) {
+    auto setTexture = [engine, sampler] (filaweb::Asset& asset, const char* name, bool linear) {
         printf("%s: %d x %d\n", name, asset.width, asset.height);
-        setTextureParameter(*engine, asset, name, sampler);
+        setTextureParameter(*engine, asset, name, linear, sampler);
     };
-    setTexture(albedo, "albedo");
-    setTexture(metallic, "metallic");
-    setTexture(roughness, "roughness");
-    setTexture(normal, "normal");
-    setTexture(ao, "ao");
+    setTexture(albedo, "albedo", false);
+    setTexture(metallic, "metallic", false);
+    setTexture(roughness, "roughness", false);
+    setTexture(normal, "normal", true);
+    setTexture(ao, "ao", false);
 
     // Create the sun.
     auto& em = EntityManager::get();

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[]) {
     puts("Reading image...");
     ifstream inputStream(inputPath.getPath(), ios::binary);
     LinearImage sourceImage = ImageDecoder::decode(inputStream, inputPath.getPath(),
-            ImageDecoder::ColorSpace::SRGB);
+            g_linearized ? ImageDecoder::ColorSpace::LINEAR : ImageDecoder::ColorSpace::SRGB);
     if (!sourceImage.isValid()) {
         cerr << "Unable to open image: " << inputPath.getPath() << endl;
         return 1;


### PR DESCRIPTION
(1) Suzanne's normal map is actually linear but we were telling GL that it is SRGB, so the shader was not reading (0.5,0.5,1.0) from a perfectly flat normal map.

(2) --linear in mipgen was not honored when consuming PNG files.

(3) The build was not passing --linear to mipgen for the normal map.