### PR TITLE
Web: allow arbitrary file extensions for KTX files.

### DIFF
--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -191,6 +191,7 @@ Asset getTexture(const char* name) {
     if (extension == "png" || extension == "rgbm") {
         return getPngTexture(rawfile);
     }
+    // Do not check for KTX here, sometimes we use an alternate file extension.
     return getKtxTexture(rawfile);
 }
 

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -96,12 +96,12 @@ function load_rawfile(url) {
 
 let load_texture = load_rawfile;
 
-function load_cubemap(name) {
+function load_cubemap(name, suffix) {
     let urlprefix = name + '/';
     let promises = {};
     promises['sh.txt'] = load_rawfile(urlprefix + 'sh.txt');
-    promises['ibl'] = load_rawfile(urlprefix + name + '_ibl.ktx');
-    promises['skybox'] = load_rawfile(urlprefix + name + '_skybox.ktx');
+    promises['ibl'] = load_rawfile(urlprefix + name + '_ibl' + suffix);
+    promises['skybox'] = load_rawfile(urlprefix + name + '_skybox' + suffix);
     let numberRemaining = Object.keys(promises).length;
     var promise = new Promise((success) => {
         for (let key in promises) {

--- a/samples/web/sandbox.html
+++ b/samples/web/sandbox.html
@@ -24,7 +24,7 @@
     <script>
     load({
         'mesh':       load_rawfile('shaderball/mesh.filamesh'),
-        'pillars_2k': load_cubemap('pillars_2k')
+        'pillars_2k': load_cubemap('pillars_2k', '.ktx')
     });
     </script>
 </body>

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -29,7 +29,7 @@
         'normal':                    load_rawfile('monkey/normal.ktx'),
         'ao':                        load_rawfile('monkey/ao.ktx'),
         'mesh':                      load_rawfile('monkey/mesh.filamesh'),
-        'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k')
+        'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k', '.ktx')
     });
     </script>
 </body>


### PR DESCRIPTION
Sometimes you want your KTX file to end in an extension other than
".ktx".  For example, GitHub Pages applies gzip encoding to bmp files
but not to ktx files (which I think is consistent with nginx defaults).

This change makes it so that a deploy script can rename the files and
apply a simple string transformation to the HTML.