### PR TITLE
Corrected exposure from ev100 formula

### DIFF
--- a/docs/Filament.md.html
+++ b/docs/Filament.md.html
@@ -2932,7 +2932,7 @@ float exposureSettings(float aperture, float shutterSpeed, float sensitivity) {
 // Computes the exposure normalization factor from
 // the camera's EV100
 float exposure(ev100) {
-    return pow(2.0, ev100) * 1.2;
+    return 1.0 / pow(2.0, ev100) * 1.2;
 }
 
 float ev100 = exposureSettings(aperture, shutterSpeed, sensitivity);


### PR DESCRIPTION
The new formula should be the correct one according to this document (first line p86): https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf