### PR TITLE
Add ASTC support to Suzanne.

### DIFF
--- a/filament/src/driver/opengl/GLUtils.h
+++ b/filament/src/driver/opengl/GLUtils.h
@@ -360,6 +360,68 @@ constexpr /* inline */ GLenum getInternalFormat(filament::driver::TextureFormat 
             // this should not happen
             return 0;
 #endif
+
+#if defined(GL_KHR_texture_compression_astc_hdr)
+        case TextureFormat::RGBA_ASTC_4x4:     return GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
+        case TextureFormat::RGBA_ASTC_5x4:     return GL_COMPRESSED_RGBA_ASTC_5x4_KHR;
+        case TextureFormat::RGBA_ASTC_5x5:     return GL_COMPRESSED_RGBA_ASTC_5x5_KHR;
+        case TextureFormat::RGBA_ASTC_6x5:     return GL_COMPRESSED_RGBA_ASTC_6x5_KHR;
+        case TextureFormat::RGBA_ASTC_6x6:     return GL_COMPRESSED_RGBA_ASTC_6x6_KHR;
+        case TextureFormat::RGBA_ASTC_8x5:     return GL_COMPRESSED_RGBA_ASTC_8x5_KHR;
+        case TextureFormat::RGBA_ASTC_8x6:     return GL_COMPRESSED_RGBA_ASTC_8x6_KHR;
+        case TextureFormat::RGBA_ASTC_8x8:     return GL_COMPRESSED_RGBA_ASTC_8x8_KHR;
+        case TextureFormat::RGBA_ASTC_10x5:    return GL_COMPRESSED_RGBA_ASTC_10x5_KHR;
+        case TextureFormat::RGBA_ASTC_10x6:    return GL_COMPRESSED_RGBA_ASTC_10x6_KHR;
+        case TextureFormat::RGBA_ASTC_10x8:    return GL_COMPRESSED_RGBA_ASTC_10x8_KHR;
+        case TextureFormat::RGBA_ASTC_10x10:   return GL_COMPRESSED_RGBA_ASTC_10x10_KHR;
+        case TextureFormat::RGBA_ASTC_12x10:   return GL_COMPRESSED_RGBA_ASTC_12x10_KHR;
+        case TextureFormat::RGBA_ASTC_12x12:   return GL_COMPRESSED_RGBA_ASTC_12x12_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_4x4:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x4:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x5:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x5:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x6:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x5:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x6:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x8:   return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x5:  return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x6:  return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x8:  return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x10: return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x10: return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x12: return GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR;
+#else
+        case TextureFormat::RGBA_ASTC_4x4:
+        case TextureFormat::RGBA_ASTC_5x4:
+        case TextureFormat::RGBA_ASTC_5x5:
+        case TextureFormat::RGBA_ASTC_6x5:
+        case TextureFormat::RGBA_ASTC_6x6:
+        case TextureFormat::RGBA_ASTC_8x5:
+        case TextureFormat::RGBA_ASTC_8x6:
+        case TextureFormat::RGBA_ASTC_8x8:
+        case TextureFormat::RGBA_ASTC_10x5:
+        case TextureFormat::RGBA_ASTC_10x6:
+        case TextureFormat::RGBA_ASTC_10x8:
+        case TextureFormat::RGBA_ASTC_10x10:
+        case TextureFormat::RGBA_ASTC_12x10:
+        case TextureFormat::RGBA_ASTC_12x12:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_4x4:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x4:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x5:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x5:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x6:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x5:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x6:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x8:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x5:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x6:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x8:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x10:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x10:
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x12:
+            // this should not happen
+            return 0;
+#endif
     }
 }
 

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -242,7 +242,37 @@ enum class CompressedPixelDataType : uint16_t {
     ETC2_EAC_RGBA8, ETC2_EAC_SRGBA8,
 
     // Available everywhere except Android/iOS
-    DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA
+    DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA,
+
+    // ASTC formats are available with a GLES extension
+    RGBA_ASTC_4x4,
+    RGBA_ASTC_5x4,
+    RGBA_ASTC_5x5,
+    RGBA_ASTC_6x5,
+    RGBA_ASTC_6x6,
+    RGBA_ASTC_8x5,
+    RGBA_ASTC_8x6,
+    RGBA_ASTC_8x8,
+    RGBA_ASTC_10x5,
+    RGBA_ASTC_10x6,
+    RGBA_ASTC_10x8,
+    RGBA_ASTC_10x10,
+    RGBA_ASTC_12x10,
+    RGBA_ASTC_12x12,
+    SRGB8_ALPHA8_ASTC_4x4,
+    SRGB8_ALPHA8_ASTC_5x4,
+    SRGB8_ALPHA8_ASTC_5x5,
+    SRGB8_ALPHA8_ASTC_6x5,
+    SRGB8_ALPHA8_ASTC_6x6,
+    SRGB8_ALPHA8_ASTC_8x5,
+    SRGB8_ALPHA8_ASTC_8x6,
+    SRGB8_ALPHA8_ASTC_8x8,
+    SRGB8_ALPHA8_ASTC_10x5,
+    SRGB8_ALPHA8_ASTC_10x6,
+    SRGB8_ALPHA8_ASTC_10x8,
+    SRGB8_ALPHA8_ASTC_10x10,
+    SRGB8_ALPHA8_ASTC_12x10,
+    SRGB8_ALPHA8_ASTC_12x12,
 };
 
 /** Supported texel formats
@@ -298,7 +328,8 @@ enum class CompressedPixelDataType : uint16_t {
  * Compressed texture formats
  * --------------------------
  *
- * A few compressed texture formats are supported as well:
+ * Many compressed texture formats are supported as well, which include (but are not limited to)
+ * the following list:
  *
  * Name             | Format
  * :----------------|:--------------------------------------------------------------------------
@@ -362,7 +393,37 @@ enum class TextureFormat : uint16_t {
     ETC2_EAC_RGBA8, ETC2_EAC_SRGBA8,
 
     // Available everywhere except Android/iOS
-    DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA
+    DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA,
+
+    // ASTC formats are available with a GLES extension
+    RGBA_ASTC_4x4,
+    RGBA_ASTC_5x4,
+    RGBA_ASTC_5x5,
+    RGBA_ASTC_6x5,
+    RGBA_ASTC_6x6,
+    RGBA_ASTC_8x5,
+    RGBA_ASTC_8x6,
+    RGBA_ASTC_8x8,
+    RGBA_ASTC_10x5,
+    RGBA_ASTC_10x6,
+    RGBA_ASTC_10x8,
+    RGBA_ASTC_10x10,
+    RGBA_ASTC_12x10,
+    RGBA_ASTC_12x12,
+    SRGB8_ALPHA8_ASTC_4x4,
+    SRGB8_ALPHA8_ASTC_5x4,
+    SRGB8_ALPHA8_ASTC_5x5,
+    SRGB8_ALPHA8_ASTC_6x5,
+    SRGB8_ALPHA8_ASTC_6x6,
+    SRGB8_ALPHA8_ASTC_8x5,
+    SRGB8_ALPHA8_ASTC_8x6,
+    SRGB8_ALPHA8_ASTC_8x8,
+    SRGB8_ALPHA8_ASTC_10x5,
+    SRGB8_ALPHA8_ASTC_10x6,
+    SRGB8_ALPHA8_ASTC_10x8,
+    SRGB8_ALPHA8_ASTC_10x10,
+    SRGB8_ALPHA8_ASTC_12x10,
+    SRGB8_ALPHA8_ASTC_12x12,
 };
 
 enum class TextureUsage : uint8_t {

--- a/libs/image/include/image/KtxBundle.h
+++ b/libs/image/include/image/KtxBundle.h
@@ -160,6 +160,35 @@ public:
     static constexpr uint32_t RGBA_S3TC_DXT3 = 0x83F2;
     static constexpr uint32_t RGBA_S3TC_DXT5 = 0x83F3;
 
+    static constexpr uint32_t RGBA_ASTC_4x4 = 0x93B0;
+    static constexpr uint32_t RGBA_ASTC_5x4 = 0x93B1;
+    static constexpr uint32_t RGBA_ASTC_5x5 = 0x93B2;
+    static constexpr uint32_t RGBA_ASTC_6x5 = 0x93B3;
+    static constexpr uint32_t RGBA_ASTC_6x6 = 0x93B4;
+    static constexpr uint32_t RGBA_ASTC_8x5 = 0x93B5;
+    static constexpr uint32_t RGBA_ASTC_8x6 = 0x93B6;
+    static constexpr uint32_t RGBA_ASTC_8x8 = 0x93B7;
+    static constexpr uint32_t RGBA_ASTC_10x5 = 0x93B8;
+    static constexpr uint32_t RGBA_ASTC_10x6 = 0x93B9;
+    static constexpr uint32_t RGBA_ASTC_10x8 = 0x93BA;
+    static constexpr uint32_t RGBA_ASTC_10x10 = 0x93BB;
+    static constexpr uint32_t RGBA_ASTC_12x10 = 0x93BC;
+    static constexpr uint32_t RGBA_ASTC_12x12 = 0x93BD;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_4x4 = 0x93D0;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_5x4 = 0x93D1;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_5x5 = 0x93D2;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_6x5 = 0x93D3;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_6x6 = 0x93D4;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_8x5 = 0x93D5;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_8x6 = 0x93D6;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_8x8 = 0x93D7;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_10x5 = 0x93D8;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_10x6 = 0x93D9;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_10x8 = 0x93DA;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_10x10 = 0x93DB;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_12x10 = 0x93DC;
+    static constexpr uint32_t SRGB8_ALPHA8_ASTC_12x12 = 0x93DD;
+
 private:
     image::KtxInfo mInfo = {};
     uint32_t mNumMipLevels;

--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -313,26 +313,51 @@ SkyLight getSkyLight(Engine& engine, const char* name) {
     return result;
 }
 
-filament::driver::CompressedPixelDataType toPixelDataType(uint32_t format) {
-    using DstFormat = filament::driver::CompressedPixelDataType;
+template<typename T>
+T toFilamentEnum(uint32_t format) {
     switch (format) {
-        case KtxBundle::RGB_S3TC_DXT1: return DstFormat::DXT1_RGB;
-        case KtxBundle::RGBA_S3TC_DXT1: return DstFormat::DXT1_RGBA;
-        case KtxBundle::RGBA_S3TC_DXT3: return DstFormat::DXT3_RGBA;
-        case KtxBundle::RGBA_S3TC_DXT5: return DstFormat::DXT5_RGBA;
+        case KtxBundle::RGB_S3TC_DXT1: return T::DXT1_RGB;
+        case KtxBundle::RGBA_S3TC_DXT1: return T::DXT1_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT3: return T::DXT3_RGBA;
+        case KtxBundle::RGBA_S3TC_DXT5: return T::DXT5_RGBA;
+        case KtxBundle::RGBA_ASTC_4x4: return T::RGBA_ASTC_4x4;
+        case KtxBundle::RGBA_ASTC_5x4: return T::RGBA_ASTC_5x4;
+        case KtxBundle::RGBA_ASTC_5x5: return T::RGBA_ASTC_5x5;
+        case KtxBundle::RGBA_ASTC_6x5: return T::RGBA_ASTC_6x5;
+        case KtxBundle::RGBA_ASTC_6x6: return T::RGBA_ASTC_6x6;
+        case KtxBundle::RGBA_ASTC_8x5: return T::RGBA_ASTC_8x5;
+        case KtxBundle::RGBA_ASTC_8x6: return T::RGBA_ASTC_8x6;
+        case KtxBundle::RGBA_ASTC_8x8: return T::RGBA_ASTC_8x8;
+        case KtxBundle::RGBA_ASTC_10x5: return T::RGBA_ASTC_10x5;
+        case KtxBundle::RGBA_ASTC_10x6: return T::RGBA_ASTC_10x6;
+        case KtxBundle::RGBA_ASTC_10x8: return T::RGBA_ASTC_10x8;
+        case KtxBundle::RGBA_ASTC_10x10: return T::RGBA_ASTC_10x10;
+        case KtxBundle::RGBA_ASTC_12x10: return T::RGBA_ASTC_12x10;
+        case KtxBundle::RGBA_ASTC_12x12: return T::RGBA_ASTC_12x12;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_4x4: return T::SRGB8_ALPHA8_ASTC_4x4;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_5x4: return T::SRGB8_ALPHA8_ASTC_5x4;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_5x5: return T::SRGB8_ALPHA8_ASTC_5x5;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_6x5: return T::SRGB8_ALPHA8_ASTC_6x5;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_6x6: return T::SRGB8_ALPHA8_ASTC_6x6;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_8x5: return T::SRGB8_ALPHA8_ASTC_8x5;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_8x6: return T::SRGB8_ALPHA8_ASTC_8x6;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_8x8: return T::SRGB8_ALPHA8_ASTC_8x8;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_10x5: return T::SRGB8_ALPHA8_ASTC_10x5;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_10x6: return T::SRGB8_ALPHA8_ASTC_10x6;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_10x8: return T::SRGB8_ALPHA8_ASTC_10x8;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_10x10: return T::SRGB8_ALPHA8_ASTC_10x10;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_12x10: return T::SRGB8_ALPHA8_ASTC_12x10;
+        case KtxBundle::SRGB8_ALPHA8_ASTC_12x12: return T::SRGB8_ALPHA8_ASTC_12x12;
     }
-    return (filament::driver::CompressedPixelDataType) 0xffff;
+    return (T) 0xffff;
+}
+
+filament::driver::CompressedPixelDataType toPixelDataType(uint32_t format) {
+    return toFilamentEnum<filament::driver::CompressedPixelDataType>(format);
 }
 
 filament::driver::TextureFormat toTextureFormat(uint32_t format) {
-    using DstFormat = filament::driver::TextureFormat;
-    switch (format) {
-        case KtxBundle::RGB_S3TC_DXT1: return DstFormat::DXT1_RGB;
-        case KtxBundle::RGBA_S3TC_DXT1: return DstFormat::DXT1_RGBA;
-        case KtxBundle::RGBA_S3TC_DXT3: return DstFormat::DXT3_RGBA;
-        case KtxBundle::RGBA_S3TC_DXT5: return DstFormat::DXT5_RGBA;
-    }
-    return (filament::driver::TextureFormat) 0xffff;
+    return toFilamentEnum<filament::driver::TextureFormat>(format);
 }
 
 }  // namespace filaweb

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -21,6 +21,7 @@ for (let ext of Module.ctx.getSupportedExtensions()) {
     if (ext == "WEBGL_compressed_texture_s3tc") {
         use_s3tc = true;
     } else if (ext == "WEBGL_compressed_texture_astc") {
+        Module.ctx.getExtension('WEBGL_compressed_texture_astc');
         use_astc = true;
     } else if (ext == "WEBGL_compressed_texture_etc1") {
         use_etc1 = true;

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -23,8 +23,9 @@
     <script src="filaweb.js"></script>
     <script>
     load({
-        'albedo':                    use_s3tc ? load_rawfile('monkey/albedo_s3tc.ktx') :
-                                                load_rawfile('monkey/albedo.ktx'),
+        'albedo':                    (use_s3tc ? load_rawfile('monkey/albedo_s3tc.ktx') :
+                                     (use_astc ? load_rawfile('monkey/albedo_astc.ktx') :
+                                                 load_rawfile('monkey/albedo.ktx'))),
         'metallic':                  load_rawfile('monkey/metallic.ktx'),
         'roughness':                 load_rawfile('monkey/roughness.ktx'),
         'normal':                    load_rawfile('monkey/normal.ktx'),


### PR DESCRIPTION
This reduces the unzipped albedo from 4 MB to 1.3 MB as seen in the attached before / after shots.

![uncompressed](https://user-images.githubusercontent.com/1288904/46321960-456a5780-c59b-11e8-8ad9-e1bb7078a9f0.png)
![astc](https://user-images.githubusercontent.com/1288904/46321961-469b8480-c59b-11e8-9618-5c43a49b044b.png)
