### PR TITLE
Workaround a UBO/glFlush interaction on some GPUs

### DIFF
--- a/filament/src/driver/opengl/OpenGLDriver.cpp
+++ b/filament/src/driver/opengl/OpenGLDriver.cpp
@@ -144,7 +144,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
     } else if (strstr(renderer, "Mali")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
         if (strstr(renderer, "Mali-T")) {
-            bugs.disable_early_fragment_tests = true;
+            bugs.disable_glFlush = true;
             bugs.disable_shared_context_draws = true;
             bugs.texture_external_needs_rebind = true;
         }
@@ -2772,7 +2772,9 @@ void OpenGLDriver::endFrame(uint32_t frameId) {
 
 void OpenGLDriver::flush(int) {
     DEBUG_MARKER()
-    glFlush();
+    if (!bugs.disable_glFlush) {
+        glFlush();
+    }
 }
 
 UTILS_NOINLINE

--- a/filament/src/driver/opengl/OpenGLDriver.h
+++ b/filament/src/driver/opengl/OpenGLDriver.h
@@ -540,8 +540,8 @@ private:
 
     struct {
         // Some drivers have issues with UBOs in the fragment shader when
-        // early_fragment_tests is used.
-        bool disable_early_fragment_tests = false;
+        // glFlush() is called between draw calls.
+        bool disable_glFlush = false;
 
         // Some drivers seem to not store the GL_ELEMENT_ARRAY_BUFFER binding
         // in the VAO state.


### PR DESCRIPTION
Some GPU seem to loose the content of UBOs for draw calls emitted 
before a glFlush followed by more draw calls.

On those GPUs, we just never call glFlush, which could result in
reduced parallelism between the cpu and gpu.

This is a workaround for #974