### PR TITLE
Improve error reporting for bindings overflow.

### DIFF
--- a/filament/src/driver/vulkan/VulkanBinder.cpp
+++ b/filament/src/driver/vulkan/VulkanBinder.cpp
@@ -422,7 +422,9 @@ void VulkanBinder::evictDescriptors(std::function<bool(const DescriptorKey&)> fi
 
 void VulkanBinder::bindUniformBuffer(uint32_t bindingIndex, VkBuffer uniformBuffer,
         VkDeviceSize offset, VkDeviceSize size) noexcept {
-    assert(bindingIndex < NUM_UBUFFER_BINDINGS);
+    ASSERT_POSTCONDITION(bindingIndex < NUM_UBUFFER_BINDINGS,
+            "Uniform bindings overflow: index = %d, capacity = %d.",
+            bindingIndex, NUM_UBUFFER_BINDINGS);
     auto& key = mDescriptorKey;
     if (key.uniformBuffers[bindingIndex] != uniformBuffer ||
         key.uniformBufferOffsets[bindingIndex] != offset ||
@@ -437,7 +439,9 @@ void VulkanBinder::bindUniformBuffer(uint32_t bindingIndex, VkBuffer uniformBuff
 void VulkanBinder::bindSampler(uint32_t bindingIndex, VkDescriptorImageInfo samplerInfo) noexcept {
     const uint32_t offset = NUM_UBUFFER_BINDINGS;
     assert(bindingIndex >= offset);
-    assert(bindingIndex < offset + NUM_SAMPLER_BINDINGS);
+    ASSERT_POSTCONDITION(bindingIndex < offset + NUM_SAMPLER_BINDINGS,
+            "Sampler bindings overflow: index = %d, capacity = %d.",
+            bindingIndex - offset, NUM_SAMPLER_BINDINGS);
     VkDescriptorImageInfo& imageInfo = mDescriptorKey.samplers[bindingIndex - offset];
     if (imageInfo.sampler != samplerInfo.sampler || imageInfo.imageView != samplerInfo.imageView ||
         imageInfo.imageLayout != samplerInfo.imageLayout) {

--- a/filament/src/driver/vulkan/VulkanBinder.h
+++ b/filament/src/driver/vulkan/VulkanBinder.h
@@ -70,7 +70,7 @@ namespace driver {
 class VulkanBinder {
 public:
     static constexpr uint32_t NUM_UBUFFER_BINDINGS = filament::BindingPoints::COUNT;
-    static constexpr uint32_t NUM_SAMPLER_BINDINGS = 8;
+    static constexpr uint32_t NUM_SAMPLER_BINDINGS = filament::MAX_SAMPLER_COUNT;
     static constexpr uint32_t NUM_SHADER_MODULES = 2;
     static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = filament::ATTRIBUTE_INDEX_COUNT;
 

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -25,7 +25,6 @@
 #include <utils/CString.h>
 #include <utils/trap.h>
 
-#include <csignal>
 #include <set>
 
 // Vulkan functions often immediately dereference pointers, so it's fine to pass in a pointer
@@ -885,6 +884,10 @@ void VulkanDriver::draw(Driver::PipelineState pipelineState, Driver::RenderPrimi
             if (!sampler->t) {
                 continue;
             }
+
+            // Obtain the global sampler binding index and pass this to VulkanBinder. Note that
+            // "binding" is an offset that is global to the shader, whereas "samplerIndex" is an
+            // offset into the virtual sampler buffer.
             uint8_t binding, group;
             if (program->samplerBindings.getSamplerBinding(bufferIdx, samplerIndex, &binding,
                     &group)) {

--- a/libs/filabridge/include/filament/EngineEnums.h
+++ b/libs/filabridge/include/filament/EngineEnums.h
@@ -35,7 +35,7 @@ enum VertexAttribute : uint8_t {
 
 // Binding points for uniform buffers and sampler buffers.
 // Effectively, these are just names.
-// These are limited by Program::NUM_UNIFORM_BINDINGS (currently 8)
+// These are limited by Program::NUM_UNIFORM_BINDINGS (currently 6)
 namespace BindingPoints {
     constexpr uint8_t PER_VIEW                = 0;    // uniforms/samplers updated per view
     constexpr uint8_t PER_RENDERABLE          = 1;    // uniforms/samplers updated per renderable
@@ -51,6 +51,7 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
 
 constexpr uint32_t ATTRIBUTE_INDEX_COUNT = 7;
 constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8; // FIXME: should match Driver::MAX_ATTRIBUTE_BUFFER_COUNT
+constexpr size_t MAX_SAMPLER_COUNT = 8;
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
 // Values <= 256, use less CPU and GPU resources.

--- a/libs/filabridge/include/filament/SamplerBindingMap.h
+++ b/libs/filabridge/include/filament/SamplerBindingMap.h
@@ -48,8 +48,10 @@ class SamplerInterfaceBlock;
 class SamplerBindingMap {
 public:
     // Assigns a range of finalized binding points to each sampler block. If a per-material SIB
-    // is provided, then material samplers are also inserted (always at the end).
-    void populate(SamplerInterfaceBlock* perMaterialSib = nullptr);
+    // is provided, then material samplers are also inserted (always at the end). The optional
+    // material name is used for error reporting only.
+    void populate(SamplerInterfaceBlock* perMaterialSib = nullptr,
+            const char* materialName = nullptr);
 
     // Given a valid Filament binding point and an offset with the block, returns true and sets
     // the output arguments: (1) the globally unique binding index, and (2) the grouping index.

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -326,7 +326,7 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.blendingMode = mBlendingMode;
     info.shading = mShading;
     info.hasShadowMultiplier = mShadowMultiplier;
-    info.samplerBindings.populate(&info.sib);
+    info.samplerBindings.populate(&info.sib, mMaterialName.c_str());
 }
 
 static void showErrorMessage(const char* materialName, uint8_t variant,


### PR DESCRIPTION
We now check for sampler overflow during material compilation rather
than waiting for run-time checks. This allows for Kokoro-based
validation of sample materials, and allows developers to catch this
issue in their asset pipeline.

We should also probably raise the upper limit (Qualcomm allows up to 16
samplers in their Vulkan implementation) but that can be a separate PR.

Fixes #507