### PR TITLE
Always wake up a job queue when a job is ran

### DIFF
--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -382,12 +382,9 @@ void JobSystem::run(JobSystem::Job*& job, uint32_t flags) noexcept {
 
     // wake-up a thread if needed...
     if (!(flags & DONT_SIGNAL)) {
-        // if it was busy before, try to wake-up another sleeping thread
-        if (activeJobs) {
-            // wake-up a queue
-            { std::lock_guard<Mutex> lock(mLock); }
-            mCondition.notify_one();
-        }
+        // wake-up a queue
+        { std::lock_guard<Mutex> lock(mLock); }
+        mCondition.notify_one();
     }
 
     // after run() returns, the job is virtually invalid (it'll die on its own)


### PR DESCRIPTION
We used to only wake up a job-queue if there was already some jobs
running, the idea was that the current thread would handle the new job
as soon as calling wait(). However, there is no guarantee that wait() 
will be called anytime soon.

cv.signal() is not very expensive on Android/Linux, as we're using
a custom implementation.