### PR TITLE
improve bindBufferRange() state tracking

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -429,8 +429,7 @@ void OpenGLDriver::bindBufferRange(GLenum target, GLuint index, GLuint buffer,
     assert(targetIndex <= 1); // sanity check
 
     // this ALSO sets the generic binding
-    if (state.buffers.genericBinding[targetIndex] != buffer
-            || state.buffers.targets[targetIndex].buffers[index].name != buffer
+        if (   state.buffers.targets[targetIndex].buffers[index].name != buffer
             || state.buffers.targets[targetIndex].buffers[index].offset != offset
             || state.buffers.targets[targetIndex].buffers[index].size != size) {
         state.buffers.targets[targetIndex].buffers[index].name = buffer;


### PR DESCRIPTION
we never rely (or should rely) on the fact that glBinderBufferRange()
also sets the generic binding, so we don't need to check for that when
calling glBindBufferRange().

This helps a little bit reducing the numbers of GL calls, especially
when several consecutive draw calls use the same material instance.