### PR TITLE
mipgen: fix dark miplevels in normal maps.

### DIFF
--- a/libs/image/include/image/ImageOps.h
+++ b/libs/image/include/image/ImageOps.h
@@ -37,6 +37,7 @@ LinearImage verticalFlip(const LinearImage& image);
 
 // Transforms normals (components live in [-1,+1]) into colors (components live in [0,+1]).
 LinearImage vectorsToColors(const LinearImage& image);
+LinearImage colorsToVectors(const LinearImage& image);
 
 // Creates a single-channel image by extracting the selected channel.
 LinearImage extractChannel(const LinearImage& image, uint32_t channel);

--- a/libs/image/src/ImageOps.cpp
+++ b/libs/image/src/ImageOps.cpp
@@ -123,8 +123,20 @@ LinearImage vectorsToColors(const LinearImage& image) {
     LinearImage result(width, height, 3);
     auto src = (float3 const*) image.getPixelRef();
     auto dst = (float3*) result.getPixelRef();
-    for (uint32_t n = 0; n < width * height; ++n) {
+    for (uint32_t n = 0, end = width * height; n < end; ++n) {
         dst[n] = 0.5f * (src[n] + float3(1));
+    }
+    return result;
+}
+
+LinearImage colorsToVectors(const LinearImage& image) {
+    ASSERT_PRECONDITION(image.getChannels() == 3, "Must be a 3-channel image.");
+    const uint32_t width = image.getWidth(), height = image.getHeight();
+    LinearImage result(width, height, 3);
+    auto src = (float3 const*) image.getPixelRef();
+    auto dst = (float3*) result.getPixelRef();
+    for (uint32_t n = 0, end = width * height; n < end; ++n) {
+        dst[n] = 2.0f * src[n] - float3(1);
     }
     return result;
 }

--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -253,6 +253,10 @@ int main(int argc, char* argv[]) {
         sourceImage = extractChannel(sourceImage, 0);
     }
 
+    if (g_filter == Filter::GAUSSIAN_NORMALS) {
+        sourceImage = colorsToVectors(sourceImage);
+    }
+
     puts("Generating miplevels...");
     uint32_t count = getMipmapCount(sourceImage);
     vector<LinearImage> miplevels(count);
@@ -306,7 +310,10 @@ int main(int argc, char* argv[]) {
             info.glBaseInternalFormat = KtxBundle::RGBA;
         }
         uint32_t mip = 0;
-        auto addLevel = [&](const LinearImage& image) {
+        auto addLevel = [&](LinearImage image) {
+            if (g_filter == Filter::GAUSSIAN_NORMALS) {
+                image = vectorsToColors(image);
+            }
             std::unique_ptr<uint8_t[]> data;
             if (astcConfig.blocksize[0] > 0) {
                 // The ASTC encoder calls exit(1) if it fails, so it's very useful to print some


### PR DESCRIPTION
When using GAUSSIAN_NORMALS, image::resampleImage automatically unitizes
its output. This means that clients (e.g. mipgen) need to ensure that
the source image is in [-1,+1] rather than [0,+1].