### PR TITLE
Do not use CMAKE_SOURCE_DIR.

### DIFF
--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -119,9 +119,9 @@ endforeach()
 
 # Run the combine-static-libs script to bundle the libraries together.
 set(FILAMAT_COMBINED_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libfilamat_combined.a")
-set(COMBINE_SCRIPT "${CMAKE_SOURCE_DIR}/build/linux/combine-static-libs.sh")
+set(COMBINE_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/../../build/linux/combine-static-libs.sh")
 if (WIN32)
-    set(COMBINE_SCRIPT "${CMAKE_SOURCE_DIR}/build/windows/combine-static-libs.bat")
+    set(COMBINE_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/../../build/windows/combine-static-libs.bat")
     set(CMAKE_AR "lib.exe")
 endif()
 add_custom_command(


### PR DESCRIPTION
This is one of those CMake gotchas, we should always use
CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR to allow
Filament to exist as a subproject.

In particular, this was causing the following build error when trying to
build Filament as a nested project.

    combine-static-libs.sh: No such file or directory

Fixes #861.