### PR TITLE
simplify MaterialParser

### DIFF
--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -40,8 +40,6 @@ using namespace filamat;
 
 namespace filament {
 
-// Make a copy of content and own the allocated memory.
-
 // ------------------------------------------------------------------------------------------------
 
 MaterialParser::MaterialParserDetails::MaterialParserDetails(Backend backend, const void* data, size_t size)


### PR DESCRIPTION
no need to hide the implementation anymore, since the whole thing
is internal and doesn't appear in public headers.

this saves a dynamic allocation when unflattening materials.