### PR TITLE
Avoid NaN when normal is colinear with fake axis.

### DIFF
--- a/libs/geometry/include/geometry/SurfaceOrientation.h
+++ b/libs/geometry/include/geometry/SurfaceOrientation.h
@@ -36,6 +36,7 @@ public:
     /**
      * The Builder is used to construct an immutable surface orientation helper.
      *
+     * Clients provide pointers into their own data, which is synchronously consumed during build().
      * At a minimum, clients must supply a vertex count and normals buffer. They can supply data in
      * any of the following three combinations:
      *

--- a/libs/geometry/src/SurfaceOrientation.cpp
+++ b/libs/geometry/src/SurfaceOrientation.cpp
@@ -136,7 +136,13 @@ SurfaceOrientation OrientationBuilderImpl::buildWithNormalsOnly() {
 
     for (size_t qindex = 0; qindex < vertexCount; ++qindex) {
         float3 n = *normal;
-        float3 b = normalize(cross(n, float3{1, 0, 0}));
+        float3 perp = cross(n, float3{1, 0, 0});
+        float sqrlen = dot(perp, perp);
+        if (sqrlen <= std::numeric_limits<float>::epsilon()) {
+            perp = cross(n, float3{0, 1, 0});
+            sqrlen = dot(perp, perp);
+        }
+        float3 b = perp / sqrlen;
         float3 t = cross(n, b);
         quats[qindex] = mat3f::packTangentFrame({t, b, n});
         normal = (const float3*) (((const uint8_t*) normal) + nstride);


### PR DESCRIPTION
I reproduced the issue by hacking our redball demo and visually verified the fix.

cc @AdrianAtGoogle