### PR TITLE
Remove Metal layer hack for MoltenVK

### DIFF
--- a/filament/src/driver/vulkan/PlatformVkCocoa.mm
+++ b/filament/src/driver/vulkan/PlatformVkCocoa.mm
@@ -47,7 +47,6 @@ void* PlatformVkCocoa::createVkSurfaceKHR(void* nativeWindow, void* instance,
         uint32_t* width, uint32_t* height) noexcept {
     // Obtain the CAMetalLayer-backed view.
     NSView* nsview = (NSView*) nativeWindow;
-    nsview = [nsview viewWithTag:METALVIEW_TAG];
     ASSERT_POSTCONDITION(nsview, "Unable to obtain Metal-backed NSView.");
     CAMetalLayer* mlayer = (CAMetalLayer*) nsview.layer;
     ASSERT_POSTCONDITION(mlayer, "Unable to obtain CAMetalLayer from NSView.");

--- a/filament/src/driver/vulkan/PlatformVkCocoa.mm
+++ b/filament/src/driver/vulkan/PlatformVkCocoa.mm
@@ -30,8 +30,6 @@
 #error VK_MVK_macos_surface is not defined
 #endif
 
-#define METALVIEW_TAG 255
-
 namespace filament {
 
 using namespace driver;

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -155,7 +155,7 @@ set(APP_SRCS
 
 if (APPLE)
     list(APPEND APP_SRCS app/NativeWindowHelperCocoa.mm)
-    list(APPEND APP_LIBS "-framework Cocoa")
+    list(APPEND APP_LIBS "-framework Cocoa -framework quartzcore")
 endif()
 
 if (LINUX)

--- a/samples/app/FilamentApp.cpp
+++ b/samples/app/FilamentApp.cpp
@@ -423,14 +423,12 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
     // rather than the one created by SDL.
     mFilamentApp->mEngine = Engine::create(config.backend);
 
-    // HACK: We don't use SDL's 2D rendering functionality, but by invoking it we cause
-    // SDL to create a Metal backing layer, which allows us to run Vulkan apps via MoltenVK.
-    #if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN) && defined(__APPLE__)
-    constexpr int METAL_DRIVER = 2;
-    SDL_CreateRenderer(mWindow, METAL_DRIVER, SDL_RENDERER_ACCELERATED);
-    #endif
-
     void* nativeWindow = ::getNativeWindow(mWindow);
+#if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN) && defined(__APPLE__)
+    // We request a Metal layer in case we want to render via Metal / MoltenVK. For OpenGL, this
+    // won't make a difference.
+    setUpMetalLayer(nativeWindow);
+#endif
     mSwapChain = mFilamentApp->mEngine->createSwapChain(nativeWindow);
     mRenderer = mFilamentApp->mEngine->createRenderer();
 

--- a/samples/app/NativeWindowHelper.h
+++ b/samples/app/NativeWindowHelper.h
@@ -20,5 +20,6 @@
 struct SDL_Window;
 
 extern "C" void* getNativeWindow(SDL_Window* sdlWindow);
+extern "C" void setUpMetalLayer(void* nativeWindow);
 
 #endif // TNT_FILAMENT_NATIVE_WINDOW_HELPER_H

--- a/samples/app/NativeWindowHelperCocoa.mm
+++ b/samples/app/NativeWindowHelperCocoa.mm
@@ -19,6 +19,7 @@
 #include <utils/Panic.h>
 
 #include <Cocoa/Cocoa.h>
+#include <QuartzCore/QuartzCore.h>
 
 #include <SDL_syswm.h>
 
@@ -29,4 +30,24 @@ void* getNativeWindow(SDL_Window* sdlWindow) {
     NSWindow* win = wmi.info.cocoa.window;
     NSView* view = [win contentView];
     return view;
+}
+
+void setUpMetalLayer(void* nativeView) {
+    NSView* view = (NSView*) nativeView;
+    [view setWantsLayer:YES];
+    CAMetalLayer* metalLayer = [CAMetalLayer layer];
+    metalLayer.bounds = view.bounds;
+
+    // It's important to set the drawableSize to the actual backing pixels. When rendering
+    // full-screen, we can skip the macOS compositor if the size matches the display size.
+    metalLayer.drawableSize = [view convertSizeToBacking:view.bounds.size];
+
+    // This is set to NO by default, but is also important to ensure we can bypass the compositor
+    // in full-screen mode
+    // See "Direct to Display" http://metalkit.org/2017/06/30/introducing-metal-2.html.
+    metalLayer.opaque = YES;
+
+    metalLayer.displaySyncEnabled = YES;
+
+    [view setLayer:metalLayer];
 }

--- a/samples/app/NativeWindowHelperCocoa.mm
+++ b/samples/app/NativeWindowHelperCocoa.mm
@@ -47,7 +47,5 @@ void setUpMetalLayer(void* nativeView) {
     // See "Direct to Display" http://metalkit.org/2017/06/30/introducing-metal-2.html.
     metalLayer.opaque = YES;
 
-    metalLayer.displaySyncEnabled = YES;
-
     [view setLayer:metalLayer];
 }


### PR DESCRIPTION
More prep for adding Metal. This removes a hack we were using to get MoltenVK to work. OpenGL and Vulkan are still supported.