### PR TITLE
HwTexture now remembers the format.

### DIFF
--- a/filament/src/driver/DriverBase.h
+++ b/filament/src/driver/DriverBase.h
@@ -102,15 +102,16 @@ struct HwUniformBuffer : public HwBase {
 
 struct HwTexture : public HwBase {
     HwTexture(driver::SamplerType target, uint8_t levels, uint8_t samples,
-              uint32_t width, uint32_t height, uint32_t depth) noexcept
+              uint32_t width, uint32_t height, uint32_t depth, Driver::TextureFormat fmt) noexcept
             : width(width), height(height), depth(depth),
-              target(target), levels(levels), samples(samples) { }
+              target(target), levels(levels), samples(samples), format(fmt) { }
     uint32_t width;
     uint32_t height;
     uint32_t depth;
     driver::SamplerType target;
-    uint8_t levels;
-    uint8_t samples;
+    uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
+    uint8_t samples : 4; // In practice this is always 1.
+    Driver::TextureFormat format;
     HwStream* hwStream = nullptr;
 };
 

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -993,7 +993,7 @@ void OpenGLDriver::createTexture(Driver::TextureHandle th, SamplerType target, u
         TextureUsage usage) {
     DEBUG_MARKER()
 
-    GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth);
+    GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format);
     glGenTextures(1, &t->gl.texture_id);
 
     // below we're using the a = foo(b = C) pattern, this is on purpose, to make sure

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -404,7 +404,7 @@ VulkanUniformBuffer::~VulkanUniformBuffer() {
 VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t levels,
         TextureFormat tformat, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage usage, VulkanStagePool& stagePool) :
-        HwTexture(target, levels, samples, w, h, depth), srcformat(tformat),
+        HwTexture(target, levels, samples, w, h, depth, tformat),
         vkformat(getVkFormat(tformat)), mContext(context), mStagePool(stagePool) {
     // Create an appropriately-sized device-only VkImage, but do not fill it yet.
     VkImageCreateInfo imageInfo {
@@ -487,7 +487,7 @@ VulkanTexture::~VulkanTexture() {
 void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t width,
         uint32_t height, int miplevel) {
     assert(width <= this->width && height <= this->height);
-    const bool reshape = getBytesPerPixel(srcformat) == 3;
+    const bool reshape = getBytesPerPixel(format) == 3;
     const void* cpuData = data.buffer;
     const uint32_t numSrcBytes = data.size;
     const uint32_t numDstBytes = reshape ? (4 * numSrcBytes / 3) : numSrcBytes;
@@ -527,7 +527,7 @@ void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t wi
 void VulkanTexture::updateCubeImage(const PixelBufferDescriptor& data,
         const FaceOffsets& faceOffsets, int miplevel) {
     assert(this->target == SamplerType::SAMPLER_CUBEMAP);
-    const bool reshape = getBytesPerPixel(srcformat) == 3;
+    const bool reshape = getBytesPerPixel(format) == 3;
     const void* cpuData = data.buffer;
     const uint32_t numSrcBytes = data.size;
     const uint32_t numDstBytes = reshape ? (4 * numSrcBytes / 3) : numSrcBytes;

--- a/filament/src/driver/vulkan/VulkanHandles.h
+++ b/filament/src/driver/vulkan/VulkanHandles.h
@@ -124,7 +124,6 @@ struct VulkanTexture : public HwTexture {
             int miplevel);
     void updateCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
             int miplevel);
-    TextureFormat srcformat;
     VkFormat vkformat;
     VkImageView imageView = VK_NULL_HANDLE;
     VkImage textureImage = VK_NULL_HANDLE;


### PR DESCRIPTION
We were stashing the GL format but not the Filament format.

This simplifies VulkanTexture and will allow us to implement a very
simple mipmap generator in DriverBase.

Motivated by #749.