### PR TITLE
filamesh: Add support for COMPRESSION

### DIFF
--- a/libs/filameshio/CMakeLists.txt
+++ b/libs/filameshio/CMakeLists.txt
@@ -21,8 +21,10 @@ set(SRCS src/MeshIO.cpp)
 include_directories(${PUBLIC_HDR_DIR})
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
-target_link_libraries(${TARGET} PUBLIC filament)
-target_link_libraries(${TARGET} PRIVATE meshoptimizer)
+target_link_libraries(${TARGET}
+    PRIVATE meshoptimizer
+    PUBLIC filament # Public only because the filamesh API needs Box.h
+)
 
 # ==================================================================================================
 # Installation

--- a/libs/filameshio/include/filameshio/filamesh.h
+++ b/libs/filameshio/include/filameshio/filamesh.h
@@ -35,8 +35,7 @@ enum IndexType : uint32_t {
 enum Flags : uint32_t {
     INTERLEAVED         = 1 << 0,
     TEXCOORD_SNORM16    = 1 << 1,
-    COMPRESSION_MESHOPT = 1 << 2,
-    COMPRESSION_DRACO   = 1 << 3,
+    COMPRESSION         = 1 << 2,
 };
 
 struct Header {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_mesh SOURCE TARGET)
     set(RESOURCE_BINS ${RESOURCE_BINS} ${target_mesh} PARENT_SCOPE)
     add_custom_command(
         OUTPUT ${target_mesh}
-        COMMAND filamesh ${source_mesh} ${target_mesh}
+        COMMAND filamesh --compress ${source_mesh} ${target_mesh}
         MAIN_DEPENDENCY ${source_mesh}
         DEPENDS filamesh)
 endfunction()

--- a/tools/filamesh/CMakeLists.txt
+++ b/tools/filamesh/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${TARGET} ${SRCS})
 target_link_libraries(${TARGET} PUBLIC math)
 target_link_libraries(${TARGET} PUBLIC utils)
 target_link_libraries(${TARGET} PUBLIC assimp)
-target_link_libraries(${TARGET} PRIVATE getopt filameshio)
+target_link_libraries(${TARGET} PRIVATE getopt filameshio meshoptimizer)
 
 # ==================================================================================================
 # Compile options and optimizations

--- a/tools/filamesh/README.md
+++ b/tools/filamesh/README.md
@@ -38,20 +38,19 @@ Note: the UV1 attribute cannot be used in interleaved mode
     uint32  : stride of the color attribute
     uint32  : offset of the UV0 attribute
     uint32  : stride of the UV0 attribute
-    uint32  : offset of the UV1 attribute (always 0xffffffff in interleaved mode)
-    uint32  : stride of the UV1 attribute (always 0xffffffff in interleaved mode)
+    uint32  : offset of the UV1 attribute (0xffffffff if UV1 is not present)
+    uint32  : stride of the UV1 attribute (0xffffffff if UV1 is not present)
     uint32  : total number of vertices
-    uint32  : size in bytes occupied by the vertices
+    uint32  : size in bytes occupied by the (compressed) vertices
     uint32  : 0 if indices are stored as uint32, 1 if stored as uint16
     uint32  : total number of indices
-    uint32  : size in bytes occupied by the indices
+    uint32  : size in bytes occupied by the (compressed) indices
 
 The `flags` field contains the following bits:
 
 - Bit 0: Specifies that vertex attributes are interleaved.
 - Bit 1: UV's are 16-bit integers normalized into [-1, +1] rather than half-floats.
 - Bit 2: Vertex and index data are compressed using zeux/meshoptimizer.
-- Bit 3: Vertex and index data are compressed using google/draco.
 
 ### Vertex data
 

--- a/tools/filamesh/src/MeshWriter.h
+++ b/tools/filamesh/src/MeshWriter.h
@@ -56,11 +56,11 @@ struct Mesh {
 };
 
 class MeshWriter {
-    bool mInterleaved;
-    bool mSnormUVs;
+    uint32_t mFlags;
+    void optimize(Mesh& mesh);
 public:
-    MeshWriter(bool interleaved, bool snormUVs) : mInterleaved(interleaved), mSnormUVs(snormUVs) {}
-    void serialize(std::ostream&, const Mesh& mesh);
+    MeshWriter(uint32_t flags) : mFlags(flags) {}
+    void serialize(std::ostream&, Mesh& mesh);
 };
 
 }

--- a/tools/filamesh/src/main.cpp
+++ b/tools/filamesh/src/main.cpp
@@ -46,6 +46,7 @@ using Assimp::Importer;
 // configuration
 bool g_interleaved = false;
 bool g_snormUVs = false;
+bool g_compression = false;
 
 Mesh g_mesh;
 float2 g_minUV = float2(std::numeric_limits<float>::max());
@@ -222,6 +223,8 @@ static void printUsage(const char* name) {
                     "       Print copyright and license information\n\n"
                     "   --interleaved, -i\n"
                     "       interleaves mesh attributes\n\n"
+                    "   --compress, -c\n"
+                    "       enable compression\n\n"
     );
 
     const std::string from("FILAMESH");
@@ -238,11 +241,12 @@ static void license() {
 }
 
 static int handleArguments(int argc, char* argv[]) {
-    static constexpr const char* OPTSTR = "hil";
+    static constexpr const char* OPTSTR = "hilc";
     static const struct option OPTIONS[] = {
             { "help",        no_argument, 0, 'h' },
             { "license",     no_argument, 0, 'l' },
             { "interleaved", no_argument, 0, 'i' },
+            { "compress",    no_argument, 0, 'c' },
             { 0, 0, 0, 0 }  // termination of the option list
     };
 
@@ -263,6 +267,9 @@ static int handleArguments(int argc, char* argv[]) {
                 // break;
             case 'i':
                 g_interleaved = true;
+                break;
+            case 'c':
+                g_compression = true;
                 break;
         }
     }
@@ -361,7 +368,17 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    MeshWriter(g_interleaved, g_snormUVs).serialize(out, g_mesh);
+    uint32_t flags = 0;
+    if (g_interleaved) {
+        flags |= filamesh::INTERLEAVED;
+    }
+    if (g_snormUVs) {
+        flags |= filamesh::TEXCOORD_SNORM16;
+    }
+    if (g_compression) {
+        flags |= filamesh::COMPRESSION;
+    }
+    MeshWriter(flags).serialize(out, g_mesh);
 
     out.flush();
     out.close();

--- a/web/docs/tutorial_suzanne.md
+++ b/web/docs/tutorial_suzanne.md
@@ -8,12 +8,12 @@ we'll also be using `filamesh` and `mipgen`.
 
 ## Create filamesh file
 
-Filament does not have an asset loading system, but it does provide a simple binary mesh format
-called `filamesh` for demonstration purposes. Let's create a filamesh file for suzanne by converting
-[this OBJ file]:
+Filament does not have an asset loading system, but it does provide a binary mesh format
+called `filamesh` for simple use cases. Let's create a compressed filamesh file for suzanne by
+converting [this OBJ file]:
 
 ```bash
-filamesh monkey.obj suzanne.filamesh
+filamesh --compress monkey.obj suzanne.filamesh
 ```
 
 ## Create mipmapped textures

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -80,7 +80,7 @@ function(add_mesh SOURCE TARGET)
     set(target_meshes ${target_meshes} ${target_mesh} PARENT_SCOPE)
     add_custom_command(
         OUTPUT ${target_mesh}
-        COMMAND filamesh ${source_mesh} ${target_mesh}
+        COMMAND filamesh --compress ${source_mesh} ${target_mesh}
         MAIN_DEPENDENCY ${source_mesh}
         DEPENDS filamesh)
 endfunction()


### PR DESCRIPTION
Note that the WebGL build uses filameshio, but Android does not. Our
Android samples therefore do not yet understand the compressed format.
For web, I measured the before / after:

```
BEFORE: filament.wasm = 505796, suzanne.filamesh = 521476
 AFTER: filament.wasm = 510915, suzanne.filamesh = 333489
```