### PR TITLE
Introduce MATERIAL_VERSION and panic.

### DIFF
--- a/filament/docs/Versioning.md
+++ b/filament/docs/Versioning.md
@@ -11,3 +11,17 @@ are the guidelines:
   number to zero when the most significant number has been incremented.
 - Increment the **least significant** number each time a new release is published. Reset this number
   to zero if one of the other two numbers have been incremented.
+
+## Material Versioning
+
+Additionally, the Filament renderer and material compiler internally contain a standalone integer
+called `MATERIAL_VERSION`, defined in `MaterialEnums.h`. This should be incremented every time we
+change the middle number in the public-facing version.
+
+When a material version mismatch is detected at run time, a panic is triggered, even in release
+builds. Therefore we should increment this only when making a serious breaking change to the
+material system (e.g. changing the size of a uniform block). Cosmetic shader changes usually do
+not merit a change to the material version number.
+
+Currently our material archives have two version chunks, one for "normal" materials and one for
+post-process materials. However for now these two numbers must be set to the same value.

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -165,6 +165,11 @@ void FEngine::init() {
             mPostProcessParser->parse() && mPostProcessParser->isPostProcessMaterial();
     assert(ppMaterialOk);
 
+    uint32_t version;
+    mPostProcessParser->getPostProcessVersion(&version);
+    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Post-process material version mismatch. "
+            "Expected %d but received %d.", MATERIAL_VERSION, version);
+
     mFullScreenTriangleVb = upcast(VertexBuffer::Builder()
             .vertexCount(3)
             .bufferCount(1)

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -79,6 +79,11 @@ Material* Material::Builder::build(Engine& engine) {
         return nullptr;
     }
 
+    uint32_t version;
+    materialParser->getMaterialVersion(&version);
+    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
+            "received %d.", MATERIAL_VERSION, version);
+
     assert(upcast(engine).getBackend() != Backend::DEFAULT &&
             "Default backend has not been resolved.");
 

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 namespace filament {
-    static constexpr size_t MATERIAL_VERSION = 1;
+    static constexpr size_t MATERIAL_VERSION = 2;
 
     enum class Shading : uint8_t {
         UNLIT,                  // no lighting applied, emissive possible

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 
 namespace filament {
+    static constexpr size_t MATERIAL_VERSION = 1;
+
     enum class Shading : uint8_t {
         UNLIT,                  // no lighting applied, emissive possible
         LIT,                    // default, standard lighting

--- a/libs/filaflat/include/filaflat/MaterialParser.h
+++ b/libs/filaflat/include/filaflat/MaterialParser.h
@@ -52,6 +52,8 @@ public:
     bool isPostProcessMaterial() const noexcept;
 
     // Accessors
+    bool getMaterialVersion(uint32_t* value) const noexcept;
+    bool getPostProcessVersion(uint32_t* value) const noexcept;
     bool getName(utils::CString*) const noexcept;
     bool getUIB(filament::UniformInterfaceBlock* uib) const noexcept;
     bool getSIB(filament::SamplerInterfaceBlock* sib) const noexcept;

--- a/libs/filaflat/src/MaterialParser.cpp
+++ b/libs/filaflat/src/MaterialParser.cpp
@@ -136,6 +136,14 @@ bool MaterialParser::isPostProcessMaterial() const noexcept {
 }
 
 // Accessors
+bool MaterialParser::getMaterialVersion(uint32_t* value) const noexcept {
+    return mImpl->getFromSimpleChunk(ChunkType::MaterialVersion, value);
+}
+
+bool MaterialParser::getPostProcessVersion(uint32_t* value) const noexcept {
+    return mImpl->getFromSimpleChunk(ChunkType::PostProcessVersion, value);
+}
+
 bool MaterialParser::getName(utils::CString* cstring) const noexcept {
    ChunkType type = ChunkType::MaterialName;
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -372,7 +372,7 @@ Package MaterialBuilder::build() noexcept {
     // Create chunk tree.
     ChunkContainer container;
 
-    SimpleFieldChunk<uint32_t> matVersion(ChunkType::MaterialVersion, 1);
+    SimpleFieldChunk<uint32_t> matVersion(ChunkType::MaterialVersion, filament::MATERIAL_VERSION);
     container.addChild(&matVersion);
 
     SimpleFieldChunk<const char*> matName(ChunkType::MaterialName, mMaterialName.c_str_safe());

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -46,7 +46,7 @@ Package PostprocessMaterialBuilder::build() {
     // Create chunk tree.
     ChunkContainer container;
 
-    SimpleFieldChunk<uint32_t> version(ChunkType::PostProcessVersion, 1);
+    SimpleFieldChunk<uint32_t> version(ChunkType::PostProcessVersion, filament::MATERIAL_VERSION);
     container.addChild(&version);
 
     std::vector<TextEntry> glslEntries;

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -55,10 +55,12 @@ static void usage(char* name) {
             "       Specify the target API: opengl (default), vulkan, metal, or all\n\n"
             "   --reflect, -r\n"
             "       Reflect the specified metadata as JSON: parameters\n\n"
-            "   --variant-filter=<filter>, -v <filter>\n"
+            "   --variant-filter=<filter>, -V <filter>\n"
             "       Filter out specified comma-separated variants:\n"
             "           directionalLighting, dynamicLighting, shadowReceiver, skinning\n"
             "       This variant filter is merged the filter from the material, if any\n\n"
+            "   --version, -v\n"
+            "       Print the material version number\n\n"
             "Internal use and debugging only:\n"
             "   --optimize-none, -g\n"
             "       Disable all shader optimizations, for debugging\n\n"
@@ -109,7 +111,7 @@ CommandlineConfig::CommandlineConfig(int argc, char** argv) : Config(), mArgc(ar
 }
 
 bool CommandlineConfig::parse() {
-    static constexpr const char* OPTSTR = "hxo:f:dm:a:p:OSEr:v:g";
+    static constexpr const char* OPTSTR = "hlxo:f:dm:a:p:OSEr:vV:g";
     static const struct option OPTIONS[] = {
             { "help",                    no_argument, nullptr, 'h' },
             { "license",                 no_argument, nullptr, 'l' },
@@ -117,7 +119,7 @@ bool CommandlineConfig::parse() {
             { "output-format",     required_argument, nullptr, 'f' },
             { "debug",                   no_argument, nullptr, 'd' },
             { "mode",              required_argument, nullptr, 'm' },
-            { "variant-filter",    required_argument, nullptr, 'v' },
+            { "variant-filter",    required_argument, nullptr, 'V' },
             { "platform",          required_argument, nullptr, 'p' },
             { "optimize",                no_argument, nullptr, 'x' }, // for backward compatibility
             { "optimize",                no_argument, nullptr, 'O' }, // for backward compatibility
@@ -127,6 +129,7 @@ bool CommandlineConfig::parse() {
             { "api",               required_argument, nullptr, 'a' },
             { "reflect",           required_argument, nullptr, 'r' },
             { "print",                   no_argument, nullptr, 't' },
+            { "version",                 no_argument, nullptr, 'v' },
             { nullptr, 0, nullptr, 0 }  // termination of the option list
     };
 
@@ -204,10 +207,15 @@ bool CommandlineConfig::parse() {
                     return false;
                 }
                 break;
-            case 'v': {
+            case 'v':
+                // Similar to --help, the --version command does an early exit in order to avoid
+                // subsequent error spew such as "Missing input filename" etc.
+                std::cout << filament::MATERIAL_VERSION << std::endl;
+                exit(0);
+                break;
+            case 'V':
                 mVariantFilter = parseVariantFilter(arg);
                 break;
-            }
             // These 2 flags are supported for backward compatibility
             case 'O':
             case 'x':


### PR DESCRIPTION
Material archives already contain two version chunks (post process and
normal) but the renderer was ignoring these. The change makes it so that
matc writes a new MaterialEnums value into these chunks, and the engine
panics when receiving a material version that it does not expect.

This also adds a --version option to matc. No changes were necessary
to matinfo because it already prints out these values.

Fixes #796.