### PR TITLE
Rename GlslChunk to TextChunk

### DIFF
--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -19,12 +19,12 @@ set(PRIVATE_HDRS
         src/eiff/BlobDictionary.h
         src/eiff/Chunk.h
         src/eiff/ChunkContainer.h
-        src/eiff/DictionaryGlslChunk.h
+        src/eiff/DictionaryTextChunk.h
         src/eiff/DictionarySpirvChunk.h
         src/eiff/Flattener.h
-        src/eiff/GlslChunk.h
+        src/eiff/TextChunk.h
         src/eiff/LineDictionary.h
-        src/eiff/MaterialGlslChunk.h
+        src/eiff/MaterialTextChunk.h
         src/eiff/MaterialInterfaceBlockChunk.h
         src/eiff/MaterialSpirvChunk.h
         src/eiff/ShaderEntry.h
@@ -37,10 +37,10 @@ set(SRCS
         src/eiff/BlobDictionary.cpp
         src/eiff/Chunk.cpp
         src/eiff/ChunkContainer.cpp
-        src/eiff/DictionaryGlslChunk.cpp
+        src/eiff/DictionaryTextChunk.cpp
         src/eiff/DictionarySpirvChunk.cpp
         src/eiff/LineDictionary.cpp
-        src/eiff/MaterialGlslChunk.cpp
+        src/eiff/MaterialTextChunk.cpp
         src/eiff/MaterialSpirvChunk.cpp
         src/eiff/MaterialInterfaceBlockChunk.cpp
         src/eiff/SimpleFieldChunk.cpp

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -537,8 +537,8 @@ Package MaterialBuilder::build() noexcept {
     }
 
     // Emit GLSL chunks (TextDictionaryReader and MaterialTextChunk).
-    filamat::DictionaryTextChunk dicGlslChunk(glslDictionary);
-    MaterialTextChunk glslChunk(glslEntries, glslDictionary);
+    filamat::DictionaryTextChunk dicGlslChunk(glslDictionary, ChunkType::DictionaryGlsl);
+    MaterialTextChunk glslChunk(glslEntries, glslDictionary, ChunkType::MaterialGlsl);
     if (!glslEntries.empty()) {
         container.addChild(&dicGlslChunk);
         container.addChild(&glslChunk);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -34,11 +34,11 @@
 #include "eiff/BlobDictionary.h"
 #include "eiff/LineDictionary.h"
 #include "eiff/MaterialInterfaceBlockChunk.h"
-#include "eiff/MaterialGlslChunk.h"
+#include "eiff/MaterialTextChunk.h"
 #include "eiff/MaterialSpirvChunk.h"
 #include "eiff/ChunkContainer.h"
 #include "eiff/SimpleFieldChunk.h"
-#include "eiff/DictionaryGlslChunk.h"
+#include "eiff/DictionaryTextChunk.h"
 #include "eiff/DictionarySpirvChunk.h"
 
 #include "filamat/sca/GLSLTools.h"
@@ -428,7 +428,7 @@ Package MaterialBuilder::build() noexcept {
     container.addChild(&matShaderModels);
 
     // Generate all shaders.
-    std::vector<GlslEntry> glslEntries;
+    std::vector<TextEntry> glslEntries;
     std::vector<SpirvEntry> spirvEntries;
     LineDictionary glslDictionary;
     BlobDictionary spirvDictionary;
@@ -450,7 +450,7 @@ Package MaterialBuilder::build() noexcept {
         const TargetApi codeGenTargetApi = params.codeGenTargetApi;
         std::vector<uint32_t>* pSpirv = (targetApi == TargetApi::VULKAN) ? &spirv : nullptr;
 
-        GlslEntry glslEntry;
+        TextEntry glslEntry;
         SpirvEntry spirvEntry;
 
         glslEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
@@ -536,9 +536,9 @@ Package MaterialBuilder::build() noexcept {
         }
     }
 
-    // Emit GLSL chunks (TextDictionaryReader and MaterialGlslChunk).
-    filamat::DictionaryGlslChunk dicGlslChunk(glslDictionary);
-    MaterialGlslChunk glslChunk(glslEntries, glslDictionary);
+    // Emit GLSL chunks (TextDictionaryReader and MaterialTextChunk).
+    filamat::DictionaryTextChunk dicGlslChunk(glslDictionary);
+    MaterialTextChunk glslChunk(glslEntries, glslDictionary);
     if (!glslEntries.empty()) {
         container.addChild(&dicGlslChunk);
         container.addChild(&glslChunk);
@@ -560,7 +560,7 @@ Package MaterialBuilder::build() noexcept {
     package.setValid(!errorOccured);
 
     // Free all shaders that were created earlier.
-    for (GlslEntry entry : glslEntries) {
+    for (TextEntry entry : glslEntries) {
         free(entry.shader);
     }
     return package;

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -144,8 +144,8 @@ Package PostprocessMaterialBuilder::build() {
     }
 
     // Emit GLSL chunks
-    DictionaryTextChunk dicGlslChunk(glslDictionary);
-    MaterialTextChunk glslChunk(glslEntries, glslDictionary);
+    DictionaryTextChunk dicGlslChunk(glslDictionary, ChunkType::DictionaryGlsl);
+    MaterialTextChunk glslChunk(glslEntries, glslDictionary, ChunkType::MaterialGlsl);
     if (!glslEntries.empty()) {
         container.addChild(&dicGlslChunk);
         container.addChild(&glslChunk);

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -23,9 +23,9 @@
 #include "GLSLPostProcessor.h"
 
 #include "eiff/ChunkContainer.h"
-#include "eiff/DictionaryGlslChunk.h"
+#include "eiff/DictionaryTextChunk.h"
 #include "eiff/DictionarySpirvChunk.h"
-#include "eiff/MaterialGlslChunk.h"
+#include "eiff/MaterialTextChunk.h"
 #include "eiff/MaterialSpirvChunk.h"
 #include "eiff/SimpleFieldChunk.h"
 
@@ -54,7 +54,7 @@ Package PostprocessMaterialBuilder::build() {
     SimpleFieldChunk<uint32_t> version(ChunkType::PostProcessVersion,1);
     container.addChild(&version);
 
-    std::vector<GlslEntry> glslEntries;
+    std::vector<TextEntry> glslEntries;
     std::vector<SpirvEntry> spirvEntries;
     LineDictionary glslDictionary;
     BlobDictionary spirvDictionary;
@@ -73,7 +73,7 @@ Package PostprocessMaterialBuilder::build() {
         const TargetApi codeGenTargetApi = params.codeGenTargetApi;
         std::vector<uint32_t>* pSpirv = (targetApi == TargetApi::VULKAN) ? &spirv : nullptr;
 
-        GlslEntry glslEntry;
+        TextEntry glslEntry;
         SpirvEntry spirvEntry;
 
         glslEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
@@ -144,8 +144,8 @@ Package PostprocessMaterialBuilder::build() {
     }
 
     // Emit GLSL chunks
-    DictionaryGlslChunk dicGlslChunk(glslDictionary);
-    MaterialGlslChunk glslChunk(glslEntries, glslDictionary);
+    DictionaryTextChunk dicGlslChunk(glslDictionary);
+    MaterialTextChunk glslChunk(glslEntries, glslDictionary);
     if (!glslEntries.empty()) {
         container.addChild(&dicGlslChunk);
         container.addChild(&glslChunk);
@@ -167,7 +167,7 @@ Package PostprocessMaterialBuilder::build() {
     package.setValid(!errorOccured);
 
     // Free all shaders that were created earlier.
-    for (GlslEntry entry : glslEntries) {
+    for (TextEntry entry : glslEntries) {
         free(entry.shader);
     }
     return package;

--- a/libs/filamat/src/eiff/DictionaryTextChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.cpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include "DictionaryGlslChunk.h"
+#include "DictionaryTextChunk.h"
 
 namespace filamat {
 
-DictionaryGlslChunk::DictionaryGlslChunk(LineDictionary& dictionary) :
+DictionaryTextChunk::DictionaryTextChunk(LineDictionary& dictionary) :
         Chunk(ChunkType::DictionaryGlsl), mDictionary(dictionary){
 }
 
-void DictionaryGlslChunk::flatten(Flattener& f) {
+void DictionaryTextChunk::flatten(Flattener& f) {
     // NumStrings
     f.writeUint32(mDictionary.getLineCount());
 

--- a/libs/filamat/src/eiff/DictionaryTextChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.cpp
@@ -18,8 +18,8 @@
 
 namespace filamat {
 
-DictionaryTextChunk::DictionaryTextChunk(LineDictionary& dictionary) :
-        Chunk(ChunkType::DictionaryGlsl), mDictionary(dictionary){
+DictionaryTextChunk::DictionaryTextChunk(LineDictionary& dictionary, ChunkType chunkType) :
+        Chunk(chunkType), mDictionary(dictionary) {
 }
 
 void DictionaryTextChunk::flatten(Flattener& f) {

--- a/libs/filamat/src/eiff/DictionaryTextChunk.h
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.h
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMAT_MATERIAL_GLSL_CHUNK_H
-#define TNT_FILAMAT_MATERIAL_GLSL_CHUNK_H
+#ifndef TNT_FILAMAT_DIC_TEXT_CHUNK_H
+#define TNT_FILAMAT_DIC_TEXT_CHUNK_H
 
+#include <stdint.h>
 #include <vector>
 
 #include "Chunk.h"
-#include "GlslChunk.h"
+#include "Flattener.h"
 #include "LineDictionary.h"
-#include "ShaderEntry.h"
 
 namespace filamat {
 
-class MaterialGlslChunk final : public GlslChunk<GlslEntry> {
+class DictionaryTextChunk : public Chunk {
 public:
-    MaterialGlslChunk(const std::vector<GlslEntry> &entries, LineDictionary &dictionary);
-    ~MaterialGlslChunk() = default;
-protected:
-    virtual const char* getShaderText(size_t entryIndex) const override;
-    virtual void writeEntryAttributes(size_t entryIndex, Flattener& f) override;
+    DictionaryTextChunk(LineDictionary& dictionary);
+    ~DictionaryTextChunk() = default;
+    virtual void flatten(Flattener& f);
+private:
+    LineDictionary& mDictionary;
 };
 
 } // namespace filamat
-#endif // TNT_FILAMAT_GLSL_CHUNK_H
+
+#endif // TNT_FILAMAT_DIC_TEXT_CHUNK_H

--- a/libs/filamat/src/eiff/DictionaryTextChunk.h
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.h
@@ -28,7 +28,7 @@ namespace filamat {
 
 class DictionaryTextChunk : public Chunk {
 public:
-    DictionaryTextChunk(LineDictionary& dictionary);
+    DictionaryTextChunk(LineDictionary& dictionary, ChunkType chunkType);
     ~DictionaryTextChunk() = default;
     virtual void flatten(Flattener& f);
 private:

--- a/libs/filamat/src/eiff/MaterialTextChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialTextChunk.cpp
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-#include "MaterialGlslChunk.h"
+#include "MaterialTextChunk.h"
 
 namespace filamat {
 
-MaterialGlslChunk::MaterialGlslChunk(const std::vector<GlslEntry> &entries,
+MaterialTextChunk::MaterialTextChunk(const std::vector<TextEntry> &entries,
                                      LineDictionary &dictionary) :
-    GlslChunk(ChunkType::MaterialGlsl, entries, dictionary) {
+    TextChunk(ChunkType::MaterialGlsl, entries, dictionary) {
 }
 
-void MaterialGlslChunk::writeEntryAttributes(size_t entryIndex, Flattener& f) {
-    const GlslEntry& entry = mEntries[entryIndex];
+void MaterialTextChunk::writeEntryAttributes(size_t entryIndex, Flattener& f) {
+    const TextEntry& entry = mEntries[entryIndex];
     f.writeUint8(entry.shaderModel);
     f.writeUint8(entry.variant);
     f.writeUint8(entry.stage);
 }
 
-const char* MaterialGlslChunk::getShaderText(size_t entryIndex) const {
+const char* MaterialTextChunk::getShaderText(size_t entryIndex) const {
     return mEntries[entryIndex].shader;
 }
 

--- a/libs/filamat/src/eiff/MaterialTextChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialTextChunk.cpp
@@ -19,8 +19,8 @@
 namespace filamat {
 
 MaterialTextChunk::MaterialTextChunk(const std::vector<TextEntry> &entries,
-                                     LineDictionary &dictionary) :
-    TextChunk(ChunkType::MaterialGlsl, entries, dictionary) {
+        LineDictionary &dictionary, ChunkType chunkType) :
+    TextChunk(chunkType, entries, dictionary) {
 }
 
 void MaterialTextChunk::writeEntryAttributes(size_t entryIndex, Flattener& f) {

--- a/libs/filamat/src/eiff/MaterialTextChunk.h
+++ b/libs/filamat/src/eiff/MaterialTextChunk.h
@@ -28,7 +28,8 @@ namespace filamat {
 
 class MaterialTextChunk final : public TextChunk<TextEntry> {
 public:
-    MaterialTextChunk(const std::vector<TextEntry> &entries, LineDictionary &dictionary);
+    MaterialTextChunk(const std::vector<TextEntry> &entries, LineDictionary &dictionary,
+            ChunkType chunkType);
     ~MaterialTextChunk() = default;
 protected:
     virtual const char* getShaderText(size_t entryIndex) const override;

--- a/libs/filamat/src/eiff/MaterialTextChunk.h
+++ b/libs/filamat/src/eiff/MaterialTextChunk.h
@@ -14,27 +14,26 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMAT_DIC_GLSL_CHUNK_H
-#define TNT_FILAMAT_DIC_GLSL_CHUNK_H
+#ifndef TNT_FILAMAT_MATERIAL_TEXT_CHUNK_H
+#define TNT_FILAMAT_MATERIAL_TEXT_CHUNK_H
 
-#include <stdint.h>
 #include <vector>
 
 #include "Chunk.h"
-#include "Flattener.h"
+#include "TextChunk.h"
 #include "LineDictionary.h"
+#include "ShaderEntry.h"
 
 namespace filamat {
 
-class DictionaryGlslChunk : public Chunk {
+class MaterialTextChunk final : public TextChunk<TextEntry> {
 public:
-    DictionaryGlslChunk(LineDictionary& dictionary);
-    ~DictionaryGlslChunk() = default;
-    virtual void flatten(Flattener& f);
-private:
-    LineDictionary& mDictionary;
+    MaterialTextChunk(const std::vector<TextEntry> &entries, LineDictionary &dictionary);
+    ~MaterialTextChunk() = default;
+protected:
+    virtual const char* getShaderText(size_t entryIndex) const override;
+    virtual void writeEntryAttributes(size_t entryIndex, Flattener& f) override;
 };
 
 } // namespace filamat
-
-#endif // TNT_FILAMAT_DIC_GLSL_CHUNK_H
+#endif // TNT_FILAMAT_TEXT_CHUNK_H

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -19,7 +19,8 @@
 
 namespace filamat {
 
-struct GlslEntry {
+// TextEntry stores a shader in ASCII text format, like GLSL.
+struct TextEntry {
     uint8_t shaderModel;
     uint8_t variant;
     uint8_t stage;

--- a/libs/filamat/src/eiff/TextChunk.h
+++ b/libs/filamat/src/eiff/TextChunk.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMAT_GLSL_CHUNK_H
-#define TNT_FILAMAT_GLSL_CHUNK_H
+#ifndef TNT_FILAMAT_TEXT_CHUNK_H
+#define TNT_FILAMAT_TEXT_CHUNK_H
 
 #include <vector>
 
@@ -30,11 +30,11 @@ using namespace utils;
 namespace filamat {
 
 template <class T>
-class GlslChunk : public Chunk {
+class TextChunk : public Chunk {
 public:
-    virtual ~GlslChunk() = default;
+    virtual ~TextChunk() = default;
 protected:
-    GlslChunk(ChunkType type, const std::vector<T>& entries, const LineDictionary& dictionary) :
+    TextChunk(ChunkType type, const std::vector<T>& entries, const LineDictionary& dictionary) :
             Chunk(type), mDictionary(dictionary), mEntries(entries) {
 
     }
@@ -132,4 +132,4 @@ protected:
 
 } // namespace filamat
 
-#endif // TNT_FILAMAT_GLSL_CHUNK_H
+#endif // TNT_FILAMAT_TEXT_CHUNK_H


### PR DESCRIPTION
This PR is in preparation for adding the Metal shading language to Filament's material blobs.
Metal shaders will be stored in material blobs in the Metal Shading Language (MSL) which, like GLSL, is an ASCII-based text format.
Because of this, we can reuse a lot of the GLSL logic with name changes for clarity.

1. The first commit renames GLSL-specific chunk files into a more generic "Text" nomenclature:

```
DictionaryGlslChunk.cpp => DictionaryTextChunk.cpp
DictionaryGlslChunk.h   => DictionaryTextChunk.h
MaterialGlslChunk.cpp   => MaterialTextChunk.cpp
MaterialGlslChunk.h     => MaterialTextChunk.h
GlslChunk.h             => TextChunk.h
```

2. The second commit makes `MaterialTextChunk` and `DictionaryTextChunk` more generic, removing from their implementations the hard-coded GLSL `ChunkType`s and instead allowing clients to pass the correct chunk type in the constructor. For example,

```
DictionaryTextChunk dicGlslChunk(glslDictionary);
```

becomes

```
DictionaryTextChunk dicGlslChunk(glslDictionary, ChunkType::DictionaryGlsl);
```
