### PR TITLE
Add build command for Markdeep files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(ENABLE_JAVA "Compile Java projects, requires a JDK and the JAVA_HOME env 
 
 option(USE_EXTERNAL_GLES3 "Experimental: Compile Filament against OpenGL ES 3" OFF)
 
-option(GENERATE_WEB_DOCS "Build WebGL documentation and tutorials" OFF)
+option(GENERATE_JS_DOCS "Build WebGL documentation and tutorials" OFF)
 
 # ==================================================================================================
 # OS specific
@@ -374,7 +374,7 @@ if (WEBGL)
     add_subdirectory(web/filament-js)
     add_subdirectory(web/samples)
 
-    if (GENERATE_WEB_DOCS)
+    if (GENERATE_JS_DOCS)
         add_subdirectory(web/docs)
     endif()
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ badges above.
 
 ## Documentation
 
-- [Filament](https://google.github.io/filament/Filament.md.html), an in-depth explanation of
+- [Filament](https://google.github.io/filament/Filament.html), an in-depth explanation of
   real-time physically based rendering, the graphics capabilities and implementation of Filament.
   This document explains the math and reasoning behind most of our decisions. This document is a
   good introduction to PBR for graphics programmers.
-- [Materials](https://google.github.io/filament/Materials.md.html), the full reference
+- [Materials](https://google.github.io/filament/Materials.html), the full reference
   documentation for our material system. This document explains our different material models, how
   to use the material compiler `matc` and how to write custom materials.
 - [Material Properties](https://google.github.io/filament/Material%20Properties.pdf), a reference

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ ISSUE_WEB_DOCS=false
 
 RUN_TESTS=false
 
-WEB_DOCS_OPTION="-DGENERATE_WEB_DOCS=OFF"
+JS_DOCS_OPTION="-DGENERATE_JS_DOCS=OFF"
 
 ENABLE_JAVA=ON
 
@@ -192,7 +192,7 @@ function build_webgl_with_target {
             -DCMAKE_BUILD_TYPE=$1 \
             -DCMAKE_INSTALL_PREFIX=../webgl-${LC_TARGET}/filament \
             -DWEBGL=1 \
-            $WEB_DOCS_OPTION \
+            $JS_DOCS_OPTION \
             ../..
         ${BUILD_COMMAND} ${BUILD_TARGETS}
         )
@@ -570,7 +570,7 @@ while getopts ":hacfijmp:tuvslw" opt; do
         a)
             ISSUE_ARCHIVES=true
             INSTALL_COMMAND=install
-            WEB_DOCS_OPTION="-DGENERATE_WEB_DOCS=ON"
+            JS_DOCS_OPTION="-DGENERATE_JS_DOCS=ON"
             ;;
         c)
             ISSUE_CLEAN=true

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,8 @@ function print_help {
     echo "        Add iOS simulator support to the iOS build."
     echo "    -l"
     echo "        Add filamat support to the Android build."
+    echo "    -w"
+    echo "        Build Web documents (compiles .md.html files to .html)."
     echo ""
     echo "Build types:"
     echo "    release"
@@ -87,6 +89,8 @@ ISSUE_WEBGL_BUILD=false
 ISSUE_ARCHIVES=false
 
 ISSUE_CMAKE_ALWAYS=false
+
+ISSUE_WEB_DOCS=false
 
 RUN_TESTS=false
 
@@ -463,6 +467,22 @@ function build_ios {
     fi
 }
 
+function build_web_docs {
+    echo "Building Web documents..."
+
+    mkdir -p out/web-docs
+    cd out/web-docs
+
+    # Create an empty npm package to link markdeep-rasterizer into
+    npm list | grep web-docs@1.0.0 > /dev/null || npm init --yes > /dev/null
+    npm list | grep markdeep-rasterizer > /dev/null || npm install ../../build/web/markdeep-rasterizer > /dev/null
+
+    # Generate documents
+    npx markdeep-rasterizer ../../docs/Filament.md.html ../../docs/Materials.md.html  ../../docs/
+
+    cd ../..
+}
+
 function validate_build_command {
     set +e
     # Make sure CMake is installed
@@ -500,6 +520,16 @@ function validate_build_command {
         echo "Error: EMSDK is not set, exiting"
         exit 1
     fi
+    # Web documents require node and npm for processing
+    if [ "$ISSUE_WEB_DOCS" == "true" ]; then
+        node_binary=`which node`
+        npm_binary=`which npm`
+        npx_binary=`which npx`
+        if [ ! "$node_binary" ] || [ ! "$npm_binary" ] || [ ! "$npx_binary" ]; then
+            echo "Error: Web documents require node, npm and npx to be installed"
+            exit 1
+        fi
+    fi
     set -e
 }
 
@@ -531,7 +561,7 @@ function run_tests {
 
 pushd `dirname $0` > /dev/null
 
-while getopts ":hacfijmp:tuvsl" opt; do
+while getopts ":hacfijmp:tuvslw" opt; do
     case ${opt} in
         h)
             print_help
@@ -609,6 +639,9 @@ while getopts ":hacfijmp:tuvsl" opt; do
             IOS_BUILD_SIMULATOR=true
             echo "iOS simulator support enabled."
             ;;
+        w)
+            ISSUE_WEB_DOCS=true
+            ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
             echo ""
@@ -661,6 +694,10 @@ fi
 
 if [ "$ISSUE_WEBGL_BUILD" == "true" ]; then
     build_webgl
+fi
+
+if [ "$ISSUE_WEB_DOCS" == "true" ]; then
+    build_web_docs
 fi
 
 if [ "$RUN_TESTS" == "true" ]; then

--- a/build/web/markdeep-rasterizer/.gitignore
+++ b/build/web/markdeep-rasterizer/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/build/web/markdeep-rasterizer/cli.js
+++ b/build/web/markdeep-rasterizer/cli.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const puppeteer = require('puppeteer');
+const fs = require('fs');
+const path = require('path');
+const cheerio = require("cheerio");
+
+const markdeepScript = '<script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script>';
+
+async function domDump(url) {
+    const browser = await puppeteer.launch({headless: true});
+    const page = await browser.newPage();
+    await page.goto(url, {waitUntil: 'networkidle0'});
+    const html = await page.content();
+    await browser.close();
+    return html;
+}
+
+var files = process.argv.slice(2);
+if (files.length < 2) {
+    console.log("npx markdeep-rasterizer <file1> ... <output_dir>");
+    console.log("Each file must be a .md.html file.");
+    console.log("The output directory is mandatory.");
+    process.exit(1);
+}
+
+var outputDir = path.join(process.cwd(), files[files.length - 1]);
+files = files.slice(0, files.length - 1);
+
+files.forEach(function(file) {
+    if (file.substring(file.length - '.md.html'.length, file.length) === '.md.html') {
+        file = file.substring(0, file.length - '.md.html'.length);
+    }
+
+    var markdeepFile = path.join(process.cwd(), file + '.md.html');
+    var outputFile = path.basename(file + '.html');
+
+    domDump('file://' + markdeepFile + '?export').then(function(dom) {
+        console.log('Processing ' + markdeepFile + '...');
+
+        // Parse the DOM
+        var $ = cheerio.load(dom);
+        // Because of ?export Markdeep generated the output in a <pre> tag
+        dom = $('pre').text();
+        // We must remove the remaining invocation of Markdeep
+        dom = dom.replace(markdeepScript, '');
+        // Now replace <pre> with its own content so we can preserve headers
+        $('pre').replaceWith(dom);
+
+        fs.writeFile(path.join(outputDir, outputFile), $.html(), function(err) {
+            if (err) console.log(err);
+        });
+    }).catch(function(e) {
+        console.log('Could no process ' + markdeepFile + '!');
+    });
+});

--- a/build/web/markdeep-rasterizer/package.json
+++ b/build/web/markdeep-rasterizer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "markdeep-rasterizer",
+  "version": "1.0.0",
+  "description": "Rasterizes Markdeep files to HTML using puppeteer",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Romain Guy <romainguy@curious-creature.com>",
+  "license": "Apache-2.0",
+  "bin": {
+    "markdeep-rasterizer": "./cli.js"
+  },
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
+    "puppeteer": "^1.12.2"
+  }
+}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+package.json

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,0 @@
-node_modules
-package-lock.json
-package.json

--- a/docs/Filament.html
+++ b/docs/Filament.html
@@ -1,0 +1,6294 @@
+<html><head><meta charset="utf-8">
+
+<style>img { max-width: 100%; }</style>
+
+</head><body style="visibility: visible;"><meta charset="UTF-8"><meta http-equiv="content-type" content="text/html;charset=UTF-8"><style>body{max-width:680px;margin:auto;padding:20px;text-align:justify;line-height:140%; -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:antialiased;color:#222;font-family:Palatino,Georgia,"Times New Roman",serif}</style><style>body{counter-reset: h1 h2 h3 h4 h5 h6 paragraph}@page{margin:0;size:auto}.md code,pre{font-family:Menlo,Consolas,monospace;font-size:13.099975100467727px;line-height:140%}.md div.title{font-size:26px;font-weight:800;line-height:120%;text-align:center}.md div.afterTitles{height:10px}.md div.subtitle{text-align:center}.md .image{display:inline-block}.md img{max-width:100%;page-break-inside:avoid}.md li{text-align:left;text-indent:0}.md pre.listing {tab-size:4;-moz-tab-size:4;-o-tab-size:4;counter-reset:line}.md pre.listing .linenumbers span.line:before{width:30px;margin-left:-52px;font-size:80%;text-align:right;counter-increment:line;content:counter(line);display:inline-block;padding-right:13px;margin-right:8px;color:#ccc}.md div.tilde{margin:20px 0 -10px;text-align:center}.md div.imagecaption,.md div.tablecaption,.md div.listingcaption{margin:7px 5px 12px;text-align: justify;font-style:italic}.md div.imagecaption{margin-bottom:0}.md blockquote.fancyquote{margin:25px 0 25px;text-align:left;line-height:160%}.md blockquote.fancyquote::before{content:"“";color:#DDD;font-family:Times New Roman;font-size:45px;line-height:0;margin-right:6px;vertical-align:-0.3em}.md span.fancyquote{font-size:118%;color:#777;font-style:italic}.md span.fancyquote::after{content:"”";font-style:normal;color:#DDD;font-family:Times New Roman;font-size:45px;line-height:0;margin-left:6px;vertical-align:-0.3em}.md blockquote.fancyquote .author{width:100%;margin-top:10px;display:inline-block;text-align:right}.md small{font-size:60%}.md big{font-size:150%}.md div.title,contents,.md .tocHeader,h1,h2,h3,h4,h5,h6,.md .shortTOC,.md .mediumTOC,.nonumberh1,.nonumberh2,.nonumberh3,.nonumberh4,.nonumberh5,.nonumberh6{font-family:Verdana,Helvetica,Arial,sans-serif;margin:13.4px 0 13.4px;padding:15px 0 3px;border-top:none;clear:both}.md h1,.md h2,.md h3,.md h4,.md h5,.md h6,.md .nonumberh1,.md .nonumberh2,.md .nonumberh3,.md .nonumberh4,.md .nonumberh5,.md .nonumberh6{page-break-after:avoid;break-after:avoid}.md svg.diagram{display:block;font-family:Menlo,Consolas,monospace;font-size:13.099975100467727px;text-align:center;stroke-linecap:round;stroke-width:2px;page-break-inside:avoid;stroke:#000;fill:#000}.md svg.diagram .opendot{fill:#FFF}.md svg.diagram text{stroke:none}@media print{@page{margin:1in 5mm;transform: scale(150%)}}@media print{.md .pagebreak{page-break-after:always;visibility:hidden}}.md a{font-family:Georgia,Palatino,'Times New Roman'}.md h1,.md .tocHeader,.md .nonumberh1{border-bottom:3px solid;font-size:20px;font-weight:bold;}.md h1,.md .nonumberh1{counter-reset: h2 h3 h4 h5 h6}.md h2,.md .nonumberh2{counter-reset: h3 h4 h5 h6;border-bottom:2px solid #999;color:#555;font-weight:bold;font-size:18px;}.md h3,.md h4,.md h5,.md h6,.md .nonumberh3,.md .nonumberh4,.md .nonumberh5,.md .nonumberh6{font-family:Helvetica,Arial,sans-serif;color:#555;font-size:16px;}.md h3{counter-reset:h4 h5 h6}.md h4{counter-reset:h5 h6}.md h5{counter-reset:h6}.md div.table{margin:16px 0 16px 0}.md table{border-collapse:collapse;line-height:140%;page-break-inside:avoid}.md table.table{margin:auto}.md table.calendar{width:100%;margin:auto;font-size:11px;font-family:Helvetica,Arial,sans-serif}.md table.calendar th{font-size:16px}.md .today{background:#ECF8FA}.md .calendar .parenthesized{color:#999;font-style:italic}.md div.tablecaption{text-align:center}.md table.table th{color:#FFF;background-color:#AAA;border:1px solid #888;padding:8px 15px 8px 15px}.md table.table td{padding:5px 15px 5px 15px;border:1px solid #888}.md table.table tr:nth-child(even){background:#EEE}.md pre.tilde{border-top: 1px solid #CCC;border-bottom: 1px solid #CCC;padding: 5px 0 5px 20px;margin:0 0 0 0;background:#FCFCFC;page-break-inside:avoid}.md a.target{width:0px;height:0px;visibility:hidden;font-size:0px;display:inline-block}.md a:link, .md a:visited{color:#38A;text-decoration:none}.md a:link:hover{text-decoration:underline}.md dt{font-weight:700}.md dl>dd{margin-top:-8px; margin-bottom:8px}.md dl>table{margin:35px 0 30px}.md code{white-space:pre-wrap;overflow-wrap:break-word;text-align:left;page-break-inside:avoid}.md .endnote{font-size:13px;line-height:15px;padding-left:10px;text-indent:-10px}.md .bib{padding-left:80px;text-indent:-80px;text-align:left}.markdeepFooter{font-size:9px;text-align:right;padding-top:80px;color:#999}.md .mediumTOC{float:right;font-size:12px;line-height:15px;border-left:1px solid #CCC;padding-left:15px;margin:15px 0px 15px 25px}.md .mediumTOC .level1{font-weight:600}.md .longTOC .level1{font-weight:600;display:block;padding-top:12px;margin:0 0 -20px}.md .shortTOC{text-align:center;font-weight:bold;margin-top:15px;font-size:14px}.md .admonition{position:relative;margin:1em 0;padding:.4rem 1rem;border-radius:.2rem;border-left:2.5rem solid rgba(68,138,255,.4);background-color:rgba(68,138,255,.15);}.md .admonition-title{font-weight:bold;border-bottom:solid 1px rgba(68,138,255,.4);padding-bottom:4px;margin-bottom:4px;margin-left: -1rem;padding-left:1rem;margin-right:-1rem;border-color:rgba(68,138,255,.4)}.md .admonition.tip{border-left:2.5rem solid rgba(50,255,90,.4);background-color:rgba(50,255,90,.15)}.md .admonition.tip::before{content:"\24d8";font-weight:bold;font-size:150%;position:relative;top:3px;color:rgba(26,128,46,.8);left:-2.95rem;display:block;width:0;height:0}.md .admonition.tip>.admonition-title{border-color:rgba(50,255,90,.4)}.md .admonition.warn,.md .admonition.warning{border-left:2.5rem solid rgba(255,145,0,.4);background-color:rgba(255,145,0,.15)}.md .admonition.warn::before,.md .admonition.warning::before{content:"\26A0";font-weight:bold;font-size:150%;position:relative;top:2px;color:rgba(128,73,0,.8);left:-2.95rem;display:block;width:0;height:0}.md .admonition.warn>.admonition-title,.md .admonition.warning>.admonition-title{border-color:rgba(255,145,0,.4)}.md .admonition.error{border-left: 2.5rem solid rgba(255,23,68,.4);background-color:rgba(255,23,68,.15)}.md .admonition.error>.admonition-title{border-color:rgba(255,23,68,.4)}.md .admonition.error::before{content: "\2612";font-family:"Arial";font-size:200%;position:relative;color:rgba(128,12,34,.8);top:-2px;left:-3rem;display:block;width:0;height:0}.md .admonition p:last-child{margin-bottom:0}.md li.checked,.md li.unchecked{list-style:none;overflow:visible;text-indent:-1.2em}.md li.checked:before,.md li.unchecked:before{content:"\2611";display:block;float:left;width:1em;font-size:120%}.md li.unchecked:before{content:"\2610"}</style><style>.md h1::before {
+content:counter(h1) " ";
+counter-increment: h1;margin-right:10px}.md h2::before {
+content:counter(h1) "."counter(h2) " ";
+counter-increment: h2;margin-right:10px}.md h3::before {
+content:counter(h1) "."counter(h2) "."counter(h3) " ";
+counter-increment: h3;margin-right:10px}.md h4::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) " ";
+counter-increment: h4;margin-right:10px}.md h5::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) "."counter(h5) " ";
+counter-increment: h5;margin-right:10px}.md h6::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) "."counter(h5) "."counter(h6) " ";
+counter-increment: h6;margin-right:10px}</style><style>.hljs{display:block;overflow-x:auto;padding:0.5em;background:#fff;color:#000;-webkit-text-size-adjust:none}.hljs-comment{color:#006a00}.hljs-keyword{color:#02E}.hljs-literal,.nginx .hljs-title{color:#aa0d91}.method,.hljs-list .hljs-title,.hljs-tag .hljs-title,.setting .hljs-value,.hljs-winutils,.tex .hljs-command,.http .hljs-title,.hljs-request,.hljs-status,.hljs-name{color:#008}.hljs-envvar,.tex .hljs-special{color:#660}.hljs-string{color:#c41a16}.hljs-tag .hljs-value,.hljs-cdata,.hljs-filter .hljs-argument,.hljs-attr_selector,.apache .hljs-cbracket,.hljs-date,.hljs-regexp{color:#080}.hljs-sub .hljs-identifier,.hljs-pi,.hljs-tag,.hljs-tag .hljs-keyword,.hljs-decorator,.ini .hljs-title,.hljs-shebang,.hljs-prompt,.hljs-hexcolor,.hljs-rule .hljs-value,.hljs-symbol,.hljs-symbol .hljs-string,.hljs-number,.css .hljs-function,.hljs-function .hljs-title,.coffeescript .hljs-attribute{color:#A0C}.hljs-function .hljs-title{font-weight:bold;color:#000}.hljs-class .hljs-title,.smalltalk .hljs-class,.hljs-type,.hljs-typename,.hljs-tag .hljs-attribute,.hljs-doctype,.hljs-class .hljs-id,.hljs-built_in,.setting,.hljs-params,.clojure .hljs-attribute{color:#5c2699}.hljs-variable{color:#3f6e74}.css .hljs-tag,.hljs-rule .hljs-property,.hljs-pseudo,.hljs-subst{color:#000}.css .hljs-class,.css .hljs-id{color:#9b703f}.hljs-value .hljs-important{color:#ff7700;font-weight:bold}.hljs-rule .hljs-keyword{color:#c5af75}.hljs-annotation,.apache .hljs-sqbracket,.nginx .hljs-built_in{color:#9b859d}.hljs-preprocessor,.hljs-preprocessor *,.hljs-pragma{color:#643820}.tex .hljs-formula{background-color:#eee;font-style:italic}.diff .hljs-header,.hljs-chunk{color:#808080;font-weight:bold}.diff .hljs-change{background-color:#bccff9}.hljs-addition{background-color:#baeeba}.hljs-deletion{background-color:#ffc8bd}.hljs-comment .hljs-doctag{font-weight:bold}.method .hljs-id{color:#000}</style><style>div.title { padding-top: 40px; } div.afterTitles { height: 15px; }</style><meta charset="utf-8">
+
+<style>img { max-width: 100%; }</style>
+
+<script type="text/x-mathjax-config">MathJax.Hub.Config({ TeX: { equationNumbers: {autoNumber: "AMS"} } });</script><span style="display:none">$$\newcommand{\n}{\hat{n}}\newcommand{\thetai}{\theta_\mathrm{i}}\newcommand{\thetao}{\theta_\mathrm{o}}\newcommand{\d}[1]{\mathrm{d}#1}\newcommand{\w}{\hat{\omega}}\newcommand{\wi}{\w_\mathrm{i}}\newcommand{\wo}{\w_\mathrm{o}}\newcommand{\wh}{\w_\mathrm{h}}\newcommand{\Li}{L_\mathrm{i}}\newcommand{\Lo}{L_\mathrm{o}}\newcommand{\Le}{L_\mathrm{e}}\newcommand{\Lr}{L_\mathrm{r}}\newcommand{\Lt}{L_\mathrm{t}}\newcommand{\O}{\mathrm{O}}\newcommand{\degrees}{{^{\large\circ}}}\newcommand{\T}{\mathsf{T}}\newcommand{\mathset}[1]{\mathbb{#1}}\newcommand{\Real}{\mathset{R}}\newcommand{\Integer}{\mathset{Z}}\newcommand{\Boolean}{\mathset{B}}\newcommand{\Complex}{\mathset{C}}\newcommand{\un}[1]{\,\mathrm{#1}}$$
+</span>
+<span class="md"><p><title>Physically-Based Rendering in Filament</title></p><div class="title"> Physically-Based Rendering in Filament </div>
+
+<div class="afterTitles"></div>
+
+<p></p><p>
+
+</p><center><a href="images/filament_logo.png" target="_blank"><img class="markdeep" src="images/filament_logo.png"></a></center>
+
+<p></p>
+<div class="longTOC"><div class="tocHeader">Contents</div><p><a href="#about" class="level1"><span class="tocNumber">1&#xA0; </span>About</a><br>
+&#xA0;&#xA0;<a href="#about/authors" class="level2"><span class="tocNumber">1.1&#xA0; </span>Authors</a><br>
+<a href="#overview" class="level1"><span class="tocNumber">2&#xA0; </span>Overview</a><br>
+&#xA0;&#xA0;<a href="#overview/principles" class="level2"><span class="tocNumber">2.1&#xA0; </span>Principles</a><br>
+&#xA0;&#xA0;<a href="#overview/physicallybasedrendering" class="level2"><span class="tocNumber">2.2&#xA0; </span>Physically based rendering</a><br>
+<a href="#notation" class="level1"><span class="tocNumber">3&#xA0; </span>Notation</a><br>
+<a href="#materialsystem" class="level1"><span class="tocNumber">4&#xA0; </span>Material system</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/standardmodel" class="level2"><span class="tocNumber">4.1&#xA0; </span>Standard model</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/dielectricsandconductors" class="level2"><span class="tocNumber">4.2&#xA0; </span>Dielectrics and conductors</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/energyconservation" class="level2"><span class="tocNumber">4.3&#xA0; </span>Energy conservation</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/specularbrdf" class="level2"><span class="tocNumber">4.4&#xA0; </span>Specular BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/specularbrdf/normaldistributionfunction(speculard)" class="level3"><span class="tocNumber">4.4.1&#xA0; </span>Normal distribution function (specular D)</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/specularbrdf/geometricshadowing(specularg)" class="level3"><span class="tocNumber">4.4.2&#xA0; </span>Geometric shadowing (specular G)</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/specularbrdf/fresnel(specularf)" class="level3"><span class="tocNumber">4.4.3&#xA0; </span>Fresnel (specular F)</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/diffusebrdf" class="level2"><span class="tocNumber">4.5&#xA0; </span>Diffuse BRDF</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/standardmodelsummary" class="level2"><span class="tocNumber">4.6&#xA0; </span>Standard model summary</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/improvingthebrdfs" class="level2"><span class="tocNumber">4.7&#xA0; </span>Improving the BRDFs</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/improvingthebrdfs/energygainindiffusereflectance" class="level3"><span class="tocNumber">4.7.1&#xA0; </span>Energy gain in diffuse reflectance</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/improvingthebrdfs/energylossinspecularreflectance" class="level3"><span class="tocNumber">4.7.2&#xA0; </span>Energy loss in specular reflectance</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/parameterization" class="level2"><span class="tocNumber">4.8&#xA0; </span>Parameterization</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/parameterization/standardparameters" class="level3"><span class="tocNumber">4.8.1&#xA0; </span>Standard parameters</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/parameterization/typesandranges" class="level3"><span class="tocNumber">4.8.2&#xA0; </span>Types and ranges</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/parameterization/remapping" class="level3"><span class="tocNumber">4.8.3&#xA0; </span>Remapping</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/parameterization/blendingandlayering" class="level3"><span class="tocNumber">4.8.4&#xA0; </span>Blending and layering</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/parameterization/craftingphysicallybasedmaterials" class="level3"><span class="tocNumber">4.8.5&#xA0; </span>Crafting physically based materials</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/clearcoatmodel" class="level2"><span class="tocNumber">4.9&#xA0; </span>Clear coat model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clearcoatmodel/clearcoatspecularbrdf" class="level3"><span class="tocNumber">4.9.1&#xA0; </span>Clear coat specular BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clearcoatmodel/integrationinthesurfaceresponse" class="level3"><span class="tocNumber">4.9.2&#xA0; </span>Integration in the surface response</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clearcoatmodel/clearcoatparameterization" class="level3"><span class="tocNumber">4.9.3&#xA0; </span>Clear coat parameterization</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clearcoatmodel/baselayermodification" class="level3"><span class="tocNumber">4.9.4&#xA0; </span>Base layer modification</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/anisotropicmodel" class="level2"><span class="tocNumber">4.10&#xA0; </span>Anisotropic model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/anisotropicmodel/anisotropicspecularbrdf" class="level3"><span class="tocNumber">4.10.1&#xA0; </span>Anisotropic specular BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/anisotropicmodel/anisotropicparameterization" class="level3"><span class="tocNumber">4.10.2&#xA0; </span>Anisotropic parameterization</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/subsurfacemodel" class="level2"><span class="tocNumber">4.11&#xA0; </span>Subsurface model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/subsurfacemodel/subsurfacespecularbrdf" class="level3"><span class="tocNumber">4.11.1&#xA0; </span>Subsurface specular BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/subsurfacemodel/subsurfaceparameterization" class="level3"><span class="tocNumber">4.11.2&#xA0; </span>Subsurface parameterization</a><br>
+&#xA0;&#xA0;<a href="#materialsystem/clothmodel" class="level2"><span class="tocNumber">4.12&#xA0; </span>Cloth model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clothmodel/clothspecularbrdf" class="level3"><span class="tocNumber">4.12.1&#xA0; </span>Cloth specular BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clothmodel/clothdiffusebrdf" class="level3"><span class="tocNumber">4.12.2&#xA0; </span>Cloth diffuse BRDF</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialsystem/clothmodel/clothparameterization" class="level3"><span class="tocNumber">4.12.3&#xA0; </span>Cloth parameterization</a><br>
+<a href="#lighting" class="level1"><span class="tocNumber">5&#xA0; </span>Lighting</a><br>
+&#xA0;&#xA0;<a href="#lighting/units" class="level2"><span class="tocNumber">5.1&#xA0; </span>Units</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/units/lightunitsvalidation" class="level3"><span class="tocNumber">5.1.1&#xA0; </span>Light units validation</a><br>
+&#xA0;&#xA0;<a href="#lighting/directlighting" class="level2"><span class="tocNumber">5.2&#xA0; </span>Direct lighting</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/directionallights" class="level3"><span class="tocNumber">5.2.1&#xA0; </span>Directional lights</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/punctuallights" class="level3"><span class="tocNumber">5.2.2&#xA0; </span>Punctual lights</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/photometriclights" class="level3"><span class="tocNumber">5.2.3&#xA0; </span>Photometric lights</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/arealights" class="level3"><span class="tocNumber">5.2.4&#xA0; </span>Area lights</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/lightsparameterization" class="level3"><span class="tocNumber">5.2.5&#xA0; </span>Lights parameterization</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/directlighting/pre-exposedlights" class="level3"><span class="tocNumber">5.2.6&#xA0; </span>Pre-exposed lights</a><br>
+&#xA0;&#xA0;<a href="#lighting/imagebasedlights" class="level2"><span class="tocNumber">5.3&#xA0; </span>Image based lights</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/ibltypes" class="level3"><span class="tocNumber">5.3.1&#xA0; </span>IBL Types</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/iblunit" class="level3"><span class="tocNumber">5.3.2&#xA0; </span>IBL Unit</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/processinglightprobes" class="level3"><span class="tocNumber">5.3.3&#xA0; </span>Processing light probes</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/distantlightprobes" class="level3"><span class="tocNumber">5.3.4&#xA0; </span>Distant light probes</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/clearcoat" class="level3"><span class="tocNumber">5.3.5&#xA0; </span>Clear coat</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/anisotropy" class="level3"><span class="tocNumber">5.3.6&#xA0; </span>Anisotropy</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/subsurface" class="level3"><span class="tocNumber">5.3.7&#xA0; </span>Subsurface</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/imagebasedlights/cloth" class="level3"><span class="tocNumber">5.3.8&#xA0; </span>Cloth</a><br>
+&#xA0;&#xA0;<a href="#lighting/staticlighting" class="level2"><span class="tocNumber">5.4&#xA0; </span>Static lighting</a><br>
+&#xA0;&#xA0;<a href="#lighting/transparencyandtranslucencylighting" class="level2"><span class="tocNumber">5.5&#xA0; </span>Transparency and translucency lighting</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/transparencyandtranslucencylighting/transparency" class="level3"><span class="tocNumber">5.5.1&#xA0; </span>Transparency</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/transparencyandtranslucencylighting/translucency" class="level3"><span class="tocNumber">5.5.2&#xA0; </span>Translucency</a><br>
+&#xA0;&#xA0;<a href="#lighting/occlusion" class="level2"><span class="tocNumber">5.6&#xA0; </span>Occlusion</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/occlusion/diffuseocclusion" class="level3"><span class="tocNumber">5.6.1&#xA0; </span>Diffuse occlusion</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/occlusion/specularocclusion" class="level3"><span class="tocNumber">5.6.2&#xA0; </span>Specular occlusion</a><br>
+&#xA0;&#xA0;<a href="#lighting/normalmapping" class="level2"><span class="tocNumber">5.7&#xA0; </span>Normal mapping</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/normalmapping/reorientednormalmapping" class="level3"><span class="tocNumber">5.7.1&#xA0; </span>Reoriented normal mapping</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#lighting/normalmapping/udnblending" class="level3"><span class="tocNumber">5.7.2&#xA0; </span>UDN blending</a><br>
+<a href="#volumetriceffects" class="level1"><span class="tocNumber">6&#xA0; </span>Volumetric effects</a><br>
+&#xA0;&#xA0;<a href="#volumetriceffects/exponentialheightfog" class="level2"><span class="tocNumber">6.1&#xA0; </span>Exponential height fog</a><br>
+<a href="#anti-aliasing" class="level1"><span class="tocNumber">7&#xA0; </span>Anti-aliasing</a><br>
+<a href="#imagingpipeline" class="level1"><span class="tocNumber">8&#xA0; </span>Imaging pipeline</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera" class="level2"><span class="tocNumber">8.1&#xA0; </span>Physically based camera</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera/exposuresettings" class="level3"><span class="tocNumber">8.1.1&#xA0; </span>Exposure settings</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera/exposurevalue" class="level3"><span class="tocNumber">8.1.2&#xA0; </span>Exposure value</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera/exposure" class="level3"><span class="tocNumber">8.1.3&#xA0; </span>Exposure</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera/automaticexposure" class="level3"><span class="tocNumber">8.1.4&#xA0; </span>Automatic exposure</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/physicallybasedcamera/bloom" class="level3"><span class="tocNumber">8.1.5&#xA0; </span>Bloom</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/opticspost-processing" class="level2"><span class="tocNumber">8.2&#xA0; </span>Optics post-processing</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/opticspost-processing/colorfringing" class="level3"><span class="tocNumber">8.2.1&#xA0; </span>Color fringing</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/opticspost-processing/lensflares" class="level3"><span class="tocNumber">8.2.2&#xA0; </span>Lens flares</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/filmicpost-processing" class="level2"><span class="tocNumber">8.3&#xA0; </span>Filmic post-processing</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/filmicpost-processing/contrast" class="level3"><span class="tocNumber">8.3.1&#xA0; </span>Contrast</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/filmicpost-processing/curves" class="level3"><span class="tocNumber">8.3.2&#xA0; </span>Curves</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/filmicpost-processing/levels" class="level3"><span class="tocNumber">8.3.3&#xA0; </span>Levels</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/filmicpost-processing/colorgrading" class="level3"><span class="tocNumber">8.3.4&#xA0; </span>Color grading</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/lightpath" class="level2"><span class="tocNumber">8.4&#xA0; </span>Light path</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/lightpath/clusteredforwardrendering" class="level3"><span class="tocNumber">8.4.1&#xA0; </span>Clustered Forward Rendering</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/lightpath/implementationnotes" class="level3"><span class="tocNumber">8.4.2&#xA0; </span>Implementation notes</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/validation" class="level2"><span class="tocNumber">8.5&#xA0; </span>Validation</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/validation/scenereferredvisualization" class="level3"><span class="tocNumber">8.5.1&#xA0; </span>Scene referred visualization</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/validation/referencerenderings" class="level3"><span class="tocNumber">8.5.2&#xA0; </span>Reference renderings</a><br>
+&#xA0;&#xA0;<a href="#imagingpipeline/coordinatessystems" class="level2"><span class="tocNumber">8.6&#xA0; </span>Coordinates systems</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/coordinatessystems/worldcoordinatessystem" class="level3"><span class="tocNumber">8.6.1&#xA0; </span>World coordinates system</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/coordinatessystems/cameracoordinatessystem" class="level3"><span class="tocNumber">8.6.2&#xA0; </span>Camera coordinates system</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#imagingpipeline/coordinatessystems/cubemapscoordinatessystem" class="level3"><span class="tocNumber">8.6.3&#xA0; </span>Cubemaps coordinates system</a><br>
+<a href="#annex" class="level1"><span class="tocNumber">9&#xA0; </span>Annex</a><br>
+&#xA0;&#xA0;<a href="#annex/specularcolor" class="level2"><span class="tocNumber">9.1&#xA0; </span>Specular color</a><br>
+&#xA0;&#xA0;<a href="#annex/importancesamplingfortheibl" class="level2"><span class="tocNumber">9.2&#xA0; </span>Importance sampling for the IBL</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/importancesamplingfortheibl/choosingimportantdirections" class="level3"><span class="tocNumber">9.2.1&#xA0; </span>Choosing important directions</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/importancesamplingfortheibl/pre-filteredimportancesampling" class="level3"><span class="tocNumber">9.2.2&#xA0; </span>Pre-filtered importance sampling</a><br>
+&#xA0;&#xA0;<a href="#annex/choosingimportantdirectionsforsamplingthebrdf" class="level2"><span class="tocNumber">9.3&#xA0; </span>Choosing important directions for sampling the BRDF</a><br>
+&#xA0;&#xA0;<a href="#annex/hammersleysequence" class="level2"><span class="tocNumber">9.4&#xA0; </span>Hammersley sequence</a><br>
+&#xA0;&#xA0;<a href="#annex/precomputinglforimage-basedlighting" class="level2"><span class="tocNumber">9.5&#xA0; </span>Precomputing L for image-based lighting</a><br>
+&#xA0;&#xA0;<a href="#annex/sphericalharmonics" class="level2"><span class="tocNumber">9.6&#xA0; </span>Spherical Harmonics</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/sphericalharmonics/basisfunctions" class="level3"><span class="tocNumber">9.6.1&#xA0; </span>Basis functions</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/sphericalharmonics/decompositionandreconstruction" class="level3"><span class="tocNumber">9.6.2&#xA0; </span>Decomposition and reconstruction</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/sphericalharmonics/decompositionof%5C(%5Cleft%5C)" class="level3"><span class="tocNumber">9.6.3&#xA0; </span>Decomposition of \(\left&lt; cos \theta \right&gt;\)</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#annex/sphericalharmonics/convolution" class="level3"><span class="tocNumber">9.6.4&#xA0; </span>Convolution</a><br>
+&#xA0;&#xA0;<a href="#annex/samplevalidationsceneformitsuba" class="level2"><span class="tocNumber">9.7&#xA0; </span>Sample validation scene for Mitsuba</a><br>
+&#xA0;&#xA0;<a href="#annex/lightassignmentwithfroxels" class="level2"><span class="tocNumber">9.8&#xA0; </span>Light assignment with froxels</a><br>
+<a href="#revisions" class="level1"><span class="tocNumber">10&#xA0; </span>Revisions</a><br>
+<a href="#bibliography" class="level1"><span class="tocNumber">11&#xA0; </span>Bibliography</a><br>
+</p></div><a class="target" name="about">&#xA0;</a><a class="target" name="about">&#xA0;</a><a class="target" name="toc1">&#xA0;</a><h1>About</h1>
+<p>
+
+
+This document is part of the <a href="https://github.com/google/filament">Filament project</a>. To report errors in this document please use the <a href="https://github.com/google/filament/issues">project&apos;s issue tracker</a>.
+
+</p>
+<a class="target" name="authors">&#xA0;</a><a class="target" name="about/authors">&#xA0;</a><a class="target" name="toc1.1">&#xA0;</a><h2>Authors</h2>
+<p>
+
+
+
+</p><ul>
+<li class="minus"><a href="https://github.com/romainguy">Romain Guy</a>, <a href="https://twitter.com/romainguy">@romainguy</a>
+</li>
+<li class="minus"><a href="https://github.com/pixelflinger">Mathias Agopian</a>, <a href="https://twitter.com/darthmoosious">@darthmoosious</a></li></ul>
+
+<p></p>
+<a class="target" name="overview">&#xA0;</a><a class="target" name="overview">&#xA0;</a><a class="target" name="toc2">&#xA0;</a><h1>Overview</h1>
+<p>
+
+
+Filament is a physically based rendering (PBR) engine for Android. The goal of Filament is to offer a set of tools and APIs for Android developers that will enable them to create high quality 2D and 3D rendering with ease.
+
+</p><p>
+
+The goal of this document is to explain the equations and theory behind the material and lighting models used in Filament. This document is intended as a reference for contributors to Filament or developers interested in the inner workings of the engine. We will provide code snippets as needed to make the relationship between theory and practice as clear as possible.
+
+</p><p>
+
+This document is not intended as a design document. It focuses solely on algorithms and its content could be used to implement PBR in any engine. However, this document explains why we chose specific algorithms/models over others.
+
+</p><p>
+
+Unless noted otherwise, all the 3D renderings present in this document have been generated in-engine (prototype or production). Many of these 3D renderings were captured during the early stages of development of Filament and do not reflect the final quality.
+
+</p>
+<a class="target" name="principles">&#xA0;</a><a class="target" name="overview/principles">&#xA0;</a><a class="target" name="toc2.1">&#xA0;</a><h2>Principles</h2>
+<p>
+
+
+Real-time rendering is an active area of research and there is a large number of equations, algorithms and implementation to choose from for every single feature that needs to be implemented (the book <em class="asterisk">Rendering real-time shadows</em>, for instance, is a 400 pages summary of dozens of shadows rendering techniques). As such, we must first define our goals (or principles, to follow Brent Burley&apos;s seminal paper Physically-based shading at Disney [<a href="#citation-burley12">Burley12</a>]) before we can make informed decisions.
+
+</p><p>
+
+</p><dl><dt>Real-time mobile performance</dt><dd><p>    Our primary goal is to design and implement a rendering system able to perform efficiently on mobile platforms. The primary target will be OpenGL ES 3.x class GPUs.
+
+</p></dd><dt>Quality</dt><dd><p>    Our rendering system will emphasize overall picture quality. We will however accept quality compromises to support low and medium performance GPUs.
+
+</p></dd><dt>Ease of use</dt><dd><p>    Artists need to be able to iterate often and quickly on their assets and our rendering system must allow them to do so intuitively. We must therefore provide parameters that are easy to understand (for instance, no specular power, no index of refraction&#x2026;).
+
+</p><p>
+
+    We also understand that not all developers have the luxury to work with artists. The physically based approach of our system will allow developers to craft visually plausible materials without the need to understand the theory behind our implementation.
+
+</p><p>
+
+    For both artists and developers, our system will rely on as few parameters as possible to reduce trial and error and allow users to quickly master the material model.
+
+</p><p>
+
+    In addition, any combination of parameter values should lead to physically plausible results. Physically implausible materials must be hard to create.
+
+</p></dd><dt>Familiarity</dt><dd><p>    Our system should use physical units everywhere possible: distances in meters or centimeters, color temperatures in Kelvin, light units in lumens or candelas, etc.
+
+</p></dd><dt>Flexibility</dt><dd><p>    A physically based approach must not preclude non-realistic rendering. User interfaces for instance will need unlit materials.
+
+</p></dd><dt>Deployment size</dt><dd><p>    While not directly related to the content of this document, it bears emphasizing our desire to keep the rendering library as small as possible so any application can bundle it without increasing the binary to undesirable sizes.
+
+</p></dd></dl><p></p>
+<a class="target" name="physicallybasedrendering">&#xA0;</a><a class="target" name="overview/physicallybasedrendering">&#xA0;</a><a class="target" name="toc2.2">&#xA0;</a><h2>Physically based rendering</h2>
+<p>
+
+
+We chose to adopt PBR for its benefits from an artistic and production efficient standpoints, and because it is compatible with our goals.
+
+</p><p>
+
+Physically based rendering is a rendering method that provides a more accurate representation of materials and how they interact with light when compared to traditional real-time models. The separation of materials and lighting at the core of the PBR method makes it easier to create realistic assets that look accurate in all lighting conditions.
+
+</p>
+<a class="target" name="notation">&#xA0;</a><a class="target" name="notation">&#xA0;</a><a class="target" name="toc3">&#xA0;</a><h1>Notation</h1>
+<p>
+
+
+$$
+\newcommand{NoL}{n \cdot l}
+\newcommand{NoV}{n \cdot v}
+\newcommand{NoH}{n \cdot h}
+\newcommand{VoH}{v \cdot h}
+\newcommand{LoH}{l \cdot h}
+\newcommand{fNormal}{f_{0}}
+\newcommand{fDiffuse}{f_d}
+\newcommand{fSpecular}{f_r}
+\newcommand{fX}{f_x}
+\newcommand{aa}{\alpha^2}
+\newcommand{fGrazing}{f_{90}}
+\newcommand{schlick}{F_{Schlick}}
+\newcommand{nior}{n_{ior}}
+\newcommand{Ed}{E_d}
+\newcommand{Lt}{L_{\bot}}
+\newcommand{Lout}{L_{out}}
+\newcommand{cosTheta}{\left&lt; \cos \theta \right&gt; }
+$$
+
+</p><p>
+
+The equations found throughout this document use the symbols described in <a href="#table_symbols">table&#xA0;1</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:center"> Symbol </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:center"> \(v\) </td><td style="text-align:left"> View unit vector </td></tr>
+<tr><td style="text-align:center"> \(l\) </td><td style="text-align:left"> Incident light unit vector </td></tr>
+<tr><td style="text-align:center"> \(n\) </td><td style="text-align:left"> Surface normal unit vector </td></tr>
+<tr><td style="text-align:center"> \(h\) </td><td style="text-align:left"> Half unit vector between \(l\) and \(v\) </td></tr>
+<tr><td style="text-align:center"> \(f\) </td><td style="text-align:left"> BRDF </td></tr>
+<tr><td style="text-align:center"> \(\fDiffuse\) </td><td style="text-align:left"> Diffuse component of a BRDF </td></tr>
+<tr><td style="text-align:center"> \(\fSpecular\) </td><td style="text-align:left"> Specular component of a BRDF </td></tr>
+<tr><td style="text-align:center"> \(\alpha\) </td><td style="text-align:left"> Perceptually linear roughness </td></tr>
+<tr><td style="text-align:center"> \(\sigma\) </td><td style="text-align:left"> Diffuse reflectance </td></tr>
+<tr><td style="text-align:center"> \(\Omega\) </td><td style="text-align:left"> Spherical domain </td></tr>
+<tr><td style="text-align:center"> \(\fNormal\) </td><td style="text-align:left"> Reflectance at normal incidence </td></tr>
+<tr><td style="text-align:center"> \(\fGrazing\) </td><td style="text-align:left"> Reflectance at grazing angle </td></tr>
+<tr><td style="text-align:center"> \(\chi^+(a)\) </td><td style="text-align:left"> Heaviside function (1 if \(a &gt; 0\) and 0 otherwise) </td></tr>
+<tr><td style="text-align:center"> \(n_{ior}\) </td><td style="text-align:left"> Index of refraction (IOR) of an interface </td></tr>
+<tr><td style="text-align:center"> \(\left&lt; \NoL \right&gt;\) </td><td style="text-align:left"> Dot product clamped to [0..1] </td></tr>
+<tr><td style="text-align:center"> \(\left&lt; a \right&gt;\) </td><td style="text-align:left"> Saturated value (clamped to [0..1]) </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_symbols">&#xA0;</a><b style="font-style:normal;">Table&#xA0;1:</b> Symbols definitions</div></div>
+
+<p></p>
+<a class="target" name="materialsystem">&#xA0;</a><a class="target" name="materialsystem">&#xA0;</a><a class="target" name="toc4">&#xA0;</a><h1>Material system</h1>
+<p>
+
+
+The sections below describe multiple material models to simplify the description of various surface features such as anisotropy or the clear coat layer. In practice however some of these models are condensed into a single one. For instance, the standard model, the clear coat model and the anisotropic model can be combined to form a single, more flexible and powerful model. Please refer to the <a href="./Materials.md.html">Materials documentation</a> to get a description of the material models as implemented in Filament.
+
+</p>
+<a class="target" name="standardmodel">&#xA0;</a><a class="target" name="materialsystem/standardmodel">&#xA0;</a><a class="target" name="toc4.1">&#xA0;</a><h2>Standard model</h2>
+<p>
+
+
+The goal of our model is to represent standard material appearances. A material model is described mathematically by a BSDF (Bidirectional Scattering Distribution Function), which is itself composed of two other functions: the BRDF (Bidirectional Reflectance Distribution Function) and the BTDF (Bidirectional Transmittance Function).
+
+</p><p>
+
+Since we aim to model commonly encountered surfaces, our standard material model will focus on the BRDF and ignore the BTDF, or approximate it greatly. Our standard model will therefore only be able to correctly mimic reflective, isotropic, dielectric or conductive surfaces with short mean free paths.
+
+</p><p>
+
+The BRDF describes the surface response of a standard material as a function made of two terms:
+
+</p><p>
+
+</p><ul>
+<li class="minus">A diffuse component, or \(f_d\)
+</li>
+<li class="minus">A specular component, or \(f_r\)</li></ul>
+
+<p></p><p>
+
+The relationship between a surface, the surface normal, incident light and these terms is shown in <a href="#figure_frfd">figure&#xA0;1</a> (we ignore subsurface scattering for now):
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_fr_fd.png" target="_blank"><img class="markdeep" src="images/diagram_fr_fd.png"></a><div class="imagecaption"><a class="target" name="figure_frfd">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;1:</b> Interaction of the light with a surface using BRDF model with a diffuse term \( f_d \) and a specular term \( f_r \)</div></div></center>
+
+<p></p><p>
+
+The complete surface response can be expressed as such:
+
+</p><p>
+
+$$\begin{equation}\label{brdf}
+f(v,l)=f_d(v,l)+f_r(v,l)
+\end{equation}$$
+
+</p><p>
+
+This equation characterizes the surface response for incident light from a single direction. The full rendering equation would require to integrate \(l\) over the entire hemisphere.
+
+</p><p>
+
+Commonly encountered surfaces are usually not made of a flat interface so we need a model that can characterize the interaction of light with an irregular interface.
+
+</p><p>
+
+A microfacet BRDF is a good physically plausible BRDF for that purpose. Such BRDF states that surfaces are not smooth at a micro level, but made of a large number of randomly aligned planar surface fragments, called microfacets. <a href="#figure_microfacetvsflat">Figure&#xA0;2</a> shows the difference between a flat interface and an irregular interface at a micro level:
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_microfacet.png" target="_blank"><img class="markdeep" src="images/diagram_microfacet.png"></a><div class="imagecaption"><a class="target" name="figure_microfacetvsflat">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;2:</b> Irregular interface as modeled by a microfacet model (left) and flat interface (right)</div></div></center>
+
+<p></p><p>
+
+Only the microfacets whose normal is oriented halfway between the light direction and the view direction will reflect visible light, as shown in <a href="#figure_microfacets">figure&#xA0;3</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_macrosurface.png" target="_blank"><img class="markdeep" src="images/diagram_macrosurface.png"></a><div class="imagecaption"><a class="target" name="figure_microfacets">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;3:</b> Microfacets</div></div></center>
+
+<p></p><p>
+
+However, not all microfacets with a properly oriented normal will contribute reflected light as the BRDF takes into account masking and shadowing. This is illustrated in <a href="#figure_microfacetshadowing">figure&#xA0;4</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_shadowing_masking.png" target="_blank"><img class="markdeep" src="images/diagram_shadowing_masking.png"></a><div class="imagecaption"><a class="target" name="figure_microfacetshadowing">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;4:</b> Masking and shadowing of microfacets</div></div></center>
+
+<p></p><p>
+
+A microfacet BRDF is heavily influenced by a <em class="underscore">roughness</em> parameter which describes how smooth (low roughness) or how rough (high roughness) a surface is at a micro level. The smoother the surface, the more facets are aligned and the more pronounced the reflected light is. The rougher the surface, the fewer facets are oriented towards the camera and incoming light is scattered away from the camera after reflection, giving a blurry aspect to the specular highlights.
+
+</p><p>
+
+<a href="#figure_roughness">Figure&#xA0;5</a> shows surfaces of different roughness and how light interacts with them.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_roughness.png" target="_blank"><img class="markdeep" src="images/diagram_roughness.png"></a><div class="imagecaption"><a class="target" name="figure_roughness">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;5:</b> Varying roughness (from left to right, rough to smooth) and the resulting BRDF specular component lobe</div></div></center>
+
+<p></p><p>
+
+A microfacet model is described by the following equation (where x stands for the specular or diffuse component):
+
+</p><p>
+
+$$\begin{equation}
+\fX(v,l) = \frac{1}{| \NoV | | \NoL |}
+\int_\Omega D(m,\alpha) G(v,l,m) f_m(v,l,m) (v \cdot m) (l \cdot m) dm
+\end{equation}$$
+
+</p><p>
+
+The term \(D\) models the distribution of the microfacets (this term is also referred to as the NDF or Normal Distribution Function). This term plays a primordial role in the appearance of surfaces as shown in <a href="#figure_roughness">figure&#xA0;5</a>.
+
+</p><p>
+
+The term \(G\) models the visibility (or occlusion or shadow-masking) of the microfacets.
+
+</p><p>
+
+Since this equation is valid for both the specular and diffuse components, the difference lies in the microfacet BRDF \(f_m\).
+
+</p><p>
+
+It is important to note that this equation is used to integrate over the hemisphere at a <em class="underscore">micro level</em>:
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_micro_vs_macro.png" target="_blank"><img class="markdeep" src="images/diagram_micro_vs_macro.png"></a><div class="imagecaption"><a class="target" name="figure_microlevel">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;6:</b> Modeling the surface response at a single point requires an integration at the micro level</div></div></center>
+
+<p></p><p>
+
+The diagram above shows that at a macro level, the surfaces is considered flat. This helps simplify our equations by assuming that a shaded fragment lit from a single direction corresponds to a single point at the surface.
+
+</p><p>
+
+At a micro level however, the surface is not flat and we cannot assume a single ray of light anymore (we can however assume that the incident rays are parallel). Since the micro facets will scatter the light in different directions given a bundle of parallel incident rays, we must integrate the surface response over a hemisphere, noted m in the above diagram.
+
+</p><p>
+
+It is obviously not practical to compute the full integration over the microfacets hemisphere for each shaded fragment. We will therefore rely on approximations of the integration for both the specular and diffuse components.
+
+</p>
+<a class="target" name="dielectricsandconductors">&#xA0;</a><a class="target" name="materialsystem/dielectricsandconductors">&#xA0;</a><a class="target" name="toc4.2">&#xA0;</a><h2>Dielectrics and conductors</h2>
+<p>
+
+
+To better understand some of the equations and behaviors shown below, we must first clearly understand the difference between metallic (conductor) and non-metallic (dielectric) surfaces.
+
+</p><p>
+
+We saw earlier that when incident light hits a surface governed by a BRDF, the light is reflected as two separate components: the diffuse reflectance and the specular reflectance. The modelization of this behavior is straightforward as shown in <a href="#figure_bsdfbrdf">figure&#xA0;7</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_fr_fd.png" target="_blank"><img class="markdeep" src="images/diagram_fr_fd.png"></a><div class="imagecaption"><a class="target" name="figure_bsdfbrdf">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;7:</b> Modelization of the BRDF part of a BSDF</div></div></center>
+
+<p></p><p>
+
+This modelization is a simplification of how the light actually interacts with the surface. In reality, part of the incident light will penetrate the surface, scatter inside, and exit the surface again as diffuse reflectance. This phenomenon is illustrated in <a href="#figure_diffusescattering">figure&#xA0;8</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_scattering.png" target="_blank"><img class="markdeep" src="images/diagram_scattering.png"></a><div class="imagecaption"><a class="target" name="figure_diffusescattering">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;8:</b> Scattering of diffuse light</div></div></center>
+
+<p></p><p>
+
+Here lies the difference between conductors and dielectrics. There is no subsurface scattering occurring with purely metallic materials, which means there is no diffuse component (and we will see later that this has an influence on the perceived color of the specular component). Scattering happens in dielectrics, which means they have both specular and diffuse components.
+
+</p><p>
+
+To properly modelize the BRDF we must therefore distinguish between dielectrics and conductors (scattering not shown for clarity), as shown in <a href="#figure_dielectricconductor">figure&#xA0;9</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_brdf_dielectric_conductor.png" target="_blank"><img class="markdeep" src="images/diagram_brdf_dielectric_conductor.png"></a><div class="imagecaption"><a class="target" name="figure_dielectricconductor">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;9:</b> BRDF modelization for dielectric and conductor surfaces</div></div></center>
+
+<p></p>
+<a class="target" name="energyconservation">&#xA0;</a><a class="target" name="materialsystem/energyconservation">&#xA0;</a><a class="target" name="toc4.3">&#xA0;</a><h2>Energy conservation</h2>
+<p>
+
+
+Energy conservation is one of the key components of a good BRDF for physically based rendering. An energy conservative BRDF states that the total amount of specular and diffuse reflectance energy is less than the total amount of incident energy. Without an energy conservative BRDF, artists must manually ensure that the light reflected off a surface is never more intense than the incident light.
+
+</p>
+<a class="target" name="specularbrdf">&#xA0;</a><a class="target" name="materialsystem/specularbrdf">&#xA0;</a><a class="target" name="toc4.4">&#xA0;</a><h2>Specular BRDF</h2>
+<p>
+
+
+For the specular term, \(f_m\) is a mirror BRDF that can be modeled with the Fresnel law, noted \(F\) in the Cook-Torrance approximation of the microfacet model integration:
+
+</p><p>
+
+$$\begin{equation}
+f_r(v,l) = \frac{D(h, \alpha) G(v, l, \alpha) F(v, h, f0)}{4(\NoV)(\NoL)}
+\end{equation}$$
+
+</p><p>
+
+Given our real-time constraints, we must use an approximation for the three terms \(D\), \(G\) and \(F\). [<a href="#citation-karis13">Karis13</a>] has compiled a great list of formulations for these three terms that can be used with the Cook-Torrance specular BRDF. The sections that follow describe the equations we picked for these terms.
+
+</p>
+<a class="target" name="normaldistributionfunction(speculard)">&#xA0;</a><a class="target" name="materialsystem/specularbrdf/normaldistributionfunction(speculard)">&#xA0;</a><a class="target" name="toc4.4.1">&#xA0;</a><h3>Normal distribution function (specular D)</h3>
+<p>
+
+
+[<a href="#citation-burley12">Burley12</a>] observed that long-tailed normal distribution functions (NDF) are a good fit for real-world surfaces. The GGX distribution described in [<a href="#citation-walter07">Walter07</a>] is a distribution with long-tailed falloff and short peak in the highlights, with a simple formulation suitable for real-time implementations. It is also a popular model, equivalent to the Trowbridge-Reitz distribution, in modern physically based renderers.
+
+</p><p>
+
+$$\begin{equation}
+D_{GGX}(h,\alpha) = \frac{\aa}{\pi ( (\NoH)^2 (\aa - 1) + 1)^2}
+\end{equation}$$
+
+</p><p>
+
+The GLSL implementation of the NDF, shown in <a href="#listing_speculard">listing&#xA0;1</a>, is simple and efficient.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">D_GGX</span><span class="hljs-params">(<span class="hljs-keyword">float</span> NoH, <span class="hljs-keyword">float</span> linearRoughness)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">float</span> a = NoH * linearRoughness;</span>
+<span class="line">    <span class="hljs-keyword">float</span> k = linearRoughness / (<span class="hljs-number">1.0</span> - NoH * NoH + a * a);</span>
+<span class="line">    <span class="hljs-keyword">return</span> k * k * (<span class="hljs-number">1.0</span> / PI);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_speculard">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;1:</b> Implementation of the specular D term in GLSL</div>
+<p>
+
+
+We can improve this implementation by using half precision floats. This optimization requires changes to the original equation as there are two problems when computing \(1 - (\NoH)^2\) in half-floats. First, this computation suffers from floating point cancellation when \((\NoH)^2\) is close to 1 (highlights). Secondly \(\NoH\) does not have enough precision around 1.
+
+</p><p>
+
+The solution involves Lagrange&apos;s identity:
+
+</p><p>
+
+$$\begin{equation}
+| a \times b |^2 = |a|^2 |b|^2 - (a \cdot b)^2
+\end{equation}$$
+
+</p><p>
+
+Since both \(n\) and \(h\) are unit vectors, \(|n \times h|^2 = 1 - (\NoH)^2\). This allows us to compute \(1 - (\NoH)^2\) directly with half precision floats by using a simple cross product. <a href="#listing_speculardfp16">Listing&#xA0;2</a> shows the final optimized implementation.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-meta">#define MEDIUMP_FLT_MAX    65504.0</span></span>
+<span class="line"><span class="hljs-meta">#define saturateMediump(x) min(x, MEDIUMP_FLT_MAX)</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> D_GGX(<span class="hljs-type">float</span> linearRoughness, <span class="hljs-type">float</span> NoH, <span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> n, <span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> h) {</span>
+<span class="line">    <span class="hljs-type">vec3</span> NxH = <span class="hljs-built_in">cross</span>(n, h);</span>
+<span class="line">    <span class="hljs-type">float</span> a = NoH * linearRoughness;</span>
+<span class="line">    <span class="hljs-type">float</span> k = linearRoughness / (<span class="hljs-built_in">dot</span>(NxH, NxH) + a * a);</span>
+<span class="line">    <span class="hljs-type">float</span> d = k * k * (<span class="hljs-number">1.0</span> / PI);</span>
+<span class="line">    <span class="hljs-keyword">return</span> saturateMediump(d);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_speculardfp16">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;2:</b> Implementation of the specular D term in GLSL optimized for fp16</div>
+
+<a class="target" name="geometricshadowing(specularg)">&#xA0;</a><a class="target" name="materialsystem/specularbrdf/geometricshadowing(specularg)">&#xA0;</a><a class="target" name="toc4.4.2">&#xA0;</a><h3>Geometric shadowing (specular G)</h3>
+<p>
+
+
+Eric Heitz showed in [<a href="#citation-heitz14">Heitz14</a>] that the Smith geometric shadowing function is the correct and exact \(G\) term to use. The Smith formulation is the following:
+
+</p><p>
+
+$$\begin{equation}
+G(v,l,\alpha) = G_1(l,\alpha) G_1(v,\alpha)
+\end{equation}$$
+
+</p><p>
+
+\(G_1\) can in turn follow several models, and is commonly set to the GGX formulation:
+
+</p><p>
+
+$$\begin{equation}
+G_1(v,\alpha) = G_{GGX}(v,\alpha) = \frac{2 (\NoV)}{\NoV + \sqrt{\aa + (1 - \aa) (\NoV)^2}}
+\end{equation}$$
+
+</p><p>
+
+The full Smith-GGX formulation thus becomes:
+
+</p><p>
+
+$$\begin{equation}
+G(v,l,\alpha) = \frac{2 (\NoL)}{\NoL + \sqrt{\aa + (1 - \aa) (\NoL)^2}} \frac{2 (\NoV)}{\NoV + \sqrt{\aa + (1 - \aa) (\NoV)^2}}
+\end{equation}$$
+
+</p><p>
+
+We can observe that the dividends \(2 (\NoL)\) and \(2 (n \cdot v)\) allow us to simplify the original function \(f_r\) by introducing a visibility function \(V\):
+
+</p><p>
+
+$$\begin{equation}
+f_r(v,l) = D(h, \alpha) V(v, l, \alpha) F(v, h, f_0)
+\end{equation}$$
+
+</p><p>
+
+Where:
+
+</p><p>
+
+$$\begin{equation}
+V(v,l,\alpha) = \frac{G(v, l, \alpha)}{4 (\NoV) (\NoL)} = V_1(l,\alpha) V_1(v,\alpha)
+\end{equation}$$
+
+</p><p>
+
+And:
+
+</p><p>
+
+$$\begin{equation}
+V_1(v,\alpha) = \frac{1}{\NoV + \sqrt{\aa + (1 - \aa) (\NoV)^2}}
+\end{equation}$$
+
+</p><p>
+
+Heitz notes however that taking the height of the microfacets into account to correlate masking and shadowing leads to more accurate results. He defines the height-correlated Smith function thusly:
+
+</p><p>
+
+$$\begin{equation}
+G(v,l,h,\alpha) = \frac{\chi^+(\VoH) \chi^+(\LoH)}{1 + \Lambda(v) + \Lambda(l)}
+\end{equation}$$
+
+</p><p>
+
+$$\begin{equation}
+\Lambda(m) = \frac{-1 + \sqrt{1 + \aa tan^2(\theta_m)}}{2} = \frac{-1 + \sqrt{1 + \aa \frac{(1 - cos^2(\theta_m))}{cos^2(\theta_m)}}}{2}
+\end{equation}$$
+
+</p><p>
+
+Replacing \(\theta_m\) by \(\NoV\), we obtain:
+
+</p><p>
+
+$$\begin{equation}
+\Lambda(v) = \frac{1}{2} \left( \frac{\sqrt{\aa + (1 - \aa)(\NoV)^2}}{\NoV} - 1 \right)
+\end{equation}$$
+
+</p><p>
+
+From which we can derive the visibility function:
+
+</p><p>
+
+$$\begin{equation}
+V(v,l,\alpha) = \frac{0.5}{\NoL \sqrt{(\NoV)^2 (1 - \aa) + \aa} + \NoV \sqrt{(\NoL)^2 (1 - \aa) + \aa}}
+\end{equation}$$
+
+</p><p>
+
+The GLSL implementation of the visibility term, shown in <a href="#listing_specularv">listing&#xA0;3</a>, is a bit more expensive than we would like since it requires two <code>sqrt</code> operations.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">V_SmithGGXCorrelated</span><span class="hljs-params">(<span class="hljs-keyword">float</span> NoV, <span class="hljs-keyword">float</span> NoL, <span class="hljs-keyword">float</span> linearRoughness)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">float</span> a2 = linearRoughness * linearRoughness;</span>
+<span class="line">    <span class="hljs-keyword">float</span> GGXV = NoL * <span class="hljs-built_in">sqrt</span>(NoV * NoV * (<span class="hljs-number">1.0</span> - a2) + a2);</span>
+<span class="line">    <span class="hljs-keyword">float</span> GGXL = NoV * <span class="hljs-built_in">sqrt</span>(NoL * NoL * (<span class="hljs-number">1.0</span> - a2) + a2);</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">0.5</span> / (GGXV + GGXL);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_specularv">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;3:</b> Implementation of the specular V term in GLSL</div>
+<p>
+
+
+We can optimize this visibility function by using an approximation after noticing that all the terms under the square roots are squares and that all the terms are in the \([0..1]\) range:
+
+</p><p>
+
+$$\begin{equation}
+V(v,l,\alpha) = \frac{0.5}{\NoL (\NoV (1 - \alpha) + \alpha) + \NoV (\NoL (1 - \alpha) + \alpha)}
+\end{equation}$$
+
+</p><p>
+
+This approximation is mathematically wrong but saves two square root operations and is good enough for real-time mobile applications, as shown in <a href="#listing_approximatedspecularv">listing&#xA0;4</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">V_SmithGGXCorrelatedFast</span><span class="hljs-params">(<span class="hljs-keyword">float</span> NoV, <span class="hljs-keyword">float</span> NoL, <span class="hljs-keyword">float</span> linearRoughness)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">float</span> a = linearRoughness;</span>
+<span class="line">    <span class="hljs-keyword">float</span> GGXV = NoL * (NoV * (<span class="hljs-number">1.0</span> - a) + a);</span>
+<span class="line">    <span class="hljs-keyword">float</span> GGXL = NoV * (NoL * (<span class="hljs-number">1.0</span> - a) + a);</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">0.5</span> / (GGXV + GGXL);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_approximatedspecularv">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;4:</b> Implementation of the approximated specular V term in GLSL</div>
+<p>
+
+
+[<a href="#citation-hammon17">Hammon17</a>] proposes the same approximation based on the same observation that the square root can be removed. It does so by rewriting the expressions as <em class="underscore">lerps</em>:
+
+</p><p>
+
+$$\begin{equation}
+V(v,l,\alpha) = \frac{0.5}{lerp(2 (\NoL) (\NoV), \NoL + \NoV, \alpha)}
+\end{equation}$$
+
+</p>
+<a class="target" name="fresnel(specularf)">&#xA0;</a><a class="target" name="materialsystem/specularbrdf/fresnel(specularf)">&#xA0;</a><a class="target" name="toc4.4.3">&#xA0;</a><h3>Fresnel (specular F)</h3>
+<p>
+
+
+The Fresnel effect plays an important role in the appearance of physically based materials. This effect models the fact that the amount of light the viewer sees reflected from a surface depends on the viewing angle. Large bodies of water are a perfect way to experience this phenomenon, as shown in <a href="#figure_fresnellake">figure&#xA0;10</a>. When looking at the water straight down (at normal incidence) you can see through the water. However, when looking further out in the distance (at grazing angle, where perceived light rays are getting parallel to the surface), you will see the specular reflections on the water become more intense.
+
+</p><p>
+
+The amount of light reflected depends not only on the viewing angle, but also on the index of refraction (IOR) of the material. At normal incidence (perpendicular to the surface, or 0&#xB0; angle), the amount of light reflected back is noted \(\fNormal\) and can be derived from the IOR as we will see in section  <a href="#toc4.8.3.2">4.8.3.2</a>. The amount of light reflected back at grazing angle is noted \(\fGrazing\) and approaches 100% for smooth materials.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/photo_fresnel_lake.jpg" target="_blank"><img class="markdeep" src="images/photo_fresnel_lake.jpg"></a><div class="imagecaption"><a class="target" name="figure_fresnellake">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;10:</b> The Fresnel effect is particularly evident on large bodies of water</div></div></center>
+
+<p></p><p>
+
+More formally, the Fresnel term defines how light reflects and refracts at the interface between two different media, or the ratio of reflected and transmitted energy. [<a href="#citation-schlick94">Schlick94</a>] describes an inexpensive approximation of the Fresnel term for the Cook-Torrance specular BRDF:
+
+</p><p>
+
+$$\begin{equation}
+F_{Schlick}(v,h,\fNormal,\fGrazing) = \fNormal + (\fGrazing - \fNormal)(1 - \VoH)^5
+\end{equation}$$
+
+</p><p>
+
+The constant \(\fNormal\) represents the specular reflectance at normal incidence and is achromatic for dielectrics, and chromatic for metals. The actual value depends on the index of refraction of the interface. The GLSL implementation of this term requires the use of a <code>pow</code>, as shown in <a href="#listing_specularf">listing&#xA0;5</a>, which can be replaced by a few multiplications.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> F_Schlick(<span class="hljs-type">float</span> VoH, <span class="hljs-type">vec3</span> f0, <span class="hljs-type">float</span> f90) {</span>
+<span class="line">    <span class="hljs-keyword">return</span> f0 + (<span class="hljs-type">vec3</span>(f90) - f0) * <span class="hljs-built_in">pow</span>(<span class="hljs-number">1.0</span> - VoH, <span class="hljs-number">5.0</span>);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_specularf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;5:</b> Implementation of the specular F term in GLSL</div>
+<p>
+
+
+This Fresnel function can be seen as interpolating between the incident specular reflectance and the reflectance at grazing angles, represented here by \(\fGrazing\). Observation of real world materials show that both dielectrics and conductors exhibit achromatic specular reflectance at grazing angles and that the Fresnel reflectance is 1.0 at 90&#xB0;. A more correct \(\fGrazing\) is discussed in section  <a href="#toc5.6.2">5.6.2</a>.
+
+</p><p>
+
+Using \(\fGrazing\) set to 1, the Schlick approximation for the Fresnel term can be optimized for scalar operations by refactoring the code slightly. The result is shown in <a href="#listing_scalarspecularf">listing&#xA0;6</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> F_Schlick(<span class="hljs-type">float</span> VoH, <span class="hljs-type">vec3</span> f0) {</span>
+<span class="line">    <span class="hljs-type">float</span> f = <span class="hljs-built_in">pow</span>(<span class="hljs-number">1.0</span> - VoH, <span class="hljs-number">5.0</span>);</span>
+<span class="line">    <span class="hljs-keyword">return</span> f + f0 * (<span class="hljs-number">1.0</span> - f);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_scalarspecularf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;6:</b> Scalar optimization of the specular F term in GLSL</div>
+
+<a class="target" name="diffusebrdf">&#xA0;</a><a class="target" name="materialsystem/diffusebrdf">&#xA0;</a><a class="target" name="toc4.5">&#xA0;</a><h2>Diffuse BRDF</h2>
+<p>
+
+
+In the diffuse term, \(f_m\) is a Lambertian function and the diffuse term of the BRDF becomes:
+
+</p><p>
+
+$$\begin{equation}
+\fDiffuse(v,l) = \frac{\sigma}{\pi} \frac{1}{| \NoV | | \NoL |}
+\int_\Omega D(m,\alpha) G(v,l,m) (v \cdot m) (l \cdot m) dm
+\end{equation}$$
+
+</p><p>
+
+Our implementation will instead use a simple Lambertian BRDF that assumes a uniform diffuse response over the microfacets hemisphere:
+
+</p><p>
+
+$$\begin{equation}
+\fDiffuse(v,l) = \frac{\sigma}{\pi}
+\end{equation}$$
+
+</p><p>
+
+In practice, the diffuse reflectance \(\sigma\) is multiplied later, as shown in <a href="#listing_diffusebrdf">listing&#xA0;8</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">Fd_Lambert</span><span class="hljs-params">()</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">1.0</span> / PI;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">vec3 Fd = diffuseColor * Fd_Lambert();</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_diffusebrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;7:</b> Implementation of the diffuse Lambertian BRDF in GLSL</div>
+<p>
+
+
+The Lambertian BRDF is obviously extremely efficient and delivers results close enough to more complex models.
+
+</p><p>
+
+However, the diffuse part would ideally be coherent with the specular term and take into account the surface roughness. Both the Disney diffuse BRDF [<a href="#citation-burley12">Burley12</a>] and Oren-Nayar model [<a href="#citation-oren94">Oren94</a>] take the roughness into account and create some retro-reflection at grazing angles. Given our constraints we decided that the extra runtime cost does not justify the slight increase in quality. This sophisticated diffuse model also renders image-based and spherical harmonics more difficult to express and implement.
+
+</p><p>
+
+For completeness, the Disney diffuse BRDF expressed in [<a href="#citation-burley12">Burley12</a>] is the following:
+
+</p><p>
+
+$$\begin{equation}
+\fDiffuse(v,l) = \frac{\sigma}{\pi} \schlick(n,l,1,\fGrazing) \schlick(n,v,1,\fGrazing)
+\end{equation}$$
+
+</p><p>
+
+Where:
+
+</p><p>
+
+$$\begin{equation}
+\fGrazing=0.5 + 2 \cdot \alpha cos^2(\theta_d)
+\end{equation}$$
+
+</p><p>
+
+It is important to note that the roughness used in this formula is the perceptually linear roughness (more on this in section  <a href="#toc4.8">4.8</a>).
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">F_Schlick</span><span class="hljs-params">(<span class="hljs-keyword">float</span> VoH, <span class="hljs-keyword">float</span> f0, <span class="hljs-keyword">float</span> f90)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> f0 + (f90 - f0) * <span class="hljs-built_in">pow</span>(<span class="hljs-number">1.0</span> - VoH, <span class="hljs-number">5.0</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">Fd_Burley</span><span class="hljs-params">(<span class="hljs-keyword">float</span> NoV, <span class="hljs-keyword">float</span> NoL, <span class="hljs-keyword">float</span> LoH, <span class="hljs-keyword">float</span> linearRoughness)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">float</span> f90 = <span class="hljs-number">0.5</span> + <span class="hljs-number">2.0</span> * linearRoughness * LoH * LoH;</span>
+<span class="line">    <span class="hljs-keyword">float</span> lightScatter = F_Schlick(NoL, <span class="hljs-number">1.0</span>, f90);</span>
+<span class="line">    <span class="hljs-keyword">float</span> viewScatter = F_Schlick(NoV, <span class="hljs-number">1.0</span>, f90);</span>
+<span class="line">    <span class="hljs-keyword">return</span> lightScatter * viewScatter * (<span class="hljs-number">1.0</span> / PI);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_diffusebrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;8:</b> Implementation of the diffuse Disney BRDF in GLSL</div>
+<p>
+
+
+<a href="#figure_lambert_vs_disney">Figure&#xA0;11</a> shows a comparison between a simple Lambertian diffuse BRDF and the higher quality Disney diffuse BRDF, using a fully rough dielectric material. For comparison purposes, the right sphere was mirrored. The surface response is very similar with both BRDFs but the Disney one exhibits some nice retro-reflections at grazing angles (look closely at the left edge of the spheres).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_lambert_vs_disney.png" target="_blank"><img class="markdeep" src="images/diagram_lambert_vs_disney.png"></a><div class="imagecaption"><a class="target" name="figure_lambert_vs_disney">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;11:</b> Comparison between the Lambertian diffuse BRDF (left) and the Disney diffuse BRDF (right)</div></div></center>
+
+<p></p><p>
+
+We could allow artists/developers to choose the Disney diffuse BRDF depending on the quality they desire and the performance of the target device. It is important to note however that the Disney diffuse BRDF is not energy conserving as expressed here.
+
+</p>
+<a class="target" name="standardmodelsummary">&#xA0;</a><a class="target" name="materialsystem/standardmodelsummary">&#xA0;</a><a class="target" name="toc4.6">&#xA0;</a><h2>Standard model summary</h2>
+<p>
+
+
+<strong class="asterisk">Specular term</strong>: a Cook-Torrance specular microfacet model, with a GGX normal distribution function, a Smith-GGX height-correlated visibility function, and a Schlick Fresnel function.
+
+</p><p>
+
+<strong class="asterisk">Diffuse term</strong>: a Lambertian diffuse model.
+
+</p><p>
+
+The full GLSL implementation of the standard model is shown in <a href="#listing_glslbrdf">listing&#xA0;9</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> D_GGX(<span class="hljs-type">float</span> NoH, <span class="hljs-type">float</span> a) {</span>
+<span class="line">    <span class="hljs-type">float</span> a2 = a * a;</span>
+<span class="line">    <span class="hljs-type">float</span> f = (NoH * a2 - NoH) * NoH + <span class="hljs-number">1.0</span>;</span>
+<span class="line">    <span class="hljs-keyword">return</span> a2 / (PI * f * f);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec3</span> F_Schlick(<span class="hljs-type">float</span> VoH, <span class="hljs-type">vec3</span> f0) {</span>
+<span class="line">    <span class="hljs-keyword">return</span> f0 + (<span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>) - f0) * <span class="hljs-built_in">pow</span>(<span class="hljs-number">1.0</span> - VoH, <span class="hljs-number">5.0</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> V_SmithGGXCorrelated(<span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> NoL, <span class="hljs-type">float</span> a) {</span>
+<span class="line">    <span class="hljs-type">float</span> a2 = a * a;</span>
+<span class="line">    <span class="hljs-type">float</span> GGXL = NoV * <span class="hljs-built_in">sqrt</span>((-NoL * a2 + NoL) * NoL + a2);</span>
+<span class="line">    <span class="hljs-type">float</span> GGXV = NoL * <span class="hljs-built_in">sqrt</span>((-NoV * a2 + NoV) * NoV + a2);</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">0.5</span> / (GGXV + GGXL);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> Fd_Lambert() {</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">1.0</span> / PI;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">void</span> BRDF(...) {</span>
+<span class="line">    <span class="hljs-type">vec3</span> h = <span class="hljs-built_in">normalize</span>(v + l);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> NoV = <span class="hljs-built_in">abs</span>(<span class="hljs-built_in">dot</span>(n, v)) + <span class="hljs-number">1e-5</span>;</span>
+<span class="line">    <span class="hljs-type">float</span> NoL = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(n, l), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">    <span class="hljs-type">float</span> NoH = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(n, h), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">    <span class="hljs-type">float</span> LoH = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(l, h), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// perceptually linear roughness (see parameterization)</span></span>
+<span class="line">    <span class="hljs-type">float</span> a = roughness * roughness;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> D = D_GGX(NoH, a);</span>
+<span class="line">    <span class="hljs-type">vec3</span>  F = F_Schlick(LoH, f0);</span>
+<span class="line">    <span class="hljs-type">float</span> V = V_SmithGGXCorrelated(NoV, NoL, a);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// specular BRDF</span></span>
+<span class="line">    <span class="hljs-type">vec3</span> Fr = (D * V) * F;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// diffuse BRDF</span></span>
+<span class="line">    <span class="hljs-type">vec3</span> Fd = diffuseColor * Fd_Lambert();</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// apply lighting...</span></span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_glslbrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;9:</b> Evaluation of the BRDF in GLSL</div>
+
+<a class="target" name="improvingthebrdfs">&#xA0;</a><a class="target" name="materialsystem/improvingthebrdfs">&#xA0;</a><a class="target" name="toc4.7">&#xA0;</a><h2>Improving the BRDFs</h2>
+<p>
+
+
+We mentioned in section  <a href="#toc4.3">4.3</a> that energy conservation is one of the key components of a good BRDF. Unfortunately the BRDFs explored previously suffer from two problems that we will examine below.
+
+</p>
+<a class="target" name="energygainindiffusereflectance">&#xA0;</a><a class="target" name="materialsystem/improvingthebrdfs/energygainindiffusereflectance">&#xA0;</a><a class="target" name="toc4.7.1">&#xA0;</a><h3>Energy gain in diffuse reflectance</h3>
+<p>
+
+
+The Lambert diffuse BRDF does not account for the light that reflects at the surface and that is therefore not able to participate in the diffuse scattering event.
+
+</p><p>
+
+[TODO: talk about the issue with fr+fd]
+
+</p>
+<a class="target" name="energylossinspecularreflectance">&#xA0;</a><a class="target" name="materialsystem/improvingthebrdfs/energylossinspecularreflectance">&#xA0;</a><a class="target" name="toc4.7.2">&#xA0;</a><h3>Energy loss in specular reflectance</h3>
+<p>
+
+
+The Cook-Torrance BRDF we presented earlier attempts to model several events at the microfacet level but does so by accounting for a single bounce of light. This approximation can cause a loss of energy at high roughness, the surface is not energy preserving. <a href="#figure_singlevsmultibounce">Figure&#xA0;12</a> shows why this loss of energy occurs. In the single bounce (or single scattering) model, a ray of light hitting the surface can be reflected back onto another microfacet and thus be discarded because of the masking and shadowing term. If we however account for multiple bounces (multiscattering), the same ray of light might escape the microfacet field and be reflected back towards the viewer.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_single_vs_multi_scatter.png" target="_blank"><img class="markdeep" src="images/diagram_single_vs_multi_scatter.png"></a><div class="imagecaption"><a class="target" name="figure_singlevsmultibounce">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;12:</b> Single scattering (left) vs multiscattering</div></div></center>
+
+<p></p><p>
+
+Based on this simple explanation, we can intuitively deduce that the rougher a surface is, the higher the chances are that energy gets lost because of the failure to account for multiple scattering events. This loss of energy appears to darken rough materials. Metallic surfaces are particularly affected because all of their reflectance is specular. This darkening effect is illustrated in <a href="#figure_metallicroughenergyloss">figure&#xA0;13</a>. With multiscattering, energy preservation can be achieved, as shown in <a href="#figure_metallicroughenergypreservation">figure&#xA0;14</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_metallic_energy_loss.png" target="_blank"><img class="markdeep" src="images/material_metallic_energy_loss.png"></a><div class="imagecaption"><a class="target" name="figure_metallicroughenergyloss">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;13:</b> Darkening increases with roughness due to single scattering</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/material_metallic_energy_preservation.png" target="_blank"><img class="markdeep" src="images/material_metallic_energy_preservation.png"></a><div class="imagecaption"><a class="target" name="figure_metallicroughenergypreservation">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;14:</b> Energy preservation with multiscattering</div></div></center>
+
+<p></p><p>
+
+We can use a white furnace, a uniform lighting environment set to pure white, to validate the energy preservation property of a BRDF. When energy preservation is achieved, a purely reflective metallic surface (\(\fNormal = 1\)) should be indistinguishable from the background, no matter the roughness of said surface. <a href="#figure_whitefurnaceloss">Figure&#xA0;15</a> shows what such a surface looks like with the specular BRDF presented in the previous sections. The loss of energy as the roughness increases is obvious. In contrast, <a href="#figure_whitefurnacepreservation">figure&#xA0;16</a> shows that accounting for multiscattering events addresses the energy loss.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_furnace_energy_loss.png" target="_blank"><img class="markdeep" src="images/material_furnace_energy_loss.png"></a><div class="imagecaption"><a class="target" name="figure_whitefurnaceloss">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;15:</b> Darkening increases with roughness due to single scattering</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/material_furnace_energy_preservation.png" target="_blank"><img class="markdeep" src="images/material_furnace_energy_preservation.png"></a><div class="imagecaption"><a class="target" name="figure_whitefurnacepreservation">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;16:</b> Energy preservation with multiscattering</div></div></center>
+
+<p></p><p>
+
+Multiple-scattering microfacet BRDFs are discussed in depth in [<a href="#citation-heitz16">Heitz16</a>]. Unfortunately this paper only presents a stochastic evaluation of the multiscattering BRDF. This solution is therefore not suitable for real-time rendering. Kulla and Conty present a different approach in [<a href="#citation-kulla17">Kulla17</a>]. Their idea is to add an energy compensation term as an additional BRDF lobe shown in equation \(\ref{energyCompensationLobe}\):
+
+</p><p>
+
+$$\begin{equation}\label{energyCompensationLobe}
+f_{ms}(l,v) = \frac{(1 - E(l)) (1 - E(v)) F_{avg}^2 E_{avg}}{\pi (1 - E_{avg}) (1 - F_{avg}(1 - E_{avg}))}
+\end{equation}$$
+
+</p><p>
+
+Where \(E\) is the directional albedo of the specular BRDF \(f_r\), with \(\fNormal\) set to 1:
+
+</p><p>
+
+$$\begin{equation}
+E(l) = \int_{\Omega} f(l,v) (\NoV) dv
+\end{equation}$$
+
+</p><p>
+
+The term \(E_{avg}\) is the cosine-weighted average of \(E\):
+
+</p><p>
+
+$$\begin{equation}
+E_{avg} = 2 \int_0^1 E(\mu) \mu d\mu
+\end{equation}$$
+
+</p><p>
+
+Similarly, \(F_{avg}\) is the cosine-weighted average of the Fresnel term:
+
+</p><p>
+
+$$\begin{equation}
+F_{avg} = 2 \int_0^1 F(\mu) \mu d\mu
+\end{equation}$$
+
+</p><p>
+
+Both terms \(E\) and \(E_{avg}\) can be precomputed and stored in lookup tables. while \(F_{avg}\) can be greatly simplified when the Schlick approximation is used:
+
+</p><p>
+
+$$\begin{equation}\label{averageFresnel}
+F_{avg} = \frac{1 + 20 \fNormal}{21}
+\end{equation}$$
+
+</p><p>
+
+This new lobe is combined with the original single scattering lobe, previously noted \(f_r\):
+
+</p><p>
+
+$$\begin{equation}
+f_{r}(l,v) = f_{ss}(l,v) + f_{ms}(l,v)
+\end{equation}$$
+
+</p><p>
+
+In [<a href="#citation-lagarde18">Lagarde18</a>], with credit to Emmanuel Turquin, Lagarde and Golubev make the observation that equation \(\ref{averageFresnel}\) can be simplified to \(\fNormal\). They also propose to apply energy compensation by adding a scaled GGX specular lobe:
+
+</p><p>
+
+$$\begin{equation}\label{energyCompensation}
+f_{ms}(l,v) = \fNormal \frac{1 - E(l)}{E(l)} f_{ss}(l,v)
+\end{equation}$$
+
+</p><p>
+
+The key insight is that \(E(l)\) can not only be precomputed but also shared with image-based lighting pre-integration. The multiscattering energy compensation formula thus becomes:
+
+</p><p>
+
+$$\begin{equation}\label{scaledEnergyCompensationLobe}
+f_r(l,v) = f_{ss}(l,v) + \fNormal \left( \frac{1}{r} - 1 \right) f_{ss}(l,v)
+\end{equation}$$
+
+</p><p>
+
+Where \(r\) is defined as:
+
+</p><p>
+
+$$\begin{equation}
+r = \int_{\Omega} D(l,v) V(l,v) \left&lt; \NoL \right&gt; dl
+\end{equation}$$
+
+</p><p>
+
+We can implement specular energy compensation at a negligible cost if we store \(r\) in the DFG lookup table presented in section  <a href="#toc5.3">5.3</a>. <a href="#listing_energycompensationimpl">Listing&#xA0;10</a> shows that the implementation is a direct conversion of equation \(\ref{scaledEnergyCompensationLobe}\).
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> energyCompensation = <span class="hljs-number">1.0</span> + f0 * (<span class="hljs-number">1.0</span> / dfg.y - <span class="hljs-number">1.0</span>);</span>
+<span class="line"><span class="hljs-comment">// Scale the specular lobe to account for multiscattering</span></span>
+<span class="line">Fr *= pixel.energyCompensation;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_energycompensationimpl">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;10:</b> Implementation of the energy compensation specular lobe</div>
+<p>
+
+
+Please refer to section  <a href="#toc5.3">5.3</a> and section  <a href="#toc5.3.4.7">5.3.4.7</a> to learn how the DFG lookup table is derived and computed.
+
+</p>
+<a class="target" name="parameterization">&#xA0;</a><a class="target" name="materialsystem/parameterization">&#xA0;</a><a class="target" name="toc4.8">&#xA0;</a><h2>Parameterization</h2>
+<p>
+
+
+Disney&apos;s material model described in [<a href="#citation-burley12">Burley12</a>] is a good starting point but its numerous parameters makes it impractical for real-time implementations. In addition, we would like our standard material model to be easy to understand and easy to use for both artists and developers.
+
+</p>
+<a class="target" name="standardparameters">&#xA0;</a><a class="target" name="materialsystem/parameterization/standardparameters">&#xA0;</a><a class="target" name="toc4.8.1">&#xA0;</a><h3>Standard parameters</h3>
+<p>
+
+
+<a href="#table_standardparameters">Table&#xA0;2</a> describes the list of parameters that satisfy our constraints.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">BaseColor</strong> </td><td style="text-align:left"> Diffuse albedo for non-metallic surfaces, and specular color for metallic surfaces </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Metallic</strong> </td><td style="text-align:left"> Whether a surface appears to be dielectric (0.0) or conductor (1.0). Often used as a binary value (0 or 1) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Roughness</strong> </td><td style="text-align:left"> Perceived smoothness (0.0) or roughness (1.0) of a surface. Smooth surfaces exhibit sharp reflections </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Reflectance</strong> </td><td style="text-align:left"> Fresnel reflectance at normal incidence for dielectric surfaces. This replaces an explicit index of refraction </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Emissive</strong> </td><td style="text-align:left"> Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This parameter is mostly useful in an HDR pipeline with a bloom pass </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Ambient occlusion</strong> </td><td style="text-align:left"> Defines how much of the ambient light is accessible to a surface point. It is a per-pixel shadowing factor between 0.0 and 1.0. This parameter will be discussed in more details in the <a href="#lighting">lighting</a> section </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_standardparameters">&#xA0;</a><b style="font-style:normal;">Table&#xA0;2:</b> Parameters of the standard model</div></div>
+
+<p></p><p>
+
+<a href="#figure_material_parameters">Figure&#xA0;17</a> shows how the metallic, roughness and reflectance parameters affect the appearance of a surface.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_parameters.png" target="_blank"><img class="markdeep" src="images/material_parameters.png"></a><div class="imagecaption"><a class="target" name="figure_material_parameters">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;17:</b> From top to bottom: varying metallic, varying dielectric roughness, varying metallic roughness, varying reflectance</div></div></center>
+
+<p></p>
+<a class="target" name="typesandranges">&#xA0;</a><a class="target" name="materialsystem/parameterization/typesandranges">&#xA0;</a><a class="target" name="toc4.8.2">&#xA0;</a><h3>Types and ranges</h3>
+<p>
+
+
+It is important to understand the type and range of the different parameters of our material model, described in <a href="#table_standardparameterstypes">table&#xA0;3</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Type and range </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">BaseColor</strong> </td><td style="text-align:left"> Linear RGB [0..1] </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Metallic</strong> </td><td style="text-align:left"> Scalar [0..1] </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Roughness</strong> </td><td style="text-align:left"> Scalar [0..1] </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Reflectance</strong> </td><td style="text-align:left"> Scalar [0..1] </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Emissive</strong> </td><td style="text-align:left"> Linear RGB [0..1] + exposure compensation </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Ambient occlusion</strong> </td><td style="text-align:left"> Scalar [0..1] </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_standardparameterstypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;3:</b> Range and type of the standard model&apos;s parameters</div></div>
+
+<p></p><p>
+
+Note that the types and ranges described here are what the shader will expect. The API and/or tools UI could and should allow to specify the parameters using other types and ranges when they are more intuitive for artists.
+
+</p><p>
+
+For instance, the base color could be expressed in sRGB space and converted to linear space before being sent off to the shader. It can also be useful for artists to express the metallic, roughness and reflectance parameters as gray values between 0 and 255 (black to white).
+
+</p><p>
+
+Another example: the emissive parameter could be expressed as a color temperature and an intensity, to simulate the light emitted by a black body.
+
+</p>
+<a class="target" name="remapping">&#xA0;</a><a class="target" name="materialsystem/parameterization/remapping">&#xA0;</a><a class="target" name="toc4.8.3">&#xA0;</a><h3>Remapping</h3>
+<p>
+
+
+To make the standard material model easier and more intuitive to use for artists, we must remap the parameters <em class="underscore">baseColor</em>, <em class="underscore">roughness</em> and <em class="underscore">reflectance</em>.
+
+</p>
+<a class="target" name="basecolorremapping">&#xA0;</a><a class="target" name="materialsystem/parameterization/remapping/basecolorremapping">&#xA0;</a><a class="target" name="toc4.8.3.1">&#xA0;</a><h4>Base color remapping</h4>
+<p>
+
+
+The base color of a material is affected by the &#x201C;metallicness&#x201D; of said material. Dielectrics have achromatic specular reflectance but retain their base color as the diffuse color. Conductors on the other hand use their base color as the specular color and do not have a diffuse component.
+
+</p><p>
+
+The lighting equations must therefore use the diffuse color and \(\fNormal\) instead of the base color. The diffuse color can easily be computed from the base color, as show in <a href="#listing_basecolortodiffuse">listing&#xA0;11</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> diffuseColor = (<span class="hljs-number">1.0</span> - metallic) * baseColor.rgb;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_basecolortodiffuse">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;11:</b> Conversion of base color to diffuse in GLSL</div>
+
+<a class="target" name="reflectanceremapping">&#xA0;</a><a class="target" name="materialsystem/parameterization/remapping/reflectanceremapping">&#xA0;</a><a class="target" name="toc4.8.3.2">&#xA0;</a><h4>Reflectance remapping</h4>
+<p>
+
+
+<strong class="asterisk">Dielectrics</strong>
+
+</p><p>
+
+The Fresnel term relies on \(\fNormal\), the specular reflectance at normal incidence angle, and is achromatic for dielectrics. We will use the remapping for dielectric surfaces described in [<a href="#citation-lagarde14">Lagarde14</a>] :
+
+</p><p>
+
+$$\begin{equation}
+\fNormal = 0.16 \cdot reflectance^2
+\end{equation}$$
+
+</p><p>
+
+The goal is to map \(\fNormal\) onto a range that can represent the Fresnel values of both common dielectric surfaces (4% reflectance) and gemstones (8% to 16%). The mapping function is chosen to yield a 4% Fresnel reflectance value for an input reflectance of 0.5 (or 128 on a linear RGB gray scale). <a href="#figure_reflectance">Figure&#xA0;18</a> show those common values and how they relate to the mapping function.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_reflectance.png" target="_blank"><img class="markdeep" src="images/diagram_reflectance.png"></a><div class="imagecaption"><a class="target" name="figure_reflectance">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;18:</b> Common reflectance values</div></div></center>
+
+<p></p><p>
+
+If the index of refraction is known (for instance, an air-water interface has an IOR of 1.33), the Fresnel reflectance can be calculated as follows:
+
+</p><p>
+
+$$\begin{equation}\label{fresnelEquation}
+\fNormal(n_{ior}) = \frac{(\nior - 1)^2}{(\nior + 1)^2}
+\end{equation}$$
+
+</p><p>
+
+And if the reflectance value is known, we can compute the corresponding IOR:
+
+</p><p>
+
+$$\begin{equation}
+n_{ior} = \frac{2}{1 - \sqrt{\fNormal}} - 1 
+\end{equation}$$
+
+</p><p>
+
+<a href="#table_commonmatreflectance">Table&#xA0;4</a> describes acceptable Fresnel reflectance values for various types of materials (no real world material has a value under 2%).
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Material </th><th style="text-align:left"> Reflectance </th><th style="text-align:left"> Linear value </th></tr>
+<tr><td style="text-align:right"> Water </td><td style="text-align:left"> 2% </td><td style="text-align:left"> 0.35 </td></tr>
+<tr><td style="text-align:right"> Fabric </td><td style="text-align:left"> 4% to 5.6% </td><td style="text-align:left"> 0.5 to 0.59 </td></tr>
+<tr><td style="text-align:right"> Common liquids </td><td style="text-align:left"> 2% to 4% </td><td style="text-align:left"> 0.35 to 0.5 </td></tr>
+<tr><td style="text-align:right"> Common gemstones </td><td style="text-align:left"> 5% to 16% </td><td style="text-align:left"> 0.56 to 1.0 </td></tr>
+<tr><td style="text-align:right"> Plastics, glass </td><td style="text-align:left"> 4% to 5% </td><td style="text-align:left"> 0.5 to 0.56 </td></tr>
+<tr><td style="text-align:right"> Other dielectric materials </td><td style="text-align:left"> 2% to 5% </td><td style="text-align:left"> 0.35 to 0.56 </td></tr>
+<tr><td style="text-align:right"> Eyes </td><td style="text-align:left"> 2.5% </td><td style="text-align:left"> 0.39 </td></tr>
+<tr><td style="text-align:right"> Skin </td><td style="text-align:left"> 2.8% </td><td style="text-align:left"> 0.42 </td></tr>
+<tr><td style="text-align:right"> Hair </td><td style="text-align:left"> 4.6% </td><td style="text-align:left"> 0.54 </td></tr>
+<tr><td style="text-align:right"> Teeth </td><td style="text-align:left"> 5.8% </td><td style="text-align:left"> 0.6 </td></tr>
+<tr><td style="text-align:right"> Default value </td><td style="text-align:left"> 4% </td><td style="text-align:left"> 0.5 </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_commonmatreflectance">&#xA0;</a><b style="font-style:normal;">Table&#xA0;4:</b> Reflectance of common materials (source: Real-Time Rendering 4th Edition)</div></div>
+
+<p></p><p>
+
+<a href="#table_fnormalmetals">Table&#xA0;5</a> lists the \(\fNormal\) values for a few metals. The values are given in sRGB and must be used as the base color in our material model. Please refer to the annex, section  <a href="#toc9.1">9.1</a>, for an explanation of how these sRGB colors are computed from measured data.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Metal </th><th style="text-align:center"> \(\fNormal\) in sRGB </th><th style="text-align:center"> Hexadecimal </th><th style="text-align:left"> Color </th></tr>
+<tr><td style="text-align:right"> Silver </td><td style="text-align:center"> 0.97, 0.96, 0.91 </td><td style="text-align:center"> #f7f4e8 </td><td style="text-align:left"> <div style="background-color: #f7f4e8; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Aluminum </td><td style="text-align:center"> 0.91, 0.92, 0.92 </td><td style="text-align:center"> #e8eaea </td><td style="text-align:left"> <div style="background-color: #e8eaea; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Titanium </td><td style="text-align:center"> 0.76, 0.73, 0.69 </td><td style="text-align:center"> #c1baaf </td><td style="text-align:left"> <div style="background-color: #c1baaf; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Iron </td><td style="text-align:center"> 0.77, 0.78, 0.78 </td><td style="text-align:center"> #c4c6c6 </td><td style="text-align:left"> <div style="background-color: #c4c6c6; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Platinum </td><td style="text-align:center"> 0.83, 0.81, 0.78 </td><td style="text-align:center"> #d3cec6 </td><td style="text-align:left"> <div style="background-color: #d3cec6; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Gold </td><td style="text-align:center"> 1.00, 0.85, 0.57 </td><td style="text-align:center"> #ffd891 </td><td style="text-align:left"> <div style="background-color: #ffd891; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Brass </td><td style="text-align:center"> 0.98, 0.90, 0.59 </td><td style="text-align:center"> #f9e596 </td><td style="text-align:left"> <div style="background-color: #f9e596; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Copper </td><td style="text-align:center"> 0.97, 0.74, 0.62 </td><td style="text-align:center"> #f7bc9e </td><td style="text-align:left"> <div style="background-color: #f7bc9e; width: 60px">&#xA0;</div> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_fnormalmetals">&#xA0;</a><b style="font-style:normal;">Table&#xA0;5:</b> \(\fNormal\) for common metals</div></div>
+
+<p></p><p>
+
+All materials have a Fresnel reflectance of 100% at grazing angles so we will set \(\fGrazing\) in the following way when evaluating the specular BRDF \(\fSpecular\):
+
+</p><p>
+
+$$\begin{equation}
+\fGrazing = 1.0
+\end{equation}$$
+
+</p><p>
+
+<a href="#figure_grazing_reflectance">Figure&#xA0;19</a> shows a red plastic ball. If you look closely at the edges of the sphere, you will be able to notice the achromatic specular reflectance at grazing angles.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_grazing_reflectance.png" target="_blank"><img class="markdeep" src="images/material_grazing_reflectance.png"></a><div class="imagecaption"><a class="target" name="figure_grazing_reflectance">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;19:</b> The specular reflectance becomes achromatic at grazing angles</div></div></center>
+
+<p></p><p>
+
+<strong class="asterisk">Conductors</strong>
+
+</p><p>
+
+The specular reflectance of metallic surfaces is chromatic:
+
+</p><p>
+
+$$\begin{equation}
+\fNormal = baseColor \cdot metallic
+\end{equation}$$
+
+</p><p>
+
+<a href="#listing_fnormal">Listing&#xA0;12</a> shows how \(\fNormal\) is computed for both dielectric and metallic materials. It shows that the color of the specular reflectance is derived from the base color in the metallic case.
+
+</p><pre class="listing tilde"><code><span class="line">vec3 f0 = 0.16 <span class="hljs-bullet">* reflectance *</span> reflectance <span class="hljs-bullet">* (1.0 - metallic) + baseColor *</span> metallic;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_fnormal">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;12:</b> Computing \(\fNormal\) for dielectric and metallic materials in GLSL</div>
+
+<a class="target" name="roughnessremappingandclamping">&#xA0;</a><a class="target" name="materialsystem/parameterization/remapping/roughnessremappingandclamping">&#xA0;</a><a class="target" name="toc4.8.3.3">&#xA0;</a><h4>Roughness remapping and clamping</h4>
+<p>
+
+
+The roughness is remapped to a perceptually linear range using the following formulation:
+
+</p><p>
+
+$$\begin{equation}
+\alpha = roughness^2
+\end{equation}$$
+
+</p><p>
+
+<a href="#figure_roughness_remap">Figure&#xA0;20</a> shows a silver metallic surface with increasing roughness (from 0.0 to 1.0), using the unmodified roughness value (bottom) and the perceptually linear roughness value (top).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_roughness_remap.png" target="_blank"><img class="markdeep" src="images/material_roughness_remap.png"></a><div class="imagecaption"><a class="target" name="figure_roughness_remap">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;20:</b> Roughness remapping comparison: perceptually linear roughness (top) and roughness (bottom)</div></div></center>
+
+<p></p><p>
+
+Using this visual comparison, it is obvious that the remapped roughness is easier to understand by artists and developers. Without this remapping, shiny metallic surfaces would have to be confined to a very small range between 0.0 and 0.05.
+
+</p><p>
+
+Brent Burley made similar observations in his presentation [<a href="#citation-burley12">Burley12</a>]. After experimenting with other remappings (cubic and quadratic mappings for instance), we have reached the conclusion that this simple square remapping delivers visually pleasing and intuitive results while being cheap for real-time applications.
+
+</p><p>
+
+Last but not least, it is important to note that the roughness parameters is used in various computations at runtime where limited floating point precision can become an issue. For instance, <em class="underscore">mediump</em> precision floats are often implemented as half-floats (fp16) on mobile GPUs.
+
+</p><p>
+
+This cause problems when computing small values like \(\frac{1}{roughness^4}\) in our lighting equations (perceptually linear roughness squared in the GGX computation). The smallest value that can be represented as a half-float is \(2^{-14}\) or \(6.1 \times 10^{-5}\). To avoid divisions by 0 on devices that do not support denormals, the result of \(\frac{1}{roughness^4}\) must therefore not be lower than \(6.1 \times 10^{-5}\). To do so, we must clamp the roughness to 0.089, which gives us \(6.274 \times 10^{-5}\). 
+
+</p><p>
+
+Denormals should also be avoided to prevent performance drops. The roughness can also not be set to 0 to avoid obvious divisions by 0.
+
+</p><p>
+
+Since we also want specular highlights to have a minimum size (a roughness close to 0 creates almost invisible highlights), we should clamp the roughness to a safe range in the shader. This clamping has the added benefit of correcting specular aliasing<sup><a href="#endnote-frostbiteroughnessclamp">1</a></sup> that can appear for low roughness values.
+
+</p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-frostbiteroughnessclamp">&#xA0;</a><sup>1</sup> The Frostbite engine clamps the roughness of analytical lights to 0.045 to reduce specular aliasing. This is possible when using single precision floats (fp32).
+</div>
+<p></p>
+<a class="target" name="blendingandlayering">&#xA0;</a><a class="target" name="materialsystem/parameterization/blendingandlayering">&#xA0;</a><a class="target" name="toc4.8.4">&#xA0;</a><h3>Blending and layering</h3>
+<p>
+
+
+As noted in [<a href="#citation-burley12">Burley12</a>] and [<a href="#citation-neubelt13">Neubelt13</a>], this model allows for robust blending between different materials by simply interpolating the different parameters. In particular, this allows to layer different materials using simple masks.
+
+</p><p>
+
+For instance, <a href="#figure_materialblending">figure&#xA0;21</a> shows how the studio Ready at Dawn used material blending and layering in <em class="underscore">The Order: 1886</em> to create complex appearances from a library of simple materials (gold, copper, wood, rust, etc.).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_blending.png" target="_blank"><img class="markdeep" src="images/material_blending.png"></a><div class="imagecaption"><a class="target" name="figure_materialblending">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;21:</b> Material blending and layering. Source: Ready at Dawn Studios</div></div></center>
+
+<p></p><p>
+
+The blending and layering of materials is effectively an interpolation of the various parameters of the material model. <a href="#figure_material_interpolation">Figure&#xA0;22</a> show an interpolation between shiny metallic chrome and rough red plastic. While the intermediate blended materials make little physical sense, they look plausible.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_interpolation.png" target="_blank"><img class="markdeep" src="images/material_interpolation.png"></a><div class="imagecaption"><a class="target" name="figure_material_interpolation">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;22:</b> Interpolation from shiny chrome (left) to rough red plastic (right)</div></div></center>
+
+<p></p>
+<a class="target" name="craftingphysicallybasedmaterials">&#xA0;</a><a class="target" name="materialsystem/parameterization/craftingphysicallybasedmaterials">&#xA0;</a><a class="target" name="toc4.8.5">&#xA0;</a><h3>Crafting physically based materials</h3>
+<p>
+
+
+Designing physically based materials is fairly easy once you understand the nature of the four main parameters: base color, metallic, roughness and reflectance.
+
+</p><p>
+
+We provide a <a href="./Material%20Properties.pdf">useful chart/reference guide</a> to help artists and developers craft their own physically based materials.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_chart.jpg" target="_blank"><img class="markdeep" src="images/material_chart.jpg"></a><div class="imagecaption">Crafting physically based materials</div></div></center>
+
+<p></p><p>
+
+In addition, here is a quick summary of how to use our material model:
+
+</p><p>
+
+</p><dl><dt>All materials</dt><dd><p>    <strong class="asterisk">Base color</strong> should be devoid of lighting information, except for micro-occlusion.
+
+</p><p>
+
+    <strong class="asterisk">Metallic</strong> is almost a binary value. Pure conductors have a metallic value of 1 and pure dielectrics have a metallic value of 0. You should try to use values close at or close to 0 and 1. Intermediate values are meant for transitions between surface types (metal to rust for instance).
+
+</p></dd><dt>Non-metallic materials</dt><dd><p>    <strong class="asterisk">Base color</strong> represents the reflected color and should be an sRGB value in the range 50-240 (strict range) or 30-240 (tolerant range).
+
+</p><p>
+
+    <strong class="asterisk">Metallic</strong> should be 0 or close to 0.
+
+</p><p>
+
+    <strong class="asterisk">Reflectance</strong> should be set to 127 sRGB (0.5 linear, 4% reflectance) if you cannot find a proper value. Do not use values under 90 sRGB (0.35 linear, 2% reflectance).
+
+</p></dd><dt>Metallic materials</dt><dd><p>    <strong class="asterisk">Base color</strong> represents both the specular color and reflectance. Use values with a luminosity of 67% to 100% (170-255 sRGB). Oxidized or dirty metals should use a lower luminosity than clean metals to take into account the non-metallic components.
+
+</p><p>
+
+    <strong class="asterisk">Metallic</strong> should be 1 or close to 1.
+
+</p><p>
+
+    <strong class="asterisk">Reflectance</strong> is ignored (calculated from the base color).
+
+</p></dd></dl><p></p>
+<a class="target" name="clearcoatmodel">&#xA0;</a><a class="target" name="materialsystem/clearcoatmodel">&#xA0;</a><a class="target" name="toc4.9">&#xA0;</a><h2>Clear coat model</h2>
+<p>
+
+
+The standard material model described previously is a good fit for isotropic surfaces made of a single layer. Multi-layer materials are unfortunately fairly common, particularly materials with a thin translucent layer over a standard layer. Real world examples of such materials include car paints, soda cans, lacquered wood, acrylic, etc.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_clear_coat.png" target="_blank"><img class="markdeep" src="images/material_clear_coat.png"></a><div class="imagecaption"><a class="target" name="figure_materialclearcoat">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;23:</b> Comparison of a blue metallic surface under the standard material model (left) and the clear coat model (right)</div></div></center>
+
+<p></p><p>
+
+A clear coat layer can be simulated as an extension of the standard material model by adding a second specular lobe, which implies evaluating a second specular BRDF. To simplify the implementation and parameterization, the clear coat layer will always be isotropic and dielectric. The base layer can be anything allowed by the standard model (dielectric or conductor).
+
+</p><p>
+
+Since incoming light will traverse the clear coat layer, we must also take the loss of energy into account as shown in <a href="#figure_clearcoatmodel">figure&#xA0;24</a>. Our model will however not simulate inter reflection and refraction behaviors.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_clear_coat.png" target="_blank"><img class="markdeep" src="images/diagram_clear_coat.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoatmodel">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;24:</b> Clear coat surface model</div></div></center>
+
+<p></p>
+<a class="target" name="clearcoatspecularbrdf">&#xA0;</a><a class="target" name="materialsystem/clearcoatmodel/clearcoatspecularbrdf">&#xA0;</a><a class="target" name="toc4.9.1">&#xA0;</a><h3>Clear coat specular BRDF</h3>
+<p>
+
+
+The clear coat layer will be modeled using the same Cook-Torrance microfacet BRDF used in the standard model. Since the clear coat layer is always isotropic and dielectric, with low roughness values (see section  <a href="#toc4.9.3">4.9.3</a>), we can choose cheaper DFG terms without notably sacrificing visual quality.
+
+</p><p>
+
+A survey of the terms listed in [<a href="#citation-karis13">Karis13</a>] and [<a href="#citation-burley12">Burley12</a>] shows that the Fresnel and NDF terms we already use in the standard model are not computationally more expensive than other terms. [<a href="#citation-kelemen01">Kelemen01</a>] describes a much simpler term that can replace our Smith-GGX visibility term:
+
+</p><p>
+
+$$\begin{equation}
+V(l,h) = \frac{1}{4(\LoH)^2}
+\end{equation}$$
+
+</p><p>
+
+This masking-shadowing function is not physically based, as shown in [<a href="#citation-heitz14">Heitz14</a>], but its simplicity makes it desirable for real-time rendering.
+
+</p><p>
+
+In summary, our clear coat BRDF is a Cook-Torrance specular microfacet model, with a GGX normal distribution function, a Kelemen visibility function, and a Schlick Fresnel function. <a href="#listing_kelemen">Listing&#xA0;13</a> shows how trivial the GLSL implementation is.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">V_Kelemen</span><span class="hljs-params">(<span class="hljs-keyword">float</span> LoH)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">0.25</span> / (LoH * LoH);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_kelemen">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;13:</b> Implementation of the Kelemen visibility term in GLSL</div>
+<p>
+
+
+<strong class="asterisk">Note on the Fresnel term</strong>
+
+</p><p>
+
+The Fresnel term of the specular BRDF requires \(\fNormal\), the specular reflectance at normal incidence angle. This parameter can be computed from an index of refraction of an interface. We will assume that our clear coat layer is made of polyurethane, a common compound <a href="https://en.wikipedia.org/wiki/List_of_polyurethane_applications#Varnish">used in coatings and varnishes</a>, or similar. An air-polyurethane interface <a href="http://www.clearpur.com/transparent-polyurethanes/">has an IOR of 1.5</a>, from which we can deduce \(\fNormal\):
+
+</p><p>
+
+$$\begin{equation}
+\fNormal(1.5) = \frac{(1.5 - 1)^2}{(1.5 + 1)^2} = 0.04
+\end{equation}$$
+
+</p><p>
+
+This corresponds to a Fresnel reflectance of 4% that we know is associated with common dielectric materials.
+
+</p>
+<a class="target" name="integrationinthesurfaceresponse">&#xA0;</a><a class="target" name="materialsystem/clearcoatmodel/integrationinthesurfaceresponse">&#xA0;</a><a class="target" name="toc4.9.2">&#xA0;</a><h3>Integration in the surface response</h3>
+<p>
+
+
+Because we must take into account the loss of energy caused by the addition of the clear coat layer, we can reformulate the BRDF from equation \(\ref{brdf}\) thusly:
+
+</p><p>
+
+$$\begin{equation}
+f(v,l)=\fDiffuse(n,l) (1 - F_c) + \fSpecular(n,l) (1 - F_c)^2 + f_c(n,l)
+\end{equation}$$
+
+</p><p>
+
+Where \(F_c\) is the Fresnel term of the clear coat BRDF and \(f_c\) the clear coat BRDF. The multiplication by \((1 - F_c)^2\) of the specular component is to remain energy conservative as the light enters and exists the clear coat layer. The multiplication by \(1 - F_c\) of the diffuse component is an attempt at energy conservation.
+
+</p>
+<a class="target" name="clearcoatparameterization">&#xA0;</a><a class="target" name="materialsystem/clearcoatmodel/clearcoatparameterization">&#xA0;</a><a class="target" name="toc4.9.3">&#xA0;</a><h3>Clear coat parameterization</h3>
+<p>
+
+
+The clear coat material model encompasses all the parameters previously defined for the standard material mode, plus two parameters described in <a href="#table_clearcoatparameters">table&#xA0;6</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">ClearCoat</strong> </td><td style="text-align:left"> Strength of the clear coat layer. Scalar between 0 and 1 </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">ClearCoatRoughness</strong> </td><td style="text-align:left"> Perceived smoothness or roughness of the clear coat layer. Scalar between 0 and 1 </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_clearcoatparameters">&#xA0;</a><b style="font-style:normal;">Table&#xA0;6:</b> Clear coat model parameters</div></div>
+
+<p></p><p>
+
+The clear coat roughness parameter is remapped and clamped in a similar way to the roughness parameter of the standard material. The main difference is that we want to lower the clear coat roughness range from [0..1] to the smaller [0..0.6] range. This remapping is arbitrary but matches the fact that clear coat layers are almost always glossy. The remapped value is squared to produce a perceptually linear roughness value.
+
+</p><p>
+
+<a href="#figure_clearcoat">Figure&#xA0;25</a> and <a href="#figure_clearcoatroughness">figure&#xA0;26</a> show how the clear coat parameters affect the appearance of a surface.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_clear_coat1.png" target="_blank"><img class="markdeep" src="images/material_clear_coat1.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoat">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;25:</b> Clear coat varying from 0.0 (left) to 1.0 (right) with metallic set to 1.0 and roughness to 0.8</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/material_clear_coat2.png" target="_blank"><img class="markdeep" src="images/material_clear_coat2.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoatroughness">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;26:</b> Clear coat roughness varying from 0.0 (left) to 1.0 (right) with metallic set to 1.0, roughness to 0.8 and clear coat to 1.0</div></div></center>
+
+<p></p><p>
+
+<a href="#listing_clearcoatbrdf">Listing&#xA0;14</a> shows the GLSL implementation of the clear coat material model after remapping, parameterization and integration in the standard surface response.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">BRDF</span><span class="hljs-params">(...)</span> </span>{</span>
+<span class="line">    <span class="hljs-comment">// compute Fd and Fr from standard model</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// remapping and linearization of clear coat roughness</span></span>
+<span class="line">    clearCoatRoughness = mix(<span class="hljs-number">0.089</span>, <span class="hljs-number">0.6</span>, clearCoatRoughness);</span>
+<span class="line">    clearCoatLinearRoughness = clearCoatRoughness * clearCoatRoughness;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// clear coat BRDF</span></span>
+<span class="line">    <span class="hljs-keyword">float</span>  Dc = D_GGX(clearCoatLinearRoughness, NoH);</span>
+<span class="line">    <span class="hljs-keyword">float</span>  Vc = V_Kelemen(clearCoatLinearRoughness, LoH);</span>
+<span class="line">    <span class="hljs-keyword">float</span>  Fc = F_Schlick(<span class="hljs-number">0.04</span>, LoH) * clearCoat; <span class="hljs-comment">// clear coat strength</span></span>
+<span class="line">    <span class="hljs-keyword">float</span> Frc = (Dc * Vc) * Fc;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// account for energy loss in the base layer</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> color * ((Fd + Fr * (<span class="hljs-number">1.0</span> - Fc)) * (<span class="hljs-number">1.0</span> - Fc) + Frc);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clearcoatbrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;14:</b> Implementation of the clear coat BRDF in GLSL</div>
+
+<a class="target" name="baselayermodification">&#xA0;</a><a class="target" name="materialsystem/clearcoatmodel/baselayermodification">&#xA0;</a><a class="target" name="toc4.9.4">&#xA0;</a><h3>Base layer modification</h3>
+<p>
+
+
+The presence of a clear coat layer means that we should recompute \(\fNormal\), since it is normally based on an air-material interface. The base layer thus requires \(\fNormal\) to be computed based on a clear coat-material interface instead.
+
+</p><p>
+
+This can be achieved by computing the material&apos;s index of refraction (IOR) from \(\fNormal\), then computing a new \(\fNormal\) based on the newly computed IOR and the IOR of the clear coat layer (1.5).
+
+</p><p>
+
+First, we compute the base layer&apos;s IOR:
+
+</p><p>
+
+$$
+IOR_{base} = \frac{1 + \sqrt{\fNormal}}{1 - \sqrt{\fNormal}}
+$$
+
+</p><p>
+
+Then we compute the new \(\fNormal\) from this new index of refraction:
+
+</p><p>
+
+$$
+f_{0_{base}} = \left( \frac{IOR_{base} - 1.5}{IOR_{base} + 1.5} \right) ^2
+$$
+
+</p><p>
+
+Since the clear coat layer&apos;s IOR is fixed, we can combine both steps to simplify:
+
+</p><p>
+
+$$
+f_{0_{base}} = \frac{\left( 1 - 5 \sqrt{\fNormal} \right) ^2}{\left( 5 - \sqrt{\fNormal} \right) ^2}
+$$
+
+</p><p>
+
+We should also modify the base layer&apos;s apparent roughness based on the IOR of the clear coat layer but this is something we have opted to leave out for now.
+
+</p>
+<a class="target" name="anisotropicmodel">&#xA0;</a><a class="target" name="materialsystem/anisotropicmodel">&#xA0;</a><a class="target" name="toc4.10">&#xA0;</a><h2>Anisotropic model</h2>
+<p>
+
+
+The standard material model described previously can only describe isotropic surfaces, that is, surfaces whose properties are identical in all directions. Many real-world materials, such as brushed metal, can, however, only be replicated using an anisotropic model.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_anisotropic.png" target="_blank"><img class="markdeep" src="images/material_anisotropic.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropic">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;27:</b> Comparison of isotropic material (left) and anisotropic material (right)</div></div></center>
+
+<p></p>
+<a class="target" name="anisotropicspecularbrdf">&#xA0;</a><a class="target" name="materialsystem/anisotropicmodel/anisotropicspecularbrdf">&#xA0;</a><a class="target" name="toc4.10.1">&#xA0;</a><h3>Anisotropic specular BRDF</h3>
+<p>
+
+
+The isotropic specular BRDF described previously can be modified to handle anisotropic materials. Burley achieves this by using an anisotropic GGX NDF:
+
+</p><p>
+
+$$\begin{equation}
+D_{aniso}(h,\alpha) = \frac{1}{\pi \alpha_t \alpha_b} \frac{1}{((\frac{t \cdot h}{\alpha_t})^2 + (\frac{b \cdot h}{\alpha_b})^2 + (\NoH)^2)^2}
+\end{equation}$$
+
+</p><p>
+
+This NDF unfortunately relies on two supplemental roughness terms noted \(\alpha_b\), the roughness along the bitangent direction, and \(\alpha_t\), the roughness along the tangent direction. Neubelt and Pettineo [<a href="#citation-neubelt13">Neubelt13</a>] propose a way to derive \(\alpha_b\) from \(\alpha_t\) by using an <em class="underscore">anisotropy</em> parameter that describes the relationship between the two roughness values for a material:
+
+</p><p>
+
+$$
+\begin{align*}
+  \alpha_t &amp;= \alpha \\
+  \alpha_b &amp;= lerp(0, \alpha, 1 - anisotropy)
+\end{align*}
+$$
+
+</p><p>
+
+The relationship defined in [<a href="#citation-burley12">Burley12</a>] is different, offers more pleasant and intuitive results, but is slightly more expensive:
+
+</p><p>
+
+$$
+\begin{align*}
+  \alpha_t &amp;= \frac{\alpha}{\sqrt{1 - 0.9 \times anisotropy}} \\
+  \alpha_b &amp;= \alpha \sqrt{1 - 0.9 \times anisotropy}
+\end{align*}
+$$
+
+</p><p>
+
+We instead opted to follow the relationship described in [<a href="#citation-kulla17">Kulla17</a>] as it allows creation of sharp highlights:
+
+</p><p>
+
+$$
+\begin{align*}
+  \alpha_t &amp;= \alpha \times (1 + anisotropy) \\
+  \alpha_b &amp;= \alpha \times (1 - anisotropy)
+\end{align*}
+$$
+
+</p><p>
+
+Note that this NDF requires the tangent and bitangent directions in addition to the normal direction. Since these directions are already needed for normal mapping, providing them may not be an issue.
+
+</p><p>
+
+The resulting implementation is described in <a href="#listing_anisotropicbrdf">listing&#xA0;15</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> at = <span class="hljs-built_in">max</span>(linearRoughness * (<span class="hljs-number">1.0</span> + anisotropy), <span class="hljs-number">0.001</span>);</span>
+<span class="line"><span class="hljs-type">float</span> ab = <span class="hljs-built_in">max</span>(linearRoughness * (<span class="hljs-number">1.0</span> - anisotropy), <span class="hljs-number">0.001</span>);</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> D_GGX_Anisotropic(<span class="hljs-type">float</span> NoH, <span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> h,</span>
+<span class="line">        <span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> t, <span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> b, <span class="hljs-type">float</span> at, <span class="hljs-type">float</span> ab) {</span>
+<span class="line">    <span class="hljs-type">float</span> ToH = <span class="hljs-built_in">dot</span>(t, h);</span>
+<span class="line">    <span class="hljs-type">float</span> BoH = <span class="hljs-built_in">dot</span>(b, h);</span>
+<span class="line">    <span class="hljs-type">float</span> a2 = at * ab;</span>
+<span class="line">    <span class="hljs-keyword">highp</span> <span class="hljs-type">vec3</span> v = <span class="hljs-type">vec3</span>(ab * ToH, at * BoH, a2 * NoH);</span>
+<span class="line">    <span class="hljs-keyword">highp</span> <span class="hljs-type">float</span> v2 = <span class="hljs-built_in">dot</span>(v, v);</span>
+<span class="line">    <span class="hljs-type">float</span> w2 = a2 / v2;</span>
+<span class="line">    <span class="hljs-keyword">return</span> a2 * w2 * w2 * (<span class="hljs-number">1.0</span> / PI);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_anisotropicbrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;15:</b> Implementation of Burley&apos;s anisotropic NDF in GLSL</div>
+<p>
+
+
+In addition, [<a href="#citation-heitz14">Heitz14</a>] presents an anisotropic masking-shadowing function to match the height-correlated GGX distribution. The masking-shadowing term can be greatly simplified by using the visibility function instead:
+
+</p><p>
+
+$$\begin{equation}
+G(v,l,h,\alpha) = \frac{\chi^+(\VoH) \chi^+(\LoH)}{1 + \Lambda(v) + \Lambda(l)}
+\end{equation}$$
+
+</p><p>
+
+$$\begin{equation}
+\Lambda(m) = \frac{-1 + \sqrt{1 + \alpha_0^2 tan^2(\theta_m)}}{2} = \frac{-1 + \sqrt{1 + \alpha_0^2 \frac{(1 - cos^2(\theta_m))}{cos^2(\theta_m)}}}{2}
+\end{equation}$$
+
+</p><p>
+
+Where:
+
+</p><p>
+
+$$\begin{equation}
+\alpha_0 = \sqrt{cos^2(\phi_0)\alpha_x^2 + sin^2(\phi_0)\alpha_y^2}
+\end{equation}$$
+
+</p><p>
+
+After derivation we obtain:
+
+</p><p>
+
+$$\begin{equation}
+V_{aniso}(\NoL,\NoV,\alpha) = \frac{1}{2((\NoL)\hat{\Lambda}_v+(\NoV)\hat{\Lambda}_l)} \\
+\hat{\Lambda}_v = \sqrt{\alpha^2_t(t \cdot v)^2+\alpha^2_b(b \cdot v)^2+(\NoV)^2} \\
+\hat{\Lambda}_l = \sqrt{\alpha^2_t(t \cdot l)^2+\alpha^2_b(b \cdot l)^2+(\NoL)^2}
+\end{equation}$$
+
+</p><p>
+
+The term \( \hat{\Lambda}_v \) is the same for every light and can be computed only once if needed. The resulting implementation is described in <a href="#listing_anisotropicv">listing&#xA0;16</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> at = <span class="hljs-built_in">max</span>(linearRoughness * (<span class="hljs-number">1.0</span> + anisotropy), <span class="hljs-number">0.001</span>);</span>
+<span class="line"><span class="hljs-type">float</span> ab = <span class="hljs-built_in">max</span>(linearRoughness * (<span class="hljs-number">1.0</span> - anisotropy), <span class="hljs-number">0.001</span>);</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> V_SmithGGXCorrelated_Anisotropic(<span class="hljs-type">float</span> at, <span class="hljs-type">float</span> ab, <span class="hljs-type">float</span> ToV, <span class="hljs-type">float</span> BoV,</span>
+<span class="line">        <span class="hljs-type">float</span> ToL, <span class="hljs-type">float</span> BoL, <span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> NoL) {</span>
+<span class="line">    <span class="hljs-type">float</span> lambdaV = NoL * <span class="hljs-built_in">length</span>(<span class="hljs-type">vec3</span>(at * ToV, ab * BoV, NoV));</span>
+<span class="line">    <span class="hljs-type">float</span> lambdaL = NoV * <span class="hljs-built_in">length</span>(<span class="hljs-type">vec3</span>(at * ToL, ab * BoL, NoL));</span>
+<span class="line">    <span class="hljs-type">float</span> v = <span class="hljs-number">0.5</span> / (lambdaV + lambdaL);</span>
+<span class="line">    <span class="hljs-keyword">return</span> saturateMediump(v);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_anisotropicv">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;16:</b> Implementation of the anisotropic visibility function in GLSL</div>
+
+<a class="target" name="anisotropicparameterization">&#xA0;</a><a class="target" name="materialsystem/anisotropicmodel/anisotropicparameterization">&#xA0;</a><a class="target" name="toc4.10.2">&#xA0;</a><h3>Anisotropic parameterization</h3>
+<p>
+
+
+The anisotropic material model encompasses all the parameters previously defined for the standard material mode, plus an extra parameter described in <a href="#table_anisotropicparameters">table&#xA0;7</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Anisotropy</strong> </td><td style="text-align:left"> Amount of anisotropy. Scalar between &#x2212;1 and 1 </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_anisotropicparameters">&#xA0;</a><b style="font-style:normal;">Table&#xA0;7:</b> Anisotropic model parameters</div></div>
+
+<p></p><p>
+
+No further remapping is required. Note that negative values will align the anisotropy with the bitangent direction instead of the tangent direction. <a href="#figure_anisotropyparameter">Figure&#xA0;28</a> shows how the anisotropy parameter affect the appearance of a rough metallic surface.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/anisotropy.png" target="_blank"><img class="markdeep" src="images/materials/anisotropy.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropyparameter">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;28:</b> Anisotropy varying from 0.0 (left) to 1.0 (right)</div></div></center>
+
+<p></p>
+<a class="target" name="subsurfacemodel">&#xA0;</a><a class="target" name="materialsystem/subsurfacemodel">&#xA0;</a><a class="target" name="toc4.11">&#xA0;</a><h2>Subsurface model</h2>
+<p>
+
+
+[TODO]
+
+</p>
+<a class="target" name="subsurfacespecularbrdf">&#xA0;</a><a class="target" name="materialsystem/subsurfacemodel/subsurfacespecularbrdf">&#xA0;</a><a class="target" name="toc4.11.1">&#xA0;</a><h3>Subsurface specular BRDF</h3>
+<p>
+
+
+[TODO]
+
+</p>
+<a class="target" name="subsurfaceparameterization">&#xA0;</a><a class="target" name="materialsystem/subsurfacemodel/subsurfaceparameterization">&#xA0;</a><a class="target" name="toc4.11.2">&#xA0;</a><h3>Subsurface parameterization</h3>
+<p>
+
+
+[TODO]
+
+</p>
+<a class="target" name="clothmodel">&#xA0;</a><a class="target" name="materialsystem/clothmodel">&#xA0;</a><a class="target" name="toc4.12">&#xA0;</a><h2>Cloth model</h2>
+<p>
+
+
+All the material models described previously are designed to simulate dense surfaces, both at a macro and at a micro level. Clothes and fabrics are however often made of loosely connected threads that absorb and scatter incident light. The microfacet BRDFs presented earlier do a poor job of recreating the nature of cloth due to their underlying assumption that a surface is made of random grooves that behave as perfect mirrors. When compared to hard surfaces, cloth is characterized by a softer specular lobe with a large falloff and the presence of fuzz lighting, caused by forward/backward scattering. Some fabrics also exhibit two-tone specular colors (velvets for instance).
+
+</p><p>
+
+<a href="#figure_materialcloth">Figure&#xA0;29</a> shows how a traditional microfacet BRDF fails to capture the appearance of a sample of denim fabric. The surface appears rigid (almost plastic-like), more similar to a tarp than a piece of clothing. This figure also shows how important the softer specular lobe caused by absorption and scattering is to the faithful recreation of the fabric.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth.png"></a><div class="imagecaption"><a class="target" name="figure_materialcloth">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;29:</b> Comparison of denim fabric rendered using a traditional microfacet BRDF (left) and our cloth BRDF (right)</div></div></center>
+
+<p></p><p>
+
+Velvet is an interesting use case for a cloth material model. As shown in <a href="#figure_materialvelvet">figure&#xA0;30</a> this type of fabric exhibits strong rim lighting due to forward and backward scattering. These scattering events are caused by fibers standing straight at the surface of the fabric. When the incident light comes from the direction opposite to the view direction, the fibers will forward-scatter the light. Similarly, when the incident light from the same direction as the view direction, the fibers will scatter the light backward.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_velvet.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_velvet.png"></a><div class="imagecaption"><a class="target" name="figure_materialvelvet">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;30:</b> Velvet fabric showcasing forward and backward scattering</div></div></center>
+
+<p></p><p>
+
+Since fibers are flexible, we should in theory model the ability to groom the surface. While our model does not replicate this characteristic, it does model a visible front facing specular contribution that can be attributed to the random variance in the direction of the fibers.
+
+</p><p>
+
+It is important to note that there are types of fabrics that are still best modeled by hard surface material models. For instance, leather, silk and satin can be recreated using the standard or anisotropic material models.
+
+</p>
+<a class="target" name="clothspecularbrdf">&#xA0;</a><a class="target" name="materialsystem/clothmodel/clothspecularbrdf">&#xA0;</a><a class="target" name="toc4.12.1">&#xA0;</a><h3>Cloth specular BRDF</h3>
+<p>
+
+
+The cloth specular BRDF we use is a modified microfacet BRDF as described by Ashikhmin and Premoze in [<a href="#citation-ashikhmin07">Ashikhmin07</a>]. In their work, Ashikhmin and Premoze note that the distribution term is what contributes most to a BRDF and that the shadowing/masking term is not necessary for their velvet distribution. The distribution term itself is an inverted Gaussian distribution. This helps achieve fuzz lighting (forward and backward scattering) while an offset is added to simulate the front facing specular contribution. The so-called velvet NDF is defined as follows:
+
+</p><p>
+
+$$\begin{equation}
+D_{velvet}(v,h,\alpha) = c_{norm}(1 + 4 exp\left(\frac{-{cot}^2\theta_{h}}{\alpha^2}\right))
+\end{equation}$$
+
+</p><p>
+
+This NDF is a variant of the NDF the same authors describe in [<a href="#citation-ashikhmin00">Ashikhmin00</a>], notably modified to include an offset (set to 1 here) and an amplitude (4). In [<a href="#citation-neubelt13">Neubelt13</a>], Neubelt and Pettineo propose a normalized version of this NDF:
+
+</p><p>
+
+$$\begin{equation}
+D_{velvet}(v,h,\alpha) = \frac{1}{\pi(1 + 4\alpha^2)} (1 + 4 \frac{exp\left(\frac{-{cot}^2\theta_{h}}{\alpha^2}\right)}{{sin}^4\theta_{h}})
+\end{equation}$$
+
+</p><p>
+
+For the full specular BRDF, we also follow [<a href="#citation-neubelt13">Neubelt13</a>] and replace the traditional denominator with a smoother variant:
+
+</p><p>
+
+$$\begin{equation}\label{clothSpecularBRDF}
+f_{r}(v,h,\alpha) = \frac{D_{velvet}(v,h,\alpha)}{4(\NoL + \NoV - (\NoL)(\NoV))}
+\end{equation}$$
+
+</p><p>
+
+The implementation of the velvet NDF is presented in <a href="#listing_clothbrdf">listing&#xA0;17</a>, optimized to properly fit in half float formats and to avoid computing a costly cotangent, relying instead on trigonometric identities. Note that we removed the Fresnel component from this BRDF.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">D_Ashikhmin</span><span class="hljs-params">(<span class="hljs-keyword">float</span> linearRoughness, <span class="hljs-keyword">float</span> NoH)</span> </span>{</span>
+<span class="line">    <span class="hljs-comment">// Ashikhmin 2007, &quot;Distribution-based BRDFs&quot;</span></span>
+<span class="line">	<span class="hljs-keyword">float</span> a2 = linearRoughness * linearRoughness;</span>
+<span class="line">	<span class="hljs-keyword">float</span> cos2h = NoH * NoH;</span>
+<span class="line">	<span class="hljs-keyword">float</span> sin2h = max(<span class="hljs-number">1.0</span> - cos2h, <span class="hljs-number">0.0078125</span>); <span class="hljs-comment">// 2^(-14/2), so sin2h^2 &gt; 0 in fp16</span></span>
+<span class="line">	<span class="hljs-keyword">float</span> sin4h = sin2h * sin2h;</span>
+<span class="line">	<span class="hljs-keyword">float</span> cot2 = -cos2h / (a2 * sin2h);</span>
+<span class="line">	<span class="hljs-keyword">return</span> <span class="hljs-number">1.0</span> / (PI * (<span class="hljs-number">4.0</span> * a2 + <span class="hljs-number">1.0</span>) * sin4h) * (<span class="hljs-number">4.0</span> * <span class="hljs-built_in">exp</span>(cot2) + sin4h);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clothbrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;17:</b> Implementation of Ashikhmin&apos;s velvet NDF in GLSL</div>
+<p>
+
+
+In [<a href="#citation-estevez17">Estevez17</a>] Estevez and Kulla propose a different NDF (called the &#x201C;Charlie&#x201D; sheen) that is based on an exponentiated sinusoidal instead of an inverted Gaussian. This NDF is appealing for several reasons: its parameterization feels more natural and intuitive, it provides a softer appearance and, as shown in equation \(\ref{charlieNDF}\), its implementation is simpler:
+
+</p><p>
+
+$$\begin{equation}\label{charlieNDF}
+D(m) = \frac{(2 + \frac{1}{\alpha}) sin(\theta)^{\frac{1}{\alpha}}}{2 \pi}
+\end{equation}$$
+
+</p><p>
+
+[<a href="#citation-estevez17">Estevez17</a>] also presents a new shadowing term that we omit here because of its cost. We instead rely on the visibility term from [<a href="#citation-neubelt13">Neubelt13</a>] (shown in equation \(\ref{clothSpecularBRDF}\) above).
+The implementation of this NDF is presented in <a href="#listing_clothcharliebrdf">listing&#xA0;18</a>, optimized to properly fit in half float formats.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">D_Charlie</span><span class="hljs-params">(<span class="hljs-keyword">float</span> linearRoughness, <span class="hljs-keyword">float</span> NoH)</span> </span>{</span>
+<span class="line">    <span class="hljs-comment">// Estevez and Kulla 2017, &quot;Production Friendly Microfacet Sheen BRDF&quot;</span></span>
+<span class="line">    <span class="hljs-keyword">float</span> invAlpha  = <span class="hljs-number">1.0</span> / linearRoughness;</span>
+<span class="line">    <span class="hljs-keyword">float</span> cos2h = NoH * NoH;</span>
+<span class="line">    <span class="hljs-keyword">float</span> sin2h = max(<span class="hljs-number">1.0</span> - cos2h, <span class="hljs-number">0.0078125</span>); <span class="hljs-comment">// 2^(-14/2), so sin2h^2 &gt; 0 in fp16</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> (<span class="hljs-number">2.0</span> + invAlpha) * <span class="hljs-built_in">pow</span>(sin2h, invAlpha * <span class="hljs-number">0.5</span>) / (<span class="hljs-number">2.0</span> * PI);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clothcharliebrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;18:</b> Implementation of the &#x201C;Charlie&#x201D; NDF in GLSL</div>
+
+<a class="target" name="sheencolor">&#xA0;</a><a class="target" name="materialsystem/clothmodel/clothspecularbrdf/sheencolor">&#xA0;</a><a class="target" name="toc4.12.1.1">&#xA0;</a><h4>Sheen color</h4>
+<p>
+
+
+To offer better control over the appearance of cloth and to give users the ability to recreate two-tone specular materials, we introduce the ability to directly modify the specular reflectance. <a href="#figure_materialclothsheen">Figure&#xA0;31</a> shows an example of using the parameter we call &#x201C;sheen color&#x201D;.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_sheen.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_sheen.png"></a><div class="imagecaption"><a class="target" name="figure_materialclothsheen">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;31:</b> Blue fabric without (left) and with (right) sheen</div></div></center>
+
+<p></p>
+<a class="target" name="clothdiffusebrdf">&#xA0;</a><a class="target" name="materialsystem/clothmodel/clothdiffusebrdf">&#xA0;</a><a class="target" name="toc4.12.2">&#xA0;</a><h3>Cloth diffuse BRDF</h3>
+<p>
+
+
+Our cloth material model still relies on a Lambertian diffuse BRDF. It is however slightly modified to be energy conservative (akin to the energy conservation of our clear coat material model) and offers an optional subsurface scattering term. This extra term is not physically based and can be used to simulate the scattering, partial absorption and re-emission of light in certain types of fabrics.
+
+</p><p>
+
+First, here is the diffuse term without the optional subsurface scattering:
+
+</p><p>
+
+$$\begin{equation}
+f_{d}(v,h) = \frac{c_{diff}}{\pi}(1 - F(v,h))
+\end{equation}$$
+
+</p><p>
+
+Where \(F(v,h)\) is the Fresnel term of the cloth specular BRDF in equation \(\ref{clothSpecularBRDF}\). In practice we&apos;ve opted to leave out the \(1 - F(v, h)\) term in the diffuse component. The effect is a bit subtle and we deemed it wasn&apos;t worth the added cost.
+
+</p><p>
+
+Subsurface scattering is implemented using the wrapped diffuse lighting technique, in its energy conservative form:
+
+</p><p>
+
+$$\begin{equation}
+f_{d}(v,h) = \frac{c_{diff}}{\pi}(1 - F(v,h)) \left&lt; \NoL + \frac{w}{(1 + w)} \right&gt; \left&lt; c_{subsurface} + \NoL \right&gt;
+\end{equation}$$
+
+</p><p>
+
+Where \(w\) is a value between 0 and 1 defining by how much the diffuse light should wrap around the terminator. To avoid introducing another parameter, we fix \(w = 0.5\). Note that with wrap diffuse lighting, the diffuse term must not be multiplied by \(\NoL\). The effect of this cheap
+subsurface scattering approximation can be seen in <a href="#figure_materialclothsubsurface">figure&#xA0;32</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_subsurface.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_subsurface.png"></a><div class="imagecaption"><a class="target" name="figure_materialclothsubsurface">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;32:</b> White cloth (left column) vs white cloth with brown subsurface scattering (right)</div></div></center>
+
+<p></p><p>
+
+The complete implementation of our cloth BRDF, including sheen color and optional subsurface scattering, can be found in <a href="#listing_clothfullbrdf">listing&#xA0;19</a>.
+
+</p><pre class="listing tilde"><code><span class="line">// specular BRDF</span>
+<span class="line">float D = distributionCloth(<span class="hljs-name">linearRoughness</span>, NoH)<span class="hljs-comment">;</span></span>
+<span class="line">float V = visibilityCloth(<span class="hljs-name">NoV</span>, NoL)<span class="hljs-comment">;</span></span>
+<span class="line">vec3  F = sheenColor<span class="hljs-comment">;</span></span>
+<span class="line">vec3 Fr = (<span class="hljs-name">D</span> * V) * F<span class="hljs-comment">;</span></span>
+<span class="line"></span>
+<span class="line">// diffuse BRDF</span>
+<span class="line">float diffuse = diffuse(<span class="hljs-name">linearRoughness</span>, NoV, NoL, LoH)<span class="hljs-comment">;</span></span>
+<span class="line">#if defined(<span class="hljs-name">MATERIAL_HAS_SUBSURFACE_COLOR</span>)</span>
+<span class="line">// energy conservative wrap diffuse</span>
+<span class="line">diffuse *= saturate((dot(n, light.l) + 0.5) / 2.25);</span>
+<span class="line">#endif</span>
+<span class="line">vec3 Fd = diffuse * pixel.diffuseColor<span class="hljs-comment">;</span></span>
+<span class="line"></span>
+<span class="line">#if defined(<span class="hljs-name">MATERIAL_HAS_SUBSURFACE_COLOR</span>)</span>
+<span class="line">// cheap subsurface scatter</span>
+<span class="line">Fd *= saturate(subsurfaceColor + NoL);</span>
+<span class="line">vec3 color = Fd + Fr * NoL<span class="hljs-comment">;</span></span>
+<span class="line">color *= (lightIntensity * lightAttenuation) * lightColor<span class="hljs-comment">;</span></span>
+<span class="line">#else</span>
+<span class="line">vec3 color = Fd + Fr<span class="hljs-comment">;</span></span>
+<span class="line">color *= (<span class="hljs-name">lightIntensity</span> * lightAttenuation * NoL) * lightColor<span class="hljs-comment">;</span></span>
+<span class="line">#endif</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clothfullbrdf">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;19:</b> Implementation of our cloth BRDF in GLSL</div>
+
+<a class="target" name="clothparameterization">&#xA0;</a><a class="target" name="materialsystem/clothmodel/clothparameterization">&#xA0;</a><a class="target" name="toc4.12.3">&#xA0;</a><h3>Cloth parameterization</h3>
+<p>
+
+
+The cloth material model encompasses all the parameters previously defined for the standard material mode except for <em class="underscore">metallic</em> and <em class="underscore">reflectance</em>. Two extra parameters described in <a href="#table_clothparameters">table&#xA0;8</a> are also available.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">SheenColor</strong> </td><td style="text-align:left"> Specular tint to create two-tone specular fabrics (defaults to 0.04 to match the standard reflectance) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">SubsurfaceColor</strong> </td><td style="text-align:left"> Tint for the diffuse color after scattering and absorption through the material </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_clothparameters">&#xA0;</a><b style="font-style:normal;">Table&#xA0;8:</b> Cloth model parameters</div></div>
+
+<p></p><p>
+
+To create a velvet-like material, the base color can be set to black (or a dark color). Chromaticity information should instead be set on the sheen color. To create more common fabrics such as denim, cotton, etc. use the base color for chromaticity and use the default sheen color or set the sheen color to the luminance of the base color.
+
+</p>
+<a class="target" name="lighting">&#xA0;</a><a class="target" name="lighting">&#xA0;</a><a class="target" name="toc5">&#xA0;</a><h1>Lighting</h1>
+<p>
+
+
+The correctness and coherence of the lighting environment is paramount to achieving plausible visuals. After surveying existing rendering engines (such as Unity or Unreal Engine 4) as well as the traditional real-time rendering literature, it is obvious that coherency is rarely achieved.
+
+</p><p>
+
+The Unreal Engine, for instance, lets artists specify the &#x201C;brightness&#x201D; of a point light in lumens, a unit of luminous power. The brightness of directional lights is however expressed using an arbitrary unnamed unit. To match the brightness of a point light with a luminous power of 5,000 lumens, the artist must use a directional light of brightness 10. This kind of mismatch makes it difficult for artists to maintain the visual integrity of a scene when adding, removing or modifying lights.
+Using solely arbitrary units is a coherent solution but it makes reusing lighting rigs a difficult task. For instance, an outdoor scene will use a directional light of brightness 10 as the sun and all other lights will be defined relative to that value. Moving these lights to an indoor environment would make them too bright.
+
+</p><p>
+
+Our goal is therefore to make all lighting correct by default, while giving artists enough freedom to achieve the desired look. We will support a number of lights, split in two categories, direct and indirect lighting:
+
+</p><p>
+
+<strong class="asterisk">Direct lighting</strong>: punctual lights, photometric lights, area lights.
+
+</p><p>
+
+<strong class="asterisk">Indirect lighting</strong>: image based lights (IBLs), for both local<sup><a href="#endnote-localprobesmobile">2</a></sup> and distant light probes.
+
+</p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-localprobesmobile">&#xA0;</a><sup>2</sup> Local light probes might be too expensive to support on mobile, we will first focus our efforts on distant light probes set at infinity
+</div>
+<p></p>
+<a class="target" name="units">&#xA0;</a><a class="target" name="lighting/units">&#xA0;</a><a class="target" name="toc5.1">&#xA0;</a><h2>Units</h2>
+<p>
+
+
+The following sections will discuss how to implement various types of lights and the proposed equations make use of different symbols and units summarized in <a href="#table_lightunits">table&#xA0;9</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Photometric term </th><th style="text-align:center"> Notation </th><th style="text-align:left"> Unit </th></tr>
+<tr><td style="text-align:right"> Luminous power </td><td style="text-align:center"> \(\Phi\) </td><td style="text-align:left"> Lumen (\(lm\)) </td></tr>
+<tr><td style="text-align:right"> Luminous intensity </td><td style="text-align:center"> \(I\) </td><td style="text-align:left"> Candela (\(cd\)) or \(\frac{lm}{sr}\) </td></tr>
+<tr><td style="text-align:right"> Illuminance </td><td style="text-align:center"> \(E\) </td><td style="text-align:left"> Lux (\(lx\)) or \(\frac{lm}{m^2}\) </td></tr>
+<tr><td style="text-align:right"> Luminance </td><td style="text-align:center"> \(L\) </td><td style="text-align:left"> Nit (\(nt\)) or \(\frac{cd}{m^2}\) </td></tr>
+<tr><td style="text-align:right"> Radiant power </td><td style="text-align:center"> \(\Phi_e\) </td><td style="text-align:left"> Watt (\(W\)) </td></tr>
+<tr><td style="text-align:right"> Luminous efficacy </td><td style="text-align:center"> \(\eta\) </td><td style="text-align:left"> Lumens per watt (\(\frac{lm}{W}\)) </td></tr>
+<tr><td style="text-align:right"> Luminous efficiency </td><td style="text-align:center"> \(V\) </td><td style="text-align:left"> Percentage (%) </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_lightunits">&#xA0;</a><b style="font-style:normal;">Table&#xA0;9:</b> Photometric units</div></div>
+
+<p></p><p>
+
+To get properly coherent lighting, we must use light units that respect the ratio between various light intensities found in real-world scenes. These intensities can vary greatly, from around 800 \(lm\) for a household light bulb to 120,000 \(lx\) for a daylight sky and sun illumination.
+
+</p><p>
+
+The easiest way to achieve lighting coherency is to adopt physical light units. This will in turn enable full reusability of lighting rigs. Using physical light units also allows us to use a physically based camera.
+
+</p><p>
+
+<a href="#table_lighttypesunits">Table&#xA0;10</a> shows the light unit associated with each type of light we intend to support.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Light type </th><th style="text-align:left"> Unit </th></tr>
+<tr><td style="text-align:right"> Directional light </td><td style="text-align:left"> Illuminance (\(lx\) or \(\frac{lm}{m^2}\)) </td></tr>
+<tr><td style="text-align:right"> Point light </td><td style="text-align:left"> Luminous power (\(lm\)) </td></tr>
+<tr><td style="text-align:right"> Spot light </td><td style="text-align:left"> Luminous power (\(lm\)) </td></tr>
+<tr><td style="text-align:right"> Photometric light </td><td style="text-align:left"> Luminous intensity (\(cd\)) </td></tr>
+<tr><td style="text-align:right"> Masked photometric light </td><td style="text-align:left"> Luminous power (\(lm\)) </td></tr>
+<tr><td style="text-align:right"> Area light </td><td style="text-align:left"> Luminous power (\(lm\)) </td></tr>
+<tr><td style="text-align:right"> Image based light </td><td style="text-align:left"> Luminance (\(\frac{cd}{m^2}\)) </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_lighttypesunits">&#xA0;</a><b style="font-style:normal;">Table&#xA0;10:</b> Intensity unity for each light type</div></div>
+
+<p></p><p>
+
+<strong class="asterisk">Notes about the radiant power unit</strong>
+
+</p><p>
+
+Even though commercially available light bulbs often display their brightness in lumens on the packaging, it is common to refer to the brightness of a light bulb by using its required energy in watts. The number of watts only indicates how much energy a bulb uses, not how bright it is. It is even more important to understand this difference now that more energy efficient bulbs are readily available (halogens, LEDs, etc.).
+
+</p><p>
+
+However, since artists might be accustomed to gauging a light&apos;s brightness by its power, we should allow users to use the power unit to define the brightness of a light. The conversion is presented in equation \(\ref{radiantPowerToLuminousPower}\).
+
+</p><p>
+
+$$\begin{equation}\label{radiantPowerToLuminousPower}
+\Phi = \Phi_e \eta
+\end{equation}$$
+
+</p><p>
+
+In equation \(\ref{radiantPowerToLuminousPower}\), \(\eta\) is the luminous efficacy of the light, expressed in lumens per watt. Knowing that the <a href="http://en.wikipedia.org/wiki/Luminous_efficacy">maximum possible luminous efficacy</a> is 683 \(\frac{lm}{W}\) we can also use luminous efficiency \(V\) (also called luminous coefficient), as shown in equation \(\ref{radiantPowerLuminousEfficiency}\).
+
+</p><p>
+
+$$\begin{equation}\label{radiantPowerLuminousEfficiency}
+\Phi = \Phi_e 683 \times V
+\end{equation}$$
+
+</p><p>
+
+<a href="#table_lighttypesefficacy">Table&#xA0;11</a> can be used as a reference to convert watts to lumens using either the luminous efficacy or the luminous efficiency of various types of lights. More specific values are available on Wikipedia&apos;s <a href="http://en.wikipedia.org/wiki/Luminous_efficacy">luminous efficacy</a> page.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Light type </th><th style="text-align:center"> Efficacy \(\eta\) </th><th style="text-align:left"> Efficiency \(V\) </th></tr>
+<tr><td style="text-align:right"> Incandescent </td><td style="text-align:center"> 14-35 </td><td style="text-align:left"> 2-5% </td></tr>
+<tr><td style="text-align:right"> LED </td><td style="text-align:center"> 28-100 </td><td style="text-align:left"> 4-15% </td></tr>
+<tr><td style="text-align:right"> Fluorescent </td><td style="text-align:center"> 60-100 </td><td style="text-align:left"> 9-15% </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_lighttypesefficacy">&#xA0;</a><b style="font-style:normal;">Table&#xA0;11:</b> Efficacy and efficiency of various light types</div></div>
+
+<p></p>
+<a class="target" name="lightunitsvalidation">&#xA0;</a><a class="target" name="lighting/units/lightunitsvalidation">&#xA0;</a><a class="target" name="toc5.1.1">&#xA0;</a><h3>Light units validation</h3>
+<p>
+
+
+One of the big advantages of using physical light units is the ability to physically validate our equations. We can use specialized devices to measure three light units.
+
+</p>
+<a class="target" name="illuminance">&#xA0;</a><a class="target" name="lighting/units/lightunitsvalidation/illuminance">&#xA0;</a><a class="target" name="toc5.1.1.1">&#xA0;</a><h4>Illuminance</h4>
+<p>
+
+
+The illuminance reaching a surface can be measured using an incident light meter. For our tests, we use a <a href="http://www.sekonic.com/products/l-478d/overview.aspx">Sekonic L-478D</a>, shown in <a href="#figure_sekonic">figure&#xA0;33</a>.
+
+</p><p>
+
+The incident light meter uses a white diffuse dome to capture the illuminance reaching a surface. It is important to orient the dome properly depending on the desired measurement. For instance, orienting the dome perpendicular to the sun on a bright clear day will give very different results than orienting the dome horizontally.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/photo_light_meter.jpg" target="_blank"><img class="markdeep" src="images/photo_light_meter.jpg"></a><div class="imagecaption"><a class="target" name="figure_sekonic">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;33:</b> Sekonic L-478D incident light meter</div></div></center>
+
+<p></p>
+<a class="target" name="luminance">&#xA0;</a><a class="target" name="lighting/units/lightunitsvalidation/luminance">&#xA0;</a><a class="target" name="toc5.1.1.2">&#xA0;</a><h4>Luminance</h4>
+<p>
+
+
+The luminance at a surface, or the product of the incident light and the surface, can be measured using a luminance meter, also often called a spot meter. While incident light meters use a diffuse hemisphere to capture light from all directions, a spot meter uses a shield to measure incident light from a single direction. For our tests, we use a <a href="http://www.sekonic.com/products/l-478dr/accessories/np-finder-5-degree-for-l-478.aspx">Sekonic 5&#xB0; Viewfinder</a> that can replace the diffuser on the L-478D to measure luminance in a 5&#xB0; cone.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/photo_incident_light_meter.jpg" target="_blank"><img class="markdeep" src="images/photo_incident_light_meter.jpg"></a><div class="imagecaption">Sekonic L-478D working as a luminance meter using a special viewfinder</div></div></center>
+
+<p></p>
+<a class="target" name="luminousintensity">&#xA0;</a><a class="target" name="lighting/units/lightunitsvalidation/luminousintensity">&#xA0;</a><a class="target" name="toc5.1.1.3">&#xA0;</a><h4>Luminous intensity</h4>
+<p>
+
+
+The luminous intensity of a light source cannot be measured directly but can be derived from the measured illuminance if we know the distance between the measuring device and the light source. Equation \(\ref{derivedLuminousIntensity}\) is a simple application of the inverse square law discussed in section  <a href="#toc5.2.2">5.2.2</a>.
+
+</p><p>
+
+$$\begin{equation}\label{derivedLuminousIntensity}
+I = E \cdot d^2
+\end{equation}$$
+
+</p>
+<a class="target" name="directlighting">&#xA0;</a><a class="target" name="lighting/directlighting">&#xA0;</a><a class="target" name="toc5.2">&#xA0;</a><h2>Direct lighting</h2>
+<p>
+
+
+We have defined the light units for all the light types supported by the renderer in the section above but we have not defined the light unit for the result of the lighting equations. Choosing physical light units means that we will compute luminance values in our shaders, and therefore that all our light evaluation functions will compute the luminance \(L_{out}\) (or outgoing radiance) at any given point. The luminance depends on the illuminance \(E\) and the BSDF \(f(v,l)\) :
+
+</p><p>
+
+$$\begin{equation}\label{luminanceEquation}
+L_{out} = f(v,l)E
+\end{equation}$$
+
+</p>
+<a class="target" name="directionallights">&#xA0;</a><a class="target" name="lighting/directlighting/directionallights">&#xA0;</a><a class="target" name="toc5.2.1">&#xA0;</a><h3>Directional lights</h3>
+<p>
+
+
+The main purpose of directional lights is to recreate important light sources for outdoor environment, i.e. the sun and/or the moon. While directional lights do not truly exist in the physical world, any light source sufficiently far from the light receptor can be assumed to be directional (i.e. all the incident light rays are parallel, as shown in  <a href="#figure_directionallight">figure&#xA0;34</a>).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_directional_light.png" target="_blank"><img class="markdeep" src="images/diagram_directional_light.png"></a><div class="imagecaption"><a class="target" name="figure_directionallight">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;34:</b> Interaction between a directional light and a surface. The light source is a virtual construct that can only be represented by a direction</div></div></center>
+
+<p></p><p>
+
+This approximation proves to work incredibly well for the diffuse response of a surface but the specular response is incorrect. The Frostbite engine solves this problem by treating the &#x201C;sun&#x201D; directional light as a disc area light. However, our tests have shown that the quality increase does not justify the added computational costs.
+
+</p><p>
+
+We earlier stated that we chose an illuminance light unit (\(lx\)) for directional lights. This is in part due to the fact that we can easily find illuminance values for the sky and the sun (online or with a light meter) but also to simplify the luminance equation described in \(\ref{luminanceEquation}\).
+
+</p><p>
+
+$$\begin{equation}\label{directionalLuminanceEquation}
+L_{out} = f(v,l) E_{\bot} \left&lt; \NoL \right&gt;
+\end{equation}$$
+
+</p><p>
+
+In the simplified luminance equation \(\ref{directionalLuminanceEquation}\), \(E_{\bot}\) is the illuminance of the light source for a surface perpendicular to said light source. If the directional light source simulates the sun, \(E_{\bot}\) is the illuminance of the sun for a surface perpendicular to the sun direction.
+
+</p><p>
+
+<a href="#table_sunskyilluminance">Table&#xA0;12</a> provides useful reference values for the sun and sky illumination, measured<sup><a href="#endnote-illuminancemeasures">3</a></sup> on a clear day in March, in California.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Light </th><th style="text-align:right"> 10am </th><th style="text-align:right"> 12pm </th><th style="text-align:right"> 5:30pm </th></tr>
+<tr><td style="text-align:right"> \(Sky_{\bot} + Sun_{\bot}\) </td><td style="text-align:right"> 120,000 </td><td style="text-align:right"> 130,000 </td><td style="text-align:right"> 90,000 </td></tr>
+<tr><td style="text-align:right"> \(Sky_{\bot}\) </td><td style="text-align:right"> 20,000 </td><td style="text-align:right"> 25,000 </td><td style="text-align:right"> 9,000 </td></tr>
+<tr><td style="text-align:right"> \(Sun_{\bot}\) </td><td style="text-align:right"> 100,000 </td><td style="text-align:right"> 105,000 </td><td style="text-align:right"> 81,000 </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_sunskyilluminance">&#xA0;</a><b style="font-style:normal;">Table&#xA0;12:</b> Illuminance values in \(lx\) (a full moon has an illuminance of 1 \(lx\))</div></div>
+
+<p></p><p>
+
+Dynamic directional lights are particularly cheap to evaluate at runtime, as shown in <a href="#listing_glsldirectionallight">listing&#xA0;20</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> l = <span class="hljs-built_in">normalize</span>(-lightDirection);</span>
+<span class="line"><span class="hljs-type">float</span> NoL = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(n, l), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// lightIntensity is the illuminance</span></span>
+<span class="line"><span class="hljs-comment">// at perpendicular incidence in lux</span></span>
+<span class="line"><span class="hljs-type">float</span> illuminance = lightIntensity * NoL;</span>
+<span class="line"><span class="hljs-type">vec3</span> luminance = BSDF(v, l) * illuminance;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_glsldirectionallight">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;20:</b> Implementation of directional lights in GLSL</div>
+<p>
+
+
+<a href="#figure_directionallighttest">Figure&#xA0;35</a> shows the effect of lighting a simple scene with a directional light setup to approximate a midday Sun (illuminance set to 110,000 \(lx\)). For illustration purposes, only direct lighting is shown.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_directional_light.png" target="_blank"><img class="markdeep" src="images/screenshot_directional_light.png"></a><div class="imagecaption"><a class="target" name="figure_directionallighttest">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;35:</b> Series of dielectric materials of varying roughness under a directional light</div></div></center>
+
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-illuminancemeasures">&#xA0;</a><sup>3</sup> Measurements taken with an incident light meter (Sekonic L-478D)
+</div>
+<p></p>
+<a class="target" name="punctuallights">&#xA0;</a><a class="target" name="lighting/directlighting/punctuallights">&#xA0;</a><a class="target" name="toc5.2.2">&#xA0;</a><h3>Punctual lights</h3>
+<p>
+
+
+Our engine will support two types of punctual lights, commonly found in most if not all rendering engines: point lights and spot lights. These types of lights are traditionally physically inaccurate for two reasons:
+
+</p><p>
+
+</p><ol start="1">
+<li class="number">They are truly punctual and infinitesimally small.
+</li>
+<li class="number">They do not follow the <a href="http://en.wikipedia.org/wiki/Inverse-square_law">inverse square law</a>.</li></ol>
+
+<p></p><p>
+
+The first issue can be addressed with area lights but, given the cheaper nature of punctual lights it is deemed practical to use infinitesimally small punctual lights whenever possible.
+
+</p><p>
+
+The second issue is easy to fix. For a given punctual light, the perceived intensity decreases proportionally to the square of the distance from the viewer (more precisely, the light receptor).
+
+</p><p>
+
+For punctual lights following the inverse square law, the term \(E\) of equation \( \ref{luminanceEquation} \) is expressed in equation \(\ref{punctualLightEquation}\), where \(d\) is the distance from a point at the surface to the light.
+
+</p><p>
+
+$$\begin{equation}\label{punctualLightEquation}
+E = L_{in} \left&lt; \NoL \right&gt; = \frac{I}{d^2} \left&lt; \NoL \right&gt;
+\end{equation}$$
+
+</p><p>
+
+The difference between point and spot lights lies in how \(E\) is computed, and in particular how the luminous intensity \(I\) is computed from the luminous power \(\Phi\).
+
+</p>
+<a class="target" name="pointlights">&#xA0;</a><a class="target" name="lighting/directlighting/punctuallights/pointlights">&#xA0;</a><a class="target" name="toc5.2.2.1">&#xA0;</a><h4>Point lights</h4>
+<p>
+
+
+A point light is defined only by a position in space, as shown in <a href="#figure_pointlight">figure&#xA0;36</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_point_light.png" target="_blank"><img class="markdeep" src="images/diagram_point_light.png"></a><div class="imagecaption"><a class="target" name="figure_pointlight">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;36:</b> Interaction between a point light and a surface. The attenuation only depends on the distance to the light</div></div></center>
+
+<p></p><p>
+
+The luminous power of a point light is calculated by integrating the luminous intensity over the light&apos;s solid angle, as show in equation \(\ref{pointLightLuminousPower}\). The luminous intensity can then be easily derived from the luminous power.
+
+</p><p>
+
+$$\begin{equation}\label{pointLightLuminousPower}
+\Phi = \int_{\Omega} I dl = \int_{0}^{2\pi} \int_{0}^{\pi} I d\theta d\phi = 4 \pi I \\
+I = \frac{\Phi}{4 \pi}
+\end{equation}$$
+
+</p><p>
+
+By simple substitution of \(I\) in \(\ref{punctualLightEquation}\) and \(E\) in \( \ref{luminanceEquation} \) we can formulate the luminance equation of a point light as a function of the luminous power (see \( \ref{pointLightLuminanceEquation} \)).
+
+</p><p>
+
+$$\begin{equation}\label{pointLightLuminanceEquation}
+L_{out} = f(v,l) \frac{\Phi}{4 \pi d^2} \left&lt; \NoL \right&gt;
+\end{equation}$$
+
+</p><p>
+
+<a href="#figure_pointlighttest">Figure&#xA0;37</a> shows the effect of lighting a simple scene with a point light subject to distance attenuation. Light falloff is exaggerated for illustration purposes.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_point_light.png" target="_blank"><img class="markdeep" src="images/screenshot_point_light.png"></a><div class="imagecaption"><a class="target" name="figure_pointlighttest">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;37:</b> Inverse square law applied to point lights evaluation</div></div></center>
+
+<p></p>
+<a class="target" name="spotlights">&#xA0;</a><a class="target" name="lighting/directlighting/punctuallights/spotlights">&#xA0;</a><a class="target" name="toc5.2.2.2">&#xA0;</a><h4>Spot lights</h4>
+<p>
+
+
+A spot light is defined by a position in space, a direction vector and two cone angles, \( \theta_{inner} \) and \( \theta_{outer} \) (see <a href="#figure_spotlight">figure&#xA0;38</a>). These two angles are used to define the angular falloff attenuation of the spot light. The light evaluation function of a spot light must therefore take into account both the inverse square law and these two angles to properly evaluate the luminance attenuation.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_spot_light.png" target="_blank"><img class="markdeep" src="images/diagram_spot_light.png"></a><div class="imagecaption"><a class="target" name="figure_spotlight">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;38:</b> Interaction between a spot light and a surface. The attenuation depends on the distance to the light and the angle between the surface the spot light&apos;s direction vector</div></div></center>
+
+<p></p><p>
+
+Equation \( \ref{spotLightLuminousPower} \) describes how the luminous power of a spot light can be calculated in a similar fashion to point lights, using \( \theta_{outer} \) the outer angle of the spot light&apos;s cone in the range [0..\(\pi\)].
+
+</p><p>
+
+$$\begin{equation}\label{spotLightLuminousPower}
+\Phi = \int_{\Omega} I dl = \int_{0}^{2\pi} \int_{0}^{\theta_{outer}} I d\theta d\phi = 2 \pi (1 - cos\frac{\theta_{outer}}{2})I \\
+I = \frac{\Phi}{2 \pi (1 - cos\frac{\theta_{outer}}{2})}
+\end{equation}$$
+
+</p><p>
+
+While this formulation is physically correct, it makes spot lights a little difficult to use: changing the outer angle of the cone changes the illumination levels. <a href="#figure_spotlighttestfocused">Figure&#xA0;39</a> shows the same scene lit by a spot light, with an outer angle of 55&#xB0; and an outer angle of 15&#xB0;. Observes how the illumination level increases as the cone aperture decreases.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_spot_light_focused.png" target="_blank"><img class="markdeep" src="images/screenshot_spot_light_focused.png"></a><div class="imagecaption"><a class="target" name="figure_spotlighttestfocused">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;39:</b> Comparison of spot light outer angles, 55&#xB0; (left) and 15&#xB0; (right)</div></div></center>
+
+<p></p><p>
+
+The coupling of illumination and the outer cone means that an artist cannot tweak the influence cone of a spot light without also changing the perceived illumination. It therefore makes sense to provide artists with a parameter to disable this coupling. Equations \( \ref{spotLightLuminousPowerB} \) shows how to formulate the luminous power for that purpose.
+
+</p><p>
+
+$$\begin{equation}\label{spotLightLuminousPowerB}
+\Phi = \pi I \\
+I = \frac{\Phi}{\pi} \\
+\end{equation}$$
+
+</p><p>
+
+With this new formulation to compute the luminous intensity, the test scene in <a href="#figure_spotlighttest">figure&#xA0;40</a> exhibits similar illumination levels with both cone apertures.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_spot_light.png" target="_blank"><img class="markdeep" src="images/screenshot_spot_light.png"></a><div class="imagecaption"><a class="target" name="figure_spotlighttest">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;40:</b> Comparison of spot light outer angles, 55&#xB0; (left) and 15&#xB0; (right)</div></div></center>
+
+<p></p><p>
+
+This new formulation can also be considered physically based if the spot&apos;s reflector is replaced with a matte, diffuse mask that absorbs light perfectly.
+
+</p><p>
+
+The spot light evaluation function can be expressed in two ways:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><strong class="asterisk">With a light absorber</strong>
+  $$\begin{equation}\label{spotAbsorber}
+  L_{out} = f(v,l) \frac{\Phi}{\pi d^2} \left&lt; \NoL \right&gt; \lambda(l)
+  \end{equation}$$
+</li>
+<li class="minus"><strong class="asterisk">With a light reflector</strong>
+  $$\begin{equation}\label{spotReflector}
+  L_{out} = f(v,l) \frac{\Phi}{2 \pi (1 - cos\frac{\theta_{outer}}{2}) d^2} \left&lt; \NoL \right&gt; \lambda(l)
+  \end{equation}$$</li></ul>
+
+<p></p><p>
+
+The term \( \lambda(l) \) in equations \( \ref{spotAbsorber} \) and \( \ref{spotReflector} \) is the spot&apos;s angle attenuation factor described in equation
+ \( \ref{spotAngleAtt} \) below.
+
+</p><p>
+
+$$\begin{equation}\label{spotAngleAtt}
+\lambda(l) = \frac{l \times spotDirection - cos\theta_{outer}}{cos\theta_{inner} - cos\theta_{outer}}
+\end{equation}$$
+
+</p>
+<a class="target" name="attenuationfunction">&#xA0;</a><a class="target" name="lighting/directlighting/punctuallights/attenuationfunction">&#xA0;</a><a class="target" name="toc5.2.2.3">&#xA0;</a><h4>Attenuation function</h4>
+<p>
+
+
+A proper evaluation of the inverse square law attenuation factor is mandatory for physically based punctual lights. The simple mathematical formulation is unfortunately impractical for implementation purposes:
+
+</p><p>
+
+</p><ol start="1">
+<li class="number">The division by the squared distance can lead to divides by 0 when objects intersect or &#x201C;touch&#x201D; light sources.
+
+<p></p><p>
+
+</p></li>
+<li class="number">The influence sphere of each light is infinite (\( \frac{I}{d^2} \) is asymptotic, it never reaches 0) which means that to correctly shade a pixel we need to evaluate every light in the world.</li></ol>
+
+<p></p><p>
+
+The first issue can be solved easily by setting the assumption that punctual lights are not truly punctual but instead small area lights. To do this we can simply treat punctual lights as spheres of 1 cm radius, as show in equation \(\ref{finitePunctualLight}\).
+
+</p><p>
+
+$$\begin{equation}\label{finitePunctualLight}
+E = \frac{I}{max(d^2, {0.01}^2)}
+\end{equation}$$
+
+</p><p>
+
+We can solve the second issue by introducing an influence radius for each light. There are several advantages to this solution. Tools can quickly show artists what parts of the world will be influenced by every light (the tool just needs to draw a sphere centered on each light). The rendering engine can cull lights more aggressively using this extra piece of information and artists/developers can assist the engine by manually tweaking the influence radius of a light.
+
+</p><p>
+
+Mathematically, the illuminance of a light should smoothly reach zero at the limit defined by the influence radius. [<a href="#citation-karis13">Karis13</a>] proposes to window the inverse square function in such a way that the majority of the light&apos;s influence remains unaffected. The proposed windowing is described in equation \(\ref{attenuationWindowing}\), where \(r\) is the light&apos;s radius of influence.
+
+</p><p>
+
+$$\begin{equation}\label{attenuationWindowing}
+E = \frac{I}{max(d^2, {0.01}^2)} \left&lt; 1 - \frac{d^4}{r^2} \right&gt;
+\end{equation}$$
+
+</p><p>
+
+<a href="#listing_glslpunctuallight">Listing&#xA0;21</a> demonstrates how to implement physically based punctual lights in GLSL. Note that the light intensity used in this piece of code is the luminous intensity \(I\) in \(cd\), converted from the luminous power  CPU-side. This snippet is not optimized and some of the computations can be offloaded to the CPU (for instance the square of the light&apos;s inverse falloff radius, or the spot scale and angle).
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> getSquareFalloffAttenuation(<span class="hljs-type">vec3</span> posToLight, <span class="hljs-type">float</span> lightInvRadius) {</span>
+<span class="line">    <span class="hljs-type">float</span> distanceSquare = <span class="hljs-built_in">dot</span>(posToLight, posToLight);</span>
+<span class="line">    <span class="hljs-type">float</span> factor = distanceSquare * lightInvRadius * lightInvRadius;</span>
+<span class="line">    <span class="hljs-type">float</span> smoothFactor = <span class="hljs-built_in">max</span>(<span class="hljs-number">1.0</span> - factor * factor, <span class="hljs-number">0.0</span>);</span>
+<span class="line">    <span class="hljs-keyword">return</span> (smoothFactor * smoothFactor) / <span class="hljs-built_in">max</span>(distanceSquare, <span class="hljs-number">1e-4</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> getSpotAngleAttenuation(<span class="hljs-type">vec3</span> l, <span class="hljs-type">vec3</span> lightDir,</span>
+<span class="line">        <span class="hljs-type">float</span> innerAngle, <span class="hljs-type">float</span> outerAngle) {</span>
+<span class="line">    <span class="hljs-comment">// the scale and offset computations can be done CPU-side</span></span>
+<span class="line">    <span class="hljs-type">float</span> cosOuter = <span class="hljs-built_in">cos</span>(outerAngle);</span>
+<span class="line">    <span class="hljs-type">float</span> spotScale = <span class="hljs-number">1.0</span> / <span class="hljs-built_in">max</span>(<span class="hljs-built_in">cos</span>(innerAngle) - cosOuter, <span class="hljs-number">1e-4</span>)</span>
+<span class="line">    <span class="hljs-type">float</span> spotOffset = -cosOuter * spotScale</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> cd = <span class="hljs-built_in">dot</span>(<span class="hljs-built_in">normalize</span>(-lightDir), l);</span>
+<span class="line">    <span class="hljs-type">float</span> attenuation = <span class="hljs-built_in">clamp</span>(cd * spotScale + spotOffset, <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">    <span class="hljs-keyword">return</span> attenuation * attenuation;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec3</span> evaluatePunctualLight() {</span>
+<span class="line">    <span class="hljs-type">vec3</span> l = <span class="hljs-built_in">normalize</span>(posToLight);</span>
+<span class="line">    <span class="hljs-type">float</span> NoL = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(n, l), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">    <span class="hljs-type">vec3</span> posToLight = lightPosition - worldPosition;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> attenuation;</span>
+<span class="line">    attenuation  = getSquareFalloffAttenuation(posToLight, lightInvRadius);</span>
+<span class="line">    attenuation *= getSpotAngleAttenuation(l, lightDir, innerAngle, outerAngle);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">vec3</span> luminance = (BSDF(v, l) * lightIntensity * attenuation * NoL) * lightColor;</span>
+<span class="line">    <span class="hljs-keyword">return</span> luminance;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_glslpunctuallight">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;21:</b> Implementation of punctual lights in GLSL</div>
+
+<a class="target" name="photometriclights">&#xA0;</a><a class="target" name="lighting/directlighting/photometriclights">&#xA0;</a><a class="target" name="toc5.2.3">&#xA0;</a><h3>Photometric lights</h3>
+<p>
+
+
+Punctual lights are an extremely practical and efficient way to light a scene but do not give artists enough control over the light distribution. The field of architectural lighting design concerns itself with designing lighting systems to serve humans needs by taking into account:
+
+</p><p>
+
+</p><ul>
+<li class="minus">The amount of light provided
+</li>
+<li class="minus">The color of the light
+</li>
+<li class="minus">The distribution of light within the space</li></ul>
+
+<p></p><p>
+
+The lighting system we have described so far can easily address the first two points but we need a way to define the distribution of light within the space. Light distribution is especially important for indoor scenes or for some types of outdoor scenes or even road lighting. <a href="#figure_lightdistributiontest">Figure&#xA0;41</a> shows scenes where the light distribution is controlled by the artist. This type of distribution control is widely used when putting objects on display (museums, stores or galleries for instance).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_photometric_lights.png" target="_blank"><img class="markdeep" src="images/screenshot_photometric_lights.png"></a><div class="imagecaption"><a class="target" name="figure_lightdistributiontest">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;41:</b> Controlling the distribution of a point light</div></div></center>
+
+<p></p><p>
+
+Photometric lights use a photometric profile to describe their intensity distribution. There are two commonly used formats, IES (Illuminating Engineering Society) and EULUMDAT (European Lumen Data format) but we will focus on the former. IES profiles are supported by many tools and engines, such as Unreal Engine 4, Frostbite, Renderman, Maya and Killzone. In addition, IES light profiles are commonly made available by bulbs and luminaires manufacturers (Philips offers <a href="http://www.usa.lighting.philips.com/connect/tools_literature/photometric_data_1.wpd">an extensive array of IES files</a> for download for instance). Photometric profiles are particularly useful when they measure a luminaire or light fixture, in which the light source is partially covered. The luminaire will block the light emitted in certain directions, thus shaping the light distribution.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/photo_photometric_lights.jpg" target="_blank"><img class="markdeep" src="images/photo_photometric_lights.jpg"></a><div class="imagecaption">Example of a real world luminaires that can be described by photometric profiles</div></div></center>
+
+<p></p><p>
+
+An IES profile stores luminous intensity for various angles on a sphere around the measured light source. This spherical coordinate system is usually referred to as the photometric web, which can be visualized using specialized tools such as <a href="http://www.photometricviewer.com/">IESviewer</a>. <a href="#figure_xarrow">Figure&#xA0;42</a> below shows the photometric web of the XArrow IES profile <a href="http://renderman.pixar.com/view/DP25764">provided by Pixar</a> for use with Renderman. This picture also shows a rendering in 3D space of the XArrow IES profile by our tool <code>lightgen</code>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_xarrow.png" target="_blank"><img class="markdeep" src="images/screenshot_xarrow.png"></a><div class="imagecaption"><a class="target" name="figure_xarrow">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;42:</b> The XArrow IES profile rendered as a photometric web and as a point light in 3D space</div></div></center>
+
+<p></p><p>
+
+The IES format is poorly documented and it is not uncommon to find syntax variations between files found on the Internet. The best resource to understand IES profile is Ian Ashdown&apos;s &#x201C;Parsing the IESNA LM-63 photometric data file&#x201D; document [<a href="#citation-ashdown98">Ashdown98</a>]. Succinctly, an IES profiles stores luminous intensities in candela at various angles around the light source. For each measured horizontal angle, a series of luminous intensities at different vertical angles is provided. It is however fairly common for measured light sources to be horizontally symmetrical. The XArrow profile shown above is a good example: intensities vary with vertical angles (vertical axis) but are symmetrical on the horizontal axis. The range of vertical angles in an IES profile is 0 to 180&#xB0; and the range of horizontal angles is 0 to 360&#xB0;.
+
+</p><p>
+
+<a href="#figure_lightensamples">Figure&#xA0;43</a> shows the series of IES profiles provided by Pixar for Renderman, rendered using our <code>lightgen</code> tool.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_lightgen_samples.png" target="_blank"><img class="markdeep" src="images/screenshot_lightgen_samples.png"></a><div class="imagecaption"><a class="target" name="figure_lightensamples">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;43:</b> Series of IES light profiles rendered with lightgen</div></div></center>
+
+<p></p><p>
+
+IES profiles can be applied directly to any punctual light, point or spot. To do so, we must first process the IES profile and generate a photometric profile as a texture. For performance considerations, the photometric profile we generate is a 1D texture that represents the average luminous intensity for all horizontal angles at a specific vertical angle (i.e., each pixel represents a vertical angle). To truly represent a photometric light, we should use a 2D texture but since most lights are fully, or mostly, symmetrical on the horizontal plane, we can accept this approximation. The values stored in the texture are normalized by the inverse maximum intensity defined in the IES profile. This allows us to easily store the texture in any float format or, at the cost of a bit of precision, in a luminance 8-bit texture (grayscale PNG for instance). Storing normalized values also allows us to treat photometric profiles as a mask:
+
+</p><p>
+
+</p><dl><dt>Photometric profile as a mask</dt><dd><p>    The luminous intensity is defined by the artist by setting the luminous power of the light, as with any other punctual light. The artist defined intensity is divided by the intensity of the light computed from the IES profile. IES profiles contain a luminous intensity but it is only valid for a bare light bulb whereas the measured intensity values take into account the light fixture. To measure the intensity of the luminaire, instead of the bulb, we perform a Monte-Carlo integration of the unit sphere using the intensities from the profile<sup><a href="#endnote-xarrowintensity">4</a></sup>.
+
+</p></dd><dt>Photometric profile</dt><dd><p>    The luminous intensity comes from the profile itself. All the values sampled from the 1D texture are simply multiplied by the maximum intensity. We also provide a multiplier for convenience.
+
+</p></dd></dl>The photometric profile can be applied at rendering time as a simple attenuation. The luminance equation \( \ref{photometricLightEvaluation} \) describes the photometric point light evaluation function.
+
+<p></p><p>
+
+$$\begin{equation}\label{photometricLightEvaluation}
+L_{out} = f(v,l) \frac{I}{d^2} \left&lt; \NoL \right&gt; \Psi(l)
+\end{equation}$$
+
+</p><p>
+
+The term \( \Psi(l) \) is the photometric attenuation function. It depends on the light vector, but also on the direction of the light. Spot lights already possess a direction vector but we need to introduce one for photometric point lights as well.
+
+</p><p>
+
+The photometric attenuation function can be easily implemented in GLSL by adding a new attenuation factor to the implementation of punctual lights (<a href="#listing_glslpunctuallight">listing&#xA0;21</a>). The modified implementation is show in <a href="#listing_glslphotometricpunctuallight">listing&#xA0;22</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> getPhotometricAttenuation(<span class="hljs-type">vec3</span> posToLight, <span class="hljs-type">vec3</span> lightDir) {</span>
+<span class="line">    <span class="hljs-type">float</span> cosTheta = <span class="hljs-built_in">dot</span>(-posToLight, lightDir);</span>
+<span class="line">    <span class="hljs-type">float</span> angle = <span class="hljs-built_in">acos</span>(cosTheta) * (<span class="hljs-number">1.0</span> / PI);</span>
+<span class="line">    <span class="hljs-keyword">return</span> texture2DLodEXT(lightProfileMap, <span class="hljs-type">vec2</span>(angle, <span class="hljs-number">0.0</span>), <span class="hljs-number">0.0</span>).r;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec3</span> evaluatePunctualLight() {</span>
+<span class="line">    <span class="hljs-type">vec3</span> l = <span class="hljs-built_in">normalize</span>(posToLight);</span>
+<span class="line">    <span class="hljs-type">float</span> NoL = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(n, l), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">    <span class="hljs-type">vec3</span> posToLight = lightPosition - worldPosition;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> attenuation;</span>
+<span class="line">    attenuation  = getSquareFalloffAttenuation(posToLight, lightInvRadius);</span>
+<span class="line">    attenuation *= getSpotAngleAttenuation(l, lightDirection, innerAngle, outerAngle);</span>
+<span class="line">    attenuation *= getPhotometricAttenuation(l, lightDirection);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">float</span> luminance = (BSDF(v, l) * lightIntensity * attenuation * NoL) * lightColor;</span>
+<span class="line">    <span class="hljs-keyword">return</span> luminance;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_glslphotometricpunctuallight">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;22:</b> Implementation of attenuation from photometric profiles in GLSL</div>
+<p>
+
+
+The light intensity is computed CPU-side (<a href="#listing_photometriclightintensity">listing&#xA0;23</a>) and depends on whether the photometric profile is used as a mask.
+
+</p><pre class="listing tilde"><code><span class="line">float multiplier;</span>
+<span class="line"><span class="hljs-comment">// Photometric profile used as a mask</span></span>
+<span class="line"><span class="hljs-keyword">if</span> (photometricLight.isMasked()) {</span>
+<span class="line">    <span class="hljs-comment">// The desired intensity is set by the artist</span></span>
+<span class="line">    <span class="hljs-comment">// The integrated intensity comes from a Monte-Carlo</span></span>
+<span class="line">    <span class="hljs-comment">// integration over the unit sphere around the luminaire</span></span>
+<span class="line">    multiplier = photometricLight.getDesiredIntensity() /</span>
+<span class="line">            photometricLight.getIntegratedIntensity();</span>
+<span class="line">} <span class="hljs-keyword">else</span> {</span>
+<span class="line">    <span class="hljs-comment">// Multiplier provided for convenience, set to 1.0 by default</span></span>
+<span class="line">    multiplier = photometricLight.getMultiplier();</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// The max intensity in cd comes from the IES profile</span></span>
+<span class="line">float lightIntensity = photometricLight.getMaxIntensity() * multiplier;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_photometriclightintensity">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;23:</b> Computing the intensity of a photometric light on the CPU</div>
+<p>
+
+
+</p><div class="endnote"><a class="target" name="endnote-xarrowintensity">&#xA0;</a><sup>4</sup> The XArrow profile declares a luminous intensity of 1,750 lm but a Monte-Carlo integration shows an intensity of only 350 lm.
+</div>
+<p></p>
+<a class="target" name="arealights">&#xA0;</a><a class="target" name="lighting/directlighting/arealights">&#xA0;</a><a class="target" name="toc5.2.4">&#xA0;</a><h3>Area lights</h3>
+<p>
+
+
+[TODO]
+
+</p>
+<a class="target" name="lightsparameterization">&#xA0;</a><a class="target" name="lighting/directlighting/lightsparameterization">&#xA0;</a><a class="target" name="toc5.2.5">&#xA0;</a><h3>Lights parameterization</h3>
+<p>
+
+
+Similarly to the parameterization of the standard material model, our goal is to make lights parameterization intuitive and easy to use for artists and developers alike. In that spirit, we decided to separate the light color (or hue) from the light intensity. A light color will therefore be defined as a linear RGB color (or sRGB in the tools UI for convenience).
+
+</p><p>
+
+The full list of light parameters is presented in <a href="#table_lightparameters">table&#xA0;13</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Type</strong> </td><td style="text-align:left"> Directional, point, spot or area </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Direction</strong> </td><td style="text-align:left"> Used for directional lights, spot lights, photometric point lights, and linear and tubular area lights (orientation) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Color</strong> </td><td style="text-align:left"> The color of emitted light, as a linear RGB color. Can be specified as an sRGB color or a color temperature in the tools </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Intensity</strong> </td><td style="text-align:left"> The light&apos;s brightness. The unit depends on the type of light </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Falloff radius</strong> </td><td style="text-align:left"> Maximum distance of influence </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Inner angle</strong> </td><td style="text-align:left"> Angle of the inner cone for spot lights, in degrees </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Outer angle</strong> </td><td style="text-align:left"> Angle of the outer cone for spot lights, in degrees </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Length</strong> </td><td style="text-align:left"> Length of the area light, used to create linear or tubular lights </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Radius</strong> </td><td style="text-align:left"> Radius of the area light, used to create spherical or tubular lights </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Photometric profile</strong> </td><td style="text-align:left"> Texture representing a photometric light profile, works only for punctual lights </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Masked profile</strong> </td><td style="text-align:left"> Boolean indicating whether the IES profile is used as a mask or not. When used as a mask, the light&apos;s brightness will be multiplied by the ratio between the user specified intensity and the integrated IES profile intensity. When not used as a mask, the user specified intensity is ignored but the IES multiplier is used instead </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">Photometric multiplier</strong> </td><td style="text-align:left"> Brightness multiplier for photometric lights (if IES as mask is turned off) </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_lightparameters">&#xA0;</a><b style="font-style:normal;">Table&#xA0;13:</b> Light types parameters</div></div>
+
+<p></p><p>
+
+<strong class="asterisk">Note</strong>: to simplify the implementation, all luminous powers will converted to luminous intensities (\(cd\)) before being sent to the shader. The conversion is light dependent and is explained in the previous sections.
+
+</p><p>
+
+<strong class="asterisk">Note</strong>: the light type can be inferred from other parameters (e.g. a point light has a length, radius, inner angle and outer angle of 0).
+
+</p>
+<a class="target" name="colortemperature">&#xA0;</a><a class="target" name="lighting/directlighting/lightsparameterization/colortemperature">&#xA0;</a><a class="target" name="toc5.2.5.1">&#xA0;</a><h4>Color temperature</h4>
+<p>
+
+
+However, real-world artificial lights are often defined by their color temperature, measured in Kelvin (K). The color temperature of a light source is the temperature of an ideal black-body radiator that radiates light of comparable hue to that of the light source. For convenience, the tools should allow the artist to specify the hue of a light source as a color temperature (a meaningful range is 1,000 K to 12,500 K).
+
+</p><p>
+
+To compute RGB values from a temperature, we can use the Planckian locus, shown in <a href="#figure_planckianlocus">figure&#xA0;44</a>. This locus is the path that the color of an incandescent black body takes in a chromaticity space as the body&apos;s temperature changes.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_planckian_locus.png" target="_blank"><img class="markdeep" src="images/diagram_planckian_locus.png"></a><div class="imagecaption"><a class="target" name="figure_planckianlocus">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;44:</b> The Planckian locus visualized on a CIE 1931 chromaticity diagram (source: Wikipedia)</div></div></center>
+
+<p></p><p>
+
+The easiest way to compute RGB values from this locus is to use the formula described in [<a href="#citation-krystek85">Krystek85</a>]. Krystek&apos;s algorithm (equation \(\ref{krystek}\)) works in the CIE 1960 (UCS) space, using the following formula where \(T\) is the desired temperature, and \(u\) and \(v\) the coordinates in UCS.
+
+</p><p>
+
+$$\begin{equation}\label{krystek}
+u(T) = \frac{0.860117757 + 1.54118254 \times 10^{-4}T + 1.28641212 \times 10^{-7}T^2}{1 + 8.42420235 \times 10^{-4}T + 7.08145163 \times 10^{-7}T^2} \\
+v(T) = \frac{0.317398726 + 4.22806245
+ \times 10^{-5}T + 4.20481691 \times 10^{-8}T^2}{1 - 2.89741816
+ \times 10^{-5}T + 1.61456053 \times 10^{-7}T^2}
+\end{equation}$$
+
+</p><p>
+
+This approximation is accurate to roughly \( 9 \times 10^{-5} \) in the range 1,000K to 15,000K. From the CIE 1960 space we can compute the coordinates in xyY space (CIES 1931), using the formula from equation \(\ref{cieToxyY}\).
+
+</p><p>
+
+$$\begin{equation}\label{cieToxyY}
+x = \frac{3u}{2u - 8v + 4} \\
+y = \frac{2v}{2u - 8v + 4}
+\end{equation}$$
+
+</p><p>
+
+The formulas above are valid for black body color temperatures, and therefore correlated color temperatures of standard illuminants. If we wish to compute the precise chromaticity coordinates of standard CIE illuminants in the D series we can use equation \(\ref{seriesDtoxyY}\).
+
+</p><p>
+
+$$\begin{equation}\label{seriesDtoxyY}
+x = \begin{cases} 0.244063 + 0.09911 \frac{10^3}{T} + 2.9678 \frac{10^6}{T^2} - 4.6070 \frac{10^9}{T^3} &amp; 4,000K \le T \le 7,000K \\
+0.237040 + 0.24748 \frac{10^3}{T} + 1.9018 \frac{10^6}{T^2} - 2.0064 \frac{10^9}{T^3} &amp; 7,000K \le T \le 25,000K \end{cases} \\
+y = -3x^2 + 2.87 x - 0.275
+\end{equation}$$
+
+</p><p>
+
+From the xyY space, we can then convert to the CIE XYZ space (equation \(\ref{xyYtoXYZ}\)).
+
+</p><p>
+
+$$\begin{equation}\label{xyYtoXYZ}
+X = \frac{xY}{y} \\
+Z = \frac{(1 - x - y)Y}{y}
+\end{equation}$$
+
+</p><p>
+
+For our needs, we will fix \(Y = 1\). This allows us to convert from the XYZ space to linear RGB with a simple 3&#xD7;3 matrix, as shown in equation \(\ref{XYZtoRGB}\).
+
+</p><p>
+
+$$\begin{equation}\label{XYZtoRGB}
+\left[ \begin{matrix} R \\ G \\ B \end{matrix} \right] = M^{-1} \left[ \begin{matrix} X \\ Y \\ Z \end{matrix} \right]
+\end{equation}$$
+
+</p><p>
+
+The transformation matrix M is calculated from the target RGB color space primaries. Equation \( \ref{XYZtoRGBValues} \) shows the conversion using the inverse matrix for the sRGB color space.
+
+</p><p>
+
+$$\begin{equation}\label{XYZtoRGBValues}
+\left[ \begin{matrix} R \\ G \\ B \end{matrix} \right] = \left[ \begin{matrix} 3.2404542 &amp; -1.5371385 &amp; -0.4985314 \\ -0.9692660 &amp; 1.8760108 &amp; 0.0415560 \\ 0.0556434 &amp; -0.2040259 &amp; 1.0572252 \end{matrix} \right] \left[ \begin{matrix} X \\ Y \\ Z \end{matrix} \right]
+\end{equation}$$
+
+</p><p>
+
+The result of these operations is a linear RGB triplet in the sRGB color space. Since we care about the chromaticity of the results, we must apply a normalization step to avoid clamping values greater than 1.0 and distort resulting colors:
+
+</p><p>
+
+$$\begin{equation}\label{normalizedRGB}
+\hat{C}_{linear} = \frac{C_{linear}}{max(C_{linear})}
+\end{equation}$$
+
+</p><p>
+
+We must finally apply the sRGB opto-electronic conversion function (OECF, shown in equation \( \ref{OECFsRGB} \)) to obtain a displayable value (the value should remain linear if passed to the renderer for shading).
+
+</p><p>
+
+$$\begin{equation}\label{OECFsRGB}
+C_{sRGB} = \begin{cases} 12.92 \times \hat{C}_{linear} &amp; \hat{C}_{linear} \le 0.0031308 \\
+1.055 \times \hat{C}_{linear}^{\frac{1}{2.4}} - 0.055 &amp; \hat{C}_{linear} \gt 0.0031308 \end{cases}
+\end{equation}$$
+
+</p><p>
+
+For convenience, <a href="#figure_colortemperaturescalecct">figure&#xA0;45</a> shows the range of correlated color temperatures from 1,000K to 12,500K. All the colors used below assume CIE \( D_{65} \) as the white point (as is the case in the sRGB color space).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_color_temperature_cct.png" target="_blank"><img class="markdeep" src="images/diagram_color_temperature_cct.png"></a><div class="imagecaption"><a class="target" name="figure_colortemperaturescalecct">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;45:</b> Scale of correlated color temperatures</div></div></center>
+
+<p></p><p>
+
+Similarly, <a href="#figure_colortemperaturescalecie">figure&#xA0;46</a> shows the range of CIE standard illuminants series D from 1,000K to 12,500K.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_color_temperature_cie.png" target="_blank"><img class="markdeep" src="images/diagram_color_temperature_cie.png"></a><div class="imagecaption"><a class="target" name="figure_colortemperaturescalecie">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;46:</b> Scale of CIE standard illuminants series D</div></div></center>
+
+<p></p><p>
+
+For reference, <a href="#figure_colortemperaturescalecctclamped">figure&#xA0;47</a> shows the range of correlated color temperatures without the normalization step presented in equation \(\ref{normalizedRGB}\).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_color_temperature_cct_clamped.png" target="_blank"><img class="markdeep" src="images/diagram_color_temperature_cct_clamped.png"></a><div class="imagecaption"><a class="target" name="figure_colortemperaturescalecctclamped">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;47:</b> Unnormalized scale of correlated color temperatures</div></div></center>
+
+<p></p><p>
+
+<a href="#table_colortemperaturesamples">Table&#xA0;14</a> presents the correlated color temperature of various common light sources as sRGB color swatches. These colors are relative to the \( D_{65} \) white point, so their perceived hue might vary based on your display&apos;s white point. See <a href="http://jila.colorado.edu/~ajsh/colour/Tspectrum.html">What colour is the Sun?</a> for more information.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Temperature (K) </th><th style="text-align:left"> Light source </th><th style="text-align:left"> Color </th></tr>
+<tr><td style="text-align:right"> 1,700-1,800 </td><td style="text-align:left"> Match flame </td><td style="text-align:left"> <div style="background-color: #ff7d00; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 1,850-1,930 </td><td style="text-align:left"> Candle flame </td><td style="text-align:left"> <div style="background-color: #ff8701; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 2,000-3,000 </td><td style="text-align:left"> Sun at sunrise/sunset </td><td style="text-align:left"> <div style="background-color: #ffa64c; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 2,500-2,900 </td><td style="text-align:left"> Household tungsten lightbulb </td><td style="text-align:left"> <div style="background-color: #ffb05e; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 3,000 </td><td style="text-align:left"> Tungsten lamp 1K </td><td style="text-align:left"> <div style="background-color: #ffb86f; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 3,200-3,500 </td><td style="text-align:left"> Quartz lights </td><td style="text-align:left"> <div style="background-color: #ffbf7b; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 3,200-3,700 </td><td style="text-align:left"> Fluorescent lights </td><td style="text-align:left"> <div style="background-color: #ffbf7b; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 3,275 </td><td style="text-align:left"> Tungsten lamp 2K </td><td style="text-align:left"> <div style="background-color: #ffc180; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 3,380 </td><td style="text-align:left"> Tungsten lamp 5K, 10K </td><td style="text-align:left"> <div style="background-color: #ffc486; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 5,000-5,400 </td><td style="text-align:left"> Sun at noon </td><td style="text-align:left"> <div style="background-color: #ffe9d7; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 5,500-6,500 </td><td style="text-align:left"> Daylight (sun + sky) </td><td style="text-align:left"> <div style="background-color: #fff3f1; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 5,500-6,500 </td><td style="text-align:left"> Sun through clouds/haze </td><td style="text-align:left"> <div style="background-color: #fff3f1; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 6,000-7,500 </td><td style="text-align:left"> Overcast sky </td><td style="text-align:left"> <div style="background-color: #faf6ff; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 6,500 </td><td style="text-align:left"> RGB monitor white point </td><td style="text-align:left"> <div style="background-color: #fff8fe; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 7,000-8,000 </td><td style="text-align:left"> Shaded areas outdoors </td><td style="text-align:left"> <div style="background-color: #ebecff; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> 8,000-10,000 </td><td style="text-align:left"> Partly cloudy sky </td><td style="text-align:left"> <div style="background-color: #d6e0ff; width: 60px">&#xA0;</div> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_colortemperaturesamples">&#xA0;</a><b style="font-style:normal;">Table&#xA0;14:</b> Normalized correlated color temperatures for common light sources</div></div>
+
+<p></p>
+<a class="target" name="pre-exposedlights">&#xA0;</a><a class="target" name="lighting/directlighting/pre-exposedlights">&#xA0;</a><a class="target" name="toc5.2.6">&#xA0;</a><h3>Pre-exposed lights</h3>
+<p>
+
+
+Physically based rendering and physical light units pose an interesting challenge: how to store and handle the large range of values produced by the lighting code? Assuming computations performed at full precision in the shaders, we still want to be able to store the linear output of the lighting pass in a reasonably sized buffer (<code>RGB16F</code> or equivalent). The most obvious and easiest way to achieve this is to simply apply the camera exposure (see the <a href="#physicallybasedcamera">Physically based camera</a> section for more information) before writing out the result of the lighting pass. This simple step is shown in <a href="#listing_preexposedlighting">listing&#xA0;24</a>:
+
+</p><pre class="listing tilde"><code><span class="line">fragColor = luminance * camera.exposure;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_preexposedlighting">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;24:</b> The output of the lighting pass is pre-exposed to fit in half-float buffers</div>
+<p>
+
+
+This solution solves the storage problem but requires intermediate computations to be performed with single precision floats. We would instead prefer to perform all (or at least most) of the lighting work using half precision floats instead. Doing so can greatly improve performance and power usage, particularly on mobile devices. Half precision floats are however ill-suited for this kind of work as common illuminance and luminance values (for the sun for instance) can exceed their range. The solution is to simply pre-expose the lights themselves instead of the result of the lighting pass. This can be done efficiently on the CPU if updating a light&apos;s constant buffer is cheap. This can also be done on the GPU, as shown in <a href="#listing_preexposedlights">listing&#xA0;25</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// The inputs must be highp/single precision,</span></span>
+<span class="line"><span class="hljs-comment">// both for range (intensity) and precision (exposure)</span></span>
+<span class="line"><span class="hljs-comment">// The output is mediump/half precision</span></span>
+<span class="line"><span class="hljs-type">float</span> computePreExposedIntensity(<span class="hljs-keyword">highp</span> <span class="hljs-type">float</span> intensity, <span class="hljs-keyword">highp</span> <span class="hljs-type">float</span> exposure) {</span>
+<span class="line">    <span class="hljs-keyword">return</span> intensity * exposure;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">Light getPointLight(<span class="hljs-type">uint</span> <span class="hljs-keyword">index</span>) {</span>
+<span class="line">    Light light;</span>
+<span class="line">    <span class="hljs-type">uint</span> lightIndex = <span class="hljs-comment">// fetch light index;</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// the intensity must be highp/single precision</span></span>
+<span class="line">    <span class="hljs-keyword">highp</span> <span class="hljs-type">vec4</span> colorIntensity  = lightsUniforms.lights[lightIndex][<span class="hljs-number">1</span>];</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// pre-expose the light</span></span>
+<span class="line">    light.colorIntensity.w = computePreExposedIntensity(</span>
+<span class="line">            colorIntensity.w, frameUniforms.exposure);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">return</span> light;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_preexposedlights">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;25:</b> Pre-exposing lights allows the entire shading pipeline to use half precision floats</div>
+<p>
+
+
+In practice we pre-expose the following lights:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Punctual lights (point and spot): on the GPU
+</li>
+<li class="minus">Directional light: on the CPU
+</li>
+<li class="minus">IBLs: on the CPU
+</li>
+<li class="minus">Material emissive: on the GPU</li></ul>
+
+<p></p>
+<a class="target" name="imagebasedlights">&#xA0;</a><a class="target" name="lighting/imagebasedlights">&#xA0;</a><a class="target" name="toc5.3">&#xA0;</a><h2>Image based lights</h2>
+<p>
+
+
+In real life, light comes from every direction either directly from light sources or indirectly after bouncing off objects in the environment, being partially absorbed in the process. In a way the whole environment around an object can be seen as a light source. Images, in particular cubemaps, are a great way to encode such an &#x201C;environment light&#x201D;. This is called Image Based Lighting (IBL) or sometimes Indirect Lighting.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ball_ibl.png" target="_blank"><img class="markdeep" src="images/screenshot_ball_ibl.png"></a><div class="imagecaption"><a class="target" name="figure_iblball">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;48:</b> The object shown here is lit only by image-encoded environment lights. Notice the subtle lighting effects that can be applied using this technique.</div></div></center>
+
+<p></p><p>
+
+There are limitations with image-based lighting. Obviously the environment image must be acquired somehow and as we&apos;ll see below it needs to be pre-processed before it can be used for lighting. Typically, the environment image is acquired offline in the real world, or generated by the engine either offline or at run time; either way, local or distant probes are used.
+
+</p><p>
+
+These probes can be used to acquire the distant or local environment. In this document, we&apos;re focusing on distant environment probes, where the light is assumed to come from infinitely far away (which means every point on the object&apos;s surface uses the same environment map).
+
+</p><p>
+
+The whole environment contributes light to a given point on the object&apos;s surface; this is called <em class="underscore">irradiance</em> (\(E\)). The resulting light bouncing off of the object is called radiance (\(L_{out}\)). Incident lighting must be applied consistently to the diffuse and specular parts of the BRDF.
+
+</p><p>
+
+The radiance \(L_{out}\) resulting from the interaction between an image based light&apos;s (IBL) irradiance and a material model (BRDF) \(f(\Theta)\)<sup><a href="#endnote-ibl1">5</a></sup> is computed as follows:
+
+</p><p>
+
+$$\begin{equation}
+L_{out}(n, v, \Theta) = \int_\Omega  f(l, v, \Theta) L_{\bot}(l) \left&lt; \NoL \right&gt; dl 
+\end{equation}$$ 
+
+</p><p>
+
+Note that here we&apos;re looking at the behavior of the surface at <strong class="asterisk">macro</strong> level (not to be confused with the micro level equation), which is why it only depends on \(\vec n\) and \(\vec v\). Essentially, we&apos;re applying the BRDF to &#x201C;point-lights&#x201D; coming from all directions and encoded in the IBL.
+
+</p>
+<a class="target" name="ibltypes">&#xA0;</a><a class="target" name="lighting/imagebasedlights/ibltypes">&#xA0;</a><a class="target" name="toc5.3.1">&#xA0;</a><h3>IBL Types </h3>
+<p>
+
+
+There are four common types of IBLs used in modern rendering engines:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><strong class="asterisk">Distant light probes</strong>, used to capture lighting information at &#x201C;infinity&#x201D;, where parallax can be ignored. Distant probes typically contain the sky, distant landscape features or buildings, etc. They are either captured by the engine or acquired from a camera as high dynamic range images (HDRI).
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Local light probes</strong>, used to capture a certain area of the world from a specific point of view. The capture is projected on a cube or sphere depending on the surrounding geometry. Local probes are more accurate than distance probes and are particularly useful to add local reflections to materials.
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Planar reflections</strong>, used to capture reflections by rendering the scene mirrored by a plane. This technique works only for flat surfaces such as building floors, roads and water.
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Screen space reflection</strong>, used to capture reflections based on the rendered scene (using the previous frame for instance) by ray-marching in the depth buffer. SSR gives great result but can be very expensive.</li></ul>
+
+<p></p><p>
+
+In addition we must distinguish between static and dynamic IBLs. Implementing a fully dynamic day/night cycle requires for instance to recompute the distant light probes dynamically<sup><a href="#endnote-ibltypes1">6</a></sup>. Both planar and screen space reflections are inherently dynamic.
+
+</p>
+<a class="target" name="iblunit">&#xA0;</a><a class="target" name="lighting/imagebasedlights/iblunit">&#xA0;</a><a class="target" name="toc5.3.2">&#xA0;</a><h3>IBL Unit </h3>
+<p>
+
+
+As discussed previously in the direct <a href="#lighting">lighting</a> section, all our lights must use physical units. As such our IBLs will use the luminance unit \(\frac{cd}{m^2}\), which is also the output unit of all our direct lighting equations. Using the luminance unit is straightforward for light probes captures by the engine (dynamically or statically offline).
+
+</p><p>
+
+High dynamic range images are a bit more delicate to handle however. Cameras do not record measured luminance but a device-dependent value that is only <em class="underscore">related</em> to the original scene luminance. As such, we must provide artists with a multiplier that allows them to recover, or at the very least closely approximate, the original absolute luminance.
+
+</p><p>
+
+To properly reconstruct the luminance of an HDRI for IBL, artists must do more than simply take photos of the environment and record extra information:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><strong class="asterisk">Color calibration</strong>: using a gray card or a <a href="http://en.wikipedia.org/wiki/ColorChecker">MacBeth ColorChecker</a>
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Camera settings</strong>: aperture, shutter and ISO
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Luminance samples</strong>: using a spot/luminance meter</li></ul>
+
+<p></p><p>
+
+[TODO] Measure and list common luminance values (clear sky, interior, etc.)
+
+</p>
+<a class="target" name="processinglightprobes">&#xA0;</a><a class="target" name="lighting/imagebasedlights/processinglightprobes">&#xA0;</a><a class="target" name="toc5.3.3">&#xA0;</a><h3>Processing light probes </h3>
+<p>
+
+
+We saw previously that the radiance of an IBL is computed by integrating over the surface&apos;s hemisphere. Since this would obviously be too expensive to do in real-time, we must first pre-process our light probes to convert them into a format better suited for real-time interactions.
+
+</p><p>
+
+The sections below will discuss the techniques used to accelerate the evaluation of light probes:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><strong class="asterisk">Specular reflectance</strong>: pre-filtered importance sampling and split-sum approximation
+
+<p></p><p>
+
+</p></li>
+<li class="minus"><strong class="asterisk">Diffuse reflectance</strong>: irradiance map and spherical harmonics</li></ul>
+
+<p></p>
+<a class="target" name="distantlightprobes">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes">&#xA0;</a><a class="target" name="toc5.3.4">&#xA0;</a><h3>Distant light probes </h3>
+
+<a class="target" name="diffusebrdfintegration">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/diffusebrdfintegration">&#xA0;</a><a class="target" name="toc5.3.4.1">&#xA0;</a><h4>Diffuse BRDF integration </h4>
+<p>
+
+
+Using the Lambertian BRDF<sup><a href="#endnote-ibldiffuse1">7</a></sup>, we get the radiance:
+
+</p><p>
+
+$$
+\begin{align*}
+   f_d(\sigma) &amp;= \frac{\sigma}{\pi} \\
+L_d(n, \sigma) &amp;= \int_{\Omega} f_d(\sigma) L_{\bot}(l) \left&lt; \NoL \right&gt; dl \\
+               &amp;= \frac{\sigma}{\pi} \int_{\Omega} L_{\bot}(l) \left&lt; \NoL \right&gt; dl \\
+               &amp;= \frac{\sigma}{\pi} E_d(n) \quad \text{with the irradiance} \; 
+        E_d(n) = \int_{\Omega} L_{\bot}(l) \left&lt; \NoL \right&gt; dl
+\end{align*}
+$$
+
+</p><p>
+
+Or in the discrete domain:
+
+</p><p>
+
+$$ E_d(n) \equiv \sum_{\forall \, i \in image} L_{\bot}(s_i) \left&lt; n \cdot s_i \right&gt; \Omega_s $$
+
+</p><p>
+
+\(\Omega_s\) is the solid-angle<sup><a href="#endnote-ibldiffuse2">8</a></sup> associated to sample \(i\).
+
+</p><p>
+
+The irradiance integral \(\Ed\) can be trivially, albeit slowly<sup><a href="#endnote-ibldiffuse3">9</a></sup>, precomputed and stored into a cubemap for efficient access at runtime. Typically, <em class="underscore">image</em> is a cubemap or an equirectangular image. The term \( \frac{\sigma}{\pi} \) is independent of the IBL and is added at runtime to obtain the <em class="underscore">radiance</em>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_river_roughness_m0.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m0.png" style="max-width:100%;"></a><div class="imagecaption"><a class="target" name="figure_ibloriginal">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;49:</b> Image-based environment</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_irradiance.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_irradiance.png" style="max-width:100%;"></a><div class="imagecaption"><a class="target" name="figure_iblirradiance">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;50:</b> Image-based irradiance map using the Lambertian BRDF</div></div></center>
+
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-ibl1">&#xA0;</a><sup>5</sup> \(\Theta\) represents the parameters of the material model \(f\), i.e.: <em class="underscore">roughness</em>, albedo and so on...
+</div>
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-ibltypes1">&#xA0;</a><sup>6</sup> This can be done through blending of static probes or by spreading the workload over time
+</div>
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-ibldiffuse1">&#xA0;</a><sup>7</sup> The Lambertian BRDF doesn&apos;t depend on \(\vec l\), \(\vec v\) or \(\theta\), so \(L_d(n,v,\theta) \equiv L_d(n,\sigma)\)
+</div>
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-ibldiffuse2">&#xA0;</a><sup>8</sup> \(\Omega_s\) can be approximated by \(\frac{2\pi}{6 \cdot width \cdot height}\) for a cubemap
+</div>
+<p></p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-ibldiffuse3">&#xA0;</a><sup>9</sup> \(O(12\,n^2\,m^2)\), with \(n\) and \(m\) respectively the dimensions of the environment and the precomputed cubemap
+</div>
+<p></p><p>
+
+However, the irradiance can also be approximated very closely by a decomposition into Spherical Harmonics (SH, described in more details in the <a href="#sphericalharmonics">Spherical Harmonics</a> section) and calculated at runtime cheaply. It is usually best to avoid texture fetches on mobile and free-up a texture unit. Even if it is stored into a cubemap, it is orders of magnitude faster to pre-compute the integral using SH decomposition followed by a rendering.
+
+</p><p>
+
+SH decomposition is similar in concept to a Fourier transform, it expresses the signal over an orthonormal base in the frequency domain. The properties that interests us most are:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Very few coefficients are needed to encode \(\cosTheta\)
+
+<p></p><p>
+
+</p></li>
+<li class="minus">Convolutions by a kernel that <em class="underscore">has a circular symmetry</em> are very inexpensive and become products in SH space</li></ul>
+
+<p></p><p>
+
+In practice only 4 or 9 coefficients (i.e.: 2 or 3 bands) are enough for \(\cosTheta\) meaning we don&apos;t need more either for \(\Lt\).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_irradiance_sh3.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_irradiance_sh3.png" style="max-width:100%;"></a><div class="imagecaption"><a class="target" name="figure_iblsh3">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;51:</b> 3 bands (9 coefficients)</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_irradiance_sh2.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_irradiance_sh2.png" style="max-width:100%;"></a><div class="imagecaption"><a class="target" name="figure_iblsh2">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;52:</b> 2 bands (4 coefficients)</div></div></center>
+
+<p></p><p>
+
+In practice we pre-convolve \(\Lt\) with \(\cosTheta\) and pre-scale these coefficients by the basis scaling factors \(K_l^m\) so that the reconstruction code is as simple as possible in the shader:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> irradianceSH(<span class="hljs-type">vec3</span> n) {</span>
+<span class="line">    <span class="hljs-comment">// uniform vec3 sphericalHarmonics[9]</span></span>
+<span class="line">    <span class="hljs-comment">// We can use only the first 2 bands for better performance</span></span>
+<span class="line">    <span class="hljs-keyword">return</span></span>
+<span class="line">          sphericalHarmonics[<span class="hljs-number">0</span>]</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">1</span>] * (n.y)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">2</span>] * (n.z)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">3</span>] * (n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">4</span>] * (n.y * n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">5</span>] * (n.y * n.z)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">6</span>] * (<span class="hljs-number">3.0</span> * n.z * n.z - <span class="hljs-number">1.0</span>)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">7</span>] * (n.z * n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">8</span>] * (n.x * n.x - n.y * n.y);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_irradiancesh">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;26:</b> GLSL code to reconstruct the irradiance from the pre-scaled SH</div>
+<p>
+
+
+Note that with 2 bands, the computation above becomes a single \(4 \times 4\) matrix-by-vector multiply.
+
+</p><p>
+
+Additionally, because of the pre-scaling by \(K_l^m\), the SH coefficients can be thought of as colors, in particular <code>sphericalHarmonics[0]</code> is directly the average irradiance.
+
+</p>
+<a class="target" name="specularbrdfintegration">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/specularbrdfintegration">&#xA0;</a><a class="target" name="toc5.3.4.2">&#xA0;</a><h4>Specular BRDF integration </h4>
+<p>
+
+
+As we&apos;ve seen above, the radiance \(\Lout\) resulting from the interaction between an IBL&apos;s irradiance and a BRDF is:
+
+</p><p>
+
+$$\begin{equation}\label{specularBRDFIntegration}
+\Lout(n, v, \Theta) = \int_\Omega f(l, v, \Theta) \Lt(l) \left&lt; \NoL \right&gt; \partial l 
+\end{equation}$$ 
+
+</p><p>
+
+We recognize the convolution of \(\Lt\) by \(f(l, v, \Theta) \left&lt; \NoL \right&gt;\), 
+i.e.: the environment is <em class="asterisk">filtered</em> using the BRDF as a kernel. Indeed at higher roughness, 
+specular reflections look more <em class="asterisk">blurry</em>.
+
+</p><p>
+
+Plugging the expression of \(f\) in equation \(\ref{specularBRDFIntegration}\), we obtain:
+
+</p><p>
+
+$$\begin{equation}
+\Lout(n,v,\Theta) = \int_\Omega D(l, v, \alpha) F(l, v, f_0, f_{90}) V(l, v, \alpha) \left&lt; \NoL \right&gt; \Lt(l) \partial l
+\end{equation}$$ 
+
+</p><p>
+
+This expression depends on \(v\), \(\alpha\), \(f_0\) and \(f_{90}\) inside the integral, 
+which makes its evaluation extremely costly and unsuitable for real-time on mobile 
+(even using pre-filtered importance sampling). 
+
+</p>
+<a class="target" name="simplifyingthebrdfintegration">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/specularbrdfintegration/simplifyingthebrdfintegration">&#xA0;</a><a class="target" name="toc5.3.4.2.1">&#xA0;</a><h5>Simplifying the BRDF integration </h5>
+<p>
+
+
+Since there is no closed-form solution or an easy way to compute the \(\Lout\) integral, we use a simplified
+equation instead: \(\hat{I}\), whereby we assume that \(v = n\), that is the view direction \(v\) is always
+equal to the surface normal \(n\). Clearly, this assumption will break all view-dependant effects of 
+the convolution, such as the increased blur in reflections closer to the viewer 
+(a.k.a. stretchy reflections). 
+
+</p><p>
+
+Such a simplification would also have a severe impact on constant environments, such as the white 
+furnace, because it would affect the magnitude of the constant (i.e. DC) term of the result. We
+can at least correct for that by using a scale factor, \(K\), in our simplified integral, which
+will make sure the average irradiance stay correct when chosen properly.
+
+</p><p>
+
+</p><ul>
+    <li class="minus">\(I\) is our original integral, i.e.: \(I(g) = \int_\Omega g(l) \left&lt; \NoL \right&gt; \partial l\)
+</li>
+    <li class="minus">\(\hat{I}\) is the simplified integral where \(v = n\)
+</li>
+    <li class="minus">\(K\) is a scale factor that ensures the average irradiance is unchanged by \(\hat{I}\)
+</li>
+    <li class="minus">\(\tilde{I}\) is our final approximation of \(I\), \(\tilde{I} = \hat{I} \times K\)</li></ul>
+
+<p></p><p>
+
+Because \(I\) is an integral multiplications can be distributed over it. i.e.: \(I(g()f()) = I(g())I(f())\).
+
+</p><p>
+
+Armed with that,
+
+</p><p>
+
+$$\begin{equation}
+I( f(\Theta) \Lt ) \approx \tilde{I}( f(\Theta) \Lt )                       \\
+\tilde{I}( f(\Theta) \Lt ) = K \times \hat{I}( f(\Theta) \Lt )              \\
+K = \frac{I(f(\Theta))}{\hat{I}(f(\Theta))}
+\end{equation}$$ 
+
+</p><p>
+
+From the equation above we can see that \(\tilde{I}\) is equivalent to \(I\)  when \(\Lt\) is a constant,
+and yields the correct result:
+
+</p><p>
+
+$$\begin{align*}
+\tilde{I}(f(\Theta)\Lt^{constant}) &amp;= \Lt^{constant} \hat{I}(f(\Theta)) \frac{I(f(\Theta))}{\hat{I}(f(\Theta))} \\
+                                   &amp;= \Lt^{constant} I(f(\Theta))                                               \\
+                                   &amp;= I(f(\Theta)\Lt^{constant})
+\end{align*}$$
+
+</p><p>
+
+Similarly, we can also demonstrate that the result is correct when \(v = n\), since in that case \(I = \hat{I}\):
+
+</p><p>
+
+$$\begin{align*}
+\tilde{I}(f(\Theta)\Lt) &amp;= I(f(\Theta)\Lt) \frac{I(f(\Theta))}{I(f(\Theta))}    \\
+                        &amp;= I(f(\Theta)\Lt)
+\end{align*}$$
+
+</p><p>
+
+Finally, we can show that the scale factor \(K\) satisfies our average irradiance (\(\bar{\Lt}\))
+requirement by plugging \(\Lt = \bar{\Lt} + (\Lt - \bar{\Lt}) = \bar{\Lt} + \Delta\Lt\) into \(\tilde{I}\):
+
+</p><p>
+
+$$\begin{align*}
+\tilde{I}(f(\Theta)\Lt) &amp;= \tilde{I}\left[f\left(\Theta\right) \left(\bar{\Lt} + \Delta\Lt\right)\right] \\
+                        &amp;= K \times \hat{I}\left[f\left(\Theta\right) \left(\bar{\Lt} + \Delta\Lt\right)\right] \\
+                        &amp;= K \times \left[\hat{I}\left(f\left(\Theta\right)\bar{\Lt}\right) + \hat{I}\left(f\left(\Theta\right)\Delta\Lt\right)\right] \\ 
+                        &amp;= K \times \hat{I}\left(f\left(\Theta\right)\bar{\Lt}\right) + K \times \hat{I}\left(f\left(\Theta\right) \Delta\Lt\right) \\
+                        &amp;= \tilde{I}\left(f\left(\Theta\right)\bar{\Lt}\right) + \tilde{I}\left(f\left(\Theta\right) \Delta\Lt\right) \\
+                        &amp;= I\left(f\left(\Theta\right)\bar{\Lt}\right) + \tilde{I}\left(f\left(\Theta\right) \Delta\Lt\right)
+\end{align*}$$
+
+</p><p>
+
+The above result shows that the average irradiance is computed correctly, i.e.: \(I(f(\Theta)\bar{\Lt})\).
+
+</p><p>
+
+A way to think about this approximation is that it splits the radiance \(\Lt\) in two parts, 
+the average \(\bar{\Lt}\) and the delta from the average \(\Delta\Lt\) and computes the correct
+integration of the average part then adds the simplified integration of the delta part:
+
+</p><p>
+
+$$\begin{equation}
+approximation(\Lt) = correct(\bar{\Lt}) + simplified(\Lt - \bar{\Lt})
+\end{equation}$$ 
+
+</p><p>
+
+Now, let&apos;s look at each term:
+
+</p><p>
+
+$$\begin{equation}\label{iblPartialEquations}
+\hat{I}(f(n, \alpha) \Lt) = \int_\Omega f(l, n, \alpha) \Lt(l) \left&lt; \NoL \right&gt; \partial l   \\
+\hat{I}(f(n, \alpha))     = \int_\Omega f(l, n, \alpha)        \left&lt; \NoL \right&gt; \partial l   \\
+I(f(n, v, \alpha))        = \int_\Omega f(l, n, v, \alpha)     \left&lt; \NoL \right&gt; \partial l
+\end{equation}$$
+
+</p><p>
+
+All three of these equations can be easily pre-calculated and stored in look-up tables, as explained 
+below.
+
+</p>
+<a class="target" name="discretedomain">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/specularbrdfintegration/discretedomain">&#xA0;</a><a class="target" name="toc5.3.4.2.2">&#xA0;</a><h5>Discrete Domain </h5>
+<p>
+
+
+In the discrete domain the equations in \ref{iblPartialEquations} become:
+
+</p><p>
+
+$$\begin{equation}
+\hat{I}(f(n, \alpha) \Lt) \equiv \frac{1}{N}\sum_{\forall \, i \in image} f(l_i, n, \alpha) \Lt(l_i) \left&lt;\NoL\right&gt;  \\
+\hat{I}(f(n, \alpha))     \equiv \frac{1}{N}\sum_{\forall \, i \in image} f(l_i, n, \alpha)          \left&lt;\NoL\right&gt;  \\
+I(f(n, v, \alpha))        \equiv \frac{1}{N}\sum_{\forall \, i \in image} f(l_i, n, v, \alpha)       \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+However, in practice we&apos;re using <em class="underscore">importance sampling</em> which needs to take the \(pdf\) of the distribution
+into account and adds a term \(\frac{\left&lt;\VoH\right&gt;}{D(h_i, \alpha)\left&lt;\NoH\right&gt;}\).
+See <a href="#importancesamplingfortheibl">Importance Sampling For The IBL</a> section:
+
+</p><p>
+
+$$\begin{equation}\label{iblImportanceSampling}
+\hat{I}(f(n, \alpha) \Lt) \equiv \frac{4}{N}\sum_i^N f(l_i, n, \alpha)    \frac{\left&lt;\VoH\right&gt;}{D(h_i, \alpha)\left&lt;\NoH\right&gt;} \Lt(l_i) \left&lt;\NoL\right&gt;  \\
+\hat{I}(f(n, \alpha))     \equiv \frac{4}{N}\sum_i^N f(l_i, n, \alpha)    \frac{\left&lt;\VoH\right&gt;}{D(h_i, \alpha)\left&lt;\NoH\right&gt;}          \left&lt;\NoL\right&gt;  \\
+I(f(n, v, \alpha))        \equiv \frac{4}{N}\sum_i^N f(l_i, n, v, \alpha) \frac{\left&lt;\VoH\right&gt;}{D(h_i, \alpha)\left&lt;\NoH\right&gt;}          \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+Recalling that for \(\hat{I}\), we assume that \(v = n\), equations \ref{iblImportanceSampling},
+simplifies to:
+
+</p><p>
+
+$$\begin{equation}
+\hat{I}(f(n, \alpha) \Lt) \equiv \frac{4}{N}\sum_i^N \frac{f(l_i, n,    \alpha)}{D(h_i, \alpha)} \Lt(l_i) \left&lt;\NoL\right&gt;  \\
+\hat{I}(f(n, \alpha))     \equiv \frac{4}{N}\sum_i^N \frac{f(l_i, n,    \alpha)}{D(h_i, \alpha)}          \left&lt;\NoL\right&gt;  \\
+I(f(n, v, \alpha))        \equiv \frac{4}{N}\sum_i^N \frac{f(l_i, n, v, \alpha)}{D(h_i, \alpha)} \frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+Then, the first two equations can be merged together such that \(LD(n, \alpha) = \frac{\hat{I}(f(n, \alpha) \Lt)}{\hat{I}(f(n, \alpha))}\)
+
+</p><p>
+
+$$\begin{equation}\label{iblLD}
+LD(n, \alpha)       \equiv \frac{\sum_i^N \frac{f(l_i, n, \alpha)}{D(h_i, \alpha)} \Lt(l_i) \left&lt;\NoL\right&gt;}{\sum_i^N \frac{f(l_i, n, \alpha)}{D(h_i, \alpha)}\left&lt;\NoL\right&gt;}
+\end{equation}$$
+$$\begin{equation}\label{iblDFV}
+I(f(n, v, \alpha))  \equiv \frac{4}{N}\sum_i^N \frac{f(l_i, n, v, \alpha)}{D(h_i, \alpha)} \frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+Note that at this point, we could almost compute both remaining equations off-line. The only difficulty
+is that we don&apos;t know \(f_0\) nor \(f_{90}\) when we precompute those integrals. We will see below that
+we can incorporate these terms at runtime for equation \ref{iblDFV}, alas, this is not possible for
+equation \ref{iblLD} and we have to assume \(f_0 = f_{90} = 1\) (i.e.: the fresnel term always evaluates to 1).
+
+</p><p>
+
+We also have to deal with the visibility term of the brdf, in practice keeping it yields to slightly
+worst results compared to the ground truth, so we also set \(V = 1\).
+
+</p><p>
+
+Let&apos;s substitute \(f\) in equations \ref{iblLD} and \ref{iblDFV}:
+
+</p><p>
+
+$$\begin{equation}
+f(l_i, n, \alpha) = D(h_i, \alpha)F(f_0, f_{90}, \left&lt;\VoH\right&gt;)V(l_i, v, \alpha)
+\end{equation}$$
+
+</p><p>
+
+The first simplification is that the term \(D(h_i, \alpha)\) in the brdf cancels out with the
+denominator (which came from the \(pdf\) due to importance sampling) and F and V disappear since we
+assume their value is 1. 
+
+</p><p>
+
+$$\begin{equation}
+LD(n, \alpha)       \equiv \frac{\sum_i^N V(l_i, v, \alpha)\left&lt;\NoL\right&gt;\Lt(l_i) }{\sum_i^N \left&lt;\NoL\right&gt;}
+\end{equation}$$
+$$\begin{equation}\label{iblFV}
+I(f(n, v, \alpha))  \equiv \frac{4}{N}\sum_i^N \color{green}{F(f_0, f_{90}, \left&lt;\VoH\right&gt;)} V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+Now, let&apos;s substitute the fresnel term into equation \ref{iblFV}:
+
+</p><p>
+
+$$\begin{equation}
+F(f_0, f_{90}, \left&lt;\VoH\right&gt;) = f_0 (1 - F_c(\left&lt;\VoH\right&gt;)) + f_{90} F_c(\left&lt;\VoH\right&gt;) \\
+F_c(\left&lt;\VoH\right&gt;) = (1 - \left&lt;\VoH\right&gt;)^5
+\end{equation}$$
+
+</p><p>
+
+$$\begin{equation}
+I(f(n, v, \alpha))  \equiv \frac{4}{N}\sum_i^N \left[\color{green}{f_0 (1 - F_c(\left&lt;\VoH\right&gt;)) + f_{90} F_c(\left&lt;\VoH\right&gt;)}\right] V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+\end{equation}$$
+
+</p><p>
+
+$$
+\begin{align*}
+I(f(n, v, \alpha))  \equiv &amp; \color{green}{f_0   } \frac{4}{N}\sum_i^N  \color{green}{(1 - F_c(\left&lt;\VoH\right&gt;))} V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+                    +      &amp; \color{green}{f_{90}} \frac{4}{N}\sum_i^N  \color{green}{     F_c(\left&lt;\VoH\right&gt;) } V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt;
+\end{align*}
+$$
+
+</p><p>
+
+And finally, we extract the equations that can be calculated off-line (i.e.: the part that doesn&apos;t 
+depend on the runtime parameters \(f_0\) and \(f_{90}\)):
+
+</p><p>
+
+$$\begin{equation}\label{iblAllEquations}
+DFG_1(\alpha, \left&lt;\NoV\right&gt;) = \frac{4}{N}\sum_i^N  \color{green}{(1 - F_c(\left&lt;\VoH\right&gt;))} V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+DFG_2(\alpha, \left&lt;\NoV\right&gt;) = \frac{4}{N}\sum_i^N  \color{green}{     F_c(\left&lt;\VoH\right&gt;) } V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+I(f(n, v, \alpha))  \equiv   \color{green}{f_0} \color{red}{DFG_1(\alpha, \left&lt;\NoV\right&gt;)} + \color{green}{f_{90}} \color{red}{DFG_2(\alpha, \left&lt;\NoV\right&gt;)}
+\end{equation}$$
+
+</p><p>
+
+Notice that \(DFG_1\) and \(DFG_2\) only depend on \(\NoV\), that is the angle between the normal \(n\) and
+the view direction \(v\). This is true because the integral is symmetrical with respect to \(n\). 
+When integrating, we can choose any \(v\) we please as long as it satisfies \(\NoV\) 
+(e.g.: when calculating \(\VoH\)).
+
+</p><p>
+
+Putting everything back together:
+
+</p><p>
+
+$$
+\begin{align*}
+\Lout(n,v,\alpha,f_0,f_{90})     &amp;\simeq \big[ f_0 \color{red}{DFG_1(\NoV, \alpha)} + f_{90} \color{red}{DFG_2(\NoV, \alpha)} \big] \times LD(n, \alpha) \\
+DFG_1(\alpha, \left&lt;\NoV\right&gt;) &amp;=      \frac{4}{N}\sum_i^N  \color{green}{(1 - F_c(\left&lt;\VoH\right&gt;))} V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+DFG_2(\alpha, \left&lt;\NoV\right&gt;) &amp;=      \frac{4}{N}\sum_i^N  \color{green}{     F_c(\left&lt;\VoH\right&gt;) } V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+LD(n, \alpha)                    &amp;=      \frac{\sum_i^N V(l_i, n, \alpha)\left&lt;\NoL\right&gt;\Lt(l_i) }{\sum_i^N \left&lt;\NoL\right&gt;}
+\end{align*}     
+$$
+
+</p>
+<a class="target" name="the%5C(dfg_1%5C)and%5C(dfg_2%5C)termvisualized">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/the%5C(dfg_1%5C)and%5C(dfg_2%5C)termvisualized">&#xA0;</a><a class="target" name="toc5.3.4.3">&#xA0;</a><h4>The \(DFG_1\) and \(DFG_2\) term visualized </h4>
+<p>
+
+
+Both \(DFG_1\) and \(DFG_2\) can either be pre-calculated in a regular 2D texture indexed by \((\NoV, \alpha)\) 
+and sampled bilinearly, or computed at runtime using an analytic approximation of the surfaces. 
+See sample code in the annex. 
+The pre-calculated textures are shown in <a href="#table_texturedfg">table&#xA0;15</a>. 
+A C++ implementation of the pre-computation can be found in section  <a href="#toc9.5">9.5</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:left"> \(DFG_1\) </th><th style="text-align:left"> \(DFG_2\) </th><th style="text-align:left"> \({ DFG_1, DFG_2, 0 }\) </th></tr>
+<tr><td style="text-align:left"> <a href="images/ibl/dfg1.png" target="_blank"><img class="markdeep" src="images/ibl/dfg1.png"></a> </td><td style="text-align:left"> <a href="images/ibl/dfg2.png" target="_blank"><img class="markdeep" src="images/ibl/dfg2.png"></a> </td><td style="text-align:left"> <a href="images/ibl/dfg.png" target="_blank"><img class="markdeep" src="images/ibl/dfg.png"></a> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_texturedfg">&#xA0;</a><b style="font-style:normal;">Table&#xA0;15:</b> Y axis: \(\alpha\). X axis: \(cos \theta\)</div></div>
+
+<p></p><p>
+
+\(DFG_1\) and \(DFG_2\)  are conveniently within the \([0, 1]\) range, however 8-bits textures don&apos;t have
+enough precision and will cause problems. 
+Unfortunately, on mobile, 16-bits or float textures are not ubiquitous and there are a limited 
+number of samplers. 
+Despite the attractive simplicity of the shader code using a texture, it might be better to use an 
+analytic approximation. Note however that since we only need to store two terms, 
+OpenGL ES 3.0&apos;s RG16F texture format is a good candidate.
+
+</p><p>
+
+Such analytic approximation is described in [<a href="#citation-karis14">Karis14</a>], itself based on [<a href="#citation-lazarov13">Lazarov13</a>]. 
+[<a href="#citation-narkowicz14">Narkowicz14</a>] is another interesting approximation. Note that these two approximations are not
+compatible with the energy compensation term presented in section  <a href="#toc5.3.4.7">5.3.4.7</a>.
+<a href="#table_textureapproxdfg">Table&#xA0;16</a> presents a visual representation of these approximations.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:left"> \(DFG_1\) </th><th style="text-align:left"> \(DFG_2\) </th><th style="text-align:left"> \({ DFG_1, DFG_2, 0 }\) </th></tr>
+<tr><td style="text-align:left"> <a href="images/ibl/dfg1_approx.png" target="_blank"><img class="markdeep" src="images/ibl/dfg1_approx.png"></a> </td><td style="text-align:left"> <a href="images/ibl/dfg2_approx.png" target="_blank"><img class="markdeep" src="images/ibl/dfg2_approx.png"></a> </td><td style="text-align:left"> <a href="images/ibl/dfg_approx.png" target="_blank"><img class="markdeep" src="images/ibl/dfg_approx.png"></a> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_textureapproxdfg">&#xA0;</a><b style="font-style:normal;">Table&#xA0;16:</b> Y axis: \(\alpha\). X axis: \(cos \theta\)</div></div>
+
+<p></p>
+<a class="target" name="the%5C(ld%5C)termvisualized">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/the%5C(ld%5C)termvisualized">&#xA0;</a><a class="target" name="toc5.3.4.4">&#xA0;</a><h4>The \(LD\) term visualized </h4>
+<p>
+
+
+\(LD\) is the convolution of the environment by a function that only depends on the \(\alpha\) parameter
+(itself related to the roughness, see section  <a href="#toc4.8.3.3">4.8.3.3</a>).
+\(LD\) can conveniently be stored in a mip-mapped cubemap where increasing LODs receive the environment
+pre-filtered with increasing roughness. This works well because this convolution is a
+powerful low-pass filter. To make good use of each mipmap level, it is necessary to remap
+\(\alpha\); we find that using a power remapping with \(\gamma = 2\) works well and is convenient.
+
+</p><p>
+
+$$
+\begin{align*}
+    \alpha       &amp;= roughness^2                        \\
+    lod_{\alpha} &amp;= \alpha^{\frac{1}{2}} = roughness   \\
+\end{align*}
+$$
+
+</p><p>
+
+See an example below:
+
+</p><p>
+
+</p><div class="image" style="max-width:100%;float:right;margin:4px 0px 0px 25px;"><a href="images/ibl/ibl_river_roughness_m0.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m0.png" style="max-width:100%;"></a><div class="imagecaption">\(\alpha=0.0\)</div></div>
+<div class="image" style="max-width:100%;float:right;margin:4px 0px 0px 25px;"><a href="images/ibl/ibl_river_roughness_m1.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m1.png" style="max-width:100%;"></a><div class="imagecaption">\(\alpha=0.2\)</div></div>
+<div class="image" style="max-width:100%;float:right;margin:4px 0px 0px 25px;"><a href="images/ibl/ibl_river_roughness_m2.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m2.png" style="max-width:100%;"></a><div class="imagecaption">\(\alpha=0.4\)</div></div>
+<div class="image" style="max-width:100%;float:right;margin:4px 0px 0px 25px;"><a href="images/ibl/ibl_river_roughness_m3.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m3.png" style="max-width:100%;"></a><div class="imagecaption">\(0.6\)</div></div>
+<div class="image" style="max-width:100%;float:right;margin:4px 0px 0px 25px;"><a href="images/ibl/ibl_river_roughness_m4.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_river_roughness_m4.png" style="max-width:100%;"></a><div class="imagecaption">\(0.8\)</div></div>
+
+<p></p>
+<a class="target" name="indirectspecularandindirectdiffusecomponentsvisualized">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/indirectspecularandindirectdiffusecomponentsvisualized">&#xA0;</a><a class="target" name="toc5.3.4.5">&#xA0;</a><h4>Indirect specular and indirect diffuse components visualized </h4>
+<p>
+
+
+<a href="#figure_iblvisualized">Figure&#xA0;53</a> shows how indirect lighting interacts with dielectrics and conductors. Direct lighting was removed for illustration purposes.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_visualization.jpg" target="_blank"><img class="markdeep" src="images/ibl/ibl_visualization.jpg"></a><div class="imagecaption"><a class="target" name="figure_iblvisualized">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;53:</b> Indirect diffuse and specular decomposition</div></div></center>
+
+<p></p>
+<a class="target" name="iblevaluationimplementation">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/iblevaluationimplementation">&#xA0;</a><a class="target" name="toc5.3.4.6">&#xA0;</a><h4>IBL evaluation implementation </h4>
+<p>
+
+
+<a href="#listing_iblevaluation">Listing&#xA0;27</a> presents a GLSL implementation to evaluate the IBL, using the various textures described in the previous sections. 
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> ibl(<span class="hljs-type">vec3</span> n, <span class="hljs-type">vec3</span> v, <span class="hljs-type">vec3</span> diffuseColor, <span class="hljs-type">vec3</span> f0, <span class="hljs-type">vec3</span> f90, <span class="hljs-type">float</span> roughness) {</span>
+<span class="line">    <span class="hljs-type">vec3</span> r = <span class="hljs-built_in">reflect</span>(n);</span>
+<span class="line">    <span class="hljs-type">vec3</span> Ld = <span class="hljs-built_in">textureCube</span>(irradianceEnvMap, r) * diffuseColor;</span>
+<span class="line">    <span class="hljs-type">vec3</span> Lld = <span class="hljs-built_in">textureCube</span>(prefilteredEnvMap, r, computeLODFromRoughness(roughness));</span>
+<span class="line">    <span class="hljs-type">vec2</span> Ldfg = <span class="hljs-built_in">textureLod</span>(dfgLut, <span class="hljs-type">vec2</span>(<span class="hljs-built_in">dot</span>(n, v), roughness), <span class="hljs-number">0.0</span>).xy;</span>
+<span class="line">    <span class="hljs-type">vec3</span> Lr =  (f0 * Ldfg.x + f90 * Ldfg.y) * Lld;</span>
+<span class="line">    <span class="hljs-keyword">return</span> Ld + Lr;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_iblevaluation">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;27:</b> GLSL implementation of image based lighting evaluation</div>
+<p>
+
+
+We can however save a couple of texture lookups by using Spherical Harmonics instead of an 
+irradiance cubemap and the analytical approximation of the \(DFG\) LUT, as shown in <a href="#listing_optimizediblevaluation">listing&#xA0;28</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> irradianceSH(<span class="hljs-type">vec3</span> n) {</span>
+<span class="line">    <span class="hljs-comment">// uniform vec3 sphericalHarmonics[9]</span></span>
+<span class="line">    <span class="hljs-comment">// We can use only the first 2 bands for better performance</span></span>
+<span class="line">    <span class="hljs-keyword">return</span></span>
+<span class="line">          sphericalHarmonics[<span class="hljs-number">0</span>]</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">1</span>] * (n.y)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">2</span>] * (n.z)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">3</span>] * (n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">4</span>] * (n.y * n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">5</span>] * (n.y * n.z)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">6</span>] * (<span class="hljs-number">3.0</span> * n.z * n.z - <span class="hljs-number">1.0</span>)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">7</span>] * (n.z * n.x)</span>
+<span class="line">        + sphericalHarmonics[<span class="hljs-number">8</span>] * (n.x * n.x - n.y * n.y);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span> this approximation is not valid if the energy compensation term</span></span>
+<span class="line"><span class="hljs-comment">// for multiscattering is applied. We use the DFG LUT solution to implement</span></span>
+<span class="line"><span class="hljs-comment">// multiscattering</span></span>
+<span class="line"><span class="hljs-type">vec2</span> prefilteredDFG(<span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> roughness) {</span>
+<span class="line">    <span class="hljs-comment">// Karis&apos; approximation based on Lazarov&apos;s</span></span>
+<span class="line">    <span class="hljs-keyword">const</span> <span class="hljs-type">vec4</span> c0 = <span class="hljs-type">vec4</span>(<span class="hljs-number">-1.0</span>, <span class="hljs-number">-0.0275</span>, <span class="hljs-number">-0.572</span>,  <span class="hljs-number">0.022</span>);</span>
+<span class="line">    <span class="hljs-keyword">const</span> <span class="hljs-type">vec4</span> c1 = <span class="hljs-type">vec4</span>( <span class="hljs-number">1.0</span>,  <span class="hljs-number">0.0425</span>,  <span class="hljs-number">1.040</span>, <span class="hljs-number">-0.040</span>);</span>
+<span class="line">    <span class="hljs-type">vec4</span> r = roughness * c0 + c1;</span>
+<span class="line">    <span class="hljs-type">float</span> a004 = <span class="hljs-built_in">min</span>(r.x * r.x, <span class="hljs-built_in">exp2</span>(<span class="hljs-number">-9.28</span> * NoV)) * r.x + r.y;</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-type">vec2</span>(<span class="hljs-number">-1.04</span>, <span class="hljs-number">1.04</span>) * a004 + r.zw;</span>
+<span class="line">    <span class="hljs-comment">// Zioma&apos;s approximation based on Karis</span></span>
+<span class="line">    <span class="hljs-comment">// return vec2(1.0, pow(1.0 - max(roughness, NoV), 3.0));</span></span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span> this is the DFG LUT implementation of the function above</span></span>
+<span class="line"><span class="hljs-type">vec2</span> prefilteredDFG_LUT(<span class="hljs-type">float</span> coord, <span class="hljs-type">float</span> NoV) {</span>
+<span class="line">    <span class="hljs-comment">// coord = sqrt(linear_roughness), which is the mapping used by the</span></span>
+<span class="line">    <span class="hljs-comment">// IBL prefiltering code when computing the mipmaps</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-built_in">textureLod</span>(dfgLut, <span class="hljs-type">vec2</span>(NoV, coord), <span class="hljs-number">0.0</span>).rg;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec3</span> evaluateSpecularIBL(<span class="hljs-type">vec3</span> r, <span class="hljs-type">float</span> roughness) {</span>
+<span class="line">    <span class="hljs-comment">// This assumes a 256x256 cubemap, with 9 mip levels</span></span>
+<span class="line">    <span class="hljs-type">float</span> lod = <span class="hljs-number">8.0</span> * roughness;</span>
+<span class="line">    <span class="hljs-comment">// decodeEnvironmentMap() either decodes RGBM or is a no-op if the</span></span>
+<span class="line">    <span class="hljs-comment">// cubemap is stored in a float texture</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> decodeEnvironmentMap(textureCubeLodEXT(environmentMap, r, lod));</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec3</span> evaluateIBL(<span class="hljs-type">vec3</span> n, <span class="hljs-type">vec3</span> v, <span class="hljs-type">vec3</span> diffuseColor, <span class="hljs-type">vec3</span> f0, <span class="hljs-type">vec3</span> f90, <span class="hljs-type">float</span> roughness) {</span>
+<span class="line">    <span class="hljs-type">float</span> NoV = <span class="hljs-built_in">max</span>(<span class="hljs-built_in">dot</span>(n, v), <span class="hljs-number">0.0</span>);</span>
+<span class="line">    <span class="hljs-type">vec3</span> r = <span class="hljs-built_in">reflect</span>(-v, n);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Specular indirect</span></span>
+<span class="line">    <span class="hljs-type">vec3</span> indirectSpecular = evaluateSpecularIBL(r, roughness);</span>
+<span class="line">    <span class="hljs-type">vec2</span> env = prefilteredDFG_LUT(roughness, NoV);</span>
+<span class="line">    <span class="hljs-type">vec3</span> specularColor = f0 * env.x + f90 * env.y;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Diffuse indirect</span></span>
+<span class="line">    <span class="hljs-comment">// We multiply by the Lambertian BRDF to compute radiance from irradiance</span></span>
+<span class="line">    <span class="hljs-comment">// With the Disney BRDF we would have to remove the Fresnel term that</span></span>
+<span class="line">    <span class="hljs-comment">// depends on NoL (it would be rolled into the SH). The Lambertian BRDF</span></span>
+<span class="line">    <span class="hljs-comment">// can be baked directly in the SH to save a multiplication here</span></span>
+<span class="line">    <span class="hljs-type">vec3</span> indirectDiffuse = <span class="hljs-built_in">max</span>(irradianceSH(n), <span class="hljs-number">0.0</span>) * Fd_Lambert();</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Indirect contribution</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> diffuseColor * indirectDiffuse + indirectSpecular * specularColor;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_optimizediblevaluation">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;28:</b> GLSL implementation of image based lighting evaluation</div>
+
+<a class="target" name="pre-integrationformultiscattering">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/pre-integrationformultiscattering">&#xA0;</a><a class="target" name="toc5.3.4.7">&#xA0;</a><h4>Pre-integration for multiscattering </h4>
+<p>
+
+
+In section  <a href="#toc4.7.2">4.7.2</a> we discussed how to use a second scaled specular lobe 
+to compensate for the energy loss due to only accounting for a single scattering event in our BRDF.
+This energy compensation lobe is scaled by a term that depends on \(r\) defined in the following way:
+
+</p><p>
+
+$$\begin{equation}
+r = \int_{\Omega} D(l,v) V(l,v) \left&lt; \NoL \right&gt; \partial l
+\end{equation}$$
+
+</p><p>
+
+Or, evaluated with importance sampling (See <a href="#importancesamplingfortheibl">Importance Sampling For The IBL</a> section):
+
+</p><p>
+
+$$\begin{equation}
+r \equiv  \frac{4}{N}\sum_i^N  V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt;
+\end{equation}$$
+
+</p><p>
+
+This equality is very similar to the terms \(DFG_1\) and \(DFG_2\) seen in equation \(\ref{iblAllEquations}\).
+In fact, it&apos;s the same, except without the Fresnel term.
+
+</p><p>
+
+By making the further assumption that \(f_{90} = 1\), we can rewrite \(DFG_1\) and \(DFG_2\) and the
+\(\Lout\) reconstruction:
+
+</p><p>
+
+$$
+\begin{align*}
+\Lout(n,v,\alpha,f_0)                           &amp;\simeq \big[ (1 - f_0) \color{red}{DFG_1^{multiscatter}(\NoV, \alpha)} + f_0 \color{red}{DFG_2^{multiscatter}(\NoV, \alpha)} \big] \times LD(n, \alpha) \\
+DFG_1^{multiscatter}(\alpha, \left&lt;\NoV\right&gt;) &amp;=      \frac{4}{N}\sum_i^N  \color{green}{F_c(\left&lt;\VoH\right&gt;)} V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+DFG_2^{multiscatter}(\alpha, \left&lt;\NoV\right&gt;) &amp;=      \frac{4}{N}\sum_i^N                                        V(l_i, v, \alpha)\frac{\left&lt;\VoH\right&gt;}{\left&lt;\NoH\right&gt;} \left&lt;\NoL\right&gt; \\
+LD(n, \alpha)                                   &amp;=      \frac{\sum_i^N V(l_i, n, \alpha)\left&lt;\NoL\right&gt;\Lt(l_i) }{\sum_i^N V(l_i, n, \alpha)\left&lt;\NoL\right&gt;}
+\end{align*}     
+$$
+
+</p><p>
+
+These two new \(DFG\) terms simply need to replace the ones used in the implementation shown in section  <a href="#toc9.5">9.5</a>:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-keyword">float</span> Fc = <span class="hljs-built_in">pow</span>(<span class="hljs-number">1</span> - VoH, <span class="hljs-number">5.0f</span>);</span>
+<span class="line">r.x += Gv * Fc;</span>
+<span class="line">r.y += Gv;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_multiscatteriblpreintegration">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;29:</b> C++ implementation of the \(L_{DFG}\) term for multiscattering</div>
+<p>
+
+
+To perform the reconstruction we need to slightly modify <a href="#listing_multiscatteriblevaluation">listing&#xA0;30</a>:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec2</span> dfg = <span class="hljs-built_in">textureLod</span>(dfgLut, <span class="hljs-type">vec2</span>(<span class="hljs-built_in">dot</span>(n, v), roughness), <span class="hljs-number">0.0</span>).xy;</span>
+<span class="line"><span class="hljs-comment">// (1 - f0) * dfg.x + f0 * dfg.y</span></span>
+<span class="line"><span class="hljs-type">vec3</span> specularColor = <span class="hljs-built_in">mix</span>(dfg.xxx, dfg.yyy, f0);</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_multiscatteriblevaluation">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;30:</b> GLSL implementation of image based lighting evaluation, with multiscattering LUT</div>
+
+<a class="target" name="summary">&#xA0;</a><a class="target" name="lighting/imagebasedlights/distantlightprobes/summary">&#xA0;</a><a class="target" name="toc5.3.4.8">&#xA0;</a><h4>Summary </h4>
+<p>
+
+
+In order to calculate the specular contribution of distant image-based lights, we had to make a few
+approximations and compromises:
+
+</p><p>
+
+</p><ul>
+    <li class="minus">\(v = n\), by far the assumption contributing to the largest error when integrating the
+          non-constant part of the IBL. This results in the complete loss of roughness anisotropy
+          with respect to the view point.
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">Roughness contribution for the non-constant part of the IBL is quantized and trilinear filtering
+          is used to interpolate between these levels. This is most visible at low roughnes (e.g.: around 0.0625
+          for a 9 LODs cubemap).
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">Because mipmap levels are used to store the pre-integrated environment, they can&apos;t be used for
+          texture minification, as they ought to. This can causes aliasing or moir&#xE9; artifacts in high frequency 
+          regions or the environment at low roughness and/or distant or small objects. 
+          This can also impact performance due to the resulting poor cache access pattern. 
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">No Fresnel for the non-constant part of the IBL.
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">Visibility = 1 for the non-constant part of the IBL.
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">Schlick&apos;s Fresnel
+
+<p></p><p>
+
+</p></li>
+    <li class="minus">\(f_{90} = 1\) in the multiscattering case.</li></ul>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_prefilter_vs_reference.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_prefilter_vs_reference.png"></a><div class="imagecaption"><a class="target" name="figure_iblprefiltervsimportancesampling">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;54:</b>
+Comparison between importance-sampled reference (top) and prefiltered IBL (middle).</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_stretchy_reflections_error.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_stretchy_reflections_error.png"></a><div class="imagecaption"><a class="target" name="figure_iblstretchyreflectionloss">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;55:</b>
+Error in reflections due to assuming \(v = n\) (bottom) &#x2014; loss of &#x201C;stretchy reflections&#x201D;.</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_trilinear_0.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_trilinear_0.png"></a><div class="imagecaption"><a class="target" name="figure_iblroughnessinlods0">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;56:</b>
+Error due to storing the roughness in cubemaps LODs at roughness = 0.0625 (i.e.: sampling exactly between levels).
+Notice how instead of bluring we see a &#x201C;cross-fade&#x201D; between two blurs.</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_trilinear_1.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_trilinear_1.png"></a><div class="imagecaption"><a class="target" name="figure_iblroughnessinlods1">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;57:</b>
+Error due to storing the roughness in cubemaps LODs at roughness = 0.125 (i.e.: sampling exactly level 1).
+When the roughness closely matches a LOD, the error due to trilinear filtering in the cubemap is
+reduced. Notice the errors due to \(v = n\) at grazing angles.</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/ibl/ibl_no_mipmaping.png" target="_blank"><img class="markdeep" src="images/ibl/ibl_no_mipmaping.png"></a><div class="imagecaption"><a class="target" name="figure_iblmoirepattern">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;58:</b>
+Moir&#xE9; pattern due to texture minification on a metallic sphere at \(\alpha = 0\)
+using an environment made of colored vertical stripes (skybox hidden).</div></div></center>
+
+<p></p>
+<a class="target" name="clearcoat">&#xA0;</a><a class="target" name="lighting/imagebasedlights/clearcoat">&#xA0;</a><a class="target" name="toc5.3.5">&#xA0;</a><h3>Clear coat </h3>
+<p>
+
+
+When sampling the IBL, the clear coat layer is calculated as a second specular lobe. This specular lobe is oriented along the view direction since we cannot reasonably integrate over the hemisphere. <a href="#listing_clearcoatibl">Listing&#xA0;31</a> demonstrates this approximation in practice. It also shows the energy conservation step. It is important to note that this second specular lobe is computed exactly the same way as the main specular lobe, using the same DFG approximation.
+
+</p><pre class="listing tilde"><code><span class="line">// clearCoat_NoV == shading_NoV if the clear coat layer doesn&apos;t have its own normal map</span>
+<span class="line">float Fc = F_Schlick(<span class="hljs-number">0.04</span>, <span class="hljs-number">1.0</span>, clearCoat_NoV) * clearCoat<span class="hljs-comment">;</span></span>
+<span class="line">// base layer attenuation for energy compensation</span>
+<span class="line">iblDiffuse  *= <span class="hljs-number">1.0</span> - Fc<span class="hljs-comment">;</span></span>
+<span class="line">iblSpecular *= sq(<span class="hljs-number">1.0</span> - Fc)<span class="hljs-comment">;</span></span>
+<span class="line">iblSpecular += specularIBL(<span class="hljs-name">r</span>, clearCoatRoughness) * Fc<span class="hljs-comment">;</span></span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clearcoatibl">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;31:</b> GLSL implementation of the clear coat specular lobe for image-based lighting</div>
+
+<a class="target" name="anisotropy">&#xA0;</a><a class="target" name="lighting/imagebasedlights/anisotropy">&#xA0;</a><a class="target" name="toc5.3.6">&#xA0;</a><h3>Anisotropy </h3>
+<p>
+
+
+[<a href="#citation-mcauley15">McAuley15</a>] describes a technique called &#x201C;bent reflection vector&#x201D;, based [<a href="#citation-revie12">Revie12</a>]. The bent reflection vector is a rough approximation of anisotropic lighting but the alternative is to use importance sampling. This approximation is sufficiently cheap to compute and provides good results, as shown in <a href="#figure_anisotropicibl1">figure&#xA0;59</a> and <a href="#figure_anisotropicibl2">figure&#xA0;60</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropic_ibl1.jpg" target="_blank"><img class="markdeep" src="images/screenshot_anisotropic_ibl1.jpg"></a><div class="imagecaption"><a class="target" name="figure_anisotropicibl1">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;59:</b> Anisotropic indirect specular reflections using bent normals (left: roughness 0.3, right: roughness: 0.0; both: anisotropy 1.0)</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropic_ibl2.jpg" target="_blank"><img class="markdeep" src="images/screenshot_anisotropic_ibl2.jpg"></a><div class="imagecaption"><a class="target" name="figure_anisotropicibl2">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;60:</b> Anisotropic reflections with varying roughness, metallicness, etc.</div></div></center>
+
+<p></p><p>
+
+The implementation of this technique is straightforward, as demonstrated in <a href="#listing_bentreflectionvector">listing&#xA0;32</a>.
+
+</p><pre class="listing tilde"><code><span class="line">vec3 anisotropicTangent = cross(<span class="hljs-name">bitangent</span>, v)<span class="hljs-comment">;</span></span>
+<span class="line">vec3 anisotropicNormal = cross(<span class="hljs-name">anisotropicTangent</span>, bitangent)<span class="hljs-comment">;</span></span>
+<span class="line">vec3 bentNormal = normalize(<span class="hljs-name">mix</span>(<span class="hljs-name">n</span>, anisotropicNormal, anisotropy))<span class="hljs-comment">;</span></span>
+<span class="line">vec3 r = reflect(<span class="hljs-name">-v</span>, bentNormal)<span class="hljs-comment">;</span></span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_bentreflectionvector">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;32:</b> GLSL implementation of the bent reflection vector</div>
+<p>
+
+
+This technique can be made more useful by accepting negative <code>anisotropy</code> values, as shown in <a href="#listing_bentreflectionvectordirection">listing&#xA0;33</a>. When the anisotropy is negative, the highlights are not in the direction of the tangent, but in the direction of the bitangent instead.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> anisotropicDirection = anisotropy &gt;= <span class="hljs-number">0.0</span> ? bitangent : tangent;</span>
+<span class="line"><span class="hljs-type">vec3</span> anisotropicTangent = <span class="hljs-built_in">cross</span>(anisotropicDirection, v);</span>
+<span class="line"><span class="hljs-type">vec3</span> anisotropicNormal = <span class="hljs-built_in">cross</span>(anisotropicTangent, anisotropicDirection);</span>
+<span class="line"><span class="hljs-type">vec3</span> bentNormal = <span class="hljs-built_in">normalize</span>(<span class="hljs-built_in">mix</span>(n, anisotropicNormal, anisotropy));</span>
+<span class="line"><span class="hljs-type">vec3</span> r = <span class="hljs-built_in">reflect</span>(-v, bentNormal);</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_bentreflectionvectordirection">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;33:</b> GLSL implementation of the bent reflection vector</div>
+<p>
+
+
+<a href="#figure_anisotropicdirection">Figure&#xA0;61</a> demonstrates this modified implementation in practice.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropy_direction.png" target="_blank"><img class="markdeep" src="images/screenshot_anisotropy_direction.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropicdirection">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;61:</b> Control of the anisotropy direction using positive (left) and negative (right) values</div></div></center>
+
+<p></p>
+<a class="target" name="subsurface">&#xA0;</a><a class="target" name="lighting/imagebasedlights/subsurface">&#xA0;</a><a class="target" name="toc5.3.7">&#xA0;</a><h3>Subsurface </h3>
+<p>
+
+
+[TODO] Explain subsurface and IBL
+
+</p>
+<a class="target" name="cloth">&#xA0;</a><a class="target" name="lighting/imagebasedlights/cloth">&#xA0;</a><a class="target" name="toc5.3.8">&#xA0;</a><h3>Cloth </h3>
+<p>
+
+
+The IBL implementation for the cloth material model is more complicated than for the other material models. The main difference stems from the use of a different NDF (&#x201C;Charlie&#x201D; vs height-correlated Smith GGX). As described in this section, we use the split-sum approximation to compute the DFG term of the BRDF when computing an IBL. This DFG term is designed for a different BRDF and cannot be used for the cloth BRDF. Since we designed our  cloth BRDF to not need a Fresnel term, we can generate a single DG term in the 3rd channel of the DFG LUT. The result is shown in <a href="#figure_dfgclothlut">figure&#xA0;62</a>.
+
+</p><p>
+
+The DG term is generated using uniform sampling as recommended in [<a href="#citation-estevez17">Estevez17</a>]. With uniform sampling the \(pdf\) is simply \(\frac{1}{2\pi}\) and we must still use the Jacobian \(\frac{1}{\eft&lt; 4 \VoH \right&gt;}\).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/ibl/dfg_cloth.png" target="_blank"><img class="markdeep" src="images/ibl/dfg_cloth.png"></a><div class="imagecaption"><a class="target" name="figure_dfgclothlut">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;62:</b> DFG LUT with a 3rd channel encoding the DG term of the cloth BRDF</div></div></center>
+
+<p></p><p>
+
+The remainder of the image-based lighting implementation follows the same steps as the implementation of regular lights, including the optional subsurface scattering term and its wrap diffuse component. Just as with the clear coat IBL implementation, we cannot integrate over the hemisphere and use the view direction as the dominant light direction to compute the wrap diffuse component.
+
+</p><pre class="listing tilde"><code><span class="line">float diffuse = Fd_Lambert() * ambientOcclusion<span class="hljs-comment">;</span></span>
+<span class="line">#if defined(<span class="hljs-name">SHADING_MODEL_CLOTH</span>)</span>
+<span class="line">#if defined(<span class="hljs-name">MATERIAL_HAS_SUBSURFACE_COLOR</span>)</span>
+<span class="line">diffuse *= saturate((<span class="hljs-name">NoV</span> + <span class="hljs-number">0.5</span>) / <span class="hljs-number">2.25</span>)<span class="hljs-comment">;</span></span>
+<span class="line">#endif</span>
+<span class="line">#endif</span>
+<span class="line"></span>
+<span class="line">vec3 indirectDiffuse = irradianceIBL(<span class="hljs-name">n</span>) * diffuse<span class="hljs-comment">;</span></span>
+<span class="line">#if defined(<span class="hljs-name">SHADING_MODEL_CLOTH</span>) &amp;&amp; defined(<span class="hljs-name">MATERIAL_HAS_SUBSURFACE_COLOR</span>)</span>
+<span class="line">indirectDiffuse *= saturate(<span class="hljs-name">subsurfaceColor</span> + NoV)<span class="hljs-comment">;</span></span>
+<span class="line">#endif</span>
+<span class="line"></span>
+<span class="line">vec3 ibl = diffuseColor * indirectDiffuse + indirectSpecular * specularColor<span class="hljs-comment">;</span></span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_clothapprox">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;34:</b> GLSL implementation of the DFG approximation for the cloth NDF</div>
+<p>
+
+
+It is important to note that this only addresses part of the IBL problem. The pre-filtered specular environment maps described earlier are convolved with the standard shading model&apos;s BRDF, which differs from the cloth BRDF. To get accurate result we should in theory provide one set of IBLs per BRDF used in the engine. Providing a second set of IBLs is however not practical for our use case so we decided to rely on the existing IBLs instead.
+
+</p>
+<a class="target" name="staticlighting">&#xA0;</a><a class="target" name="lighting/staticlighting">&#xA0;</a><a class="target" name="toc5.4">&#xA0;</a><h2>Static lighting</h2>
+<p>
+
+
+[TODO] Spherical-harmonics or spherical-gaussian lightmaps, irradiance volumes, PRT?&#x2026;
+
+</p>
+<a class="target" name="transparencyandtranslucencylighting">&#xA0;</a><a class="target" name="lighting/transparencyandtranslucencylighting">&#xA0;</a><a class="target" name="toc5.5">&#xA0;</a><h2>Transparency and translucency lighting</h2>
+<p>
+
+
+Transparent and translucent materials are important to add realism and correctness to scenes. Filament must therefore provide lighting models for both types of materials to allow artists to properly recreate realistic scenes. Translucency can also be used effectively in a number of non-realistic settings.
+
+</p>
+<a class="target" name="transparency">&#xA0;</a><a class="target" name="lighting/transparencyandtranslucencylighting/transparency">&#xA0;</a><a class="target" name="toc5.5.1">&#xA0;</a><h3>Transparency</h3>
+<p>
+
+
+To properly light a transparent surface, we must first understand how the material&apos;s opacity is applied. Observe a window and you will see that the diffuse reflectance is transparent. On the other hand, the brighter the specular reflectance, the less opaque the window appears. This effect can be seen in <a href="#figure_cameratransparency">figure&#xA0;63</a>: the scene is properly reflected onto the glass surfaces but the specular highlight of the sun is bright enough to appear opaque.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_camera_transparency.jpg" target="_blank"><img class="markdeep" src="images/screenshot_camera_transparency.jpg"></a><div class="imagecaption"><a class="target" name="figure_cameratransparency">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;63:</b> Example of a complex object where lit surface transparency plays an important role</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_car.jpg" target="_blank"><img class="markdeep" src="images/screenshot_car.jpg"></a><div class="imagecaption"><a class="target" name="figure_litcar">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;64:</b> Example of a complex object where lit surface transparency plays an important role</div></div></center>
+
+<p></p><p>
+
+To properly implement opacity, we will use the premultiplied alpha format. Given a desired opacity noted \( \alpha_{opacity} \) and a diffuse color \( \sigma \) (linear, unpremultiplied), we can compute the effective opacity of a fragment.
+
+</p><p>
+
+$$\begin{align*}
+color &amp;= \sigma * \alpha_{opacity} \\
+opacity &amp;= \alpha_{opacity}
+\end{align*}$$
+
+</p><p>
+
+The physical interpretation is that the RGB components of the source color define how much light is emitted by the pixel, whereas the alpha component defines how much of the light behind the pixel is blocked by said pixel. We must therefore use the following blending functions:
+
+</p><p>
+
+$$\begin{align*}
+Blend_{src} &amp;= 1 \\
+Blend_{dst} &amp;= 1 - src_{\alpha}
+\end{align*}$$
+
+</p><p>
+
+The GLSL implementation of these equations is presented in <a href="#listing_surfacetransparency">listing&#xA0;35</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// baseColor has already been premultiplied</span></span>
+<span class="line"><span class="hljs-type">vec4</span> shadeSurface(<span class="hljs-type">vec4</span> baseColor) {</span>
+<span class="line">    <span class="hljs-type">float</span> alpha = baseColor.a;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">vec3</span> diffuseColor = evaluateDiffuseLighting();</span>
+<span class="line">    <span class="hljs-type">vec3</span> specularColor = evaluateSpecularLighting();    </span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-type">vec4</span>(diffuseColor + specularColor, alpha);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_surfacetransparency">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;35:</b> Implementation of lit surface transparency in GLSL</div>
+
+<a class="target" name="translucency">&#xA0;</a><a class="target" name="lighting/transparencyandtranslucencylighting/translucency">&#xA0;</a><a class="target" name="toc5.5.2">&#xA0;</a><h3>Translucency</h3>
+<p>
+
+
+Translucent materials can be divided into two categories:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Surface translucency
+</li>
+<li class="minus"> Volume translucency</li></ul>
+
+<p></p><p>
+
+Volume translucency is useful to light particle systems, for instance clouds or smoke. Surface translucency can be used to imitate materials with transmitted scattering such as wax, marble, skin, etc.
+
+</p><p>
+
+[TODO] Surface translucency (BRDF+BTDF, BSSRDF)
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_translucency.png" target="_blank"><img class="markdeep" src="images/screenshot_translucency.png"></a><div class="imagecaption"><a class="target" name="figure_translucency">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;65:</b> Front-lit translucent object (left) and back-lit translucent object (right), using approximated BTDF and BSSRDF. Model: Lucy from the Stanford University Computer Graphics Laboratory</div></div></center>
+
+<p></p>
+<a class="target" name="occlusion">&#xA0;</a><a class="target" name="lighting/occlusion">&#xA0;</a><a class="target" name="toc5.6">&#xA0;</a><h2>Occlusion</h2>
+<p>
+
+
+Occlusion is an important darkening factor used to recreate shadowing at various scales:
+
+</p><p>
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Small&#xA0;scale</dt></td><td><dd><p>    Micro-occlusion used to handle creases, cracks and cavities.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Medium&#xA0;scale</dt></td><td><dd><p>    Macro-occlusion used to handle occlusion by an object&apos;s own geometry or by geometry baked in normal maps (bricks, etc.).
+
+</p></dd></td></tr><tr valign="top"><td><dt>Large&#xA0;scale</dt></td><td><dd><p>    Occlusion coming from contact between objects, or from an object&apos;s own geometry.
+
+</p></dd></td></tr></tbody></table></dl>We currently ignore micro-occlusion, which is often exposed in tools and engines under the form of a &#x201C;cavity map&#x201D;. S&#xE9;bastien Lagarde offers an interesting discussion in [<a href="#citation-lagarde14">Lagarde14</a>] on how micro-occlusion is handled in Frostbite: diffuse micro-occlusion is pre-baked in diffuse maps and specular micro-occlusion is pre-baked in reflectance textures.
+In our system, micro-occlusion can simply be baked in the base color map. This must be done knowing that the specular light will not be affected by micro-occlusion.
+
+<p></p><p>
+
+Medium scale ambient occlusion is pre-baked in ambient occlusion maps, exposed as a material parameter, as seen in the material <a href="#parameterization">parameterization</a> section earlier.
+
+</p><p>
+
+Large scale ambient occlusion is often computed using screen-space techniques such as <em class="asterisk">SSAO</em> (screen-space ambient occlusion), <em class="asterisk">HBAO</em> (horizon based ambient occlusion), etc. Note that these techniques can also contribute to medium scale ambient occlusion when the camera is close enough to surfaces.
+
+</p><p>
+
+<strong class="asterisk">Note</strong>: to prevent over darkening when using both medium and large scale occlusion, Lagarde recommends to use \(min({AO}_{medium}, {AO}_{large})\).
+
+</p>
+<a class="target" name="diffuseocclusion">&#xA0;</a><a class="target" name="lighting/occlusion/diffuseocclusion">&#xA0;</a><a class="target" name="toc5.6.1">&#xA0;</a><h3>Diffuse occlusion</h3>
+<p>
+
+
+Morgan McGuire formalizes ambient occlusion in the context of physically based rendering in [<a href="#citation-mcguire10">McGuire10</a>]. In his formulation, McGuire defines an ambient illumination function \( L_a \), which in our case is encoded with spherical harmonics. He also defines a visibility function \(V\), with \(V(l)=1\) if there is an unoccluded line of sight from the surface in direction \(l\), and 0 otherwise.
+
+</p><p>
+
+With these two functions, the ambient term of the rendering equation can be expressed as shown in equation \(\ref{diffuseAO}\).
+
+</p><p>
+
+$$\begin{equation}\label{diffuseAO}
+L(l,v) = \int_{\Omega} f(l,v) L_a(l) V(l) \left&lt; \NoL \right&gt; dl
+\end{equation}$$
+
+</p><p>
+
+This expression can be approximated by separating the visibility term from the illumination function, as shown in equation \(\ref{diffuseAOApprox}\).
+
+</p><p>
+
+$$\begin{equation}\label{diffuseAOApprox}
+L(l,v) \approx \left( \pi \int_{\Omega} f(l,v) L_a(l) dl \right) \left( \frac{1}{\pi} \int_{\Omega} V(l) \left&lt; \NoL \right&gt; dl \right)
+\end{equation}$$
+
+</p><p>
+
+This approximation is only exact when the distant light \( L_a \) is constant and \(f\) is a Lambertian term. McGuire states however that this approximation is reasonable if both functions are relatively smooth over most of the sphere. This happens to be the case with a distant light probe (IBL).
+
+</p><p>
+
+The left term of this approximation is the pre-computed diffuse component of our IBL. The right term is a scalar factor between 0 and 1 that indicates the fractional accessibility of a point. Its opposite is the diffuse ambient occlusion term, show in equation \(\ref{diffuseAOTerm}\).
+
+</p><p>
+
+$$\begin{equation}\label{diffuseAOTerm}
+{AO} = 1 - \frac{1}{\pi} \int_{\Omega} V(l) \left&lt; \NoL \right&gt; dl
+\end{equation}$$
+
+</p><p>
+
+Since we use a pre-computed diffuse term, we cannot compute the exact accessibility of shaded points at runtime. To compensate for this lack of information in our precomputed term, we partially reconstruct incident lighting by applying an ambient occlusion factor specific to the surface&apos;s material at the shaded point.
+
+</p><p>
+
+In practice, baked ambient occlusion is stored as a grayscale texture which can often be lower resolution than other textures (base color or normals for instance). It is important to note that the ambient occlusion property of our material model intends to recreate macro-level diffuse ambient occlusion. While this approximation is not physically correct, it constitutes an acceptable tradeoff of quality vs performance.
+
+</p><p>
+
+<a href="#figure_aocomparison">Figure&#xA0;66</a> shows two different materials without and with diffuse ambient occlusion. Notice how the material ambient occlusion is used to recreate the natural shadowing that occurs between the different tiles. Without ambient occlusion, both materials appear too flat.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ao.jpg" target="_blank"><img class="markdeep" src="images/screenshot_ao.jpg"></a><div class="imagecaption"><a class="target" name="figure_aocomparison">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;66:</b> Comparison of materials without diffuse ambient occlusion (left) and with (right)</div></div></center>
+
+<p></p><p>
+
+Applying baked diffuse ambient occlusion in a GLSL shader is straightforward, as shown in <a href="#listing_bakeddiffuseao">listing&#xA0;36</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// diffuse indirect</span></span>
+<span class="line"><span class="hljs-type">vec3</span> indirectDiffuse = <span class="hljs-built_in">max</span>(irradianceSH(n), <span class="hljs-number">0.0</span>) * Fd_Lambert();</span>
+<span class="line"><span class="hljs-comment">// ambient occlusion</span></span>
+<span class="line">indirectDiffuse *= <span class="hljs-built_in">texture2D</span>(aoMap, outUV).r;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_bakeddiffuseao">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;36:</b> Implementation of baked diffuse ambient occlusion in GLSL</div>
+<p>
+
+
+Note how the ambient occlusion term is only applied to indirect lighting.
+
+</p>
+<a class="target" name="specularocclusion">&#xA0;</a><a class="target" name="lighting/occlusion/specularocclusion">&#xA0;</a><a class="target" name="toc5.6.2">&#xA0;</a><h3>Specular occlusion</h3>
+<p>
+
+
+Specular micro-occlusion can be derived from \(\fNormal\), itself derived from the diffuse color. The derivation is based on the knowledge that no real-world material has a reflectance lower than 2%. Values in the 0-2% range can therefore be treated as pre-baked specular occlusion used to smoothly extinguish the Fresnel term.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> f90 = <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">dot</span>(f0, <span class="hljs-number">50.0</span> * <span class="hljs-number">0.33</span>), <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line"><span class="hljs-comment">// cheap luminance approximation</span></span>
+<span class="line"><span class="hljs-type">float</span> f90 = <span class="hljs-built_in">clamp</span>(<span class="hljs-number">50.0</span> * f0.g, <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_specularmicroocclusion">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;37:</b> Pre-baked specular occlusion in GLSL</div>
+<p>
+
+
+The derivations mentioned earlier for ambient occlusion assume Lambertian surfaces and are only valid for indirect diffuse lighting. The lack of information about surface accessibility is particularly harmful to the reconstruction of indirect specular lighting. It usually manifests itself as light leaks.
+
+</p><p>
+
+S&#xE9;bastien Lagarde proposes an empirical approach to derive the specular occlusion term from the diffuse occlusion term in [<a href="#citation-lagarde14">Lagarde14</a>]. The result does not have any physical basis but produces visually pleasant results. The goal of his formulation is return the diffuse occlusion term unmodified for rough surfaces. For smooth surfaces, the formulation, implemented in <a href="#listing_specularocclusion">listing&#xA0;38</a>, reduces the influence of occlusion at normal incidence and increases it at grazing angles.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> computeSpecularAO(<span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> ao, <span class="hljs-type">float</span> roughness) {</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-built_in">clamp</span>(<span class="hljs-built_in">pow</span>(NoV + ao, <span class="hljs-built_in">exp2</span>(<span class="hljs-number">-16.0</span> * roughness - <span class="hljs-number">1.0</span>)) - <span class="hljs-number">1.0</span> + ao, <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// specular indirect</span></span>
+<span class="line"><span class="hljs-type">vec3</span> indirectSpecular = evaluateSpecularIBL(r, roughness);</span>
+<span class="line"><span class="hljs-comment">// ambient occlusion</span></span>
+<span class="line"><span class="hljs-type">float</span> ao = <span class="hljs-built_in">texture2D</span>(aoMap, outUV).r;</span>
+<span class="line">indirectSpecular *= computeSpecularAO(NoV, ao, roughness);</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_specularocclusion">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;38:</b> Implementation of Lagarde&apos;s specular occlusion factor in GLSL</div>
+<p>
+
+
+Note how the specular occlusion factor is only applied to indirect lighting.
+
+</p>
+<a class="target" name="horizonspecularocclusion">&#xA0;</a><a class="target" name="lighting/occlusion/specularocclusion/horizonspecularocclusion">&#xA0;</a><a class="target" name="toc5.6.2.1">&#xA0;</a><h4>Horizon specular occlusion</h4>
+<p>
+
+
+When computing the specular IBL contribution for a surface that uses a normal map, it is possible to end up with a reflection vector pointing towards the surface. If this reflection vector is used for shading directly, the surface will be lit in places where it should not be lit (assuming opaque surfaces). This is another occurrence of light leaking that can easily be minimized using a simple technique described by Jeff Russell [<a href="#citation-russell15">Russell15</a>].
+
+</p><p>
+
+The key idea is to occlude light coming from behind the surface. This can easily be achieved since a negative dot product between the reflected vector and the surface&apos;s normal indicates a reflection vector pointing towards the surface. Our implementation shown in <a href="#listing_horizonocclusion">listing&#xA0;39</a> is similar to Russell&apos;s, albeit without the artist controlled horizon fading factor.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// specular indirect</span></span>
+<span class="line"><span class="hljs-type">vec3</span> indirectSpecular = evaluateSpecularIBL(r, roughness);</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// horizon occlusion with falloff, should be computed for direct specular too</span></span>
+<span class="line"><span class="hljs-type">float</span> horizon = <span class="hljs-built_in">min</span>(<span class="hljs-number">1.0</span> + <span class="hljs-built_in">dot</span>(r, n), <span class="hljs-number">1.0</span>);</span>
+<span class="line">indirectSpecular *= horizon * horizon;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_horizonocclusion">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;39:</b> Implementation of horizon specular occlusion in GLSL</div>
+<p>
+
+
+Horizon specular occlusion fading is cheap but can easily be omitted to improve performance as needed.
+
+</p>
+<a class="target" name="normalmapping">&#xA0;</a><a class="target" name="lighting/normalmapping">&#xA0;</a><a class="target" name="toc5.7">&#xA0;</a><h2>Normal mapping</h2>
+<p>
+
+
+There are two common use cases of normal maps: replacing high-poly meshes with low-poly meshes (using a base map) and adding surface details (using a detail map).
+
+</p><p>
+
+Let&apos;s imagine that we want to render a piece of furniture covered in tufted leather. Modeling the geometry to accurately represent the tufted pattern would require too many triangles so we instead bake a high-poly mesh into a normal map. Once the base map is applied to a simplified mesh (in this case, a quad), we get the result in <a href="#figure_normalmapped">figure&#xA0;67</a>. The base map used to create this effect is shown in <a href="#figure_basenormalmap">figure&#xA0;68</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_mapping.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_mapping.jpg"></a><div class="imagecaption"><a class="target" name="figure_normalmapped">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;67:</b> Low-poly mesh without normal mapping (left) and with (right)</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_map.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_map.jpg"></a><div class="imagecaption"><a class="target" name="figure_basenormalmap">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;68:</b> Normal map used as a base map</div></div></center>
+
+<p></p><p>
+
+A simple problem arises if we now want to combine this base map with a second normal map. For instance, let&apos;s use the detail map shown in <a href="#figure_detailnormalmap">figure&#xA0;69</a> to add cracks in the leather.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_map_detail.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_map_detail.jpg"></a><div class="imagecaption"><a class="target" name="figure_detailnormalmap">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;69:</b> Normal map used as a detail map</div></div></center>
+
+<p></p><p>
+
+Given the nature of normal maps (XYZ components stored in tangent space), it is fairly obvious that naive approaches such as linear or overlay blending cannot work. We will use two more advanced techniques: a mathematically correct one and an approximation suitable for real-time shading.
+
+</p>
+<a class="target" name="reorientednormalmapping">&#xA0;</a><a class="target" name="lighting/normalmapping/reorientednormalmapping">&#xA0;</a><a class="target" name="toc5.7.1">&#xA0;</a><h3>Reoriented normal mapping</h3>
+<p>
+
+
+Colin Barr&#xE9;-Brisebois and Stephen Hill propose in [<a href="#citation-hill12">Hill12</a>] a mathematically sound solution called <em class="asterisk">Reoriented Normal Mapping</em>, which consists in rotating the basis of the detail map onto the normal from the base map. This technique relies on the shortest arc quaternion to apply the rotation, which greatly simplifies thanks to the properties of the tangent space.
+
+</p><p>
+
+Following the simplifications described in [<a href="#citation-hill12">Hill12</a>], we can produce the GLSL implementation shown in <a href="#listing_reorientednormalmapping">listing&#xA0;40</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> t = <span class="hljs-built_in">texture</span>(baseMap,   uv).xyz * <span class="hljs-type">vec3</span>( <span class="hljs-number">2.0</span>,  <span class="hljs-number">2.0</span>, <span class="hljs-number">2.0</span>) + <span class="hljs-type">vec3</span>(<span class="hljs-number">-1.0</span>, <span class="hljs-number">-1.0</span>,  <span class="hljs-number">0.0</span>);</span>
+<span class="line"><span class="hljs-type">vec3</span> u = <span class="hljs-built_in">texture</span>(detailMap, uv).xyz * <span class="hljs-type">vec3</span>(<span class="hljs-number">-2.0</span>, <span class="hljs-number">-2.0</span>, <span class="hljs-number">2.0</span>) + <span class="hljs-type">vec3</span>( <span class="hljs-number">1.0</span>,  <span class="hljs-number">1.0</span>, <span class="hljs-number">-1.0</span>);</span>
+<span class="line"><span class="hljs-type">vec3</span> r = <span class="hljs-built_in">normalize</span>(t * <span class="hljs-built_in">dot</span>(t, u) - u * t.z);</span>
+<span class="line"><span class="hljs-keyword">return</span> r;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_reorientednormalmapping">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;40:</b> Implementation of reoriented normal mapping in GLSL</div>
+<p>
+
+
+Note that this implementation assumes that the normals are stored uncompressed and in the [0..1] range in the source textures.
+
+</p><p>
+
+The normalization step is not strictly necessary and can be skipped if the technique is used at runtime. If so, the computation of <code>r</code> becomes <code>t * dot(t, u) / t.z - u</code>.
+
+</p><p>
+
+Since this technique is slightly more expensive than the one described below, we will mostly use it offline. We therefore provide a simple offline tool to combine two normal maps. <a href="#figure_blendednormalmaps">Figure&#xA0;70</a> presents the output of the tool with the base map and the detail map shown previously.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_map_blended.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_map_blended.jpg"></a><div class="imagecaption"><a class="target" name="figure_blendednormalmaps">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;70:</b> Blended normal and detail map (left) and resulting render when combined with a diffuse map (right)</div></div></center>
+
+<p></p>
+<a class="target" name="udnblending">&#xA0;</a><a class="target" name="lighting/normalmapping/udnblending">&#xA0;</a><a class="target" name="toc5.7.2">&#xA0;</a><h3>UDN blending</h3>
+<p>
+
+
+The technique called UDN blending, described in [<a href="#citation-hill12">Hill12</a>], is a variant of the partial derivative blending technique. Its main advantage is the low number of shader instructions it requires (see <a href="#listing_udnblending">listing&#xA0;41</a>). While it leads to a reduction in details over flat areas, UDN blending is interesting if blending must be performed at runtime.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> t = <span class="hljs-built_in">texture</span>(baseMap,   uv).xyz * <span class="hljs-number">2.0</span> - <span class="hljs-number">1.0</span>;</span>
+<span class="line"><span class="hljs-type">vec3</span> u = <span class="hljs-built_in">texture</span>(detailMap, uv).xyz * <span class="hljs-number">2.0</span> - <span class="hljs-number">1.0</span>;</span>
+<span class="line"><span class="hljs-type">vec3</span> r = <span class="hljs-built_in">normalize</span>(t.xy + u.xy, t.z);</span>
+<span class="line"><span class="hljs-keyword">return</span> r;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_udnblending">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;41:</b> Implementation of UDN blending in GLSL</div>
+<p>
+
+
+The results are visually close to Reoriented Normal Mapping but a careful comparison of the data shows that UDN is indeed less correct. <a href="#figure_blendednormalmapsudn">Figure&#xA0;71</a> presents the result of the UDN blending approach using the same source data as in the previous examples.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_map_blended_udn.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_map_blended_udn.jpg"></a><div class="imagecaption"><a class="target" name="figure_blendednormalmapsudn">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;71:</b> Blended normal and detail map using the UDN blending technique</div></div></center>
+
+<p></p>
+<a class="target" name="volumetriceffects">&#xA0;</a><a class="target" name="volumetriceffects">&#xA0;</a><a class="target" name="toc6">&#xA0;</a><h1>Volumetric effects</h1>
+
+<a class="target" name="exponentialheightfog">&#xA0;</a><a class="target" name="volumetriceffects/exponentialheightfog">&#xA0;</a><a class="target" name="toc6.1">&#xA0;</a><h2>Exponential height fog</h2>
+<p>
+
+
+</p><center><div class="image" style><a href="images/screenshot_fog1.jpg" target="_blank"><img class="markdeep" src="images/screenshot_fog1.jpg"></a><div class="imagecaption"><a class="target" name="figure_exponentialheightfog1">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;72:</b> Example of directional in-scattering with exponential height fog</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_fog2.jpg" target="_blank"><img class="markdeep" src="images/screenshot_fog2.jpg"></a><div class="imagecaption"><a class="target" name="figure_exponentialheightfog2">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;73:</b> Example of directional in-scattering with exponential height fog</div></div></center>
+
+<p></p>
+<a class="target" name="anti-aliasing">&#xA0;</a><a class="target" name="anti-aliasing">&#xA0;</a><a class="target" name="toc7">&#xA0;</a><h1>Anti-aliasing</h1>
+<p>
+
+
+[TODO] MSAA, geometric AA (normals and roughness), shader anti-aliasing (object-space shading?)
+
+</p>
+<a class="target" name="imagingpipeline">&#xA0;</a><a class="target" name="imagingpipeline">&#xA0;</a><a class="target" name="toc8">&#xA0;</a><h1>Imaging pipeline</h1>
+<p>
+
+
+The <a href="#lighting">lighting</a> section of this document describes how light interacts with surfaces in the scene in a physically based manner. To achieve plausible results, we must go a step further and consider the transformations necessary to convert the scene luminance, as computed by our lighting equations, into displayable pixel values.
+
+</p><p>
+
+The series of transformations we are going to use form the following imaging pipeline:
+
+</p><p>
+
+<svg class="diagram" xmlns="http://www.w3.org/2000/svg" version="1.1" height="432" width="672" style="margin:0 auto 0 auto;"><g transform="translate(8,16 )">
+<path d="M 8,0 L 8,64 " style="fill:none;"/>
+<path d="M 120,0 L 120,64 " style="fill:none;"/>
+<path d="M 176,0 L 176,64 " style="fill:none;"/>
+<path d="M 296,0 L 296,64 " style="fill:none;"/>
+<path d="M 352,0 L 352,64 " style="fill:none;"/>
+<path d="M 352,112 L 352,176 " style="fill:none;"/>
+<path d="M 352,224 L 352,288 " style="fill:none;"/>
+<path d="M 352,336 L 352,400 " style="fill:none;"/>
+<path d="M 416,64 L 416,104 " style="fill:none;"/>
+<path d="M 416,176 L 416,216 " style="fill:none;"/>
+<path d="M 416,288 L 416,328 " style="fill:none;"/>
+<path d="M 480,0 L 480,64 " style="fill:none;"/>
+<path d="M 480,112 L 480,176 " style="fill:none;"/>
+<path d="M 480,224 L 480,288 " style="fill:none;"/>
+<path d="M 480,336 L 480,400 " style="fill:none;"/>
+<path d="M 536,336 L 536,400 " style="fill:none;"/>
+<path d="M 648,336 L 648,400 " style="fill:none;"/>
+<path d="M 8,0 L 120,0 " style="fill:none;"/>
+<path d="M 176,0 L 296,0 " style="fill:none;"/>
+<path d="M 352,0 L 480,0 " style="fill:none;"/>
+<path d="M 120,32 L 168,32 " style="fill:none;"/>
+<path d="M 296,32 L 344,32 " style="fill:none;"/>
+<path d="M 8,64 L 120,64 " style="fill:none;"/>
+<path d="M 176,64 L 296,64 " style="fill:none;"/>
+<path d="M 352,64 L 480,64 " style="fill:none;"/>
+<path d="M 352,112 L 480,112 " style="fill:none;"/>
+<path d="M 352,176 L 480,176 " style="fill:none;"/>
+<path d="M 352,224 L 480,224 " style="fill:none;"/>
+<path d="M 352,288 L 480,288 " style="fill:none;"/>
+<path d="M 352,336 L 480,336 " style="fill:none;"/>
+<path d="M 536,336 L 648,336 " style="fill:none;"/>
+<path d="M 480,368 L 528,368 " style="fill:none;"/>
+<path d="M 352,400 L 480,400 " style="fill:none;"/>
+<path d="M 536,400 L 648,400 " style="fill:none;"/>
+<polygon points="536,368 524,362.4 524,373.6 " style="stroke:none" transform="rotate(0,528,368 )"/>
+<polygon points="424,328 412,322.4 412,333.6 " style="stroke:none" transform="rotate(90,416,328 )"/>
+<polygon points="424,216 412,210.4 412,221.6 " style="stroke:none" transform="rotate(90,416,216 )"/>
+<polygon points="424,104 412,98.4 412,109.6 " style="stroke:none" transform="rotate(90,416,104 )"/>
+<polygon points="352,32 340,26.4 340,37.6 " style="stroke:none" transform="rotate(0,344,32 )"/>
+<polygon points="176,32 164,26.4 164,37.6 " style="stroke:none" transform="rotate(0,168,32 )"/>
+<g transform="translate(0,0)"><text text-anchor="middle" x="48" y="20">S</text><text text-anchor="middle" x="56" y="20">c</text><text text-anchor="middle" x="64" y="20">e</text><text text-anchor="middle" x="72" y="20">n</text><text text-anchor="middle" x="80" y="20">e</text><text text-anchor="middle" x="200" y="20">N</text><text text-anchor="middle" x="208" y="20">o</text><text text-anchor="middle" x="216" y="20">r</text><text text-anchor="middle" x="224" y="20">m</text><text text-anchor="middle" x="232" y="20">a</text><text text-anchor="middle" x="240" y="20">l</text><text text-anchor="middle" x="248" y="20">i</text><text text-anchor="middle" x="256" y="20">z</text><text text-anchor="middle" x="264" y="20">e</text><text text-anchor="middle" x="272" y="20">d</text><text text-anchor="middle" x="32" y="36">l</text><text text-anchor="middle" x="40" y="36">u</text><text text-anchor="middle" x="48" y="36">m</text><text text-anchor="middle" x="56" y="36">i</text><text text-anchor="middle" x="64" y="36">n</text><text text-anchor="middle" x="72" y="36">a</text><text text-anchor="middle" x="80" y="36">n</text><text text-anchor="middle" x="88" y="36">c</text><text text-anchor="middle" x="96" y="36">e</text><text text-anchor="middle" x="200" y="36">l</text><text text-anchor="middle" x="208" y="36">u</text><text text-anchor="middle" x="216" y="36">m</text><text text-anchor="middle" x="224" y="36">i</text><text text-anchor="middle" x="232" y="36">n</text><text text-anchor="middle" x="240" y="36">a</text><text text-anchor="middle" x="248" y="36">n</text><text text-anchor="middle" x="256" y="36">c</text><text text-anchor="middle" x="264" y="36">e</text><text text-anchor="middle" x="368" y="36">W</text><text text-anchor="middle" x="376" y="36">h</text><text text-anchor="middle" x="384" y="36">i</text><text text-anchor="middle" x="392" y="36">t</text><text text-anchor="middle" x="400" y="36">e</text><text text-anchor="middle" x="416" y="36">b</text><text text-anchor="middle" x="424" y="36">a</text><text text-anchor="middle" x="432" y="36">l</text><text text-anchor="middle" x="440" y="36">a</text><text text-anchor="middle" x="448" y="36">n</text><text text-anchor="middle" x="456" y="36">c</text><text text-anchor="middle" x="464" y="36">e</text><text text-anchor="middle" x="216" y="52">(</text><text text-anchor="middle" x="224" y="52">H</text><text text-anchor="middle" x="232" y="52">D</text><text text-anchor="middle" x="240" y="52">R</text><text text-anchor="middle" x="248" y="52">)</text><text text-anchor="middle" x="368" y="148">C</text><text text-anchor="middle" x="376" y="148">o</text><text text-anchor="middle" x="384" y="148">l</text><text text-anchor="middle" x="392" y="148">o</text><text text-anchor="middle" x="400" y="148">r</text><text text-anchor="middle" x="416" y="148">g</text><text text-anchor="middle" x="424" y="148">r</text><text text-anchor="middle" x="432" y="148">a</text><text text-anchor="middle" x="440" y="148">d</text><text text-anchor="middle" x="448" y="148">i</text><text text-anchor="middle" x="456" y="148">n</text><text text-anchor="middle" x="464" y="148">g</text><text text-anchor="middle" x="368" y="260">T</text><text text-anchor="middle" x="376" y="260">o</text><text text-anchor="middle" x="384" y="260">n</text><text text-anchor="middle" x="392" y="260">e</text><text text-anchor="middle" x="408" y="260">m</text><text text-anchor="middle" x="416" y="260">a</text><text text-anchor="middle" x="424" y="260">p</text><text text-anchor="middle" x="432" y="260">p</text><text text-anchor="middle" x="440" y="260">i</text><text text-anchor="middle" x="448" y="260">n</text><text text-anchor="middle" x="456" y="260">g</text><text text-anchor="middle" x="576" y="356">P</text><text text-anchor="middle" x="584" y="356">i</text><text text-anchor="middle" x="592" y="356">x</text><text text-anchor="middle" x="600" y="356">e</text><text text-anchor="middle" x="608" y="356">l</text><text text-anchor="middle" x="400" y="372">O</text><text text-anchor="middle" x="408" y="372">E</text><text text-anchor="middle" x="416" y="372">T</text><text text-anchor="middle" x="424" y="372">F</text><text text-anchor="middle" x="576" y="372">v</text><text text-anchor="middle" x="584" y="372">a</text><text text-anchor="middle" x="592" y="372">l</text><text text-anchor="middle" x="600" y="372">u</text><text text-anchor="middle" x="608" y="372">e</text><text text-anchor="middle" x="576" y="388">(</text><text text-anchor="middle" x="584" y="388">L</text><text text-anchor="middle" x="592" y="388">D</text><text text-anchor="middle" x="600" y="388">R</text><text text-anchor="middle" x="608" y="388">)</text></g></g></svg>
+
+</p><p>
+
+<strong class="asterisk">Note</strong>: the <em class="asterisk">OETF</em> step is the application of the opto-electronic transfer function of the target color space. For clarity this diagram does not include post-processing steps such as vignette, bloom, etc. These effects will be discussed separately.
+
+</p><p>
+
+[TODO] Color spaces (ACES, sRGB, Rec. 709, Rec. 2020, etc.), gamma/linear, etc.
+
+</p>
+<a class="target" name="physicallybasedcamera">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera">&#xA0;</a><a class="target" name="toc8.1">&#xA0;</a><h2>Physically based camera</h2>
+<p>
+
+
+The first step in the image transformation process is to use a physically based camera to properly expose the scene&apos;s outgoing luminance.
+
+</p>
+<a class="target" name="exposuresettings">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposuresettings">&#xA0;</a><a class="target" name="toc8.1.1">&#xA0;</a><h3>Exposure settings</h3>
+<p>
+
+
+Because we use photometric units throughout the lighting pipeline, the light reaching the camera is an energy expressed in luminance \(L\), in \(cd.m^{-2}\). Light incident to the camera sensor can cover a large range of values, from \(10^{-5}cd.m^{-2}\) for starlight to \(10^{9}cd.m^{-2}\) for the sun. Since we obviously cannot manipulate and even less record such a large range of values, we need to remap them.
+
+</p><p>
+
+This range remapping is done in a camera by exposing the sensor for a certain time. To maximize the use of the limited range of the sensor, the scene&apos;s light range is centered around the &#x201C;middle gray&#x201D;, a value halfway between black and white. The exposition is therefore achieved by manipulating, either manually or automatically, 3 settings:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Aperture
+</li>
+<li class="minus">Shutter speed
+</li>
+<li class="minus">Sensitivity (also called gain)</li></ul>
+
+<p></p><p>
+
+</p><dl><dt>Aperture</dt><dd><p>    Noted \(N\) and expressed in f-stops &#x192;, this setting controls how open or closed the camera system&apos;s aperture is. Since an f-stop indicate the ratio of the lens&apos; focal length to the diameter of the entrance pupil, high-values (&#x192;/16) indicate a small aperture and small values (&#x192;/1.4) indicate a wide aperture. In addition to the exposition, the aperture setting controls the depth of field.
+
+</p></dd><dt>Shutter speed</dt><dd><p>    Noted \(t\) and expressed in seconds \(s\), this setting controls how long the aperture remains opened (it also controls the timing of the sensor shutter(s), whether electronic or mechanical). In addition to the exposition, the shutter speed controls motion blur.
+
+</p></dd><dt>Sensitivity</dt><dd><p>    Noted \(S\) and expressed in ISO, this setting controls how the light reaching the sensor is quantized. Because of its unit, this setting is often referred to as simply the &#x201C;ISO&#x201D; or &#x201C;ISO setting&#x201D;. In addition to the exposition, the sensitivity setting controls the amount of noise.
+
+</p></dd></dl><p></p>
+<a class="target" name="exposurevalue">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposurevalue">&#xA0;</a><a class="target" name="toc8.1.2">&#xA0;</a><h3>Exposure value</h3>
+<p>
+
+
+Since referring to these 3 settings in our equations would be unwieldy, we instead summarize the &#x201C;exposure triangle&#x201D; by an exposure value, noted EV<sup><a href="#endnote-reciprocity">10</a></sup>.
+
+</p><p>
+
+The EV is expressed in a base-2 logarithmic scale, with a difference of 1 EV called a stop. One positive stop (+1 EV) corresponds to a factor of two in luminance and one negative stop (&#x2212;1 EV) corresponds to a factor of half in luminance.
+
+</p><p>
+
+Equation \( \ref{ev} \) shows the <a href="https://en.wikipedia.org/wiki/Exposure_value">formal definition of EV</a>.
+
+</p><p>
+
+$$\begin{equation}\label{ev}
+EV = log_2(\frac{N^2}{t})
+\end{equation}$$
+
+</p><p>
+
+Note that this definition is only function of the aperture and shutter speed, but not the sensitivity. An exposure value is by convention defined for ISO 100, or \( EV_{100} \), and because we wish to work with this convention, we need to be able to express \( EV_{100} \) as a function of the sensitivity.
+
+</p><p>
+
+Since we know that EV is a base-2 logarithmic scale in which each stop increases or decreases the brightness by a factor of 2, we can formally define \( EV_{S} \), the exposure value at given sensitivity (equation \(\ref{evS}\)).
+
+</p><p>
+
+$$\begin{equation}\label{evS}
+{EV}_S = EV_{100} + log_2(\frac{S}{100})
+\end{equation}$$
+
+</p><p>
+
+Calculating the \( EV_{100} \) as a function of the 3 camera settings is trivial, as shown in \(\ref{ev100}\).
+
+</p><p>
+
+$$\begin{equation}\label{ev100}
+{EV}_{100} = EV_{S} - log_2(\frac{S}{100}) = log_2(\frac{N^2}{t}) - log_2(\frac{S}{100})
+\end{equation}$$
+
+</p><p>
+
+Note that the operator (photographer, etc.) can achieve the same exposure (and therefore EV) with several combinations of aperture, shutter speed and sensitivity. This allows some artistic control in the process (depth of field vs motion blur vs grain).
+
+</p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-reciprocity">&#xA0;</a><sup>10</sup> We assume a digital sensor, which means we don&apos;t need to take reciprocity failure into account
+</div>
+<p></p>
+<a class="target" name="exposurevalueandluminance">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposurevalue/exposurevalueandluminance">&#xA0;</a><a class="target" name="toc8.1.2.1">&#xA0;</a><h4>Exposure value and luminance</h4>
+<p>
+
+
+A camera, similar to a spot meter, is able to measure the average luminance of a scene and convert it into EV to achieve automatic exposure, or at the very least offer the user exposure guidance.
+
+</p><p>
+
+It is possible to define EV as a function of the scene luminance \(L\), given a per-device calibration constant \(K\) (equation \( \ref{evK} \)).
+
+</p><p>
+
+$$\begin{equation}\label{evK}
+EV = log_2(\frac{L \times S}{K})
+\end{equation}$$
+
+</p><p>
+
+That constant \(K\) is the reflected-light meter constant, which varies between manufacturers. We could find two common values for this constant: 12.5, used by Canon, Nikon and Sekonic, and 14, used by Pentax and Minolta. Given the wide availability of Canon and Nikon cameras, as well as our own usage of Sekonic light meters, we will choose to use \( K = 12.5 \).
+
+</p><p>
+
+Since we want to work with \( EV_{100} \), we can substitute \(K\) and \(S\) in equation \( \ref{evK} \) to obtain equation \( \ref{ev100L} \).
+
+</p><p>
+
+$$\begin{equation}\label{ev100L}
+EV = log_2(L \frac{100}{12.5})
+\end{equation}$$
+
+</p><p>
+
+Given this relationship, it would be possible to implement automatic exposure in our engine by first measuring the average luminance of a frame. An easy way to achieve this is to simply downsample a luminance buffer down to 1 pixel and read the remaining value. This technique is unfortunately rarely stable and can easily be affected by extreme values. Many games use a different approach which consists in using a luminance histogram to remove extreme values.
+
+</p><p>
+
+For validation and testing purposes, the luminance can be computed from a given EV:
+
+</p><p>
+
+$$\begin{equation}
+L = 2^{EV_{100}} \times \frac{12.5}{100} = 2^{EV_{100} - 3}
+\end{equation}$$
+
+</p>
+<a class="target" name="exposurevalueandilluminance">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposurevalue/exposurevalueandilluminance">&#xA0;</a><a class="target" name="toc8.1.2.2">&#xA0;</a><h4>Exposure value and illuminance</h4>
+<p>
+
+
+It is possible to define EV as a function of the illuminance \(E\), given a per-device calibration constant \(C\):
+
+</p><p>
+
+$$\begin{equation}\label{evC}
+EV = log_2(\frac{E \times S}{C})
+\end{equation}$$
+
+</p><p>
+
+The constant \(C\) is the incident-light meter constant, which varies between manufacturers and/or types of sensors. There are two common types of sensors: flat and hemispherical. For flat sensors, a common value is 250. With hemispherical sensors, we could find two common values: 320, used by Minolta, and 340, used by Sekonic.
+
+</p><p>
+
+Since we want to work with \( EV_{100} \), we can substitute \(S\) \( \ref{evC} \) to obtain equation \( \ref{ev100C} \).
+
+</p><p>
+
+$$\begin{equation}\label{ev100C}
+EV = log_2(E \frac{100}{C})
+\end{equation}$$
+
+</p><p>
+
+The illuminance can then be computed from a given EV. For a flat sensor with \( C = 250 \) we obtain equation \( \ref{eFlatSensor} \).
+
+</p><p>
+
+$$\begin{equation}\label{eFlatSensor}
+E = 2^{EV_{100}} \times 2.5
+\end{equation}$$
+
+</p><p>
+
+For a hemispherical sensor with \( C = 340 \) we obtain equation \( \ref{eHemisphereSensor} \)
+
+</p><p>
+
+$$\begin{equation}\label{eHemisphereSensor}
+E = 2^{EV_{100}} \times 3.4
+\end{equation}$$
+
+</p>
+<a class="target" name="exposurecompensation">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposurevalue/exposurecompensation">&#xA0;</a><a class="target" name="toc8.1.2.3">&#xA0;</a><h4>Exposure compensation</h4>
+<p>
+
+
+Even though an exposure value actually indicates combinations of camera settings, it is often used by photographers to describe light intensity. This is why cameras let photographers apply an exposure compensation to over or under-expose an image. This setting can be used for artistic control but also to achieve proper exposure (snow for instance will be exposed for as 18% middle-gray).
+
+</p><p>
+
+Applying an exposure compensation \(EC\) is a simple as adding an offset to the exposure value, as shown in equation \( \ref{ec} \).
+
+</p><p>
+
+$$\begin{equation}\label{ec}
+EV_{100}&apos; = EV_{100} - EC
+\end{equation}$$
+
+</p><p>
+
+This equation uses a negative sign because we are using \(EC\) in f-stops to adjust the final exposure. Increasing the EV is akin to closing down the aperture of the lens (or reducing shutter speed or reducing sensitivity). A higher EV will produce darker images.
+
+</p>
+<a class="target" name="exposure">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/exposure">&#xA0;</a><a class="target" name="toc8.1.3">&#xA0;</a><h3>Exposure</h3>
+<p>
+
+
+To convert the scene luminance into normalized luminance, we must use the <a href="https://en.wikipedia.org/wiki/Exposure_value#Camera_settings_vs._photometric_exposure">photometric exposure</a> (or luminous exposure), or amount of scene luminance that reaches the camera sensor. The photometric exposure, expressed in lux seconds and noted \(H\), is given by equation \( \ref{photometricExposure} \).
+
+</p><p>
+
+$$\begin{equation}\label{photometricExposure}
+H = \frac{q \cdot t}{N^2} L
+\end{equation}$$
+
+</p><p>
+
+Where \(L\) is the luminance of the scene, \(t\) the shutter speed, \(N\) the aperture and \(q\) the lens and vignetting attenuation (typically \( q = 0.65 \)<sup><a href="#endnote-lensattenuation">11</a></sup>). This definition does not take the sensor sensitivity into account. To do so, we must use one of the three ways to relate photometric exposure and sensitivity: saturation-based speed, noise-based speed and standard output sensitivity.
+
+</p><p>
+
+We choose the saturation-based speed relation, which gives us \( H_{sat} \), the maximum possible exposure that does not lead to clipped or bloomed camera output (equation \( \ref{hSat} \)).
+
+</p><p>
+
+$$\begin{equation}\label{hSat}
+H_{sat} = \frac{78}{S_{sat}}
+\end{equation}$$
+
+</p><p>
+
+We combine equations \( \ref{hSat} \) and \( \ref{photometricExposure} \) in equation \( \ref{lmax} \) to compute the maximum luminance \( L_{max} \) that will saturate the sensor given exposure settings \(S\), \(N\) and \(t\).
+
+</p><p>
+
+$$\begin{equation}\label{lmax}
+L_{max} = \frac{N^2}{q \cdot t} \frac{78}{S}
+\end{equation}$$
+
+</p><p>
+
+This maximum luminance can then be used to normalize incident luminance \(L\) as shown in equation \( \ref{normalizedLuminance} \).
+
+</p><p>
+
+$$\begin{equation}\label{normalizedLuminance}
+L&apos; = L \frac{1}{L_{max}}
+\end{equation}$$
+
+</p><p>
+
+\( L_{max} \) can be simplified using equation \( \ref{ev} \), \( S = 100 \) and \( q = 0.65 \):
+
+</p><p>
+
+$$\begin{align*}
+L_{max} &amp;= \frac{N^2}{t} \frac{78}{q \cdot S} \\
+L_{max} &amp;= 2^{EV_{100}} \frac{78}{q \cdot S} \\
+L_{max} &amp;= 2^{EV_{100}} \times 1.2
+\end{align*}$$
+
+</p><p>
+
+<a href="#listing_fragmentexposure">Listing&#xA0;42</a> shows how the exposure term can be applied directly to the pixel color computed in a fragment shader.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// Computes the camera&apos;s EV100 from exposure settings</span></span>
+<span class="line"><span class="hljs-comment">// aperture in f-stops</span></span>
+<span class="line"><span class="hljs-comment">// shutterSpeed in seconds</span></span>
+<span class="line"><span class="hljs-comment">// sensitivity in ISO</span></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">exposureSettings</span><span class="hljs-params">(<span class="hljs-keyword">float</span> aperture, <span class="hljs-keyword">float</span> shutterSpeed, <span class="hljs-keyword">float</span> sensitivity)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> log2((aperture * aperture) / shutterSpeed * <span class="hljs-number">100.0</span> / sensitivity);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// Computes the exposure normalization factor from</span></span>
+<span class="line"><span class="hljs-comment">// the camera&apos;s EV100</span></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">float</span> <span class="hljs-title">exposure</span><span class="hljs-params">(ev100)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">1.0</span> / (<span class="hljs-built_in">pow</span>(<span class="hljs-number">2.0</span>, ev100) * <span class="hljs-number">1.2</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">float</span> ev100 = exposureSettings(aperture, shutterSpeed, sensitivity);</span>
+<span class="line"><span class="hljs-keyword">float</span> exposure = exposure(ev100);</span>
+<span class="line"></span>
+<span class="line">vec4 color = evaluateLighting();</span>
+<span class="line">color.rgb *= exposure;</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_fragmentexposure">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;42:</b> Implementation of exposure in GLSL</div>
+<p>
+
+
+In practice the exposure factor can be pre-computed on the CPU to save shader instructions.
+
+</p><p>
+
+</p><div class="endnote"><a class="target" name="endnote-lensattenuation">&#xA0;</a><sup>11</sup> See <em class="asterisk">Film Speed, Measurements and calculations</em> on Wikipedia (<a href="https://en.wikipedia.org/wiki/Film_speed)" class="url">https://en.wikipedia.org/wiki/Film_speed)</a>
+</div>
+<p></p>
+<a class="target" name="automaticexposure">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/automaticexposure">&#xA0;</a><a class="target" name="toc8.1.4">&#xA0;</a><h3>Automatic exposure</h3>
+<p>
+
+
+The process described above relies on artists setting the camera exposure settings manually. This can prove cumbersome in practice since camera movements and/or dynamic effects can greatly affect the scene&apos;s luminance. Since we know how to compute the exposure value from a given luminance (see section  <a href="#toc8.1.2.1">8.1.2.1</a>), we can transform our camera into a spot meter. To do so, we need to measure the scene&apos;s luminance.
+
+</p><p>
+
+There are two common techniques used to measure the scene&apos;s luminance:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><strong class="asterisk">Luminance downsampling</strong>, by downsampling the previous frame successively until obtaining a 1&#xD7;1 log luminance buffer that can be read on the CPU (this could also be achieved using a compute shader). The result is the average log luminance of the scene. The first downsampling must extract the luminance of each pixel first. This technique can be unstable and its output should be smoothed over time.
+</li>
+<li class="minus"><strong class="asterisk">Using a luminance histogram</strong>, to find the average log luminance. This technique has an advantage over the previous one as it allows to ignore extreme values and offers more stable results.</li></ul>
+
+<p></p><p>
+
+Note that both methods will find the average luminance after multiplication by the albedo. This is not entirely correct but the alternative is to keep a luminance buffer that contains the luminance of each pixel before multiplication by the surface albedo. This is expensive both computationally and memory-wise.
+
+</p><p>
+
+These two techniques also limit the metering system to average metering, where each pixel has the same influence (or weight) over the final exposure. Cameras typically offer 3 modes of metering:
+
+</p><p>
+
+</p><dl><dt>Spot metering</dt><dd><p>    In which only a small circle in the center of the image contributes to the final exposure. That circle is usually 1 to 5% of the total image size.
+
+</p></dd><dt>Center-weighted metering</dt><dd><p>    Gives more influence to scene luminance values located in the center of the screen.
+
+</p></dd><dt>Multi-zone or matrix metering</dt><dd><p>    A metering mode that differs for each manufacturer. The goal of this mode is to prioritize exposure for the most important parts of the scene. This is often achieved by splitting the image into a grid and by classifying each cell (using focus information, min/max luminance, etc.). Advanced implementations attempt to compare the scene to a known dataset to achieve proper exposure (backlit sunset, overcast snowy day, etc.).
+
+</p></dd></dl><p></p>
+<a class="target" name="spotmetering">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/automaticexposure/spotmetering">&#xA0;</a><a class="target" name="toc8.1.4.1">&#xA0;</a><h4>Spot metering</h4>
+<p>
+
+
+The weight \(w\) of each luminance value to use when computing the scene luminance is given by equation \( \ref{spotMetering} \).
+
+</p><p>
+
+$$\begin{equation}\label{spotMetering}
+w(x,y) = \begin{cases} 1 &amp; \left| p_{x,y} - s_{x,y} \right| \le s_r \\ 0 &amp; \left| p_{x,y} - s_{x,y} \right| \gt s_r \end{cases}
+\end{equation}$$
+
+</p><p>
+
+Where \(p\) is the position of the pixel, \(s\) the center of the spot and \( s_r \) the radius of the spot.
+
+</p>
+<a class="target" name="center-weightedmetering">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/automaticexposure/center-weightedmetering">&#xA0;</a><a class="target" name="toc8.1.4.2">&#xA0;</a><h4>Center-weighted metering</h4>
+<p>
+
+
+$$\begin{equation}\label{centerMetering}
+w(x,y) = smooth(\left| p_{x,y} - c \right| \times \frac{2}{width} )
+\end{equation}$$
+
+</p><p>
+
+Where \(c\) is the center of the time and \( smooth() \) a smoothing function such as GLSL&apos;s <code>smoothstep()</code>.
+
+</p>
+<a class="target" name="adaptation">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/automaticexposure/adaptation">&#xA0;</a><a class="target" name="toc8.1.4.3">&#xA0;</a><h4>Adaptation</h4>
+<p>
+
+
+To smooth the result of the metering, we can use equation \( \ref{adaptation} \), an exponential feedback loop as described by Pattanaik et al. in [Pattanaik00].
+
+</p><p>
+
+$$\begin{equation}\label{adaptation}
+L_{avg} = L_{avg} + (L - L_{avg}) \times (1 - e^{-\Delta t \cdot \tau})
+\end{equation}$$
+
+</p><p>
+
+Where \( \Delta t \) is the delta time from the previous frame and \(\tau\) a constant that controls the adaptation rate.
+
+</p>
+<a class="target" name="bloom">&#xA0;</a><a class="target" name="imagingpipeline/physicallybasedcamera/bloom">&#xA0;</a><a class="target" name="toc8.1.5">&#xA0;</a><h3>Bloom</h3>
+<p>
+
+
+Because the EV scale is almost perceptually linear, the exposure value is also often used as a light unit. This means we could let artists specify the intensity of lights or emissive surfaces using exposure compensation as a unit. The intensity of emitted light would therefore be relative to the exposure settings. Using exposure compensation as a light unit should be avoided whenever possible but can be useful to force (or cancel) a bloom effect around emissive surfaces independently of the camera settings (for instance, a lightsaber in a game should always bloom).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_bloom.jpg" target="_blank"><img class="markdeep" src="images/screenshot_bloom.jpg"></a><div class="imagecaption"><a class="target" name="figure_bloom">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;74:</b> Saturated photosites on a sensor create a blooming effect in the bright parts of the scene</div></div></center>
+
+<p></p><p>
+
+With \(c\) the bloom color and \( EV_{100} \) the current exposure value, we can easily compute the luminance of the bloom value as show in equation \( \ref{bloomEV} \).
+
+</p><p>
+
+$$\begin{equation}\label{bloomEV}
+EV_{bloom} = EV_{100} + EC \\
+L_{bloom} = c \times 2^{EV_{bloom} - 3}
+\end{equation}$$
+
+</p><p>
+
+Equation \( \ref{bloomEV} \) can be used in a fragment shader to implement emissive blooms, as shown in <a href="#listing_fragmentemissive">listing&#xA0;43</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec4</span> surfaceShading() {</span>
+<span class="line">    <span class="hljs-type">vec4</span> color = evaluateLights();</span>
+<span class="line">    <span class="hljs-comment">// rgb = color, w = exposure compensation</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> emissive = getEmissive();</span>
+<span class="line">    color.rgb += emissive.rgb * <span class="hljs-built_in">pow</span>(<span class="hljs-number">2.0</span>, ev100 + emissive.w - <span class="hljs-number">3.0</span>);</span>
+<span class="line">    color.rgb *= exposure;</span>
+<span class="line">    <span class="hljs-keyword">return</span> color;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_fragmentemissive">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;43:</b> Implementation of emissive bloom in GLSL</div>
+
+<a class="target" name="opticspost-processing">&#xA0;</a><a class="target" name="imagingpipeline/opticspost-processing">&#xA0;</a><a class="target" name="toc8.2">&#xA0;</a><h2>Optics post-processing</h2>
+
+<a class="target" name="colorfringing">&#xA0;</a><a class="target" name="imagingpipeline/opticspost-processing/colorfringing">&#xA0;</a><a class="target" name="toc8.2.1">&#xA0;</a><h3>Color fringing</h3>
+<p>
+
+
+[TODO]
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_fringing.jpg" target="_blank"><img class="markdeep" src="images/screenshot_fringing.jpg"></a><div class="imagecaption"><a class="target" name="figure_fringing">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;75:</b> Example of color fringing: look at the ear on the left or the chin at the bottom.</div></div></center>
+
+<p></p>
+<a class="target" name="lensflares">&#xA0;</a><a class="target" name="imagingpipeline/opticspost-processing/lensflares">&#xA0;</a><a class="target" name="toc8.2.2">&#xA0;</a><h3>Lens flares</h3>
+<p>
+
+
+[TODO] Notes: there is a physically based approach to generating lens flares, by tracing rays through the optical assembly of the lens, but we are going to use an image-based approach. This approach is cheaper and has a few welcome benefits such as free emitters occlusion and unlimited light sources support.
+
+</p>
+<a class="target" name="filmicpost-processing">&#xA0;</a><a class="target" name="imagingpipeline/filmicpost-processing">&#xA0;</a><a class="target" name="toc8.3">&#xA0;</a><h2>Filmic post-processing</h2>
+<p>
+
+
+[TODO] Perform post-processing on the scene referred data (linear space, before tone-mapping) as much as possible
+
+</p><p>
+
+It is important to provide color correction tools to give artists greater artistic control over the final image. These tools are found in every photo or video processing application, such as Adobe Photoshop or Adobe After Effects.
+
+</p>
+<a class="target" name="contrast">&#xA0;</a><a class="target" name="imagingpipeline/filmicpost-processing/contrast">&#xA0;</a><a class="target" name="toc8.3.1">&#xA0;</a><h3>Contrast</h3>
+
+<a class="target" name="curves">&#xA0;</a><a class="target" name="imagingpipeline/filmicpost-processing/curves">&#xA0;</a><a class="target" name="toc8.3.2">&#xA0;</a><h3>Curves</h3>
+
+<a class="target" name="levels">&#xA0;</a><a class="target" name="imagingpipeline/filmicpost-processing/levels">&#xA0;</a><a class="target" name="toc8.3.3">&#xA0;</a><h3>Levels</h3>
+
+<a class="target" name="colorgrading">&#xA0;</a><a class="target" name="imagingpipeline/filmicpost-processing/colorgrading">&#xA0;</a><a class="target" name="toc8.3.4">&#xA0;</a><h3>Color grading</h3>
+
+<a class="target" name="lightpath">&#xA0;</a><a class="target" name="imagingpipeline/lightpath">&#xA0;</a><a class="target" name="toc8.4">&#xA0;</a><h2>Light path</h2>
+<p>
+
+
+The light path, or rendering method, used by the engine can have serious performance implications and may impose strong limitations on how many lights can be used in a scene. There are traditionally two different rendering methods used by 3D engines forward and deferred rendering.
+
+</p><p>
+
+Our goal is to use a rendering method that obeys the following constraints:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Low bandwidth requirements
+</li>
+<li class="minus">Multiple dynamic lights per pixel</li></ul>
+
+<p></p><p>
+
+Additionally, we would like to easily support:
+
+</p><p>
+
+</p><ul>
+<li class="minus">MSAA
+</li>
+<li class="minus">Transparency
+</li>
+<li class="minus">Multiple material models</li></ul>
+
+<p></p><p>
+
+Deferred rendering is used by many modern 3D rendering engines to easily support dozens, hundreds or even thousands of light source (amongst other benefits). This method is unfortunately very expensive in terms of bandwidth. With our default PBR material model, our G-buffer would use between 160 and 192 bits per pixel, which would translate directly to rather high bandwidth requirements.
+
+</p><p>
+
+Forward rendering methods on the other hand have historically been bad at handling multiple lights. A common implementation is to render the scene multiple times, once per visible light, and to blend (add) the results. Another technique consists in assigning a fixed maximum of lights to each object in the scene. This is however impractical when objects occupy a vast amount of space in the world (building, road, etc.).
+
+</p><p>
+
+Tiled shading can be applied to both forward and deferred rendering methods. The idea is to split the screen in a grid of tiles and for each tile, find the list of lights that affect the pixels within that tile. This has the advantage of reducing overdraw (in deferred rendering) and shading computations of large objects (in forward rendering). This technique suffers however from depth discontinuities issues that can lead to large amounts of extraneous work.
+
+</p><p>
+
+The scene displayed in <a href="#figure_sponza">figure&#xA0;76</a> was rendered using clustered forward rendering.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_sponza.jpg" target="_blank"><img class="markdeep" src="images/screenshot_sponza.jpg"></a><div class="imagecaption"><a class="target" name="figure_sponza">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;76:</b> Clustered forward rendering with dozens of dynamic lights and MSAA</div></div></center>
+
+<p></p><p>
+
+<a href="#figure_sponzatiles">Figure&#xA0;77</a> shows the same scene split in tiles (in this case, a 1280&#xD7;720 render target with 80&#xD7;80px tiles).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_sponza_tiles.jpg" target="_blank"><img class="markdeep" src="images/screenshot_sponza_tiles.jpg"></a><div class="imagecaption"><a class="target" name="figure_sponzatiles">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;77:</b> Tiled shading (16&#xD7;9 tiles)</div></div></center>
+
+<p></p>
+<a class="target" name="clusteredforwardrendering">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/clusteredforwardrendering">&#xA0;</a><a class="target" name="toc8.4.1">&#xA0;</a><h3>Clustered Forward Rendering</h3>
+<p>
+
+
+We decided to explore another method called Clustered Shading, in its forward variant. Clustered shading expands on the idea of tiled rendering but adds a segmentation on the 3rd axis. The &#x201C;clustering&#x201D; is done in view space, by splitting the frustum into a 3D grid.
+
+</p><p>
+
+The frustum is first sliced on the depth axis as show in <a href="#figure_sponzaslices">figure&#xA0;78</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_sponza_slices.jpg" target="_blank"><img class="markdeep" src="images/screenshot_sponza_slices.jpg"></a><div class="imagecaption"><a class="target" name="figure_sponzaslices">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;78:</b> Depth slicing (16 slices)</div></div></center>
+
+<p></p><p>
+
+And the depth slices are then combined with the screen tiles to &#x201C;voxelize&#x201D; the frustum. We call each cluster a froxel as it makes it clear what they represent (a voxel in frustum space). The result of the &#x201C;froxelization&#x201D; pass is shown in <a href="#figure_froxel1">figure&#xA0;79</a> and <a href="#figure_froxel2">figure&#xA0;80</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_sponza_froxels1.jpg" target="_blank"><img class="markdeep" src="images/screenshot_sponza_froxels1.jpg"></a><div class="imagecaption"><a class="target" name="figure_froxel1">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;79:</b> Frustum voxelization (5&#xD7;3 tiles, 8 depth slices)</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_sponza_froxels2.jpg" target="_blank"><img class="markdeep" src="images/screenshot_sponza_froxels2.jpg"></a><div class="imagecaption"><a class="target" name="figure_froxel2">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;80:</b> Frustum voxelization (5&#xD7;3 tiles, 8 depth slices)</div></div></center>
+
+<p></p><p>
+
+Before rendering a frame, each light in the scene is assigned to any froxel it intersects with. The result of the lights assignment pass is a list of lights for each froxel. During the rendering pass, we can compute the ID of the froxel a fragment belongs to and therefore the list of lights that can affect that fragment.
+
+</p><p>
+
+The depth slicing is not linear, but exponential. In a typical scene, there will be more pixels close to the near plane than to the far plane. An exponential grid of froxels will therefore improve the assignment of lights where it matters the most.
+
+</p><p>
+
+<a href="#figure_froxeldistribution">Figure&#xA0;81</a> shows how much world space unit each depth slice uses with exponential slicing.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_froxels1.png" target="_blank"><img class="markdeep" src="images/diagram_froxels1.png"></a><div class="imagecaption"><a class="target" name="figure_froxeldistribution">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;81:</b> Near: 0.1m, Far: 100m, 16 slices</div></div></center>
+
+<p></p><p>
+
+A simple exponential voxelization is unfortunately not enough. The graphic above clearly illustrates how world space is distributed across slices but it fails to show what happens close to the near plane. If we examine the same distribution in a smaller range (0.1m to 7m) we can see an interesting problem appear as shown in <a href="#figure_froxeldistributionclose">figure&#xA0;82</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_froxels2.png" target="_blank"><img class="markdeep" src="images/diagram_froxels2.png"></a><div class="imagecaption"><a class="target" name="figure_froxeldistributionclose">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;82:</b> Depth distribution in the 0.1-7m range</div></div></center>
+
+<p></p><p>
+
+This graphic shows that a simple exponential distribution uses up half of the slices very close to the camera. In this particular case, we use 8 slices out of 16in the first 5 meters. Since dynamic world lights are either point lights (spheres) or spot lights (cones), such a fine resolution is completely unnecessary so close to the near plane.
+
+</p><p>
+
+Our solution is to manually tweak the size of the first froxel depending on the scene and the near and far planes. By doing so, we can better distribute the remaining froxels across the frustum. <a href="#figure_froxeldistributionexp">Figure&#xA0;83</a> shows for instance what happens when we use a special froxel between 0.1m and 5m.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_froxels3.png" target="_blank"><img class="markdeep" src="images/diagram_froxels3.png"></a><div class="imagecaption"><a class="target" name="figure_froxeldistributionexp">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;83:</b> Near: 0.1, Far: 100m, 16 slices, Special froxel: 0.1-5m</div></div></center>
+
+<p></p><p>
+
+This new distribution is much more efficient and allows a better assignment of the lights throughout the entire frustum.
+
+</p>
+<a class="target" name="implementationnotes">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes">&#xA0;</a><a class="target" name="toc8.4.2">&#xA0;</a><h3>Implementation notes</h3>
+<p>
+
+
+Lights assignment can be done in two different ways, on the GPU or on the CPU.
+
+</p>
+<a class="target" name="gpulightsassignment">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes/gpulightsassignment">&#xA0;</a><a class="target" name="toc8.4.2.1">&#xA0;</a><h4>GPU lights assignment</h4>
+<p>
+
+
+This implementation requires OpenGL ES 3.1 and support for compute shaders. The lights are stored in Shader Storage Buffer Objects (SSBO) and passed to a compute shader that assigns each light to the corresponding froxels.
+
+</p><p>
+
+The frustum voxelization can be executed only once by a first compute shader (as long as the projection matrix does not change), and the lights assignment can be performed each frame by another compute shader.
+
+</p><p>
+
+The threading model of compute shaders is particularly well suited for this task. We simply invoke as many workgroups as we have froxels (we can directly map the X, Y and Z workgroup counts to our froxel grid resolution). Each workground will in turn be threaded and traverse all the lights to assign.
+
+</p><p>
+
+Intersection tests imply simple sphere/frustum or cone/frustum tests.
+
+</p><p>
+
+See the annex for the source code of a GPU implementation (point lights only).
+
+</p>
+<a class="target" name="cpulightsassignment">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes/cpulightsassignment">&#xA0;</a><a class="target" name="toc8.4.2.2">&#xA0;</a><h4>CPU lights assignment</h4>
+<p>
+
+
+On non-OpenGL ES 3.1 devices, lights assignment can be performed efficiently on the CPU. The algorithm is different from the GPU implementation. Instead of iterating over every light for each froxel, the engine will &#x201C;rasterize&#x201D; each light as froxels. For instance, given a point light&#x2019;s center and radius, it is trivial to compute the list of froxels it intersects with.
+
+</p><p>
+
+This technique has the added benefit of providing tighter culling than in the GPU variant. The CPU implementation can also more easily generate a packed list of lights.
+
+</p>
+<a class="target" name="shading">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes/shading">&#xA0;</a><a class="target" name="toc8.4.2.3">&#xA0;</a><h4>Shading</h4>
+<p>
+
+
+The list of lights per froxel can be passed to the fragment shader either as an SSBO (OpenGL ES 3.1) or a texture.
+
+</p>
+<a class="target" name="fromdepthtofroxel">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes/fromdepthtofroxel">&#xA0;</a><a class="target" name="toc8.4.2.4">&#xA0;</a><h4>From depth to froxel</h4>
+<p>
+
+
+Given a near plane \(n\), a far plane \(f\), a maximum number of depth slices \(m\) and a linear depth value \(z\) in the range [0..1], equation \(\ref{zToCluster}\) can be used to compute the index of the cluster for a given position.
+
+</p><p>
+
+$$\begin{equation}\label{zToCluster}
+zToCluster(z,n,f,m)=floor \left( max \left( log2(z) \frac{m}{-log2(\frac{n}{f})} + m, 0 \right) \right)
+\end{equation}$$
+
+</p><p>
+
+This formula suffers however from the resolution issue mentioned previously. We can fix it by introducing \(sn\), a special near value that defines the extent of the first froxel (the first froxel occupies the range [n..sn], the remaining froxels [sn..f]).
+
+</p><p>
+
+$$\begin{equation}\label{zToClusterFix}
+zToCluster(z,n,sn,f,m)=floor \left( max \left( log2(z) \frac{m-1}{-log2(\frac{sn}{f})} + m, 0 \right) \right)
+\end{equation}$$
+
+</p><p>
+
+Equation \(\ref{linearZ}\) can be used to compute a linear depth value from <code>gl_FragCoord.z</code> (assuming a standard OpenGL projection matrix).
+
+</p><p>
+
+$$\begin{equation}\label{linearZ}
+linearZ(z)=\frac{n}{f+z(n-f)}
+\end{equation}$$
+
+</p><p>
+
+This equation can be simplified by pre-computing two terms \(c0\) and \(c1\), as shown in equation \(\ref{linearZFix}\).
+
+</p><p>
+
+$$\begin{equation}\label{linearZFix}
+c1 = \frac{f}{n} \\
+c0 = 1 - c1 \\
+linearZ(z)=\frac{1}{z \cdot c0 + c1}
+\end{equation}$$
+
+</p><p>
+
+This simplification is important because we pass the linear z value to a <code>log2</code> in \(\ref{zToClusterFix}\). Since the division becomes a negation under a logarithmic, we can avoid a division by using \(-log2(z \cdot c0 + c1)\) instead.
+
+</p><p>
+
+All put together, computing the froxel index of a given fragment can be implemented fairly easily as shown in <a href="#listing_fragcoordtofroxel">listing&#xA0;44</a>.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-meta">#define MAX_LIGHT_COUNT 16 // max number of lights per froxel</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">uniform</span> <span class="hljs-type">uvec4</span> froxels; <span class="hljs-comment">// res x, res y, count y, count y</span></span>
+<span class="line"><span class="hljs-keyword">uniform</span> <span class="hljs-type">vec4</span> zParams;  <span class="hljs-comment">// c0, c1, index scale, index bias</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">uint</span> getDepthSlice() {</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-type">uint</span>(<span class="hljs-built_in">max</span>(<span class="hljs-number">0.0</span>, <span class="hljs-built_in">log2</span>(zParams.x * <span class="hljs-built_in">gl_FragCoord</span>.z + zParams.y) *</span>
+<span class="line">            zParams.z + zParams.w));</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">uint</span> getFroxelOffset(<span class="hljs-type">uint</span> depthSlice) {</span>
+<span class="line">    <span class="hljs-type">uvec2</span> froxelCoord = <span class="hljs-type">uvec2</span>(<span class="hljs-built_in">gl_FragCoord</span>.xy) / froxels.xy;</span>
+<span class="line">    froxelCoord.y = (froxels.w - <span class="hljs-number">1</span>u) - froxelCoord.y;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">uint</span> <span class="hljs-keyword">index</span> = froxelCoord.x + froxelCoord.y * froxels.z +</span>
+<span class="line">            depthSlice * froxels.z * froxels.w;</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-keyword">index</span> * MAX_FROXEL_LIGHT_COUNT;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">uint</span> slice = getDepthSlice();</span>
+<span class="line"><span class="hljs-type">uint</span> <span class="hljs-keyword">offset</span> = getFroxelOffset(slice);</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// Compute lighting...</span></span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_fragcoordtofroxel">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;44:</b> GLSL implementation to compute a froxel index from a fragment&apos;s screen coordinates</div>
+<p>
+
+
+Several uniforms must be pre-computed for perform the index evaluation efficiently. The code used to pre-compute these uniforms can be found in listing ?.
+
+</p><pre class="listing tilde"><code><span class="line">froxels[<span class="hljs-number">0</span>] = TILE_RESOLUTION_IN_PX;</span>
+<span class="line">froxels[<span class="hljs-number">1</span>] = TILE_RESOLUTION_IN_PX;</span>
+<span class="line">froxels[<span class="hljs-number">2</span>] = numberOfTilesInX;</span>
+<span class="line">froxels[<span class="hljs-number">3</span>] = numberOfTilesInY;</span>
+<span class="line"></span>
+<span class="line">zParams[<span class="hljs-number">0</span>] = <span class="hljs-number">1.0f</span> - Z_FAR / Z_NEAR;</span>
+<span class="line">zParams[<span class="hljs-number">1</span>] = Z_FAR / Z_NEAR;</span>
+<span class="line">zParams[<span class="hljs-number">2</span>] = (MAX_DEPTH_SLICES - <span class="hljs-number">1</span>) / log2(Z_SPECIAL_NEAR / Z_FAR);</span>
+<span class="line">zParams[<span class="hljs-number">3</span>] = MAX_DEPTH_SLICES;</span></code></pre><div class="listingcaption tilde">Listing ?</div>
+
+<a class="target" name="fromfroxeltodepth">&#xA0;</a><a class="target" name="imagingpipeline/lightpath/implementationnotes/fromfroxeltodepth">&#xA0;</a><a class="target" name="toc8.4.2.5">&#xA0;</a><h4>From froxel to depth</h4>
+<p>
+
+
+Given a froxel index \(i\), a special near plane \(sn\), a far plane \(f\) and a maximum number of depth slices \(m\), equation \(\ref{clusterToZ}\) computes the minimum depth of a given froxel.
+
+</p><p>
+
+$$\begin{equation}\label{clusterToZ}
+clusterToZ(i \ge 1,sn,f,m)=2^{(i-m) \frac{-log2(\frac{sn}{f})}{m-1}}
+\end{equation}$$
+
+</p><p>
+
+For \(i=0\), the z value is 0. The result of this equation is in the [0..1] range and should be multiplied by \(f\) to get a distance in world units.
+
+</p><p>
+
+The compute shader implementation should use <code>exp2</code> instead of a <code>pow</code>. The division can be precomputed and passed as a uniform.
+
+</p>
+<a class="target" name="validation">&#xA0;</a><a class="target" name="imagingpipeline/validation">&#xA0;</a><a class="target" name="toc8.5">&#xA0;</a><h2>Validation</h2>
+<p>
+
+
+Given the complexity of our lighting system, it is important to validate our implementation. We will do so in several ways: using reference renderings, light measurements and data visualization.
+
+</p><p>
+
+[TODO] Explain light measurement validation (reading EV from the render target and comparing against values measure with light meters/cameras, etc.)
+
+</p>
+<a class="target" name="scenereferredvisualization">&#xA0;</a><a class="target" name="imagingpipeline/validation/scenereferredvisualization">&#xA0;</a><a class="target" name="toc8.5.1">&#xA0;</a><h3>Scene referred visualization</h3>
+<p>
+
+
+A quick and easy way to validate a scene&apos;s lighting is to modify the shader to output colors that provide an intuitive mapping to relevant data. This can easily be done by using a custom debug tone-mapping operator that outputs fake colors.
+
+</p>
+<a class="target" name="luminancestops">&#xA0;</a><a class="target" name="imagingpipeline/validation/scenereferredvisualization/luminancestops">&#xA0;</a><a class="target" name="toc8.5.1.1">&#xA0;</a><h4>Luminance stops</h4>
+<p>
+
+
+With emissive materials and IBLs, it is fairly easy to obtain a scene in which specular highlights are brighter than their apparent caster. This type of issue can be difficult to observe after tone-mapping and quantization but is fairly obvious in the scene-referred space. <a href="#figure_luminanceviz">Figure&#xA0;84</a> shows how the custom operator described in <a href="#listing_tonemapluminanceviz">listing&#xA0;45</a> is used to show the exposed luminance of a scene.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_luminance_debug.png" target="_blank"><img class="markdeep" src="images/screenshot_luminance_debug.png"></a><div class="imagecaption"><a class="target" name="figure_luminanceviz">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;84:</b> Visualizing luminance by color coding the stops: cyan is middle gray, blue is 1 stop darker, green 1 stop brighter, etc.</div></div></center>
+
+<p></p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">vec3</span> Tonemap_DisplayRange(<span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> x) {</span>
+<span class="line">    <span class="hljs-comment">// The 5th color in the array (cyan) represents middle gray (18%)</span></span>
+<span class="line">    <span class="hljs-comment">// Every stop above or below middle gray causes a color shift</span></span>
+<span class="line">    <span class="hljs-type">float</span> v = <span class="hljs-built_in">log2</span>(luminance(x) / <span class="hljs-number">0.18</span>);</span>
+<span class="line">    v = <span class="hljs-built_in">clamp</span>(v + <span class="hljs-number">5.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">15.0</span>);</span>
+<span class="line">    <span class="hljs-type">int</span> <span class="hljs-keyword">index</span> = <span class="hljs-type">int</span>(<span class="hljs-built_in">floor</span>(v));</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-built_in">mix</span>(debugColors[<span class="hljs-keyword">index</span>], debugColors[<span class="hljs-built_in">min</span>(<span class="hljs-number">15</span>, <span class="hljs-keyword">index</span> + <span class="hljs-number">1</span>)], <span class="hljs-built_in">fract</span>(v));</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-type">vec3</span> debugColors[<span class="hljs-number">16</span>] = <span class="hljs-type">vec3</span>[](</span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>),         <span class="hljs-comment">// black</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.1647</span>),      <span class="hljs-comment">// darkest blue</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.3647</span>),      <span class="hljs-comment">// darker blue</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.6647</span>),      <span class="hljs-comment">// dark blue</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.9647</span>),      <span class="hljs-comment">// blue</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.9255</span>, <span class="hljs-number">0.9255</span>),   <span class="hljs-comment">// cyan</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.5647</span>, <span class="hljs-number">0.0</span>),      <span class="hljs-comment">// dark green</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.7843</span>, <span class="hljs-number">0.0</span>),      <span class="hljs-comment">// green</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">1.0</span>, <span class="hljs-number">0.0</span>),         <span class="hljs-comment">// yellow</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.90588</span>, <span class="hljs-number">0.75294</span>, <span class="hljs-number">0.0</span>), <span class="hljs-comment">// yellow-orange</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">0.5647</span>, <span class="hljs-number">0.0</span>),      <span class="hljs-comment">// orange</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>),         <span class="hljs-comment">// bright red</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.8392</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>),      <span class="hljs-comment">// red</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">1.0</span>),         <span class="hljs-comment">// magenta</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">0.6</span>, <span class="hljs-number">0.3333</span>, <span class="hljs-number">0.7882</span>),   <span class="hljs-comment">// purple</span></span>
+<span class="line">     <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">1.0</span>, <span class="hljs-number">1.0</span>)          <span class="hljs-comment">// white</span></span>
+<span class="line">);</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_tonemapluminanceviz">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;45:</b> GLSL implementation of a custom debug tone-mapping operator for luminance visualization</div>
+
+<a class="target" name="referencerenderings">&#xA0;</a><a class="target" name="imagingpipeline/validation/referencerenderings">&#xA0;</a><a class="target" name="toc8.5.2">&#xA0;</a><h3>Reference renderings</h3>
+<p>
+
+
+To validate our implementation against reference renderings, we will use a commercial-grade Open Source physically based offline path tracer called Mitsuba. Mitsuba offers many different integrators, samplers and material models, which should allow us to provide fair comparisons with our real-time renderer. This path tracer also relies on a simple XML scene description format that should be easy to automatically generate from our own scene descriptions.
+
+</p><p>
+
+<a href="#figure_mitsubareference">Figure&#xA0;85</a> and <a href="#figure_filamentreference">figure&#xA0;86</a> show a simple scene, a perfectly smooth dielectric sphere, rendered respectively with Mitsuba and Filament.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ref_mitsuba.jpg" target="_blank"><img class="markdeep" src="images/screenshot_ref_mitsuba.jpg"></a><div class="imagecaption"><a class="target" name="figure_mitsubareference">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;85:</b> Rendered in 2048&#xD7;1440 in 1 minute and 42 seconds on a 12 core 2013 MacPro</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ref_filament.jpg" target="_blank"><img class="markdeep" src="images/screenshot_ref_filament.jpg"></a><div class="imagecaption"><a class="target" name="figure_filamentreference">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;86:</b> Rendered in 2048&#xD7;1440 with MSAA 4x at 60 fps on a Nexus 9 device (Tegra K1 GPU)</div></div></center>
+
+<p></p><p>
+
+The parameters used to render both scenes are the following:
+
+</p><p>
+
+<strong class="asterisk">Filament</strong>
+
+</p><p>
+
+</p><ul>
+<li class="minus">Material
+<ul>
+  <li class="minus">Base color: sRGB 0.81, 0, 0
+</li>
+  <li class="minus">Metallic: 0
+</li>
+  <li class="minus">Roughness: 0
+</li>
+  <li class="minus">Reflectance: 0.5
+</li></ul>
+</li><li class="minus">Indirect light: IBL
+<ul>
+  <li class="minus">256&#xD7;256 cubemap generated by cmgen from office.exr
+</li>
+  <li class="minus">Multiplier: 35,000
+</li></ul>
+</li><li class="minus">Direct light: directional light
+<ul>
+  <li class="minus">Linear color: 1.0, 0.96, 0.95
+</li>
+  <li class="minus">Intensity: 120,000 lux
+</li></ul>
+</li><li class="minus">Exposure
+<ul>
+  <li class="minus">Aperture: f/16
+</li>
+  <li class="minus">Shutter speed: 1/125s
+</li>
+  <li class="minus">ISO: 100</li></ul></li></ul>
+
+<p></p><p>
+
+<strong class="asterisk">Mitsuba</strong>
+
+</p><p>
+
+</p><ul>
+<li class="minus">BSDF: roughplastic
+<ul>
+  <li class="minus">Distribution: GGX
+</li>
+  <li class="minus">Alpha: 0
+</li>
+  <li class="minus">Diffuse reflectance: sRGB 0.81, 0, 0
+</li></ul>
+</li><li class="minus">Emitter: environment map
+<ul>
+  <li class="minus">Source: office.exr
+</li>
+  <li class="minus">Scale: 35,000
+</li></ul>
+</li><li class="minus">Emitter: directional
+<ul>
+  <li class="minus">Irradiance: linear RGB 120,000 115,200 114,000
+</li></ul>
+</li><li class="minus">Film: LDR
+<ul>
+  <li class="minus">Exposure: &#x2212;15.23, computed from log2(filamentExposure)
+</li></ul>
+</li><li class="minus">Integrator: path
+</li>
+<li class="minus">Sampler: ldsampler
+<ul>
+  <li class="minus">Sample count: 256</li></ul></li></ul>
+
+<p></p><p>
+
+The full Mitsuba scene can be found as an annex. Both scenes were rendered at the same resolution (2048&#xD7;1440).
+
+</p>
+<a class="target" name="comparison">&#xA0;</a><a class="target" name="imagingpipeline/validation/referencerenderings/comparison">&#xA0;</a><a class="target" name="toc8.5.2.1">&#xA0;</a><h4>Comparison</h4>
+<p>
+
+
+The slight differences between the two renderings come from the various approximations used by Filament: RGBM 256&#xD7;256 reflection probe, RGBM 1024&#xD7;1024 background map, Lambert diffuse, split-sum approximation, analytical approximation of the DFG term, etc.
+
+</p><p>
+
+<a href="#figure_referencecomparison">Figure&#xA0;87</a> shows the luminance gradient of the images produced by both engines. The comparison was performed on LDR images.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ref_comparison.png" target="_blank"><img class="markdeep" src="images/screenshot_ref_comparison.png"></a><div class="imagecaption"><a class="target" name="figure_referencecomparison">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;87:</b> Luminance gradients from Mitsuba (left) and Filament (right)</div></div></center>
+
+<p></p><p>
+
+The biggest difference is visible at grazing angles, which is most likely explained by Filament&apos;s use of a Lambertian diffuse term. The Disney diffuse term and its grazing retro-reflections would move Filament closer to Mitsuba.
+
+</p>
+<a class="target" name="coordinatessystems">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems">&#xA0;</a><a class="target" name="toc8.6">&#xA0;</a><h2>Coordinates systems</h2>
+
+<a class="target" name="worldcoordinatessystem">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/worldcoordinatessystem">&#xA0;</a><a class="target" name="toc8.6.1">&#xA0;</a><h3>World coordinates system</h3>
+<p>
+
+
+Filament uses a Y-up, right-handed coordinate system.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_coordinates.jpg" target="_blank"><img class="markdeep" src="images/screenshot_coordinates.jpg"></a><div class="imagecaption"><a class="target" name="figure_coordinates">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;88:</b> Red +X, green +Y, blue +Z (rendered in Marmoset Toolbag).</div></div></center>
+
+<p></p>
+<a class="target" name="cameracoordinatessystem">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/cameracoordinatessystem">&#xA0;</a><a class="target" name="toc8.6.2">&#xA0;</a><h3>Camera coordinates system</h3>
+<p>
+
+
+Filament&apos;s Camera looks towards its local -Z axis. That is, when placing a camera in the world
+without any transform applied to it, the camera looks down the world&apos;s -Z axis.
+
+</p>
+<a class="target" name="cubemapscoordinatessystem">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/cubemapscoordinatessystem">&#xA0;</a><a class="target" name="toc8.6.3">&#xA0;</a><h3>Cubemaps coordinates system</h3>
+<p>
+
+
+All cubemaps used in Filament follow the OpenGL convention for face
+alignment shown in <a href="#figure_cubemapcoordinates">figure&#xA0;89</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cubemap_coordinates.png" target="_blank"><img class="markdeep" src="images/screenshot_cubemap_coordinates.png"></a><div class="imagecaption"><a class="target" name="figure_cubemapcoordinates">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;89:</b> Horizontal cross representation of a cubemap following the OpenGL faces alignment convention.</div></div></center>
+
+<p></p><p>
+
+Note that environment background and reflection probes are mirrored (see section  <a href="#toc8.6.3.1">8.6.3.1</a>).
+
+</p>
+<a class="target" name="mirroring">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/cubemapscoordinatessystem/mirroring">&#xA0;</a><a class="target" name="toc8.6.3.1">&#xA0;</a><h4>Mirroring</h4>
+<p>
+
+
+To simplify the rendering of reflections, IBL cubemaps are stored mirrored on the X axis. This is
+the default behaviour of the <code>cmgen</code> tool. This means that an IBL cubemap used as environment 
+background needs to be mirrored again at runtime. 
+An easy way to achieve this for skyboxes is to use textured back faces. Filament does
+this by default.
+
+</p>
+<a class="target" name="equirectangularenvironmentmaps">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/cubemapscoordinatessystem/equirectangularenvironmentmaps">&#xA0;</a><a class="target" name="toc8.6.3.2">&#xA0;</a><h4>Equirectangular environment maps</h4>
+<p>
+
+
+To convert equirectangular environment maps to horizontal/vertical cross cubemaps we position the
++Z face in the center of the source rectilinear environment map.
+
+</p>
+<a class="target" name="worldspaceorientationofenvironmentmapsandskyboxes">&#xA0;</a><a class="target" name="imagingpipeline/coordinatessystems/cubemapscoordinatessystem/worldspaceorientationofenvironmentmapsandskyboxes">&#xA0;</a><a class="target" name="toc8.6.3.3">&#xA0;</a><h4>World space orientation of environment maps and Skyboxes</h4>
+<p>
+
+
+When specifying a skybox or an IBL in Filament, the specified cubemap is oriented such that its 
+-Z face points towards the +Z axis of the world (this is because filament assumes mirrored cubemaps, 
+see section  <a href="#toc8.6.3.1">8.6.3.1</a>). However, because environments and skyboxes are expected to be pre-mirrored, 
+their -Z (back) face points towards the world&apos;s -Z axis as expected (and the camera looks toward that 
+direction by default, see section  <a href="#toc8.6.2">8.6.2</a>).
+
+</p>
+<a class="target" name="annex">&#xA0;</a><a class="target" name="annex">&#xA0;</a><a class="target" name="toc9">&#xA0;</a><h1>Annex</h1>
+
+<a class="target" name="specularcolor">&#xA0;</a><a class="target" name="annex/specularcolor">&#xA0;</a><a class="target" name="toc9.1">&#xA0;</a><h2>Specular color</h2>
+<p>
+
+
+The specular color of a metallic surface, or \(\fNormal\), can be computed directly from measured spectral data. Online databases such as <a href="https://refractiveindex.info/?shelf=3d&amp;book=metals&amp;page=brass">Refractive Index</a> provide tables of complex IOR measured at different wavelengths for various materials.
+
+</p><p>
+
+Earlier in this document, we presented equation \(\ref{fresnelEquation}\) to compute the Fresnel reflectance at normal incidence for a dielectric surface given its IOR. The same equation can be rewritten for conductors by using complex numbers to represent the surface&apos;s IOR:
+
+</p><p>
+
+$$\begin{equation}
+c_{ior} = n_{ior} + ik
+\end{equation}$$
+
+</p><p>
+
+Equation \(\ref{fresnelComplexIOR}\) presents the resulting Fresnel formula, where \(c^*\) is the conjugate of the complex number \(c\):
+
+</p><p>
+
+$$\begin{equation}\label{fresnelComplexIOR}
+\fNormal(c_{ior}) = \frac{(c_{ior} - 1)(c_{ior}^* - 1)}{(c_{ior} + 1)(c_{ior}^* + 1)}
+\end{equation}$$
+
+</p><p>
+
+To compute the specular color of a material we need to evaluate the complex Fresnel equation at each spectral sample of complex IOR over the visible spectrum. For each spectral sample, we obtain a spectral reflectance sample. To find the RGB color at normal incidence, we must multiply each sample by the CIE XYZ CMFs (color matching functions) and the spectral power distribution of the desired illuminant. We choose the standard illuminant D65 because we want to compute a color in the sRGB color space.
+
+</p><p>
+
+We then sum (integrate) and normalize all the samples to obtain \(\fNormal\) in the XYZ color space. From there, a simple color space conversion yields a linear sRGB color or a non-linear sRGB color after applying the opto-electronic transfer function (OETF, commonly known as &#x201C;gamma&#x201D; curve). Note that for some materials such as gold the final sRGB color might fall out of gamut. We use a simple normalization step as a cheap form of gamut remapping but it would be interesting to consider computing values in a color space with a wider gamut (for instance BT.2020).
+
+</p><p>
+
+To achieve the desired result we used the ICE 1931 2&#xB0; CMFs, from 360nm to 830nm at 1nm intervals (<a href="http://cvrl.ioo.ucl.ac.uk/cmfs.htm">source</a>), and the CIE Standard Illuminant D65 relative spectral power distribution, from 300nm to 830nm, at 5nm intervals (<a href="http://files.cie.co.at/204.xls">source</a>).
+
+</p><p>
+
+Our implementation is presented in <a href="#listing_specularcolorimpl">listing&#xA0;46</a>, with the actual data omitted for brevity.
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// CIE 1931 2-deg color matching functions (CMFs), from 360nm to 830nm,</span></span>
+<span class="line"><span class="hljs-comment">// at 1nm intervals</span></span>
+<span class="line"><span class="hljs-comment">//</span></span>
+<span class="line"><span class="hljs-comment">// Data source:</span></span>
+<span class="line"><span class="hljs-comment">//     http://cvrl.ioo.ucl.ac.uk/cmfs.htm</span></span>
+<span class="line"><span class="hljs-comment">//     http://cvrl.ioo.ucl.ac.uk/database/text/cmfs/ciexyz31.htm</span></span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_XYZ_START = <span class="hljs-number">360</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_XYZ_COUNT = <span class="hljs-number">471</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> float3 CIE_XYZ[CIE_XYZ_COUNT] = { ... };</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// CIE Standard Illuminant D65 relative spectral power distribution,</span></span>
+<span class="line"><span class="hljs-comment">// from 300nm to 830, at 5nm intervals</span></span>
+<span class="line"><span class="hljs-comment">//</span></span>
+<span class="line"><span class="hljs-comment">// Data source:</span></span>
+<span class="line"><span class="hljs-comment">//     https://en.wikipedia.org/wiki/Illuminant_D65</span></span>
+<span class="line"><span class="hljs-comment">//     https://cielab.xyz/pdf/CIE_sel_colorimetric_tables.xls</span></span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_D65_INTERVAL = <span class="hljs-number">5</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_D65_START = <span class="hljs-number">300</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_D65_END = <span class="hljs-number">830</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> CIE_D65_COUNT = <span class="hljs-number">107</span>;</span>
+<span class="line"><span class="hljs-keyword">const</span> <span class="hljs-keyword">float</span> CIE_D65[CIE_D65_COUNT] = { ... };</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-class"><span class="hljs-keyword">struct</span> <span class="hljs-title">Sample</span> {</span></span>
+<span class="line">    <span class="hljs-keyword">float</span> w = <span class="hljs-number">0.0f</span>; <span class="hljs-comment">// wavelength</span></span>
+<span class="line">    <span class="hljs-built_in">std</span>::<span class="hljs-keyword">complex</span>&lt;<span class="hljs-keyword">float</span>&gt; ior; <span class="hljs-comment">// complex IOR, n + ik</span></span>
+<span class="line">};</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> <span class="hljs-keyword">float</span> <span class="hljs-title">illuminantD65</span><span class="hljs-params">(<span class="hljs-keyword">float</span> w)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">auto</span> i0 = <span class="hljs-keyword">size_t</span>((w - CIE_D65_START) / CIE_D65_INTERVAL);</span>
+<span class="line">    uint2 indexBounds{i0, <span class="hljs-built_in">std</span>::min(i0 + <span class="hljs-number">1</span>, CIE_D65_END)};</span>
+<span class="line"></span>
+<span class="line">    float2 wavelengthBounds = CIE_D65_START + float2{indexBounds} * CIE_D65_INTERVAL;</span>
+<span class="line">    <span class="hljs-keyword">float</span> t = (w - wavelengthBounds.x) / (wavelengthBounds.y - wavelengthBounds.x);</span>
+<span class="line">    <span class="hljs-keyword">return</span> lerp(CIE_D65[indexBounds.x], CIE_D65[indexBounds.y], t);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// For std::lower_bound</span></span>
+<span class="line"><span class="hljs-keyword">bool</span> <span class="hljs-keyword">operator</span>&lt;(<span class="hljs-keyword">const</span> Sample&amp; lhs, <span class="hljs-keyword">const</span> Sample&amp; rhs) {</span>
+<span class="line">    <span class="hljs-keyword">return</span> lhs.w &lt; rhs.w;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// The wavelength w must be between 360nm and 830nm</span></span>
+<span class="line"><span class="hljs-keyword">static</span> <span class="hljs-built_in">std</span>::<span class="hljs-keyword">complex</span>&lt;<span class="hljs-keyword">float</span>&gt; findSample(<span class="hljs-keyword">const</span> <span class="hljs-built_in">std</span>::<span class="hljs-built_in">vector</span>&lt;sample&gt;&amp; samples, <span class="hljs-keyword">float</span> w) {</span>
+<span class="line">    <span class="hljs-keyword">auto</span> i1 = <span class="hljs-built_in">std</span>::lower_bound(</span>
+<span class="line">	        samples.begin(), samples.end(), Sample{w, <span class="hljs-number">0.0f</span> + <span class="hljs-number">0.0</span><span class="hljs-keyword">if</span>});</span>
+<span class="line">    <span class="hljs-keyword">auto</span> i0 = i1 - <span class="hljs-number">1</span>;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Interpolate the complex IORs</span></span>
+<span class="line">    <span class="hljs-keyword">float</span> t = (w - i0-&gt;w) / (i1-&gt;w - i0-&gt;w);</span>
+<span class="line">    <span class="hljs-keyword">float</span> n = lerp(i0-&gt;ior.real(), i1-&gt;ior.real(), t);</span>
+<span class="line">    <span class="hljs-keyword">float</span> k = lerp(i0-&gt;ior.imag(), i1-&gt;ior.imag(), t);</span>
+<span class="line">    <span class="hljs-keyword">return</span> { n, k };</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> <span class="hljs-keyword">float</span> <span class="hljs-title">fresnel</span><span class="hljs-params">(<span class="hljs-keyword">const</span> <span class="hljs-built_in">std</span>::<span class="hljs-keyword">complex</span>&lt;<span class="hljs-keyword">float</span>&gt;&amp; sample)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> (((sample - (<span class="hljs-number">1.0f</span> + <span class="hljs-number">0</span><span class="hljs-keyword">if</span>)) * (<span class="hljs-built_in">std</span>::conj(sample) - (<span class="hljs-number">1.0f</span> + <span class="hljs-number">0</span><span class="hljs-keyword">if</span>))) /</span>
+<span class="line">            ((sample + (<span class="hljs-number">1.0f</span> + <span class="hljs-number">0</span><span class="hljs-keyword">if</span>)) * (<span class="hljs-built_in">std</span>::conj(sample) + (<span class="hljs-number">1.0f</span> + <span class="hljs-number">0</span><span class="hljs-keyword">if</span>)))).real();</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> float3 <span class="hljs-title">XYZ_to_sRGB</span><span class="hljs-params">(<span class="hljs-keyword">const</span> float3&amp; v)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">const</span> mat3f XYZ_sRGB{</span>
+<span class="line">             <span class="hljs-number">3.2404542f</span>, <span class="hljs-number">-0.9692660f</span>,  <span class="hljs-number">0.0556434f</span>,</span>
+<span class="line">            <span class="hljs-number">-1.5371385f</span>,  <span class="hljs-number">1.8760108f</span>, <span class="hljs-number">-0.2040259f</span>,</span>
+<span class="line">            <span class="hljs-number">-0.4985314f</span>,  <span class="hljs-number">0.0415560f</span>,  <span class="hljs-number">1.0572252f</span></span>
+<span class="line">    };</span>
+<span class="line">    <span class="hljs-keyword">return</span> XYZ_sRGB * v;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// Outputs a linear sRGB color</span></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> float3 <span class="hljs-title">computeColor</span><span class="hljs-params">(<span class="hljs-keyword">const</span> <span class="hljs-built_in">std</span>::<span class="hljs-built_in">vector</span>&lt;sample&gt;&amp; samples)</span> </span>{</span>
+<span class="line">    float3 xyz{<span class="hljs-number">0.0f</span>};</span>
+<span class="line">    <span class="hljs-keyword">float</span> y = <span class="hljs-number">0.0f</span>;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">size_t</span> i = <span class="hljs-number">0</span>; i &lt; CIE_XYZ_COUNT; i++) {</span>
+<span class="line">        <span class="hljs-comment">// Current wavelength</span></span>
+<span class="line">        <span class="hljs-keyword">float</span> w = CIE_XYZ_START + i;</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-comment">// Find most appropriate CIE XYZ sample for the wavelength</span></span>
+<span class="line">        <span class="hljs-keyword">auto</span> sample = findSample(samples, w);</span>
+<span class="line">        <span class="hljs-comment">// Compute Fresnel reflectance at normal incidence</span></span>
+<span class="line">        <span class="hljs-keyword">float</span> f0 = fresnel(sample);</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-comment">// We need to multiply by the spectral power distribution of the illuminant</span></span>
+<span class="line">        <span class="hljs-keyword">float</span> d65 = illuminantD65(w);</span>
+<span class="line"></span>
+<span class="line">        xyz += f0 * CIE_XYZ[i] * d65;</span>
+<span class="line">        y += CIE_XYZ[i].y * d65;</span>
+<span class="line">    }</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Normalize so that 100% reflectance at every wavelength yields Y=1</span></span>
+<span class="line">    xyz /= y;</span>
+<span class="line"></span>
+<span class="line">    float3 linear = XYZ_to_sRGB(xyz);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// Normalize out-of-gamut values</span></span>
+<span class="line">    <span class="hljs-keyword">if</span> (any(greaterThan(linear, float3{<span class="hljs-number">1.0f</span>}))) linear *= <span class="hljs-number">1.0f</span> / max(linear);</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">return</span> linear;</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_specularcolorimpl">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;46:</b> C++ implementation to compute the base color of a metallic surface from spectral data</div>
+<p>
+
+
+Special thanks to Naty Hoffman for his valuable help on this topic.
+
+</p>
+<a class="target" name="importancesamplingfortheibl">&#xA0;</a><a class="target" name="annex/importancesamplingfortheibl">&#xA0;</a><a class="target" name="toc9.2">&#xA0;</a><h2>Importance sampling for the IBL</h2>
+<p>
+
+
+In the discrete domain, the integral can be approximated with sampling as defined in equation \(\ref{iblSampling}\).
+
+</p><p>
+
+$$\begin{equation}\label{iblSampling}
+\Lout(n,v,\Theta) \equiv \frac{1}{N} \sum_{i}^{N} f(l_{i}^{uniform},v,\Theta) L_{\perp}(l_i) \left&lt; n \cdot l_i^{uniform} \right&gt;
+\end{equation}$$
+
+</p><p>
+
+Unfortunately, we would need too many samples to evaluate this integral. A technique commonly used
+is to choose samples that are more &#x201C;important&#x201D; more often, this is called <em class="underscore">importance sampling</em>.
+In our case we&apos;ll use the distribution of micro-facets normals, \(D_{ggx}\), as the distribution of
+important samples.
+
+</p><p>
+
+The evaluation of \( \Lout(n,v,\Theta) \) with importance sampling is presented in equation \(\ref{annexIblImportanceSampling}\).
+
+</p><p>
+
+$$\begin{equation}\label{annexIblImportanceSampling}
+\Lout(n,v,\Theta) \equiv \frac{1}{N} \sum_{i}^{N} \frac{f(l_{i},v,\Theta)}{p(l_i,v,\Theta)} L_{\perp}(l_i) \left&lt; n \cdot l_i \right&gt;
+\end{equation}$$
+
+</p><p>
+
+In equation \(\ref{annexIblImportanceSampling}\), \(p\) is the probability density function (PDF) of the
+distribution of <em class="underscore">important direction samples</em> \(l_i\). These samples depend on \(h_i\), \(v\) and \(\alpha\).
+The definition of the PDF is shown in equation \(\ref{iblPDF}\).
+
+</p><p>
+
+\(h_i\) is given by the distribution we chose, see section  <a href="#toc9.2.1">9.2.1</a> for more details.
+
+</p><p>
+
+The <em class="underscore">important direction samples</em> \(l_i\) are calculated as the reflection of \(v\) around \(h_i\), and therefore
+<strong class="asterisk">do not</strong> have the same PDF as \(h_i\). The PDF of a transformed distribution is given by:
+
+</p><p>
+
+$$\begin{equation}
+p(T_r(x)) = p(x) |J(T_r)|
+\end{equation}$$
+
+</p><p>
+
+Where \(|J(T_r)|\) is the determinant of the Jacobian of the transform. In our case we&apos;re considering
+the transform from \(h_i\) to \(l_i\) and the determinant of its Jacobian is given in \ref{iblPDF}.
+
+</p><p>
+
+$$\begin{equation}\label{iblPDF}
+p(l,v,\Theta) = D(h,\alpha) \left&lt; \NoH \right&gt; |J_{h \rightarrow l}| \\
+|J_{h \rightarrow l}| = \frac{1}{4 \left&lt; \VoH \right&gt;}
+\end{equation}$$
+
+</p>
+<a class="target" name="choosingimportantdirections">&#xA0;</a><a class="target" name="annex/importancesamplingfortheibl/choosingimportantdirections">&#xA0;</a><a class="target" name="toc9.2.1">&#xA0;</a><h3>Choosing important directions</h3>
+<p>
+
+
+Refer to section  <a href="#toc9.3">9.3</a> for more details. Given a uniform distribution \((\zeta_{\phi},\zeta_{\theta})\) the important direction \(l\) is defined by equation \(\ref{importantDirection}\).
+
+</p><p>
+
+$$\begin{equation}\label{importantDirection}
+\phi = 2 \pi \zeta_{\phi} \\
+\theta = cos^{-1} \sqrt{\frac{1 - \zeta_{\theta}}{(\alpha^2 - 1)\zeta_{\theta}+1}} \\
+l = \{ cos \phi sin \theta, sin \phi sin \theta, cos \theta \}
+\end{equation}$$
+
+</p><p>
+
+Typically, \( (\zeta_{\phi},\zeta_{\theta}) \) are chosen using the Hammersley uniform distribution algorithm described in section  <a href="#toc9.4">9.4</a>.
+
+</p>
+<a class="target" name="pre-filteredimportancesampling">&#xA0;</a><a class="target" name="annex/importancesamplingfortheibl/pre-filteredimportancesampling">&#xA0;</a><a class="target" name="toc9.2.2">&#xA0;</a><h3>Pre-filtered importance sampling</h3>
+<p>
+
+
+Importance sampling considers only the PDF to generate important directions; in particular, it is oblivious to the actual content of the IBL. If the latter contains high frequencies in areas without a lot of samples, the integration won&#x2019;t be accurate. This can be somewhat mitigated by using a technique called <em class="underscore">pre-filtered importance sampling</em>, in addition this allows the integral to converge with many fewer samples.
+
+</p><p>
+
+Pre-filtered importance sampling uses several images of the environment increasingly low-pass filtered. This is typically implemented very efficiently with mipmaps and a box filter. The LOD is selected based on the sample importance, that is, low probability samples use a higher LOD index (more filtered).
+
+</p><p>
+
+This technique is described in details in [<a href="#citation-krivanek08">Krivanek08</a>].
+
+</p><p>
+
+The cubemap LOD is determined in the following way:
+
+</p><p>
+
+$$\begin{align*}
+lod &amp;= log_4 \left( K\frac{\Omega_s}{\Omega_p} \right) \\
+K &amp;= 4.0 \\
+\Omega_s &amp;= \frac{1}{N \cdot p(l_i)} \\
+\Omega_p &amp;\approx \frac{4\pi}{6 \cdot width \cdot height}
+\end{align*}$$
+
+</p><p>
+
+Where \(K\) is a constant determined empirically, \(p\) the PDF of the BRDF, \( \Omega_{s} \) the solid angle associated to the sample and \(\Omega_p\) the solid angle associated with the texel in the cubemap.
+
+</p><p>
+
+Cubemap sampling is done using seamless trilinear filtering. It is extremely important to sample the cubemap correctly across faces using OpenGL&apos;s seamless sampling feature or any other technique that avoids/reduces seams.
+
+</p><p>
+
+<a href="#table_importancesamplingviz">Table&#xA0;17</a> shows a comparison between importance sampling and pre-filtered importance sampling when applied to <a href="#figure_importancesamplingref">figure&#xA0;90</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/image_is_original.png" target="_blank"><img class="markdeep" src="images/image_is_original.png"></a><div class="imagecaption"><a class="target" name="figure_importancesamplingref">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;90:</b> Importance sampling image reference</div></div></center>
+
+<p></p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:left"> Samples </th><th style="text-align:left"> Importance sampling </th><th style="text-align:left"> Pre-filtered importance sampling </th></tr>
+<tr><td style="text-align:left"> 4096 </td><td style="text-align:left"> <a href="images/image_is_4096.png" target="_blank"><img class="markdeep" src="images/image_is_4096.png"></a> </td><td style="text-align:left"> &#xA0; </td></tr>
+<tr><td style="text-align:left"> 1024 </td><td style="text-align:left"> <a href="images/image_is_1024.png" target="_blank"><img class="markdeep" src="images/image_is_1024.png"></a> </td><td style="text-align:left"> <a href="images/image_fis_1024.png" target="_blank"><img class="markdeep" src="images/image_fis_1024.png"></a> </td></tr>
+<tr><td style="text-align:left"> 32 </td><td style="text-align:left"> <a href="images/image_is_32.png" target="_blank"><img class="markdeep" src="images/image_is_32.png"></a> </td><td style="text-align:left"> <a href="images/image_fis_32.png" target="_blank"><img class="markdeep" src="images/image_fis_32.png"></a> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_importancesamplingviz">&#xA0;</a><b style="font-style:normal;">Table&#xA0;17:</b> Importance sampling vs pre-filtered importance sampling with \(\alpha = 0.4\)</div></div>
+
+<p></p><p>
+
+The reference renderer used in the comparison below performs no approximation. In particular, it does not assume \(v = n\) and does not perform the split sum approximation.  The pre-filtered renderer uses all the techniques discussed in this section: pre-filtered cubemaps, the analytic formulation of the DFG term, and of course the split sum approximation.
+
+</p><p>
+
+Left: reference renderer, right: pre-filtered importance sampling.
+
+</p><p>
+
+</p><table width="100%"><tbody><tr valign="top"><td>
+
+<p></p><p>
+
+</p><center><a href="images/image_is_ref_1.png" target="_blank"><img class="markdeep" src="images/image_is_ref_1.png"></a></center>
+
+<p></p><p>
+
+</p></td><td>
+
+<p></p><p>
+
+ </p><center><a href="images/image_filtered_1.png" target="_blank"><img class="markdeep" src="images/image_filtered_1.png"></a></center>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td>
+
+<p></p><p>
+
+</p><center><a href="images/image_is_ref_2.png" target="_blank"><img class="markdeep" src="images/image_is_ref_2.png"></a></center>
+
+<p></p><p>
+
+</p></td><td>
+
+<p></p><p>
+
+ </p><center><a href="images/image_filtered_2.png" target="_blank"><img class="markdeep" src="images/image_filtered_2.png"></a></center>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td>
+
+<p></p><p>
+
+</p><center><a href="images/image_is_ref_3.png" target="_blank"><img class="markdeep" src="images/image_is_ref_3.png"></a></center>
+
+<p></p><p>
+
+</p></td><td>
+
+<p></p><p>
+
+ </p><center><a href="images/image_filtered_3.png" target="_blank"><img class="markdeep" src="images/image_filtered_3.png"></a></center>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td>
+
+<p></p><p>
+
+</p><center><a href="images/image_is_ref_4.png" target="_blank"><img class="markdeep" src="images/image_is_ref_4.png"></a></center>
+
+<p></p><p>
+
+</p></td><td>
+
+<p></p><p>
+
+ </p><center><a href="images/image_filtered_4.png" target="_blank"><img class="markdeep" src="images/image_filtered_4.png"></a></center>
+
+<p></p><p>
+
+</p></td></tr></tbody></table>
+
+<p></p>
+<a class="target" name="choosingimportantdirectionsforsamplingthebrdf">&#xA0;</a><a class="target" name="annex/choosingimportantdirectionsforsamplingthebrdf">&#xA0;</a><a class="target" name="toc9.3">&#xA0;</a><h2>Choosing important directions for sampling the BRDF</h2>
+<p>
+
+
+For simplicity we use the \( D \) term of the BRDF as the PDF, however the PDF must be normalized such that the integral over the hemisphere is 1:
+
+</p><p>
+
+$$\begin{equation}
+\int_{\Omega}p(m)dm = 1 \\
+\int_{\Omega}D(m)(n \cdot m)dm = 1 \\
+\int_{\phi=0}^{2\pi}\int_{\theta=0}^{\frac{\pi}{2}}D(\theta,\phi) cos \theta sin \theta d\theta d\phi = 1 \\
+\end{equation}$$
+
+</p><p>
+
+The PDF of the BRDF can therefore be expressed as in equation \(\ref{importantPDF}\):
+
+</p><p>
+
+$$\begin{equation}\label{importantPDF}
+p(\theta,\phi) = \frac{\alpha^2}{\pi(cos^2\theta (\alpha^2-1) + 1)^2} cos\theta sin\theta
+\end{equation}$$
+
+</p><p>
+
+The term \(sin\theta\) comes from the differential solid angle \(sin\theta d\phi d\theta\) since we integrate over a sphere. We sample \(\theta\) and \(\phi\) independently:
+
+</p><p>
+
+$$\begin{align*}
+p(\theta) &amp;= \int_0^{2\pi} p(\theta,\phi) d\phi = \frac{2\alpha^2}{(cos^2\theta (\alpha^2-1) + 1)^2} cos\theta sin\theta \\
+p(\phi) &amp;= \frac{p(\theta,\phi)}{p(\phi)} = \frac{1}{2\pi}
+\end{align*}$$
+
+</p><p>
+
+The expression of \( p(\phi) \) is true for an isotropic distribution of normals.
+
+</p><p>
+
+We then calculate the cumulative distribution function (CDF) for each variable:
+
+</p><p>
+
+$$\begin{align*}
+P(s_{\phi}) &amp;= \int_{0}^{s_{\phi}} p(\phi) d\phi = \frac{s_{\phi}}{2\pi} \\
+P(s_{\theta}) &amp;= \int_{0}^{s_{\theta}} p(\theta) d\theta = 2 \alpha^2 \left( \frac{1}{(2\alpha^4-4\alpha^2+2) cos(s_{\theta})^2 + 2\alpha^2 - 2} - \frac{1}{2\alpha^4-2\alpha^2} \right)
+\end{align*}$$
+
+</p><p>
+
+We set \( P(s_{\phi}) \) and \( P(s_{\theta}) \) to random variables \( \zeta_{\phi} \) and \( \zeta_{\theta} \) and solve for \( s_{\phi} \) and \( s_{\theta} \) respectively:
+
+</p><p>
+
+$$\begin{align*}
+P(s_{\phi}) &amp;= \zeta_{\phi} \rightarrow s_{\phi} = 2\pi\zeta_{\phi} \\
+P(s_{\theta}) &amp;= \zeta_{\theta} \rightarrow s_{\theta} = cos^{-1} \sqrt{\frac{1-\zeta_{\theta}}{(\alpha^2-1)\zeta_{\theta}+1}}
+\end{align*}$$
+
+</p><p>
+
+So given a uniform distribution \( (\zeta_{\phi},\zeta_{\theta}) \), our important direction \(l\) is defined as:
+
+</p><p>
+
+$$\begin{align*}
+\phi &amp;= 2\pi\zeta_{\phi} \\
+\theta &amp;= cos^{-1} \sqrt{\frac{1-\zeta_{\theta}}{(\alpha^2-1)\zeta_{\theta}+1}} \\
+l &amp;= \{ cos\phi sin\theta,sin\phi sin\theta,cos\theta \}
+\end{align*}$$
+
+</p>
+<a class="target" name="hammersleysequence">&#xA0;</a><a class="target" name="annex/hammersleysequence">&#xA0;</a><a class="target" name="toc9.4">&#xA0;</a><h2>Hammersley sequence</h2>
+<pre class="listing tilde"><code><span class="line">vec2f hammersley(<span class="hljs-type">uint</span> i, <span class="hljs-type">float</span> numSamples) {</span>
+<span class="line">    <span class="hljs-type">uint</span> bits = i;</span>
+<span class="line">    bits = (bits &lt;&lt; <span class="hljs-number">16</span>) | (bits &gt;&gt; <span class="hljs-number">16</span>);</span>
+<span class="line">    bits = ((bits &amp; <span class="hljs-number">0x55555555</span>) &lt;&lt; <span class="hljs-number">1</span>) | ((bits &amp; <span class="hljs-number">0xAAAAAAAA</span>) &gt;&gt; <span class="hljs-number">1</span>);</span>
+<span class="line">    bits = ((bits &amp; <span class="hljs-number">0x33333333</span>) &lt;&lt; <span class="hljs-number">2</span>) | ((bits &amp; <span class="hljs-number">0xCCCCCCCC</span>) &gt;&gt; <span class="hljs-number">2</span>);</span>
+<span class="line">    bits = ((bits &amp; <span class="hljs-number">0x0F0F0F0F</span>) &lt;&lt; <span class="hljs-number">4</span>) | ((bits &amp; <span class="hljs-number">0xF0F0F0F0</span>) &gt;&gt; <span class="hljs-number">4</span>);</span>
+<span class="line">    bits = ((bits &amp; <span class="hljs-number">0x00FF00FF</span>) &lt;&lt; <span class="hljs-number">8</span>) | ((bits &amp; <span class="hljs-number">0xFF00FF00</span>) &gt;&gt; <span class="hljs-number">8</span>);</span>
+<span class="line">    <span class="hljs-keyword">return</span> vec2f(i / numSamples, bits / <span class="hljs-built_in">exp2</span>(<span class="hljs-number">32</span>));</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde">C++ implementation of a Hammersley sequence generator</div>
+
+<a class="target" name="precomputinglforimage-basedlighting">&#xA0;</a><a class="target" name="annex/precomputinglforimage-basedlighting">&#xA0;</a><a class="target" name="toc9.5">&#xA0;</a><h2>Precomputing L for image-based lighting</h2>
+<p>
+
+
+The term \( L_{DFG} \) is only dependent on \( \NoV \). Below, the normal is arbitrarily set to \( n=\left[0, 0, 1\right] \) and \(v\) is chosen to satisfy \( \NoV \). The vector \( h_i \) is the \( D_{GGX}(\alpha) \) important direction sample \(i\).
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> GDFG(<span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> NoL, <span class="hljs-type">float</span> a) {</span>
+<span class="line">    <span class="hljs-type">float</span> a2 = a * a;</span>
+<span class="line">    <span class="hljs-type">float</span> GGXL = NoV * <span class="hljs-built_in">sqrt</span>((-NoL * a2 + NoL) * NoL + a2);</span>
+<span class="line">    <span class="hljs-type">float</span> GGXV = NoL * <span class="hljs-built_in">sqrt</span>((-NoV * a2 + NoV) * NoV + a2);</span>
+<span class="line">    <span class="hljs-keyword">return</span> (<span class="hljs-number">2</span> * NoL) / (GGXV + GGXL);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">float2 DFG(<span class="hljs-type">float</span> NoV, <span class="hljs-type">float</span> a) {</span>
+<span class="line">    float3 V;</span>
+<span class="line">    V.x = <span class="hljs-built_in">sqrt</span>(<span class="hljs-number">1.0</span>f - NoV*NoV);</span>
+<span class="line">    V.y = <span class="hljs-number">0.0</span>f;</span>
+<span class="line">    V.z = NoV;</span>
+<span class="line"></span>
+<span class="line">    float2 r = <span class="hljs-number">0.0</span>f;</span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-type">uint</span> i = <span class="hljs-number">0</span>; i &lt; sampleCount; i++) {</span>
+<span class="line">        float2 Xi = hammersley(i, sampleCount);</span>
+<span class="line">        float3 H = importanceSampleGGX(Xi, a, N);</span>
+<span class="line">        float3 L = <span class="hljs-number">2.0</span>f * <span class="hljs-built_in">dot</span>(V, H) * H - V;</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-type">float</span> VoH = saturate(<span class="hljs-built_in">dot</span>(V, H));</span>
+<span class="line">        <span class="hljs-type">float</span> NoL = saturate(L.z);</span>
+<span class="line">        <span class="hljs-type">float</span> NoH = saturate(H.z);</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-keyword">if</span> (NoL &gt; <span class="hljs-number">0.0</span>f) {</span>
+<span class="line">            <span class="hljs-type">float</span> G = GDFG(NoV, NoL, a);</span>
+<span class="line">            <span class="hljs-type">float</span> Gv = G * VoH / NoH;</span>
+<span class="line">            <span class="hljs-type">float</span> Fc = <span class="hljs-built_in">pow</span>(<span class="hljs-number">1</span> - VoH, <span class="hljs-number">5.0</span>f);</span>
+<span class="line">            r.x += Gv * (<span class="hljs-number">1</span> - Fc);</span>
+<span class="line">            r.y += Gv * Fc;</span>
+<span class="line">        }</span>
+<span class="line">    }</span>
+<span class="line">    <span class="hljs-keyword">return</span> r * (<span class="hljs-number">1.0</span>f / sampleCount);</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde">C++ implementation of the \( L_{DFG} \) term</div>
+
+<a class="target" name="sphericalharmonics">&#xA0;</a><a class="target" name="annex/sphericalharmonics">&#xA0;</a><a class="target" name="toc9.6">&#xA0;</a><h2>Spherical Harmonics</h2>
+<p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:center"> Symbol </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:center"> \(K^m_l\) </td><td style="text-align:left"> Normalization factors </td></tr>
+<tr><td style="text-align:center"> \(P^m_l(x)\) </td><td style="text-align:left"> Associated Legendre polynomials </td></tr>
+<tr><td style="text-align:center"> \(y^m_l\) </td><td style="text-align:left"> Spherical harmonics bases, or SH bases </td></tr>
+<tr><td style="text-align:center"> \(L^m_l\) </td><td style="text-align:left"> SH coefficients of the \(L(s)\) function defined on the unit sphere </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_shsymbols">&#xA0;</a><b style="font-style:normal;">Table&#xA0;18:</b> Spherical harmonics symbols definitions</div></div>
+
+<p></p>
+<a class="target" name="basisfunctions">&#xA0;</a><a class="target" name="annex/sphericalharmonics/basisfunctions">&#xA0;</a><a class="target" name="toc9.6.1">&#xA0;</a><h3>Basis functions</h3>
+<p>
+
+
+Spherical parameterization of points on the surface of the unit sphere:
+
+</p><p>
+
+$$\begin{equation}
+\{ x, y, z \} = \{ cos \phi sin \theta, sin \phi sin \theta, cos \theta \}
+\end{equation}$$
+
+</p><p>
+
+The complex spherical harmonics bases are given by:
+
+</p><p>
+
+$$\begin{equation}
+Y^m_l(\theta, \phi) = K^m_l e^{im\theta} P^{|m|}_l(cos \theta), l \in N, -l &lt;= m &lt;= l
+\end{equation}$$
+
+</p><p>
+
+However we only need the real bases:
+
+</p><p>
+
+$$\begin{align*}
+y^{m &gt; 0}_l &amp;= \sqrt{2} K^m_l cos(m \phi) P^m_l(cos \theta) \\
+y^{m &lt; 0}_l &amp;= \sqrt{2} K^m_l sin(m \phi) P^{|m|}_l(cos \theta) \\
+y^0_l &amp;= K^0_l P^0_l(cos \theta)
+\end{align*}$$
+
+</p><p>
+
+The normalization factors are given by:
+
+</p><p>
+
+$$\begin{equation}
+K^m_l = \sqrt{\frac{(2l + 1)(l - |m|)!}{4 \pi (l + |m|)!}}
+\end{equation}$$
+
+</p><p>
+
+The associated Legendre polynomials \(P^{|m|}_l\) can be calculated from the following recursions:
+
+</p><p>
+
+$$\begin{equation}\label{shRecursions}
+P^0_0(x) = 1 \\
+P^0_1(x) = x \\
+P^l_l(x) = (-1)^l (2l - 1)!! (1 - x^2)^{\frac{l}{2}} \\
+P^m_l(x) = \frac{((2l - 1) x P^m_{l - 1} - (l + m - 1) P^m_{l - 2})}{l - m} \\
+\end{equation}$$
+
+</p><p>
+
+Computing \(y^{|m|}_l\) requires to compute \(P^{|m|}_l(z)\) first.
+This can be accomplished fairly easily using the recursions in equation \(\ref{shRecursions}\).
+The third recursion can be used to &#x201C;move diagonally&#x201D; in <a href="#table_basisfunctions">table&#xA0;20</a>, i.e. calculating \(y^0_0\), \(y^1_1\), \(y^2_2\) etc.
+Then, the fourth recursion can be used to move vertically.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:center"> Band index </th><th style="text-align:center"> Basis functions \(-l &lt;= m &lt;= l\) </th></tr>
+<tr><td style="text-align:center"> \(l = 0\) </td><td style="text-align:center"> \(y^0_0\) </td></tr>
+<tr><td style="text-align:center"> \(l = 1\) </td><td style="text-align:center"> \(y^{-1}_1\) \(y^0_1\) \(y^1_1\) </td></tr>
+<tr><td style="text-align:center"> \(l = 2\) </td><td style="text-align:center"> \(y^{-2}_2\) \(y^{-1}_2\) \(y^0_2\) \(y^1_2\) \(y^2_2\) </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_basisfunctions">&#xA0;</a><b style="font-style:normal;">Table&#xA0;19:</b> Basis functions per band</div></div>
+
+<p></p><p>
+
+It&#x2019;s also fairly easy to compute the trigonometric terms recursively:
+
+</p><p>
+
+$$\begin{align*}
+C_m &amp;\equiv cos(m \phi) \\
+S_m &amp;\equiv sin(m \phi) \\
+\{ x, y, z \} &amp;= \{ cos \phi sin \theta, sin \phi sin \theta, cos \theta \}
+\end{align*}$$
+
+</p><p>
+
+Using the angle sum trigonometric identities:
+
+</p><p>
+
+$$\begin{align*}
+cos(m \phi + \phi) &amp;= cos(m \phi) cos(\phi) - sin(m \phi) sin(\phi) \Leftrightarrow C_{m + 1} = \frac{(x C_m - y S_m)}{sin(\theta)^{|m + 1|}} \\
+sin(m \phi + \phi) &amp;= sin(m \phi) sin(\phi) + cos(m \phi) sin(\phi) \Leftrightarrow S_{m + 1} = \frac{(x S_m - y C_m)}{sin(\theta)^{|m + 1|}}
+\end{align*}$$
+
+</p><p>
+
+The equations above have an extra term \(sin(\theta)^{-|m + 1|}\) but we can compensate for that in the \(P^{|m|}_l(z)\) recursion by multiplying \(P^l_l(z)\) by \(sin(\theta)^{|m + 1|}\) which greatly simplifies the third equation in \(\ref{shRecursions}\) because \(P^l_l(cos \theta) sin(\theta)^{-l} = (-1)^l(2l - 1)!!\).
+
+</p><p>
+
+<a href="#listing_nonnormalizedshbasis">Listing&#xA0;47</a> shows the C++ code to compute the non-normalized SH basis \(\frac{y^m_l(s)}{\sqrt{2} K^m_l}\):
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> <span class="hljs-keyword">inline</span> size_t <span class="hljs-title">SHindex</span><span class="hljs-params">(<span class="hljs-keyword">ssize_t</span> m, <span class="hljs-keyword">size_t</span> l)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">return</span> l * (l + <span class="hljs-number">1</span>) + m;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">void</span> <span class="hljs-title">computeShBasis</span><span class="hljs-params">(</span>
+<span class="line">        <span class="hljs-keyword">double</span>* <span class="hljs-keyword">const</span> SHb,</span>
+<span class="line">        <span class="hljs-keyword">size_t</span> numBands,</span>
+<span class="line">        <span class="hljs-keyword">const</span> vec3&amp; s)</span></span>
+<span class="line"></span>{</span>
+<span class="line">    <span class="hljs-comment">// handle m=0 separately, since it produces only one coefficient</span></span>
+<span class="line">    <span class="hljs-keyword">double</span> Pml_2 = <span class="hljs-number">0</span>;</span>
+<span class="line">    <span class="hljs-keyword">double</span> Pml_1 = <span class="hljs-number">1</span>;</span>
+<span class="line">    SHb[<span class="hljs-number">0</span>] =  Pml_1;</span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">ssize_t</span> l = <span class="hljs-number">1</span>; l &lt; numBands; l++) {</span>
+<span class="line">        <span class="hljs-keyword">double</span> Pml = ((<span class="hljs-number">2</span> * l - <span class="hljs-number">1</span>) * Pml_1 * s.z - (l - <span class="hljs-number">1</span>) * Pml_2) / l;</span>
+<span class="line">        Pml_2 = Pml_1;</span>
+<span class="line">        Pml_1 = Pml;</span>
+<span class="line">        SHb[SHindex(<span class="hljs-number">0</span>, l)] = Pml;</span>
+<span class="line">    }</span>
+<span class="line">    <span class="hljs-keyword">double</span> Pmm = <span class="hljs-number">1</span>;</span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">ssize_t</span> m = <span class="hljs-number">1</span>; m &lt; numBands ; m++) {</span>
+<span class="line">        Pmm = (<span class="hljs-number">1</span> - <span class="hljs-number">2</span> * m) * Pmm;</span>
+<span class="line">        <span class="hljs-keyword">double</span> Pml_2 = Pmm;</span>
+<span class="line">        <span class="hljs-keyword">double</span> Pml_1 = (<span class="hljs-number">2</span> * m + <span class="hljs-number">1</span>)*Pmm*s.z;</span>
+<span class="line">        <span class="hljs-comment">// l == m</span></span>
+<span class="line">        SHb[SHindex(-m, m)] = Pml_2;</span>
+<span class="line">        SHb[SHindex( m, m)] = Pml_2;</span>
+<span class="line">        <span class="hljs-keyword">if</span> (m + <span class="hljs-number">1</span> &lt; numBands) {</span>
+<span class="line">            <span class="hljs-comment">// l == m+1</span></span>
+<span class="line">            SHb[SHindex(-m, m + <span class="hljs-number">1</span>)] = Pml_1;</span>
+<span class="line">            SHb[SHindex( m, m + <span class="hljs-number">1</span>)] = Pml_1;</span>
+<span class="line">            <span class="hljs-keyword">for</span> (<span class="hljs-keyword">ssize_t</span> l = m + <span class="hljs-number">2</span>; l &lt; numBands; l++) {</span>
+<span class="line">                <span class="hljs-keyword">double</span> Pml = ((<span class="hljs-number">2</span> * l - <span class="hljs-number">1</span>) * Pml_1 * s.z - (l + m - <span class="hljs-number">1</span>) * Pml_2)</span>
+<span class="line">                        / (l - m);</span>
+<span class="line">                Pml_2 = Pml_1;</span>
+<span class="line">                Pml_1 = Pml;</span>
+<span class="line">                SHb[SHindex(-m, l)] = Pml;</span>
+<span class="line">                SHb[SHindex( m, l)] = Pml;</span>
+<span class="line">            }</span>
+<span class="line">        }</span>
+<span class="line">    }</span>
+<span class="line">    <span class="hljs-keyword">double</span> Cm = s.x;</span>
+<span class="line">    <span class="hljs-keyword">double</span> Sm = s.y;</span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-keyword">ssize_t</span> m = <span class="hljs-number">1</span>; m &lt;= numBands ; m++) {</span>
+<span class="line">        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">ssize_t</span> l = m; l &lt; numBands ; l++) {</span>
+<span class="line">            SHb[SHindex(-m, l)] *= Sm;</span>
+<span class="line">            SHb[SHindex( m, l)] *= Cm;</span>
+<span class="line">        }</span>
+<span class="line">        <span class="hljs-keyword">double</span> Cm1 = Cm * s.x - Sm * s.y;</span>
+<span class="line">        <span class="hljs-keyword">double</span> Sm1 = Sm * s.x + Cm * s.y;</span>
+<span class="line">        Cm = Cm1;</span>
+<span class="line">        Sm = Sm1;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_nonnormalizedshbasis">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;47:</b> C++ implementation to compute a non-normalized SH basis</div>
+<p>
+
+
+SH bases \(y^m_l(s)\) for the first 3 bands:
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:center"> Band </th><th style="text-align:center"> \(m = -2\) </th><th style="text-align:center"> \(m = -1\) </th><th style="text-align:center"> \(m = 0\) </th><th style="text-align:center"> \(m = 1\) </th><th style="text-align:center"> \(m = 2\)                     </th></tr>
+<tr><td style="text-align:center"> \(l = 0\) </td><td style="text-align:center">  </td><td style="text-align:center">  </td><td style="text-align:center"> \(\frac{1}{2}\sqrt{\frac{1}{\pi}}\) </td><td style="text-align:center">  </td><td style="text-align:center">  </td></tr>
+<tr><td style="text-align:center"> \(l = 1\) </td><td style="text-align:center">  </td><td style="text-align:center"> \(-\frac{1}{2}\sqrt{\frac{3}{\pi}}y\) </td><td style="text-align:center"> \(\frac{1}{2}\sqrt{\frac{3}{\pi}}z\) </td><td style="text-align:center"> \(-\frac{1}{2}\sqrt{\frac{3}{\pi}}x\) </td><td style="text-align:center">  </td></tr>
+<tr><td style="text-align:center"> \(l = 2\) </td><td style="text-align:center"> \(\frac{1}{2}\sqrt{\frac{15}{\pi}}xy\) </td><td style="text-align:center"> \(-\frac{1}{2}\sqrt{\frac{15}{\pi}}yz\) </td><td style="text-align:center"> \(\frac{1}{4}\sqrt{\frac{5}{\pi}}(2z^2 - x^2 - y^2)\) </td><td style="text-align:center"> \(-\frac{1}{2}\sqrt{\frac{15}{\pi}}xz\) </td><td style="text-align:center"> \(\frac{1}{4}\sqrt{\frac{15}{\pi}}(x^2 - y^2)\)  </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_basisfunctions">&#xA0;</a><b style="font-style:normal;">Table&#xA0;20:</b> Basis functions per band</div></div>
+
+<p></p>
+<a class="target" name="decompositionandreconstruction">&#xA0;</a><a class="target" name="annex/sphericalharmonics/decompositionandreconstruction">&#xA0;</a><a class="target" name="toc9.6.2">&#xA0;</a><h3>Decomposition and reconstruction</h3>
+<p>
+
+
+A function \(L(s)\) defined on a sphere is projected to the SH basis as follows:
+
+</p><p>
+
+$$\begin{equation}
+L^m_l = \int_\Omega L(s) y^m_l(s) ds \\
+L^m_l = \int_{\theta = 0}^{\pi} \int_{\phi = 0}^{2\pi} L(\theta, \phi) y^m_l(\theta, \phi) sin \theta d\theta d\phi
+\end{equation}$$
+
+</p><p>
+
+Note that each \(L^m_l\) is a vector of 3 values, one for each RGB color channel.
+
+</p><p>
+
+The inverse transformation, or reconstruction, or rendering, from the SH coefficients is given by:
+
+</p><p>
+
+$$\begin{equation}
+\hat{L}(s) = \sum_l \sum_{m = -l}^l L^m_l y^m_l(s)
+\end{equation}$$
+
+</p>
+<a class="target" name="decompositionof%5C(%5Cleft%5C)">&#xA0;</a><a class="target" name="annex/sphericalharmonics/decompositionof%5C(%5Cleft%5C)">&#xA0;</a><a class="target" name="toc9.6.3">&#xA0;</a><h3>Decomposition of \(\left&lt; cos \theta \right&gt;\)</h3>
+<p>
+
+
+Since \(\left&lt; cos \theta \right&gt;\) does not depend on \(\phi\) (azimuthal independence), the integral simplifies to:
+
+</p><p>
+
+$$\begin{align*}
+C^0_l &amp;= 2\pi \int_0^{\pi} \left&lt; cos \theta \right&gt; y^0_l(\theta) sin \theta d\theta \\
+C^0_l &amp;= 2\pi K^)_l \int_0^{\frac{\pi}{2}} P^0_l(cos \theta) cos \theta sin \theta d\theta \\
+C^m_l &amp;= 0, m != 0
+\end{align*}$$
+
+</p><p>
+
+In [<a href="#citation-ramamoorthi01">Ramamoorthi01</a>] an analytical solution to the integral is described:
+
+</p><p>
+
+$$\begin{align*}
+C_1 &amp;= \sqrt{\frac{\pi}{3}} \\
+C_{odd} &amp;= 0 \\
+C_{l, even} &amp;= 2\pi \sqrt{\frac{2l + 1}{4\pi}} \frac{(-1)^{\frac{l}{2} - 1}}{(l + 2)(l - 1)} \frac{l!}{2^l (\frac{l!}{2})^2}
+\end{align*}$$
+
+</p><p>
+
+The first few coefficients are:
+
+</p><p>
+
+$$\begin{align*}
+C_0 &amp;= +0.88623 \\
+C_1 &amp;= +1.02333 \\
+C_2 &amp;= +0.49542 \\
+C_3 &amp;= +0.00000 \\
+C_4 &amp;= -0.11078
+\end{align*}$$
+
+</p><p>
+
+Very few coefficients are needed to reasonably approximate \(\left&lt; cos \theta \right&gt;\), as shown in <a href="#figure_shcosthetaapprox">figure&#xA0;91</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/chart_sh_cos_thera_approx.png" target="_blank"><img class="markdeep" src="images/chart_sh_cos_thera_approx.png"></a><div class="imagecaption"><a class="target" name="figure_shcosthetaapprox">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;91:</b> Approximation of \(cos \theta\) with SH coefficients</div></div></center>
+
+<p></p>
+<a class="target" name="convolution">&#xA0;</a><a class="target" name="annex/sphericalharmonics/convolution">&#xA0;</a><a class="target" name="toc9.6.4">&#xA0;</a><h3>Convolution</h3>
+<p>
+
+
+Convolutions by a kernel \(h\) that has a circular symmetry can be applied directly and easily in SH space:
+
+</p><p>
+
+$$\begin{equation}
+(h * f)^m_l = \sqrt{\frac{4\pi}{2l + 1}} h^0_l(s) f^m_l(s)
+\end{equation}$$
+
+</p><p>
+
+Conveniently, \(\sqrt{\frac{4\pi}{2l + 1}} = \frac{1}{K^0_l}\), so in practice we pre-multiply \(C_l\) by \(\frac{1}{K^0_l}\) and we get a simpler expression:
+
+</p><p>
+
+$$\begin{equation}
+\hat{C}_{l, even} = 2\pi \frac{(-1)^{\frac{l}{2} - 1}}{(l + 2)(l - 1)} \frac{l!}{2^l (\frac{l!}{2})^2} \\
+\hat{C}_l = \frac{2\pi}{3}
+\end{equation}$$
+
+</p><p>
+
+Here is the C++ code to compute \(\hat{C}_l\):
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-function"><span class="hljs-keyword">static</span> <span class="hljs-keyword">double</span> <span class="hljs-title">factorial</span><span class="hljs-params">(<span class="hljs-keyword">size_t</span> n, <span class="hljs-keyword">size_t</span> d = <span class="hljs-number">1</span>)</span></span>;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// &lt; cos(theta) &gt; SH coefficients pre-multiplied by 1 / K(0,l)</span></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">double</span> <span class="hljs-title">computeTruncatedCosSh</span><span class="hljs-params">(<span class="hljs-keyword">size_t</span> l)</span> </span>{</span>
+<span class="line">    <span class="hljs-keyword">if</span> (l == <span class="hljs-number">0</span>) {</span>
+<span class="line">        <span class="hljs-keyword">return</span> M_PI;</span>
+<span class="line">    } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (l == <span class="hljs-number">1</span>) {</span>
+<span class="line">        <span class="hljs-keyword">return</span> <span class="hljs-number">2</span> * M_PI / <span class="hljs-number">3</span>;</span>
+<span class="line">    } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (l &amp; <span class="hljs-number">1</span>) {</span>
+<span class="line">        <span class="hljs-keyword">return</span> <span class="hljs-number">0</span>;</span>
+<span class="line">    }</span>
+<span class="line">    <span class="hljs-keyword">const</span> <span class="hljs-keyword">size_t</span> l_2 = l / <span class="hljs-number">2</span>;</span>
+<span class="line">    <span class="hljs-keyword">double</span> A0 = ((l_2 &amp; <span class="hljs-number">1</span>) ? <span class="hljs-number">1.0</span> : <span class="hljs-number">-1.0</span>) / ((l + <span class="hljs-number">2</span>) * (l - <span class="hljs-number">1</span>));</span>
+<span class="line">    <span class="hljs-keyword">double</span> A1 = factorial(l, l_2) / (factorial(l_2) * (<span class="hljs-number">1</span> &lt;&lt; l));</span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-number">2</span> * M_PI * A0 * A1;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// returns n! / d!</span></span>
+<span class="line"><span class="hljs-function"><span class="hljs-keyword">double</span> <span class="hljs-title">factorial</span><span class="hljs-params">(<span class="hljs-keyword">size_t</span> n, <span class="hljs-keyword">size_t</span> d )</span> </span>{</span>
+<span class="line">   d = <span class="hljs-built_in">std</span>::max(<span class="hljs-keyword">size_t</span>(<span class="hljs-number">1</span>), d);</span>
+<span class="line">   n = <span class="hljs-built_in">std</span>::max(<span class="hljs-keyword">size_t</span>(<span class="hljs-number">1</span>), n);</span>
+<span class="line">   <span class="hljs-keyword">double</span> r = <span class="hljs-number">1.0</span>;</span>
+<span class="line">   <span class="hljs-keyword">if</span> (n == d) {</span>
+<span class="line">       <span class="hljs-comment">// intentionally left blank</span></span>
+<span class="line">   } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (n &gt; d) {</span>
+<span class="line">       <span class="hljs-keyword">for</span> ( ; n&gt;d ; n--) {</span>
+<span class="line">           r *= n;</span>
+<span class="line">       }</span>
+<span class="line">   } <span class="hljs-keyword">else</span> {</span>
+<span class="line">       <span class="hljs-keyword">for</span> ( ; d&gt;n ; d--) {</span>
+<span class="line">           r *= d;</span>
+<span class="line">       }</span>
+<span class="line">       r = <span class="hljs-number">1.0</span> / r;</span>
+<span class="line">   }</span>
+<span class="line">   <span class="hljs-keyword">return</span> r;</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="samplevalidationsceneformitsuba">&#xA0;</a><a class="target" name="annex/samplevalidationsceneformitsuba">&#xA0;</a><a class="target" name="toc9.7">&#xA0;</a><h2>Sample validation scene for Mitsuba</h2>
+<pre class="listing tilde"><code><span class="line"><span class="hljs-tag">&lt;<span class="hljs-name">scene</span> <span class="hljs-attr">version</span>=<span class="hljs-string">&quot;0.5.0&quot;</span>&gt;</span></span>
+<span class="line">    <span class="hljs-tag">&lt;<span class="hljs-name">integrator</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;path&quot;</span>/&gt;</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-tag">&lt;<span class="hljs-name">shape</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;serialized&quot;</span> <span class="hljs-attr">id</span>=<span class="hljs-string">&quot;sphere_mesh&quot;</span>&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;filename&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;plastic_sphere.serialized&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">integer</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;shapeIndex&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;0&quot;</span>/&gt;</span></span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">bsdf</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;roughplastic&quot;</span>&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;distribution&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;ggx&quot;</span>/&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;alpha&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;0.0&quot;</span>/&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">srgb</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;diffuseReflectance&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;0.81, 0.0, 0.0&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;/<span class="hljs-name">bsdf</span>&gt;</span></span>
+<span class="line">    <span class="hljs-tag">&lt;/<span class="hljs-name">shape</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-tag">&lt;<span class="hljs-name">emitter</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;envmap&quot;</span>&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;filename&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;../../environments/office/office.exr&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;scale&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;35000.0&quot;</span> /&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">boolean</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;cache&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;false&quot;</span> /&gt;</span></span>
+<span class="line">    <span class="hljs-tag">&lt;/<span class="hljs-name">emitter</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-tag">&lt;<span class="hljs-name">emitter</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;directional&quot;</span>&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">vector</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;direction&quot;</span> <span class="hljs-attr">x</span>=<span class="hljs-string">&quot;-1&quot;</span> <span class="hljs-attr">y</span>=<span class="hljs-string">&quot;-1&quot;</span> <span class="hljs-attr">z</span>=<span class="hljs-string">&quot;1&quot;</span> /&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">rgb</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;irradiance&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;120000.0, 115200.0, 114000.0&quot;</span> /&gt;</span></span>
+<span class="line">    <span class="hljs-tag">&lt;/<span class="hljs-name">emitter</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-tag">&lt;<span class="hljs-name">sensor</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;perspective&quot;</span>&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;farClip&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;12.0&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;focusDistance&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;4.1&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;fov&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;45&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">string</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;fovAxis&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;y&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;nearClip&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;0.01&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">transform</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;toWorld&quot;</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">lookat</span> <span class="hljs-attr">target</span>=<span class="hljs-string">&quot;0, 0, 0&quot;</span> <span class="hljs-attr">origin</span>=<span class="hljs-string">&quot;0, 0, -3.1&quot;</span> <span class="hljs-attr">up</span>=<span class="hljs-string">&quot;0, 1, 0&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;/<span class="hljs-name">transform</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">sampler</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;ldsampler&quot;</span>&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">integer</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;sampleCount&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;256&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;/<span class="hljs-name">sampler</span>&gt;</span></span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-tag">&lt;<span class="hljs-name">film</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;ldrfilm&quot;</span>&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">integer</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;height&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;1440&quot;</span>/&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">integer</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;width&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;2048&quot;</span>/&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">float</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;exposure&quot;</span> <span class="hljs-attr">value</span>=<span class="hljs-string">&quot;-15.23&quot;</span> /&gt;</span></span>
+<span class="line">            <span class="hljs-tag">&lt;<span class="hljs-name">rfilter</span> <span class="hljs-attr">type</span>=<span class="hljs-string">&quot;gaussian&quot;</span>/&gt;</span></span>
+<span class="line">        <span class="hljs-tag">&lt;/<span class="hljs-name">film</span>&gt;</span></span>
+<span class="line">    <span class="hljs-tag">&lt;/<span class="hljs-name">sensor</span>&gt;</span></span>
+<span class="line"><span class="hljs-tag">&lt;/<span class="hljs-name">scene</span>&gt;</span></span></code></pre>
+<a class="target" name="lightassignmentwithfroxels">&#xA0;</a><a class="target" name="annex/lightassignmentwithfroxels">&#xA0;</a><a class="target" name="toc9.8">&#xA0;</a><h2>Light assignment with froxels</h2>
+<p>
+
+
+Assigning lights to froxels can be implemented on the GPU using two compute shaders. The first one, shown in <a href="#listing_froxelgeneration">listing&#xA0;48</a>, creates the froxels data (4 planes + a min Z and max Z per froxel) in an SSBO and needs to be run only once. The shader requires the following uniforms:
+
+</p><p>
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Projection&#xA0;matrix</dt></td><td><dd><p>    The projection matrix used to render the scene (view space to clip space transformation).
+
+</p></dd></td></tr><tr valign="top"><td><dt>Inverse&#xA0;projection&#xA0;matrix</dt></td><td><dd><p>    The inverse of the projection matrix used to render the scene (clip space to view space transformation).
+
+</p></dd></td></tr><tr valign="top"><td><dt>Depth&#xA0;parameters</dt></td><td><dd><p>    \(-log2(\frac{z_{lighnear}}{z_{far}}) \frac{1}{maxSlices-1}\), maximum number of depth slices, Z near and Z far.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Clip&#xA0;space&#xA0;size</dt></td><td><dd><p>    \(\frac{F_x \times F_r}{w} \times 2\), with \(F_x\) the number of tiles on the X axis, \(F_r\) the resolution in pixels of a tile and w the width in pixels of the render target.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line"><span class="hljs-meta">#version 310 es</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">precision</span> <span class="hljs-keyword">highp</span> <span class="hljs-type">float</span>;</span>
+<span class="line"><span class="hljs-keyword">precision</span> <span class="hljs-keyword">highp</span> <span class="hljs-type">int</span>;</span>
+<span class="line"></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-meta">#define FROXEL_RESOLUTION 80u</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">local_size_x</span> = <span class="hljs-number">1</span>, <span class="hljs-keyword">local_size_y</span> = <span class="hljs-number">1</span>, <span class="hljs-keyword">local_size_z</span> = <span class="hljs-number">1</span>) <span class="hljs-keyword">in</span>;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">0</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">mat4</span> projectionMatrix;</span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">1</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">mat4</span> projectionInverseMatrix;</span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">2</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">vec4</span> depthParams; <span class="hljs-comment">// index scale, index bias, near, far</span></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">3</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">float</span> clipSpaceSize;</span>
+<span class="line"></span>
+<span class="line">struct Froxel {</span>
+<span class="line">    <span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span> the planes should be stored in vec4[4] but the</span></span>
+<span class="line">    <span class="hljs-comment">// Adreno shader compiler has a bug that causes the data</span></span>
+<span class="line">    <span class="hljs-comment">// to not be read properly inside the loop</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> plane0;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane1;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane2;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane3;</span>
+<span class="line">    <span class="hljs-type">vec2</span> minMaxZ;</span>
+<span class="line">};</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">binding</span> = <span class="hljs-number">0</span>, <span class="hljs-keyword">std140</span>) <span class="hljs-keyword">writeonly</span> <span class="hljs-keyword">restrict</span> <span class="hljs-keyword">buffer</span> FroxelBuffer {</span>
+<span class="line">    Froxel data[];</span>
+<span class="line">} froxels;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">shared</span> <span class="hljs-type">vec4</span> corners[<span class="hljs-number">4</span>];</span>
+<span class="line"><span class="hljs-keyword">shared</span> <span class="hljs-type">vec2</span> minMaxZ;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec4</span> projectionToView(<span class="hljs-type">vec4</span> p) {</span>
+<span class="line">    p = projectionInverseMatrix * p;</span>
+<span class="line">    <span class="hljs-keyword">return</span> p / p.w;</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">vec4</span> createPlane(<span class="hljs-type">vec4</span> b, <span class="hljs-type">vec4</span> c) {</span>
+<span class="line">    <span class="hljs-comment">// standard plane equation, with a at (0, 0, 0)</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-type">vec4</span>(<span class="hljs-built_in">normalize</span>(<span class="hljs-built_in">cross</span>(c.xyz, b.xyz)), <span class="hljs-number">1.0</span>);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">void</span> main() {</span>
+<span class="line">    <span class="hljs-type">uint</span> <span class="hljs-keyword">index</span> = <span class="hljs-built_in">gl_WorkGroupID</span>.x + <span class="hljs-built_in">gl_WorkGroupID</span>.y * <span class="hljs-built_in">gl_NumWorkGroups</span>.x +</span>
+<span class="line">            <span class="hljs-built_in">gl_WorkGroupID</span>.z * <span class="hljs-built_in">gl_NumWorkGroups</span>.x * <span class="hljs-built_in">gl_NumWorkGroups</span>.y;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">gl_LocalInvocationIndex</span> == <span class="hljs-number">0</span>u) {</span>
+<span class="line">        <span class="hljs-comment">// first tile the screen and build the frustum for the current tile</span></span>
+<span class="line">        <span class="hljs-type">vec2</span> renderTargetSize = <span class="hljs-type">vec2</span>(FROXEL_RESOLUTION * <span class="hljs-built_in">gl_NumWorkGroups</span>.xy);</span>
+<span class="line">        <span class="hljs-type">vec2</span> frustumMin = <span class="hljs-type">vec2</span>(FROXEL_RESOLUTION * <span class="hljs-built_in">gl_WorkGroupID</span>.xy);</span>
+<span class="line">        <span class="hljs-type">vec2</span> frustumMax = <span class="hljs-type">vec2</span>(FROXEL_RESOLUTION * (<span class="hljs-built_in">gl_WorkGroupID</span>.xy + <span class="hljs-number">1</span>u));</span>
+<span class="line"></span>
+<span class="line">        corners[<span class="hljs-number">0</span>] = <span class="hljs-type">vec4</span>(</span>
+<span class="line">            frustumMin.x / renderTargetSize.x * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            (renderTargetSize.y - frustumMin.y) / renderTargetSize.y</span>
+<span class="line">			    * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span></span>
+<span class="line">        );</span>
+<span class="line">        corners[<span class="hljs-number">1</span>] = <span class="hljs-type">vec4</span>(</span>
+<span class="line">            frustumMax.x / renderTargetSize.x * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            (renderTargetSize.y - frustumMin.y) / renderTargetSize.y</span>
+<span class="line">			    * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span></span>
+<span class="line">        );</span>
+<span class="line">        corners[<span class="hljs-number">2</span>] = <span class="hljs-type">vec4</span>(</span>
+<span class="line">            frustumMax.x / renderTargetSize.x * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            (renderTargetSize.y - frustumMax.y) / renderTargetSize.y</span>
+<span class="line">			    * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span></span>
+<span class="line">        );</span>
+<span class="line">        corners[<span class="hljs-number">3</span>] = <span class="hljs-type">vec4</span>(</span>
+<span class="line">            frustumMin.x / renderTargetSize.x * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            (renderTargetSize.y - frustumMax.y) / renderTargetSize.y</span>
+<span class="line">			    * clipSpaceSize - <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span>,</span>
+<span class="line">            <span class="hljs-number">1.0</span></span>
+<span class="line">        );</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-type">uint</span> froxelSlice = <span class="hljs-built_in">gl_WorkGroupID</span>.z;</span>
+<span class="line">        minMaxZ = <span class="hljs-type">vec2</span>(<span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>);</span>
+<span class="line">        <span class="hljs-keyword">if</span> (froxelSlice &gt; <span class="hljs-number">0</span>u) {</span>
+<span class="line">            minMaxZ.x = <span class="hljs-built_in">exp2</span>((<span class="hljs-type">float</span>(froxelSlice) - depthParams.y) * depthParams.x)</span>
+<span class="line">                    * depthParams.w;</span>
+<span class="line">        }</span>
+<span class="line">        minMaxZ.y = <span class="hljs-built_in">exp2</span>((<span class="hljs-type">float</span>(froxelSlice + <span class="hljs-number">1</span>u) - depthParams.y) * depthParams.x)</span>
+<span class="line">                * depthParams.w;</span>
+<span class="line">    }</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">gl_LocalInvocationIndex</span> == <span class="hljs-number">0</span>u) {</span>
+<span class="line">        <span class="hljs-type">vec4</span> frustum[<span class="hljs-number">4</span>];</span>
+<span class="line">        frustum[<span class="hljs-number">0</span>] = projectionToView(corners[<span class="hljs-number">0</span>]);</span>
+<span class="line">        frustum[<span class="hljs-number">1</span>] = projectionToView(corners[<span class="hljs-number">1</span>]);</span>
+<span class="line">        frustum[<span class="hljs-number">2</span>] = projectionToView(corners[<span class="hljs-number">2</span>]);</span>
+<span class="line">        frustum[<span class="hljs-number">3</span>] = projectionToView(corners[<span class="hljs-number">3</span>]);</span>
+<span class="line"></span>
+<span class="line">        froxels.data[<span class="hljs-keyword">index</span>].plane0 = createPlane(frustum[<span class="hljs-number">0</span>], frustum[<span class="hljs-number">1</span>]);</span>
+<span class="line">        froxels.data[<span class="hljs-keyword">index</span>].plane1 = createPlane(frustum[<span class="hljs-number">1</span>], frustum[<span class="hljs-number">2</span>]);</span>
+<span class="line">        froxels.data[<span class="hljs-keyword">index</span>].plane2 = createPlane(frustum[<span class="hljs-number">2</span>], frustum[<span class="hljs-number">3</span>]);</span>
+<span class="line">        froxels.data[<span class="hljs-keyword">index</span>].plane3 = createPlane(frustum[<span class="hljs-number">3</span>], frustum[<span class="hljs-number">0</span>]);</span>
+<span class="line">        froxels.data[<span class="hljs-keyword">index</span>].minMaxZ = minMaxZ;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_froxelgeneration">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;48:</b> GLSL implementation of froxels data generation (compute shader)</div>
+<p>
+
+
+The second compute shader, shown in <a href="#listing_froxelevaluation">listing&#xA0;49</a>, runs every frame (if the camera and/or lights have changed) and assigns all the lights to their respective froxels. This shader relies only on a couple of uniforms (the number of point/spot lights and the view matrix) and four SSBOs:
+
+</p><p>
+
+</p><dl><dt>Light index buffer</dt><dd><p>    For each froxel, the index of each light that affects said froxel. The indices for point lights are written first and if there is enough space left, the indices for spot lights are written as well. A sentinel of value 0&#xD7;7fffffffu separates point and spot lights and/or marks the end of the froxel&apos;s list of lights. Each froxel has a maximum number of lights (point + spot).
+
+</p></dd><dt>Point lights buffer</dt><dd><p>    Array of structures describing the scene&apos;s point lights.
+
+</p></dd><dt>Spot lights buffer</dt><dd><p>    Array of structures describing the scene&apos;s spot lights.
+
+</p></dd><dt>Froxels buffer</dt><dd><p>    The list of froxels represented by planes, created by the previous compute shader.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line"><span class="hljs-meta">#version 310 es</span></span>
+<span class="line"><span class="hljs-keyword">precision</span> <span class="hljs-keyword">highp</span> <span class="hljs-type">float</span>;</span>
+<span class="line"><span class="hljs-keyword">precision</span> <span class="hljs-keyword">highp</span> <span class="hljs-type">int</span>;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-meta">#define LIGHT_BUFFER_SENTINEL 0x7fffffffu</span></span>
+<span class="line"><span class="hljs-meta">#define MAX_FROXEL_LIGHT_COUNT 32u</span></span>
+<span class="line"></span>
+<span class="line"><span class="hljs-meta">#define THREADS_PER_FROXEL_X 8u</span></span>
+<span class="line"><span class="hljs-meta">#define THREADS_PER_FROXEL_Y 8u</span></span>
+<span class="line"><span class="hljs-meta">#define THREADS_PER_FROXEL_Z 1u</span></span>
+<span class="line"><span class="hljs-meta">#define THREADS_PER_FROXEL (THREADS_PER_FROXEL_X * \</span></span>
+<span class="line">        THREADS_PER_FROXEL_Y * THREADS_PER_FROXEL_Z)</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">local_size_x</span> = THREADS_PER_FROXEL_X,</span>
+<span class="line">       <span class="hljs-keyword">local_size_y</span> = THREADS_PER_FROXEL_Y,</span>
+<span class="line">       <span class="hljs-keyword">local_size_z</span> = THREADS_PER_FROXEL_Z) <span class="hljs-keyword">in</span>;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-comment">// x = point lights, y = spot lights</span></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">0</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">uvec2</span> totalLightCount;</span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">location</span> = <span class="hljs-number">1</span>) <span class="hljs-keyword">uniform</span> <span class="hljs-type">mat4</span> viewMatrix;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">binding</span> = <span class="hljs-number">0</span>, <span class="hljs-keyword">packed</span>) <span class="hljs-keyword">writeonly</span> <span class="hljs-keyword">restrict</span> <span class="hljs-keyword">buffer</span> LightIndexBuffer {</span>
+<span class="line">    <span class="hljs-type">uint</span> <span class="hljs-keyword">index</span>[];</span>
+<span class="line">} lightIndexBuffer;</span>
+<span class="line"></span>
+<span class="line">struct PointLight {</span>
+<span class="line">    <span class="hljs-type">vec4</span> positionFalloff; <span class="hljs-comment">// x, y, z, falloff</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> colorIntensity;  <span class="hljs-comment">// r, g, b, intensity</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> directionIES;    <span class="hljs-comment">// dir x, dir y, dir z, IES profile index</span></span>
+<span class="line">};</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">binding</span> = <span class="hljs-number">1</span>, <span class="hljs-keyword">std140</span>) <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">restrict</span> <span class="hljs-keyword">buffer</span> PointLightBuffer {</span>
+<span class="line">    PointLight lights[];</span>
+<span class="line">} pointLights;</span>
+<span class="line"></span>
+<span class="line">struct SpotLight {</span>
+<span class="line">    <span class="hljs-type">vec4</span> positionFalloff; <span class="hljs-comment">// x, y, z, falloff</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> colorIntensity;  <span class="hljs-comment">// r, g, b, intensity</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> directionIES;    <span class="hljs-comment">// dir x, dir y, dir z, IES profile index</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> angle;           <span class="hljs-comment">// angle scale, angle offset, unused, unused</span></span>
+<span class="line">};</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">binding</span> = <span class="hljs-number">2</span>, <span class="hljs-keyword">std140</span>) <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">restrict</span> <span class="hljs-keyword">buffer</span> SpotLightBuffer {</span>
+<span class="line">    SpotLight lights[];</span>
+<span class="line">} spotLights;</span>
+<span class="line"></span>
+<span class="line">struct Froxel {</span>
+<span class="line">    <span class="hljs-comment">// <span class="hljs-doctag">NOTE:</span> the planes should be stored in vec4[4] but the</span></span>
+<span class="line">    <span class="hljs-comment">// Adreno shader compiler has a bug that causes the data</span></span>
+<span class="line">    <span class="hljs-comment">// to not be read properly inside the loop</span></span>
+<span class="line">    <span class="hljs-type">vec4</span> plane0;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane1;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane2;</span>
+<span class="line">    <span class="hljs-type">vec4</span> plane3;</span>
+<span class="line">    <span class="hljs-type">vec2</span> minMaxZ;</span>
+<span class="line">};</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">layout</span>(<span class="hljs-keyword">binding</span> = <span class="hljs-number">3</span>, <span class="hljs-keyword">std140</span>) <span class="hljs-keyword">readonly</span> <span class="hljs-keyword">restrict</span> <span class="hljs-keyword">buffer</span> FroxelBuffer {</span>
+<span class="line">    Froxel data[];</span>
+<span class="line">} froxels;</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-keyword">shared</span> <span class="hljs-type">uint</span> groupLightCounter;</span>
+<span class="line"><span class="hljs-keyword">shared</span> <span class="hljs-type">uint</span> groupLightIndexBuffer[MAX_FROXEL_LIGHT_COUNT];</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">float</span> signedDistanceFromPlane(<span class="hljs-type">vec4</span> p, <span class="hljs-type">vec4</span> plane) {</span>
+<span class="line">    <span class="hljs-comment">// plane.w == 0.0, simplify computation</span></span>
+<span class="line">    <span class="hljs-keyword">return</span> <span class="hljs-built_in">dot</span>(plane.xyz, p.xyz);</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">void</span> synchronize() {</span>
+<span class="line">    <span class="hljs-built_in">memoryBarrierShared</span>();</span>
+<span class="line">    <span class="hljs-built_in">barrier</span>();</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line"><span class="hljs-type">void</span> main() {</span>
+<span class="line">    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">gl_LocalInvocationIndex</span> == <span class="hljs-number">0</span>u) {</span>
+<span class="line">        groupLightCounter = <span class="hljs-number">0</span>u;</span>
+<span class="line">    }</span>
+<span class="line">    <span class="hljs-built_in">memoryBarrierShared</span>();</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">uint</span> froxelIndex = <span class="hljs-built_in">gl_WorkGroupID</span>.x + <span class="hljs-built_in">gl_WorkGroupID</span>.y * <span class="hljs-built_in">gl_NumWorkGroups</span>.x +</span>
+<span class="line">            <span class="hljs-built_in">gl_WorkGroupID</span>.z * <span class="hljs-built_in">gl_NumWorkGroups</span>.x * <span class="hljs-built_in">gl_NumWorkGroups</span>.y;</span>
+<span class="line">    Froxel current = froxels.data[froxelIndex];</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">uint</span> <span class="hljs-keyword">offset</span> = <span class="hljs-built_in">gl_LocalInvocationID</span>.x +</span>
+<span class="line">	        <span class="hljs-built_in">gl_LocalInvocationID</span>.y * THREADS_PER_FROXEL_X;</span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-type">uint</span> i = <span class="hljs-number">0</span>u; i &lt; totalLightCount.x &amp;&amp;</span>
+<span class="line">		    groupLightCounter &lt; MAX_FROXEL_LIGHT_COUNT &amp;&amp;</span>
+<span class="line">            <span class="hljs-keyword">offset</span> + i &lt; totalLightCount.x; i += THREADS_PER_FROXEL) {</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-type">uint</span> currentLight = <span class="hljs-keyword">offset</span> + i;</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-type">vec4</span> center = pointLights.lights[currentLight].positionFalloff;</span>
+<span class="line">        center.xyz = (viewMatrix * <span class="hljs-type">vec4</span>(center.xyz, <span class="hljs-number">1.0</span>)).xyz;</span>
+<span class="line">        <span class="hljs-type">float</span> r = <span class="hljs-built_in">inversesqrt</span>(center.w);</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-keyword">if</span> (-center.z + r &gt; current.minMaxZ.x &amp;&amp;</span>
+<span class="line">                -center.z - r &lt;= current.minMaxZ.y) {</span>
+<span class="line">            <span class="hljs-keyword">if</span> (signedDistanceFromPlane(center, current.plane0) &lt; r &amp;&amp;</span>
+<span class="line">                signedDistanceFromPlane(center, current.plane1) &lt; r &amp;&amp;</span>
+<span class="line">                signedDistanceFromPlane(center, current.plane2) &lt; r &amp;&amp;</span>
+<span class="line">                signedDistanceFromPlane(center, current.plane3) &lt; r) {</span>
+<span class="line"></span>
+<span class="line">                <span class="hljs-type">uint</span> <span class="hljs-keyword">index</span> = <span class="hljs-built_in">atomicAdd</span>(groupLightCounter, <span class="hljs-number">1</span>u);</span>
+<span class="line">                groupLightIndexBuffer[<span class="hljs-keyword">index</span>] = currentLight;</span>
+<span class="line">            }</span>
+<span class="line">        }</span>
+<span class="line">    }</span>
+<span class="line"></span>
+<span class="line">    synchronize();</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-type">uint</span> pointLightCount = groupLightCounter;</span>
+<span class="line">    <span class="hljs-keyword">offset</span> = froxelIndex * MAX_FROXEL_LIGHT_COUNT;</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">for</span> (<span class="hljs-type">uint</span> i = <span class="hljs-built_in">gl_LocalInvocationIndex</span>; i &lt; pointLightCount;</span>
+<span class="line">            i += THREADS_PER_FROXEL) {</span>
+<span class="line">        lightIndexBuffer.<span class="hljs-keyword">index</span>[<span class="hljs-keyword">offset</span> + i] = groupLightIndexBuffer[i];</span>
+<span class="line">    }</span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-keyword">if</span> (<span class="hljs-built_in">gl_LocalInvocationIndex</span> == <span class="hljs-number">0</span>u) {</span>
+<span class="line">        <span class="hljs-keyword">if</span> (pointLightCount &lt; MAX_FROXEL_LIGHT_COUNT) {</span>
+<span class="line">            lightIndexBuffer.<span class="hljs-keyword">index</span>[<span class="hljs-keyword">offset</span> + pointLightCount] = LIGHT_BUFFER_SENTINEL;</span>
+<span class="line">        }</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><div class="listingcaption tilde"><a class="target" name="listing_froxelevaluation">&#xA0;</a><b style="font-style:normal;">Listing&#xA0;49:</b> GLSL implementation of assigning lights to froxels (compute shader)</div>
+
+<a class="target" name="revisions">&#xA0;</a><a class="target" name="revisions">&#xA0;</a><a class="target" name="toc10">&#xA0;</a><h1>Revisions</h1>
+<p>
+
+
+</p><table class="schedule"><tbody><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2019-2-20">&#xA0;</a>Wednesday<br>20 Feb 2019</td><td><b>Cloth shading</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Removed Fresnel term from the cloth BRDF
+</li>
+ <li class="minus">Removed cloth DFG approximations, replaced with a new channel in the DFG LUT</li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-21">&#xA0;</a>Tuesday<br>21 Aug 2018</td><td><b>Multiscattering</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Added section  <a href="#toc4.7.2">4.7.2</a> on how to compensate for energy loss in single scattering BRDFs</li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-17">&#xA0;</a>Friday<br>17 Aug 2018</td><td><b>Specular color</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Added section  <a href="#toc9.1">9.1</a> to explain how the base color of various metals is computed</li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-15">&#xA0;</a>Wednesday<br>15 Aug 2018</td><td><b>Fresnel</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Added a description of the Fresnel effect in section  <a href="#toc4.4.3">4.4.3</a></li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-9">&#xA0;</a>Thursday<br>9 Aug 2018</td><td><b>Lighting</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Added explanation about pre-exposed lights</li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-7">&#xA0;</a>Tuesday<br>7 Aug 2018</td><td><b>Cloth model</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p><ul>
+ <li class="minus">Added description of the &#x201C;Charlie&#x201D; NDF</li></ul>
+
+<p></p><p>
+
+</p></td></tr><tr valign="top"><td style="width:100px;padding-right:15px" rowspan="2"><a class="target" name="schedule1_2018-8-3">&#xA0;</a>Friday<br>3 Aug 2018</td><td><b>First public version</b></td></tr><tr valign="top"><td style="padding-bottom:25px">
+
+<p></p><p>
+
+</p></td></tr></tbody></table>
+
+<p></p>
+<a class="target" name="bibliography">&#xA0;</a><a class="target" name="bibliography">&#xA0;</a><a class="target" name="toc11">&#xA0;</a><h1>Bibliography</h1>
+<p>
+
+</p><div class="bib">[<a class="target" name="citation-ashdown98">&#xA0;</a><b>Ashdown98</b>] Ian Ashdown. 1998. Parsing the IESNA LM-63 photometric data file. <a href="http://lumen.iee.put.poznan.pl/kw/iesna.txt" class="url">http://lumen.iee.put.poznan.pl/kw/iesna.txt</a>
+</div><div class="bib">[<a class="target" name="citation-ashikhmin00">&#xA0;</a><b>Ashikhmin00</b>] Michael Ashikhmin, Simon Premoze and Peter Shirley. A Microfacet-based BRDF Generator. <em class="asterisk">SIGGRAPH &apos;00 Proceedings</em>, 65-74.
+</div><div class="bib">[<a class="target" name="citation-ashikhmin07">&#xA0;</a><b>Ashikhmin07</b>] Michael Ashikhmin and Simon Premoze. 2007. Distribution-based BRDFs.
+</div><div class="bib">[<a class="target" name="citation-burley12">&#xA0;</a><b>Burley12</b>] Brent Burley. 2012. Physically Based Shading at Disney. <em class="asterisk">Physically Based Shading in Film and Game Production, ACM SIGGRAPH 2012 Courses</em>.
+</div><div class="bib">[<a class="target" name="citation-estevez17">&#xA0;</a><b>Estevez17</b>] Alejandro Conty Estevez and Christopher Kulla. 2017. Production Friendly Microfacet Sheen BRDF. <em class="asterisk">ACM SIGGRAPH 2017</em>.
+</div><div class="bib">[<a class="target" name="citation-hammon17">&#xA0;</a><b>Hammon17</b>] Earl Hammon. 217. PBR Diffuse Lighting for GGX+Smith Microsurfaces. <em class="asterisk">GDC 2017</em>.
+</div><div class="bib">[<a class="target" name="citation-heitz14">&#xA0;</a><b>Heitz14</b>] Eric Heitz. 2014. Understanding the Masking-Shadowing Function
+in Microfacet-Based BRDFs. <em class="asterisk">Journal of Computer Graphics Techniques</em>, 3 (2).
+</div><div class="bib">[<a class="target" name="citation-heitz16">&#xA0;</a><b>Heitz16</b>] Eric Heitz et al. 2016. Multiple-Scattering Microfacet BSDFs with the Smith Model. <em class="asterisk">ACM SIGGRAPH 2016</em>.
+</div><div class="bib">[<a class="target" name="citation-hill12">&#xA0;</a><b>Hill12</b>] Colin Barr&#xE9;-Brisebois and Stephen Hill. 2012. Blending in Detail. <a href="http://blog.selfshadow.com/publications/blending-in-detail/" class="url">http://blog.selfshadow.com/publications/blending-in-detail/</a>
+</div><div class="bib">[<a class="target" name="citation-karis13">&#xA0;</a><b>Karis13</b>] Brian Karis. 2013. Specular BRDF Reference. <a href="http://graphicrants.blogspot.com/2013/08/specular-brdf-reference.html" class="url">http://graphicrants.blogspot.com/2013/08/specular-brdf-reference.html</a>
+</div><div class="bib">[<a class="target" name="citation-karis14">&#xA0;</a><b>Karis14</b>] Brian Karis. 2014. Physically Based Shading on Mobile. <a href="https://www.unrealengine.com/blog/physically-based-shading-on-mobile" class="url">https://www.unrealengine.com/blog/physically-based-shading-on-mobile</a>
+</div><div class="bib">[<a class="target" name="citation-kelemen01">&#xA0;</a><b>Kelemen01</b>] Csaba Kelemen et al. 2001. A Microfacet Based Coupled Specular-Matte BRDF Model with Importance Sampling. <em class="asterisk">Eurographics Short Presentations</em>.
+</div><div class="bib">[<a class="target" name="citation-krystek85">&#xA0;</a><b>Krystek85</b>] M. Krystek. 1985. An algorithm to calculate correlated color temperature. <em class="asterisk">Color Research &amp; Application</em>, 10 (1), 38&#x2013;40.
+</div><div class="bib">[<a class="target" name="citation-krivanek08">&#xA0;</a><b>Krivanek08</b>] Jaroslave Kriv&#xE0;nek and Mark Colbert. 2008. Real-time Shading with Filtered Importance Sampling. <em class="asterisk">Eurographics Symposium on Rendering 2008</em>, Volume 27, Number 4.
+</div><div class="bib">[<a class="target" name="citation-kulla17">&#xA0;</a><b>Kulla17</b>] Christopher Kulla and Alejandro Conty. 2017. Revisiting Physically Based Shading at Imageworks. <em class="asterisk">ACM SIGGRAPH 2017</em>
+</div><div class="bib">[<a class="target" name="citation-lagarde14">&#xA0;</a><b>Lagarde14</b>] S&#xE9;bastien Lagarde and Charles de Rousiers. 2014. Moving Frostbite to PBR. <em class="asterisk">Physically Based Shading in Theory and Practice, ACM SIGGRAPH 2014 Courses</em>.
+</div><div class="bib">[<a class="target" name="citation-lagarde18">&#xA0;</a><b>Lagarde18</b>] S&#xE9;bastien Lagarde and Evgenii Golubev. 2018. The road toward unified rendering with Unity&#x2019;s high definition rendering pipeline. <em class="asterisk">Advances in Real-Time Rendering in Games, ACM SIGGRAPH 2018 Courses</em>.
+</div><div class="bib">[<a class="target" name="citation-lazarov13">&#xA0;</a><b>Lazarov13</b>] Dimitar Lazarov. 2013. Physically-Based Shading in Call of Duty: Black Ops. <em class="asterisk">Physically Based Shading in Theory and Practice, ACM SIGGRAPH 2013 Courses</em>.
+</div><div class="bib">[<a class="target" name="citation-mcauley15">&#xA0;</a><b>McAuley15</b>] Stephen McAuley. 2015. Rendering the World of Far Cry 4. <em class="asterisk">GDC 2015</em>.
+</div><div class="bib">[<a class="target" name="citation-mcguire10">&#xA0;</a><b>McGuire10</b>] Morgan McGuire. 2010. Ambient Occlusion Volumes. <em class="asterisk">High Performance Graphics</em>.
+</div><div class="bib">[<a class="target" name="citation-narkowicz14">&#xA0;</a><b>Narkowicz14</b>] Krzysztof Narkowicz. 2014. Analytical DFG Term for IBL. <a href="https://knarkowicz.wordpress.com/2014/12/27/analytical-dfg-term-for-ibl" class="url">https://knarkowicz.wordpress.com/2014/12/27/analytical-dfg-term-for-ibl</a>
+</div><div class="bib">[<a class="target" name="citation-neubelt13">&#xA0;</a><b>Neubelt13</b>] David Neubelt and Matt Pettineo. 2013. Crafting a Next-Gen Material Pipeline for The Order: 1886. <em class="asterisk">Physically Based Shading in Theory and Practice, ACM SIGGRAPH 2013 Courses</em>.
+</div><div class="bib">[<a class="target" name="citation-oren94">&#xA0;</a><b>Oren94</b>] Michael Oren and Shree K. Nayar. 1994. Generalization of lambert&apos;s reflectance model. <em class="asterisk">SIGGRAPH</em>, 239&#x2013;246. ACM.
+</div><div class="bib">[<a class="target" name="citation-pattanaik00">&#xA0;</a><b>Pattanaik00</b>] Sumanta Pattanaik00 et al. 2000. Time-Dependent Visual Adaptation
+For Fast Realistic Image Display. <em class="asterisk">SIGGRAPH &apos;00 Proceedings of the 27th annual conference on Computer graphics and interactive techniques</em>, 47-54.
+</div><div class="bib">[<a class="target" name="citation-ramamoorthi01">&#xA0;</a><b>Ramamoorthi01</b>] Ravi Ramamoorthi and Pat Hanrahan. 2001. On the relationship between radiance and irradiance: determining the illumination from images of a convex Lambertian object. <em class="asterisk">Journal of the Optical Society of America</em>, Volume 18, Number 10, October 2001.
+</div><div class="bib">[<a class="target" name="citation-revie12">&#xA0;</a><b>Revie12</b>] Donald Revie. 2012.  Implementing Fur in Deferred Shading. <em class="asterisk">GPU Pro 2</em>, Chapter 2.
+</div><div class="bib">[<a class="target" name="citation-russell15">&#xA0;</a><b>Russell15</b>] Jeff Russell. 2015. Horizon Occlusion for Normal Mapped Reflections. <a href="http://marmosetco.tumblr.com/post/81245981087" class="url">http://marmosetco.tumblr.com/post/81245981087</a>
+</div><div class="bib">[<a class="target" name="citation-schlick94">&#xA0;</a><b>Schlick94</b>] Christophe Schlick. 1994. An Inexpensive BRDF Model for Physically-Based Rendering. <em class="asterisk">Computer Graphics Forum</em>, 13 (3), 233&#x2013;246.
+</div><div class="bib">[<a class="target" name="citation-walter07">&#xA0;</a><b>Walter07</b>] Bruce Walter et al. 2007. Microfacet Models for Refraction through Rough Surfaces. <em class="asterisk">Proceedings of the Eurographics Symposium on Rendering</em>.
+</div>
+<p></p></span><div class="markdeepFooter"><i>formatted by <a href="http://casual-effects.com/markdeep" style="color:#999">Markdeep&#xA0;1.03&#xA0;&#xA0;</a></i><div style="display:inline-block;font-size:13px;font-family:&apos;Times New Roman&apos;,serif;vertical-align:middle;transform:translate(-3px,-1px)rotate(135deg);">&#x2712;</div></div><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script></body></html>

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -1,0 +1,1928 @@
+<html><head><meta charset="utf-8">
+
+<style>img { max-width: 100%; }</style>
+
+</head><body style="visibility: visible;"><meta charset="UTF-8"><meta http-equiv="content-type" content="text/html;charset=UTF-8"><style>body{max-width:680px;margin:auto;padding:20px;text-align:justify;line-height:140%; -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:antialiased;color:#222;font-family:Palatino,Georgia,"Times New Roman",serif}</style><style>body{counter-reset: h1 h2 h3 h4 h5 h6 paragraph}@page{margin:0;size:auto}.md code,pre{font-family:Menlo,Consolas,monospace;font-size:13.099975100467727px;line-height:140%}.md div.title{font-size:26px;font-weight:800;line-height:120%;text-align:center}.md div.afterTitles{height:10px}.md div.subtitle{text-align:center}.md .image{display:inline-block}.md img{max-width:100%;page-break-inside:avoid}.md li{text-align:left;text-indent:0}.md pre.listing {tab-size:4;-moz-tab-size:4;-o-tab-size:4;counter-reset:line}.md pre.listing .linenumbers span.line:before{width:30px;margin-left:-52px;font-size:80%;text-align:right;counter-increment:line;content:counter(line);display:inline-block;padding-right:13px;margin-right:8px;color:#ccc}.md div.tilde{margin:20px 0 -10px;text-align:center}.md div.imagecaption,.md div.tablecaption,.md div.listingcaption{margin:7px 5px 12px;text-align: justify;font-style:italic}.md div.imagecaption{margin-bottom:0}.md blockquote.fancyquote{margin:25px 0 25px;text-align:left;line-height:160%}.md blockquote.fancyquote::before{content:"“";color:#DDD;font-family:Times New Roman;font-size:45px;line-height:0;margin-right:6px;vertical-align:-0.3em}.md span.fancyquote{font-size:118%;color:#777;font-style:italic}.md span.fancyquote::after{content:"”";font-style:normal;color:#DDD;font-family:Times New Roman;font-size:45px;line-height:0;margin-left:6px;vertical-align:-0.3em}.md blockquote.fancyquote .author{width:100%;margin-top:10px;display:inline-block;text-align:right}.md small{font-size:60%}.md big{font-size:150%}.md div.title,contents,.md .tocHeader,h1,h2,h3,h4,h5,h6,.md .shortTOC,.md .mediumTOC,.nonumberh1,.nonumberh2,.nonumberh3,.nonumberh4,.nonumberh5,.nonumberh6{font-family:Verdana,Helvetica,Arial,sans-serif;margin:13.4px 0 13.4px;padding:15px 0 3px;border-top:none;clear:both}.md h1,.md h2,.md h3,.md h4,.md h5,.md h6,.md .nonumberh1,.md .nonumberh2,.md .nonumberh3,.md .nonumberh4,.md .nonumberh5,.md .nonumberh6{page-break-after:avoid;break-after:avoid}.md svg.diagram{display:block;font-family:Menlo,Consolas,monospace;font-size:13.099975100467727px;text-align:center;stroke-linecap:round;stroke-width:2px;page-break-inside:avoid;stroke:#000;fill:#000}.md svg.diagram .opendot{fill:#FFF}.md svg.diagram text{stroke:none}@media print{@page{margin:1in 5mm;transform: scale(150%)}}@media print{.md .pagebreak{page-break-after:always;visibility:hidden}}.md a{font-family:Georgia,Palatino,'Times New Roman'}.md h1,.md .tocHeader,.md .nonumberh1{border-bottom:3px solid;font-size:20px;font-weight:bold;}.md h1,.md .nonumberh1{counter-reset: h2 h3 h4 h5 h6}.md h2,.md .nonumberh2{counter-reset: h3 h4 h5 h6;border-bottom:2px solid #999;color:#555;font-weight:bold;font-size:18px;}.md h3,.md h4,.md h5,.md h6,.md .nonumberh3,.md .nonumberh4,.md .nonumberh5,.md .nonumberh6{font-family:Helvetica,Arial,sans-serif;color:#555;font-size:16px;}.md h3{counter-reset:h4 h5 h6}.md h4{counter-reset:h5 h6}.md h5{counter-reset:h6}.md div.table{margin:16px 0 16px 0}.md table{border-collapse:collapse;line-height:140%;page-break-inside:avoid}.md table.table{margin:auto}.md table.calendar{width:100%;margin:auto;font-size:11px;font-family:Helvetica,Arial,sans-serif}.md table.calendar th{font-size:16px}.md .today{background:#ECF8FA}.md .calendar .parenthesized{color:#999;font-style:italic}.md div.tablecaption{text-align:center}.md table.table th{color:#FFF;background-color:#AAA;border:1px solid #888;padding:8px 15px 8px 15px}.md table.table td{padding:5px 15px 5px 15px;border:1px solid #888}.md table.table tr:nth-child(even){background:#EEE}.md pre.tilde{border-top: 1px solid #CCC;border-bottom: 1px solid #CCC;padding: 5px 0 5px 20px;margin:0 0 0 0;background:#FCFCFC;page-break-inside:avoid}.md a.target{width:0px;height:0px;visibility:hidden;font-size:0px;display:inline-block}.md a:link, .md a:visited{color:#38A;text-decoration:none}.md a:link:hover{text-decoration:underline}.md dt{font-weight:700}.md dl>dd{margin-top:-8px; margin-bottom:8px}.md dl>table{margin:35px 0 30px}.md code{white-space:pre-wrap;overflow-wrap:break-word;text-align:left;page-break-inside:avoid}.md .endnote{font-size:13px;line-height:15px;padding-left:10px;text-indent:-10px}.md .bib{padding-left:80px;text-indent:-80px;text-align:left}.markdeepFooter{font-size:9px;text-align:right;padding-top:80px;color:#999}.md .mediumTOC{float:right;font-size:12px;line-height:15px;border-left:1px solid #CCC;padding-left:15px;margin:15px 0px 15px 25px}.md .mediumTOC .level1{font-weight:600}.md .longTOC .level1{font-weight:600;display:block;padding-top:12px;margin:0 0 -20px}.md .shortTOC{text-align:center;font-weight:bold;margin-top:15px;font-size:14px}.md .admonition{position:relative;margin:1em 0;padding:.4rem 1rem;border-radius:.2rem;border-left:2.5rem solid rgba(68,138,255,.4);background-color:rgba(68,138,255,.15);}.md .admonition-title{font-weight:bold;border-bottom:solid 1px rgba(68,138,255,.4);padding-bottom:4px;margin-bottom:4px;margin-left: -1rem;padding-left:1rem;margin-right:-1rem;border-color:rgba(68,138,255,.4)}.md .admonition.tip{border-left:2.5rem solid rgba(50,255,90,.4);background-color:rgba(50,255,90,.15)}.md .admonition.tip::before{content:"\24d8";font-weight:bold;font-size:150%;position:relative;top:3px;color:rgba(26,128,46,.8);left:-2.95rem;display:block;width:0;height:0}.md .admonition.tip>.admonition-title{border-color:rgba(50,255,90,.4)}.md .admonition.warn,.md .admonition.warning{border-left:2.5rem solid rgba(255,145,0,.4);background-color:rgba(255,145,0,.15)}.md .admonition.warn::before,.md .admonition.warning::before{content:"\26A0";font-weight:bold;font-size:150%;position:relative;top:2px;color:rgba(128,73,0,.8);left:-2.95rem;display:block;width:0;height:0}.md .admonition.warn>.admonition-title,.md .admonition.warning>.admonition-title{border-color:rgba(255,145,0,.4)}.md .admonition.error{border-left: 2.5rem solid rgba(255,23,68,.4);background-color:rgba(255,23,68,.15)}.md .admonition.error>.admonition-title{border-color:rgba(255,23,68,.4)}.md .admonition.error::before{content: "\2612";font-family:"Arial";font-size:200%;position:relative;color:rgba(128,12,34,.8);top:-2px;left:-3rem;display:block;width:0;height:0}.md .admonition p:last-child{margin-bottom:0}.md li.checked,.md li.unchecked{list-style:none;overflow:visible;text-indent:-1.2em}.md li.checked:before,.md li.unchecked:before{content:"\2611";display:block;float:left;width:1em;font-size:120%}.md li.unchecked:before{content:"\2610"}</style><style>.md h1::before {
+content:counter(h1) " ";
+counter-increment: h1;margin-right:10px}.md h2::before {
+content:counter(h1) "."counter(h2) " ";
+counter-increment: h2;margin-right:10px}.md h3::before {
+content:counter(h1) "."counter(h2) "."counter(h3) " ";
+counter-increment: h3;margin-right:10px}.md h4::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) " ";
+counter-increment: h4;margin-right:10px}.md h5::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) "."counter(h5) " ";
+counter-increment: h5;margin-right:10px}.md h6::before {
+content:counter(h1) "."counter(h2) "."counter(h3) "."counter(h4) "."counter(h5) "."counter(h6) " ";
+counter-increment: h6;margin-right:10px}</style><style>.hljs{display:block;overflow-x:auto;padding:0.5em;background:#fff;color:#000;-webkit-text-size-adjust:none}.hljs-comment{color:#006a00}.hljs-keyword{color:#02E}.hljs-literal,.nginx .hljs-title{color:#aa0d91}.method,.hljs-list .hljs-title,.hljs-tag .hljs-title,.setting .hljs-value,.hljs-winutils,.tex .hljs-command,.http .hljs-title,.hljs-request,.hljs-status,.hljs-name{color:#008}.hljs-envvar,.tex .hljs-special{color:#660}.hljs-string{color:#c41a16}.hljs-tag .hljs-value,.hljs-cdata,.hljs-filter .hljs-argument,.hljs-attr_selector,.apache .hljs-cbracket,.hljs-date,.hljs-regexp{color:#080}.hljs-sub .hljs-identifier,.hljs-pi,.hljs-tag,.hljs-tag .hljs-keyword,.hljs-decorator,.ini .hljs-title,.hljs-shebang,.hljs-prompt,.hljs-hexcolor,.hljs-rule .hljs-value,.hljs-symbol,.hljs-symbol .hljs-string,.hljs-number,.css .hljs-function,.hljs-function .hljs-title,.coffeescript .hljs-attribute{color:#A0C}.hljs-function .hljs-title{font-weight:bold;color:#000}.hljs-class .hljs-title,.smalltalk .hljs-class,.hljs-type,.hljs-typename,.hljs-tag .hljs-attribute,.hljs-doctype,.hljs-class .hljs-id,.hljs-built_in,.setting,.hljs-params,.clojure .hljs-attribute{color:#5c2699}.hljs-variable{color:#3f6e74}.css .hljs-tag,.hljs-rule .hljs-property,.hljs-pseudo,.hljs-subst{color:#000}.css .hljs-class,.css .hljs-id{color:#9b703f}.hljs-value .hljs-important{color:#ff7700;font-weight:bold}.hljs-rule .hljs-keyword{color:#c5af75}.hljs-annotation,.apache .hljs-sqbracket,.nginx .hljs-built_in{color:#9b859d}.hljs-preprocessor,.hljs-preprocessor *,.hljs-pragma{color:#643820}.tex .hljs-formula{background-color:#eee;font-style:italic}.diff .hljs-header,.hljs-chunk{color:#808080;font-weight:bold}.diff .hljs-change{background-color:#bccff9}.hljs-addition{background-color:#baeeba}.hljs-deletion{background-color:#ffc8bd}.hljs-comment .hljs-doctag{font-weight:bold}.method .hljs-id{color:#000}</style><style>div.title { padding-top: 40px; } div.afterTitles { height: 15px; }</style><meta charset="utf-8">
+
+<style>img { max-width: 100%; }</style>
+
+<script type="text/x-mathjax-config">MathJax.Hub.Config({ TeX: { equationNumbers: {autoNumber: "AMS"} } });</script><span style="display:none">$$\newcommand{\n}{\hat{n}}\newcommand{\thetai}{\theta_\mathrm{i}}\newcommand{\thetao}{\theta_\mathrm{o}}\newcommand{\d}[1]{\mathrm{d}#1}\newcommand{\w}{\hat{\omega}}\newcommand{\wi}{\w_\mathrm{i}}\newcommand{\wo}{\w_\mathrm{o}}\newcommand{\wh}{\w_\mathrm{h}}\newcommand{\Li}{L_\mathrm{i}}\newcommand{\Lo}{L_\mathrm{o}}\newcommand{\Le}{L_\mathrm{e}}\newcommand{\Lr}{L_\mathrm{r}}\newcommand{\Lt}{L_\mathrm{t}}\newcommand{\O}{\mathrm{O}}\newcommand{\degrees}{{^{\large\circ}}}\newcommand{\T}{\mathsf{T}}\newcommand{\mathset}[1]{\mathbb{#1}}\newcommand{\Real}{\mathset{R}}\newcommand{\Integer}{\mathset{Z}}\newcommand{\Boolean}{\mathset{B}}\newcommand{\Complex}{\mathset{C}}\newcommand{\un}[1]{\,\mathrm{#1}}$$
+</span>
+<span class="md"><p><title>Filament Materials Guide</title></p><div class="title"> Filament Materials Guide </div>
+
+<div class="afterTitles"></div>
+
+<p></p><p>
+
+</p><center><a href="images/filament_logo.png" target="_blank"><img class="markdeep" src="images/filament_logo.png"></a></center>
+
+<p></p>
+<div class="longTOC"><div class="tocHeader">Contents</div><p><a href="#about" class="level1"><span class="tocNumber">1&#xA0; </span>About</a><br>
+&#xA0;&#xA0;<a href="#about/authors" class="level2"><span class="tocNumber">1.1&#xA0; </span>Authors</a><br>
+<a href="#overview" class="level1"><span class="tocNumber">2&#xA0; </span>Overview</a><br>
+&#xA0;&#xA0;<a href="#overview/coreconcepts" class="level2"><span class="tocNumber">2.1&#xA0; </span>Core concepts</a><br>
+<a href="#materialmodels" class="level1"><span class="tocNumber">3&#xA0; </span>Material models</a><br>
+&#xA0;&#xA0;<a href="#materialmodels/litmodel" class="level2"><span class="tocNumber">3.1&#xA0; </span>Lit model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/basecolor" class="level3"><span class="tocNumber">3.1.1&#xA0; </span>Base color</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/metallic" class="level3"><span class="tocNumber">3.1.2&#xA0; </span>Metallic</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/roughness" class="level3"><span class="tocNumber">3.1.3&#xA0; </span>Roughness</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/non-metals" class="level3"><span class="tocNumber">3.1.4&#xA0; </span>Non-metals</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/metals" class="level3"><span class="tocNumber">3.1.5&#xA0; </span>Metals</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/reflectance" class="level3"><span class="tocNumber">3.1.6&#xA0; </span>Reflectance</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/clearcoat" class="level3"><span class="tocNumber">3.1.7&#xA0; </span>Clear coat</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/clearcoatroughness" class="level3"><span class="tocNumber">3.1.8&#xA0; </span>Clear coat roughness</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/anisotropy" class="level3"><span class="tocNumber">3.1.9&#xA0; </span>Anisotropy</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/anisotropydirection" class="level3"><span class="tocNumber">3.1.10&#xA0; </span>Anisotropy direction</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/ambientocclusion" class="level3"><span class="tocNumber">3.1.11&#xA0; </span>Ambient occlusion</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/normal" class="level3"><span class="tocNumber">3.1.12&#xA0; </span>Normal</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/clearcoatnormal" class="level3"><span class="tocNumber">3.1.13&#xA0; </span>Clear coat normal</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/emissive" class="level3"><span class="tocNumber">3.1.14&#xA0; </span>Emissive</a><br>
+&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel" class="level2"><span class="tocNumber">3.2&#xA0; </span>Subsurface model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel/thickness" class="level3"><span class="tocNumber">3.2.1&#xA0; </span>Thickness</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel/subsurfacecolor" class="level3"><span class="tocNumber">3.2.2&#xA0; </span>Subsurface color</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel/subsurfacepower" class="level3"><span class="tocNumber">3.2.3&#xA0; </span>Subsurface power</a><br>
+&#xA0;&#xA0;<a href="#materialmodels/clothmodel" class="level2"><span class="tocNumber">3.3&#xA0; </span>Cloth model</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/clothmodel/sheencolor" class="level3"><span class="tocNumber">3.3.1&#xA0; </span>Sheen color</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/clothmodel/subsurfacecolor" class="level3"><span class="tocNumber">3.3.2&#xA0; </span>Subsurface color</a><br>
+&#xA0;&#xA0;<a href="#materialmodels/unlitmodel" class="level2"><span class="tocNumber">3.4&#xA0; </span>Unlit model</a><br>
+<a href="#materialdefinitions" class="level1"><span class="tocNumber">4&#xA0; </span>Material definitions</a><br>
+&#xA0;&#xA0;<a href="#materialdefinitions/format" class="level2"><span class="tocNumber">4.1&#xA0; </span>Format</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/format/differenceswithjson" class="level3"><span class="tocNumber">4.1.1&#xA0; </span>Differences with JSON</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/format/example" class="level3"><span class="tocNumber">4.1.2&#xA0; </span>Example</a><br>
+&#xA0;&#xA0;<a href="#materialdefinitions/materialblock" class="level2"><span class="tocNumber">4.2&#xA0; </span>Material block</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/name" class="level3"><span class="tocNumber">4.2.1&#xA0; </span>name</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/shadingmodel" class="level3"><span class="tocNumber">4.2.2&#xA0; </span>shadingModel</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/parameters" class="level3"><span class="tocNumber">4.2.3&#xA0; </span>parameters</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/requires" class="level3"><span class="tocNumber">4.2.4&#xA0; </span>requires</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/variables" class="level3"><span class="tocNumber">4.2.5&#xA0; </span>variables</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/blending" class="level3"><span class="tocNumber">4.2.6&#xA0; </span>blending</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/vertexdomain" class="level3"><span class="tocNumber">4.2.7&#xA0; </span>vertexDomain</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/interpolation" class="level3"><span class="tocNumber">4.2.8&#xA0; </span>interpolation</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/culling" class="level3"><span class="tocNumber">4.2.9&#xA0; </span>culling</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/colorwrite" class="level3"><span class="tocNumber">4.2.10&#xA0; </span>colorWrite</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthwrite" class="level3"><span class="tocNumber">4.2.11&#xA0; </span>depthWrite</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthculling" class="level3"><span class="tocNumber">4.2.12&#xA0; </span>depthCulling</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/doublesided" class="level3"><span class="tocNumber">4.2.13&#xA0; </span>doubleSided</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/transparency" class="level3"><span class="tocNumber">4.2.14&#xA0; </span>transparency</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/maskthreshold" class="level3"><span class="tocNumber">4.2.15&#xA0; </span>maskThreshold</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/shadowmultiplier" class="level3"><span class="tocNumber">4.2.16&#xA0; </span>shadowMultiplier</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/curvaturetoroughness" class="level3"><span class="tocNumber">4.2.17&#xA0; </span>curvatureToRoughness</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/limitoverinterpolation" class="level3"><span class="tocNumber">4.2.18&#xA0; </span>limitOverInterpolation</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/clearcoatiorchange" class="level3"><span class="tocNumber">4.2.19&#xA0; </span>clearCoatIorChange</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/variantfilter" class="level3"><span class="tocNumber">4.2.20&#xA0; </span>variantFilter</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/flipuv" class="level3"><span class="tocNumber">4.2.21&#xA0; </span>flipUV</a><br>
+&#xA0;&#xA0;<a href="#materialdefinitions/vertexblock" class="level2"><span class="tocNumber">4.3&#xA0; </span>Vertex block</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/vertexblock/materialvertexinputs" class="level3"><span class="tocNumber">4.3.1&#xA0; </span>Material vertex inputs</a><br>
+&#xA0;&#xA0;<a href="#materialdefinitions/fragmentblock" class="level2"><span class="tocNumber">4.4&#xA0; </span>Fragment block</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/fragmentblock/preparematerialfunction" class="level3"><span class="tocNumber">4.4.1&#xA0; </span>prepareMaterial function</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/fragmentblock/materialfragmentinputs" class="level3"><span class="tocNumber">4.4.2&#xA0; </span>Material fragment inputs</a><br>
+&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis" class="level2"><span class="tocNumber">4.5&#xA0; </span>Shader public APIs</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/types" class="level3"><span class="tocNumber">4.5.1&#xA0; </span>Types</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/math" class="level3"><span class="tocNumber">4.5.2&#xA0; </span>Math</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/matrices" class="level3"><span class="tocNumber">4.5.3&#xA0; </span>Matrices</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/frameconstants" class="level3"><span class="tocNumber">4.5.4&#xA0; </span>Frame constants</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/vertexonly" class="level3"><span class="tocNumber">4.5.5&#xA0; </span>Vertex only</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/shaderpublicapis/fragmentonly" class="level3"><span class="tocNumber">4.5.6&#xA0; </span>Fragment only</a><br>
+<a href="#compilingmaterials" class="level1"><span class="tocNumber">5&#xA0; </span>Compiling materials</a><br>
+&#xA0;&#xA0;<a href="#compilingmaterials/shadervalidation" class="level2"><span class="tocNumber">5.1&#xA0; </span>Shader validation</a><br>
+&#xA0;&#xA0;<a href="#compilingmaterials/flags" class="level2"><span class="tocNumber">5.2&#xA0; </span>Flags</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#compilingmaterials/flags/&#x2014;platform" class="level3"><span class="tocNumber">5.2.1&#xA0; </span>&#x2014;platform</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#compilingmaterials/flags/&#x2014;api" class="level3"><span class="tocNumber">5.2.2&#xA0; </span>&#x2014;api</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#compilingmaterials/flags/&#x2014;optimize-size" class="level3"><span class="tocNumber">5.2.3&#xA0; </span>&#x2014;optimize-size</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#compilingmaterials/flags/&#x2014;reflect" class="level3"><span class="tocNumber">5.2.4&#xA0; </span>&#x2014;reflect</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#compilingmaterials/flags/&#x2014;variant-filter" class="level3"><span class="tocNumber">5.2.5&#xA0; </span>&#x2014;variant-filter</a><br>
+<a href="#handlingcolors" class="level1"><span class="tocNumber">6&#xA0; </span>Handling colors</a><br>
+&#xA0;&#xA0;<a href="#handlingcolors/linearcolors" class="level2"><span class="tocNumber">6.1&#xA0; </span>Linear colors</a><br>
+&#xA0;&#xA0;<a href="#handlingcolors/pre-multipliedalpha" class="level2"><span class="tocNumber">6.2&#xA0; </span>Pre-multiplied alpha</a><br>
+</p></div><a class="target" name="about">&#xA0;</a><a class="target" name="about">&#xA0;</a><a class="target" name="toc1">&#xA0;</a><h1>About</h1>
+<p>
+
+
+This document is part of the <a href="https://github.com/google/filament">Filament project</a>. To report errors in this document please use the <a href="https://github.com/google/filament/issues">project&apos;s issue tracker</a>.
+
+</p>
+<a class="target" name="authors">&#xA0;</a><a class="target" name="about/authors">&#xA0;</a><a class="target" name="toc1.1">&#xA0;</a><h2>Authors</h2>
+<p>
+
+
+
+</p><ul>
+<li class="minus"><a href="https://github.com/romainguy">Romain Guy</a>, <a href="https://twitter.com/romainguy">@romainguy</a></li></ul>
+
+<p></p>
+<a class="target" name="overview">&#xA0;</a><a class="target" name="overview">&#xA0;</a><a class="target" name="toc2">&#xA0;</a><h1>Overview</h1>
+<p>
+
+
+Filament is a physically based rendering (PBR) engine for Android. Filament offers a customizable
+material system that you can use to create both simple and complex materials. This document
+describes all the features available to materials and how to create your own material.
+
+</p>
+<a class="target" name="coreconcepts">&#xA0;</a><a class="target" name="overview/coreconcepts">&#xA0;</a><a class="target" name="toc2.1">&#xA0;</a><h2>Core concepts</h2>
+<p>
+
+
+</p><dl><dt>Material</dt><dd><p>    A material defines the visual appearance of a surface. To completely describe and render a
+    surface, a material provides the following information:
+
+</p><p>
+
+</p><ul>
+    <li class="minus">Material model
+</li>
+    <li class="minus">Set of use-controllable named parameters
+</li>
+    <li class="minus">Raster state (blending mode, backface culling, etc.)
+</li>
+    <li class="minus">Vertex shader code
+</li>
+    <li class="minus">Fragment shader code</li></ul>
+
+<p></p></dd><dt>Material model</dt><dd><p>    Also called <em class="underscore">shading model</em> or <em class="underscore">lighting model</em>, the material model defines the intrinsic
+    properties of a surface. These properties have a direct influence on the way lighting is
+    computed and therefore on the appearance of a surface.
+
+</p></dd><dt>Material definition</dt><dd><p>    A text file that describes all the information required by a material. This is the file that you
+    will directly author to create new materials.
+
+</p></dd><dt>Material package</dt><dd><p>    At runtime, materials are loaded from <em class="underscore">material packages</em> compiled from material definitions
+    using the <code>matc</code> tool. A material package contains all the information required to describe a
+    material, and shaders generated for the target runtime platforms. This is necessary because
+    different platforms (Android, macOS, Linux, etc.) use different graphics APIs or different
+    variants of similar graphics APIs (OpenGL vs OpenGL ES for instance).
+
+</p></dd><dt>Material instance</dt><dd><p>    A material instance is a reference to a material and a set of values for the different values of
+    that material. Material instances are not covered in this document as they are created and
+    manipulated directly from code using Filament&apos;s APIs.
+
+</p></dd></dl><p></p>
+<a class="target" name="materialmodels">&#xA0;</a><a class="target" name="materialmodels">&#xA0;</a><a class="target" name="toc3">&#xA0;</a><h1>Material models</h1>
+<p>
+
+
+Filament materials can use one of the following material models:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Lit (or standard)
+</li>
+<li class="minus">Subsurface
+</li>
+<li class="minus">Cloth
+</li>
+<li class="minus">Unlit</li></ul>
+
+<p></p>
+<a class="target" name="litmodel">&#xA0;</a><a class="target" name="materialmodels/litmodel">&#xA0;</a><a class="target" name="toc3.1">&#xA0;</a><h2>Lit model</h2>
+<p>
+
+
+The lit model is Filament&apos;s standard material model. This physically-based shading model was
+designed after to offer good interoperability with other common tools and engines such as <em class="underscore">Unity 5</em>,
+<em class="underscore">Unreal Engine 4</em>, <em class="underscore">Substance Designer</em> or <em class="underscore">Marmoset Toolbag</em>.
+
+</p><p>
+
+This material model can be used to describe a large number of non-metallic surfaces (<em class="underscore">dielectrics</em>)
+or metallic surfaces (<em class="underscore">conductors</em>).
+
+</p><p>
+
+The appearance of a material using the standard model is controlled using the properties described
+in <a href="#table_standardproperties">table&#xA0;1</a>.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:left"> Diffuse albedo for non-metallic surfaces, and specular color for metallic surfaces </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">metallic</strong> </td><td style="text-align:left"> Whether a surface appears to be dielectric (0.0) or conductor (1.0). Often used as a binary value (0 or 1) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">roughness</strong> </td><td style="text-align:left"> Perceived smoothness (1.0) or roughness (0.0) of a surface. Smooth surfaces exhibit sharp reflections </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">reflectance</strong> </td><td style="text-align:left"> Fresnel reflectance at normal incidence for dielectric surfaces. This directly controls the strength of the reflections </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoat</strong> </td><td style="text-align:left"> Strength of the clear coat layer </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoatRoughness</strong> </td><td style="text-align:left"> Perceived smoothness or roughness of the clear coat layer </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">anisotropy</strong> </td><td style="text-align:left"> Amount of anisotropy in either the tangent or bitangent direction </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">anisotropyDirection</strong> </td><td style="text-align:left"> Local surface direction </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">ambientOcclusion</strong> </td><td style="text-align:left"> Defines how much of the ambient light is accessible to a surface point. It is a per-pixel shadowing factor between 0.0 and 1.0 </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">normal</strong> </td><td style="text-align:left"> A detail normal used to perturb the surface using <em class="underscore">bump mapping</em> (<em class="underscore">normal mapping</em>) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:left"> A detail normal used to perturb the clear coat layer using <em class="underscore">bump mapping</em> (<em class="underscore">normal mapping</em>) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:left"> Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_standardproperties">&#xA0;</a><b style="font-style:normal;">Table&#xA0;1:</b> Properties of the standard model</div></div>
+
+<p></p><p>
+
+The type and range of each property is described in <a href="#table_standardpropertiestypes">table&#xA0;2</a>.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:center"> Type </th><th style="text-align:center"> Range </th><th style="text-align:left"> Note </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">metallic</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Should be 0 or 1 </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">roughness</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> &#xA0; </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">reflectance</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Prefer values &gt; 0.35 </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoat</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Should be 0 or 1 </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoatRoughness</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Remaps to [0..0.6] </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">anisotropy</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [&#x2212;1..1] </td><td style="text-align:left"> Anisotropy is in the tangent direction when this value is positive </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">anisotropyDirection</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">ambientOcclusion</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> &#xA0; </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">normal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=[-n..n] </td><td style="text-align:left"> Alpha is the exposure compensation </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_standardpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;2:</b> Range and type of the standard model&apos;s properties</div></div>
+
+<p></p><p>
+
+</p><div class="admonition note"><div class="admonition-title"> About linear RGB</div>
+
+<p></p><p>
+
+    Several material model properties expect RGB colors. Filament materials use RGB colors in linear
+    space and you must take proper care of supplying colors in that space. See the <a href="#linearcolors">Linear colors</a> section for more information.</p></div>
+
+<p></p><p>
+
+</p><div class="admonition note"><div class="admonition-title"> About pre-multiplied RGB</div>
+
+<p></p><p>
+
+    Filament materials expect colors to use pre-multiplied alpha. See the <a href="#pre-multipliedalpha">Pre-multiplied alpha</a> section for more information.</p></div>
+
+<p></p>
+<a class="target" name="basecolor">&#xA0;</a><a class="target" name="materialmodels/litmodel/basecolor">&#xA0;</a><a class="target" name="toc3.1.1">&#xA0;</a><h3>Base color</h3>
+<p>
+
+
+The <code>baseColor</code> property defines the perceived color of an object (sometimes called albedo). The
+effect of <code>baseColor</code> depends on the nature of the surface, controlled by the <code>metallic</code> property
+explained in the <a href="#metallic">Metallic</a> section.
+
+</p><p>
+
+</p><dl><dt>Non-metals (dielectrics)</dt><dd><p>  Defines the diffuse color of the surface. Real-world values are typically found in the range
+  \([10..240]\) if the value is encoded between 0 and 255, or in the range \([0.04..0.94]\) between 0
+  and 1. Several examples of base colors for non-metallic surfaces can be found in
+  <a href="#table_basecolorsdielectrics">table&#xA0;3</a>.
+
+</p></dd></dl><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Metal </th><th style="text-align:center"> sRGB </th><th style="text-align:center"> Hexadecimal </th><th style="text-align:left"> Color </th></tr>
+<tr><td style="text-align:right"> Coal </td><td style="text-align:center"> 0.19, 0.19, 0.19 </td><td style="text-align:center"> #323232 </td><td style="text-align:left"> <div style="background-color: #323232; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Rubber </td><td style="text-align:center"> 0.21, 0.21, 0.21 </td><td style="text-align:center"> #353535 </td><td style="text-align:left"> <div style="background-color: #353535; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Mud </td><td style="text-align:center"> 0.33, 0.24, 0.19 </td><td style="text-align:center"> #553d31 </td><td style="text-align:left"> <div style="background-color: #875c3c; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Wood </td><td style="text-align:center"> 0.53, 0.36, 0.24 </td><td style="text-align:center"> #875c3c </td><td style="text-align:left"> <div style="background-color: #c4c6c6; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Vegetation </td><td style="text-align:center"> 0.48, 0.51, 0.31 </td><td style="text-align:center"> #7b824e </td><td style="text-align:left"> <div style="background-color: #7b824e; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Brick </td><td style="text-align:center"> 0.58, 0.49, 0.46 </td><td style="text-align:center"> #947d75 </td><td style="text-align:left"> <div style="background-color: #947d75; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Sand </td><td style="text-align:center"> 0.69, 0.66, 0.52 </td><td style="text-align:center"> #b1a884 </td><td style="text-align:left"> <div style="background-color: #b1a884; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Concrete </td><td style="text-align:center"> 0.75, 0.75, 0.73 </td><td style="text-align:center"> #c0bfbb </td><td style="text-align:left"> <div style="background-color: #c0bfbb; width: 60px">&#xA0;</div> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_basecolorsdielectrics">&#xA0;</a><b style="font-style:normal;">Table&#xA0;3:</b> <code>baseColor</code> for common non-metals</div></div>
+
+<p></p><p>
+
+</p><dl><dt>Metals (conductors)</dt><dd><p>  Defines the specular color of the surface. Real-world values are typically found in the range
+  \([170..255]\) if the value is encoded between 0 and 255, or in the range \([0.66..1.0]\) between 0 and
+  1. Several examples of base colors for metallic surfaces can be found in <a href="#table_basecolorsconductors">table&#xA0;4</a>.
+
+</p></dd></dl><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Metal </th><th style="text-align:center"> sRGB </th><th style="text-align:center"> Hexadecimal </th><th style="text-align:left"> Color </th></tr>
+<tr><td style="text-align:right"> Silver </td><td style="text-align:center"> 0.97, 0.96, 0.91 </td><td style="text-align:center"> #f7f4e8 </td><td style="text-align:left"> <div style="background-color: #faf9f5; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Aluminum </td><td style="text-align:center"> 0.91, 0.92, 0.92 </td><td style="text-align:center"> #e8eaea </td><td style="text-align:left"> <div style="background-color: #f4f5f5; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Titanium </td><td style="text-align:center"> 0.76, 0.73, 0.69 </td><td style="text-align:center"> #c1baaf </td><td style="text-align:left"> <div style="background-color: #cec8c2; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Iron </td><td style="text-align:center"> 0.77, 0.78, 0.78 </td><td style="text-align:center"> #c4c6c6 </td><td style="text-align:left"> <div style="background-color: #c0bdba; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Platinum </td><td style="text-align:center"> 0.83, 0.81, 0.78 </td><td style="text-align:center"> #d3cec6 </td><td style="text-align:left"> <div style="background-color: #d6d1c8; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Gold </td><td style="text-align:center"> 1.00, 0.85, 0.57 </td><td style="text-align:center"> #ffd891 </td><td style="text-align:left"> <div style="background-color: #fedc9d; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Brass </td><td style="text-align:center"> 0.98, 0.90, 0.59 </td><td style="text-align:center"> #f9e596 </td><td style="text-align:left"> <div style="background-color: #f4e4ad; width: 60px">&#xA0;</div> </td></tr>
+<tr><td style="text-align:right"> Copper </td><td style="text-align:center"> 0.97, 0.74, 0.62 </td><td style="text-align:center"> #f7bc9e </td><td style="text-align:left"> <div style="background-color: #fbd8b8; width: 60px">&#xA0;</div> </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_basecolorsconductors">&#xA0;</a><b style="font-style:normal;">Table&#xA0;4:</b> <code>baseColor</code> for common metals</div></div>
+
+<p></p>
+<a class="target" name="metallic">&#xA0;</a><a class="target" name="materialmodels/litmodel/metallic">&#xA0;</a><a class="target" name="toc3.1.2">&#xA0;</a><h3>Metallic</h3>
+<p>
+
+
+The <code>metallic</code> property defines whether the surface is a metallic (<em class="underscore">conductor</em>) or a non-metallic
+(<em class="underscore">dielectric</em>) surface. This property should be used as a binary value, set to either 0 or 1.
+Intermediate values are only truly useful to create transitions between different types of surfaces
+when using textures.
+
+</p><p>
+
+This property can dramatically change the appearance of a surface. Non-metallic surfaces have
+chromatic diffuse reflection and achromatic specular reflection (reflected light does not change
+color). Metallic surfaces do not have any diffuse reflection and chromatic specular reflection
+(reflected light takes on the color of the surfaced as defined by <code>baseColor</code>). 
+
+</p><p>
+
+The effect of <code>metallic</code> is shown in <a href="#figure_metallicproperty">figure&#xA0;1</a> (click on the image to see a
+larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/metallic.png" target="_blank"><img class="markdeep" src="images/materials/metallic.png"></a><div class="imagecaption"><a class="target" name="figure_metallicproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;1:</b> <code>metallic</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p>
+<a class="target" name="roughness">&#xA0;</a><a class="target" name="materialmodels/litmodel/roughness">&#xA0;</a><a class="target" name="toc3.1.3">&#xA0;</a><h3>Roughness</h3>
+<p>
+
+
+The <code>roughness</code> property controls the perceived smoothness of the surface. When <code>roughness</code> is set
+to 0, the surface is perfectly smooth and highly glossy. The rougher a surface is, the &#x201C;blurrier&#x201D;
+the reflections are. This property is often called <em class="underscore">glossiness</em> in other engines and tools, and is
+simply the opposite of the roughness (<code>roughness = 1 - glossiness</code>).
+
+</p>
+<a class="target" name="non-metals">&#xA0;</a><a class="target" name="materialmodels/litmodel/non-metals">&#xA0;</a><a class="target" name="toc3.1.4">&#xA0;</a><h3>Non-metals</h3>
+<p>
+
+
+The effect of <code>roughness</code> on non-metallic surfaces is shown in <a href="#figure_roughnessproperty">figure&#xA0;2</a> (click
+on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/dielectric_roughness.png" target="_blank"><img class="markdeep" src="images/materials/dielectric_roughness.png"></a><div class="imagecaption"><a class="target" name="figure_roughnessproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;2:</b> Dielectric <code>roughness</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p>
+<a class="target" name="metals">&#xA0;</a><a class="target" name="materialmodels/litmodel/metals">&#xA0;</a><a class="target" name="toc3.1.5">&#xA0;</a><h3>Metals</h3>
+<p>
+
+
+The effect of <code>roughness</code> on metallic surfaces is shown in <a href="#figure_roughnessconductorproperty">figure&#xA0;3</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/conductor_roughness.png" target="_blank"><img class="markdeep" src="images/materials/conductor_roughness.png"></a><div class="imagecaption"><a class="target" name="figure_roughnessconductorproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;3:</b> Conductor <code>roughness</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p>
+<a class="target" name="reflectance">&#xA0;</a><a class="target" name="materialmodels/litmodel/reflectance">&#xA0;</a><a class="target" name="toc3.1.6">&#xA0;</a><h3>Reflectance</h3>
+<p>
+
+
+The <code>reflectance</code> property only affects non-metallic surfaces. This property can be used to control
+the specular intensity. This value is defined between 0 and 1 and represents a remapping of a
+percentage of reflectance. For instance, the default value of 0.5 corresponds to a reflectance of
+4%. Values below 0.35 (2% reflectance) should be avoided as no real-world materials have such
+low reflectance.
+
+</p><p>
+
+The effect of <code>reflectance</code> on non-metallic surfaces is shown in <a href="#figure_reflectanceproperty">figure&#xA0;4</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/reflectance.png" target="_blank"><img class="markdeep" src="images/materials/reflectance.png"></a><div class="imagecaption"><a class="target" name="figure_reflectanceproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;4:</b> <code>reflectance</code> varying from 0.0 (left)
+to 1.0 (right)</div></div></center>
+
+<p></p><p>
+
+<a href="#figure_reflectance">Figure&#xA0;5</a> shows common values and how they relate to the mapping function.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/diagram_reflectance.png" target="_blank"><img class="markdeep" src="images/diagram_reflectance.png"></a><div class="imagecaption"><a class="target" name="figure_reflectance">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;5:</b> Common reflectance values</div></div></center>
+
+<p></p><p>
+
+<a href="#table_commonmatreflectance">Table&#xA0;5</a> describes acceptable reflectance values for various types of materials
+(no real world material has a value under 2%).
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Material </th><th style="text-align:left"> Reflectance </th><th style="text-align:left"> Property value </th></tr>
+<tr><td style="text-align:right"> Water </td><td style="text-align:left"> 2% </td><td style="text-align:left"> 0.35 </td></tr>
+<tr><td style="text-align:right"> Fabric </td><td style="text-align:left"> 4% to 5.6% </td><td style="text-align:left"> 0.5 to 0.59 </td></tr>
+<tr><td style="text-align:right"> Common liquids </td><td style="text-align:left"> 2% to 4% </td><td style="text-align:left"> 0.35 to 0.5 </td></tr>
+<tr><td style="text-align:right"> Common gemstones </td><td style="text-align:left"> 5% to 16% </td><td style="text-align:left"> 0.56 to 1.0 </td></tr>
+<tr><td style="text-align:right"> Plastics, glass </td><td style="text-align:left"> 4% to 5% </td><td style="text-align:left"> 0.5 to 0.56 </td></tr>
+<tr><td style="text-align:right"> Other dielectric materials </td><td style="text-align:left"> 2% to 5% </td><td style="text-align:left"> 0.35 to 0.56 </td></tr>
+<tr><td style="text-align:right"> Eyes </td><td style="text-align:left"> 2.5% </td><td style="text-align:left"> 0.39 </td></tr>
+<tr><td style="text-align:right"> Skin </td><td style="text-align:left"> 2.8% </td><td style="text-align:left"> 0.42 </td></tr>
+<tr><td style="text-align:right"> Hair </td><td style="text-align:left"> 4.6% </td><td style="text-align:left"> 0.54 </td></tr>
+<tr><td style="text-align:right"> Teeth </td><td style="text-align:left"> 5.8% </td><td style="text-align:left"> 0.6 </td></tr>
+<tr><td style="text-align:right"> Default value </td><td style="text-align:left"> 4% </td><td style="text-align:left"> 0.5 </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_commonmatreflectance">&#xA0;</a><b style="font-style:normal;">Table&#xA0;5:</b> Reflectance of common materials</div></div>
+
+<p></p>
+<a class="target" name="clearcoat">&#xA0;</a><a class="target" name="materialmodels/litmodel/clearcoat">&#xA0;</a><a class="target" name="toc3.1.7">&#xA0;</a><h3>Clear coat</h3>
+<p>
+
+
+Multi-layer materials are fairly common, particularly materials with a thin translucent
+layer over a base layer. Real world examples of such materials include car paints, soda cans,
+lacquered wood and acrylic.
+
+</p><p>
+
+The <code>clearCoat</code> property can be used to describe materials with two layers. The clear coat layer
+will always be isotropic and dielectric.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_carbon_fiber.png" target="_blank"><img class="markdeep" src="images/material_carbon_fiber.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoat">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;6:</b> Comparison of a carbon-fiber material under the standard material model
+(left) and the clear coat model (right)</div></div></center>
+
+<p></p><p>
+
+The <code>clearCoat</code> property controls the strength of the clear coat layer. This should be treated as a
+binary value, set to either 0 or 1. Intermediate values are useful to control transitions between
+parts of the surface that have a clear coat layers and parts that don&apos;t.
+
+</p><p>
+
+The effect of <code>clearCoat</code> on a rough metal is shown in <a href="#figure_clearcoatproperty">figure&#xA0;7</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/clear_coat.png" target="_blank"><img class="markdeep" src="images/materials/clear_coat.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoatproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;7:</b> <code>clearCoat</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p><p>
+
+</p><div class="admonition warning">The clear coat layer effectively doubles the cost of specular computations. Do not assign a
+    value, even 0.0, to the clear coat property if you don&apos;t need this second layer.</div>
+
+<p></p>
+<a class="target" name="clearcoatroughness">&#xA0;</a><a class="target" name="materialmodels/litmodel/clearcoatroughness">&#xA0;</a><a class="target" name="toc3.1.8">&#xA0;</a><h3>Clear coat roughness</h3>
+<p>
+
+
+The <code>clearCoatRoughness</code> property is similar to the <code>roughness</code> property but applies only to the
+clear coat layer. In addition, since clear coat layers are never completely rough, the value between
+0 and 1 is remapped internally to an actual roughness of 0 to 0.6.
+
+</p><p>
+
+The effect of <code>clearCoatRoughness</code> on a rough metal is shown in <a href="#figure_clearcoatroughnessproperty">figure&#xA0;8</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/clear_coat_roughness.png" target="_blank"><img class="markdeep" src="images/materials/clear_coat_roughness.png"></a><div class="imagecaption"><a class="target" name="figure_clearcoatroughnessproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;8:</b> <code>clearCoatRoughness</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p>
+<a class="target" name="anisotropy">&#xA0;</a><a class="target" name="materialmodels/litmodel/anisotropy">&#xA0;</a><a class="target" name="toc3.1.9">&#xA0;</a><h3>Anisotropy</h3>
+<p>
+
+
+Many real-world materials, such as brushed metal, can only be replicated using an anisotropic
+reflectance model. A material can be changed from the default isotropic model to an anisotropic
+model by using the <code>anisotropy</code> property.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/material_anisotropic.png" target="_blank"><img class="markdeep" src="images/material_anisotropic.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropic">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;9:</b> Comparison of isotropic material
+(left) and anistropic material (right)</div></div></center>
+
+<p></p><p>
+
+The effect of <code>anisotropy</code> on a rough metal is shown in <a href="#figure_anisotropyproperty">figure&#xA0;10</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/materials/anisotropy.png" target="_blank"><img class="markdeep" src="images/materials/anisotropy.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropyproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;10:</b> <code>anisotropy</code> varying from 0.0
+(left) to 1.0 (right)</div></div></center>
+
+<p></p><p>
+
+The <a href="#figure_anisotropydir">figure&#xA0;11</a> below shows how the direction of the anisotropic highlights can be
+controlled by using either positive or negative values: positive values define anisotropy in the
+tangent direction and negative values in the bitangent direction.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropy_direction.png" target="_blank"><img class="markdeep" src="images/screenshot_anisotropy_direction.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropydir">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;11:</b> Positive (left) vs negative
+(right) <code>anisotropy</code> values</div></div></center>
+
+<p></p><p>
+
+</p><div class="admonition tip">The anisotropic material model is slightly more expensive than the standard material model. Do
+    not assign a value (even 0.0) to the <code>anisotropy</code> property if you don&apos;t need anisotropy.</div>
+
+<p></p>
+<a class="target" name="anisotropydirection">&#xA0;</a><a class="target" name="materialmodels/litmodel/anisotropydirection">&#xA0;</a><a class="target" name="toc3.1.10">&#xA0;</a><h3>Anisotropy direction</h3>
+<p>
+
+
+The <code>anisotropyDirection</code> property defines the direction of the surface at a given point and thus
+control the shape of the specular highlights. It is specified as vector of 3 values that usually
+come from a texture, encoding the directions local to the surface.
+
+</p><p>
+
+The effect of <code>anisotropyDirection</code> on a metal is shown in <a href="#figure_anisotropydirectionproperty">figure&#xA0;13</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropy.png" target="_blank"><img class="markdeep" src="images/screenshot_anisotropy.png"></a><div class="imagecaption"><a class="target" name="figure_anisotropydirectionproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;12:</b> Anisotropic metal rendered
+with a direction map</div></div></center>
+
+<p></p><p>
+
+The result shown in <a href="#figure_anisotropydirectionproperty">figure&#xA0;13</a> was obtained using the direction map shown
+in <a href="#figure_anisotropydirectionproperty">figure&#xA0;13</a>.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_anisotropy_map.jpg" target="_blank"><img class="markdeep" src="images/screenshot_anisotropy_map.jpg"></a><div class="imagecaption"><a class="target" name="figure_anisotropydirectionproperty">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;13:</b> Example of a direction map</div></div></center>
+
+<p></p>
+<a class="target" name="ambientocclusion">&#xA0;</a><a class="target" name="materialmodels/litmodel/ambientocclusion">&#xA0;</a><a class="target" name="toc3.1.11">&#xA0;</a><h3>Ambient occlusion</h3>
+<p>
+
+
+The <code>ambientOcclusion</code> property defines how much of the ambient light is accessible to a surface
+point. It is a per-pixel shadowing factor between 0.0 (fully shadowed) and 1.0 (fully lit). This
+property only affects diffuse indirect lighting (image-based lighting), not direct lights such as
+directional, point and spot lights, nor specular lighting.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_ao.jpg" target="_blank"><img class="markdeep" src="images/screenshot_ao.jpg"></a><div class="imagecaption"><a class="target" name="figure_aoexample">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;14:</b> Comparison of materials without diffuse ambient occlusion
+(left) and with (right)</div></div></center>
+
+<p></p>
+<a class="target" name="normal">&#xA0;</a><a class="target" name="materialmodels/litmodel/normal">&#xA0;</a><a class="target" name="toc3.1.12">&#xA0;</a><h3>Normal</h3>
+<p>
+
+
+The <code>normal</code> property defines the normal of the surface at a given point. It usually comes from a
+<em class="underscore">normal map</em> texture, which allows to vary the property per-pixel. The normal is supplied in tangent
+space, which means that +Z points outside of the surface.
+
+</p><p>
+
+For example, let&apos;s imagine that we want to render a piece of furniture covered in tufted leather.
+Modeling the geometry to accurately represent the tufted pattern would require too many triangles
+so we instead bake a high-poly mesh into a normal map. Once the base map is applied to a simplified
+mesh, we get the result in <a href="#figure_normalmapped">figure&#xA0;15</a>.
+
+</p><p>
+
+Note that the <code>normal</code> property affects the <em class="underscore">base layer</em> and not the clear coat layer.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_normal_mapping.jpg" target="_blank"><img class="markdeep" src="images/screenshot_normal_mapping.jpg"></a><div class="imagecaption"><a class="target" name="figure_normalmapped">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;15:</b> Low-poly mesh without normal mapping (left)
+and with (right)</div></div></center>
+
+<p></p><p>
+
+</p><div class="admonition warning">Using a normal map increases the runtime cost of the material model.</div>
+
+<p></p>
+<a class="target" name="clearcoatnormal">&#xA0;</a><a class="target" name="materialmodels/litmodel/clearcoatnormal">&#xA0;</a><a class="target" name="toc3.1.13">&#xA0;</a><h3>Clear coat normal</h3>
+<p>
+
+
+The <code>clearCoatNormal</code> property defines the normal of the clear coat layer at a given point. It
+behaves otherwise like the <code>normal</code> property.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_clear_coat_normal.jpg" target="_blank"><img class="markdeep" src="images/screenshot_clear_coat_normal.jpg"></a><div class="imagecaption"><a class="target" name="figure_clearcoatnormalmapped">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;16:</b> A material with a clear coat normal
+map and a surface normal map</div></div></center>
+
+<p></p><p>
+
+</p><div class="admonition warning">Using a clear coat normal map increases the runtime cost of the material model.</div>
+
+<p></p>
+<a class="target" name="emissive">&#xA0;</a><a class="target" name="materialmodels/litmodel/emissive">&#xA0;</a><a class="target" name="toc3.1.14">&#xA0;</a><h3>Emissive</h3>
+<p>
+
+
+The <code>emissive</code> property can be used to simulate additional light emitted by the surface. It is
+defined as a <code>float4</code> value that contains an RGB color (in linear space) as well as an exposure
+compensation value (in the alpha channel).
+
+</p><p>
+
+Even though an exposure value actually indicates combinations of camera settings, it is often used
+by photographers to describe light intensity. This is why cameras let photographers apply an
+exposure compensation to over or under-expose an image. This setting can be used for artistic
+control but also to achieve proper exposure (snow for instance will be exposed for as
+18% middle-grey).
+
+</p><p>
+
+The exposure compensation value of the emissive property can be used to force the emissive color
+to be brighter (positive values) or darker (negative values) than the current exposure. If the bloom
+effect is enabled, using a positive exposure compensation can force the surface to bloom.
+
+</p>
+<a class="target" name="subsurfacemodel">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel">&#xA0;</a><a class="target" name="toc3.2">&#xA0;</a><h2>Subsurface model</h2>
+
+<a class="target" name="thickness">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel/thickness">&#xA0;</a><a class="target" name="toc3.2.1">&#xA0;</a><h3>Thickness</h3>
+
+<a class="target" name="subsurfacecolor">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel/subsurfacecolor">&#xA0;</a><a class="target" name="toc3.2.2">&#xA0;</a><h3>Subsurface color</h3>
+
+<a class="target" name="subsurfacepower">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel/subsurfacepower">&#xA0;</a><a class="target" name="toc3.2.3">&#xA0;</a><h3>Subsurface power</h3>
+
+<a class="target" name="clothmodel">&#xA0;</a><a class="target" name="materialmodels/clothmodel">&#xA0;</a><a class="target" name="toc3.3">&#xA0;</a><h2>Cloth model</h2>
+<p>
+
+
+All the material models described previously are designed to simulate dense surfaces, both at a
+macro and at a micro level. Clothes and fabrics are however often made of loosely connected threads
+that absorb and scatter incident light. When compared to hard surfaces, cloth is characterized by
+a softer specular lob with a large falloff and the presence of fuzz lighting, caused by
+forward/backward scattering. Some fabrics also exhibit two-tone specular colors
+(velvets for instance).
+
+</p><p>
+
+<a href="#figure_materialcloth">Figure&#xA0;17</a> shows how the standard material model fails to capture the appearance of a
+sample of denim fabric. The surface appears rigid (almost plastic-like), more similar to a tarp
+than a piece of clothing. This figure also shows how important the softer specular lobe caused by
+absorption and scattering is to the faithful recreation of the fabric.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth.png"></a><div class="imagecaption"><a class="target" name="figure_materialcloth">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;17:</b> Comparison of denim fabric rendered using the standard model
+(left) and the cloth model (right)</div></div></center>
+
+<p></p><p>
+
+Velvet is an interesting use case for a cloth material model. As shown in <a href="#figure_materialvelvet">figure&#xA0;18</a>
+this type of fabric exhibits strong rim lighting due to forward and backward scattering. These
+scattering events are caused by fibers standing straight at the surface of the fabric. When the
+incident light comes from the direction opposite to the view direction, the fibers will forward
+scatter the light. Similarly, when the incident light from the same direction as the view
+direction, the fibers will scatter the light backward.
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_velvet.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_velvet.png"></a><div class="imagecaption"><a class="target" name="figure_materialvelvet">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;18:</b> Velvet fabric showcasing forward and
+backward scattering</div></div></center>
+
+<p></p><p>
+
+It is important to note that there are types of fabrics that are still best modeled by hard surface
+material models. For instance, leather, silk and satin can be recreated using the standard or
+anisotropic material models.
+
+</p><p>
+
+The cloth material model encompasses all the parameters previously defined for the standard
+material mode except for <em class="underscore">metallic</em> and <em class="underscore">reflectance</em>. Two extra parameters described in
+<a href="#table_clothproperties">table&#xA0;6</a> are also available.
+
+</p><p>
+
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Parameter </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">sheenColor</strong> </td><td style="text-align:left"> Specular tint to create two-tone specular fabrics (defaults to \(\sqrt{baseColor}\)) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">subsurfaceColor</strong> </td><td style="text-align:left"> Tint for the diffuse color after scattering and absorption through the material </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_clothproperties">&#xA0;</a><b style="font-style:normal;">Table&#xA0;6:</b> Cloth model parameters</div></div>
+
+<p></p><p>
+
+The type and range of each property is described in <a href="#table_clothpropertiestypes">table&#xA0;7</a>.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:center"> Type </th><th style="text-align:center"> Range </th><th style="text-align:left"> Note </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">sheenColor</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">subsurfaceColor</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_clothpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;7:</b> Range and type of the cloth model&apos;s properties</div></div>
+
+<p></p><p>
+
+To create a velvet-like material, the base color can be set to black (or a dark color).
+Chromaticity information should instead be set on the sheen color. To create more common fabrics
+such as denim, cotton, etc. use the base color for chromaticity and use the default sheen color
+or set the sheen color to the luminance of the base color.
+
+</p><p>
+
+</p><div class="admonition tip">To see the effect of the <code>roughness</code> parameter make sure the <code>sheenColor</code> is brighter than
+    <code>baseColor</code>. This can be used to create a fuzz effect. Taking the luminance of <code>baseColor</code>
+    as the <code>sheenColor</code> will produce a fairly natural effect that works for common cloth. A dark
+    <code>baseColor</code> combined with a bright/saturated <code>sheenColor</code> can be used to create velvet.</div>
+
+<p></p><p>
+
+</p><div class="admonition tip">The <code>subsurfaceColor</code> parameter should be used with care. High values can interfere with shadows
+    in some areas. It is best suited for subtle transmission effects through the material.</div>
+
+<p></p>
+<a class="target" name="sheencolor">&#xA0;</a><a class="target" name="materialmodels/clothmodel/sheencolor">&#xA0;</a><a class="target" name="toc3.3.1">&#xA0;</a><h3>Sheen color</h3>
+<p>
+
+
+The <code>sheenColor</code> property can be used to directly modify the specular reflectance. It offers
+better control over the appearance of cloth and gives give the ability to create
+two-tone specular materials.
+
+</p><p>
+
+The effect of <code>sheenColor</code> is shown in <a href="#figure_materialclothsheen">figure&#xA0;19</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_sheen.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_sheen.png"></a><div class="imagecaption"><a class="target" name="figure_materialclothsheen">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;19:</b> Blue fabric without (left) and with (right) sheen</div></div></center>
+
+<p></p>
+<a class="target" name="subsurfacecolor">&#xA0;</a><a class="target" name="materialmodels/clothmodel/subsurfacecolor">&#xA0;</a><a class="target" name="toc3.3.2">&#xA0;</a><h3>Subsurface color</h3>
+<p>
+
+
+The <code>subsurfaceColor</code> property is not physically-based and can be used to simulate the scattering,
+partial absorption and re-emission of light in certain types of fabrics. This is particularly
+useful to create softer fabrics.
+
+</p><p>
+
+</p><div class="admonition warning">The cloth material model is more expensive to compute when the <code>subsurfaceColor</code> property is used.</div>
+
+<p></p><p>
+
+The effect of <code>subsurfaceColor</code> is shown in <a href="#figure_materialclothsubsurface">figure&#xA0;20</a>
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_cloth_subsurface.png" target="_blank"><img class="markdeep" src="images/screenshot_cloth_subsurface.png"></a><div class="imagecaption"><a class="target" name="figure_materialclothsubsurface">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;20:</b> White cloth (left column) vs white cloth with
+brown subsurface scatting (right)</div></div></center>
+
+<p></p>
+<a class="target" name="unlitmodel">&#xA0;</a><a class="target" name="materialmodels/unlitmodel">&#xA0;</a><a class="target" name="toc3.4">&#xA0;</a><h2>Unlit model</h2>
+<p>
+
+
+The unlit material model can be used to turn off all lighting computations. Its primary purpose is
+to render pre-lit elements such as a cubemap, external content (such as a video or camera stream),
+user interfaces, visualization/debugging etc. The unlit model exposes only two properties described
+in <a href="#table_unlitproperties">table&#xA0;8</a>.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:left"> Definition </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:left"> Surface diffuse color </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:left"> Additional diffuse color to simulate emissive surfaces. This property is mostly useful in an HDR pipeline with a bloom pass </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_unlitproperties">&#xA0;</a><b style="font-style:normal;">Table&#xA0;8:</b> Properties of the standard model</div></div>
+
+<p></p><p>
+
+The type and range of each property is described in <a href="#table_unlitpropertiestypes">table&#xA0;9</a>.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:center"> Type </th><th style="text-align:center"> Range </th><th style="text-align:left"> Note </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=N/A </td><td style="text-align:left"> Pre-multiplied linear RGB, alpha is ignored </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_unlitpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;9:</b> Range and type of the unlit model&apos;s properties</div></div>
+
+<p></p><p>
+
+The value of <code>emissive</code> is simply added to <code>baseColor</code> when present. The main use of <code>emissive</code>
+is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass.
+
+</p><p>
+
+<a href="#figure_materialunlit">Figure&#xA0;21</a> shows an example of the unlit material model
+(click on the image to see a larger version).
+
+</p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_unlit.jpg" target="_blank"><img class="markdeep" src="images/screenshot_unlit.jpg"></a><div class="imagecaption"><a class="target" name="figure_materialunlit">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;21:</b> The unlit model is used to render debug information</div></div></center>
+
+<p></p>
+<a class="target" name="materialdefinitions">&#xA0;</a><a class="target" name="materialdefinitions">&#xA0;</a><a class="target" name="toc4">&#xA0;</a><h1>Material definitions</h1>
+<p>
+
+
+A material definition is a text file that describes all the information required by a material:
+
+</p><p>
+
+</p><ul>
+<li class="minus">Name
+</li>
+<li class="minus">User parameters
+</li>
+<li class="minus">Material model
+</li>
+<li class="minus">Required attributes
+</li>
+<li class="minus">Interpolants (called <em class="underscore">variables</em>)
+</li>
+<li class="minus">Raster state (blending mode, etc.)
+</li>
+<li class="minus">Shader code (fragment shader, optionally vertex shader)</li></ul>
+
+<p></p>
+<a class="target" name="format">&#xA0;</a><a class="target" name="materialdefinitions/format">&#xA0;</a><a class="target" name="toc4.1">&#xA0;</a><h2>Format</h2>
+<p>
+
+
+The material definition format is a format loosely based on <a href="https://www.json.org/">JSON</a> that we
+call <em class="underscore">JSONish</em>. At the top level a material definition is composed of 3 different blocks that use
+the JSON object notation:
+
+</p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    // material properties</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">vertex {</span>
+<span class="line">    // vertex shader, optional</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    // fragment shader</span>
+<span class="line">}</span></code></pre><p>
+
+A minimum viable material definition must contain a <code>material</code> section and a <code>fragment</code> block. The
+<code>vertex</code> block is optional.
+
+</p>
+<a class="target" name="differenceswithjson">&#xA0;</a><a class="target" name="materialdefinitions/format/differenceswithjson">&#xA0;</a><a class="target" name="toc4.1.1">&#xA0;</a><h3>Differences with JSON</h3>
+<p>
+
+
+In JSON, an object is made of key/value <em class="underscore">pairs</em>. A JSON pair has the following syntax:
+
+</p><pre class="listing tilde"><code><span class="line">&quot;key&quot; : value</span></code></pre><p>
+
+Where value can be a string, number, object, array or a literal (<code>true</code>, <code>false</code> or <code>null</code>). While
+this syntax is perfectly valid in a material definition, a variant without quotes around strings is
+also accepted in JSONish:
+
+</p><pre class="listing tilde"><code><span class="line">key : value</span></code></pre><p>
+
+Quotes remain mandatory when the string contains spaces.
+
+</p><p>
+
+The <code>vertex</code> and <code>fragment</code> blocks contain unescaped, unquoted GLSL code, which is not valid in JSON.
+
+</p><p>
+
+Single-line C++-style comments are allowed.
+
+</p><p>
+
+The key of a pair is case-sensitive.
+
+</p><p>
+
+The value of a pair is not case-sensitive.
+
+</p>
+<a class="target" name="example">&#xA0;</a><a class="target" name="materialdefinitions/format/example">&#xA0;</a><a class="target" name="toc4.1.2">&#xA0;</a><h3>Example</h3>
+<p>
+
+
+The following code listing shows an example of a valid material definition. This definition uses
+the <em class="underscore">lit</em> material model (see <a href="#litmodel">Lit model</a> section), uses the default opaque blending mode, requires
+that a set of UV coordinates be presented in the rendered mesh and defines 3 user parameters. The
+following sections of this document describe the <code>material</code> and <code>fragment</code> blocks in detail.
+
+</p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    name : &quot;Textured material&quot;,</span>
+<span class="line">    parameters : [</span>
+<span class="line">        {</span>
+<span class="line">           type : sampler2d,</span>
+<span class="line">           name : texture</span>
+<span class="line">        },</span>
+<span class="line">        {</span>
+<span class="line">           type : float,</span>
+<span class="line">           name : metallic</span>
+<span class="line">        },</span>
+<span class="line">        {</span>
+<span class="line">            type : float,</span>
+<span class="line">            name : roughness</span>
+<span class="line">        }</span>
+<span class="line">    ],</span>
+<span class="line">    requires : [</span>
+<span class="line">        uv0</span>
+<span class="line">    ],</span>
+<span class="line">    shadingModel : lit,</span>
+<span class="line">    blending : opaque</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    void material(inout MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        material.baseColor = texture(materialParams_texture, getUV0());</span>
+<span class="line">        material.metallic = materialParams.metallic;</span>
+<span class="line">        material.roughness = materialParams.roughness;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="materialblock">&#xA0;</a><a class="target" name="materialdefinitions/materialblock">&#xA0;</a><a class="target" name="toc4.2">&#xA0;</a><h2>Material block</h2>
+<p>
+
+
+The material block is mandatory block that contains a list of property pairs to describe all
+non-shader data.
+
+</p>
+<a class="target" name="name">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/name">&#xA0;</a><a class="target" name="toc4.2.1">&#xA0;</a><h3>name</h3>
+<p>
+
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Type</dt></td><td><dd><p>     <code>string</code>
+
+</p></dd></td></tr><tr valign="top"><td><dt>Value</dt></td><td><dd><p>      Any string. Double quotes are required if the name contains spaces.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Description</dt></td><td><dd><p>      Sets the name of the material. The name is retained at runtime for debugging purpose.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    name : stone</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">material {</span>
+<span class="line">    name : &quot;Wet pavement&quot;</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="shadingmodel">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/shadingmodel">&#xA0;</a><a class="target" name="toc4.2.2">&#xA0;</a><h3>shadingModel</h3>
+<p>
+
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Type</dt></td><td><dd><p>     <code>string</code>
+
+</p></dd></td></tr><tr valign="top"><td><dt>Value</dt></td><td><dd><p>      Any of <code>lit</code>, <code>subsurface</code>, <code>cloth</code>, <code>unlit</code>. Defaults to <code>lit</code>.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Description</dt></td><td><dd><p>      Selects the material model as described in the <a href="#materialmodels">Material models</a> section.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    shadingModel : unlit</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">material {</span>
+<span class="line">    shadingModel : &quot;subsurface&quot;</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="parameters">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/parameters">&#xA0;</a><a class="target" name="toc4.2.3">&#xA0;</a><h3>parameters</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     array of parameter objects
+
+</p></dd><dt>Value</dt><dd><p>      Each entry is an object with the properties <code>name</code> and <code>type</code>, both of <code>string</code> type. The
+      name must be a valid GLSL identifier. The type must be one of the types described in
+      <a href="#table_materialparamstypes">table&#xA0;10</a>.
+
+</p></dd></dl><div class="table">
+<table class="table"><tbody><tr><th style="text-align:left"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> bool </td><td style="text-align:left"> Single boolean </td></tr>
+<tr><td style="text-align:left"> bool2 </td><td style="text-align:left"> Vector of 2 booleans </td></tr>
+<tr><td style="text-align:left"> bool3 </td><td style="text-align:left"> Vector of 3 booleans </td></tr>
+<tr><td style="text-align:left"> bool4 </td><td style="text-align:left"> Vector of 4 booleans </td></tr>
+<tr><td style="text-align:left"> float </td><td style="text-align:left"> Single float </td></tr>
+<tr><td style="text-align:left"> float2 </td><td style="text-align:left"> Vector of 2 floats </td></tr>
+<tr><td style="text-align:left"> float3 </td><td style="text-align:left"> Vector of 3 floats </td></tr>
+<tr><td style="text-align:left"> float4 </td><td style="text-align:left"> Vector of 4 floats </td></tr>
+<tr><td style="text-align:left"> int </td><td style="text-align:left"> Single integer </td></tr>
+<tr><td style="text-align:left"> int2 </td><td style="text-align:left"> Vector of 2 integers </td></tr>
+<tr><td style="text-align:left"> int3 </td><td style="text-align:left"> Vector of 3 integers </td></tr>
+<tr><td style="text-align:left"> int4 </td><td style="text-align:left"> Vector of 4 integers </td></tr>
+<tr><td style="text-align:left"> uint </td><td style="text-align:left"> Single unsigned integer </td></tr>
+<tr><td style="text-align:left"> uint2 </td><td style="text-align:left"> Vector of 2 unsigned integers </td></tr>
+<tr><td style="text-align:left"> uint3 </td><td style="text-align:left"> Vector of 3 unsigned integers </td></tr>
+<tr><td style="text-align:left"> uint4 </td><td style="text-align:left"> Vector of 4 unsigned integers </td></tr>
+<tr><td style="text-align:left"> float3&#xD7;3 </td><td style="text-align:left"> Matrix of 3&#xD7;3 floats </td></tr>
+<tr><td style="text-align:left"> float4&#xD7;4 </td><td style="text-align:left"> Matrix of 4&#xD7;4 floats </td></tr>
+<tr><td style="text-align:left"> sampler2d </td><td style="text-align:left"> 2D texture </td></tr>
+<tr><td style="text-align:left"> samplerExternal </td><td style="text-align:left"> External texture (platform-specific) </td></tr>
+<tr><td style="text-align:left"> samplerCubemap </td><td style="text-align:left"> Cubemap texture </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_materialparamstypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;10:</b> Material parameter types</div></div>
+
+<p></p><p>
+
+</p><dl><dt>Samplers</dt><dd><p>      Sampler types can also specify a <code>format</code> (defaults to <code>float</code>) and a <code>precision</code> (defaults
+      to <code>default</code>). The format can be one of <code>int</code>, <code>float</code>. The precision can be one of <code>default</code>
+      (best precision for the platform, typically <code>high</code> on desktop, <code>medium</code> on mobile),
+      <code>low</code>, <code>medium</code>, <code>high</code>.
+
+</p></dd><dt>Arrays</dt><dd><p>      A parameter can define an array of values by appending <code>[size]</code> after the type name, where
+      <code>size</code> is a positive integer. For instance: <code>float[9]</code> declares an array of nine <code>float</code>
+      values. Arrays of samplers are <em class="underscore">not</em> supported at the moment.
+
+</p></dd><dt>Description</dt><dd><p>      Lists the parameters required by your material. These parameters can be set at runtime using
+      Filament&apos;s material API. Accessing parameters from the shaders varies depending on the type of
+      parameter:
+
+</p><p>
+
+</p><ul>
+    <li class="minus"><strong class="asterisk">Samplers types</strong>: use the parameter name prefixed with <code>materialParams_</code>. For instance,
+          <code>materialParams_myTexture</code>.
+</li>
+    <li class="minus"><strong class="asterisk">Other types</strong>: use the parameter name as the field of a structure called <code>materialParams</code>.
+          For instance, <code>materialParams.myColor</code>.</li></ul>
+
+<p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    parameters : [</span>
+<span class="line">        {</span>
+<span class="line">           type : float4,</span>
+<span class="line">           name : albedo</span>
+<span class="line">        },</span>
+<span class="line">        {</span>
+<span class="line">           type      : sampler2d,</span>
+<span class="line">           format    : float,</span>
+<span class="line">           precision : high,</span>
+<span class="line">           name      : roughness</span>
+<span class="line">        },</span>
+<span class="line">        {</span>
+<span class="line">            type : float2,</span>
+<span class="line">            name : metallicReflectance</span>
+<span class="line">        }</span>
+<span class="line">    ],</span>
+<span class="line">    requires : [</span>
+<span class="line">        uv0</span>
+<span class="line">    ],</span>
+<span class="line">    shadingModel : lit,</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    void material(inout MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        material.baseColor = materialParams.albedo;</span>
+<span class="line">        material.roughness = texture(materialParams_roughness, getUV0());</span>
+<span class="line">        material.metallic = materialParams.metallicReflectance.x;</span>
+<span class="line">        material.reflectance = materialParams.metallicReflectance.y;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="requires">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/requires">&#xA0;</a><a class="target" name="toc4.2.4">&#xA0;</a><h3>requires</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     array of <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Each entry must be any of <code>uv0</code>, <code>uv1</code>, <code>color</code>, <code>position</code>, <code>tangents</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Lists the vertex attributes required by the material. The <code>position</code> attribute is always
+      required and does not need to be specified. The <code>tangents</code> attribute is automatically required
+      when selecting any shading model that is not <code>unlit</code>. See the shader sections of this document
+      for more information on how to access these attributes from the shaders.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    parameters : [</span>
+<span class="line">        {</span>
+<span class="line">           type : sampler2d,</span>
+<span class="line">           name : texture</span>
+<span class="line">        },</span>
+<span class="line">    ],</span>
+<span class="line">    requires : [</span>
+<span class="line">        uv0</span>
+<span class="line">    ],</span>
+<span class="line">    shadingModel : lit,</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    void material(inout MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        material.baseColor = texture(materialParams_texture, getUV0());</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="variables">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/variables">&#xA0;</a><a class="target" name="toc4.2.5">&#xA0;</a><h3>variables</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     array of <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Up to 4 strings, each must be a valid GLSL identifier.
+
+</p></dd><dt>Description</dt><dd><p>      Defines custom interpolants (or variables) that are output by the material&apos;s vertex shader.
+      Each entry of the array defines the name of an  interpolant. The full name in the fragment
+      shader is the name of the interpolant with the <code>variable_</code> prefix. For instance, if you
+      declare a variable called <code>eyeDirection</code> you can access it in the fragment shader using
+      <code>variable_eyeDirection</code>. In the vertex shader, the interpolant name is simply a member of
+      the <code>MaterialVertexInputs</code> structure (<code>material.eyeDirection</code> in your example). Each
+      interpolant is of type <code>float4</code> (<code>vec4</code>) in the shaders.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    name : Skybox,</span>
+<span class="line">    parameters : [</span>
+<span class="line">        {</span>
+<span class="line">           type : samplerCubemap,</span>
+<span class="line">           name : skybox</span>
+<span class="line">        }</span>
+<span class="line">    ],</span>
+<span class="line">    variables : [</span>
+<span class="line">         eyeDirection</span>
+<span class="line">    ],</span>
+<span class="line">    vertexDomain : device,</span>
+<span class="line">    depthWrite : false,</span>
+<span class="line">    shadingModel : unlit</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    void material(inout MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        float3 sky = texture(materialParams_skybox, variable_eyeDirection.xyz).rgb;</span>
+<span class="line">        material.baseColor = vec4(sky, 1.0);</span>
+<span class="line">    }</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">vertex {</span>
+<span class="line">    void materialVertex(inout MaterialVertexInputs material) {</span>
+<span class="line">        float3 p = getPosition().xyz;</span>
+<span class="line">        float3 u = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;</span>
+<span class="line">        material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), u);</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="blending">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/blending">&#xA0;</a><a class="target" name="toc4.2.6">&#xA0;</a><h3>blending</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Any of <code>opaque</code>, <code>transparent</code>, <code>fade</code>, <code>add</code>, <code>masked</code>. Defaults to <code>opaque</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Defines how/if the rendered object is blended with the content of the render target.
+      The possible blending modes are:
+
+</p><p>
+
+</p><ul>
+    <li class="minus"><strong class="asterisk">Opaque</strong>: blending is disabled, the alpha channel of the material&apos;s output is ignored.
+</li>
+    <li class="minus"><strong class="asterisk">Transparent</strong>: blending is enabled. The material&apos;s output is alpha composited with the
+          render target, using Porter-Duff&apos;s <code>source over</code> rule. This blending mode assumes
+          pre-multiplied alpha.
+</li>
+    <li class="minus"><strong class="asterisk">Fade</strong>: acts as <code>transparent</code> but transparency is also applied to specular lighting. In
+          <code>transparent</code> mode, the material&apos;s alpha values only applies to diffuse lighting. This
+          blending mode is useful to fade lit objects in and out.
+</li>
+    <li class="minus"><strong class="asterisk">Add</strong>: blending is enabled. The material&apos;s output is added to the content of the
+          render target.
+</li>
+    <li class="minus"><strong class="asterisk">Masked</strong>: blending is disabled. This blending mode enables alpha masking. The alpha channel
+          of the material&apos;s output defines whether a fragment is discarded or not. See the <a href="#maskthreshold">maskThreshold</a> section for more information.</li></ul>
+
+<p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    blending : transparent</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="vertexdomain">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/vertexdomain">&#xA0;</a><a class="target" name="toc4.2.7">&#xA0;</a><h3>vertexDomain</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Any of <code>object</code>, <code>world</code>, <code>view</code>, <code>device</code>. Defaults to <code>object</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Defines the domain (or coordinate space) of the rendered mesh. The domain influences how the
+      vertices are transformed in the vertex shader. The possible domains are:
+
+</p><p>
+
+</p><ul>
+     <li class="minus"><strong class="asterisk">Object</strong>: the vertices are defined in the object (or model) coordinate space. The
+            vertices are transformed using the rendered object&apos;s transform matrix
+</li>
+     <li class="minus"><strong class="asterisk">World</strong>: the vertices are defined in world coordinate space. The vertices are not
+            transformed using the rendered object&apos;s transform.
+</li>
+     <li class="minus"><strong class="asterisk">View</strong>: the vertices are defined in view (or eye or camera) coordinate space. The
+            vertices are not transformed using the rendered object&apos;s transform.
+</li>
+     <li class="minus"><strong class="asterisk">Device</strong>:  the vertices are defined in normalized device (or clip) coordinate space.
+            The vertices are not transformed using the rendered object&apos;s transform.</li></ul>
+
+<p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    vertexDomain : device</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="interpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/interpolation">&#xA0;</a><a class="target" name="toc4.2.8">&#xA0;</a><h3>interpolation</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Any of <code>smooth</code>, <code>flat</code>. Defaults to <code>smooth</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Defines how interpolants (or variables) are interpolated between vertices. When this property
+      is set to <code>smooth</code>, a perspective correct interpolation is performed on each interpolant.
+      When set to <code>flat</code>, no interpolation is performed and all the fragments within a given
+      triangle will be shaded the same.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    interpolation : flat</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="culling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/culling">&#xA0;</a><a class="target" name="toc4.2.9">&#xA0;</a><h3>culling</h3>
+<p>
+
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Type</dt></td><td><dd><p>     <code>string</code>
+
+</p></dd></td></tr><tr valign="top"><td><dt>Value</dt></td><td><dd><p>      Any of <code>none</code>, <code>front</code>, <code>back</code>, <code>frontAndBack</code>. Defaults to <code>back</code>.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Description</dt></td><td><dd><p>      Defines which triangles should be culled: none, front-facing triangles, back-facing
+      triangles or all.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    culling : none</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="colorwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/colorwrite">&#xA0;</a><a class="target" name="toc4.2.10">&#xA0;</a><h3>colorWrite</h3>
+<p>
+
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Type</dt></td><td><dd><p>     <code>boolean</code>
+
+</p></dd></td></tr><tr valign="top"><td><dt>Value</dt></td><td><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>true</code>.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Description</dt></td><td><dd><p>      Enables or disables writes to the color buffer.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    colorWrite : false</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="depthwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthwrite">&#xA0;</a><a class="target" name="toc4.2.11">&#xA0;</a><h3>depthWrite</h3>
+<p>
+
+
+</p><dl><table><tbody><tr valign="top"><td><dt>Type</dt></td><td><dd><p>     <code>boolean</code>
+
+</p></dd></td></tr><tr valign="top"><td><dt>Value</dt></td><td><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>true</code>.
+
+</p></dd></td></tr><tr valign="top"><td><dt>Description</dt></td><td><dd><p>      Enables or disables writes to the depth buffer.
+
+</p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    depthWrite : false</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="depthculling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthculling">&#xA0;</a><a class="target" name="toc4.2.12">&#xA0;</a><h3>depthCulling</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>true</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Enables or disables depth testing. When depth testing is disabled, an object rendered with
+      this material will always appear on top of other opaque objects.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    depthCulling : false</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="doublesided">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/doublesided">&#xA0;</a><a class="target" name="toc4.2.13">&#xA0;</a><h3>doubleSided</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>false</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Enables or disables two-sided rendering. When set to <code>true</code>, <code>culling</code> is automatically set to
+      <code>none</code>; if the triangle is back-facing, the triangle&apos;s normal is automatically flipped to
+      become front-facing.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    doubleSided : true</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="transparency">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/transparency">&#xA0;</a><a class="target" name="toc4.2.14">&#xA0;</a><h3>transparency</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Any of <code>default</code>, <code>twoPassesOneSide</code> or <code>twoPassesTwoSides</code>. Defaults to <code>default</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Controls how transparent objects are rendered. It is only valid when the <code>blending</code> mode is
+      not <code>opaque</code>. None of these methods can accurately render concave geometry, but in practice
+      they are often good enough.
+
+</p></dd></dl>The three possible transparency modes are:
+
+<p></p><p>
+
+</p><ul>
+<li class="minus"><code>default</code>: the transparent object is rendered normally (as seen in <a href="#figure_transparencydefault">figure&#xA0;22</a>),
+   honoring the <code>culling</code> mode, etc.
+</li>
+<li class="minus"><code>twoPassesOneSide</code>: the transparent object is first rendered in the depth buffer, then again in
+  the color buffer, honoring the <code>cullling</code> mode. This effectively renders only half of the
+  transparent object as shown in <a href="#figure_transparencytwopassesoneside">figure&#xA0;23</a>.
+</li>
+<li class="minus"><code>twoPassesTwoSides</code>: the transparent object is rendered twice in the color buffer: first with its
+  back faces, then with its front faces. This mode lets you render both set of faces while reducing
+  or eliminating sorting issues, as shown in <a href="#figure_transparencytwopassestwosides">figure&#xA0;24</a>.
+  <code>twoPassesTwoSides</code> can be combined with <code>doubleSided</code> for better effect.</li></ul>
+
+<p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    transparency : twoPassesOneSide</span>
+<span class="line">}</span></code></pre><p>
+
+</p><center><div class="image" style><a href="images/screenshot_transparency_default.png" target="_blank"><img class="markdeep" src="images/screenshot_transparency_default.png"></a><div class="imagecaption"><a class="target" name="figure_transparencydefault">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;22:</b> This double sided model shows the type of sorting issues transparent
+objects can be subject to in <code>default</code> mode</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_twopasses_oneside.png" target="_blank"><img class="markdeep" src="images/screenshot_twopasses_oneside.png"></a><div class="imagecaption"><a class="target" name="figure_transparencytwopassesoneside">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;23:</b> In <code>twoPassesOneSide</code> mode, only one set of faces is visible
+and correctly sorted</div></div></center>
+
+<p></p><p>
+
+</p><center><div class="image" style><a href="images/screenshot_twopasses_twosides.png" target="_blank"><img class="markdeep" src="images/screenshot_twopasses_twosides.png"></a><div class="imagecaption"><a class="target" name="figure_transparencytwopassestwosides">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;24:</b> In <code>twoPassesTwoSides</code> mode, both set of faces are visible
+and sorting issues are minimized or eliminated</div></div></center>
+
+<p></p>
+<a class="target" name="maskthreshold">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/maskthreshold">&#xA0;</a><a class="target" name="toc4.2.15">&#xA0;</a><h3>maskThreshold</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>number</code>
+
+</p></dd><dt>Value</dt><dd><p>      A value between <code>0.0</code> and <code>1.0</code>. Defaults to <code>0.4</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Sets the minimum alpha value a fragment must have to not be discarded when the <code>blending</code> mode
+      is set to <code>masked</code>. When the blending mode is not <code>masked</code>, this value is ignored. This value
+      can be used to controlled the appearance of alpha-masked objects.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    blending : masked,</span>
+<span class="line">    maskThreshold : 0.5</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="shadowmultiplier">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/shadowmultiplier">&#xA0;</a><a class="target" name="toc4.2.16">&#xA0;</a><h3>shadowMultiplier</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>false</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Only available in the <code>unlit</code> shading model. If this property is enabled, the final color
+      computed by the material is multiplied by the shadowing factor (or visibility). This allows to
+      create transparent shadow-receiving objects (for instance an invisible ground plane in AR).
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    name : &quot;Invisible shadow plane&quot;,</span>
+<span class="line">    shadingModel : unlit,</span>
+<span class="line">    shadowMultiplier : true,</span>
+<span class="line">    blending : transparent</span>
+<span class="line">}</span>
+<span class="line"></span>
+<span class="line">fragment {</span>
+<span class="line">    void material(inout MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        // baseColor defines the color and opacity of the final shadow</span>
+<span class="line">        material.baseColor = vec4(0.0, 0.0, 0.0, 0.7);</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="curvaturetoroughness">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/curvaturetoroughness">&#xA0;</a><a class="target" name="toc4.2.17">&#xA0;</a><h3>curvatureToRoughness</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>false</code>.
+
+</p></dd><dt>Description</dt><dd><p>     Reduces specular aliasing by increasing roughness based on the local geometric curvature.
+     This property is particularly effective if you only use MSAA as your anti-aliasing method.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    curvatureToRoughness : true</span>
+<span class="line">}</span></code></pre><p>
+
+</p><center><div class="image" style><a href="images/screenshot_curvature_to_roughness.jpg" target="_blank"><img class="markdeep" src="images/screenshot_curvature_to_roughness.jpg"></a><div class="imagecaption"><a class="target" name="figure_curvaturetoroughness">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;25:</b> Close up of a glossy metallic surface rendered normally (left) and
+with <code>curvatureToRoughness</code> (right).</div></div></center>
+
+<p></p>
+<a class="target" name="limitoverinterpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/limitoverinterpolation">&#xA0;</a><a class="target" name="toc4.2.18">&#xA0;</a><h3>limitOverInterpolation</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>false</code>.
+
+</p></dd><dt>Description</dt><dd><p>     Reduces specular aliasing by attempting to eliminate normal over-interpolation. When this
+     property is turned on, the material switches to centroid normal interpolation when the
+     interpolated normals are too long. This property should only be used if your anti-aliasing
+     method is MSAA. The effects are a lot more subtle than <code>curvatureToRoughness</code>, which should be
+     used first to eliminate specular aliasing.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    limitOverInterpolation : true</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="clearcoatiorchange">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/clearcoatiorchange">&#xA0;</a><a class="target" name="toc4.2.19">&#xA0;</a><h3>clearCoatIorChange</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>true</code>.
+
+</p></dd><dt>Description</dt><dd><p>     When adding a clear coat layer, the change in index of refraction (IoR) is taken into account
+     to modify the specular color of the base layer. This appears to darken <code>baseColor</code>. When this
+     effect is disabled, <code>baseColor</code> is left unmodified. See <a href="#figure_clearcoatiorchange">figure&#xA0;26</a> for an
+     example of how this property can affect a red metallic base layer.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    clearCoatIorChange : false</span>
+<span class="line">}</span></code></pre><p>
+
+</p><center><div class="image" style><a href="images/screenshot_clear_coat_ior_change.jpg" target="_blank"><img class="markdeep" src="images/screenshot_clear_coat_ior_change.jpg"></a><div class="imagecaption"><a class="target" name="figure_clearcoatiorchange">&#xA0;</a><b style="font-style:normal;">Figure&#xA0;26:</b> The same rough metallic ball with a clear coat layer rendered
+with <code>clearCoatIorChange</code> enabled (left) and disabled
+(right).</div></div></center>
+
+<p></p>
+<a class="target" name="variantfilter">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/variantfilter">&#xA0;</a><a class="target" name="toc4.2.20">&#xA0;</a><h3>variantFilter</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     array of <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Each entry must be any of <code>dynamicLighting</code>, <code>directionalLighting</code>, <code>shadowReceiver</code> or <code>skinning</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Used to specify a list of shader variants that the application guarantees will never be
+      needed. These shader variants are skipped during the code generation phase, thus reducing
+      the overall size of the material.
+      Note that some variants may automatically be filtered out. For instance, all lighting related
+      variants (<code>directionalLighting</code>, etc.) are filtered out when compiling an <code>unlit</code> material.
+      Use the variant filter with caution, filtering out a variant required at runtime may lead
+      to crashes.
+
+</p></dd></dl>Description of the variants:
+
+<p></p><p>
+
+</p><ul>
+<li class="minus"><code>directionalLighting</code>, used when a directional light is present in the scene
+</li>
+<li class="minus"><code>dynamicLighting</code>, used when a non-directional light (point, spot, etc.) is present in the scene
+</li>
+<li class="minus"><code>shadowReceiver</code>, used when an object can receive shadows
+</li>
+<li class="minus"><code>skinning</code>, used when an object is animated using GPU skinning</li></ul>
+
+<p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    name : &quot;Invisible shadow plane&quot;,</span>
+<span class="line">    shadingModel : unlit,</span>
+<span class="line">    shadowMultiplier : true,</span>
+<span class="line">    blending : transparent,</span>
+<span class="line">    variantFilter : [ skinning ]</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="flipuv">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/flipuv">&#xA0;</a><a class="target" name="toc4.2.21">&#xA0;</a><h3>flipUV</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>boolean</code>
+
+</p></dd><dt>Value</dt><dd><p>      <code>true</code> or <code>false</code>. Defaults to <code>true</code>.
+
+</p></dd><dt>Description</dt><dd><p>     When set to <code>true</code> (default value), the Y coordinate of UV attributes will be flipped when
+     read by this material&apos;s vertex shader. Flipping is equivalent to <code>y = 1.0 - y</code>. When set
+     to <code>false</code>, flipping is disabled and the UV attributes are read as is.
+
+</p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    flipUV : false</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="vertexblock">&#xA0;</a><a class="target" name="materialdefinitions/vertexblock">&#xA0;</a><a class="target" name="toc4.3">&#xA0;</a><h2>Vertex block</h2>
+<p>
+
+
+The vertex block is optional and can be used to control the vertex shading stage of the material.
+The vertex block must contain valid
+<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf">ESSL 3.0</a> code
+(the version of GLSL supported in OpenGL ES 3.0). You are free to create multiple functions inside
+the vertex block but you <strong class="asterisk">must</strong> declare the <code>materialVertex</code> function:
+
+</p><pre class="listing tilde"><code><span class="line">vertex {</span>
+<span class="line">    <span class="hljs-type">void</span> materialVertex(<span class="hljs-keyword">inout</span> MaterialVertexInputs material) {</span>
+<span class="line">        <span class="hljs-comment">// vertex shading code</span></span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><p>
+
+This function will be invoked automatically at runtime by the shading system and gives you the
+ability to read and modify material properties using the <code>MaterialVertexInputs</code> structure. This full
+definition of the structure can be found in the <a href="#materialvertexinputs">Material vertex inputs</a> section.
+
+</p><p>
+
+You can use this structure to compute your custom variables/interpolants or to modify the value of
+the attributes. For instance, the following vertex blocks modifies both the color and the UV
+coordinates of the vertex over time:
+
+</p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    requires : [uv0, color]</span>
+<span class="line">}</span>
+<span class="line">vertex {</span>
+<span class="line">    <span class="hljs-type">void</span> materialVertex(<span class="hljs-keyword">inout</span> MaterialVertexInputs material) {</span>
+<span class="line">        material.color *= <span class="hljs-built_in">sin</span>(getTime());</span>
+<span class="line">        material.uv0 *= <span class="hljs-built_in">sin</span>(getTime());</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><p>
+
+In addition to the <code>MaterialVertexInputs</code> structure, your vertex shading code can use all the public
+APIs listed in the <a href="#shaderpublicapis">Shader public APIs</a> section.
+
+</p>
+<a class="target" name="materialvertexinputs">&#xA0;</a><a class="target" name="materialdefinitions/vertexblock/materialvertexinputs">&#xA0;</a><a class="target" name="toc4.3.1">&#xA0;</a><h3>Material vertex inputs</h3>
+<pre class="listing tilde"><code><span class="line">struct MaterialVertexInputs {</span>
+<span class="line">    float4 color;         <span class="hljs-comment">// if the color attribute is required</span></span>
+<span class="line">    float2 uv0;           <span class="hljs-comment">// if the uv0 attribute is required</span></span>
+<span class="line">    float2 uv1;           <span class="hljs-comment">// if the uv1 attribute is required</span></span>
+<span class="line">    float3 worldNormal;   <span class="hljs-comment">// only if the shading model is not unlit</span></span>
+<span class="line">    float4 worldPosition; <span class="hljs-comment">// always available</span></span>
+<span class="line">    <span class="hljs-comment">// variable* names are replaced with actual names</span></span>
+<span class="line">    float4 variable0;     <span class="hljs-comment">// if 1 or more variables is defined</span></span>
+<span class="line">    float4 variable1;     <span class="hljs-comment">// if 2 or more variables is defined</span></span>
+<span class="line">    float4 variable2;     <span class="hljs-comment">// if 3 or more variables is defined</span></span>
+<span class="line">    float4 variable3;     <span class="hljs-comment">// if 4 or more variables is defined</span></span>
+<span class="line">};</span></code></pre><p>
+
+
+
+</p><div class="admonition tip"><div class="admonition-title"> UV attributes</div>
+
+<p></p><p>
+
+    By default the vertex shader of a material will flip the Y coordinate of the UV attributes
+    of the current mesh: <code>material.uv0 = vec2(mesh_uv0.x, 1.0 - mesh_uv0.y)</code>. You can control
+    this behavior using the <code>flipUV</code> property and setting it to <code>false</code>.</p></div>
+
+<p></p>
+<a class="target" name="fragmentblock">&#xA0;</a><a class="target" name="materialdefinitions/fragmentblock">&#xA0;</a><a class="target" name="toc4.4">&#xA0;</a><h2>Fragment block</h2>
+<p>
+
+
+The fragment block must be used to control the fragment shading stage of the material. The vertex
+block must contain valid
+<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf">ESSL 3.0</a>
+code (the version of GLSL supported in OpenGL ES 3.0). You are free to create multiple functions
+inside the vertex block but you <strong class="asterisk">must</strong> declare the <code>material</code> function:
+
+</p><pre class="listing tilde"><code><span class="line">fragment {</span>
+<span class="line">    <span class="hljs-type">void</span> material(<span class="hljs-keyword">inout</span> MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        <span class="hljs-comment">// fragment shading code</span></span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre><p>
+
+This function will be invoked automatically at runtime by the shading system and gives you the
+ability to read and modify material properties using the <code>MaterialInputs</code> structure. This full
+definition of the structure can be found in the <a href="#materialfragmentinputs">Material fragment inputs</a> section. The full
+definition of the various members of the structure can be found in the <a href="#materialmodels">Material models</a> section
+of this document.
+
+</p><p>
+
+The goal of the <code>material()</code> function is to compute the material properties specific to the selected
+shading model. For instance, here is a fragment block that creates a glossy red metal using the
+standard lit shading model:
+
+</p><pre class="listing tilde"><code><span class="line">fragment {</span>
+<span class="line">    <span class="hljs-type">void</span> material(<span class="hljs-keyword">inout</span> MaterialInputs material) {</span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line">        material.baseColor.rgb = <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>);</span>
+<span class="line">        material.metallic = <span class="hljs-number">1.0</span>;</span>
+<span class="line">        material.roughness = <span class="hljs-number">0.0</span>;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="preparematerialfunction">&#xA0;</a><a class="target" name="materialdefinitions/fragmentblock/preparematerialfunction">&#xA0;</a><a class="target" name="toc4.4.1">&#xA0;</a><h3>prepareMaterial function</h3>
+<p>
+
+
+Note that you <strong class="asterisk">must</strong> call <code>prepareMaterial(material)</code> before exiting the  <code>material()</code> function.
+This <code>prepareMaterial</code> function sets up the internal state of the material mdoel. Some of the APIs
+described in the Fragment APIs section - like <code>shading_normal</code> for instance - can only be accessed
+<em class="underscore">after</em> invoking <code>prepareMaterial()</code>.
+
+</p><p>
+
+It is also important to remember that the <code>normal</code> property - as described in the Material fragment
+inputs section - only has an effect when modified <em class="underscore">before</em> calling <code>prepareMaterial()</code>. Here is an
+example of a fragment shader that properly modifies the <code>normal</code> property to implement a glossy red
+plastic with bump mapping:
+
+</p><pre class="listing tilde"><code><span class="line">fragment {</span>
+<span class="line">    <span class="hljs-type">void</span> material(<span class="hljs-keyword">inout</span> MaterialInputs material) {</span>
+<span class="line">        <span class="hljs-comment">// fetch the normal in tangent space</span></span>
+<span class="line">        <span class="hljs-type">vec3</span> normal = <span class="hljs-built_in">texture</span>(materialParams_normalMap, getUV0()).xyz;</span>
+<span class="line">        material.normal = normal * <span class="hljs-number">2.0</span> - <span class="hljs-number">1.0</span>;</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-comment">// prepare the material</span></span>
+<span class="line">        prepareMaterial(material);</span>
+<span class="line"></span>
+<span class="line">        <span class="hljs-comment">// from now on, shading_normal, etc. can be accessed</span></span>
+<span class="line">        material.baseColor.rgb = <span class="hljs-type">vec3</span>(<span class="hljs-number">1.0</span>, <span class="hljs-number">0.0</span>, <span class="hljs-number">0.0</span>);</span>
+<span class="line">        material.metallic = <span class="hljs-number">0.0</span>;</span>
+<span class="line">        material.roughness = <span class="hljs-number">1.0</span>;</span>
+<span class="line">    }</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="materialfragmentinputs">&#xA0;</a><a class="target" name="materialdefinitions/fragmentblock/materialfragmentinputs">&#xA0;</a><a class="target" name="toc4.4.2">&#xA0;</a><h3>Material fragment inputs</h3>
+<pre class="listing tilde"><code><span class="line">struct MaterialInputs {</span>
+<span class="line">    float4 baseColor;           <span class="hljs-comment">// default: float4(1.0)</span></span>
+<span class="line">    float4 emissive;            <span class="hljs-comment">// default: float4(0.0)</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// no other field is available with the unlit shading model</span></span>
+<span class="line">    <span class="hljs-type">float</span>  roughness;           <span class="hljs-comment">// default: 1.0</span></span>
+<span class="line">    <span class="hljs-type">float</span>  metallic;            <span class="hljs-comment">// default: 0.0, not available with cloth</span></span>
+<span class="line">    <span class="hljs-type">float</span>  reflectance;         <span class="hljs-comment">// default: 0.5, not available with cloth</span></span>
+<span class="line">    <span class="hljs-type">float</span>  ambientOcclusion;    <span class="hljs-comment">// default: 0.0</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// not available when the shading model is subsurface or cloth</span></span>
+<span class="line">    <span class="hljs-type">float</span>  clearCoat;           <span class="hljs-comment">// default: 1.0</span></span>
+<span class="line">    <span class="hljs-type">float</span>  clearCoatRoughness;  <span class="hljs-comment">// default: 0.0</span></span>
+<span class="line">    float3 clearCoatNormal;     <span class="hljs-comment">// default: float3(0.0, 0.0, 1.0)</span></span>
+<span class="line">    <span class="hljs-type">float</span>  anisotropy;          <span class="hljs-comment">// default: 0.0</span></span>
+<span class="line">    float3 anisotropyDirection; <span class="hljs-comment">// default: float3(1.0, 0.0, 0.0)</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// only available when the shading model is subsurface</span></span>
+<span class="line">    <span class="hljs-type">float</span>  thickness;           <span class="hljs-comment">// default: 0.5</span></span>
+<span class="line">    <span class="hljs-type">float</span>  subsurfacePower;     <span class="hljs-comment">// default: 12.234</span></span>
+<span class="line">    float3 subsurfaceColor;     <span class="hljs-comment">// default: float3(1.0)</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// only available when the shading model is cloth</span></span>
+<span class="line">    float3 sheenColor;         <span class="hljs-comment">// default: sqrt(baseColor)</span></span>
+<span class="line">    float3 subsurfaceColor;    <span class="hljs-comment">// default: float3(0.0)</span></span>
+<span class="line"></span>
+<span class="line">    <span class="hljs-comment">// not available when the shading model is unlit</span></span>
+<span class="line">    <span class="hljs-comment">// must be set before calling prepareMaterial()</span></span>
+<span class="line">    float3 normal;             <span class="hljs-comment">// default: float3(0.0, 0.0, 1.0)</span></span>
+<span class="line">}</span></code></pre>
+<a class="target" name="shaderpublicapis">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis">&#xA0;</a><a class="target" name="toc4.5">&#xA0;</a><h2>Shader public APIs</h2>
+
+<a class="target" name="types">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/types">&#xA0;</a><a class="target" name="toc4.5.1">&#xA0;</a><h3>Types</h3>
+<p>
+
+
+While GLSL types can be used directly (<code>vec4</code> or <code>mat4</code>) we recommend the use of the following
+type aliases:
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> GLSL type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">bool2</strong> </td><td style="text-align:center"> bvec2 </td><td style="text-align:left"> A vector of 2 booleans </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">bool3</strong> </td><td style="text-align:center"> bvec3 </td><td style="text-align:left"> A vector of 3 booleans </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">bool4</strong> </td><td style="text-align:center"> bvec4 </td><td style="text-align:left"> A vector of 4 booleans </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">int2</strong> </td><td style="text-align:center"> ivec2 </td><td style="text-align:left"> A vector of 2 integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">int3</strong> </td><td style="text-align:center"> ivec3 </td><td style="text-align:left"> A vector of 3 integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">int4</strong> </td><td style="text-align:center"> ivec4 </td><td style="text-align:left"> A vector of 4 integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">uint2</strong> </td><td style="text-align:center"> uvec2 </td><td style="text-align:left"> A vector of 2 unsigned integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">uint3</strong> </td><td style="text-align:center"> uvec3 </td><td style="text-align:left"> A vector of 3 unsigned integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">uint4</strong> </td><td style="text-align:center"> uvec4 </td><td style="text-align:left"> A vector of 4 unsigned integers </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">float2</strong> </td><td style="text-align:center"> float2 </td><td style="text-align:left"> A vector of 2 floats </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">float3</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> A vector of 3 floats </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">float4</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> A vector of 4 floats </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">float4&#xD7;4</strong> </td><td style="text-align:center"> mat4 </td><td style="text-align:left"> A 4&#xD7;4 float matrix </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">float3&#xD7;3</strong> </td><td style="text-align:center"> mat3 </td><td style="text-align:left"> A 3&#xD7;3 float matrix </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="math">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/math">&#xA0;</a><a class="target" name="toc4.5.2">&#xA0;</a><h3>Math</h3>
+<p>
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">PI</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> A constant that represent \(\pi\) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">HALF_PI</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> A constant that represent \(\frac{\pi}{2}\) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">saturate(float x)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Clamps the specified value between 0.0 and 1.0 </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">pow5(float x)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Computes \(x^5\) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">sq(float x)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Computes \(x^2\) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">max3(float3 v)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Returns the maximum value of the specified <code>float3</code> </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">mulMat4&#xD7;4Float3(float4&#xD7;4 m, float3 v)</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Returns \(m * v\) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">mulMat3&#xD7;3Float3(float4&#xD7;4 m, float3 v)</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Returns \(m * v\) </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="matrices">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/matrices">&#xA0;</a><a class="target" name="toc4.5.3">&#xA0;</a><h3>Matrices</h3>
+<p>
+
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getViewFromWorldMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from world space to view/eye space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldFromViewMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from view/eye space to world space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getClipFromViewMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from view/eye space to clip (NDC) space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getViewFromClipMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from clip (NDC) space to view/eye space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getClipFromWorldMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from world to clip (NDC) space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldFromClipMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from clip (NDC) space to world space </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="frameconstants">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/frameconstants">&#xA0;</a><a class="target" name="toc4.5.4">&#xA0;</a><h3>Frame constants</h3>
+<p>
+
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getResolution()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Resolution of the view in pixels: <code>width</code>, <code>height</code>, <code>1 / width</code>, <code>1 / height</code> </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldCameraPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the camera/eye in world space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getTime()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Current time in seconds, may be reset regularly to avoid precision loss </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getUserTime()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Current time in seconds: <code>time</code>, <code>(double)time - time</code>, <code>0</code>, <code>0</code> </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getUserTimeMode(float m)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Current time modulo m in seconds </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getExposure()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Photometric exposure of the camera </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getEV100()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> <a href="https://en.wikipedia.org/wiki/Exposure_value">Exposure value at ISO 100</a> of the camera </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="vertexonly">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/vertexonly">&#xA0;</a><a class="target" name="toc4.5.5">&#xA0;</a><h3>Vertex only</h3>
+<p>
+
+
+The following APIs are only available from the vertex block:
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getPosition()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Vertex position in the domain defined by the material (default: object/model space) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldFromModelMatrix()</strong> </td><td style="text-align:center"> float4&#xD7;4 </td><td style="text-align:left"> Matrix that converts from model (object) space to world space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldFromModelNormalMatrix()</strong> </td><td style="text-align:center"> float3&#xD7;3 </td><td style="text-align:left"> Matrix that converts normals from model (object) space to world space </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="fragmentonly">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis/fragmentonly">&#xA0;</a><a class="target" name="toc4.5.6">&#xA0;</a><h3>Fragment only</h3>
+<p>
+
+
+The following APIs are only available from the fragment block:
+</p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldTangentFrame()</strong> </td><td style="text-align:center"> float3&#xD7;3 </td><td style="text-align:left"> Matrix containing in each column the <code>tangent</code> (<code>frame[0]</code>), <code>bi-tangent</code> (<code>frame[1]</code>) and <code>normal</code> (<code>frame[2]</code>) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the <code>normal</code> is valid in this matrix. </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the fragment in world space </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldViewVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized vector in world space from the fragment position to the eye </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldNormalVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized normal in world space, after bump mapping (must be used after <code>prepareMaterial()</code>) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldReflectedVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Reflection of the view vector about the normal (must be used after <code>prepareMaterial()</code>) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getNdotV()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> The result of <code>dot(normal, view)</code>, always strictly greater than 0 (must be used after <code>prepareMaterial()</code>) </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getColor()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Interpolated color of the fragment, if the color attribute is required </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getUV0()</strong> </td><td style="text-align:center"> float2 </td><td style="text-align:left"> First interpolated set of UV coordinates, if the uv0 attribute is required </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getUV1()</strong> </td><td style="text-align:center"> float2 </td><td style="text-align:left"> First interpolated set of UV coordinates, if the uv1 attribute is required </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">inverseTonemap(float3)</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Applies the inverse tone mapping operator to the specified linear sRGB color and returns a linear sRGB color. This operation may be an approximation </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">inverseTonemapSRGB(float3)</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Applies the inverse tone mapping operator to the specified non-linear sRGB color and returns a linear sRGB color. This operation may be an approximation </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">luminance(float3)</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Computes the luminance of the specified linear sRGB color </td></tr>
+</tbody></table></div>
+
+<p></p>
+<a class="target" name="compilingmaterials">&#xA0;</a><a class="target" name="compilingmaterials">&#xA0;</a><a class="target" name="toc5">&#xA0;</a><h1>Compiling materials</h1>
+<p>
+
+
+Material packages can be compiled from material definitions using the command line tool called
+<code>matc</code>. The simplest way to use <code>matc</code> is to specify an input material definition (<code>car_paint.mat</code>
+in the example below) and an output material package (<code>car_paint.filamat</code> in the example below):
+
+</p><pre class="listing backtick"><code><span class="line">$ matc -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat</span></code></pre>
+<a class="target" name="shadervalidation">&#xA0;</a><a class="target" name="compilingmaterials/shadervalidation">&#xA0;</a><a class="target" name="toc5.1">&#xA0;</a><h2>Shader validation</h2>
+<p>
+
+
+<code>matc</code> attempts to validate shaders when compiling a material package. The example below shows an
+example of an error message generated when compiling a material definition containing a typo in the
+fragment shader (<code>metalic</code> instead of <code>metallic</code>). The reported line numbers are line numbers in the
+source material definition file.
+
+</p><pre class="listing backtick"><code><span class="line">ERROR: 0:13: &apos;metalic&apos; : no such field in structure</span>
+<span class="line">ERROR: 0:13: &apos;&apos; : compilation terminated</span>
+<span class="line">ERROR: 2 compilation errors.  No code generated.</span>
+<span class="line"></span>
+<span class="line">Could not compile material metal.mat</span></code></pre>
+<a class="target" name="flags">&#xA0;</a><a class="target" name="compilingmaterials/flags">&#xA0;</a><a class="target" name="toc5.2">&#xA0;</a><h2>Flags</h2>
+<p>
+
+
+The command line flags relevant to application development are described in <a href="#table_matcflags">table&#xA0;11</a>.
+</p><div class="table">
+<table class="table"><tbody><tr><th style="text-align:right"> Flag </th><th style="text-align:center"> Value </th><th style="text-align:left"> Usage </th></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-o</strong>, <strong class="asterisk">&#x2014;output</strong> </td><td style="text-align:center"> [path] </td><td style="text-align:left"> Specify the output file path </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-p</strong>, <strong class="asterisk">&#x2014;platform</strong> </td><td style="text-align:center"> desktop/mobile/all </td><td style="text-align:left"> Select the target platform(s) </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-a</strong>, <strong class="asterisk">&#x2014;api</strong> </td><td style="text-align:center"> opengl/vulkan/all </td><td style="text-align:left"> Specify the target graphics API </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-S</strong>, <strong class="asterisk">&#x2014;optimize-size</strong> </td><td style="text-align:center"> N/A </td><td style="text-align:left"> Optimize compiled material for size instead of just performance </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-r</strong>, <strong class="asterisk">&#x2014;reflect</strong> </td><td style="text-align:center"> parameters </td><td style="text-align:left"> Outputs the specified metadata as JSON </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">-v</strong>, <strong class="asterisk">&#x2014;variant-filter</strong> </td><td style="text-align:center"> [variant] </td><td style="text-align:left"> Filters out the specified, comma-separated variants </td></tr>
+</tbody></table><div class="tablecaption"><a class="target" name="table_matcflags">&#xA0;</a><b style="font-style:normal;">Table&#xA0;11:</b> List of <code>matc</code> flags</div></div>
+
+<p></p><p>
+
+<code>matc</code> offers a few other flags that are irrelevant to application developers and for internal
+use only.
+
+</p>
+<a class="target" name="--platform">&#xA0;</a><a class="target" name="compilingmaterials/flags/&#x2014;platform">&#xA0;</a><a class="target" name="toc5.2.1">&#xA0;</a><h3>&#x2014;platform</h3>
+<p>
+
+
+By default, <code>matc</code> generates material packages containing shaders for all supported platforms. If
+you wish to reduce the size of your material packages, it is recommended to select only the
+appropriate target platform. For instance, to compile a material package for Android only, run
+the following command:
+
+</p><pre class="listing backtick"><code><span class="line">$ matc -p mobile -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat</span></code></pre>
+<a class="target" name="--api">&#xA0;</a><a class="target" name="compilingmaterials/flags/&#x2014;api">&#xA0;</a><a class="target" name="toc5.2.2">&#xA0;</a><h3>&#x2014;api</h3>
+<p>
+
+
+By default, <code>matc</code> generates material packages containing shaders for the OpenGL API. You can choose
+to generate shaders for the Vulkan API in addition to the OpenGL shaders. If you intend on targeting
+only Vulkan capable devices, you can reduce the size of the material packages by generating only
+the set of Vulkan shaders:
+
+</p><pre class="listing backtick"><code><span class="line">$ matc -a vulkan -o ./materials/bin/car_paint.filamat ./materials/src/car_paint.mat</span></code></pre>
+<a class="target" name="--optimize-size">&#xA0;</a><a class="target" name="compilingmaterials/flags/&#x2014;optimize-size">&#xA0;</a><a class="target" name="toc5.2.3">&#xA0;</a><h3>&#x2014;optimize-size</h3>
+<p>
+
+
+This flag applies fewer optimization techniques to try and keep the final material as small as
+possible. If the compiled material is deemed too large by default, using this flag might be
+a good compromise between runtime performance and size.
+
+</p>
+<a class="target" name="--reflect">&#xA0;</a><a class="target" name="compilingmaterials/flags/&#x2014;reflect">&#xA0;</a><a class="target" name="toc5.2.4">&#xA0;</a><h3>&#x2014;reflect</h3>
+<p>
+
+
+This flag was designed to help build tools around <code>matc</code>. It allows you to print out specific
+metadata in JSON format. The example below prints out the list of parameters defined in Filament&apos;s
+standard skybox material. It produces a list of 2 parameters, named <code>showSun</code> and <code>skybox</code>,
+respectively a boolean and a cubemap texture.
+
+</p><pre class="listing backtick"><code><span class="line">$ matc --reflect parameters filament/src/materials/skybox.mat </span>
+<span class="line">{</span>
+<span class="line">  &quot;parameters&quot;: [</span>
+<span class="line">    {</span>
+<span class="line">      &quot;name&quot;: &quot;showSun&quot;,</span>
+<span class="line">      &quot;type&quot;: &quot;bool&quot;,</span>
+<span class="line">      &quot;size&quot;: &quot;1&quot;</span>
+<span class="line">    },</span>
+<span class="line">    {</span>
+<span class="line">      &quot;name&quot;: &quot;skybox&quot;,</span>
+<span class="line">      &quot;type&quot;: &quot;samplerCubemap&quot;,</span>
+<span class="line">      &quot;format&quot;: &quot;float&quot;,</span>
+<span class="line">      &quot;precision&quot;: &quot;default&quot;</span>
+<span class="line">    }</span>
+<span class="line">  ]</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="--variant-filter">&#xA0;</a><a class="target" name="compilingmaterials/flags/&#x2014;variant-filter">&#xA0;</a><a class="target" name="toc5.2.5">&#xA0;</a><h3>&#x2014;variant-filter</h3>
+<p>
+
+
+This flag can be used to further reduce the size of a compiled material. It is used to specify a
+list of shader variants that the application guarantees will never be needed. These shader variants
+are skipped during the code generation phase of <code>matc</code>, thus reducing the overall size of the
+material.
+
+</p><p>
+
+The variants must be specified as a comma-separated list, using one of the following available
+variants:
+
+</p><p>
+
+</p><ul>
+<li class="minus"><code>directionalLighting</code>, used when a directional light is present in the scene
+</li>
+<li class="minus"><code>dynamicLighting</code>, used when a non-directional light (point, spot, etc.) is present in the scene
+</li>
+<li class="minus"><code>shadowReceiver</code>, used when an object can receive shadows
+</li>
+<li class="minus"><code>skinning</code>, used when an object is animated using GPU skinning</li></ul>
+
+<p></p><p>
+
+Example:
+</p><pre class="listing backtick"><code><span class="line"><span class="hljs-comment">--variant-filter=skinning,shadowReceiver</span></span></code></pre><p>
+
+Note that some variants may automatically be filtered out. For instance, all lighting related
+variants (<code>directionalLighting</code>, etc.) are filtered out when compiling an <code>unlit</code> material.
+
+</p><p>
+
+When this flag is used, the specified variant filters are merged with the variant filters specified
+in the material itself.
+
+</p><p>
+
+Use this flag with caution, filtering out a variant required at runtime may lead to crashes.
+
+</p>
+<a class="target" name="handlingcolors">&#xA0;</a><a class="target" name="handlingcolors">&#xA0;</a><a class="target" name="toc6">&#xA0;</a><h1>Handling colors</h1>
+
+<a class="target" name="linearcolors">&#xA0;</a><a class="target" name="handlingcolors/linearcolors">&#xA0;</a><a class="target" name="toc6.1">&#xA0;</a><h2>Linear colors</h2>
+<p>
+
+
+If the color data comes from a texture, simply make sure you use an sRGB texture to benefit from
+automatic hardware conversion from sRGB to linear. If the color data is passed as a parameter to
+the material you can convert from sRGB to linear by running the following algorithm on each
+color channel:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-type">float</span> sRGB_to_linear(<span class="hljs-type">float</span> color) {</span>
+<span class="line">	<span class="hljs-keyword">return</span> color &lt;= <span class="hljs-number">0.04045</span> ? color / <span class="hljs-number">12.92</span> : <span class="hljs-built_in">pow</span>((color + <span class="hljs-number">0.055</span>) / <span class="hljs-number">1.055</span>, <span class="hljs-number">2.4</span>);</span>
+<span class="line">}</span></code></pre><p>
+
+Alternatively you can use one of the two cheaper but less accurate versions shown below:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// Cheaper</span></span>
+<span class="line">linearColor = <span class="hljs-built_in">pow</span>(color, <span class="hljs-number">2.2</span>);</span>
+<span class="line"><span class="hljs-comment">// Cheapest</span></span>
+<span class="line">linearColor = color * color;</span></code></pre>
+<a class="target" name="pre-multipliedalpha">&#xA0;</a><a class="target" name="handlingcolors/pre-multipliedalpha">&#xA0;</a><a class="target" name="toc6.2">&#xA0;</a><h2>Pre-multiplied alpha</h2>
+<p>
+
+
+A color uses pre-multiplied alpha if its RGB components are multiplied by the alpha channel:
+
+</p><pre class="listing tilde"><code><span class="line"><span class="hljs-comment">// Compute pre-multiplied color</span></span>
+<span class="line">color.rgb *= color.a;</span></code></pre><p>
+
+If the color is sampled from a texture, you can simply ensure that the texture data is
+pre-multiplied ahead of time. On Android, any texture uploaded from a
+<a href="https://developer.android.com/reference/android/graphics/Bitmap.html">Bitmap</a> will be
+pre-multiplied by default.
+
+</p><p>
+
+</p></span><div class="markdeepFooter"><i>formatted by <a href="http://casual-effects.com/markdeep" style="color:#999">Markdeep&#xA0;1.03&#xA0;&#xA0;</a></i><div style="display:inline-block;font-size:13px;font-family:&apos;Times New Roman&apos;,serif;vertical-align:middle;transform:translate(-3px,-1px)rotate(135deg);">&#x2712;</div></div><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><script>window.alreadyProcessedMarkdeep||(document.body.style.visibility="visible")</script>
+</body></html>


### PR DESCRIPTION
build.sh -w can now be used to "rasterize" Markdeep .md.html files
to regular, static .html files. These files load faster and do not
suffer from an initial flash of uninitialized content.

This new command requires node, npm and nx to run puppeteer to
"rasterize" the Markdeep documents. This should eventually be
integrated in the actual build system to automatically re-generate
the HTML files when the Markdeep documents are edited.