### PR TITLE
Fix filamat build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ endif()
 
 # Building filamat increases build times and isn't required for non-desktop platforms, so turn it
 # off by default.
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (NOT WEBGL AND NOT IOS)
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" ON)
 else()
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" OFF)

--- a/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
+++ b/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
@@ -18,8 +18,6 @@
 
 #include <filamat/MaterialBuilder.h>
 
-#include <private/filament/EngineEnums.h>
-
 using namespace filament;
 using namespace filamat;
 

--- a/android/samples/README.md
+++ b/android/samples/README.md
@@ -44,9 +44,6 @@ Demonstrates how to render into a `TextureView` instead of a `SurfaceView`:
 Demonstrates how to programatically generate Filament materials, as opposed to compiling them on the
 host machine:
 
-**Important:** The `material-builder` sample requires the `filamat` static library which can be compiled by adding
-the `-l` flag to the `./build.sh` command.
-
 ![Material Builder](../../docs/images/samples/sample_image_based_lighting.jpg)
 
 ## Prerequisites

--- a/android/samples/material-builder/README.md
+++ b/android/samples/material-builder/README.md
@@ -14,11 +14,10 @@ library is slower and thus it is not built by the default `build.sh` command. To
 flag to the `build.sh` command:
 
 ```
-./build.sh -i -l -p android release
+./build.sh -i -p android release
 ```
 
 Explanation of flags:
 
 - The `-i` flag installs the libraries to `out/android-release/`, so this sample can find them.
-- The `-l` flag additionally builds the `filamat` library, needed by the `material-builder` sample.
 - The `-p` flag and `android` argument choose Android as the platform to build for.

--- a/build.sh
+++ b/build.sh
@@ -37,8 +37,6 @@ function print_help {
     echo "        Add Vulkan support to the Android build."
     echo "    -s"
     echo "        Add iOS simulator support to the iOS build."
-    echo "    -l"
-    echo "        Add filamat support to the Android build."
     echo "    -w"
     echo "        Build Web documents (compiles .md.html files to .html)."
     echo ""
@@ -106,9 +104,6 @@ ENABLE_JAVA=ON
 INSTALL_COMMAND=
 
 VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=OFF"
-
-BUILD_FILAMAT_ANDROID=false
-FILAMAT_ANDROID_OPTION="-DFILAMENT_BUILD_FILAMAT=OFF"
 
 IOS_BUILD_SIMULATOR=false
 
@@ -275,7 +270,6 @@ function build_android_target {
             -DCMAKE_INSTALL_PREFIX=../android-${LC_TARGET}/filament \
             -DCMAKE_TOOLCHAIN_FILE=../../build/toolchain-${ARCH}-linux-android.cmake \
             ${VULKAN_ANDROID_OPTION} \
-            ${FILAMAT_ANDROID_OPTION} \
             ../..
     fi
 
@@ -391,31 +385,27 @@ function build_android {
     cd ../..
 
 
-    if [[ "$BUILD_FILAMAT_ANDROID" == "true" ]]; then
+    cd android/filamat-android
 
-        cd android/filamat-android
+    if [[ "$ISSUE_DEBUG_BUILD" == "true" ]]; then
+        ./gradlew -Pfilament_dist_dir=../../out/android-debug/filament assembleDebug
 
-        if [[ "$ISSUE_DEBUG_BUILD" == "true" ]]; then
-            ./gradlew -Pfilament_dist_dir=../../out/android-debug/filament assembleDebug
-
-            if [[ "$INSTALL_COMMAND" ]]; then
-                echo "Installing out/filamat-android-debug.aar..."
-                cp build/outputs/aar/filamat-android-debug.aar ../../out/
-            fi
+        if [[ "$INSTALL_COMMAND" ]]; then
+            echo "Installing out/filamat-android-debug.aar..."
+            cp build/outputs/aar/filamat-android-debug.aar ../../out/
         fi
-
-        if [[ "$ISSUE_RELEASE_BUILD" == "true" ]]; then
-            ./gradlew -Pfilament_dist_dir=../../out/android-release/filament assembleRelease
-
-            if [[ "$INSTALL_COMMAND" ]]; then
-                echo "Installing out/filamat-android-release.aar..."
-                cp build/outputs/aar/filamat-android-release.aar ../../out/
-            fi
-        fi
-
-        cd ../..
-
     fi
+
+    if [[ "$ISSUE_RELEASE_BUILD" == "true" ]]; then
+        ./gradlew -Pfilament_dist_dir=../../out/android-release/filament assembleRelease
+
+        if [[ "$INSTALL_COMMAND" ]]; then
+            echo "Installing out/filamat-android-release.aar..."
+            cp build/outputs/aar/filamat-android-release.aar ../../out/
+        fi
+    fi
+
+    cd ../..
 }
 
 function ensure_ios_toolchain {
@@ -677,12 +667,6 @@ while getopts ":hacfijmp:tuvslw" opt; do
             echo "File > Settings > Build > Compiler. In the command-line options field, "
             echo "add -Pextra_cmake_args=-DFILAMENT_SUPPORTS_VULKAN=ON."
             echo "Also be sure to pass Engine.Backend.VULKAN to Engine.create."
-            echo ""
-            ;;
-        l)
-            FILAMAT_ANDROID_OPTION="-DFILAMENT_BUILD_FILAMAT=ON"
-            BUILD_FILAMAT_ANDROID=true
-            echo "Building filamat JNI library for Android."
             echo ""
             ;;
         s)

--- a/build/android/build.sh
+++ b/build/android/build.sh
@@ -21,15 +21,15 @@ FILAMENT_ANDROID_CI_BUILD=true
 #     $BUILD_DEBUG
 #     $BUILD_RELEASE
 source `dirname $0`/../common/ci-common.sh
-if [  "$LC_UNAME" == "linux" ]; then
+if [[  "$LC_UNAME" == "linux" ]]; then
     source `dirname $0`/../linux/ci-common.sh
-elif [ "$LC_UNAME" == "darwin" ]; then
+elif [[ "$LC_UNAME" == "darwin" ]]; then
     source `dirname $0`/../mac/ci-common.sh
 fi
 source `dirname $0`/../common/build-common.sh
 
-yes | $ANDROID_HOME/tools/bin/sdkmanager --update >/dev/null && \
-    yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null
+yes | ${ANDROID_HOME}/tools/bin/sdkmanager --update >/dev/null && \
+    yes | ${ANDROID_HOME}/tools/bin/sdkmanager --licenses >/dev/null
 
 pushd `dirname $0`/../.. > /dev/null
 ./build.sh -p android -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE

--- a/build/common/build-common.sh
+++ b/build/common/build-common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ ! "$TARGET" ]; then
-    if [ "$1" ]; then
+if [[ ! "$TARGET" ]]; then
+    if [[ "$1" ]]; then
         TARGET=$1
     else
         TARGET=release
@@ -15,21 +15,21 @@ BUILD_RELEASE=
 GENERATE_ARCHIVES=
 RUN_TESTS=
 
-if [ "$TARGET" == "presubmit" ]; then
+if [[ "$TARGET" == "presubmit" ]]; then
     BUILD_RELEASE=release
 fi
 
-if [ "$TARGET" == "debug" ]; then
+if [[ "$TARGET" == "debug" ]]; then
     BUILD_DEBUG=debug
     GENERATE_ARCHIVES=-a
 fi
 
-if [ "$TARGET" == "release" ]; then
+if [[ "$TARGET" == "release" ]]; then
     BUILD_RELEASE=release
     GENERATE_ARCHIVES=-a
 fi
 
-if [ "$TARGET" == "continuous" ]; then
+if [[ "$TARGET" == "continuous" ]]; then
     BUILD_DEBUG=debug
     BUILD_RELEASE=release
     GENERATE_ARCHIVES=-a

--- a/build/common/ci-common.sh
+++ b/build/common/ci-common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$KOKORO_BUILD_ID" ]; then
+if [[ "$KOKORO_BUILD_ID" ]]; then
     echo "Running job $KOKORO_JOB_NAME"
     TARGET=`echo "$KOKORO_JOB_NAME" | awk -F "/" '{print $NF}'`
 fi

--- a/build/linux/ci-common.sh
+++ b/build/linux/ci-common.sh
@@ -12,10 +12,10 @@ NINJA_VERSION=1.8.2
 # Steps specific to our CI environment
 # CI runs on Ubuntu 14.04, we need to install clang-7.0 and the
 # appropriate libc++ ourselves
-if [ "$KOKORO_BUILD_ID" ]; then
+if [[ "$KOKORO_BUILD_ID" ]]; then
     sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/asm
 
-    if [ "$FILAMENT_ANDROID_CI_BUILD" ]; then
+    if [[ "$FILAMENT_ANDROID_CI_BUILD" ]]; then
         # Update NDK
         yes | $ANDROID_HOME/tools/bin/sdkmanager "ndk-bundle" > /dev/null
 

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -26,6 +26,8 @@
 
 namespace filament {
 
+static constexpr size_t MATERIAL_VERSION = 2;
+
 /**
  * Supported shading models
  */

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -22,8 +22,6 @@
 
 namespace filament {
 
-static constexpr size_t MATERIAL_VERSION = 2;
-
 static constexpr size_t VERTEX_DOMAIN_COUNT = 4;
 
 static constexpr size_t POST_PROCESS_STAGES_COUNT = 4;

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include <filament/driver/DriverEnums.h>
-#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filamat/Package.h>


### PR DESCRIPTION
Filamat public headers were including a private header. This PR fixes
this problem. It also forces filamat to always be compiled to avoid
breaking filamat without noticing. The flag `-l` is not available anymore
in `build.sh` as a result.

See issue #1001 for more information.