### PR TITLE
Add glslminifier tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
 
     add_subdirectory(${TOOLS}/cmgen)
     add_subdirectory(${TOOLS}/filamesh)
+    add_subdirectory(${TOOLS}/glslminifier)
     add_subdirectory(${TOOLS}/matc)
     add_subdirectory(${TOOLS}/matinfo)
     add_subdirectory(${TOOLS}/mipgen)

--- a/build/common/test_list.txt
+++ b/build/common/test_list.txt
@@ -6,4 +6,5 @@ libs/utils/test_utils
 libs/filamat/test_filamat
 tools/matc/test_matc
 tools/cmgen/test_cmgen compare
+tools/glslminifier/test_glslminifier
 libs/filameshio/test_filameshio

--- a/tools/glslminifier/CMakeLists.txt
+++ b/tools/glslminifier/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.1)
+project(glslminifier)
+
+set(TARGET glslminifier)
+
+# ==================================================================================================
+# Source files
+# ==================================================================================================
+set(SRCS src/main.cpp src/GlslMinify.cpp)
+
+# ==================================================================================================
+# Target definitions
+# ==================================================================================================
+add_executable(${TARGET} ${SRCS})
+target_link_libraries(${TARGET} PRIVATE utils getopt)
+
+# =================================================================================================
+# Licenses
+# ==================================================================================================
+set(MODULE_LICENSES getopt)
+set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR}/generated)
+list_licenses(${GENERATION_ROOT}/licenses/licenses.inc ${MODULE_LICENSES})
+target_include_directories(${TARGET} PRIVATE ${GENERATION_ROOT})
+
+# ==================================================================================================
+# Installation
+# ==================================================================================================
+install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
+
+# ==================================================================================================
+# Tests
+# ==================================================================================================
+if (NOT ANDROID)
+    add_executable(test_${TARGET}
+            src/GlslMinify.cpp
+            tests/test_glslminifier.cpp
+    )
+    target_include_directories(test_${TARGET} PRIVATE src)
+    target_link_libraries(test_${TARGET} PRIVATE gtest)
+endif()

--- a/tools/glslminifier/src/GlslMinify.cpp
+++ b/tools/glslminifier/src/GlslMinify.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GlslMinify.h"
+
+#include <regex>
+
+namespace glslminifier {
+
+using std::regex;
+
+// Slash slash comments:
+// [\t ]*           check for tabs and spaces up until
+// \/\/             two consecutive forward slashes
+// .*               match the rest of the line
+const static regex slashSlashCommentsRegex(R"regex([\t ]*\/\/.*)regex");
+
+// Star comments:
+// [\t ]*           check for tabs and spaces up until
+// \/\*             the characters '/' + '*'
+// [\w\W]*?         match any character, including newlines. The ? makes it "non-greedy"
+// \*\/             stop the match at the first occurrence of '*' + '/'
+const static regex starCommentsRegex(R"regex([\t ]*\/\*[\w\W]*?\*\/)regex");
+
+// Empty lines:
+// (\n|\r\n)+       match 1 or more newlines (either linux or Windows-style)
+//                  The capture group will only capture a single newline sequence.
+const static regex emptyLinesRegex(R"regex((\n|\r\n)+)regex");
+
+// Indentation:
+// (^|\n)           match the beginning of the file, or a newline character (C++14 does not support
+//                  the multiline option, unfortunately)
+// [ \t]+           match at least one leading space or tab character
+const static regex indentationRegex(R"regex((^|\n)[ \t]+)regex");
+
+std::string minifyGlsl(const std::string& glsl, GlslMinifyOptions options) noexcept {
+    std::string minified = glsl;
+
+    if (options & GlslMinifyOptions::STRIP_COMMENTS)  {
+        minified = regex_replace(minified, slashSlashCommentsRegex, "");
+        minified = regex_replace(minified, starCommentsRegex, "");
+    }
+
+    if (options & GlslMinifyOptions::STRIP_EMPTY_LINES) {
+        // Replace the group of newlines with a single newline, which is in the first capture group.
+        minified = regex_replace(minified, emptyLinesRegex, "$1");
+    }
+
+    if (options & GlslMinifyOptions::STRIP_INDENTATION) {
+        // Replace the indentation with whatever was captured in the first capture group, which will
+        // either be a newline or nothing at all (in the case of the first line).
+        // We do this to preserve newlines when stripping indentation.
+        minified = regex_replace(minified, indentationRegex, "$1");
+    }
+
+    return minified;
+}
+
+} // namespace glslminifier

--- a/tools/glslminifier/src/GlslMinify.h
+++ b/tools/glslminifier/src/GlslMinify.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+#ifndef TNT_GLSLMINIFY_H
+#define TNT_GLSLMINIFY_H
+
+namespace glslminifier {
+
+enum GlslMinifyOptions : uint32_t {
+    NONE                = 0x0,
+
+    // Remove comments, both slash-slash (//) and slash-asterisk (/**/)
+    STRIP_COMMENTS      = 0x1,
+
+    // Removes empty lines (two or more consecutive newlines are turned into one).
+    STRIP_EMPTY_LINES   = 0x2,
+
+    // Removes indentation.
+    STRIP_INDENTATION   = 0x4,
+
+    ALL                 = 0xFFFFFFFF
+};
+
+std::string minifyGlsl(const std::string& glsl,
+        GlslMinifyOptions options = GlslMinifyOptions::ALL) noexcept;
+
+} // namesapce glslminifier
+
+#endif //TNT_GLSLMINIFY_H

--- a/tools/glslminifier/src/main.cpp
+++ b/tools/glslminifier/src/main.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GlslMinify.h"
+
+#include <utils/Path.h>
+
+#include <getopt/getopt.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace utils;
+using namespace glslminifier;
+
+static bool g_writeToStdOut = true;
+static const char* g_outputFile = "";
+static const char* g_inputFile = "";
+GlslMinifyOptions g_optimizationLevel = GlslMinifyOptions::ALL;
+
+static const char* USAGE = R"TXT(
+GLSLMINIFIER minifies GLSL shader code by removing comments, blank lines and indentation.
+
+Usage:
+    GLSLMINIFIER [options] <input file>
+
+Options:
+   --help, -h
+       Print this message.
+   --license, -L
+       Print copyright and license information.
+   --output, -o
+       Specify path to output file. If none provided, writes to stdout.
+   --optimization, -O [none]
+       Set the level of optimization. "none" performs a simple passthrough.
+
+Example:
+    GLSLMINIFIER -o output.fs.min input.fs
+    > Output file: output.fs.min
+)TXT";
+
+static void printUsage(const char* name) {
+    std::string execName(Path(name).getName());
+    const std::string from("GLSLMINIFIER");
+    std::string usage(USAGE);
+    for (size_t pos = usage.find(from); pos != std::string::npos; pos = usage.find(from, pos)) {
+        usage.replace(pos, from.length(), execName);
+    }
+    puts(usage.c_str());
+}
+
+static void license() {
+    cout <<
+    #include "licenses/licenses.inc"
+    ;
+}
+
+static int handleArguments(int argc, char* argv[]) {
+    static constexpr const char* OPTSTR = "hLo:O:";
+    static const struct option OPTIONS[] = {
+            { "help",                 no_argument, nullptr, 'h' },
+            { "license",              no_argument, nullptr, 'L' },
+            { "output",         required_argument, nullptr, 'o' },
+            { "optimization",   required_argument, nullptr, 'O' },
+            { nullptr, 0, nullptr, 0 }  // termination of the option list
+    };
+
+    int opt;
+    int optionIndex = 0;
+
+    while ((opt = getopt_long(argc, argv, OPTSTR, OPTIONS, &optionIndex)) >= 0) {
+        std::string arg(optarg ? optarg : "");
+        switch (opt) {
+            default:
+            case 'h':
+                printUsage(argv[0]);
+                exit(0);
+            case 'L':
+                license();
+                exit(0);
+            case 'o':
+                g_outputFile = optarg;
+                g_writeToStdOut = false;
+                break;
+            case 'O':
+                if (arg == "none") {
+                    g_optimizationLevel = GlslMinifyOptions::NONE;
+                } else {
+                    std::cerr << "Warning: unknown optimization level." << std::endl;
+                }
+                break;
+        }
+    }
+
+    return optind;
+}
+
+int main(int argc, char* argv[]) {
+    const int optionIndex = handleArguments(argc, argv);
+    const int numArgs = argc - optionIndex;
+    if (numArgs < 1) {
+        printUsage(argv[0]);
+        return 1;
+    }
+    if (numArgs > 1) {
+        cerr << "Only one input file should be specified on the command line." << endl;
+        return 1;
+    }
+    g_inputFile = argv[optionIndex];
+
+    // Read the contents of the input file.
+    ifstream inStream(g_inputFile, ios::binary);
+    if (!inStream) {
+        cerr << "Unable to read " << g_inputFile << endl;
+        exit(1);
+    }
+    string inputStr((istreambuf_iterator<char>(inStream)), istreambuf_iterator<char>());
+
+    // Minify the GLSL.
+    string result = minifyGlsl(inputStr, g_optimizationLevel);
+
+    if (g_writeToStdOut) {
+        cout << result;
+        return 0;
+    }
+
+    // Create the output path if it doesn't exist already.
+    const Path outputDir = Path(g_outputFile).getParent();
+    if (!outputDir.exists()) {
+        outputDir.mkdirRecursive();
+    }
+
+    // Open the output file for writing.
+    ofstream outStream(g_outputFile, ios::binary);
+    if (!outStream) {
+        cerr << "Unable to open " << g_outputFile << endl;
+        exit(1);
+    }
+    outStream << result;
+    return 0;
+}

--- a/tools/glslminifier/tests/test_glslminifier.cpp
+++ b/tools/glslminifier/tests/test_glslminifier.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "GlslMinify.h"
+
+#include <string>
+
+using std::string;
+
+using namespace glslminifier;
+
+class GlslminifierTest : public testing::Test {};
+
+TEST_F(GlslminifierTest, EmptyString) {
+    EXPECT_EQ(minifyGlsl(""), "");
+}
+
+TEST_F(GlslminifierTest, GlslNoChanges) {
+    std::string glsl = R"glsl("void main() { gl_FragColor = vec4(1.0); })glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::ALL), glsl);
+}
+
+TEST_F(GlslminifierTest, RemoveSlashSlashComments) {
+    std::string glsl = R"glsl(
+        #version 330
+        void main() {// This is a comment at the end of a line.
+            // This is a comment, and this whole line should be removed.
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+            // Another comment.
+        }
+        // This is a comment without a trailing newline.)glsl";
+    std::string expected = R"glsl(
+        #version 330
+        void main() {
+
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+
+        }
+)glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_COMMENTS), expected);
+}
+
+TEST_F(GlslminifierTest, RemoveStarComments) {
+    std::string glsl = R"glsl(
+        #version 330
+        void main() {   /* this is a comment block at the end of a line */
+            /* this is a comment block
+               that spans
+               multiple lines */
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+            /* this is another comment block */
+        }
+        )glsl";
+    std::string expected = R"glsl(
+        #version 330
+        void main() {
+
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+
+        }
+        )glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_COMMENTS), expected);
+}
+
+TEST_F(GlslminifierTest, RemoveBlankLines) {
+    std::string glsl = R"glsl(
+        #version 330
+
+
+        void main() {
+
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+
+        }
+        )glsl";
+    std::string expected = R"glsl(
+        #version 330
+        void main() {
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+        }
+        )glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_EMPTY_LINES), expected);
+}
+
+TEST_F(GlslminifierTest, RemoveBlankLinesWindows) {
+    std::string glsl = "line one\r\n\r\n\r\nline two";
+    std::string expected = "line one\r\nline two";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_EMPTY_LINES), expected);
+}
+
+TEST_F(GlslminifierTest, RemoveIndentation) {
+    std::string glsl = R"glsl(     #version 330
+        void main() {
+            gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+        }
+        )glsl";
+    std::string expected = R"glsl(#version 330
+void main() {
+gl_FragColor = vec4(2.0 / 4.0, 0.0, 0.0, 1.0);
+}
+)glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_INDENTATION), expected);
+}
+
+TEST_F(GlslminifierTest, TrailingNewline) {
+    // Ensure trailing newlines are acceptable when stripping identation.
+    std::string glsl = R"glsl(trailing newline;
+)glsl";
+    EXPECT_EQ(minifyGlsl(glsl, GlslMinifyOptions::STRIP_INDENTATION), glsl);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Right now, shader code is included in our binaries without any type of minification- that is, they include unnecessary comments, newlines, etc. This adds a tool, `glslminifier`, which can be used to strip glsl files to reduce binary size. Stripping comments and newlines saves around 59Kib at the moment, and there's room for more improvement.

This PR only adds the `glslminifier` tool. It will be enabled in a later PR.