### PR TITLE
Fixes various MSVC issues in public headers

### DIFF
--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -54,7 +54,7 @@ public:
      * element type.
      */
     template <typename OTHER>
-    QUATERNION<T>& operator *= (const QUATERNION<OTHER>& r) {
+    constexpr QUATERNION<T>& operator *= (const QUATERNION<OTHER>& r) {
         QUATERNION<T>& q = static_cast<QUATERNION<T>&>(*this);
         q = q * r;
         return q;
@@ -62,14 +62,14 @@ public:
 
     /* compound assignment products by a scalar
      */
-    QUATERNION<T>& operator *= (T v) {
+    constexpr QUATERNION<T>& operator *= (T v) {
         QUATERNION<T>& lhs = static_cast<QUATERNION<T>&>(*this);
         for (size_t i = 0; i < QUATERNION<T>::size(); i++) {
             lhs[i] *= v;
         }
         return lhs;
     }
-    QUATERNION<T>& operator /= (T v) {
+    constexpr QUATERNION<T>& operator /= (T v) {
         QUATERNION<T>& lhs = static_cast<QUATERNION<T>&>(*this);
         for (size_t i = 0; i < QUATERNION<T>::size(); i++) {
             lhs[i] /= v;
@@ -172,12 +172,12 @@ public:
     }
 
     friend inline
-    constexpr T MATH_PURE norm(const QUATERNION<T>& q) {
+    T MATH_PURE norm(const QUATERNION<T>& q) {
         return std::sqrt( dot(q, q) );
     }
 
     friend inline
-    constexpr T MATH_PURE length(const QUATERNION<T>& q) {
+    T MATH_PURE length(const QUATERNION<T>& q) {
         return norm(q);
     }
 
@@ -187,8 +187,8 @@ public:
     }
 
     friend inline
-    constexpr QUATERNION<T> MATH_PURE normalize(const QUATERNION<T>& q) {
-        return length(q) ? q / length(q) : QUATERNION<T>(1);
+    QUATERNION<T> MATH_PURE normalize(const QUATERNION<T>& q) {
+        return length(q) ? q / length(q) : QUATERNION<T>(static_cast<T>(1));
     }
 
     friend inline

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -55,7 +55,7 @@ public:
      * element type.
      */
     template<typename OTHER>
-    VECTOR<T>& operator +=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator +=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] += v[i];
@@ -63,7 +63,7 @@ public:
         return lhs;
     }
     template<typename OTHER>
-    VECTOR<T>& operator -=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator -=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] -= v[i];
@@ -76,14 +76,14 @@ public:
      * like "vector *= scalar" by letting the compiler implicitly convert a scalar
      * to a vector (assuming the BASE<T> allows it).
      */
-    VECTOR<T>& operator +=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator +=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] += v[i];
         }
         return lhs;
     }
-    VECTOR<T>& operator -=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator -=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] -= v[i];
@@ -136,7 +136,7 @@ public:
      * element type.
      */
     template<typename OTHER>
-    VECTOR<T>& operator *=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator *=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] *= v[i];
@@ -144,7 +144,7 @@ public:
         return lhs;
     }
     template<typename OTHER>
-    VECTOR<T>& operator /=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator /=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] /= v[i];
@@ -157,14 +157,14 @@ public:
      * like "vector *= scalar" by letting the compiler implicitly convert a scalar
      * to a vector (assuming the BASE<T> allows it).
      */
-    VECTOR<T>& operator *=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator *=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] *= v[i];
         }
         return lhs;
     }
-    VECTOR<T>& operator /=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator /=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] /= v[i];
@@ -254,7 +254,7 @@ public:
     friend inline
     bool MATH_PURE operator ==(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         // w/ inlining we end-up with many branches that will pollute the BPU cache
-        #pragma nounroll
+        MATH_NOUNROLL
         for (size_t i = 0; i < lv.size(); i++)
             if (lv[i] != rv[i])
                 return false;
@@ -271,7 +271,7 @@ public:
     friend inline
     bool MATH_PURE operator >(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         // w/ inlining we end-up with many branches that will pollute the BPU cache
-        #pragma nounroll
+        MATH_NOUNROLL
         for (size_t i = 0; i < lv.size(); i++) {
             if (lv[i] != rv[i]) {
                 return lv[i] > rv[i];
@@ -290,7 +290,7 @@ public:
     friend inline
     bool MATH_PURE operator <(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         // w/ inlining we end-up with many branches that will pollute the BPU cache
-        #pragma nounroll
+        MATH_NOUNROLL
         for (size_t i = 0; i < lv.size(); i++) {
             if (lv[i] != rv[i]) {
                 return lv[i] < rv[i];
@@ -392,11 +392,11 @@ public:
         return r;
     }
 
-    friend inline constexpr T MATH_PURE norm(const VECTOR<T>& lv) {
+    friend inline T MATH_PURE norm(const VECTOR<T>& lv) {
         return std::sqrt(dot(lv, lv));
     }
 
-    friend inline constexpr T MATH_PURE length(const VECTOR<T>& lv) {
+    friend inline T MATH_PURE length(const VECTOR<T>& lv) {
         return norm(lv);
     }
 

--- a/libs/math/include/math/compiler.h
+++ b/libs/math/include/math/compiler.h
@@ -46,6 +46,22 @@
 
 #ifdef _MSC_VER
 #   define MATH_EMPTY_BASES __declspec(empty_bases)
-#else
+// MSVC does not support loop unrolling hints
+#   define MATH_NOUNROLL
+
+// Sadly, MSVC does not support __builtin_constant_p
+#   ifndef MAKE_CONSTEXPR
+#       define MAKE_CONSTEXPR(e) (e)
+#   endif
+
+#else // _MSC_VER
+
 #   define MATH_EMPTY_BASES
-#endif
+// C++11 allows pragmas to be specified as part of defines using the _Pragma syntax.
+#   define MATH_NOUNROLL _Pragma("nounroll")
+
+#   ifndef MAKE_CONSTEXPR
+#       define MAKE_CONSTEXPR(e) __builtin_constant_p(e) ? (e) : (e)
+#   endif
+
+#endif // _MSC_VER

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -21,17 +21,7 @@
 #include <limits>
 #include <type_traits>
 
-#ifdef __cplusplus
-#   define LIKELY( exp )    (__builtin_expect( !!(exp), true ))
-#   define UNLIKELY( exp )  (__builtin_expect( !!(exp), false ))
-#else
-#   define LIKELY( exp )    (__builtin_expect( !!(exp), 1 ))
-#   define UNLIKELY( exp )  (__builtin_expect( !!(exp), 0 ))
-#endif
-
-#ifndef MAKE_CONSTEXPR
-#define MAKE_CONSTEXPR(e) __builtin_constant_p(e) ? (e) : (e)
-#endif
+#include <math/compiler.h>
 
 namespace math {
 
@@ -122,7 +112,7 @@ constexpr half::fp16 half::ftoh(float f) noexcept {
     unsigned int sign = in.getS();
 
     in.setS(0);
-    if (UNLIKELY(in.getE() == 0xFF)) { // inf or nan
+    if (MATH_UNLIKELY(in.getE() == 0xFF)) { // inf or nan
         out.setE(0x1F);
         out.setM(in.getM() ? 0x200 : 0);
     } else {
@@ -151,7 +141,7 @@ constexpr float half::htof(half::fp16 in) noexcept {
 #endif // __ARM_NEON
 
 inline constexpr math::half operator"" _h(long double v) {
-    return math::half(v);
+    return math::half(static_cast<float>(v));
 }
 
 } // namespace math
@@ -202,9 +192,5 @@ public:
 };
 
 } // namespace std
-
-#undef LIKELY
-#undef UNLIKELY
-#undef MAKE_CONSTEXPR
 
 #endif // TNT_MATH_HALF_H

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -19,11 +19,9 @@
 
 #include <math/TMatHelpers.h>
 #include <math/vec2.h>
+#include <math/compiler.h>
 #include <stdint.h>
 #include <sys/types.h>
-
-
-#define PURE __attribute__((pure))
 
 namespace math {
 // -------------------------------------------------------------------------------------
@@ -348,7 +346,7 @@ constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1) {
 
 // matrix * column-vector, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat22<U>::col_type PURE operator *(const TMat22<T>& lhs, const TVec2<U>& rhs) {
+constexpr typename TMat22<U>::col_type MATH_PURE operator *(const TMat22<T>& lhs, const TVec2<U>& rhs) {
     // Result is initialized to zero.
     typename TMat22<U>::col_type result = {};
     for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
@@ -359,7 +357,7 @@ constexpr typename TMat22<U>::col_type PURE operator *(const TMat22<T>& lhs, con
 
 // row-vector * matrix, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat22<U>::row_type PURE operator *(const TVec2<U>& lhs, const TMat22<T>& rhs) {
+constexpr typename TMat22<U>::row_type MATH_PURE operator *(const TVec2<U>& lhs, const TMat22<T>& rhs) {
     typename TMat22<U>::row_type result;
     for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
@@ -369,14 +367,14 @@ constexpr typename TMat22<U>::row_type PURE operator *(const TVec2<U>& lhs, cons
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type MATH_PURE
 operator*(TMat22<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type MATH_PURE
 operator*(U lhs, const TMat22<T>& rhs) {
     return rhs * lhs;
 }
@@ -387,7 +385,7 @@ operator*(U lhs, const TMat22<T>& rhs) {
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat22<T>::col_type PURE diag(const TMat22<T>& m) {
+constexpr typename TMat22<T>::col_type MATH_PURE diag(const TMat22<T>& m) {
     return matrix::diag(m);
 }
 
@@ -400,8 +398,6 @@ typedef details::TMat22<float> mat2f;
 
 // ----------------------------------------------------------------------------------------
 }  // namespace math
-
-#undef PURE
 
 namespace std {
 template <typename T>

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -20,12 +20,11 @@
 #include <math/quat.h>
 #include <math/TMatHelpers.h>
 #include <math/vec3.h>
+#include <math/compiler.h>
 
 #include <limits.h>
 #include <stdint.h>
 #include <sys/types.h>
-
-#define PURE __attribute__((pure))
 
 namespace math {
 // -------------------------------------------------------------------------------------
@@ -392,7 +391,7 @@ constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) {
 
 // matrix * column-vector, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat33<U>::col_type PURE operator *(const TMat33<T>& lhs, const TVec3<U>& rhs) {
+constexpr typename TMat33<U>::col_type MATH_PURE operator *(const TMat33<T>& lhs, const TVec3<U>& rhs) {
     // Result is initialized to zero.
     typename TMat33<U>::col_type result = {};
     for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
@@ -403,7 +402,7 @@ constexpr typename TMat33<U>::col_type PURE operator *(const TMat33<T>& lhs, con
 
 // row-vector * matrix, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat33<U>::row_type PURE operator *(const TVec3<U>& lhs, const TMat33<T>& rhs) {
+constexpr typename TMat33<U>::row_type MATH_PURE operator *(const TVec3<U>& lhs, const TMat33<T>& rhs) {
     typename TMat33<U>::row_type result;
     for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
@@ -413,14 +412,14 @@ constexpr typename TMat33<U>::row_type PURE operator *(const TVec3<U>& lhs, cons
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type MATH_PURE
 operator*(TMat33<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type MATH_PURE
 operator*(U lhs, const TMat33<T>& rhs) {
     return rhs * lhs;
 }
@@ -455,7 +454,7 @@ constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t 
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat33<T>::col_type PURE diag(const TMat33<T>& m) {
+constexpr typename TMat33<T>::col_type MATH_PURE diag(const TMat33<T>& m) {
     return matrix::diag(m);
 }
 
@@ -468,8 +467,6 @@ typedef details::TMat33<float> mat3f;
 
 // ----------------------------------------------------------------------------------------
 }  // namespace math
-
-#undef PURE
 
 namespace std {
 template <typename T>

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -22,12 +22,11 @@
 #include <math/TMatHelpers.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
+#include <math/compiler.h>
 
 #include <stdint.h>
 #include <sys/types.h>
 #include <limits>
-
-#define PURE __attribute__((pure))
 
 namespace math {
 // -------------------------------------------------------------------------------------
@@ -353,10 +352,10 @@ public:
 
 template <typename T>
 constexpr TMat44<T>::TMat44() {
-    m_value[0] = col_type(1, 0, 0, 0);
-    m_value[1] = col_type(0, 1, 0, 0);
-    m_value[2] = col_type(0, 0, 1, 0);
-    m_value[3] = col_type(0, 0, 0, 1);
+    m_value[0] = col_type(1.0f, 0.0f, 0.0f, 0.0f);
+    m_value[1] = col_type(0.0f, 1.0f, 0.0f, 0.0f);
+    m_value[2] = col_type(0.0f, 0.0f, 1.0f, 0.0f);
+    m_value[3] = col_type(0.0f, 0.0f, 0.0f, 1.0f);
 }
 
 template <typename T>
@@ -545,7 +544,7 @@ constexpr TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& cente
 
 // matrix * column-vector, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat44<T>::col_type PURE operator *(const TMat44<T>& lhs, const TVec4<U>& rhs) {
+constexpr typename TMat44<T>::col_type MATH_PURE operator *(const TMat44<T>& lhs, const TVec4<U>& rhs) {
     // Result is initialized to zero.
     typename TMat44<T>::col_type result = {};
     for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
@@ -556,14 +555,14 @@ constexpr typename TMat44<T>::col_type PURE operator *(const TMat44<T>& lhs, con
 
 // mat44 * vec3, result is vec3( mat44 * {vec3, 1} )
 template <typename T, typename U>
-constexpr typename TMat44<T>::col_type PURE operator *(const TMat44<T>& lhs, const TVec3<U>& rhs) {
+constexpr typename TMat44<T>::col_type MATH_PURE operator *(const TMat44<T>& lhs, const TVec3<U>& rhs) {
     return lhs * TVec4<U>{ rhs, 1 };
 }
 
 
 // row-vector * matrix, result is a vector of the same type than the input vector
 template <typename T, typename U>
-constexpr typename TMat44<U>::row_type PURE operator *(const TVec4<U>& lhs, const TMat44<T>& rhs) {
+constexpr typename TMat44<U>::row_type MATH_PURE operator *(const TVec4<U>& lhs, const TMat44<T>& rhs) {
     typename TMat44<U>::row_type result;
     for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
@@ -573,14 +572,14 @@ constexpr typename TMat44<U>::row_type PURE operator *(const TVec4<U>& lhs, cons
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template <typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
 operator *(TMat44<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template <typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type PURE
+constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
 operator *(U lhs, const TMat44<T>& rhs) {
     return rhs * lhs;
 }
@@ -591,7 +590,7 @@ operator *(U lhs, const TMat44<T>& rhs) {
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat44<T>::col_type PURE diag(const TMat44<T>& m) {
+constexpr typename TMat44<T>::col_type MATH_PURE diag(const TMat44<T>& m) {
     return matrix::diag(m);
 }
 
@@ -604,8 +603,6 @@ typedef details::TMat44<float> mat4f;
 
 // ----------------------------------------------------------------------------------------
 }  // namespace math
-
-#undef PURE
 
 namespace std {
 template <typename T>

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -21,13 +21,10 @@
 #include <math/TQuatHelpers.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
+#include <math/compiler.h>
 
 #include <stdint.h>
 #include <sys/types.h>
-
-#ifndef PURE
-#define PURE __attribute__((pure))
-#endif
 
 namespace math {
 // -------------------------------------------------------------------------------------
@@ -125,7 +122,7 @@ public:
 
     // constructs a quaternion from an axis and angle
     template <typename A, typename B>
-    constexpr static TQuaternion PURE fromAxisAngle(const TVec3<A>& axis, B angle) {
+    constexpr static TQuaternion MATH_PURE fromAxisAngle(const TVec3<A>& axis, B angle) {
         return TQuaternion(std::sin(angle*0.5) * normalize(axis), std::cos(angle*0.5));
     }
 };
@@ -160,7 +157,5 @@ constexpr inline quat operator"" _k(unsigned long long v) {
 
 // ----------------------------------------------------------------------------------------
 }  // namespace math
-
-#undef PURE
 
 #endif  // MATH_QUAT_H_

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -682,7 +682,7 @@ public:
     }
 
     void* allocate(size_t size, size_t alignment = 1) noexcept {
-        return mArena.template alloc(size, alignment, 0);
+        return mArena.template alloc<uint8_t>(size, alignment, 0);
     }
 
     template <typename T>

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -30,10 +30,18 @@
 #define __has_builtin(x) 0
 #endif
 
-#define UTILS_PUBLIC  __attribute__((visibility("default")))
+#if __has_attribute(visibility)
+#    define UTILS_PUBLIC  __attribute__((visibility("default")))
+#else
+#    define UTILS_PUBLIC  
+#endif
 
-#ifndef TNT_DEV
-#    define UTILS_PRIVATE __attribute__((visibility("hidden")))
+#if __has_attribute(visibility)
+#    ifndef TNT_DEV
+#        define UTILS_PRIVATE __attribute__((visibility("hidden")))
+#    else
+#        define UTILS_PRIVATE
+#    endif
 #else
 #    define UTILS_PRIVATE
 #endif


### PR DESCRIPTION
Relates to #522 and #517 and serves mostly as a basis for discussion.

Summary of changes:
- Introduced constexpr in places where MSVC complained about missing constexpr
- Removed constexpr from functions that directly or transitively called std::sqrt (since it's not constexpr)
- Some places needed `static_cast` when templates were instantiated with T=float and A=int (i.e. `math::float3(1)`), because MSVC will emit a warning for implicit conversions from int to float.
- Moved some leftover compiler defines into compiler.h, and added dummy defines for MSVC (PURE -> MATH_PURE, MAKE_CONSTEXPR)
- Moved #pragma nounroll into a new define MATH_NOUNROLL using _Pragma("nounroll") to replace the original #pragma (which can't go into a #define itself)
- This also has the "fix" for the Allocator being unable to determine the template arg, by explicitly setting it to uint8_t for the void* case.

This is not guaranteed to fix _all_ issues that currently exist in the public headers, but it did allow me to compile my C wrapper from earlier using MSVC, while compiling the rest with Clang.