### PR TITLE
rework scissor/viewport API a bit in the backend

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -120,14 +120,11 @@ void ShadowMap::beginRenderPass(DriverApi& driver) const noexcept {
     params.flags.discardStart = TargetBufferFlags::DEPTH;
     params.flags.discardEnd = TargetBufferFlags::COLOR_AND_STENCIL;
     params.clearDepth = 1.0;
-    params.viewport.width = params.viewport.height = mShadowMapDimension;
-    // Disable scissor and viewport to avoid bugs in some drivers where the GPU memory is reloaded
-    // needlessly.
-    params.flags.clear |= RenderPassFlags::IGNORE_SCISSOR | RenderPassFlags::IGNORE_VIEWPORT;
+    params.viewport = mViewport;
+    // disable scissor for clearing so the whole surface is cleared, but set the viewport to the
+    // the inset-by-1 rectangle.
+    params.flags.clear |= RenderPassFlags::IGNORE_SCISSOR;
     driver.beginRenderPass(mShadowMapRenderTarget, params);
-
-    driver.viewport(mViewport.left, mViewport.bottom,
-            mViewport.width, mViewport.height);
 }
 
 void ShadowMap::update(

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -55,9 +55,8 @@ public:
         if (mSbHandle) {
             driver.bindSamplers(BindingPoints::PER_MATERIAL_INSTANCE, mSbHandle);
         }
-        driver.setViewportScissor(
-                mScissorRect[0], mScissorRect[1],
-                uint32_t(mScissorRect[2]), uint32_t(mScissorRect[3]));
+        driver.setViewportScissor(mScissorRect.left, mScissorRect.bottom,
+                mScissorRect.width, mScissorRect.height);
     }
 
     template <typename T>
@@ -77,15 +76,17 @@ public:
     SamplerGroup const& getSamplerGroup() const noexcept { return mSamplers; }
 
     void setScissor(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept {
-        mScissorRect[0] = left;
-        mScissorRect[1] = bottom;
-        mScissorRect[2] = (int32_t)std::min(width,  (uint32_t)std::numeric_limits<int32_t>::max());
-        mScissorRect[3] = (int32_t)std::min(height, (uint32_t)std::numeric_limits<int32_t>::max());
+        mScissorRect = { left, bottom,
+                std::min(width, (uint32_t)std::numeric_limits<int32_t>::max()),
+                std::min(height, (uint32_t)std::numeric_limits<int32_t>::max())
+        };
     }
 
     void unsetScissor() noexcept {
-        mScissorRect[0] = mScissorRect[1] = 0;
-        mScissorRect[2] = mScissorRect[3] = std::numeric_limits<int32_t>::max();
+        mScissorRect = { 0, 0,
+                (uint32_t)std::numeric_limits<int32_t>::max(),
+                (uint32_t)std::numeric_limits<int32_t>::max()
+        };
     }
 
     void setPolygonOffset(float scale, float constant) noexcept {
@@ -115,8 +116,9 @@ private:
     uint64_t mMaterialSortingKey = 0;
 
     // Scissor rectangle is specified as: Left Bottom Width Height.
-    int32_t mScissorRect[4] = {
-        0, 0, std::numeric_limits<int32_t>::max(), std::numeric_limits<int32_t>::max()
+    driver::Viewport mScissorRect = { 0, 0,
+            (uint32_t)std::numeric_limits<int32_t>::max(),
+            (uint32_t)std::numeric_limits<int32_t>::max()
     };
 };
 

--- a/filament/src/driver/DriverAPI.inc
+++ b/filament/src/driver/DriverAPI.inc
@@ -425,12 +425,6 @@ DECL_DRIVER_API_1(commit,
  * -----------------------
  */
 
-DECL_DRIVER_API_4(viewport,
-        ssize_t, left,
-        ssize_t, bottom,
-        size_t, width,
-        size_t, height)
-
 DECL_DRIVER_API_2(bindUniformBuffer,
         size_t, index,
         Driver::UniformBufferHandle, ubh)

--- a/libs/filabridge/include/filament/driver/DriverEnums.h
+++ b/libs/filabridge/include/filament/driver/DriverEnums.h
@@ -95,7 +95,6 @@ struct RenderPassFlags {
 
     // Extra RenderPass-only flags stashed in the "clear" field.
     static const uint8_t IGNORE_SCISSOR = 0x10;
-    static const uint8_t IGNORE_VIEWPORT = 0x20;
 };
 
 struct RenderPassParams {


### PR DESCRIPTION
- the IGNORE_VIEWPORT flag is gone. It wasn't actually needed and what
  it was doing was ambiguous.

- removed the backend viewport() API which wasn't actually needed.

- beginRenderPass() now ALWAYS sets the viewport and scissor but 
  doesn't necessarily clears honoring the scissor (based on the
  IGNORE_SCISSOR flag).

- the GLES backend now just sets the scissor when it needs it, as opposed
  to always trying to keep it set. we now rely on state tracking to
  de-dup the gl calls.