### PR TITLE
Add Metal skeleton code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,16 @@ if (FILAMENT_SUPPORTS_VULKAN)
     add_definitions(-DFILAMENT_DRIVER_SUPPORTS_VULKAN)
 endif()
 
+# Build with Metal support on non-WebGL Apple platforms.
+if (APPLE AND NOT WEBGL)
+    option(FILAMENT_SUPPORTS_METAL "Include the Metal backend" ON)
+else()
+    option(FILAMENT_SUPPORTS_METAL "Include the Metal backend" OFF)
+endif()
+if (FILAMENT_SUPPORTS_METAL)
+    add_definitions(-DFILAMENT_SUPPORTS_METAL)
+endif()
+
 # ==================================================================================================
 # Distribution
 # ==================================================================================================

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -192,6 +192,17 @@ endif()
 add_definitions(-DSYSTRACE_TAG=2 )
 
 # ==================================================================================================
+# Metal Sources
+# ==================================================================================================
+
+if (FILAMENT_SUPPORTS_METAL)
+    list(APPEND SRCS
+            src/driver/metal/MetalDriver.mm
+            src/driver/metal/PlatformMetal.mm
+    )
+endif()
+
+# ==================================================================================================
 # Vulkan Sources
 # ==================================================================================================
 
@@ -238,8 +249,8 @@ else()
     set(MATC_TARGET desktop)
 endif()
 
-# Include SPIRV when building default materials on platforms that support Vulkan.
-if (FILAMENT_SUPPORTS_VULKAN)
+# Generate shader code for all platforms when Vulkan or Metal is supported.
+if (FILAMENT_SUPPORTS_VULKAN OR FILAMENT_SUPPORTS_METAL)
     set(MATC_BASE_FLAGS -a all)
 else()
     set(MATC_BASE_FLAGS -a opengl)

--- a/filament/include/filament/driver/Platform.h
+++ b/filament/include/filament/driver/Platform.h
@@ -118,6 +118,12 @@ public:
             uint32_t* width, uint32_t* height) noexcept = 0;
 };
 
+class UTILS_PUBLIC MetalPlatform : public Platform {
+public:
+    ~MetalPlatform() noexcept override;
+
+};
+
 } // namespace driver
 } // namespace filament
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -356,8 +356,25 @@ int FEngine::loop() {
     if (platform == nullptr) {
         platform = Platform::create(&mBackend);
         mPlatform = platform;
-        slog.d << "FEngine resolved backend: "
-               << (mBackend == driver::Backend::VULKAN ? "Vulkan" : "OpenGL") << io::endl;
+        slog.d << "FEngine resolved backend: ";
+        switch (mBackend) {
+            case driver::Backend::OPENGL:
+                slog.d << "OpenGL";
+                break;
+
+            case driver::Backend::VULKAN:
+                slog.d << "Vulkan";
+                break;
+
+            case driver::Backend::METAL:
+                slog.d << "Metal";
+                break;
+
+            default:
+                slog.d << "Unknown";
+                break;
+        }
+        slog.d << io::endl;
     }
     mDriver = platform->createDriver(mSharedGLContext);
     mDriverBarrier.latch();

--- a/filament/src/driver/Platform.cpp
+++ b/filament/src/driver/Platform.cpp
@@ -37,6 +37,7 @@
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "driver/vulkan/PlatformVkCocoa.h"
     #endif
+    #include "driver/metal/PlatformMetal.h"
 #elif defined(__linux__)
     #ifndef USE_EXTERNAL_GLES3
         #include "driver/opengl/PlatformGLX.h"
@@ -73,6 +74,8 @@ OpenGLPlatform::~OpenGLPlatform() noexcept = default;
 
 VulkanPlatform::~VulkanPlatform() noexcept = default;
 
+MetalPlatform::~MetalPlatform() noexcept = default;
+
 // Creates the platform-specific Platform object. The caller takes ownership and is
 // responsible for destroying it. Initialization of the backend API is deferred until
 // createDriver(). The passed-in backend hint is replaced with the resolved backend.
@@ -104,6 +107,13 @@ Platform* Platform::create(Backend* backend) noexcept {
         #else
             return nullptr;
         #endif
+    }
+    if (*backend == Backend::METAL) {
+#if defined(FILAMENT_SUPPORTS_METAL)
+        return new PlatformMetal();
+#else
+        return nullptr;
+#endif
     }
     #if defined(USE_EXTERNAL_GLES3)
         return nullptr;

--- a/filament/src/driver/metal/MetalDriver.h
+++ b/filament/src/driver/metal/MetalDriver.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_METALDRIVER_H
+#define TNT_FILAMENT_DRIVER_METALDRIVER_H
+
+#include "driver/Driver.h"
+#include "driver/DriverBase.h"
+
+#include <utils/compiler.h>
+#include <utils/Log.h>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace filament {
+namespace driver {
+namespace metal {
+
+struct MetalDriverImpl;
+
+struct MetalProgram;
+
+class MetalDriver final : public DriverBase {
+    MetalDriver(driver::MetalPlatform* const platform) noexcept;
+    virtual ~MetalDriver() noexcept;
+
+public:
+    static Driver* create(driver::MetalPlatform* platform);
+
+private:
+
+    driver::MetalPlatform& mPlatform;
+
+    MetalDriverImpl* pImpl;
+
+#ifndef NDEBUG
+    void debugCommand(const char* methodName) override;
+#endif
+
+    virtual ShaderModel getShaderModel() const noexcept override final { return ShaderModel::GL_CORE_41; }
+
+    /*
+     * Driver interface
+     */
+
+    template<typename T>
+    friend class ::filament::ConcreteDispatcher;
+
+#define DECL_DRIVER_API(methodName, paramsDecl, params) \
+    UTILS_ALWAYS_INLINE void methodName(paramsDecl);
+
+#define DECL_DRIVER_API_SYNCHRONOUS(RetType, methodName, paramsDecl, params) \
+    RetType methodName(paramsDecl) override;
+
+#define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params) \
+    RetType methodName##Synchronous() noexcept override; \
+    UTILS_ALWAYS_INLINE void methodName(RetType, paramsDecl);
+
+#include "driver/DriverAPI.inc"
+
+    /*
+     * Memory management
+     */
+
+    // Copied from VulkanDriver.h
+
+    // For now we're not bothering to store handles in pools, just simple on-demand allocation.
+    // We have a little map from integer handles to "blobs" which get replaced with the Hw objects.
+    using Blob = std::vector<uint8_t>;
+    using HandleMap = std::unordered_map<HandleBase::HandleId, Blob>;
+    std::mutex mHandleMapMutex;
+    HandleMap mHandleMap;
+    HandleBase::HandleId mNextId = 1;
+
+    template<typename Dp, typename B>
+    Handle<B> alloc_handle() {
+        std::lock_guard<std::mutex> lock(mHandleMapMutex);
+        mHandleMap[mNextId] = Blob(sizeof(Dp));
+        return Handle<B>(mNextId++);
+    }
+
+    template<typename Dp, typename B>
+    Dp* handle_cast(HandleMap& handleMap, Handle<B>& handle) noexcept {
+        std::lock_guard<std::mutex> lock(mHandleMapMutex);
+        assert(handle);
+        auto iter = handleMap.find(handle.getId());
+        assert(iter != handleMap.end());
+        Blob& blob = iter->second;
+        assert(blob.size() == sizeof(Dp));
+        return reinterpret_cast<Dp*>(blob.data());
+    }
+
+    template<typename Dp, typename B>
+    const Dp* handle_const_cast(HandleMap& handleMap, const Handle<B>& handle) noexcept {
+        std::lock_guard<std::mutex> lock(mHandleMapMutex);
+        assert(handle);
+        auto iter = handleMap.find(handle.getId());
+        assert(iter != handleMap.end());
+        Blob& blob = iter->second;
+        assert(blob.size() == sizeof(Dp));
+        return reinterpret_cast<const Dp*>(blob.data());
+    }
+
+    template<typename Dp, typename B, typename ... ARGS>
+    Dp* construct_handle(HandleMap& handleMap, Handle<B>& handle, ARGS&& ... args) noexcept {
+        std::lock_guard<std::mutex> lock(mHandleMapMutex);
+        auto iter = handleMap.find(handle.getId());
+        assert(iter != handleMap.end());
+        Blob& blob = iter->second;
+        assert(blob.size() == sizeof(Dp));
+        Dp* addr = reinterpret_cast<Dp*>(blob.data());
+        new(addr) Dp(std::forward<ARGS>(args)...);
+        return addr;
+    }
+
+    template<typename Dp, typename B>
+    void destruct_handle(HandleMap& handleMap, Handle<B>& handle) noexcept {
+        std::lock_guard<std::mutex> lock(mHandleMapMutex);
+        assert(handle);
+        // Call the destructor, remove the blob, don't bother reclaiming the integer id.
+        auto iter = handleMap.find(handle.getId());
+        assert(iter != handleMap.end());
+        Blob& blob = iter->second;
+        assert(blob.size() == sizeof(Dp));
+        reinterpret_cast<Dp*>(blob.data())->~Dp();
+        handleMap.erase(handle.getId());
+    }
+};
+
+} // namespace metal
+} // namespace driver
+} // namespace filament
+
+#endif // TNT_FILAMENT_DRIVER_METALDRIVER_H

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -1,0 +1,416 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "driver/CommandStream.h"
+#include "driver/CommandStreamDispatcher.h"
+#include "driver/metal/MetalDriver.h"
+
+#include <AppKit/AppKit.h>
+#include <Metal/Metal.h>
+#include <QuartzCore/QuartzCore.h>
+
+#include <utils/Log.h>
+#include <utils/Panic.h>
+#include <utils/trap.h>
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "HidingNonVirtualFunction"
+
+namespace filament {
+namespace driver {
+namespace metal {
+
+struct MetalDriverImpl {
+    id<MTLDevice> mDevice = nullptr;
+};
+
+Driver* MetalDriver::create(MetalPlatform* const platform) {
+    assert(platform);
+    return new MetalDriver(platform);
+}
+
+MetalDriver::MetalDriver(driver::MetalPlatform* platform) noexcept
+        : DriverBase(new ConcreteDispatcher<MetalDriver>(this)),
+        mPlatform(*platform),
+        pImpl(new MetalDriverImpl) {
+    pImpl->mDevice = MTLCreateSystemDefaultDevice();
+}
+
+MetalDriver::~MetalDriver() noexcept {
+    delete pImpl;
+    [pImpl->mDevice release];
+}
+
+#define METAL_DEBUG_COMMANDS 0
+#if !defined(NDEBUG)
+void MetalDriver::debugCommand(const char *methodName) {
+#if METAL_DEBUG_COMMANDS
+    utils::slog.d << methodName << utils::io::endl;
+#endif
+}
+#endif
+
+void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
+
+}
+
+void MetalDriver::setPresentationTime(int64_t monotonic_clock_ns) {
+
+}
+
+void MetalDriver::endFrame(uint32_t frameId) {
+
+}
+
+void MetalDriver::flush(int dummy) {
+
+}
+
+void MetalDriver::createVertexBuffer(Driver::VertexBufferHandle vbh, uint8_t bufferCount,
+        uint8_t attributeCount, uint32_t vertexCount, Driver::AttributeArray attributes,
+        Driver::BufferUsage usage) {
+
+}
+
+void MetalDriver::createIndexBuffer(Driver::IndexBufferHandle ibh, Driver::ElementType elementType,
+        uint32_t indexCount, Driver::BufferUsage usage) {
+
+}
+
+void MetalDriver::createTexture(Driver::TextureHandle th, Driver::SamplerType target, uint8_t levels,
+        Driver::TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+        uint32_t depth, Driver::TextureUsage usage) {
+
+}
+
+void MetalDriver::createSamplerBuffer(Driver::SamplerBufferHandle sbh, size_t size) {
+
+}
+
+void MetalDriver::createUniformBuffer(Driver::UniformBufferHandle ubh, size_t size,
+        Driver::BufferUsage usage) {
+
+}
+
+void MetalDriver::createRenderPrimitive(Driver::RenderPrimitiveHandle rph, int dummy) {
+
+}
+
+void MetalDriver::createProgram(Driver::ProgramHandle rph, Program&& program) {
+
+}
+
+void MetalDriver::createDefaultRenderTarget(Driver::RenderTargetHandle rth, int dummy) {
+
+}
+
+void MetalDriver::createRenderTarget(Driver::RenderTargetHandle rth,
+        Driver::TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
+        uint8_t samples, Driver::TextureFormat format, Driver::TargetBufferInfo color,
+        Driver::TargetBufferInfo depth, Driver::TargetBufferInfo stencil) {
+
+}
+
+void MetalDriver::createFence(Driver::FenceHandle, int dummy) {
+
+}
+
+void MetalDriver::createSwapChain(Driver::SwapChainHandle sch, void* nativeWindow, uint64_t flags) {
+
+}
+
+void MetalDriver::createStreamFromTextureId(Driver::StreamHandle, intptr_t externalTextureId,
+        uint32_t width, uint32_t height) {
+
+}
+
+Driver::VertexBufferHandle MetalDriver::createVertexBufferSynchronous() noexcept {
+    return Driver::VertexBufferHandle {1};
+}
+
+Driver::IndexBufferHandle MetalDriver::createIndexBufferSynchronous() noexcept {
+    return Driver::IndexBufferHandle {1};
+}
+
+Driver::TextureHandle MetalDriver::createTextureSynchronous() noexcept {
+    return Driver::TextureHandle {1};
+}
+
+Driver::SamplerBufferHandle MetalDriver::createSamplerBufferSynchronous() noexcept {
+    return Driver::SamplerBufferHandle {1};
+}
+
+Driver::UniformBufferHandle MetalDriver::createUniformBufferSynchronous() noexcept {
+    return Driver::UniformBufferHandle {1};
+}
+
+Driver::RenderPrimitiveHandle MetalDriver::createRenderPrimitiveSynchronous() noexcept {
+    return Driver::RenderPrimitiveHandle {1};
+}
+
+Driver::ProgramHandle MetalDriver::createProgramSynchronous() noexcept {
+    return Driver::ProgramHandle {1};
+}
+
+Driver::RenderTargetHandle MetalDriver::createDefaultRenderTargetSynchronous() noexcept {
+    return Driver::RenderTargetHandle {1};
+}
+
+Driver::RenderTargetHandle MetalDriver::createRenderTargetSynchronous() noexcept {
+    return Driver::RenderTargetHandle {1};
+}
+
+Driver::FenceHandle MetalDriver::createFenceSynchronous() noexcept {
+    return Driver::FenceHandle {};
+}
+
+Driver::SwapChainHandle MetalDriver::createSwapChainSynchronous() noexcept {
+    return Driver::SwapChainHandle {1};
+}
+
+Driver::StreamHandle MetalDriver::createStreamFromTextureIdSynchronous() noexcept {
+    return {};
+}
+
+void MetalDriver::destroyVertexBuffer(Driver::VertexBufferHandle vbh) {
+
+}
+
+void MetalDriver::destroyIndexBuffer(Driver::IndexBufferHandle ibh) {
+
+}
+
+void MetalDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
+
+}
+
+void MetalDriver::destroyProgram(Driver::ProgramHandle ph) {
+
+}
+
+void MetalDriver::destroySamplerBuffer(Driver::SamplerBufferHandle sbh) {
+
+}
+
+void MetalDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
+
+}
+
+void MetalDriver::destroyTexture(Driver::TextureHandle th) {
+
+}
+
+void MetalDriver::destroyRenderTarget(Driver::RenderTargetHandle rth) {
+
+}
+
+void MetalDriver::destroySwapChain(Driver::SwapChainHandle sch) {
+
+}
+
+void MetalDriver::destroyStream(Driver::StreamHandle sh) {
+
+}
+
+void MetalDriver::terminate() {
+
+}
+
+Driver::StreamHandle MetalDriver::createStream(void* stream) {
+    return {};
+}
+
+void MetalDriver::setStreamDimensions(Driver::StreamHandle stream, uint32_t width,
+        uint32_t height) {
+
+}
+
+int64_t MetalDriver::getStreamTimestamp(Driver::StreamHandle stream) {
+    return 0;
+}
+
+void MetalDriver::updateStreams(driver::DriverApi* driver) {
+
+}
+
+void MetalDriver::destroyFence(Driver::FenceHandle fh) {
+
+}
+
+Driver::FenceStatus MetalDriver::wait(Driver::FenceHandle fh, uint64_t timeout) {
+    return FenceStatus::ERROR;
+}
+
+bool MetalDriver::isTextureFormatSupported(Driver::TextureFormat format) {
+    return true;
+}
+
+bool MetalDriver::isRenderTargetFormatSupported(Driver::TextureFormat format) {
+    return true;
+}
+
+bool MetalDriver::isFrameTimeSupported() {
+    return false;
+}
+
+void MetalDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh, size_t index,
+        Driver::BufferDescriptor&& data, uint32_t byteOffset, uint32_t byteSize) {
+
+}
+
+void MetalDriver::updateIndexBuffer(Driver::IndexBufferHandle ibh, Driver::BufferDescriptor&& data,
+        uint32_t byteOffset, uint32_t byteSize) {
+
+}
+
+void MetalDriver::update2DImage(Driver::TextureHandle th, uint32_t level, uint32_t xoffset,
+        uint32_t yoffset, uint32_t width, uint32_t height, Driver::PixelBufferDescriptor&& data) {
+
+}
+
+void MetalDriver::updateCubeImage(Driver::TextureHandle th, uint32_t level,
+        Driver::PixelBufferDescriptor&& data, Driver::FaceOffsets faceOffsets) {
+
+}
+
+void MetalDriver::setExternalImage(Driver::TextureHandle th, void* image) {
+
+}
+
+void MetalDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHandle sh) {
+
+}
+
+void MetalDriver::generateMipmaps(Driver::TextureHandle th) {
+
+}
+
+void MetalDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh,
+        Driver::BufferDescriptor&& data) {
+
+}
+
+void MetalDriver::updateSamplerBuffer(Driver::SamplerBufferHandle sbh,
+        SamplerBuffer&& samplerBuffer) {
+
+}
+
+void MetalDriver::beginRenderPass(Driver::RenderTargetHandle rth,
+        const Driver::RenderPassParams& params) {
+}
+
+void MetalDriver::endRenderPass(int dummy) {
+
+}
+
+void MetalDriver::discardSubRenderTargetBuffers(Driver::RenderTargetHandle rth,
+        Driver::TargetBufferFlags targetBufferFlags, uint32_t left, uint32_t bottom, uint32_t width,
+        uint32_t height) {
+
+}
+
+void MetalDriver::resizeRenderTarget(Driver::RenderTargetHandle rth, uint32_t width,
+        uint32_t height) {
+
+}
+
+void MetalDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
+        Driver::VertexBufferHandle vbh, Driver::IndexBufferHandle ibh, uint32_t enabledAttributes) {
+
+}
+
+void MetalDriver::setRenderPrimitiveRange(Driver::RenderPrimitiveHandle rph,
+        Driver::PrimitiveType pt, uint32_t offset, uint32_t minIndex, uint32_t maxIndex,
+        uint32_t count) {
+
+}
+
+void MetalDriver::setViewportScissor(int32_t left, int32_t bottom, uint32_t width,
+        uint32_t height) {
+
+}
+
+void MetalDriver::makeCurrent(Driver::SwapChainHandle schDraw, Driver::SwapChainHandle schRead) {
+
+}
+
+void MetalDriver::commit(Driver::SwapChainHandle sch) {
+
+}
+
+void MetalDriver::viewport(ssize_t left, ssize_t bottom, size_t width, size_t height) {
+
+}
+
+void MetalDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle ubh) {
+
+}
+
+void MetalDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHandle ubh,
+        size_t offset, size_t size) {
+
+}
+
+void MetalDriver::bindSamplers(size_t index, Driver::SamplerBufferHandle sbh) {
+
+}
+
+void MetalDriver::insertEventMarker(const char* string, size_t len) {
+
+}
+
+void MetalDriver::pushGroupMarker(const char* string, size_t len) {
+
+}
+
+void MetalDriver::popGroupMarker(int dummy) {
+
+}
+
+void MetalDriver::readPixels(Driver::RenderTargetHandle src, uint32_t x, uint32_t y, uint32_t width,
+        uint32_t height, Driver::PixelBufferDescriptor&& data) {
+
+}
+
+void MetalDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_t y, uint32_t width,
+        uint32_t height, Driver::PixelBufferDescriptor&& data) {
+
+}
+
+void MetalDriver::blit(Driver::TargetBufferFlags buffers, Driver::RenderTargetHandle dst,
+        int32_t dstLeft, int32_t dstBottom, uint32_t dstWidth, uint32_t dstHeight,
+        Driver::RenderTargetHandle src, int32_t srcLeft, int32_t srcBottom, uint32_t srcWidth,
+        uint32_t srcHeight) {
+
+}
+
+void MetalDriver::draw(Driver::PipelineState ps, Driver::RenderPrimitiveHandle rph) {
+
+}
+
+void MetalDriver::enumerateSamplerBuffers(const MetalProgram *program,
+        const std::function<void(const SamplerBuffer::Sampler*, uint8_t)>& f) {
+}
+
+} // namespace metal
+} // namespace driver
+
+// explicit instantiation of the Dispatcher
+template class ConcreteDispatcher<driver::metal::MetalDriver>;
+
+} // namespace filament
+
+#pragma clang diagnostic pop

--- a/filament/src/driver/metal/PlatformMetal.h
+++ b/filament/src/driver/metal/PlatformMetal.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H
+#define TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H
+
+#include <stdint.h>
+
+#include <filament/driver/DriverEnums.h>
+#include <filament/driver/Platform.h>
+
+namespace filament {
+
+class PlatformMetal final : public driver::MetalPlatform {
+public:
+    Driver* createDriver(void* sharedContext) noexcept override;
+    int getOSVersion() const noexcept override { return 0; }
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H

--- a/filament/src/driver/metal/PlatformMetal.mm
+++ b/filament/src/driver/metal/PlatformMetal.mm
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PlatformMetal.h"
+#include "MetalDriver.h"
+
+namespace filament {
+
+using namespace driver;
+
+Driver* PlatformMetal::createDriver(void* sharedContext) noexcept {
+    return metal::MetalDriver::create(this);
+}
+
+} // namespace filament

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -44,7 +44,8 @@ enum class Backend : uint8_t {
     DEFAULT = 0,  //!< Automatically selects an appropriate driver for the platform.
     OPENGL = 1,   //!< Selects the OpenGL driver (which supports OpenGL ES as well).
     VULKAN = 2,   //!< Selects the Vulkan driver if the platform supports it.
-    NOOP = 3,     //!< Selects the no-op driver for testing purposes.
+    METAL = 3,    //!< Selects the Metal driver if the platform supports it.
+    NOOP = 4,     //!< Selects the no-op driver for testing purposes.
 };
 
 /**


### PR DESCRIPTION
Boilerplate code for adding the Metal backend. Most of this is driver API stubs inside of `MetalDriver.mm`. Selecting Metal as the backend will compile and run without error, but with a blank screen.