### PR TITLE
rework multisample driver api

### DIFF
--- a/filament/src/RenderTargetPool.cpp
+++ b/filament/src/RenderTargetPool.cpp
@@ -87,7 +87,7 @@ RenderTargetPool::Target const* RenderTargetPool::get(
                 entry.attachments, target_w, target_h, samples, format, {}, {}, {});
     } else {
         entry.texture = driver.createTexture(Driver::SamplerType::SAMPLER_2D, 1,
-                format, samples, target_w, target_h, 1, Driver::TextureUsage::COLOR_ATTACHMENT);
+                format, 1, target_w, target_h, 1, Driver::TextureUsage::COLOR_ATTACHMENT);
 
         entry.target = driver.createRenderTarget(
                 entry.attachments, target_w, target_h, samples, format,

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -278,13 +278,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
             ppm.start();
 
-            if (useMSAA > 1) {
-                // Note: MSAA, when used is applied before tone-mapping (which is not ideal)
-                // (tone mapping currently only works without multi-sampling)
-                // this blit does a MSAA resolve
-                ppm.blit(hdrFormat);
-            }
-
             const bool translucent = mSwapChain->isTransparent();
             Handle<HwProgram> toneMappingProgram = engine.getPostProcessProgram(
                     translucent ? PostProcessStage::TONE_MAPPING_TRANSLUCENT

--- a/filament/src/driver/opengl/OpenGLDriver.h
+++ b/filament/src/driver/opengl/OpenGLDriver.h
@@ -177,6 +177,8 @@ public:
             RenderBuffer depth;
             RenderBuffer stencil;
             GLuint fbo = 0;
+            GLuint fbo_draw = 0;
+            TargetBufferFlags resolve = TargetBufferFlags::NONE; // attachments in fbo_draw to resolve
             uint8_t samples : 4;
             uint8_t colorLevel : 4; // Allows up to 15 levels (max texture size of 32768 x 32768)
         } gl;

--- a/filament/src/driver/opengl/gl_headers.cpp
+++ b/filament/src/driver/opengl/gl_headers.cpp
@@ -105,6 +105,11 @@ namespace glext {
             GLenum textarget, GLuint texture, GLint level, GLsizei samples) {
         PANIC_PRECONDITION("glFramebufferTexture2DMultisampleEXT should not be called on iOS.");
     }
+
+    void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
+            GLenum internalformat, GLsizei width, GLsizei height) {
+        PANIC_PRECONDITION("glRenderbufferStorageMultisampleEXT should not be called on iOS.");
+    }
 }
 
 #endif

--- a/filament/src/driver/opengl/gl_headers.cpp
+++ b/filament/src/driver/opengl/gl_headers.cpp
@@ -34,6 +34,7 @@ PFNGLPUSHGROUPMARKEREXTPROC glPushGroupMarkerEXT;
 PFNGLPOPGROUPMARKEREXTPROC glPopGroupMarkerEXT;
 #endif
 #if GL_EXT_multisampled_render_to_texture
+PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
 PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
 #endif
 }
@@ -77,6 +78,9 @@ public:
         glFramebufferTexture2DMultisampleEXT =
                 (PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC)eglGetProcAddress(
                         "glFramebufferTexture2DMultisampleEXT");
+        glRenderbufferStorageMultisampleEXT =
+                (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)eglGetProcAddress(
+                        "glRenderbufferStorageMultisampleEXT");
 #endif
     }
 } instance;

--- a/filament/src/driver/opengl/gl_headers.h
+++ b/filament/src/driver/opengl/gl_headers.h
@@ -37,6 +37,7 @@
         extern PFNGLPOPGROUPMARKEREXTPROC glPopGroupMarkerEXT;
 #endif
 #if GL_EXT_multisampled_render_to_texture
+        extern PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
         extern PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
 #endif
     }

--- a/filament/src/driver/opengl/gl_headers.h
+++ b/filament/src/driver/opengl/gl_headers.h
@@ -62,6 +62,9 @@
     namespace glext {
         void glFramebufferTexture2DMultisampleEXT (GLenum target, GLenum attachment,
                 GLenum textarget, GLuint texture, GLint level, GLsizei samples);
+
+        void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
+                GLenum internalformat, GLsizei width, GLsizei height);
     }
 
 #else


### PR DESCRIPTION
It's now possible to create a multisample FBO with a non-multisample
texture attachment. In this case, the drive is responsible for
automatically resolving the multisample buffer into the texture on
endRenderPass().

This allows us to avoid doing a "resolve blit" on the client side, but 
more importantly, it allows the driver to do this efficiently,
especially on tilers.

The semantic of this operation is the same than with
EXT_multisampled_render_to_texture. i.e. the multisample buffer is
lost after resolve. For GL/GLES drivers if 
EXT_multisampled_render_to_texture is not available this behavior
is emulated with a renderbuffer + blit.


This CL also fixes the creation of attachments to a face of a cubemap.