### PR TITLE
Rotate WebGL samples IBL by 180.

### DIFF
--- a/samples/web/sandbox.cpp
+++ b/samples/web/sandbox.cpp
@@ -61,7 +61,7 @@ void setup(Engine* engine, View* view, Scene* scene) {
     app.params.lightDirection.x = 1;
     app.params.lightDirection.y = -1;
     app.params.lightDirection.z = -0.4;
-    app.params.iblRotation = 109 * M_PI / 180;
+    app.params.iblRotation = 289 * M_PI / 180;
 
     // These initial values look pretty nice with the shaderball.
     app.params.clearCoat = 0.7f;

--- a/samples/web/suzanne.cpp
+++ b/samples/web/suzanne.cpp
@@ -186,8 +186,6 @@ void setup(Engine* engine, View* view, Scene* scene) {
     auto skylight = filaweb::getSkyLight(*engine, "syferfontein_18d_clear_2k");
     scene->setIndirectLight(skylight.indirectLight);
     scene->setSkybox(skylight.skybox);
-    skylight.indirectLight->setRotation(
-            mat3f::rotate(M_PI, float3{ 0, 1, 0 }));
     skylight.indirectLight->setIntensity(100000);
 
     app.cam = engine->createCamera();


### PR DESCRIPTION
This is being done simply to maintain the rough alignment between
the light source and the env map. See 09830cd for more information.