### PR TITLE
Add filter parameter to the blit() backend function

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -219,7 +219,8 @@ FrameGraphResource PostProcessManager::dynamicScaling(FrameGraph& fg,
                 auto in = resources.getRenderTarget(data.input);
                 auto out = resources.getRenderTarget(data.output);
                 driver.blit(TargetBufferFlags::COLOR,
-                        out.target, out.params.viewport, in.target, in.params.viewport);
+                        out.target, out.params.viewport, in.target, in.params.viewport,
+                        SamplerMagFilter::LINEAR);
             });
 
     return ppScaling.getData().output;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -345,7 +345,7 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, filament::Viewport const& 
     // Verify that the source swap chain is readable.
     assert(mSwapChain->isReadable());
     driver.blit(TargetBufferFlags::COLOR,
-            viewRenderTarget, dstViewport, viewRenderTarget, srcViewport);
+            viewRenderTarget, dstViewport, viewRenderTarget, srcViewport, SamplerMagFilter::LINEAR);
     if (flags & SET_PRESENTATION_TIME) {
         // TODO: Implement this properly, see https://github.com/google/filament/issues/633
     }

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -227,7 +227,8 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
                     mFormat, { mHandle, level++, layer }, {}, {});
             driver.blit(TargetBufferFlags::COLOR,
                     dstrth, { 0, 0, dstw, dsth },
-                    srcrth, { 0, 0, srcw, srch });
+                    srcrth, { 0, 0, srcw, srch },
+                    SamplerMagFilter::LINEAR);
             driver.destroyRenderTarget(srcrth);
             srcrth = dstrth;
             srcw = dstw;

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -482,12 +482,13 @@ DECL_DRIVER_API_6(readStreamPixels,
  * --------------------
  */
 
-DECL_DRIVER_API_5(blit,
+DECL_DRIVER_API_6(blit,
         Driver::TargetBufferFlags, buffers,
         Driver::RenderTargetHandle, dst,
         driver::Viewport, dstRect,
         Driver::RenderTargetHandle, src,
-        driver::Viewport, srcRect)
+        driver::Viewport, srcRect,
+        Driver::SamplerMagFilter, filter)
 
 DECL_DRIVER_API_2(draw,
         Driver::PipelineState, state,

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -578,8 +578,8 @@ void MetalDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_t
 
 void MetalDriver::blit(Driver::TargetBufferFlags buffers,
         Driver::RenderTargetHandle dst, driver::Viewport dstRect,
-        Driver::RenderTargetHandle src, driver::Viewport srcRect) {
-
+        Driver::RenderTargetHandle src, driver::Viewport srcRect,
+        Driver::SamplerMagFilter filter) {
 }
 
 void MetalDriver::draw(Driver::PipelineState ps, Driver::RenderPrimitiveHandle rph) {

--- a/filament/src/driver/vulkan/VulkanDriver.cpp
+++ b/filament/src/driver/vulkan/VulkanDriver.cpp
@@ -844,7 +844,8 @@ void VulkanDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_
 
 void VulkanDriver::blit(TargetBufferFlags buffers,
         Driver::RenderTargetHandle dst, driver::Viewport dstRect,
-        Driver::RenderTargetHandle src, driver::Viewport srcRect) {
+        Driver::RenderTargetHandle src, driver::Viewport srcRect,
+        Driver::SamplerMagFilter filter) {
     auto dstTarget = handle_cast<VulkanRenderTarget>(mHandleMap, dst);
     auto srcTarget = handle_cast<VulkanRenderTarget>(mHandleMap, src);
 
@@ -891,7 +892,8 @@ void VulkanDriver::blit(TargetBufferFlags buffers,
         // TODO: Issue vkCmdResolveImage for MSAA targets.
 
         vkCmdBlitImage(cmdbuffer, srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, blitRegions, VK_FILTER_LINEAR);
+                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, blitRegions,
+                filter == SamplerMagFilter::NEAREST ? VK_FILTER_NEAREST : VK_FILTER_LINEAR);
 
         VulkanTexture::transitionImageLayout(cmdbuffer, dstImage, VK_IMAGE_LAYOUT_UNDEFINED,
                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dstLevel, 1);


### PR DESCRIPTION
Because with OpenGL ES backends, it's not allowed
to blit with a linear filter when depth/stencil is used, we need to
expose the filtering option.
In the GLES backend if the linear filter is selected and depth/stencil 
is selected, filtering is downgraded to nearest silently.