### PR TITLE
Compile filamat and dependencies for all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,10 +265,17 @@ endif()
 # ==================================================================================================
 # Sub-projects
 # ==================================================================================================
+# spirv-tools must come before filamat, as filamat relies on the presence of the
+# spirv-tools_SOURCE_DIR variable.
+add_subdirectory(${EXTERNAL}/spirv-tools)
+add_subdirectory(${EXTERNAL}/glslang/tnt)
+add_subdirectory(${EXTERNAL}/spirv-cross/tnt)
+
 # Common to all platforms
 add_subdirectory(${EXTERNAL}/libgtest/tnt)
 add_subdirectory(${LIBRARIES}/filabridge)
 add_subdirectory(${LIBRARIES}/filaflat)
+add_subdirectory(${LIBRARIES}/filamat)
 add_subdirectory(${LIBRARIES}/filameshio)
 add_subdirectory(${LIBRARIES}/image)
 add_subdirectory(${LIBRARIES}/math)
@@ -299,15 +306,6 @@ if (WEBGL)
 endif()
 
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
-    # spirv-tools must come before filamat, as filamat relies on the presence of the
-    # spirv-tools_SOURCE_DIR variable.
-    add_subdirectory(${EXTERNAL}/spirv-tools)
-    add_subdirectory(${EXTERNAL}/glslang/tnt)
-    add_subdirectory(${EXTERNAL}/spirv-cross/tnt)
-
-    # filamat is only needed for samples and matc
-    add_subdirectory(${LIBRARIES}/filamat)
-
     add_subdirectory(${FILAMENT}/samples)
 
     add_subdirectory(${LIBRARIES}/bluegl)

--- a/third_party/spirv-cross/tnt/CMakeLists.txt
+++ b/third_party/spirv-cross/tnt/CMakeLists.txt
@@ -15,7 +15,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(SPIRV-Cross)
 
-option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert" OFF)
+# Use assertions instead of exceptions so we can succesfully compile with -fno-exceptions.
+option(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS "Instead of throwing exceptions assert" ON)
 
 if(${CMAKE_GENERATOR} MATCHES "Makefile")
   if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
@@ -25,9 +26,11 @@ endif()
 
 set(spirv-compiler-options "")
 set(spirv-compiler-defines "")
+set(spirv-compiler-public-defines "")
 
 if(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
-  set(spirv-compiler-defines ${spirv-compiler-defines} SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+  # This needs to be public, because exceptions are exposed in public headers.
+  set(spirv-compiler-public-defines ${spirv-compiler-public-defines} SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
 endif()
 
 # To specify special debug or optimization options, use
@@ -61,6 +64,7 @@ macro(spirv_cross_add_library name config_name)
       PUBLIC_HEADERS "${hdrs}")
   target_compile_options(${name} PRIVATE ${spirv-compiler-options})
   target_compile_definitions(${name} PRIVATE ${spirv-compiler-defines})
+  target_compile_definitions(${name} PUBLIC ${spirv-compiler-public-defines})
 endmacro()
 
 spirv_cross_add_library(spirv-cross-core spirv_cross_core STATIC

--- a/third_party/spirv-cross/tnt/README.md
+++ b/third_party/spirv-cross/tnt/README.md
@@ -1,3 +1,5 @@
+## Updating
+
 To update to the spirv-cross that's currently on GitHub master, do the following.
 
 ```
@@ -10,3 +12,19 @@ git add spirv-cross
 ```
 
 Please be sure to test Filament before uploading your CL.
+
+## Filament-specific changes to CMakeLists.txt
+
+The Filament-specific `CMakeLists.txt` under the `tnt` directory has the following changes made from
+`spirv-cross`'s provided `CMakeLists.txt`:
+- Exceptions turned off in favor of assertions
+- Removal of installation rules
+- Removal of unused `spirv-cross` libraries
+- Removal of the `spirv-cross` executable
+- Removal of `spirv-cross` test cases
+
+To see all changes, run the following diff command from the `third_party/spirv-cross` directory:
+
+```
+diff CMakeLists.txt tnt/CMakeLists.txt
+```

--- a/third_party/spirv-tools/CMakeLists.txt
+++ b/third_party/spirv-tools/CMakeLists.txt
@@ -60,6 +60,11 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   set(SPIRV_TIMER_ENABLED ON)
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
   add_definitions(-DSPIRV_FREEBSD)
+# Filament specific changes
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Emscripten")
+  # Allow spirv-tools to compile with Emscripten
+  add_definitions(-DSPIRV_EMSCRIPTEN)
+# End Filament specific changes
 else()
   message(FATAL_ERROR "Your platform '${CMAKE_SYSTEM_NAME}' is not supported!")
 endif()


### PR DESCRIPTION
This change enables `filamat` to compile for all platforms, both desktop and non-desktop. Specifically, web and Android were having issues with Spir-V cross, which by default uses exceptions.