### PR TITLE
Incorrect order of arguments in glBlendFuncSeparate function call.

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -575,7 +575,7 @@ void OpenGLDriver::blendFunction(GLenum srcRGB, GLenum srcA, GLenum dstRGB, GLen
         state.raster.blendFunctionSrcA = srcA;
         state.raster.blendFunctionDstRGB = dstRGB;
         state.raster.blendFunctionDstA = dstA;
-        glBlendFuncSeparate(srcRGB, dstRGB, dstA, srcA);
+        glBlendFuncSeparate(srcRGB, dstRGB, srcA, dstA);
     }
 }
 


### PR DESCRIPTION
According to [documentation](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBlendFuncSeparate.xhtml) function call should look like this:
`glBlendFuncSeparate(srcRGB, dstRGB, srcA, dstA);`
instead:
`glBlendFuncSeparate(srcRGB, dstRGB, dstA, srcA);`
