### PR TITLE
remove the "byteSize" parameter from update[Vertex|Index]Buffer

### DIFF
--- a/android/filament-android/src/main/cpp/IndexBuffer.cpp
+++ b/android/filament-android/src/main/cpp/IndexBuffer.cpp
@@ -91,8 +91,7 @@ Java_com_google_android_filament_IndexBuffer_nSetBuffer(JNIEnv *env, jclass type
 
     BufferDescriptor desc(data, sizeInBytes, &JniBufferCallback::invoke, callback);
 
-    indexBuffer->setBuffer(*engine, std::move(desc),
-            (uint32_t) destOffsetInBytes, (uint32_t) sizeInBytes);
+    indexBuffer->setBuffer(*engine, std::move(desc), (uint32_t) destOffsetInBytes);
 
     return 0;
 }

--- a/android/filament-android/src/main/cpp/VertexBuffer.cpp
+++ b/android/filament-android/src/main/cpp/VertexBuffer.cpp
@@ -110,7 +110,7 @@ Java_com_google_android_filament_VertexBuffer_nSetBufferAt(JNIEnv *env, jclass t
     BufferDescriptor desc(data, sizeInBytes, &JniBufferCallback::invoke, callback);
 
     vertexBuffer->setBufferAt(*engine, (uint8_t) bufferIndex, std::move(desc),
-            (uint32_t) destOffsetInBytes, (uint32_t) sizeInBytes);
+            (uint32_t) destOffsetInBytes);
 
     return 0;
 }

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -75,11 +75,21 @@ public:
         friend class details::FIndexBuffer;
     };
 
-    void setBuffer(Engine& engine,
-            BufferDescriptor&& buffer,
-            uint32_t byteOffset = 0,
-            uint32_t byteSize = 0);
+    /**
+     * Asynchronously copy-initializes a region of this IndexBuffer from the data provided.
+     *
+     * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
+     * @param buffer A BufferDescriptor representing the data used to initialize the IndexBuffer.
+     *               BufferDescriptor points to raw, untyped data that will be interpreted as
+     *               either 16-bit or 32-bits indices baed on the Type of this IndexBuffer.
+     * @param byteOffset Offset in *bytes* into the IndexBuffer
+     */
+    void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
+    /**
+     * Returns the size of this IndexBuffer in elements.
+     * @return The number of indices the IndexBuffer holds.
+     */
     size_t getIndexCount() const noexcept;
 };
 

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -60,8 +60,7 @@ public:
         // no-op if bufferIndex is out of bounds
         Builder& attribute(VertexAttribute attribute, uint8_t bufferIndex,
                 AttributeType attributeType,
-                uint32_t byteOffset = 0,
-                uint8_t byteStride = 0) noexcept;     // default is attribute size
+                uint32_t byteOffset = 0, uint8_t byteStride = 0) noexcept;
 
         // no-op if attribute is an invalid enum
         Builder& normalized(VertexAttribute attribute, bool normalize = true) noexcept;
@@ -96,8 +95,7 @@ public:
      */
     void setBufferAt(Engine& engine, uint8_t bufferIndex,
             BufferDescriptor&& buffer,
-            uint32_t byteOffset = 0,
-            uint32_t byteSize = 0);
+            uint32_t byteOffset = 0);
 
     /**
      * Specifies the quaternion type for the "populateTangentQuaternions" utility.

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -69,14 +69,8 @@ void FIndexBuffer::terminate(FEngine& engine) {
     driver.destroyIndexBuffer(mHandle);
 }
 
-void FIndexBuffer::setBuffer(FEngine& engine,
-        BufferDescriptor&& buffer, uint32_t byteOffset, uint32_t byteSize) {
-
-    if (byteSize == 0) {
-        byteSize = uint32_t(buffer.size);
-    }
-
-    engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset, byteSize);
+void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
+    engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
 }
 
 } // namespace details
@@ -88,8 +82,8 @@ void FIndexBuffer::setBuffer(FEngine& engine,
 using namespace details;
 
 void IndexBuffer::setBuffer(Engine& engine,
-        IndexBuffer::BufferDescriptor&& buffer, uint32_t byteOffset, uint32_t byteSize) {
-    upcast(this)->setBuffer(upcast(engine), std::move(buffer), byteOffset, byteSize);
+        IndexBuffer::BufferDescriptor&& buffer, uint32_t byteOffset) {
+    upcast(this)->setBuffer(upcast(engine), std::move(buffer), byteOffset);
 }
 
 size_t IndexBuffer::getIndexCount() const noexcept {

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -174,15 +174,10 @@ size_t FVertexBuffer::getVertexCount() const noexcept {
 }
 
 void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
-        driver::BufferDescriptor&& buffer, uint32_t byteOffset, uint32_t byteSize) {
-
-    if (byteSize == 0) {
-        byteSize = uint32_t(buffer.size);
-    }
-
+        driver::BufferDescriptor&& buffer, uint32_t byteOffset) {
     if (bufferIndex < mBufferCount) {
-        engine.getDriverApi().updateVertexBuffer(mHandle, bufferIndex,
-                std::move(buffer), byteOffset, byteSize);
+        engine.getDriverApi().updateVertexBuffer(mHandle,
+                bufferIndex, std::move(buffer), byteOffset);
     } else {
         ASSERT_PRECONDITION_NON_FATAL(bufferIndex < mBufferCount,
                 "bufferIndex must be < bufferCount");
@@ -202,9 +197,8 @@ size_t VertexBuffer::getVertexCount() const noexcept {
 }
 
 void VertexBuffer::setBufferAt(Engine& engine, uint8_t bufferIndex,
-        driver::BufferDescriptor&& buffer, uint32_t byteOffset, uint32_t byteSize) {
-    upcast(this)->setBufferAt(upcast(engine), bufferIndex,
-            std::move(buffer), byteOffset, byteSize);
+        driver::BufferDescriptor&& buffer, uint32_t byteOffset) {
+    upcast(this)->setBufferAt(upcast(engine), bufferIndex, std::move(buffer), byteOffset);
 }
 
 void VertexBuffer::populateTangentQuaternions(const QuatTangentContext& ctx) {

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -41,8 +41,7 @@ public:
 
     size_t getIndexCount() const noexcept { return mIndexCount; }
 
-    void setBuffer(FEngine& engine,
-            BufferDescriptor&& buffer, uint32_t byteOffset = 0, uint32_t byteSize = 0);
+    void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
 private:
     friend class IndexBuffer;

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -53,8 +53,7 @@ public:
 
     // no-op if bufferIndex out of range
     void setBufferAt(FEngine& engine, uint8_t bufferIndex,
-            driver::BufferDescriptor&& buffer,
-            uint32_t byteOffset = 0, uint32_t byteSize = 0);
+            driver::BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
 private:
     friend class VertexBuffer;

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -323,18 +323,16 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
  * -----------------------
  */
 
-DECL_DRIVER_API_5(updateVertexBuffer,
+DECL_DRIVER_API_4(updateVertexBuffer,
         Driver::VertexBufferHandle, vbh,
         size_t, index,
         Driver::BufferDescriptor&&, data,
-        uint32_t, byteOffset,
-        uint32_t, byteSize)
+        uint32_t, byteOffset)
 
-DECL_DRIVER_API_4(updateIndexBuffer,
+DECL_DRIVER_API_3(updateIndexBuffer,
         Driver::IndexBufferHandle, ibh,
         Driver::BufferDescriptor&&, data,
-        uint32_t, byteOffset,
-        uint32_t, byteSize)
+        uint32_t, byteOffset)
 
 DECL_DRIVER_API_2(updateUniformBuffer,
         Driver::UniformBufferHandle, ubh,

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -341,14 +341,14 @@ bool MetalDriver::isFrameTimeSupported() {
 // Dynamically updated vertex / index buffers will require synchronization.
 
 void MetalDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh, size_t index,
-        Driver::BufferDescriptor&& data, uint32_t byteOffset, uint32_t byteSize) {
+        Driver::BufferDescriptor&& data, uint32_t byteOffset) {
     assert(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers
     auto* vb = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     memcpy(vb->buffers[index].contents, data.buffer, data.size);
 }
 
 void MetalDriver::updateIndexBuffer(Driver::IndexBufferHandle ibh, Driver::BufferDescriptor&& data,
-        uint32_t byteOffset, uint32_t byteSize) {
+        uint32_t byteOffset) {
     assert(byteOffset == 0);    // TODO: handle byteOffset for index buffers
     auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     memcpy(ib->buffer.contents, data.buffer, data.size);

--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -1701,18 +1701,14 @@ void OpenGLDriver::makeCurrent(Driver::SwapChainHandle schDraw, Driver::SwapChai
 // Updating driver objects
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::updateVertexBuffer(
-        Driver::VertexBufferHandle vbh,
-        size_t index,
-        BufferDescriptor&& p,
-        uint32_t byteOffset,
-        uint32_t byteSize) {
+void OpenGLDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh,
+        size_t index, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
     GLVertexBuffer* eb = handle_cast<GLVertexBuffer *>(vbh);
 
     bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[index]);
-    glBufferSubData(GL_ARRAY_BUFFER, byteOffset, byteSize, p.buffer);
+    glBufferSubData(GL_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
 
@@ -1720,8 +1716,7 @@ void OpenGLDriver::updateVertexBuffer(
 }
 
 void OpenGLDriver::updateIndexBuffer(
-        Driver::IndexBufferHandle ibh,
-        BufferDescriptor&& p, uint32_t byteOffset, uint32_t byteSize) {
+        Driver::IndexBufferHandle ibh, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
     GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
@@ -1729,7 +1724,7 @@ void OpenGLDriver::updateIndexBuffer(
 
     bindVertexArray(nullptr);
     bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
-    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, byteSize, p.buffer);
+    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
 

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -523,16 +523,16 @@ bool VulkanDriver::isFrameTimeSupported() {
 }
 
 void VulkanDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh, size_t index,
-        BufferDescriptor&& p, uint32_t byteOffset, uint32_t byteSize) {
+        BufferDescriptor&& p, uint32_t byteOffset) {
     auto& vb = *handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);
-    vb.buffers[index]->loadFromCpu(p.buffer, byteOffset, byteSize);
+    vb.buffers[index]->loadFromCpu(p.buffer, byteOffset, p.size);
     scheduleDestroy(std::move(p));
 }
 
 void VulkanDriver::updateIndexBuffer(Driver::IndexBufferHandle ibh, BufferDescriptor&& p,
-        uint32_t byteOffset, uint32_t byteSize) {
+        uint32_t byteOffset) {
     auto& ib = *handle_cast<VulkanIndexBuffer>(mHandleMap, ibh);
-    ib.buffer->loadFromCpu(p.buffer, byteOffset, byteSize);
+    ib.buffer->loadFromCpu(p.buffer, byteOffset, p.size);
     scheduleDestroy(std::move(p));
 }
 


### PR DESCRIPTION
It was redundant with BufferDescriptor::size.