### PR TITLE
Split RenderPassParams into multiple structs

### DIFF
--- a/android/filament-android/src/main/cpp/Renderer.cpp
+++ b/android/filament-android/src/main/cpp/Renderer.cpp
@@ -58,8 +58,8 @@ Java_com_google_android_filament_Renderer_nMirrorFrame(JNIEnv *, jclass, jlong n
         jint flags) {
     Renderer *renderer = (Renderer *) nativeRenderer;
     SwapChain *dstSwapChain = (SwapChain *) nativeDstSwapChain;
-    const Viewport dstViewport {dstLeft, dstBottom, (uint32_t) dstWidth, (uint32_t) dstHeight};
-    const Viewport srcViewport {srcLeft, srcBottom, (uint32_t) srcWidth, (uint32_t) srcHeight};
+    const filament::Viewport dstViewport {dstLeft, dstBottom, (uint32_t) dstWidth, (uint32_t) dstHeight};
+    const filament::Viewport srcViewport {srcLeft, srcBottom, (uint32_t) srcWidth, (uint32_t) srcHeight};
     renderer->mirrorFrame(dstSwapChain, dstViewport, srcViewport, (uint32_t) flags);
 }
 

--- a/filament/include/filament/Viewport.h
+++ b/filament/include/filament/Viewport.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_VIEWPORT_H
 #define TNT_FILAMENT_VIEWPORT_H
 
+#include <filament/driver/DriverEnums.h>
+
 #include <utils/compiler.h>
 
 #include <math/scalar.h>
@@ -30,7 +32,7 @@ namespace filament {
 /*
  * Viewport describes a view port in pixel coordinates
  */
-class UTILS_PUBLIC Viewport {
+class UTILS_PUBLIC Viewport : public driver::Viewport {
 public:
     Viewport() noexcept = default;
     Viewport(const Viewport& viewport) noexcept = default;
@@ -41,24 +43,16 @@ public:
     /*
      * Create a Viewport from its left-bottom coordinates and size in pixels
      */
-    Viewport(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept
-            : left(left), bottom(bottom), width(width), height(height) { }
+    Viewport(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept {
+        this->left = left;
+        this->bottom = bottom;
+        this->width = width;
+        this->height = height;
+    }
 
     bool empty() const noexcept { return !width || !height; }
 
     Viewport scale(filament::math::float2 s) const noexcept;
-
-    // left coordinate in pixels
-    int32_t left = 0;
-
-    // bottom coordinate in pixels
-    int32_t bottom = 0;
-
-    // width in pixels
-    uint32_t width = 0;
-
-    // height in pixels
-    uint32_t height = 0;
 
 private:
     friend bool operator==(Viewport const& rhs, Viewport const& lhs) noexcept {

--- a/filament/include/filament/Viewport.h
+++ b/filament/include/filament/Viewport.h
@@ -43,11 +43,8 @@ public:
     /*
      * Create a Viewport from its left-bottom coordinates and size in pixels
      */
-    Viewport(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept {
-        this->left = left;
-        this->bottom = bottom;
-        this->width = width;
-        this->height = height;
+    Viewport(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept
+            : driver::Viewport{ left, bottom, width, height } {
     }
 
     bool empty() const noexcept { return !width || !height; }

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -134,7 +134,7 @@ void Froxelizer::setOptions(float zLightNear, float zLightFar) noexcept {
 }
 
 
-void Froxelizer::setViewport(Viewport const& viewport) noexcept {
+void Froxelizer::setViewport(filament::Viewport const& viewport) noexcept {
     if (UTILS_UNLIKELY(mViewport != viewport)) {
         mViewport = viewport;
         mDirtyFlags |= VIEWPORT_CHANGED;
@@ -150,7 +150,7 @@ void Froxelizer::setProjection(const mat4f& projection, float near, float far) n
 }
 
 bool Froxelizer::prepare(
-        FEngine::DriverApi& driverApi, ArenaScope& arena, Viewport const& viewport,
+        FEngine::DriverApi& driverApi, ArenaScope& arena, filament::Viewport const& viewport,
         const filament::math::mat4f& projection, float projectionNear, float projectionFar) noexcept {
     setViewport(viewport);
     setProjection(projection, projectionNear, projectionFar);
@@ -206,7 +206,7 @@ bool Froxelizer::prepare(
 
 void Froxelizer::computeFroxelLayout(
         uint2* dim, uint16_t* countX, uint16_t* countY, uint16_t* countZ,
-        Viewport const& viewport) noexcept {
+        filament::Viewport const& viewport) noexcept {
 
     if (SUPPORTS_NON_SQUARE_FROXELS == false) {
         // calculate froxel dimension from FROXEL_BUFFER_ENTRY_COUNT_MAX and viewport
@@ -250,7 +250,7 @@ UTILS_NOINLINE
 bool Froxelizer::update() noexcept {
     bool uniformsNeedUpdating = false;
     if (UTILS_UNLIKELY(mDirtyFlags & VIEWPORT_CHANGED)) {
-        Viewport const& viewport = mViewport;
+        filament::Viewport const& viewport = mViewport;
 
         uint2 froxelDimension;
         uint16_t froxelCountX, froxelCountY, froxelCountZ;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -115,14 +115,14 @@ void ShadowMap::terminate(DriverApi& driverApi) noexcept {
 
 void ShadowMap::beginRenderPass(DriverApi& driver) const noexcept {
     RenderPassParams params = {};
-    params.clear = TargetBufferFlags::SHADOW;
-    params.discardStart = TargetBufferFlags::DEPTH;
-    params.discardEnd = TargetBufferFlags::COLOR_AND_STENCIL;
+    params.flags.clear = TargetBufferFlags::SHADOW;
+    params.flags.discardStart = TargetBufferFlags::DEPTH;
+    params.flags.discardEnd = TargetBufferFlags::COLOR_AND_STENCIL;
     params.clearDepth = 1.0;
-    params.width = params.height = mShadowMapDimension;
+    params.viewport.width = params.viewport.height = mShadowMapDimension;
     // Disable scissor and viewport to avoid bugs in some drivers where the GPU memory is reloaded
     // needlessly.
-    params.clear |= RenderPassParams::IGNORE_SCISSOR | RenderPassParams::IGNORE_VIEWPORT;
+    params.flags.clear |= RenderPassFlags::IGNORE_SCISSOR | RenderPassFlags::IGNORE_VIEWPORT;
     driver.beginRenderPass(mShadowMapRenderTarget, params);
 
     driver.viewport(mViewport.left, mViewport.bottom,

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -220,8 +220,9 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
             uint32_t dsth = std::max(srch >> 1, 1u);
             dstrth = driver.createRenderTarget(TargetBufferFlags::COLOR, dstw, dsth, mSampleCount,
                     mFormat, { mHandle, level++, layer }, {}, {});
-            driver.blit(TargetBufferFlags::COLOR, dstrth, 0, 0, dstw, dsth, srcrth, 0, 0,
-                    srcw, srch);
+            driver.blit(TargetBufferFlags::COLOR,
+                    dstrth, { 0, 0, dstw, dsth },
+                    srcrth, { 0, 0, srcw, srch });
             driver.destroyRenderTarget(srcrth);
             srcrth = dstrth;
             srcw = dstw;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -95,7 +95,7 @@ void FView::terminate(FEngine& engine) {
     mFroxelizer.terminate(driver);
 }
 
-void FView::setViewport(Viewport const& viewport) noexcept {
+void FView::setViewport(filament::Viewport const& viewport) noexcept {
     mViewport = viewport;
 }
 
@@ -316,7 +316,7 @@ void FView::prepareShadowing(FEngine& engine, driver::DriverApi& driver,
 }
 
 void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaScope& arena,
-        Viewport const& viewport) noexcept {
+        filament::Viewport const& viewport) noexcept {
     SYSTRACE_CALL();
 
     UniformBuffer& u = getUb();
@@ -398,7 +398,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 }
 
 void FView::prepare(FEngine& engine, driver::DriverApi& driver, ArenaScope& arena,
-        Viewport const& viewport, filament::math::float4 const& userTime) noexcept {
+        filament::Viewport const& viewport, filament::math::float4 const& userTime) noexcept {
     JobSystem& js = engine.getJobSystem();
 
     /*
@@ -592,7 +592,7 @@ UTILS_NOINLINE
     });
 }
 
-void FView::prepareCamera(const CameraInfo& camera, const Viewport& viewport) const noexcept {
+void FView::prepareCamera(const CameraInfo& camera, const filament::Viewport& viewport) const noexcept {
     SYSTRACE_CALL();
 
     const mat4f viewFromWorld(camera.view);
@@ -782,11 +782,11 @@ Camera& View::getCamera() noexcept {
 }
 
 
-void View::setViewport(Viewport const& viewport) noexcept {
+void View::setViewport(filament::Viewport const& viewport) noexcept {
     upcast(this)->setViewport(viewport);
 }
 
-Viewport const& View::getViewport() const noexcept {
+filament::Viewport const& View::getViewport() const noexcept {
     return upcast(this)->getViewport();
 }
 

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -479,18 +479,12 @@ DECL_DRIVER_API_6(readStreamPixels,
  * --------------------
  */
 
-DECL_DRIVER_API_11(blit,
+DECL_DRIVER_API_5(blit,
         Driver::TargetBufferFlags, buffers,
         Driver::RenderTargetHandle, dst,
-        int32_t, dstLeft,
-        int32_t, dstBottom,
-        uint32_t, dstWidth,
-        uint32_t, dstHeight,
+        driver::Viewport, dstRect,
         Driver::RenderTargetHandle, src,
-        int32_t, srcLeft,
-        int32_t, srcBottom,
-        uint32_t, srcWidth,
-        uint32_t, srcHeight)
+        driver::Viewport, srcRect)
 
 DECL_DRIVER_API_2(draw,
         Driver::PipelineState, state,

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -385,11 +385,9 @@ void MetalDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_t
 
 }
 
-void MetalDriver::blit(Driver::TargetBufferFlags buffers, Driver::RenderTargetHandle dst,
-        int32_t dstLeft, int32_t dstBottom, uint32_t dstWidth, uint32_t dstHeight,
-        Driver::RenderTargetHandle src, int32_t srcLeft, int32_t srcBottom, uint32_t srcWidth,
-        uint32_t srcHeight) {
-
+void MetalDriver::blit(Driver::TargetBufferFlags buffers,
+        Driver::RenderTargetHandle dst, driver::Viewport dstRect,
+        Driver::RenderTargetHandle src, driver::Viewport srcRect) {
 }
 
 void MetalDriver::draw(Driver::PipelineState ps, Driver::RenderPrimitiveHandle rph) {

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -122,14 +122,11 @@ struct RenderTargetResource final : public VirtualResource {  // 104
             uint32_t width, uint32_t height, TextureFormat format)
             : desc(desc), imported(imported),
               attachments(targets), format(format), width(width), height(height)  {
-        targetInfo.params.left   = desc.viewport.left;
-        targetInfo.params.bottom = desc.viewport.bottom;
-        targetInfo.params.width  = desc.viewport.width;
-        targetInfo.params.height = desc.viewport.height;
+        targetInfo.params.viewport   = desc.viewport;
         // if Descriptor was initialized with default values, set the viewport to width/height
-        if (targetInfo.params.width == 0 && targetInfo.params.height == 0) {
-            targetInfo.params.width  = width;
-            targetInfo.params.height = height;
+        if (targetInfo.params.viewport.width == 0 && targetInfo.params.viewport.height == 0) {
+            targetInfo.params.viewport.width  = width;
+            targetInfo.params.viewport.height = height;
         }
     }
 
@@ -223,7 +220,7 @@ struct RenderTarget { // 32
 
         if (pos != renderTargetCache.end()) {
             cache = pos->get();
-            cache->targetInfo.params.clear |= userTargetFlags.clear;
+            cache->targetInfo.params.flags.clear |= userTargetFlags.clear;
         } else {
             uint8_t attachments = 0;
             uint32_t width = 0;
@@ -303,7 +300,7 @@ struct RenderTarget { // 32
                                 TargetBufferFlags(attachments), width, height, colorFormat);
                 renderTargetCache.emplace_back(pRenderTargetResource, fg);
                 cache = pRenderTargetResource;
-                cache->targetInfo.params.clear |= userTargetFlags.clear;
+                cache->targetInfo.params.flags.clear |= userTargetFlags.clear;
             }
         }
     }
@@ -592,9 +589,9 @@ FrameGraphPassResources::getRenderTarget(FrameGraphResource r) const noexcept {
             assert(renderTarget->cache);
             info = renderTarget->cache->targetInfo;
             // overwrite discard flags with the per-rendertarget (per-pass) computed value
-            info.params.discardStart = renderTarget->targetFlags.discardStart;
-            info.params.discardEnd   = renderTarget->targetFlags.discardEnd;
-            info.params.dependencies = renderTarget->targetFlags.dependencies;
+            info.params.flags.discardStart = renderTarget->targetFlags.discardStart;
+            info.params.flags.discardEnd   = renderTarget->targetFlags.discardEnd;
+            info.params.flags.dependencies = renderTarget->targetFlags.dependencies;
             assert(info.target);
             break;
         }

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -54,8 +54,8 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.output);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
 
             });
 
@@ -102,8 +102,8 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.outColor);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::STENCIL, rt.params.flags.discardEnd);
             });
 
     fg.present(renderPass.getData().outColor);
@@ -143,8 +143,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 depthPrepassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.outDepth);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardEnd);
             });
 
     struct ColorPassData {
@@ -180,8 +180,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 colorPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.outColor);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
             });
 
     fg.present(colorPass.getData().outColor);
@@ -216,8 +216,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.output);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
             });
 
 
@@ -239,8 +239,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
                 postProcessPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.output);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
             });
 
 
@@ -308,8 +308,8 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 auto const& rt = resources.getRenderTarget(data.output);
                 rt1 = rt.target;
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
             });
 
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
@@ -324,10 +324,10 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 renderPassExecuted2 = true;
                 auto const& rt = resources.getRenderTarget(data.output);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(0x40|0x80, rt.params.clear);
+                EXPECT_EQ(0x40|0x80, rt.params.flags.clear);
                 EXPECT_EQ(rt1.getId(), rt.target.getId()); // FIXME: this test is always true the NoopDriver
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
 
             });
 

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -79,17 +79,17 @@ enum BufferUsage : uint8_t {
  */
 
 struct Viewport {
-    int32_t left = 0;
-    int32_t bottom = 0;
-    uint32_t width = 0;
-    uint32_t height = 0;
+    int32_t left;
+    int32_t bottom;
+    uint32_t width;
+    uint32_t height;
 };
 
 struct RenderPassFlags {
-    uint8_t clear = 0;
-    uint8_t discardStart = 0;
-    uint8_t discardEnd = 0;
-    uint8_t dependencies = 0;
+    uint8_t clear;
+    uint8_t discardStart;
+    uint8_t discardEnd;
+    uint8_t dependencies;
 
     static constexpr uint8_t DEPENDENCY_BY_REGION = 1; // see "framebuffer-local" in Vulkan spec.
 
@@ -101,10 +101,10 @@ struct RenderPassFlags {
 struct RenderPassParams {
     // RenderPass flags are 4 bytes.  The first three are buffer selections composed from
     // TargetBufferFlags. The last byte is an optional dependency hint (used only for Vulkan).
-    RenderPassFlags flags;
+    RenderPassFlags flags{};
 
     // Viewport (16 bytes)
-    Viewport viewport;
+    Viewport viewport{};
 
     // Clear values (32 bytes)
     filament::math::float4 clearColor = {};

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -77,32 +77,40 @@ enum BufferUsage : uint8_t {
  * Selects which buffers to clear at the beginning of the render pass, as well as which buffers
  * can be discarded and the beginning and end of the render pass.
  */
-struct RenderPassParams {
-    // RenderPass flags are 4 bytes.  The first three are buffer selections composed from
-    // TargetBufferFlags. The last byte is an optional dependency hint (used only for Vulkan).
-    union {
-        struct {
-            uint8_t clear;
-            uint8_t discardStart;
-            uint8_t discardEnd;
-            uint8_t dependencies;
-        };
-        uint32_t flags = 0;
-    };
-    static constexpr uint8_t DEPENDENCY_BY_REGION = 1; // see "framebuffer-local" in Vulkan spec.
-    // Viewport (16 bytes)
+
+struct Viewport {
     int32_t left = 0;
     int32_t bottom = 0;
     uint32_t width = 0;
     uint32_t height = 0;
+};
+
+struct RenderPassFlags {
+    uint8_t clear;
+    uint8_t discardStart;
+    uint8_t discardEnd;
+    uint8_t dependencies;
+
+    static constexpr uint8_t DEPENDENCY_BY_REGION = 1; // see "framebuffer-local" in Vulkan spec.
+
+    // Extra RenderPass-only flags stashed in the "clear" field.
+    static const uint8_t IGNORE_SCISSOR = 0x10;
+    static const uint8_t IGNORE_VIEWPORT = 0x20;
+};
+
+struct RenderPassParams {
+    // RenderPass flags are 4 bytes.  The first three are buffer selections composed from
+    // TargetBufferFlags. The last byte is an optional dependency hint (used only for Vulkan).
+    RenderPassFlags flags;
+
+    // Viewport (16 bytes)
+    Viewport viewport;
+
     // Clear values (32 bytes)
     filament::math::float4 clearColor = {};
     double clearDepth = 1.0;
     uint32_t clearStencil = 0;
     uint32_t reserved1 = 0;
-    // Extra RenderPass-only flags stashed in the "clear" field.
-    static const uint8_t IGNORE_SCISSOR = 0x10;
-    static const uint8_t IGNORE_VIEWPORT = 0x20;
 };
 
 /**

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -86,10 +86,10 @@ struct Viewport {
 };
 
 struct RenderPassFlags {
-    uint8_t clear;
-    uint8_t discardStart;
-    uint8_t discardEnd;
-    uint8_t dependencies;
+    uint8_t clear = 0;
+    uint8_t discardStart = 0;
+    uint8_t discardEnd = 0;
+    uint8_t dependencies = 0;
 
     static constexpr uint8_t DEPENDENCY_BY_REGION = 1; // see "framebuffer-local" in Vulkan spec.
 


### PR DESCRIPTION
We split out Viewport and RenderPassFlags.