### PR TITLE
Fix Windows Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,10 @@ endif()
 #  -fsanitize=undefined causes extremely long link times
 #  -fsanitize=address causes a crash with assimp, which we can't explain for now
 #set(EXTRA_SANITIZE_OPTIONS "-fsanitize=undefined -fsanitize=address")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector")
+# clang-cl.exe on Windows does not support -fstack-protector.
+if (NOT CLANG_CL)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstack-protector")
+endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${EXTRA_SANITIZE_OPTIONS}")
 
 # ==================================================================================================

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -137,6 +137,8 @@ set(PRIVATE_HDRS
         src/driver/Handle.h
         src/driver/Program.h
         src/driver/SamplerBuffer.h
+        src/driver/noop/NoopDriver.cpp
+        src/driver/noop/PlatformNoop.cpp
         src/FilamentAPI-impl.h
         src/FrameInfo.h
         src/Intersections.h
@@ -151,17 +153,6 @@ set(MATERIAL_SRCS
         src/materials/skybox.mat
         src/materials/skyboxRGBM.mat
 )
-
-# The noop driver is only useful for ensuring we don't have certain build issues.
-# Remove it from release builds, since it uses some space needlessly.
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-    list(APPEND SRCS src/driver/noop/NoopDriver.cpp)
-    list(APPEND SRCS src/driver/noop/PlatformNoop.cpp)
-endif()
-
-if(IOS AND NOT FILAMENT_SUPPORTS_VULKAN)
-    message(FATAL_ERROR "Filament for iOS must be built with Vulkan support.")
-endif()
 
 # Embed the binary resource blob for materials.
 get_resgen_vars(${RESOURCE_DIR} materials)

--- a/filament/src/driver/noop/NoopDriver.cpp
+++ b/filament/src/driver/noop/NoopDriver.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// The noop driver is only useful for ensuring we don't have certain build issues.
+// Remove it from release builds, since it uses some space needlessly.
+#ifndef NDEBUG
+
 #include "driver/noop/NoopDriver.h"
 #include "driver/CommandStreamDispatcher.h"
 
@@ -41,3 +45,5 @@ driver::ShaderModel NoopDriver::getShaderModel() const noexcept {
 template class ConcreteDispatcher<NoopDriver>;
 
 } // namespace filament
+
+#endif

--- a/filament/src/driver/noop/PlatformNoop.cpp
+++ b/filament/src/driver/noop/PlatformNoop.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// The noop driver is only useful for ensuring we don't have certain build issues.
+// Remove it from release builds, since it uses some space needlessly.
+#ifndef NDEBUG
+
 #include "driver/noop/PlatformNoop.h"
 
 #include "driver/noop/NoopDriver.h"
@@ -25,3 +29,5 @@ Driver* PlatformNoop::createDriver(void* const sharedGLContext) noexcept {
 }
 
 } // namespace filament
+
+#endif


### PR DESCRIPTION
Fixed some issues on Windows:

- `clang-cl` doesn't handle `-fstack-protector`
- Moved `NoopDriver` and `PlatformNoop` into `SRCS` because multi-configuration generators like Visual Studio or Xcode can't handle conditional source lists (i.e., `CMAKE_BUILD_TYPE` is empty for them).
- Deleted unnecessary check for iOS