### PR TITLE
Link iOS sample apps with the geometry library

### DIFF
--- a/ios/samples/hello-pbr/hello-pbr.xcodeproj/project.pbxproj
+++ b/ios/samples/hello-pbr/hello-pbr.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 					"-lfilameshio",
 					"-lmeshoptimizer",
 					"-limage",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-pbr";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -356,6 +357,7 @@
 					"-lfilameshio",
 					"-lmeshoptimizer",
 					"-limage",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-pbr";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -394,6 +396,7 @@
 					"-lfilameshio",
 					"-lmeshoptimizer",
 					"-limage",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-pbr";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -432,6 +435,7 @@
 					"-lfilameshio",
 					"-lmeshoptimizer",
 					"-limage",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-pbr";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/samples/hello-triangle/hello-triangle.xcodeproj/project.pbxproj
+++ b/ios/samples/hello-triangle/hello-triangle.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 					"-lfilabridge",
 					"-lutils",
 					"-lsmol-v",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-triangle";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -328,6 +329,7 @@
 					"-lfilabridge",
 					"-lutils",
 					"-lsmol-v",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-triangle";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -363,6 +365,7 @@
 					"-lfilabridge",
 					"-lutils",
 					"-lsmol-v",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-triangle";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -398,6 +401,7 @@
 					"-lfilabridge",
 					"-lutils",
 					"-lsmol-v",
+					"-lgeometry",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.hello-triangle";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
@prideout Seems like this is a temporary dependency? If so, we can revert this change when Filament no longer depends on `geometry`.