### PR TITLE
Fix, Vulkan samples not compiling on Windows

### DIFF
--- a/libs/bluevk/CMakeLists.txt
+++ b/libs/bluevk/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(${TARGET} utils)
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
-if (NOT ANDROID)
+# test_bluevk is not supported on Android or Windows
+if (NOT ANDROID AND NOT WIN32)
     add_executable(test_bluevk tests/test_bluevk_sdl.cpp)
     target_link_libraries(test_bluevk PRIVATE dl bluevk sdl2)
 endif()

--- a/samples/vk_animation.cpp
+++ b/samples/vk_animation.cpp
@@ -58,7 +58,7 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
     #include "generated/material/bakedColor.inc"
 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "animation";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_depthtesting.cpp
+++ b/samples/vk_depthtesting.cpp
@@ -59,7 +59,7 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
     #include "generated/material/bakedColor.inc"
 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "depthtesting";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_hellotriangle.cpp
+++ b/samples/vk_hellotriangle.cpp
@@ -58,7 +58,7 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
     #include "generated/material/bakedColor.inc"
 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "hellotriangle";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_imgui.cpp
+++ b/samples/vk_imgui.cpp
@@ -23,7 +23,7 @@
 #include "app/Config.h"
 #include "app/FilamentApp.h"
 
-int main(int argc, char* argv[]) {
+int main(int argc, char** argv) {
     bool showDemo = false;
     bool showMetrics = false;
     auto imgui = [&showDemo, &showMetrics] (filament::Engine*, filament::View*) {

--- a/samples/vk_strobecolor.cpp
+++ b/samples/vk_strobecolor.cpp
@@ -25,7 +25,7 @@
 
 using namespace filament;
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "strobecolor";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_texturedquad.cpp
+++ b/samples/vk_texturedquad.cpp
@@ -72,7 +72,7 @@ static constexpr uint8_t BAKED_TEXTURE_PACKAGE[] = {
     #include "generated/material/bakedTexture.inc"
 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "texturedquad";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_vbotest.cpp
+++ b/samples/vk_vbotest.cpp
@@ -40,7 +40,7 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] {
     #include "generated/material/bakedColor.inc"
 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "vbotest";
     config.backend = Engine::Backend::VULKAN;

--- a/samples/vk_viewtest.cpp
+++ b/samples/vk_viewtest.cpp
@@ -34,7 +34,7 @@ struct App {
 static const math::float2 TRIANGLE_VERTICES[3] = { {1, 0}, {-0.5, 0.866}, {-0.5, -0.866} };
 static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 
-int main() {
+int main(int argc, char** argv) {
     Config config;
     config.title = "viewtest";
     config.backend = Engine::Backend::VULKAN;


### PR DESCRIPTION
* The full `main` signature with `argc` and `argv` arguments must be declared in order for SDL to compile.
* test_bluevk does not compile on Windows