### PR TITLE
fix #755: a race condition cousing a deadlock

### DIFF
--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -70,8 +70,7 @@ public:
         uint16_t parent;                                        //  2 |  2
         std::atomic<uint16_t> runningJobCount = { 1 };          //  2 |  2
         mutable std::atomic<uint16_t> refCount = { 1 };         //  2 |  2
-        std::atomic_bool hasWaiter = { false };                 //  1 |  1
-                                                                //  5 |  1 (padding)
+                                                                //  6 |  2 (padding)
                                                                 // 64 | 64
     };
 


### PR DESCRIPTION
This reverts a JobSystem optimization that attempted to avoid signaling
a condition when there was no waiters. Unfortunately, there was a
race that caused the the signaling thread to miss that the waiter flag
was set, thus not signaling.