### PR TITLE
Deprecate set method on MaterialBuilder

### DIFF
--- a/build/common/test_list.txt
+++ b/build/common/test_list.txt
@@ -3,5 +3,6 @@ filament/test/test_filament_exposure --gtest_filter=-FilamentExposureWithEngineT
 libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils
+libs/filamat/test_filamat
 tools/matc/test_matc
 tools/cmgen/test_cmgen compare

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -120,9 +120,6 @@ public:
     // set the interpolation mode
     MaterialBuilder& interpolation(Interpolation interpolation) noexcept;
 
-    // declares that this property is modified by the material
-    MaterialBuilder& set(Property p) noexcept;
-
     // add a parameter (i.e.: a uniform) to this material
     MaterialBuilder& parameter(UniformType type, const char* name) noexcept;
 
@@ -230,17 +227,17 @@ public:
         bool isSampler;
     };
 
+    using PropertyList = bool[filament::MATERIAL_PROPERTIES_COUNT];
+    using VariableList = utils::CString[filament::MATERIAL_VARIABLES_COUNT];
+
     // Preview the first shader that would generated in the MaterialPackage.
     // This is used to run Static Code Analysis before generating a package.
     // Outputs the chosen shader model in the model parameter
     const std::string peek(filament::driver::ShaderType type,
-            filament::driver::ShaderModel& model) noexcept;
+            filament::driver::ShaderModel& model, const PropertyList& properties) noexcept;
 
     // Returns true if any of the parameter samplers is of type samplerExternal
     bool hasExternalSampler() const noexcept;
-
-    using PropertyList = bool[filament::MATERIAL_PROPERTIES_COUNT];
-    using VariableList = utils::CString[filament::MATERIAL_VARIABLES_COUNT];
 
     static constexpr size_t MAX_PARAMETERS_COUNT = 32;
     using ParameterList = Parameter[MAX_PARAMETERS_COUNT];

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -248,14 +248,14 @@ public:
     // returns a list of at least getParameterCount() parameters
     const ParameterList& getParameters() const noexcept { return mParameters; }
 
-    TargetApi getTargetApi() const { return mTargetApi; }
-
-    Platform getPlatform() const { return mPlatform; }
-
     uint8_t getVariantFilter() const { return mVariantFilter; }
 
 private:
     void prepareToBuild(MaterialInfo& info) noexcept;
+
+    // Return true if:
+    // The shader is syntactically and semantically valid
+    bool runStaticCodeAnalysis() noexcept;
 
     bool isLit() const noexcept { return mShading != filament::Shading::UNLIT; }
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -313,7 +313,6 @@ bool MaterialBuilder::runStaticCodeAnalysis() noexcept {
     shaderCode = peek(ShaderType::FRAGMENT, model, mProperties);
     result = glslTools.analyzeFragmentShader(shaderCode, model, mTargetApi);
     return result;
-
 }
 
 static void showErrorMessage(const char* materialName, uint8_t variant,

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -132,20 +132,6 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel m
     return true;
 }
 
-bool GLSLTools::process(MaterialBuilder& builder,
-        const MaterialBuilder::PropertyList& properties) const noexcept {
-    // At this point the shader is syntactically correct. Perform semantic analysis now.
-    ShaderModel model;
-
-    std::string shaderCode = builder.peek(ShaderType::VERTEX, model, properties);
-    bool result = analyzeVertexShader(shaderCode, model, builder.getTargetApi());
-    if (!result) return result;
-
-    shaderCode = builder.peek(ShaderType::FRAGMENT, model, properties);
-    result = analyzeFragmentShader(shaderCode, model, builder.getTargetApi());
-    return result;
-}
-
 void GLSLTools::init() {
     // According to glslang, InitializeProcess should be called exactly once per process.
     static bool initializeCalled = false;
@@ -156,7 +142,8 @@ void GLSLTools::init() {
 }
 
 bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn,
-        MaterialBuilder::PropertyList& properties) const noexcept {
+        MaterialBuilder::PropertyList& properties,
+        MaterialBuilder::TargetApi targetApi) const noexcept {
     filamat::MaterialBuilder builder(builderIn);
 
     // Some fields in MaterialInputs only exist if the property is set (e.g: normal, subsurface
@@ -174,7 +161,7 @@ bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn,
 
     GLSLangCleaner cleaner;
     int version = glslangVersionFromShaderModel(model);
-    EShMessages msg = glslangFlagsFromTargetApi(builderIn.getTargetApi());
+    EShMessages msg = glslangFlagsFromTargetApi(targetApi);
     const TBuiltInResource* builtins = &DefaultTBuiltInResource;
     bool ok = tShader.parse(builtins, version, false, msg);
     if (!ok) {

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -123,9 +123,6 @@ public:
             filament::driver::ShaderModel model,
             filamat::MaterialBuilder::TargetApi targetApi) const noexcept;
 
-    // Return true if:
-    // The shader is syntactically and semantically valid AND
-    // The shader features a materialVertex( function
     bool analyzeVertexShader(const std::string& shaderCode,
             filament::driver::ShaderModel model,
             filamat::MaterialBuilder::TargetApi targetApi) const noexcept;
@@ -140,7 +137,8 @@ public:
     // Use static code analysis on the fragment shader AST to guess properties used in user provided
     // glgl code. Populate properties accordingly.
     bool findProperties(const filamat::MaterialBuilder& builder,
-            MaterialBuilder::PropertyList& properties) const noexcept;
+            MaterialBuilder::PropertyList& properties,
+            MaterialBuilder::TargetApi targetApi) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::driver::ShaderModel model);
 

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -113,7 +113,6 @@ private:
 class GLSLTools {
 public:
     static void init();
-    static void terminate();
 
     // Return true if:
     // The shader is syntactically and semantically valid AND
@@ -133,15 +132,15 @@ public:
 
     // Analyze the first fragment shader the builder will construct and guess properties used (the
     // builder is modified accordingly). Return true if all operation succeeded.
-    bool process(filamat::MaterialBuilder& builder) const noexcept;
+    bool process(filamat::MaterialBuilder& builder,
+            const MaterialBuilder::PropertyList& properties) const noexcept;
 
     // Public for unit tests.
     using Property = filamat::MaterialBuilder::Property;
-    using PropertySet = std::set<Property>;
     // Use static code analysis on the fragment shader AST to guess properties used in user provided
     // glgl code. Populate properties accordingly.
     bool findProperties(const filamat::MaterialBuilder& builder,
-            PropertySet& properties) const noexcept;
+            MaterialBuilder::PropertyList& properties) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::driver::ShaderModel model);
 
@@ -166,12 +165,12 @@ private:
     // findPropertyWritesOperations("material", 0, ...);
     // Does nothing if the parameter is not marked as OUT or INOUT
     bool findPropertyWritesOperations(const std::string& functionName, size_t parameterIdx,
-            TIntermNode* rootNode, PropertySet& properties) const noexcept;
+            TIntermNode* rootNode, MaterialBuilder::PropertyList& properties) const noexcept;
 
     // Look at a symbol access and find out if it affects filament MaterialInput fields. Will follow
     // function calls if necessary.
-    void scanSymbolForProperty(Symbol& symbol, TIntermNode* rootNode, PropertySet& properties)
-            const noexcept;
+    void scanSymbolForProperty(Symbol& symbol, TIntermNode* rootNode,
+            MaterialBuilder::PropertyList& properties) const noexcept;
 
 };
 

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -138,7 +138,7 @@ public:
     // glgl code. Populate properties accordingly.
     bool findProperties(const filamat::MaterialBuilder& builder,
             MaterialBuilder::PropertyList& properties,
-            MaterialBuilder::TargetApi targetApi) const noexcept;
+            MaterialBuilder::TargetApi targetApi = MaterialBuilder::TargetApi::OPENGL) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::driver::ShaderModel model);
 

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -18,7 +18,21 @@
 
 #include "sca/ASTHelpers.h"
 
+#include <filamat/Enums.h>
+
 using namespace ASTUtils;
+
+static ::testing::AssertionResult PropertyListsMatch(const MaterialBuilder::PropertyList& expected,
+        const MaterialBuilder::PropertyList& actual) {
+    for (size_t i = 0; i < filament::MATERIAL_PROPERTIES_COUNT; i++) {
+        if (expected[i] != actual[i]) {
+            const auto& str = Enums::toString<Property>(Property(i));
+            return ::testing::AssertionFailure() << "actual[" << str << "] (" << actual[i] <<
+            ") != expected[" << str << "] (" << expected[i] << ")";
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
 
 filamat::MaterialBuilder makeBuilder(const std::string shaderCode) {
     filamat::MaterialBuilder builder;
@@ -48,10 +62,6 @@ protected:
     virtual void SetUp() {
         GLSLTools::init();
     }
-
-    virtual void TearDown() {
-        GLSLTools::terminate();
-    }
 };
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerNothingDetected) {
@@ -63,10 +73,10 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerNothingDetected) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerNotFollowingINParameters) {
@@ -82,10 +92,10 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerNotFollowingINParameters) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerDirectAssign) {
@@ -98,11 +108,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerDirectAssign) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 
@@ -116,11 +126,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerDirectAssignWithSwizzling) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolAsOutParameterWithAliasing) {
@@ -138,11 +148,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolAsOutParameterWithAliasing) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolAsOutParameterWithAliasingAndSwizzling) {
@@ -160,11 +170,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolAsOutParameterWithAliasingAndSw
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolInOutInChainWithDirectIndexIntoStruct) {
@@ -187,11 +197,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolInOutInChainWithDirectIndexInto
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolInOutInChain) {
@@ -214,11 +224,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSymbolInOutInChain) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
 // Tests all attributes in Property type.
@@ -232,11 +242,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerBaseColor) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::BASE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerRoughness) {
     std::string shaderCode(R"(
@@ -248,11 +258,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerRoughness) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::ROUGHNESS);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::ROUGHNESS)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerMetallic) {
     std::string shaderCode(R"(
@@ -264,11 +274,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerMetallic) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::METALLIC);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::METALLIC)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerReflectance) {
     std::string shaderCode(R"(
@@ -280,11 +290,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerReflectance) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::REFLECTANCE);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::REFLECTANCE)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerAmbientOcclusion) {
     std::string shaderCode(R"(
@@ -296,11 +306,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerAmbientOcclusion) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::AMBIENT_OCCLUSION);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::AMBIENT_OCCLUSION)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoat) {
     std::string shaderCode(R"(
@@ -313,11 +323,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoat) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::LIT);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::CLEAR_COAT);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::CLEAR_COAT)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoatRoughness) {
     std::string shaderCode(R"(
@@ -330,11 +340,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoatRoughness) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::LIT);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::CLEAR_COAT_ROUGHNESS);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::CLEAR_COAT_ROUGHNESS)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoatNormal) {
     std::string shaderCode(R"(
@@ -347,11 +357,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerClearCoatNormal) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::LIT);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::CLEAR_COAT_NORMAL);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::CLEAR_COAT_NORMAL)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerThickness) {
     std::string shaderCode(R"(
@@ -364,11 +374,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerThickness) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::SUBSURFACE);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::THICKNESS);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::THICKNESS)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSubsurfacePower) {
     std::string shaderCode(R"(
@@ -381,11 +391,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSubsurfacePower) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::SUBSURFACE);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::SUBSURFACE_POWER);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::SUBSURFACE_POWER)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSubsurfaceColor) {
     std::string shaderCode(R"(
@@ -398,11 +408,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSubsurfaceColor) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::SUBSURFACE);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::SUBSURFACE_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::SUBSURFACE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerAnisotropicDirection) {
     std::string shaderCode(R"(
@@ -415,11 +425,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerAnisotropicDirection) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::LIT);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::ANISOTROPY_DIRECTION);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::ANISOTROPY_DIRECTION)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerAnisotropic) {
     std::string shaderCode(R"(
@@ -432,11 +442,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerAnisotropic) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::LIT);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::ANISOTROPY);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::ANISOTROPY)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerSheenColor) {
     std::string shaderCode(R"(
@@ -449,11 +459,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerSheenColor) {
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     builder.shading(filamat::MaterialBuilder::Shading::CLOTH);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::SHEEN_COLOR);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::SHEEN_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, StaticCodeAnalyzerNormal) {
     std::string shaderCode(R"(
@@ -465,11 +475,11 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerNormal) {
 
     filamat::MaterialBuilder builder = makeBuilder(shaderCode);
     GLSLTools glslTools;
-    GLSLTools::PropertySet properties;
+    MaterialBuilder::PropertyList properties {false};
     glslTools.findProperties(builder, properties);
-    GLSLTools::PropertySet expected;
-    expected.insert(filamat::MaterialBuilder::Property::NORMAL);
-    EXPECT_EQ(expected, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::NORMAL)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 TEST_F(MaterialCompiler, EmptyName) {
     std::string shaderCode(R"(

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -26,9 +26,10 @@ static ::testing::AssertionResult PropertyListsMatch(const MaterialBuilder::Prop
         const MaterialBuilder::PropertyList& actual) {
     for (size_t i = 0; i < filament::MATERIAL_PROPERTIES_COUNT; i++) {
         if (expected[i] != actual[i]) {
-            const auto& str = Enums::toString<Property>(Property(i));
-            return ::testing::AssertionFailure() << "actual[" << str << "] (" << actual[i] <<
-            ") != expected[" << str << "] (" << expected[i] << ")";
+            const auto& propString = Enums::toString<Property>(Property(i));
+            return ::testing::AssertionFailure()
+                    << "actual[" << propString << "] (" << actual[i]
+                    << ") != expected[" << propString << "] (" << expected[i] << ")";
         }
     }
     return ::testing::AssertionSuccess();

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -181,10 +181,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
-            .set(Property::NORMAL)
-            .set(Property::BASE_COLOR)
-            .set(Property::SHEEN_COLOR)
-            .set(Property::ROUGHNESS)
             .require(VertexAttribute::UV0)
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "normalMap")
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "basecolorMap")

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -282,19 +282,9 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
-            .set(Property::BASE_COLOR)
-            .set(Property::METALLIC)
-            .set(Property::ROUGHNESS)
-            .set(Property::AMBIENT_OCCLUSION)
             .material(shader.c_str())
             .shading(Shading::LIT);
 
-    if (g_pbrConfig.clearCoat) {
-        builder.set(Property::CLEAR_COAT);
-    }
-    if (g_pbrConfig.anisotropy) {
-        builder.set(Property::ANISOTROPY);
-    }
     if (hasBaseColorMap) {
         builder
             .require(VertexAttribute::UV0)
@@ -317,7 +307,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     }
     if (hasNormalMap) {
         builder
-            .set(Property::NORMAL)
             .require(VertexAttribute::UV0)
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "normalMap");
     }

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -261,25 +261,19 @@ static void setup(Engine* engine, View*, Scene* scene) {
 
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
-            .set(Property::BASE_COLOR)
-            .set(Property::METALLIC)
-            .set(Property::ROUGHNESS)
             .material(shader.c_str())
             .shading(Shading::LIT);
 
     if (hasNormalMap) {
         builder
             .require(VertexAttribute::UV0)
-            .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "normalMap")
-            .set(Property::NORMAL);
+            .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "normalMap");
     }
 
     if (hasClearCoatNormalMap) {
         builder
             .require(VertexAttribute::UV0)
-            .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "clearCoatNormalMap")
-            .set(Property::CLEAR_COAT)
-            .set(Property::CLEAR_COAT_NORMAL);
+            .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "clearCoatNormalMap");
     }
 
     if (hasBaseColorMap) {

--- a/samples/sample_opacity_mask.cpp
+++ b/samples/sample_opacity_mask.cpp
@@ -197,9 +197,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             .name("DefaultMaterial")
             .require(VertexAttribute::UV0)
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "opacityMaskMap")
-            .set(Property::BASE_COLOR)
-            .set(Property::METALLIC)
-            .set(Property::ROUGHNESS)
             .material(R"SHADER(
                 void material(inout MaterialInputs material) {
                     prepareMaterial(material);

--- a/samples/sample_pbr.cpp
+++ b/samples/sample_pbr.cpp
@@ -219,9 +219,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
-            .set(Property::BASE_COLOR)
-            .set(Property::METALLIC)
-            .set(Property::ROUGHNESS)
             .material(shader.c_str())
             .shading(Shading::LIT);
 

--- a/samples/sample_position_offset.cpp
+++ b/samples/sample_position_offset.cpp
@@ -129,8 +129,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     Package pkg = MaterialBuilder()
             .name("PositionOffset")
-            .set(Property::BASE_COLOR)
-            .set(Property::ROUGHNESS)
             .material(R"SHADER(
                 void material(inout MaterialInputs material) {
                     prepareMaterial(material);

--- a/samples/sample_subsurface.cpp
+++ b/samples/sample_subsurface.cpp
@@ -182,10 +182,6 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
-            .set(Property::NORMAL)
-            .set(Property::BASE_COLOR)
-            .set(Property::ROUGHNESS)
-            .set(Property::THICKNESS)
             .require(VertexAttribute::UV0)
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "normalMap")
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "basecolorMap")

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -31,7 +31,6 @@ namespace matc {
 
 static constexpr const char* PARAM_KEY_NAME              = "name";
 static constexpr const char* PARAM_KEY_INTERPOLATION     = "interpolation";
-static constexpr const char* PARAM_KEY_DEFINES           = "defines";
 static constexpr const char* PARAM_KEY_PARAMETERS        = "parameters";
 static constexpr const char* PARAM_KEY_VARIABLES         = "variables";
 static constexpr const char* PARAM_KEY_REQUIRES          = "requires";
@@ -51,7 +50,6 @@ static constexpr const char* PARAM_KEY_VARIANT_FILTER    = "variantFilter";
 ParametersProcessor::ParametersProcessor() {
     mConfigProcessor[PARAM_KEY_NAME]              = &ParametersProcessor::processName;
     mConfigProcessor[PARAM_KEY_INTERPOLATION]     = &ParametersProcessor::processInterpolation;
-    mConfigProcessor[PARAM_KEY_DEFINES]           = &ParametersProcessor::processDefines;
     mConfigProcessor[PARAM_KEY_PARAMETERS]        = &ParametersProcessor::processParameters;
     mConfigProcessor[PARAM_KEY_VARIABLES]         = &ParametersProcessor::processVariables;
     mConfigProcessor[PARAM_KEY_REQUIRES]          = &ParametersProcessor::processRequires;
@@ -70,7 +68,6 @@ ParametersProcessor::ParametersProcessor() {
 
     mRootAsserts[PARAM_KEY_NAME]              = JsonishValue::Type::STRING;
     mRootAsserts[PARAM_KEY_INTERPOLATION]     = JsonishValue::Type::STRING;
-    mRootAsserts[PARAM_KEY_DEFINES]           = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_PARAMETERS]        = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_VARIABLES]         = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_REQUIRES]          = JsonishValue::Type::ARRAY;
@@ -167,25 +164,6 @@ bool ParametersProcessor::processInterpolation(filamat::MaterialBuilder& builder
     }
 
     builder.interpolation(stringToEnum(mStringToInterpolation, interpolationString->getString()));
-    return true;
-}
-
-bool ParametersProcessor::processDefines(filamat::MaterialBuilder& builder,
-        const JsonishValue& value) {
-    auto jsonArray = value.toJsonArray();
-    for (auto v : jsonArray->getElements()) {
-        if (v->getType() != JsonishValue::Type::STRING) {
-            std::cerr << PARAM_KEY_DEFINES << " array values must be STRING." << std::endl;
-            return false;
-        }
-
-        auto jsonString = v->toJsonString();
-        if (!Enums::isValid<Property>(jsonString->getString())) {
-            return logEnumIssue(PARAM_KEY_DEFINES, *jsonString, Enums::map<Property>());
-        }
-        builder.set(Enums::toEnum<Property>(jsonString->getString()));
-    }
-
     return true;
 }
 


### PR DESCRIPTION
The `set()` method is no longer needed on `MaterialBuilder`, as static code analysis will be performed automatically. Likewise, this PR deprecates the "defines" field on material definitions, which is no longer useful to clients.