### PR TITLE
get rid of JobSystem::reset()

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -146,7 +146,6 @@ void FRenderer::render(FView const* view) {
 
         // and wait for all jobs to finish as a safety (this should be a no-op)
         js.runAndWait(masterJob);
-        js.reset();
     }
 }
 

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -93,11 +93,8 @@ public:
 
     // If a parent is not specified when creating a job, that job will automatically take the
     // master job as a parent.
-    // The master job is reset when calling reset()
+    // The master job is reset when waited on.
     Job* setMasterJob(Job* job) noexcept { return mMasterJob = job; }
-
-    // Clears the master job
-    void reset() noexcept { mMasterJob = nullptr; }
 
 
     // NOTE: All methods below must be called from the same thread and that thread must be

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -422,6 +422,10 @@ void JobSystem::waitAndRelease(Job*& job) noexcept {
         }
     } while (!hasJobCompleted(job) && !exitRequested());
 
+    if (job == mMasterJob) {
+        mMasterJob = nullptr;
+    }
+
     release(job);
 }
 

--- a/tools/cmgen/src/CubemapIBL.cpp
+++ b/tools/cmgen/src/CubemapIBL.cpp
@@ -826,5 +826,4 @@ void CubemapIBL::DFG(Image& dst, bool multiscatter) {
                 }
             }, jobs::CountSplitter<1, 8>());
     js.runAndWait(job);
-    js.reset();
 }

--- a/tools/cmgen/src/CubemapUtils.cpp
+++ b/tools/cmgen/src/CubemapUtils.cpp
@@ -136,7 +136,6 @@ void CubemapUtils::cubemapToEquirectangular(Image& dst, const Cubemap& src) {
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
             std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
     js.runAndWait(job);
-    js.reset();
 }
 
 void CubemapUtils::cubemapToOctahedron(Image& dst, const Cubemap& src) {
@@ -172,7 +171,6 @@ void CubemapUtils::cubemapToOctahedron(Image& dst, const Cubemap& src) {
     auto job = jobs::parallel_for(js, nullptr, 0, uint32_t(h),
             std::ref(parallelJobTask), jobs::CountSplitter<1, 8>());
     js.runAndWait(job);
-    js.reset();
 }
 
 void CubemapUtils::crossToCubemap(Cubemap& dst, const Image& src) {

--- a/tools/cmgen/src/CubemapUtils.h
+++ b/tools/cmgen/src/CubemapUtils.h
@@ -134,7 +134,6 @@ void CubemapUtils::process(
     }
     // wait for all our threads to finish
     js.runAndWait(parent);
-    js.reset();
 
     for (STATE& s : states) {
         reduce(s);

--- a/tools/skygen/src/main.cpp
+++ b/tools/skygen/src/main.cpp
@@ -156,7 +156,6 @@ static void generateSky(LinearImage image) {
     );
 
     js.runAndWait(job);
-    js.reset();
 
     // cleanup sky data
     arhosekskymodelstate_free(jobData.skyState[0]);


### PR DESCRIPTION
It was only used to clear the master job, instead the master job is
cleared when waited on.