### PR TITLE
reduce AAR's content by about 150K

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
 if (ANDROID OR WEBGL)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
 endif()
 
 # ==================================================================================================
@@ -169,6 +169,7 @@ endif()
 #  -fsanitize=undefined causes extremely long link times
 #  -fsanitize=address causes a crash with assimp, which we can't explain for now
 #set(EXTRA_SANITIZE_OPTIONS "-fsanitize=undefined -fsanitize=address")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${EXTRA_SANITIZE_OPTIONS}")
 
 # ==================================================================================================

--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -29,11 +29,12 @@ set_target_properties(smol-v PROPERTIES IMPORTED_LOCATION
 
 include_directories(${FILAMENT_DIR}/include)
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-stack-protector")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math -ffp-contract=fast")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility-inlines-hidden")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility=hidden")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer -ffunction-sections -fdata-sections")
 
 set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
 set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")

--- a/libs/utils/src/CallStack.cpp
+++ b/libs/utils/src/CallStack.cpp
@@ -30,7 +30,7 @@
 #define HAS_EXECINFO 0
 #endif
 
-#if !defined(WIN32)
+#if !defined(NDEBUG) && !defined(WIN32)
 #include <cxxabi.h>
 #endif
 
@@ -56,7 +56,7 @@ CallStack CallStack::unwind(size_t ignore) noexcept {
 
 // ------------------------------------------------------------------------------------------------
 
-intptr_t CallStack::operator [](size_t index) const {
+intptr_t CallStack::operator[](size_t index) const {
     if (index >= m_frame_count) {
 #ifdef __EXCEPTIONS
         throw std::out_of_range("out-of-range access in CallStack::operator[]");
@@ -78,13 +78,13 @@ void CallStack::update_gcc(size_t ignore) noexcept {
     // reset the object
     ssize_t size = 0;
 
-    void *array[NUM_FRAMES];
+    void* array[NUM_FRAMES];
 #if HAS_EXECINFO
     size = ::backtrace(array, NUM_FRAMES);
     size -= ignore;
 #endif
     for (ssize_t i = 0; i < size; i++) {
-        m_stack[i].pc = intptr_t(array[ignore+i]);
+        m_stack[i].pc = intptr_t(array[ignore + i]);
     }
     size--; // the last one seems to always be 0x0
 
@@ -92,7 +92,7 @@ void CallStack::update_gcc(size_t ignore) noexcept {
     m_frame_count = size_t(std::max(ssize_t(0), size));
 }
 
-bool CallStack::operator <(const CallStack& rhs) const {
+bool CallStack::operator<(const CallStack& rhs) const {
     if (m_frame_count != rhs.m_frame_count) {
         return m_frame_count < rhs.m_frame_count;
     }
@@ -102,7 +102,7 @@ bool CallStack::operator <(const CallStack& rhs) const {
 // ------------------------------------------------------------------------------------------------
 
 utils::CString CallStack::demangleTypeName(const char* mangled) {
-#if !defined(WIN32)
+#if !defined(NDEBUG) && !defined(WIN32)
     size_t len;
     int status;
     std::unique_ptr<char, FreeDeleter> demangled(abi::__cxa_demangle(mangled, nullptr, &len, &status));


### PR DESCRIPTION
We simply don't emit unwind tables, which are not needed anyways since
we're compiling without exceptions. the combined saving for all four 
targets we support is about 120K.

This seems to improve .aar's compression, for a total gain of 152 KiB. 

We also disable stack-protector in the jni code, since it wasn't
enabled in libfilament.a anyways. However, we now compile all debug 
builds with -fstack-protector