### PR TITLE
Sort FADE materials with TRANSPARENT materials

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -132,12 +132,23 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     parser->getInterpolation(&mInterpolation);
     parser->getVertexDomain(&mVertexDomain);
     parser->getRequiredAttributes(&mRequiredAttributes);
+
     if (mBlendingMode == BlendingMode::MASKED) {
         parser->getMaskThreshold(&mMaskThreshold);
     }
+
+    // The fade blending mode only affects shading. For proper sorting we need to
+    // treat this blending mode as a regular transparent blending operation.
+    if (UTILS_UNLIKELY(mBlendingMode == BlendingMode::FADE)) {
+        mRenderBlendingMode = BlendingMode::TRANSPARENT;
+    } else {
+        mRenderBlendingMode = mBlendingMode;
+    }
+
     if (mShading == Shading::UNLIT) {
         parser->hasShadowMultiplier(&mHasShadowMultiplier);
     }
+
     mIsVariantLit = mShading != Shading::UNLIT || mHasShadowMultiplier;
 
     // create raster state

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -169,7 +169,7 @@ void RenderPass::setupColorCommand(Command& cmdDraw, bool hasDepthPass,
     uint64_t keyBlending = cmdDraw.key;
     keyBlending &= ~(PASS_MASK | BLENDING_MASK);
     keyBlending |= uint64_t(Pass::BLENDED);
-    keyBlending |= makeField(ma->getBlendingMode(), BLENDING_MASK, BLENDING_SHIFT);
+    keyBlending |= makeField(ma->getRenderBlendingMode(), BLENDING_MASK, BLENDING_SHIFT);
 
     uint64_t keyDraw = cmdDraw.key;
     keyDraw &= ~(PASS_MASK | BLENDING_MASK | MATERIAL_MASK);

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -91,6 +91,7 @@ public:
     Shading getShading() const noexcept { return mShading; }
     Interpolation getInterpolation() const noexcept { return mInterpolation; }
     BlendingMode getBlendingMode() const noexcept { return mBlendingMode; }
+    BlendingMode getRenderBlendingMode() const noexcept { return mRenderBlendingMode; }
     VertexDomain getVertexDomain() const noexcept { return mVertexDomain; }
     CullingMode getCullingMode() const noexcept { return mCullingMode; }
     TransparencyMode getTransparencyMode() const noexcept { return mTransparencyMode; }
@@ -115,17 +116,20 @@ public:
 private:
     // try to order by frequency of use
     mutable std::array<Handle<HwProgram>, VARIANT_COUNT> mCachedPrograms;
+
     Driver::RasterState mRasterState;
-    Shading mShading;
+    BlendingMode mRenderBlendingMode;
+    TransparencyMode mTransparencyMode;
     bool mIsVariantLit;
+    Shading mShading;
+
     BlendingMode mBlendingMode;
     Interpolation mInterpolation;
     VertexDomain mVertexDomain;
-    TransparencyMode mTransparencyMode;
-    AttributeBitset mRequiredAttributes;
-    bool mDoubleSided;
     CullingMode mCullingMode;
+    AttributeBitset mRequiredAttributes;
     float mMaskThreshold;
+    bool mDoubleSided;
     bool mHasShadowMultiplier = false;
     bool mHasCustomDepthShader = false;
     bool mIsDefaultMaterial = false;


### PR DESCRIPTION
FADE is just a variant of TRANSPARENT that only affects shading.
This change introduces the "render blending mode" which is the
blending mode that must be used when generating the render keys.