### PR TITLE
JNI fix for badly-sized PixelBufferDescriptors. (!)

### DIFF
--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -36,8 +36,10 @@ using namespace driver;
 
 static size_t getTextureDataSize(const Texture *texture, size_t level,
         Texture::Format format, Texture::Type type, size_t stride, size_t alignment) {
+    // Zero stride implies tight row-to-row packing.
+    stride = stride == 0 ? texture->getWidth(level) : std::max(size_t(1), stride >> level);
     return Texture::computeTextureDataSize(format, type,
-            std::max(size_t(1), stride >> level), texture->getHeight(level), alignment);
+            stride, texture->getHeight(level), alignment);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL


### PR DESCRIPTION
Amazingly, the size field in PixelBufferDescriptor was often totally
incorrect for Java-based clients. The reason we did not notice: OpenGL
often consumes a pointer to image data without consuming a byte count
(e.g. glTexImage2D).

OpenGL infers size from dimensions + format, but Vulkan does not. This
caused texture corruption with Vulkan on Android.

This fix follows a pattern used in other places such as
FRenderer::readPixels.