### PR TITLE
implemented Stream::getTimestamp()

### DIFF
--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -176,6 +176,15 @@ public:
      */
     void readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             driver::PixelBufferDescriptor&& buffer) noexcept;
+
+    /**
+     * Returns the presentation time of the currently displayed frame in nanosecond.
+     *
+     * This value can change at any time.
+     *
+     * @return timestamp in nanosecond.
+     */
+    int64_t getTimestamp() const noexcept;
 };
 
 } // namespace filament

--- a/filament/include/filament/driver/Platform.h
+++ b/filament/include/filament/driver/Platform.h
@@ -73,7 +73,7 @@ public:
     // swap draw buffers (i.e. for double-buffered rendering).
     virtual void commit(SwapChain* swapChain) noexcept = 0;
 
-    virtual void setPresentationTime(long time) noexcept = 0;
+    virtual void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept = 0;
 
     virtual bool canCreateFence() noexcept { return false; }
     virtual Fence* createFence() noexcept = 0;
@@ -90,7 +90,7 @@ public:
 
     // detach destroys the texture associated to the stream
     virtual void detach(Stream* stream) noexcept = 0;
-    virtual void updateTexImage(Stream* stream) noexcept = 0;
+    virtual void updateTexImage(Stream* stream, int64_t* timestamp) noexcept = 0;
 
     // external texture storage
     virtual ExternalTexture* createExternalTextureStorage() noexcept = 0;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -273,7 +273,7 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewpor
                 viewRenderTarget, dstViewport.left, dstViewport.bottom, dstViewport.width, dstViewport.height,
                 viewRenderTarget, srcViewport.left, srcViewport.bottom, srcViewport.width, srcViewport.height);
     if (flags & SET_PRESENTATION_TIME) {
-        uint64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
+        int64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
         driver.setPresentationTime(monotonic_clock_ns);
     }
 
@@ -313,7 +313,7 @@ bool FRenderer::beginFrame(FSwapChain* swapChain) {
     mSwapChain = swapChain;
     swapChain->makeCurrent(driver);
 
-    uint64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
+    int64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
     driver.beginFrame(monotonic_clock_ns, mFrameId);
     driver.setPresentationTime(monotonic_clock_ns);
 

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -24,6 +24,8 @@
 #include <filament/driver/PixelBufferDescriptor.h>
 
 #include <utils/Panic.h>
+#include <filament/Stream.h>
+
 
 namespace filament {
 
@@ -134,6 +136,12 @@ void FStream::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uin
     }
 }
 
+int64_t FStream::getTimestamp() const noexcept {
+    FEngine::DriverApi& driver = mEngine.getDriverApi();
+    return driver.getStreamTimestamp(mStreamHandle);
+}
+
+
 } // namespace details
 
 // ------------------------------------------------------------------------------------------------
@@ -153,6 +161,10 @@ void Stream::setDimensions(uint32_t width, uint32_t height) noexcept {
 void Stream::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         driver::PixelBufferDescriptor&& buffer) noexcept {
     upcast(this)->readPixels(xoffset, yoffset, width, height, std::move(buffer));
+}
+
+int64_t Stream::getTimestamp() const noexcept {
+    return upcast(this)->getTimestamp();
 }
 
 } // namespace filament

--- a/filament/src/details/Stream.h
+++ b/filament/src/details/Stream.h
@@ -50,6 +50,8 @@ public:
 
     uint32_t getHeight() const noexcept { return mHeight; }
 
+    int64_t getTimestamp() const noexcept;
+
 private:
     FEngine& mEngine;
     Handle<HwStream> mStreamHandle;

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -205,11 +205,11 @@
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
 DECL_DRIVER_API_2(beginFrame,
-        uint64_t, monotonic_clock_ns,
+        int64_t, monotonic_clock_ns,
         uint32_t, frameId)
 
 DECL_DRIVER_API_1(setPresentationTime,
-        uint64_t, monotonic_clock_ns)
+        int64_t, monotonic_clock_ns)
 
 DECL_DRIVER_API_1(endFrame,
         uint32_t, frameId)
@@ -299,13 +299,13 @@ DECL_DRIVER_API_SYNCHRONOUS_1(Driver::StreamHandle, createStream, void*, stream)
 
 DECL_DRIVER_API_SYNCHRONOUS_3(void, setStreamDimensions, Driver::StreamHandle, stream, uint32_t, width, uint32_t, height)
 
+DECL_DRIVER_API_SYNCHRONOUS_1(int64_t, getStreamTimestamp, Driver::StreamHandle, stream)
+
 DECL_DRIVER_API_SYNCHRONOUS_1(void, updateStreams, driver::DriverApi*, driver)
 
 DECL_DRIVER_API_SYNCHRONOUS_1(void, destroyFence, Driver::FenceHandle, fh)
 
-DECL_DRIVER_API_SYNCHRONOUS_2(Driver::FenceStatus, wait,
-        Driver::FenceHandle, fh,
-        uint64_t, timeout)
+DECL_DRIVER_API_SYNCHRONOUS_2(Driver::FenceStatus, wait, Driver::FenceHandle, fh, uint64_t, timeout)
 
 DECL_DRIVER_API_SYNCHRONOUS_1(bool, isTextureFormatSupported, Driver::TextureFormat, format)
 

--- a/filament/src/driver/android/ExternalStreamManagerAndroid.h
+++ b/filament/src/driver/android/ExternalStreamManagerAndroid.h
@@ -42,7 +42,7 @@ public:
     void release(EGLStream* stream) noexcept;
     void attach(EGLStream* stream, intptr_t tname) noexcept;
     void detach(EGLStream* stream) noexcept;
-    void updateTexImage(EGLStream* stream) noexcept;
+    void updateTexImage(EGLStream* stream, int64_t* timestamp) noexcept;
 
 private:
     VirtualMachineEnv& mVm;
@@ -59,6 +59,7 @@ private:
     JNIEnv* getEnvironmentSlow() noexcept;
 
     jmethodID mSurfaceTextureClass_updateTexImage;
+    jmethodID mSurfaceTextureClass_getTimestamp;
     jmethodID mSurfaceTextureClass_attachToGLContext;
     jmethodID mSurfaceTextureClass_detachFromGLContext;
 
@@ -67,6 +68,8 @@ private:
     int  (*ASurfaceTexture_attachToGLContext)(ASurfaceTexture*, uint32_t);
     int  (*ASurfaceTexture_detachFromGLContext)(ASurfaceTexture*);
     int  (*ASurfaceTexture_updateTexImage)(ASurfaceTexture*);
+    int64_t (*ASurfaceTexture_getTimestamp)(ASurfaceTexture*);   // available since api 28
+
 };
 
 } // namespace filament

--- a/filament/src/driver/opengl/OpenGLDriver.h
+++ b/filament/src/driver/opengl/OpenGLDriver.h
@@ -122,10 +122,8 @@ public:
              * This is for making a cpu copy of the camera frame
              */
             GLuint externalTexture2DId = 0;
-            GLuint width = 0;
-            GLuint height = 0;
             GLuint fbo = 0;
-        } gl;
+        } gl;   // 20 bytes
 
         /*
          * The fields below are access from the main application thread
@@ -133,10 +131,11 @@ public:
          */
         struct {
             // texture id used to texture from, always used in the GL thread
-            GLuint read[ROUND_ROBIN_TEXTURE_COUNT];
+            GLuint read[ROUND_ROBIN_TEXTURE_COUNT];     // 12 bytes
             // texture id to write into, always used from the user thread
-            GLuint write[ROUND_ROBIN_TEXTURE_COUNT];
-            Info infos[ROUND_ROBIN_TEXTURE_COUNT];
+            GLuint write[ROUND_ROBIN_TEXTURE_COUNT];    // 12 bytes
+            Info infos[ROUND_ROBIN_TEXTURE_COUNT];      // 48 bytes
+            int64_t timestamp = 0;
             uint8_t cur = 0;
         } user_thread;
     };

--- a/filament/src/driver/opengl/PlatformCocoaGL.h
+++ b/filament/src/driver/opengl/PlatformCocoaGL.h
@@ -45,13 +45,13 @@ public:
         return driver::FenceStatus::ERROR;
     }
 
-    void setPresentationTime(long time) noexcept final override {}
+    void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final { return nullptr; }
     void destroyStream(Stream* stream) noexcept final {}
     void attach(Stream* stream, intptr_t tname) noexcept final {}
     void detach(Stream* stream) noexcept final {}
-    void updateTexImage(Stream* stream) noexcept final {}
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final {}
 
     ExternalTexture* createExternalTextureStorage() noexcept final { return nullptr; }
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/opengl/PlatformDummyGL.h
+++ b/filament/src/driver/opengl/PlatformDummyGL.h
@@ -48,7 +48,7 @@ public:
     void destroyStream(Stream* stream) noexcept final override {}
     void attach(Stream* stream, intptr_t tname) noexcept final override {}
     void detach(Stream* stream) noexcept final override {}
-    void updateTexImage(Stream* stream) noexcept final override {}
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final override {}
 
     ExternalTexture* createExternalTextureStorage() noexcept final override { return nullptr; }
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/opengl/PlatformEGL.cpp
+++ b/filament/src/driver/opengl/PlatformEGL.cpp
@@ -330,12 +330,12 @@ void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     }
 }
 
-void PlatformEGL::setPresentationTime(long time) noexcept {
+void PlatformEGL::setPresentationTime(int64_t presentationTimeInNanosecond) noexcept {
     if (mCurrentDrawSurface != EGL_NO_SURFACE) {
       eglPresentationTimeANDROID(
                         mEGLDisplay,
                         mCurrentDrawSurface,
-                        time);
+                        presentationTimeInNanosecond);
     }
 }
 
@@ -396,8 +396,8 @@ void PlatformEGL::detach(Stream* stream) noexcept {
     mExternalStreamManager.detach(stream);
 }
 
-void PlatformEGL::updateTexImage(Stream* stream) noexcept {
-    mExternalStreamManager.updateTexImage(stream);
+void PlatformEGL::updateTexImage(Stream* stream, int64_t* timestamp) noexcept {
+    mExternalStreamManager.updateTexImage(stream, timestamp);
 }
 
 Platform::ExternalTexture* PlatformEGL::createExternalTextureStorage() noexcept {

--- a/filament/src/driver/opengl/PlatformEGL.h
+++ b/filament/src/driver/opengl/PlatformEGL.h
@@ -46,7 +46,7 @@ public:
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
     void commit(SwapChain* swapChain) noexcept final;
 
-    void setPresentationTime(long time) noexcept final;
+    void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept final;
 
     bool canCreateFence() noexcept final { return true; }
     Fence* createFence() noexcept final;
@@ -57,7 +57,7 @@ public:
     void destroyStream(Stream* stream) noexcept final;
     void attach(Stream* stream, intptr_t tname) noexcept final;
     void detach(Stream* stream) noexcept final;
-    void updateTexImage(Stream* stream) noexcept final;
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final;
 
     ExternalTexture* createExternalTextureStorage() noexcept final;
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/opengl/PlatformGLX.h
+++ b/filament/src/driver/opengl/PlatformGLX.h
@@ -43,13 +43,13 @@ public:
     void destroyFence(Fence* fence) noexcept override;
     driver::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept override;
 
-    void setPresentationTime(long time) noexcept final override {}
+    void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }
     void destroyStream(Stream* stream) noexcept final override {}
     void attach(Stream* stream, intptr_t tname) noexcept final override {}
     void detach(Stream* stream) noexcept final override {}
-    void updateTexImage(Stream* stream) noexcept final override {}
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final override {}
 
     ExternalTexture* createExternalTextureStorage() noexcept final override { return nullptr; }
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/opengl/PlatformWGL.h
+++ b/filament/src/driver/opengl/PlatformWGL.h
@@ -41,13 +41,13 @@ public:
     void destroyFence(Fence* fence) noexcept override;
     driver::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept override;
 
-    void setPresentationTime(long time) noexcept final override {}
+    void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }
     void destroyStream(Stream* stream) noexcept final override {}
     void attach(Stream* stream, intptr_t tname) noexcept final override {}
     void detach(Stream* stream) noexcept final override {}
-    void updateTexImage(Stream* stream) noexcept final override {}
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final override {}
 
     ExternalTexture* createExternalTextureStorage() noexcept final override { return nullptr; }
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/opengl/PlatformWebGL.h
+++ b/filament/src/driver/opengl/PlatformWebGL.h
@@ -42,13 +42,13 @@ public:
     void destroyFence(Fence* fence) noexcept final override;
     driver::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept final override;
 
-    void setPresentationTime(long time) noexcept final override {}
+    void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }
     void destroyStream(Stream* stream) noexcept final override {}
     void attach(Stream* stream, intptr_t tname) noexcept final override {}
     void detach(Stream* stream) noexcept final override {}
-    void updateTexImage(Stream* stream) noexcept final override {}
+    void updateTexImage(Stream* stream, int64_t* timestamp) noexcept final override {}
 
     ExternalTexture* createExternalTextureStorage() noexcept final override { return nullptr; }
     void reallocateExternalStorage(ExternalTexture* ets,

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -194,7 +194,7 @@ void VulkanDriver::terminate() {
     mContext.instance = nullptr;
 }
 
-void VulkanDriver::beginFrame(uint64_t monotonic_clock_ns, uint32_t frameId) {
+void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     // We allow multiple beginFrame / endFrame pairs before commit(), so gracefully return early
     // if the swap chain has already been acquired.
     if (mContext.cmdbuffer) {
@@ -228,7 +228,7 @@ void VulkanDriver::beginFrame(uint64_t monotonic_clock_ns, uint32_t frameId) {
     mBinder.gc();
 }
 
-void VulkanDriver::setPresentationTime(uint64_t monotonic_clock_ns) {
+void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void VulkanDriver::endFrame(uint32_t frameId) {
@@ -465,6 +465,10 @@ Handle<HwStream> VulkanDriver::createStream(void* nativeStream) {
 }
 
 void VulkanDriver::setStreamDimensions(Driver::StreamHandle sh, uint32_t width, uint32_t height) {
+}
+
+int64_t VulkanDriver::getStreamTimestamp(Driver::StreamHandle sh) {
+    return 0;
 }
 
 void VulkanDriver::updateStreams(CommandStream* driver) {


### PR DESCRIPTION
this returns a timestamp in nanosecond corresponding
to the desired presentation time of the latest frame
bound to a filament texture.