### PR TITLE
Vulkan: support R16G16B16 textures via DataReshaper.

### DIFF
--- a/filament/src/driver/vulkan/VulkanDriverImpl.cpp
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.cpp
@@ -640,10 +640,11 @@ VkFormat getVkFormat(TextureFormat format) {
         case TextureFormat::DEPTH24_STENCIL8:  return VK_FORMAT_D24_UNORM_S8_UINT;
         case TextureFormat::DEPTH32F_STENCIL8: return VK_FORMAT_D32_SFLOAT_S8_UINT;
 
-        // 48 bits per element. Note that many GPU vendors do not support these.
-        case TextureFormat::RGB16F:            return VK_FORMAT_R16G16B16_SFLOAT;
-        case TextureFormat::RGB16UI:           return VK_FORMAT_R16G16B16_UINT;
-        case TextureFormat::RGB16I:            return VK_FORMAT_R16G16B16_SINT;
+        // 48 bits per element. In practice, very few GPU vendors support these. So, we simply
+        // always reshape them into 64-bit formats.
+        case TextureFormat::RGB16F:            return VK_FORMAT_R16G16B16A16_SFLOAT;
+        case TextureFormat::RGB16UI:           return VK_FORMAT_R16G16B16A16_UINT;
+        case TextureFormat::RGB16I:            return VK_FORMAT_R16G16B16A16_SINT;
 
         // 64 bits per element.
         case TextureFormat::RG32F:             return VK_FORMAT_R32G32_SFLOAT;

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -475,7 +475,8 @@ VulkanTexture::~VulkanTexture() {
 void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t width,
         uint32_t height, int miplevel) {
     assert(width <= this->width && height <= this->height);
-    const bool reshape = getBytesPerPixel(format) == 3;
+    const uint32_t srcBytesPerTexel = getBytesPerPixel(format);
+    const bool reshape = srcBytesPerTexel == 3 || srcBytesPerTexel == 6;
     const void* cpuData = data.buffer;
     const uint32_t numSrcBytes = data.size;
     const uint32_t numDstBytes = reshape ? (4 * numSrcBytes / 3) : numSrcBytes;
@@ -484,10 +485,19 @@ void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t wi
     VulkanStage const* stage = mStagePool.acquireStage(numDstBytes);
     void* mapped;
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
-    if (reshape) {
-        DataReshaper::reshape<uint8_t, 3, 4>(mapped, cpuData, numSrcBytes);
-    } else {
-        memcpy(mapped, cpuData, numSrcBytes);
+    switch (srcBytesPerTexel) {
+        case 3:
+            // Morph the data from 3 bytes per texel to 4 bytes per texel and set alpha to 1.
+            DataReshaper::reshape<uint8_t, 3, 4>(mapped, cpuData, numSrcBytes);
+            break;
+        case 6:
+            // Morph the data from 6 bytes per texel to 8 bytes per texel. Note that this does not
+            // set alpha to 1 for half-float formats, but in practice that's fine since alpha is
+            // just a dummy channel in this situation.
+            DataReshaper::reshape<uint16_t, 3, 4>(mapped, cpuData, numSrcBytes);
+            break;
+        default:
+            memcpy(mapped, cpuData, numSrcBytes);
     }
     vmaUnmapMemory(mContext.allocator, stage->memory);
     vmaFlushAllocation(mContext.allocator, stage->memory, 0, numDstBytes);


### PR DESCRIPTION
This change happens to "fix" issue #875, although we may wish to rethink
our DFG representation in the future.