### PR TITLE
Improve JobSystem::wait

### DIFF
--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -689,6 +689,7 @@ void FView::cullRenderables(JobSystem& js,
 
 void FView::prepareVisibleLights(FLightManager const& lcm, utils::JobSystem&,
         Frustum const& frustum, FScene::LightSoa& lightData) noexcept {
+    SYSTRACE_CALL();
 
     auto const* UTILS_RESTRICT sphereArray     = lightData.data<FScene::POSITION_RADIUS>();
     auto const* UTILS_RESTRICT directions      = lightData.data<FScene::DIRECTION>();

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -376,8 +376,12 @@ private:
     }
 
     // these have thread contention, keep them together
-    utils::Mutex mLock;
-    utils::Condition mCondition;
+    utils::Mutex mLooperLock;
+    utils::Condition mLooperCondition;
+
+    utils::Mutex mWaiterLock;
+    utils::Condition mWaiterCondition;
+
     std::atomic<uint32_t> mActiveJobs = { 0 };
     utils::Arena<utils::ThreadSafeObjectPoolAllocator<Job>, LockingPolicy::NoLock> mJobPool;
 


### PR DESCRIPTION
JobSystem::waitAndRelease used to spin to wait for the job to finish,
usually this wasn't a problem because the spinning thread was
able to handle other jobs. However, in cases where no job was
available it would actually spin in burn cpu cycles.

we now use a (separate) condition variable to handle that case.