### PR TITLE
Install filamat and dependencies as single static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,6 @@ if (FILAMENT_BUILD_FILAMAT)
     add_subdirectory(${EXTERNAL}/spirv-tools)
     add_subdirectory(${EXTERNAL}/glslang/tnt)
     add_subdirectory(${EXTERNAL}/spirv-cross/tnt)
-    add_subdirectory(android/filamat-android)
     add_subdirectory(${LIBRARIES}/filamat)
 endif()
 

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -1,95 +1,50 @@
 cmake_minimum_required(VERSION 3.4.1)
-project(filamat-java)
 
-if (NOT ENABLE_JAVA)
-    return()
-endif()
+set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
 
-find_package(Java)
-if (NOT Java_FOUND)
-    message(WARNING "JDK not found, skipping Java projects")
-    return()
-endif()
+add_library(filamat STATIC IMPORTED)
+set_target_properties(filamat PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilamat.a)
 
-# Android already has the JNI headers in its system include path.
-if (NOT ANDROID)
-    find_package(JNI)
-    if (NOT JNI_FOUND)
-        message(WARNING "JNI not found, skipping Java projects")
-        return()
-    endif()
-endif()
+add_library(utils STATIC IMPORTED)
+set_target_properties(utils PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libutils.a)
 
-if (NOT DEFINED ENV{JAVA_HOME})
-    message(WARNING "The JAVA_HOME environment variable must be set to compile Java projects")
-    message(WARNING "Skipping Java projects")
-    return()
-endif()
+add_library(filabridge STATIC IMPORTED)
+set_target_properties(filabridge PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilabridge.a)
 
-# ==================================================================================================
-# JNI bindings
-# ==================================================================================================
-set(TARGET filamat-jni)
+add_library(smol-v STATIC IMPORTED)
+set_target_properties(smol-v PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libsmol-v.a)
 
-set(JNI_SOURCE_FILES
-        src/main/cpp/MaterialBuilder.cpp)
+add_library(shaders STATIC IMPORTED)
+set_target_properties(shaders PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libshaders.a)
 
-add_library(${TARGET} SHARED ${JNI_SOURCE_FILES})
+include_directories(${FILAMENT_DIR}/include)
 
-target_include_directories(${TARGET} PRIVATE ${JNI_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-stack-protector")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math -ffp-contract=fast")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility-inlines-hidden")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer -ffunction-sections -fdata-sections")
 
-set(EXPORTED_SYMBOLS)
-if (APPLE)
-    set(EXPORTED_SYMBOLS "-exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/libfilamat-jni.symbols")
-elseif (ANDROID)
-    set(EXPORTED_SYMBOLS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libfilamat-jni.map")
-endif()
+set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
+set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_SOURCE_DIR}/libfilamat-jni.map")
 
-# This is necessary to avoid a CMake error due to setting RPATH on non-elf platforms.
-# Setting this also causes CMake to issue a warning on Mac:
-# "Policy CMP0068 is not set: RPATH settings on macOS do not affect install_name." which can be
-# safely ignored.
-set(CMAKE_SKIP_RPATH TRUE)
-
-set_target_properties(${TARGET} PROPERTIES
-        CXX_STANDARD 14
-        COMPILE_FLAGS "-fno-exceptions -fvisibility=hidden"
-        LINK_FLAGS "${GC_SECTIONS} ${EXPORTED_SYMBOLS}")
-
-target_compile_options(${TARGET} PRIVATE
-        $<$<PLATFORM_ID:Linux>:-fPIC>
+add_library(filamat-jni SHARED
+        src/main/cpp/MaterialBuilder.cpp
 )
 
-target_link_libraries(${TARGET} filamat)
+target_link_libraries(filamat-jni
+        filamat
+        filabridge
+        shaders
+        utils
+        log
+        smol-v
+)
 
-set(INSTALL_TYPE LIBRARY)
-if (WIN32 OR CYGWIN)
-    set(INSTALL_TYPE RUNTIME)
-endif()
-install(TARGETS ${TARGET} ${INSTALL_TYPE} DESTINATION lib/${DIST_DIR})
-install(CODE "execute_process(COMMAND ${CMAKE_STRIP} -x ${CMAKE_INSTALL_PREFIX}/lib/${DIST_DIR}/lib${TARGET}${CMAKE_SHARED_LIBRARY_SUFFIX})")
-
-# ==================================================================================================
-# Java APIs
-# ==================================================================================================
-
-# Android builds its Java bindings for filamat through Gradle.
-if (ANDROID)
-    return()
-endif()
-
-set(TARGET filamat-java)
-
-include(UseJava)
-
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8")
-
-set(JAVA_SOURCE_FILES
-        src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
-        src/main/java/com/google/android/filament/filamat/MaterialPackage.java)
-
-add_jar(${TARGET}
-        SOURCES ${JAVA_SOURCE_FILES}
-        INCLUDE_JARS ../../java/lib/support-annotations.jar)
-
-install_jar(${TARGET} lib)

--- a/android/filamat-android/build.gradle
+++ b/android/filamat-android/build.gradle
@@ -43,6 +43,19 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        externalNativeBuild {
+            cmake {
+                arguments.add("-DANDROID_PIE=ON")
+                arguments.add("-DANDROID_PLATFORM=android-21")
+                arguments.add("-DANDROID_STL=c++_static")
+                arguments.add("-DFILAMENT_DIST_DIR=${filament_path}".toString())
+                cppFlags.add("-std=c++14")
+                if (project.hasProperty('extra_cmake_args')) {
+                    arguments.add(extra_cmake_args)
+                }
+            }
+        }
     }
 
     buildTypes {
@@ -52,17 +65,16 @@ android {
         }
     }
 
-    sourceSets {
-        main {
-            jniLibs.srcDirs "${filament_path}/lib"
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
         }
     }
 
-    // Ensure that only the libfilamat-jni.so library is included in the AAR, in case any other
-    // libraries happen to be present.
-    packagingOptions {
-        exclude '**/*.so'
-        merge '**/libfilamat-jni.so'
+    sourceSets {
+        main {
+            jni.srcDirs "src/main/cpp"
+        }
     }
 
     compileOptions {
@@ -75,4 +87,3 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:support-annotations:28.0.0'
 }
-

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -92,10 +92,48 @@ target_compile_options(${TARGET} PRIVATE
 # ==================================================================================================
 # Installation
 # ==================================================================================================
-# Currently disabled because we don't need it
-# To properly support Vulkan, filamat needs to support SPIR-V compilation
-# install(DIRECTORY ${PUBLIC_HDR_DIR}/filamat DESTINATION include)
-# install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})
+
+# Filamat has dependencies on a bunch of SPIRV-related libraries. To make things simpler, we bundle
+# them together into a single shared library and copy this into the installation folder. This
+# requires us to explicitly list the dependencies below, as CMake doesn't have a way to recursively
+# query dependencies.
+set(FILAMAT_DEPS
+        OGLCompiler
+        OSDependent
+        SPIRV
+        SPIRV-Tools
+        SPIRV-Tools-opt
+        SPVRemapper
+        filamat
+        glslang
+        spirv-cross-core
+        spirv-cross-glsl
+        spirv-cross-msl
+        )
+
+# Loop through the dependent libraries and query their location on disk.
+set(FILAMAT_DEPS_FILES )
+foreach(DEPENDENCY ${FILAMAT_DEPS})
+    list(APPEND FILAMAT_DEPS_FILES "$<TARGET_FILE:${DEPENDENCY}>")
+endforeach()
+
+# Run the combine-static-libs script to bundle the libraries together.
+set(FILAMAT_COMBINED_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libfilamat_combined.a")
+set(COMBINE_SCRIPT "${CMAKE_SOURCE_DIR}/build/linux/combine-static-libs.sh")
+if (WIN32)
+    set(COMBINE_SCRIPT "${CMAKE_SOURCE_DIR}/build/windows/combine-static-libs.bat")
+    set(CMAKE_AR "lib.exe")
+endif()
+add_custom_command(
+    TARGET filamat POST_BUILD
+    COMMAND "${COMBINE_SCRIPT}" "${CMAKE_AR}" "${FILAMAT_COMBINED_OUTPUT}" ${FILAMAT_DEPS_FILES}
+    COMMENT "Combining filamat dependencies into single shared library"
+    VERBATIM
+)
+
+set(FILAMAT_LIB_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}filamat${CMAKE_STATIC_LIBRARY_SUFFIX})
+install(FILES "${FILAMAT_COMBINED_OUTPUT}" DESTINATION lib/${DIST_DIR} RENAME ${FILAMAT_LIB_NAME})
+install(DIRECTORY ${PUBLIC_HDR_DIR}/filamat DESTINATION include)
 
 # ==================================================================================================
 # Tests

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -91,3 +91,9 @@ endif()
 # ==================================================================================================
 add_library(${TARGET} STATIC ${RESGEN_SOURCE})
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+# ==================================================================================================
+# Installation
+# ==================================================================================================
+
+install(TARGETS ${TARGET} ARCHIVE DESTINATION lib/${DIST_DIR})


### PR DESCRIPTION
Install filamat as a single static library to make linking against it easy. This updates the `android/filamat-android/CMakeLists.txt` to __only__ be used to build filamat-jni for Android, invoked through Gradle. It now closely mirrors `android/filament-android/CMakeLists.txt`.

 TODO:
- Desktop `filamat-jni` library
- C++ / Java example of using `filamat`.