### PR TITLE
fix SamplerBindingMap for non postprocess materials

### DIFF
--- a/libs/filabridge/src/SamplerBindingMap.cpp
+++ b/libs/filabridge/src/SamplerBindingMap.cpp
@@ -34,6 +34,8 @@ void SamplerBindingMap::populate(uint8_t firstSamplerBinding,
         filament::SamplerInterfaceBlock const* sib;
         if (blockIndex == filament::BindingPoints::PER_MATERIAL_INSTANCE) {
             sib = perMaterialSib;
+        } else if (perMaterialSib && blockIndex == filament::BindingPoints::POST_PROCESS) {
+            sib = nullptr;
         } else {
             sib = filament::SibGenerator::getSib(blockIndex);
         }


### PR DESCRIPTION
This fixes #935

SamplerBindingMap was always adding the post-process samplers to the
map -- but matc doesn't generate those. This led the vulkan backend
to believe there was a post-process sampler bound, when there wasn't.

This is also technically a bug in the Vulkan backend because it should
have used the SamplerInterfaceBlock to determine which shaders are
actually used instead of blindly going through the whole list and 
trusting SamplerBindingMap.

The fix is kind of a hack, but the whole SamplerBindingMap is kind of a
hack anyways.