### PR TITLE
Add C++ sample for compressed textures.

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(RESOURCE_DIR  "${GENERATION_ROOT}/generated/resources")
 set(MATERIAL_DIR  "${GENERATION_ROOT}/generated/material")
+set(TEXTURE_DIR "${GENERATION_ROOT}/generated/texture")
 set(RESOURCE_BINS)
 
 # ==================================================================================================
@@ -41,6 +42,7 @@ set(MATERIAL_SRCS
         materials/sandboxLitTransparent.mat
         materials/sandboxSubsurface.mat
         materials/sandboxUnlit.mat
+        materials/texturedLit.mat
         materials/transparentColor.mat)
 
 if (CMAKE_CROSSCOMPILING)
@@ -73,7 +75,7 @@ foreach (mat_src ${MATERIAL_SRCS})
 endforeach()
 
 # ==================================================================================================
-# Build aggregated resource files
+# Build common resources
 # ==================================================================================================
 
 get_resgen_vars(${RESOURCE_DIR} resources)
@@ -89,17 +91,54 @@ if (DEFINED RESGEN_SOURCE_FLAGS)
     set_source_files_properties(${RESGEN_SOURCE} PROPERTIES COMPILE_FLAGS ${RESGEN_SOURCE_FLAGS})
 endif()
 
+add_library(common-resources ${RESGEN_SOURCE})
+
+# ==================================================================================================
+# Build suzanne resources
+# ==================================================================================================
+
+function(add_ktxfiles SOURCE TARGET EXTRA_ARGS)
+    set(source_path "${ROOT_DIR}/${SOURCE}")
+    set(target_path "${TEXTURE_DIR}/${TARGET}")
+    set(KTX_FILES ${KTX_FILES} ${target_path} PARENT_SCOPE)
+    add_custom_command(
+        OUTPUT ${target_path}
+        COMMAND mipgen --strip-alpha ${EXTRA_ARGS} ${source_path} ${target_path}
+        MAIN_DEPENDENCY ${source_path}
+        DEPENDS mipgen)
+endfunction()
+
+add_ktxfiles("assets/models/monkey/albedo.png" "albedo_s3tc.ktx" "--compression=s3tc_rgb_dxt1")
+add_ktxfiles("assets/models/monkey/normal.png" "normal.ktx" "--kernel=NORMALS;--linear")
+add_ktxfiles("assets/models/monkey/roughness.png" "roughness.ktx" "--grayscale")
+add_ktxfiles("assets/models/monkey/metallic.png" "metallic.ktx" "--grayscale")
+add_ktxfiles("assets/models/monkey/ao.png" "ao.ktx" "--grayscale")
+
+get_resgen_vars(${RESOURCE_DIR} textures)
+
+add_custom_command(
+        OUTPUT ${RESGEN_OUTPUTS}
+        COMMAND resgen ${RESGEN_FLAGS} ${KTX_FILES}
+        DEPENDS resgen ${KTX_FILES}
+        COMMENT "Aggregating textures"
+)
+
+if (DEFINED RESGEN_SOURCE_FLAGS)
+    set_source_files_properties(${RESGEN_SOURCE} PROPERTIES COMPILE_FLAGS ${RESGEN_SOURCE_FLAGS})
+endif()
+
+add_library(suzanne-resources ${RESGEN_SOURCE})
+
 # ==================================================================================================
 # Common library
 # ==================================================================================================
 
-set(APP_LIBS filament sdl2 stb math filamat utils getopt imgui filagui image)
+set(APP_LIBS filament sdl2 stb math filamat utils getopt imgui filagui image common-resources)
 if (WIN32)
     list(APPEND APP_LIBS sdl2main)
 endif()
 
 set(APP_SRCS
-        ${RESGEN_SOURCE}
         app/CameraManipulator.cpp
         app/Cube.cpp
         app/FilamentApp.cpp
@@ -176,9 +215,11 @@ if (NOT ANDROID)
 
     add_filamesh_demo(sample_cloth)
     add_filamesh_demo(sample_normal_map)
+    add_filamesh_demo(suzanne)
 
     # Sample app specific
     target_link_libraries(frame_generator PRIVATE imageio)
+    target_link_libraries(suzanne PRIVATE suzanne-resources)
 endif()
 
 # ==================================================================================================

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filament/Engine.h>
+#include <filament/IndirectLight.h>
+#include <filament/LightManager.h>
+#include <filament/RenderableManager.h>
+#include <filament/Scene.h>
+#include <filament/TransformManager.h>
+#include <filament/View.h>
+
+#include <filameshio/MeshReader.h>
+
+#include <image/KtxBundle.h>
+#include <image/KtxUtility.h>
+
+#include "app/Config.h"
+#include "app/FilamentApp.h"
+#include "app/IBL.h"
+
+#include "generated/resources/resources.h"
+#include "generated/resources/textures.h"
+
+using namespace filament;
+using namespace image;
+using namespace math;
+
+struct App {
+    Material* material;
+    MaterialInstance* materialInstance;
+    MeshReader::Mesh mesh;
+    mat4f transform;
+    Texture* albedo;
+    Texture* normal;
+    Texture* roughness;
+    Texture* metallic;
+    Texture* ao;
+};
+
+static const char* IBL_FOLDER = "envs/venetian_crossroads";
+
+int main(int argc, char** argv) {
+    Config config;
+    config.title = "suzanne";
+    // config.backend = Backend::VULKAN;
+    config.iblDirectory = FilamentApp::getRootPath() + IBL_FOLDER;
+
+    App app;
+    auto setup = [config, &app](Engine* engine, View* view, Scene* scene) {
+        auto& tcm = engine->getTransformManager();
+        auto& rcm = engine->getRenderableManager();
+        auto& em = utils::EntityManager::get();
+
+        // Create textures. The KTX bundles are freed by KtxUtility.
+        auto albedo = new image::KtxBundle(TEXTURES_ALBEDO_S3TC_DATA, TEXTURES_ALBEDO_S3TC_SIZE);
+        auto ao = new image::KtxBundle(TEXTURES_AO_DATA, TEXTURES_AO_SIZE);
+        auto metallic = new image::KtxBundle(TEXTURES_METALLIC_DATA, TEXTURES_METALLIC_SIZE);
+        auto normal = new image::KtxBundle(TEXTURES_NORMAL_DATA, TEXTURES_NORMAL_SIZE);
+        auto roughness = new image::KtxBundle(TEXTURES_ROUGHNESS_DATA, TEXTURES_ROUGHNESS_SIZE);
+        app.albedo = KtxUtility::createTexture(engine, albedo, true, false);
+        app.ao = KtxUtility::createTexture(engine, ao, false, false);
+        app.metallic = KtxUtility::createTexture(engine, metallic, false, false);
+        app.normal = KtxUtility::createTexture(engine, normal, false, false);
+        app.roughness = KtxUtility::createTexture(engine, roughness, false, false);
+        TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
+                TextureSampler::MagFilter::LINEAR);
+
+        // Instantiate material.
+        app.material = Material::Builder()
+                .package(RESOURCES_TEXTUREDLIT_DATA, RESOURCES_TEXTUREDLIT_SIZE).build(*engine);
+        app.materialInstance = app.material->createInstance();
+        app.materialInstance->setParameter("albedo", app.albedo, sampler);
+        app.materialInstance->setParameter("ao", app.ao, sampler);
+        app.materialInstance->setParameter("metallic", app.metallic, sampler);
+        app.materialInstance->setParameter("normal", app.normal, sampler);
+        app.materialInstance->setParameter("roughness", app.roughness, sampler);
+
+        auto ibl = FilamentApp::get().getIBL()->getIndirectLight();
+        ibl->setIntensity(100000);
+        ibl->setRotation(mat3f::rotate(0.5f, float3{ 0, 1, 0 }));
+
+        // Add geometry into the scene.
+        app.mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr, nullptr,
+                app.materialInstance);
+        auto ti = tcm.getInstance(app.mesh.renderable);
+        app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
+        rcm.setCastShadows(rcm.getInstance(app.mesh.renderable), false);
+        scene->addEntity(app.mesh.renderable);
+        tcm.setTransform(ti, app.transform);
+    };
+
+    auto cleanup = [&app](Engine* engine, View*, Scene*) {
+        Fence::waitAndDestroy(engine->createFence());
+        engine->destroy(app.materialInstance);
+        engine->destroy(app.mesh.renderable);
+        engine->destroy(app.material);
+        engine->destroy(app.albedo);
+        engine->destroy(app.normal);
+        engine->destroy(app.roughness);
+        engine->destroy(app.metallic);
+        engine->destroy(app.ao);
+    };
+
+    FilamentApp::get().run(config, setup, cleanup);
+}


### PR DESCRIPTION
This is similar to its WebGL and Android counterparts, we simply did not
have a version for desktop. This uses resgen to package the model's
textures (albedo, normal, roughness, metallic, ao) into a library that
is linked only to this sample.

This is a good test because it applies multiple textures to the model.
Moreover Aaron was asking me for a C++ example that uses compressed
textures.

For now this selects the OpenGL backend. We can change it to use Vulkan
after we add support for 3-band formats to VulkanDriver.

![screen shot 2018-12-10 at 3 56 41 pm](https://user-images.githubusercontent.com/1288904/49769511-515a5000-fc95-11e8-9c84-c706e43459f7.png)
