### PR TITLE
remove an incorrect assert() in shadow mapping

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -285,7 +285,12 @@ void ShadowMap::computeShadowCameraDirectional(
         // i.e. the -z axis (see: ortho)
         const float znear = -lsLightFrustum.max.z;
         const float zfar = -lsLightFrustum.min.z;
-        assert(znear < zfar);
+
+        // if znear >= zfar, it means we don't have any shadow caster in front of a shadow receiver
+        if (UTILS_UNLIKELY(znear >= zfar)) {
+            mHasVisibleShadows = false;
+            return;
+        }
 
         // The light's projection, ortho for directional lights, perspective otherwise
         const mat4f Mp = mat4f::ortho(-1, 1, -1, 1, znear, zfar);


### PR DESCRIPTION
when we compute the depth range of the shadow map, if znear is behind
zfar, it just means we don't have any shadow caster in front of
a receiver, and we can just bail out without shadowing -- as opposed
to asserting.