### PR TITLE
Fix a crasher when allocating the last Job

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -238,7 +238,7 @@ public:
                 break;
             }
         }
-        return storage + currentHead.offset;
+        return (currentHead.offset >= 0) ? (storage + currentHead.offset) : nullptr;
     }
 
     void push(void* p) noexcept {

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -336,13 +336,13 @@ private:
     Job* pop(WorkQueue& workQueue) noexcept {
         size_t index = workQueue.pop();
         assert(index <= MAX_JOB_COUNT);
-        return !index ? nullptr : (mJobStorageBase - 1) + index;
+        return !index ? nullptr : &mJobStorageBase[index - 1];
     }
 
     Job* steal(WorkQueue& workQueue) noexcept {
         size_t index = workQueue.steal();
         assert(index <= MAX_JOB_COUNT);
-        return !index ? nullptr : (mJobStorageBase - 1) + index;
+        return !index ? nullptr : &mJobStorageBase[index - 1];
     }
 
     // these have thread contention, keep them together


### PR DESCRIPTION
Instead of returning nullptr, the pool allocator returned an
invalid pointer.