### PR TITLE
Improve skygen

### DIFF
--- a/libs/imageio/src/ImageEncoder.cpp
+++ b/libs/imageio/src/ImageEncoder.cpp
@@ -711,7 +711,7 @@ EXREncoder::~EXREncoder() {
 }
 
 static int toEXRCompression(const std::string& c) {
-    if (c == "") {
+    if (c.empty()) {
         return TINYEXR_COMPRESSIONTYPE_PIZ;
     } else if (c == "RAW") {
         return TINYEXR_COMPRESSIONTYPE_NONE;


### PR DESCRIPTION
Bring back the normalization and gamma correction command line flags,
render the ground in the lower half of the image.