### PR TITLE
better cross conversion. Fix #283.

### DIFF
--- a/tools/cmgen/src/Cubemap.cpp
+++ b/tools/cmgen/src/Cubemap.cpp
@@ -95,7 +95,6 @@ Cubemap::Address Cubemap::getAddressFor(const double3& r) {
  * right or bottom. This works well with cubemaps stored as a cross in memory.
  */
 void Cubemap::makeSeamless() {
-    Geometry geometry = mGeometry;
     size_t dim = getDimensions();
     auto stitch = [ & ](void* dst, size_t incDst, void const* src, ssize_t incSrc) {
         for (size_t i = 0; i < dim; ++i) {
@@ -108,41 +107,26 @@ void Cubemap::makeSeamless() {
     const size_t bpr = getImageForFace(Face::NX).getBytesPerRow();
     const size_t bpp = getImageForFace(Face::NX).getBytesPerPixel();
 
-    if (geometry == Geometry::HORIZONTAL_CROSS ||
-        geometry == Geometry::VERTICAL_CROSS) {
-        stitch(  getImageForFace(Face::NX).getPixelRef(0, dim), bpp,
-                getImageForFace(Face::NY).getPixelRef(0, dim - 1), -bpr);
+    stitch(getImageForFace(Face::NX).getPixelRef(0, dim), bpp,
+            getImageForFace(Face::NY).getPixelRef(0, dim - 1), -bpr);
 
-        stitch(  getImageForFace(Face::PY).getPixelRef(dim, 0), bpr,
-                getImageForFace(Face::PX).getPixelRef(dim - 1, 0), -bpp);
+    stitch(getImageForFace(Face::PY).getPixelRef(dim, 0), bpr,
+            getImageForFace(Face::PX).getPixelRef(dim - 1, 0), -bpp);
 
-        stitch(  getImageForFace(Face::PX).getPixelRef(0, dim), bpp,
-                getImageForFace(Face::NY).getPixelRef(dim - 1, 0), bpr);
+    stitch(getImageForFace(Face::PX).getPixelRef(0, dim), bpp,
+            getImageForFace(Face::NY).getPixelRef(dim - 1, 0), bpr);
 
-        stitch(  getImageForFace(Face::NY).getPixelRef(dim, 0), bpr,
-                getImageForFace(Face::PX).getPixelRef(0, dim - 1), bpp);
+    stitch(getImageForFace(Face::NY).getPixelRef(dim, 0), bpr,
+            getImageForFace(Face::PX).getPixelRef(0, dim - 1), bpp);
 
-        if (geometry == Geometry::HORIZONTAL_CROSS) { // horizontal cross
-            stitch(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
-                    getImageForFace(Face::NY).getPixelRef(dim - 1, dim - 1), -bpp);
+    stitch(getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
+            getImageForFace(Face::NY).getPixelRef(dim - 1, dim - 1), -bpp);
 
-            stitch(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
-                    getImageForFace(Face::NX).getPixelRef(0, 0), bpr);
+    stitch(getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
+            getImageForFace(Face::NX).getPixelRef(0, 0), bpr);
 
-            stitch(  getImageForFace(Face::NY).getPixelRef(0, dim), bpp,
-                    getImageForFace(Face::NZ).getPixelRef(dim - 1, dim - 1), -bpp);
-
-        } else {
-            stitch(  getImageForFace(Face::NZ).getPixelRef(0, dim), bpp,
-                    getImageForFace(Face::PY).getPixelRef(0, dim - 1), bpp);
-
-            stitch(  getImageForFace(Face::NZ).getPixelRef(dim, 0), bpr,
-                    getImageForFace(Face::PX).getPixelRef(dim - 1, dim - 1), -bpr);
-
-            stitch(  getImageForFace(Face::PX).getPixelRef(dim, 0), bpr,
-                    getImageForFace(Face::NZ).getPixelRef(dim - 1, dim - 1), -bpr);
-        }
-    }
+    stitch(getImageForFace(Face::NY).getPixelRef(0, dim), bpp,
+            getImageForFace(Face::NZ).getPixelRef(dim - 1, dim - 1), -bpp);
 }
 
 Cubemap::Texel Cubemap::filterAt(const Image& image, double x, double y) {

--- a/tools/cmgen/src/Cubemap.h
+++ b/tools/cmgen/src/Cubemap.h
@@ -78,15 +78,8 @@ public:
 
     size_t getDimensions() const;
 
-    enum class Geometry {
-        HORIZONTAL_CROSS,
-        VERTICAL_CROSS,
-    };
-    void setGeometry(Geometry geometry) { mGeometry = geometry; }
-    Geometry getGeometry() const { return mGeometry; }
     void makeSeamless();
 
-private:
     struct Address {
         Face face;
         double s = 0;
@@ -97,11 +90,11 @@ private:
     // (this is why this is private)
     static Address getAddressFor(const math::double3& direction);
 
+private:
     size_t mDimensions = 0;
     double mScale = 1;
     double mUpperBound = 0;
     Image mFaces[6];
-    Geometry mGeometry = Geometry::HORIZONTAL_CROSS;
 };
 
 inline const Image& Cubemap::getImageForFace(Face face) const {

--- a/tools/cmgen/src/CubemapUtils.cpp
+++ b/tools/cmgen/src/CubemapUtils.cpp
@@ -141,8 +141,8 @@ void CubemapUtils::crossToCubemap(Cubemap& dst, const Image& src) {
                             break;
                     }
 
-                    size_t sampleCount = std::max(1lu, dim / dimension);
-                    sampleCount = std::min(256lu, sampleCount * sampleCount);
+                    size_t sampleCount = std::max(size_t(1), dim / dimension);
+                    sampleCount = std::min(size_t(256), sampleCount * sampleCount);
                     for (size_t i = 0; i < sampleCount; i++) {
                         const double2 h = hammersley(uint32_t(i), 1.0f / sampleCount);
                         size_t u = dx + size_t((x + h.x) * dim / dimension);

--- a/tools/cmgen/src/CubemapUtils.cpp
+++ b/tools/cmgen/src/CubemapUtils.cpp
@@ -16,9 +16,11 @@
 
 #include "CubemapUtils.h"
 
-#include <string.h>
-
 #include <math/mat4.h>
+
+#include <algorithm>
+
+#include <string.h>
 
 using namespace math;
 using namespace image;

--- a/tools/cmgen/src/CubemapUtils.h
+++ b/tools/cmgen/src/CubemapUtils.h
@@ -49,6 +49,9 @@ public:
     // Convert equirectangular Image to a Cubemap
     static void equirectangularToCubemap(Cubemap& dst, const Image& src);
 
+    // Convert h or v cross Image to a Cubemap
+    static void crossToCubemap(Cubemap& dst, const Image& src);
+
     // clamp image to acceptable range
     static void clamp(Image& src);
 
@@ -60,9 +63,6 @@ public:
 
     // Create a cubemap object and its backing Image
     static Cubemap create(Image& image, size_t dim, bool horizontal = true);
-
-    // Copy an image
-    static void copyImage(Image& dst, const Image& src);
 
     // Sets a Cubemap faces from a cross image
     static void setAllFacesFromCross(Cubemap& cm, const Image& image);

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -440,15 +440,14 @@ int main(int argc, char* argv[]) {
         if ((isPOT(width) && (width * 3 == height * 4)) ||
             (isPOT(height) && (height * 3 == width * 4))) {
             // This is cross cubemap
-            const bool isHorizontal = width > height;
-            size_t dim = std::max(height, width) / 4;
+            size_t dim = g_output_size ? g_output_size : 256;
             if (!g_quiet) {
                 std::cout << "Loading cross... " << std::endl;
             }
 
             Image temp;
-            Cubemap cml = CubemapUtils::create(temp, dim, isHorizontal);
-            CubemapUtils::copyImage(temp, inputImage);
+            Cubemap cml = CubemapUtils::create(temp, dim);
+            CubemapUtils::crossToCubemap(cml, inputImage);
             images.push_back(std::move(temp));
             levels.push_back(std::move(cml));
         } else if (width == 2 * height) {

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -46,6 +46,10 @@ using namespace image;
 enum class ShFile {
     SH_NONE, SH_CROSS, SH_TEXT
 };
+
+static const size_t DFG_LUT_DEFAULT_SIZE = 128;
+static const size_t IBL_DEFAULT_SIZE = 256;
+
 static image::ImageEncoder::Format g_format = image::ImageEncoder::Format::PNG;
 static bool g_ktxContainer = false;
 static std::string g_compression;
@@ -93,7 +97,7 @@ static void iblDiffuseIrradiance(const utils::Path& iname, const std::vector<Cub
         const utils::Path& dir);
 static void iblMipmapPrefilter(const utils::Path& iname, const std::vector<Image>& images,
         const std::vector<Cubemap>& levels, const utils::Path& dir);
-static void iblLutDfg(const utils::Path& filename, size_t size = 128, bool multiscatter = false);
+static void iblLutDfg(const utils::Path& filename, size_t size, bool multiscatter = false);
 static void extractCubemapFaces(const utils::Path& iname, const Cubemap& cm, const utils::Path& dir);
 static void outputSh(std::ostream& out, const std::unique_ptr<math::double3[]>& sh, size_t numBands);
 static void outputSpectrum(std::ostream& out, const std::unique_ptr<math::double3[]>& sh,
@@ -370,7 +374,7 @@ int main(int argc, char* argv[]) {
         if (!g_quiet) {
             std::cout << "Generating IBL DFG LUT..." << std::endl;
         }
-        size_t size = g_output_size ? g_output_size : 128;
+        size_t size = g_output_size ? g_output_size : DFG_LUT_DEFAULT_SIZE;
         iblLutDfg(g_dfg_filename, size, g_dfg_multiscatter);
         if (num_args < 1) return 0;
     }
@@ -440,7 +444,7 @@ int main(int argc, char* argv[]) {
         if ((isPOT(width) && (width * 3 == height * 4)) ||
             (isPOT(height) && (height * 3 == width * 4))) {
             // This is cross cubemap
-            size_t dim = g_output_size ? g_output_size : 256;
+            size_t dim = g_output_size ? g_output_size : IBL_DEFAULT_SIZE;
             if (!g_quiet) {
                 std::cout << "Loading cross... " << std::endl;
             }
@@ -452,7 +456,7 @@ int main(int argc, char* argv[]) {
             levels.push_back(std::move(cml));
         } else if (width == 2 * height) {
             // we assume a spherical (equirectangular) image, which we will convert to a cross image
-            size_t dim = g_output_size ? g_output_size : 256;
+            size_t dim = g_output_size ? g_output_size : IBL_DEFAULT_SIZE;
             if (!g_quiet) {
                 std::cout << "Converting equirectangular image... " << std::endl;
             }
@@ -474,7 +478,7 @@ int main(int argc, char* argv[]) {
             std::cout << iname << " does not exist; generating UV grid..." << std::endl;
         }
 
-        size_t dim = g_output_size ? g_output_size : 256;
+        size_t dim = g_output_size ? g_output_size : IBL_DEFAULT_SIZE;
         Image temp;
         Cubemap cml = CubemapUtils::create(temp, dim);
 
@@ -729,7 +733,7 @@ void iblRoughnessPrefilter(const utils::Path& iname,
     // This is useful for debugging.
     const bool DEBUG_FULL_RESOLUTION = false;
 
-    const size_t baseExp = __builtin_ctz(g_output_size ? g_output_size : 256);
+    const size_t baseExp = __builtin_ctz(g_output_size ? g_output_size : IBL_DEFAULT_SIZE);
     size_t numSamples = g_num_samples;
     const size_t numLevels = baseExp + 1;
 
@@ -817,7 +821,7 @@ void iblDiffuseIrradiance(const utils::Path& iname,
         outputDir.mkdirRecursive();
     }
 
-    const size_t baseExp = __builtin_ctz(g_output_size ? g_output_size : 256);
+    const size_t baseExp = __builtin_ctz(g_output_size ? g_output_size : IBL_DEFAULT_SIZE);
     size_t numSamples = g_num_samples;
     const size_t dim = 1U << baseExp;
     Image image;


### PR DESCRIPTION
- internal cross storage is now always horizontal
  and seamless.

- source cross images are now always converted to
  internal format, conversion includes rescaling
  and sampling if scaling down.

- vertical cross is supported again

- fixes #283