### PR TITLE
Fix example running a different app than built

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ You are now ready to build:
 
 Run it:
 ```
-> samples\Release\lightbulb.exe ..\..\assets\models\monkey\monkey.obj
+> samples\Release\material_sandbox.exe ..\..\assets\models\monkey\monkey.obj
 ```
 
 #### Tips


### PR DESCRIPTION
The Windows example should run the same program as was built in the previous step.