### PR TITLE
gltfio: fix up and enhance AABB functionality.

### DIFF
--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -34,6 +34,7 @@ struct ResourceConfiguration {
     class filament::Engine* engine;
     utils::Path basePath;
     bool normalizeSkinningWeights;
+    bool recomputeBoundingBoxes;
 };
 
 /**
@@ -60,7 +61,8 @@ public:
 private:
     bool createTextures(details::FFilamentAsset* asset) const;
     void computeTangents(details::FFilamentAsset* asset) const;
-    void normalizeWeights(details::FFilamentAsset* asset) const;
+    void normalizeSkinningWeights(details::FFilamentAsset* asset) const;
+    void updateBoundingBoxes(details::FFilamentAsset* asset) const;
     details::AssetPool* mPool;
     const ResourceConfiguration mConfig;
 };


### PR DESCRIPTION
gltfio computes two types of bounding boxes: one for renderables (used
for frustum culling) and one for the overall asset (used for
positioning the camera or asset).

Both of these are based on the min+max attributes in the glTF file, but
the asset-level box was incorrect because only two corners of the
transformed AABB were considered.

This CL also adds optional computation of bounding boxes that crawls
through the vertex positions. This is useful when diagnosing potential
issues with the asset's min+max info.

These enhancements are motivated by a culling issue seen with the voxel
Cathedral on sketchfab.