### PR TITLE
don't call EGL during static initialization

### DIFF
--- a/filament/src/driver/opengl/PlatformEGL.cpp
+++ b/filament/src/driver/opengl/PlatformEGL.cpp
@@ -143,6 +143,8 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
         return nullptr;
     }
 
+    importGLESExtensionsEntryPoints();
+
     auto extensions = split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
 
     eglCreateSyncKHR = (PFNEGLCREATESYNCKHRPROC) eglGetProcAddress("eglCreateSyncKHR");

--- a/filament/src/driver/opengl/gl_headers.cpp
+++ b/filament/src/driver/opengl/gl_headers.cpp
@@ -19,6 +19,7 @@
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>
 #include <GLES2/gl2ext.h>
+#include <mutex>
 
 namespace glext {
 #ifdef GL_QCOM_tiled_rendering
@@ -37,14 +38,11 @@ PFNGLPOPGROUPMARKEREXTPROC glPopGroupMarkerEXT;
 PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
 PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
 #endif
-}
 
-using namespace glext;
+static std::once_flag sGlExtInitialized;
 
-namespace filament {
-static class GLESExtInit {
-public:
-    GLESExtInit() noexcept {
+void importGLESExtensionsEntryPoints() {
+    std::call_once(sGlExtInitialized, []() {
 #ifdef GL_QCOM_tiled_rendering
         glStartTilingQCOM =
                 (PFNGLSTARTTILINGQCOMPROC)eglGetProcAddress(
@@ -82,9 +80,10 @@ public:
                 (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)eglGetProcAddress(
                         "glRenderbufferStorageMultisampleEXT");
 #endif
-    }
-} instance;
-} // namespace filament
+    });
+}
+
+} // namespace glext
 
 #endif
 

--- a/filament/src/driver/opengl/gl_headers.h
+++ b/filament/src/driver/opengl/gl_headers.h
@@ -24,6 +24,10 @@
 
     /* The Android NDK doesn't exposes extensions, fake it with eglGetProcAddress */
     namespace glext {
+        // importGLESExtensionsEntryPoints is thread-safe and can be called multiple times.
+        // it is currently called from PlatformEGL.
+        void importGLESExtensionsEntryPoints();
+
 #ifdef GL_QCOM_tiled_rendering
         extern PFNGLSTARTTILINGQCOMPROC glStartTilingQCOM;
         extern PFNGLENDTILINGQCOMPROC glEndTilingQCOM;


### PR DESCRIPTION
On Android this can cause a dead-lock, because it looks like dlopen()
holds a lock while calling static initializers.

Bug: 126424427