### PR TITLE
Disable depth prepass for WebGL.

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -571,7 +571,7 @@ void FRenderer::ColorPass::renderColorPass(FEngine& engine, JobSystem& js,
     switch (view.getDepthPrepass()) {
         case View::DepthPrepass::DEFAULT:
             // TODO: better default strategy (can even change on a per-frame basis)
-#ifdef ANDROID
+#if defined(ANDROID) || defined(__EMSCRIPTEN__)
             commandType = COLOR;
 #else
             commandType = DEPTH_AND_COLOR;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -187,6 +187,14 @@ public:
     }
 
     void setDepthPrepass(DepthPrepass prepass) noexcept {
+#ifdef __EMSCRIPTEN__
+        if (prepass == View::DepthPrepass::ENABLED) {
+            utils::slog.w << "WARNING: " <<
+                "Depth prepass cannot be enabled on web due to invariance requirements." <<
+                utils::io::endl;
+            return;
+        }
+#endif
         mDepthPrepass = prepass;
     }
 


### PR DESCRIPTION
WebGL does not always honor the invariant GLSL decoration, so we cannot allow the depth prepass on web.

This fixes the black flakes seen with the Intel HD Graphics 615 in Pixelbook laptops.