### PR TITLE
DriverAPI: add generateMipmaps and canGenerateMipmaps.

### DIFF
--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -203,6 +203,11 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
         return;
     }
 
+    if (engine.getDriverApi().canGenerateMipmaps()) {
+         engine.getDriverApi().generateMipmaps(mHandle);
+         return;
+    }
+
     auto generateMipsForLayer = [this, &engine](uint16_t layer) {
         FEngine::DriverApi& driver = engine.getDriverApi();
 

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -316,6 +316,8 @@ DECL_DRIVER_API_SYNCHRONOUS_1(bool, isRenderTargetFormatSupported, Driver::Textu
 
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 
+DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
+
 /*
  * Updating driver objects
  * -----------------------
@@ -356,6 +358,9 @@ DECL_DRIVER_API_4(updateCubeImage,
         uint32_t, level,
         Driver::PixelBufferDescriptor&&, data,
         Driver::FaceOffsets, faceOffsets)
+
+DECL_DRIVER_API_1(generateMipmaps,
+        Driver::TextureHandle, th)
 
 DECL_DRIVER_API_2(setExternalImage,
         Driver::TextureHandle, th,

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -405,6 +405,14 @@ void MetalDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHand
 
 }
 
+void MetalDriver::generateMipmaps(Driver::TextureHandle th) {
+
+}
+
+bool MetalDriver::canGenerateMipmaps() {
+    return false;
+}
+
 void MetalDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh,
         Driver::BufferDescriptor&& data) {
     auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1750,6 +1750,30 @@ void OpenGLDriver::updateCubeImage(Driver::TextureHandle th, uint32_t level,
     }
 }
 
+void OpenGLDriver::generateMipmaps(Driver::TextureHandle th) {
+    DEBUG_MARKER()
+
+    GLTexture* t = handle_cast<GLTexture *>(th);
+    assert(t->gl.target != GL_TEXTURE_2D_MULTISAMPLE);
+    // Note: glGenerateMimap can also fail if the internal format is not both
+    // color-renderable and filterable (i.e.: doesn't work for depth)
+    bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t, t->gl.targetIndex);
+    activeTexture(MAX_TEXTURE_UNITS - 1);
+    glGenerateMipmap(t->gl.target);
+
+    t->gl.baseLevel = 0;
+    t->gl.maxLevel = static_cast<uint8_t>(t->levels - 1);
+
+    glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+    glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+
+    CHECK_GL_ERROR(utils::slog.e)
+}
+
+bool OpenGLDriver::canGenerateMipmaps() {
+    return true;
+}
+
 void OpenGLDriver::setTextureData(GLTexture* t,
                                   uint32_t level,
                                   uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -556,6 +556,12 @@ void VulkanDriver::setExternalImage(Driver::TextureHandle th, void* image) {
 void VulkanDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHandle sh) {
 }
 
+void VulkanDriver::generateMipmaps(Driver::TextureHandle th) { }
+
+bool VulkanDriver::canGenerateMipmaps() {
+    return false;
+}
+
 void VulkanDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh, BufferDescriptor&& data) {
     if (data.size > 0) {
         auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);


### PR DESCRIPTION
Fixes #808.  See also comments in #749.