### PR TITLE
Add S3TC support to imageio and Suzanne.

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -235,6 +235,7 @@ void OpenGLDriver::initExtensionsGLES(GLint major, GLint minor, std::set<StaticS
     ext.OES_EGL_image_external_essl3 = hasExtension(exts, "GL_OES_EGL_image_external_essl3");
     ext.EXT_debug_marker = hasExtension(exts, "GL_EXT_debug_marker");
     ext.EXT_color_buffer_half_float = hasExtension(exts, "GL_EXT_color_buffer_half_float");
+    ext.texture_compression_s3tc = hasExtension(exts, "WEBGL_compressed_texture_s3tc");
 }
 
 void OpenGLDriver::initExtensionsGL(GLint major, GLint minor, std::set<StaticString> const& exts) {

--- a/libs/image/include/image/KtxBundle.h
+++ b/libs/image/include/image/KtxBundle.h
@@ -155,6 +155,11 @@ public:
 
     static constexpr uint32_t ENDIAN_DEFAULT = 0x04030201;
 
+    static constexpr uint32_t RGB_S3TC_DXT1 = 0x83F0;
+    static constexpr uint32_t RGBA_S3TC_DXT1 = 0x83F1;
+    static constexpr uint32_t RGBA_S3TC_DXT3 = 0x83F2;
+    static constexpr uint32_t RGBA_S3TC_DXT5 = 0x83F3;
+
 private:
     image::KtxInfo mInfo = {};
     uint32_t mNumMipLevels;

--- a/libs/imageio/CMakeLists.txt
+++ b/libs/imageio/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
-target_link_libraries(${TARGET} PUBLIC image math png tinyexr utils z astcenc)
+target_link_libraries(${TARGET} PUBLIC image math png tinyexr utils z astcenc stb)
 if (WIN32)
     target_link_libraries(${TARGET} PRIVATE wsock32)
 endif()

--- a/libs/imageio/include/imageio/BlockCompression.h
+++ b/libs/imageio/include/imageio/BlockCompression.h
@@ -56,7 +56,18 @@ struct AstcConfig {
     bool srgb;
 };
 
-enum class AstcFormat {
+enum class CompressedFormat {
+    INVALID = 0,
+
+    RGB_S3TC_DXT1 = 0x83F0,
+    RGBA_S3TC_DXT1 = 0x83F1,
+    RGBA_S3TC_DXT3 = 0x83F2,
+    RGBA_S3TC_DXT5 = 0x83F3,
+    SRGB_S3TC_DXT1 = 0x8C4C,
+    SRGB_ALPHA_S3TC_DXT1 = 0x8C4D,
+    SRGB_ALPHA_S3TC_DXT3 = 0x8C4E,
+    SRGB_ALPHA_S3TC_DXT5 = 0x8C4F,
+
     RGBA_ASTC_4x4 = 0x93B0,
     RGBA_ASTC_5x4 = 0x93B1,
     RGBA_ASTC_5x5 = 0x93B2,
@@ -87,23 +98,36 @@ enum class AstcFormat {
     SRGB8_ALPHA8_ASTC_12x12 = 0x93DD,
 };
 
-// Represents the result of compression, including which of the 28 internal formats that the
-// encoder finally settled on, based on the hints supplied in AstcConfig.
-struct AstcTexture {
-    const AstcFormat format;
+// Represents the opaque result of compression and the chosen texture format.
+struct CompressedTexture {
+    const CompressedFormat format;
     const uint32_t size;
     std::unique_ptr<uint8_t[]> data;
 };
 
 // Uses the CPU to compress a linear image (1 to 4 channels) into an ASTC texture. The 16-byte
 // header block that ARM uses in their file format is not included.
-AstcTexture astcCompress(const LinearImage& source, AstcConfig config);
+CompressedTexture astcCompress(const LinearImage& source, AstcConfig config);
 
 // Parses a simple underscore-delimited string to produce an ASTC compression configuration. This
 // makes it easy to incorporate the compression API into command-line tools. If the string is
 // malformed, this returns a config with a 0x0 blocksize. Example strings: fast_ldr_4x4,
 // thorough_normals_6x6, veryfast_hdr_12x10
 AstcConfig astcParseOptionString(const std::string& options);
+
+// Informs the S3TC encoder of the desired output.
+struct S3tcConfig {
+    CompressedFormat format;
+    bool srgb;
+};
+
+// Uses the CPU to compress a linear image (1 to 4 channels) into an S3TC texture.
+CompressedTexture s3tcCompress(const LinearImage& source, S3tcConfig config);
+
+// Parses an underscore-delimited string to produce an S3TC compression configuration. Currently
+// this only accepts "rgb_dxt1" and "rgba_dxt5". If the string is malformed, this returns a config
+// with an invalid format.
+S3tcConfig s3tcParseOptionString(const std::string& options);
 
 } // namespace image
 

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -84,6 +84,8 @@ function(add_ktxfiles SOURCE TARGET EXTRA_ARGS)
 endfunction()
 
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo.ktx" "")
+add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_astc.ktx" "--compression=astc_fast_ldr_4x4")
+add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_s3tc.ktx" "--compression=s3tc_rgb_dxt1")
 add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal.ktx" "--kernel=NORMALS;--linear")
 add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness.ktx" "--grayscale")
 add_ktxfiles("assets/models/monkey/metallic.png" "monkey/metallic.ktx" "--grayscale")

--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -16,9 +16,6 @@
 
 #include "filaweb.h"
 
-#include <string>
-#include <sstream>
-
 #include <utils/Path.h>
 
 #include <imgui.h>
@@ -31,6 +28,9 @@
 #include <emscripten.h>
 
 #include <image/KtxBundle.h>
+
+#include <string>
+#include <sstream>
 
 using namespace filament;
 using namespace image;
@@ -311,6 +311,28 @@ SkyLight getSkyLight(Engine& engine, const char* name) {
     result.skybox = Skybox::Builder().environment(skybox).build(engine);
 
     return result;
+}
+
+filament::driver::CompressedPixelDataType toPixelDataType(uint32_t format) {
+    using DstFormat = filament::driver::CompressedPixelDataType;
+    switch (format) {
+        case KtxBundle::RGB_S3TC_DXT1: return DstFormat::DXT1_RGB;
+        case KtxBundle::RGBA_S3TC_DXT1: return DstFormat::DXT1_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT3: return DstFormat::DXT3_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT5: return DstFormat::DXT5_RGBA;
+    }
+    return (filament::driver::CompressedPixelDataType) 0xffff;
+}
+
+filament::driver::TextureFormat toTextureFormat(uint32_t format) {
+    using DstFormat = filament::driver::TextureFormat;
+    switch (format) {
+        case KtxBundle::RGB_S3TC_DXT1: return DstFormat::DXT1_RGB;
+        case KtxBundle::RGBA_S3TC_DXT1: return DstFormat::DXT1_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT3: return DstFormat::DXT3_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT5: return DstFormat::DXT5_RGBA;
+    }
+    return (filament::driver::TextureFormat) 0xffff;
 }
 
 }  // namespace filaweb

--- a/samples/web/filaweb.h
+++ b/samples/web/filaweb.h
@@ -60,6 +60,9 @@ struct SkyLight {
 
 SkyLight getSkyLight(filament::Engine& engine, const char* name);
 
+filament::driver::CompressedPixelDataType toPixelDataType(uint32_t format);
+filament::driver::TextureFormat toTextureFormat(uint32_t format);
+
 static const auto NoopCallback = [](filament::Engine*, filament::View*) {};
 
 class Application {

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -4,6 +4,29 @@ let context_ready = false;
 let previous_mouse_buttons = 0;
 let queued_mouse_events = [];
 
+let use_astc = false;
+let use_s3tc = false;
+let use_etc1 = false;
+
+let canvas = document.getElementById('filament-canvas');
+let ctx = GL.createContext(canvas, {
+    majorVersion: 2,
+    minorVersion: 0,
+    antialias: false,
+    depth: false,
+    alpha: false
+});
+GL.makeContextCurrent(ctx);
+for (let ext of Module.ctx.getSupportedExtensions()) {
+    if (ext == "WEBGL_compressed_texture_s3tc") {
+        use_s3tc = true;
+    } else if (ext == "WEBGL_compressed_texture_astc") {
+        use_astc = true;
+    } else if (ext == "WEBGL_compressed_texture_etc1") {
+        use_etc1 = true;
+    }
+}
+
 // This is usually (not always) called before the wasm has finished JIT compiling.
 async function load(promises) {
     for (let name in promises) {
@@ -13,18 +36,8 @@ async function load(promises) {
     maybe_launch();
 }
 
-// This is called as soon as the wasm has finished JIT compilation. We also create the WebGL 2.0
-// context here.
+// This is called as soon as the wasm has finished JIT compilation.
 Module.postRun = function() {
-    let canvas = document.getElementById('filament-canvas');
-    let ctx = GL.createContext(canvas, {
-        majorVersion: 2,
-        minorVersion: 0,
-        antialias: false,
-        depth: false,
-        alpha: false
-    });
-    GL.makeContextCurrent(ctx);
     context_ready = true;
     maybe_launch();
 }

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -23,7 +23,8 @@
     <script src="filaweb.js"></script>
     <script>
     load({
-        'albedo':                    load_rawfile('monkey/albedo.ktx'),
+        'albedo':                    use_s3tc ? load_rawfile('monkey/albedo_s3tc.ktx') :
+                                                load_rawfile('monkey/albedo.ktx'),
         'metallic':                  load_rawfile('monkey/metallic.ktx'),
         'roughness':                 load_rawfile('monkey/roughness.ktx'),
         'normal':                    load_rawfile('monkey/normal.ktx'),

--- a/tools/mipgen/CMakeLists.txt
+++ b/tools/mipgen/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
 # =================================================================================================
 # Licenses
 # ==================================================================================================
-set(MODULE_LICENSES getopt libpng tinyexr libz astcenc)
+set(MODULE_LICENSES getopt libpng tinyexr libz astcenc stb)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR}/generated)
 list_licenses(${GENERATION_ROOT}/licenses/licenses.inc ${MODULE_LICENSES})
 target_include_directories(${TARGET} PRIVATE ${GENERATION_ROOT})


### PR DESCRIPTION
At build time, mipgen now creates several compressed and non-compressed variants for albedo.

For ASTC we use the ARM encoder, for S3TC we use the STB encoder. These are somewhat limited so we may wish to investigate other libraries in the future (e.g., AMD Compressenator).

At run time, we detect which of these variants to download, based on available WebGL extensions. In practice, this means that desktop browsers will use the S3TC variant and mobile browsers will use the ASTC variant.

The before/after screenshots below show Suzanne with all textures removed except albedo.  The developer pane shows that unzipped albedo went from ~4 MB to 682 KB using S3TC.

Mobile support (ASTC and ETC2) is coming in a future PR, stay tuned.

<img width="1336" alt="s3tc" src="https://user-images.githubusercontent.com/1288904/46315157-80f82800-c581-11e8-95d9-ed7fc554fb47.png">
<img width="1336" alt="noncompressed" src="https://user-images.githubusercontent.com/1288904/46315164-83f31880-c581-11e8-9fda-5e53fedae35e.png">
