### PR TITLE
Add Metal shading language compilation to matc

### DIFF
--- a/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
@@ -153,6 +153,10 @@ inline constexpr uint8_t getSamplerBindingsStart(driver::Backend api) noexcept {
             const uint8_t numUniformBlockBindings = filament::BindingPoints::COUNT;
             return numUniformBlockBindings;
         }
+
+        case driver::Backend::METAL:
+            // Metal has a separate namespace for uniforms and samplers- collisions aren't an issue.
+            return 0;
     }
 }
 

--- a/libs/filaflat/include/filaflat/FilaflatDefs.h
+++ b/libs/filaflat/include/filaflat/FilaflatDefs.h
@@ -55,6 +55,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialSib = charTo64bitNum("MAT_SIB "),
     MaterialGlsl = charTo64bitNum("MAT_GLSL"),
     MaterialSpirv = charTo64bitNum("MAT_SPIR"),
+    MaterialMetal = charTo64bitNum("MAT_METL"),
     MaterialShaderModels = charTo64bitNum("MAT_SMDL"),
     MaterialSamplerBindings = charTo64bitNum("MAT_SAMP"),   // no longer used
 
@@ -87,6 +88,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
 
     DictionaryGlsl = charTo64bitNum("DIC_GLSL"),
     DictionarySpirv = charTo64bitNum("DIC_SPIR"),
+    DictionaryMetal = charTo64bitNum("DIC_METL")
 };
 
 } // namespace filamat

--- a/libs/filaflat/src/TextDictionaryReader.h
+++ b/libs/filaflat/src/TextDictionaryReader.h
@@ -31,8 +31,9 @@ namespace filaflat {
 struct TextDictionaryReader {
     bool unflatten(Unflattener& unflattener, BlobDictionary& dictionary);
 
-    static bool unflatten(ChunkContainer const& container, BlobDictionary& blobDictionary) {
-        Unflattener dictionaryUnflattener(container, filamat::ChunkType::DictionaryGlsl);
+    static bool unflatten(ChunkContainer const& container, BlobDictionary& blobDictionary,
+            filamat::ChunkType chunkType) {
+        Unflattener dictionaryUnflattener(container, chunkType);
         TextDictionaryReader dictionary;
         return dictionary.unflatten(dictionaryUnflattener, blobDictionary);
     }

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -51,6 +51,7 @@ public:
         ALL,
         OPENGL,
         VULKAN,
+        METAL
     };
 
     enum class Optimization {

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -30,19 +30,20 @@
 
 namespace filamat {
 
+using SpirvBlob = std::vector<uint32_t>;
+
 class GLSLPostProcessor {
 public:
     GLSLPostProcessor(MaterialBuilder::Optimization optimization, bool printShaders);
 
     ~GLSLPostProcessor();
 
-    using SpirvBlob = std::vector<uint32_t>;
-
     bool process(const std::string& inputShader, filament::driver::ShaderType shaderType,
             filament::driver::ShaderModel shaderModel, std::string* outputGlsl,
-            SpirvBlob* outputSpirv);
+            SpirvBlob* outputSpirv, std::string* outputMsl);
 
 private:
+
     void fullOptimization(const glslang::TShader& tShader,
             filament::driver::ShaderModel shaderModel) const;
     void preprocessOptimization(glslang::TShader& tShader,
@@ -55,6 +56,7 @@ private:
     const bool mPrintShaders;
     std::string* mGlslOutput = nullptr;
     SpirvBlob* mSpirvOutput = nullptr;
+    std::string* mMslOutput = nullptr;
     EShLanguage mShLang = EShLangFragment;
     int mLangVersion = 0;
 };

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -67,6 +67,9 @@ std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
     if (mTargetApi == TargetApi::VULKAN) {
         out << "#define TARGET_VULKAN_ENVIRONMENT\n";
     }
+    if (mTargetApi == TargetApi::METAL) {
+        out << "#define TARGET_METAL_ENVIRONMENT\n";
+    }
     if (mCodeGenTargetApi == TargetApi::VULKAN) {
         out << "#define CODEGEN_TARGET_VULKAN_ENVIRONMENT\n";
     }

--- a/third_party/spirv-cross/tnt/CMakeLists.txt
+++ b/third_party/spirv-cross/tnt/CMakeLists.txt
@@ -80,4 +80,8 @@ spirv_cross_add_library(spirv-cross-glsl spirv_cross_glsl STATIC
     ../spirv_glsl.cpp
     ../spirv_glsl.hpp)
 
-target_link_libraries(spirv-cross-glsl spirv-cross-core)
+spirv_cross_add_library(spirv-cross-msl spirv_cross_msl STATIC
+    ../spirv_msl.cpp
+    ../spirv_msl.hpp)
+
+target_link_libraries(spirv-cross-glsl spirv-cross-msl spirv-cross-core)

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -52,7 +52,7 @@ static void usage(char* name) {
             "   --optimize-size, -S\n"
             "       Optimize generated shader code for size instead of just performance\n\n"
             "   --api, -a\n"
-            "       Specify the target API: opengl (default), vulkan or all\n\n"
+            "       Specify the target API: opengl (default), vulkan, metal, or all\n\n"
             "   --reflect, -r\n"
             "       Reflect the specified metadata as JSON: parameters\n\n"
             "   --variant-filter=<filter>, -v <filter>\n"
@@ -196,8 +196,10 @@ bool CommandlineConfig::parse() {
                     mTargetApi = TargetApi::VULKAN;
                 } else if (arg == "all") {
                     mTargetApi = TargetApi::ALL;
+                } else if (arg == "metal") {
+                    mTargetApi = TargetApi::METAL;
                 } else {
-                    std::cerr << "Unrecognized target API. Must be 'opengl'|'vulkan'|'all'."
+                    std::cerr << "Unrecognized target API. Must be 'opengl'|'vulkan'|'metal'|'all'."
                             << std::endl;
                     return false;
                 }


### PR DESCRIPTION
Add Metal shader compilation to `matc`. Metal shaders are stored in a new text chunk (`MAT_METL`) with associated dictionary (`DIC_METL`). Also update the `mat_info` tool to show Metal shader information via the `--print-metal` flag.