### PR TITLE
Add JavaScript utility functions to reduce boilerplate.

### DIFF
--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -273,7 +273,7 @@ scene.setIndirectLight(indirectLight);
 ## Add background
 
 At this point you can run the demo and you should see a red plastic ball against a black background.
-Without a skybox, the reflections on the ball are not representative of the its surroundings.
+Without a skybox, the reflections on the ball are not representative of its surroundings.
 Here's one way to create a texture for the skybox:
 
 ```js

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -260,7 +260,7 @@ const indirectLight = Filament.IndirectLight.Builder()
 scene.setIndirectLight(indirectLight);
 ```
 
-Phew, that was a lot of boilerplate! Filament provides a JavaScript utility to make this simpler,
+Filament provides a JavaScript utility to make this simpler,
 simply replace the **create IBL** comment with the following snippet.
 
 ```js {fragment="create IBL"}

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -115,11 +115,7 @@ class App {
   }
 
   render() {
-    if (this.renderer.beginFrame(this.swapChain)) {
-      this.renderer.render(this.view);
-      this.renderer.endFrame();
-    }
-    this.engine.execute();
+    this.renderer.render(this.swapChain, this.view);
     window.requestAnimationFrame(this.render);
   }
 

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -275,7 +275,7 @@ At the point you can run the demo and you should see a red plastic ball against 
 Without a skybox, the reflections on the ball aren't truly representative of the its surroundings.
 Here's one way to create a texture for the skybox:
 
-```js {fragment="create skybox"}
+```js
 const sky_package = Filament.Buffer(Filament.assets['pillars_2k_skybox.ktx']);
 const skyktx = new Filament.KtxBundle(sky_package);
 const skytex = Filament.Texture.Builder()
@@ -293,13 +293,11 @@ skytex.setImageCube(engine, 0, pixelbuffer);
 ```
 
 Again, this is a lot of boilerplate, so Filament provides a Javascript utility for you. Replace
-**create skybox** with the following. *NOTE: not yet implemented.*
+**create skybox** with the following.
 
-```js
-const sky_package = Filament.Buffer(Filament.assets['pillars_2k_skybox.ktx']);
-const skytex = Filament.createTextureFromKtx(sky_package, {'rgbm': True});
-```
 ```js {fragment="create skybox"}
+const skydata = Filament.assets['pillars_2k_skybox.ktx'];
+const skytex = Filament.createTextureFromKtx(skydata, engine, {'rgbm': true});
 const skybox = Filament.Skybox.Builder().environment(skytex).build(engine);
 scene.setSkybox(skybox);
 ```

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -293,7 +293,7 @@ const pixelbuffer = Filament.PixelBuffer(uint8array, format, datatype);
 skytex.setImageCube(engine, 0, pixelbuffer);
 ```
 
-Again, this is a lot of boilerplate. Filament provides a Javascript utility to make it easier.
+Filament provides a Javascript utility to make this easier.
 Replace **create skybox** with the following.
 
 ```js {fragment="create skybox"}

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -115,30 +115,29 @@ class App {
   }
 
   render() {
+    const eye = [0, 0, 4], center = [0, 0, 0], up = [0, 1, 0];
+    const radians = Date.now() / 10000;
+    vec3.rotateY(eye, eye, center, radians);
+    this.camera.lookAt(eye, center, up);
     this.renderer.render(this.swapChain, this.view);
     window.requestAnimationFrame(this.render);
   }
 
   resize() {
-    // Adjust the canvas resolution and Filament viewport.
     const dpr = window.devicePixelRatio;
     const width = this.canvas.width = window.innerWidth * dpr;
     const height = this.canvas.height = window.innerHeight * dpr;
     this.view.setViewport([0, 0, width, height]);
-
-    // Adjust the camera frustum.
-    const eye = [0, 0, 0], center = [0, 0, -1], up = [0, 1, 0];
-    this.camera.lookAt(eye, center, up);
     this.camera.setProjectionFov(45, width / height, 1.0, 10.0, Fov.VERTICAL);
   }
 }
 ```
 
 The above boilerplate should be familiar to you from the previous tutorial, although it loads in a
-new set of assets and the camera uses a perspective projection.
+new set of assets. We also added some animation to the camera.
 
 Next let's create a material instance from the package that we built at the beginning the tutorial.
-Replace the **create material** todo with the following snippet.
+Replace the **create material** comment with the following snippet.
 
 ```js {fragment="create material"}
 const material_package = Filament.Buffer(Filament.assets['plastic.filamat']);
@@ -192,10 +191,6 @@ Filament.RenderableManager.Builder(1)
   .material(0, matinstance)
   .geometry(0, PrimitiveType.TRIANGLES, vb, ib)
   .build(engine, renderable);
-
-const transform = mat4.fromTranslation(mat4.create(), [0, 0, -4]);
-const tcm = this.engine.getTransformManager();
-tcm.setTransform(tcm.getInstance(renderable), transform);
 ```
 
 At this point, the app is rendering a sphere, but it is black so it doesn't show up. To prove that
@@ -206,7 +201,7 @@ did in the first tutorial.
 
 We'll be creating two types of light sources: a directional light source that represents the sun,
 and an image-based light (IBL) defined by one of the KTX files we built at the start of the demo.
-First, replace the **create sunlight** todo with the following snippet.
+First, replace the **create sunlight** comment with the following snippet.
 
 ```js {fragment="create sunlight"}
 const sunlight = Filament.EntityManager.get().create();
@@ -265,7 +260,7 @@ scene.setIndirectLight(indirectLight);
 ```
 
 This is a lot of boilerplate, so Filament provides a JavaScript utilitiy to make this simpler;
-simply replace the **create IBL** todo with the following snippet. *NOTE: not yet implemented.*
+simply replace the **create IBL** comment with the following snippet. *NOTE: not yet implemented.*
 
 ```js
 const ibl_package = Filament.Buffer(Filament.assets['pillars_2k_ibl.ktx']);

--- a/libs/filamentjs/docs/tutorial_triangle.md
+++ b/libs/filamentjs/docs/tutorial_triangle.md
@@ -244,11 +244,7 @@ const tcm = this.engine.getTransformManager();
 tcm.setTransform(tcm.getInstance(this.triangle), transform);
 
 // Render the frame.
-if (this.renderer.beginFrame(this.swapChain)) {
-  this.renderer.render(this.view);
-  this.renderer.endFrame();
-}
-this.engine.execute();
+this.renderer.render(this.swapChain, this.view);
 ```
 
 The first half of our render method obtains the transform component of the triangle entity and uses

--- a/libs/filamentjs/jsbindings.cpp
+++ b/libs/filamentjs/jsbindings.cpp
@@ -283,7 +283,15 @@ class_<Engine>("Engine")
 class_<SwapChain>("SwapChain");
 
 class_<Renderer>("Renderer")
-    .function("render", &Renderer::render, allow_raw_pointers())
+    .function("renderView", &Renderer::render, allow_raw_pointers())
+    .function("render", EMBIND_LAMBDA(void, (Renderer* self, SwapChain* swapChain, View* view), {
+        auto engine = self->getEngine();
+        if (self->beginFrame(swapChain)) {
+            self->render(view);
+            self->endFrame();
+        }
+        engine->execute();
+    }), allow_raw_pointers())
     .function("beginFrame", &Renderer::beginFrame, allow_raw_pointers())
     .function("endFrame", &Renderer::endFrame, allow_raw_pointers());
 

--- a/libs/filamentjs/jsbindings.cpp
+++ b/libs/filamentjs/jsbindings.cpp
@@ -505,7 +505,11 @@ class_<TexBuilder>("Texture$Builder")
 
 class_<IndirectLight>("IndirectLight")
     .class_function("Builder", (IblBuilder (*)()) [] { return IblBuilder(); })
-    .function("setIntensity", &IndirectLight::setIntensity);
+    .function("setIntensity", &IndirectLight::setIntensity)
+    .function("getIntensity", &IndirectLight::getIntensity)
+    .function("setRotation", EMBIND_LAMBDA(void, (IndirectLight* self, flatmat3 value), {
+        return self->setRotation(value.m);
+    }), allow_raw_pointers());
 
 class_<IblBuilder>("IndirectLight$Builder")
     .function("build", EMBIND_LAMBDA(IndirectLight*, (IblBuilder* builder, Engine* engine), {

--- a/libs/filamentjs/tests/testwasm.js
+++ b/libs/filamentjs/tests/testwasm.js
@@ -211,17 +211,10 @@ class App {
   }
 
   render() {
-    // Test setting transforms.
     const transform = mat4.fromTranslation(mat4.create(), [0, 0, -4]);
     const tcm = this.engine.getTransformManager();
     tcm.setTransform(tcm.getInstance(this.sphereEntity), transform);
-
-    // Render the frame.
-    if (this.renderer.beginFrame(this.swapChain)) {
-      this.renderer.render(this.view);
-      this.renderer.endFrame();
-    }
-    this.engine.execute();
+    this.renderer.render(this.swapChain, this.view);
     window.requestAnimationFrame(this.render);
   }
 

--- a/libs/filamentjs/utilities.js
+++ b/libs/filamentjs/utilities.js
@@ -152,4 +152,13 @@ Filament.loadMathExtensions = function() {
     out[3] = packSnorm16(src[3]);
     return out;
   }
+  // In gl-matrix, mat3 rotation assumes rotation about the Z axis, so here we add a function
+  // to allow an arbitrary axis.
+  const fromRotationZ = mat3.fromRotation;
+  mat3.fromRotation = function(out, radians, axis) {
+    if (axis) {
+      return mat3.fromMat4(out, mat4.fromRotation(mat4.create(), radians, axis));
+    }
+    return fromRotationZ(out, radians);
+  };
 };


### PR DESCRIPTION
This cleans up the redball tutorial and sneaks in some camera animation. More importantly, this PR  adds the following features to the JS bindings:

- One-line `render` method
- createTextureFromKtx
- createIblFromKtx
