### PR TITLE
Fix Metal sampler binding and memory leak

### DIFF
--- a/filament/src/driver/metal/MetalContext.h
+++ b/filament/src/driver/metal/MetalContext.h
@@ -59,11 +59,6 @@ struct MetalContext {
     PipelineStateCache pipelineStateCache;
     SamplerStateCache samplerStateCache;
 
-    id<MTLSamplerState> boundSamplers[NUM_SAMPLER_BINDINGS] = {};
-    id<MTLTexture> boundTextures[NUM_SAMPLER_BINDINGS] = {};
-    bool samplersDirty = true;
-    bool texturesDirty = true;
-
     MetalSamplerGroup* samplerBindings[NUM_SAMPLER_BINDINGS] = {};
 
     // Surface-related properties.

--- a/filament/src/driver/metal/MetalDriver.h
+++ b/filament/src/driver/metal/MetalDriver.h
@@ -139,7 +139,7 @@ private:
     }
 
     void enumerateSamplerGroups(const MetalProgram* program,
-            const std::function<void(const SamplerGroup::Sampler*, uint8_t)>& f);
+            const std::function<void(const SamplerGroup::Sampler*, size_t)>& f);
 };
 
 } // namespace metal

--- a/filament/src/driver/metal/MetalDriver.mm
+++ b/filament/src/driver/metal/MetalDriver.mm
@@ -54,8 +54,8 @@ MetalDriver::MetalDriver(driver::MetalPlatform* platform) noexcept
 }
 
 MetalDriver::~MetalDriver() noexcept {
-    delete mContext;
     [mContext->device release];
+    delete mContext;
 }
 
 #define METAL_DEBUG_COMMANDS 0

--- a/filament/src/driver/metal/MetalHandles.h
+++ b/filament/src/driver/metal/MetalHandles.h
@@ -97,7 +97,7 @@ struct MetalProgram : public HwProgram {
 
     id<MTLFunction> vertexFunction;
     id<MTLFunction> fragmentFunction;
-    Program::SamplerGroupInfo samplerBindings;
+    Program::SamplerGroupInfo samplerGroupInfo;
 };
 
 struct MetalTexture : public HwTexture {

--- a/filament/src/driver/metal/MetalHandles.mm
+++ b/filament/src/driver/metal/MetalHandles.mm
@@ -222,7 +222,7 @@ MetalProgram::MetalProgram(id<MTLDevice> device, const Program& program) noexcep
         [library release];
     }
 
-    samplerBindings = program.getSamplerGroupInfo();
+    samplerGroupInfo = program.getSamplerGroupInfo();
 }
 
 MetalProgram::~MetalProgram() {

--- a/filament/src/driver/metal/MetalState.h
+++ b/filament/src/driver/metal/MetalState.h
@@ -37,6 +37,7 @@ inline bool operator==(const driver::SamplerParams& lhs, const driver::SamplerPa
 namespace metal {
 
 static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = filament::ATTRIBUTE_INDEX_COUNT;
+static constexpr uint32_t NUM_SAMPLER_GROUPS = BindingPoints::COUNT;
 static constexpr uint32_t NUM_SAMPLER_BINDINGS = filament::MAX_SAMPLER_COUNT;
 static constexpr uint32_t VERTEX_BUFFER_START = BindingPoints::COUNT;
 


### PR DESCRIPTION
Update Metal driver to use new `SamplerGroupInfo`. We're no longer keeping track of which textures / samplers are already bound to the command encoder as the process was error-prone and isn't worth the effort for now.

Also fixed a memory leak when creating a new depth texture inside of `createRenderTargetR`.

Fixes #1008