### PR TITLE
Fix matc crash for empty material function

### DIFF
--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -217,7 +217,7 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
     std::vector<FunctionParameter> functionMaterialParameters;
     ASTUtils::getFunctionParameters(functionMaterialDef, functionMaterialParameters);
 
-    if (functionMaterialParameters.size() < parameterIdx) {
+    if (functionMaterialParameters.size() <= parameterIdx) {
         std::cerr << "Unable to find function '" << functionName <<  "' parameterIndex: " <<
                 parameterIdx << std::endl;
         return false;


### PR DESCRIPTION
`matc` crashes when encountering the following material function:

```
fragment {
    void material(inout MaterialInputs material) {
    }
}
```
```
libc++abi.dylib: terminating with uncaught exception of type std::out_of_range: vector
```

This fixes the crash and lets matc exit gracefully, albeit with an error code.
