### PR TITLE
FilamentApp can now use KTX environments.

### DIFF
--- a/libs/image/include/image/KtxUtility.h
+++ b/libs/image/include/image/KtxUtility.h
@@ -142,6 +142,23 @@ namespace KtxUtility {
         return texture;
     }
 
+    /**
+     * Creates a Texture object from a KTX bundle, populates all of its faces and miplevels,
+     * and automatically destroys the bundle after all the texture data has been uploaded.
+     *
+     * @param engine Used to create the Filament Texture
+     * @param ktx In-memory representation of a KTX file
+     * @param srgb Forces the KTX-specified format into an SRGB format if possible
+     * @param rgbm Interpret alpha as an HDR multiplier
+     */
+    inline Texture* createTexture(Engine* engine, KtxBundle* ktx, bool srgb, bool rgbm) {
+        auto freeKtx = [] (void* userdata) {
+            KtxBundle* ktx = (KtxBundle*) userdata;
+            delete ktx;
+        };
+        return createTexture(engine, *ktx, srgb, rgbm, freeKtx, ktx);
+    }
+
     template<typename T>
     T toCompressedFilamentEnum(uint32_t format) {
         switch (format) {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 # Common library
 # ==================================================================================================
 
-set(APP_LIBS filament sdl2 stb math filamat utils getopt imgui filagui)
+set(APP_LIBS filament sdl2 stb math filamat utils getopt imgui filagui image)
 if (WIN32)
     list(APPEND APP_LIBS sdl2main)
 endif()
@@ -186,7 +186,7 @@ if (NOT ANDROID)
     add_filamesh_demo(sample_normal_map)
 
     # Sample app specific
-    target_link_libraries(frame_generator PRIVATE image imageio)
+    target_link_libraries(frame_generator PRIVATE imageio)
 endif()
 
 # ==================================================================================================

--- a/samples/app/IBL.h
+++ b/samples/app/IBL.h
@@ -19,6 +19,8 @@
 
 #include <math/vec3.h>
 
+#include <string>
+
 namespace filament {
 class Engine;
 class IndexBuffer;
@@ -40,6 +42,7 @@ public:
     ~IBL();
 
     bool loadFromDirectory(const utils::Path& path);
+    bool loadFromKtx(const std::string& prefix);
 
     filament::IndirectLight* getIndirectLight() const noexcept {
         return mIndirectLight;


### PR DESCRIPTION
We already have several KTX environments in the repo, so you can clone a fresh tree and do:

    gltf_viewer --ibl={FILAMENT}/docs/webgl/pillars_2k DamagedHelmet.gltf

This results in the screenshot below.

Note that we have several hundred files in `samples/envs`, we should consider replacing those or copying the environments from `docs/webgl` (which git would internally de-dup, due to content hashing).

<img width="976" alt="screen shot 2018-11-30 at 1 10 44 pm" src="https://user-images.githubusercontent.com/1288904/49315424-83540100-f4a2-11e8-8ee1-54294395dbf0.png">
