### PR TITLE
Fixes assertion failure in AtomicFreeList used by Job System Allocator

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -232,9 +232,12 @@ public:
         HeadPtr currentHead = mHead.load();
         while (currentHead.offset >= 0) {
             Node* const next = storage[currentHead.offset].next.load(std::memory_order_relaxed);
-            assert(!next || next >= storage);
             newHead = { next ? int32_t(next - storage) : -1, currentHead.tag + 1 };
             if (mHead.compare_exchange_weak(currentHead, newHead)) {
+                // This assert needs to occur after we have validated that there was no race condition
+                // Otherwise, next might already contain application data, if another thread
+                // raced ahead of us after we loaded mHead, but before we loaded mHead->next.
+                assert(!next || next >= storage);
                 break;
             }
         }
@@ -288,6 +291,10 @@ private:
         std::atomic<Node*> next;
     };
 
+    // This struct is using a 32-bit offset into the arena rather than
+    // a direct pointer, because together with the 32-bit tag, it needs to 
+    // fit into 8 bytes. If it was any larger, it would not be possible to
+    // access it atomically.
     struct alignas(8) HeadPtr {
         int32_t offset;
         uint32_t tag;


### PR DESCRIPTION
I believe this fixes #524, given the following rationale:

The assert on `next` should not occur before `compare_exchange_weak` succeeds, because only that indicates the absence of a race condition.

Between the atomic load of `mHead` and `storage[currentHead.offset].next`, another thread might have already returned the storage pointed at by mHead to a caller, which could have overwritten the memory with it's own data (hence making it moot to assert anything about the value of `next`).

It would also be nice if someone could check if the comments I added are actually correct.

After making this change, I tested both my app and the material_sandbox with 100 monkeys, and both didn't crash anymore.