### PR TITLE
Add Init and Shutdown methods to MaterialBuilder

### DIFF
--- a/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
+++ b/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
@@ -23,6 +23,18 @@
 using namespace filament;
 using namespace filamat;
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderInit(JNIEnv *env,
+        jclass type) {
+    MaterialBuilder::init();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShutdown(JNIEnv *env,
+        jclass type) {
+    MaterialBuilder::shutdown();
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nCreateMaterialBuilder(JNIEnv *env,
         jclass type) {

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -26,6 +26,10 @@ public class MaterialBuilder {
     private final BuilderFinalizer mFinalizer;
     private final long mNativeObject;
 
+    static {
+        System.loadLibrary("filamat-jni");
+    }
+
     public enum VertexAttribute {
         POSITION,               // XYZ position (float3)
         TANGENTS,               // tangent, bitangent and normal, encoded as a quaternion (4 floats or half floats)
@@ -47,6 +51,14 @@ public class MaterialBuilder {
         DESKTOP,
         MOBILE,
         ALL
+    }
+
+    public static void init() {
+        nMaterialBuilderInit();
+    }
+
+    public static void shutdown() {
+        nMaterialBuilderShutdown();
     }
 
     public MaterialBuilder() {
@@ -123,6 +135,9 @@ public class MaterialBuilder {
             }
         }
     }
+
+    private static native void nMaterialBuilderInit();
+    private static native void nMaterialBuilderShutdown();
 
     private static native long nCreateMaterialBuilder();
     private static native void nDestroyMaterialBuilder(long nativeBuilder);

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -61,6 +62,13 @@ public:
         PERFORMANCE
     };
 
+    // Must be called first before building any materials.
+    static void init();
+
+    // Call when finished building materials to release all internal resources. After calling
+    // shutdown, another call to MaterialBuilder::init must precede another material build.
+    static void shutdown();
+
 protected:
     // Looks at platform and target API, then decides on shader models and output formats.
     void prepare();
@@ -78,6 +86,12 @@ protected:
     };
     std::vector<CodeGenParams> mCodeGenPermutations;
     uint8_t mVariantFilter = 0;
+
+    // Keeps track of how many times MaterialBuilder::init() has been called without a call to
+    // MaterialBuilder::shutdown(). Internally, glslang does something similar. We keep track for
+    // ourselves so we can inform the user if MaterialBuilder::init() hasn't been called before
+    // attempting to build a material.
+    static std::atomic<int> materialBuilderClients;
 };
 
 class UTILS_PUBLIC MaterialBuilder : public MaterialBuilderBase {

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -37,7 +37,6 @@ using namespace filament::driver;
 namespace filamat {
 
 Package PostprocessMaterialBuilder::build() {
-    GLSLTools::init();
     prepare();
 
     // Create a postprocessor to optimize / compile to Spir-V if necessary.

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -133,12 +133,12 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel m
 }
 
 void GLSLTools::init() {
-    // According to glslang, InitializeProcess should be called exactly once per process.
-    static bool initializeCalled = false;
-    if (!initializeCalled) {
-        InitializeProcess();
-        initializeCalled = true;
-    }
+    // Each call to InitializeProcess must be matched with a call to FinalizeProcess.
+    InitializeProcess();
+}
+
+void GLSLTools::shutdown() {
+    FinalizeProcess();
 }
 
 bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn,

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -113,6 +113,7 @@ private:
 class GLSLTools {
 public:
     static void init();
+    static void shutdown();
 
     // Return true if:
     // The shader is syntactically and semantically valid AND

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -246,6 +246,7 @@ bool MaterialCompiler::run(const Config& config) {
     }
     auto buffer = input->read();
 
+    MaterialBuilder::init();
     MaterialBuilder builder;
     // Before attempting an expensive lex, let's find out if we were sent pure JSON.
     bool parsed;
@@ -275,6 +276,7 @@ bool MaterialCompiler::run(const Config& config) {
 
     // Write builder.build() to output.
     Package package = builder.build();
+    MaterialBuilder::shutdown();
     if (!package.isValid()) {
         std::cerr << "Could not compile material " << input->getName() << std::endl;
         return false;

--- a/tools/matc/src/matc/MaterialCompiler.h
+++ b/tools/matc/src/matc/MaterialCompiler.h
@@ -38,6 +38,7 @@ public:
     MaterialCompiler();
 
     bool run(const Config& config) override;
+
     bool checkParameters(const Config& config) override;
 
 private:

--- a/tools/matc/src/matc/PostprocessMaterialCompiler.cpp
+++ b/tools/matc/src/matc/PostprocessMaterialCompiler.cpp
@@ -23,6 +23,7 @@ using namespace filamat;
 namespace matc {
 
 bool PostprocessMaterialCompiler::run(const Config& config) {
+    PostprocessMaterialBuilder::init();
     PostprocessMaterialBuilder builder;
     builder
         .platform(config.getPlatform())
@@ -31,6 +32,7 @@ bool PostprocessMaterialCompiler::run(const Config& config) {
         .printShaders(config.printShaders());
 
     Package package = builder.build();
+    PostprocessMaterialBuilder::shutdown();
     if (!package.isValid()) {
         return false;
     }


### PR DESCRIPTION
`init` prepares glslang for material compilation. `shutdown` frees resources. Internally, we keep track of calls to `init` vs `shutdown` so we can warn users if `init` has not been called. glslang [does something similar](https://github.com/KhronosGroup/glslang/blob/58d6905ea01f7c44652eb082d26b662ca811df25/glslang/MachineIndependent/ShaderLang.cpp#L1271).