### PR TITLE
Add glRenderbufferStorageMultisampleEXT declaration to iOS

### DIFF
--- a/filament/src/driver/opengl/gl_headers.cpp
+++ b/filament/src/driver/opengl/gl_headers.cpp
@@ -105,6 +105,11 @@ namespace glext {
             GLenum textarget, GLuint texture, GLint level, GLsizei samples) {
         PANIC_PRECONDITION("glFramebufferTexture2DMultisampleEXT should not be called on iOS.");
     }
+
+    void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
+            GLenum internalformat, GLsizei width, GLsizei height) {
+        PANIC_PRECONDITION("glRenderbufferStorageMultisampleEXT should not be called on iOS.");
+    }
 }
 
 #endif

--- a/filament/src/driver/opengl/gl_headers.h
+++ b/filament/src/driver/opengl/gl_headers.h
@@ -62,6 +62,9 @@
     namespace glext {
         void glFramebufferTexture2DMultisampleEXT (GLenum target, GLenum attachment,
                 GLenum textarget, GLuint texture, GLint level, GLsizei samples);
+
+        void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
+                GLenum internalformat, GLsizei width, GLsizei height);
     }
 
 #else


### PR DESCRIPTION
iOS only has headers up to OpenGL ES 3.0, so we have to fake this in order for Filament to compile.