### PR TITLE
a fast approximation of pow() and pow(x, 2.2f)

### DIFF
--- a/filament/test/filament_benchmark.cpp
+++ b/filament/test/filament_benchmark.cpp
@@ -63,7 +63,6 @@ void benchmark(Profiler& p, const char* const name, T f) {
 }
 
 // ------------------------------------------------------------------------------------------------
-
 int main() {
 
     std::mt19937 gen;
@@ -76,14 +75,22 @@ int main() {
     std::vector<float3> boxesCenter(batch);
     std::vector<float3> boxesExtent(batch);
     std::vector<float4> spheres(batch);
+    std::vector<float4> colors(batch);
+    std::vector<float4> colors_results(batch);
     std::vector<half4> spheresHalf(batch);
     for (size_t i=0 ; i<batch ; i++) {
         float4& sphere = spheres[i];
+        float4& color = colors[i];
         float z = std::fabs(rand(gen));
         sphere.z = -z;
         sphere.x = rand(gen, std::uniform_real_distribution<float>::param_type{-z, z});
         sphere.y = rand(gen, std::uniform_real_distribution<float>::param_type{-z, z});
         sphere.w = rand(gen, std::uniform_real_distribution<float>::param_type{0.11f, 25.0f});
+
+        color.x = rand(gen, std::uniform_real_distribution<float>::param_type{0.0f, 1.0f});
+        color.y = rand(gen, std::uniform_real_distribution<float>::param_type{0.0f, 1.0f});
+        color.z = rand(gen, std::uniform_real_distribution<float>::param_type{0.0f, 1.0f});
+        color.w = rand(gen, std::uniform_real_distribution<float>::param_type{0.0f, 1.0f});
 
         boxesCenter[i] = sphere.xyz;
         boxesExtent[i] = {
@@ -166,6 +173,34 @@ int main() {
                     spheres[i].z,
                     spheres[i].w
             );
+        }
+    });
+
+    benchmark(p, "pow(float4, 2.2f)", [&]() {
+        for (size_t i = 0; i < batch; i++) {
+            colors_results[i] = pow(colors[i], 2.2f);
+        }
+    });
+
+    benchmark(p, "fast::pow(float4, 2.2f)", [&]() {
+        for (size_t i = 0; i < batch; i++) {
+            colors_results[i] = {
+                    fast::pow(colors[i].x, 2.2f),
+                    fast::pow(colors[i].y, 2.2f),
+                    fast::pow(colors[i].z, 2.2f),
+                    fast::pow(colors[i].w, 2.2f),
+            };
+        }
+    });
+
+    benchmark(p, "fast::pow2dot2(float4)", [&]() {
+        for (size_t i = 0; i < batch; i++) {
+            colors_results[i] = {
+                    fast::pow2dot2(colors[i].x),
+                    fast::pow2dot2(colors[i].y),
+                    fast::pow2dot2(colors[i].z),
+                    fast::pow2dot2(colors[i].w),
+            };
         }
     });
 

--- a/libs/math/include/math/fast.h
+++ b/libs/math/include/math/fast.h
@@ -119,6 +119,22 @@ constexpr float exp(float x) noexcept {
     return float(exp(double(x)));
 }
 
+inline float MATH_PURE pow(float a, float b) noexcept {
+    constexpr int fudgeMinRMSE = 486411;
+    constexpr int K = (127<<23) - fudgeMinRMSE;
+    union { float f; int x; } u = { a };
+    u.x = (int)(b * (u.x - K) + K);
+    return u.f;
+}
+
+// this is more precise than pow() above
+inline float MATH_PURE pow2dot2(float a) noexcept {
+    union { float f; int x; } u = { a };
+    constexpr int K = (127<<23);
+    u.x = (int)(0.2f * (u.x - K) + K);
+    return a * a * u.f; // a^2 * a^0.2
+}
+
 /*
  * unsigned saturated arithmetic
  */


### PR DESCRIPTION
fast::pow(x, 2.2f) is about 100x faster than std::pow.
std::pow(x, 2.2f) takes roughly 1000 cycles.