### PR TITLE
More headers clean-up

### DIFF
--- a/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
+++ b/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
@@ -18,7 +18,7 @@
 
 #include <filamat/MaterialBuilder.h>
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 using namespace filament;
 using namespace filamat;

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -18,7 +18,6 @@
 #define TNT_FILAMENT_MATERIAL_H
 
 #include <filament/Color.h>
-#include <filament/EngineEnums.h>
 #include <filament/FilamentAPI.h>
 #include <filament/MaterialEnums.h>
 #include <filament/MaterialInstance.h>

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -17,8 +17,8 @@
 #ifndef TNT_FILAMENT_VERTEXBUFFER_H
 #define TNT_FILAMENT_VERTEXBUFFER_H
 
-#include <filament/EngineEnums.h>
 #include <filament/FilamentAPI.h>
+#include <filament/MaterialEnums.h>
 
 #include <filament/driver/BufferDescriptor.h>
 #include <filament/driver/DriverEnums.h>

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAFLAT_MATERIAL_PARSER_H
 #define TNT_FILAFLAT_MATERIAL_PARSER_H
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filament/driver/DriverEnums.h>

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -21,6 +21,7 @@
 
 #include "driver/Handle.h"
 
+#include <private/filament/EngineEnums.h>
 #include <filament/VertexBuffer.h>
 
 #include <utils/bitset.h>

--- a/filament/src/driver/Program.h
+++ b/filament/src/driver/Program.h
@@ -17,8 +17,8 @@
 #ifndef TNT_FILAMENT_DRIVER_PROGRAM_H
 #define TNT_FILAMENT_DRIVER_PROGRAM_H
 
-#include <filament/EngineEnums.h>
-#include <filament/SamplerBindingMap.h>
+#include <private/filament/EngineEnums.h>
+#include <private/filament/SamplerBindingMap.h>
 
 #include <private/filament/SamplerInterfaceBlock.h>
 #include <private/filament/UniformInterfaceBlock.h>

--- a/filament/src/driver/metal/MetalState.h
+++ b/filament/src/driver/metal/MetalState.h
@@ -21,7 +21,7 @@
 
 #include "driver/Driver.h"
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 #include <memory>
 #include <tsl/robin_map.h>

--- a/filament/src/driver/vulkan/VulkanBinder.h
+++ b/filament/src/driver/vulkan/VulkanBinder.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DRIVER_VULKANBINDER_H
 #define TNT_FILAMENT_DRIVER_VULKANBINDER_H
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 #include <bluevk/BlueVK.h>
 #include <utils/Hash.h>

--- a/filament/src/driver/vulkan/VulkanHandles.h
+++ b/filament/src/driver/vulkan/VulkanHandles.h
@@ -21,8 +21,8 @@
 #include "VulkanBinder.h"
 #include "VulkanBuffer.h"
 
-#include <filament/EngineEnums.h>
-#include <filament/SamplerBindingMap.h>
+#include <private/filament/EngineEnums.h>
+#include <private/filament/SamplerBindingMap.h>
 
 namespace filament {
 namespace driver {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -17,11 +17,12 @@
 #ifndef TNT_FILAMENT_MATERIAL_ENUM_H
 #define TNT_FILAMENT_MATERIAL_ENUM_H
 
+#include <utils/bitset.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
 namespace filament {
-static constexpr size_t MATERIAL_VERSION = 2;
 
 enum class Shading : uint8_t {
     UNLIT,                  // no lighting applied, emissive possible
@@ -56,7 +57,6 @@ enum class TransparencyMode : uint8_t {
                             // mode is ignored. Can be combined with two-sided lighting
 };
 
-static constexpr size_t VERTEX_DOMAIN_COUNT = 4;
 enum class VertexDomain : uint8_t {
     OBJECT,                 // vertices are in object space, default
     WORLD,                  // vertices are in world space
@@ -65,45 +65,20 @@ enum class VertexDomain : uint8_t {
     // when adding more entries, make sure to update VERTEX_DOMAIN_COUNT
 };
 
-static constexpr size_t POST_PROCESS_STAGES_COUNT = 4;
-enum class PostProcessStage : uint8_t {
-    TONE_MAPPING_OPAQUE,           // Tone mapping post-process
-    TONE_MAPPING_TRANSLUCENT,      // Tone mapping post-process
-    ANTI_ALIASING_OPAQUE,          // Anti-aliasing stage
-    ANTI_ALIASING_TRANSLUCENT,     // Anti-aliasing stage
+// Update hasIntegerTarget() in VertexBuffer when adding an attribute that will
+// be read as integers in the shaders
+enum VertexAttribute : uint8_t {
+    POSITION        = 0, // XYZ position (float3)
+    TANGENTS        = 1, // tangent, bitangent and normal, encoded as a quaternion (float4)
+    COLOR           = 2, // vertex color (float4)
+    UV0             = 3, // texture coordinates (float2)
+    UV1             = 4, // texture coordinates (float2)
+    BONE_INDICES    = 5, // indices of 4 bones, as unsigned integers (uvec4)
+    BONE_WEIGHTS    = 6, // weights of the 4 bones (normalized float4)
 };
 
-// ------------------------------------------------------------------------------------------------
-
-static constexpr size_t MATERIAL_VARIABLES_COUNT = 4;
-enum class Variable : uint8_t {
-    CUSTOM0,
-    CUSTOM1,
-    CUSTOM2,
-    CUSTOM3
-    // when adding more variables, make sure to update MATERIAL_VARIABLES_COUNT
-};
-
-static constexpr size_t MATERIAL_PROPERTIES_COUNT = 16;
-enum class Property : uint8_t {
-    BASE_COLOR,              // float4, all shading models
-    ROUGHNESS,               // float,  lit shading models only
-    METALLIC,                // float,  all shading models, except unlit and cloth
-    REFLECTANCE,             // float,  all shading models, except unlit and cloth
-    AMBIENT_OCCLUSION,       // float,  lit shading models only, except subsurface and cloth
-    CLEAR_COAT,              // float,  lit shading models only, except subsurface and cloth
-    CLEAR_COAT_ROUGHNESS,    // float,  lit shading models only, except subsurface and cloth
-    CLEAR_COAT_NORMAL,       // float,  lit shading models only, except subsurface and cloth
-    ANISOTROPY,              // float,  lit shading models only, except subsurface and cloth
-    ANISOTROPY_DIRECTION,    // float3, lit shading models only, except subsurface and cloth
-    THICKNESS,               // float,  subsurface shading model only
-    SUBSURFACE_POWER,        // float,  subsurface shading model only
-    SUBSURFACE_COLOR,        // float3, subsurface and cloth shading models only
-    SHEEN_COLOR,             // float3, cloth shading model only
-    EMISSIVE,                // float4, all shading models
-    NORMAL,                  // float3, all shading models only, except unlit
-    // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
-};
+// can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t
+using AttributeBitset = utils::bitset32;
 
 
 } // namespace filament

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -17,20 +17,21 @@
 #ifndef TNT_FILAMENT_ENGINE_ENUM_H
 #define TNT_FILAMENT_ENGINE_ENUM_H
 
-#include <utils/bitset.h>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace filament {
 
-// Update hasIntegerTarget() in VertexBuffer when adding an attribute that will
-// be read as integers in the shaders
-enum VertexAttribute : uint8_t {
-    POSITION        = 0, // XYZ position (float3)
-    TANGENTS        = 1, // tangent, bitangent and normal, encoded as a quaternion (float4)
-    COLOR           = 2, // vertex color (float4)
-    UV0             = 3, // texture coordinates (float2)
-    UV1             = 4, // texture coordinates (float2)
-    BONE_INDICES    = 5, // indices of 4 bones, as unsigned integers (uvec4)
-    BONE_WEIGHTS    = 6, // weights of the 4 bones (normalized float4)
+static constexpr size_t MATERIAL_VERSION = 2;
+
+static constexpr size_t VERTEX_DOMAIN_COUNT = 4;
+
+static constexpr size_t POST_PROCESS_STAGES_COUNT = 4;
+enum class PostProcessStage : uint8_t {
+    TONE_MAPPING_OPAQUE,           // Tone mapping post-process
+    TONE_MAPPING_TRANSLUCENT,      // Tone mapping post-process
+    ANTI_ALIASING_OPAQUE,          // Anti-aliasing stage
+    ANTI_ALIASING_TRANSLUCENT,     // Anti-aliasing stage
 };
 
 // Binding points for uniform buffers and sampler buffers.
@@ -61,9 +62,6 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.
 constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
-
-// can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t
-using AttributeBitset = utils::bitset32;
 
 // TODO This should be injected by the engine as a define of the shader.
 static constexpr bool   CONFIG_IBL_RGBM  = true;

--- a/libs/filabridge/include/private/filament/SamplerBindingMap.h
+++ b/libs/filabridge/include/private/filament/SamplerBindingMap.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DRIVER_SAMPLERBINDINGMAP_H
 #define TNT_FILAMENT_DRIVER_SAMPLERBINDINGMAP_H
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 #include <tsl/robin_map.h>
 #include <vector>

--- a/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
@@ -19,7 +19,7 @@
 
 
 #include <filament/driver/DriverEnums.h>
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 #include <utils/compiler.h>
 #include <utils/CString.h>

--- a/libs/filabridge/src/SamplerBindingMap.cpp
+++ b/libs/filabridge/src/SamplerBindingMap.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "filament/SamplerBindingMap.h"
+#include "private/filament/SamplerBindingMap.h"
 
 #include "private/filament/SamplerInterfaceBlock.h"
 

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -16,7 +16,7 @@
 
 #include "private/filament/SibGenerator.h"
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 
 #include "private/filament/SamplerInterfaceBlock.h"
 

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -18,7 +18,7 @@
 
 #include "private/filament/UniformInterfaceBlock.h"
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/driver/DriverEnums.h>
 
 namespace filament {

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include <filament/driver/DriverEnums.h>
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filamat/Package.h>
@@ -98,8 +98,36 @@ class UTILS_PUBLIC MaterialBuilder : public MaterialBuilderBase {
 public:
     MaterialBuilder();
 
-    using Property = filament::Property;
-    using Variable = filament::Variable;
+    static constexpr size_t MATERIAL_VARIABLES_COUNT = 4;
+    enum class Variable : uint8_t {
+        CUSTOM0,
+        CUSTOM1,
+        CUSTOM2,
+        CUSTOM3
+        // when adding more variables, make sure to update MATERIAL_VARIABLES_COUNT
+    };
+
+    static constexpr size_t MATERIAL_PROPERTIES_COUNT = 16;
+    enum class Property : uint8_t {
+        BASE_COLOR,              // float4, all shading models
+        ROUGHNESS,               // float,  lit shading models only
+        METALLIC,                // float,  all shading models, except unlit and cloth
+        REFLECTANCE,             // float,  all shading models, except unlit and cloth
+        AMBIENT_OCCLUSION,       // float,  lit shading models only, except subsurface and cloth
+        CLEAR_COAT,              // float,  lit shading models only, except subsurface and cloth
+        CLEAR_COAT_ROUGHNESS,    // float,  lit shading models only, except subsurface and cloth
+        CLEAR_COAT_NORMAL,       // float,  lit shading models only, except subsurface and cloth
+        ANISOTROPY,              // float,  lit shading models only, except subsurface and cloth
+        ANISOTROPY_DIRECTION,    // float3, lit shading models only, except subsurface and cloth
+        THICKNESS,               // float,  subsurface shading model only
+        SUBSURFACE_POWER,        // float,  subsurface shading model only
+        SUBSURFACE_COLOR,        // float3, subsurface and cloth shading models only
+        SHEEN_COLOR,             // float3, cloth shading model only
+        EMISSIVE,                // float4, all shading models
+        NORMAL,                  // float3, all shading models only, except unlit
+        // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
+    };
+
     using BlendingMode = filament::BlendingMode;
     using Shading = filament::Shading;
     using Interpolation = filament::Interpolation;
@@ -245,8 +273,8 @@ public:
         bool isSampler;
     };
 
-    using PropertyList = bool[filament::MATERIAL_PROPERTIES_COUNT];
-    using VariableList = utils::CString[filament::MATERIAL_VARIABLES_COUNT];
+    using PropertyList = bool[MATERIAL_PROPERTIES_COUNT];
+    using VariableList = utils::CString[MATERIAL_VARIABLES_COUNT];
 
     // Preview the first shader that would generated in the MaterialPackage.
     // This is used to run Static Code Analysis before generating a package.

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -91,7 +91,7 @@ void MaterialBuilderBase::prepare() {
 }
 
 MaterialBuilder::MaterialBuilder() : mMaterialName("Unnamed") {
-    std::fill_n(mProperties, filament::MATERIAL_PROPERTIES_COUNT, false);
+    std::fill_n(mProperties, MATERIAL_PROPERTIES_COUNT, false);
     mShaderModels.reset();
 }
 
@@ -138,7 +138,7 @@ MaterialBuilder& MaterialBuilder::variable(Variable v, const char* name) noexcep
         case Variable::CUSTOM1:
         case Variable::CUSTOM2:
         case Variable::CUSTOM3:
-            assert(size_t(v) < filament::MATERIAL_VARIABLES_COUNT);
+            assert(size_t(v) < MATERIAL_VARIABLES_COUNT);
             mVariables[size_t(v)] = CString(name);
             break;
     }

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
@@ -21,7 +21,7 @@
 #include "../shaders/MaterialInfo.h"
 
 #include <private/filament/SamplerInterfaceBlock.h>
-#include <filament/SamplerBindingMap.h>
+#include <private/filament/SamplerBindingMap.h>
 #include <private/filament/UniformInterfaceBlock.h>
 
 namespace filamat {

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -18,7 +18,7 @@
 
 #include <cstring>
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>
@@ -150,7 +150,7 @@ bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn,
     // for cloth shading model). Give our shader all properties. This will enable us to parse and
     // static code analyse the AST.
     MaterialBuilder::PropertyList allProperties;
-    std::fill_n(allProperties, filament::MATERIAL_PROPERTIES_COUNT, true);
+    std::fill_n(allProperties, MaterialBuilder::MATERIAL_PROPERTIES_COUNT, true);
 
     ShaderModel model;
     std::string shaderCode = builder.peek(ShaderType::FRAGMENT, model, allProperties);

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -382,7 +382,7 @@ std::ostream& CodeGenerator::generateFunction(std::ostream& out, const char* ret
 }
 
 std::ostream& CodeGenerator::generateMaterialProperty(std::ostream& out,
-        Property property, bool isSet) const {
+        MaterialBuilder::Property property, bool isSet) const {
     if (isSet) {
         out << "#define " << "MATERIAL_HAS_" << getConstantName(property) << "\n";
     }
@@ -480,7 +480,8 @@ std::ostream& CodeGenerator::generateShaderUnlit(std::ostream& out, ShaderType t
 }
 
 /* static */
-char const* CodeGenerator::getConstantName(Property property) noexcept {
+char const* CodeGenerator::getConstantName(MaterialBuilder::Property property) noexcept {
+    using Property = MaterialBuilder::Property;
     switch (property) {
         case Property::BASE_COLOR:           return "BASE_COLOR";
         case Property::ROUGHNESS:            return "ROUGHNESS";

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -26,7 +26,7 @@
 #include <filamat/MaterialBuilder.h>
 
 #include <filament/driver/DriverEnums.h>
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 #include <private/filament/SamplerInterfaceBlock.h>
 #include <private/filament/UniformInterfaceBlock.h>
@@ -96,7 +96,7 @@ public:
 
     // generate material properties getters
     std::ostream& generateMaterialProperty(std::ostream& out,
-            filament::Property property, bool isSet) const;
+            MaterialBuilder::Property property, bool isSet) const;
 
     std::ostream& generateFunction(std::ostream& out,
             const char* returnType, const char* name, const char* body) const;
@@ -126,7 +126,7 @@ private:
             filament::driver::SamplerFormat format, bool multisample) const noexcept;
 
     // return name of the material property (e.g.: "ROUGHNESS")
-    static char const* getConstantName(filament::Property property) noexcept;
+    static char const* getConstantName(MaterialBuilder::Property property) noexcept;
 
     static char const* getPrecisionQualifier(filament::driver::Precision precision,
             filament::driver::Precision defaultPrecision) noexcept;

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -18,10 +18,10 @@
 #define TNT_FILAMAT_MATERIALINFO_H
 
 #include <filament/driver/DriverEnums.h>
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 #include <private/filament/UniformInterfaceBlock.h>
-#include <filament/SamplerBindingMap.h>
+#include <private/filament/SamplerBindingMap.h>
 #include <private/filament/SamplerInterfaceBlock.h>
 
 #include <utils/compiler.h>

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -47,6 +47,7 @@ static const char* getShadingDefine(filament::Shading shading) noexcept {
 
 static void generateMaterialDefines(std::ostream& os, const CodeGenerator& cg,
         MaterialBuilder::PropertyList const properties) noexcept {
+    using Property = MaterialBuilder::Property;
     cg.generateMaterialProperty(os, Property::BASE_COLOR,           properties[ 0]);
     cg.generateMaterialProperty(os, Property::ROUGHNESS,            properties[ 1]);
     cg.generateMaterialProperty(os, Property::METALLIC,             properties[ 2]);

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filamat/MaterialBuilder.h>

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -24,7 +24,7 @@ using namespace ASTUtils;
 
 static ::testing::AssertionResult PropertyListsMatch(const MaterialBuilder::PropertyList& expected,
         const MaterialBuilder::PropertyList& actual) {
-    for (size_t i = 0; i < filament::MATERIAL_PROPERTIES_COUNT; i++) {
+    for (size_t i = 0; i < MaterialBuilder::MATERIAL_PROPERTIES_COUNT; i++) {
         if (expected[i] != actual[i]) {
             const auto& propString = Enums::toString<Property>(Property(i));
             return ::testing::AssertionFailure()

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -24,7 +24,7 @@
 #include <filaflat/Unflattener.h>
 
 #include <filament/MaterialChunkType.h>
-#include <filament/EngineEnums.h>
+#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filament/driver/DriverEnums.h>


### PR DESCRIPTION
- EngineEnums.h is not a private headers as it contained mostly private
stuff

- MaterialEnums.h is still public, but now only contains public stuff.
Private parts were moved to MaterialEnums.h or MaterialBuilder.h

- And finally SamplerBinderMap is moved under private/ as well, since
it's certainly not a public API.

With this change, the public headers of filabridge become more reasonable
and limited.