### PR TITLE
Make 4-channel versions of certain image operations.

### DIFF
--- a/libs/image/src/ImageSampler.cpp
+++ b/libs/image/src/ImageSampler.cpp
@@ -18,6 +18,7 @@
 #include <image/ImageOps.h>
 
 #include <math/vec3.h>
+#include <math/vec4.h>
 #include <utils/Panic.h>
 #include <utils/CString.h>
 
@@ -204,12 +205,22 @@ FilterFunction createFilterFunction(Filter ftype) {
     return fn;
 }
 
-void normalize(LinearImage& image) {
-    ASSERT_PRECONDITION(image.getChannels() == 3, "Must be a 3-channel image.");
+template <class VecT>
+void normalizeImpl(LinearImage& image) {
     const uint32_t width = image.getWidth(), height = image.getHeight();
-    auto vecs = (math::float3*) image.getPixelRef();
+    auto vecs = (VecT*) image.getPixelRef();
     for (uint32_t n = 0; n < width * height; ++n) {
         vecs[n] = normalize(vecs[n]);
+    }
+}
+
+void normalize(LinearImage& image) {
+    ASSERT_PRECONDITION(image.getChannels() == 3 || image.getChannels() == 4,
+                        "Must be a 3 or 4 channel image");
+    if (image.getChannels() == 3) {
+      normalizeImpl<math::float3>(image);
+    } else {
+      normalizeImpl<math::float4>(image);
     }
 }
 


### PR DESCRIPTION
Background: with the Vulkan backend, RGB8 textures do
not work (at least not on my hardware). This makes me unable to run some
examples, because they use normal maps in RGB8 format.

It appears that the following commit addresses the problem by adding a
special command line option to mipgen:
https://github.com/google/filament/commit/8dda07bf2c19f9ebd8ab499ca2c3849d7b1f031f

However, processing normal maps with this option does not work: certain
assertions in the image library fail.

This PR changes these functions in the image library to handle 4-channel
images instead of failing.