### PR TITLE
Deprecate MaterialBuilder::postprocessor

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -35,16 +35,6 @@
 
 namespace filamat {
 
-// Shader postprocessor, called after generation of a shader but before writing it to the package.
-// Must return false if an error occured while postProcessing the shader and true if everything was
-// ok.
-using PostProcessCallBack = std::function<bool(
-        const std::string& /* inputShader */,
-        filament::driver::ShaderType,
-        filament::driver::ShaderModel,
-        std::string* /* outputGlsl */,
-        std::vector<uint32_t>* /* outputSpirv */ )>;
-
 struct MaterialInfo;
 
 class UTILS_PUBLIC MaterialBuilderBase {
@@ -106,10 +96,6 @@ public:
     using SamplerFormat = filament::driver::SamplerFormat;
     using SamplerPrecision = filament::driver::Precision;
     using CullingMode = filament::driver::CullingMode;
-
-    // Each shader generated while building the package content can be post-processed via this
-    // callback.
-    MaterialBuilder& postProcessor(PostProcessCallBack callback);
 
     // set name of this material
     MaterialBuilder& name(const char* name) noexcept;
@@ -290,8 +276,6 @@ private:
     bool mDepthTest = true;
     bool mDepthWrite = true;
     bool mDepthWriteSet = false;
-
-    PostProcessCallBack mPostprocessorCallback = nullptr;
 };
 
 } // namespace filamat

--- a/libs/filamat/include/filamat/PostprocessMaterialBuilder.h
+++ b/libs/filamat/include/filamat/PostprocessMaterialBuilder.h
@@ -31,10 +31,6 @@ public:
 
     Package build();
 
-    // Each shader generated while building the package content can be post-processed via this
-    // callback.
-    PostprocessMaterialBuilder& postProcessor(PostProcessCallBack callback);
-
     // specifies desktop vs mobile; works in concert with TargetApi to determine the shader models
     // (used to generate code) and final output representations (spirv and/or text).
     PostprocessMaterialBuilder& platform(Platform platform) noexcept {
@@ -58,9 +54,6 @@ public:
         mPrintShaders = printShaders;
         return *this;
     }
-
-private:
-    PostProcessCallBack mPostprocessorCallback = nullptr;
 };
 
 } // namespace

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -127,11 +127,6 @@ public:
             filament::driver::ShaderModel model,
             filamat::MaterialBuilder::TargetApi targetApi) const noexcept;
 
-    // Analyze the first fragment shader the builder will construct and guess properties used (the
-    // builder is modified accordingly). Return true if all operation succeeded.
-    bool process(filamat::MaterialBuilder& builder,
-            const MaterialBuilder::PropertyList& properties) const noexcept;
-
     // Public for unit tests.
     using Property = filamat::MaterialBuilder::Property;
     // Use static code analysis on the fragment shader AST to guess properties used in user provided


### PR DESCRIPTION
Deprecate the `postprocessor` method of `MaterialBuilder`, which isn't needed by clients anymore.