### PR TITLE
Add constexpr constructor to StaticString

### DIFF
--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -77,7 +77,7 @@ public:
     using const_pointer   = const value_type*;
     using const_iterator  = const value_type*;
 
-    StaticString() noexcept = default;
+    constexpr StaticString() noexcept = default;
 
     // initialization from a string literal
     template <size_t N>


### PR DESCRIPTION
Fixes a header usage problem for MSVC, which complains about StaticString not having a constexpr constructor thus making the "make" method not constexpr.