### PR TITLE
Add return 0 to main functions to avoid crashes on Windows

### DIFF
--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -115,4 +115,6 @@ int main(int argc, char** argv) {
     };
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_animation.cpp
+++ b/samples/vk_animation.cpp
@@ -138,4 +138,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_depthtesting.cpp
+++ b/samples/vk_depthtesting.cpp
@@ -135,4 +135,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_hellopbr.cpp
+++ b/samples/vk_hellopbr.cpp
@@ -97,4 +97,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_hellotriangle.cpp
+++ b/samples/vk_hellotriangle.cpp
@@ -122,4 +122,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_imgui.cpp
+++ b/samples/vk_imgui.cpp
@@ -54,4 +54,6 @@ int main(int argc, char** argv) {
     config.title = "ImGui Demo";
     auto nop = [](filament::Engine*, filament::View*, filament::Scene*) {};
     FilamentApp::get().run(config, nop, nop, imgui);
+
+    return 0;
 }

--- a/samples/vk_shadowtest.cpp
+++ b/samples/vk_shadowtest.cpp
@@ -124,6 +124,8 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }
 
 static GroundPlane createGroundPlane(Engine* engine) {

--- a/samples/vk_strobecolor.cpp
+++ b/samples/vk_strobecolor.cpp
@@ -47,4 +47,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_texturedquad.cpp
+++ b/samples/vk_texturedquad.cpp
@@ -165,4 +165,6 @@ int main(int argc, char** argv) {
     });
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_vbotest.cpp
+++ b/samples/vk_vbotest.cpp
@@ -90,4 +90,6 @@ int main(int argc, char** argv) {
     };
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }

--- a/samples/vk_viewtest.cpp
+++ b/samples/vk_viewtest.cpp
@@ -72,4 +72,6 @@ int main(int argc, char** argv) {
     };
 
     FilamentApp::get().run(config, setup, cleanup);
+
+    return 0;
 }


### PR DESCRIPTION
The `main` function needs a return value otherwise we see crashes in Debug mode on Windows:

```
UNHANDLED EXCEPTION - Reason: Illegal Instruction (0xc000001d)
```