### PR TITLE
VulkanDriver: do not defer uploads.

### DIFF
--- a/filament/src/driver/vulkan/VulkanBuffer.cpp
+++ b/filament/src/driver/vulkan/VulkanBuffer.cpp
@@ -69,11 +69,13 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
         });
     };
 
-    // If possible, perform the upload immediately, otherwise queue up the work.
+    // If inside beginFrame / endFrame, use the swap context, otherwise use the work cmdbuffer.
     if (mContext.currentCommands) {
         copyToDevice(mContext.currentCommands->cmdbuffer);
     } else {
-        mContext.pendingWork.emplace_back(copyToDevice);
+        VkCommandBuffer work = acquireWorkCommandBuffer(mContext);
+        copyToDevice(work);
+        flushWorkCommandBuffer(mContext);
     }
 }
 

--- a/filament/src/driver/vulkan/VulkanDriverImpl.h
+++ b/filament/src/driver/vulkan/VulkanDriverImpl.h
@@ -47,6 +47,7 @@ struct VulkanCommandBuffer {
     VkCommandBuffer cmdbuffer;
     VkFence fence;
     VulkanDisposer::Set resources;
+    bool submitted;
 };
 
 // For now we only support a single-device, single-instance scenario. Our concept of "context" is a
@@ -89,7 +90,6 @@ struct SwapContext {
     VulkanAttachment attachment;
     VulkanCommandBuffer commands;
     VulkanTaskQueue pendingWork;
-    bool submitted;
 };
 
 // The SurfaceContext stores various state (including the swap chain) that we tightly associate
@@ -126,12 +126,14 @@ VkBlendFactor getBlendFactor(BlendFunction mode);
 VkCullModeFlags getCullMode(CullingMode mode);
 VkFrontFace getFrontFace(bool inverseFrontFaces);
 void waitForIdle(VulkanContext& context);
-void acquireCommandBuffer(VulkanContext& context);
+void acquireSwapCommandBuffer(VulkanContext& context);
 void releaseCommandBuffer(VulkanContext& context);
 void performPendingWork(VulkanTaskQueue& work, VkCommandBuffer cmdbuf);
 void flushCommandBuffer(VulkanContext& context);
 VkFormat findSupportedFormat(VulkanContext& context, const std::vector<VkFormat>& candidates,
         VkImageTiling tiling, VkFormatFeatureFlags features);
+VkCommandBuffer acquireWorkCommandBuffer(VulkanContext& context);
+void flushWorkCommandBuffer(VulkanContext& context);
 
 } // namespace filament
 } // namespace driver

--- a/filament/src/driver/vulkan/VulkanHandles.cpp
+++ b/filament/src/driver/vulkan/VulkanHandles.cpp
@@ -357,11 +357,13 @@ void VulkanUniformBuffer::loadFromCpu(const void* cpuData, uint32_t numBytes) {
         });
     };
 
-    // If possible, perform the upload immediately, otherwise queue up the work.
+    // If inside beginFrame / endFrame, use the swap context, otherwise use the work cmdbuffer.
     if (mContext.currentCommands) {
         copyToDevice(mContext.currentCommands->cmdbuffer);
     } else {
-        mContext.pendingWork.emplace_back(copyToDevice);
+        VkCommandBuffer work = acquireWorkCommandBuffer(mContext);
+        copyToDevice(work);
+        flushWorkCommandBuffer(mContext);
     }
 }
 
@@ -502,12 +504,13 @@ void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t wi
         });
     };
 
-    // If possible, perform the upload immediately, otherwise queue up the work.
+    // If inside beginFrame / endFrame, use the swap context, otherwise use the work cmdbuffer.
     if (mContext.currentCommands) {
         copyToDevice(mContext.currentCommands->cmdbuffer);
     } else {
-        mContext.pendingWork.emplace_back(copyToDevice);
-        waitForIdle(mContext); // TODO: use the work cmd buffer directly and flush it afterwards.
+        VkCommandBuffer work = acquireWorkCommandBuffer(mContext);
+        copyToDevice(work);
+        flushWorkCommandBuffer(mContext);
     }
 }
 
@@ -545,11 +548,13 @@ void VulkanTexture::updateCubeImage(const PixelBufferDescriptor& data,
         });
     };
 
-    // If possible, perform the upload immediately, otherwise queue up the work.
+    // If inside beginFrame / endFrame, use the swap context, otherwise use the work cmdbuffer.
     if (mContext.currentCommands) {
         copyToDevice(mContext.currentCommands->cmdbuffer);
     } else {
-        mContext.pendingWork.emplace_back(copyToDevice);
+        VkCommandBuffer work = acquireWorkCommandBuffer(mContext);
+        copyToDevice(work);
+        flushWorkCommandBuffer(mContext);
     }
 }
 


### PR DESCRIPTION
This gets us closer to being able to remove the pendingWork queues.