### PR TITLE
API change: rename matrix factory functions

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -462,7 +462,7 @@ mat4f ShadowMap::applyLISPSM(CameraInfo const& camera, float dzn, float dzf, mat
         };
 
         const mat4f Wp = warpFrustum(nopt, nopt + d);
-        const mat4f Wv = mat4f::translate(-p);
+        const mat4f Wv = mat4f::translation(-p);
         W = Wp * Wv;
     }
     return W;

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -567,13 +567,13 @@ TEST(FilamentTest, Bones) {
         static mat3f normal(PerRenderableUibBone const& bone) noexcept {
             quatf q = bone.q;
             float3 is = bone.ns.xyz;
-            return mat3f(mat3(q) * mat3::scale(is));
+            return mat3f(mat3(q) * mat3::scaling(is));
         }
         static  mat4f vertice(PerRenderableUibBone const& bone) noexcept {
             quatf q = bone.q;
             float3 t = bone.t.xyz;
             float3 s = bone.s.xyz;
-            return mat4f(mat4::translate(t) * mat4(q) * mat4::scale(s));
+            return mat4f(mat4::translation(t) * mat4(q) * mat4::scaling(s));
         }
         static float3 normal(float3 n, PerRenderableUibBone const& bone) noexcept {
             quatf q = bone.q;
@@ -651,36 +651,36 @@ TEST(FilamentTest, Bones) {
     };
 
     Test::check(mat4f{});
-    Test::check(mat4f::translate(float3{1,2,3}));
+    Test::check(mat4f::translation(float3{ 1, 2, 3 }));
 
-    Test::check(mat4f::scale(float3{2,2,2}));
+    Test::check(mat4f::scaling(float3{ 2, 2, 2 }));
 
-    Test::check(mat4f::scale(float3{4,2,3}));
-    Test::check(mat4f::scale(float3{4,-2,-3}));
-    Test::check(mat4f::scale(float3{-4,2,-3}));
-    Test::check(mat4f::scale(float3{-4,-2,3}));
+    Test::check(mat4f::scaling(float3{ 4, 2, 3 }));
+    Test::check(mat4f::scaling(float3{ 4, -2, -3 }));
+    Test::check(mat4f::scaling(float3{ -4, 2, -3 }));
+    Test::check(mat4f::scaling(float3{ -4, -2, 3 }));
 
-    Test::check(mat4f::scale(float3{-4,-2,-3}));
-    Test::check(mat4f::scale(float3{-4,2,3}));
-    Test::check(mat4f::scale(float3{4,-2,3}));
-    Test::check(mat4f::scale(float3{4,2,-3}));
+    Test::check(mat4f::scaling(float3{ -4, -2, -3 }));
+    Test::check(mat4f::scaling(float3{ -4, 2, 3 }));
+    Test::check(mat4f::scaling(float3{ 4, -2, 3 }));
+    Test::check(mat4f::scaling(float3{ 4, 2, -3 }));
 
-    Test::check(mat4f::rotate(M_PI_2, float3{0,0,1}));
-    Test::check(mat4f::rotate(M_PI_2, float3{0,1,0}));
-    Test::check(mat4f::rotate(M_PI_2, float3{1,0,0}));
-    Test::check(mat4f::rotate(M_PI_2, float3{0,1,1}));
-    Test::check(mat4f::rotate(M_PI_2, float3{1,0,1}));
-    Test::check(mat4f::rotate(M_PI_2, float3{1,1,0}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{0,0,1}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{0,1,0}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{1,0,0}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{0,1,1}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{1,0,1}));
-    Test::check(mat4f::rotate(-M_PI_2, float3{1,1,0}));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 0, 1 }));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 1, 0 }));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 0, 0 }));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 1, 1 }));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 0, 1 }));
+    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 1, 0 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 0, 1 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 1, 0 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 0, 0 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 1, 1 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 0, 1 }));
+    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 1, 0 }));
 
-    mat4f m = mat4f::translate(float3{1,2,3}) *
-              mat4f::rotate(-M_PI_2, float3{1,1,0}) *
-              mat4f::scale(float3{-2,3,0.04});
+    mat4f m = mat4f::translation(float3{ 1, 2, 3 }) *
+                                                    mat4f::rotation(-M_PI_2, float3{ 1, 1, 0 }) *
+                                                    mat4f::scaling(float3{ -2, 3, 0.04 });
 
     Test::check(m);
 

--- a/libs/math/include/math/TMatHelpers.h
+++ b/libs/math/include/math/TMatHelpers.h
@@ -449,8 +449,9 @@ public:
         static_assert(BASE<T>::NUM_ROWS == 3 || BASE<T>::NUM_ROWS == 4, "3x3 or 4x4 matrices only");
     }
 
-    template <typename A, typename VEC>
-    static BASE<T> rotate(A radian, const VEC& about) {
+    template<typename A, typename VEC,
+            typename = typename std::enable_if<std::is_arithmetic<A>::value>::type>
+    static BASE<T> rotation(A radian, const VEC& about) {
         BASE<T> r;
         T c = std::cos(radian);
         T s = std::sin(radian);

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -253,26 +253,19 @@ public:
     }
 
     template <typename A>
-    static constexpr TMat22 translate(const TVec2<A>& t) {
+    static constexpr TMat22 translation(const TVec2<A>& t) {
         TMat22 r;
         r[2] = t;
         return r;
     }
 
     template <typename A>
-    static constexpr TMat22 translate(A t) {
-        TMat22 r;
-        r[1] = TVec2<T>{ t };
-        return r;
-    }
-
-    template <typename A>
-    static constexpr TMat22 scale(const TVec2<A>& s) {
+    static constexpr TMat22 scaling(const TVec2<A>& s) {
         return TMat22{ s };
     }
 
     template <typename A>
-    static constexpr TMat22 scale(A s) {
+    static constexpr TMat22 scaling(A s) {
         return TMat22{ TVec2<T>{ s, s } };
     }
 };

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -269,26 +269,19 @@ public:
             size_t storageSize = sizeof(int16_t));
 
     template <typename A>
-    static constexpr TMat33 translate(const TVec3<A>& t) {
+    static constexpr TMat33 translation(const TVec3<A>& t) {
         TMat33 r;
         r[2] = t;
         return r;
     }
 
     template <typename A>
-    static constexpr TMat33 translate(A t) {
-        TMat33 r;
-        r[2] = TVec3<T>{ t };
-        return r;
-    }
-
-    template <typename A>
-    static constexpr TMat33 scale(const TVec3<A>& s) {
+    static constexpr TMat33 scaling(const TVec3<A>& s) {
         return TMat33{ s };
     }
 
     template <typename A>
-    static constexpr TMat33 scale(A s) {
+    static constexpr TMat33 scaling(A s) {
         return TMat33{ TVec3<T>{ s } };
     }
 };

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -320,26 +320,19 @@ public:
     }
 
     template <typename A>
-    static constexpr TMat44 translate(const TVec3<A>& t) {
+    static constexpr TMat44 translation(const TVec3<A>& t) {
         TMat44 r;
         r[3] = TVec4<T>{ t, 1 };
         return r;
     }
 
     template <typename A>
-    static constexpr TMat44 translate(A t) {
-        TMat44 r;
-        r[3] = TVec4<T>{ t, t, t, 1 };
-        return r;
-    }
-
-    template <typename A>
-    static constexpr TMat44 scale(const TVec3<A>& s) {
+    static constexpr TMat44 scaling(const TVec3<A>& s) {
         return TMat44{ TVec4<T>{ s, 1 } };
     }
 
     template <typename A>
-    static constexpr TMat44 scale(A s) {
+    static constexpr TMat44 scaling(A s) {
         return TMat44{ TVec4<T>{ s, s, s, 1 } };
     }
 };

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -520,7 +520,7 @@ TYPED_TEST(MatTestT, Translation4) {
 
     V3T translateBy(-7.3, 1.1, 14.4);
     V3T translation(translateBy[0], translateBy[1], translateBy[2]);
-    M44T translation_matrix = M44T::translate(translation);
+    M44T translation_matrix = M44T::translation(translation);
 
     V4T p1(9.9, 3.1, 41.1, 1.0);
     V4T p2(-18.0, 0.0, 1.77, 1.0);
@@ -532,7 +532,7 @@ TYPED_TEST(MatTestT, Translation4) {
     EXPECT_VEC_EQ((translation_matrix * p3).xyz, translateBy + p3.xyz);
     EXPECT_VEC_EQ((translation_matrix * p4).xyz, translateBy + p4.xyz);
 
-    translation_matrix = M44T::translate(2.7);
+    translation_matrix = M44T::translation(V3T{2.7});
     EXPECT_VEC_EQ((translation_matrix * p1).xyz, V3T{2.7} + p1.xyz);
 }
 
@@ -545,7 +545,7 @@ TYPED_TEST(MatTestT, Scale4) {
 
     V3T scaleBy(2.0, 3.0, 4.0);
     V3T scale(scaleBy[0], scaleBy[1], scaleBy[2]);
-    M44T scale_matrix = M44T::scale(scale);
+    M44T scale_matrix = M44T::scaling(scale);
 
     V4T p1(9.9, 3.1, 41.1, 1.0);
     V4T p2(-18.0, 0.0, 1.77, 1.0);
@@ -557,7 +557,7 @@ TYPED_TEST(MatTestT, Scale4) {
     EXPECT_VEC_EQ((scale_matrix * p3).xyz, scaleBy * p3.xyz);
     EXPECT_VEC_EQ((scale_matrix * p4).xyz, scaleBy * p4.xyz);
 
-    scale_matrix = M44T::scale(3.0);
+    scale_matrix = M44T::scaling(3.0);
     EXPECT_VEC_EQ((scale_matrix * p1).xyz, V3T{3.0} * p1.xyz);
 }
 
@@ -632,7 +632,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
 
     for (size_t i = 0; i < 100; ++i) {
         M44T r = M44T::eulerZYX(rand_gen(), rand_gen(), rand_gen());
-        M44T t = M44T::translate(V3T(rand_gen(), rand_gen(), rand_gen()));
+        M44T t = M44T::translation(V3T(rand_gen(), rand_gen(), rand_gen()));
         QuatT qr = r.toQuaternion();
         M44T tr = t * r;
         QuatT qtr = tr.toQuaternion();
@@ -644,7 +644,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
     }
 
     M44T r = M44T::eulerZYX(1, 2, 3);
-    M44T t = M44T::translate(V3T(20, -15, 2));
+    M44T t = M44T::translation(V3T(20, -15, 2));
     QuatT qr = r.toQuaternion();
     M44T tr = t * r;
     QuatT qtr = tr.toQuaternion();

--- a/samples/app/CameraManipulator.cpp
+++ b/samples/app/CameraManipulator.cpp
@@ -24,7 +24,7 @@ static constexpr inline double radians(T deg) {
 }
 
 static inline double3 rotateVector(double rx, double ry, const double3& v) {
-    return (mat3::rotate(ry, double3{ 0, 1, 0}) * mat3::rotate(rx, double3{ 1, 0, 0})) * v;
+    return (mat3::rotation(ry, double3{ 0, 1, 0 }) * mat3::rotation(rx, double3{ 1, 0, 0 })) * v;
 }
 
 //------------------------------------------------------------------------------
@@ -113,10 +113,10 @@ void CameraManipulator::rotate(const double2& delta, double rotate_speed) {
 
 void CameraManipulator::updateCameraTransform() {
     if (mCamera) {
-        mat4 rotate_z  = mat4::rotate(mRotation.z, double3(0, 0, 1));
-        mat4 rotate_x  = mat4::rotate(mRotation.x, double3(1, 0, 0));
-        mat4 rotate_y  = mat4::rotate(mRotation.y, double3(0, 1, 0));
-        mat4 translate = mat4::translate(mTranslation);
+        mat4 rotate_z  = mat4::rotation(mRotation.z, double3(0, 0, 1));
+        mat4 rotate_x  = mat4::rotation(mRotation.x, double3(1, 0, 0));
+        mat4 rotate_y  = mat4::rotation(mRotation.y, double3(0, 1, 0));
+        mat4 translate = mat4::translation(mTranslation);
         mat4 view = translate * (rotate_y * rotate_x * rotate_z);
         mCamera->setModelMatrix(mat4f(view));
         if (mCameraChanged) {

--- a/samples/app/Cube.cpp
+++ b/samples/app/Cube.cpp
@@ -121,7 +121,7 @@ void Cube::mapFrustum(filament::Engine& engine, filament::math::mat4 const& tran
 
 
 void Cube::mapAabb(filament::Engine& engine, filament::Box const& box) {
-    mat4 p = mat4::translate(box.center) * mat4::scale(box.halfExtent);
+    mat4 p = mat4::translation(box.center) * mat4::scaling(box.halfExtent);
     return mapFrustum(engine, p);
 }
 

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -135,7 +135,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     center.z -= 4.0f / scaleFactor;
 
     auto rooti = tcm.getInstance(g_meshSet->rootEntity);
-    tcm.setTransform(rooti, mat4f::scale(float3(scaleFactor)) * mat4f::translate(center));
+    tcm.setTransform(rooti, mat4f::scaling(float3(scaleFactor)) * mat4f::translation(center));
 
     for (auto renderable : g_meshSet->getRenderables()) {
         if (rcm.hasComponent(renderable)) {

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -299,7 +299,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         slog.d << "light count = " << n << io::endl;
 
         Entity discoBall = em.create();
-        tcm.create(discoBall, {}, mat4f::translate(float3{ 0, 3, -14 }));
+        tcm.create(discoBall, {}, mat4f::translation(float3{ 0, 3, -14 }));
         auto parent = tcm.getInstance(discoBall);
 
         for (size_t i = 0, c = n; i < c; i++) {
@@ -409,7 +409,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         scene->addEntity(planeRenderable);
 
         tcm.setTransform(tcm.getInstance(planeRenderable),
-                filament::math::mat4f::translate(float3{0, -1, -4}));
+                filament::math::mat4f::translation(float3{ 0, -1, -4 }));
     }
 }
 #pragma clang diagnostic pop
@@ -439,8 +439,9 @@ int main(int argc, char* argv[]) {
         filamentApp.animate([lastTime](filament::Engine* engine, filament::View*, double now) mutable {
             auto& tcm = engine->getTransformManager();
             tcm.setTransform(tcm.getInstance(g_discoBallEntity),
-                    mat4f::translate(float3{ 0, 2, -4, }) *
-                    mat4f::rotate(g_discoAngle, float3{ 0, 1, 0 })
+                    mat4f::translation(float3{ 0, 2, -4, }) *
+                                                            mat4f::rotation(g_discoAngle,
+                                                                    float3{ 0, 1, 0 })
             );
             if (lastTime != 0) {
                 double dT = now - lastTime;

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -258,7 +258,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
         scene->addEntity(planeRenderable);
 
         tcm.setTransform(tcm.getInstance(planeRenderable),
-                filament::math::mat4f::translate(float3{0, -1, -4}));
+                filament::math::mat4f::translation(float3{ 0, -1, -4 }));
     }
 }
 
@@ -373,7 +373,7 @@ static void gui(filament::Engine* engine, filament::View*) {
     if (ibl) {
         ibl->getIndirectLight()->setIntensity(params.iblIntensity);
         ibl->getIndirectLight()->setRotation(
-                mat3f::rotate(params.iblRotation, float3{ 0, 1, 0 }));
+                mat3f::rotation(params.iblRotation, float3{ 0, 1, 0 }));
     }
 }
 

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 
         auto ibl = FilamentApp::get().getIBL()->getIndirectLight();
         ibl->setIntensity(100000);
-        ibl->setRotation(mat3f::rotate(0.5f, float3{ 0, 1, 0 }));
+        ibl->setRotation(mat3f::rotation(0.5f, float3{ 0, 1, 0 }));
 
         // Add geometry into the scene.
         app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr,

--- a/samples/vk_animation.cpp
+++ b/samples/vk_animation.cpp
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
             -ZOOM, ZOOM, 0, 1);
         auto& tcm = engine->getTransformManager();
         tcm.setTransform(tcm.getInstance(app.renderable),
-             filament::math::mat4f::rotate(now, filament::math::float3{0, 0, 1}));
+                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 0, 1 }));
     });
 
     FilamentApp::get().run(config, setup, cleanup);

--- a/samples/vk_depthtesting.cpp
+++ b/samples/vk_depthtesting.cpp
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
                 -ZOOM, ZOOM, -5, 5);
         auto& tcm = engine->getTransformManager();
         tcm.setTransform(tcm.getInstance(app.colorTriangle),
-                filament::math::mat4f::rotate(now, filament::math::float3{0, 1, 0}));
+                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 1, 0 }));
     });
 
     FilamentApp::get().run(config, setup, cleanup);

--- a/samples/vk_hellopbr.cpp
+++ b/samples/vk_hellopbr.cpp
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
     FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
         auto& tcm = engine->getTransformManager();
         auto ti = tcm.getInstance(app.mesh.renderable);
-        tcm.setTransform(ti, app.transform * mat4f::rotate(now, float3{0, 1, 0}));
+        tcm.setTransform(ti, app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
     });
 
     FilamentApp::get().run(config, setup, cleanup);

--- a/samples/vk_hellotriangle.cpp
+++ b/samples/vk_hellotriangle.cpp
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
             -ZOOM, ZOOM, 0, 1);
         auto& tcm = engine->getTransformManager();
         tcm.setTransform(tcm.getInstance(app.renderable),
-             filament::math::mat4f::rotate(now, filament::math::float3{0, 0, 1}));
+                filament::math::mat4f::rotation(now, filament::math::float3{ 0, 0, 1 }));
     });
 
     FilamentApp::get().run(config, setup, cleanup);

--- a/samples/vk_shadowtest.cpp
+++ b/samples/vk_shadowtest.cpp
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
     FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {
         auto& tcm = engine->getTransformManager();
         auto ti = tcm.getInstance(app.meshes->getRenderables()[0]);
-        tcm.setTransform(ti, app.transform * mat4f::rotate(now, float3{0, 1, 0}));
+        tcm.setTransform(ti, app.transform * mat4f::rotation(now, float3{ 0, 1, 0 }));
     });
 
     FilamentApp::get().run(config, setup, cleanup);
@@ -173,7 +173,7 @@ static GroundPlane createGroundPlane(Engine* engine) {
         .build(*engine, renderable);
 
     auto& tcm = engine->getTransformManager();
-    tcm.setTransform(tcm.getInstance(renderable), mat4f::translate(float3{0, -1, -4}));
+    tcm.setTransform(tcm.getInstance(renderable), mat4f::translation(float3{ 0, -1, -4 }));
     return {
         .vb = vertexBuffer,
         .ib = indexBuffer,


### PR DESCRIPTION
scale() -> scaling()
translate() -> translation()
rotate() -> rotation()

These static functions create a matrix, they don't modify it.
Fixes #826