### PR TITLE
Finally, use KTX for envmaps in WebGL demos.

### DIFF
--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -107,23 +107,19 @@ add_mesh("third_party/shader_ball/shader_ball.obj" "shaderball/mesh.filamesh")
 # Generate IBL and skybox images using cmgen.
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${CMAKE_CURRENT_SOURCE_DIR}/../../${SOURCE}")
-    foreach(FACE nx ny nz px py pz)
-        set(target_skybox ${target_skybox} ${TARGET}/${FACE}.rgbm)
-        foreach(MIP 0 1 2 3 4 5 6 7 8)
-            set(target_envmap ${target_envmap} ${TARGET}/m${MIP}_${FACE}.rgbm)
-        endforeach()
-    endforeach()
+    set(target_skybox "public/${TARGET}/${TARGET}_skybox.ktx")
+    set(target_envmap "public/${TARGET}/${TARGET}_ibl.ktx")
     set(target_skyboxes ${target_skyboxes} ${target_skybox} PARENT_SCOPE)
+    set(target_envmaps ${target_envmaps} ${target_envmap} PARENT_SCOPE)
     add_custom_command(
         OUTPUT ${target_skybox} ${target_envmap}
-        COMMAND cmgen -x public --format=rgbm --size=256 --extract-blur=0.1 ${source_envmap}
+        COMMAND cmgen -x public --format=ktx --size=256 --extract-blur=0.1 ${source_envmap}
         MAIN_DEPENDENCY ${source_envmap}
         DEPENDS cmgen)
-    set(target_envmaps ${target_envmaps} ${target_envmap} PARENT_SCOPE)
 endfunction()
 
-add_envmap("third_party/environments/syferfontein_18d_clear_2k.hdr" "public/syferfontein_18d_clear_2k")
-add_envmap("third_party/environments/pillars_2k.hdr" "public/pillars_2k")
+add_envmap("third_party/environments/syferfontein_18d_clear_2k.hdr" "syferfontein_18d_clear_2k")
+add_envmap("third_party/environments/pillars_2k.hdr" "pillars_2k")
 
 add_custom_target(sample_assets DEPENDS
     ${target_ktxfiles}

--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -19,6 +19,8 @@
 
 #include "../app/CameraManipulator.h"
 
+#include <image/KtxBundle.h>
+
 #include <filagui/ImGuiHelper.h>
 
 #include <filament/Camera.h>
@@ -35,14 +37,14 @@
 
 namespace filaweb {
 
-// Filaweb defines three kinds of assets: raw files, single-mip textures, and cubemaps.
+// Filaweb defines three kinds of assets: raw files, textures, and cubemaps.
 // For simplicity all three kinds are represented with a single struct.
 struct Asset {
     std::unique_ptr<uint8_t[]> data;
+    std::unique_ptr<image::KtxBundle> ktx;
     uint32_t nbytes;
     uint32_t width;
     uint32_t height;
-    uint32_t channels;
     uint32_t envMipCount;
     std::unique_ptr<Asset> envShCoeffs;
     std::unique_ptr<Asset[]> envFaces;

--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -45,10 +45,9 @@ struct Asset {
     uint32_t nbytes;
     uint32_t width;
     uint32_t height;
-    uint32_t envMipCount;
     std::unique_ptr<Asset> envShCoeffs;
-    std::unique_ptr<Asset[]> envFaces;
-    std::unique_ptr<Asset[]> skyFaces;
+    std::unique_ptr<Asset> envFaces;
+    std::unique_ptr<Asset> skyFaces;
     char url[256];
 };
 

--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -37,18 +37,16 @@
 
 namespace filaweb {
 
-// Filaweb defines three kinds of assets: raw files, textures, and cubemaps.
+// Filaweb defines three kinds of assets: textures, environments, and raw files.
 // For simplicity all three kinds are represented with a single struct.
 struct Asset {
-    std::unique_ptr<uint8_t[]> data;
-    std::unique_ptr<image::KtxBundle> ktx;
-    uint32_t nbytes;
-    uint32_t width;
-    uint32_t height;
+    std::unique_ptr<image::KtxBundle> texture;
     std::unique_ptr<Asset> envShCoeffs;
-    std::unique_ptr<Asset> envFaces;
-    std::unique_ptr<Asset> skyFaces;
-    char url[256];
+    std::unique_ptr<Asset> envIBL;
+    std::unique_ptr<Asset> envSky;
+    std::unique_ptr<uint8_t[]> rawData;
+    uint32_t rawSize;
+    char rawUrl[256];
 };
 
 Asset getRawFile(const char* name);

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -96,30 +96,21 @@ function load_rawfile(url) {
 
 let load_texture = load_rawfile;
 
-function load_cubemap(urlprefix, nmips) {
+function load_cubemap(name) {
+    let urlprefix = name + '/';
     let promises = {};
-    let name = '';
     promises['sh.txt'] = load_rawfile(urlprefix + 'sh.txt');
-    for (let i = 0; i < nmips; i++) {
-        for (let face of 'px nx py ny pz nz'.split(' ')) {
-            name = 'm' + i + '_' + face + '.rgbm';
-            promises[name] = load_texture(urlprefix + name);
-        }
-    }
-    for (let face of 'px nx py ny pz nz'.split(' ')) {
-        name = face + '.rgbm';
-        promises[name] = load_texture(urlprefix + name);
-    }
+    promises['ibl'] = load_rawfile(urlprefix + name + '_ibl.ktx');
+    promises['skybox'] = load_rawfile(urlprefix + name + '_skybox.ktx');
     let numberRemaining = Object.keys(promises).length;
     var promise = new Promise((success) => {
-        for (let name in promises) {
-            promises[name].then((result) => {
-                assets[urlprefix + name] = result;
+        for (let key in promises) {
+            promises[key].then((result) => {
+                assets[urlprefix + key] = result;
                 if (--numberRemaining == 0) {
                     success({
                         kind: 'cubemap',
                         name: urlprefix,
-                        nmips: nmips,
                     });
                 }
             });

--- a/samples/web/sandbox.cpp
+++ b/samples/web/sandbox.cpp
@@ -79,10 +79,10 @@ void setup(Engine* engine, View* view, Scene* scene) {
     static auto mesh = filaweb::getRawFile("mesh");
 
     // Create mesh.
-    const uint8_t* mdata = mesh.data.get();
+    const uint8_t* mdata = mesh.rawData.get();
     const auto destructor = [](void* buffer, size_t size, void* user) {
         auto asset = (filaweb::Asset*) user;
-        asset->data.reset();
+        asset->rawData.reset();
     };
     MaterialInstance* materialInstance = app.params.materialInstance[MATERIAL_LIT];
     app.filamesh = decodeMesh(*engine, mdata, 0, materialInstance, destructor, &mesh);

--- a/samples/web/sandbox.html
+++ b/samples/web/sandbox.html
@@ -24,7 +24,7 @@
     <script>
     load({
         'mesh':       load_rawfile('shaderball/mesh.filamesh'),
-        'pillars_2k': load_cubemap('pillars_2k/', 9)
+        'pillars_2k': load_cubemap('pillars_2k')
     });
     </script>
 </body>

--- a/samples/web/suzanne.cpp
+++ b/samples/web/suzanne.cpp
@@ -59,11 +59,11 @@ static SuzanneApp app;
 
 static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, string name, bool linear,
         TextureSampler const &sampler) {
-    const auto& info = asset.ktx->getInfo();
+    const auto& info = asset.texture->getInfo();
 
     const auto destructor = [](void* buffer, size_t size, void* user) {
         auto asset = (filaweb::Asset*) user;
-        asset->ktx.reset();
+        asset->texture.reset();
     };
 
     Texture::Format format;
@@ -76,7 +76,7 @@ static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, strin
 
     uint8_t* data;
     uint32_t nbytes;
-    asset.ktx->getBlob({}, &data, &nbytes);
+    asset.texture->getBlob({}, &data, &nbytes);
     Texture::PixelBufferDescriptor pb(data, nbytes, format, Texture::Type::UBYTE, destructor,
             &asset);
 
@@ -119,11 +119,11 @@ void setup(Engine* engine, View* view, Scene* scene) {
     static auto ao = filaweb::getTexture("ao");
 
     // Create mesh.
-    printf("%s: %d bytes\n", "mesh", mesh.nbytes);
-    const uint8_t* mdata = mesh.data.get();
+    printf("%s: %d bytes\n", "mesh", mesh.rawSize);
+    const uint8_t* mdata = mesh.rawData.get();
     const auto destructor = [](void* buffer, size_t size, void* user) {
         auto asset = (filaweb::Asset*) user;
-        asset->data.reset();
+        asset->rawData.reset();
     };
     app.filamesh = decodeMesh(*engine, mdata, 0, app.mi, destructor, &mesh);
     scene->addEntity(app.filamesh->renderable);

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -29,7 +29,7 @@
         'normal':                    load_rawfile('monkey/normal.ktx'),
         'ao':                        load_rawfile('monkey/ao.ktx'),
         'mesh':                      load_rawfile('monkey/mesh.filamesh'),
-        'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k/', 9)
+        'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k')
     });
     </script>
 </body>


### PR DESCRIPTION
Now that cmgen supports KTX without any known bugs, we can finally turn this on. For each envmap/skybox pair, this reduces the number of downloads from 61 files to 3 files. This could go down to 2 if we use KTX metadata, which I'll look into next.