### PR TITLE
Set cache size to 64 bytes on all platforms

### DIFF
--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -167,12 +167,12 @@ bool Froxelizer::prepare(
 
     // froxel buffer (~32 KiB)
     mFroxelBufferUser = {
-            driverApi.allocatePod<FroxelEntry>(FROXEL_BUFFER_ENTRY_COUNT_MAX, CACHELINE_SIZE),
+            driverApi.allocatePod<FroxelEntry>(FROXEL_BUFFER_ENTRY_COUNT_MAX),
             FROXEL_BUFFER_ENTRY_COUNT_MAX };
 
     // record buffer (~64 KiB)
     mRecordBufferUser = {
-            driverApi.allocatePod<RecordBufferType>(RECORD_BUFFER_ENTRY_COUNT, CACHELINE_SIZE),
+            driverApi.allocatePod<RecordBufferType>(RECORD_BUFFER_ENTRY_COUNT),
             RECORD_BUFFER_ENTRY_COUNT };
 
     /*

--- a/libs/utils/include/utils/architecture.h
+++ b/libs/utils/include/utils/architecture.h
@@ -21,13 +21,7 @@
 
 namespace utils {
 
-#ifdef __ARM_32BIT_STATE
-// on ARM 32-bits, assume 32-bytes cache lines
-constexpr size_t CACHELINE_SIZE = 32;
-#else
-// on ARM64 and x86 we assume 64-bytes cache lines
 constexpr size_t CACHELINE_SIZE = 64;
-#endif
 
 } // namespace utils
 


### PR DESCRIPTION
We used to assume 32-bytes cache lines when running on ARM 32-bit mode,
however, that was wrong because 32-bit mode doesn't change the cpu's
cache line. On all modern platforms we support, the cache line
is 64 bytes.

Set Job storage to 48 bytes on all platforms.