### PR TITLE
VulkanDriver: introduce disposer and command buffer wrapper.

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -221,13 +221,23 @@ endif()
 if (FILAMENT_SUPPORTS_VULKAN)
     list(APPEND SRCS
             src/driver/vulkan/VulkanBinder.cpp
+            src/driver/vulkan/VulkanBinder.h
             src/driver/vulkan/VulkanBuffer.cpp
+            src/driver/vulkan/VulkanBuffer.h
+            src/driver/vulkan/VulkanDisposer.cpp
+            src/driver/vulkan/VulkanDisposer.h
             src/driver/vulkan/VulkanDriver.cpp
+            src/driver/vulkan/VulkanDriver.h
             src/driver/vulkan/VulkanDriverImpl.cpp
+            src/driver/vulkan/VulkanDriverImpl.h
             src/driver/vulkan/VulkanFboCache.cpp
+            src/driver/vulkan/VulkanFboCache.h
             src/driver/vulkan/VulkanHandles.cpp
+            src/driver/vulkan/VulkanHandles.h
             src/driver/vulkan/VulkanSamplerCache.cpp
+            src/driver/vulkan/VulkanSamplerCache.h
             src/driver/vulkan/VulkanStagePool.cpp
+            src/driver/vulkan/VulkanStagePool.h
     )
     if (LINUX)
         list(APPEND SRCS src/driver/vulkan/PlatformVkLinux.cpp)

--- a/filament/src/driver/vulkan/VulkanBuffer.cpp
+++ b/filament/src/driver/vulkan/VulkanBuffer.cpp
@@ -36,7 +36,6 @@ VulkanBuffer::VulkanBuffer(VulkanContext& context, VulkanStagePool& stagePool,
 }
 
 VulkanBuffer::~VulkanBuffer() {
-    assert(!hasPendingWork(mContext) && "Buffer destroyed while work is pending.");
     vmaDestroyBuffer(mContext.allocator, mGpuBuffer, mGpuMemory);
 }
 
@@ -71,8 +70,8 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
     };
 
     // If possible, perform the upload immediately, otherwise queue up the work.
-    if (mContext.cmdbuffer) {
-        copyToDevice(mContext.cmdbuffer);
+    if (mContext.currentCommands) {
+        copyToDevice(mContext.currentCommands->cmdbuffer);
     } else {
         mContext.pendingWork.emplace_back(copyToDevice);
     }

--- a/filament/src/driver/vulkan/VulkanDisposer.cpp
+++ b/filament/src/driver/vulkan/VulkanDisposer.cpp
@@ -16,22 +16,20 @@
 
 #include "driver/vulkan/VulkanDisposer.h"
 
-#include <utils/Panic.h>
-
 namespace filament {
 namespace driver {
 
 void VulkanDisposer::createDisposable(Key resource, std::function<void()> destructor) noexcept {
-    mDisposables[resource] = { 1, destructor };
+    mDisposables[resource].destructor = destructor;
 }
 
 void VulkanDisposer::addReference(Key resource) noexcept {
-    ASSERT_POSTCONDITION(mDisposables[resource].refcount > 0, "Unexpected ref count.");
+    assert(mDisposables[resource].refcount > 0);
     ++mDisposables[resource].refcount;
 }
 
 void VulkanDisposer::removeReference(Key resource) noexcept {
-    ASSERT_POSTCONDITION(mDisposables[resource].refcount > 0, "Unexpected ref count.");
+    assert(mDisposables[resource].refcount > 0);
     if (--mDisposables[resource].refcount == 0) {
         mGraveyard.emplace_back(std::move(mDisposables[resource]));
         mDisposables.erase(resource);
@@ -61,7 +59,7 @@ void VulkanDisposer::gc() noexcept {
 
 void VulkanDisposer::reset() noexcept {
     gc();
-    for (auto iter : mDisposables) {
+    for (auto& iter : mDisposables) {
         iter.second.destructor();
     }
     mDisposables.clear();

--- a/filament/src/driver/vulkan/VulkanDisposer.cpp
+++ b/filament/src/driver/vulkan/VulkanDisposer.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "driver/vulkan/VulkanDisposer.h"
+
+#include <utils/Panic.h>
+
+namespace filament {
+namespace driver {
+
+void VulkanDisposer::createDisposable(Key resource, std::function<void()> destructor) noexcept {
+    mDisposables[resource] = { 1, destructor };
+}
+
+void VulkanDisposer::addReference(Key resource) noexcept {
+    ASSERT_POSTCONDITION(mDisposables[resource].refcount > 0, "Unexpected ref count.");
+    ++mDisposables[resource].refcount;
+}
+
+void VulkanDisposer::removeReference(Key resource) noexcept {
+    ASSERT_POSTCONDITION(mDisposables[resource].refcount > 0, "Unexpected ref count.");
+    if (--mDisposables[resource].refcount == 0) {
+        mGraveyard.emplace_back(std::move(mDisposables[resource]));
+        mDisposables.erase(resource);
+    }
+}
+void VulkanDisposer::acquire(Key resource, Set& resources) noexcept {
+    auto iter = resources.find(resource);
+    if (iter == resources.end()) {
+        resources.insert(resource);
+        addReference(resource);
+    }
+}
+
+void VulkanDisposer::release(Set& resources) {
+    for (auto resource : resources) {
+        removeReference(resource);
+    }
+    resources.clear();
+}
+
+void VulkanDisposer::gc() noexcept {
+    for (auto& ptr : mGraveyard) {
+        ptr.destructor();
+    }
+    mGraveyard.clear();
+}
+
+void VulkanDisposer::reset() noexcept {
+    gc();
+    for (auto iter : mDisposables) {
+        iter.second.destructor();
+    }
+    mDisposables.clear();
+}
+
+} // namespace filament
+} // namespace driver

--- a/filament/src/driver/vulkan/VulkanDisposer.h
+++ b/filament/src/driver/vulkan/VulkanDisposer.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_VULKANDISPOSER_H
+#define TNT_FILAMENT_DRIVER_VULKANDISPOSER_H
+
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace filament {
+namespace driver {
+
+// VulkanDisposer tracks resources (such as textures or vertex buffers) that need deferred
+// destruction due to potential use by one or more reference holders. An example of a reference
+// holder is an active Vulkan command buffer. Resources are represented with void* to allow callers
+// to use any type of handle. Reference holders (e.g. VulkanCommandBuffer) have an associated
+// robin_set of resource handles.
+class VulkanDisposer {
+public:
+    using Key = const void*;
+    using Set = tsl::robin_set<Key>;
+
+    // Adds the given resource to the disposer and sets its reference count to 1.
+    void createDisposable(Key resource, std::function<void()> destructor) noexcept;
+
+    // Increments the reference count.
+    void addReference(Key resource) noexcept;
+
+    // Decrements the reference count and moves it to the graveyard if it becomes 0.
+    void removeReference(Key resource) noexcept;
+
+    // If the given resource is not in the given set, then it gets added to the set and its
+    // reference count is incremented.
+    void acquire(Key resource, Set& resources) noexcept;
+
+    // Decrements the reference count for all resources in the set, then clears it.
+    void release(Set& resources);
+
+    // Invokes the destructor function for each disposable in the graveyard.
+    void gc() noexcept;
+
+    // Invokes the destructor function for all disposables, regardless of reference count.
+    void reset() noexcept;
+
+private:
+    struct Disposable {
+        size_t refcount;
+        std::function<void()> destructor;
+    };
+    tsl::robin_map<Key, Disposable> mDisposables;
+    std::vector<Disposable> mGraveyard;
+};
+
+} // namespace filament
+} // namespace driver
+
+#endif // TNT_FILAMENT_DRIVER_VULKANDISPOSER_H

--- a/filament/src/driver/vulkan/VulkanDisposer.h
+++ b/filament/src/driver/vulkan/VulkanDisposer.h
@@ -61,7 +61,7 @@ public:
 
 private:
     struct Disposable {
-        size_t refcount;
+        size_t refcount = 1;
         std::function<void()> destructor;
     };
     tsl::robin_map<Key, Disposable> mDisposables;

--- a/filament/src/driver/vulkan/VulkanDriver.h
+++ b/filament/src/driver/vulkan/VulkanDriver.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_DRIVER_VULKANDRIVER_H
 
 #include "VulkanBinder.h"
+#include "VulkanDisposer.h"
 #include "VulkanDriverImpl.h"
 #include "VulkanFboCache.h"
 #include "VulkanSamplerCache.h"
@@ -127,7 +128,7 @@ private:
     }
 
     template<typename Dp, typename B>
-    void destruct_handle(HandleMap& handleMap, Handle<B>& handle) noexcept {
+    void destruct_handle(HandleMap& handleMap, const Handle<B>& handle) noexcept {
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         // Call the destructor, remove the blob, don't bother reclaiming the integer id.
         auto iter = handleMap.find(handle.getId());
@@ -143,6 +144,7 @@ private:
     VulkanStagePool mStagePool;
     VulkanFboCache mFramebufferCache;
     VulkanSamplerCache mSamplerCache;
+    VulkanDisposer mDisposer;
     VulkanRenderTarget* mCurrentRenderTarget = nullptr;
     VulkanSamplerGroup* mSamplerBindings[VulkanBinder::NUM_SAMPLER_BINDINGS] = {};
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;

--- a/filament/src/driver/vulkan/VulkanDriverImpl.h
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_DRIVER_VULKANDRIVER_IMPL_H
 
 #include "VulkanBinder.h"
+#include "VulkanDisposer.h"
 
 #include <filament/driver/DriverEnums.h>
 
@@ -42,11 +43,10 @@ using VulkanTaskQueue = std::vector<VulkanTask>;
 
 struct VulkanSurfaceContext;
 
-// The work context is used for activities unrelated to the swap chain or draw calls, such as
-// uploads, blits, and transitions.
-struct WorkContext {
+struct VulkanCommandBuffer {
     VkCommandBuffer cmdbuffer;
     VkFence fence;
+    VulkanDisposer::Set resources;
 };
 
 // For now we only support a single-device, single-instance scenario. Our concept of "context" is a
@@ -64,13 +64,16 @@ struct VulkanContext {
     bool debugMarkersSupported;
     VulkanTaskQueue pendingWork;
     VulkanBinder::RasterState rasterState;
-    VkCommandBuffer cmdbuffer;
+    VulkanCommandBuffer* currentCommands;
     VulkanSurfaceContext* currentSurface;
     VkRenderPassBeginInfo currentRenderPass;
     VkViewport viewport;
     VkFormat depthFormat;
     VmaAllocator allocator;
-    WorkContext work;
+
+    // The work context is used for activities unrelated to the swap chain or draw calls, such as
+    // uploads, blits, and transitions.
+    VulkanCommandBuffer work;
 };
 
 struct VulkanAttachment {
@@ -84,8 +87,7 @@ struct VulkanAttachment {
 // Typically there are only 2 or 3 instances of the SwapContext per SwapChain.
 struct SwapContext {
     VulkanAttachment attachment;
-    VkCommandBuffer cmdbuffer;
-    VkFence fence;
+    VulkanCommandBuffer commands;
     VulkanTaskQueue pendingWork;
     bool submitted;
 };


### PR DESCRIPTION
This introduces a reference counting mechanism to allow us to defer
destruction of Vulkan resources to the correct time, rather than doing
an aggressive flush-and-wait before every vkDestroy*().

This also preps for removal of the "pending work" queues of
std::function, in favor of using the new Vulkan command buffer
designated for extra-frame activities such as uploads, blits, and layout
transitions.