### PR TITLE
Vulkan: fix bad std::move usage.

### DIFF
--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -524,14 +524,14 @@ void VulkanDriver::load2DImage(Driver::TextureHandle th,
         PixelBufferDescriptor&& data) {
     assert(data.type != driver::PixelDataType::COMPRESSED && "Compression not yet supported.");
     assert(xoffset == 0 && yoffset == 0 && "Offsets not yet supported.");
-    handle_cast<VulkanTexture>(mHandleMap, th)->load2DImage(std::move(data), width, height, level);
+    handle_cast<VulkanTexture>(mHandleMap, th)->load2DImage(data, width, height, level);
     scheduleDestroy(std::move(data));
 }
 
 void VulkanDriver::loadCubeImage(Driver::TextureHandle th, uint32_t level,
         PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     assert(data.type != driver::PixelDataType::COMPRESSED && "Compression not yet supported.");
-    handle_cast<VulkanTexture>(mHandleMap, th)->loadCubeImage(std::move(data), faceOffsets, level);
+    handle_cast<VulkanTexture>(mHandleMap, th)->loadCubeImage(data, faceOffsets, level);
     scheduleDestroy(std::move(data));
 }
 

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -483,7 +483,7 @@ VulkanTexture::~VulkanTexture() {
     vkFreeMemory(mContext.device, textureImageMemory, VKALLOC);
 }
 
-void VulkanTexture::load2DImage(PixelBufferDescriptor&& data, uint32_t width, uint32_t height,
+void VulkanTexture::load2DImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
         int miplevel) {
     assert(width <= this->width && height <= this->height);
     const void* cpuData = data.buffer;
@@ -520,7 +520,7 @@ void VulkanTexture::load2DImage(PixelBufferDescriptor&& data, uint32_t width, ui
     }
 }
 
-void VulkanTexture::loadCubeImage(PixelBufferDescriptor&& data,  const FaceOffsets& faceOffsets,
+void VulkanTexture::loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
         int miplevel) {
     const void* cpuData = data.buffer;
     const uint32_t numBytes = data.size;

--- a/filament/src/driver/vulkan/VulkanHandles.h
+++ b/filament/src/driver/vulkan/VulkanHandles.h
@@ -119,8 +119,10 @@ struct VulkanTexture : public HwTexture {
             TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
             TextureUsage usage, VulkanStagePool& stagePool);
     ~VulkanTexture();
-    void load2DImage(PixelBufferDescriptor&& data, uint32_t width, uint32_t height, int miplevel);
-    void loadCubeImage(PixelBufferDescriptor&& data, const FaceOffsets& faceOffsets, int miplevel);
+    void load2DImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
+            int miplevel);
+    void loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
+            int miplevel);
     VkFormat format;
     VkImageView imageView = VK_NULL_HANDLE;
     VkImage textureImage = VK_NULL_HANDLE;


### PR DESCRIPTION
Tested by running vk_hellopbr with MoltenVK, still works. :)