### PR TITLE
gltfio: transparency fixups

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -572,11 +572,11 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
             matkey.alphaMode = AlphaMode::OPAQUE;
             break;
         case cgltf_alpha_mode_mask:
-            matkey.alphaMode = AlphaMode::MASKED;
+            matkey.alphaMode = AlphaMode::MASK;
             matkey.alphaMaskThreshold = inputMat->alpha_cutoff;
             break;
         case cgltf_alpha_mode_blend:
-            matkey.alphaMode = AlphaMode::TRANSPARENT;
+            matkey.alphaMode = AlphaMode::BLEND;
             break;
     }
 

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -108,7 +108,7 @@ static std::string shaderFromKey(const MaterialKey& config, const UvMap& uvmap) 
         )SHADER";
     }
 
-    if (config.alphaMode == AlphaMode::TRANSPARENT) {
+    if (config.alphaMode == AlphaMode::BLEND) {
         shader += R"SHADER(
             material.baseColor.rgb *= material.baseColor.a;
         )SHADER";
@@ -207,7 +207,6 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
             .name(name)
             .flipUV(false)
             .material(shader.c_str())
-            .culling(config.doubleSided ? CullingMode::NONE : CullingMode::BACK)
             .doubleSided(config.doubleSided);
 
     auto uvset = (uint8_t*) &uvmap.front();
@@ -275,15 +274,16 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
     }
 
     switch(config.alphaMode) {
-        case AlphaMode::MASKED:
+        case AlphaMode::OPAQUE:
+            builder.blending(MaterialBuilder::BlendingMode::OPAQUE);
+            break;
+        case AlphaMode::MASK:
             builder.blending(MaterialBuilder::BlendingMode::MASKED);
             builder.maskThreshold(config.alphaMaskThreshold);
             break;
-        case AlphaMode::TRANSPARENT:
+        case AlphaMode::BLEND:
             builder.blending(MaterialBuilder::BlendingMode::TRANSPARENT);
-            break;
-        default:
-            builder.blending(MaterialBuilder::BlendingMode::OPAQUE);
+            builder.depthWrite(true);
     }
 
     builder.shading(config.unlit ? Shading::UNLIT : Shading::LIT);

--- a/libs/gltfio/src/MaterialGenerator.h
+++ b/libs/gltfio/src/MaterialGenerator.h
@@ -31,8 +31,8 @@ namespace details {
 
 enum class AlphaMode : uint8_t {
     OPAQUE,
-    MASKED,
-    TRANSPARENT
+    MASK,
+    BLEND
 };
 
 // NOTE: This key is processed by MurmurHashFn so please make padding explicit.


### PR DESCRIPTION
- rename gltfio::AlphaMode to use glTF nomenclature
- keep depth writes enabled for transparent renderables