### PR TITLE
Add compression to mipgen and change bitrate to block size.

### DIFF
--- a/libs/imageio/include/imageio/BlockCompression.h
+++ b/libs/imageio/include/imageio/BlockCompression.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <string>
 
+#include <math/vec2.h>
+
 #include <stdint.h>
 
 namespace image {
@@ -44,18 +46,51 @@ enum class AstcSemantic {
     NORMALS,
 };
 
-// Gets passed to the encoder function to control the quality and speed of compression.
-// The specified bitrate can be anywhere from 0.8 to 8.0.
+// The encoder configuration controls the quality and speed of compression, as well as the resulting
+// format. The specified block size must be one of the 14 block sizes that can be consumed by ES 3.2
+// as per https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glCompressedTexImage2D.xhtml
 struct AstcConfig {
     AstcPreset quality;
     AstcSemantic semantic;
-    float bitrate;
+    math::ushort2 blocksize;
+    bool srgb;
+};
+
+enum class AstcFormat {
+    RGBA_ASTC_4x4 = 0x93B0,
+    RGBA_ASTC_5x4 = 0x93B1,
+    RGBA_ASTC_5x5 = 0x93B2,
+    RGBA_ASTC_6x5 = 0x93B3,
+    RGBA_ASTC_6x6 = 0x93B4,
+    RGBA_ASTC_8x5 = 0x93B5,
+    RGBA_ASTC_8x6 = 0x93B6,
+    RGBA_ASTC_8x8 = 0x93B7,
+    RGBA_ASTC_10x5 = 0x93B8,
+    RGBA_ASTC_10x6 = 0x93B9,
+    RGBA_ASTC_10x8 = 0x93BA,
+    RGBA_ASTC_10x10 = 0x93BB,
+    RGBA_ASTC_12x10 = 0x93BC,
+    RGBA_ASTC_12x12 = 0x93BD,
+    SRGB8_ALPHA8_ASTC_4x4 = 0x93D0,
+    SRGB8_ALPHA8_ASTC_5x4 = 0x93D1,
+    SRGB8_ALPHA8_ASTC_5x5 = 0x93D2,
+    SRGB8_ALPHA8_ASTC_6x5 = 0x93D3,
+    SRGB8_ALPHA8_ASTC_6x6 = 0x93D4,
+    SRGB8_ALPHA8_ASTC_8x5 = 0x93D5,
+    SRGB8_ALPHA8_ASTC_8x6 = 0x93D6,
+    SRGB8_ALPHA8_ASTC_8x8 = 0x93D7,
+    SRGB8_ALPHA8_ASTC_10x5 = 0x93D8,
+    SRGB8_ALPHA8_ASTC_10x6 = 0x93D9,
+    SRGB8_ALPHA8_ASTC_10x8 = 0x93DA,
+    SRGB8_ALPHA8_ASTC_10x10 = 0x93DB,
+    SRGB8_ALPHA8_ASTC_12x10 = 0x93DC,
+    SRGB8_ALPHA8_ASTC_12x12 = 0x93DD,
 };
 
 // Represents the result of compression, including which of the 28 internal formats that the
 // encoder finally settled on, based on the hints supplied in AstcConfig.
 struct AstcTexture {
-    const uint32_t gl_internal_format;
+    const AstcFormat format;
     const uint32_t size;
     std::unique_ptr<uint8_t[]> data;
 };
@@ -66,8 +101,8 @@ AstcTexture astcCompress(const LinearImage& source, AstcConfig config);
 
 // Parses a simple underscore-delimited string to produce an ASTC compression configuration. This
 // makes it easy to incorporate the compression API into command-line tools. If the string is
-// malformed, this returns a config with a 0 bitrate. Example strings: fast_ldr_4.2,
-// thorough_normals_8.0, veryfast_hdr_1.0
+// malformed, this returns a config with a 0x0 blocksize. Example strings: fast_ldr_4x4,
+// thorough_normals_6x6, veryfast_hdr_12x10
 AstcConfig astcParseOptionString(const std::string& options);
 
 } // namespace image

--- a/third_party/astcenc/Source/astc_image_load_store.cpp
+++ b/third_party/astcenc/Source/astc_image_load_store.cpp
@@ -1261,7 +1261,7 @@ void compute_error_metrics(int compute_hdr_error_metrics, int input_components, 
 	This image loader will choose one based on filename.
 */
 
-
+#if 0
 
 astc_codec_image *astc_codec_load_image(const char *input_filename, int padding, int *load_result)
 {
@@ -1453,3 +1453,20 @@ int astc_codec_store_image(const astc_codec_image * output_image, const char *ou
 
 	return store_result;
 }
+
+#else
+
+astc_codec_image *astc_codec_load_image(const char *input_filename, int padding, int *load_result) {
+	return nullptr;
+}
+
+int astc_codec_store_image(const astc_codec_image * output_image, const char *output_filename,
+		int bitness, const char **format_string) {
+	return 0;
+}
+
+int get_output_filename_enforced_bitness(const char *output_filename) {
+	return 0;
+}
+
+#endif

--- a/third_party/astcenc/tnt/CMakeLists.txt
+++ b/third_party/astcenc/tnt/CMakeLists.txt
@@ -24,7 +24,6 @@ set(SOURCES
     ${SRCDIR}/astc_percentile_tables.cpp
     ${SRCDIR}/astc_pick_best_endpoint_format.cpp
     ${SRCDIR}/astc_quantization.cpp
-    ${SRCDIR}/astc_stb_tga.cpp
     ${SRCDIR}/astc_toplevel.cpp
     ${SRCDIR}/astc_symbolic_physical.cpp
     ${SRCDIR}/astc_weight_align.cpp
@@ -41,6 +40,6 @@ add_definitions(-Wno-tautological-compare)
 
 add_library(${TARGET} STATIC ${SOURCES})
 
-target_link_libraries(${TARGET} LINK_PUBLIC stb)
+target_link_libraries(${TARGET} LINK_PUBLIC)
 
 target_include_directories (${TARGET} PUBLIC ${HDRDIR})

--- a/third_party/astcenc/tnt/README
+++ b/third_party/astcenc/tnt/README
@@ -16,6 +16,7 @@ mv license.txt LICENSE
 rm Source/stb_image.c Source/imgdiff.cpp
 sed -i "" 's/stb_image.c/stb_image.h/g' Source/astc_stb_tga.cpp
 sed -i "" 's/main/standalone_main/g' Source/astc_toplevel.cpp
+add #if 0 to astc_image_load_store.cpp
 
 #
 # Copy modified source into the Filament repo.

--- a/tools/mipgen/CMakeLists.txt
+++ b/tools/mipgen/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SRCS src/main.cpp)
 # Target definitions
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt stb)
 
 # =================================================================================================
 # Licenses

--- a/tools/mipgen/CMakeLists.txt
+++ b/tools/mipgen/CMakeLists.txt
@@ -12,12 +12,12 @@ set(SRCS src/main.cpp)
 # Target definitions
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt stb)
+target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
 
 # =================================================================================================
 # Licenses
 # ==================================================================================================
-set(MODULE_LICENSES getopt libpng tinyexr libz astcenc stb)
+set(MODULE_LICENSES getopt libpng tinyexr libz astcenc)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR}/generated)
 list_licenses(${GENERATION_ROOT}/licenses/licenses.inc ${MODULE_LICENSES})
 target_include_directories(${TARGET} PRIVATE ${GENERATION_ROOT})

--- a/tools/mipgen/CMakeLists.txt
+++ b/tools/mipgen/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt stb)
 # =================================================================================================
 # Licenses
 # ==================================================================================================
-set(MODULE_LICENSES getopt libpng tinyexr libz astcenc)
+set(MODULE_LICENSES getopt libpng tinyexr libz astcenc stb)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR}/generated)
 list_licenses(${GENERATION_ROOT}/licenses/licenses.inc ${MODULE_LICENSES})
 target_include_directories(${TARGET} PRIVATE ${GENERATION_ROOT})

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -31,9 +31,6 @@
 #include <fstream>
 #include <iostream>
 
-#define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
-
 using namespace image;
 using namespace std;
 using namespace utils;

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -31,6 +31,9 @@
 #include <fstream>
 #include <iostream>
 
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+
 using namespace image;
 using namespace std;
 using namespace utils;
@@ -163,7 +166,6 @@ static int handleArguments(int argc, char* argv[]) {
                 g_createGallery = true;
                 break;
             case 'k': {
-                bool isvalid;
                 g_filter = filterFromString(arg.c_str());
                 if (g_filter == Filter::DEFAULT) {
                     cerr << "Warning: unrecognized filter, falling back to DEFAULT." << endl;


### PR DESCRIPTION
The compression API now takes block size instead of bit rate. Otherwise it is quite possible for the encoder to generate a block size that is not one of the valid block sizes that graphics API's can actually consume.