### PR TITLE
Move call to endFrame after commit

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -383,12 +383,12 @@ void FRenderer::endFrame() {
     }
     mFrameSkipper.endFrame();
 
-    driver.endFrame(mFrameId);
-
     if (mSwapChain) {
         mSwapChain->commit(driver);
         mSwapChain = nullptr;
     }
+
+    driver.endFrame(mFrameId);
 
     // Run the component managers' GC in parallel
     // WARNING: while doing this we can't access any component manager


### PR DESCRIPTION
This moves the call to `endFrame` after `commit`. This is done in preparation for Metal. Certain resources (like command buffers) are allocated on a per-frame basis inside of `beginFrame`. Since they are still needed in `commit`, this makes it straightforward to free them inside of `endFrame`. We could always free them inside of `commit`, except that this isn't called in the case of canceled frames.
