### PR TITLE
Install requirements for linking against filameshio

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -17,6 +17,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityInstance.h
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/CString.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/Path.h
         ${PUBLIC_HDR_DIR}/${TARGET}/unwindows.h
 )
 

--- a/third_party/meshoptimizer/CMakeLists.txt
+++ b/third_party/meshoptimizer/CMakeLists.txt
@@ -37,3 +37,5 @@ if(BUILD_DEMO)
     add_executable(demo demo/main.cpp demo/miniz.cpp demo/objparser.cpp)
     target_link_libraries(demo meshoptimizer)
 endif()
+
+install(TARGETS meshoptimizer ARCHIVE DESTINATION lib/${DIST_DIR})


### PR DESCRIPTION
`filameshio` depends on the meshoptimizer lib, so install that alongside other Filament libs. `MeshReader.h` also includes the `utils/Path.h` header, so copy that to the install folder as well.