### PR TITLE
Add View::setFrontFaceWindingInverted() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Run `build.sh -h` for more information.
 ##### Linux toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm64 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm64 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Linux/aarch64-linux-android-4.9
 ```
@@ -450,7 +450,7 @@ $ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm64 --api 24
 ##### Darwin toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm64 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm64 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Darwin/aarch64-linux-android-4.9
 ```
@@ -487,7 +487,7 @@ binaries should be found in `out/android-release/filament/lib/arm64-v8a`.
 ##### Linux toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Linux/arm-linux-androideabi-4.9
 ```
@@ -495,7 +495,7 @@ $ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 24 \
 ##### Darwin toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch arm --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Darwin/arm-linux-androideabi-4.9
 ```
@@ -532,7 +532,7 @@ binaries should be found in `out/android-release/filament/lib/armeabi-v7a`.
 ##### Linux toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86_64 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86_64 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Linux/x86_64-linux-android-4.9
 ```
@@ -540,7 +540,7 @@ $ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86_64 --api 2
 ##### Darwin toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86_64 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86_64 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Darwin/x86_64-linux-android-4.9
 ```
@@ -577,7 +577,7 @@ binaries should be found in `out/android-release/filament/lib/x86_64`.
 ##### Linux toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Linux/i686-linux-android-4.9
 ```
@@ -585,7 +585,7 @@ $ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86 --api 24 \
 ##### Darwin toolchain
 
 ```
-$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86 --api 24 \
+$ $SDK/ndk-bundle/build/tools/make_standalone_toolchain.py --arch x86 --api 21 \
         --stl libc++ --force \
         --install-dir toolchains/Darwin/i686-linux-android-4.9
 ```

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -177,3 +177,17 @@ Java_com_google_android_filament_View_nIsPostProcessingEnabled(JNIEnv*,
     View* view = (View*) nativeView;
     return static_cast<jboolean>(view->isPostProcessingEnabled());
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nSetFrontFaceWindingInverted(JNIEnv*,
+        jclass, jlong nativeView, jboolean inverted) {
+    View* view = (View*) nativeView;
+    view->setFrontFaceWindingInverted(inverted);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_View_nIsFrontFaceWindingInverted(JNIEnv*,
+        jclass, jlong nativeView) {
+    View* view = (View*) nativeView;
+    return static_cast<jboolean>(view->isFrontFaceWindingInverted());
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -212,6 +212,14 @@ public class View {
         nSetPostProcessingEnabled(getNativeObject(), enabled);
     }
 
+    public boolean isFrontFaceWindingInverted() {
+        return nIsFrontFaceWindingInverted(getNativeObject());
+    }
+
+    public void setFrontFaceWindingInverted(boolean inverted) {
+        nSetFrontFaceWindingInverted(getNativeObject(), inverted);
+    }
+
     public void setDynamicLightingOptions(float zLightNear, float zLightFar) {
         nSetDynamicLightingOptions(getNativeObject(), zLightNear, zLightFar);
     }
@@ -258,4 +266,6 @@ public class View {
     private static native void nSetDepthPrepass(long nativeView, int value);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);
+    private static native void nSetFrontFaceWindingInverted(long nativeView, boolean inverted);
+    private static native boolean nIsFrontFaceWindingInverted(long nativeView);
 }

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -444,6 +444,27 @@ public:
     //! Returns true if post-processing is enabled. See setPostProcessingEnabled() for more info.
     bool isPostProcessingEnabled() const noexcept;
 
+    /**
+     * Inverts the winding order of front faces. By default front faces use a counter-clockwise
+     * winding order. When the winding order is inverted, front faces are faces with a clockwise
+     * winding order.
+     *
+     * Changing the winding order will directly affect the culling mode in materials
+     * (see Material::getCullingMode()).
+     *
+     * Inverting the winding order of front faces is useful when rendering mirrored reflections
+     * (water, mirror surfaces, front camera in AR, etc.).
+     *
+     * @param inverted True to invert front faces, false otherwise.
+     */
+    void setFrontFaceWindingInverted(bool inverted) noexcept;
+
+    /**
+     * Returns true if the winding order of front faces is inverted.
+     * See setFrontFaceWindingInverted() for more information.
+     */
+    bool isFrontFaceWindingInverted() const noexcept;
+
     // for debugging...
 
     //! debugging: allows to entirely disable frustum culling. (culling enabled by default).

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -197,10 +197,10 @@ public:
 
 
     using RenderFlags = uint8_t;
-    static constexpr RenderFlags HAS_SHADOWING          = 0x01;
-    static constexpr RenderFlags HAS_DIRECTIONAL_LIGHT  = 0x02;
-    static constexpr RenderFlags HAS_DYNAMIC_LIGHTING   = 0x04;
-
+    static constexpr RenderFlags HAS_SHADOWING           = 0x01;
+    static constexpr RenderFlags HAS_DIRECTIONAL_LIGHT   = 0x02;
+    static constexpr RenderFlags HAS_DYNAMIC_LIGHTING    = 0x04;
+    static constexpr RenderFlags HAS_INVERSE_FRONT_FACES = 0x08;
 
     explicit RenderPass(const char* name) noexcept : mName(name) { }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -863,6 +863,14 @@ bool View::isPostProcessingEnabled() const noexcept {
     return upcast(this)->hasPostProcessPass();
 }
 
+void View::setFrontFaceWindingInverted(bool inverted) noexcept {
+    upcast(this)->setFrontFaceWindingInverted(inverted);
+}
+
+bool View::isFrontFaceWindingInverted() const noexcept {
+    return upcast(this)->isFrontFaceWindingInverted();
+}
+
 void View::setDepthPrepass(View::DepthPrepass prepass) noexcept {
     upcast(this)->setDepthPrepass(prepass);
 }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -99,6 +99,10 @@ public:
     void setFrustumCullingEnabled(bool culling) noexcept { mCulling = culling; }
     bool isFrustumCullingEnabled() const noexcept { return mCulling; }
 
+    void setFrontFaceWindingInverted(bool inverted) noexcept { mFrontFaceWindingInverted = inverted; }
+    bool isFrontFaceWindingInverted() const noexcept { return mFrontFaceWindingInverted; }
+
+
     void setVisibleLayers(uint8_t select, uint8_t values) noexcept;
     uint8_t getVisibleLayers() const noexcept {
         return mVisibleLayers;
@@ -243,7 +247,6 @@ private:
     static FScene::RenderableSoa::iterator partition(
             FScene::RenderableSoa::iterator begin, FScene::RenderableSoa::iterator end, uint8_t mask) noexcept;
 
-
     // these are accessed in the render loop, keep together
     Handle<HwSamplerBuffer> mPerViewSbh;
     Handle<HwUniformBuffer> mPerViewUbh;
@@ -253,7 +256,6 @@ private:
     Handle<HwSamplerBuffer> getUsh() const noexcept { return mPerViewSbh; }
     Handle<HwUniformBuffer> getUbh() const noexcept { return mPerViewUbh; }
     Handle<HwUniformBuffer> getLightUbh() const noexcept { return mLightUbh; }
-
 
     FScene* mScene = nullptr;
     FCamera* mCullingCamera = nullptr;
@@ -267,6 +269,7 @@ private:
     Viewport mViewport;
     LinearColorA mClearColor;
     bool mCulling = true;
+    bool mFrontFaceWindingInverted = false;
     bool mClearTargetColor = true;
     bool mClearTargetDepth = true;
     bool mClearTargetStencil = false;

--- a/filament/src/driver/Driver.h
+++ b/filament/src/driver/Driver.h
@@ -198,7 +198,8 @@ public:
                 DepthFunc depthFunc                 : 3;        // 28
                 bool colorWrite                     : 1;        // 29
                 bool alphaToCoverage                : 1;        // 30
-                uint8_t padding                     : 2;        // 32
+                bool inverseFrontFaces              : 1;        // 31
+                uint8_t padding                     : 1;        // 32
             };
             uint32_t u = 0;
         };

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -539,6 +539,13 @@ void OpenGLDriver::disable(GLenum cap) noexcept {
     }
 }
 
+void OpenGLDriver::frontFace(GLenum mode) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.frontFace, mode, [&]() {
+        glFrontFace(mode);
+    });
+}
+
 void OpenGLDriver::cullFace(GLenum mode) noexcept {
     // WARNING: don't call this without updating mRasterState
     update_state(state.raster.cullFace, mode, [&]() {
@@ -629,6 +636,8 @@ void OpenGLDriver::setRasterStateSlow(Driver::RasterState rs) noexcept {
             cullFace(GL_FRONT_AND_BACK);
             break;
     }
+
+    frontFace(rs.inverseFrontFaces ? GL_CW : GL_CCW);
 
     if (rs.culling != CullingMode::NONE) {
         enable(GL_CULL_FACE);

--- a/filament/src/driver/opengl/OpenGLDriver.h
+++ b/filament/src/driver/opengl/OpenGLDriver.h
@@ -345,6 +345,7 @@ private:
     inline void disableVertexAttribArray(GLuint index) noexcept;
     inline void enable(GLenum cap) noexcept;
     inline void disable(GLenum cap) noexcept;
+    inline void frontFace(GLenum mode) noexcept;
     inline void cullFace(GLenum mode) noexcept;
     inline void blendEquation(GLenum modeRGB, GLenum modeA) noexcept;
     inline void blendFunction(GLenum srcRGB, GLenum srcA, GLenum dstRGB, GLenum dstA) noexcept;
@@ -404,6 +405,7 @@ private:
         } vao;
 
         struct {
+            GLenum frontFace            = GL_CCW;
             GLenum cullFace             = GL_BACK;
             GLenum blendEquationRGB     = GL_FUNC_ADD;
             GLenum blendEquationA       = GL_FUNC_ADD;

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -848,6 +848,7 @@ void VulkanDriver::draw(Driver::PipelineState pipelineState, Driver::RenderPrimi
 
     auto& vkraster = mContext.rasterState.rasterization;
     vkraster.cullMode = getCullMode(rasterState.culling);
+    vkraster.frontFace = getFrontFace(rasterState.inverseFrontFaces);
     vkraster.depthBiasEnable = (depthOffset.constant || depthOffset.slope) ? VK_TRUE : VK_FALSE;
     vkraster.depthBiasConstantFactor = depthOffset.constant;
     vkraster.depthBiasSlopeFactor = depthOffset.slope;

--- a/filament/src/driver/vulkan/VulkanDriverImpl.cpp
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.cpp
@@ -712,6 +712,11 @@ VkCullModeFlags getCullMode(CullingMode mode) {
     }
 }
 
+VkFrontFace getFrontFace(bool inverseFrontFaces) {
+    return inverseFrontFaces ?
+            VkFrontFace::VK_FRONT_FACE_CLOCKWISE : VkFrontFace::VK_FRONT_FACE_COUNTER_CLOCKWISE;
+}
+
 void waitForIdle(VulkanContext& context) {
     // If there's no valid GPU then we have nothing to do.
     if (!context.device) {

--- a/filament/src/driver/vulkan/VulkanDriverImpl.h
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.h
@@ -119,6 +119,7 @@ bool hasPendingWork(VulkanContext& context);
 VkCompareOp getCompareOp(SamplerCompareFunc func);
 VkBlendFactor getBlendFactor(BlendFunction mode);
 VkCullModeFlags getCullMode(CullingMode mode);
+VkFrontFace getFrontFace(bool inverseFrontFaces);
 void waitForIdle(VulkanContext& context);
 void acquireCommandBuffer(VulkanContext& context);
 void releaseCommandBuffer(VulkanContext& context);

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -16,7 +16,8 @@ material {
     vertexDomain : device,
     depthWrite : false,
     shadingModel : unlit,
-    variantFilter : [ skinning ]
+    variantFilter : [ skinning ],
+    culling: none
 }
 
 fragment {

--- a/filament/src/materials/skyboxRGBM.mat
+++ b/filament/src/materials/skyboxRGBM.mat
@@ -16,7 +16,8 @@ material {
     vertexDomain : device,
     depthWrite : false,
     shadingModel : unlit,
-    variantFilter : [ skinning ]
+    variantFilter : [ skinning ],
+    culling: none
 }
 
 fragment {


### PR DESCRIPTION
This API can be used to flip all meshes in a render pass
inside out. This is useful for mirrored rendering.

This change also disables face culling on the default skybox
renderable. Since it is unlit, there is no downside to this
and the mesh being in the device vertex domain it can never
be backfacing unless front face winding is inverted.