### PR TITLE
OpenGL Backend fix for INVALID_OPERATION regression.

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1909,9 +1909,11 @@ void OpenGLDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh, BufferDe
     assert(ub->size >= p.size);
     assert(ub->gl.ubo);
 
-    bindBuffer(GL_UNIFORM_BUFFER, ub->gl.ubo);
-    glBufferSubData(GL_UNIFORM_BUFFER, 0, p.size, p.buffer);
-    CHECK_GL_ERROR(utils::slog.e)
+    if (p.size > 0) {
+        bindBuffer(GL_UNIFORM_BUFFER, ub->gl.ubo);
+        glBufferSubData(GL_UNIFORM_BUFFER, 0, p.size, p.buffer);
+        CHECK_GL_ERROR(utils::slog.e)
+    }
 
     scheduleDestroy(std::move(p));
 }


### PR DESCRIPTION
Recent changes to UBO management introduce the possibility of calling glBufferSubData on zero-length regions, which cause a cascade of `GL_INVALID_OPERATION` with the Suzanne WebGL demo. Note that the WebGL variant of BufferSubData has special behavior when length = 0.

This also seems like a potentially useful optimization for non-web platforms, since a CPU branch is likely cheaper than a GL entry point.