### PR TITLE
new frame graph for filament

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -46,6 +46,9 @@ set(SRCS
         src/components/LightManager.cpp
         src/components/RenderableManager.cpp
         src/components/TransformManager.cpp
+        src/fg/FrameGraph.cpp
+        src/driver/noop/NoopDriver.cpp
+        src/driver/noop/PlatformNoop.cpp
         src/driver/opengl/gl_headers.cpp
         src/driver/opengl/OpenGLBlitter.cpp
         src/driver/opengl/GLUtils.cpp
@@ -100,6 +103,9 @@ set(PRIVATE_HDRS
         src/components/LightManager.h
         src/components/RenderableManager.h
         src/components/TransformManager.h
+        src/fg/FrameGraph.h
+        src/fg/FrameGraphPass.h
+        src/fg/FrameGraphResource.h
         src/details/Allocators.h
         src/details/Camera.h
         src/details/Culler.h
@@ -137,8 +143,6 @@ set(PRIVATE_HDRS
         src/driver/Handle.h
         src/driver/Program.h
         src/driver/SamplerBuffer.h
-        src/driver/noop/NoopDriver.cpp
-        src/driver/noop/PlatformNoop.cpp
         src/FilamentAPI-impl.h
         src/FrameInfo.h
         src/Intersections.h

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -105,6 +105,7 @@ set(PRIVATE_HDRS
         src/components/TransformManager.h
         src/fg/FrameGraph.h
         src/fg/FrameGraphPass.h
+        src/fg/FrameGraphPassResources.h
         src/fg/FrameGraphResource.h
         src/details/Allocators.h
         src/details/Camera.h

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -21,6 +21,8 @@
 
 #include "UniformBuffer.h"
 
+#include "fg/FrameGraphResource.h"
+
 #include "driver/DriverApiForward.h"
 #include "driver/Handle.h"
 
@@ -58,6 +60,23 @@ public:
             Viewport const& vp,
             RenderTargetPool::Target const* linearTarget,
             Viewport const& svp);
+
+
+    FrameGraphResource msaa(
+            FrameGraph& fg, FrameGraphResource input,
+            driver::TextureFormat outFormat) noexcept;
+
+    FrameGraphResource toneMapping(
+            FrameGraph& fg, FrameGraphResource input, driver::TextureFormat outFormat,
+            bool translucent) noexcept;
+
+    FrameGraphResource fxaa(
+            FrameGraph& fg, FrameGraphResource input, driver::TextureFormat outFormat,
+            bool translucent) noexcept;
+
+    FrameGraphResource dynamicScaling(
+            FrameGraph& fg, FrameGraphResource input,
+            driver::TextureFormat outFormat, Viewport const& outViewport) noexcept;
 
 
 private:

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -41,8 +41,8 @@ class PostProcessManager {
 public:
     void init(details::FEngine& engine) noexcept;
     void terminate(driver::DriverApi& driver) noexcept;
-    void setSource(uint32_t viewportWidth, uint32_t viewportHeight,
-            const RenderTargetPool::Target* pos) const noexcept;
+    void setSource(uint32_t viewportWidth, uint32_t viewportHeight, Handle <HwTexture> texture,
+            uint32_t textureWidth, uint32_t textureHeight) const noexcept;
 
     // start() is a scam, it does nothing
     void start() noexcept { }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FrameGraph.h"
+
+#include <utils/Panic.h>
+#include <utils/Log.h>
+
+using namespace utils;
+
+namespace filament {
+
+using namespace fg;
+
+// ------------------------------------------------------------------------------------------------
+
+namespace fg {
+
+struct Resource {
+    explicit Resource(const char* name) noexcept : name(name) { }
+    // constants
+    const char* const name;         // for debugging
+    // computed during compile()
+    PassNode* writer = nullptr;     // last writer to this resource
+    PassNode* first = nullptr;      // pass that needs to instantiate the resource
+    PassNode* last = nullptr;       // pass that can destroy the resource
+    uint32_t writerCount = 0;       // # of passes writing to this resource
+    uint32_t readerCount = 0;       // # of passes reading from this resource
+};
+
+struct ResourceNode {
+    ResourceNode(const char* name, uint16_t index) noexcept : name(name), index(index) { }
+    ResourceNode(ResourceNode const&) = delete;
+    ResourceNode(ResourceNode&&) noexcept = default;
+
+    // constants
+    const char* const name;
+    uint16_t const index;
+
+    // updated by the builder
+    uint16_t version = 0;
+
+    // set during compile()
+    Resource* resource = nullptr;
+};
+
+struct PassNode {
+    // TODO: use something less heavy than a std::vector<>
+    using ResourceList = std::vector<FrameGraphResource>;
+
+    PassNode(const char* name, uint32_t id, FrameGraphPassExecutor* base) noexcept
+            : name(name), id(id), base(base) {
+    }
+    PassNode(PassNode const&) = delete;
+    PassNode(PassNode&& rhs) noexcept
+            : name(rhs.name), id(rhs.id), base(rhs.base),
+              reads(std::move(rhs.reads)),
+              writes(std::move(rhs.writes)),
+              devirtualize(std::move(rhs.devirtualize)),
+              destroy(std::move(rhs.destroy)),
+              refCount(rhs.refCount) {
+        rhs.base = nullptr;
+    }
+
+    PassNode& operator=(PassNode const&) = delete;
+    PassNode& operator=(PassNode&&) = delete;
+
+    ~PassNode() { delete base; }
+
+    // for FrameGraphBuilder
+    void read(ResourceNode const& resource) {
+        // just record that we're reading from this resource (at the given version)
+        reads.push_back({ resource.index, resource.version });
+    }
+
+    void write(ResourceNode& resource) {
+        // invalidate existing handles to this resource
+        ++resource.version;
+        // record the write
+        writes.push_back({ resource.index, resource.version });
+    }
+
+    // constants
+    const char* const name;                     // our name
+    const uint32_t id;                          // a unique id (only for debugging)
+    FrameGraphPassExecutor* base = nullptr;     // type eraser for calling execute()
+
+    // set by the builder
+    ResourceList reads;                     // resources we're reading from
+    ResourceList writes;                    // resources we're writing to
+
+    // computed during compile()
+    std::vector<uint16_t> devirtualize;     // resources we need to create before executing
+    std::vector<uint16_t> destroy;          // resources we need to destroy after executing
+    uint32_t refCount = 0;                  // count resources that have a reference to us
+};
+
+struct Alias {
+    FrameGraphResource from, to;
+};
+
+} // namespace fg
+
+// ------------------------------------------------------------------------------------------------
+
+FrameGraphPassExecutor::FrameGraphPassExecutor() = default;
+FrameGraphPassExecutor::~FrameGraphPassExecutor() = default;
+
+// ------------------------------------------------------------------------------------------------
+
+FrameGraphBuilder::FrameGraphBuilder(FrameGraph& fg, PassNode& pass) noexcept
+    : mFrameGraph(fg), mPass(pass) {
+}
+
+ResourceNode* FrameGraphBuilder::getResource(FrameGraphResource input) {
+    FrameGraph& frameGraph = mFrameGraph;
+    auto& registry = frameGraph.mResourceNodes;
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(input.isValid(),
+            "using an uninitialized resource handle")) {
+        return nullptr;
+    }
+
+    assert(input.index < registry.size());
+    auto& resource = registry[input.index];
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(input.version == resource.version,
+            "using an invalid resource handle (version=%u) for resource=\"%s\" (id=%u, version=%u)",
+            input.version, resource.name, resource.index, resource.version)) {
+        return nullptr;
+    }
+
+    return &resource;
+}
+
+FrameGraphResource FrameGraphBuilder::createTexture(
+        const char* name, CreateFlags flags, FrameGraphResource::TextureDesc const& desc) noexcept {
+    FrameGraph& frameGraph = mFrameGraph;
+    ResourceNode& resource = frameGraph.createResource(name);
+    switch (flags) {
+        case UNKNOWN:
+            // we just create a resource, but we don't use it in this pass
+            break;
+        case READ:
+            mPass.read(resource);
+            break;
+        case WRITE:
+            mPass.write(resource);
+            break;
+    }
+    return { resource.index, resource.version };
+}
+
+FrameGraphResource FrameGraphBuilder::read(FrameGraphResource const& input) {
+    ResourceNode* resource = getResource(input);
+    if (!resource) {
+        return {};
+    }
+    mPass.read(*resource);
+    return input;
+}
+
+FrameGraphResource FrameGraphBuilder::write(FrameGraphResource const& output) {
+    ResourceNode* resource = getResource(output);
+    if (!resource) {
+        return {};
+    }
+
+    mPass.write(*resource);
+
+    /*
+     * We invalidate and rename handles that are writen into, to avoid undefined order
+     * access to the resources.
+     *
+     * e.g. forbidden graphs
+     *
+     *         +-> [R1] -+
+     *        /           \
+     *  (A) -+             +-> (A)
+     *        \           /
+     *         +-> [R2] -+        // failure when setting R2 from (A)
+     *
+     */
+
+    return { resource->index, resource->version };
+}
+
+// ------------------------------------------------------------------------------------------------
+
+FrameGraph::FrameGraph() = default;
+
+FrameGraph::~FrameGraph() = default;
+
+bool FrameGraph::isValid(FrameGraphResource handle) const noexcept {
+    if (!handle.isValid()) return false;
+    auto const& registry = mResourceNodes;
+    assert(handle.index < registry.size());
+    auto& resource = registry[handle.index];
+    return handle.version == resource.version;
+}
+
+void FrameGraph::moveResource(FrameGraphResource from, FrameGraphResource to) {
+    // FIXME: what checks need to happen?
+    mAliases.push_back({from, to});
+}
+
+void FrameGraph::present(FrameGraphResource input) {
+    struct Dummy {
+    };
+    addPass<Dummy>("Present",
+            [&input](FrameGraphBuilder& builder, Dummy& data) {
+                builder.read(input);
+            },
+            [](FrameGraphPassResources const& resources, Dummy const& data) {
+            });
+}
+
+PassNode& FrameGraph::createPass(const char* name, FrameGraphPassExecutor* base) noexcept {
+    auto& frameGraphPasses = mPassNodes;
+    const uint32_t id = (uint32_t)frameGraphPasses.size();
+    frameGraphPasses.emplace_back(name, id, base);
+    return frameGraphPasses.back();
+}
+
+ResourceNode& FrameGraph::createResource(const char* name) noexcept {
+    auto& registry = mResourceNodes;
+    uint16_t id = (uint16_t)registry.size();
+    registry.emplace_back(name, id);
+    return registry.back();
+}
+
+FrameGraph& FrameGraph::compile() noexcept {
+    auto& registry = mResourceNodes;
+    mResourceRegistry.reserve(registry.size());
+
+    // create the sub-resources
+    for (ResourceNode& node : registry) {
+        mResourceRegistry.emplace_back(node.name);
+        node.resource = &mResourceRegistry.back();
+    }
+
+    // remap them
+    for (auto const& alias : mAliases) {
+        registry[alias.to.index].resource = registry[alias.from.index].resource;
+    }
+
+    for (PassNode& pass : mPassNodes) {
+        // compute passes reference counts (i.e. resources we're writing to)
+        pass.refCount = (uint32_t)pass.writes.size();
+
+        // compute resources reference counts (i.e. resources we're reading from), and first/last users
+        for (FrameGraphResource resource : pass.reads) {
+            Resource* subResource = registry[resource.index].resource;
+
+            // add a reference for each pass that reads from this resource
+            subResource->readerCount++;
+
+            // figure out which is the first pass to need this resource
+            subResource->first = subResource->first ? subResource->first : &pass;
+
+            // figure out which is the last pass to need this resource
+            subResource->last = &pass;
+        }
+
+        // set the writers
+        for (FrameGraphResource resource : pass.writes) {
+            Resource* subResource = registry[resource.index].resource;
+            subResource->writer = &pass;
+            subResource->writerCount++;
+        }
+    }
+
+    // cull passes and resources...
+    std::vector<Resource*> stack;
+    stack.reserve(registry.size());
+    for (Resource& resource : mResourceRegistry) {
+        if (resource.readerCount == 0) {
+            stack.push_back(&resource);
+        }
+    }
+
+    while (!stack.empty()) {
+        Resource const* const pSubResource = stack.back();
+        stack.pop_back();
+
+        // by construction, this resource cannot have more than one producer because
+        // - two unrelated passes can't write in the same resource
+        // - passes that read + write into the resource imply that the refcount is not null
+
+        assert(pSubResource->writerCount <= 1);
+
+        // if a resource doesn't have a writer and is not imported, then we the graph is not
+        // set correctly. For now we ignore this.
+        if (!pSubResource->writer) {
+            slog.d << "resource \"" << pSubResource->name << "\" is never written!" << io::endl;
+            continue; // TODO: this shouldn't happen in a valid graph
+        }
+
+        PassNode* const writer = pSubResource->writer;
+        assert(writer->refCount >= 1);
+        if (--writer->refCount == 0) {
+            // this pass is culled
+            auto const& reads = writer->reads;
+            for (FrameGraphResource resource : reads) {
+                Resource* r = registry[resource.index].resource;
+                if (--r->readerCount == 0) {
+                    stack.push_back(r);
+                }
+            }
+        }
+    }
+
+    for (size_t index = 0, c = mResourceRegistry.size() ; index < c ; index++) {
+        auto& resource = mResourceRegistry[index];
+        assert(!resource.first == !resource.last);
+        if (resource.readerCount && resource.first && resource.last) {
+            resource.first->devirtualize.push_back((uint16_t)index);
+            resource.last->destroy.push_back((uint16_t)index);
+        }
+    }
+
+    return *this;
+}
+
+void FrameGraph::execute() noexcept {
+    auto const& resources = mResources;
+    for (PassNode const& node : mPassNodes) {
+        if (!node.refCount) continue;
+
+        for (size_t id : node.devirtualize) {
+            // TODO: create concrete resources
+        }
+
+        assert(node.base);
+        node.base->execute(resources);
+
+        for (uint32_t id : node.destroy) {
+            // TODO: delete concrete resources
+        }
+    }
+
+    // reset the frame graph state
+    mPassNodes.clear();
+    mResourceNodes.clear();
+    mAliases.clear();
+}
+
+void FrameGraph::export_graphviz(utils::io::ostream& out) {
+    bool removeCulled = false;
+
+    out << "digraph framegraph {\n";
+    out << "rankdir = LR\n";
+    out << "bgcolor = black\n";
+    out << "node [shape=rectangle, fontname=\"helvetica\", fontsize=10]\n\n";
+
+    auto const& registry = mResourceNodes;
+    auto const& frameGraphPasses = mPassNodes;
+
+    // declare passes
+    for (auto const& node : frameGraphPasses) {
+        if (removeCulled && !node.refCount) continue;
+        out << "\"P" << node.id << "\" [label=\"" << node.name
+               << "\\nrefs: " << node.refCount
+               << "\\nseq: " << node.id
+               << "\", style=filled, fillcolor="
+               << (node.refCount ? "darkorange" : "darkorange4") << "]\n";
+    }
+
+    // declare resources nodes
+    out << "\n";
+    for (auto const& node : registry) {
+        auto subresource = registry[node.index].resource;
+        if (removeCulled && !subresource->readerCount) continue;
+        for (size_t version = 0; version <= node.version; version++) {
+            out << "\"R" << node.index << "_" << version << "\""
+                   "[label=\"" << node.name << "\\n(version: " << version << ")"
+                   "\\nid:" << node.index <<
+                   "\\nrefs:" << subresource->readerCount
+                   <<"\""
+                   ", style=filled, fillcolor="
+                   << (subresource->readerCount ? "skyblue" : "skyblue4") << "]\n";
+        }
+    }
+
+    // connect passes to resources
+    out << "\n";
+    for (auto const& node : frameGraphPasses) {
+        if (removeCulled && !node.refCount) continue;
+        out << "P" << node.id << " -> { ";
+        for (auto const& writer : node.writes) {
+            auto resource = registry[writer.index].resource;
+            if (removeCulled && !resource->readerCount) continue;
+            out << "R" << writer.index << "_" << writer.version << " ";
+        }
+        out << "} [color=red2]\n";
+    }
+
+    // connect resources to passes
+    out << "\n";
+    for (auto const& node : registry) {
+        auto subresource = registry[node.index].resource;
+        if (removeCulled && !subresource->readerCount) continue;
+        for (size_t version = 0; version <= node.version; version++) {
+            out << "R" << node.index << "_" << version << " -> { ";
+
+            // who reads us...
+            for (auto const& pass : frameGraphPasses) {
+                if (removeCulled && !pass.refCount) continue;
+                for (auto const& read : pass.reads) {
+                    if (read.index == node.index && read.version == version ) {
+                        out << "P" << pass.id << " ";
+                    }
+                }
+            }
+            out << "} [color=lightgreen]\n";
+        }
+    }
+
+    // aliases...
+    if (!mAliases.empty()) {
+        out << "\n";
+        for (auto const& alias : mAliases) {
+            out << "R" << alias.from.index << "_" << alias.from.version << " -> ";
+            out << "R" << alias.to.index << "_" << alias.to.version;
+            out << " [color=yellow, style=dashed]\n";
+        }
+    }
+
+    out << "}" << utils::io::endl;
+}
+
+} // namespace filament

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -16,6 +16,14 @@
 
 #include "FrameGraph.h"
 
+#include "FrameGraphPassResources.h"
+
+#include "driver/Driver.h"
+#include "driver/Handle.h"
+#include "driver/CommandStream.h"
+
+#include <filament/driver/DriverEnums.h>
+
 #include <utils/Panic.h>
 #include <utils/Log.h>
 
@@ -23,6 +31,7 @@ using namespace utils;
 
 namespace filament {
 
+using namespace driver;
 using namespace fg;
 
 // ------------------------------------------------------------------------------------------------
@@ -30,28 +39,121 @@ using namespace fg;
 namespace fg {
 
 struct Resource {
-    explicit Resource(const char* name) noexcept : name(name) { }
+    explicit Resource(const char* name, bool imported) noexcept : name(name), imported(imported) { }
+    Resource(Resource const&) = delete;
+    Resource(Resource&&) = default;
+    Resource& operator=(Resource const&) = delete;
+
+    ~Resource() noexcept;
+
     // constants
     const char* const name;         // for debugging
+    bool imported;
+
     // computed during compile()
     PassNode* writer = nullptr;     // last writer to this resource
     PassNode* first = nullptr;      // pass that needs to instantiate the resource
     PassNode* last = nullptr;       // pass that can destroy the resource
     uint32_t writerCount = 0;       // # of passes writing to this resource
     uint32_t readerCount = 0;       // # of passes reading from this resource
+    FrameGraphResource::Descriptor desc;
+    FrameGraph::Builder::RWFlags readFlags = 0;
+    FrameGraph::Builder::RWFlags writeFlags = 0;
+
+    // concrete resource -- set when the resource is created
+    void create(DriverApi& driver) noexcept;
+    void destroy(DriverApi& driver) noexcept;
+    Handle<HwTexture> textures[2] = {};  // color, depth
+    FrameGraphPassResources::RenderTarget target;
 };
 
+Resource::~Resource() noexcept {
+    if (!imported) {
+        assert(!textures[0]);
+        assert(!textures[1]);
+        assert(!target.target);
+    }
+}
+
+void Resource::create(DriverApi& driver) noexcept {
+    uint8_t discardStart = TargetBufferFlags::ALL;
+    uint8_t discardEnd = TargetBufferFlags::ALL;
+    if (readerCount) {
+        assert(readFlags);
+        if (readFlags & FrameGraph::Builder::COLOR) {
+            discardEnd &= ~TargetBufferFlags::COLOR;
+            textures[0] = driver.createTexture(desc.type, desc.levels,
+                    desc.format, 1,
+                    desc.width, desc.height, desc.depth,
+                    TextureUsage::COLOR_ATTACHMENT);
+        }
+        if (readFlags & FrameGraph::Builder::DEPTH) {
+            discardEnd &= ~TargetBufferFlags::DEPTH;
+            textures[1] = driver.createTexture(desc.type, desc.levels,
+                    TextureFormat::DEPTH24, 1,
+                    desc.width, desc.height, desc.depth,
+                    TextureUsage::DEPTH_ATTACHMENT);
+        }
+    }
+    if (writerCount) {
+        assert(writeFlags);
+        uint32_t attachments = 0;
+        if (writeFlags & FrameGraph::Builder::COLOR) {
+            discardStart &= ~TargetBufferFlags::COLOR;
+            attachments |= uint32_t(TargetBufferFlags::COLOR);
+        }
+        if (writeFlags & FrameGraph::Builder::DEPTH) {
+            discardStart &= ~TargetBufferFlags::DEPTH;
+            attachments |= TargetBufferFlags::DEPTH;
+        }
+
+        target.target = driver.createRenderTarget(TargetBufferFlags(attachments),
+                desc.width, desc.height, desc.samples, desc.format,
+                { textures[0] }, { textures[1] }, {});
+
+        target.params = {};
+        target.params.discardStart = discardStart;
+        target.params.discardEnd = discardEnd;
+        target.params.left = 0;
+        target.params.bottom = 0;
+        target.params.width = desc.width;
+        target.params.height = desc.height;
+        target.params.dependencies = RenderPassParams::DEPENDENCY_BY_REGION;
+    }
+}
+
+void Resource::destroy(DriverApi& driver) noexcept {
+    if (!imported) {
+        for (auto& texture : textures) {
+            if (texture) {
+                driver.destroyTexture(texture);
+                texture.clear(); // needed because of noop driver
+            }
+        }
+        if (target.target) {
+            driver.destroyRenderTarget(target.target);
+            target.target.clear(); // needed because of noop driver
+        }
+    }
+}
+
 struct ResourceNode {
-    ResourceNode(const char* name, uint16_t index) noexcept : name(name), index(index) { }
+    ResourceNode(const char* name, uint16_t index, bool imported) noexcept
+            : name(name), index(index), imported(imported) {
+    }
     ResourceNode(ResourceNode const&) = delete;
     ResourceNode(ResourceNode&&) noexcept = default;
 
     // constants
     const char* const name;
     uint16_t const index;
+    bool imported;
 
     // updated by the builder
     uint16_t version = 0;
+    FrameGraphResource::Descriptor desc;
+    FrameGraph::Builder::RWFlags readFlags  = 0;
+    FrameGraph::Builder::RWFlags writeFlags = 0;
 
     // set during compile()
     Resource* resource = nullptr;
@@ -80,7 +182,7 @@ struct PassNode {
 
     ~PassNode() { delete base; }
 
-    // for FrameGraphBuilder
+    // for Builder
     void read(ResourceNode const& resource) {
         // just record that we're reading from this resource (at the given version)
         reads.push_back({ resource.index, resource.version });
@@ -89,6 +191,10 @@ struct PassNode {
     void write(ResourceNode& resource) {
         // invalidate existing handles to this resource
         ++resource.version;
+        // writing to an imported resource should count as a side-effect
+        if (resource.imported) {
+            hasSideEffect = true;
+        }
         // record the write
         writes.push_back({ resource.index, resource.version });
     }
@@ -101,6 +207,7 @@ struct PassNode {
     // set by the builder
     ResourceList reads;                     // resources we're reading from
     ResourceList writes;                    // resources we're writing to
+    bool hasSideEffect = false;             // whether this pass has side effects
 
     // computed during compile()
     std::vector<uint16_t> devirtualize;     // resources we need to create before executing
@@ -121,64 +228,35 @@ FrameGraphPassExecutor::~FrameGraphPassExecutor() = default;
 
 // ------------------------------------------------------------------------------------------------
 
-FrameGraphBuilder::FrameGraphBuilder(FrameGraph& fg, PassNode& pass) noexcept
+FrameGraph::Builder::Builder(FrameGraph& fg, PassNode& pass) noexcept
     : mFrameGraph(fg), mPass(pass) {
 }
 
-ResourceNode* FrameGraphBuilder::getResource(FrameGraphResource input) {
+FrameGraphResource FrameGraph::Builder::createTexture(
+        const char* name, FrameGraphResource::Descriptor const& desc) noexcept {
     FrameGraph& frameGraph = mFrameGraph;
-    auto& registry = frameGraph.mResourceNodes;
-
-    if (!ASSERT_POSTCONDITION_NON_FATAL(input.isValid(),
-            "using an uninitialized resource handle")) {
-        return nullptr;
-    }
-
-    assert(input.index < registry.size());
-    auto& resource = registry[input.index];
-
-    if (!ASSERT_POSTCONDITION_NON_FATAL(input.version == resource.version,
-            "using an invalid resource handle (version=%u) for resource=\"%s\" (id=%u, version=%u)",
-            input.version, resource.name, resource.index, resource.version)) {
-        return nullptr;
-    }
-
-    return &resource;
-}
-
-FrameGraphResource FrameGraphBuilder::createTexture(
-        const char* name, CreateFlags flags, FrameGraphResource::TextureDesc const& desc) noexcept {
-    FrameGraph& frameGraph = mFrameGraph;
-    ResourceNode& resource = frameGraph.createResource(name);
-    switch (flags) {
-        case UNKNOWN:
-            // we just create a resource, but we don't use it in this pass
-            break;
-        case READ:
-            mPass.read(resource);
-            break;
-        case WRITE:
-            mPass.write(resource);
-            break;
-    }
+    ResourceNode& resource = frameGraph.createResource(name, false);
+    resource.desc = desc;
     return { resource.index, resource.version };
 }
 
-FrameGraphResource FrameGraphBuilder::read(FrameGraphResource const& input) {
-    ResourceNode* resource = getResource(input);
+FrameGraphResource FrameGraph::Builder::read(FrameGraphResource const& input, RWFlags readFlags) {
+    ResourceNode* resource = mFrameGraph.getResource(input);
     if (!resource) {
         return {};
     }
+    resource->readFlags |= readFlags;
     mPass.read(*resource);
     return input;
 }
 
-FrameGraphResource FrameGraphBuilder::write(FrameGraphResource const& output) {
-    ResourceNode* resource = getResource(output);
+FrameGraphResource FrameGraph::Builder::write(FrameGraphResource const& output, RWFlags writeFlags) {
+    ResourceNode* resource = mFrameGraph.getResource(output);
     if (!resource) {
         return {};
     }
 
+    resource->writeFlags |= writeFlags;
     mPass.write(*resource);
 
     /*
@@ -196,6 +274,56 @@ FrameGraphResource FrameGraphBuilder::write(FrameGraphResource const& output) {
      */
 
     return { resource->index, resource->version };
+}
+
+FrameGraph::Builder& FrameGraph::Builder::sideEffect() noexcept {
+    mPass.hasSideEffect = true;
+    return *this;
+}
+
+// ------------------------------------------------------------------------------------------------
+
+FrameGraphPassResources::FrameGraphPassResources(FrameGraph& fg, fg::PassNode const& pass) noexcept
+    : mFrameGraph(fg), mPass(pass) {
+}
+
+Handle<HwTexture> FrameGraphPassResources::getTexture(
+        FrameGraphResource r, TextureUsage attachment) const noexcept {
+    // TODO: we should check that this FrameGraphResource is indeed used by this pass
+    (void)mPass; // suppress unused warning
+    Resource const* const pResource = mFrameGraph.mResourceNodes[r.index].resource;
+    assert(pResource);
+
+    switch (attachment) {
+        case TextureUsage::DEFAULT:
+            if (pResource->readFlags == FrameGraph::Builder::DEPTH) {
+                return pResource->textures[1];
+            }
+            [[clang::fallthrough]];
+        case TextureUsage::COLOR_ATTACHMENT:
+            return pResource->textures[0];
+
+        case TextureUsage::DEPTH_ATTACHMENT:
+            return pResource->textures[1];
+    }
+}
+
+FrameGraphPassResources::RenderTarget const& FrameGraphPassResources::getRenderTarget(
+        FrameGraphResource r) const noexcept {
+    // TODO: we should check that this FrameGraphResource is indeed used by this pass
+    (void)mPass; // suppress unused warning
+    Resource const* const pResource = mFrameGraph.mResourceNodes[r.index].resource;
+    assert(pResource);
+    return pResource->target;
+}
+
+FrameGraphResource::Descriptor const& FrameGraphPassResources::getDescriptor(
+        FrameGraphResource r) const noexcept {
+    // TODO: we should check that this FrameGraphResource is indeed used by this pass
+    (void)mPass; // suppress unused warning
+    Resource const* const pResource = mFrameGraph.mResourceNodes[r.index].resource;
+    assert(pResource);
+    return pResource->desc;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -221,10 +349,11 @@ void FrameGraph::present(FrameGraphResource input) {
     struct Dummy {
     };
     addPass<Dummy>("Present",
-            [&input](FrameGraphBuilder& builder, Dummy& data) {
+            [&input](Builder& builder, Dummy& data) {
                 builder.read(input);
+                builder.sideEffect();
             },
-            [](FrameGraphPassResources const& resources, Dummy const& data) {
+            [](FrameGraphPassResources const& resources, Dummy const& data, DriverApi&) {
             });
 }
 
@@ -235,63 +364,111 @@ PassNode& FrameGraph::createPass(const char* name, FrameGraphPassExecutor* base)
     return frameGraphPasses.back();
 }
 
-ResourceNode& FrameGraph::createResource(const char* name) noexcept {
+ResourceNode& FrameGraph::createResource(const char* name, bool imported) noexcept {
     auto& registry = mResourceNodes;
     uint16_t id = (uint16_t)registry.size();
-    registry.emplace_back(name, id);
+    registry.emplace_back(name, id, imported);
     return registry.back();
 }
 
-FrameGraph& FrameGraph::compile() noexcept {
+
+ResourceNode* FrameGraph::getResource(FrameGraphResource r) {
     auto& registry = mResourceNodes;
-    mResourceRegistry.reserve(registry.size());
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(r.isValid(),
+            "using an uninitialized resource handle")) {
+        return nullptr;
+    }
+
+    assert(r.index < registry.size());
+    auto& resource = registry[r.index];
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(r.version == resource.version,
+            "using an invalid resource handle (version=%u) for resource=\"%s\" (id=%u, version=%u)",
+            r.version, resource.name, resource.index, resource.version)) {
+        return nullptr;
+    }
+
+    return &resource;
+}
+FrameGraphResource::Descriptor* FrameGraph::getDescriptor(FrameGraphResource r) {
+    ResourceNode* node = getResource(r);
+    return node ? &node->desc : nullptr;
+}
+
+FrameGraphResource FrameGraph::importResource(const char* name, Handle <HwRenderTarget> target) {
+    ResourceNode& resource = createResource(name, true);
+    return { resource.index, resource.version };
+}
+
+FrameGraph& FrameGraph::compile() noexcept {
+    auto& resourceNodes = mResourceNodes;
+    auto& resourceRegistry = mResourceRegistry;
+    resourceRegistry.reserve(resourceNodes.size());
 
     // create the sub-resources
-    for (ResourceNode& node : registry) {
-        mResourceRegistry.emplace_back(node.name);
-        node.resource = &mResourceRegistry.back();
+    for (ResourceNode& node : resourceNodes) {
+        resourceRegistry.emplace_back(node.name, node.imported);
+        node.resource = &resourceRegistry.back();
+        node.resource->desc = node.desc;
+        node.resource->readFlags = node.readFlags;
+        node.resource->writeFlags = node.writeFlags;
     }
 
     // remap them
     for (auto const& alias : mAliases) {
-        registry[alias.to.index].resource = registry[alias.from.index].resource;
+        // disconnect all writes to "from"
+        auto& from = resourceNodes[alias.from.index];
+        auto& to = resourceNodes[alias.to.index];
+        for (PassNode& pass : mPassNodes) {
+            auto pos = std::find_if(pass.writes.begin(), pass.writes.end(),
+                    [&from](FrameGraphResource const& r) { return r.index == from.index; });
+            if (pos != pass.writes.end()) {
+                pass.writes.erase(pos);
+            }
+        }
+
+        // read flags are combined
+        from.resource->readFlags |= to.resource->readFlags;
+
+        // write flags are set to the "to" resource, since writers are disconnected from the "from"
+        from.resource->writeFlags = to.resource->writeFlags;
+
+        // alias "to" to "from"
+        to.resource = from.resource;
     }
 
+    // compute passes and resource reference counts
     for (PassNode& pass : mPassNodes) {
         // compute passes reference counts (i.e. resources we're writing to)
-        pass.refCount = (uint32_t)pass.writes.size();
+        pass.refCount = (uint32_t)pass.writes.size() + (uint32_t)pass.hasSideEffect;
 
-        // compute resources reference counts (i.e. resources we're reading from), and first/last users
+        // compute resources reference counts (i.e. resources we're reading from)
         for (FrameGraphResource resource : pass.reads) {
-            Resource* subResource = registry[resource.index].resource;
+            Resource* subResource = resourceNodes[resource.index].resource;
 
             // add a reference for each pass that reads from this resource
             subResource->readerCount++;
-
-            // figure out which is the first pass to need this resource
-            subResource->first = subResource->first ? subResource->first : &pass;
-
-            // figure out which is the last pass to need this resource
-            subResource->last = &pass;
         }
 
         // set the writers
         for (FrameGraphResource resource : pass.writes) {
-            Resource* subResource = registry[resource.index].resource;
+            Resource* subResource = resourceNodes[resource.index].resource;
             subResource->writer = &pass;
+
+            // add a reference for each pass that writes to this resource
             subResource->writerCount++;
         }
     }
 
     // cull passes and resources...
     std::vector<Resource*> stack;
-    stack.reserve(registry.size());
-    for (Resource& resource : mResourceRegistry) {
+    stack.reserve(resourceNodes.size());
+    for (Resource& resource : resourceRegistry) {
         if (resource.readerCount == 0) {
             stack.push_back(&resource);
         }
     }
-
     while (!stack.empty()) {
         Resource const* const pSubResource = stack.back();
         stack.pop_back();
@@ -315,7 +492,7 @@ FrameGraph& FrameGraph::compile() noexcept {
             // this pass is culled
             auto const& reads = writer->reads;
             for (FrameGraphResource resource : reads) {
-                Resource* r = registry[resource.index].resource;
+                Resource* r = resourceNodes[resource.index].resource;
                 if (--r->readerCount == 0) {
                     stack.push_back(r);
                 }
@@ -323,8 +500,31 @@ FrameGraph& FrameGraph::compile() noexcept {
         }
     }
 
-    for (size_t index = 0, c = mResourceRegistry.size() ; index < c ; index++) {
-        auto& resource = mResourceRegistry[index];
+    // compute first/last users for active passes
+    for (PassNode& pass : mPassNodes) {
+        if (!pass.refCount) {
+            assert(!pass.hasSideEffect);
+            continue;
+        }
+        for (FrameGraphResource resource : pass.reads) {
+            Resource* subResource = resourceNodes[resource.index].resource;
+            // figure out which is the first pass to need this resource
+            subResource->first = subResource->first ? subResource->first : &pass;
+            // figure out which is the last pass to need this resource
+            subResource->last = &pass;
+        }
+        for (FrameGraphResource resource : pass.writes) {
+            Resource* subResource = resourceNodes[resource.index].resource;
+            // figure out which is the first pass to need this resource
+            subResource->first = subResource->first ? subResource->first : &pass;
+            // figure out which is the last pass to need this resource
+            subResource->last = &pass;
+        }
+    }
+
+    // add resource to devirtualize or destroy to the corresponding list for each active pass
+    for (size_t index = 0, c = resourceRegistry.size() ; index < c ; index++) {
+        auto& resource = resourceRegistry[index];
         assert(!resource.first == !resource.last);
         if (resource.readerCount && resource.first && resource.last) {
             resource.first->devirtualize.push_back((uint16_t)index);
@@ -335,26 +535,32 @@ FrameGraph& FrameGraph::compile() noexcept {
     return *this;
 }
 
-void FrameGraph::execute() noexcept {
-    auto const& resources = mResources;
+void FrameGraph::execute(DriverApi& driver) noexcept {
+    auto& resourceRegistry = mResourceRegistry;
     for (PassNode const& node : mPassNodes) {
         if (!node.refCount) continue;
+        assert(node.base);
 
+        FrameGraphPassResources resources(*this, node);
+
+        // create concrete resources
         for (size_t id : node.devirtualize) {
-            // TODO: create concrete resources
+            resourceRegistry[id].create(driver);
         }
 
-        assert(node.base);
-        node.base->execute(resources);
+        // execute the pass
+        node.base->execute(resources, driver);
 
+        // destroy concrete resources
         for (uint32_t id : node.destroy) {
-            // TODO: delete concrete resources
+            resourceRegistry[id].destroy(driver);
         }
     }
 
     // reset the frame graph state
     mPassNodes.clear();
     mResourceNodes.clear();
+    mResourceRegistry.clear();
     mAliases.clear();
 }
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_FRAMEGRAPH_H
+#define TNT_FILAMENT_FRAMEGRAPH_H
+
+
+#include "FrameGraphPass.h"
+#include "FrameGraphResource.h"
+
+#include <utils/Log.h>
+
+#include <vector>
+
+/*
+ * A somewhat generic frame graph API.
+ *
+ * The design is largely inspired from Yuriy O'Donnell 2017 GDC talk
+ * "FrameGraph: Extensible Rendering Architecture in Frostbite"
+ *
+ */
+
+namespace filament {
+
+namespace fg {
+struct Resource;
+struct ResourceNode;
+struct PassNode;
+struct Alias;
+} // namespace fg
+
+class FrameGraph;
+
+// ------------------------------------------------------------------------------------------------
+
+class FrameGraphPassResources {
+public:
+};
+
+// ------------------------------------------------------------------------------------------------
+
+class FrameGraphBuilder {
+public:
+    FrameGraphBuilder(FrameGraph& fg, fg::PassNode& pass) noexcept;
+    FrameGraphBuilder(FrameGraphBuilder const&) = delete;
+    FrameGraphBuilder& operator = (FrameGraphBuilder const&) = delete;
+
+    // create a resource
+    enum CreateFlags : uint32_t {
+        UNKNOWN, READ, WRITE
+    };
+    FrameGraphResource createTexture(const char* name, CreateFlags flags,
+            FrameGraphResource::TextureDesc const& desc) noexcept;
+
+    // read from a resource (i.e. add a reference to that resource)
+    FrameGraphResource read(FrameGraphResource const& input /*, read-flags*/);
+
+    // write to a resource (i.e. add a reference to the pass that's doing the writing))
+    FrameGraphResource write(FrameGraphResource const& output  /*, write-flags*/);
+
+private:
+    fg::ResourceNode* getResource(FrameGraphResource handle);
+    FrameGraph& mFrameGraph;
+    fg::PassNode& mPass;
+};
+
+// ------------------------------------------------------------------------------------------------
+
+class FrameGraph {
+public:
+    FrameGraph();
+    FrameGraph(FrameGraph const&) = delete;
+    FrameGraph& operator = (FrameGraph const&) = delete;
+    ~FrameGraph();
+
+    template <typename Data, typename Setup, typename Execute>
+    FrameGraphPass<Data, Execute>& addPass(const char* name, Setup setup, Execute&& execute) {
+        static_assert(sizeof(Execute) < 1024, "Execute() lambda is capturing too much data.");
+
+        // create the FrameGraph pass (TODO: use special allocator)
+        auto* const pass = new FrameGraphPass<Data, Execute>(std::forward<Execute>(execute));
+
+        // record in our pass list
+        fg::PassNode& node = createPass(name, pass);
+
+        // call the setup code, which will declare used resources
+        FrameGraphBuilder builder(*this, node);
+        setup(builder, pass->getData());
+
+        // return a reference to the pass to the user
+        return *pass;
+    }
+
+    void moveResource(FrameGraphResource from, FrameGraphResource to);
+
+    void present(FrameGraphResource input);
+
+    bool isValid(FrameGraphResource handle) const noexcept ;
+
+    FrameGraph& compile() noexcept;
+
+    void execute() noexcept;
+
+    void export_graphviz(utils::io::ostream& out);
+
+private:
+    friend class FrameGraphBuilder;
+
+    FrameGraphPassResources mResources;
+
+    fg::PassNode& createPass(const char* name, FrameGraphPassExecutor* base) noexcept;
+
+    fg::ResourceNode& createResource(const char* name) noexcept;
+
+    // list of frame graph passes
+    std::vector<fg::PassNode> mPassNodes;
+
+    // frame graph concrete resources
+    std::vector<fg::ResourceNode> mResourceNodes;
+
+    std::vector<fg::Resource> mResourceRegistry;
+
+    std::vector<fg::Alias> mAliases;
+};
+
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_FRAMEGRAPH_H

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -75,7 +75,7 @@ public:
         // Writing to an imported resources adds a side-effect (see sideEffect() below).
         FrameGraphResource write(FrameGraphResource const& output, RWFlags writeFlags = COLOR);
 
-        // Declare that this pass has side effects outside the framefraph (i.e. it can't be culled)
+        // Declare that this pass has side effects outside the framegraph (i.e. it can't be culled)
         // Calling write() on an imported resource automatically adds a side-effect.
         Builder& sideEffect() noexcept;
 

--- a/filament/src/fg/FrameGraphPass.h
+++ b/filament/src/fg/FrameGraphPass.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_FRAMEGRAPHPASS_H
 #define TNT_FILAMENT_FRAMEGRAPHPASS_H
 
+#include "driver/DriverApiForward.h"
+
 #include <limits>
 
 #include <stdint.h>
@@ -27,7 +29,7 @@ class FrameGraphPassResources;
 
 class FrameGraphPassExecutor {
     friend class FrameGraph;
-    virtual void execute(FrameGraphPassResources const& resources) noexcept = 0;
+    virtual void execute(FrameGraphPassResources const& resources, driver::DriverApi& driver) noexcept = 0;
 public:
     FrameGraphPassExecutor();
     virtual ~FrameGraphPassExecutor();
@@ -41,8 +43,8 @@ class FrameGraphPass final : private FrameGraphPassExecutor {
     explicit FrameGraphPass(Execute&& execute) noexcept
             : FrameGraphPassExecutor(), mExecute(std::forward<Execute>(execute)) {
     }
-    void execute(FrameGraphPassResources const& resources) noexcept final {
-        mExecute(resources, mData);
+    void execute(FrameGraphPassResources const& resources, driver::DriverApi& driver) noexcept final {
+        mExecute(resources, mData, driver);
     }
     Execute mExecute;
     Data mData;
@@ -51,7 +53,6 @@ public:
     Data const& getData() const noexcept { return mData; }
     Data& getData() noexcept { return mData; }
 };
-
 
 } // namespace filament
 

--- a/filament/src/fg/FrameGraphPass.h
+++ b/filament/src/fg/FrameGraphPass.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_FRAMEGRAPHPASS_H
+#define TNT_FILAMENT_FRAMEGRAPHPASS_H
+
+#include <limits>
+
+#include <stdint.h>
+
+namespace filament {
+
+class FrameGraphPassResources;
+
+class FrameGraphPassExecutor {
+    friend class FrameGraph;
+    virtual void execute(FrameGraphPassResources const& resources) noexcept = 0;
+public:
+    FrameGraphPassExecutor();
+    virtual ~FrameGraphPassExecutor();
+    FrameGraphPassExecutor(FrameGraphPassExecutor const&) = delete;
+    FrameGraphPassExecutor& operator = (FrameGraphPassExecutor const&) = delete;
+};
+
+template <typename Data, typename Execute>
+class FrameGraphPass final : private FrameGraphPassExecutor {
+    friend class FrameGraph;
+    explicit FrameGraphPass(Execute&& execute) noexcept
+            : FrameGraphPassExecutor(), mExecute(std::forward<Execute>(execute)) {
+    }
+    void execute(FrameGraphPassResources const& resources) noexcept final {
+        mExecute(resources, mData);
+    }
+    Execute mExecute;
+    Data mData;
+
+public:
+    Data const& getData() const noexcept { return mData; }
+    Data& getData() noexcept { return mData; }
+};
+
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_FRAMEGRAPHPASS_H

--- a/filament/src/fg/FrameGraphPassResources.h
+++ b/filament/src/fg/FrameGraphPassResources.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_FRAMEGRAPHPASSRESOURCES_H
+#define TNT_FILAMENT_FRAMEGRAPHPASSRESOURCES_H
+
+#include <filament/driver/DriverEnums.h>
+
+#include "driver/Handle.h"
+
+namespace filament {
+
+namespace fg {
+struct PassNode;
+} // namespace fg
+
+class FrameGraph;
+class FrameGraphResource;
+
+class FrameGraphPassResources {
+public:
+
+    struct RenderTarget {
+        Handle<HwRenderTarget> target;
+        driver::RenderPassParams params;
+    };
+
+    Handle<HwTexture> getTexture(FrameGraphResource r,
+            driver::TextureUsage attachment = driver::TextureUsage::DEFAULT) const noexcept;
+
+    RenderTarget const& getRenderTarget(FrameGraphResource r) const noexcept;
+
+    FrameGraphResource::Descriptor const& getDescriptor(FrameGraphResource r) const noexcept;
+
+private:
+    friend class FrameGraph;
+    explicit FrameGraphPassResources(FrameGraph& fg, fg::PassNode const& pass) noexcept;
+    FrameGraph& mFrameGraph;
+    fg::PassNode const& mPass;
+};
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_FRAMEGRAPHPASSRESOURCES_H

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -17,11 +17,15 @@
 #ifndef TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
 #define TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
 
+#include <filament/driver/DriverEnums.h>
+
 #include <limits>
 
 #include <stdint.h>
 
 namespace filament {
+
+class FrameGraph;
 
 /*
  * A FrameGraph resource.
@@ -29,10 +33,17 @@ namespace filament {
  * This is used to represent a virtual resource.
  */
 
-struct FrameGraphResource {
+class FrameGraphResource {
+public:
 
-    struct TextureDesc {
-        // TODO: descriptor for textures and render targets
+    struct Descriptor {
+        uint32_t width = 1;     // width of resource in pixel
+        uint32_t height = 1;    // height of resource in pixel
+        uint32_t depth = 1;     // # of images for 3D textures
+        uint8_t levels = 1;     // # of levels for textures
+        uint8_t samples = 1;    // # of sample for render targets
+        driver::SamplerType type = driver::SamplerType::SAMPLER_2D;     // texture target type
+        driver::TextureFormat format = driver::TextureFormat::RGBA8;    // resource internal format
     };
 
     static constexpr uint16_t UNINITIALIZED = std::numeric_limits<uint16_t>::max();

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
+#define TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
+
+#include <limits>
+
+#include <stdint.h>
+
+namespace filament {
+
+/*
+ * A FrameGraph resource.
+ *
+ * This is used to represent a virtual resource.
+ */
+
+struct FrameGraphResource {
+
+    struct TextureDesc {
+        // TODO: descriptor for textures and render targets
+    };
+
+    static constexpr uint16_t UNINITIALIZED = std::numeric_limits<uint16_t>::max();
+    // index to the resource handle
+    uint16_t index = UNINITIALIZED;
+    // version of the resource when it was created. When this version doesn't match the
+    // resource handle's version, this resource has become invalid.
+    uint16_t version = 0;
+    bool isValid() const noexcept { return index != UNINITIALIZED; }
+};
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
-#define TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
+#ifndef TNT_FILAMENT_FRAMEGRAPHRESOURCE_H
+#define TNT_FILAMENT_FRAMEGRAPHRESOURCE_H
 
 #include <filament/driver/DriverEnums.h>
 
@@ -57,4 +57,4 @@ public:
 
 } // namespace filament
 
-#endif //TNT_FILAMENT_FRAMEGRAPHRESOURCEHANDLE_H
+#endif //TNT_FILAMENT_FRAMEGRAPHRESOURCE_H

--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -9,13 +9,9 @@ if(NOT IOS)
     # The following tests rely on private APIs that are stripped
     # away in Release builds
     if (TNT_DEV)
-        add_executable(test_${TARGET} filament_test.cpp)
+        add_executable(test_${TARGET} filament_test_exposure.cpp filament_framegraph_test.cpp filament_test.cpp)
         target_link_libraries(test_${TARGET} PRIVATE filament gtest)
         target_compile_options(test_${TARGET} PRIVATE ${COMPILER_FLAGS})
-
-        add_executable(test_${TARGET}_exposure filament_test_exposure.cpp)
-        target_link_libraries(test_${TARGET}_exposure PRIVATE filament gtest)
-        target_compile_options(test_${TARGET}_exposure PRIVATE ${COMPILER_FLAGS})
 
         add_executable(test_depth depth_test.cpp)
     endif()

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -1,0 +1,371 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fg/FrameGraph.h"
+
+using namespace filament;
+
+TEST(FrameGraphTest, SimpleRenderPass) {
+
+    FrameGraph fg;
+
+    bool renderPassExecuted = false;
+
+    struct RenderPassData {
+        FrameGraphResource output;
+    };
+
+    auto& renderPass = fg.addPass<RenderPassData>("Render",
+            [&](FrameGraphBuilder& builder, RenderPassData& data) {
+                data.output = builder.createTexture("renderTarget", FrameGraphBuilder::WRITE, {});
+                EXPECT_TRUE(data.output.isValid());
+                EXPECT_TRUE(fg.isValid(data.output));
+            },
+            [&renderPassExecuted](FrameGraphPassResources const& resources, RenderPassData const& data) {
+                renderPassExecuted = true;
+            });
+
+    fg.present(renderPass.getData().output);
+
+    fg.compile().execute();
+
+    EXPECT_TRUE(renderPassExecuted);
+}
+
+
+TEST(FrameGraphTest, SimpleRenderAndPostProcessPasses) {
+
+    FrameGraph fg;
+
+    bool renderPassExecuted = false;
+    bool postProcessPassExecuted = false;
+
+    struct RenderPassData {
+        FrameGraphResource output;
+    };
+
+    auto& renderPass = fg.addPass<RenderPassData>("Render",
+            [&](FrameGraphBuilder& builder, RenderPassData& data) {
+                data.output = builder.createTexture("renderTarget", FrameGraphBuilder::WRITE, {});
+                EXPECT_TRUE(data.output.isValid());
+                EXPECT_TRUE(fg.isValid(data.output));
+            },
+            [&renderPassExecuted](FrameGraphPassResources const& resources, RenderPassData const& data) {
+                renderPassExecuted = true;
+            });
+
+
+    struct PostProcessPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+
+    auto& postProcessPass = fg.addPass<PostProcessPassData>("PostProcess",
+            [&](FrameGraphBuilder& builder, PostProcessPassData& data) {
+                data.input = builder.read(renderPass.getData().output);
+                data.output = builder.write(data.input);
+                EXPECT_TRUE(data.input.isValid());
+                EXPECT_TRUE(data.output.isValid());
+                EXPECT_FALSE(fg.isValid(data.input));
+                EXPECT_TRUE(fg.isValid(data.output));
+            },
+            [&postProcessPassExecuted](FrameGraphPassResources const& resources, PostProcessPassData const& data) {
+                postProcessPassExecuted = true;
+            });
+
+    fg.present(postProcessPass.getData().output);
+
+    EXPECT_FALSE(fg.isValid(renderPass.getData().output));
+    EXPECT_FALSE(fg.isValid(postProcessPass.getData().input));
+    EXPECT_TRUE(fg.isValid(postProcessPass.getData().output));
+
+    fg.compile();
+
+    fg.export_graphviz(utils::slog.d);
+
+    fg.execute();
+
+
+    EXPECT_TRUE(renderPassExecuted);
+    EXPECT_TRUE(postProcessPassExecuted);
+}
+
+
+TEST(FrameGraphTest, SimplePassCulling) {
+
+    FrameGraph fg;
+
+    bool renderPassExecuted = false;
+    bool postProcessPassExecuted = false;
+    bool culledPassExecuted = false;
+
+    struct RenderPassData {
+        FrameGraphResource output;
+    };
+
+    auto& renderPass = fg.addPass<RenderPassData>("Render",
+            [&](FrameGraphBuilder& builder, RenderPassData& data) {
+                data.output = builder.createTexture("renderTarget", FrameGraphBuilder::WRITE, {});
+            },
+            [&renderPassExecuted](FrameGraphPassResources const& resources, RenderPassData const& data) {
+                renderPassExecuted = true;
+            });
+
+
+    struct PostProcessPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+
+    auto& postProcessPass = fg.addPass<PostProcessPassData>("PostProcess",
+            [&](FrameGraphBuilder& builder, PostProcessPassData& data) {
+                data.input = builder.read(renderPass.getData().output);
+                data.output = builder.createTexture("postprocess-renderTarget", FrameGraphBuilder::WRITE, {});
+            },
+            [&postProcessPassExecuted](FrameGraphPassResources const& resources, PostProcessPassData const& data) {
+                postProcessPassExecuted = true;
+            });
+
+
+    struct CulledPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+
+    auto& culledPass = fg.addPass<CulledPassData>("CulledPass",
+            [&](FrameGraphBuilder& builder, CulledPassData& data) {
+                data.input = builder.read(renderPass.getData().output);
+                data.output = builder.createTexture("unused-rendertarget", FrameGraphBuilder::WRITE, {});
+            },
+            [&culledPassExecuted](FrameGraphPassResources const& resources, CulledPassData const& data) {
+                culledPassExecuted = true;
+            });
+
+    fg.present(postProcessPass.getData().output);
+
+    EXPECT_TRUE(fg.isValid(renderPass.getData().output));
+    EXPECT_TRUE(fg.isValid(postProcessPass.getData().input));
+    EXPECT_TRUE(fg.isValid(postProcessPass.getData().output));
+    EXPECT_TRUE(fg.isValid(culledPass.getData().input));
+    EXPECT_TRUE(fg.isValid(culledPass.getData().output));
+
+    //fg.export_graphviz(utils::slog.d);
+
+    fg.compile();
+
+    //fg.export_graphviz(utils::slog.d);
+
+    fg.execute();
+
+    EXPECT_TRUE(renderPassExecuted);
+    EXPECT_TRUE(postProcessPassExecuted);
+    EXPECT_FALSE(culledPassExecuted);
+}
+
+
+TEST(FrameGraphTest, BadGraph) {
+
+    /*
+     * We invalidate and rename handles that are writen into, to avoid undefined order
+     * access to the resources.
+     *
+     * e.g. forbidden graphs
+     *
+     *              +->[R1]-+
+     *             /         \
+     * [R0]->(A)--+           +-> (A)
+     *             \         /
+     *              +->[R2]-+        // failure when setting R2 from (A)
+     *
+     */
+
+    FrameGraph fg;
+
+    bool R0exec = false;
+    bool R1exec = false;
+    bool R2exec = false;
+
+    struct R0Data {
+        FrameGraphResource output;
+    };
+
+    auto& R0 = fg.addPass<R0Data>("R1",
+            [&](FrameGraphBuilder& builder, R0Data& data) {
+                data.output = builder.createTexture("A", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, R0Data const&) {
+                R0exec = true;
+            });
+
+
+    struct RData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+
+    auto& R1 = fg.addPass<RData>("R1",
+            [&](FrameGraphBuilder& builder, RData& data) {
+                data.input = builder.read(R0.getData().output);
+                data.output = builder.write(data.input);
+            },
+            [&](FrameGraphPassResources const&, RData const&) {
+                R1exec = true;
+            });
+
+    fg.present(R1.getData().output);
+
+    auto& R2 = fg.addPass<RData>("R2",
+            [&](FrameGraphBuilder& builder, RData& data) {
+                EXPECT_FALSE(fg.isValid(R0.getData().output));
+            },
+            [&](FrameGraphPassResources const&, RData const&) {
+                R2exec = true;
+            });
+
+    EXPECT_FALSE(fg.isValid(R2.getData().output));
+
+    fg.compile();
+
+    fg.execute();
+
+    EXPECT_TRUE(R0exec);
+    EXPECT_TRUE(R1exec);
+    EXPECT_FALSE(R2exec);
+}
+
+TEST(FrameGraphTest, ComplexGraph) {
+
+    FrameGraph fg;
+
+    struct DepthPassData {
+        FrameGraphResource output;
+    };
+    auto& depthPass = fg.addPass<DepthPassData>("Depth pass",
+            [&](FrameGraphBuilder& builder, DepthPassData& data) {
+                data.output = builder.createTexture("Depth Buffer", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, DepthPassData const&) {
+            });
+
+
+
+    // buggy pass
+    struct BuffyPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+    auto& buggyPass = fg.addPass<BuffyPassData>("Bug",
+            [&](FrameGraphBuilder& builder, BuffyPassData& data) {
+                data.input = builder.read(depthPass.getData().output);
+                data.output = builder.createTexture("Buggy output", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, BuffyPassData const&) {
+            });
+    fg.present(buggyPass.getData().output);
+
+
+
+    struct GBufferPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+        FrameGraphResource gbuffers[3];
+    };
+    auto& gbufferPass = fg.addPass<GBufferPassData>("Gbuffer pass",
+            [&](FrameGraphBuilder& builder, GBufferPassData& data) {
+                data.input = builder.read(depthPass.getData().output);
+                data.output = builder.write(data.input);
+                data.gbuffers[0] = builder.createTexture("Gbuffer 1", FrameGraphBuilder::WRITE, {});
+                data.gbuffers[1] = builder.createTexture("Gbuffer 2", FrameGraphBuilder::WRITE, {});
+                data.gbuffers[2] = builder.createTexture("Gbuffer 3", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, GBufferPassData const&) {
+            });
+
+
+    struct LightingPassData {
+        FrameGraphResource input[4];
+        FrameGraphResource output;
+    };
+    auto& lightingPass = fg.addPass<LightingPassData>("Lighting pass",
+            [&](FrameGraphBuilder& builder, LightingPassData& data) {
+                data.input[0] = builder.read(gbufferPass.getData().output);
+                data.input[1] = builder.read(gbufferPass.getData().gbuffers[0]);
+                data.input[2] = builder.read(gbufferPass.getData().gbuffers[1]);
+                data.input[3] = builder.read(gbufferPass.getData().gbuffers[2]);
+                data.output = builder.createTexture("Lighting buffer", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, LightingPassData const&) {
+            });
+
+
+    struct ConvolutionPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+    auto& convolutionPass = fg.addPass<ConvolutionPassData>("Convolution",
+            [&](FrameGraphBuilder& builder, ConvolutionPassData& data) {
+                data.input = builder.read(gbufferPass.getData().gbuffers[2]); //builder.createTexture("Cubemap", FrameGraphBuilder::READ, {});
+                data.output = builder.createTexture("Reflection probe", FrameGraphBuilder::WRITE, {});
+            },
+            [&](FrameGraphPassResources const&, ConvolutionPassData const&) {
+            });
+
+    fg.present(lightingPass.getData().output);
+
+    fg.moveResource(convolutionPass.getData().output, lightingPass.getData().output);
+
+    fg.compile();
+
+    fg.export_graphviz(utils::slog.d);
+
+    fg.execute();
+}
+
+TEST(FrameGraphTest, MoveResource) {
+
+    FrameGraph fg;
+
+    struct RenderPassData {
+        FrameGraphResource input;
+        FrameGraphResource output;
+    };
+
+    auto& renderPass = fg.addPass<RenderPassData>("Render",
+            [&](FrameGraphBuilder& builder, RenderPassData& data) {
+                data.input = builder.createTexture("render-inout", FrameGraphBuilder::READ, {});
+                data.output = builder.write(data.input);
+            },
+            [](FrameGraphPassResources const& resources, RenderPassData const& data) {
+            });
+    fg.present(renderPass.getData().output);
+
+    auto& debugPass = fg.addPass<RenderPassData>("Debug",
+            [&](FrameGraphBuilder& builder, RenderPassData& data) {
+                data.input = builder.createTexture("debug-inout", FrameGraphBuilder::READ, {});
+                data.output = builder.write(data.input);
+            },
+            [](FrameGraphPassResources const& resources, RenderPassData const& data) {
+            });
+    fg.present(debugPass.getData().output);
+
+    fg.moveResource(renderPass.getData().output, debugPass.getData().input);
+
+    fg.compile();
+    fg.export_graphviz(utils::slog.d);
+    fg.execute();
+}

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -42,7 +42,7 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                 FrameGraphResource::Descriptor desc {
                     .format = driver::TextureFormat::RGBA16F
                 };
-                data.output = builder.write(builder.createTexture("renderTarget", desc));
+                data.output = builder.write(builder.createResource("renderTarget", desc));
                 EXPECT_TRUE(data.output.isValid());
                 EXPECT_TRUE(fg.isValid(data.output));
             },
@@ -80,7 +80,7 @@ TEST(FrameGraphTest, SimpleRenderAndPostProcessPasses) {
                 FrameGraphResource::Descriptor desc {
                         .format = driver::TextureFormat::RGBA16F
                 };
-                data.output = builder.write(builder.createTexture("renderTarget", desc));
+                data.output = builder.write(builder.createResource("renderTarget", desc));
                 EXPECT_TRUE(data.output.isValid());
                 EXPECT_TRUE(fg.isValid(data.output));
             },
@@ -151,7 +151,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
 
     auto& renderPass = fg.addPass<RenderPassData>("Render",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
-                data.output = builder.write(builder.createTexture("renderTarget"));
+                data.output = builder.write(builder.createResource("renderTarget"));
             },
             [=, &renderPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -169,7 +169,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
     auto& postProcessPass = fg.addPass<PostProcessPassData>("PostProcess",
             [&](FrameGraph::Builder& builder, PostProcessPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
-                data.output = builder.write(builder.createTexture("postprocess-renderTarget"));
+                data.output = builder.write(builder.createResource("postprocess-renderTarget"));
             },
             [=, &postProcessPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -187,7 +187,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
     auto& culledPass = fg.addPass<CulledPassData>("CulledPass",
             [&](FrameGraph::Builder& builder, CulledPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
-                data.output = builder.write(builder.createTexture("unused-rendertarget"));
+                data.output = builder.write(builder.createResource("unused-rendertarget"));
             },
             [=, &culledPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -246,7 +246,7 @@ TEST(FrameGraphTest, BadGraph) {
 
     auto& R0 = fg.addPass<R0Data>("R1",
             [&](FrameGraph::Builder& builder, R0Data& data) {
-                data.output = builder.write(builder.createTexture("A"));
+                data.output = builder.write(builder.createResource("A"));
             },
             [=, &R0exec](FrameGraphPassResources const&, R0Data const&, driver::DriverApi&) {
                 R0exec = true;
@@ -297,7 +297,7 @@ TEST(FrameGraphTest, ComplexGraph) {
     };
     auto& depthPass = fg.addPass<DepthPassData>("Depth pass",
             [&](FrameGraph::Builder& builder, DepthPassData& data) {
-                data.output = builder.write(builder.createTexture("Depth Buffer"));
+                data.output = builder.write(builder.createResource("Depth Buffer"));
             },
             [=](FrameGraphPassResources const&, DepthPassData const&, driver::DriverApi&) {
             });
@@ -312,7 +312,7 @@ TEST(FrameGraphTest, ComplexGraph) {
     auto& buggyPass = fg.addPass<BuffyPassData>("Bug",
             [&](FrameGraph::Builder& builder, BuffyPassData& data) {
                 data.input = builder.read(depthPass.getData().output);
-                data.output = builder.write(builder.createTexture("Buggy output"));
+                data.output = builder.write(builder.createResource("Buggy output"));
             },
             [&](FrameGraphPassResources const&, BuffyPassData const&, driver::DriverApi&) {
             });
@@ -329,9 +329,9 @@ TEST(FrameGraphTest, ComplexGraph) {
             [&](FrameGraph::Builder& builder, GBufferPassData& data) {
                 data.input = builder.read(depthPass.getData().output);
                 data.output = builder.write(data.input);
-                data.gbuffers[0] = builder.write(builder.createTexture("Gbuffer 1"));
-                data.gbuffers[1] = builder.write(builder.createTexture("Gbuffer 2"));
-                data.gbuffers[2] = builder.write(builder.createTexture("Gbuffer 3"));
+                data.gbuffers[0] = builder.write(builder.createResource("Gbuffer 1"));
+                data.gbuffers[1] = builder.write(builder.createResource("Gbuffer 2"));
+                data.gbuffers[2] = builder.write(builder.createResource("Gbuffer 3"));
             },
             [=](FrameGraphPassResources const&, GBufferPassData const&, driver::DriverApi&) {
             });
@@ -347,7 +347,7 @@ TEST(FrameGraphTest, ComplexGraph) {
                 data.input[1] = builder.read(gbufferPass.getData().gbuffers[0]);
                 data.input[2] = builder.read(gbufferPass.getData().gbuffers[1]);
                 data.input[3] = builder.read(gbufferPass.getData().gbuffers[2]);
-                data.output = builder.write(builder.createTexture("Lighting buffer"));
+                data.output = builder.write(builder.createResource("Lighting buffer"));
             },
             [=](FrameGraphPassResources const&, LightingPassData const&, driver::DriverApi&) {
             });
@@ -360,7 +360,7 @@ TEST(FrameGraphTest, ComplexGraph) {
     auto& convolutionPass = fg.addPass<ConvolutionPassData>("Convolution",
             [&](FrameGraph::Builder& builder, ConvolutionPassData& data) {
                 data.input = builder.read(gbufferPass.getData().gbuffers[2]); //builder.createTexture("Cubemap", Builder::READ, {});
-                data.output = builder.write(builder.createTexture("Reflection probe"));
+                data.output = builder.write(builder.createResource("Reflection probe"));
             },
             [=](FrameGraphPassResources const&, ConvolutionPassData const&, driver::DriverApi&) {
             });
@@ -387,7 +387,7 @@ TEST(FrameGraphTest, MoveResource) {
 
     auto& renderPass = fg.addPass<RenderPassData>("Render",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
-                data.input = builder.read(builder.createTexture("render-inout"));
+                data.input = builder.read(builder.createResource("render-inout"));
                 data.output = builder.write(data.input);
             },
             [=](FrameGraphPassResources const& resources, RenderPassData const& data, driver::DriverApi&) {
@@ -396,7 +396,7 @@ TEST(FrameGraphTest, MoveResource) {
 
     auto& debugPass = fg.addPass<RenderPassData>("Debug",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
-                data.input = builder.read(builder.createTexture("debug-inout"));
+                data.input = builder.read(builder.createResource("debug-inout"));
                 data.output = builder.write(data.input);
             },
             [=](FrameGraphPassResources const& resources, RenderPassData const& data, driver::DriverApi&) {

--- a/filament/test/filament_test_exposure.cpp
+++ b/filament/test/filament_test_exposure.cpp
@@ -145,8 +145,3 @@ TEST_F(FilamentExposureTest, ComputeIlluminanceFromEV100) {
     int32_t sunny16 = static_cast<int32_t>(roundf(Exposure::illuminance(16.0f, 1 / 125.0f, 100.0f)));
     EXPECT_EQ(80000, sunny16);
 }
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/libs/utils/include/utils/Log.h
+++ b/libs/utils/include/utils/Log.h
@@ -97,7 +97,7 @@ private:
     const char* getFormat(type t) const noexcept;
 
     class Buffer {
-        char mStorage[1024];
+        char mStorage[16384];
     public:
         char* curr = mStorage;
         size_t size = sizeof(mStorage);


### PR DESCRIPTION
The design of the frame graph is largely inspired from Yuriy O'Donnell's '17 GDC talk.
This is still work in progress, in particular the API might change.

Currently supported: importing resources, culling of unreferenced passes, versioning to guarantee graph integrity, resource aliasing, resource lifetime tracking.

There is enough support for running filament's post processing all within the framegraph.

One of the major missing piece to at least get back to parity with the previous code, is tracking accesses to renter targets attachments so that we can discard them properly. Currently no discard is performed, which is not great for tilers.