### PR TITLE
Add another folder to the build's "clean" task.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -117,6 +117,7 @@ function build_clean {
     echo "Cleaning build directories..."
     rm -Rf out
     rm -Rf android/filament-android/build
+    rm -Rf android/filament-android/.externalNativeBuild
 }
 
 function generate_toolchain {


### PR DESCRIPTION
Gradle creates a hidden .externalNativeBuild folder when issuing CMake
for the first time. This folder contains cached command line parameters
that get passed to CMake, and these can become stale when switching
between "normal" Android builds and Vulkan-enabled Android builds, which
leads to frustrating build errors.