### PR TITLE
mipgen: support generation of 4-band KTX files

### DIFF
--- a/libs/image/include/image/ImageOps.h
+++ b/libs/image/include/image/ImageOps.h
@@ -56,6 +56,9 @@ LinearImage cropRegion(const LinearImage& image, uint32_t l, uint32_t t, uint32_
 // Lexicographically compares two images, similar to memcmp.
 int compare(const LinearImage& a, const LinearImage& b, float epsilon = 0.0f);
 
+// Sets all pixels in all channels to the given value.
+void clearToValue(LinearImage& img, float value);
+
 } // namespace image
 
 #endif /* IMAGE_LINEARIMAGE_H */

--- a/libs/image/src/ImageOps.cpp
+++ b/libs/image/src/ImageOps.cpp
@@ -236,4 +236,12 @@ int compare(const LinearImage& a, const LinearImage& b, float epsilon) {
             [epsilon](float x, float y) { return x < y - epsilon; });
 }
 
+void clearToValue(LinearImage& image, float value) {
+    const uint32_t nvals = image.getWidth() * image.getHeight() * image.getChannels();
+    float* data = image.getPixelRef();
+    for (uint32_t index = 0; index < nvals; ++index) {
+        data[index] = value;
+    }
+}
+
 } // namespace image


### PR DESCRIPTION
This is useful because our Vulkan backend currently does not accept
3-band texture data. (although we intend to fix that soon)