### PR TITLE
Introduce addEntities method to Scene.

### DIFF
--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -94,6 +94,14 @@ public:
     void addEntity(utils::Entity entity);
 
     /**
+     * Adds a contiguous list of entities to the Scene.
+     *
+     * @param entities
+     * @param count
+     */
+    void addEntities(const utils::Entity* entities, size_t count);
+
+    /**
      * Removes the Renderable from the Scene.
      *
      * @param entity The Entity to remove from the Scene. If the specified

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -678,7 +678,7 @@ inline void FEngine::destroy(const FMaterial* ptr) {
     if (ptr != nullptr) {
         auto pos = mMaterialInstances.find(ptr);
         if (pos != mMaterialInstances.cend()) {
-            // we've destroyed the material before destroying all its instances
+            // ensure we've destroyed all instances before destroying the material
             if (!ASSERT_PRECONDITION_NON_FATAL(pos->second.empty(),
                     "destroying material \"%s\" but %u instances still alive",
                     ptr->getName().c_str(), (*pos).second.size())) {

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -317,6 +317,10 @@ void FScene::addEntity(Entity entity) {
     mEntities.insert(entity);
 }
 
+void FScene::addEntities(const Entity* entities, size_t count) {
+    mEntities.insert(entities, entities + count);
+}
+
 void FScene::remove(Entity entity) {
     mEntities.erase(entity);
 }
@@ -402,6 +406,10 @@ void Scene::setIndirectLight(IndirectLight const* ibl) noexcept {
 
 void Scene::addEntity(Entity entity) {
     upcast(this)->addEntity(entity);
+}
+
+void Scene::addEntities(const Entity* entities, size_t count) {
+    upcast(this)->addEntities(entities, count);
 }
 
 void Scene::remove(Entity entity) {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -62,6 +62,7 @@ public:
     FIndirectLight const* getIndirectLight() const noexcept { return mIndirectLight; }
 
     void addEntity(utils::Entity entity);
+    void addEntities(const utils::Entity* entities, size_t count);
     void remove(utils::Entity entity);
 
     size_t getRenderableCount() const noexcept;


### PR DESCRIPTION
This is an efficient method that allows clients to add a slew of
entities to the scene. This is particularly useful for the upcoming
gltfio library, which is agnostic of the Scene and exposes a flat
list of entities.