### PR TITLE
Move MeshReader into filamesh namespace.

### DIFF
--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -30,6 +30,8 @@ namespace filament {
     class MaterialInstance;
 }
 
+namespace filamesh {
+
 /**
  * This API can be used to read meshes stored in the "filamesh" format produced
  * by the command line tool of the same name. This file format is documented in
@@ -77,5 +79,7 @@ public:
             void const* data, Callback destructor, void* user,
             filament::MaterialInstance* defaultMaterial);
 };
+
+} // namespace filamesh
 
 #endif // TNT_FILAMENT_FILAMESHIO_MESHREADER_H

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -53,6 +53,8 @@ static size_t fileSize(int fd) {
     return filesize;
 }
 
+namespace filamesh {
+
 MeshReader::Mesh MeshReader::loadMeshFromFile(filament::Engine* engine, const utils::Path& path,
         MaterialRegistry& materials) {
 
@@ -265,3 +267,5 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
     return mesh;
 }
+
+} // namespace filamesh

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -47,6 +47,7 @@
 
 using namespace math;
 using namespace filament;
+using namespace filamesh;
 using namespace filamat;
 using namespace utils;
 

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -46,6 +46,7 @@
 
 using namespace math;
 using namespace filament;
+using namespace filamesh;
 using namespace filamat;
 using namespace utils;
 

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -43,7 +43,7 @@ using namespace math;
 struct App {
     Material* material;
     MaterialInstance* materialInstance;
-    MeshReader::Mesh mesh;
+    filamesh::MeshReader::Mesh mesh;
     mat4f transform;
     Texture* albedo;
     Texture* normal;
@@ -111,8 +111,8 @@ int main(int argc, char** argv) {
         ibl->setRotation(mat3f::rotate(0.5f, float3{ 0, 1, 0 }));
 
         // Add geometry into the scene.
-        app.mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr, nullptr,
-                app.materialInstance);
+        app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr,
+                nullptr, app.materialInstance);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.mesh.renderable), false);

--- a/samples/vk_hellopbr.cpp
+++ b/samples/vk_hellopbr.cpp
@@ -29,6 +29,7 @@
 #include "generated/resources/resources.h"
 
 using namespace filament;
+using namespace filamesh;
 using namespace math;
 using Backend = Engine::Backend;
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -71,6 +71,7 @@
 
 using namespace emscripten;
 using namespace filament;
+using namespace filamesh;
 using namespace image;
 
 // Many methods require a thin layer of C++ glue which is elegantly expressed with a lambda.


### PR DESCRIPTION
This class will not extend well to glTF so this cordons it off into the
filamesh namespace, which is an already-existing namespace that we use
for the things related to the filamesh file format.

For glTF we might create a new library with its own MeshReader so
this will mitigate confusion.