### PR TITLE
Change source URLs from cielab.xyz to official CIE site

### DIFF
--- a/docs/Filament.md.html
+++ b/docs/Filament.md.html
@@ -3402,7 +3402,7 @@ To compute the specular color of a material we need to evaluate the complex Fres
 
 We then sum (integrate) and normalize all the samples to obtain $\fNormal$ in the XYZ color space. From there, a simple color space conversion yields a linear sRGB color or a non-linear sRGB color after applying the opto-electronic transfer function (OETF, commonly known as "gamma" curve). Note that for some materials such as gold the final sRGB color might fall out of gamut. We use a simple normalization step as a cheap form of gamut remapping but it would be interesting to consider computing values in a color space with a wider gamut (for instance BT.2020).
 
-To achieve the desired result we used the ICE 1931 2 degrees CMFs, from 360nm to 830nm at 1nm intervals ([source](http://cvrl.ioo.ucl.ac.uk/cmfs.htm)), and the CIE Standard Illuminant D65 relative spectral power distribution, from 300nm to 830nm, at 5nm intervals ([source](https://cielab.xyz/pdf/CIE_sel_colorimetric_tables.xls)).
+To achieve the desired result we used the ICE 1931 2 degrees CMFs, from 360nm to 830nm at 1nm intervals ([source](http://cvrl.ioo.ucl.ac.uk/cmfs.htm)), and the CIE Standard Illuminant D65 relative spectral power distribution, from 300nm to 830nm, at 5nm intervals ([source, at "Selected Colorimetric Tables"](http://www.cie.co.at/technical-work/technical-resources)).
 
 Our implementation is presented in listing [specularColorImpl], with the actual data omitted for brevity.
 
@@ -3422,7 +3422,7 @@ const float3 CIE_XYZ[CIE_XYZ_COUNT] = { ... };
 //
 // Data source:
 //     https://en.wikipedia.org/wiki/Illuminant_D65
-//     https://cielab.xyz/pdf/CIE_sel_colorimetric_tables.xls
+//     http://www.cie.co.at/technical-work/technical-resources
 const size_t CIE_D65_INTERVAL = 5;
 const size_t CIE_D65_START = 300;
 const size_t CIE_D65_END = 830;


### PR DESCRIPTION
Link to colorimetric table spreadsheet found at http://www.cie.co.at/technical-work/technical-resources (the official CIE web site) rather than from cielab.xyz, which is not an official source of that spreadsheet.