### PR TITLE
Add ETC support to mipgen / imageio / suzanne.

### DIFF
--- a/libs/image/include/image/KtxBundle.h
+++ b/libs/image/include/image/KtxBundle.h
@@ -189,6 +189,17 @@ public:
     static constexpr uint32_t SRGB8_ALPHA8_ASTC_12x10 = 0x93DC;
     static constexpr uint32_t SRGB8_ALPHA8_ASTC_12x12 = 0x93DD;
 
+    static constexpr uint32_t R11_EAC = 0x9270;
+    static constexpr uint32_t SIGNED_R11_EAC = 0x9271;
+    static constexpr uint32_t RG11_EAC = 0x9272;
+    static constexpr uint32_t SIGNED_RG11_EAC = 0x9273;
+    static constexpr uint32_t RGB8_ETC2 = 0x9274;
+    static constexpr uint32_t SRGB8_ETC2 = 0x9275;
+    static constexpr uint32_t RGB8_ALPHA1_ETC2 = 0x9276;
+    static constexpr uint32_t SRGB8_ALPHA1_ETC = 0x9277;
+    static constexpr uint32_t RGBA8_ETC2_EAC = 0x9278;
+    static constexpr uint32_t SRGB8_ALPHA8_ETC2_EAC = 0x9279;
+
 private:
     image::KtxInfo mInfo = {};
     uint32_t mNumMipLevels;

--- a/libs/imageio/include/imageio/BlockCompression.h
+++ b/libs/imageio/include/imageio/BlockCompression.h
@@ -30,34 +30,19 @@
 
 namespace image {
 
-// Controls how fast compression occurs at the cost of quality in the resulting image.
-enum class AstcPreset {
-    VERYFAST,
-    FAST,
-    MEDIUM,
-    THOROUGH,
-    EXHAUSTIVE,
-};
-
-// Informs the encoder what texels represent; this is especially crucial for normal maps.
-enum class AstcSemantic {
-    COLORS_LDR,
-    COLORS_HDR,
-    NORMALS,
-};
-
-// The encoder configuration controls the quality and speed of compression, as well as the resulting
-// format. The specified block size must be one of the 14 block sizes that can be consumed by ES 3.2
-// as per https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glCompressedTexImage2D.xhtml
-struct AstcConfig {
-    AstcPreset quality;
-    AstcSemantic semantic;
-    math::ushort2 blocksize;
-    bool srgb;
-};
-
 enum class CompressedFormat {
     INVALID = 0,
+
+    R11_EAC = 0x9270,
+    SIGNED_R11_EAC = 0x9271,
+    RG11_EAC = 0x9272,
+    SIGNED_RG11_EAC = 0x9273,
+    RGB8_ETC2 = 0x9274,
+    SRGB8_ETC2 = 0x9275,
+    RGB8_ALPHA1_ETC2 = 0x9276,
+    SRGB8_ALPHA1_ETC = 0x9277,
+    RGBA8_ETC2_EAC = 0x9278,
+    SRGB8_ALPHA8_ETC2_EAC = 0x9279,
 
     RGB_S3TC_DXT1 = 0x83F0,
     RGBA_S3TC_DXT1 = 0x83F1,
@@ -105,6 +90,34 @@ struct CompressedTexture {
     std::unique_ptr<uint8_t[]> data;
 };
 
+// ASTC ////////////////////////////////////////////////////////////////////////////////////////////
+
+// Controls how fast compression occurs at the cost of quality in the resulting image.
+enum class AstcPreset {
+    VERYFAST,
+    FAST,
+    MEDIUM,
+    THOROUGH,
+    EXHAUSTIVE,
+};
+
+// Informs the encoder what texels represent; this is especially crucial for normal maps.
+enum class AstcSemantic {
+    COLORS_LDR,
+    COLORS_HDR,
+    NORMALS,
+};
+
+// The encoder configuration controls the quality and speed of compression, as well as the resulting
+// format. The specified block size must be one of the 14 block sizes that can be consumed by ES 3.2
+// as per https://www.khronos.org/registry/OpenGL-Refpages/es3/html/glCompressedTexImage2D.xhtml
+struct AstcConfig {
+    AstcPreset quality;
+    AstcSemantic semantic;
+    math::ushort2 blocksize;
+    bool srgb;
+};
+
 // Uses the CPU to compress a linear image (1 to 4 channels) into an ASTC texture. The 16-byte
 // header block that ARM uses in their file format is not included.
 CompressedTexture astcCompress(const LinearImage& source, AstcConfig config);
@@ -114,6 +127,37 @@ CompressedTexture astcCompress(const LinearImage& source, AstcConfig config);
 // malformed, this returns a config with a 0x0 blocksize. Example strings: fast_ldr_4x4,
 // thorough_normals_6x6, veryfast_hdr_12x10
 AstcConfig astcParseOptionString(const std::string& options);
+
+// ETC /////////////////////////////////////////////////////////////////////////////////////////////
+
+enum class EtcErrorMetric {
+    RGBA,
+    RGBX,
+    REC709,
+    NUMERIC,
+    NORMALXYZ,
+};
+
+// Informs the ETC encoder of the desired output. Effort sets the quality / speed tradeoff with
+// a number between 0 and 100.
+struct EtcConfig {
+    CompressedFormat format;
+    EtcErrorMetric metric;
+    int effort;
+};
+
+// Uses the CPU to compress a linear image (1 to 4 channels) into an ETC texture.
+CompressedTexture etcCompress(const LinearImage& source, EtcConfig config);
+
+// Converts a string into an ETC compression configuration where the string has the form
+// FORMAT_METRIC_EFFORT where:
+// - FORMAT is one of: r11, signed_r11, rg11, signed_rg11, rgb8, srgb8, rgb8_alpha,
+//   srgb8_alpha, rgba8, and srgb8_alpha8
+// - METRIC is one of: rgba, rgbx, rec709, numeric, and normalxyz
+// - EFFORT is an integer between 0 and 100
+EtcConfig etcParseOptionString(const std::string& options);
+
+// S3TC ////////////////////////////////////////////////////////////////////////////////////////////
 
 // Informs the S3TC encoder of the desired output.
 struct S3tcConfig {

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -83,13 +83,18 @@ function(add_ktxfiles SOURCE TARGET EXTRA_ARGS)
         DEPENDS mipgen)
 endfunction()
 
+set(ETC_R11_ARGS "--grayscale;--compression=etc_r11_numeric_40")
+
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo.ktx" "")
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_astc.ktx" "--compression=astc_fast_ldr_4x4")
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_s3tc.ktx" "--compression=s3tc_rgb_dxt1")
 add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal.ktx" "--kernel=NORMALS;--linear")
 add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness.ktx" "--grayscale")
+add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness_etc.ktx" "${ETC_R11_ARGS}")
 add_ktxfiles("assets/models/monkey/metallic.png" "monkey/metallic.ktx" "--grayscale")
+add_ktxfiles("assets/models/monkey/metallic.png" "monkey/metallic_etc.ktx" "${ETC_R11_ARGS}")
 add_ktxfiles("assets/models/monkey/ao.png" "monkey/ao.ktx" "--grayscale")
+add_ktxfiles("assets/models/monkey/ao.png" "monkey/ao_etc.ktx" "${ETC_R11_ARGS}")
 
 # Convert OBJ files into filamesh files.
 function(add_mesh SOURCE TARGET)

--- a/samples/web/filaweb.cpp
+++ b/samples/web/filaweb.cpp
@@ -348,6 +348,16 @@ T toFilamentEnum(uint32_t format) {
         case KtxBundle::SRGB8_ALPHA8_ASTC_10x10: return T::SRGB8_ALPHA8_ASTC_10x10;
         case KtxBundle::SRGB8_ALPHA8_ASTC_12x10: return T::SRGB8_ALPHA8_ASTC_12x10;
         case KtxBundle::SRGB8_ALPHA8_ASTC_12x12: return T::SRGB8_ALPHA8_ASTC_12x12;
+        case KtxBundle::R11_EAC: return T::EAC_R11;
+        case KtxBundle::SIGNED_R11_EAC: return T::EAC_R11_SIGNED;
+        case KtxBundle::RG11_EAC: return T::EAC_RG11;
+        case KtxBundle::SIGNED_RG11_EAC: return T::EAC_RG11_SIGNED;
+        case KtxBundle::RGB8_ETC2: return T::ETC2_RGB8;
+        case KtxBundle::SRGB8_ETC2: return T::ETC2_SRGB8;
+        case KtxBundle::RGB8_ALPHA1_ETC2: return T::ETC2_RGB8_A1;
+        case KtxBundle::SRGB8_ALPHA1_ETC: return T::ETC2_SRGB8_A1;
+        case KtxBundle::RGBA8_ETC2_EAC: return T::ETC2_EAC_RGBA8;
+        case KtxBundle::SRGB8_ALPHA8_ETC2_EAC: return T::ETC2_EAC_SRGBA8;
     }
     return (T) 0xffff;
 }

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -6,7 +6,7 @@ let queued_mouse_events = [];
 
 let use_astc = false;
 let use_s3tc = false;
-let use_etc1 = false;
+let use_etc = false;
 
 let canvas = document.getElementById('filament-canvas');
 let ctx = GL.createContext(canvas, {
@@ -19,12 +19,14 @@ let ctx = GL.createContext(canvas, {
 GL.makeContextCurrent(ctx);
 for (let ext of Module.ctx.getSupportedExtensions()) {
     if (ext == "WEBGL_compressed_texture_s3tc") {
+        Module.ctx.getExtension('WEBGL_compressed_texture_s3tc');
         use_s3tc = true;
     } else if (ext == "WEBGL_compressed_texture_astc") {
         Module.ctx.getExtension('WEBGL_compressed_texture_astc');
         use_astc = true;
-    } else if (ext == "WEBGL_compressed_texture_etc1") {
-        use_etc1 = true;
+    } else if (ext == "WEBGL_compressed_texture_etc") {
+        Module.ctx.getExtension('WEBGL_compressed_texture_etc');
+        use_etc = true;
     }
 }
 

--- a/samples/web/suzanne.cpp
+++ b/samples/web/suzanne.cpp
@@ -66,14 +66,6 @@ static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, strin
         asset->texture.reset();
     };
 
-    Texture::Format format;
-    switch (info.glTypeSize) {
-        case 1: format = Texture::Format::R; break;
-        case 2: format = Texture::Format::RG; break;
-        case 3: format = Texture::Format::RGB; break;
-        case 4: format = Texture::Format::RGBA; break;
-    }
-
     uint8_t* data;
     uint32_t nbytes;
     asset.texture->getBlob({}, &data, &nbytes);
@@ -95,6 +87,14 @@ static Texture* setTextureParameter(Engine& engine, filaweb::Asset& asset, strin
         texture->setImage(engine, 0, std::move(pb));
         app.mi->setParameter(name.c_str(), texture, sampler);
         return texture;
+    }
+
+    Texture::Format format;
+    switch (info.glTypeSize) {
+        case 1: format = Texture::Format::R; break;
+        case 2: format = Texture::Format::RG; break;
+        case 3: format = Texture::Format::RGB; break;
+        case 4: format = Texture::Format::RGBA; break;
     }
 
     Texture::PixelBufferDescriptor pb(data, nbytes, format, Texture::Type::UBYTE, destructor,

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -22,14 +22,19 @@
     <script src="suzanne.js"></script>
     <script src="filaweb.js"></script>
     <script>
+
+    function load_etcfile(basename) {
+        return use_etc ? load_rawfile(basename + "_etc.ktx") : load_rawfile(basename + ".ktx");
+    }
+
     load({
         'albedo':                    (use_s3tc ? load_rawfile('monkey/albedo_s3tc.ktx') :
                                      (use_astc ? load_rawfile('monkey/albedo_astc.ktx') :
                                                  load_rawfile('monkey/albedo.ktx'))),
-        'metallic':                  load_rawfile('monkey/metallic.ktx'),
-        'roughness':                 load_rawfile('monkey/roughness.ktx'),
+        'metallic':                  load_etcfile('monkey/metallic'),
+        'roughness':                 load_etcfile('monkey/roughness'),
         'normal':                    load_rawfile('monkey/normal.ktx'),
-        'ao':                        load_rawfile('monkey/ao.ktx'),
+        'ao':                        load_etcfile('monkey/ao'),
         'mesh':                      load_rawfile('monkey/mesh.filamesh'),
         'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k', '.ktx')
     });


### PR DESCRIPTION
This shrinks file size as follows, although it seems to darken the rendered result.

```
  1398209 Oct  2 16:22 ao.ktx
   699172 Oct  2 16:20 ao_etc.ktx
  1398209 Oct  2 16:22 metallic.ktx
   699172 Oct  2 16:19 metallic_etc.ktx
  1398209 Oct  2 16:22 roughness.ktx
   699172 Oct  2 16:20 roughness_etc.ktx
```

![before](https://user-images.githubusercontent.com/1288904/46382592-8c6e5080-c660-11e8-854e-d838972e80fd.png)
![after](https://user-images.githubusercontent.com/1288904/46382597-8d9f7d80-c660-11e8-86ba-3b8c46c1b38d.png)
