### PR TITLE
Fix diabolical VAO state management bug.

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1301,7 +1301,7 @@ void OpenGLDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
         glDeleteVertexArrays(1, &rp->gl.vao);
         // binding of a bound VAO is reset to 0
         if (state.vao.p == rp) {
-            state.vao.p = &mDefaultVAO;
+            bindVertexArray(nullptr);
         }
         destruct(rph, rp);
     }


### PR DESCRIPTION
When clients deleted renderables that referred to index buffers that
were still active, it was possible for our shadow ELEMENT_ARRAY_BUFFER
binding to get out of sync with the actual binding.

It is somewhat amazing that this has never caused issues before. Perhaps
it is rare for clients to "recycle" index buffers across multiple
renderable lifetimes.

This fixes #718.