### PR TITLE
Fix JS API leaks by auto-deleting builders, etc.

### DIFF
--- a/web/docs/tutorial_triangle.md
+++ b/web/docs/tutorial_triangle.md
@@ -226,7 +226,9 @@ code to the top of the render method.
 const radians = Date.now() / 1000;
 const transform = mat4.fromRotation(mat4.create(), radians, [0, 0, 1]);
 const tcm = this.engine.getTransformManager();
-tcm.setTransform(tcm.getInstance(this.triangle), transform);
+const inst = tcm.getInstance(this.triangle);
+tcm.setTransform(inst, transform);
+inst.delete();
 
 // Render the frame.
 this.renderer.render(this.swapChain, this.view);

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -122,4 +122,22 @@ Filament.loadClassExtensions = function() {
         this._setBuffer(engine, getBufferDescriptor(buffer));
     };
 
+    Filament.RenderableManager$Builder.prototype.build =
+    Filament.LightManager$Builder.prototype.build =
+        function(engine, entity) {
+            const result = this._build(engine, entity);
+            this.delete();
+            return result;
+        };
+
+    Filament.VertexBuffer$Builder.prototype.build =
+    Filament.IndexBuffer$Builder.prototype.build =
+    Filament.Texture$Builder.prototype.build =
+    Filament.IndirectLight$Builder.prototype.build =
+    Filament.Skybox$Builder.prototype.build =
+        function(engine) {
+            const result = this._build(engine);
+            this.delete();
+            return result;
+        };
 };

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -15,6 +15,7 @@
 */
 
 // Private utility that converts an asset string or Uint8Array into a low-level buffer descriptor.
+// Note that the low-level buffer descriptor must be manually deleted.
 function getBufferDescriptor(buffer) {
     if ('string' == typeof buffer || buffer instanceof String) {
         buffer = Filament.assets[buffer];
@@ -56,7 +57,10 @@ Filament.loadClassExtensions = function() {
     /// package ::argument:: asset string, or Uint8Array, or [Buffer] with filamat contents
     /// ::retval:: an instance of [createMaterial]
     Filament.Engine.prototype.createMaterial = function(buffer) {
-        return this._createMaterial(getBufferDescriptor(buffer));
+        buffer = getBufferDescriptor(buffer);
+        const result = this._createMaterial(buffer);
+        buffer.delete();
+        return result;
     };
 
     /// createTextureFromKtx ::method:: Utility function that creates a [Texture] from a KTX file.
@@ -64,7 +68,10 @@ Filament.loadClassExtensions = function() {
     /// options ::argument:: Options dictionary. For now, the `rgbm` boolean is the only option.
     /// ::retval:: [Texture]
     Filament.Engine.prototype.createTextureFromKtx = function(buffer, options) {
-        return Filament._createTextureFromKtx(getBufferDescriptor(buffer), this, options);
+        buffer = getBufferDescriptor(buffer);
+        const result = Filament._createTextureFromKtx(buffer, this, options);
+        buffer.delete();
+        return result;
     };
 
     /// createIblFromKtx ::method:: Utility that creates an [IndirectLight] from a KTX file.
@@ -72,7 +79,10 @@ Filament.loadClassExtensions = function() {
     /// options ::argument:: Options dictionary. For now, the `rgbm` boolean is the only option.
     /// ::retval:: [IndirectLight]
     Filament.Engine.prototype.createIblFromKtx = function(buffer, options) {
-        return Filament._createIblFromKtx(getBufferDescriptor(buffer), this, options);
+        buffer = getBufferDescriptor(buffer);
+        const result = Filament._createIblFromKtx(buffer, this, options);
+        buffer.delete();
+        return result;
     };
 
     /// createSkyFromKtx ::method:: Utility function that creates a [Skybox] from a KTX file.
@@ -90,7 +100,10 @@ Filament.loadClassExtensions = function() {
     /// options ::argument:: JavaScript object with optional `rgbm`, `noalpha`, and `nomips` keys.
     /// ::retval:: [Texture]
     Filament.Engine.prototype.createTextureFromPng = function(buffer, options) {
-        return Filament._createTextureFromPng(getBufferDescriptor(buffer), this, options);
+        buffer = getBufferDescriptor(buffer);
+        const result = Filament._createTextureFromPng(buffer, this, options);
+        buffer.delete();
+        return result;
     };
 
     /// loadFilamesh ::method:: Consumes the contents of a filamesh file and creates a renderable.
@@ -100,7 +113,10 @@ Filament.loadClassExtensions = function() {
     /// ::retval:: JavaScript object with keys `renderable`, `vertexBuffer`, and `indexBuffer`. \
     /// These are of type [Entity], [VertexBuffer], and [IndexBuffer].
     Filament.Engine.prototype.loadFilamesh = function(buffer, definstance, matinstances) {
-        return Filament._loadFilamesh(this, getBufferDescriptor(buffer), definstance, matinstances);
+        buffer = getBufferDescriptor(buffer);
+        const result = Filament._loadFilamesh(this, buffer, definstance, matinstances);
+        buffer.delete();
+        return result;
     };
 
     /// VertexBuffer ::core class::
@@ -110,7 +126,9 @@ Filament.loadClassExtensions = function() {
     /// bufferIndex ::argument:: non-negative integer
     /// buffer ::argument:: asset string, or Uint8Array, or [Buffer]
     Filament.VertexBuffer.prototype.setBufferAt = function(engine, bufferIndex, buffer) {
-        this._setBufferAt(engine, bufferIndex, getBufferDescriptor(buffer));
+        buffer = getBufferDescriptor(buffer);
+        this._setBufferAt(engine, bufferIndex, buffer);
+        buffer.delete();
     };
 
     /// IndexBuffer ::core class::
@@ -119,7 +137,9 @@ Filament.loadClassExtensions = function() {
     /// engine ::argument:: [Engine]
     /// buffer ::argument:: asset string, or Uint8Array, or [Buffer]
     Filament.IndexBuffer.prototype.setBuffer = function(engine, buffer) {
-        this._setBuffer(engine, getBufferDescriptor(buffer));
+        buffer = getBufferDescriptor(buffer);
+        this._setBuffer(engine, buffer);
+        buffer.delete();
     };
 
     Filament.RenderableManager$Builder.prototype.build =
@@ -140,4 +160,28 @@ Filament.loadClassExtensions = function() {
             this.delete();
             return result;
         };
+
+    Filament.KtxBundle.prototype.getBlob = function(index) {
+        const blob = this._getBlob(index);
+        const result = blob.getBytes();
+        blob.delete();
+        return result;
+    }
+
+    Filament.KtxBundle.prototype.getCubeBlob = function(miplevel) {
+        const blob = this._getCubeBlob(miplevel);
+        const result = blob.getBytes();
+        blob.delete();
+        return result;
+    }
+
+    Filament.Texture.prototype.setImage = function(engine, level, pbd) {
+        this._setImage(engine, level, pbd);
+        pbd.delete();
+    }
+
+    Filament.Texture.prototype.setImageCube = function(engine, level, pbd) {
+        this._setImageCube(engine, level, pbd);
+        pbd.delete();
+    }
 };

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -578,11 +578,11 @@ class_<TextureSampler>("TextureSampler")
 class_<Texture>("Texture")
     .class_function("Builder", (TexBuilder (*)()) [] { return TexBuilder(); })
     .function("generateMipmaps", &Texture::generateMipmaps)
-    .function("setImage", EMBIND_LAMBDA(void, (Texture* self,
+    .function("_setImage", EMBIND_LAMBDA(void, (Texture* self,
             Engine* engine, uint8_t level, PixelBufferDescriptor pbd), {
         self->setImage(*engine, level, std::move(*pbd.pbd));
     }), allow_raw_pointers())
-    .function("setImageCube", EMBIND_LAMBDA(void, (Texture* self,
+    .function("_setImageCube", EMBIND_LAMBDA(void, (Texture* self,
             Engine* engine, uint8_t level, PixelBufferDescriptor pbd), {
         uint32_t faceSize = pbd.pbd->size / 6;
         Texture::FaceOffsets offsets;
@@ -776,13 +776,14 @@ class_<KtxBundle>("KtxBundle")
     }), allow_raw_pointers())
 
     .function("isCubemap", &KtxBundle::isCubemap)
-    .function("getBlob", EMBIND_LAMBDA(BufferDescriptor, (KtxBundle* self, KtxBlobIndex index), {
+    .function("_getBlob", EMBIND_LAMBDA(BufferDescriptor, (KtxBundle* self, KtxBlobIndex index), {
         uint8_t* data;
         uint32_t size;
         self->getBlob(index, &data, &size);
         return BufferDescriptor(data, size);
     }), allow_raw_pointers())
-    .function("getCubeBlob", EMBIND_LAMBDA(BufferDescriptor, (KtxBundle* self, uint32_t miplevel), {
+    .function("_getCubeBlob", EMBIND_LAMBDA(BufferDescriptor,
+            (KtxBundle* self, uint32_t miplevel), {
         uint8_t* data;
         uint32_t size;
         self->getBlob({miplevel}, &data, &size);

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -424,9 +424,9 @@ class_<Camera>("Camera")
     .function("lookAt", &Camera::lookAt);
 
 class_<RenderBuilder>("RenderableManager$Builder")
-    .function("build", EMBIND_LAMBDA(void, (RenderBuilder* builder,
+    .function("_build", EMBIND_LAMBDA(int, (RenderBuilder* builder,
             Engine* engine, utils::Entity entity), {
-        builder->build(*engine, entity);
+        return (int) builder->build(*engine, entity);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("boundingBox", RenderBuilder, (RenderBuilder* builder, Box box), {
         return &builder->boundingBox(box); })
@@ -462,12 +462,15 @@ class_<TransformManager>("TransformManager")
             (TransformManager* self, TransformManager::Instance instance, flatmat4 m), {
         self->setTransform(instance, m.m); }), allow_raw_pointers());
 
+/// TransformManager$Instance ::class:: Component instance returned by [TransformManager]
+/// Be sure to call the instance's `delete` method when you're done with it.
 class_<TransformManager::Instance>("TransformManager$Instance");
+    /// delete ::method:: Frees an instance obtained via `getInstance`
 
 class_<LightBuilder>("LightManager$Builder")
-    .function("build", EMBIND_LAMBDA(void, (LightBuilder* builder,
+    .function("_build", EMBIND_LAMBDA(int, (LightBuilder* builder,
             Engine* engine, utils::Entity entity), {
-        builder->build(*engine, entity);
+        return (int) builder->build(*engine, entity);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("castShadows", LightBuilder, (LightBuilder* builder, bool enable), {
         return &builder->castShadows(enable); })
@@ -498,7 +501,7 @@ class_<LightManager>("LightManager")
         return LightBuilder(lt); });
 
 class_<VertexBuilder>("VertexBuffer$Builder")
-    .function("build", EMBIND_LAMBDA(VertexBuffer*, (VertexBuilder* builder, Engine* engine), {
+    .function("_build", EMBIND_LAMBDA(VertexBuffer*, (VertexBuilder* builder, Engine* engine), {
         return builder->build(*engine);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("attribute", VertexBuilder, (VertexBuilder* builder,
@@ -525,7 +528,7 @@ class_<VertexBuffer>("VertexBuffer")
     }), allow_raw_pointers());
 
 class_<IndexBuilder>("IndexBuffer$Builder")
-    .function("build", EMBIND_LAMBDA(IndexBuffer*, (IndexBuilder* builder, Engine* engine), {
+    .function("_build", EMBIND_LAMBDA(IndexBuffer*, (IndexBuilder* builder, Engine* engine), {
         return builder->build(*engine);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("indexCount", IndexBuilder, (IndexBuilder* builder, int count), {
@@ -593,7 +596,7 @@ class_<Texture>("Texture")
     }), allow_raw_pointers());
 
 class_<TexBuilder>("Texture$Builder")
-    .function("build", EMBIND_LAMBDA(Texture*, (TexBuilder* builder, Engine* engine), {
+    .function("_build", EMBIND_LAMBDA(Texture*, (TexBuilder* builder, Engine* engine), {
         return builder->build(*engine);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("width", TexBuilder, (TexBuilder* builder, uint32_t width), {
@@ -622,7 +625,7 @@ class_<IndirectLight>("IndirectLight")
     }), allow_raw_pointers());
 
 class_<IblBuilder>("IndirectLight$Builder")
-    .function("build", EMBIND_LAMBDA(IndirectLight*, (IblBuilder* builder, Engine* engine), {
+    .function("_build", EMBIND_LAMBDA(IndirectLight*, (IblBuilder* builder, Engine* engine), {
         return builder->build(*engine);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("reflections", IblBuilder, (IblBuilder* builder, Texture const* cubemap), {
@@ -650,7 +653,7 @@ class_<Skybox>("Skybox")
     .class_function("Builder", (SkyBuilder (*)()) [] { return SkyBuilder(); });
 
 class_<SkyBuilder>("Skybox$Builder")
-    .function("build", EMBIND_LAMBDA(Skybox*, (SkyBuilder* builder, Engine* engine), {
+    .function("_build", EMBIND_LAMBDA(Skybox*, (SkyBuilder* builder, Engine* engine), {
         return builder->build(*engine);
     }), allow_raw_pointers())
     .BUILDER_FUNCTION("environment", SkyBuilder, (SkyBuilder* builder, Texture* cubemap), {

--- a/web/filament-js/utilities.js
+++ b/web/filament-js/utilities.js
@@ -263,7 +263,7 @@ Filament._createTextureFromKtx = function(ktxdata, engine, options) {
     if (ktx.isCompressed()) {
         if (ktx.isCubemap()) {
             for (var level = 0; level < nlevels; level++) {
-                const uint8array = ktx.getCubeBlob(level).getBytes();
+                const uint8array = ktx.getCubeBlob(level);
                 const facesize = uint8array.length / 6;
                 const pixelbuffer = Filament.CompressedPixelBuffer(uint8array, cdatatype, facesize);
                 tex.setImageCube(engine, level, pixelbuffer);
@@ -271,7 +271,7 @@ Filament._createTextureFromKtx = function(ktxdata, engine, options) {
             return tex;
         }
         for (var level = 0; level < nlevels; level++) {
-            const uint8array = ktx.getBlob([level, 0, 0]).getBytes();
+            const uint8array = ktx.getBlob([level, 0, 0]);
             const pixelbuffer = Filament.CompressedPixelBuffer(uint8array, cdatatype);
             tex.setImage(engine, level, pixelbuffer);
         }
@@ -280,13 +280,13 @@ Filament._createTextureFromKtx = function(ktxdata, engine, options) {
 
     if (ktx.isCubemap()) {
         for (var level = 0; level < nlevels; level++) {
-            const uint8array = ktx.getCubeBlob(level).getBytes();
+            const uint8array = ktx.getCubeBlob(level);
             const pixelbuffer = Filament.PixelBuffer(uint8array, pbformat, datatype);
             tex.setImageCube(engine, level, pixelbuffer);
         }
     } else {
         for (var level = 0; level < nlevels; level++) {
-            const uint8array = ktx.getBlob([level, 0, 0]).getBytes();
+            const uint8array = ktx.getBlob([level, 0, 0]);
             const pixelbuffer = Filament.PixelBuffer(uint8array, pbformat, datatype);
             tex.setImage(engine, level, pixelbuffer);
         }

--- a/web/samples/leaks.html
+++ b/web/samples/leaks.html
@@ -88,14 +88,13 @@ class App {
             indices[j++] = 1 + (i % (nverts - 1));
         }
         // Create vertex buffer.
-        const vbuilder = Filament.VertexBuffer.Builder()
+        this.vb = Filament.VertexBuffer.Builder()
             .vertexCount(nverts)
             .bufferCount(2)
             .attribute(VertexAttribute.POSITION, 0, AttributeType.FLOAT2, 0, 8)
             .attribute(VertexAttribute.COLOR, 1, AttributeType.UBYTE4, 0, 4)
-            .normalized(VertexAttribute.COLOR);
-        this.vb = vbuilder.build(engine);
-        vbuilder.delete();
+            .normalized(VertexAttribute.COLOR)
+            .build(engine);
         const pbuf = Filament.Buffer(positions);
         const cbuf = Filament.Buffer(colors);
         this.vb.setBufferAt(engine, 0, pbuf);
@@ -103,11 +102,10 @@ class App {
         pbuf.delete();
         cbuf.delete();
         // Create index buffer.
-        const ibuilder = Filament.IndexBuffer.Builder()
+        this.ib = Filament.IndexBuffer.Builder()
             .indexCount(indices.length)
-            .bufferType(IndexType.USHORT);
-        this.ib = ibuilder.build(engine);
-        ibuilder.delete();
+            .bufferType(IndexType.USHORT)
+            .build(engine);
         const ibuf = Filament.Buffer(indices);
         this.ib.setBuffer(engine, ibuf);
         ibuf.delete();
@@ -115,9 +113,8 @@ class App {
         const rbuilder = Filament.RenderableManager.Builder(1)
             .boundingBox([ [-1, -1, -1], [1, 1, 1] ])
             .material(0, minstance)
-            .geometry(0, PrimitiveType.TRIANGLES, this.vb, this.ib);
-        rbuilder.build(engine, polygon);
-        rbuilder.delete();
+            .geometry(0, PrimitiveType.TRIANGLES, this.vb, this.ib)
+            .build(engine, polygon);
     }
 
     animate() {
@@ -127,8 +124,8 @@ class App {
             this.frame = 0;
             this.nsides = (this.nsides | 0) + 1;
             this.nsides = this.nsides % 10;
-            // Destroy and recreate the renderable component.
-            for (var k = 0; k < 100; k++) {
+            // Repeatedly destroy and recreate the renderable component to test for leaks.
+            for (var k = 0; k < 1000; k++) {
                 this.engine.destroyEntity(this.polygon);
                 this.engine.destroyVertexBuffer(this.vb);
                 this.engine.destroyIndexBuffer(this.ib);

--- a/web/samples/leaks.html
+++ b/web/samples/leaks.html
@@ -95,20 +95,14 @@ class App {
             .attribute(VertexAttribute.COLOR, 1, AttributeType.UBYTE4, 0, 4)
             .normalized(VertexAttribute.COLOR)
             .build(engine);
-        const pbuf = Filament.Buffer(positions);
-        const cbuf = Filament.Buffer(colors);
-        this.vb.setBufferAt(engine, 0, pbuf);
-        this.vb.setBufferAt(engine, 1, cbuf);
-        pbuf.delete();
-        cbuf.delete();
+        this.vb.setBufferAt(engine, 0, positions);
+        this.vb.setBufferAt(engine, 1, colors);
         // Create index buffer.
         this.ib = Filament.IndexBuffer.Builder()
             .indexCount(indices.length)
             .bufferType(IndexType.USHORT)
             .build(engine);
-        const ibuf = Filament.Buffer(indices);
-        this.ib.setBuffer(engine, ibuf);
-        ibuf.delete();
+        this.ib.setBuffer(engine, indices);
         // Create renderable component.
         const rbuilder = Filament.RenderableManager.Builder(1)
             .boundingBox([ [-1, -1, -1], [1, 1, 1] ])

--- a/web/samples/parquet.html
+++ b/web/samples/parquet.html
@@ -100,7 +100,9 @@ class App {
         const radians = Date.now() / 1000;
         const transform = mat4.fromRotation(mat4.create(), radians, [0, 1, 0]);
         const tcm = this.engine.getTransformManager();
-        tcm.setTransform(tcm.getInstance(this.shaderball), transform);
+        const inst = tcm.getInstance(this.shaderball);
+        tcm.setTransform(inst, transform);
+        inst.delete();
         this.renderer.render(this.swapChain, this.view);
         window.requestAnimationFrame(this.render);
     }

--- a/web/samples/suzanne.html
+++ b/web/samples/suzanne.html
@@ -115,7 +115,9 @@ class App {
         const radians = Date.now() / 1000;
         const transform = mat4.fromRotation(mat4.create(), radians, [0, 1, 0]);
         const tcm = this.engine.getTransformManager();
-        tcm.setTransform(tcm.getInstance(this.shaderball), transform);
+        const inst = tcm.getInstance(this.shaderball);
+        tcm.setTransform(inst, transform);
+        inst.delete();
         this.renderer.render(this.swapChain, this.view);
         window.requestAnimationFrame(this.render);
     }

--- a/web/samples/triangle.html
+++ b/web/samples/triangle.html
@@ -82,7 +82,9 @@ class App {
         const radians = Date.now() / 1000;
         const transform = mat4.fromRotation(mat4.create(), radians, [0, 0, 1]);
         const tcm = this.engine.getTransformManager();
-        tcm.setTransform(tcm.getInstance(this.triangle), transform);
+        const inst = tcm.getInstance(this.triangle);
+        tcm.setTransform(inst, transform);
+        inst.delete();
         this.renderer.render(this.swapChain, this.view);
         window.requestAnimationFrame(this.render);
     }


### PR DESCRIPTION
The new `build()` wrapper solves the builder leak, it does not solve the tiny leak incurred when users call `getInstance` on a component manager without calling embind's `delete` method afterwards. Since there's no way to auto-delete component instances, this CL fixes up our sample code and docstrings.

Fixes #429