### PR TITLE
Add Metal state creation logic

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -204,6 +204,7 @@ add_definitions(-DSYSTRACE_TAG=2 )
 if (FILAMENT_SUPPORTS_METAL)
     list(APPEND SRCS
             src/driver/metal/MetalDriver.mm
+            src/driver/metal/MetalState.mm
             src/driver/metal/PlatformMetal.mm
     )
 endif()

--- a/filament/src/driver/metal/MetalEnums.h
+++ b/filament/src/driver/metal/MetalEnums.h
@@ -23,6 +23,8 @@
 
 #include <utils/Panic.h>
 
+#include <Availability.h>
+
 namespace filament {
 namespace driver {
 
@@ -57,14 +59,16 @@ constexpr inline MTLIndexType getIndexType(size_t elementSize) noexcept {
     ASSERT_POSTCONDITION(false, "Index element size not supported.");
 }
 
-constexpr inline MTLVertexFormat getMetalFormat(ElementType type, bool normalized) noexcept {
+inline MTLVertexFormat getMetalFormat(ElementType type, bool normalized) noexcept {
     if (normalized) {
         switch (type) {
             // Single Component Types
+#if MAC_OS_X_VERSION_MAX_ALLOWED > 101300 || IPHONE_OS_VERSION_MAX_ALLOWED > 110000
             case ElementType::BYTE: return MTLVertexFormatCharNormalized;
             case ElementType::UBYTE: return MTLVertexFormatUCharNormalized;
             case ElementType::SHORT: return MTLVertexFormatShortNormalized;
             case ElementType::USHORT: return MTLVertexFormatUShortNormalized;
+#endif
             // Two Component Types
             case ElementType::BYTE2: return MTLVertexFormatChar2Normalized;
             case ElementType::UBYTE2: return MTLVertexFormatUChar2Normalized;
@@ -87,11 +91,13 @@ constexpr inline MTLVertexFormat getMetalFormat(ElementType type, bool normalize
     }
     switch (type) {
         // Single Component Types
+#if MAC_OS_X_VERSION_MAX_ALLOWED > 101300 || IPHONE_OS_VERSION_MAX_ALLOWED > 110000
         case ElementType::BYTE: return MTLVertexFormatChar;
         case ElementType::UBYTE: return MTLVertexFormatUChar;
         case ElementType::SHORT: return MTLVertexFormatShort;
         case ElementType::USHORT: return MTLVertexFormatUShort;
         case ElementType::HALF: return MTLVertexFormatHalf;
+#endif
         case ElementType::INT: return MTLVertexFormatInt;
         case ElementType::UINT: return MTLVertexFormatUInt;
         case ElementType::FLOAT: return MTLVertexFormatFloat;

--- a/filament/src/driver/metal/MetalEnums.h
+++ b/filament/src/driver/metal/MetalEnums.h
@@ -59,7 +59,7 @@ constexpr inline MTLIndexType getIndexType(size_t elementSize) noexcept {
     ASSERT_POSTCONDITION(false, "Index element size not supported.");
 }
 
-inline MTLVertexFormat getMetalFormat(ElementType type, bool normalized) noexcept {
+constexpr inline MTLVertexFormat getMetalFormat(ElementType type, bool normalized) noexcept {
     if (normalized) {
         switch (type) {
             // Single Component Types

--- a/filament/src/driver/metal/MetalState.h
+++ b/filament/src/driver/metal/MetalState.h
@@ -291,10 +291,9 @@ struct SamplerStateCreator {
 using SamplerStateCache = StateCache<driver::SamplerParams, id<MTLSamplerState>,
         SamplerStateCreator>;
 
-// Raster-related states
+// Raster-related state
 
 using CullModeStateTracker = StateTracker<MTLCullMode>;
-using WindingStateTracker = StateTracker<MTLWinding>;
 
 } // namespace metal
 } // namespace driver

--- a/filament/src/driver/metal/MetalState.h
+++ b/filament/src/driver/metal/MetalState.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_METAL_STATE_H
+#define TNT_METAL_STATE_H
+
+#include <Metal/Metal.h>
+
+#include "driver/Driver.h"
+
+#include <filament/EngineEnums.h>
+
+#include <memory>
+#include <tsl/robin_map.h>
+#include <utils/Hash.h>
+
+namespace filament {
+namespace driver {
+
+inline bool operator==(const driver::SamplerParams& lhs, const driver::SamplerParams& rhs) {
+    return lhs.u == rhs.u;
+}
+
+namespace metal {
+
+static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = filament::ATTRIBUTE_INDEX_COUNT;
+static constexpr uint32_t NUM_SAMPLER_BINDINGS = filament::MAX_SAMPLER_COUNT;
+static constexpr uint32_t VERTEX_BUFFER_START = BindingPoints::COUNT;
+
+// Forward declarations necessary here, definitions at end of file.
+inline bool operator==(const MTLViewport& lhs, const MTLViewport& rhs);
+inline bool operator!=(const MTLViewport& lhs, const MTLViewport& rhs);
+
+// VertexDescription is part of Metal's pipeline state, and represents how vertex attributes are
+// laid out in memory.
+// Vertex attributes are "turned on" by setting format to something other than
+// MTLVertexFormatInvalid, which is the default.
+struct VertexDescription {
+    struct Attribute {
+        MTLVertexFormat format;
+        uint32_t buffer;
+        uint32_t offset;
+    };
+    struct Layout {
+        uint32_t stride;
+    };
+    Attribute attributes[MAX_VERTEX_ATTRIBUTES] = {};
+    Layout layouts[MAX_VERTEX_ATTRIBUTES] = {};
+
+    bool operator==(const VertexDescription& rhs) const noexcept {
+        bool result = true;
+        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+            result &= (
+                    this->attributes[i].format == rhs.attributes[i].format &&
+                    this->attributes[i].buffer == rhs.attributes[i].buffer &&
+                    this->attributes[i].offset == rhs.attributes[i].offset
+            );
+        }
+        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+            result &= this->layouts[i].stride == rhs.layouts[i].stride;
+        }
+        return result;
+    }
+
+    bool operator!=(const VertexDescription& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+struct BlendState {
+    MTLBlendOperation alphaBlendOperation = MTLBlendOperationAdd;
+    MTLBlendOperation rgbBlendOperation = MTLBlendOperationAdd;
+    MTLBlendFactor destinationAlphaBlendFactor = MTLBlendFactorZero;
+    MTLBlendFactor destinationRGBBlendFactor = MTLBlendFactorZero;
+    MTLBlendFactor sourceAlphaBlendFactor = MTLBlendFactorOne;
+    MTLBlendFactor sourceRGBBlendFactor = MTLBlendFactorOne;
+    bool blendingEnabled = false;
+    char padding[3] = { 0 };
+
+    bool operator==(const BlendState& rhs) const noexcept {
+        return (
+                this->blendingEnabled == rhs.blendingEnabled &&
+                this->alphaBlendOperation == rhs.alphaBlendOperation &&
+                this->rgbBlendOperation == rhs.rgbBlendOperation &&
+                this->destinationAlphaBlendFactor == rhs.destinationAlphaBlendFactor &&
+                this->destinationRGBBlendFactor == rhs.destinationRGBBlendFactor &&
+                this->sourceAlphaBlendFactor == rhs.sourceAlphaBlendFactor &&
+                this->sourceRGBBlendFactor == rhs.sourceRGBBlendFactor
+        );
+    }
+
+    bool operator!=(const BlendState& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+// StateCache caches Metal state objects using StateType as a key.
+// MetalType is the corresponding Metal API type.
+// StateCreator is a functor that creates a new state of type MetalType. It is assumed that this
+// type is created with a positive reference count (i.e., a new* method, per Apple convention), and
+// thus each cached object is released in StateCache's destructor.
+template<typename StateType,
+         typename MetalType,
+         typename StateCreator>
+class StateCache {
+
+public:
+
+    StateCache() = default;
+
+    StateCache(const StateCache&) = delete;
+    StateCache& operator=(const StateCache&) = delete;
+
+    ~StateCache() {
+        for (auto it = mStateCache.begin(); it != mStateCache.end(); ++it) {
+            [it.value() release];
+        }
+    }
+
+    void setDevice(id<MTLDevice> device) noexcept { mDevice = device; }
+
+    MetalType getOrCreateState(const StateType& state) noexcept {
+        // Check if a valid state already exists in the cache.
+        auto iter = mStateCache.find(state);
+        if (UTILS_LIKELY(iter != mStateCache.end())) {
+            auto foundState = iter.value();
+            return foundState;
+        }
+
+        // If we reach this point, we couldn't find one in the cache; create a new one.
+        const auto& metalObject = creator(mDevice, state);
+
+        mStateCache.emplace(std::make_pair(
+            state,
+            metalObject
+        ));
+
+        return metalObject;
+    }
+
+private:
+
+    StateCreator creator;
+    id<MTLDevice> mDevice = nil;
+
+    using HashFn = utils::hash::MurmurHashFn<StateType>;
+    tsl::robin_map<StateType, MetalType, HashFn> mStateCache;
+
+};
+
+// StateTracker keeps track of state changes made to a Metal command encoder.
+// Different kinds of state, like pipeline state, uniform buffer state, etc, are passed to the
+// current Metal command encoder and persist throughout the lifetime of the encoder (a frame).
+// StateTracker is used to prevent calling redundant state change methods.
+template<typename StateType>
+class StateTracker {
+
+public:
+
+    // Call to force the state to dirty at the beginning of each frame, as all state must be
+    // re-bound.
+    void invalidate() noexcept { mStateDirty = true; }
+
+    void updateState(const StateType& newState) noexcept {
+        if (mCurrentState != newState) {
+            mCurrentState = newState;
+            mStateDirty = true;
+        }
+    }
+
+    // Returns true if the state has changed since the last call to stateChanged.
+    bool stateChanged() noexcept {
+        bool ret = mStateDirty;
+        mStateDirty = false;
+        return ret;
+    }
+
+    const StateType& getState() const {
+        return mCurrentState;
+    }
+
+private:
+
+    bool mStateDirty = true;
+    StateType mCurrentState = {};
+
+};
+
+// Pipeline state
+
+struct PipelineState {
+    id<MTLFunction> vertexFunction = nil;
+    id<MTLFunction> fragmentFunction = nil;
+    VertexDescription vertexDescription;
+    MTLPixelFormat colorAttachmentPixelFormat = MTLPixelFormatInvalid;
+    MTLPixelFormat depthAttachmentPixelFormat = MTLPixelFormatInvalid;
+    BlendState blendState;
+
+    bool operator==(const PipelineState& rhs) const noexcept {
+        return (
+                this->vertexFunction == rhs.vertexFunction &&
+                this->fragmentFunction == rhs.fragmentFunction &&
+                this->vertexDescription == rhs.vertexDescription &&
+                this->colorAttachmentPixelFormat == rhs.colorAttachmentPixelFormat &&
+                this->depthAttachmentPixelFormat == rhs.depthAttachmentPixelFormat &&
+                this->blendState == rhs.blendState
+        );
+    }
+
+    bool operator!=(const PipelineState& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+struct PipelineStateCreator {
+    id<MTLRenderPipelineState> operator()(id<MTLDevice> device, const PipelineState& state)
+            noexcept;
+};
+
+using PipelineStateTracker = StateTracker<PipelineState>;
+
+using PipelineStateCache = StateCache<PipelineState, id<MTLRenderPipelineState>,
+        PipelineStateCreator>;
+
+// Depth-stencil State
+
+struct DepthStencilState {
+    MTLCompareFunction compareFunction = MTLCompareFunctionNever;
+    bool depthWriteEnabled = false;
+
+    bool operator==(const DepthStencilState& rhs) const noexcept {
+        return this->compareFunction == rhs.compareFunction &&
+               this->depthWriteEnabled == rhs.depthWriteEnabled;
+    }
+
+    bool operator!=(const DepthStencilState& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+struct DepthStateCreator {
+    id<MTLDepthStencilState> operator()(id<MTLDevice> device, const DepthStencilState& state)
+            noexcept;
+};
+
+using DepthStencilStateTracker = StateTracker<DepthStencilState>;
+
+using DepthStencilStateCache = StateCache<DepthStencilState, id<MTLDepthStencilState>,
+        DepthStateCreator>;
+
+// Uniform buffers
+
+struct UniformBufferState {
+    bool bound = false;
+    Driver::UniformBufferHandle ubh;
+    uint64_t offset = 0;
+
+    bool operator==(const UniformBufferState& rhs) const noexcept {
+        return this->bound == rhs.bound &&
+               this->ubh.getId() == rhs.ubh.getId() &&
+               this->offset == rhs.offset;
+    }
+
+    bool operator!=(const UniformBufferState& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+using UniformBufferStateTracker = StateTracker<UniformBufferState>;
+
+// Sampler states
+
+struct SamplerStateCreator {
+    id<MTLSamplerState> operator()(id<MTLDevice> device, const driver::SamplerParams& state)
+            noexcept;
+};
+
+using SamplerStateCache = StateCache<driver::SamplerParams, id<MTLSamplerState>,
+        SamplerStateCreator>;
+
+// Raster-related states
+
+using CullModeStateTracker = StateTracker<MTLCullMode>;
+using WindingStateTracker = StateTracker<MTLWinding>;
+
+} // namespace metal
+} // namespace driver
+} // namespace filament
+
+#endif //TNT_METAL_STATE_H

--- a/filament/src/driver/metal/MetalState.mm
+++ b/filament/src/driver/metal/MetalState.mm
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalState.h"
+
+#include "MetalEnums.h"
+
+#include <tsl/robin_map.h>
+#include <utils/Hash.h>
+#include <utils/compiler.h>
+
+namespace filament {
+namespace driver {
+namespace metal {
+
+id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device,
+        const PipelineState& state) noexcept {
+    MTLRenderPipelineDescriptor* descriptor = [MTLRenderPipelineDescriptor new];
+
+    // Shader Functions
+    descriptor.vertexFunction = state.vertexFunction;
+    descriptor.fragmentFunction = state.fragmentFunction;
+
+    // Vertex attributes
+    MTLVertexDescriptor* vertex = [MTLVertexDescriptor vertexDescriptor];
+
+    const auto& vertexDescription = state.vertexDescription;
+
+    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+        if (vertexDescription.attributes[i].format > MTLVertexFormatInvalid) {
+            const auto& attribute = vertexDescription.attributes[i];
+            vertex.attributes[i].format = attribute.format;
+            vertex.attributes[i].bufferIndex = VERTEX_BUFFER_START + attribute.buffer;
+            vertex.attributes[i].offset = attribute.offset;
+        }
+    }
+
+    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+        if (vertexDescription.layouts[i].stride > 0) {
+            const auto& layout = vertexDescription.layouts[i];
+            vertex.layouts[VERTEX_BUFFER_START + i].stride = layout.stride;
+            vertex.layouts[VERTEX_BUFFER_START + i].stepFunction = MTLVertexStepFunctionPerVertex;
+        }
+    }
+
+    descriptor.vertexDescriptor = vertex;
+
+    // Color attachments
+    descriptor.colorAttachments[0].pixelFormat = state.colorAttachmentPixelFormat;
+
+    const auto& bs = state.blendState;
+    descriptor.colorAttachments[0].blendingEnabled = bs.blendingEnabled;
+    descriptor.colorAttachments[0].alphaBlendOperation = bs.alphaBlendOperation;
+    descriptor.colorAttachments[0].rgbBlendOperation = bs.rgbBlendOperation;
+    descriptor.colorAttachments[0].destinationAlphaBlendFactor = bs.destinationAlphaBlendFactor;
+    descriptor.colorAttachments[0].destinationRGBBlendFactor = bs.destinationRGBBlendFactor;
+    descriptor.colorAttachments[0].sourceAlphaBlendFactor = bs.sourceAlphaBlendFactor;
+    descriptor.colorAttachments[0].sourceRGBBlendFactor = bs.sourceRGBBlendFactor;
+
+    // Depth attachment
+    descriptor.depthAttachmentPixelFormat = state.depthAttachmentPixelFormat;
+
+    NSError* error = nullptr;
+    id<MTLRenderPipelineState> pipeline = [device newRenderPipelineStateWithDescriptor:descriptor
+                                                                                 error:&error];
+    assert(error == nullptr);
+
+    [descriptor release];
+
+    return pipeline;
+}
+
+id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
+        const DepthStencilState& state) noexcept {
+    MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
+    depthStencilDescriptor.depthCompareFunction = state.compareFunction;
+    depthStencilDescriptor.depthWriteEnabled = state.depthWriteEnabled;
+    id<MTLDepthStencilState> depthStencilState =
+            [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
+    [depthStencilDescriptor release];
+    return depthStencilState;
+}
+
+id<MTLSamplerState> SamplerStateCreator::operator()(id<MTLDevice> device,
+        const driver::SamplerParams& state) noexcept {
+    MTLSamplerDescriptor* samplerDescriptor = [[MTLSamplerDescriptor new] autorelease];
+    samplerDescriptor.minFilter = getFilter(state.filterMin);
+    samplerDescriptor.magFilter = getFilter(state.filterMag);
+    samplerDescriptor.mipFilter = getMipFilter(state.filterMin);
+    samplerDescriptor.sAddressMode = getAddressMode(state.wrapS);
+    samplerDescriptor.tAddressMode = getAddressMode(state.wrapT);
+    samplerDescriptor.rAddressMode = getAddressMode(state.wrapR);
+    samplerDescriptor.maxAnisotropy = 1u << state.anisotropyLog2;
+    samplerDescriptor.compareFunction =
+            state.compareMode == SamplerCompareMode::NONE ?
+                MTLCompareFunctionNever : getCompareFunction(state.compareFunc);
+    return [device newSamplerStateWithDescriptor:samplerDescriptor];
+}
+
+} // namespace metal
+} // namespace driver
+} // namespace filament


### PR DESCRIPTION
This adds a few state-management classes for Metal, `StateCache` and `StateTracker`, as well as some logic to create various Metal state objects.