### PR TITLE
 Add fullscreen button to embedded JS demos.

### DIFF
--- a/libs/filamentjs/docs/build.py
+++ b/libs/filamentjs/docs/build.py
@@ -154,12 +154,12 @@ def weave(name):
     with open(f'tutorial_{name}.md', 'r') as fin:
         markdown = fin.read()
         if ENABLE_EMBEDDED_DEMO:
-            style = 'style="width:100%;height:200px;border:none"'
             if name == 'triangle':
                 markdown = PREAMBLE + markdown
-            iframe = f"<iframe {style} src='demo_{name}.html'>" \
-                    "</iframe>\n\n"
-            markdown = iframe + markdown
+            markdown = '<div class="demo_frame">' + \
+                f'<iframe src="demo_{name}.html"></iframe>' + \
+                f'<a href="demo_{name}.html">&#x1F517;</a>' + \
+                '</div>\n' + markdown
         rendered = mistletoe.markdown(markdown, PygmentsRenderer)
     template = open('tutorial_template.html').read()
     rendered = template.replace('$BODY', rendered)

--- a/libs/filamentjs/docs/build.py
+++ b/libs/filamentjs/docs/build.py
@@ -204,9 +204,8 @@ def spawn_local_server():
     import socketserver
     Handler = http.server.SimpleHTTPRequestHandler
     Handler.extensions_map.update({ '.wasm': 'application/wasm' })
-    server_dir = OUTPUT_DIR + '..'
-    Handler.directory = server_dir
-    os.chdir(server_dir)
+    Handler.directory = OUTPUT_DIR
+    os.chdir(OUTPUT_DIR)
     socketserver.TCPServer.allow_reuse_address = True
     port = 8000
     print(f"serving docs at http://localhost:{port}")

--- a/libs/filamentjs/docs/main.css
+++ b/libs/filamentjs/docs/main.css
@@ -23,12 +23,6 @@ code, div.highlight pre {
   color: rgb(0, 137, 235);
 }
 
-iframe {
-  border: none;
-  width: 100%;
-  height: 100%;
-}
-
 a {
   text-decoration: none;
   color: black;
@@ -105,4 +99,23 @@ nav li {
   nav {
     text-align: right;
   }
+}
+
+div.demo_frame {
+  width: 100%;
+  height: 200px;
+  border: none;
+}
+
+iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+div.demo_frame > a {
+  position: relative;
+  float: right;
+  right: 10px;
+  bottom: 35px;
 }

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -1,4 +1,5 @@
-This tutorial will create the above demo, introducing you to materials and textures.
+This tutorial will describe how to create the redball demo, introducing you to materials and
+textures.
 
 You'll need to use a couple command-line tools: `matc` and `cmgen`. You can find these in the
 appropriate [Filament release](//github.com/google/filament/releases). You should choose the

--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -1,3 +1,4 @@
+
 This tutorial will describe how to create the redball demo, introducing you to materials and
 textures.
 


### PR DESCRIPTION
This simply overlays an `<a>` that jumps to the src page of the `<iframe>`.

![untitled](https://user-images.githubusercontent.com/1288904/47234629-4e289f00-d38b-11e8-9fea-f70a7ce3f6fe.gif)
