### PR TITLE
Update "Directory structure" in toplevel README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,47 +98,50 @@ Many other features have been either prototyped or planned:
 
 ## Directory structure
 
-- `filament`:                Filament engine and its supporting libraries and tools
-  - `android`:               Android libraries and projects
-    - `build`:               Custom Gradle tasks for Android builds
-    - `filament-android`:    Filament library (AAR) for Android
-    - `samples`:             Android-specific Filament samples
-  - `art`:                   Source for various artworks (logos, PDF manuals, etc.)
-  - `assets`:                3D assets to use with sample applications
-  - `build`:                 CMake build scripts
-  - `docs`:                  Documentation
-    - `math`:                Mathematica notebooks used to explore BRDFs, equations, etc.
-  - `filament`:              Filament engine
-  - `ide`:                   Configuration files for IDEs (CLion, etc.)
-  - `ios`:                   Sample projects for iOS
-  - `java`:                  Java bindings for Filament libraries
-  - `libs`:                  Libraries
-    - `bluegl`:                OpenGL bindings for macOS, Linux and Windows
-    - `bluevk`:                Vulkan bindings for macOS, Linux, Windows and Android
-    - `filabridge`:            Library shared by the Filament engine and host tools
-    - `filaflat`:              Serialization/deserialization library used for materials
-    - `filagui`:               Helper library for [Dear ImGui](https://github.com/ocornut/imgui)
-    - `filamat`:               Material generation library
-    - `filameshio`:            Tiny mesh parsing library (see also `tools/filamesh`)
-    - `image`:                 Image filtering and simple transforms
-    - `imageio`:               Image file reading / writing, only intended for internal use
-    - `math`:                  Math library
-    - `utils`:                 Utility library (threads, memory, data structures, etc.)
-  - `samples`:               Sample desktop applications
-  - `shaders`:               Shaders used by `filamat` and `matc`
-  - `third_party`:           External libraries and assets
-    - `environments`:        Environment maps under CC0 license that can be used with `cmgen`
-    - `textures`:            Textures under CC0 license
-  - `tools`:                 Host tools
-    - `cmgen`:               Image-based lighting asset generator
-    - `filamesh`:            Mesh converter
-    - `matc`:                Material compiler
-    - `matinfo`              Displays information about materials compiled with `matc`
-    - `mipgen`               Generates a series of miplevels from a source image.
-    - `normal-blending`:     Tool to blend normal maps
-    - `roughness-prefilter`: Pre-filters a roughness map from a normal map to reduce aliasing
-    - `skygen`:              Physically-based sky environment texture generator
-    - `specular-color`:      Computes the specular color of conductors based on spectral data
+This repository not only contains the core Filament engine, but also its supporting libraries
+and tools.
+
+- `android`:               Android libraries and projects
+  - `build`:               Custom Gradle tasks for Android builds
+  - `filament-android`:    Filament library (AAR) for Android
+  - `samples`:             Android-specific Filament samples
+- `art`:                   Source for various artworks (logos, PDF manuals, etc.)
+- `assets`:                3D assets to use with sample applications
+- `build`:                 CMake build scripts
+- `docs`:                  Documentation
+  - `math`:                Mathematica notebooks used to explore BRDFs, equations, etc.
+- `filament`:              Filament rendering engine (minimal dependencies)
+- `ide`:                   Configuration files for IDEs (CLion, etc.)
+- `ios`:                   Sample projects for iOS
+- `java`:                  Java bindings for Filament libraries
+- `libs`:                  Libraries
+  - `bluegl`:              OpenGL bindings for macOS, Linux and Windows
+  - `bluevk`:              Vulkan bindings for macOS, Linux, Windows and Android
+  - `filabridge`:          Library shared by the Filament engine and host tools
+  - `filaflat`:            Serialization/deserialization library used for materials
+  - `filagui`:             Helper library for [Dear ImGui](https://github.com/ocornut/imgui)
+  - `filamat`:             Material generation library
+  - `filameshio`:          Tiny mesh parsing library (see also `tools/filamesh`)
+  - `image`:               Image filtering and simple transforms
+  - `imageio`:             Image file reading / writing, only intended for internal use
+  - `math`:                Math library
+  - `utils`:               Utility library (threads, memory, data structures, etc.)
+- `samples`:               Sample desktop applications
+- `shaders`:               Shaders used by `filamat` and `matc`
+- `third_party`:           External libraries and assets
+  - `environments`:        Environment maps under CC0 license that can be used with `cmgen`
+  - `textures`:            Textures under CC0 license
+- `tools`:                 Host tools
+  - `cmgen`:               Image-based lighting asset generator
+  - `filamesh`:            Mesh converter
+  - `matc`:                Material compiler
+  - `matinfo`              Displays information about materials compiled with `matc`
+  - `mipgen`               Generates a series of miplevels from a source image
+  - `normal-blending`:     Tool to blend normal maps
+  - `roughness-prefilter`: Pre-filters a roughness map from a normal map to reduce aliasing
+  - `skygen`:              Physically-based sky environment texture generator
+  - `specular-color`:      Computes the specular color of conductors based on spectral data
+- `web`:                   JavaScript bindings, documentation, and samples
 
 ## Building Filament
 


### PR DESCRIPTION
I don't think it's useful to indent the entire tree, so this removes
the redundant root. More importantly, it adds the "web" folder. :)