### PR TITLE
Remove unnecessary function parameter

### DIFF
--- a/shaders/src/brdf.fs
+++ b/shaders/src/brdf.fs
@@ -173,7 +173,7 @@ float distribution(float linearRoughness, float NoH, const vec3 h) {
 #endif
 }
 
-float visibility(float roughness, float linearRoughness, float NoV, float NoL, float LoH) {
+float visibility(float linearRoughness, float NoV, float NoL, float LoH) {
 #if BRDF_SPECULAR_V == SPECULAR_V_SMITH_GGX
     return V_SmithGGXCorrelated(linearRoughness, NoV, NoL);
 #elif BRDF_SPECULAR_V == SPECULAR_V_SMITH_GGX_FAST

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -336,7 +336,7 @@ vec3 isEvaluateIBL(const PixelParams pixel, vec3 n, vec3 v, float NoV) {
             vec3 L = decodeDataForIBL(texture(light_iblSpecular, l, mipLevel));
 
             float D = distribution(linearRoughness, NoH, h);
-            float V = visibility(pixel.roughness, linearRoughness, NoV, NoL, LoH);
+            float V = visibility(linearRoughness, NoV, NoL, LoH);
             vec3  F = fresnel(pixel.f0, LoH);
             vec3 Fr = F * (D * V * NoL * ipdf * invNumSamples);
 

--- a/shaders/src/shading_model_standard.fs
+++ b/shaders/src/shading_model_standard.fs
@@ -54,7 +54,7 @@ vec3 isotropicLobe(const PixelParams pixel, const Light light, const vec3 h,
         float NoV, float NoL, float NoH, float LoH) {
 
     float D = distribution(pixel.linearRoughness, NoH, h);
-    float V = visibility(pixel.roughness, pixel.linearRoughness, NoV, NoL, LoH);
+    float V = visibility(pixel.linearRoughness, NoV, NoL, LoH);
     vec3  F = fresnel(pixel.f0, LoH);
 
     return (D * V) * F;

--- a/shaders/src/shading_model_subsurface.fs
+++ b/shaders/src/shading_model_subsurface.fs
@@ -16,7 +16,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
     if (NoL > 0.0) {
         // specular BRDF
         float D = distribution(pixel.linearRoughness, NoH, h);
-        float V = visibility(pixel.roughness, pixel.linearRoughness, shading_NoV, NoL, LoH);
+        float V = visibility(pixel.linearRoughness, shading_NoV, NoL, LoH);
         vec3  F = fresnel(pixel.f0, LoH);
         Fr = (D * V) * F * pixel.energyCompensation;
     }


### PR DESCRIPTION
Our visibility terms don't make use of roughness, only of
roughness^2. This change simplifies the shaders, which will
help for specular AA.