### PR TITLE
Fix incomplete framebuffer assert thrown for iOS

### DIFF
--- a/filament/src/driver/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/src/driver/opengl/PlatformCocoaTouchGL.mm
@@ -111,6 +111,8 @@ void PlatformCocoaTouchGL::makeCurrent(SwapChain* drawSwapChain, SwapChain* read
     if (pImpl->mCurrentGlLayer != glLayer) {
         pImpl->mCurrentGlLayer = glLayer;
 
+        glBindFramebuffer(GL_FRAMEBUFFER, pImpl->mDefaultFramebuffer);
+
         glBindRenderbuffer(GL_RENDERBUFFER, pImpl->mDefaultColorbuffer);
         [pImpl->mGLContext renderbufferStorage:GL_RENDERBUFFER fromDrawable:glLayer];
 
@@ -122,11 +124,11 @@ void PlatformCocoaTouchGL::makeCurrent(SwapChain* drawSwapChain, SwapChain* read
 
         glBindRenderbuffer(GL_RENDERBUFFER, pImpl->mDefaultDepthbuffer);
         glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
-    }
 
-    // Test the framebuffer for completeness.
-    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-    ASSERT_POSTCONDITION(status == GL_FRAMEBUFFER_COMPLETE, "Incomplete framebuffer.");
+        // Test the framebuffer for completeness.
+        GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+        ASSERT_POSTCONDITION(status == GL_FRAMEBUFFER_COMPLETE, "Incomplete framebuffer.");
+    }
 }
 
 void PlatformCocoaTouchGL::commit(Platform::SwapChain* swapChain) noexcept {


### PR DESCRIPTION
`makeCurrent` can be called with a bound framebuffer of 0, which is invalid on iOS. We need to explicitly bind the default framebuffer before calling `glRenderbufferStorage`. Fixes #814 