### PR TITLE
Program::shader() now only takes a void* + size

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -452,8 +452,8 @@ Handle<HwProgram> FEngine::createPostProcessProgram(MaterialParser& parser,
     Program pb;
     pb      .diagnostics(CString("Post Process"))
             .withSamplerBindings(pBindings)
-            .withVertexShader(vShaderBuilder.getShader())
-            .withFragmentShader(fShaderBuilder.getShader())
+            .withVertexShader(vShaderBuilder.data(), vShaderBuilder.size())
+            .withFragmentShader(fShaderBuilder.data(), fShaderBuilder.size())
             .addUniformBlock(BindingPoints::PER_VIEW, &PerViewUib::getUib())
             .addUniformBlock(BindingPoints::POST_PROCESS, &PostProcessingUib::getUib())
             .addSamplerBlock(BindingPoints::POST_PROCESS, &PostProcessSib::getSib());

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -316,8 +316,8 @@ Handle<HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
 
     Program pb;
     pb      .diagnostics(mName, variantKey)
-            .withVertexShader(vsBuilder.getShader())
-            .withFragmentShader(fsBuilder.getShader())
+            .withVertexShader(vsBuilder.data(), vsBuilder.size())
+            .withFragmentShader(fsBuilder.data(), fsBuilder.size())
             .withSamplerBindings(&mSamplerBindings)
             .addUniformBlock(BindingPoints::PER_VIEW, &UibGenerator::getPerViewUib())
             .addUniformBlock(BindingPoints::LIGHTS, &UibGenerator::getLightsUib())

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -147,39 +147,26 @@ bool MaterialParser::getPostProcessVersion(uint32_t* value) const noexcept {
 
 bool MaterialParser::getName(utils::CString* cstring) const noexcept {
    ChunkType type = ChunkType::MaterialName;
-
    const uint8_t* start = mImpl->mChunkContainer.getChunkStart(type);
    const uint8_t* end = mImpl->mChunkContainer.getChunkEnd(type);
    Unflattener unflattener(start, end);
-
-   CString s;
-   if (unflattener.read(&s)) {
-       *cstring =  CString(s.c_str());
-       return true;
-   } else {
-       *cstring = CString("");
-       return false;
-   }
+   return unflattener.read(cstring);
 }
 
 bool MaterialParser::getUIB(UniformInterfaceBlock* uib) const noexcept {
     auto type = MaterialUib;
-
     const uint8_t* start = mImpl->mChunkContainer.getChunkStart(type);
     const uint8_t* end = mImpl->mChunkContainer.getChunkEnd(type);
     Unflattener unflattener(start, end);
-
-    return ChunkUniformInterfaceBlock().unflatten(unflattener, uib);
+    return ChunkUniformInterfaceBlock::unflatten(unflattener, uib);
 }
 
 bool MaterialParser::getSIB(SamplerInterfaceBlock* sib) const noexcept {
     auto type = MaterialSib;
-
     const uint8_t* start = mImpl->mChunkContainer.getChunkStart(type);
     const uint8_t* end = mImpl->mChunkContainer.getChunkEnd(type);
     Unflattener unflattener(start, end);
-
-    return ChunkSamplerInterfaceBlock().unflatten(unflattener, sib);
+    return ChunkSamplerInterfaceBlock::unflatten(unflattener, sib);
 }
 
 bool MaterialParser::getShaderModels(uint32_t* value) const noexcept {

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -89,11 +89,11 @@ protected:
 };
 
 struct ChunkUniformInterfaceBlock {
-    bool unflatten(filaflat::Unflattener& unflattener, UniformInterfaceBlock* uib);
+    static bool unflatten(filaflat::Unflattener& unflattener, UniformInterfaceBlock* uib);
 };
 
 struct ChunkSamplerInterfaceBlock {
-    bool unflatten(filaflat::Unflattener& unflattener, SamplerInterfaceBlock* sib);
+    static bool unflatten(filaflat::Unflattener& unflattener, SamplerInterfaceBlock* sib);
 };
 
 } // namespace filamat

--- a/filament/src/driver/Program.cpp
+++ b/filament/src/driver/Program.cpp
@@ -16,6 +16,9 @@
 
 #include "driver/Program.h"
 
+#include <private/filament/SamplerInterfaceBlock.h>
+#include <private/filament/UniformInterfaceBlock.h>
+
 using namespace utils;
 
 namespace filament {
@@ -49,13 +52,10 @@ Program& Program::withSamplerBindings(const SamplerBindingMap* bindings) {
     return *this;
 }
 
-Program& Program::shader(Program::Shader shader, CString const& source) {
-    mShadersSource[size_t(shader)] = source;
-    return *this;
-}
-
-Program& Program::shader(Program::Shader shader, CString&& source) noexcept {
-    source.swap(mShadersSource[size_t(shader)]);
+Program& Program::shader(Program::Shader shader, void const* data, size_t size) noexcept {
+    std::vector<uint8_t> blob(size);
+    std::copy_n((const uint8_t *)data, size, blob.data());
+    mShadersSource[size_t(shader)] = std::move(blob);
     return *this;
 }
 

--- a/filament/src/driver/metal/MetalHandles.mm
+++ b/filament/src/driver/metal/MetalHandles.mm
@@ -204,7 +204,7 @@ MetalProgram::MetalProgram(id<MTLDevice> device, const Program& program) noexcep
         if (source.empty()) {
             continue;
         }
-        NSString* objcSource = [NSString stringWithCString:source.c_str()
+        NSString* objcSource = [NSString stringWithCString:(const char*)source.data()
                                                   encoding:NSUTF8StringEncoding];
         NSError* error = nil;
         id<MTLLibrary> library = [device newLibraryWithSource:objcSource

--- a/filament/src/driver/opengl/OpenGLProgram.cpp
+++ b/filament/src/driver/opengl/OpenGLProgram.cpp
@@ -16,14 +16,16 @@
 
 #include "driver/opengl/OpenGLProgram.h"
 
-#include <cctype>
-#include <sstream>
+#include <private/filament/SamplerInterfaceBlock.h>
+#include <private/filament/UniformInterfaceBlock.h>
+
+#include "driver/opengl/OpenGLDriver.h"
 
 #include <utils/Log.h>
 #include <utils/compiler.h>
 #include <utils/Panic.h>
 
-#include "driver/opengl/OpenGLDriver.h"
+#include <cctype>
 
 namespace filament {
 
@@ -62,9 +64,9 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
                 break;
         }
 
-        if (shadersSource[i].length()) {
+        if (!shadersSource[i].empty()) {
             GLint status;
-            char const* const source = shadersSource[i].c_str();
+            char const* const source = (const char*)shadersSource[i].data();
 
             GLuint shaderId = glCreateShader(glShaderType);
             glShaderSource(shaderId, 1, &source, nullptr);

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -61,7 +61,7 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
         VkShaderModuleCreateInfo moduleInfo = {};
         moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
         moduleInfo.codeSize = blob.size();
-        moduleInfo.pCode = (uint32_t*) blob.c_str();
+        moduleInfo.pCode = (uint32_t*) blob.data();
         VkResult result = vkCreateShaderModule(context.device, &moduleInfo, VKALLOC, module);
         ASSERT_POSTCONDITION(result == VK_SUCCESS, "Unable to create shader module.");
     }

--- a/libs/filaflat/include/filaflat/ShaderBuilder.h
+++ b/libs/filaflat/include/filaflat/ShaderBuilder.h
@@ -27,6 +27,8 @@ namespace filaflat {
 class ShaderBuilder {
 public:
     ShaderBuilder();
+    ShaderBuilder(ShaderBuilder const& rhs) = delete;
+    ShaderBuilder& operator=(ShaderBuilder const&rhs) = delete;
     ~ShaderBuilder();
 
     // Before using a shader buffer to create a shader you should reset it.
@@ -36,13 +38,10 @@ public:
     void announce(size_t size);
 
     // Append a data blob to the shader. Returns true if successful.
-    void appendPart(const char* data, size_t size) noexcept;
+    void append(const char* data, size_t size) noexcept;
 
-    // returns a copy of the shader string
-    utils::CString getShader() const { return { mShader, mCursor }; }
-
-    // returns the shader string. valid until next api call.
-    char const* c_str() const noexcept { return mShader; }
+    // returns the shader blob. valid until next api call.
+    void const* data() const noexcept { return mShader; }
 
     size_t size() const { return mCursor; }
 

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -108,12 +108,12 @@ bool MaterialChunk::getTextShader(Unflattener unflattener, BlobDictionary& dicti
             return false;
         }
         const char* string = dictionary.getString(lineIndex);
-        shader.appendPart(string, strlen(string));
-        shader.appendPart("\n", 1);
+        shader.append(string, strlen(string));
+        shader.append("\n", 1);
     }
 
     // Write the terminating null character.
-    shader.appendPart("", 1);
+    shader.append("", 1);
 
     return true;
 }
@@ -137,7 +137,7 @@ bool MaterialChunk::getSpirvShader(Unflattener unflattener, BlobDictionary& dict
     const char* shaderContent = dictionary.getBlob(index, &shaderSize);
     builder.reset();
     builder.announce(shaderSize);
-    builder.appendPart(shaderContent, shaderSize);
+    builder.append(shaderContent, shaderSize);
     return true;
 }
 

--- a/libs/filaflat/src/ShaderBuilder.cpp
+++ b/libs/filaflat/src/ShaderBuilder.cpp
@@ -33,17 +33,16 @@ ShaderBuilder::~ShaderBuilder() {
 
 void ShaderBuilder::reset() {
     mCursor = 0;
-    mShader[0] = '\0';
 }
 
 void ShaderBuilder::announce(size_t size) {
     if (size > mCapacity) {
         mCapacity = (uint32_t)size;
-        mShader = (char *)realloc(mShader, size);
+        mShader = (char*)realloc(mShader, size);
     }
 }
 
-void ShaderBuilder::appendPart(const char* data, size_t size) noexcept {
+void ShaderBuilder::append(const char* data, size_t size) noexcept {
     size_t available = mCapacity - mCursor;
     assert(size <= available);
     memcpy(mShader + mCursor, data, size);

--- a/libs/filaflat/src/Unflattener.cpp
+++ b/libs/filaflat/src/Unflattener.cpp
@@ -40,7 +40,7 @@ bool Unflattener::read(const char** blob, size_t* size) noexcept {
     mCursor += nbytes;
     bool overflowed = mCursor > mEnd;
     if (!overflowed) {
-        *blob = (const char*) start;
+        *blob = (const char*)start;
         *size = nbytes;
     }
     return !overflowed;
@@ -55,7 +55,7 @@ bool Unflattener::read(const char** s) noexcept {
     if (!overflowed) {
         mCursor++;
     }
-    *s = (char*) start;
+    *s = (char*)start;
     return !overflowed;
 }
 

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -200,6 +200,7 @@ public:
 
     CString() noexcept = default;
 
+    // cstr must be a null terminated string and length == strlen(cstr)
     CString(const char* cstr, size_type length);
 
     template<size_t N>

--- a/libs/utils/src/CString.cpp
+++ b/libs/utils/src/CString.cpp
@@ -35,9 +35,7 @@ int StaticString::compare(const StaticString& rhs) const noexcept {
 UTILS_NOINLINE
 CString::CString(const char* cstr, size_type length) {
     if (length && cstr) {
-        // I think we can't use this assert with vulkan, because shaders are returned as CString
-        // (see ShaderBuilder).
-        // assert(length == strlen(cstr));
+        assert(length == strlen(cstr));
         Data* p = (Data*)malloc(sizeof(Data) + length + 1);
         p->length = length;
         mCStr = (value_type*)(p + 1);

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -909,7 +909,7 @@ static bool parseChunks(Config config, void* data, size_t size) {
 
             const auto& item = info[config.shaderIndex];
             parser.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
-            std::cout << builder.c_str();
+            std::cout << builder.data();
 
             return true;
         }
@@ -935,7 +935,7 @@ static bool parseChunks(Config config, void* data, size_t size) {
             parser.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
 
             // Build std::vector<uint32_t> since that's what the Khronos libraries consume.
-            uint32_t const* words = reinterpret_cast<uint32_t const*>(builder.c_str());
+            uint32_t const* words = reinterpret_cast<uint32_t const*>(builder.data());
             assert(0 == (builder.size() % 4));
             const std::vector<uint32_t> spirv(words, words + builder.size() / 4);
 
@@ -969,7 +969,7 @@ static bool parseChunks(Config config, void* data, size_t size) {
 
             const auto& item = info[config.shaderIndex];
             parser.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
-            std::cout << builder.getShader().c_str();
+            std::cout << builder.data();
 
             return true;
         }


### PR DESCRIPTION
Program::shader() was taking a string before which didn't make sense
for spirv.  Now it's just a blob, in the case of GL/Metal, the blob
must be a null terminated c-string, and the size must include the
terminating null character.

This fixes an out-of-bound access in ShaderBuilder::getShader() (which
doesn't exist anymore), because it was creating a CString passing
a size that included the null terminating char, which is not was CString
expects. CString can now assert() in that case.

driver::Program now uses a std::vector<> for storage, which we should
fix at some point (b/c it's a public header). CString was not suited to
store binary blobs.