### PR TITLE
Install the image library

### DIFF
--- a/libs/image/CMakeLists.txt
+++ b/libs/image/CMakeLists.txt
@@ -52,6 +52,12 @@ add_library(image_headers INTERFACE)
 target_include_directories(image_headers INTERFACE ${PUBLIC_HDR_DIR})
 
 # ==================================================================================================
+# Installation
+# ==================================================================================================
+install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
+install(DIRECTORY ${PUBLIC_HDR_DIR}/image DESTINATION include)
+
+# ==================================================================================================
 # Tests
 # ==================================================================================================
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS)


### PR DESCRIPTION
This allows client to properly make use of the (very useful!) KTX texture loading, when using the libraries from an installed location.