### PR TITLE
JS users no longer need to call loadMathExtensions()

### DIFF
--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -74,8 +74,6 @@ tutorial](tutorial_triangle.html). Change the last script tag from `triangle.js`
 Next, create `redball.js` with the following content.
 
 ```js {fragment="root"}
-Filament.loadMathExtensions();
-
 Filament.init([ 'plastic.filamat', 'pillars_2k_ibl.ktx', 'pillars_2k_skybox.ktx' ], () => {
   // Create some global aliases to enums for convenience.
   window.VertexAttribute = Filament.VertexAttribute;

--- a/libs/filamentjs/tests/testwasm.js
+++ b/libs/filamentjs/tests/testwasm.js
@@ -1,6 +1,3 @@
-// Extend gl-matrix.
-Filament.loadMathExtensions();
-
 Filament.init([
   'bakedColor.filamat',
   'sandboxLit.filamat',

--- a/libs/filamentjs/utilities.js
+++ b/libs/filamentjs/utilities.js
@@ -63,10 +63,7 @@ Filament.PixelBuffer = function(typedarray, format, datatype) {
 // Geometry Utilities
 // ------------------
 
-// These are some lightweight optional functions. Using them requires the presence of gl-matrix,
-// which is not bundled into filament.js.
-
-/// IcoSphere ::class:: Utility class for constructing spheres.
+/// IcoSphere ::class:: Utility class for constructing spheres (requires glMatrix).
 ///
 /// The constructor takes an integer subdivision level, with 0 being an icosahedron.
 ///
@@ -159,19 +156,25 @@ function clamp(v, least, most) {
   return Math.max(Math.min(most, v), least);
 }
 
-function packSnorm16(v) {
-  return Math.round(clamp(v, -1.0, 1.0) * 32767.0);
+/// packSnorm16 ::function:: Converts a float in [-1, +1] into a half-float.
+/// value ::argument:: float
+/// ::retval:: half-float
+Filament.packSnorm16 = function(value) {
+  return Math.round(clamp(value, -1.0, 1.0) * 32767.0);
 }
 
 /// loadMathExtensions ::function:: Extends the [glMatrix](http://glmatrix.net/) math library.
-/// Filament does not require its clients to use glMatrix, so calling this function is optional.
-/// This adds `vec4.packSnorm16` and `mat3.fromRotation` to the glMatrix library.
+/// Filament does not require its clients to use glMatrix, but if its usage is detected then
+/// the [init] function will automatically call `loadMathExtensions`.
+/// This defines the following functions:
+/// - **vec4.packSnorm16** can be used to create half-floats (see [packSnorm16])
+/// - **mat3.fromRotation** now takes an arbitrary axis
 Filament.loadMathExtensions = function() {
   vec4.packSnorm16 = function(out, src) {
-    out[0] = packSnorm16(src[0]);
-    out[1] = packSnorm16(src[1]);
-    out[2] = packSnorm16(src[2]);
-    out[3] = packSnorm16(src[3]);
+    out[0] = Filament.packSnorm16(src[0]);
+    out[1] = Filament.packSnorm16(src[1]);
+    out[2] = Filament.packSnorm16(src[2]);
+    out[3] = Filament.packSnorm16(src[3]);
     return out;
   }
   // In gl-matrix, mat3 rotation assumes rotation about the Z axis, so here we add a function

--- a/libs/filamentjs/wasmloader.js
+++ b/libs/filamentjs/wasmloader.js
@@ -40,8 +40,8 @@ Filament.remainingInitializationTasks = 1;
 /// WebAssembly module has been loaded. Clients should only pass asset URL's that absolutely must
 /// be ready at initialization time.
 ///
-/// When the callback is called, each downloaded asset is available in the form of Uint8Array in the
-/// `Filament.assets` object. The key is the URL and the value is the Uint8Array.
+/// When the callback is called, each downloaded asset is available in the `Filament.assets` global
+/// object, which contains a mapping from URL's to Uint8Array objects.
 ///
 /// assets ::argument:: Array of strings containing URL's of required assets.
 /// onready ::argument:: callback that gets invoked after all assets have been downloaded and the \
@@ -50,6 +50,14 @@ Filament.init = function(assets, onready) {
     Filament.onReady = onready;
     Filament.remainingInitializationTasks += assets.length;
     Filament.assets = {};
+
+    // Usage of glmatrix is optional. If it exists, then go ahead and augment it with some
+    // useful math functions.
+    if (typeof glMatrix !== 'undefined') {
+        Filament.loadMathExtensions();
+    }
+
+    // Issue a fetch for each asset. After the last asset is downloaded, trigger the callback.
     assets.forEach(function(name) {
         fetch(name).then(function(response) {
             if (!response.ok) {


### PR DESCRIPTION
We still do not require our JS users to use the glMatrix library, but we might as well simplify things when they do.