### PR TITLE
Repair generateMipmaps for cubemaps.

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -171,7 +171,7 @@ private:
 
 ### Misc
 
-- Use `auto` only when the type appears on the same line or with iterators
+- Use `auto` only when the type appears on the same line or with iterators and lambdas.
 ```
 auto foo = new Foo();
 for (auto& i : collection) { }


### PR DESCRIPTION
This functionality regressed when we replaced the OpenGL implementation
with our own.

I proved both the regression and the fix by running suzanne with the
following hacks.

```
--- a/libs/image/include/image/KtxUtility.h
+++ b/libs/image/include/image/KtxUtility.h
@@ -129,8 +129,9 @@ namespace KtxUtility {
             for (uint32_t level = 0; level < nmips; ++level) {
                 ktx.getBlob({level, 0, 0}, &data, &size);
                 PixelBufferDescriptor pbd(data, size * 6, dataformat, datatype, cb, cbuser);
-                texture->setImage(*engine, level, std::move(pbd), Texture::FaceOffsets(size));
+                if (level == 0) texture->setImage(*engine, level, std::move(pbd), Texture::FaceOffsets(size));
             }
+            texture->generateMipmaps(*engine);
             return texture;
         }

--- a/samples/app/IBL.cpp
+++ b/samples/app/IBL.cpp
@@ -54,7 +54,7 @@ IBL::~IBL() {
 bool IBL::loadFromKtx(const std::string& prefix) {
     // First check for compressed variants of the environment.
     Path iblPath(prefix + "_ibl_s3tc.ktx");
-    if (!iblPath.exists()) {
+    if (true || !iblPath.exists()) {
```