### PR TITLE
Add jniLibs search path to filament-android for Vulkan.

### DIFF
--- a/android/filament-android/build.gradle
+++ b/android/filament-android/build.gradle
@@ -77,6 +77,12 @@ android {
     sourceSets {
         main {
             jni.srcDirs "src/main/cpp"
+            // To enable validation layers with the Vulkan backend, uncomment the following lines
+            // to copy the appropriate files from the NDK to the device. Also be sure to use a debug
+            // configuration for the native build.
+            // jniLibs {
+            //     srcDirs = ["${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"]
+            // }
         }
     }
 

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -82,6 +82,15 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
             }
         }
     }
+
+    // To enable validation layers in Android, set the jniLibs property in the gradle file for
+    // filament-android as follows. This copies the appropriate libraries from the NDK to the
+    // device. This makes the aar much larger, so it should be avoided in release builds.
+    //
+    // sourceSets { main { jniLibs {
+    //   srcDirs = ["${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"]
+    // } } }
+
     if (!enabledLayers.empty()) {
         instanceCreateInfo.enabledLayerCount = (uint32_t) enabledLayers.size();
         instanceCreateInfo.ppEnabledLayerNames = enabledLayers.data();


### PR DESCRIPTION
This allows Filament to find validation layers in debug builds.  It does not hurt anything for non-Vulkan builds.