### PR TITLE
Fixes an overflow issue when exactly 256 bones are used

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -286,7 +286,7 @@ void FRenderableManager::create(
                     driver.createUniformBuffer(count * sizeof(PerRenderableUibBone),
                             driver::BufferUsage::DYNAMIC),
                     UniformBuffer{ count * sizeof(PerRenderableUibBone) },
-                    (uint8_t)count
+                    count
             });
             assert(bones);
             if (bones) {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -141,7 +141,7 @@ private:
     struct Bones {
         filament::Handle<HwUniformBuffer> handle;
         UniformBuffer bones;
-        uint8_t count;
+        size_t count;
     };
 
     friend class ::FilamentTest_Bones_Test;


### PR DESCRIPTION
I was trying to fill out all 256 bone matrices in an attempt to debug a model issue I had when I noticed this actually causes a crash.
The reason is the silent downcast of the bone count to uint8_t, which overflows to 0. That makes it impossible to set any bone matrices afterwards.

p.s.: uint16_t would have been sufficient here but since the entire public API surface uses size_t for the bone count, I opted to use it here as well. It doesn't seem like this struct will be allocated terribly often so it shouldn't have a noticeable memory impact.