### PR TITLE
Fix / simplify roughness-prefilter.

### DIFF
--- a/tools/roughness-prefilter/src/main.cpp
+++ b/tools/roughness-prefilter/src/main.cpp
@@ -23,6 +23,7 @@
 #include <math/vec3.h>
 
 #include <image/ImageOps.h>
+#include <image/ImageSampler.h>
 
 #include <imageio/ImageDecoder.h>
 #include <imageio/ImageEncoder.h>
@@ -216,12 +217,12 @@ void prefilter(const LinearImage& normal, const size_t mipLevel, LinearImage& ou
     const size_t sampleCount = 1u << mipLevel;
 
     for (size_t y = 0; y < height; y++) {
-        auto outputRow = output.get<float3>(0, y);
+        auto outputRow = output.get<float>(0, y);
         for (size_t x = 0; x < width; x++, outputRow++) {
             const float2 uv = (float2(x, y) + 0.5f) / float2(width, height);
             const float2 pos = uv * normal.getWidth();
             const float roughness = g_roughness;
-            *outputRow = float3(solveVMF(pos, sampleCount, roughness, normal));
+            *outputRow = solveVMF(pos, sampleCount, roughness, normal);
         }
     }
 }
@@ -234,15 +235,15 @@ void prefilter(const LinearImage& normal, const LinearImage& roughness, const si
     const size_t sampleCount = 1u << mipLevel;
 
     for (size_t y = 0; y < height; y++) {
-        auto outputRow = output.get<float3>(0, y);
+        auto outputRow = output.get<float>(0, y);
         for (size_t x = 0; x < width; x++, outputRow++) {
-            auto data = roughness.get<float3>(x, y);
+            auto data = roughness.get<float>(x, y);
             if (FIRST_MIP) {
                 *outputRow = *data;
             } else {
                 const float2 uv = (float2(x, y) + 0.5f) / float2(width, height);
                 const float2 pos = uv * normal.getWidth();
-                *outputRow = float3(solveVMF(pos, sampleCount, data->r, normal));
+                *outputRow = solveVMF(pos, sampleCount, *data, normal);
             }
         }
     }
@@ -318,6 +319,8 @@ int main(int argc, char* argv[]) {
             std::cerr << "The input normal and roughness maps must have the same dimensions" << std::endl;
             exit(1);
         }
+
+        roughnessImage = extractChannel(roughnessImage, 0);
     }
 
     if (!g_formatSpecified) {
@@ -332,42 +335,10 @@ int main(int argc, char* argv[]) {
     const size_t height = hasRoughnessMap ? roughnessImage.getHeight() : normalImage.getHeight();
     const size_t mipLevels = size_t(std::log2f(width)) + 1;
 
-    bool exportGrayscale = false;
-    switch (g_format) {
-        case ImageEncoder::Format::DDS:
-        case ImageEncoder::Format::DDS_LINEAR:
-        case ImageEncoder::Format::PNG:
-        case ImageEncoder::Format::PNG_LINEAR:
-            exportGrayscale = true;
-            break;
-        default:
-            break;
-    }
-
     if (hasRoughnessMap) {
-        mipImages.push_back(std::move(roughnessImage));
-        LinearImage* prevMip = &mipImages.at(0);
-
-        for (size_t i = 1; i <= mipLevels; i++) {
-            const size_t w = width >> i;
-            const size_t h = height >> i;
-
-            LinearImage image(w, h, 3);
-
-            for (size_t y = 0; y < h; y++) {
-                auto dst = image.get<float3>(0, y);
-                for (size_t x = 0; x < w; x++, dst++) {
-                    float3 aa = *prevMip->get<float3>(x * 2,     y * 2);
-                    float3 ba = *prevMip->get<float3>(x * 2 + 1, y * 2);
-                    float3 ab = *prevMip->get<float3>(x * 2,     y * 2 + 1);
-                    float3 bb = *prevMip->get<float3>(x * 2 + 1, y * 2 + 1);
-                    *dst = (aa + ba + ab + bb) / 4.0f;
-                }
-            }
-
-            mipImages.push_back(std::move(image));
-            prevMip = &mipImages.at(i);
-        }
+        mipImages.resize(mipLevels);
+        mipImages[0] = roughnessImage;
+        image::generateMipmaps(roughnessImage, image::Filter::BOX, &mipImages[1], mipLevels - 1);
     }
 
     JobSystem js;
@@ -376,22 +347,22 @@ int main(int argc, char* argv[]) {
     JobSystem::Job* parent = js.createJob();
     for (size_t i = 0; i < mipLevels; i++) {
         JobSystem::Job* mip = jobs::createJob(js, parent,
-                [&normalImage, &mipImages, outputMap, i, width, height, exportGrayscale, hasRoughnessMap]() {
+                [&normalImage, &mipImages, outputMap, i, width, height, hasRoughnessMap]() {
             const size_t w = width >> i;
             const size_t h = height >> i;
 
-            LinearImage image(w, h, 3);
+            LinearImage image(w, h, 1);
 
             if (i == 0) {
                 if (hasRoughnessMap) {
                     if (mipImages.at(0).getWidth() == image.getWidth()) {
-                        const size_t size = image.getWidth() * image.getHeight() * 12;
+                        const size_t size = image.getWidth() * image.getHeight() * sizeof(float);
                         memcpy(image.getPixelRef(), mipImages.at(0).getPixelRef(), size);
                     } else {
                         prefilter<true>(normalImage, mipImages.at(0), 0, image);
                     }
                 } else {
-                    std::fill_n(image.get<float3>(), w * h, float3(g_roughness));
+                    std::fill_n(image.get<float>(), w * h, g_roughness);
                 }
             } else {
                 if (hasRoughnessMap) {
@@ -410,9 +381,6 @@ int main(int argc, char* argv[]) {
             if (!outputStream.good()) {
                 std::cerr << "The output file cannot be opened: " << out << std::endl;
                 return;
-            }
-            if (exportGrayscale) {
-                image = extractChannel(image, 0);
             }
             ImageEncoder::encode(outputStream, g_format, image, g_compression, out.getPath());
             outputStream.close();


### PR DESCRIPTION
This tool was producing bad output for the monkey roughness map because the monkey roughness map has an (unnecessary) alpha channel, and the tool was assuming that the source image has 3 channels.

This commit fixes that particular case, and changes the tool so that it operates on single-channel data instead of 3-channel data.