### PR TITLE
Fix the JS IcoSphere tangents.

### DIFF
--- a/libs/filamentjs/docs/tutorial_redball.md
+++ b/libs/filamentjs/docs/tutorial_redball.md
@@ -96,7 +96,7 @@ class App {
 
     // TODO: create material
     // TODO: create sphere
-    // TODO: create sunlight
+    // TODO: create lights
     // TODO: create IBL
     // TODO: create skybox
 
@@ -198,26 +198,31 @@ did in the first tutorial.
 
 ## Add lighting
 
-We'll be creating two types of light sources: a directional light source that represents the sun,
-and an image-based light (IBL) defined by one of the KTX files we built at the start of the demo.
-First, replace the **create sunlight** comment with the following snippet.
+In this section we will create some directional light sources, as well as an image-based light (IBL)
+defined by one of the KTX files we built at the start of the demo. First, replace the **create
+lights** comment with the following snippet.
 
-```js {fragment="create sunlight"}
+```js {fragment="create lights"}
 const sunlight = Filament.EntityManager.get().create();
 scene.addEntity(sunlight);
-
 Filament.LightManager.Builder(LightType.SUN)
   .color([0.98, 0.92, 0.89])
   .intensity(110000.0)
   .direction([0.6, -1.0, -0.8])
-  .castShadows(true)
   .sunAngularRadius(1.9)
   .sunHaloSize(10.0)
   .sunHaloFalloff(80.0)
   .build(engine, sunlight);
+
+const backlight = Filament.EntityManager.get().create();
+scene.addEntity(backlight);
+Filament.LightManager.Builder(LightType.DIRECTIONAL)
+        .direction([-1, 0, 1])
+        .intensity(50000.0)
+        .build(engine, backlight);
 ```
 
-We are using a light type of `SUN`, which is similar to `DIRECTIONAL`, but has some extra
+The `SUN` light source is similar to the `DIRECTIONAL` light source, but has some extra
 parameters because Filament will automatically draw a disk into the skybox.
 
 Next we need to create an `IndirectLight` object from the KTX IBL. One way of doing this is the

--- a/libs/filamentjs/utilities.js
+++ b/libs/filamentjs/utilities.js
@@ -130,7 +130,8 @@ Filament.IcoSphere = function(nsubdivs) {
     const src = this.vertices.subarray(i * 3, i * 3 + 3);
     const dst = this.tangents.subarray(i * 4, i * 4 + 4);
     const n = vec3.normalize(vec3.create(), src);
-    const b = vec3.cross(vec3.create(), n, [1, 0, 0]);
+    const b = vec3.cross(vec3.create(), n, [0, 1, 0]);
+    vec3.normalize(b, b);
     const t = vec3.cross(vec3.create(), b, n);
     const q = quat.fromMat3(quat.create(), [t[0], t[1], t[2], b[0], b[1], b[2], n[0], n[1], n[2]]);
     vec4.packSnorm16(dst, q);


### PR DESCRIPTION
We were not normalizing one of the orthonormal basis vectors, causing the visual aberration reported in #423.  (As a somewhat unrelated change, I also changed the arbitrary bitangent such that the discontinuity is at the Y+ pole where it is often less visible.)

Before / After screenshots below.

This CL also add a "back light" to the redball demo to lighten up the dark area in the IBL.

Fixes #423

<img width="837" alt="before" src="https://user-images.githubusercontent.com/1288904/47598385-cc6adf80-d94f-11e8-837a-4aa5d2a2e716.png">
<img width="837" alt="after1" src="https://user-images.githubusercontent.com/1288904/47598387-ce34a300-d94f-11e8-9d8e-a169cdb03c4d.png">
