### PR TITLE
Filaweb now uses compression for the IBL.

### DIFF
--- a/samples/web/CMakeLists.txt
+++ b/samples/web/CMakeLists.txt
@@ -116,15 +116,39 @@ add_mesh("assets/models/monkey/monkey.obj" "monkey/mesh.filamesh")
 add_mesh("third_party/shader_ball/shader_ball.obj" "shaderball/mesh.filamesh")
 
 # Generate IBL and skybox images using cmgen.
+set(CMGEN_ARGS -x public --format=ktx --size=256 --extract-blur=0.1)
+set(CMGEN_ARGS_S3TC ${CMGEN_ARGS} --compression=s3tc_rgba_dxt5)
+set(CMGEN_ARGS_ETC ${CMGEN_ARGS} --compression=etc_rgba8_rgba_40)
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${CMAKE_CURRENT_SOURCE_DIR}/../../${SOURCE}")
+
+    file(MAKE_DIRECTORY "public/${TARGET}")
+
     set(target_skybox "public/${TARGET}/${TARGET}_skybox.ktx")
     set(target_envmap "public/${TARGET}/${TARGET}_ibl.ktx")
+
+    set(target_envmap_etc "public/${TARGET}/${TARGET}_ibl_etc.ktx")
+    set(target_envmap_s3tc "public/${TARGET}/${TARGET}_ibl_s3tc.ktx")
+
     set(target_skyboxes ${target_skyboxes} ${target_skybox} PARENT_SCOPE)
-    set(target_envmaps ${target_envmaps} ${target_envmap} PARENT_SCOPE)
-    add_custom_command(
-        OUTPUT ${target_skybox} ${target_envmap}
-        COMMAND cmgen -x public --format=ktx --size=256 --extract-blur=0.1 ${source_envmap}
+
+    set(target_envmaps ${target_envmaps}
+            ${target_envmap} ${target_envmap_etc} ${target_envmap_s3tc} PARENT_SCOPE)
+
+    add_custom_command(OUTPUT ${target_skybox}
+                ${target_envmap} ${target_envmap_etc} ${target_envmap_s3tc}
+
+        # First create an S3TC-encoded envmap, then rename it.
+        COMMAND cmgen ${CMGEN_ARGS_S3TC} ${source_envmap}
+        COMMAND mv ${target_envmap} ${target_envmap_s3tc}
+
+        # Now create an ETC-encoded envmap, then rename it.
+        COMMAND cmgen ${CMGEN_ARGS_ETC} ${source_envmap}
+        COMMAND mv ${target_envmap} ${target_envmap_etc}
+
+        # Finally, create KTX files for the uncompressed envmap.
+        COMMAND cmgen ${CMGEN_ARGS} ${source_envmap}
+
         MAIN_DEPENDENCY ${source_envmap}
         DEPENDS cmgen)
 endfunction()

--- a/samples/web/filaweb.js
+++ b/samples/web/filaweb.js
@@ -113,9 +113,15 @@ function load_rawfile(url) {
 let load_texture = load_rawfile;
 
 function load_cubemap(name, suffix) {
+    let compressed_suffix = suffix;
+    if (use_etc) {
+        compressed_suffix = '_etc' + suffix;
+    } else if (use_s3tc) {
+        compressed_suffix = '_s3tc' + suffix;
+    }
     let urlprefix = name + '/';
     let promises = {};
-    promises['ibl'] = load_rawfile(urlprefix + name + '_ibl' + suffix);
+    promises['ibl'] = load_rawfile(urlprefix + name + '_ibl' + compressed_suffix);
     promises['skybox'] = load_rawfile(urlprefix + name + '_skybox' + suffix);
     let numberRemaining = Object.keys(promises).length;
     var promise = new Promise((success) => {


### PR DESCRIPTION
The web build now invokes cmgen three times for each IBL: uncompressed, S3TC (desktop), and ETC (mobile). Alternatively, we could enhance cmgen to accept multiple compression strings, but per discussion with Mathias we decided to keep it simple.

I decided not to use compression for the skybox in our web demos because the quality is too poor (see PR image). I did not try playing with compression settings, might be worth revisiting in the future.

![neither](https://user-images.githubusercontent.com/1288904/46756965-9bb35680-cc7d-11e8-9706-0716744618bd.png)
![s3tc_skybox_and_ibl](https://user-images.githubusercontent.com/1288904/46756966-9e15b080-cc7d-11e8-8b5b-7c13c700d6be.png)
![s3tc_ibl](https://user-images.githubusercontent.com/1288904/46756970-a241ce00-cc7d-11e8-888f-8d3a6767c1ff.png)
<img width="574" alt="etc_ibl" src="https://user-images.githubusercontent.com/1288904/46756977-a5d55500-cc7d-11e8-9e29-c6bfb31b9770.png">
