### PR TITLE
Fix regression with non-Vulkan backends.

### DIFF
--- a/libs/filaflat/src/TextDictionaryReader.cpp
+++ b/libs/filaflat/src/TextDictionaryReader.cpp
@@ -32,7 +32,9 @@ bool TextDictionaryReader::unflatten(Unflattener& f, BlobDictionary& dictionary)
         if (!f.read(&str)) {
             return false;
         }
-        dictionary.addBlob(str, strlen(str));
+        // BlobDictionary hold binary chunks and does not care if the data holds text, it is
+        // therefore crucial to include the trailing null.
+        dictionary.addBlob(str, strlen(str) + 1);
     }
     return true;
 }


### PR DESCRIPTION
This fixes the "shader is not ASCII" error seen with GL backend, introduced when we changed blob ownership semantics to accommodate shader compression. It was due to missing null terminators.

We actually never bothered including the trailing null in blob length, which was wrong but happened to work because the BlobDictionary held a weak reference to chunk data. SInce it now holds an actual copy, the lack of null caused our strings to contain garbage memory.