### PR TITLE
Fix utils::Path concat for relative paths.

### DIFF
--- a/libs/utils/src/Path.cpp
+++ b/libs/utils/src/Path.cpp
@@ -70,7 +70,9 @@ bool Path::isDirectory() const {
 Path Path::concat(const Path& path) const {
     if (path.isEmpty()) return *this;
     if (path.isAbsolute()) return path;
-    if (m_path.back() != SEPARATOR) return Path(m_path + SEPARATOR + path.getPath());
+    if (m_path.back() != SEPARATOR && !m_path.empty()) {
+        return Path(m_path + SEPARATOR + path.getPath());
+    }
     return Path(m_path + path.getPath());
 }
 


### PR DESCRIPTION
Concating with an empty path should not prepend a slash since doing so implies that the user wants to access the system's root folder.

Fixes #332