### PR TITLE
Document UV flipping behavior and add control attribute

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1159,6 +1159,25 @@ material {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+### flipUV
+
+Type
+:    `boolean`
+
+Value
+:     `true` or `false`. Defaults to `true`.
+
+Description
+:    When set to `true` (default value), the Y coordinate of UV attributes will be flipped when
+     read by this material's vertex shader. Flipping is equivalent to `y = 1.0 - y`. When set
+     to `false`, flipping is disabled and the UV attributes are read as is.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
+material {
+    flipUV : false
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 ## Vertex block
 
 The vertex block is optional and can be used to control the vertex shading stage of the material.
@@ -1214,6 +1233,11 @@ struct MaterialVertexInputs {
     float4 variable3;     // if 4 or more variables is defined
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+!!! TIP: UV attributes
+    By default the vertex shader of a material will flip the Y coordinate of the UV attributes
+    of the current mesh: `material.uv0 = vec2(mesh_uv0.x, 1.0 - mesh_uv0.y)`. You can control
+    this behavior using the `flipUV` property and setting it to `false`.
 
 ## Fragment block
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -167,10 +167,15 @@ public:
     MaterialBuilder& shadowMultiplier(bool shadowMultiplier) noexcept;
 
     // reduce specular aliasing by locally increasing roughness using geometric curvature
+    // disabled by default
     MaterialBuilder& curvatureToRoughness(bool curvatureToRoughness) noexcept;
 
     // reduce specular aliasing at silhouette by preventing over-interpolation of geometric normals
+    // disabled by default
     MaterialBuilder& limitOverInterpolation(bool limitOverInterpolation) noexcept;
+
+    // enable/disable flipping of the Y coordinate of UV attributes, enabled by default
+    MaterialBuilder& flipUV(bool flipUV) noexcept;
 
     // specifies how transparent objects should be rendered (default is DEFAULT)
     MaterialBuilder& transparencyMode(TransparencyMode mode) noexcept;
@@ -285,6 +290,8 @@ private:
 
     bool mCurvatureToRoughness = false;
     bool mLimitOverInterpolation = false;
+
+    bool mFlipUV = true;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -226,6 +226,11 @@ MaterialBuilder& MaterialBuilder::limitOverInterpolation(bool limitOverInterpola
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::flipUV(bool flipUV) noexcept {
+    mFlipUV = flipUV;
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::transparencyMode(TransparencyMode mode) noexcept {
     mTransparencyMode = mode;
     return *this;
@@ -298,6 +303,7 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.hasExternalSamplers = hasExternalSampler();
     info.curvatureToRoughness = mCurvatureToRoughness;
     info.limitOverInterpolation = mLimitOverInterpolation;
+    info.flipUV = mFlipUV;
     info.requiredAttributes = mRequiredAttributes;
     info.blendingMode = mBlendingMode;
     info.shading = mShading;

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -39,6 +39,7 @@ struct UTILS_PUBLIC MaterialInfo {
     bool hasShadowMultiplier;
     bool curvatureToRoughness;
     bool limitOverInterpolation;
+    bool flipUV;
     filament::AttributeBitset requiredAttributes;
     filament::BlendingMode blendingMode;
     filament::Shading shading;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -152,6 +152,7 @@ const std::string ShaderGenerator::createVertexProgram(filament::driver::ShaderM
 
     cg.generateProlog(vs, ShaderType::VERTEX, material.hasExternalSamplers);
 
+    cg.generateDefine(vs, "FLIP_UV_ATTRIBUTE", material.flipUV);
     cg.generateDefine(vs, "GEOMETRIC_SPECULAR_AA_NORMAL", material.limitOverInterpolation);
 
     bool litVariants = lit || material.hasShadowMultiplier;

--- a/shaders/src/common_material.vs
+++ b/shaders/src/common_material.vs
@@ -31,10 +31,18 @@ void initMaterialVertex(out MaterialVertexInputs material) {
     material.color = mesh_color;
 #endif
 #ifdef HAS_ATTRIBUTE_UV0
+    #ifdef FLIP_UV_ATTRIBUTE
     material.uv0 = vec2(mesh_uv0.x, 1.0 - mesh_uv0.y);
+    #else
+    material.uv0 = mesh_uv0;
+    #endif
 #endif
 #ifdef HAS_ATTRIBUTE_UV1
+    #ifdef FLIP_UV_ATTRIBUTE
     material.uv1 = vec2(mesh_uv1.x, 1.0 - mesh_uv1.y);
+    #else
+    material.uv1 = mesh_uv1;
+    #endif
 #endif
 #ifdef VARIABLE_CUSTOM0
     material.VARIABLE_CUSTOM0 = vec4(0.0);

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -48,6 +48,7 @@ static constexpr const char* PARAM_KEY_SHADING                  = "shadingModel"
 static constexpr const char* PARAM_KEY_VARIANT_FILTER           = "variantFilter";
 static constexpr const char* PARAM_KEY_CURVATURE_TO_ROUGHNESS   = "curvatureToRoughness";
 static constexpr const char* PARAM_KEY_LIMIT_OVER_INTERPOLATION = "limitOverInterpolation";
+static constexpr const char* PARAM_KEY_FLIP_UV                  = "flipUV";
 
 ParametersProcessor::ParametersProcessor() {
     mConfigProcessor[PARAM_KEY_NAME]              = &ParametersProcessor::processName;
@@ -71,6 +72,7 @@ ParametersProcessor::ParametersProcessor() {
             = &ParametersProcessor::processCurvatureToRoughness;
     mConfigProcessor[PARAM_KEY_LIMIT_OVER_INTERPOLATION]
             = &ParametersProcessor::processLimitOverInterpolation;
+    mConfigProcessor[PARAM_KEY_FLIP_UV]           = &ParametersProcessor::processFlipUV;
 
     mRootAsserts[PARAM_KEY_NAME]                     = JsonishValue::Type::STRING;
     mRootAsserts[PARAM_KEY_INTERPOLATION]            = JsonishValue::Type::STRING;
@@ -91,6 +93,7 @@ ParametersProcessor::ParametersProcessor() {
     mRootAsserts[PARAM_KEY_VARIANT_FILTER]           = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_CURVATURE_TO_ROUGHNESS]   = JsonishValue::Type::BOOL;
     mRootAsserts[PARAM_KEY_LIMIT_OVER_INTERPOLATION] = JsonishValue::Type::BOOL;
+    mRootAsserts[PARAM_KEY_FLIP_UV]                  = JsonishValue::Type::BOOL;
 
     mStringToInterpolation["smooth"] = MaterialBuilder::Interpolation::SMOOTH;
     mStringToInterpolation["flat"] = MaterialBuilder::Interpolation::FLAT;
@@ -458,6 +461,11 @@ bool ParametersProcessor::processCurvatureToRoughness(filamat::MaterialBuilder& 
 bool ParametersProcessor::processLimitOverInterpolation(filamat::MaterialBuilder& builder,
         const JsonishValue& value) {
     builder.limitOverInterpolation(value.toJsonBool()->getBool());
+    return true;
+}
+
+bool ParametersProcessor::processFlipUV(filamat::MaterialBuilder& builder, const JsonishValue& value) {
+    builder.flipUV(value.toJsonBool()->getBool());
     return true;
 }
 

--- a/tools/matc/src/matc/ParametersProcessor.h
+++ b/tools/matc/src/matc/ParametersProcessor.h
@@ -53,6 +53,7 @@ private:
     bool processShadowMultiplier(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processCurvatureToRoughness(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processLimitOverInterpolation(filamat::MaterialBuilder &builder, const JsonishValue &value);
+    bool processFlipUV(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processShading(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processVariantFilter(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processParameter(filamat::MaterialBuilder& builder, const JsonishObject& value) const


### PR DESCRIPTION
Materials can disbale this behavior by setting flipUV: false
in the header section of the material definition.

Fixes #672