### PR TITLE
 filamesh: Compress attributes individually.

### DIFF
--- a/docs/webgl/reference.html
+++ b/docs/webgl/reference.html
@@ -422,7 +422,7 @@
 <li>Consumes the contents of a filamesh file and creates a renderable.</li>
 <li><em>buffer</em> asset string, or Uint8Array, or <a href="#Buffer">Buffer</a> with filamesh contents</li>
 <li><em>definstance</em> Optional default <a href="#MaterialInstance">MaterialInstance</a></li>
-<li><em>matinstances</em> Optional object that gets fukked with name =&gt; <a href="#MaterialInstance">MaterialInstance</a></li>
+<li><em>matinstances</em> Optional object that gets filled with name =&gt; <a href="#MaterialInstance">MaterialInstance</a></li>
 <li><em>returns</em> JavaScript object with keys <code>renderable</code>, <code>vertexBuffer</code>, and <code>indexBuffer</code>. These are of type <a href="#Entity">Entity</a>, <a href="#VertexBuffer">VertexBuffer</a>, and <a href="#IndexBuffer">IndexBuffer</a>.</li>
 </ul>
 </li>

--- a/libs/filameshio/CMakeLists.txt
+++ b/libs/filameshio/CMakeLists.txt
@@ -9,11 +9,11 @@ set(PUBLIC_HDR_DIR include)
 # ==================================================================================================
 set(PUBLIC_HDRS
     ${PUBLIC_HDR_DIR}/${TARGET}/filamesh.h
-    ${PUBLIC_HDR_DIR}/${TARGET}/MeshIO.h
+    ${PUBLIC_HDR_DIR}/${TARGET}/MeshReader.h
 )
 
-set(DIST_HDRS ${PUBLIC_HDR_DIR}/${TARGET}/MeshIO.h)
-set(SRCS src/MeshIO.cpp)
+set(DIST_HDRS ${PUBLIC_HDR_DIR}/${TARGET}/MeshReader.h)
+set(SRCS src/MeshReader.cpp)
 
 # ==================================================================================================
 # Includes and target definition

--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_FILAMESHIO_MESHIO_H
-#define TNT_FILAMENT_FILAMESHIO_MESHIO_H
+#ifndef TNT_FILAMENT_FILAMESHIO_MESHREADER_H
+#define TNT_FILAMENT_FILAMESHIO_MESHREADER_H
 
 #include <utils/Entity.h>
 #include <utils/Path.h>
@@ -35,7 +35,7 @@ namespace filament {
  * by the command line tool of the same name. This file format is documented in
  * "docs/filamesh.md" in the Filament distribution.
  */
-class MeshIO {
+class MeshReader {
 public:
     using Callback = void(*)(void* buffer, size_t size, void* user);
     using MaterialRegistry = std::map<std::string, filament::MaterialInstance*>;
@@ -78,4 +78,4 @@ public:
             filament::MaterialInstance* defaultMaterial);
 };
 
-#endif // TNT_FILAMENT_FILAMESHIO_MESHIO_H
+#endif // TNT_FILAMENT_FILAMESHIO_MESHREADER_H

--- a/libs/filameshio/include/filameshio/filamesh.h
+++ b/libs/filameshio/include/filameshio/filamesh.h
@@ -38,6 +38,16 @@ enum Flags : uint32_t {
     COMPRESSION         = 1 << 2,
 };
 
+// Each of these fields specifies a number of bytes within the compressed data. This is ignored
+// when the INTERLEAVED flag is enabled.
+struct CompressionHeader {
+    uint32_t positions;
+    uint32_t tangents;
+    uint32_t colors;
+    uint32_t uv0;
+    uint32_t uv1;
+};
+
 struct Header {
     uint32_t version;
     uint32_t parts;

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 #include <filameshio/filamesh.h>
 
 #include <filament/Box.h>
@@ -53,7 +53,7 @@ static size_t fileSize(int fd) {
     return filesize;
 }
 
-MeshIO::Mesh MeshIO::loadMeshFromFile(filament::Engine* engine, const utils::Path& path,
+MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const utils::Path& path,
         const MaterialRegistry& materials) {
 
     Mesh mesh;
@@ -81,7 +81,7 @@ MeshIO::Mesh MeshIO::loadMeshFromFile(filament::Engine* engine, const utils::Pat
     return mesh;
 }
 
-MeshIO::Mesh MeshIO::loadMeshFromBuffer(filament::Engine* engine,
+MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         void const* data, Callback destructor, void* user,
         MaterialInstance* defaultMaterial) {
     MaterialRegistry reg;
@@ -89,7 +89,7 @@ MeshIO::Mesh MeshIO::loadMeshFromBuffer(filament::Engine* engine,
     return loadMeshFromBuffer(engine, data, destructor, user, reg);
 }
 
-MeshIO::Mesh MeshIO::loadMeshFromBuffer(filament::Engine* engine,
+MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         void const* data, Callback destructor, void* user,
         const MaterialRegistry& materials) {
     const uint8_t* p = (const uint8_t*) data;

--- a/libs/filameshio/tests/test_filamesh.cpp
+++ b/libs/filameshio/tests/test_filamesh.cpp
@@ -19,7 +19,7 @@
 #include <filament/RenderableManager.h>
 
 #include <filameshio/filamesh.h>
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 
 #include <math/half.h>
 #include <math/mat3.h>
@@ -157,7 +157,7 @@ TEST_F(FilameshTest, NonInterleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshIO::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);
@@ -206,7 +206,7 @@ TEST_F(FilameshTest, Interleaved) {
 
     // Deserialize the mesh as a smoke test.
     MaterialInstance* mi = engine->getDefaultMaterial()->createInstance();
-    auto mesh = MeshIO::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
+    auto mesh = MeshReader::loadMeshFromBuffer(engine, stream.str().data(), nullptr, nullptr, mi);
     auto& rm = engine->getRenderableManager();
     auto inst = rm.getInstance(mesh.renderable);
     EXPECT_EQ(rm.getPrimitiveCount(inst), 1);

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -43,7 +43,7 @@
 #include <utils/EntityManager.h>
 
 #include <filamat/MaterialBuilder.h>
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 
 using namespace math;
 using namespace filament;
@@ -53,7 +53,7 @@ using namespace utils;
 static std::vector<Path> g_filenames;
 
 static std::map<std::string, MaterialInstance*> g_materialInstances;
-static std::vector<MeshIO::Mesh> g_meshes;
+static std::vector<MeshReader::Mesh> g_meshes;
 static const Material* g_material;
 static Entity g_light;
 static std::map<std::string, Texture*> g_maps;
@@ -216,7 +216,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
 
     auto& tcm = engine->getTransformManager();
     for (const auto& filename : g_filenames) {
-        MeshIO::Mesh mesh  = MeshIO::loadMeshFromFile(engine, filename, g_materialInstances);
+        MeshReader::Mesh mesh  = MeshReader::loadMeshFromFile(engine, filename, g_materialInstances);
         if (mesh.renderable) {
             auto ei = tcm.getInstance(mesh.renderable);
             tcm.setTransform(ei, mat4f{ mat3f(g_config.scale), float3(0.0f, 0.0f, -4.0f) } *

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -42,7 +42,7 @@
 #include <utils/EntityManager.h>
 
 #include <filamat/MaterialBuilder.h>
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 
 using namespace math;
 using namespace filament;
@@ -52,7 +52,7 @@ using namespace utils;
 static std::vector<Path> g_filenames;
 
 static std::map<std::string, MaterialInstance*> g_materialInstances;
-static std::vector<MeshIO::Mesh> g_meshes;
+static std::vector<MeshReader::Mesh> g_meshes;
 static const Material* g_material;
 static Entity g_light;
 static Texture* g_normalMap = nullptr;
@@ -306,7 +306,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
 
     auto& tcm = engine->getTransformManager();
     for (const auto& filename : g_filenames) {
-        MeshIO::Mesh mesh  = MeshIO::loadMeshFromFile(engine, filename, g_materialInstances);
+        MeshReader::Mesh mesh  = MeshReader::loadMeshFromFile(engine, filename, g_materialInstances);
         if (mesh.renderable) {
             auto ei = tcm.getInstance(mesh.renderable);
             tcm.setTransform(ei, mat4f{ mat3f(g_config.scale), float3(0.0f, 0.0f, -4.0f) } *

--- a/samples/vk_hellopbr.cpp
+++ b/samples/vk_hellopbr.cpp
@@ -21,7 +21,7 @@
 #include <filament/TransformManager.h>
 #include <filament/View.h>
 
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 
 #include "app/Config.h"
 #include "app/FilamentApp.h"
@@ -36,7 +36,7 @@ struct App {
     utils::Entity light;
     Material* material;
     MaterialInstance* materialInstance;
-    MeshIO::Mesh mesh;
+    MeshReader::Mesh mesh;
     mat4f transform;
 };
 
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
         mi->setParameter("reflectance", 0.5f);
 
         // Add geometry into the scene.
-        app.mesh = MeshIO::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr, nullptr, mi);
+        app.mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr, nullptr, mi);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.mesh.renderable), false);

--- a/tools/filamesh/src/MeshWriter.h
+++ b/tools/filamesh/src/MeshWriter.h
@@ -60,7 +60,7 @@ class MeshWriter {
     void optimize(Mesh& mesh);
 public:
     MeshWriter(uint32_t flags) : mFlags(flags) {}
-    void serialize(std::ostream&, Mesh& mesh);
+    bool serialize(std::ostream&, Mesh& mesh);
 };
 
 }

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -109,7 +109,7 @@ Filament.loadClassExtensions = function() {
     /// loadFilamesh ::method:: Consumes the contents of a filamesh file and creates a renderable.
     /// buffer ::argument:: asset string, or Uint8Array, or [Buffer] with filamesh contents
     /// definstance ::argument:: Optional default [MaterialInstance]
-    /// matinstances ::argument:: Optional object that gets fukked with name => [MaterialInstance]
+    /// matinstances ::argument:: Optional object that gets filled with name => [MaterialInstance]
     /// ::retval:: JavaScript object with keys `renderable`, `vertexBuffer`, and `indexBuffer`. \
     /// These are of type [Entity], [VertexBuffer], and [IndexBuffer].
     Filament.Engine.prototype.loadFilamesh = function(buffer, definstance, matinstances) {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -32,7 +32,7 @@
  * this explicit rather than mysterious.
  */
 
-#include <filameshio/MeshIO.h>
+#include <filameshio/MeshReader.h>
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
@@ -873,12 +873,12 @@ class_<KtxInfo>("KtxInfo")
 
 register_vector<std::string>("RegistryKeys");
 
-class_<MeshIO::MaterialRegistry>("MeshIO$MaterialRegistry")
+class_<MeshReader::MaterialRegistry>("MeshReader$MaterialRegistry")
     .constructor<>()
-    .function("size", &MeshIO::MaterialRegistry::size)
-    .function("get", internal::MapAccess<MeshIO::MaterialRegistry>::get)
-    .function("set", internal::MapAccess<MeshIO::MaterialRegistry>::set)
-    .function("keys", EMBIND_LAMBDA(std::vector<std::string>, (MeshIO::MaterialRegistry* self), {
+    .function("size", &MeshReader::MaterialRegistry::size)
+    .function("get", internal::MapAccess<MeshReader::MaterialRegistry>::get)
+    .function("set", internal::MapAccess<MeshReader::MaterialRegistry>::set)
+    .function("keys", EMBIND_LAMBDA(std::vector<std::string>, (MeshReader::MaterialRegistry* self), {
         std::vector<std::string> result;
         for (const auto& pair : *self) {
             result.emplace_back(pair.first);
@@ -886,17 +886,17 @@ class_<MeshIO::MaterialRegistry>("MeshIO$MaterialRegistry")
         return result;
     }), allow_raw_pointers());
 
-// MeshIO ::class:: Simple parser for filamesh files.
+// MeshReader ::class:: Simple parser for filamesh files.
 // JavaScript clients are encouraged to use the [loadFilamesh] helper function instead of using
 // this class directly.
-class_<MeshIO>("MeshIO")
+class_<MeshReader>("MeshReader")
     // loadMeshFromBuffer ::static method:: Parses a filamesh buffer.
     // engine ::argument:: [Engine]
     // buffer ::argument:: [Buffer]
-    // materials ::argument:: [MeshIO$MaterialRegistry]
-    // ::retval:: the [MeshIO$Mesh] object
-    .class_function("loadMeshFromBuffer", EMBIND_LAMBDA(MeshIO::Mesh,
-            (Engine* engine, BufferDescriptor buffer, const MeshIO::MaterialRegistry& matreg), {
+    // materials ::argument:: [MeshReader$MaterialRegistry]
+    // ::retval:: the [MeshReader$Mesh] object
+    .class_function("loadMeshFromBuffer", EMBIND_LAMBDA(MeshReader::Mesh,
+            (Engine* engine, BufferDescriptor buffer, const MeshReader::MaterialRegistry& matreg), {
         // This destruction lambda is called for the vertex buffer AND index buffer, so release
         // CPU memory only after both have been uploaded to the GPU.
         struct Bundle { int count; BufferDescriptor buffer; };
@@ -908,23 +908,23 @@ class_<MeshIO>("MeshIO")
             }
         };
         // Parse the filamesh buffer. This creates the VB, IB, and renderable.
-        return MeshIO::loadMeshFromBuffer(
+        return MeshReader::loadMeshFromBuffer(
                 engine, buffer.bd->buffer,
                 destructor, bundle, matreg);
     }), allow_raw_pointers());
 
-// MeshIO$Mesh ::class:: Property accessor for objects created by [MeshIO].
+// MeshReader$Mesh ::class:: Property accessor for objects created by [MeshReader].
 // This exposes three getter methods: `renderable()`, `vertexBuffer()`, and `indexBuffer()`. These
 // are of type [Entity], [VertexBuffer], and [IndexBuffer]. JavaScript clients are encouraged to
 // use the [loadFilamesh] helper function instead of using this class directly.
-class_<MeshIO::Mesh>("MeshIO$Mesh")
-    .function("renderable", EMBIND_LAMBDA(utils::Entity, (MeshIO::Mesh mesh), {
+class_<MeshReader::Mesh>("MeshReader$Mesh")
+    .function("renderable", EMBIND_LAMBDA(utils::Entity, (MeshReader::Mesh mesh), {
         return mesh.renderable;
     }), allow_raw_pointers())
-    .function("vertexBuffer", EMBIND_LAMBDA(VertexBuffer*, (MeshIO::Mesh mesh), {
+    .function("vertexBuffer", EMBIND_LAMBDA(VertexBuffer*, (MeshReader::Mesh mesh), {
         return mesh.vertexBuffer;
     }), allow_raw_pointers())
-    .function("indexBuffer", EMBIND_LAMBDA(IndexBuffer*, (MeshIO::Mesh mesh), {
+    .function("indexBuffer", EMBIND_LAMBDA(IndexBuffer*, (MeshReader::Mesh mesh), {
         return mesh.indexBuffer;
     }), allow_raw_pointers());
 

--- a/web/filament-js/utilities.js
+++ b/web/filament-js/utilities.js
@@ -81,14 +81,14 @@ Filament.CompressedPixelBuffer = function(typedarray, cdatatype, faceSize) {
 
 Filament._loadFilamesh = function(engine, buffer, definstance, matinstances) {
     matinstances = matinstances || {};
-    const registry = new Filament.MeshIO$MaterialRegistry();
+    const registry = new Filament.MeshReader$MaterialRegistry();
     for (var key in matinstances) {
         registry.set(key, matinstances[key]);
     }
     if (definstance) {
         registry.set("DefaultMaterial", definstance);
     }
-    const mesh = Filament.MeshIO.loadMeshFromBuffer(engine, buffer, registry);
+    const mesh = Filament.MeshReader.loadMeshFromBuffer(engine, buffer, registry);
     const keys = registry.keys();
     for (var i = 0; i < keys.size(); i++) {
         const key = keys.get(i);


### PR DESCRIPTION

- The first commit reduces compressed suzanne from 333489 bytes to 272761.
- The second commit renames the MeshIO class to `MeshReader` to make it symmetric with `MeshWriter`.