### PR TITLE
Add BufferDescriptor API to Material::Builder.

### DIFF
--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -25,6 +25,7 @@
 #include <filament/Texture.h>
 #include <filament/TextureSampler.h>
 
+#include <filament/driver/BufferDescriptor.h>
 #include <filament/driver/DriverEnums.h>
 
 #include <utils/compiler.h>
@@ -58,6 +59,7 @@ public:
     using VertexDomain = filament::VertexDomain;
     using TransparencyMode = filament::TransparencyMode;
 
+    using BufferDescriptor = driver::BufferDescriptor;
     using ParameterType = filament::driver::UniformType;
     using Precision = filament::driver::Precision;
     using SamplerType = filament::driver::SamplerType;
@@ -87,9 +89,14 @@ public:
         Builder& operator=(Builder const& rhs) noexcept;
         Builder& operator=(Builder&& rhs) noexcept;
 
-        // This does not copies the content of the RAM, only copy references.
+        // This does not copy the content of the RAM, it only makes a weak reference.
         // The RAM must stay valid until build() is called.
         Builder& package(const void* payload, size_t size);
+
+        // Alternatively, clients can submit a BufferDescriptor instead of void *, which is
+        // auto-released if a callback is present. Note that some language bindings (e.g.,
+        // JavaScript) prefer descriptors over the void * API.
+        Builder& package(BufferDescriptor&& buffer);
 
         /**
          * Creates the Material object and returns a pointer to it.

--- a/samples/vk_hellotriangle.cpp
+++ b/samples/vk_hellotriangle.cpp
@@ -54,9 +54,11 @@ static const Vertex TRIANGLE_VERTICES[3] = {
 
 static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 
-static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
+static constexpr uint8_t BAKED_COLOR[] = {
     #include "generated/material/bakedColor.inc"
 };
+
+static auto BAKED_COLOR_PACKAGE = Material::BufferDescriptor(BAKED_COLOR, sizeof(BAKED_COLOR));
 
 int main(int argc, char** argv) {
     Config config;
@@ -76,17 +78,13 @@ int main(int argc, char** argv) {
                 .attribute(VertexAttribute::COLOR, 0, VertexBuffer::AttributeType::UBYTE4, 8, 12)
                 .normalized(VertexAttribute::COLOR)
                 .build(*engine);
-        app.vb->setBufferAt(*engine, 0,
-                VertexBuffer::BufferDescriptor(TRIANGLE_VERTICES, 36, nullptr));
+        app.vb->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(TRIANGLE_VERTICES, 36));
         app.ib = IndexBuffer::Builder()
                 .indexCount(3)
                 .bufferType(IndexBuffer::IndexType::USHORT)
                 .build(*engine);
-        app.ib->setBuffer(*engine,
-                IndexBuffer::BufferDescriptor(TRIANGLE_INDICES, 6, nullptr));
-        app.mat = Material::Builder()
-                .package((void*) BAKED_COLOR_PACKAGE, sizeof(BAKED_COLOR_PACKAGE))
-                .build(*engine);
+        app.ib->setBuffer(*engine, IndexBuffer::BufferDescriptor(TRIANGLE_INDICES, 6));
+        app.mat = Material::Builder().package(std::move(BAKED_COLOR_PACKAGE)).build(*engine);
         app.renderable = EntityManager::get().create();
         RenderableManager::Builder(1)
                 .boundingBox({{ -1, -1, -1 }, { 1, 1, 1 }})


### PR DESCRIPTION
@pixelflinger, please take a look since you might want to clean this up after it goes in, I decided to avoid touching `BuilderBase`.

Per discussion with Romain, this is motivated by our upcoming JS bindings, which prefer dealing with buffer descriptors instead of void * style API.