### PR TITLE
Add the ability to build several platforms, but not all

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,8 @@ function print_help {
     echo "        Do not compile desktop Java projects"
     echo "    -m"
     echo "        Compile with make instead of ninja."
-    echo "    -p [desktop|android|ios|webgl|all]"
+    echo "    -p platform1,platform2,..."
+    echo "        Where platformN is [desktop|android|ios|webgl|all]."
     echo "        Platform(s) to build, defaults to desktop."
     echo "        Building for Android or iOS will automatically generate / download"
     echo "        the toolchains if needed and perform a partial desktop build."
@@ -52,12 +53,19 @@ function print_help {
     echo "Examples:"
     echo "    Desktop release build:"
     echo "        \$ ./$SELF_NAME release"
+    echo ""
     echo "    Desktop debug and release builds:"
     echo "        \$ ./$SELF_NAME debug release"
+    echo ""
     echo "    Clean, desktop debug build and create archive of build artifacts:"
     echo "        \$ ./$SELF_NAME -c -a debug"
+    echo ""
     echo "    Android release build type:"
     echo "        \$ ./$SELF_NAME -p android release"
+    echo ""
+    echo "    Desktop and Android release builds, with installation:"
+    echo "        \$ ./$SELF_NAME -p desktop,android -i release"
+    echo ""
     echo "    Desktop matc target, release build:"
     echo "        \$ ./$SELF_NAME release matc"
     echo ""
@@ -71,6 +79,7 @@ ISSUE_CLEAN=false
 ISSUE_DEBUG_BUILD=false
 ISSUE_RELEASE_BUILD=false
 
+# Default: build desktop only
 ISSUE_ANDROID_BUILD=false
 ISSUE_IOS_BUILD=false
 ISSUE_DESKTOP_BUILD=true
@@ -550,38 +559,31 @@ while getopts ":hacfijmp:tuvs" opt; do
             BUILD_COMMAND="make"
             ;;
         p)
-            case $OPTARG in
-                desktop)
-                    ISSUE_ANDROID_BUILD=false
-                    ISSUE_IOS_BUILD=false
-                    ISSUE_DESKTOP_BUILD=true
-                    ISSUE_WEBGL_BUILD=false
-                ;;
-                android)
-                    ISSUE_ANDROID_BUILD=true
-                    ISSUE_IOS_BUILD=false
-                    ISSUE_DESKTOP_BUILD=false
-                    ISSUE_WEBGL_BUILD=false
-                ;;
-                ios)
-                    ISSUE_ANDROID_BUILD=false
-                    ISSUE_IOS_BUILD=true
-                    ISSUE_DESKTOP_BUILD=false
-                    ISSUE_WEBGL_BUILD=false
-                ;;
-                webgl)
-                    ISSUE_ANDROID_BUILD=false
-                    ISSUE_IOS_BUILD=false
-                    ISSUE_DESKTOP_BUILD=false
-                    ISSUE_WEBGL_BUILD=true
-                ;;
-                all)
-                    ISSUE_ANDROID_BUILD=true
-                    ISSUE_IOS_BUILD=true
-                    ISSUE_DESKTOP_BUILD=true
-                    ISSUE_WEBGL_BUILD=false
-                ;;
-            esac
+            ISSUE_DESKTOP_BUILD=false
+            platforms=$(echo "$OPTARG" | tr ',' '\n')
+            for platform in $platforms
+            do
+                case $platform in
+                    desktop)
+                        ISSUE_DESKTOP_BUILD=true
+                    ;;
+                    android)
+                        ISSUE_ANDROID_BUILD=true
+                    ;;
+                    ios)
+                        ISSUE_IOS_BUILD=true
+                    ;;
+                    webgl)
+                        ISSUE_WEBGL_BUILD=true
+                    ;;
+                    all)
+                        ISSUE_ANDROID_BUILD=true
+                        ISSUE_IOS_BUILD=true
+                        ISSUE_DESKTOP_BUILD=true
+                        ISSUE_WEBGL_BUILD=false
+                    ;;
+                esac
+            done
             ;;
         t)
             GENERATE_TOOLCHAINS=true


### PR DESCRIPTION
build.sh -p all builds everything which may be too much. -p now
accepts a list of platforms. For instance to build Android and
desktop:

./build.sh -p android,desktop release