### PR TITLE
API CHANGE: remove deprecated RGBM enum.

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -60,7 +60,7 @@ public class Texture {
         RG16F, RG16UI, RG16I,
         R11F_G11F_B10F,
         RGBA8, SRGB8_A8, RGBA8_SNORM,
-        RGBM, // Deprecated but still honored; see Texture.Builder.rgbm
+        UNUSED, // The RGBM InternalFormat has been replaced with a flag (Texture.Builder.rgbm)
         RGB10_A2, RGBA8UI, RGBA8I,
         DEPTH32F, DEPTH24_STENCIL8, DEPTH32F_STENCIL8,
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -90,8 +90,7 @@ IndirectLight* IndirectLight::Builder::build(Engine& engine) {
             return nullptr;
         }
 
-        if (!ASSERT_POSTCONDITION_NON_FATAL( mImpl->mReflectionsMap->isRgbm() ||
-                mImpl->mReflectionsMap->getFormat() == Texture::InternalFormat::RGBM,
+        if (!ASSERT_POSTCONDITION_NON_FATAL( mImpl->mReflectionsMap->isRgbm(),
                 "reflection map must have RGBM enabled")) {
             return nullptr;
         }

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -95,9 +95,7 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
         : mSkyboxTexture(upcast(builder->mEnvironmentMap)),
           mRenderableManager(engine.getRenderableManager()) {
 
-    const bool rgbm = mSkyboxTexture->getFormat() == Texture::InternalFormat::RGBM ||
-            mSkyboxTexture->isRgbm();
-    FMaterial const* material = engine.getSkyboxMaterial(rgbm);
+    FMaterial const* material = engine.getSkyboxMaterial(mSkyboxTexture->isRgbm());
     mSkyboxMaterialInstance = material->createInstance();
 
     TextureSampler sampler(TextureSampler::MagFilter::LINEAR, TextureSampler::WrapMode::REPEAT);

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -241,7 +241,6 @@ size_t FTexture::getFormatSize(InternalFormat format) noexcept {
         case TextureFormat::RGBA8:
         case TextureFormat::SRGB8_A8:
         case TextureFormat::RGBA8_SNORM:
-        case TextureFormat::RGBM:
         case TextureFormat::RGB10_A2:
         case TextureFormat::RGBA8UI:
         case TextureFormat::RGBA8I:

--- a/filament/src/driver/CommandStream.cpp
+++ b/filament/src/driver/CommandStream.cpp
@@ -332,7 +332,6 @@ io::ostream& operator<<(io::ostream& out, TextureFormat format) {
         CASE(TextureFormat, RGBA8)
         CASE(TextureFormat, SRGB8_A8)
         CASE(TextureFormat, RGBA8_SNORM)
-        CASE(TextureFormat, RGBM)
         CASE(TextureFormat, RGB5_A1)
         CASE(TextureFormat, RGBA4)
         CASE(TextureFormat, RGB10_A2)

--- a/filament/src/driver/Driver.cpp
+++ b/filament/src/driver/Driver.cpp
@@ -104,7 +104,6 @@ const DriverBase::Entry DriverBase::mTextureInfo[] = {
         { TF::RGBA8,             SF::FLOAT,  SP::LOW    },
         { TF::SRGB8_A8,          SF::FLOAT,  SP::LOW    },
         { TF::RGBA8_SNORM,       SF::FLOAT,  SP::LOW    },
-        { TF::RGBM,              SF::FLOAT,  SP::LOW    },
         { TF::RGB10_A2,          SF::FLOAT,  SP::MEDIUM },
         { TF::RGBA8UI,           SF::UINT,   SP::LOW    },
         { TF::RGBA8I,            SF::INT,    SP::LOW    },

--- a/filament/src/driver/opengl/GLUtils.h
+++ b/filament/src/driver/opengl/GLUtils.h
@@ -288,7 +288,6 @@ constexpr /* inline */ GLenum getInternalFormat(filament::driver::TextureFormat 
         case TextureFormat::RGBA8:             return GL_RGBA8;
         case TextureFormat::SRGB8_A8:          return GL_SRGB8_ALPHA8;
         case TextureFormat::RGBA8_SNORM:       return GL_RGBA8_SNORM;
-        case TextureFormat::RGBM:              return GL_RGBA8;
         case TextureFormat::RGB10_A2:          return GL_RGB10_A2;
         case TextureFormat::RGBA8UI:           return GL_RGBA8UI;
         case TextureFormat::RGBA8I:            return GL_RGBA8I;
@@ -421,6 +420,8 @@ constexpr /* inline */ GLenum getInternalFormat(filament::driver::TextureFormat 
             // this should not happen
             return 0;
 #endif
+        case TextureFormat::UNUSED:
+            return 0;
     }
 }
 

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1455,7 +1455,6 @@ bool OpenGLDriver::isRenderTargetFormatSupported(Driver::TextureFormat format) {
         case TextureFormat::RG16I:
         case TextureFormat::RGBA8:
         case TextureFormat::SRGB8_A8:
-        case TextureFormat::RGBM:
         case TextureFormat::RGB10_A2:
         case TextureFormat::RGBA8UI:
         case TextureFormat::RGBA8I:

--- a/filament/src/driver/vulkan/VulkanDriverImpl.cpp
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.cpp
@@ -606,7 +606,6 @@ VkFormat getVkFormat(TextureFormat format) {
         case TextureFormat::RGBA8:             return VK_FORMAT_R8G8B8A8_UNORM;
         case TextureFormat::SRGB8_A8:          return VK_FORMAT_R8G8B8A8_SRGB;
         case TextureFormat::RGBA8_SNORM:       return VK_FORMAT_R8G8B8A8_SNORM;
-        case TextureFormat::RGBM:              return VK_FORMAT_R8G8B8A8_UNORM;
         case TextureFormat::RGB10_A2:          return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
         case TextureFormat::RGBA8UI:           return VK_FORMAT_R8G8B8A8_UINT;
         case TextureFormat::RGBA8I:            return VK_FORMAT_R8G8B8A8_SINT;

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -368,7 +368,7 @@ enum class TextureFormat : uint16_t {
     RG16F, RG16UI, RG16I,
     R11F_G11F_B10F,
     RGBA8, SRGB8_A8,RGBA8_SNORM,
-    RGBM, // Deprecated but still honored; see Texture::Builder::rgbm
+    UNUSED, // The RGBM InternalFormat has been replaced with a flag (Texture::Builder::rgbm)
     RGB10_A2, RGBA8UI, RGBA8I,
     DEPTH32F, DEPTH24_STENCIL8, DEPTH32F_STENCIL8,
 


### PR DESCRIPTION
Clients should use the new `rgbm` builder flag instead, which allows the skybox and IBL to use compressed textures.

Sceneform needs to be updated, and we have a tentative CL for that.