### PR TITLE
Remove use of iostream in filamat

### DIFF
--- a/libs/filamat/src/sca/ASTHelpers.cpp
+++ b/libs/filamat/src/sca/ASTHelpers.cpp
@@ -18,10 +18,11 @@
 
 #include "GLSLTools.h"
 
-#include <iostream>
-
 #include <intermediate.h>
 #include <localintermediate.h>
+
+#include <utils/Log.h>
+
 using namespace glslang;
 
 namespace ASTUtils {
@@ -232,67 +233,67 @@ public:
 
     void pad() {
        for (int i = 0; i < depth; ++i) {
-           std::cerr << "    ";
+           utils::slog.e << "    ";
        }
     }
 
     bool visitBinary(TVisit, TIntermBinary* node) override {
         pad();
-        std::cerr << "Binary " << op2Str(node->getOp());
-        std::cerr << std::endl;
+        utils::slog.e << "Binary " << op2Str(node->getOp());
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     bool visitUnary(TVisit, TIntermUnary* node) override {
         pad();
-        std::cerr << "Unary" << op2Str(node->getOp());
-        std::cerr << std::endl;
+        utils::slog.e << "Unary" << op2Str(node->getOp());
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     bool visitAggregate(TVisit, TIntermAggregate* node) override {
         pad();
-        std::cerr << "Aggregate" << op2Str(node->getOp());
-        std::cerr << std::endl;
+        utils::slog.e << "Aggregate" << op2Str(node->getOp());
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     bool visitSelection(TVisit, TIntermSelection* node) override {
         pad();
-        std::cerr << "Selection";
-        std::cerr << std::endl;
+        utils::slog.e << "Selection";
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     void visitConstantUnion(TIntermConstantUnion* node) override {
         pad();
-        std::cerr << "ConstantUnion";
-        std::cerr << std::endl;
+        utils::slog.e << "ConstantUnion";
+        utils::slog.e << utils::io::endl;
     }
 
     void visitSymbol(TIntermSymbol* node) override {
         pad();
-        std::cerr << "Symbol " << node->getAsSymbolNode()->getName().c_str();
-        std::cerr << std::endl;
+        utils::slog.e << "Symbol " << node->getAsSymbolNode()->getName().c_str();
+        utils::slog.e << utils::io::endl;
     }
 
     bool visitLoop(TVisit, TIntermLoop* node) override {
         pad();
-        std::cerr << "Loop";
-        std::cerr << std::endl;
+        utils::slog.e << "Loop";
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     bool visitBranch(TVisit, TIntermBranch* node) override {
         pad();
-        std::cerr << "Branch";
-        std::cerr << std::endl;
+        utils::slog.e << "Branch";
+        utils::slog.e << utils::io::endl;
         return true;
     }
 
     bool visitSwitch(TVisit, TIntermSwitch* node) override {
-        std::cerr << "Binary ";
-        std::cerr << std::endl;
+        utils::slog.e << "Binary ";
+        utils::slog.e << utils::io::endl;
         return true;
     }
 };

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -66,8 +66,8 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
     EShMessages msg = glslangFlagsFromTargetApi(targetApi);
     bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
     if (!ok) {
-        std::cerr << "ERROR: Unable to parse fragment shader:" << std::endl;
-        std::cerr << tShader.getInfoLog() << std::flush;
+        utils::slog.e << "ERROR: Unable to parse fragment shader:" << utils::io::endl;
+        utils::slog.e << tShader.getInfoLog() << utils::io::flush;
         return false;
     }
 
@@ -75,8 +75,8 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
     // Check there is a material function definition in this shader.
     TIntermNode* materialFctNode = ASTUtils::getFunctionByNameOnly("material", *root);
     if (materialFctNode == nullptr) {
-        std::cerr << "ERROR: Invalid fragment shader:" << std::endl;
-        std::cerr << "ERROR: Unable to find material() function" << std::endl;
+        utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
+        utils::slog.e << "ERROR: Unable to find material() function" << utils::io::endl;
         return false;
     }
 
@@ -84,8 +84,8 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
     TIntermAggregate* prepareMaterialNode = ASTUtils::getFunctionByNameOnly("prepareMaterial",
             *root);
     if (prepareMaterialNode == nullptr) {
-        std::cerr << "ERROR: Invalid fragment shader:" << std::endl;
-        std::cerr << "ERROR: Unable to find prepareMaterial() function" << std::endl;
+        utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
+        utils::slog.e << "ERROR: Unable to find prepareMaterial() function" << utils::io::endl;
         return false;
     }
 
@@ -93,8 +93,8 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
     bool prepareMaterialCalled = isFunctionCalled(prepareMaterialSignature,
             *materialFctNode, *root);
     if (!prepareMaterialCalled) {
-        std::cerr << "ERROR: Invalid fragment shader:" << std::endl;
-        std::cerr << "ERROR: prepareMaterial() is not called" << std::endl;
+        utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
+        utils::slog.e << "ERROR: prepareMaterial() is not called" << utils::io::endl;
         return false;
     }
 
@@ -115,8 +115,8 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel m
     EShMessages msg = glslangFlagsFromTargetApi(targetApi);
     bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
     if (!ok) {
-        std::cerr << "ERROR: Unable to parse vertex shader" << std::endl;
-        std::cerr << tShader.getInfoLog() << std::flush;
+        utils::slog.e << "ERROR: Unable to parse vertex shader" << utils::io::endl;
+        utils::slog.e << tShader.getInfoLog() << utils::io::flush;
         return false;
     }
 
@@ -124,8 +124,8 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel m
     // Check there is a material function definition in this shader.
     TIntermNode* materialFctNode = ASTUtils::getFunctionByNameOnly("materialVertex", *root);
     if (materialFctNode == nullptr) {
-        std::cerr << "ERROR: Invalid vertex shader" << std::endl;
-        std::cerr << "ERROR: Unable to find materialVertex() function" << std::endl;
+        utils::slog.e << "ERROR: Invalid vertex shader" << utils::io::endl;
+        utils::slog.e << "ERROR: Unable to find materialVertex() function" << utils::io::endl;
         return false;
     }
 
@@ -193,7 +193,7 @@ bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn, Proper
     if (!ok) {
         // Even with all properties set the shader doesn't build. This is likely a syntax error
         // with user provided code.
-        std::cerr << tShader.getInfoLog() << std::endl;
+        utils::slog.e << tShader.getInfoLog() << utils::io::endl;
         return false;
     }
 
@@ -210,7 +210,8 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
     glslang::TIntermAggregate* functionMaterialDef =
             ASTUtils::getFunctionBySignature(functionName, *rootNode);
     if (functionMaterialDef == nullptr) {
-        std::cerr << "Unable to find function '" << functionName << "' definition." << std::endl;
+        utils::slog.e << "Unable to find function '" << functionName << "' definition."
+                << utils::io::endl;
         return false;
     }
 
@@ -218,8 +219,8 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
     ASTUtils::getFunctionParameters(functionMaterialDef, functionMaterialParameters);
 
     if (functionMaterialParameters.size() <= parameterIdx) {
-        std::cerr << "Unable to find function '" << functionName <<  "' parameterIndex: " <<
-                parameterIdx << std::endl;
+        utils::slog.e << "Unable to find function '" << functionName <<  "' parameterIndex: " <<
+                parameterIdx << utils::io::endl;
         return false;
     }
 
@@ -233,7 +234,8 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
     std::deque<Symbol> symbols;
     bool ok = findSymbolsUsage(functionName, *rootNode, symbols);
     if (!ok) {
-        std::cerr << "Unable to trace usage of symbols in function '" << functionName << std::endl;
+        utils::slog.e << "Unable to trace usage of symbols in function '" << functionName
+                << utils::io::endl;
         return false;
     }
 

--- a/libs/utils/include/utils/Log.h
+++ b/libs/utils/include/utils/Log.h
@@ -86,6 +86,7 @@ private:
     friend ostream& hex(ostream& s) noexcept;
     friend ostream& dec(ostream& s) noexcept;
     friend ostream& endl(ostream& s) noexcept;
+    friend ostream& flush(ostream& s) noexcept;
 
     enum type {
         SHORT, USHORT, INT, UINT, LONG, ULONG, LONG_LONG, ULONG_LONG, DOUBLE, LONG_DOUBLE
@@ -132,6 +133,7 @@ inline ostream& operator<<(ostream& stream, const VECTOR<T>& v) {
 inline ostream& hex(ostream& s) noexcept { return s.hex(); }
 inline ostream& dec(ostream& s) noexcept { return s.dec(); }
 inline ostream& endl(ostream& s) noexcept { s << "\n"; return s.flush(); }
+inline ostream& flush(ostream& s) noexcept { return s.flush(); }
 
 #else  // UTILS_TINY_IO
 
@@ -139,6 +141,7 @@ using ostream = std::ostream;
 inline ostream& hex(ostream& s) noexcept { return s << std::hex; }
 inline ostream& dec(ostream& s) noexcept { return s << std::dec; }
 inline ostream& endl(ostream& s) noexcept { return s << std::endl; }
+inline ostream& flush(ostream& s) noexcept { return s << std::flush; }
 
 #endif // UTILS_TINY_IO
 } // namespace io


### PR DESCRIPTION
Use `utils::slog` instead of `iostream` in `filamat`.

`matc` Binary size difference:
```
Before: 5790796
After:  5786756
===============
Diff:      4040
```
