### PR TITLE
Add CLEAR flag to mirrorFrame

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -29,6 +29,7 @@ public class Renderer {
 
     public static final int MIRROR_FRAME_FLAG_COMMIT = 0x1;
     public static final int MIRROR_FRAME_FLAG_SET_PRESENTATION_TIME = 0x2;
+    public static final int MIRROR_FRAME_FLAG_CLEAR = 0x4;
 
     Renderer(@NonNull Engine engine, long nativeRenderer) {
         mEngine = engine;

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -162,6 +162,14 @@ public:
      * mirrorFrame()
      */
     static constexpr MirrorFrameFlag SET_PRESENTATION_TIME = 0x2;
+    /**
+     * Indicates that the dstSwapChain passed into mirrorFrame() should be
+     * cleared to black before the frame is mirrored into the specified viewport.
+     *
+     * @see
+     * mirrorFrame()
+     */
+    static constexpr MirrorFrameFlag CLEAR = 0x4;
 
     /**
      * Mirror the currently rendered view to the indicated swap chain, using the

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -254,10 +254,14 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewpor
 
     RenderPassParams params = {};
     // Clear color to black if the CLEAR flag is set.
-    if ((flags & CLEAR) != 0) {
+    if (flags & CLEAR) {
         params.clear = TargetBufferFlags::COLOR;
         params.clearColor = {0.f, 0.f, 0.f, 1.f};
-        params.clear |= RenderPassParams::IGNORE_SCISSOR | RenderPassParams::IGNORE_VIEWPORT;
+        params.left = 0;
+        params.bottom = 0;
+        params.width = std::numeric_limits<uint32_t>::max();
+        params.height = std::numeric_limits<uint32_t>::max();
+        params.clear |= RenderPassParams::IGNORE_SCISSOR;
     }
     driver.beginRenderPass(viewRenderTarget, params);
 
@@ -266,14 +270,14 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewpor
     driver.blit(TargetBufferFlags::COLOR,
                 viewRenderTarget, dstViewport.left, dstViewport.bottom, dstViewport.width, dstViewport.height,
                 viewRenderTarget, srcViewport.left, srcViewport.bottom, srcViewport.width, srcViewport.height);
-    if ((flags & SET_PRESENTATION_TIME) != 0) {
+    if (flags & SET_PRESENTATION_TIME) {
         uint64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
         driver.setPresentationTime(monotonic_clock_ns);
     }
 
     driver.endRenderPass();
 
-    if ((flags & COMMIT) != 0) {
+    if (flags & COMMIT) {
         dstSwapChain->commit(driver);
     }
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -252,17 +252,29 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewpor
     // destination.
     driver.makeCurrent(dstSwapChain->getHwHandle(), mSwapChain->getHwHandle());
 
+    RenderPassParams params = {};
+    // Clear color to black if the CLEAR flag is set.
+    if ((flags & CLEAR) != 0) {
+        params.clear = TargetBufferFlags::COLOR;
+        params.clearColor = {0.f, 0.f, 0.f, 1.f};
+        params.clear |= RenderPassParams::IGNORE_SCISSOR | RenderPassParams::IGNORE_VIEWPORT;
+    }
+    driver.beginRenderPass(viewRenderTarget, params);
+
     // Verify that the source swap chain is readable.
     assert(mSwapChain->isReadable());
     driver.blit(TargetBufferFlags::COLOR,
                 viewRenderTarget, dstViewport.left, dstViewport.bottom, dstViewport.width, dstViewport.height,
                 viewRenderTarget, srcViewport.left, srcViewport.bottom, srcViewport.width, srcViewport.height);
     if ((flags & SET_PRESENTATION_TIME) != 0) {
-      uint64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
-      driver.setPresentationTime(monotonic_clock_ns);
+        uint64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
+        driver.setPresentationTime(monotonic_clock_ns);
     }
+
+    driver.endRenderPass();
+
     if ((flags & COMMIT) != 0) {
-      dstSwapChain->commit(driver);
+        dstSwapChain->commit(driver);
     }
 
     // Reset the context and read/draw surface to the current surface so that

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -257,6 +257,8 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewpor
     if (flags & CLEAR) {
         params.clear = TargetBufferFlags::COLOR;
         params.clearColor = {0.f, 0.f, 0.f, 1.f};
+        params.discardStart = TargetBufferFlags::ALL;
+        params.discardEnd = TargetBufferFlags::NONE;
         params.left = 0;
         params.bottom = 0;
         params.width = std::numeric_limits<uint32_t>::max();


### PR DESCRIPTION
Adds a clear flag to the mirror frame call which clears the entire surface to black before mirroring in the current view.  Also exposes maxViewportDimensions through the driver API so that the full viewport dimensions can be used for the clear.