### PR TITLE
Corrected typo in formula

### DIFF
--- a/docs/Filament.md.html
+++ b/docs/Filament.md.html
@@ -915,7 +915,7 @@ $$
 Since the clear coat layer's IOR is fixed, we can combine both steps to simplify:
 
 $$
-f_{0_{base}} = \frac{\left( 1 - 5 \sqrt{\fNormal} \right) ^2}{\left( 5 \sqrt{\fNormal} \right) ^2}
+f_{0_{base}} = \frac{\left( 1 - 5 \sqrt{\fNormal} \right) ^2}{\left( 5 - \sqrt{\fNormal} \right) ^2}
 $$
 
 We should also modify the base layer's apparent roughness based on the IOR of the clear coat layer but this is something we have opted to leave out for now.


### PR DESCRIPTION
It looks like there is a minus sign missing in there, see https://www.wolframalpha.com/input/?i=(((1%2Bsqrt(x))+%2F+(1+-+sqrt(x)))+-+1.5)+%2F+(((1%2Bsqrt(x))+%2F+(1+-+sqrt(x)))+%2B+1.5)

I'm not sure what the code does though https://github.com/google/filament/blob/master/shaders/src/brdf.fs#L282