### PR TITLE
Fix depth prepass

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -220,16 +220,6 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     parser->hasCustomDepthShader(&mHasCustomDepthShader);
     mIsDefaultMaterial = builder->mDefaultMaterial;
 
-    // pre-cache the shared variants -- these variants are shared with the default material.
-    if (UTILS_UNLIKELY(!mIsDefaultMaterial && !mHasCustomDepthShader)) {
-        auto& cachedPrograms = mCachedPrograms;
-        for (uint8_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
-            if (Variant(i).isDepthPass()) {
-                cachedPrograms[i] = engine.getDefaultMaterial()->getProgram(i);
-            }
-        }
-    }
-
     bool colorWrite;
     parser->getColorWrite(&colorWrite);
     mRasterState.colorWrite = colorWrite;
@@ -247,17 +237,8 @@ FMaterial::~FMaterial() noexcept {
 void FMaterial::terminate(FEngine& engine) {
     DriverApi& driverApi = engine.getDriverApi();
     auto& cachedPrograms = mCachedPrograms;
-    for (size_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
-        if (!mIsDefaultMaterial) {
-            // The depth variants may be shared with the default material, in which case
-            // we should not free it now.
-            bool isSharedVariant = Variant(i).isDepthPass() && !mHasCustomDepthShader;
-            if (isSharedVariant) {
-                // we don't own this variant, skip.
-                continue;
-            }
-        }
-        driverApi.destroyProgram(cachedPrograms[i]);
+    for (const auto& cachedProgram : cachedPrograms) {
+        driverApi.destroyProgram(cachedProgram);
     }
     mDefaultInstance.terminate(engine);
 }

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -28,7 +28,6 @@ namespace filament {
         Variant() noexcept = default;
         constexpr Variant(uint8_t key) noexcept : key(key) { }
 
-
         // DIR: Directional Lighting
         // DYN: Dynamic Lighting
         // SRE: Shadow Receiver


### PR DESCRIPTION
The engine tries to be smart by using a single vertex shader when
rendering unskinned, non-alpha masked, non-customized materials.
This leads to a lot of issues when laying down the depth prepass.
This change simply gets rid of this optimization (which wasn't
properly profiled anyway). Correctness is more important.

Fixes #645