### PR TITLE
Enable ETC for Suzanne normal map.

### DIFF
--- a/libs/imageio/src/BlockCompression.cpp
+++ b/libs/imageio/src/BlockCompression.cpp
@@ -19,6 +19,7 @@
 #include <image/ImageOps.h>
 
 #include <cmath>
+#include <thread>
 
 #include <astcenc.h>
 #include <Etc.h>
@@ -186,7 +187,7 @@ CompressedTexture astcCompress(const LinearImage& original, AstcConfig config) {
 
     // Perform compression.
 
-    constexpr int threadcount = 1; // TODO: set this thread count
+    const int threadcount = std::thread::hardware_concurrency();
     constexpr astc_decode_mode decode_mode = DECODE_LDR; // TODO: honor the config semantic
     constexpr swizzlepattern swz_encode = { 0, 1, 2, 3 };
     constexpr swizzlepattern swz_decode = { 0, 1, 2, 3 };
@@ -317,7 +318,7 @@ S3tcConfig s3tcParseOptionString(const std::string& options) {
 
 CompressedTexture etcCompress(const LinearImage& original, EtcConfig config) {
     LinearImage source = extendToFourChannels(original);
-    constexpr int threadcount = 1; // TODO: set this thread count
+    const int threadcount = std::thread::hardware_concurrency();
     Etc::Image::Format etcformat;
     switch (config.format) {
         case CompressedFormat::R11_EAC: etcformat = Etc::Image::Format::R11; break;

--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -85,10 +85,14 @@ endfunction()
 
 set(ETC_R11_ARGS "--grayscale;--compression=etc_r11_numeric_40")
 
+# TODO: Instead of "rgb8" we should be using "rg11", but that causes an assertion etc2comp.
+set(ETC_NORMALS_ARGS "--kernel=NORMALS;--linear;--compression=etc_rgb8_normalxyz_40")
+
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo.ktx" "")
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_astc.ktx" "--compression=astc_fast_ldr_4x4")
 add_ktxfiles("assets/models/monkey/albedo.png" "monkey/albedo_s3tc.ktx" "--compression=s3tc_rgb_dxt1")
 add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal.ktx" "--kernel=NORMALS;--linear")
+add_ktxfiles("assets/models/monkey/normal.png" "monkey/normal_etc.ktx" "${ETC_NORMALS_ARGS}")
 add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness.ktx" "--grayscale")
 add_ktxfiles("assets/models/monkey/roughness.png" "monkey/roughness_etc.ktx" "${ETC_R11_ARGS}")
 add_ktxfiles("assets/models/monkey/metallic.png" "monkey/metallic.ktx" "--grayscale")

--- a/samples/web/suzanne.html
+++ b/samples/web/suzanne.html
@@ -33,7 +33,7 @@
                                                  load_rawfile('monkey/albedo.ktx'))),
         'metallic':                  load_etcfile('monkey/metallic'),
         'roughness':                 load_etcfile('monkey/roughness'),
-        'normal':                    load_rawfile('monkey/normal.ktx'),
+        'normal':                    load_etcfile('monkey/normal'),
         'ao':                        load_etcfile('monkey/ao'),
         'mesh':                      load_rawfile('monkey/mesh.filamesh'),
         'syferfontein_18d_clear_2k': load_cubemap('syferfontein_18d_clear_2k', '.ktx')

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -80,7 +80,7 @@ Options:
        format specific compression:
            KTX:
              astc_[fast|thorough]_[ldr|hdr]_WxH, where WxH is a valid block size
-             st3c_rgb_dxt1, st3c_rgba_dxt5
+             s3tc_rgb_dxt1, s3tc_rgba_dxt5
              etc_FORMAT_METRIC_EFFORT
                FORMAT is r11, signed_r11, rg11, signed_rg11, rgb8, srgb8, rgb8_alpha
                          srgb8_alpha, rgba8, or srgb8_alpha8


### PR DESCRIPTION
Due to an assertion in etc2comp, this unfortunately uses RGB8 instead of RG11 but it still helps quite a bit (3.3 MB savings in the unzipped KTX size).

Before / After screenshots below.

![before](https://user-images.githubusercontent.com/1288904/46431660-3d2c2c80-c701-11e8-9b22-886f2b86a898.png)
![after](https://user-images.githubusercontent.com/1288904/46431663-3ef5f000-c701-11e8-8062-5ee30167f8f3.png)
