### PR TITLE
Fix fxaa offset (#868)

### DIFF
--- a/shaders/src/post_process.fs
+++ b/shaders/src/post_process.fs
@@ -50,6 +50,8 @@ vec4 PostProcess_AntiAliasing() {
 
     // Next, compute the coordinates of the texel center and its bounding box. There is no need to
     // clamp the min corner since the wrap mode will do it automatically.
+
+    // vertex_uv is already interpolated to pixel center by the GPU
     HIGHP vec2 texelCenter = min(vertex_uv, upperBound);
     HIGHP vec2 texelMaxCorner = min(vertex_uv + halfTexel, upperBound);
     HIGHP vec2 texelMinCorner = vertex_uv - halfTexel;

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -17,10 +17,8 @@ void main() {
 #endif
 
 #if POST_PROCESS_ANTI_ALIASING
-    // Account for the texture actual size
-    vertex_uv *= postProcessUniforms.uvScale;
-    // Compute texel center
-    vertex_uv = (floor(vertex_uv) + vec2(0.5, 0.5)) * frameUniforms.resolution.zw;
+    // texel to uv, accounting for the texture actual size
+    vertex_uv *= frameUniforms.resolution.zw * postProcessUniforms.uvScale;
 #endif
 
     gl_Position = position;


### PR DESCRIPTION
vertex shader interpolants are interpolated at pixel centers by the GPU,
but we were doing our own "pixel-center" adjustment, so we ended-up with
"vertex_uv" at a pixel corner instead of center.

The half-pixel adjustment is removed.

This leads to sharper looking images because in addition to shifting 
everything by 0.5 pixels, this was essentially applying a box-filter
to the whole picture -- kind of like taking 1 mip level down.