### PR TITLE
Prevent cmgen outputting to the console whilst the quiet flag is enabled

### DIFF
--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -647,7 +647,7 @@ void sphericalHarmonics(const utils::Path& iname, const Cubemap& inputCubemap) {
         sh = CubemapSH::computeSH(inputCubemap, g_sh_compute, g_sh_irradiance);
     }
 
-    if (g_sh_output) {
+    if (!g_quiet && g_sh_output) {
         outputSh(std::cout, sh, g_sh_compute);
     }
 


### PR DESCRIPTION
Currently `cmgen` writes to the console (when generating the spherical harmonics) even with the `--quiet` flag enabled which I assume is a mistake.