### PR TITLE
split CommandStream.h and add systrace option

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -127,6 +127,7 @@ set(PRIVATE_HDRS
         src/driver/CircularBuffer.h
         src/driver/CommandBufferQueue.h
         src/driver/CommandStream.h
+        src/driver/CommandStreamDispatcher.h
         src/driver/Driver.h
         src/driver/DriverAPI.inc
         src/driver/DriverApi.h

--- a/filament/src/driver/CommandStream.h
+++ b/filament/src/driver/CommandStream.h
@@ -183,37 +183,6 @@ public:
 
 // ------------------------------------------------------------------------------------------------
 
-template<typename ConcreteDriver>
-class ConcreteDispatcher final : public Dispatcher {
-public:
-    // initialize the dispatch table
-    explicit ConcreteDispatcher(ConcreteDriver* driver) noexcept : Dispatcher() {
-#define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params)
-#define DECL_DRIVER_API(methodName, paramsDecl, params)                 methodName##_ = methodName;
-#define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params) methodName##_ = methodName;
-#include "driver/DriverAPI.inc"
-    }
-private:
-#define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params)
-#define DECL_DRIVER_API(methodName, paramsDecl, params)                                         \
-    static void methodName(Driver& driver, CommandBase* base, intptr_t* next) {                 \
-        using Type = CommandType<decltype(&Driver::methodName)>;                                \
-        using Cmd = typename Type::template Command<&Driver::methodName>;                       \
-        ConcreteDriver& concreteDriver = static_cast<ConcreteDriver&>(driver);                  \
-        Cmd::execute(&ConcreteDriver::methodName, concreteDriver, base, next);                  \
-     }
-#define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params)                         \
-    static void methodName(Driver& driver, CommandBase* base, intptr_t* next) {                 \
-        using Type = CommandType<decltype(&Driver::methodName)>;                                \
-        using Cmd = typename Type::template Command<&Driver::methodName>;                       \
-        ConcreteDriver& concreteDriver = static_cast<ConcreteDriver&>(driver);                  \
-        Cmd::execute(&ConcreteDriver::methodName, concreteDriver, base, next);                  \
-     }
-#include "driver/DriverAPI.inc"
-};
-
-// ------------------------------------------------------------------------------------------------
-
 #ifdef NDEBUG
     #define DEBUG_COMMAND(methodName, params...)
 #else

--- a/filament/src/driver/CommandStreamDispatcher.h
+++ b/filament/src/driver/CommandStreamDispatcher.h
@@ -1,0 +1,82 @@
+#include <utility>
+
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_COMMANDSTREAM_DISPATCHER_H
+#define TNT_FILAMENT_DRIVER_COMMANDSTREAM_DISPATCHER_H
+
+#include "driver/Driver.h"
+#include "driver/CommandStream.h"
+
+#include <utils/compiler.h>
+#include <utils/Systrace.h>
+
+#include <cstddef>
+#include <stdint.h>
+
+
+#define DEBUG_LEVEL_NONE       0
+#define DEBUG_LEVEL_SYSTRACE   1
+
+// set to the desired debug level
+#define DEBUG_LEVEL             DEBUG_LEVEL_NONE
+
+
+#if DEBUG_LEVEL == DEBUG_LEVEL_NONE
+#   define SYSTRACE()
+#elif DEBUG_LEVEL == DEBUG_LEVEL_SYSTRACE
+#   define SYSTRACE() SYSTRACE_CALL();
+#else
+#   error "invalid debug level"
+#endif
+
+namespace filament {
+
+template<typename ConcreteDriver>
+class ConcreteDispatcher final : public Dispatcher {
+public:
+    // initialize the dispatch table
+    explicit ConcreteDispatcher(ConcreteDriver* driver) noexcept : Dispatcher() {
+#define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params)
+#define DECL_DRIVER_API(methodName, paramsDecl, params)                 methodName##_ = methodName;
+#define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params) methodName##_ = methodName;
+#include "driver/DriverAPI.inc"
+    }
+private:
+#define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params)
+#define DECL_DRIVER_API(methodName, paramsDecl, params)                                         \
+    static void methodName(Driver& driver, CommandBase* base, intptr_t* next) {                 \
+        SYSTRACE()                                                                              \
+        using Type = CommandType<decltype(&Driver::methodName)>;                                \
+        using Cmd = typename Type::template Command<&Driver::methodName>;                       \
+        ConcreteDriver& concreteDriver = static_cast<ConcreteDriver&>(driver);                  \
+        Cmd::execute(&ConcreteDriver::methodName, concreteDriver, base, next);                  \
+     }
+#define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params)                         \
+    static void methodName(Driver& driver, CommandBase* base, intptr_t* next) {                 \
+        SYSTRACE()                                                                              \
+        using Type = CommandType<decltype(&Driver::methodName)>;                                \
+        using Cmd = typename Type::template Command<&Driver::methodName>;                       \
+        ConcreteDriver& concreteDriver = static_cast<ConcreteDriver&>(driver);                  \
+        Cmd::execute(&ConcreteDriver::methodName, concreteDriver, base, next);                  \
+     }
+#include "driver/DriverAPI.inc"
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_DRIVER_COMMANDSTREAM_DISPATCHER_H

--- a/filament/src/driver/noop/NoopDriver.cpp
+++ b/filament/src/driver/noop/NoopDriver.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "driver/noop/NoopDriver.h"
-#include "driver/CommandStream.h"
+#include "driver/CommandStreamDispatcher.h"
 
 namespace filament {
 

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -24,7 +24,7 @@
 #include <utils/Systrace.h>
 
 #include "driver/DriverApi.h"
-#include "driver/CommandStream.h"
+#include "driver/CommandStreamDispatcher.h"
 #include "driver/opengl/OpenGLProgram.h"
 #include "driver/opengl/OpenGLBlitter.h"
 
@@ -41,7 +41,6 @@
 
 #define DEBUG_MARKER_NONE       0
 #define DEBUG_MARKER_OPENGL     1
-#define DEBUG_MARKER_SYSTRACE   2
 
 // set to the desired debug marker level
 #define DEBUG_MARKER_LEVEL      DEBUG_MARKER_NONE
@@ -49,9 +48,6 @@
 #if DEBUG_MARKER_LEVEL == DEBUG_MARKER_OPENGL
 #   define DEBUG_MARKER() \
         DebugMarker _debug_marker(*this, __PRETTY_FUNCTION__);
-#elif DEBUG_MARKER_LEVEL == DEBUG_MARKER_SYSTRACE
-#   define DEBUG_MARKER() \
-        SYSTRACE_CALL();
 #else
 #   define DEBUG_MARKER()
 #endif
@@ -2005,9 +2001,6 @@ void OpenGLDriver::beginRenderPass(Driver::RenderTargetHandle rth,
             std::array<GLenum, 3> attachments; // NOLINT(cppcoreguidelines-pro-type-member-init)
             GLsizei attachmentCount = getAttachments(attachments, rt, discardFlags);
             if (attachmentCount) {
-#if DEBUG_MARKER_LEVEL == DEBUG_MARKER_SYSTRACE
-                SYSTRACE_NAME("glInvalidateFramebuffer");
-#endif
                 glInvalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
                 CHECK_GL_ERROR(utils::slog.e)
             }
@@ -2056,9 +2049,6 @@ void OpenGLDriver::endRenderPass(int) {
         std::array<GLenum, 3> attachments; // NOLINT(cppcoreguidelines-pro-type-member-init)
         GLsizei attachmentCount = getAttachments(attachments, rt, discardFlags);
         if (attachmentCount) {
-#if DEBUG_MARKER_LEVEL == DEBUG_MARKER_SYSTRACE
-            SYSTRACE_NAME("glInvalidateFramebuffer");
-#endif
             glInvalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
         }
 

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -16,7 +16,7 @@
 
 #include "driver/vulkan/VulkanDriver.h"
 
-#include "driver/CommandStream.h"
+#include "driver/CommandStreamDispatcher.h"
 
 #include "VulkanBuffer.h"
 #include "VulkanHandles.h"


### PR DESCRIPTION
systrace can now be enabled in the CommandStream's Dispatcher, which
allows it to work with all backends.