### PR TITLE
Add transparent-rendering iOS demo

### DIFF
--- a/ios/samples/transparent-rendering/.gitignore
+++ b/ios/samples/transparent-rendering/.gitignore
@@ -1,0 +1,4 @@
+## User settings
+xcuserdata/
+/generated/
+

--- a/ios/samples/transparent-rendering/build-materials.sh
+++ b/ios/samples/transparent-rendering/build-materials.sh
@@ -1,0 +1,17 @@
+# Compile bakedColor material.
+matc_path="../../../out/release/filament/bin/matc"
+if [[ ! -e "${matc_path}" ]]; then
+  echo "No matc binary could be found in ../../../out/release/filament/bin/."
+  echo "Ensure Filament has been built/installed before building this app."
+  exit 1
+fi
+mkdir -p "${PROJECT_DIR}/generated/"
+"${matc_path}" \
+    --api all \
+    -f header \
+    -o "${PROJECT_DIR}/generated/bakedColor.inc" \
+    "${PROJECT_DIR}/transparent-rendering/bakedColor.mat"
+
+# FilamentView.mm includes bakedColor.filamat, so touch it to force Xcode to
+# recompile it.
+touch "${PROJECT_DIR}/transparent-rendering/FilamentView.mm"

--- a/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.pbxproj
+++ b/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.pbxproj
@@ -1,0 +1,560 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4366F7EC220E481600542309 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A535216006AF00E4AEA0 /* ViewController.m */; };
+		4366F7ED220E481600542309 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A540216006B100E4AEA0 /* main.m */; };
+		4366F7EE220E481600542309 /* FilamentView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A5482160073300E4AEA0 /* FilamentView.mm */; };
+		4366F7EF220E481600542309 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A532216006AF00E4AEA0 /* AppDelegate.m */; };
+		4366F7F2220E481600542309 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A53C216006B100E4AEA0 /* LaunchScreen.storyboard */; };
+		4366F7F3220E481600542309 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A53A216006B100E4AEA0 /* Assets.xcassets */; };
+		4366F7F4220E481600542309 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A537216006AF00E4AEA0 /* Main.storyboard */; };
+		43CA3CAA2176AA6900B497B4 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A535216006AF00E4AEA0 /* ViewController.m */; };
+		43CA3CAB2176AA6900B497B4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A540216006B100E4AEA0 /* main.m */; };
+		43CA3CAC2176AA6900B497B4 /* FilamentView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A5482160073300E4AEA0 /* FilamentView.mm */; };
+		43CA3CAD2176AA6900B497B4 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 43E4A532216006AF00E4AEA0 /* AppDelegate.m */; };
+		43CA3CB02176AA6900B497B4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A53C216006B100E4AEA0 /* LaunchScreen.storyboard */; };
+		43CA3CB12176AA6900B497B4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A53A216006B100E4AEA0 /* Assets.xcassets */; };
+		43CA3CB22176AA6900B497B4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43E4A537216006AF00E4AEA0 /* Main.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4366F7E82209317900542309 /* bakedColor.mat */ = {isa = PBXFileReference; lastKnownFileType = text; path = bakedColor.mat; sourceTree = "<group>"; };
+		4366F7F8220E481600542309 /* transparent-rendering-Metal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "transparent-rendering-Metal.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43CA3CB82176AA6900B497B4 /* transparent-rendering-OpenGL.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "transparent-rendering-OpenGL.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43E4A531216006AF00E4AEA0 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		43E4A532216006AF00E4AEA0 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		43E4A534216006AF00E4AEA0 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		43E4A535216006AF00E4AEA0 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		43E4A538216006AF00E4AEA0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		43E4A53A216006B100E4AEA0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		43E4A53D216006B100E4AEA0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		43E4A53F216006B100E4AEA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		43E4A540216006B100E4AEA0 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		43E4A5472160073300E4AEA0 /* FilamentView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FilamentView.h; sourceTree = "<group>"; };
+		43E4A5482160073300E4AEA0 /* FilamentView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FilamentView.mm; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4366F7F0220E481600542309 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		43CA3CAE2176AA6900B497B4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		43E4A525216006AF00E4AEA0 = {
+			isa = PBXGroup;
+			children = (
+				43E4A530216006AF00E4AEA0 /* transparent-rendering */,
+				43E4A52F216006AF00E4AEA0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		43E4A52F216006AF00E4AEA0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				43CA3CB82176AA6900B497B4 /* transparent-rendering-OpenGL.app */,
+				4366F7F8220E481600542309 /* transparent-rendering-Metal.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		43E4A530216006AF00E4AEA0 /* transparent-rendering */ = {
+			isa = PBXGroup;
+			children = (
+				4366F7E82209317900542309 /* bakedColor.mat */,
+				43E4A531216006AF00E4AEA0 /* AppDelegate.h */,
+				43E4A532216006AF00E4AEA0 /* AppDelegate.m */,
+				43E4A534216006AF00E4AEA0 /* ViewController.h */,
+				43E4A535216006AF00E4AEA0 /* ViewController.m */,
+				43E4A5472160073300E4AEA0 /* FilamentView.h */,
+				43E4A5482160073300E4AEA0 /* FilamentView.mm */,
+				43E4A537216006AF00E4AEA0 /* Main.storyboard */,
+				43E4A53A216006B100E4AEA0 /* Assets.xcassets */,
+				43E4A53C216006B100E4AEA0 /* LaunchScreen.storyboard */,
+				43E4A53F216006B100E4AEA0 /* Info.plist */,
+				43E4A540216006B100E4AEA0 /* main.m */,
+			);
+			path = "transparent-rendering";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4366F7E9220E481600542309 /* transparent-rendering-Metal */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4366F7F5220E481600542309 /* Build configuration list for PBXNativeTarget "transparent-rendering-Metal" */;
+			buildPhases = (
+				4366F7EA220E481600542309 /* ShellScript */,
+				4366F7EB220E481600542309 /* Sources */,
+				4366F7F0220E481600542309 /* Frameworks */,
+				4366F7F1220E481600542309 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "transparent-rendering-Metal";
+			productName = "transparent-rendering";
+			productReference = 4366F7F8220E481600542309 /* transparent-rendering-Metal.app */;
+			productType = "com.apple.product-type.application";
+		};
+		43CA3CA72176AA6900B497B4 /* transparent-rendering-OpenGL */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 43CA3CB52176AA6900B497B4 /* Build configuration list for PBXNativeTarget "transparent-rendering-OpenGL" */;
+			buildPhases = (
+				4366F7E7220930EF00542309 /* ShellScript */,
+				43CA3CA82176AA6900B497B4 /* Sources */,
+				43CA3CAE2176AA6900B497B4 /* Frameworks */,
+				43CA3CAF2176AA6900B497B4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "transparent-rendering-OpenGL";
+			productName = "transparent-rendering";
+			productReference = 43CA3CB82176AA6900B497B4 /* transparent-rendering-OpenGL.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		43E4A526216006AF00E4AEA0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1000;
+				ORGANIZATIONNAME = Google;
+			};
+			buildConfigurationList = 43E4A529216006AF00E4AEA0 /* Build configuration list for PBXProject "transparent-rendering" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 43E4A525216006AF00E4AEA0;
+			productRefGroup = 43E4A52F216006AF00E4AEA0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				43CA3CA72176AA6900B497B4 /* transparent-rendering-OpenGL */,
+				4366F7E9220E481600542309 /* transparent-rendering-Metal */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4366F7F1220E481600542309 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4366F7F2220E481600542309 /* LaunchScreen.storyboard in Resources */,
+				4366F7F3220E481600542309 /* Assets.xcassets in Resources */,
+				4366F7F4220E481600542309 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		43CA3CAF2176AA6900B497B4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43CA3CB02176AA6900B497B4 /* LaunchScreen.storyboard in Resources */,
+				43CA3CB12176AA6900B497B4 /* Assets.xcassets in Resources */,
+				43CA3CB22176AA6900B497B4 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		4366F7E7220930EF00542309 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/build-materials.sh\"\n";
+		};
+		4366F7EA220E481600542309 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/build-materials.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4366F7EB220E481600542309 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4366F7EC220E481600542309 /* ViewController.m in Sources */,
+				4366F7ED220E481600542309 /* main.m in Sources */,
+				4366F7EE220E481600542309 /* FilamentView.mm in Sources */,
+				4366F7EF220E481600542309 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		43CA3CA82176AA6900B497B4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				43CA3CAA2176AA6900B497B4 /* ViewController.m in Sources */,
+				43CA3CAB2176AA6900B497B4 /* main.m in Sources */,
+				43CA3CAC2176AA6900B497B4 /* FilamentView.mm in Sources */,
+				43CA3CAD2176AA6900B497B4 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		43E4A537216006AF00E4AEA0 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				43E4A538216006AF00E4AEA0 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		43E4A53C216006B100E4AEA0 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				43E4A53D216006B100E4AEA0 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		4366F7F6220E481600542309 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_METAL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/include",
+					generated/,
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/transparent-rendering/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "../../../out/ios-debug/filament/lib/$(CURRENT_ARCH)";
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.transparent-rendering";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "../../../out/ios-debug/filament/include";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4366F7F7220E481600542309 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_METAL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/include",
+					generated/,
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/transparent-rendering/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "../../../out/ios-release/filament/lib/$(CURRENT_ARCH)";
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.transparent-rendering";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "../../../out/ios-release/filament/include";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		43CA3CB62176AA6900B497B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_OPENGL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/include",
+					generated/,
+				);
+				INFOPLIST_FILE = "transparent-rendering/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "../../../out/ios-debug/filament/lib/$(CURRENT_ARCH)";
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.transparent-rendering";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "../../../out/ios-debug/filament/include";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		43CA3CB72176AA6900B497B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_OPENGL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/include",
+					generated/,
+				);
+				INFOPLIST_FILE = "transparent-rendering/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "../../../out/ios-release/filament/lib/$(CURRENT_ARCH)";
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.transparent-rendering";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "../../../out/ios-release/filament/include";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		43E4A542216006B100E4AEA0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VALID_ARCHS = arm64;
+			};
+			name = Debug;
+		};
+		43E4A543216006B100E4AEA0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = arm64;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4366F7F5220E481600542309 /* Build configuration list for PBXNativeTarget "transparent-rendering-Metal" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4366F7F6220E481600542309 /* Debug */,
+				4366F7F7220E481600542309 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		43CA3CB52176AA6900B497B4 /* Build configuration list for PBXNativeTarget "transparent-rendering-OpenGL" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				43CA3CB62176AA6900B497B4 /* Debug */,
+				43CA3CB72176AA6900B497B4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		43E4A529216006AF00E4AEA0 /* Build configuration list for PBXProject "transparent-rendering" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				43E4A542216006B100E4AEA0 /* Debug */,
+				43E4A543216006B100E4AEA0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 43E4A526216006AF00E4AEA0 /* Project object */;
+}

--- a/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:transparent-rendering.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/samples/transparent-rendering/transparent-rendering.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/samples/transparent-rendering/transparent-rendering/AppDelegate.h
+++ b/ios/samples/transparent-rendering/transparent-rendering/AppDelegate.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow* window;
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/AppDelegate.m
+++ b/ios/samples/transparent-rendering/transparent-rendering/AppDelegate.m
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/samples/transparent-rendering/transparent-rendering/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/samples/transparent-rendering/transparent-rendering/Assets.xcassets/Contents.json
+++ b/ios/samples/transparent-rendering/transparent-rendering/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/samples/transparent-rendering/transparent-rendering/Base.lproj/LaunchScreen.storyboard
+++ b/ios/samples/transparent-rendering/transparent-rendering/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios/samples/transparent-rendering/transparent-rendering/Base.lproj/Main.storyboard
+++ b/ios/samples/transparent-rendering/transparent-rendering/Base.lproj/Main.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_5" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="B3q-vU-ULy">
+                                <rect key="frame" x="68" y="80" width="279" height="636"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <mutableString key="text">This is a native UITextView. The triangle is rendered by Filament.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tincidunt neque a metus laoreet imperdiet. In cursus arcu quis turpis viverra convallis. Sed eu laoreet metus. Nunc id est lacus. Sed hendrerit elementum velit a finibus. Mauris vitae scelerisque erat. Proin ultricies quam nec justo vehicula, sed porta nulla facilisis.
+
+Phasellus orci lectus, ullamcorper efficitur urna non, sodales venenatis sem. Suspendisse auctor, enim non dapibus malesuada, est urna sollicitudin sapien, in sodales mi nulla quis odio. Suspendisse viverra vel orci vitae vestibulum. Fusce tristique ligula nisi, bibendum gravida est volutpat sed. Vivamus ut justo porttitor, feugiat lorem eget, rutrum orci. Donec nec nibh vitae ex consectetur pulvinar. Sed dignissim, metus a tincidunt finibus, justo massa auctor nunc, sit amet cursus ligula sapien ut enim. Quisque ut congue libero, in ultricies tortor. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Aenean ac justo in tortor commodo efficitur et ut leo.
+</mutableString>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2KD-1D-oAh" customClass="FilamentView">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <viewLayoutGuide key="safeArea" id="cdP-0z-J5l"/>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="140.57971014492756" y="133.25892857142856"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios/samples/transparent-rendering/transparent-rendering/FilamentView.h
+++ b/ios/samples/transparent-rendering/transparent-rendering/FilamentView.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface FilamentView : UIView
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/FilamentView.mm
+++ b/ios/samples/transparent-rendering/transparent-rendering/FilamentView.mm
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FilamentView.h"
+
+#import <filament/Engine.h>
+#import <filament/Renderer.h>
+#import <filament/Scene.h>
+#import <filament/View.h>
+#import <filament/RenderableManager.h>
+#import <filament/TransformManager.h>
+
+// These defines are set in the "Preprocessor Macros" build setting for each scheme.
+#if !FILAMENT_APP_USE_METAL && \
+    !FILAMENT_APP_USE_OPENGL
+#error A valid FILAMENT_APP_USE_ backend define must be set.
+#endif
+
+#define METAL_AVAILABLE __has_include(<QuartzCore/CAMetalLayer.h>)
+
+#if !METAL_AVAILABLE && FILAMENT_APP_USE_METAL
+#error The iOS simulator does not support Metal.
+#endif
+
+using namespace filament;
+using utils::Entity;
+using utils::EntityManager;
+
+struct App {
+    VertexBuffer* vb;
+    IndexBuffer* ib;
+    Material* mat;
+    Entity renderable;
+};
+
+struct Vertex {
+    filament::math::float2 position;
+    uint32_t color;
+};
+
+static const Vertex TRIANGLE_VERTICES[3] = {
+    {{1, 0}, 0xffff0000u},
+    {{cos(M_PI * 2 / 3), sin(M_PI * 2 / 3)}, 0xff00ff00u},
+    {{cos(M_PI * 4 / 3), sin(M_PI * 4 / 3)}, 0xff0000ffu},
+};
+
+static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
+
+// This file is compiled via the matc tool. See the "Run Script" build phase.
+static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
+#include "bakedColor.inc"
+};
+
+@implementation FilamentView {
+    Engine* engine;
+    Renderer* renderer;
+    Scene* scene;
+    View* filaView;
+    Camera* camera;
+    SwapChain* swapChain;
+    App app;
+    CADisplayLink* displayLink;
+
+    // The amount of rotation to apply to the camera to offset the device's rotation (in radians)
+    float deviceRotation;
+    float desiredRotation;
+}
+
+- (instancetype)initWithCoder:(NSCoder*)coder
+{
+    if (self = [super initWithCoder:coder]) {
+#if FILAMENT_APP_USE_OPENGL
+        [self initializeGLLayer];
+#elif FILAMENT_APP_USE_METAL
+        [self initializeMetalLayer];
+#endif
+        [self initializeFilament];
+        self.contentScaleFactor = UIScreen.mainScreen.nativeScale;
+    }
+
+    // Call renderloop 60 times a second.
+    displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(renderloop)];
+    displayLink.preferredFramesPerSecond = 60;
+    [displayLink addToRunLoop:NSRunLoop.currentRunLoop forMode:NSDefaultRunLoopMode];
+
+    // Call didRotate when the device orientation changes.
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didRotate:)
+                                                 name:UIDeviceOrientationDidChangeNotification
+                                               object:nil];
+
+    return self;
+}
+
+- (void)dealloc
+{
+    engine->destroy(renderer);
+    engine->destroy(scene);
+    engine->destroy(filaView);
+    engine->destroy(camera);
+    engine->destroy(swapChain);
+    engine->destroy(&engine);
+}
+
+- (void)initializeMetalLayer
+{
+#if METAL_AVAILABLE
+    CAMetalLayer* metalLayer = (CAMetalLayer*) self.layer;
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+
+    CGRect nativeBounds = [UIScreen mainScreen].nativeBounds;
+    metalLayer.drawableSize = nativeBounds.size;
+
+    // This is necessary so iOS composites the Filament view on top of other UIViews.
+    metalLayer.opaque = NO;
+#endif
+}
+
+- (void)initializeGLLayer
+{
+    CAEAGLLayer* glLayer = (CAEAGLLayer*) self.layer;
+
+    // This is necessary so iOS composites the Filament view on top of other UIViews.
+    glLayer.opaque = NO;
+}
+
+- (void)initializeFilament
+{
+#if FILAMENT_APP_USE_OPENGL
+    engine = Engine::create(filament::Engine::Backend::OPENGL);
+#elif FILAMENT_APP_USE_METAL
+    engine = Engine::create(filament::Engine::Backend::METAL);
+#endif
+    // The SwapChain::CONFIG_TRANSPARENT flag informs Filament that we will be rendering transparent
+    // content.
+    swapChain = engine->createSwapChain((__bridge void*) self.layer, SwapChain::CONFIG_TRANSPARENT);
+
+    renderer = engine->createRenderer();
+    scene = engine->createScene();
+    camera = engine->createCamera();
+
+    filaView = engine->createView();
+
+    // Set a transparent clear color.
+    filaView->setClearColor({0.0f, 0.0f, 0.0f, 0.0f});
+
+    filaView->setPostProcessingEnabled(false);
+    filaView->setDepthPrepass(filament::View::DepthPrepass::DISABLED);
+
+    app.vb = VertexBuffer::Builder()
+        .vertexCount(3)
+        .bufferCount(1)
+        .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT2, 0, 12)
+        .attribute(VertexAttribute::COLOR, 0, VertexBuffer::AttributeType::UBYTE4, 8, 12)
+        .normalized(VertexAttribute::COLOR)
+        .build(*engine);
+    app.vb->setBufferAt(*engine, 0,
+                        VertexBuffer::BufferDescriptor(TRIANGLE_VERTICES, 36, nullptr));
+
+    app.ib = IndexBuffer::Builder()
+        .indexCount(3)
+        .bufferType(IndexBuffer::IndexType::USHORT)
+        .build(*engine);
+    app.ib->setBuffer(*engine,
+                      IndexBuffer::BufferDescriptor(TRIANGLE_INDICES, 6, nullptr));
+
+    app.mat = Material::Builder()
+        .package((void*) BAKED_COLOR_PACKAGE, sizeof(BAKED_COLOR_PACKAGE))
+        .build(*engine);
+
+    app.renderable = EntityManager::get().create();
+    RenderableManager::Builder(1)
+        .boundingBox({{ -1, -1, -1 }, { 1, 1, 1 }})
+        .material(0, app.mat->getDefaultInstance())
+        .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, app.vb, app.ib, 0, 3)
+        .culling(false)
+        .receiveShadows(false)
+        .castShadows(false)
+        .build(*engine, app.renderable);
+    scene->addEntity(app.renderable);
+
+    filaView->setScene(scene);
+    filaView->setCamera(camera);
+    CGRect nativeBounds = [UIScreen mainScreen].nativeBounds;
+    filaView->setViewport(Viewport(0, 0, nativeBounds.size.width, nativeBounds.size.height));
+}
+
+- (void)renderloop
+{
+    [self update];
+    if (self->renderer->beginFrame(self->swapChain)) {
+        self->renderer->render(self->filaView);
+        self->renderer->endFrame();
+    }
+}
+
+- (void)update
+{
+    constexpr float ZOOM = 1.5f;
+    const uint32_t w = filaView->getViewport().width;
+    const uint32_t h = filaView->getViewport().height;
+    const float aspect = (float) w / h;
+    camera->setProjection(Camera::Projection::ORTHO,
+                          -aspect * ZOOM, aspect * ZOOM,
+                          -ZOOM, ZOOM, 0, 1);
+    auto& tcm = engine->getTransformManager();
+
+    [self updateRotation];
+
+    tcm.setTransform(tcm.getInstance(app.renderable),
+                     filament::math::mat4f::rotate(CACurrentMediaTime(), filament::math::float3{0, 0, 1}) *
+                     filament::math::mat4f::rotate(deviceRotation, filament::math::float3{0, 0, 1}));
+}
+
+- (void)didRotate:(NSNotification*)notification
+{
+    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+    desiredRotation = [self rotationForDeviceOrientation:orientation];
+}
+
+- (void)updateRotation
+{
+    static const float ROTATION_SPEED = 0.1;
+    float diff = abs(desiredRotation - deviceRotation);
+    if (diff > FLT_EPSILON) {
+        if (desiredRotation > deviceRotation) {
+            deviceRotation += fmin(ROTATION_SPEED, diff);
+        }
+        if (desiredRotation < deviceRotation) {
+            deviceRotation -= fmin(ROTATION_SPEED, diff);
+        }
+    }
+}
+
++ (Class) layerClass
+{
+#if FILAMENT_APP_USE_OPENGL
+    return [CAEAGLLayer class];
+#elif FILAMENT_APP_USE_METAL
+    return [CAMetalLayer class];
+#endif
+}
+
+- (float)rotationForDeviceOrientation:(UIDeviceOrientation)orientation
+{
+    switch (orientation) {
+        default:
+        case UIDeviceOrientationPortrait:
+            return 0.0f;
+
+        case UIDeviceOrientationLandscapeRight:
+            return M_PI_2;
+
+        case UIDeviceOrientationLandscapeLeft:
+            return -M_PI_2;
+
+        case UIDeviceOrientationPortraitUpsideDown:
+            return M_PI;
+    }
+}
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/Info.plist
+++ b/ios/samples/transparent-rendering/transparent-rendering/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ios/samples/transparent-rendering/transparent-rendering/ViewController.h
+++ b/ios/samples/transparent-rendering/transparent-rendering/ViewController.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/ViewController.m
+++ b/ios/samples/transparent-rendering/transparent-rendering/ViewController.m
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (BOOL)shouldAutorotate
+{
+    return NO;
+}
+
+@end

--- a/ios/samples/transparent-rendering/transparent-rendering/bakedColor.mat
+++ b/ios/samples/transparent-rendering/transparent-rendering/bakedColor.mat
@@ -1,0 +1,15 @@
+material {
+    name : bakedColor,
+    requires : [
+        color
+    ],
+    shadingModel : unlit,
+    culling : none
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        material.baseColor = getColor();
+    }
+}

--- a/ios/samples/transparent-rendering/transparent-rendering/main.m
+++ b/ios/samples/transparent-rendering/transparent-rendering/main.m
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char* argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}


### PR DESCRIPTION
iOS actually supports transparent rendering quite easy. This adds a new iOS transparent-rendering sample. It's the exact same as the hello-triangle sample, with the addition of a `UITextView` and the following changes to `FilamentView.mm`:

```
@@ -124,13 +124,18 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {

     CGRect nativeBounds = [UIScreen mainScreen].nativeBounds;
     metalLayer.drawableSize = nativeBounds.size;
+
+    // This is necessary so iOS composites the Filament view on top of other UIViews.
+    metalLayer.opaque = NO;
 #endif
 }

 - (void)initializeGLLayer
 {
     CAEAGLLayer* glLayer = (CAEAGLLayer*) self.layer;
-    glLayer.opaque = YES;
+
+    // This is necessary so iOS composites the Filament view on top of other UIViews.
+    glLayer.opaque = NO;
 }

 - (void)initializeFilament
@@ -140,13 +145,19 @@ static constexpr uint8_t BAKED_COLOR_PACKAGE[] = {
 #elif FILAMENT_APP_USE_METAL
     engine = Engine::create(filament::Engine::Backend::METAL);
 #endif
-    swapChain = engine->createSwapChain((__bridge void*) self.layer);
+    // The SwapChain::CONFIG_TRANSPARENT flag informs Filament that we will be rendering transparent
+    // content.
+    swapChain = engine->createSwapChain((__bridge void*) self.layer, SwapChain::CONFIG_TRANSPARENT);
+
     renderer = engine->createRenderer();
     scene = engine->createScene();
     camera = engine->createCamera();

     filaView = engine->createView();
-    filaView->setClearColor({0.1, 0.125, 0.25, 1.0});
+
+    // Set a transparent clear color.
+    filaView->setClearColor({0.0f, 0.0f, 0.0f, 0.0f});
+
     filaView->setPostProcessingEnabled(false);
     filaView->setDepthPrepass(filament::View::DepthPrepass::DISABLED);
```
![transparent-rendering](https://user-images.githubusercontent.com/5298046/53601902-08ae8680-3b62-11e9-9f65-724f068ed85d.png)
