### PR TITLE
Fixed uninitialized properties in the Viewport class.

### DIFF
--- a/filament/include/filament/Viewport.h
+++ b/filament/include/filament/Viewport.h
@@ -34,7 +34,9 @@ namespace filament {
  */
 class UTILS_PUBLIC Viewport : public driver::Viewport {
 public:
-    Viewport() noexcept = default;
+    Viewport() noexcept : driver::Viewport{ 0, 0, 0, 0 } {
+    }
+
     Viewport(const Viewport& viewport) noexcept = default;
     Viewport(Viewport&& viewport) noexcept = default;
     Viewport& operator=(const Viewport& viewport) noexcept = default;


### PR DESCRIPTION
The default constructor of the Viewport class left the view properties in an uninitialized state that could lead to an undeterministic behavior in the later stages during rendering.
In our case, the issue manifested in the Froxelizer class in the setViewport() method that was flaky because sometimes the old viewport in the Froxelizer class (mViewport) was equal to the newly set viewport which caused the mDirtyFlags to not be updated. This then resulted in a crash because Froxelizer's mPlanesX and mPlanesY were not allocated in the update() function even though they were used.