### PR TITLE
experimental: add octahedron output support

### DIFF
--- a/tools/cmgen/src/CubemapUtils.h
+++ b/tools/cmgen/src/CubemapUtils.h
@@ -51,6 +51,8 @@ public:
 
     static void cubemapToEquirectangular(Image& dst, const Cubemap& src);
 
+    static void cubemapToOctahedron(Image& dst, const Cubemap& src);
+
     // Convert h or v cross Image to a Cubemap
     static void crossToCubemap(Cubemap& dst, const Image& src);
 


### PR DESCRIPTION
Octahedron output support for cmgen. use —type=octahedron.

This is still fairly experimental.