### PR TITLE
Remove codeGenTargetApi builder method from MaterialBuilder

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -79,7 +79,6 @@ protected:
     TargetApi mTargetApi = TargetApi::OPENGL;
     Optimization mOptimization = Optimization::NONE;
     bool mPrintShaders = false;
-    TargetApi mCodeGenTargetApi = TargetApi::OPENGL;
     utils::bitset32 mShaderModels;
     struct CodeGenParams {
         int shaderModel;
@@ -202,11 +201,6 @@ public:
     // TODO: this is present here for matc's "--print" flag, but ideally does not belong inside
     // MaterialBuilder
     MaterialBuilder& printShaders(bool printShaders) noexcept;
-
-    // specifies vulkan vs opengl; this method can be used to override which target API is used
-    // during the code generation step. This can be useful when the post-processor uses a
-    // different intermediate representation.
-    MaterialBuilder& codeGenTargetApi(TargetApi targetApi) noexcept;
 
     // specifies a list of variants that should be filtered out during code generation.
     MaterialBuilder& variantFilter(uint8_t variantFilter) noexcept;

--- a/libs/filamat/include/filamat/PostprocessMaterialBuilder.h
+++ b/libs/filamat/include/filamat/PostprocessMaterialBuilder.h
@@ -46,15 +46,6 @@ public:
     // (used to generate code) and final output representations (spirv and/or text).
     PostprocessMaterialBuilder& targetApi(TargetApi targetApi) noexcept {
         mTargetApi = targetApi;
-        mCodeGenTargetApi = targetApi;
-        return *this;
-    }
-
-    // specifies vulkan vs opengl; this method can be used to override which target API is used
-    // during the code generation step. This can be useful when the post-processor uses a
-    // different intermediate representation.
-    PostprocessMaterialBuilder& codeGenTargetApi(TargetApi targetApi) noexcept {
-        mCodeGenTargetApi = targetApi;
         return *this;
     }
 

--- a/tools/matc/src/matc/Config.h
+++ b/tools/matc/src/matc/Config.h
@@ -111,17 +111,6 @@ public:
         return mTargetApi;
     }
 
-    /**
-     * Returns the target API suitable for the current optimization level. It might be
-     * different than the target API returned by getTargetApi().
-     */
-    TargetApi getCodeGenTargetApi() const noexcept {
-        // When optimizing OpenGL we use SPIRV as an intermediate representation so we must force
-        // the target API to be Vulkan for the generated shaders to compile
-        return mOptimizationLevel > Optimization::PREPROCESSOR && mTargetApi != TargetApi::VULKAN ?
-                TargetApi::VULKAN : mTargetApi;
-    }
-
     bool printShaders() const noexcept {
         return mPrintShaders;
     }

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -288,7 +288,6 @@ bool MaterialCompiler::run(const Config& config) {
         .platform(config.getPlatform())
         .targetApi(config.getTargetApi())
         .optimization(config.getOptimizationLevel())
-        .codeGenTargetApi(config.getCodeGenTargetApi())
         .printShaders(config.printShaders())
         .variantFilter(config.getVariantFilter() | builder.getVariantFilter());
 

--- a/tools/matc/src/matc/PostprocessMaterialCompiler.cpp
+++ b/tools/matc/src/matc/PostprocessMaterialCompiler.cpp
@@ -37,8 +37,7 @@ bool PostprocessMaterialCompiler::run(const Config& config) {
         .platform(config.getPlatform())
         .targetApi(config.getTargetApi())
         .optimization(config.getOptimizationLevel())
-        .printShaders(config.printShaders())
-        .codeGenTargetApi(config.getCodeGenTargetApi());
+        .printShaders(config.printShaders());
 
     Package package = builder.build();
     if (!package.isValid()) {


### PR DESCRIPTION
Deprecate the `codeGenTargetApi` method on `MaterialBuilder`, as it is confusing and not useful to clients. Clients should only care about setting `targetApi` correctly.

Tested before and after change with all optimization, platform, and API combinations on all materials inside `samples/materials`.