### PR TITLE
fix linux debug build

### DIFF
--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -14,5 +14,6 @@ if(NOT IOS)
         target_compile_options(test_${TARGET} PRIVATE ${COMPILER_FLAGS})
 
         add_executable(test_depth depth_test.cpp)
+        target_link_libraries(test_depth PRIVATE utils)
     endif()
 endif()


### PR DESCRIPTION
It looks like out static libc++abi that we use on linux needs
pthread, even if the exe doesn't use it. 
Adding libutils to this test fixes the build on my local linux machine.

The real fix is probably something else, bug I don't quite
understand these shenanigans.