### PR TITLE
Fix incorrect SPIR-V instructions

### DIFF
--- a/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
+++ b/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
@@ -168,6 +168,8 @@ bool GLSLPostProcessor::process(const std::string& inputShader,
     }
 
     program.addShader(&tShader);
+    // Even though we only have a single shader stage, linking is still necessary to finalize
+    // SPIR-V types
     bool linkOk = program.link(msg);
     if (!linkOk) {
         std::cerr << tShader.getInfoLog() << std::endl;
@@ -227,6 +229,8 @@ void GLSLPostProcessor::preprocessOptimization(glslang::TShader& tShader,
                 mConfig.getOptimizationLevel());
         ok = spirvShader.parse(&DefaultTBuiltInResource, mLangVersion, false, msg);
         program.addShader(&spirvShader);
+        // Even though we only have a single shader stage, linking is still necessary to finalize
+        // SPIR-V types
         bool linkOk = program.link(msg);
         if (!ok || !linkOk) {
             std::cerr << spirvShader.getInfoLog() << std::endl;

--- a/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
+++ b/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
@@ -149,7 +149,7 @@ bool GLSLPostProcessor::process(const std::string& inputShader,
         mShLang = EShLangFragment;
     }
 
-    glslang::TProgram program;
+    TProgram program;
     TShader tShader(mShLang);
 
     // The cleaner must be declared after the TShader to prevent ASAN failures.

--- a/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
+++ b/tools/matc/src/matc/sca/GLSLPostProcessor.cpp
@@ -219,16 +219,19 @@ void GLSLPostProcessor::preprocessOptimization(glslang::TShader& tShader,
     }
 
     if (mSpirvOutput) {
+        TProgram program;
         TShader spirvShader(mShLang);
         const char* shaderCString = glsl.c_str();
         spirvShader.setStrings(&shaderCString, 1);
         GLSLTools::prepareShaderParser(spirvShader, mShLang, mLangVersion,
                 mConfig.getOptimizationLevel());
         ok = spirvShader.parse(&DefaultTBuiltInResource, mLangVersion, false, msg);
-        if (!ok) {
+        program.addShader(&spirvShader);
+        bool linkOk = program.link(msg);
+        if (!ok || !linkOk) {
             std::cerr << spirvShader.getInfoLog() << std::endl;
         } else {
-            GlslangToSpv(*spirvShader.getIntermediate(), *mSpirvOutput);
+            GlslangToSpv(*program.getIntermediate(mShLang), *mSpirvOutput);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/baldurk/renderdoc/issues/1097

`matc` outputs shaders with invalid SPIR-V instructions (see linked Renderdoc issue):

```
%_runtimearr_float = OpTypeRuntimeArray %float
%_runtimearr_float_0 = OpTypeRuntimeArray %float
%gl_PerVertex = OpTypeStruct %v4float %float %_runtimearr_float %_runtimearr_float_0
```

Not sure if this is just a bug with glslang, incorrect usage on our side, or potentially both. According to [glslang documentation](https://github.com/KhronosGroup/glslang/blob/8751c13ce2cea72974586bf4005737903a7ed539/glslang/Public/ShaderLang.h#L668-L670) when compiling shader programs, we need to be adding them to a `TProgram` and calling `link`. This fixes the issue.