### PR TITLE
Fix max anisotropy in Vulkan backend

### DIFF
--- a/filament/src/driver/vulkan/VulkanSamplerCache.cpp
+++ b/filament/src/driver/vulkan/VulkanSamplerCache.cpp
@@ -110,7 +110,7 @@ VkSampler VulkanSamplerCache::getSampler(driver::SamplerParams params) noexcept 
         .addressModeV = getWrapMode(params.wrapT),
         .addressModeW = getWrapMode(params.wrapR),
         .anisotropyEnable = params.anisotropyLog2 == 0 ? 0u : 1u,
-        .maxAnisotropy = (float) params.anisotropyLog2,
+        .maxAnisotropy = (float)(1u << params.anisotropyLog2),
         .borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK,
         .unnormalizedCoordinates = VK_FALSE,
         .compareEnable = getCompareEnable(params.compareMode),


### PR DESCRIPTION
Noticed this when working on the Metal backend. Anisotropy is provided as a logarithmic value, so we should bit-shift to get the correct value, as the [OpenGL driver does](https://github.com/google/filament/blob/master/filament/src/driver/opengl/OpenGLDriver.cpp#L2469).