### PR TITLE
Initialize MaterialBuilder in samples

### DIFF
--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -180,6 +180,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         return;
     }
 
+    MaterialBuilder::init();
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
             .require(VertexAttribute::UV0)

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -280,6 +280,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     }
     shader += "}\n";
 
+    MaterialBuilder::init();
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
             .material(shader.c_str())

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -260,6 +260,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
 
     shader += "}\n";
 
+    MaterialBuilder::init();
     MaterialBuilder builder = MaterialBuilder()
             .name("DefaultMaterial")
             .material(shader.c_str())


### PR DESCRIPTION
`MaterialBuilder::init` now must be called before building any materials.