### PR TITLE
Handle Vulkan ClipSpace in GLSL rather than C++.

### DIFF
--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -59,7 +59,6 @@ FView::FView(FEngine& engine)
     : mFroxelizer(engine),
       mPerViewUb(engine.getPerViewUib()),
       mPerViewSb(engine.getPerViewSib()),
-      mClipSpace01(engine.getBackend() == Backend::VULKAN),
       mDirectionalShadowMap(engine) {
     DriverApi& driver = engine.getDriverApi();
 
@@ -573,16 +572,7 @@ void FView::prepareCamera(const CameraInfo& camera, const Viewport& viewport) co
     const mat4f worldFromView(camera.model);
     const mat4f projectionMatrix(camera.projection);
 
-    // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
-    // See https://matthewwellings.com/blog/the-new-vulkan-coordinate-system/
-    const math::mat4f correction(math::mat4f::row_major_init{
-            1.0f,  0.0f, 0.0f, 0.0f,
-            0.0f, -1.0f, 0.0f, 0.0f,
-            0.0f,  0.0f, 0.5f, 0.5f,
-            0.0f,  0.0f, 0.0f, 1.0f,
-    });
-
-    const mat4f clipFromView(mClipSpace01 ? correction * projectionMatrix : projectionMatrix);
+    const mat4f clipFromView(projectionMatrix);
     const mat4f viewFromClip(Camera::inverseProjection(clipFromView));
     const mat4f clipFromWorld(clipFromView * viewFromWorld);
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -283,7 +283,6 @@ private:
     UniformBuffer& getUb() const noexcept { return mPerViewUb; }
 
     utils::CString mName;
-    const bool mClipSpace01;
 
     // the following values are set by prepare()
     Range mVisibleRenderables;

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -6,4 +6,10 @@ void main() {
     initMaterialVertex(material);
     gl_Position = getClipFromWorldMatrix() * material.worldPosition;
 #endif
+
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
+    gl_Position.y = -gl_Position.y;
+    gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
+#endif
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -86,4 +86,10 @@ void main() {
 #else
     gl_Position = getClipFromWorldMatrix() * material.worldPosition;
 #endif
+
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
+    gl_Position.y = -gl_Position.y;
+    gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
+#endif
 }


### PR DESCRIPTION
Recall that Vulkan has a right-handed NDC system. Currently, our Vulkan
backend is not handling VERTEX_DOMAIN_DEVICE correctly, but we didn't
notice because the culling mode is not honored yet (a separate PR is on
the way for that).

To fix this, we considered adding a shader-based fixup only for the
device domain and keeping our Vulkanish projection matrix as-is.
However, this would cause the skybox shader to compute an incorrect
wrong eye vector due to in the inconsistent definition of clip space.

After discussion with Mathias and Ben, we decided that the most elegant
fix is for Filament to have only one canonical clip space, which for
now is the clip space that OpenGL requires.

Ben pointed out that spirv-cross has a flag for injecting shader-based
fixups. However we don't invoke spirv-cross for the Vulkan target, and
it's easy just to do this on our own.