### PR TITLE
Add filamat-jni to CMake and build.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,14 @@ if (FILAMENT_SUPPORTS_VULKAN)
     add_definitions(-DFILAMENT_DRIVER_SUPPORTS_VULKAN)
 endif()
 
+# Building filamat increases build times and isn't required for non-desktop platforms, so turn it
+# off by default.
+if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+    option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" ON)
+else()
+    option(FILAMENT_BUILD_FILAMAT "Include the Vulkan backend" OFF)
+endif()
+
 # ==================================================================================================
 # Distribution
 # ==================================================================================================
@@ -313,6 +321,7 @@ endfunction()
 # ==================================================================================================
 # Sub-projects
 # ==================================================================================================
+
 # Common to all platforms
 add_subdirectory(${EXTERNAL}/libgtest/tnt)
 add_subdirectory(${LIBRARIES}/filabridge)
@@ -327,6 +336,16 @@ add_subdirectory(${EXTERNAL}/robin-map/tnt)
 add_subdirectory(${EXTERNAL}/smol-v/tnt)
 add_subdirectory(${EXTERNAL}/benchmark/tnt)
 add_subdirectory(${EXTERNAL}/meshoptimizer)
+
+if (FILAMENT_BUILD_FILAMAT)
+    # spirv-tools must come before filamat, as filamat relies on the presence of the
+    # spirv-tools_SOURCE_DIR variable.
+    add_subdirectory(${EXTERNAL}/spirv-tools)
+    add_subdirectory(${EXTERNAL}/glslang/tnt)
+    add_subdirectory(${EXTERNAL}/spirv-cross/tnt)
+    add_subdirectory(android/filamat-android)
+    add_subdirectory(${LIBRARIES}/filamat)
+endif()
 
 if (FILAMENT_SUPPORTS_VULKAN)
     add_subdirectory(${LIBRARIES}/bluevk)
@@ -349,15 +368,8 @@ if (WEBGL)
 endif()
 
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
-    # spirv-tools must come before filamat, as filamat relies on the presence of the
-    # spirv-tools_SOURCE_DIR variable.
-    add_subdirectory(${EXTERNAL}/spirv-tools)
-    add_subdirectory(${EXTERNAL}/glslang/tnt)
-    add_subdirectory(${EXTERNAL}/spirv-cross/tnt)
-
     add_subdirectory(${LIBRARIES}/bluegl)
     add_subdirectory(${LIBRARIES}/filagui)
-    add_subdirectory(${LIBRARIES}/filamat)
     add_subdirectory(${LIBRARIES}/imageio)
 
     add_subdirectory(${FILAMENT}/java)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ endif()
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" ON)
 else()
-    option(FILAMENT_BUILD_FILAMAT "Include the Vulkan backend" OFF)
+    option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" OFF)
 endif()
 
 # ==================================================================================================

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -53,7 +53,7 @@ set(CMAKE_SKIP_RPATH TRUE)
 
 set_target_properties(${TARGET} PROPERTIES
         CXX_STANDARD 14
-        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden"
+        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden $<$<PLATFORM_ID:Linux>:-fPIC>"
         LINK_FLAGS "${GC_SECTIONS} ${EXPORTED_SYMBOLS}")
 
 target_link_libraries(${TARGET} filamat)

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -1,0 +1,91 @@
+cmake_minimum_required(VERSION 3.4.1)
+project(filamat-java)
+
+if (NOT ENABLE_JAVA)
+    return()
+endif()
+
+find_package(Java)
+if (NOT Java_FOUND)
+    message(WARNING "JDK not found, skipping Java projects")
+    return()
+endif()
+
+# Android already has the JNI headers in its system include path.
+if (NOT ANDROID)
+    find_package(JNI)
+    if (NOT JNI_FOUND)
+        message(WARNING "JNI not found, skipping Java projects")
+        return()
+    endif()
+endif()
+
+if (NOT DEFINED ENV{JAVA_HOME})
+    message(WARNING "The JAVA_HOME environment variable must be set to compile Java projects")
+    message(WARNING "Skipping Java projects")
+    return()
+endif()
+
+# ==================================================================================================
+# JNI bindings
+# ==================================================================================================
+set(TARGET filamat-jni)
+
+set(JNI_SOURCE_FILES
+        src/main/cpp/MaterialBuilder.cpp)
+
+add_library(${TARGET} SHARED ${JNI_SOURCE_FILES})
+
+target_include_directories(${TARGET} PRIVATE ${JNI_INCLUDE_DIRS})
+
+set(EXPORTED_SYMBOLS)
+if (APPLE)
+    set(EXPORTED_SYMBOLS "-exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/libfilamat-jni.symbols")
+elseif (ANDROID)
+    set(EXPORTED_SYMBOLS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libfilamat-jni.map")
+endif()
+
+# This is necessary to avoid a CMake error due to setting RPATH on non-elf platforms.
+# Setting this also causes CMake to issue a warning on Mac:
+# "Policy CMP0068 is not set: RPATH settings on macOS do not affect install_name." which can be
+# safely ignored.
+set(CMAKE_SKIP_RPATH TRUE)
+
+set_target_properties(${TARGET} PROPERTIES
+        CXX_STANDARD 14
+        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden"
+        LINK_FLAGS "${GC_SECTIONS} ${EXPORTED_SYMBOLS}")
+
+target_link_libraries(${TARGET} filamat)
+
+set(INSTALL_TYPE LIBRARY)
+if (WIN32 OR CYGWIN)
+    set(INSTALL_TYPE RUNTIME)
+endif()
+install(TARGETS ${TARGET} ${INSTALL_TYPE} DESTINATION lib/${DIST_DIR})
+install(CODE "execute_process(COMMAND ${CMAKE_STRIP} -x ${CMAKE_INSTALL_PREFIX}/lib/${DIST_DIR}/lib${TARGET}${CMAKE_SHARED_LIBRARY_SUFFIX})")
+
+# ==================================================================================================
+# Java APIs
+# ==================================================================================================
+
+# Android builds its Java bindings for filamat through Gradle.
+if (ANDROID)
+    return()
+endif()
+
+set(TARGET filamat-java)
+
+include(UseJava)
+
+set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8")
+
+set(JAVA_SOURCE_FILES
+        src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+        src/main/java/com/google/android/filament/filamat/MaterialPackage.java)
+
+add_jar(${TARGET}
+        SOURCES ${JAVA_SOURCE_FILES}
+        INCLUDE_JARS ../../../java/lib/support-annotations.jar)
+
+install_jar(${TARGET} lib)

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -86,6 +86,6 @@ set(JAVA_SOURCE_FILES
 
 add_jar(${TARGET}
         SOURCES ${JAVA_SOURCE_FILES}
-        INCLUDE_JARS ../../../java/lib/support-annotations.jar)
+        INCLUDE_JARS ../../java/lib/support-annotations.jar)
 
 install_jar(${TARGET} lib)

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -53,8 +53,12 @@ set(CMAKE_SKIP_RPATH TRUE)
 
 set_target_properties(${TARGET} PROPERTIES
         CXX_STANDARD 14
-        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden $<$<PLATFORM_ID:Linux>:-fPIC>"
+        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden"
         LINK_FLAGS "${GC_SECTIONS} ${EXPORTED_SYMBOLS}")
+
+target_compile_options(${TARGET} PRIVATE
+        $<$<PLATFORM_ID:Linux>:-fPIC>
+)
 
 target_link_libraries(${TARGET} filamat)
 

--- a/android/filamat-android/libfilamat-jni.map
+++ b/android/filamat-android/libfilamat-jni.map
@@ -1,0 +1,4 @@
+LIBFILAMAT {
+  global: Java_com_google_android_filament_*; JNI*;
+  local: *;
+};

--- a/android/filamat-android/libfilamat-jni.symbols
+++ b/android/filamat-android/libfilamat-jni.symbols
@@ -1,0 +1,1 @@
+_Java_com_google_android_filament_*

--- a/third_party/spirv-cross/tnt/CMakeLists.txt
+++ b/third_party/spirv-cross/tnt/CMakeLists.txt
@@ -65,6 +65,7 @@ macro(spirv_cross_add_library name config_name)
   target_compile_options(${name} PRIVATE ${spirv-compiler-options})
   target_compile_definitions(${name} PRIVATE ${spirv-compiler-defines})
   target_compile_definitions(${name} PUBLIC ${spirv-compiler-public-defines})
+  target_compile_options(${name} PRIVATE $<$<PLATFORM_ID:Linux>:-fPIC>)
 endmacro()
 
 spirv_cross_add_library(spirv-cross-core spirv_cross_core STATIC


### PR DESCRIPTION
This adds CMake configuration and an option to `build.sh` to build the `filamat-jni` libraries for Android. It isn't enabled by default, as building `filamat` and thus Spir-V related tools increases the build time significantly. For now, we can build it manually- in the future this might be turned on in a separate CI job.