### PR TITLE
Always centers the camera to the world origin

### DIFF
--- a/filament/src/DebugRegistry.cpp
+++ b/filament/src/DebugRegistry.cpp
@@ -43,8 +43,11 @@ void *FDebugRegistry::getPropertyAddress(const char *name) noexcept {
 }
 
 void FDebugRegistry::registerProperty(utils::StaticString name, void *p, Type type) noexcept {
-    mProperties.push_back({name.c_str(), type});
-    mPropertyMap[name] = p;
+    auto& propertyMap = mPropertyMap;
+    if (propertyMap.find(name) == propertyMap.end()) {
+        mProperties.push_back({ name.c_str(), type });
+        propertyMap[name] = p;
+    }
 }
 
 inline std::pair<DebugRegistry::Property const *, size_t> FDebugRegistry::getProperties() const noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -375,6 +375,9 @@ public:
             float dzn = -1.0f;
             float dzf =  1.0f;
         } shadowmap;
+        struct {
+            bool camera_at_origin = true;
+        } view;
     } debug;
 };
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -329,6 +329,8 @@ static void gui(filament::Engine* engine, filament::View*) {
 
         if (ImGui::CollapsingHeader("Debug")) {
             DebugRegistry& debug = engine->getDebugRegistry();
+            ImGui::Checkbox("Camera at origin",
+                    debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
             ImGui::Checkbox("Light Far uses shadow casters",
                     debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
             ImGui::Checkbox("Focus shadow casters",


### PR DESCRIPTION
This is effectively moving all shader computations to view space,
improving floating-point precision in the shaders, by staying
around zero where fp precision is highest. This also ensures that
when the camera is very far from the origin, objects are still
rendered and lit properly.

Below is a before/after with the scene/camera positioned at 1600 Km from the origin -- at this distance fp32 precision is about 10cm.

<img width="1136" alt="before" src="https://user-images.githubusercontent.com/1240896/53673438-4ed81880-3c3c-11e9-9393-0ccf7296c430.png">

<img width="1136" alt="after" src="https://user-images.githubusercontent.com/1240896/53673513-ef2e3d00-3c3c-11e9-8e75-275a3b4fee55.png">
