### PR TITLE
fix filameshio test

### DIFF
--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -85,6 +85,9 @@ struct MaterialParserDetails {
                 mDictionaryTag = ChunkType::DictionarySpirv;
                 break;
             default:
+                // this is for testing purpose -- for e.g.: with the NoopDriver
+                mMaterialTag = ChunkType::MaterialGlsl;
+                mDictionaryTag = ChunkType::DictionaryGlsl;
                 break;
         }
     }


### PR DESCRIPTION
when testing we're often using the NoopDriver, which
is has neither spirv or text shaders, so we default
to text to make this case work.