### PR TITLE
Build all run-time variants on Windows for CI release and continuous

### DIFF
--- a/build/windows/build.bat
+++ b/build/windows/build.bat
@@ -19,6 +19,16 @@ cmake --version
 
 cd github\filament
 
+:: If this is a continuous or release build, build all Filament static library
+:: variants (/MD, /MDd, /MT, /MTd)
+if %KOKORO_JOB_TYPE% == CONTINUOUS_INTEGRATION (set FILAMENT_BUILD_ALL_VARIANTS=1)
+if %KOKORO_JOB_TYPE% == RELEASE (set FILAMENT_BUILD_ALL_VARIANTS=1)
+
+if %FILAMENT_BUILD_ALL_VARIANTS% == 1 (
+    echo KOKORO_JOB_TYPE is %KOKORO_JOB_TYPE%
+    echo Building additional Filament static library variants.
+)
+
 mkdir out\cmake-release
 cd out\cmake-release
 if errorlevel 1 exit /b %errorlevel%
@@ -38,6 +48,14 @@ if errorlevel 1 exit /b %errorlevel%
 
 ninja install
 if errorlevel 1 exit /b %errorlevel%
+
+if %FILAMENT_BUILD_ALL_VARIANTS% == 1 (
+    cd ..
+    :: Build variants and copy them inside cmake-release\install
+    call %~dp0variants.bat
+    if errorlevel 1 exit /b %errorlevel%
+    cd cmake-release
+)
 
 :: Create an archive
 dir .\install

--- a/build/windows/build.bat
+++ b/build/windows/build.bat
@@ -21,10 +21,10 @@ cd github\filament
 
 :: If this is a continuous or release build, build all Filament static library
 :: variants (/MD, /MDd, /MT, /MTd)
-if %KOKORO_JOB_TYPE% == CONTINUOUS_INTEGRATION (set FILAMENT_BUILD_ALL_VARIANTS=1)
-if %KOKORO_JOB_TYPE% == RELEASE (set FILAMENT_BUILD_ALL_VARIANTS=1)
+if "%KOKORO_JOB_TYPE%" == "CONTINUOUS_INTEGRATION" (set FILAMENT_BUILD_ALL_VARIANTS=1)
+if "%KOKORO_JOB_TYPE%" == "RELEASE" (set FILAMENT_BUILD_ALL_VARIANTS=1)
 
-if %FILAMENT_BUILD_ALL_VARIANTS% == 1 (
+if "%FILAMENT_BUILD_ALL_VARIANTS%" == "1" (
     echo KOKORO_JOB_TYPE is %KOKORO_JOB_TYPE%
     echo Building additional Filament static library variants.
 )
@@ -49,7 +49,7 @@ if errorlevel 1 exit /b %errorlevel%
 ninja install
 if errorlevel 1 exit /b %errorlevel%
 
-if %FILAMENT_BUILD_ALL_VARIANTS% == 1 (
+if "%FILAMENT_BUILD_ALL_VARIANTS%" == "1" (
     cd ..
     :: Build variants and copy them inside cmake-release\install
     call %~dp0variants.bat

--- a/build/windows/variants.bat
+++ b/build/windows/variants.bat
@@ -1,0 +1,66 @@
+:: /MT flag version is built by default. Move these libs into a separate directory.
+mkdir cmake-release\install\lib\x86_64\mt
+move cmake-release\install\lib\x86_64\*.lib cmake-release\install\lib\x86_64\mt\
+
+:: /MD flag.
+mkdir cmake-release-md
+cd cmake-release-md
+
+cmake ..\.. -G Ninja ^
+    -DCMAKE_CXX_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_C_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_LINKER:PATH="lld-link.exe" ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DUSE_STATIC_CRT=OFF
+if errorlevel 1 exit /b %errorlevel%
+
+ninja install
+if errorlevel 1 exit /b %errorlevel%
+
+xcopy .\install\lib\x86_64\*.lib ..\cmake-release\install\lib\x86_64\md\
+
+cd ..
+
+:: Debug builds
+
+:: /MTd flag.
+
+mkdir cmake-release-mtd
+cd cmake-release-mtd
+
+cmake ..\.. -G Ninja ^
+    -DCMAKE_CXX_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_C_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_LINKER:PATH="lld-link.exe" ^
+    -DCMAKE_BUILD_TYPE=Debug ^
+    -DUSE_STATIC_CRT=ON
+if errorlevel 1 exit /b %errorlevel%
+
+ninja install
+if errorlevel 1 exit /b %errorlevel%
+
+xcopy .\install\lib\x86_64\*.lib ..\cmake-release\install\lib\x86_64\mtd\
+
+cd ..
+
+:: /MDd flag.
+
+mkdir cmake-release-mdd
+cd cmake-release-mdd
+
+cmake ..\.. -G Ninja ^
+    -DCMAKE_CXX_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_C_COMPILER:PATH="clang-cl.exe" ^
+    -DCMAKE_LINKER:PATH="lld-link.exe" ^
+    -DCMAKE_BUILD_TYPE=Debug ^
+    -DUSE_STATIC_CRT=OFF
+if errorlevel 1 exit /b %errorlevel%
+
+ninja install
+if errorlevel 1 exit /b %errorlevel%
+
+xcopy .\install\lib\x86_64\*.lib ..\cmake-release\install\lib\x86_64\mdd\
+
+cd ..
+
+exit /b 0

--- a/filament/README.md
+++ b/filament/README.md
@@ -114,16 +114,24 @@ clean:
 
 ### Windows
 
+Note that the static libraries distributed for Windows include several
+variants: mt, md, mtd, mdd. These correspond to the [run-time library
+flags](https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2017)
+`/MT`, `/MD`, `/MTd`, and `/MDd`, respectively. Here we use the mt variant.
+
+When building Filament from source, the `USE_STATIC_CRT` CMake option can be
+used to change the run-time library version.
+
 ```
-FILAMENT_LIBS=lib/x86_64/filament.lib lib/x86_64/bluegl.lib \
-              lib/x86_64/filabridge.lib lib/x86_64/filaflat.lib lib/x86_64/utils.lib
+FILAMENT_LIBS=lib/x86_64/mt/filament.lib lib/x86_64/mt/bluegl.lib \
+              lib/x86_64/mt/filabridge.lib lib/x86_64/mt/filaflat.lib lib/x86_64/mt/utils.lib
 CC=clang-cl.exe
 
 main.exe: main.obj
 	$(CC) main.obj $(FILAMENT_LIBS) gdi32.lib user32.lib opengl32.lib
 
 main.obj: main.cpp
-	$(CC) /Iinclude/ /std:c++14 /c main.cpp
+	$(CC) /MT /Iinclude/ /std:c++14 /c main.cpp
 
 clean:
 	del main.exe main.obj


### PR DESCRIPTION
Add all Windows runtime variants (`/MD`, `/MDd`, `/MT`, and `/MTd`) to Windows release builds. Fixes #810.

The Windows release directory structure will look like:
```
bin
docs
include
lib
|-- x86_64
    |-- md
        |-- *.lib
    |-- mdd
        |-- *.lib
    |-- mt
        |-- *.lib
    |-- mtd
        |-- *.lib
    |-- filamat-jni.dll
    |-- filament-jni.dll
```