### PR TITLE
Include unwindows.h in mat4.h

### DIFF
--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -24,6 +24,8 @@
 #include <math/vec4.h>
 #include <math/compiler.h>
 
+#include <utils/unwindows.h> // Because we use NEAR and FAR for projection matrices.
+
 #include <stdint.h>
 #include <sys/types.h>
 #include <limits>


### PR DESCRIPTION
Includes unwindows.h in mat4.h so that there aren't include-order-requirements because of use of near/far in projection matrix functions.