### PR TITLE
don’t leak the ExternalContext object

### DIFF
--- a/filament/include/filament/driver/ExternalContext.h
+++ b/filament/include/filament/driver/ExternalContext.h
@@ -24,6 +24,9 @@
 #include <utils/compiler.h>
 
 namespace filament {
+namespace details {
+class FEngine;
+}
 
 class Driver;
 
@@ -38,11 +41,6 @@ public:
         uintptr_t image;
     };
 
-    // Creates the platform-specific ExternalContext object. The caller takes ownership and is
-    // responsible for destroying it. Initialization of the backend API is deferred until
-    // createDriver(). The passed-in backend hint is replaced with the resolved backend.
-    static ExternalContext* create(driver::Backend* backendHint) noexcept;
-
     // Creates and and initializes the low-level API (e.g. an OpenGL context or Vulkan instance),
     // then creates the concrete Driver. Returns null on failure.
     virtual std::unique_ptr<Driver> createDriver(void* sharedGLContext) noexcept = 0;
@@ -50,6 +48,11 @@ public:
     virtual ~ExternalContext() noexcept;
 
     virtual int getOSVersion() const noexcept = 0;
+
+private:
+    friend class details::FEngine;
+    static ExternalContext* create(driver::Backend* backendHint) noexcept;
+    static void destroy(ExternalContext** context) noexcept;
 };
 
 class UTILS_PUBLIC ContextManagerGL : public ExternalContext {

--- a/filament/src/driver/ExternalContext.cpp
+++ b/filament/src/driver/ExternalContext.cpp
@@ -62,6 +62,9 @@ ContextManagerGL::~ContextManagerGL() noexcept = default;
 
 ContextManagerVk::~ContextManagerVk() noexcept = default;
 
+// Creates the platform-specific ExternalContext object. The caller takes ownership and is
+// responsible for destroying it. Initialization of the backend API is deferred until
+// createDriver(). The passed-in backend hint is replaced with the resolved backend.
 ExternalContext* ExternalContext::create(Backend* backend) noexcept {
     assert(backend);
     if (*backend == Backend::DEFAULT) {
@@ -100,6 +103,12 @@ ExternalContext* ExternalContext::create(Backend* backend) noexcept {
         return new ContextManagerDummy();
     #endif
     return nullptr;
+}
+
+// destroys an ExternalContext create by create()
+void ExternalContext::destroy(ExternalContext** context) noexcept {
+    delete *context;
+    *context = nullptr;
 }
 
 } // namespace driver


### PR DESCRIPTION
FEngine doesn’t take ownership of ExternalContext if
it’s passed as a parameter, however, in the common
case it’s not, and FEngine owns it — and must take
care of destroying it.


Also fix this behavior in “single thread” mode,
the given ExternalContext was ignored.