### PR TITLE
Ensure the base layer is never glossier than the clear coat layer

### DIFF
--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -82,7 +82,7 @@ void getPixelParams(const MaterialInputs material, out PixelParams pixel) {
 #endif
 #endif
 
-    // Remaps the roughnes to a perceptually linear roughness (roughness^2)
+    // Remaps the roughness to a perceptually linear roughness (roughness^2)
     // TODO: the base layer's roughness should not be higher than the clear coat layer's
     pixel.roughness = roughness;
     pixel.linearRoughness = roughness * roughness;


### PR DESCRIPTION
When the clear coat layer uses a high roughness, the base layer should not be perceived as glossy. The screenshot below shows the problem (no dynamic light, only an IBL):

<img width="1136" alt="screen shot 2018-10-08 at 4 50 05 pm" src="https://user-images.githubusercontent.com/869684/46639381-778b3480-cb1a-11e8-9a3c-86df01ae4cc4.png">

In this screenshot, the base layer is a glossy black dielectric and the clear coat layer uses the max roughness. You can see how glossy reflections appear at grazing angle. With a rough clear coat layer, light should be diffuse and it shouldn't be possible to see glossy reflections from the base layer.

We simulate the diffusion effect by making sure the base layer is never glossier than the clear coat layer. It's incorrect but better than nothing. Here is the same scene with the fix:

<img width="1136" alt="screen shot 2018-10-08 at 4 50 03 pm" src="https://user-images.githubusercontent.com/869684/46639444-ecf70500-cb1a-11e8-83ba-c92f7ff6d673.png">
