### PR TITLE
Fix up emissive energy compensation for glTF.

### DIFF
--- a/samples/app/MeshAssimp.cpp
+++ b/samples/app/MeshAssimp.cpp
@@ -144,8 +144,12 @@ std::string shaderFromConfig(MaterialConfig config) {
             material.roughness = materialParams.roughnessFactor * metallicRoughness.g;
             material.metallic = materialParams.metallicFactor * metallicRoughness.b;
             material.ambientOcclusion = texture(materialParams_aoMap, aoUV).r;
-            material.emissive = texture(materialParams_emissiveMap, emissiveUV);
+            material.emissive.rgb = texture(materialParams_emissiveMap, emissiveUV).rgb;
             material.emissive.rgb *= materialParams.emissiveFactor.rgb;
+
+            // The opinionated lighting model specified by glTF does not account for energy
+            // compensation, using this value basically disables it:
+            material.emissive.a = 3.0;
         )SHADER";
     }
 


### PR DESCRIPTION
Our treatment of emissive values in glTF was not matching other viewers because we were interpreting emissive texture alpha as an energy compensation term, but the glTF lighting model does not include an energy compensation term for emissive.

This change makes gltf_viewer appear more consistent with other viewers.  Before / After screenshots of the boombox:

![before](https://user-images.githubusercontent.com/1288904/53276978-7c5e1880-36b6-11e9-95a8-af80b888337e.png)
![after](https://user-images.githubusercontent.com/1288904/53276981-7d8f4580-36b6-11e9-84b0-81e7614322ed.png)
