### PR TITLE
code size optimizations

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -162,7 +162,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
     // Figure out if we have the extension we need
     GLint n;
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-    std::set<StaticString> exts;
+    ExtentionSet exts;
     for (GLint i = 0; i < n; i++) {
         const char * const ext = (const char*)glGetStringi(GL_EXTENSIONS, (GLuint)i);
         exts.emplace(ext, strlen(ext));
@@ -240,11 +240,12 @@ OpenGLDriver::~OpenGLDriver() noexcept {
 // Driver interface concrete implementation
 // ------------------------------------------------------------------------------------------------
 
-bool OpenGLDriver::hasExtension(std::set<StaticString> const& map, const char* ext) noexcept {
-    return map.find({ ext, (StaticString::size_type) strlen(ext) }) != map.end();
+UTILS_NOINLINE
+bool OpenGLDriver::hasExtension(ExtentionSet const& map, utils::StaticString ext) noexcept {
+    return map.find(ext) != map.end();
 }
 
-void OpenGLDriver::initExtensionsGLES(GLint major, GLint minor, std::set<StaticString> const& exts) {
+void OpenGLDriver::initExtensionsGLES(GLint major, GLint minor, ExtentionSet const& exts) {
     // figure out and initialize the extensions we need
     ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
     ext.texture_compression_etc2 = true;
@@ -256,7 +257,7 @@ void OpenGLDriver::initExtensionsGLES(GLint major, GLint minor, std::set<StaticS
     ext.EXT_multisampled_render_to_texture = hasExtension(exts, "GL_EXT_multisampled_render_to_texture");
 }
 
-void OpenGLDriver::initExtensionsGL(GLint major, GLint minor, std::set<StaticString> const& exts) {
+void OpenGLDriver::initExtensionsGL(GLint major, GLint minor, ExtentionSet const& exts) {
     ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
     ext.texture_compression_etc2 = hasExtension(exts, "GL_ARB_ES3_compatibility");
     ext.texture_compression_s3tc = hasExtension(exts, "GL_EXT_texture_compression_s3tc");

--- a/filament/src/driver/opengl/OpenGLDriver.h
+++ b/filament/src/driver/opengl/OpenGLDriver.h
@@ -275,9 +275,11 @@ private:
     using GetProcAddressType = MustCastToRightType (*)(const char* name);
     GetProcAddressType getProcAddress = nullptr;
 
-    static bool hasExtension(std::set<utils::StaticString> const& exts, const char* ext) noexcept;
-    void initExtensionsGLES(GLint major, GLint minor, std::set<utils::StaticString> const& extensionsMap);
-    void initExtensionsGL(GLint major, GLint minor, std::set<utils::StaticString> const& extensionsMap);
+    // this is chosen to minimize code size
+    using ExtentionSet = std::set<utils::StaticString>;
+    static bool hasExtension(ExtentionSet const& exts, utils::StaticString ext) noexcept;
+    void initExtensionsGLES(GLint major, GLint minor, ExtentionSet const& extensionsMap);
+    void initExtensionsGL(GLint major, GLint minor, ExtentionSet const& extensionsMap);
 
 
     /* Misc... */

--- a/libs/utils/include/utils/Profiler.h
+++ b/libs/utils/include/utils/Profiler.h
@@ -183,22 +183,7 @@ public:
         ioctl(fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
     }
 
-    Counters readCounters() noexcept {
-        Counters outCounters{};
-        Counters counters; // NOLINT
-        ssize_t n = read(mCountersFd[0], &counters, sizeof(Counters));
-        if (n > 0) {
-            outCounters.nr = counters.nr;
-            outCounters.time_enabled = counters.time_enabled;
-            outCounters.time_running = counters.time_running;
-            for (size_t i = 0; i < size_t(EVENT_COUNT); i++) {
-                if (mCountersFd[i] >= 0) {
-                    outCounters.counters[i] = counters.counters[mIds[i]];
-                }
-            }
-        }
-        return outCounters;
-    }
+    Counters readCounters() noexcept;
 
 #else // !__linux__
 
@@ -218,7 +203,7 @@ public:
     }
 
 private:
-    UTILS_UNUSED uint8_t mIds[EVENT_COUNT];
+    UTILS_UNUSED uint8_t mIds[EVENT_COUNT] = {};
     int mCountersFd[EVENT_COUNT];
     uint32_t mEnabledEvents = 0;
 };

--- a/libs/utils/src/Profiler.cpp
+++ b/libs/utils/src/Profiler.cpp
@@ -202,4 +202,25 @@ uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
     return mEnabledEvents;
 }
 
+#if defined(__linux__)
+
+Profiler::Counters Profiler::readCounters() noexcept {
+    Counters outCounters{};
+    Counters counters; // NOLINT
+    ssize_t n = read(mCountersFd[0], &counters, sizeof(Counters));
+    if (n > 0) {
+        outCounters.nr = counters.nr;
+        outCounters.time_enabled = counters.time_enabled;
+        outCounters.time_running = counters.time_running;
+        for (size_t i = 0; i < size_t(EVENT_COUNT); i++) {
+            // in theory we should check that mCountersFd[i] >= 0, but we don't to avoid
+            // a branch, mIds[] is initialized such we won't access past the counters array.
+            outCounters.counters[i] = counters.counters[mIds[i]];
+        }
+    }
+    return outCounters;
+}
+
+#endif // __linux__
+
 } // namespace utils


### PR DESCRIPTION
- make Profiler::readCounters() not inline as it didn't need to be, 
it's not performance critical and it's sufficiently large.

- don't inline hasExtensions(), same reason.