### PR TITLE
geometry: add JS bindings for SurfaceOrientation

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -197,4 +197,11 @@ Filament.loadClassExtensions = function() {
         this._setImageCube(engine, level, pbd);
         pbd.delete();
     }
+
+    Filament.SurfaceOrientation$Builder.prototype.build = function() {
+        const result = this._build();
+        this.delete();
+        return result;
+    };
+
 };


### PR DESCRIPTION
These bindings are not user friendly because clients need to manually allocate / deallocate memory. However it gets the job done.

Fixes #959.