### PR TITLE
Metal context cleanup

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -205,6 +205,7 @@ add_definitions(-DSYSTRACE_TAG=2 )
 
 if (FILAMENT_SUPPORTS_METAL)
     list(APPEND SRCS
+            src/driver/metal/MetalContext.mm
             src/driver/metal/MetalDriver.mm
             src/driver/metal/MetalHandles.mm
             src/driver/metal/MetalState.mm

--- a/filament/src/driver/metal/MetalContext.h
+++ b/filament/src/driver/metal/MetalContext.h
@@ -73,6 +73,11 @@ struct MetalContext {
     MTLPixelFormat currentDepthPixelFormat = MTLPixelFormatInvalid;
 };
 
+// Acquire the current surface's CAMetalDrawable for the current frame if it has not already been
+// acquired.
+// This method returns the drawable and stores it in the context's currentDrawable field.
+id<CAMetalDrawable> acquireDrawable(MetalContext* context);
+
 } // namespace metal
 } // namespace driver
 } // namespace filament

--- a/filament/src/driver/metal/MetalContext.h
+++ b/filament/src/driver/metal/MetalContext.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_METALCONTEXT_H
+#define TNT_METALCONTEXT_H
+
+#include <Metal/Metal.h>
+#include <QuartzCore/QuartzCore.h>
+
+#include "MetalState.h"
+
+namespace filament {
+namespace driver {
+namespace metal {
+
+struct MetalRenderTarget;
+struct MetalSamplerBuffer;
+struct MetalSwapChain;
+
+struct MetalContext {
+    id<MTLDevice> mDevice = nullptr;
+    id<MTLCommandQueue> mCommandQueue = nullptr;
+
+    // A pool for autoreleased objects throughout the lifetime of the Metal driver.
+    NSAutoreleasePool* mDriverPool = nil;
+
+    // A pool for autoreleased objects allocated during the execution of a frame.
+    // The pool is created in beginFrame() and drained in endFrame().
+    NSAutoreleasePool* mFramePool = nil;
+
+    // Single use, re-created each frame.
+    id<MTLCommandBuffer> mCurrentCommandBuffer = nullptr;
+    id<MTLRenderCommandEncoder> mCurrentCommandEncoder = nullptr;
+
+    RenderPassFlags mCurrentRenderPassFlags;
+    MetalRenderTarget* mCurrentRenderTarget = nullptr;
+
+    // State trackers.
+    PipelineStateTracker mPipelineState;
+    DepthStencilStateTracker mDepthStencilState;
+    UniformBufferStateTracker mUniformState[VERTEX_BUFFER_START];
+    CullModeStateTracker mCullModeState;
+
+    // State caches.
+    DepthStencilStateCache mDepthStencilStateCache;
+    PipelineStateCache mPipelineStateCache;
+    SamplerStateCache mSamplerStateCache;
+
+    id<MTLSamplerState> mBoundSamplers[NUM_SAMPLER_BINDINGS] = {};
+    id<MTLTexture> mBoundTextures[NUM_SAMPLER_BINDINGS] = {};
+    bool mSamplersDirty = true;
+    bool mTexturesDirty = true;
+
+    MetalSamplerBuffer* mSamplerBindings[NUM_SAMPLER_BINDINGS] = {};
+
+    // Surface-related properties.
+    MetalSwapChain* mCurrentSurface = nullptr;
+    id<CAMetalDrawable> mCurrentDrawable = nullptr;
+    MTLPixelFormat mCurrentSurfacePixelFormat = MTLPixelFormatInvalid;
+    MTLPixelFormat mCurrentDepthPixelFormat = MTLPixelFormatInvalid;
+};
+
+} // namespace metal
+} // namespace driver
+} // namespace filament
+
+#endif //TNT_METALCONTEXT_H

--- a/filament/src/driver/metal/MetalContext.h
+++ b/filament/src/driver/metal/MetalContext.h
@@ -32,7 +32,7 @@ struct MetalSwapChain;
 
 struct MetalContext {
     id<MTLDevice> device = nullptr;
-    id<MTLCommandQueue> mCommandQueue = nullptr;
+    id<MTLCommandQueue> commandQueue = nullptr;
 
     // A pool for autoreleased objects throughout the lifetime of the Metal driver.
     NSAutoreleasePool* driverPool = nil;

--- a/filament/src/driver/metal/MetalContext.h
+++ b/filament/src/driver/metal/MetalContext.h
@@ -31,46 +31,46 @@ struct MetalSamplerBuffer;
 struct MetalSwapChain;
 
 struct MetalContext {
-    id<MTLDevice> mDevice = nullptr;
+    id<MTLDevice> device = nullptr;
     id<MTLCommandQueue> mCommandQueue = nullptr;
 
     // A pool for autoreleased objects throughout the lifetime of the Metal driver.
-    NSAutoreleasePool* mDriverPool = nil;
+    NSAutoreleasePool* driverPool = nil;
 
     // A pool for autoreleased objects allocated during the execution of a frame.
     // The pool is created in beginFrame() and drained in endFrame().
-    NSAutoreleasePool* mFramePool = nil;
+    NSAutoreleasePool* framePool = nil;
 
     // Single use, re-created each frame.
-    id<MTLCommandBuffer> mCurrentCommandBuffer = nullptr;
-    id<MTLRenderCommandEncoder> mCurrentCommandEncoder = nullptr;
+    id<MTLCommandBuffer> currentCommandBuffer = nullptr;
+    id<MTLRenderCommandEncoder> currentCommandEncoder = nullptr;
 
-    RenderPassFlags mCurrentRenderPassFlags;
-    MetalRenderTarget* mCurrentRenderTarget = nullptr;
+    RenderPassFlags currentRenderPassFlags;
+    MetalRenderTarget* currentRenderTarget = nullptr;
 
     // State trackers.
-    PipelineStateTracker mPipelineState;
-    DepthStencilStateTracker mDepthStencilState;
-    UniformBufferStateTracker mUniformState[VERTEX_BUFFER_START];
-    CullModeStateTracker mCullModeState;
+    PipelineStateTracker pipelineState;
+    DepthStencilStateTracker depthStencilState;
+    UniformBufferStateTracker uniformState[VERTEX_BUFFER_START];
+    CullModeStateTracker cullModeState;
 
     // State caches.
-    DepthStencilStateCache mDepthStencilStateCache;
-    PipelineStateCache mPipelineStateCache;
-    SamplerStateCache mSamplerStateCache;
+    DepthStencilStateCache depthStencilStateCache;
+    PipelineStateCache pipelineStateCache;
+    SamplerStateCache samplerStateCache;
 
-    id<MTLSamplerState> mBoundSamplers[NUM_SAMPLER_BINDINGS] = {};
-    id<MTLTexture> mBoundTextures[NUM_SAMPLER_BINDINGS] = {};
-    bool mSamplersDirty = true;
-    bool mTexturesDirty = true;
+    id<MTLSamplerState> boundSamplers[NUM_SAMPLER_BINDINGS] = {};
+    id<MTLTexture> boundTextures[NUM_SAMPLER_BINDINGS] = {};
+    bool samplersDirty = true;
+    bool texturesDirty = true;
 
-    MetalSamplerBuffer* mSamplerBindings[NUM_SAMPLER_BINDINGS] = {};
+    MetalSamplerBuffer* samplerBindings[NUM_SAMPLER_BINDINGS] = {};
 
     // Surface-related properties.
-    MetalSwapChain* mCurrentSurface = nullptr;
-    id<CAMetalDrawable> mCurrentDrawable = nullptr;
-    MTLPixelFormat mCurrentSurfacePixelFormat = MTLPixelFormatInvalid;
-    MTLPixelFormat mCurrentDepthPixelFormat = MTLPixelFormatInvalid;
+    MetalSwapChain* currentSurface = nullptr;
+    id<CAMetalDrawable> currentDrawable = nullptr;
+    MTLPixelFormat currentSurfacePixelFormat = MTLPixelFormatInvalid;
+    MTLPixelFormat currentDepthPixelFormat = MTLPixelFormatInvalid;
 };
 
 } // namespace metal

--- a/filament/src/driver/metal/MetalContext.mm
+++ b/filament/src/driver/metal/MetalContext.mm
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalContext.h"
+
+#include "MetalHandles.h"
+
+#include <utils/Panic.h>
+
+namespace filament {
+namespace driver {
+namespace metal {
+
+id<CAMetalDrawable> acquireDrawable(MetalContext* context) {
+    if (!context->currentDrawable) {
+        context->currentDrawable = [context->currentSurface->layer nextDrawable];
+    }
+    ASSERT_POSTCONDITION(context->currentDrawable != nil, "Could not obtain drawable.");
+    return context->currentDrawable;
+}
+
+} // namespace metal
+} // namespace driver
+} // namespace filament

--- a/filament/src/driver/metal/MetalDriver.h
+++ b/filament/src/driver/metal/MetalDriver.h
@@ -31,7 +31,7 @@ namespace filament {
 namespace driver {
 namespace metal {
 
-struct MetalDriverImpl;
+struct MetalContext;
 
 struct MetalProgram;
 
@@ -46,7 +46,7 @@ private:
 
     driver::MetalPlatform& mPlatform;
 
-    MetalDriverImpl* pImpl;
+    MetalContext* mContext;
 
 #ifndef NDEBUG
     void debugCommand(const char* methodName) override;

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -28,7 +28,6 @@
 
 #include <utils/Log.h>
 #include <utils/Panic.h>
-#include <utils/trap.h>
 
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "HidingNonVirtualFunction"
@@ -404,15 +403,7 @@ void MetalDriver::beginRenderPass(Driver::RenderTargetHandle rth,
     // Color
 
     if (renderTarget->isDefaultRenderTarget) {
-        // Lazily acquire the next drawable, if we haven't already acquired it for this frame.
-        if (!mContext->currentDrawable) {
-            mContext->currentDrawable = [mContext->currentSurface->layer nextDrawable];
-        }
-        if (mContext->currentDrawable == nil) {
-            utils::slog.e << "Could not obtain drawable." << utils::io::endl;
-            utils::debug_trap();
-        }
-        descriptor.colorAttachments[0].texture = mContext->currentDrawable.texture;
+        descriptor.colorAttachments[0].texture = acquireDrawable(mContext).texture;
         mContext->currentSurfacePixelFormat = mContext->currentDrawable.texture.pixelFormat;
     } else {
         descriptor.colorAttachments[0].texture = renderTarget->color;

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -47,7 +47,7 @@ MetalDriver::MetalDriver(driver::MetalPlatform* platform) noexcept
         mContext(new MetalContext) {
     mContext->driverPool = [[NSAutoreleasePool alloc] init];
     mContext->device = MTLCreateSystemDefaultDevice();
-    mContext->mCommandQueue = [mContext->device newCommandQueue];
+    mContext->commandQueue = [mContext->device newCommandQueue];
     mContext->pipelineStateCache.setDevice(mContext->device);
     mContext->depthStencilStateCache.setDevice(mContext->device);
     mContext->samplerStateCache.setDevice(mContext->device);
@@ -69,7 +69,7 @@ void MetalDriver::debugCommand(const char *methodName) {
 
 void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     mContext->framePool = [[NSAutoreleasePool alloc] init];
-    mContext->currentCommandBuffer = [mContext->mCommandQueue commandBuffer];
+    mContext->currentCommandBuffer = [mContext->commandQueue commandBuffer];
 }
 
 void MetalDriver::setPresentationTime(int64_t monotonic_clock_ns) {
@@ -280,7 +280,7 @@ void MetalDriver::destroyStream(Driver::StreamHandle sh) {
 }
 
 void MetalDriver::terminate() {
-    [mContext->mCommandQueue release];
+    [mContext->commandQueue release];
     [mContext->driverPool drain];
 }
 

--- a/filament/src/driver/metal/MetalHandles.h
+++ b/filament/src/driver/metal/MetalHandles.h
@@ -22,8 +22,9 @@
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h> // for CAMetalLayer
 
-#include "MetalState.h" // for MetalState::VertexDescription
+#include "MetalContext.h"
 #include "MetalEnums.h"
+#include "MetalState.h" // for MetalState::VertexDescription
 #include "driver/TextureReshaper.h"
 
 #include <utils/Panic.h>


### PR DESCRIPTION
No functional changes, just cleaning up.

- Rename `MetalImpl` to `MetalContext` and move the definition into a header
- Remove "m" prefix from MetalContext variables
- Factor out an `acquireDrawable` function