### PR TITLE
Better Camera component management

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -263,6 +263,23 @@ public:
     Camera* createCamera(utils::Entity entity) noexcept;
 
     /**
+     * Returns the Camera component of the given its entity.
+     *
+     * @param entity An entity.
+     * @return A pointer to the Camera component for this entity or nullptr if the entity didn't
+     *         have a Camera component. The pointer is valid until destroyCameraComponent()
+     *         (or destroyCamera()) is called or the entity itself is destroyed.
+     */
+    Camera* getCameraComponent(utils::Entity entity) noexcept;
+
+    /**
+     * Destroys the Camera component associated with the given entity.
+     *
+     * @param entity An entity.
+     */
+    void destroyCameraComponent(utils::Entity entity) noexcept;
+
+    /**
      * Creates a Fence.
      *
      * @param type Type of Fence to create
@@ -331,7 +348,9 @@ public:
     /**
      * helper for destroying the Camera component and its Entity in one call
      *
-     * @param camera Camera component to destroy. The associated entity is destroyed as well.
+     * @param camera Camera component to destroy. The associated entity as well as all its
+     *               components managed by filament are destroyed.
+     * @deprecated use destroyCameraComponent(Entity) instead
      */
     inline void destroy(const Camera* camera) {
         destroy(camera->getEntity());

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -597,6 +597,16 @@ FCamera* FEngine::createCamera(Entity entity) noexcept {
     return mCameraManager.create(entity);
 }
 
+FCamera* FEngine::getCameraComponent(Entity entity) noexcept {
+    auto ci = mCameraManager.getInstance(entity);
+    return ci ? mCameraManager.getCamera(ci) : nullptr;
+}
+
+void FEngine::destroyCameraComponent(utils::Entity entity) noexcept {
+    mCameraManager.destroy(entity);
+}
+
+
 void FEngine::createRenderable(const RenderableManager::Builder& builder, Entity entity) {
     mRenderableManager.create(builder, entity);
     auto& tcm = mTransformManager;
@@ -821,6 +831,14 @@ Scene* Engine::createScene() noexcept {
 
 Camera* Engine::createCamera(Entity entity) noexcept {
     return upcast(this)->createCamera(entity);
+}
+
+Camera* Engine::getCameraComponent(utils::Entity entity) noexcept {
+    return upcast(this)->getCameraComponent(entity);
+}
+
+void Engine::destroyCameraComponent(utils::Entity entity) noexcept {
+    upcast(this)->destroyCameraComponent(entity);
 }
 
 Fence* Engine::createFence(Fence::Type type) noexcept {

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -62,6 +62,10 @@ public:
         return Instance(mManager.getInstance(e));
     }
 
+    FCamera* getCamera(Instance i) noexcept {
+        return mManager.elementAt<CAMERA>(i);
+    }
+
     FCamera* create(utils::Entity entity);
 
     void destroy(utils::Entity e) noexcept;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -216,9 +216,13 @@ public:
 
     FScene* createScene() noexcept;
     FView* createView() noexcept;
-    FCamera* createCamera(utils::Entity entity) noexcept;
     FFence* createFence(Fence::Type type = Fence::Type::SOFT) noexcept;
     FSwapChain* createSwapChain(void* nativeWindow, uint64_t flags) noexcept;
+
+    FCamera* createCamera(utils::Entity entity) noexcept;
+    FCamera* getCameraComponent(utils::Entity entity) noexcept;
+    void destroyCameraComponent(utils::Entity entity) noexcept;
+
 
     void destroy(const FVertexBuffer* p);
     void destroy(const FFence* p);


### PR DESCRIPTION
- getCameraComponent(Entity) retrieves a Camera component from an entity
- destroyCameraComponent(Entity) destroys just the camera component
  attached to an entity.

destroyCamera() are now deprecated because the API is confusing, it's
not immediately clear that it's destroying all component + the entity
itself.

Node: We don't add the corresponding Java APIs yet because there is no 
easy way to guarantee they're safe without making sure that 
getCameraComponent() will always return the same instance (which it
wouldn't currently).