### PR TITLE
Turn on shaders optimization by default

### DIFF
--- a/android/build/filament-tasks.gradle
+++ b/android/build/filament-tasks.gradle
@@ -96,7 +96,7 @@ class MaterialCompiler extends DefaultTask {
                 standardOutput out
                 errorOutput err
                 executable "${matcPath}"
-                args('-O', '-p', 'mobile', '-o', getOutputFile(file), file)
+                args('-p', 'mobile', '-o', getOutputFile(file), file)
             }
         }
 

--- a/android/samples/hello-triangle/app/src/main/materials/baked_color.mat
+++ b/android/samples/hello-triangle/app/src/main/materials/baked_color.mat
@@ -2,7 +2,7 @@
 //
 // This source material must be compiled to a binary material using the matc tool.
 // The command used to compile this material is:
-// matc -p mobile -a opengl -O -o app/src/main/assets/baked_color.filamat app/src/materials/baked_color.mat
+// matc -p mobile -a opengl -o app/src/main/assets/baked_color.filamat app/src/materials/baked_color.mat
 //
 // See build.gradle for an example of how to compile materials automatically
 // Please refer to the documentation for more information about matc and the materials system.

--- a/android/samples/lit-cube/app/src/main/materials/lit.mat
+++ b/android/samples/lit-cube/app/src/main/materials/lit.mat
@@ -7,7 +7,7 @@
 //
 // This source material must be compiled to a binary material using the matc tool.
 // The command used to compile this material is:
-// matc -p mobile -a opengl -O -o app/src/main/assets/lit.filamat app/src/materials/lit.mat
+// matc -p mobile -a opengl -o app/src/main/assets/lit.filamat app/src/materials/lit.mat
 //
 // See build.gradle for an example of how to compile materials automatically
 // Please refer to the documentation for more information about matc and the materials system.

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1397,9 +1397,7 @@ The command line flags relevant to application development are described in tabl
 **-o**, **--output**            | [path]             | Specify the output file path
 **-p**, **--platform**          | desktop/mobile/all | Select the target platform(s)
 **-a**, **--api**               | opengl/vulkan/all  | Specify the target graphics API
-**-O**, **--optimize**          | N/A                | Optimize compiled material for performance
-**-S**, **--optimize-size**     | N/A                | Optimize compiled material for size and performance
-**-E**, **--preprocessor-only** | N/A                | Optimize compiled material by running only the preprocessor
+**-S**, **--optimize-size**     | N/A                | Optimize compiled material for size instead of just performance
 **-r**, **--reflect**           | parameters         | Outputs the specified metadata as JSON
 **-v**, **--variant-filter**    | [variant]          | Filters out the specified, comma-separated variants
 [Table [matcFlags]: List of `matc` flags]
@@ -1415,7 +1413,7 @@ appropriate target platform. For instance, to compile a material package for And
 the following command:
 
 ```text
-$ matc -p mobile -O -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat
+$ matc -p mobile -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat
 ```
 
 ### --api
@@ -1426,28 +1424,14 @@ only Vulkan capable devices, you can reduce the size of the material packages by
 the set of Vulkan shaders:
 
 ```text
-$ matc -a vulkan -O -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat
+$ matc -a vulkan -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat
 ```
-
-### --optimize
-
-This flag runs a separate optimization pass on the compiled material. This optimization pass applies
-many optimization techniques to attempt to make the generated shaders faster to compile and execute
-at runtime. In some cases using this flag might increase the size of the compiled material file.
-It is recommended to use this flag when compiling your application in release mode.
 
 ### --optimize-size
 
-This flag is similar to `--optimize` but applies fewer optimization techniques to try and keep the
-final material as small as possible. If the compiled material is deemed too large with `--optimize`,
-using this flag might be a good compromise between runtime performance and size.
-
-### --preprocessor-only
-
-This flags optimizes the compiled material by running only the preprocessor on the generated
-shaders. This flag may result in compiled materials that are smaller than with `--optimize-size`.
-This flag is only recommended if the size of the compiled material is more important than runtime
-performance and if `--optimize-size` does not deliver satisfactory results.
+This flag applies fewer optimization techniques to try and keep the final material as small as
+possible. If the compiled material is deemed too large by default, using this flag might be
+a good compromise between runtime performance and size.
 
 ### --reflect
 

--- a/docs/webgl/tutorial_redball.html
+++ b/docs/webgl/tutorial_redball.html
@@ -42,7 +42,7 @@ fragment {
 </pre></div>
 
 <p>Next, invoke <code>matc</code> as follows.</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>matc -O -a opengl -p mobile -o plastic.filamat plastic.mat
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>matc -a opengl -p mobile -o plastic.filamat plastic.mat
 </pre></div>
 
 <p>You should now have a material archive in your working directory, which we'll use later in the

--- a/docs/webgl/tutorial_suzanne.html
+++ b/docs/webgl/tutorial_suzanne.html
@@ -102,7 +102,7 @@ fragment {
 </pre></div>
 
 <p>Next, invoke <code>matc</code> as follows.</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>matc -O -a opengl -p mobile -o textured.filamat textured.mat
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>matc -a opengl -p mobile -o textured.filamat textured.mat
 </pre></div>
 
 <p>You should now have a material archive in your working directory. For the suzanne asset, the normal

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -255,8 +255,8 @@ else()
 endif()
 
 # Only optimize materials in Release mode (so error message lines match the source code)
-if (CMAKE_BUILD_TYPE MATCHES Release)
-    set(MATC_OPT_FLAGS -O)
+if (NOT CMAKE_BUILD_TYPE MATCHES Release)
+    set(MATC_OPT_FLAGS -g)
 endif()
 
 foreach (mat_src ${MATERIAL_SRCS})

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 # Optimize materials for performance in Release mode.
 set(MATC_FLAGS -a all)
 if (NOT CMAKE_BUILD_TYPE MATCHES Release)
-    set(MATC_FLAGS ${MATC_FLAGS} -O)
+    set(MATC_FLAGS ${MATC_FLAGS} -g)
 endif()
 
 foreach (mat_src ${MATERIAL_SRCS})

--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 # Optimize materials for performance in Release mode.
 set(MATC_FLAGS -a all)
-if (CMAKE_BUILD_TYPE MATCHES Release)
+if (NOT CMAKE_BUILD_TYPE MATCHES Release)
     set(MATC_FLAGS ${MATC_FLAGS} -O)
 endif()
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -67,7 +67,7 @@ protected:
     using ShaderModel = filament::driver::ShaderModel;
     Platform mPlatform = Platform::DESKTOP;
     TargetApi mTargetApi = TargetApi::OPENGL;
-    Optimization mOptimization = Optimization::NONE;
+    Optimization mOptimization = Optimization::PERFORMANCE;
     bool mPrintShaders = false;
     utils::bitset32 mShaderModels;
     struct CodeGenParams {
@@ -177,7 +177,7 @@ public:
     // (used to generate code) and final output representations (spirv and/or text).
     MaterialBuilder& targetApi(TargetApi targetApi) noexcept;
 
-    // specifies the level of optimization to apply to the shaders (default is NONE)
+    // specifies the level of optimization to apply to the shaders (default is PERFORMANCE)
     MaterialBuilder& optimization(Optimization optimization) noexcept;
 
     // if true, will output the generated GLSL shader code to stdout

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -54,7 +54,7 @@ set(MATC_TARGET desktop)
 # Optimize materials for performance in Release mode.
 set(MATC_FLAGS -a all)
 if (NOT CMAKE_BUILD_TYPE MATCHES Release)
-    set(MATC_FLAGS -O ${MATC_FLAGS})
+    set(MATC_FLAGS -g ${MATC_FLAGS})
 endif()
 
 foreach (mat_src ${MATERIAL_SRCS})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -53,7 +53,7 @@ set(MATC_TARGET desktop)
 
 # Optimize materials for performance in Release mode.
 set(MATC_FLAGS -a all)
-if (CMAKE_BUILD_TYPE MATCHES Release)
+if (NOT CMAKE_BUILD_TYPE MATCHES Release)
     set(MATC_FLAGS -O ${MATC_FLAGS})
 endif()
 

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -49,12 +49,8 @@ static void usage(char* name) {
             "       Specify path to output file\n\n"
             "   --platform, -p\n"
             "       Shader family to generate: desktop, mobile or all (default)\n\n"
-            "   --optimize, -O, -x\n"
-            "       Optimize generated shader code for performance\n\n"
             "   --optimize-size, -S\n"
-            "       Optimize generated shader code for performance and size\n\n"
-            "   --preprocessor-only, -E\n"
-            "       Optimize by running only the preprocessor\n\n"
+            "       Optimize generated shader code for size instead of just performance\n\n"
             "   --api, -a\n"
             "       Specify the target API: opengl (default), vulkan or all\n\n"
             "   --reflect, -r\n"
@@ -63,7 +59,11 @@ static void usage(char* name) {
             "       Filter out specified comma-separated variants:\n"
             "           directionalLighting, dynamicLighting, shadowReceiver, skinning\n"
             "       This variant filter is merged the filter from the material, if any\n\n"
-            "Internal use only:\n"
+            "Internal use and debugging only:\n"
+            "   --optimize-none, -g\n"
+            "       Disable all shader optimizations, for debugging\n\n"
+            "   --preprocessor-only, -E\n"
+            "       Optimize shaders by running only the preprocessor\n\n"
             "   --output-format, -f\n"
             "       Specify output format: blob (default) or header\n\n"
             "   --debug, -d\n"
@@ -86,12 +86,30 @@ static void license() {
     ;
 }
 
+static uint8_t parseVariantFilter(const std::string& arg) {
+    std::stringstream ss(arg);
+    std::string item;
+    uint8_t variantFilter = 0;
+    while (std::getline(ss, item, ',')) {
+        if (item == "directionalLighting") {
+            variantFilter |= filament::Variant::DIRECTIONAL_LIGHTING;
+        } else if (item == "dynamicLighting") {
+            variantFilter |= filament::Variant::DYNAMIC_LIGHTING;
+        } else if (item == "shadowReceiver") {
+            variantFilter |= filament::Variant::SHADOW_RECEIVER;
+        } else if (item == "skinning") {
+            variantFilter |= filament::Variant::SKINNING;
+        }
+    }
+    return variantFilter;
+}
+
 CommandlineConfig::CommandlineConfig(int argc, char** argv) : Config(), mArgc(argc), mArgv(argv) {
     mIsValid = parse();
 }
 
 bool CommandlineConfig::parse() {
-    static constexpr const char* OPTSTR = "hxo:f:dm:a:p:OSEr:v:";
+    static constexpr const char* OPTSTR = "hxo:f:dm:a:p:OSEr:v:g";
     static const struct option OPTIONS[] = {
             { "help",                    no_argument, nullptr, 'h' },
             { "license",                 no_argument, nullptr, 'l' },
@@ -101,14 +119,15 @@ bool CommandlineConfig::parse() {
             { "mode",              required_argument, nullptr, 'm' },
             { "variant-filter",    required_argument, nullptr, 'v' },
             { "platform",          required_argument, nullptr, 'p' },
-            { "optimize",                no_argument, nullptr, 'x' },
-            { "optimize",                no_argument, nullptr, 'O' },
+            { "optimize",                no_argument, nullptr, 'x' }, // for backward compatibility
+            { "optimize",                no_argument, nullptr, 'O' }, // for backward compatibility
             { "optimize-size",           no_argument, nullptr, 'S' },
+            { "optimize-none",           no_argument, nullptr, 'g' },
             { "preprocessor-only",       no_argument, nullptr, 'E' },
             { "api",               required_argument, nullptr, 'a' },
             { "reflect",           required_argument, nullptr, 'r' },
             { "print",                   no_argument, nullptr, 't' },
-            { 0, 0, 0, 0 }  // termination of the option list
+            { nullptr, 0, nullptr, 0 }  // termination of the option list
     };
 
     int opt;
@@ -141,7 +160,7 @@ bool CommandlineConfig::parse() {
                 }
                 break;
             case 'd':
-                mDebug= true;
+                mDebug = true;
                 break;
             case 'm':
                 if (arg == "material") {
@@ -184,23 +203,10 @@ bool CommandlineConfig::parse() {
                 }
                 break;
             case 'v': {
-                std::stringstream ss(arg);
-                std::string item;
-                uint8_t variantFilter = 0;
-                while (std::getline(ss, item, ',')) {
-                    if (item == "directionalLighting") {
-                        variantFilter |= filament::Variant::DIRECTIONAL_LIGHTING;
-                    } else if (item == "dynamicLighting") {
-                        variantFilter |= filament::Variant::DYNAMIC_LIGHTING;
-                    } else if (item == "shadowReceiver") {
-                        variantFilter |= filament::Variant::SHADOW_RECEIVER;
-                    } else if (item == "skinning") {
-                        variantFilter |= filament::Variant::SKINNING;
-                    }
-                }
-                mVariantFilter = variantFilter;
+                mVariantFilter = parseVariantFilter(arg);
                 break;
             }
+            // These 2 flags are supported for backward compatibility
             case 'O':
             case 'x':
                 mOptimizationLevel = Optimization::PERFORMANCE;
@@ -210,6 +216,9 @@ bool CommandlineConfig::parse() {
                 break;
             case 'E':
                 mOptimizationLevel = Optimization::PREPROCESSOR;
+                break;
+            case 'g':
+                mOptimizationLevel = Optimization::NONE;
                 break;
             case 'r':
                 mReflectionTarget = Metadata::PARAMETERS;

--- a/tools/matc/src/matc/Config.h
+++ b/tools/matc/src/matc/Config.h
@@ -51,11 +51,11 @@ public:
         PARAMETERS
     };
 
-    virtual ~Config() {}
+    virtual ~Config() = default;
 
     class Output {
     public:
-        virtual ~Output() {}
+        virtual ~Output() = default;
         virtual bool open() noexcept = 0;
         virtual bool write(const uint8_t* data, size_t size) noexcept = 0;
         virtual std::ostream& getOutputStream() noexcept = 0;
@@ -65,7 +65,7 @@ public:
 
     class Input {
     public:
-        virtual ~Input() {}
+        virtual ~Input() = default;
         virtual ssize_t open() noexcept = 0;
         virtual std::unique_ptr<const char[]> read() noexcept = 0;
         virtual bool close() noexcept = 0;
@@ -123,7 +123,7 @@ protected:
     bool mDebug = false;
     bool mIsValid = true;
     bool mPrintShaders = false;
-    Optimization mOptimizationLevel = Optimization::NONE;
+    Optimization mOptimizationLevel = Optimization::PERFORMANCE;
     Metadata mReflectionTarget = Metadata::NONE;
     Mode mMode = Mode::MATERIAL;
     Platform mPlatform = Platform::ALL;

--- a/web/docs/build.py
+++ b/web/docs/build.py
@@ -198,7 +198,7 @@ def tangle(name):
 def build_filamat(name):
     matsrc = SCRIPT_DIR + name + '.mat'
     matdst = os.path.join(OUTPUT_DIR, name + '.filamat')
-    flags = '-O -a opengl -p mobile'
+    flags = '-a opengl -p mobile'
     matc_exec = os.path.join(TOOLS_DIR, 'matc/matc')
     retval = os.system(f"{matc_exec} {flags} -o {matdst} {matsrc}")
     if retval != 0:

--- a/web/docs/tutorial_redball.md
+++ b/web/docs/tutorial_redball.md
@@ -44,7 +44,7 @@ fragment {
 Next, invoke `matc` as follows.
 
 ```bash
-matc -O -a opengl -p mobile -o plastic.filamat plastic.mat
+matc -a opengl -p mobile -o plastic.filamat plastic.mat
 ```
 
 You should now have a material archive in your working directory, which we'll use later in the

--- a/web/docs/tutorial_suzanne.md
+++ b/web/docs/tutorial_suzanne.md
@@ -115,7 +115,7 @@ fragment {
 Next, invoke `matc` as follows.
 
 ```bash
-matc -O -a opengl -p mobile -o textured.filamat textured.mat
+matc -a opengl -p mobile -o textured.filamat textured.mat
 ```
 
 You should now have a material archive in your working directory. For the suzanne asset, the normal

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -20,7 +20,7 @@ set(MATERIAL_NAMES
 
 set(MATC_FLAGS -a opengl -m material -p mobile)
 if (NOT CMAKE_BUILD_TYPE MATCHES Release)
-    set(MATC_FLAGS -O ${MATC_FLAGS})
+    set(MATC_FLAGS -g ${MATC_FLAGS})
 endif()
 
 set(MATERIAL_BINS)

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -19,7 +19,7 @@ set(MATERIAL_NAMES
     nonlit)
 
 set(MATC_FLAGS -a opengl -m material -p mobile)
-if (CMAKE_BUILD_TYPE MATCHES Release)
+if (NOT CMAKE_BUILD_TYPE MATCHES Release)
     set(MATC_FLAGS -O ${MATC_FLAGS})
 endif()
 


### PR DESCRIPTION
Release builds of Filament only work well with optimize shaders,
turning optimizations on by default will help avoid mismatches.

This change also adds -g to disable all optimizations, for debug
builds.

This PR fixes #606 