### PR TITLE
remove vector comparison operators

### DIFF
--- a/filament/include/filament/Box.h
+++ b/filament/include/filament/Box.h
@@ -143,7 +143,7 @@ struct Aabb {
      * @return true if min >= max, i.e: the volume of the box is null or negative
      */
     bool isEmpty() const noexcept {
-        return min >= max;
+        return any(greaterThanEqual(min, max));
     }
 };
 

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -424,10 +424,9 @@ TEST(FilamentTest, ColorConversion) {
     EXPECT_PRED2(vec3eq, (sRGBColor{1.0f, 0.0f, 0.0f}),
             Color::toSRGB<ACCURATE>({1.0f, 0.0f, 0.0f}));
 
-    // 0.5 is > 0.5
-    EXPECT_LT((sRGBColor{0.5f, 0.0f, 0.0f}), Color::toSRGB<FAST>({0.5f, 0.0f, 0.0f}));
-    // 0.5 is > 0.5
-    EXPECT_LT((sRGBColor{0.5f, 0.0f, 0.0f}), Color::toSRGB<ACCURATE>({0.5f, 0.0f, 0.0f}));
+    EXPECT_LT((sRGBColor{0.5f, 0.0f, 0.0f}.x), Color::toSRGB<FAST>({0.5f, 0.0f, 0.0f}).x);
+
+    EXPECT_LT((sRGBColor{0.5f, 0.0f, 0.0f}.x), Color::toSRGB<ACCURATE>({0.5f, 0.0f, 0.0f}).x);
 
     EXPECT_PRED1(isGray, Color::toSRGB<FAST>(LinearColor{0.5f}));
     EXPECT_PRED1(isGray, Color::toSRGB<ACCURATE>(LinearColor{0.5f}));
@@ -443,10 +442,10 @@ TEST(FilamentTest, ColorConversion) {
     // 1.0 stays 1.0
     EXPECT_PRED2(vec3eq, (LinearColor{1.0f, 0.0f, 0.0f}), Color::toLinear<ACCURATE>({1.0f, 0.0f, 0.0f}));
 
-    // 0.5 is < 0.5
-    EXPECT_GT((LinearColor{0.5f, 0.0f, 0.0f}), Color::toLinear<FAST>({0.5f, 0.0f, 0.0f}));
-    // 0.5 is < 0.5
-    EXPECT_GT((LinearColor{0.5f, 0.0f, 0.0f}), Color::toLinear<ACCURATE>({0.5f, 0.0f, 0.0f}));
+
+    EXPECT_GT((LinearColor{0.5f, 0.0f, 0.0f}.x), Color::toLinear<FAST>({0.5f, 0.0f, 0.0f}).x);
+
+    EXPECT_GT((LinearColor{0.5f, 0.0f, 0.0f}.x), Color::toLinear<ACCURATE>({0.5f, 0.0f, 0.0f}).x);
 
     EXPECT_PRED1(isGray, Color::toLinear<FAST>(sRGBColor{0.5f}));
     EXPECT_PRED1(isGray, Color::toLinear<ACCURATE>(sRGBColor{0.5f}));

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -270,44 +270,6 @@ public:
 
     template<typename RT>
     friend inline
-    bool MATH_PURE operator >(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        // w/ inlining we end-up with many branches that will pollute the BPU cache
-        MATH_NOUNROLL
-        for (size_t i = 0; i < lv.size(); i++) {
-            if (lv[i] != rv[i]) {
-                return lv[i] > rv[i];
-            }
-        }
-        return false;
-    }
-
-    template<typename RT>
-    friend inline
-    constexpr bool MATH_PURE operator <=(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        return !(lv > rv);
-    }
-
-    template<typename RT>
-    friend inline
-    bool MATH_PURE operator <(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        // w/ inlining we end-up with many branches that will pollute the BPU cache
-        MATH_NOUNROLL
-        for (size_t i = 0; i < lv.size(); i++) {
-            if (lv[i] != rv[i]) {
-                return lv[i] < rv[i];
-            }
-        }
-        return false;
-    }
-
-    template<typename RT>
-    friend inline
-    constexpr bool MATH_PURE operator >=(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        return !(lv < rv);
-    }
-
-    template<typename RT>
-    friend inline
     VECTOR<bool> MATH_PURE equal(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         VECTOR<bool> r;
         for (size_t i = 0; i < lv.size(); i++) {

--- a/libs/utils/test/test_StructureOfArrays.cpp
+++ b/libs/utils/test/test_StructureOfArrays.cpp
@@ -30,6 +30,9 @@ struct TestFloat4 : public float4 {
         z = -3;
         w = -4;
     }
+    friend bool operator < (TestFloat4 const& lhs, TestFloat4 const& rhs) noexcept {
+        return any(lessThan(lhs, rhs));
+    }
 };
 
 using SoA = utils::StructureOfArrays<float, double, TestFloat4>;


### PR DESCRIPTION
they're dangerous as they will make things like
std::min() work, but probably won't do the
right thing.