### PR TITLE
improve skinning memory usage and udpates

### DIFF
--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -72,6 +72,10 @@ public:
         return static_cast<char*>(mBuffer) + offset;
     }
 
+    void* invalidate() noexcept {
+        return invalidateUniforms(0, mSize);
+    }
+
     // pointer to the uniform buffer
     void const* getBuffer() const noexcept { return mBuffer; }
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -99,6 +99,7 @@ public:
     inline void setLayerMask(Instance instance, uint8_t layerMask) noexcept;
     inline void setReceiveShadows(Instance instance, bool enable) noexcept;
     inline void setCulling(Instance instance, bool enable) noexcept;
+    inline void setSkinning(Instance instance, bool enable) noexcept;
     inline void setPrimitives(Instance instance, utils::Slice<FRenderPrimitive> const& primitives) noexcept;
     inline void setBones(Instance instance, Bone const* transforms, size_t boneCount, size_t offset = 0) noexcept;
     inline void setBones(Instance instance, math::mat4f const* transforms, size_t boneCount, size_t offset = 0) noexcept;
@@ -175,11 +176,11 @@ private:
 
             union {
                 // this specific usage of union is permitted. All fields are identical
-                Field<AABB>                 aabb;
-                Field<LAYERS>               layers;
-                Field<VISIBILITY>           visibility;
-                Field<PRIMITIVES>           primitives;
-                Field<BONES>                bones;
+                Field<AABB>         aabb;
+                Field<LAYERS>       layers;
+                Field<VISIBILITY>   visibility;
+                Field<PRIMITIVES>   primitives;
+                Field<BONES>        bones;
             };
         };
 
@@ -242,6 +243,13 @@ void FRenderableManager::setCulling(Instance instance, bool enable) noexcept {
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.culling = enable;
+    }
+}
+
+void FRenderableManager::setSkinning(Instance instance, bool enable) noexcept {
+    if (instance) {
+        Visibility& visibility = mManager[instance].visibility;
+        visibility.skinning = enable;
     }
 }
 


### PR DESCRIPTION
- use the exact required size for bone data instead of always the max
of 256 bones. This also reduces the amount of data to update and
copy into the command stream.

- also get rid of the "reuse component" optimization, which is less
needed now that renderables don't have their own transform UBO.