### PR TITLE
Fix, can't set material parameters on default material instance

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -325,6 +325,11 @@ void FEngine::prepare() {
             item->commit(*this);
         }
     }
+
+    // Commit default material instances.
+    for (auto& material : mMaterials) {
+        material->getDefaultInstance()->commit(*this);
+    }
 }
 
 void FEngine::gc() {

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -69,7 +69,7 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
 
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms = UniformBuffer(material->getUniformInterfaceBlock());
-        mUbHandle = driver.createUniformBuffer(mUniforms.getSize(), driver::BufferUsage::STATIC);
+        mUbHandle = driver.createUniformBuffer(mUniforms.getSize(), driver::BufferUsage::DYNAMIC);
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {


### PR DESCRIPTION
Setting material parameters on default material instances has no effect- i.e., the following:

```
MaterialInstance* instance = material->getDefaultInstance();
instance->setParameter("myParameter", RgbType::LINEAR, {1.0, 0.0, 0.0});
```

This happens with both float and sampler parameters. I'm a bit surprised this hasn't been discovered yet, so maybe I'm missing something.

Also, I think the UBO usage flag for the default material instance should match explicitly-created instances (`DYNAMIC`) unless we want the semantics that the default instance's parameters aren't meant to change...