### PR TITLE
Add a separate DFG LUT size flag in cmgen

### DIFF
--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -63,6 +63,7 @@ static double g_extract_blur = 0.0;
 static utils::Path g_extract_dir;
 
 static size_t g_output_size = 0;
+static size_t g_dfg_lut_output_size = 0;
 
        bool g_quiet = false; // needed outside of this file
 static bool g_debug = false;
@@ -315,6 +316,13 @@ static int handleCommandLineArgments(int argc, char* argv[]) {
                     exit(0);
                 }
                 break;
+            case 'l':
+                g_dfg_lut_output_size = std::stoul(arg);
+                if (!isPOT(g_dfg_lut_output_size)) {
+                    std::cerr << "DFG LUT output size must be a power of two" << std::endl;
+                    exit(0);
+                }
+                break;
             case 'z':
                 g_sh_compute = 1;
                 g_sh_output = true;
@@ -420,7 +428,7 @@ int main(int argc, char* argv[]) {
         if (!g_quiet) {
             std::cout << "Generating IBL DFG LUT..." << std::endl;
         }
-        size_t size = g_output_size ? g_output_size : DFG_LUT_DEFAULT_SIZE;
+        size_t size = g_dfg_lut_output_size ? g_dfg_lut_output_size : DFG_LUT_DEFAULT_SIZE;
         iblLutDfg(g_dfg_filename, size, g_dfg_multiscatter);
         if (num_args < 1) return 0;
     }

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -48,7 +48,7 @@ enum class ShFile {
     SH_NONE, SH_CROSS, SH_TEXT
 };
 
-static const size_t DFG_LUT_DEFAULT_SIZE = 256;
+static const size_t DFG_LUT_DEFAULT_SIZE = 128;
 static const size_t IBL_DEFAULT_SIZE = 256;
 
 enum class OutputType {

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -165,7 +165,7 @@ static void printUsage(char* name) {
             "   --size=power-of-two, -s power-of-two\n"
             "       Size of the output cubemaps (base level), 256 by default\n\n"
             "   --dfg-lut-size=power-of-two, -g power-of-two\n"
-            "       Size of the output DFG LUT, 256 by default\n\n"
+            "       Size of the output DFG LUT, 128 by default\n\n"
             "   --deploy=dir, -x dir\n"
             "       Generate everything needed for deployment into <dir>\n\n"
             "   --extract=dir\n"

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -48,7 +48,7 @@ enum class ShFile {
     SH_NONE, SH_CROSS, SH_TEXT
 };
 
-static const size_t DFG_LUT_DEFAULT_SIZE = 128;
+static const size_t DFG_LUT_DEFAULT_SIZE = 256;
 static const size_t IBL_DEFAULT_SIZE = 256;
 
 enum class OutputType {
@@ -164,6 +164,8 @@ static void printUsage(char* name) {
             "           DDS: 8, 16 (default), 32\n\n"
             "   --size=power-of-two, -s power-of-two\n"
             "       Size of the output cubemaps (base level), 256 by default\n\n"
+            "   --dfg-lut-size=power-of-two, -g power-of-two\n"
+            "       Size of the output DFG LUT, 256 by default\n\n"
             "   --deploy=dir, -x dir\n"
             "       Generate everything needed for deployment into <dir>\n\n"
             "   --extract=dir\n"
@@ -220,6 +222,7 @@ static int handleCommandLineArgments(int argc, char* argv[]) {
             { "format",               required_argument, nullptr, 'f' },
             { "compression",          required_argument, nullptr, 'c' },
             { "size",                 required_argument, nullptr, 's' },
+            { "dfg-lut-size",         required_argument, nullptr, 'g' },
             { "extract",              required_argument, nullptr, 'e' },
             { "extract-blur",         required_argument, nullptr, 'r' },
             { "sh",                   optional_argument, nullptr, 'z' },
@@ -316,7 +319,7 @@ static int handleCommandLineArgments(int argc, char* argv[]) {
                     exit(0);
                 }
                 break;
-            case 'l':
+            case 'g':
                 g_dfg_lut_output_size = std::stoul(arg);
                 if (!isPOT(g_dfg_lut_output_size)) {
                     std::cerr << "DFG LUT output size must be a power of two" << std::endl;


### PR DESCRIPTION
Hi,

This PR aims to implement a flag `--dfg-lut-size` separate from `--size` in `cmgen`.

Right now whenever a user passes the custom flag `--size=512`, with the goal of increasing the size of each cubemap face to `512`, the size of the DFG LUT is automatically increased to `512` as well. From my understanding the size of the DFG LUT and the cubemap do not need to be connected like that.

I have opted for the shorthand `-g` as `-d` and `-l` are already in use.

Kind regards,

Tim van Scherpenzeel