### PR TITLE
Fix post processing issue for Metal

### DIFF
--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -6,10 +6,10 @@ LAYOUT_LOCATION(0) out vec2 vertex_uv;
 void main() {
     vertex_uv = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
 
-#if defined(TARGET_VULKAN_ENVIRONMENT)
-    // In Vulkan, drawing the top row of pixels occurs when position.y = -1.0, but we're
-    // sampling from a rectangle the sits in the lower-left corner of the texture. Therefore
-    // we need to apply an offset to get the correct texture coordinate.
+#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
+    // In Vulkan and Metal, drawing the top row of pixels occurs when position.y = -1.0 (1.0 for
+    // Metal), but we're sampling from a rectangle the sits in the lower-left corner of the texture.
+    // Therefore we need to apply an offset to get the correct texture coordinate.
     //
     // For example, if the sampled area height is 180 and the texture height is 200,
     // we need to sample the texture in the range [20,200) rather than [0,180).


### PR DESCRIPTION
This fixes incorrect post-processing when Metal render target dimensions weren't a multiple of 32.