### PR TITLE
Raise sampler limit to 16.

### DIFF
--- a/libs/filabridge/include/filament/EngineEnums.h
+++ b/libs/filabridge/include/filament/EngineEnums.h
@@ -51,7 +51,7 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
 
 constexpr uint32_t ATTRIBUTE_INDEX_COUNT = 7;
 constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8; // FIXME: should match Driver::MAX_ATTRIBUTE_BUFFER_COUNT
-constexpr size_t MAX_SAMPLER_COUNT = 8;
+constexpr size_t MAX_SAMPLER_COUNT = 16; // Matches the Adreno Vulkan driver.
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
 // Values <= 256, use less CPU and GPU resources.


### PR DESCRIPTION
In practice this limits materials to 10 samplers since Filament uses 5
for lights and skips 1 slot for the post-process sampler. This can
probably be optimized.