### PR TITLE
Major cleanup/refactoring

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -11,7 +11,9 @@ set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(PUBLIC_HDRS
         include/backend/BufferDescriptor.h
         include/backend/PixelBufferDescriptor.h
+        include/backend/PipelineState.h
         include/backend/Platform.h
+        include/backend/TargetBufferInfo.h
 )
 
 set(SRCS

--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_PIPELINESTATE_H
+#define TNT_FILAMENT_DRIVER_PIPELINESTATE_H
+
+#include "private/backend/Handle.h"
+
+#include <filament/backend/DriverEnums.h>
+
+#include <stdint.h>
+
+namespace filament {
+namespace driver {
+
+struct PipelineState {
+    Handle<HwProgram> program;
+    RasterState rasterState;
+    PolygonOffset polygonOffset;
+};
+
+
+} // namespace driver
+} // namespace filament
+
+#endif //TNT_FILAMENT_DRIVER_PIPELINESTATE_H

--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -23,7 +23,9 @@
 
 namespace filament {
 
+namespace driver {
 class Driver;
+} // namespace driver
 
 namespace driver {
 
@@ -46,7 +48,7 @@ public:
     // Creates and initializes the low-level API (e.g. an OpenGL context or Vulkan instance),
     // then creates the concrete Driver. Returns null on failure.
     // The caller takes ownership of the returned Driver* and must destroy it with delete.
-    virtual Driver* createDriver(void* sharedContext) noexcept = 0;
+    virtual driver::Driver* createDriver(void* sharedContext) noexcept = 0;
 };
 
 class UTILS_PUBLIC OpenGLPlatform : public Platform {

--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_TARGETBUFFERINFO_H
+#define TNT_FILAMENT_DRIVER_TARGETBUFFERINFO_H
+
+#include "private/backend/Handle.h"
+
+#include <filament/backend/DriverEnums.h>
+
+#include <stdint.h>
+
+namespace filament {
+namespace driver {
+
+class TargetBufferInfo {
+public:
+    // ctor for 2D textures
+    TargetBufferInfo(Handle<HwTexture> h, uint8_t level = 0) noexcept // NOLINT(google-explicit-constructor)
+            : handle(h), level(level) { }
+    // ctor for cubemaps
+    TargetBufferInfo(Handle<HwTexture> h, uint8_t level, TextureCubemapFace face) noexcept
+            : handle(h), level(level), face(face) { }
+    // ctor for 3D textures
+    TargetBufferInfo(Handle<HwTexture> h, uint8_t level, uint16_t layer) noexcept
+            : handle(h), level(level), layer(layer) { }
+
+    // texture to be used as render target
+    Handle<HwTexture> handle;
+    // level to be used
+    uint8_t level = 0;
+    union {
+        // face if texture is a cubemap
+        TextureCubemapFace face;
+        // for 3D textures
+        uint16_t layer = 0;
+    };
+    TargetBufferInfo() noexcept { }
+};
+
+} // namespace driver
+} // namespace filament
+
+#endif //TNT_FILAMENT_DRIVER_TARGETBUFFERINFO_H

--- a/filament/backend/include/private/backend/CircularBuffer.h
+++ b/filament/backend/include/private/backend/CircularBuffer.h
@@ -23,6 +23,7 @@
 #include <utils/compiler.h>
 
 namespace filament {
+namespace driver {
 
 class CircularBuffer {
 public:
@@ -83,6 +84,7 @@ private:
     void* mHead = nullptr;
 };
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_CIRCULARBUFFER_H

--- a/filament/backend/include/private/backend/CommandBufferQueue.h
+++ b/filament/backend/include/private/backend/CommandBufferQueue.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 namespace filament {
+namespace driver {
 
 /*
  * A producer-consumer command queue that uses a CircularBuffer as main storage
@@ -74,6 +75,7 @@ public:
     void requestExit();
 };
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_COMMANDBUFFERQUEUE_H

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -20,8 +20,18 @@
 #define TNT_FILAMENT_DRIVER_COMMANDSTREAM_H
 
 #include "private/backend/CircularBuffer.h"
+
+#include <backend/BufferDescriptor.h>
+#include <backend/PipelineState.h>
+#include <backend/PixelBufferDescriptor.h>
+#include <backend/TargetBufferInfo.h>
+
+#include "private/backend/DriverApi.h"
 #include "private/backend/Handle.h"
 #include "private/backend/Program.h"
+#include "private/backend/SamplerGroup.h"
+
+// FIXME: we'd like to not need this header here.
 #include "private/backend/Driver.h"
 
 #include <filament/backend/DriverEnums.h>

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -20,7 +20,12 @@
 #define TNT_FILAMENT_DRIVER_COMMANDSTREAM_H
 
 #include "private/backend/CircularBuffer.h"
+#include "private/backend/Handle.h"
+#include "private/backend/Program.h"
 #include "private/backend/Driver.h"
+
+#include <filament/backend/DriverEnums.h>
+
 
 #include <utils/compiler.h>
 
@@ -39,6 +44,7 @@
 namespace filament {
 namespace driver {
 
+class Driver;
 class CommandBase;
 
 /*

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -37,6 +37,7 @@
 #define DEBUG_COMMAND_STREAM false
 
 namespace filament {
+namespace driver {
 
 class CommandBase;
 
@@ -300,6 +301,7 @@ PodType* CommandStream::allocatePod(size_t count, size_t alignment) noexcept {
     return static_cast<PodType*>(allocate(count * sizeof(PodType), alignment));
 }
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_COMMANDSTREAM_H

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -17,25 +17,22 @@
 #ifndef TNT_FILAMENT_DRIVER_DRIVER_H
 #define TNT_FILAMENT_DRIVER_DRIVER_H
 
-#include <memory>
-
-#include <stdint.h>
-
-#include <math/vec4.h>
-
-#include <utils/compiler.h>
-#include <utils/Log.h>
-
+#include <backend/PipelineState.h>
 #include <backend/PixelBufferDescriptor.h>
 #include <backend/BufferDescriptor.h>
-#include <backend/Platform.h>
-
-#include <filament/backend/DriverEnums.h>
+#include <backend/TargetBufferInfo.h>
 
 #include "private/backend/Handle.h"
 #include "private/backend/DriverApiForward.h"
 #include "private/backend/Program.h"
 #include "private/backend/SamplerGroup.h"
+
+#include <filament/backend/DriverEnums.h>
+
+#include <utils/compiler.h>
+#include <utils/Log.h>
+
+#include <stdint.h>
 
 namespace filament {
 namespace driver {
@@ -44,56 +41,10 @@ template<typename T>
 class ConcreteDispatcher;
 class Dispatcher;
 
-/* ------------------------------------------------------------------------------------------------
- * Driver interface and factory
- * ------------------------------------------------------------------------------------------------
- */
-
 class Driver {
 public:
-    struct TargetBufferInfo {
-        // ctor for 2D textures
-        TargetBufferInfo(Handle<HwTexture> h, uint8_t level = 0) noexcept // NOLINT(google-explicit-constructor)
-                : handle(h), level(level) { }
-        // ctor for cubemaps
-        TargetBufferInfo(Handle<HwTexture> h, uint8_t level, TextureCubemapFace face) noexcept
-                : handle(h), level(level), face(face) { }
-        // ctor for 3D textures
-        TargetBufferInfo(Handle<HwTexture> h, uint8_t level, uint16_t layer) noexcept
-                : handle(h), level(level), layer(layer) { }
-
-        // texture to be used as render target
-        Handle<HwTexture> handle;
-        // level to be used
-        uint8_t level = 0;
-        union {
-            // face if texture is a cubemap
-            TextureCubemapFace face;
-            // for 3D textures
-            uint16_t layer = 0;
-        };
-        TargetBufferInfo() noexcept { }
-    };
-
-    struct PipelineState {
-        Handle<HwProgram> program;
-        RasterState rasterState;
-        PolygonOffset polygonOffset;
-    };
-
     static size_t getElementTypeSize(ElementType type) noexcept;
 
-    // This is here to be compatible with CommandStream (nice for debugging)
-    template<typename CALLABLE>
-    inline void queueCommand(CALLABLE command) {
-        command();
-    }
-
-    // --------------------------------------------------------------------------------------------
-    // DriverAPI interface
-    // --------------------------------------------------------------------------------------------
-
-public:
     virtual ~Driver() noexcept;
 
     // called from the main thread (NOT the render-thread) at various intervals, this
@@ -109,12 +60,10 @@ public:
 #endif
 
     /*
-     *
      * Asynchronous calls here only to provide a type to CommandStream. They must be non-virtual
      * so that calling the concrete implementation won't go through a vtable.
      *
      * Synchronous calls are virtual and are called directly by CommandStream.
-     *
      */
 
 #define DECL_DRIVER_API(methodName, paramsDecl, params) \
@@ -134,36 +83,37 @@ public:
 } // namespace filament
 
 #if !defined(NDEBUG)
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::TargetBufferInfo& tbi);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::PipelineState& ps);
 
 utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::AttributeArray& type);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::RasterState& rs);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::PolygonOffset& po);
 utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::FaceOffsets& type);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ShaderModel model);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PrimitiveType type);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ElementType type);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::PolygonOffset& po);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::PipelineState& ps);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::RasterState& rs);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::TargetBufferInfo& tbi);
+
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::BufferDescriptor const& b);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::BufferUsage usage);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::CullingMode mode);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerType type);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerFormat format);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::Precision precision);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureFormat format);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureUsage usage);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureCubemapFace face);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerWrapMode wrap);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerMinFilter filter);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerMagFilter filter);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerCompareMode mode);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerCompareFunc func);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerParams params);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ElementType type);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PixelBufferDescriptor const& b);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PixelDataFormat format);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PixelDataType type);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::BufferDescriptor const& b);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PixelBufferDescriptor const& b);
-utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::Viewport const& v);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::Precision precision);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PrimitiveType type);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::RenderPassParams const& b);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerCompareFunc func);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerCompareMode mode);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerFormat format);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerMagFilter filter);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerMinFilter filter);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerParams params);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerType type);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::SamplerWrapMode wrap);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ShaderModel model);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureCubemapFace face);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureFormat format);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::TextureUsage usage);
+utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::Viewport const& v);
 #endif
 
 #endif // TNT_FILAMENT_DRIVER_DRIVER_H

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -51,23 +51,6 @@ class Dispatcher;
 
 class Driver {
 public:
-    // constants
-    static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8;
-
-    static constexpr uint64_t FENCE_WAIT_FOR_EVER = driver::FENCE_WAIT_FOR_EVER;
-
-    struct Attribute {
-        static constexpr uint8_t FLAG_NORMALIZED     = 0x1;
-        static constexpr uint8_t FLAG_INTEGER_TARGET = 0x2;
-        uint32_t offset = 0;
-        uint8_t stride = 0;
-        uint8_t buffer = 0xFF;
-        ElementType type = ElementType::BYTE;
-        uint8_t flags = 0x0;
-    };
-
-    using AttributeArray = std::array<Attribute, MAX_ATTRIBUTE_BUFFER_COUNT>;
-
     struct TargetBufferInfo {
         // ctor for 2D textures
         TargetBufferInfo(Handle<HwTexture> h, uint8_t level = 0) noexcept // NOLINT(google-explicit-constructor)
@@ -90,73 +73,6 @@ public:
             uint16_t layer = 0;
         };
         TargetBufferInfo() noexcept { }
-    };
-
-    struct RasterState {
-        using CullingMode = driver::CullingMode;
-        using DepthFunc = driver::SamplerCompareFunc;
-        using BlendEquation = driver::BlendEquation;
-        using BlendFunction = driver::BlendFunction;
-
-        RasterState() noexcept {
-            static_assert(sizeof(RasterState) == sizeof(uint32_t),
-                    "RasterState size not what was intended");
-            culling = CullingMode::BACK;
-            blendEquationRGB = BlendEquation::ADD;
-            blendEquationAlpha = BlendEquation::ADD;
-            blendFunctionSrcRGB = BlendFunction::ONE;
-            blendFunctionSrcAlpha = BlendFunction::ONE;
-            blendFunctionDstRGB = BlendFunction::ZERO;
-            blendFunctionDstAlpha = BlendFunction::ZERO;
-        }
-
-        bool operator == (RasterState rhs) const noexcept { return u == rhs.u; }
-        bool operator != (RasterState rhs) const noexcept { return u != rhs.u; }
-
-        void disableBlending() noexcept {
-            blendEquationRGB = BlendEquation::ADD;
-            blendEquationAlpha = BlendEquation::ADD;
-            blendFunctionSrcRGB = BlendFunction::ONE;
-            blendFunctionSrcAlpha = BlendFunction::ONE;
-            blendFunctionDstRGB = BlendFunction::ZERO;
-            blendFunctionDstAlpha = BlendFunction::ZERO;
-        }
-
-        // note: clang reduces this entire function to a simple load/mask/compare
-        bool hasBlending() const noexcept {
-            // there could be other cases where blending would end-up being disabled,
-            // but this is common and easy to check
-            return !(blendEquationRGB == BlendEquation::ADD &&
-                     blendEquationAlpha == BlendEquation::ADD &&
-                     blendFunctionSrcRGB == BlendFunction::ONE &&
-                     blendFunctionSrcAlpha == BlendFunction::ONE &&
-                     blendFunctionDstRGB == BlendFunction::ZERO &&
-                     blendFunctionDstAlpha == BlendFunction::ZERO);
-        }
-
-        union {
-            struct {
-                CullingMode culling                 : 2;        //  2
-                BlendEquation blendEquationRGB      : 3;        //  5
-                BlendEquation blendEquationAlpha    : 3;        //  8
-                BlendFunction blendFunctionSrcRGB   : 4;        // 12
-                BlendFunction blendFunctionSrcAlpha : 4;        // 16
-                BlendFunction blendFunctionDstRGB   : 4;        // 20
-                BlendFunction blendFunctionDstAlpha : 4;        // 24
-                bool depthWrite                     : 1;        // 25
-                DepthFunc depthFunc                 : 3;        // 28
-                bool colorWrite                     : 1;        // 29
-                bool alphaToCoverage                : 1;        // 30
-                bool inverseFrontFaces              : 1;        // 31
-                uint8_t padding                     : 1;        // 32
-            };
-            uint32_t u = 0;
-        };
-    };
-
-    struct PolygonOffset {
-        float slope = 0;        // factor in GL-speak
-        float constant = 0;     // units in GL-speak
     };
 
     struct PipelineState {
@@ -218,12 +134,12 @@ public:
 } // namespace filament
 
 #if !defined(NDEBUG)
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::AttributeArray& type);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::RasterState& rs);
 utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::TargetBufferInfo& tbi);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::PolygonOffset& po);
 utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::PipelineState& ps);
 
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::AttributeArray& type);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::RasterState& rs);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::PolygonOffset& po);
 utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::FaceOffsets& type);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ShaderModel model);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PrimitiveType type);

--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -38,6 +38,7 @@
 #include "private/backend/SamplerGroup.h"
 
 namespace filament {
+namespace driver {
 
 template<typename T>
 class ConcreteDispatcher;
@@ -53,52 +54,7 @@ public:
     // constants
     static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8;
 
-    /*
-     * Driver types...
-     */
-    using ShaderModel = driver::ShaderModel;
-
-    // remap the public types into the Driver class
-    using BufferDescriptor = driver::BufferDescriptor;
-    using BufferUsage = driver::BufferUsage;
-    using ElementType = driver::ElementType;
-    using FaceOffsets = driver::FaceOffsets;
-    using FenceStatus = driver::FenceStatus;
-    using PixelBufferDescriptor = driver::PixelBufferDescriptor;
-    using PixelDataFormat = driver::PixelDataFormat;
-    using PixelDataType = driver::PixelDataType;
-    using PrimitiveType = driver::PrimitiveType;
-    using RenderPassParams = driver::RenderPassParams;
-    using SamplerCompareFunc = driver::SamplerCompareFunc;
-    using SamplerCompareMode = driver::SamplerCompareMode;
-    using SamplerFormat = driver::SamplerFormat;
-    using SamplerMagFilter = driver::SamplerMagFilter;
-    using SamplerMinFilter = driver::SamplerMinFilter;
-    using SamplerParams = driver::SamplerParams;
-    using SamplerPrecision = driver::Precision;
-    using SamplerType = driver::SamplerType;
-    using SamplerWrapMode = driver::SamplerWrapMode;
-    using TargetBufferFlags = driver::TargetBufferFlags;
-    using TextureCubemapFace = driver::TextureCubemapFace;
-    using TextureFormat = driver::TextureFormat;
-    using TextureUsage = driver::TextureUsage;
-    using UniformType = driver::UniformType;
-
     static constexpr uint64_t FENCE_WAIT_FOR_EVER = driver::FENCE_WAIT_FOR_EVER;
-
-    // Types used by the command stream
-    // (we use this renaming because the macro-system doesn't deal well with "<" and ">")
-    using FenceHandle           = Handle<HwFence>;
-    using IndexBufferHandle     = Handle<HwIndexBuffer>;
-    using ProgramHandle         = Handle<HwProgram>;
-    using RenderPrimitiveHandle = Handle<HwRenderPrimitive>;
-    using RenderTargetHandle    = Handle<HwRenderTarget>;
-    using SamplerGroupHandle    = Handle<HwSamplerGroup>;
-    using StreamHandle          = Handle<HwStream>;
-    using SwapChainHandle       = Handle<HwSwapChain>;
-    using TextureHandle         = Handle<HwTexture>;
-    using UniformBufferHandle   = Handle<HwUniformBuffer>;
-    using VertexBufferHandle    = Handle<HwVertexBuffer>;
 
     struct Attribute {
         static constexpr uint8_t FLAG_NORMALIZED     = 0x1;
@@ -114,17 +70,17 @@ public:
 
     struct TargetBufferInfo {
         // ctor for 2D textures
-        TargetBufferInfo(TextureHandle h, uint8_t level = 0) noexcept // NOLINT(google-explicit-constructor)
+        TargetBufferInfo(Handle<HwTexture> h, uint8_t level = 0) noexcept // NOLINT(google-explicit-constructor)
                 : handle(h), level(level) { }
         // ctor for cubemaps
-        TargetBufferInfo(TextureHandle h, uint8_t level, TextureCubemapFace face) noexcept
+        TargetBufferInfo(Handle<HwTexture> h, uint8_t level, TextureCubemapFace face) noexcept
                 : handle(h), level(level), face(face) { }
         // ctor for 3D textures
-        TargetBufferInfo(TextureHandle h, uint8_t level, uint16_t layer) noexcept
+        TargetBufferInfo(Handle<HwTexture> h, uint8_t level, uint16_t layer) noexcept
                 : handle(h), level(level), layer(layer) { }
 
         // texture to be used as render target
-        TextureHandle handle;
+        Handle<HwTexture> handle;
         // level to be used
         uint8_t level = 0;
         union {
@@ -204,7 +160,7 @@ public:
     };
 
     struct PipelineState {
-        ProgramHandle program;
+        Handle<HwProgram> program;
         RasterState rasterState;
         PolygonOffset polygonOffset;
     };
@@ -258,16 +214,17 @@ public:
 #include "private/backend/DriverAPI.inc"
 };
 
+} // namespace driver
 } // namespace filament
 
 #if !defined(NDEBUG)
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::AttributeArray& type);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::FaceOffsets& type);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::RasterState& rs);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::TargetBufferInfo& tbi);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::PolygonOffset& po);
-utils::io::ostream& operator<<(utils::io::ostream& out, const filament::Driver::PipelineState& ps);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::AttributeArray& type);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::RasterState& rs);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::TargetBufferInfo& tbi);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::PolygonOffset& po);
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::Driver::PipelineState& ps);
 
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::driver::FaceOffsets& type);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ShaderModel model);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::PrimitiveType type);
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::driver::ElementType type);

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -265,9 +265,9 @@ DECL_DRIVER_API_R_8(driver::RenderTargetHandle, createRenderTarget,
         uint32_t, height,
         uint8_t, samples,
         driver::TextureFormat, format,
-        driver::Driver::TargetBufferInfo, color,
-        driver::Driver::TargetBufferInfo, depth,
-        driver::Driver::TargetBufferInfo, stencil)
+        driver::TargetBufferInfo, color,
+        driver::TargetBufferInfo, depth,
+        driver::TargetBufferInfo, stencil)
 
 DECL_DRIVER_API_R_0(driver::FenceHandle, createFence)
 
@@ -485,7 +485,7 @@ DECL_DRIVER_API_6(blit,
         driver::SamplerMagFilter, filter)
 
 DECL_DRIVER_API_2(draw,
-        driver::Driver::PipelineState, state,
+        driver::PipelineState, state,
         driver::RenderPrimitiveHandle, rph)
 
 #pragma clang diagnostic pop

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -227,7 +227,7 @@ DECL_DRIVER_API_R_5(driver::VertexBufferHandle, createVertexBuffer,
         uint8_t, bufferCount,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
-        driver::Driver::AttributeArray, attributes,
+        driver::AttributeArray, attributes,
         driver::BufferUsage, usage)
 
 DECL_DRIVER_API_R_3(driver::IndexBufferHandle, createIndexBuffer,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -223,73 +223,73 @@ DECL_DRIVER_API_0(flush)
  * -----------------------
  */
 
-DECL_DRIVER_API_R_5(Driver::VertexBufferHandle, createVertexBuffer,
+DECL_DRIVER_API_R_5(driver::VertexBufferHandle, createVertexBuffer,
         uint8_t, bufferCount,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
-        Driver::AttributeArray, attributes,
-        Driver::BufferUsage, usage)
+        driver::Driver::AttributeArray, attributes,
+        driver::BufferUsage, usage)
 
-DECL_DRIVER_API_R_3(Driver::IndexBufferHandle, createIndexBuffer,
-        Driver::ElementType, elementType,
+DECL_DRIVER_API_R_3(driver::IndexBufferHandle, createIndexBuffer,
+        driver::ElementType, elementType,
         uint32_t, indexCount,
-        Driver::BufferUsage, usage)
+        driver::BufferUsage, usage)
 
-DECL_DRIVER_API_R_8(Driver::TextureHandle, createTexture,
-        Driver::SamplerType, target,
+DECL_DRIVER_API_R_8(driver::TextureHandle, createTexture,
+        driver::SamplerType, target,
         uint8_t, levels,
-        Driver::TextureFormat, format,
+        driver::TextureFormat, format,
         uint8_t, samples,
         uint32_t, width,
         uint32_t, height,
         uint32_t, depth,
-        Driver::TextureUsage, usage)
+        driver::TextureUsage, usage)
 
-DECL_DRIVER_API_R_1(Driver::SamplerGroupHandle, createSamplerGroup,
+DECL_DRIVER_API_R_1(driver::SamplerGroupHandle, createSamplerGroup,
         size_t, size)
 
-DECL_DRIVER_API_R_2(Driver::UniformBufferHandle, createUniformBuffer,
+DECL_DRIVER_API_R_2(driver::UniformBufferHandle, createUniformBuffer,
         size_t, size,
-        Driver::BufferUsage, usage)
+        driver::BufferUsage, usage)
 
-DECL_DRIVER_API_R_0(Driver::RenderPrimitiveHandle, createRenderPrimitive)
+DECL_DRIVER_API_R_0(driver::RenderPrimitiveHandle, createRenderPrimitive)
 
-DECL_DRIVER_API_R_1(Driver::ProgramHandle, createProgram,
-        Program&&, program)
+DECL_DRIVER_API_R_1(driver::ProgramHandle, createProgram,
+        driver::Program&&, program)
 
-DECL_DRIVER_API_R_0(Driver::RenderTargetHandle, createDefaultRenderTarget)
+DECL_DRIVER_API_R_0(driver::RenderTargetHandle, createDefaultRenderTarget)
 
-DECL_DRIVER_API_R_8(Driver::RenderTargetHandle, createRenderTarget,
-        Driver::TargetBufferFlags, targetBufferFlags,
+DECL_DRIVER_API_R_8(driver::RenderTargetHandle, createRenderTarget,
+        driver::TargetBufferFlags, targetBufferFlags,
         uint32_t, width,
         uint32_t, height,
         uint8_t, samples,
-        Driver::TextureFormat, format,
-        Driver::TargetBufferInfo, color,
-        Driver::TargetBufferInfo, depth,
-        Driver::TargetBufferInfo, stencil)
+        driver::TextureFormat, format,
+        driver::Driver::TargetBufferInfo, color,
+        driver::Driver::TargetBufferInfo, depth,
+        driver::Driver::TargetBufferInfo, stencil)
 
-DECL_DRIVER_API_R_0(Driver::FenceHandle, createFence)
+DECL_DRIVER_API_R_0(driver::FenceHandle, createFence)
 
-DECL_DRIVER_API_R_2(Driver::SwapChainHandle, createSwapChain, void*, nativeWindow, uint64_t, flags)
+DECL_DRIVER_API_R_2(driver::SwapChainHandle, createSwapChain, void*, nativeWindow, uint64_t, flags)
 
-DECL_DRIVER_API_R_3(Driver::StreamHandle, createStreamFromTextureId, intptr_t, externalTextureId, uint32_t, width, uint32_t, height)
+DECL_DRIVER_API_R_3(driver::StreamHandle, createStreamFromTextureId, intptr_t, externalTextureId, uint32_t, width, uint32_t, height)
 
 /*
  * Destroying driver objects
  * -------------------------
  */
 
-DECL_DRIVER_API_1(destroyVertexBuffer,    Driver::VertexBufferHandle, vbh)
-DECL_DRIVER_API_1(destroyIndexBuffer,     Driver::IndexBufferHandle, ibh)
-DECL_DRIVER_API_1(destroyRenderPrimitive, Driver::RenderPrimitiveHandle, rph)
-DECL_DRIVER_API_1(destroyProgram,         Driver::ProgramHandle, ph)
-DECL_DRIVER_API_1(destroySamplerGroup,   Driver::SamplerGroupHandle, sbh)
-DECL_DRIVER_API_1(destroyUniformBuffer,   Driver::UniformBufferHandle, ubh)
-DECL_DRIVER_API_1(destroyTexture,         Driver::TextureHandle, th)
-DECL_DRIVER_API_1(destroyRenderTarget,    Driver::RenderTargetHandle, rth)
-DECL_DRIVER_API_1(destroySwapChain,       Driver::SwapChainHandle, sch)
-DECL_DRIVER_API_1(destroyStream,          Driver::StreamHandle, sh)
+DECL_DRIVER_API_1(destroyVertexBuffer,    driver::VertexBufferHandle, vbh)
+DECL_DRIVER_API_1(destroyIndexBuffer,     driver::IndexBufferHandle, ibh)
+DECL_DRIVER_API_1(destroyRenderPrimitive, driver::RenderPrimitiveHandle, rph)
+DECL_DRIVER_API_1(destroyProgram,         driver::ProgramHandle, ph)
+DECL_DRIVER_API_1(destroySamplerGroup,    driver::SamplerGroupHandle, sbh)
+DECL_DRIVER_API_1(destroyUniformBuffer,   driver::UniformBufferHandle, ubh)
+DECL_DRIVER_API_1(destroyTexture,         driver::TextureHandle, th)
+DECL_DRIVER_API_1(destroyRenderTarget,    driver::RenderTargetHandle, rth)
+DECL_DRIVER_API_1(destroySwapChain,       driver::SwapChainHandle, sch)
+DECL_DRIVER_API_1(destroyStream,          driver::StreamHandle, sh)
 
 /*
  * Synchronous APIs
@@ -298,21 +298,21 @@ DECL_DRIVER_API_1(destroyStream,          Driver::StreamHandle, sh)
 
 DECL_DRIVER_API_SYNCHRONOUS_0(void, terminate)
 
-DECL_DRIVER_API_SYNCHRONOUS_1(Driver::StreamHandle, createStream, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_1(driver::StreamHandle, createStream, void*, stream)
 
-DECL_DRIVER_API_SYNCHRONOUS_3(void, setStreamDimensions, Driver::StreamHandle, stream, uint32_t, width, uint32_t, height)
+DECL_DRIVER_API_SYNCHRONOUS_3(void, setStreamDimensions, driver::StreamHandle, stream, uint32_t, width, uint32_t, height)
 
-DECL_DRIVER_API_SYNCHRONOUS_1(int64_t, getStreamTimestamp, Driver::StreamHandle, stream)
+DECL_DRIVER_API_SYNCHRONOUS_1(int64_t, getStreamTimestamp, driver::StreamHandle, stream)
 
 DECL_DRIVER_API_SYNCHRONOUS_1(void, updateStreams, driver::DriverApi*, driver)
 
-DECL_DRIVER_API_SYNCHRONOUS_1(void, destroyFence, Driver::FenceHandle, fh)
+DECL_DRIVER_API_SYNCHRONOUS_1(void, destroyFence, driver::FenceHandle, fh)
 
-DECL_DRIVER_API_SYNCHRONOUS_2(Driver::FenceStatus, wait, Driver::FenceHandle, fh, uint64_t, timeout)
+DECL_DRIVER_API_SYNCHRONOUS_2(driver::FenceStatus, wait, driver::FenceHandle, fh, uint64_t, timeout)
 
-DECL_DRIVER_API_SYNCHRONOUS_1(bool, isTextureFormatSupported, Driver::TextureFormat, format)
+DECL_DRIVER_API_SYNCHRONOUS_1(bool, isTextureFormatSupported, driver::TextureFormat, format)
 
-DECL_DRIVER_API_SYNCHRONOUS_1(bool, isRenderTargetFormatSupported, Driver::TextureFormat, format)
+DECL_DRIVER_API_SYNCHRONOUS_1(bool, isRenderTargetFormatSupported, driver::TextureFormat, format)
 
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 
@@ -324,78 +324,78 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
  */
 
 DECL_DRIVER_API_4(updateVertexBuffer,
-        Driver::VertexBufferHandle, vbh,
+        driver::VertexBufferHandle, vbh,
         size_t, index,
-        Driver::BufferDescriptor&&, data,
+        driver::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
 DECL_DRIVER_API_3(updateIndexBuffer,
-        Driver::IndexBufferHandle, ibh,
-        Driver::BufferDescriptor&&, data,
+        driver::IndexBufferHandle, ibh,
+        driver::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
 DECL_DRIVER_API_2(updateUniformBuffer,
-        Driver::UniformBufferHandle, ubh,
-        Driver::BufferDescriptor&&, buffer)
+        driver::UniformBufferHandle, ubh,
+        driver::BufferDescriptor&&, buffer)
 
 DECL_DRIVER_API_2(updateSamplerGroup,
-        Driver::SamplerGroupHandle, ubh,
-        SamplerGroup&&, samplerGroup)
+        driver::SamplerGroupHandle, ubh,
+        driver::SamplerGroup&&, samplerGroup)
 
 DECL_DRIVER_API_7(update2DImage,
-        Driver::TextureHandle, th,
+        driver::TextureHandle, th,
         uint32_t, level,
         uint32_t, xoffset,
         uint32_t, yoffset,
         uint32_t, width,
         uint32_t, height,
-        Driver::PixelBufferDescriptor&&, data)
+        driver::PixelBufferDescriptor&&, data)
 
 DECL_DRIVER_API_4(updateCubeImage,
-        Driver::TextureHandle, th,
+        driver::TextureHandle, th,
         uint32_t, level,
-        Driver::PixelBufferDescriptor&&, data,
-        Driver::FaceOffsets, faceOffsets)
+        driver::PixelBufferDescriptor&&, data,
+        driver::FaceOffsets, faceOffsets)
 
 DECL_DRIVER_API_1(generateMipmaps,
-        Driver::TextureHandle, th)
+        driver::TextureHandle, th)
 
 DECL_DRIVER_API_2(setExternalImage,
-        Driver::TextureHandle, th,
+        driver::TextureHandle, th,
         void*, image)
 
 DECL_DRIVER_API_2(setExternalStream,
-        Driver::TextureHandle, th,
-        Driver::StreamHandle, sh)
+        driver::TextureHandle, th,
+        driver::StreamHandle, sh)
 
 DECL_DRIVER_API_2(beginRenderPass,
-        Driver::RenderTargetHandle, rth,
-        const Driver::RenderPassParams&, params)
+        driver::RenderTargetHandle, rth,
+        const driver::RenderPassParams&, params)
 
 DECL_DRIVER_API_0(endRenderPass)
 
 DECL_DRIVER_API_6(discardSubRenderTargetBuffers,
-        Driver::RenderTargetHandle, rth,
-        Driver::TargetBufferFlags, targetBufferFlags,
+        driver::RenderTargetHandle, rth,
+        driver::TargetBufferFlags, targetBufferFlags,
         uint32_t, left,
         uint32_t, bottom,
         uint32_t, width,
         uint32_t, height)
 
 DECL_DRIVER_API_3(resizeRenderTarget,
-        Driver::RenderTargetHandle, rth,
+        driver::RenderTargetHandle, rth,
         uint32_t, width,
         uint32_t, height)
 
 DECL_DRIVER_API_4(setRenderPrimitiveBuffer,
-        Driver::RenderPrimitiveHandle, rph,
-        Driver::VertexBufferHandle, vbh,
-        Driver::IndexBufferHandle, ibh,
+        driver::RenderPrimitiveHandle, rph,
+        driver::VertexBufferHandle, vbh,
+        driver::IndexBufferHandle, ibh,
         uint32_t, enabledAttributes)
 
 DECL_DRIVER_API_6(setRenderPrimitiveRange,
-        Driver::RenderPrimitiveHandle, rph,
-        Driver::PrimitiveType, pt,
+        driver::RenderPrimitiveHandle, rph,
+        driver::PrimitiveType, pt,
         uint32_t, offset,
         uint32_t, minIndex,
         uint32_t, maxIndex,
@@ -413,12 +413,12 @@ DECL_DRIVER_API_4(setViewportScissor,
  */
 
 DECL_DRIVER_API_2(makeCurrent,
-        Driver::SwapChainHandle, schDraw,
-        Driver::SwapChainHandle, schRead)
+        driver::SwapChainHandle, schDraw,
+        driver::SwapChainHandle, schRead)
 
 
 DECL_DRIVER_API_1(commit,
-        Driver::SwapChainHandle, sch)
+        driver::SwapChainHandle, sch)
 
 /*
  * Setting rendering state
@@ -427,17 +427,17 @@ DECL_DRIVER_API_1(commit,
 
 DECL_DRIVER_API_2(bindUniformBuffer,
         size_t, index,
-        Driver::UniformBufferHandle, ubh)
+        driver::UniformBufferHandle, ubh)
 
 DECL_DRIVER_API_4(bindUniformBufferRange,
         size_t, index,
-        Driver::UniformBufferHandle, ubh,
+        driver::UniformBufferHandle, ubh,
         size_t, offset,
         size_t, size)
 
 DECL_DRIVER_API_2(bindSamplers,
         size_t, index,
-        Driver::SamplerGroupHandle, sbh)
+        driver::SamplerGroupHandle, sbh)
 
 DECL_DRIVER_API_2(insertEventMarker,
         const char*, string,
@@ -456,20 +456,20 @@ DECL_DRIVER_API_0(popGroupMarker)
  */
 
 DECL_DRIVER_API_6(readPixels,
-        Driver::RenderTargetHandle, src,
+        driver::RenderTargetHandle, src,
         uint32_t, x,
         uint32_t, y,
         uint32_t, width,
         uint32_t, height,
-        Driver::PixelBufferDescriptor&&, data)
+        driver::PixelBufferDescriptor&&, data)
 
 DECL_DRIVER_API_6(readStreamPixels,
-        Driver::StreamHandle, sh,
+        driver::StreamHandle, sh,
         uint32_t, x,
         uint32_t, y,
         uint32_t, width,
         uint32_t, height,
-        Driver::PixelBufferDescriptor&&, data)
+        driver::PixelBufferDescriptor&&, data)
 
 /*
  * Rendering operations
@@ -477,16 +477,16 @@ DECL_DRIVER_API_6(readStreamPixels,
  */
 
 DECL_DRIVER_API_6(blit,
-        Driver::TargetBufferFlags, buffers,
-        Driver::RenderTargetHandle, dst,
+        driver::TargetBufferFlags, buffers,
+        driver::RenderTargetHandle, dst,
         driver::Viewport, dstRect,
-        Driver::RenderTargetHandle, src,
+        driver::RenderTargetHandle, src,
         driver::Viewport, srcRect,
-        Driver::SamplerMagFilter, filter)
+        driver::SamplerMagFilter, filter)
 
 DECL_DRIVER_API_2(draw,
-        Driver::PipelineState, state,
-        Driver::RenderPrimitiveHandle, rph)
+        driver::Driver::PipelineState, state,
+        driver::RenderPrimitiveHandle, rph)
 
 #pragma clang diagnostic pop
 

--- a/filament/backend/include/private/backend/DriverApiForward.h
+++ b/filament/backend/include/private/backend/DriverApiForward.h
@@ -19,10 +19,9 @@
 
 
 namespace filament {
+namespace driver {
 
 class CommandStream;
-
-namespace driver {
 
 using DriverApi = CommandStream;
 

--- a/filament/backend/include/private/backend/Handle.h
+++ b/filament/backend/include/private/backend/Handle.h
@@ -27,6 +27,7 @@
 #include <utils/Log.h>
 
 namespace filament {
+namespace driver {
 
 struct HwVertexBuffer;
 struct HwFence;
@@ -99,7 +100,21 @@ private:
 #endif
 };
 
+// Types used by the command stream
+// (we use this renaming because the macro-system doesn't deal well with "<" and ">")
+using FenceHandle           = Handle<HwFence>;
+using IndexBufferHandle     = Handle<HwIndexBuffer>;
+using ProgramHandle         = Handle<HwProgram>;
+using RenderPrimitiveHandle = Handle<HwRenderPrimitive>;
+using RenderTargetHandle    = Handle<HwRenderTarget>;
+using SamplerGroupHandle    = Handle<HwSamplerGroup>;
+using StreamHandle          = Handle<HwStream>;
+using SwapChainHandle       = Handle<HwSwapChain>;
+using TextureHandle         = Handle<HwTexture>;
+using UniformBufferHandle   = Handle<HwUniformBuffer>;
+using VertexBufferHandle    = Handle<HwVertexBuffer>;
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_HANDLE_H

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -27,13 +27,14 @@
 #include <vector>
 
 namespace filament {
+namespace driver {
 
 class Program {
 public:
 
     static constexpr size_t NUM_SHADER_TYPES = 2;
-    static constexpr size_t NUM_UNIFORM_BINDINGS = filament::BindingPoints::COUNT;
-    static constexpr size_t NUM_SAMPLER_BINDINGS = filament::BindingPoints::COUNT;
+    static constexpr size_t NUM_UNIFORM_BINDINGS = BindingPoints::COUNT;
+    static constexpr size_t NUM_SAMPLER_BINDINGS = BindingPoints::COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,
@@ -116,6 +117,7 @@ private:
     uint8_t mVariant;
 };
 
+} // namespace driver;
 } // namespace filament;
 
 #endif // TNT_FILAMENT_DRIVER_PROGRAM_H

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -29,6 +29,7 @@
 #include "private/backend/Handle.h"
 
 namespace filament {
+namespace driver {
 
 class SamplerGroup {
 public:
@@ -95,6 +96,7 @@ private:
     uint8_t mSize = 0;
 };
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_SAMPLERGROUP_H

--- a/filament/backend/src/CircularBuffer.cpp
+++ b/filament/backend/src/CircularBuffer.cpp
@@ -33,6 +33,7 @@
 using namespace utils;
 
 namespace filament {
+namespace driver {
 
 CircularBuffer::CircularBuffer(size_t size) {
 #if HAS_MMAP
@@ -152,4 +153,5 @@ void CircularBuffer::circularize() noexcept {
     mTail = mHead;
 }
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/CommandBufferQueue.cpp
+++ b/filament/backend/src/CommandBufferQueue.cpp
@@ -26,6 +26,7 @@
 using namespace utils;
 
 namespace filament {
+namespace driver {
 
 CommandBufferQueue::CommandBufferQueue(size_t requiredSize, size_t bufferSize)
         : mRequiredSize((requiredSize + CircularBuffer::BLOCK_MASK) & ~CircularBuffer::BLOCK_MASK),
@@ -119,4 +120,5 @@ void CommandBufferQueue::releaseBuffer(CommandBufferQueue::Slice const& buffer) 
     mCondition.notify_one();
 }
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -43,7 +43,7 @@ static void printParameterPack(io::ostream& out, const FIRST& first, const REMAI
 }
 
 static UTILS_NOINLINE UTILS_UNUSED std::string extractMethodName(std::string& command) noexcept {
-    constexpr const char startPattern[] = "::Command<&(filament::Driver::";
+    constexpr const char startPattern[] = "::Command<&(filament::driver::Driver::";
     auto pos = command.rfind(startPattern);
     auto end = command.rfind('(');
     pos += sizeof(startPattern) - 1;
@@ -128,7 +128,7 @@ void CommandType<void (Driver::*)(ARGS...)>::Command<METHOD>::log() noexcept  {
     template void CommandType<decltype(&Driver::methodName)>::Command<&Driver::methodName>::log();
 #define DECL_DRIVER_API_RETURN(RetType, methodName, paramsDecl, params) \
     template void CommandType<decltype(&Driver::methodName##R)>::Command<&Driver::methodName##R>::log();
-#include "DriverAPI.inc"
+#include "private/backend/DriverAPI.inc"
 #endif
 
 // ------------------------------------------------------------------------------------------------
@@ -483,11 +483,11 @@ io::ostream& operator<<(io::ostream& out, SamplerParams params) {
     return out;
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::AttributeArray& type) {
+io::ostream& operator<<(io::ostream& out, const AttributeArray& type) {
     return out << "AttributeArray[" << type.max_size() << "]{}";
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::FaceOffsets& type) {
+io::ostream& operator<<(io::ostream& out, const FaceOffsets& type) {
     return out << "FaceOffsets{"
            << type[0] << ", "
            << type[1] << ", "
@@ -497,7 +497,7 @@ io::ostream& operator<<(io::ostream& out, const Driver::FaceOffsets& type) {
            << type[5] << "}";
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::RasterState& rs) {
+io::ostream& operator<<(io::ostream& out, const RasterState& rs) {
     // TODO: implement decoding of enums
     return out << "RasterState{"
            << rs.culling << ", "
@@ -509,20 +509,20 @@ io::ostream& operator<<(io::ostream& out, const Driver::RasterState& rs) {
            << uint8_t(rs.blendFunctionDstAlpha) << "}";
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::TargetBufferInfo& tbi) {
+io::ostream& operator<<(io::ostream& out, const TargetBufferInfo& tbi) {
     return out << "TargetBufferInfo{"
            << "h=" << tbi.handle << ", "
            << "level=" << tbi.level << ", "
            << "face=" << tbi.face << "}";
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::PolygonOffset& po) {
+io::ostream& operator<<(io::ostream& out, const PolygonOffset& po) {
     return out << "PolygonOffset{"
            << "slope=" << po.slope << ", "
            << "constant=" << po.constant << "}";
 }
 
-io::ostream& operator<<(io::ostream& out, const Driver::PipelineState& ps) {
+io::ostream& operator<<(io::ostream& out, const PipelineState& ps) {
     return out << "PipelineState{"
            << "program=" << ps.program << ", "
            << "rasterState=" << ps.rasterState << ", "
@@ -530,7 +530,7 @@ io::ostream& operator<<(io::ostream& out, const Driver::PipelineState& ps) {
 }
 
 UTILS_PRIVATE
-io::ostream& operator<<(io::ostream& out, filament::driver::BufferDescriptor const& b) {
+io::ostream& operator<<(io::ostream& out, BufferDescriptor const& b) {
     out << "BufferDescriptor { buffer=" << b.buffer
     << ", size=" << b.size
     << ", callback=" << b.getCallback()
@@ -539,7 +539,7 @@ io::ostream& operator<<(io::ostream& out, filament::driver::BufferDescriptor con
 }
 
 UTILS_PRIVATE
-io::ostream& operator<<(io::ostream& out, filament::driver::PixelBufferDescriptor const& b) {
+io::ostream& operator<<(io::ostream& out, PixelBufferDescriptor const& b) {
     BufferDescriptor const& base = static_cast<BufferDescriptor const&>(b);
     out << "PixelBufferDescriptor { " << base
     << ", left=" << b.left
@@ -562,7 +562,7 @@ io::ostream& operator<<(io::ostream& out, filament::driver::Viewport const& view
 }
 
 UTILS_PRIVATE
-io::ostream& operator<<(io::ostream& out, filament::driver::RenderPassParams const& params) {
+io::ostream& operator<<(io::ostream& out, RenderPassParams const& params) {
     out << "RenderPassParams{"
         <<   "clear=" << params.flags.clear
         << ", discardStart=" << params.flags.discardStart

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -23,9 +23,10 @@
 
 #include <functional>
 
-namespace filament {
-
 using namespace utils;
+
+namespace filament {
+namespace driver {
 
 // ------------------------------------------------------------------------------------------------
 // A few utility functions for debugging...
@@ -138,6 +139,7 @@ void CustomCommand::execute(Driver&, CommandBase* base, intptr_t* next) noexcept
     static_cast<CustomCommand*>(base)->~CustomCommand();
 }
 
+} // namespace driver
 } // namespace filament
 
 

--- a/filament/backend/src/CommandStreamDispatcher.h
+++ b/filament/backend/src/CommandStreamDispatcher.h
@@ -1,5 +1,3 @@
-#include <utility>
-
 /*
  * Copyright (C) 2018 The Android Open Source Project
  *
@@ -26,8 +24,9 @@
 #include <utils/Systrace.h>
 
 #include <cstddef>
-#include <stdint.h>
+#include <utility>
 
+#include <stdint.h>
 
 #define DEBUG_LEVEL_NONE       0
 #define DEBUG_LEVEL_SYSTRACE   1
@@ -45,6 +44,7 @@
 #endif
 
 namespace filament {
+namespace driver {
 
 template<typename ConcreteDriver>
 class ConcreteDispatcher final : public Dispatcher {
@@ -75,6 +75,7 @@ private:
 #include "private/backend/DriverAPI.inc"
 };
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_COMMANDSTREAM_DISPATCHER_H

--- a/filament/backend/src/DataReshaper.h
+++ b/filament/backend/src/DataReshaper.h
@@ -20,6 +20,7 @@
 #include <stddef.h>
 
 namespace filament {
+namespace driver {
 
 // This little utility adds padding to multi-channel interleaved data by inserting dummy values.
 // This is very useful for platforms that only accept 4-component data, since users often wish to
@@ -36,7 +37,7 @@ public:
             for (size_t component = 0; component < numSrcChannels; ++component) {
                 out[component] = in[component];
             }
-            for (size_t component = numSrcChannels; component < numDstChannels; ++component) {
+            for (size_t component = (size_t)numSrcChannels; component < numDstChannels; ++component) {
                 out[component] = maxValue;
             }
             in += numSrcChannels;
@@ -45,6 +46,7 @@ public:
     }
 };
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_DATARESHAPER_H

--- a/filament/backend/src/Driver.cpp
+++ b/filament/backend/src/Driver.cpp
@@ -31,8 +31,7 @@
 using namespace utils;
 
 namespace filament {
-
-using namespace driver;
+namespace driver {
 
 DriverBase::DriverBase(Dispatcher* dispatcher) noexcept
         : mDispatcher(dispatcher) {
@@ -89,4 +88,5 @@ size_t Driver::getElementTypeSize(ElementType type) noexcept {
     }
 }
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -20,6 +20,8 @@
 #include <utils/compiler.h>
 #include <utils/CString.h>
 
+#include <backend/Platform.h>
+
 #include <filament/backend/DriverEnums.h>
 
 #include "private/backend/Driver.h"

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -48,16 +48,14 @@ struct HwBase {
 };
 
 struct HwVertexBuffer : public HwBase {
-    static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = Driver::MAX_ATTRIBUTE_BUFFER_COUNT;
-
-    Driver::AttributeArray attributes;    // 8*8
+    AttributeArray attributes;            // 8*8
     uint32_t vertexCount;                 //   4
     uint8_t bufferCount;                  //   1
     uint8_t attributeCount;               //   1
     uint8_t padding[2]{};                 //   2 -> 56 bytes
 
     HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            Driver::AttributeArray const& attributes) noexcept
+            AttributeArray const& attributes) noexcept
             : attributes(attributes),
               vertexCount(elementCount),
               bufferCount(bufferCount),

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 
 namespace filament {
+namespace driver {
 
 class Dispatcher;
 
@@ -79,7 +80,7 @@ struct HwRenderPrimitive : public HwBase {
     uint32_t maxIndex = 0;
     uint32_t count = 0;
     uint32_t maxVertexCount = 0;
-    Driver::PrimitiveType type = Driver::PrimitiveType::TRIANGLES;
+    PrimitiveType type = PrimitiveType::TRIANGLES;
 };
 
 struct HwProgram : public HwBase {
@@ -102,16 +103,16 @@ struct HwUniformBuffer : public HwBase {
 
 struct HwTexture : public HwBase {
     HwTexture(driver::SamplerType target, uint8_t levels, uint8_t samples,
-              uint32_t width, uint32_t height, uint32_t depth, Driver::TextureFormat fmt) noexcept
+              uint32_t width, uint32_t height, uint32_t depth, TextureFormat fmt) noexcept
             : width(width), height(height), depth(depth),
               target(target), levels(levels), samples(samples), format(fmt) { }
     uint32_t width;
     uint32_t height;
     uint32_t depth;
-    driver::SamplerType target;
+    SamplerType target;
     uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
     uint8_t samples : 4; // In practice this is always 1.
-    Driver::TextureFormat format;
+    TextureFormat format;
     HwStream* hwStream = nullptr;
 };
 
@@ -122,17 +123,17 @@ struct HwRenderTarget : public HwBase {
 };
 
 struct HwFence : public HwBase {
-    driver::Platform::Fence* fence = nullptr;
+    Platform::Fence* fence = nullptr;
 };
 
 struct HwSwapChain : public HwBase {
-    driver::Platform::SwapChain* swapChain = nullptr;
+    Platform::SwapChain* swapChain = nullptr;
 };
 
 struct HwStream : public HwBase {
     HwStream() = default;
-    explicit HwStream(driver::Platform::Stream* stream) : stream(stream) { }
-    driver::Platform::Stream* stream = nullptr;
+    explicit HwStream(Platform::Stream* stream) : stream(stream) { }
+    Platform::Stream* stream = nullptr;
     uint32_t width = 0;
     uint32_t height = 0;
 };
@@ -172,6 +173,7 @@ private:
 };
 
 
+} // namespace driver
 } // namespace filament
 
 #endif // TNT_FILAMENT_DRIVER_DRIVERBASE_H

--- a/filament/backend/src/Handle.cpp
+++ b/filament/backend/src/Handle.cpp
@@ -16,15 +16,19 @@
 
 #include "private/backend/Handle.h"
 
-#include <string>
+#ifndef NDEBUG
+#   include <string>
+#endif
 
 #include <utils/CallStack.h>
 
 using namespace utils;
 
 namespace filament {
+namespace driver {
 
-#if !defined(NDEBUG)
+#ifndef NDEBUG
+
 static char const * const kOurNamespace = "filament::";
 
 // removes all occurrences of "what" from "str"
@@ -64,6 +68,8 @@ template io::ostream& operator<<(io::ostream& out, const Handle<HwRenderTarget>&
 template io::ostream& operator<<(io::ostream& out, const Handle<HwFence>& h) noexcept;
 template io::ostream& operator<<(io::ostream& out, const Handle<HwSwapChain>& h) noexcept;
 template io::ostream& operator<<(io::ostream& out, const Handle<HwStream>& h) noexcept;
+
 #endif
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -19,6 +19,7 @@
 using namespace utils;
 
 namespace filament {
+namespace driver {
 
 // We want these in the .cpp file so they're not inlined (not worth it)
 Program::Program() noexcept = default;
@@ -69,4 +70,5 @@ io::ostream& operator<<(io::ostream& out, const Program& builder) {
 
 #endif
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/SamplerGroup.cpp
+++ b/filament/backend/src/SamplerGroup.cpp
@@ -17,6 +17,7 @@
 #include "private/backend/SamplerGroup.h"
 
 namespace filament {
+namespace driver {
 
 // create a sampler buffer
 SamplerGroup::SamplerGroup(size_t count) noexcept : mSize(uint8_t(count)) {
@@ -91,4 +92,5 @@ utils::io::ostream& operator<<(utils::io::ostream& out, const SamplerGroup& rhs)
 }
 #endif
 
+} // namespace driver
 } // namespace filament

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -36,7 +36,7 @@ struct MetalContext;
 struct MetalProgram;
 
 class MetalDriver final : public DriverBase {
-    MetalDriver(driver::MetalPlatform* const platform) noexcept;
+    MetalDriver(driver::MetalPlatform* platform) noexcept;
     virtual ~MetalDriver() noexcept;
 
 public:
@@ -59,7 +59,7 @@ private:
      */
 
     template<typename T>
-    friend class ::filament::ConcreteDispatcher;
+    friend class driver::ConcreteDispatcher;
 
 #define DECL_DRIVER_API(methodName, paramsDecl, params) \
     UTILS_ALWAYS_INLINE void methodName(paramsDecl);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -129,8 +129,8 @@ void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int dum
 
 void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, TextureFormat format, Driver::TargetBufferInfo color,
-        Driver::TargetBufferInfo depth, Driver::TargetBufferInfo stencil) {
+        uint8_t samples, TextureFormat format, TargetBufferInfo color,
+        TargetBufferInfo depth, TargetBufferInfo stencil) {
 
     auto getColorTexture = [&]() -> id<MTLTexture> {
         if (color.handle) {
@@ -577,7 +577,7 @@ void MetalDriver::blit(TargetBufferFlags buffers,
         SamplerMagFilter filter) {
 }
 
-void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph) {
+void MetalDriver::draw(driver::PipelineState ps, Handle<HwRenderPrimitive> rph) {
     ASSERT_PRECONDITION(mContext->currentCommandEncoder != nullptr,
             "Attempted to draw without a valid command encoder.");
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -86,7 +86,7 @@ void MetalDriver::flush(int dummy) {
 }
 
 void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
-        uint8_t attributeCount, uint32_t vertexCount, Driver::AttributeArray attributes,
+        uint8_t attributeCount, uint32_t vertexCount, AttributeArray attributes,
         BufferUsage usage) {
     // TODO: Take BufferUsage into account when creating the buffer.
     construct_handle<MetalVertexBuffer>(mHandleMap, vbh, mContext->device, bufferCount,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -85,51 +85,51 @@ void MetalDriver::flush(int dummy) {
 
 }
 
-void MetalDriver::createVertexBufferR(Driver::VertexBufferHandle vbh, uint8_t bufferCount,
+void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
         uint8_t attributeCount, uint32_t vertexCount, Driver::AttributeArray attributes,
-        Driver::BufferUsage usage) {
+        BufferUsage usage) {
     // TODO: Take BufferUsage into account when creating the buffer.
     construct_handle<MetalVertexBuffer>(mHandleMap, vbh, mContext->device, bufferCount,
             attributeCount, vertexCount, attributes);
 }
 
-void MetalDriver::createIndexBufferR(Driver::IndexBufferHandle ibh, Driver::ElementType elementType,
-        uint32_t indexCount, Driver::BufferUsage usage) {
+void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
+        uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     construct_handle<MetalIndexBuffer>(mHandleMap, ibh, mContext->device, elementSize, indexCount);
 }
 
-void MetalDriver::createTextureR(Driver::TextureHandle th, Driver::SamplerType target, uint8_t levels,
-        Driver::TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
-        uint32_t depth, Driver::TextureUsage usage) {
+void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
+        TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+        uint32_t depth, TextureUsage usage) {
     construct_handle<MetalTexture>(mHandleMap, th, mContext->device, target, levels, format, samples,
             width, height, depth, usage);
 }
 
-void MetalDriver::createSamplerGroupR(Driver::SamplerGroupHandle sbh, size_t size) {
+void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
     construct_handle<MetalSamplerGroup>(mHandleMap, sbh, size);
 }
 
-void MetalDriver::createUniformBufferR(Driver::UniformBufferHandle ubh, size_t size,
-        Driver::BufferUsage usage) {
+void MetalDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
+        BufferUsage usage) {
     construct_handle<MetalUniformBuffer>(mHandleMap, ubh, mContext->device, size);
 }
 
-void MetalDriver::createRenderPrimitiveR(Driver::RenderPrimitiveHandle rph, int dummy) {
+void MetalDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int dummy) {
     construct_handle<MetalRenderPrimitive>(mHandleMap, rph);
 }
 
-void MetalDriver::createProgramR(Driver::ProgramHandle rph, Program&& program) {
+void MetalDriver::createProgramR(Handle<HwProgram> rph, Program&& program) {
     construct_handle<MetalProgram>(mHandleMap, rph, mContext->device, program);
 }
 
-void MetalDriver::createDefaultRenderTargetR(Driver::RenderTargetHandle rth, int dummy) {
+void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int dummy) {
     construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext);
 }
 
-void MetalDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, Driver::TextureFormat format, Driver::TargetBufferInfo color,
+void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
+        TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
+        uint8_t samples, TextureFormat format, Driver::TargetBufferInfo color,
         Driver::TargetBufferInfo depth, Driver::TargetBufferInfo stencil) {
 
     auto getColorTexture = [&]() -> id<MTLTexture> {
@@ -167,123 +167,123 @@ void MetalDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
             "Stencil buffer not supported.");
 }
 
-void MetalDriver::createFenceR(Driver::FenceHandle, int dummy) {
+void MetalDriver::createFenceR(Handle<HwFence>, int dummy) {
 
 }
 
-void MetalDriver::createSwapChainR(Driver::SwapChainHandle sch, void* nativeWindow, uint64_t flags) {
+void MetalDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags) {
     auto* metalLayer = (CAMetalLayer*) nativeWindow;
     construct_handle<MetalSwapChain>(mHandleMap, sch, mContext->device, metalLayer);
 }
 
-void MetalDriver::createStreamFromTextureIdR(Driver::StreamHandle, intptr_t externalTextureId,
+void MetalDriver::createStreamFromTextureIdR(Handle<HwStream>, intptr_t externalTextureId,
         uint32_t width, uint32_t height) {
 
 }
 
-Driver::VertexBufferHandle MetalDriver::createVertexBufferS() noexcept {
+Handle<HwVertexBuffer> MetalDriver::createVertexBufferS() noexcept {
     return alloc_handle<MetalVertexBuffer, HwVertexBuffer>();
 }
 
-Driver::IndexBufferHandle MetalDriver::createIndexBufferS() noexcept {
+Handle<HwIndexBuffer> MetalDriver::createIndexBufferS() noexcept {
     return alloc_handle<MetalIndexBuffer, HwIndexBuffer>();
 }
 
-Driver::TextureHandle MetalDriver::createTextureS() noexcept {
+Handle<HwTexture> MetalDriver::createTextureS() noexcept {
     return alloc_handle<MetalTexture, HwTexture>();
 }
 
-Driver::SamplerGroupHandle MetalDriver::createSamplerGroupS() noexcept {
+Handle<HwSamplerGroup> MetalDriver::createSamplerGroupS() noexcept {
     return alloc_handle<MetalSamplerGroup, HwSamplerGroup>();
 }
 
-Driver::UniformBufferHandle MetalDriver::createUniformBufferS() noexcept {
+Handle<HwUniformBuffer> MetalDriver::createUniformBufferS() noexcept {
     return alloc_handle<MetalUniformBuffer, HwUniformBuffer>();
 }
 
-Driver::RenderPrimitiveHandle MetalDriver::createRenderPrimitiveS() noexcept {
+Handle<HwRenderPrimitive> MetalDriver::createRenderPrimitiveS() noexcept {
     return alloc_handle<MetalRenderPrimitive, HwRenderPrimitive>();
 }
 
-Driver::ProgramHandle MetalDriver::createProgramS() noexcept {
+Handle<HwProgram> MetalDriver::createProgramS() noexcept {
     return alloc_handle<MetalProgram, HwProgram>();
 }
 
-Driver::RenderTargetHandle MetalDriver::createDefaultRenderTargetS() noexcept {
+Handle<HwRenderTarget> MetalDriver::createDefaultRenderTargetS() noexcept {
     return alloc_handle<MetalRenderTarget, HwRenderTarget>();
 }
 
-Driver::RenderTargetHandle MetalDriver::createRenderTargetS() noexcept {
+Handle<HwRenderTarget> MetalDriver::createRenderTargetS() noexcept {
     return alloc_handle<MetalRenderTarget, HwRenderTarget>();
 }
 
-Driver::FenceHandle MetalDriver::createFenceS() noexcept {
+Handle<HwFence> MetalDriver::createFenceS() noexcept {
     return {};
 }
 
-Driver::SwapChainHandle MetalDriver::createSwapChainS() noexcept {
+Handle<HwSwapChain> MetalDriver::createSwapChainS() noexcept {
     return alloc_handle<MetalSwapChain, HwSwapChain>();
 }
 
-Driver::StreamHandle MetalDriver::createStreamFromTextureIdS() noexcept {
+Handle<HwStream> MetalDriver::createStreamFromTextureIdS() noexcept {
     return {};
 }
 
-void MetalDriver::destroyVertexBuffer(Driver::VertexBufferHandle vbh) {
+void MetalDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     if (vbh) {
         destruct_handle<MetalVertexBuffer>(mHandleMap, vbh);
     }
 }
 
-void MetalDriver::destroyIndexBuffer(Driver::IndexBufferHandle ibh) {
+void MetalDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         destruct_handle<MetalIndexBuffer>(mHandleMap, ibh);
     }
 }
 
-void MetalDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
+void MetalDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     if (rph) {
         destruct_handle<MetalRenderPrimitive>(mHandleMap, rph);
     }
 }
 
-void MetalDriver::destroyProgram(Driver::ProgramHandle ph) {
+void MetalDriver::destroyProgram(Handle<HwProgram> ph) {
     if (ph) {
         destruct_handle<MetalProgram>(mHandleMap, ph);
     }
 }
 
-void MetalDriver::destroySamplerGroup(Driver::SamplerGroupHandle sbh) {
+void MetalDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
     if (sbh) {
         destruct_handle<MetalSamplerGroup>(mHandleMap, sbh);
     }
 }
 
-void MetalDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
+void MetalDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
     if (ubh) {
         destruct_handle<MetalUniformBuffer>(mHandleMap, ubh);
     }
 }
 
-void MetalDriver::destroyTexture(Driver::TextureHandle th) {
+void MetalDriver::destroyTexture(Handle<HwTexture> th) {
     if (th) {
         destruct_handle<MetalTexture>(mHandleMap, th);
     }
 }
 
-void MetalDriver::destroyRenderTarget(Driver::RenderTargetHandle rth) {
+void MetalDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     if (rth) {
         destruct_handle<MetalRenderTarget>(mHandleMap, rth);
     }
 }
 
-void MetalDriver::destroySwapChain(Driver::SwapChainHandle sch) {
+void MetalDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     if (sch) {
         destruct_handle<MetalSwapChain>(mHandleMap, sch);
     }
 }
 
-void MetalDriver::destroyStream(Driver::StreamHandle sh) {
+void MetalDriver::destroyStream(Handle<HwStream> sh) {
     // no-op
 }
 
@@ -300,16 +300,16 @@ ShaderModel MetalDriver::getShaderModel() const noexcept {
 #endif
 }
 
-Driver::StreamHandle MetalDriver::createStream(void* stream) {
+Handle<HwStream> MetalDriver::createStream(void* stream) {
     return {};
 }
 
-void MetalDriver::setStreamDimensions(Driver::StreamHandle stream, uint32_t width,
+void MetalDriver::setStreamDimensions(Handle<HwStream> stream, uint32_t width,
         uint32_t height) {
 
 }
 
-int64_t MetalDriver::getStreamTimestamp(Driver::StreamHandle stream) {
+int64_t MetalDriver::getStreamTimestamp(Handle<HwStream> stream) {
     return 0;
 }
 
@@ -317,20 +317,20 @@ void MetalDriver::updateStreams(driver::DriverApi* driver) {
 
 }
 
-void MetalDriver::destroyFence(Driver::FenceHandle fh) {
+void MetalDriver::destroyFence(Handle<HwFence> fh) {
 
 }
 
-Driver::FenceStatus MetalDriver::wait(Driver::FenceHandle fh, uint64_t timeout) {
+FenceStatus MetalDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
     return FenceStatus::ERROR;
 }
 
-bool MetalDriver::isTextureFormatSupported(Driver::TextureFormat format) {
+bool MetalDriver::isTextureFormatSupported(TextureFormat format) {
     return getMetalFormat(format) != MTLPixelFormatInvalid ||
            TextureReshaper::canReshapeTextureFormat(format);
 }
 
-bool MetalDriver::isRenderTargetFormatSupported(Driver::TextureFormat format) {
+bool MetalDriver::isRenderTargetFormatSupported(TextureFormat format) {
     MTLPixelFormat mtlFormat = getMetalFormat(format);
     // RGB9E5 isn't supported on Mac as a color render target.
     return mtlFormat != MTLPixelFormatInvalid && mtlFormat != MTLPixelFormatRGB9E5Float;
@@ -343,43 +343,43 @@ bool MetalDriver::isFrameTimeSupported() {
 // TODO: the implementations here for updateVertexBuffer and updateIndexBuffer assume static usage.
 // Dynamically updated vertex / index buffers will require synchronization.
 
-void MetalDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh, size_t index,
-        Driver::BufferDescriptor&& data, uint32_t byteOffset) {
+void MetalDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
+        BufferDescriptor&& data, uint32_t byteOffset) {
     assert(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers
     auto* vb = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     memcpy(vb->buffers[index].contents, data.buffer, data.size);
 }
 
-void MetalDriver::updateIndexBuffer(Driver::IndexBufferHandle ibh, Driver::BufferDescriptor&& data,
+void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
         uint32_t byteOffset) {
     assert(byteOffset == 0);    // TODO: handle byteOffset for index buffers
     auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     memcpy(ib->buffer.contents, data.buffer, data.size);
 }
 
-void MetalDriver::update2DImage(Driver::TextureHandle th, uint32_t level, uint32_t xoffset,
-        uint32_t yoffset, uint32_t width, uint32_t height, Driver::PixelBufferDescriptor&& data) {
+void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t xoffset,
+        uint32_t yoffset, uint32_t width, uint32_t height, PixelBufferDescriptor&& data) {
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
     tex->load2DImage(level, xoffset, yoffset, width, height, data);
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::updateCubeImage(Driver::TextureHandle th, uint32_t level,
-        Driver::PixelBufferDescriptor&& data, Driver::FaceOffsets faceOffsets) {
+void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
+        PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
     tex->loadCubeImage(data, faceOffsets, level);
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::setExternalImage(Driver::TextureHandle th, void* image) {
+void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 
 }
 
-void MetalDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHandle sh) {
+void MetalDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 
 }
 
-void MetalDriver::generateMipmaps(Driver::TextureHandle th) {
+void MetalDriver::generateMipmaps(Handle<HwTexture> th) {
 
 }
 
@@ -387,21 +387,21 @@ bool MetalDriver::canGenerateMipmaps() {
     return false;
 }
 
-void MetalDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh,
-        Driver::BufferDescriptor&& data) {
+void MetalDriver::updateUniformBuffer(Handle<HwUniformBuffer> ubh,
+        BufferDescriptor&& data) {
     auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);
     buffer->copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::updateSamplerGroup(Driver::SamplerGroupHandle sbh,
+void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     auto sb = handle_cast<MetalSamplerGroup>(mHandleMap, sbh);
     *sb->sb = samplerGroup;
 }
 
-void MetalDriver::beginRenderPass(Driver::RenderTargetHandle rth,
-        const Driver::RenderPassParams& params) {
+void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
+        const RenderPassParams& params) {
     auto renderTarget = handle_cast<MetalRenderTarget>(mHandleMap, rth);
     mContext->currentRenderTarget = renderTarget;
     mContext->currentRenderPassFlags = params.flags;
@@ -479,27 +479,27 @@ void MetalDriver::endRenderPass(int dummy) {
     mContext->currentCommandEncoder = nullptr;
 }
 
-void MetalDriver::discardSubRenderTargetBuffers(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags targetBufferFlags, uint32_t left, uint32_t bottom, uint32_t width,
+void MetalDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
+        TargetBufferFlags targetBufferFlags, uint32_t left, uint32_t bottom, uint32_t width,
         uint32_t height) {
 
 }
 
-void MetalDriver::resizeRenderTarget(Driver::RenderTargetHandle rth, uint32_t width,
+void MetalDriver::resizeRenderTarget(Handle<HwRenderTarget> rth, uint32_t width,
         uint32_t height) {
 
 }
 
-void MetalDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
-        Driver::VertexBufferHandle vbh, Driver::IndexBufferHandle ibh, uint32_t enabledAttributes) {
+void MetalDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh, uint32_t enabledAttributes) {
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);
     auto vertexBuffer = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     auto indexBuffer = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     primitive->setBuffers(vertexBuffer, indexBuffer, enabledAttributes);
 }
 
-void MetalDriver::setRenderPrimitiveRange(Driver::RenderPrimitiveHandle rph,
-        Driver::PrimitiveType pt, uint32_t offset, uint32_t minIndex, uint32_t maxIndex,
+void MetalDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
+        PrimitiveType pt, uint32_t offset, uint32_t minIndex, uint32_t maxIndex,
         uint32_t count) {
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);
     primitive->type = pt;
@@ -514,20 +514,20 @@ void MetalDriver::setViewportScissor(int32_t left, int32_t bottom, uint32_t widt
 
 }
 
-void MetalDriver::makeCurrent(Driver::SwapChainHandle schDraw, Driver::SwapChainHandle schRead) {
+void MetalDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> schRead) {
     ASSERT_PRECONDITION_NON_FATAL(schDraw == schRead,
                                   "Metal driver does not support distinct draw/read swap chains.");
     auto* swapChain = handle_cast<MetalSwapChain>(mHandleMap, schDraw);
     mContext->currentSurface = swapChain;
 }
 
-void MetalDriver::commit(Driver::SwapChainHandle sch) {
+void MetalDriver::commit(Handle<HwSwapChain> sch) {
     [mContext->currentCommandBuffer presentDrawable:mContext->currentDrawable];
     [mContext->currentCommandBuffer commit];
     mContext->currentDrawable = nil;
 }
 
-void MetalDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle ubh) {
+void MetalDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
     mContext->uniformState[index].updateState(UniformBufferState {
         .bound = true,
         .ubh = ubh,
@@ -535,7 +535,7 @@ void MetalDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle ub
     });
 }
 
-void MetalDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHandle ubh,
+void MetalDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
         size_t offset, size_t size) {
     mContext->uniformState[index].updateState(UniformBufferState {
         .bound = true,
@@ -544,7 +544,7 @@ void MetalDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHand
     });
 }
 
-void MetalDriver::bindSamplers(size_t index, Driver::SamplerGroupHandle sbh) {
+void MetalDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
     auto sb = handle_cast<MetalSamplerGroup>(mHandleMap, sbh);
     mContext->samplerBindings[index] = sb;
 }
@@ -561,23 +561,23 @@ void MetalDriver::popGroupMarker(int dummy) {
 
 }
 
-void MetalDriver::readPixels(Driver::RenderTargetHandle src, uint32_t x, uint32_t y, uint32_t width,
-        uint32_t height, Driver::PixelBufferDescriptor&& data) {
+void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y, uint32_t width,
+        uint32_t height, PixelBufferDescriptor&& data) {
 
 }
 
-void MetalDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_t y, uint32_t width,
-        uint32_t height, Driver::PixelBufferDescriptor&& data) {
+void MetalDriver::readStreamPixels(Handle<HwStream> sh, uint32_t x, uint32_t y, uint32_t width,
+        uint32_t height, PixelBufferDescriptor&& data) {
 
 }
 
-void MetalDriver::blit(Driver::TargetBufferFlags buffers,
-        Driver::RenderTargetHandle dst, driver::Viewport dstRect,
-        Driver::RenderTargetHandle src, driver::Viewport srcRect,
-        Driver::SamplerMagFilter filter) {
+void MetalDriver::blit(TargetBufferFlags buffers,
+        Handle<HwRenderTarget> dst, driver::Viewport dstRect,
+        Handle<HwRenderTarget> src, driver::Viewport srcRect,
+        SamplerMagFilter filter) {
 }
 
-void MetalDriver::draw(Driver::PipelineState ps, Driver::RenderPrimitiveHandle rph) {
+void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph) {
     ASSERT_PRECONDITION(mContext->currentCommandEncoder != nullptr,
             "Attempted to draw without a valid command encoder.");
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);
@@ -758,11 +758,11 @@ void MetalDriver::enumerateSamplerGroups(
 }
 
 } // namespace metal
-} // namespace driver
 
 // explicit instantiation of the Dispatcher
-template class ConcreteDispatcher<driver::metal::MetalDriver>;
+template class ConcreteDispatcher<metal::MetalDriver>;
 
+} // namespace driver
 } // namespace filament
 
 #pragma clang diagnostic pop

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -28,24 +28,24 @@
 namespace filament {
 namespace driver {
 
-constexpr inline MTLCompareFunction getMetalCompareFunction(Driver::RasterState::DepthFunc func)
+constexpr inline MTLCompareFunction getMetalCompareFunction(RasterState::DepthFunc func)
         noexcept {
     switch (func) {
-        case Driver::RasterState::DepthFunc::LE:
+        case RasterState::DepthFunc::LE:
             return MTLCompareFunctionLessEqual;
-        case Driver::RasterState::DepthFunc::GE:
+        case RasterState::DepthFunc::GE:
             return MTLCompareFunctionGreaterEqual;
-        case Driver::RasterState::DepthFunc::L:
+        case RasterState::DepthFunc::L:
             return MTLCompareFunctionLess;
-        case Driver::RasterState::DepthFunc::G:
+        case RasterState::DepthFunc::G:
             return MTLCompareFunctionGreater;
-        case Driver::RasterState::DepthFunc::E:
+        case RasterState::DepthFunc::E:
             return MTLCompareFunctionEqual;
-        case Driver::RasterState::DepthFunc::NE:
+        case RasterState::DepthFunc::NE:
             return MTLCompareFunctionNotEqual;
-        case Driver::RasterState::DepthFunc::A:
+        case RasterState::DepthFunc::A:
             return MTLCompareFunctionAlways;
-        case Driver::RasterState::DepthFunc::N:
+        case RasterState::DepthFunc::N:
             return MTLCompareFunctionNever;
     }
 }

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -46,7 +46,7 @@ struct MetalSwapChain : public HwSwapChain {
 
 struct MetalVertexBuffer : public HwVertexBuffer {
     MetalVertexBuffer(id<MTLDevice> device, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t vertexCount, Driver::AttributeArray const& attributes);
+            uint32_t vertexCount, AttributeArray const& attributes);
     ~MetalVertexBuffer();
 
     std::vector<id<MTLBuffer>> buffers;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -107,7 +107,7 @@ struct MetalTexture : public HwTexture {
     ~MetalTexture();
 
     void load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-            uint32_t height, Driver::PixelBufferDescriptor& data) noexcept;
+            uint32_t height, PixelBufferDescriptor& data) noexcept;
     void loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
             int miplevel);
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -82,7 +82,7 @@ MetalSwapChain::~MetalSwapChain() {
 }
 
 MetalVertexBuffer::MetalVertexBuffer(id<MTLDevice> device, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t vertexCount, Driver::AttributeArray const& attributes)
+            uint32_t vertexCount, AttributeArray const& attributes)
     : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes) {
     buffers.reserve(bufferCount);
 
@@ -176,7 +176,7 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
 
         vertexDescription.attributes[attributeIndex] = {
                 .format = getMetalFormat(attribute.type,
-                                         attribute.flags & Driver::Attribute::FLAG_NORMALIZED),
+                                         attribute.flags & Attribute::FLAG_NORMALIZED),
                 .buffer = bufferIndex,
                 .offset = 0
         };

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -275,7 +275,7 @@ MetalTexture::~MetalTexture() {
 }
 
 void MetalTexture::load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-        uint32_t height, Driver::PixelBufferDescriptor& data) noexcept {
+        uint32_t height, PixelBufferDescriptor& data) noexcept {
     void* buffer = reshaper.reshape(data.buffer, data.size);
 
     MTLRegion region {

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -268,7 +268,7 @@ using DepthStencilStateCache = StateCache<DepthStencilState, id<MTLDepthStencilS
 
 struct UniformBufferState {
     bool bound = false;
-    Driver::UniformBufferHandle ubh;
+    Handle<HwUniformBuffer> ubh;
     uint64_t offset = 0;
 
     bool operator==(const UniformBufferState& rhs) const noexcept {

--- a/filament/backend/src/metal/PlatformMetal.h
+++ b/filament/backend/src/metal/PlatformMetal.h
@@ -26,7 +26,7 @@ namespace filament {
 
 class PlatformMetal final : public driver::MetalPlatform {
 public:
-    Driver* createDriver(void* sharedContext) noexcept override;
+    driver::Driver* createDriver(void* sharedContext) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -19,6 +19,8 @@
 
 namespace filament {
 
+using namespace driver;
+
 Driver* NoopDriver::create() {
     return new NoopDriver();
 }
@@ -37,6 +39,6 @@ driver::ShaderModel NoopDriver::getShaderModel() const noexcept {
 }
 
 // explicit instantiation of the Dispatcher
-template class ConcreteDispatcher<NoopDriver>;
+template class driver::ConcreteDispatcher<NoopDriver>;
 
 } // namespace filament

--- a/filament/backend/src/noop/NoopDriver.h
+++ b/filament/backend/src/noop/NoopDriver.h
@@ -24,22 +24,22 @@
 
 namespace filament {
 
-class NoopDriver final : public DriverBase {
+class NoopDriver final : public driver::DriverBase {
     NoopDriver() noexcept;
     ~NoopDriver() noexcept override;
 
 public:
-    static Driver* create();
+    static driver::Driver* create();
 
 private:
-    ShaderModel getShaderModel() const noexcept final;
+    driver::ShaderModel getShaderModel() const noexcept final;
 
     /*
      * Driver interface
      */
 
     template<typename T>
-    friend class ConcreteDispatcher;
+    friend class driver::ConcreteDispatcher;
 
 #define DECL_DRIVER_API(methodName, paramsDecl, params) \
     UTILS_ALWAYS_INLINE void methodName(paramsDecl) { }

--- a/filament/backend/src/noop/PlatformNoop.cpp
+++ b/filament/backend/src/noop/PlatformNoop.cpp
@@ -20,7 +20,7 @@
 
 namespace filament {
 
-Driver* PlatformNoop::createDriver(void* const sharedGLContext) noexcept {
+driver::Driver* PlatformNoop::createDriver(void* const sharedGLContext) noexcept {
     return NoopDriver::create();
 }
 

--- a/filament/backend/src/noop/PlatformNoop.h
+++ b/filament/backend/src/noop/PlatformNoop.h
@@ -25,13 +25,13 @@ namespace filament {
 class PlatformNoop final : public driver::Platform {
 public:
 
-    int getOSVersion() const noexcept final override { return 0; }
+    int getOSVersion() const noexcept final { return 0; }
 
-    ~PlatformNoop() noexcept override { }
+    ~PlatformNoop() noexcept override = default;
 
 protected:
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    driver::Driver* createDriver(void* sharedContext) noexcept override;
 };
 
 } // namespace filament

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1044,7 +1044,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::framebufferTexture(Driver::TargetBufferInfo& binfo,
+void OpenGLDriver::framebufferTexture(driver::TargetBufferInfo& binfo,
         GLRenderTarget* rt, GLenum attachment) noexcept {
     GLTexture const* t = handle_cast<const GLTexture*>(binfo.handle);
 
@@ -1216,9 +1216,9 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         uint32_t height,
         uint8_t samples,
         TextureFormat format,
-        Driver::TargetBufferInfo color,
-        Driver::TargetBufferInfo depth,
-        Driver::TargetBufferInfo stencil) {
+        TargetBufferInfo color,
+        TargetBufferInfo depth,
+        TargetBufferInfo stencil) {
     DEBUG_MARKER()
 
     GLRenderTarget* rt = construct<GLRenderTarget>(rth, width, height);
@@ -2918,9 +2918,7 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
     }
 }
 
-void OpenGLDriver::draw(
-        Driver::PipelineState state,
-        Handle<HwRenderPrimitive> rph) {
+void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
     OpenGLProgram* p = handle_cast<OpenGLProgram*>(state.program);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -857,12 +857,12 @@ Handle<HwStream> OpenGLDriver::createStreamFromTextureIdS() noexcept {
 }
 
 void OpenGLDriver::createVertexBufferR(
-    Driver::VertexBufferHandle vbh,
+        Handle<HwVertexBuffer> vbh,
     uint8_t bufferCount,
     uint8_t attributeCount,
     uint32_t elementCount,
     Driver::AttributeArray attributes,
-    Driver::BufferUsage usage) {
+    BufferUsage usage) {
     DEBUG_MARKER()
 
     GLVertexBuffer* vb = construct<GLVertexBuffer>(vbh,
@@ -888,10 +888,10 @@ void OpenGLDriver::createVertexBufferR(
 }
 
 void OpenGLDriver::createIndexBufferR(
-        Driver::IndexBufferHandle ibh,
-        Driver::ElementType elementType,
+        Handle<HwIndexBuffer> ibh,
+        ElementType elementType,
         uint32_t indexCount,
-        Driver::BufferUsage usage) {
+        BufferUsage usage) {
     DEBUG_MARKER()
 
     uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
@@ -904,7 +904,7 @@ void OpenGLDriver::createIndexBufferR(
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::createRenderPrimitiveR(Driver::RenderPrimitiveHandle rph, int) {
+void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int) {
     DEBUG_MARKER()
 
     GLRenderPrimitive* rp = construct<GLRenderPrimitive>(rph);
@@ -912,23 +912,23 @@ void OpenGLDriver::createRenderPrimitiveR(Driver::RenderPrimitiveHandle rph, int
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::createProgramR(Driver::ProgramHandle ph, Program&& program) {
+void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program) {
     DEBUG_MARKER()
 
     construct<OpenGLProgram>(ph, this, program);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::createSamplerGroupR(Driver::SamplerGroupHandle sbh, size_t size) {
+void OpenGLDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
     DEBUG_MARKER()
 
     construct<GLSamplerGroup>(sbh, size);
 }
 
 void OpenGLDriver::createUniformBufferR(
-        Driver::UniformBufferHandle ubh,
+        Handle<HwUniformBuffer> ubh,
         size_t size,
-        Driver::BufferUsage usage) {
+        BufferUsage usage) {
     DEBUG_MARKER()
 
     GLUniformBuffer* ub = construct<GLUniformBuffer>(ubh, size, usage);
@@ -983,7 +983,7 @@ void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
     t->depth = depth;
 }
 
-void OpenGLDriver::createTextureR(Driver::TextureHandle th, SamplerType target, uint8_t levels,
+void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage usage) {
     DEBUG_MARKER()
@@ -1192,7 +1192,7 @@ GLuint OpenGLDriver::framebufferRenderbuffer(uint32_t width, uint32_t height, ui
 }
 
 void OpenGLDriver::createDefaultRenderTargetR(
-        Driver::RenderTargetHandle rth, int) {
+        Handle<HwRenderTarget> rth, int) {
     DEBUG_MARKER()
 
     construct<GLRenderTarget>(rth, 0, 0);  // FIXME: we don't know the width/height
@@ -1208,8 +1208,8 @@ void OpenGLDriver::createDefaultRenderTargetR(
     rt->gl.depth.rb = depthbuffer;  // FIXME: populate format
 }
 
-void OpenGLDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags targets,
+void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
+        TargetBufferFlags targets,
         uint32_t width,
         uint32_t height,
         uint8_t samples,
@@ -1324,21 +1324,21 @@ void OpenGLDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::createFenceR(Driver::FenceHandle fh, int) {
+void OpenGLDriver::createFenceR(Handle<HwFence> fh, int) {
     DEBUG_MARKER()
 
     HwFence* f = construct<HwFence>(fh);
     f->fence = mPlatform.createFence();
 }
 
-void OpenGLDriver::createSwapChainR(Driver::SwapChainHandle sch, void* nativeWindow, uint64_t flags) {
+void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags) {
     DEBUG_MARKER()
 
     HwSwapChain* sc = construct<HwSwapChain>(sch);
     sc->swapChain = mPlatform.createSwapChain(nativeWindow, flags);
 }
 
-void OpenGLDriver::createStreamFromTextureIdR(Driver::StreamHandle sh,
+void OpenGLDriver::createStreamFromTextureIdR(Handle<HwStream> sh,
         intptr_t externalTextureId, uint32_t width, uint32_t height) {
     DEBUG_MARKER()
 
@@ -1359,7 +1359,7 @@ void OpenGLDriver::createStreamFromTextureIdR(Driver::StreamHandle sh,
 // Destroying driver objects
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::destroyVertexBuffer(Driver::VertexBufferHandle vbh) {
+void OpenGLDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     DEBUG_MARKER()
 
     if (vbh) {
@@ -1379,7 +1379,7 @@ void OpenGLDriver::destroyVertexBuffer(Driver::VertexBufferHandle vbh) {
     }
 }
 
-void OpenGLDriver::destroyIndexBuffer(Driver::IndexBufferHandle ibh) {
+void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     DEBUG_MARKER()
 
     if (ibh) {
@@ -1395,7 +1395,7 @@ void OpenGLDriver::destroyIndexBuffer(Driver::IndexBufferHandle ibh) {
     }
 }
 
-void OpenGLDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
+void OpenGLDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
     if (rph) {
@@ -1409,7 +1409,7 @@ void OpenGLDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
     }
 }
 
-void OpenGLDriver::destroyProgram(Driver::ProgramHandle ph) {
+void OpenGLDriver::destroyProgram(Handle<HwProgram> ph) {
     DEBUG_MARKER()
 
     if (ph) {
@@ -1418,7 +1418,7 @@ void OpenGLDriver::destroyProgram(Driver::ProgramHandle ph) {
     }
 }
 
-void OpenGLDriver::destroySamplerGroup(Driver::SamplerGroupHandle sbh) {
+void OpenGLDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
 
     if (sbh) {
@@ -1427,7 +1427,7 @@ void OpenGLDriver::destroySamplerGroup(Driver::SamplerGroupHandle sbh) {
     }
 }
 
-void OpenGLDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
+void OpenGLDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
     DEBUG_MARKER()
 
     if (ubh) {
@@ -1452,7 +1452,7 @@ void OpenGLDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
     }
 }
 
-void OpenGLDriver::destroyTexture(Driver::TextureHandle th) {
+void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
     DEBUG_MARKER()
 
     if (th) {
@@ -1469,7 +1469,7 @@ void OpenGLDriver::destroyTexture(Driver::TextureHandle th) {
     }
 }
 
-void OpenGLDriver::destroyRenderTarget(Driver::RenderTargetHandle rth) {
+void OpenGLDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     DEBUG_MARKER()
 
     if (rth) {
@@ -1502,7 +1502,7 @@ void OpenGLDriver::destroyRenderTarget(Driver::RenderTargetHandle rth) {
     }
 }
 
-void OpenGLDriver::destroySwapChain(Driver::SwapChainHandle sch) {
+void OpenGLDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     DEBUG_MARKER()
 
     if (sch) {
@@ -1512,7 +1512,7 @@ void OpenGLDriver::destroySwapChain(Driver::SwapChainHandle sch) {
     }
 }
 
-void OpenGLDriver::destroyStream(Driver::StreamHandle sh) {
+void OpenGLDriver::destroyStream(Handle<HwStream> sh) {
     DEBUG_MARKER()
 
     if (sh) {
@@ -1553,7 +1553,7 @@ Handle<HwStream> OpenGLDriver::createStream(void* nativeStream) {
     return sh;
 }
 
-void OpenGLDriver::updateStreams(driver::DriverApi* driver) {
+void OpenGLDriver::updateStreams(DriverApi* driver) {
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {
         OpenGLBlitter::State state;
         for (GLTexture* t : mExternalStreams) {
@@ -1574,7 +1574,7 @@ void OpenGLDriver::updateStreams(driver::DriverApi* driver) {
     }
 }
 
-void OpenGLDriver::setStreamDimensions(Driver::StreamHandle sh, uint32_t width, uint32_t height) {
+void OpenGLDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint32_t height) {
     if (sh) {
         GLStream* s = handle_cast<GLStream*>(sh);
         s->width = width;
@@ -1582,7 +1582,7 @@ void OpenGLDriver::setStreamDimensions(Driver::StreamHandle sh, uint32_t width, 
     }
 }
 
-int64_t OpenGLDriver::getStreamTimestamp(Driver::StreamHandle sh) {
+int64_t OpenGLDriver::getStreamTimestamp(Handle<HwStream> sh) {
     if (sh) {
         GLStream* s = handle_cast<GLStream*>(sh);
         return s->user_thread.timestamp;
@@ -1590,7 +1590,7 @@ int64_t OpenGLDriver::getStreamTimestamp(Driver::StreamHandle sh) {
     return 0;
 }
 
-void OpenGLDriver::destroyFence(Driver::FenceHandle fh) {
+void OpenGLDriver::destroyFence(Handle<HwFence> fh) {
     if (fh) {
         HwFence* f = handle_cast<HwFence*>(fh);
         mPlatform.destroyFence(f->fence);
@@ -1598,7 +1598,7 @@ void OpenGLDriver::destroyFence(Driver::FenceHandle fh) {
     }
 }
 
-Driver::FenceStatus OpenGLDriver::wait(Driver::FenceHandle fh, uint64_t timeout) {
+FenceStatus OpenGLDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
     if (fh) {
         HwFence* f = handle_cast<HwFence*>(fh);
         return mPlatform.waitFence(f->fence, timeout);
@@ -1606,17 +1606,17 @@ Driver::FenceStatus OpenGLDriver::wait(Driver::FenceHandle fh, uint64_t timeout)
     return FenceStatus::ERROR;
 }
 
-bool OpenGLDriver::isTextureFormatSupported(Driver::TextureFormat format) {
-    if (driver::isETC2Compression(format)) {
+bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
+    if (isETC2Compression(format)) {
         return ext.texture_compression_etc2;
     }
-    if (driver::isS3TCCompression(format)) {
+    if (isS3TCCompression(format)) {
         return ext.texture_compression_s3tc;
     }
     return getInternalFormat(format) != 0;
 }
 
-bool OpenGLDriver::isRenderTargetFormatSupported(Driver::TextureFormat format) {
+bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
     // Supported formats per http://docs.gl/es3/glRenderbufferStorage, note that desktop OpenGL may
     // support more formats, but it requires querying GL_INTERNALFORMAT_SUPPORTED which is not
     // available in OpenGL ES.
@@ -1688,7 +1688,7 @@ bool OpenGLDriver::isFrameTimeSupported() {
 // ------------------------------------------------------------------------------------------------
 
 
-void OpenGLDriver::commit(Driver::SwapChainHandle sch) {
+void OpenGLDriver::commit(Handle<HwSwapChain> sch) {
     DEBUG_MARKER()
 
     if (sch) {
@@ -1697,7 +1697,7 @@ void OpenGLDriver::commit(Driver::SwapChainHandle sch) {
     }
 }
 
-void OpenGLDriver::makeCurrent(Driver::SwapChainHandle schDraw, Driver::SwapChainHandle schRead) {
+void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> schRead) {
     DEBUG_MARKER()
 
     if (schDraw && schRead) {
@@ -1711,7 +1711,7 @@ void OpenGLDriver::makeCurrent(Driver::SwapChainHandle schDraw, Driver::SwapChai
 // Updating driver objects
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh,
+void OpenGLDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh,
         size_t index, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
@@ -1726,7 +1726,7 @@ void OpenGLDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh,
 }
 
 void OpenGLDriver::updateIndexBuffer(
-        Driver::IndexBufferHandle ibh, BufferDescriptor&& p, uint32_t byteOffset) {
+        Handle<HwIndexBuffer> ibh, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
     GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
@@ -1741,7 +1741,7 @@ void OpenGLDriver::updateIndexBuffer(
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh, BufferDescriptor&& p) {
+void OpenGLDriver::updateUniformBuffer(Handle<HwUniformBuffer> ubh, BufferDescriptor&& p) {
     DEBUG_MARKER()
 
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer *>(ubh);
@@ -1760,7 +1760,7 @@ void OpenGLDriver::updateBuffer(GLenum target,
     assert(buffer->id);
 
     bindBuffer(target, buffer->id);
-    if (buffer->usage == driver::BufferUsage::STREAM) {
+    if (buffer->usage == BufferUsage::STREAM) {
 
         buffer->size = (uint32_t)p.size;
 
@@ -1815,7 +1815,7 @@ void OpenGLDriver::updateBuffer(GLenum target,
 }
 
 
-void OpenGLDriver::updateSamplerGroup(Driver::SamplerGroupHandle sbh,
+void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     DEBUG_MARKER()
 
@@ -1823,13 +1823,13 @@ void OpenGLDriver::updateSamplerGroup(Driver::SamplerGroupHandle sbh,
     *sb->sb = std::move(samplerGroup); // NOLINT(performance-move-const-arg)
 }
 
-void OpenGLDriver::update2DImage(Driver::TextureHandle th,
+void OpenGLDriver::update2DImage(Handle<HwTexture> th,
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& data) {
     DEBUG_MARKER()
 
     GLTexture* t = handle_cast<GLTexture *>(th);
-    if (data.type == driver::PixelDataType::COMPRESSED) {
+    if (data.type == PixelDataType::COMPRESSED) {
         setCompressedTextureData(t,
                 level, xoffset, yoffset, 0, width, height, 1, std::move(data), nullptr);
     } else {
@@ -1838,19 +1838,19 @@ void OpenGLDriver::update2DImage(Driver::TextureHandle th,
     }
 }
 
-void OpenGLDriver::updateCubeImage(Driver::TextureHandle th, uint32_t level,
+void OpenGLDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
         PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     DEBUG_MARKER()
 
     GLTexture* t = handle_cast<GLTexture *>(th);
-    if (data.type == driver::PixelDataType::COMPRESSED) {
+    if (data.type == PixelDataType::COMPRESSED) {
         setCompressedTextureData(t, level, 0, 0, 0, 0, 0, 0, std::move(data), &faceOffsets);
     } else {
         setTextureData(t, level, 0, 0, 0, 0, 0, 0, std::move(data), &faceOffsets);
     }
 }
 
-void OpenGLDriver::generateMipmaps(Driver::TextureHandle th) {
+void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     DEBUG_MARKER()
 
     GLTexture* t = handle_cast<GLTexture *>(th);
@@ -2040,7 +2040,7 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::setExternalImage(Driver::TextureHandle th, void* image) {
+void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     if (ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()
 
@@ -2058,7 +2058,7 @@ void OpenGLDriver::setExternalImage(Driver::TextureHandle th, void* image) {
     }
 }
 
-void OpenGLDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHandle sh) {
+void OpenGLDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
     if (ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()
 
@@ -2132,8 +2132,8 @@ void OpenGLDriver::replaceStream(GLTexture* t, GLStream* hwStream) noexcept {
     t->hwStream = hwStream;
 }
 
-void OpenGLDriver::beginRenderPass(Driver::RenderTargetHandle rth,
-        const Driver::RenderPassParams& params) {
+void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
+        const RenderPassParams& params) {
     DEBUG_MARKER()
 
     mRenderPassTarget = rth;
@@ -2237,8 +2237,8 @@ void OpenGLDriver::resolve(GLRenderTarget const* rt, TargetBufferFlags discardFl
     }
 }
 
-void OpenGLDriver::discardSubRenderTargetBuffers(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags buffers,
+void OpenGLDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
+        TargetBufferFlags buffers,
         uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
     DEBUG_MARKER()
 
@@ -2284,7 +2284,7 @@ GLsizei OpenGLDriver::getAttachments(std::array<GLenum, 3>& attachments,
     return attachmentCount;
 }
 
-void OpenGLDriver::resizeRenderTarget(Driver::RenderTargetHandle rth,
+void OpenGLDriver::resizeRenderTarget(Handle<HwRenderTarget> rth,
         uint32_t width, uint32_t height) {
     DEBUG_MARKER()
 
@@ -2326,8 +2326,8 @@ void OpenGLDriver::resizeRenderTarget(Driver::RenderTargetHandle rth,
     }
 }
 
-void OpenGLDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
-        Driver::VertexBufferHandle vbh, Driver::IndexBufferHandle ibh,
+void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {
     DEBUG_MARKER()
 
@@ -2375,8 +2375,8 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
     }
 }
 
-void OpenGLDriver::setRenderPrimitiveRange(Driver::RenderPrimitiveHandle rph,
-        Driver::PrimitiveType pt, uint32_t offset,
+void OpenGLDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
+        PrimitiveType pt, uint32_t offset,
         uint32_t minIndex, uint32_t maxIndex, uint32_t count) {
     DEBUG_MARKER()
 
@@ -2424,7 +2424,7 @@ void OpenGLDriver::setViewportScissor(
 
 #define DEBUG_NO_EXTERNAL_STREAM_COPY false
 
-void OpenGLDriver::updateStream(GLTexture* t, driver::DriverApi* driver) noexcept {
+void OpenGLDriver::updateStream(GLTexture* t, DriverApi* driver) noexcept {
     SYSTRACE_CALL();
 
     GLStream* s = static_cast<GLStream*>(t->hwStream);
@@ -2517,7 +2517,7 @@ void OpenGLDriver::updateStream(GLTexture* t, driver::DriverApi* driver) noexcep
     }
 }
 
-void OpenGLDriver::readStreamPixels(Driver::StreamHandle sh,
+void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     DEBUG_MARKER()
@@ -2591,7 +2591,7 @@ void OpenGLDriver::readStreamPixels(Driver::StreamHandle sh,
 // Setting rendering state
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle ubh) {
+void OpenGLDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
     DEBUG_MARKER()
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer *>(ubh);
     assert(ub->gl.ubo.base == 0);
@@ -2599,7 +2599,7 @@ void OpenGLDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle u
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHandle ubh,
+void OpenGLDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
         size_t offset, size_t size) {
     DEBUG_MARKER()
 
@@ -2611,7 +2611,7 @@ void OpenGLDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHan
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::bindSamplers(size_t index, Driver::SamplerGroupHandle sbh) {
+void OpenGLDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
 
     GLSamplerGroup* sb = handle_cast<GLSamplerGroup *>(sbh);
@@ -2621,7 +2621,7 @@ void OpenGLDriver::bindSamplers(size_t index, Driver::SamplerGroupHandle sbh) {
 }
 
 
-GLuint OpenGLDriver::getSamplerSlow(driver::SamplerParams params) const noexcept {
+GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     assert(mSamplerMap.find(params.u) == mSamplerMap.end());
 
     GLuint s;
@@ -2673,7 +2673,7 @@ void OpenGLDriver::popGroupMarker(int) {
 // Read-back ops
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::readPixels(Driver::RenderTargetHandle src,
+void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     DEBUG_MARKER()
@@ -2742,7 +2742,7 @@ void OpenGLDriver::readPixels(Driver::RenderTargetHandle src,
 void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     insertEventMarker("beginFrame");
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {
-        driver::OpenGLPlatform& platform = mPlatform;
+        OpenGLPlatform& platform = mPlatform;
         const size_t index = getIndexForTextureTarget(GL_TEXTURE_EXTERNAL_OES);
         for (GLTexture const* t : mExternalStreams) {
             assert(t && t->hwStream);
@@ -2856,9 +2856,9 @@ void OpenGLDriver::clearWithGeometryPipe(
 }
 
 void OpenGLDriver::blit(TargetBufferFlags buffers,
-        Driver::RenderTargetHandle dst, driver::Viewport dstRect,
-        Driver::RenderTargetHandle src, driver::Viewport srcRect,
-        Driver::SamplerMagFilter filter) {
+        Handle<HwRenderTarget> dst, Viewport dstRect,
+        Handle<HwRenderTarget> src, Viewport srcRect,
+        SamplerMagFilter filter) {
     DEBUG_MARKER()
 
     GLbitfield mask = 0;
@@ -2918,7 +2918,7 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
 
 void OpenGLDriver::draw(
         Driver::PipelineState state,
-        Driver::RenderPrimitiveHandle rph) {
+        Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
     OpenGLProgram* p = handle_cast<OpenGLProgram*>(state.program);
@@ -2940,6 +2940,6 @@ void OpenGLDriver::draw(
 }
 
 // explicit instantiation of the Dispatcher
-template class ConcreteDispatcher<OpenGLDriver>;
+template class driver::ConcreteDispatcher<OpenGLDriver>;
 
 } // namespace filament

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -614,7 +614,7 @@ void OpenGLDriver::polygonOffset(GLfloat factor, GLfloat units) noexcept {
     });
 }
 
-void OpenGLDriver::setRasterStateSlow(Driver::RasterState rs) noexcept {
+void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
     mRasterState = rs;
 
     // culling state
@@ -861,7 +861,7 @@ void OpenGLDriver::createVertexBufferR(
     uint8_t bufferCount,
     uint8_t attributeCount,
     uint32_t elementCount,
-    Driver::AttributeArray attributes,
+    AttributeArray attributes,
     BufferUsage usage) {
     DEBUG_MARKER()
 
@@ -869,6 +869,8 @@ void OpenGLDriver::createVertexBufferR(
             bufferCount, attributeCount, elementCount, attributes);
 
     GLsizei n = GLsizei(vb->bufferCount);
+
+    assert(n <= (GLsizei)vb->gl.buffers.size());
     glGenBuffers(n, vb->gl.buffers.data());
 
     for (GLsizei i = 0; i < n; i++) {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -37,6 +37,7 @@ namespace filament {
 
 namespace driver {
 class PixelBufferDescriptor;
+class TargetBufferInfo;
 } // namespace driver
 
 class OpenGLProgram;
@@ -284,7 +285,7 @@ private:
 
     /* Misc... */
 
-    void framebufferTexture(Driver::TargetBufferInfo& binfo, GLRenderTarget* rt, GLenum attachment) noexcept;
+    void framebufferTexture(driver::TargetBufferInfo& binfo, GLRenderTarget* rt, GLenum attachment) noexcept;
 
     void framebufferRenderbuffer(GLRenderTarget::GL::RenderBuffer* rb, GLenum attachment,
             GLenum internalformat, uint32_t width, uint32_t height, uint8_t samples, GLuint fbo) noexcept;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -61,7 +61,7 @@ public:
     struct GLVertexBuffer : public driver::HwVertexBuffer {
         using HwVertexBuffer::HwVertexBuffer;
         struct {
-            std::array<GLuint, MAX_ATTRIBUTE_BUFFER_COUNT> buffers;  // 4*6 bytes
+            std::array<GLuint, driver::MAX_ATTRIBUTE_BUFFER_COUNT> buffers;  // 4*6 bytes
         } gl;
     };
 
@@ -292,8 +292,8 @@ private:
     GLuint framebufferRenderbuffer(uint32_t width, uint32_t height, uint8_t samples,
             GLenum attachment, GLenum internalformat, GLuint fbo) noexcept;
 
-    void setRasterStateSlow(RasterState rs) noexcept;
-    void setRasterState(RasterState rs) noexcept {
+    void setRasterStateSlow(driver::RasterState rs) noexcept;
+    void setRasterState(driver::RasterState rs) noexcept {
         if (UTILS_UNLIKELY(rs != mRasterState)) {
             setRasterStateSlow(rs);
         }
@@ -485,7 +485,7 @@ private:
     static constexpr const size_t TEXTURE_TARGET_COUNT =
             sizeof(state.textures.units[0].targets) / sizeof(state.textures.units[0].targets[0]);
 
-    Driver::RasterState mRasterState;
+    driver::RasterState mRasterState;
 
     GLfloat mMaxAnisotropy = 0.0f;
     driver::ShaderModel mShaderModel;

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -28,6 +28,7 @@ namespace filament {
 
 using namespace filament::math;
 using namespace utils;
+using namespace driver;
 
 OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) noexcept
         :  HwProgram(programBuilder.getName()), mIsValid(false) {
@@ -196,7 +197,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
             const uint8_t index = indicesRun[tmu];
             assert(index < sb.getSize());
 
-            Driver::TextureHandle th = samplers[index].t;
+            Handle<HwTexture> th = samplers[index].t;
             if (UTILS_UNLIKELY(!th)) {
                 continue; // this can happen if the SamplerGroup isn't initialized
             }

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -33,10 +33,10 @@
 
 namespace filament {
 
-class OpenGLProgram : public HwProgram {
+class OpenGLProgram : public driver::HwProgram {
 public:
 
-    OpenGLProgram(OpenGLDriver* gl, const Program& builder) noexcept;
+    OpenGLProgram(OpenGLDriver* gl, const driver::Program& builder) noexcept;
     ~OpenGLProgram() noexcept;
 
     bool isValid() const noexcept { return mIsValid; }
@@ -60,7 +60,7 @@ public:
     }
 
     struct {
-        GLuint shaders[Program::NUM_SHADER_TYPES];
+        GLuint shaders[driver::Program::NUM_SHADER_TYPES];
         GLuint program;
     } gl; // 12 bytes
 
@@ -68,8 +68,8 @@ public:
 
 private:
     static constexpr uint8_t NUM_TEXTURE_UNITS = OpenGLDriver::MAX_TEXTURE_UNITS;
-    static constexpr uint8_t VERTEX_SHADER_BIT   = uint8_t(1) << size_t(Program::Shader::VERTEX);
-    static constexpr uint8_t FRAGMENT_SHADER_BIT = uint8_t(1) << size_t(Program::Shader::FRAGMENT);
+    static constexpr uint8_t VERTEX_SHADER_BIT   = uint8_t(1) << size_t(driver::Program::Shader::VERTEX);
+    static constexpr uint8_t FRAGMENT_SHADER_BIT = uint8_t(1) << size_t(driver::Program::Shader::FRAGMENT);
 
     struct BlockInfo {
         uint8_t binding : 3;    // binding (i.e.: index in mSamplerBindings)
@@ -80,7 +80,7 @@ private:
         static_assert(NUM_TEXTURE_UNITS <= 16, "NUM_TEXTURE_UNITS must be <= 16");
 
         // if NUM_SAMPLER_BINDINGS > 8, the binding bitfield must be increased accordingly
-        static_assert(Program::NUM_SAMPLER_BINDINGS <= 8, "NUM_SAMPLER_BINDINGS must be <= 8");
+        static_assert(driver::Program::NUM_SAMPLER_BINDINGS <= 8, "NUM_SAMPLER_BINDINGS must be <= 8");
     };
 
     uint8_t mUsedBindingsCount = 0;
@@ -88,7 +88,7 @@ private:
     bool mIsValid = false;
 
     // information about each USED sampler buffer (no gaps)
-    std::array<BlockInfo, Program::NUM_SAMPLER_BINDINGS> mBlockInfos;   // 8 bytes
+    std::array<BlockInfo, driver::Program::NUM_SAMPLER_BINDINGS> mBlockInfos;   // 8 bytes
 
     // runs of indices into SamplerGroup -- run start index and size given by BlockInfo
     std::array<uint8_t, NUM_TEXTURE_UNITS> mIndicesRuns;    // 16 bytes

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -31,7 +31,7 @@ public:
     PlatformCocoaGL();
     ~PlatformCocoaGL() noexcept final;
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    driver::Driver* createDriver(void* sharedContext) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -31,7 +31,7 @@ public:
     PlatformCocoaTouchGL();
     ~PlatformCocoaTouchGL() noexcept final;
 
-    Driver* createDriver(void* sharedGLContext) noexcept override;
+    driver::Driver* createDriver(void* sharedGLContext) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/PlatformDummyGL.h
@@ -27,7 +27,7 @@ namespace filament {
 class PlatformDummyGL final : public driver::OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedGLContext) noexcept override;
     void terminate() noexcept override { }
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override {

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -38,7 +38,7 @@ public:
 
     PlatformEGL() noexcept;
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    driver::Driver* createDriver(void* sharedContext) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -30,7 +30,7 @@ namespace filament {
 class PlatformGLX final : public driver::OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedGLContext) noexcept override;
 
     void terminate() noexcept override;
 

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -29,7 +29,7 @@ namespace filament {
 
 class PlatformWGL final : public driver::OpenGLPlatform {
 public:
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedGLContext) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -30,7 +30,7 @@ namespace filament {
 class PlatformWebGL final : public driver::OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedGLContext) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override;

--- a/filament/backend/src/vulkan/PlatformVkAndroid.h
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.h
@@ -27,7 +27,7 @@ namespace filament {
 class PlatformVkAndroid final : public driver::VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance,
             uint32_t* width, uint32_t* height) noexcept override;

--- a/filament/backend/src/vulkan/PlatformVkCocoa.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.h
@@ -26,7 +26,7 @@ namespace filament {
 
 class PlatformVkCocoa final : public driver::VulkanPlatform {
 public:
-    Driver* createDriver(void* sharedContext) noexcept override;
+    driver::Driver* createDriver(void* sharedContext) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance,
             uint32_t* width, uint32_t* height) noexcept override;
     int getOSVersion() const noexcept override { return 0; }

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
@@ -26,7 +26,7 @@ namespace filament {
 
 class PlatformVkCocoaTouch final : public driver::VulkanPlatform {
 public:
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedContext) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance,
             uint32_t* width, uint32_t* height) noexcept override;
     int getOSVersion() const noexcept override { return 0; }

--- a/filament/backend/src/vulkan/PlatformVkLinux.h
+++ b/filament/backend/src/vulkan/PlatformVkLinux.h
@@ -29,7 +29,7 @@ namespace filament {
 class PlatformVkLinux final : public driver::VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance,
             uint32_t* width, uint32_t* height) noexcept override;

--- a/filament/backend/src/vulkan/PlatformVkWindows.h
+++ b/filament/backend/src/vulkan/PlatformVkWindows.h
@@ -27,7 +27,7 @@ namespace filament {
 class PlatformVkWindows final : public driver::VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    driver::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance,
             uint32_t* width, uint32_t* height) noexcept override;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -298,7 +298,7 @@ void VulkanDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 }
 
 void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
-        uint8_t attributeCount, uint32_t elementCount, Driver::AttributeArray attributes,
+        uint8_t attributeCount, uint32_t elementCount, AttributeArray attributes,
         BufferUsage usage) {
     auto vertexBuffer = construct_handle<VulkanVertexBuffer>(mHandleMap, vbh, mContext, mStagePool,
             bufferCount, attributeCount, elementCount, attributes);
@@ -954,8 +954,8 @@ void VulkanDriver::draw(Driver::PipelineState pipelineState, Handle<HwRenderPrim
     const VulkanRenderPrimitive& prim = *handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
 
     Handle<HwProgram> programHandle = pipelineState.program;
-    Driver::RasterState rasterState = pipelineState.rasterState;
-    Driver::PolygonOffset depthOffset = pipelineState.polygonOffset;
+    RasterState rasterState = pipelineState.rasterState;
+    PolygonOffset depthOffset = pipelineState.polygonOffset;
 
     auto* program = handle_cast<VulkanProgram>(mHandleMap, programHandle);
     mDisposer.acquire(program, commands->resources);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -371,8 +371,8 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
-        TextureFormat format, Driver::TargetBufferInfo color, Driver::TargetBufferInfo depth,
-        Driver::TargetBufferInfo stencil) {
+        TextureFormat format, TargetBufferInfo color, TargetBufferInfo depth,
+        TargetBufferInfo stencil) {
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
             width, height, color.level);
     if (color.handle) {
@@ -947,7 +947,7 @@ void VulkanDriver::blit(TargetBufferFlags buffers,
     }
 }
 
-void VulkanDriver::draw(Driver::PipelineState pipelineState, Handle<HwRenderPrimitive> rph) {
+void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph) {
     VulkanCommandBuffer* commands = mContext.currentCommands;
     ASSERT_POSTCONDITION(commands, "Draw calls can occur only within a beginFrame / endFrame.");
     VkCommandBuffer cmdbuffer = commands->cmdbuffer;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -262,12 +262,12 @@ void VulkanDriver::flush(int) {
     // Todo: equivalent of glFlush()
 }
 
-void VulkanDriver::createSamplerGroupR(Driver::SamplerGroupHandle sbh, size_t count) {
+void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t count) {
     construct_handle<VulkanSamplerGroup>(mHandleMap, sbh, mContext, count);
 }
 
-void VulkanDriver::createUniformBufferR(Driver::UniformBufferHandle ubh, size_t size,
-        Driver::BufferUsage usage) {
+void VulkanDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
+        BufferUsage usage) {
     auto uniformBuffer = construct_handle<VulkanUniformBuffer>(mHandleMap, ubh, mContext,
             mStagePool, size, usage);
     mDisposer.createDisposable(uniformBuffer, [this, ubh] () {
@@ -275,7 +275,7 @@ void VulkanDriver::createUniformBufferR(Driver::UniformBufferHandle ubh, size_t 
     });
 }
 
-void VulkanDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
+void VulkanDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
     if (ubh) {
         auto buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
         mBinder.unbindUniformBuffer(buffer->getGpuBuffer());
@@ -283,23 +283,23 @@ void VulkanDriver::destroyUniformBuffer(Driver::UniformBufferHandle ubh) {
     }
 }
 
-void VulkanDriver::createRenderPrimitiveR(Driver::RenderPrimitiveHandle rph, int) {
+void VulkanDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int) {
     auto renderPrimitive = construct_handle<VulkanRenderPrimitive>(mHandleMap, rph, mContext);
     mDisposer.createDisposable(renderPrimitive, [this, rph] () {
         destruct_handle<VulkanRenderPrimitive>(mHandleMap, rph);
     });
 }
 
-void VulkanDriver::destroyRenderPrimitive(Driver::RenderPrimitiveHandle rph) {
+void VulkanDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     if (rph) {
         auto renderPrimitive = handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
         mDisposer.removeReference(renderPrimitive);
     }
 }
 
-void VulkanDriver::createVertexBufferR(Driver::VertexBufferHandle vbh, uint8_t bufferCount,
+void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
         uint8_t attributeCount, uint32_t elementCount, Driver::AttributeArray attributes,
-        Driver::BufferUsage usage) {
+        BufferUsage usage) {
     auto vertexBuffer = construct_handle<VulkanVertexBuffer>(mHandleMap, vbh, mContext, mStagePool,
             bufferCount, attributeCount, elementCount, attributes);
     mDisposer.createDisposable(vertexBuffer, [this, vbh] () {
@@ -307,15 +307,15 @@ void VulkanDriver::createVertexBufferR(Driver::VertexBufferHandle vbh, uint8_t b
     });
 }
 
-void VulkanDriver::destroyVertexBuffer(Driver::VertexBufferHandle vbh) {
+void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     if (vbh) {
         auto vertexBuffer = handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);
         mDisposer.removeReference(vertexBuffer);
     }
 }
 
-void VulkanDriver::createIndexBufferR(Driver::IndexBufferHandle ibh,
-        Driver::ElementType elementType, uint32_t indexCount, Driver::BufferUsage usage) {
+void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
+        ElementType elementType, uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct_handle<VulkanIndexBuffer>(mHandleMap, ibh, mContext, mStagePool,
             elementSize, indexCount);
@@ -324,14 +324,14 @@ void VulkanDriver::createIndexBufferR(Driver::IndexBufferHandle ibh,
     });
 }
 
-void VulkanDriver::destroyIndexBuffer(Driver::IndexBufferHandle ibh) {
+void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         auto indexBuffer = handle_cast<VulkanIndexBuffer>(mHandleMap, ibh);
         mDisposer.removeReference(indexBuffer);
     }
 }
 
-void VulkanDriver::createTextureR(Driver::TextureHandle th, SamplerType target, uint8_t levels,
+void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage usage) {
     auto vktexture = construct_handle<VulkanTexture>(mHandleMap, th, mContext, target, levels,
@@ -341,7 +341,7 @@ void VulkanDriver::createTextureR(Driver::TextureHandle th, SamplerType target, 
     });
 }
 
-void VulkanDriver::destroyTexture(Driver::TextureHandle th) {
+void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
     if (th) {
         auto texture = handle_cast<VulkanTexture>(mHandleMap, th);
         mBinder.unbindImageView(texture->imageView);
@@ -349,28 +349,28 @@ void VulkanDriver::destroyTexture(Driver::TextureHandle th) {
     }
 }
 
-void VulkanDriver::createProgramR(Driver::ProgramHandle ph, Program&& program) {
+void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program) {
     auto vkprogram = construct_handle<VulkanProgram>(mHandleMap, ph, mContext, program);
     mDisposer.createDisposable(vkprogram, [this, ph] () {
         destruct_handle<VulkanProgram>(mHandleMap, ph);
     });
 }
 
-void VulkanDriver::destroyProgram(Driver::ProgramHandle ph) {
+void VulkanDriver::destroyProgram(Handle<HwProgram> ph) {
     if (ph) {
         mDisposer.removeReference(handle_cast<VulkanProgram>(mHandleMap, ph));
     }
 }
 
-void VulkanDriver::createDefaultRenderTargetR(Driver::RenderTargetHandle rth, int) {
+void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext);
     mDisposer.createDisposable(renderTarget, [this, rth] () {
         destruct_handle<VulkanRenderTarget>(mHandleMap, rth);
     });
 }
 
-void VulkanDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
+void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
+        TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
         TextureFormat format, Driver::TargetBufferInfo color, Driver::TargetBufferInfo depth,
         Driver::TargetBufferInfo stencil) {
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
@@ -400,16 +400,16 @@ void VulkanDriver::createRenderTargetR(Driver::RenderTargetHandle rth,
     });
 }
 
-void VulkanDriver::destroyRenderTarget(Driver::RenderTargetHandle rth) {
+void VulkanDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     if (rth) {
         mDisposer.removeReference(handle_cast<VulkanRenderTarget>(mHandleMap, rth));
     }
 }
 
-void VulkanDriver::createFenceR(Driver::FenceHandle fh, int) {
+void VulkanDriver::createFenceR(Handle<HwFence> fh, int) {
 }
 
-void VulkanDriver::createSwapChainR(Driver::SwapChainHandle sch, void* nativeWindow,
+void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
         uint64_t flags) {
     auto* swapChain = construct_handle<VulkanSwapChain>(mHandleMap, sch);
     VulkanSurfaceContext& sc = swapChain->surfaceContext;
@@ -423,7 +423,7 @@ void VulkanDriver::createSwapChainR(Driver::SwapChainHandle sch, void* nativeWin
     mContext.currentSurface = &sc;
 }
 
-void VulkanDriver::createStreamFromTextureIdR(Driver::StreamHandle sh, intptr_t externalTextureId,
+void VulkanDriver::createStreamFromTextureIdR(Handle<HwStream> sh, intptr_t externalTextureId,
         uint32_t width, uint32_t height) {
 }
 
@@ -475,7 +475,7 @@ Handle<HwStream> VulkanDriver::createStreamFromTextureIdS() noexcept {
     return {};
 }
 
-void VulkanDriver::destroySamplerGroup(Driver::SamplerGroupHandle sbh) {
+void VulkanDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
     if (sbh) {
         // Unlike most of the other "Hw" handles, the sampler buffer is an abstract concept and does
         // not map to any Vulkan objects. To handle destruction, the only thing we need to do is
@@ -491,7 +491,7 @@ void VulkanDriver::destroySamplerGroup(Driver::SamplerGroupHandle sbh) {
     }
 }
 
-void VulkanDriver::destroySwapChain(Driver::SwapChainHandle sch) {
+void VulkanDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     if (sch) {
         VulkanSurfaceContext& surfaceContext = handle_cast<VulkanSwapChain>(mHandleMap, sch)->surfaceContext;
         waitForIdle(mContext);
@@ -515,33 +515,33 @@ void VulkanDriver::destroySwapChain(Driver::SwapChainHandle sch) {
     }
 }
 
-void VulkanDriver::destroyStream(Driver::StreamHandle sh) {
+void VulkanDriver::destroyStream(Handle<HwStream> sh) {
 }
 
 Handle<HwStream> VulkanDriver::createStream(void* nativeStream) {
     return {};
 }
 
-void VulkanDriver::setStreamDimensions(Driver::StreamHandle sh, uint32_t width, uint32_t height) {
+void VulkanDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint32_t height) {
 }
 
-int64_t VulkanDriver::getStreamTimestamp(Driver::StreamHandle sh) {
+int64_t VulkanDriver::getStreamTimestamp(Handle<HwStream> sh) {
     return 0;
 }
 
 void VulkanDriver::updateStreams(CommandStream* driver) {
 }
 
-void VulkanDriver::destroyFence(Driver::FenceHandle fh) {
+void VulkanDriver::destroyFence(Handle<HwFence> fh) {
 }
 
-Driver::FenceStatus VulkanDriver::wait(Driver::FenceHandle fh, uint64_t timeout) {
+FenceStatus VulkanDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
     return FenceStatus::ERROR;
 }
 
 // We create all textures using VK_IMAGE_TILING_OPTIMAL, so our definition of "supported" is that
 // the GPU supports the given texture format with non-zero optimal tiling features.
-bool VulkanDriver::isTextureFormatSupported(Driver::TextureFormat format) {
+bool VulkanDriver::isTextureFormatSupported(TextureFormat format) {
     assert(mContext.physicalDevice);
     VkFormat vkformat = getVkFormat(format);
     if (vkformat == VK_FORMAT_UNDEFINED) {
@@ -552,7 +552,7 @@ bool VulkanDriver::isTextureFormatSupported(Driver::TextureFormat format) {
     return info.optimalTilingFeatures != 0;
 }
 
-bool VulkanDriver::isRenderTargetFormatSupported(Driver::TextureFormat format) {
+bool VulkanDriver::isRenderTargetFormatSupported(TextureFormat format) {
     assert(mContext.physicalDevice);
     VkFormat vkformat = getVkFormat(format);
     if (vkformat == VK_FORMAT_UNDEFINED) {
@@ -567,21 +567,21 @@ bool VulkanDriver::isFrameTimeSupported() {
     return false;
 }
 
-void VulkanDriver::updateVertexBuffer(Driver::VertexBufferHandle vbh, size_t index,
+void VulkanDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
         BufferDescriptor&& p, uint32_t byteOffset) {
     auto& vb = *handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);
     vb.buffers[index]->loadFromCpu(p.buffer, byteOffset, p.size);
     scheduleDestroy(std::move(p));
 }
 
-void VulkanDriver::updateIndexBuffer(Driver::IndexBufferHandle ibh, BufferDescriptor&& p,
+void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     auto& ib = *handle_cast<VulkanIndexBuffer>(mHandleMap, ibh);
     ib.buffer->loadFromCpu(p.buffer, byteOffset, p.size);
     scheduleDestroy(std::move(p));
 }
 
-void VulkanDriver::update2DImage(Driver::TextureHandle th,
+void VulkanDriver::update2DImage(Handle<HwTexture> th,
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& data) {
     assert(xoffset == 0 && yoffset == 0 && "Offsets not yet supported.");
@@ -589,25 +589,25 @@ void VulkanDriver::update2DImage(Driver::TextureHandle th,
     scheduleDestroy(std::move(data));
 }
 
-void VulkanDriver::updateCubeImage(Driver::TextureHandle th, uint32_t level,
+void VulkanDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
         PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     handle_cast<VulkanTexture>(mHandleMap, th)->updateCubeImage(data, faceOffsets, level);
     scheduleDestroy(std::move(data));
 }
 
-void VulkanDriver::setExternalImage(Driver::TextureHandle th, void* image) {
+void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 
-void VulkanDriver::setExternalStream(Driver::TextureHandle th, Driver::StreamHandle sh) {
+void VulkanDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 }
 
-void VulkanDriver::generateMipmaps(Driver::TextureHandle th) { }
+void VulkanDriver::generateMipmaps(Handle<HwTexture> th) { }
 
 bool VulkanDriver::canGenerateMipmaps() {
     return false;
 }
 
-void VulkanDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh, BufferDescriptor&& data) {
+void VulkanDriver::updateUniformBuffer(Handle<HwUniformBuffer> ubh, BufferDescriptor&& data) {
     if (data.size > 0) {
         auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
         buffer->loadFromCpu(data.buffer, (uint32_t) data.size);
@@ -615,14 +615,14 @@ void VulkanDriver::updateUniformBuffer(Driver::UniformBufferHandle ubh, BufferDe
     }
 }
 
-void VulkanDriver::updateSamplerGroup(Driver::SamplerGroupHandle sbh,
+void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     auto* sb = handle_cast<VulkanSamplerGroup>(mHandleMap, sbh);
     *sb->sb = samplerGroup;
 }
 
-void VulkanDriver::beginRenderPass(Driver::RenderTargetHandle rth,
-        const Driver::RenderPassParams& params) {
+void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth,
+        const RenderPassParams& params) {
 
     assert(mContext.currentCommands);
     assert(mContext.currentSurface);
@@ -730,25 +730,25 @@ void VulkanDriver::endRenderPass(int) {
     mContext.currentRenderPass.renderPass = VK_NULL_HANDLE;
 }
 
-void VulkanDriver::discardSubRenderTargetBuffers(Driver::RenderTargetHandle rth,
-        Driver::TargetBufferFlags buffers,
+void VulkanDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
+        TargetBufferFlags buffers,
         uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
 }
 
-void VulkanDriver::resizeRenderTarget(Driver::RenderTargetHandle rth,
+void VulkanDriver::resizeRenderTarget(Handle<HwRenderTarget> rth,
         uint32_t width, uint32_t height) {
 }
 
-void VulkanDriver::setRenderPrimitiveBuffer(Driver::RenderPrimitiveHandle rph,
-        Driver::VertexBufferHandle vbh, Driver::IndexBufferHandle ibh,
+void VulkanDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {
     auto primitive = handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
     primitive->setBuffers(handle_cast<VulkanVertexBuffer>(mHandleMap, vbh),
             handle_cast<VulkanIndexBuffer>(mHandleMap, ibh), enabledAttributes);
 }
 
-void VulkanDriver::setRenderPrimitiveRange(Driver::RenderPrimitiveHandle rph,
-        Driver::PrimitiveType pt, uint32_t offset,
+void VulkanDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
+        PrimitiveType pt, uint32_t offset,
         uint32_t minIndex, uint32_t maxIndex, uint32_t count) {
     auto& primitive = *handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
     primitive.setPrimitiveType(pt);
@@ -777,14 +777,14 @@ void VulkanDriver::setViewportScissor(
     vkCmdSetScissor(mContext.currentCommands->cmdbuffer, 0, 1, &scissor);
 }
 
-void VulkanDriver::makeCurrent(Driver::SwapChainHandle drawSch, Driver::SwapChainHandle readSch) {
+void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
     ASSERT_PRECONDITION_NON_FATAL(drawSch == readSch,
                                   "Vulkan driver does not support distinct draw/read swap chains.");
     VulkanSurfaceContext& sContext = handle_cast<VulkanSwapChain>(mHandleMap, drawSch)->surfaceContext;
     mContext.currentSurface = &sContext;
 }
 
-void VulkanDriver::commit(Driver::SwapChainHandle sch) {
+void VulkanDriver::commit(Handle<HwSwapChain> sch) {
     // Tell Vulkan we're done appending to the command buffer.
     ASSERT_POSTCONDITION(mContext.currentCommands,
             "Vulkan driver requires at least one frame before a commit.");
@@ -828,7 +828,7 @@ void VulkanDriver::commit(Driver::SwapChainHandle sch) {
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkQueuePresentKHR error.");
 }
 
-void VulkanDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle ubh) {
+void VulkanDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
     auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
     // The driver API does not currently expose offset / range, but it will do so in the future.
     const VkDeviceSize offset = 0;
@@ -836,13 +836,13 @@ void VulkanDriver::bindUniformBuffer(size_t index, Driver::UniformBufferHandle u
     mBinder.bindUniformBuffer((uint32_t) index, buffer->getGpuBuffer(), offset, size);
 }
 
-void VulkanDriver::bindUniformBufferRange(size_t index, Driver::UniformBufferHandle ubh,
+void VulkanDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
         size_t offset, size_t size) {
     auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
     mBinder.bindUniformBuffer((uint32_t)index, buffer->getGpuBuffer(), offset, size);
 }
 
-void VulkanDriver::bindSamplers(size_t index, Driver::SamplerGroupHandle sbh) {
+void VulkanDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
     auto* hwsb = handle_cast<VulkanSamplerGroup>(mHandleMap, sbh);
     mSamplerBindings[index] = hwsb;
 }
@@ -872,21 +872,21 @@ void VulkanDriver::popGroupMarker(int) {
     }
 }
 
-void VulkanDriver::readPixels(Driver::RenderTargetHandle src,
+void VulkanDriver::readPixels(Handle<HwRenderTarget> src,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     scheduleDestroy(std::move(p));
 }
 
-void VulkanDriver::readStreamPixels(Driver::StreamHandle sh, uint32_t x, uint32_t y, uint32_t width,
+void VulkanDriver::readStreamPixels(Handle<HwStream> sh, uint32_t x, uint32_t y, uint32_t width,
         uint32_t height, PixelBufferDescriptor&& p) {
     scheduleDestroy(std::move(p));
 }
 
 void VulkanDriver::blit(TargetBufferFlags buffers,
-        Driver::RenderTargetHandle dst, driver::Viewport dstRect,
-        Driver::RenderTargetHandle src, driver::Viewport srcRect,
-        Driver::SamplerMagFilter filter) {
+        Handle<HwRenderTarget> dst, driver::Viewport dstRect,
+        Handle<HwRenderTarget> src, driver::Viewport srcRect,
+        SamplerMagFilter filter) {
     auto dstTarget = handle_cast<VulkanRenderTarget>(mHandleMap, dst);
     auto srcTarget = handle_cast<VulkanRenderTarget>(mHandleMap, src);
 
@@ -947,13 +947,13 @@ void VulkanDriver::blit(TargetBufferFlags buffers,
     }
 }
 
-void VulkanDriver::draw(Driver::PipelineState pipelineState, Driver::RenderPrimitiveHandle rph) {
+void VulkanDriver::draw(Driver::PipelineState pipelineState, Handle<HwRenderPrimitive> rph) {
     VulkanCommandBuffer* commands = mContext.currentCommands;
     ASSERT_POSTCONDITION(commands, "Draw calls can occur only within a beginFrame / endFrame.");
     VkCommandBuffer cmdbuffer = commands->cmdbuffer;
     const VulkanRenderPrimitive& prim = *handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
 
-    Driver::ProgramHandle programHandle = pipelineState.program;
+    Handle<HwProgram> programHandle = pipelineState.program;
     Driver::RasterState rasterState = pipelineState.rasterState;
     Driver::PolygonOffset depthOffset = pipelineState.polygonOffset;
 
@@ -1107,11 +1107,10 @@ void VulkanDriver::debugCommand(const char* methodName) {
 }
 #endif
 
-} // namespace driver
-
 // explicit instantiation of the Dispatcher
-template class ConcreteDispatcher<driver::VulkanDriver>;
+template class ConcreteDispatcher<VulkanDriver>;
 
+} // namespace driver
 } // namespace filament
 
 #pragma clang diagnostic pop

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -59,7 +59,7 @@ private:
     ShaderModel getShaderModel() const noexcept final;
 
     template<typename T>
-    friend class ::filament::ConcreteDispatcher;
+    friend class driver::ConcreteDispatcher;
 
 #define DECL_DRIVER_API(methodName, paramsDecl, params) \
     UTILS_ALWAYS_INLINE void methodName(paramsDecl);

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -297,7 +297,7 @@ void VulkanRenderTarget::setDepthImage(VulkanAttachment d) {
 
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-        Driver::AttributeArray const& attributes) :
+        AttributeArray const& attributes) :
         HwVertexBuffer(bufferCount, attributeCount, elementCount, attributes) {
     buffers.reserve(bufferCount);
     for (uint8_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
@@ -668,13 +668,13 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
         if (!(enabledAttributes & (1U << attribIndex))) {
             continue;
         }
-        const Driver::Attribute& attrib = vertexBuffer->attributes[attribIndex];
+        const Attribute& attrib = vertexBuffer->attributes[attribIndex];
         buffers.push_back(vertexBuffer->buffers[attrib.buffer]->getGpuBuffer());
         offsets.push_back(attrib.offset);
         varray.attributes[bufferIndex] = {
             .location = attribIndex, // matches the GLSL layout specifier
             .binding = bufferIndex,  // matches the position within vkCmdBindVertexBuffers
-            .format = getVkFormat(attrib.type, attrib.flags & Driver::Attribute::FLAG_NORMALIZED),
+            .format = getVkFormat(attrib.type, attrib.flags & Attribute::FLAG_NORMALIZED),
             .offset = 0
         };
         varray.buffers[bufferIndex] = {

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -627,7 +627,7 @@ void VulkanTexture::copyBufferToImage(VkCommandBuffer cmd, VkBuffer buffer, VkIm
     vkCmdCopyBufferToImage(cmd, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 }
 
-void VulkanRenderPrimitive::setPrimitiveType(Driver::PrimitiveType pt) {
+void VulkanRenderPrimitive::setPrimitiveType(driver::PrimitiveType pt) {
     this->type = pt;
     switch (pt) {
         case driver::PrimitiveType::NONE:

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -86,7 +86,7 @@ struct VulkanSwapChain : public HwSwapChain {
 struct VulkanVertexBuffer : public HwVertexBuffer {
     VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, uint8_t bufferCount,
             uint8_t attributeCount, uint32_t elementCount,
-            Driver::AttributeArray const& attributes);
+            AttributeArray const& attributes);
     std::vector<std::unique_ptr<VulkanBuffer>> buffers;
 };
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -149,7 +149,7 @@ private:
 
 struct VulkanRenderPrimitive : public HwRenderPrimitive {
     explicit VulkanRenderPrimitive(VulkanContext& context) {}
-    void setPrimitiveType(Driver::PrimitiveType pt);
+    void setPrimitiveType(driver::PrimitiveType pt);
     void setBuffers(VulkanVertexBuffer* vertexBuffer, VulkanIndexBuffer* indexBuffer,
             uint32_t enabledAttributes);
     VulkanVertexBuffer* vertexBuffer = nullptr;

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -190,7 +190,7 @@ void FEngine::init() {
     driverApi.setRenderPrimitiveBuffer(mFullScreenTriangleRph,
             mFullScreenTriangleVb->getHwHandle(), mFullScreenTriangleIb->getHwHandle(),
             mFullScreenTriangleVb->getDeclaredAttributes().getValue());
-    driverApi.setRenderPrimitiveRange(mFullScreenTriangleRph, Driver::PrimitiveType::TRIANGLES,
+    driverApi.setRenderPrimitiveRange(mFullScreenTriangleRph, PrimitiveType::TRIANGLES,
             0, 0, 2, (uint32_t)mFullScreenTriangleIb->getIndexCount());
 
     mDefaultIblTexture = upcast(Texture::Builder()
@@ -429,7 +429,7 @@ const FMaterial* FEngine::getSkyboxMaterial(bool rgbm) const noexcept {
 }
 
 
-Handle<HwProgram> FEngine::createPostProcessProgram(MaterialParser& parser,
+driver::Handle<driver::HwProgram> FEngine::createPostProcessProgram(MaterialParser& parser,
         ShaderModel shaderModel, PostProcessStage stage) const noexcept {
     ShaderBuilder& vShaderBuilder = getVertexShaderBuilder();
     ShaderBuilder& fShaderBuilder = getFragmentShaderBuilder();
@@ -479,8 +479,8 @@ Handle<HwProgram> FEngine::createPostProcessProgram(MaterialParser& parser,
     return program;
 }
 
-Handle<HwProgram> FEngine::getPostProcessProgramSlow(PostProcessStage stage) const noexcept {
-    Handle<HwProgram>* const postProcessPrograms = mPostProcessPrograms;
+driver::Handle<driver::HwProgram> FEngine::getPostProcessProgramSlow(PostProcessStage stage) const noexcept {
+    driver::Handle<driver::HwProgram>* const postProcessPrograms = mPostProcessPrograms;
     if (!postProcessPrograms[(uint8_t)stage]) {
         ShaderModel shaderModel = getDriver().getShaderModel();
         postProcessPrograms[(uint8_t)stage] = createPostProcessProgram(*mPostProcessParser, shaderModel, stage);

--- a/filament/src/GPUBuffer.cpp
+++ b/filament/src/GPUBuffer.cpp
@@ -16,7 +16,6 @@
 
 #include "GPUBuffer.h"
 #include "private/backend/DriverApi.h"
-#include "private/backend/Driver.h"
 
 #include <math/half.h>
 

--- a/filament/src/GPUBuffer.h
+++ b/filament/src/GPUBuffer.h
@@ -76,7 +76,7 @@ public:
     void swap(GPUBuffer& rhs) noexcept;
 
 
-    void setSampler(size_t index, SamplerGroup& group) const noexcept {
+    void setSampler(size_t index, driver::SamplerGroup& group) const noexcept {
         group.setSampler(index, { getHandle(), getSamplerParams() });
     }
 
@@ -84,13 +84,13 @@ private:
     // this is really hidden implementation details (the fact we're using a texture should be
     // exposed as little as possible)
     friend class SamplerGroup;
-    Handle<HwTexture> getHandle() const noexcept { return mTexture; }
+    driver::Handle<driver::HwTexture> getHandle() const noexcept { return mTexture; }
     driver::SamplerParams getSamplerParams() const noexcept { return driver::SamplerParams{}; }
 
 private:
     void commitSlow(driver::DriverApi& driverApi, void const* begin, void const* end) noexcept;
 
-    Handle<HwTexture> mTexture;
+    driver::Handle<driver::HwTexture> mTexture;
     uint32_t mSize = 0;
     uint16_t mWidth;
     uint16_t mHeight;

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -160,8 +160,8 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     mIsVariantLit = mShading != Shading::UNLIT || mHasShadowMultiplier;
 
     // create raster state
-    using BlendFunction = Driver::RasterState::BlendFunction;
-    using DepthFunc = Driver::RasterState::DepthFunc;
+    using BlendFunction = RasterState::BlendFunction;
+    using DepthFunc = RasterState::DepthFunc;
     switch (mBlendingMode) {
         case BlendingMode::OPAQUE:
         case BlendingMode::MASKED:

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -279,7 +279,7 @@ bool FMaterial::hasParameter(const char* name) const noexcept {
     return true;
 }
 
-Handle<HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
+driver::Handle<driver::HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
     const ShaderModel sm = mEngine.getDriver().getShaderModel();
 
     assert(!Variant::isReserved(variantKey));

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -114,9 +114,9 @@ FrameGraphResource PostProcessManager::toneMapping(FrameGraph& fg, FrameGraphRes
             [=](FrameGraphPassResources const& resources,
                     PostProcessToneMapping const& data, DriverApi& driver) {
                 Driver::PipelineState pipeline;
-                pipeline.rasterState.culling = Driver::RasterState::CullingMode::NONE;
+                pipeline.rasterState.culling = RasterState::CullingMode::NONE;
                 pipeline.rasterState.colorWrite = true;
-                pipeline.rasterState.depthFunc = Driver::RasterState::DepthFunc::A;
+                pipeline.rasterState.depthFunc = RasterState::DepthFunc::A;
                 pipeline.program = toneMappingProgram;
 
                 auto const& textureDesc = resources.getDescriptor(data.input);
@@ -170,9 +170,9 @@ FrameGraphResource PostProcessManager::fxaa(FrameGraph& fg,
             [=](FrameGraphPassResources const& resources,
                     PostProcessFXAA const& data, DriverApi& driver) {
                 Driver::PipelineState pipeline;
-                pipeline.rasterState.culling = Driver::RasterState::CullingMode::NONE;
+                pipeline.rasterState.culling = RasterState::CullingMode::NONE;
                 pipeline.rasterState.colorWrite = true;
-                pipeline.rasterState.depthFunc = Driver::RasterState::DepthFunc::A;
+                pipeline.rasterState.depthFunc = RasterState::DepthFunc::A;
                 pipeline.program = antiAliasingProgram;
 
                 auto const& textureDesc = resources.getDescriptor(data.input);

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -113,7 +113,7 @@ FrameGraphResource PostProcessManager::toneMapping(FrameGraph& fg, FrameGraphRes
             },
             [=](FrameGraphPassResources const& resources,
                     PostProcessToneMapping const& data, DriverApi& driver) {
-                Driver::PipelineState pipeline;
+                PipelineState pipeline;
                 pipeline.rasterState.culling = RasterState::CullingMode::NONE;
                 pipeline.rasterState.colorWrite = true;
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::A;
@@ -169,7 +169,7 @@ FrameGraphResource PostProcessManager::fxaa(FrameGraph& fg,
             },
             [=](FrameGraphPassResources const& resources,
                     PostProcessFXAA const& data, DriverApi& driver) {
-                Driver::PipelineState pipeline;
+                PipelineState pipeline;
                 pipeline.rasterState.culling = RasterState::CullingMode::NONE;
                 pipeline.rasterState.colorWrite = true;
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::A;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -52,7 +52,7 @@ void PostProcessManager::terminate(driver::DriverApi& driver) noexcept {
 }
 
 void PostProcessManager::setSource(uint32_t viewportWidth, uint32_t viewportHeight,
-        Handle<HwTexture> texture, uint32_t textureWidth, uint32_t textureHeight) const noexcept {
+        driver::Handle<driver::HwTexture> texture, uint32_t textureWidth, uint32_t textureHeight) const noexcept {
     FEngine& engine = *mEngine;
     DriverApi& driver = engine.getDriverApi();
 
@@ -88,13 +88,13 @@ FrameGraphResource PostProcessManager::toneMapping(FrameGraph& fg, FrameGraphRes
         driver::TextureFormat outFormat, bool dithering, bool translucent) noexcept {
 
     FEngine* engine = mEngine;
-    Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine->getFullScreenRenderPrimitive();
+    driver::Handle<driver::HwRenderPrimitive> const& fullScreenRenderPrimitive = engine->getFullScreenRenderPrimitive();
 
     struct PostProcessToneMapping {
         FrameGraphResource input;
         FrameGraphResource output;
     };
-    Handle<HwProgram> toneMappingProgram = engine->getPostProcessProgram(
+    driver::Handle<driver::HwProgram> toneMappingProgram = engine->getPostProcessProgram(
             translucent ? PostProcessStage::TONE_MAPPING_TRANSLUCENT
                         : PostProcessStage::TONE_MAPPING_OPAQUE);
 
@@ -143,14 +143,14 @@ FrameGraphResource PostProcessManager::fxaa(FrameGraph& fg,
         FrameGraphResource input, driver::TextureFormat outFormat, bool translucent) noexcept {
 
     FEngine* engine = mEngine;
-    Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine->getFullScreenRenderPrimitive();
+    driver::Handle<driver::HwRenderPrimitive> const& fullScreenRenderPrimitive = engine->getFullScreenRenderPrimitive();
 
     struct PostProcessFXAA {
         FrameGraphResource input;
         FrameGraphResource output;
     };
 
-    Handle<HwProgram> antiAliasingProgram = engine->getPostProcessProgram(
+    driver::Handle<driver::HwProgram> antiAliasingProgram = engine->getPostProcessProgram(
             translucent ? PostProcessStage::ANTI_ALIASING_TRANSLUCENT
                         : PostProcessStage::ANTI_ALIASING_OPAQUE);
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -36,7 +36,7 @@ class PostProcessManager {
 public:
     void init(details::FEngine& engine) noexcept;
     void terminate(driver::DriverApi& driver) noexcept;
-    void setSource(uint32_t viewportWidth, uint32_t viewportHeight, Handle<HwTexture> texture,
+    void setSource(uint32_t viewportWidth, uint32_t viewportHeight, driver::Handle<driver::HwTexture> texture,
             uint32_t textureWidth, uint32_t textureHeight) const noexcept;
 
     FrameGraphResource toneMapping(FrameGraph& fg, FrameGraphResource input,
@@ -54,8 +54,8 @@ private:
 
     // we need only one of these
     mutable UniformBuffer mPostProcessUb;
-    Handle<HwSamplerGroup> mPostProcessSbh;
-    Handle<HwUniformBuffer> mPostProcessUbh;
+    driver::Handle<driver::HwSamplerGroup> mPostProcessSbh;
+    driver::Handle<driver::HwUniformBuffer> mPostProcessUbh;
 };
 
 } // namespace filament

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -98,7 +98,7 @@ void RenderPass::render(
     }
 
     // Take care not to upload data within the render pass (synchronize can commit froxel data)
-    driver::DriverApi& driver = engine.getDriverApi();
+    DriverApi& driver = engine.getDriverApi();
     beginRenderPass(driver, viewport, camera);
 
     // Now, execute all commands
@@ -120,8 +120,8 @@ void RenderPass::recordDriverCommands(
     SYSTRACE_CALL();
 
     if (!commands.empty()) {
-        driver::Driver::PipelineState pipeline;
-        driver::Handle<driver::HwUniformBuffer> uboHandle = scene.getRenderableUBO();
+        PipelineState pipeline;
+        Handle<HwUniformBuffer> uboHandle = scene.getRenderableUBO();
         FMaterialInstance const* UTILS_RESTRICT mi = nullptr;
         FMaterial const* UTILS_RESTRICT ma = nullptr;
         Command const* UTILS_RESTRICT c;
@@ -485,12 +485,12 @@ void RenderPass::updateSummedPrimitiveCounts(
 // ------------------------------------------------------------------------------------------------
 
 FRenderer::ColorPass::ColorPass(const char* name,
-        JobSystem& js, JobSystem::Job* jobFroxelize, FView& view, driver::Handle<driver::HwRenderTarget> const rth)
+        JobSystem& js, JobSystem::Job* jobFroxelize, FView& view, Handle<HwRenderTarget> const rth)
         : RenderPass(name), js(js), jobFroxelize(jobFroxelize), view(view), rth(rth) {
 }
 
 void FRenderer::ColorPass::beginRenderPass(
-        driver::DriverApi& driver, filament::Viewport const& viewport, const CameraInfo& camera) noexcept {
+        DriverApi& driver, filament::Viewport const& viewport, const CameraInfo& camera) noexcept {
     // wait for froxelization to finish
     // (this could even be a special command between the depth and color passes)
     js.waitAndRelease(jobFroxelize);
@@ -547,7 +547,7 @@ void FRenderer::ColorPass::endRenderPass(DriverApi& driver, filament::Viewport c
 
 void FRenderer::ColorPass::renderColorPass(FEngine& engine,
         JobSystem& js, JobSystem::Job* sync,
-        driver::Handle<driver::HwRenderTarget> const rth, FView& view, filament::Viewport const& scaledViewport,
+        Handle<HwRenderTarget> const rth, FView& view, filament::Viewport const& scaledViewport,
         GrowingSlice<Command>& commands) noexcept {
 
     CameraInfo const& cameraInfo = view.getCameraInfo();
@@ -599,7 +599,7 @@ FRenderer::ShadowPass::ShadowPass(const char* name,
         : RenderPass(name), shadowMap(shadowMap) {
 }
 
-void FRenderer::ShadowPass::beginRenderPass(driver::DriverApi& driver,
+void FRenderer::ShadowPass::beginRenderPass(DriverApi& driver,
         filament::Viewport const&, const CameraInfo&) noexcept {
     shadowMap.beginRenderPass(driver);
 }
@@ -625,7 +625,7 @@ void FRenderer::ShadowPass::renderShadowMap(FEngine& engine, JobSystem& js,
     // populate the RenderPrimitive array with the proper LOD
     view.updatePrimitivesLod(engine, cameraInfo, soa, vr);
 
-    driver::DriverApi& driver = engine.getDriverApi();
+    DriverApi& driver = engine.getDriverApi();
     view.prepareCamera(cameraInfo, viewport);
     view.commitUniforms(driver);
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -289,10 +289,10 @@ void RenderPass::generateCommandsImpl(uint32_t,
 
     Command cmdDepth;
     cmdDepth.primitive.materialVariant = Variant{ Variant::DEPTH_VARIANT };
-    cmdDepth.primitive.rasterState = Driver::RasterState();
+    cmdDepth.primitive.rasterState = {};
     cmdDepth.primitive.rasterState.colorWrite = false;
     cmdDepth.primitive.rasterState.depthWrite = true;
-    cmdDepth.primitive.rasterState.depthFunc = Driver::RasterState::DepthFunc::L;
+    cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::L;
     cmdDepth.primitive.rasterState.alphaToCoverage = false;
     cmdDepth.primitive.rasterState.inverseFrontFaces = inverseFrontFaces;
 
@@ -439,7 +439,7 @@ void RenderPass::generateCommandsImpl(uint32_t,
             }
 
             if (depthPass) {
-                Driver::RasterState rs = mi->getMaterial()->getRasterState();
+                RasterState rs = mi->getMaterial()->getRasterState();
 
                 // unconditionally write the command
                 cmdDepth.primitive.primitiveHandle = primitive.getHwHandle();

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -120,8 +120,8 @@ void RenderPass::recordDriverCommands(
     SYSTRACE_CALL();
 
     if (!commands.empty()) {
-        Driver::PipelineState pipeline;
-        Handle<HwUniformBuffer> uboHandle = scene.getRenderableUBO();
+        driver::Driver::PipelineState pipeline;
+        driver::Handle<driver::HwUniformBuffer> uboHandle = scene.getRenderableUBO();
         FMaterialInstance const* UTILS_RESTRICT mi = nullptr;
         FMaterial const* UTILS_RESTRICT ma = nullptr;
         Command const* UTILS_RESTRICT c;
@@ -485,7 +485,7 @@ void RenderPass::updateSummedPrimitiveCounts(
 // ------------------------------------------------------------------------------------------------
 
 FRenderer::ColorPass::ColorPass(const char* name,
-        JobSystem& js, JobSystem::Job* jobFroxelize, FView& view, Handle<HwRenderTarget> const rth)
+        JobSystem& js, JobSystem::Job* jobFroxelize, FView& view, driver::Handle<driver::HwRenderTarget> const rth)
         : RenderPass(name), js(js), jobFroxelize(jobFroxelize), view(view), rth(rth) {
 }
 
@@ -547,7 +547,7 @@ void FRenderer::ColorPass::endRenderPass(DriverApi& driver, filament::Viewport c
 
 void FRenderer::ColorPass::renderColorPass(FEngine& engine,
         JobSystem& js, JobSystem::Job* sync,
-        Handle<HwRenderTarget> const rth, FView& view, filament::Viewport const& scaledViewport,
+        driver::Handle<driver::HwRenderTarget> const rth, FView& view, filament::Viewport const& scaledViewport,
         GrowingSlice<Command>& commands) noexcept {
 
     CameraInfo const& cameraInfo = view.getCameraInfo();

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -176,7 +176,7 @@ public:
         FMaterialInstance const* mi = nullptr;                      // 8 bytes (4)
         driver::Handle<driver::HwRenderPrimitive> primitiveHandle;  // 4 bytes
         driver::Handle<driver::HwUniformBuffer> perRenderableBones; // 4 bytes
-        driver::Driver::RasterState rasterState;                    // 4 bytes
+        driver::RasterState rasterState;                            // 4 bytes
         uint16_t index = 0;                                         // 2 bytes
         Variant materialVariant;                                    // 1 byte
         uint8_t reserved = { };                                     // 1 byte

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -173,13 +173,13 @@ public:
     }
 
     struct PrimitiveInfo { // 24 bytes
-        FMaterialInstance const* mi = nullptr;              // 8 bytes (4)
-        Handle<HwRenderPrimitive> primitiveHandle;          // 4 bytes
-        Handle<HwUniformBuffer> perRenderableBones;         // 4 bytes
-        Driver::RasterState rasterState;                    // 4 bytes
-        uint16_t index = 0;                                 // 2 bytes
-        Variant materialVariant;                            // 1 byte
-        uint8_t reserved = { };                             // 1 byte
+        FMaterialInstance const* mi = nullptr;                      // 8 bytes (4)
+        driver::Handle<driver::HwRenderPrimitive> primitiveHandle;  // 4 bytes
+        driver::Handle<driver::HwUniformBuffer> perRenderableBones; // 4 bytes
+        driver::Driver::RasterState rasterState;                    // 4 bytes
+        uint16_t index = 0;                                         // 2 bytes
+        Variant materialVariant;                                    // 1 byte
+        uint8_t reserved = { };                                     // 1 byte
     };
 
     struct alignas(8) Command {     // 32 bytes

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -223,7 +223,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     //        so when skipping post-process (which draws directly into it), we can't rely on it.
     const bool colorPassNeedsDepthBuffer = hasPostProcess;
 
-    const Handle<HwRenderTarget> viewRenderTarget = getRenderTarget();
+    const driver::Handle<driver::HwRenderTarget> viewRenderTarget = getRenderTarget();
     FrameGraphResource output = fg.importResource("viewRenderTarget",
             { .viewport = vp }, viewRenderTarget, vp.width, vp.height);
 
@@ -320,7 +320,7 @@ void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, filament::Viewport const& 
     FEngine& engine = getEngine();
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    const Handle<HwRenderTarget> viewRenderTarget = getRenderTarget();
+    const driver::Handle<driver::HwRenderTarget> viewRenderTarget = getRenderTarget();
 
     // Set the current swap chain as the read surface, and the destination
     // swap chain as the draw surface so that blitting between default render

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -163,7 +163,7 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
     }
 }
 
-void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, Handle<HwUniformBuffer> renderableUbh) noexcept {
+void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, driver::Handle<driver::HwUniformBuffer> renderableUbh) noexcept {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     const size_t size = visibleRenderables.size() * sizeof(PerRenderableUib);
 
@@ -207,7 +207,7 @@ void FScene::terminate(FEngine& engine) {
     mRenderableViewUbh.clear();
 }
 
-void FScene::prepareDynamicLights(const CameraInfo& camera, ArenaScope& rootArena, Handle<HwUniformBuffer> lightUbh) noexcept {
+void FScene::prepareDynamicLights(const CameraInfo& camera, ArenaScope& rootArena, driver::Handle<driver::HwUniformBuffer> lightUbh) noexcept {
     FEngine::DriverApi& driver = mEngine.getDriverApi();
     FLightManager& lcm = mEngine.getLightManager();
     FScene::LightSoa& lightData = getLightData();

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -88,11 +88,11 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
     mViewport = { 1, 1, dim - 2, dim - 2 };
 
     mShadowMapHandle = driver.createTexture(
-            Driver::SamplerType::SAMPLER_2D, 1, Driver::TextureFormat::DEPTH16, 1, dim, dim, 1,
+            SamplerType::SAMPLER_2D, 1, TextureFormat::DEPTH16, 1, dim, dim, 1,
             TextureUsage::DEPTH_ATTACHMENT);
 
     mShadowMapRenderTarget = driver.createRenderTarget(
-            TargetBufferFlags::SHADOW, dim, dim, 1, Driver::TextureFormat::DEPTH16,
+            TargetBufferFlags::SHADOW, dim, dim, 1, TextureFormat::DEPTH16,
             {}, { mShadowMapHandle }, {});
 
     SamplerParams s;

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -175,7 +175,7 @@ void FTexture::setExternalStream(FEngine& engine, FStream* stream) noexcept {
         engine.getDriverApi().setExternalStream(mHandle, stream->getHandle());
     } else {
         mStream = nullptr;
-        engine.getDriverApi().setExternalStream(mHandle, Handle<HwStream>());
+        engine.getDriverApi().setExternalStream(mHandle, driver::Handle<driver::HwStream>());
     }
 }
 
@@ -215,11 +215,11 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
         uint8_t level = 0;
         uint32_t srcw = mWidth;
         uint32_t srch = mHeight;
-        Driver::RenderTargetHandle srcrth = driver.createRenderTarget(TargetBufferFlags::COLOR,
+        driver::Handle<driver::HwRenderTarget> srcrth = driver.createRenderTarget(TargetBufferFlags::COLOR,
                 srcw, srch, mSampleCount, mFormat, { mHandle, level++, layer }, {}, {});
 
         // Perform a blit for all miplevels down to 1x1.
-        Driver::RenderTargetHandle dstrth;
+        driver::Handle<driver::HwRenderTarget> dstrth;
         do {
             uint32_t dstw = std::max(srcw >> 1, 1u);
             uint32_t dsth = std::max(srch >> 1, 1u);

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -96,7 +96,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         entry.stride = byteStride;
         entry.type = attributeType;
         if (hasIntegerTarget(attribute)) {
-            entry.flags |= Driver::Attribute::FLAG_INTEGER_TARGET;
+            entry.flags |= Attribute::FLAG_INTEGER_TARGET;
         }
         mImpl->mDeclaredAttributes.set(attribute);
     }
@@ -108,9 +108,9 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
     if (size_t(attribute) < MAX_ATTRIBUTE_BUFFERS_COUNT) {
         FVertexBuffer::AttributeData& entry = mImpl->mAttributes[attribute];
         if (normalized) {
-            entry.flags |= Driver::Attribute::FLAG_NORMALIZED;
+            entry.flags |= Attribute::FLAG_NORMALIZED;
         } else {
-            entry.flags &= ~Driver::Attribute::FLAG_NORMALIZED;
+            entry.flags &= ~Attribute::FLAG_NORMALIZED;
         }
     }
     return *this;
@@ -139,13 +139,13 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
     mDeclaredAttributes = builder->mDeclaredAttributes;
     uint8_t attributeCount = (uint8_t) mDeclaredAttributes.count();
 
-    Driver::AttributeArray attributeArray;
+    AttributeArray attributeArray;
 
     static_assert(attributeArray.size() == MAX_ATTRIBUTE_BUFFERS_COUNT,
-            "Driver::Attribute and Builder::Attribute arrays must match");
+            "Attribute and Builder::Attribute arrays must match");
 
-    static_assert(sizeof(Driver::Attribute) == sizeof(AttributeData),
-            "Driver::Attribute and Builder::Attribute must match");
+    static_assert(sizeof(Attribute) == sizeof(AttributeData),
+            "Attribute and Builder::Attribute must match");
 
     auto const& declaredAttributes = mDeclaredAttributes;
     auto const& attributes = mAttributes;

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -33,6 +33,7 @@
 namespace filament {
 
 using namespace details;
+using namespace driver;
 using namespace filament::math;
 
 struct VertexBuffer::BuilderDetails {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -115,7 +115,7 @@ public:
     inline uint8_t getLayerMask(Instance instance) const noexcept;
     inline uint8_t getPriority(Instance instance) const noexcept;
 
-    inline Handle<HwUniformBuffer> getBonesUbh(Instance instance) const noexcept;
+    inline driver::Handle<driver::HwUniformBuffer> getBonesUbh(Instance instance) const noexcept;
 
 
     inline size_t getLevelCount(Instance instance) const noexcept { return 1; }
@@ -139,7 +139,7 @@ private:
             utils::Slice<FRenderPrimitive>& primitives) noexcept;
 
     struct Bones {
-        filament::Handle<HwUniformBuffer> handle;
+        filament::driver::Handle<driver::HwUniformBuffer> handle;
         UniformBuffer bones;
         size_t count;
     };
@@ -289,9 +289,9 @@ Box const& FRenderableManager::getAABB(Instance instance) const noexcept {
     return mManager[instance].aabb;
 }
 
-Handle<HwUniformBuffer> FRenderableManager::getBonesUbh(Instance instance) const noexcept {
+driver::Handle<driver::HwUniformBuffer> FRenderableManager::getBonesUbh(Instance instance) const noexcept {
     std::unique_ptr<Bones> const& bones = mManager[instance].bones;
-    return bones ? bones->handle : Handle<HwUniformBuffer>{};
+    return bones ? bones->handle : driver::Handle<driver::HwUniformBuffer>{};
 }
 
 utils::Slice<FRenderPrimitive> const& FRenderableManager::getRenderPrimitives(

--- a/filament/src/details/DFG.h
+++ b/filament/src/details/DFG.h
@@ -41,7 +41,7 @@ public:
         return mLUT != nullptr;
     }
 
-    Handle<HwTexture> getTexture() const noexcept {
+    driver::Handle<driver::HwTexture> getTexture() const noexcept {
         return mLUT->getHwHandle();
     }
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -60,9 +60,16 @@
 namespace filament {
 
 class Renderer;
+class MaterialParser;
+
+
+namespace driver {
+
 class Driver;
 class Program;
-class MaterialParser;
+
+} // namespac driver
+
 
 namespace details {
 
@@ -112,7 +119,7 @@ public:
 
     ~FEngine() noexcept;
 
-    Driver& getDriver() const noexcept { return *mDriver; }
+    driver::Driver& getDriver() const noexcept { return *mDriver; }
     DriverApi& getDriverApi() noexcept { return mCommandStream; }
     DFG* getDFG() const noexcept { return mDFG.get(); }
 
@@ -128,16 +135,16 @@ public:
     const FMaterial* getSkyboxMaterial(bool rgbm) const noexcept;
     const FIndirectLight* getDefaultIndirectLight() const noexcept { return mDefaultIbl; }
 
-    Handle <HwProgram> getPostProcessProgramSlow(PostProcessStage stage) const noexcept;
-    Handle<HwProgram> getPostProcessProgram(PostProcessStage stage) const noexcept {
-        Handle<HwProgram> program = mPostProcessPrograms[uint8_t(stage)];
+    driver::Handle<driver::HwProgram> getPostProcessProgramSlow(PostProcessStage stage) const noexcept;
+    driver::Handle<driver::HwProgram> getPostProcessProgram(PostProcessStage stage) const noexcept {
+        driver::Handle<driver::HwProgram> program = mPostProcessPrograms[uint8_t(stage)];
         if (UTILS_UNLIKELY(!program)) {
             return getPostProcessProgramSlow(stage);
         }
         return program;
     }
 
-    Handle<HwRenderPrimitive> getFullScreenRenderPrimitive() const noexcept {
+    driver::Handle<driver::HwRenderPrimitive> getFullScreenRenderPrimitive() const noexcept {
         return mFullScreenTriangleRph;
     }
 
@@ -264,7 +271,7 @@ private:
     void init();
 
     int loop();
-    void flushCommandBuffer(CommandBufferQueue& commandBufferQueue);
+    void flushCommandBuffer(driver::CommandBufferQueue& commandBufferQueue);
 
     template<typename T, typename L>
     void terminateAndDestroy(const T* p, ResourceList<T, L>& list);
@@ -272,16 +279,16 @@ private:
     template<typename T, typename L>
     void cleanupResourceList(ResourceList<T, L>& list);
 
-    Handle<HwProgram> createPostProcessProgram(MaterialParser& parser,
+    driver::Handle<driver::HwProgram> createPostProcessProgram(MaterialParser& parser,
             driver::ShaderModel model, PostProcessStage stage) const noexcept;
 
-    Driver* mDriver = nullptr;
+    driver::Driver* mDriver = nullptr;
 
     Backend mBackend;
     Platform* mPlatform = nullptr;
     void* mSharedGLContext = nullptr;
     bool mTerminated = false;
-    Handle<HwRenderPrimitive> mFullScreenTriangleRph;
+    driver::Handle<driver::HwRenderPrimitive> mFullScreenTriangleRph;
     FVertexBuffer* mFullScreenTriangleVb = nullptr;
     FIndexBuffer* mFullScreenTriangleIb = nullptr;
 
@@ -314,7 +321,7 @@ private:
     std::unique_ptr<DFG> mDFG;
 
     std::thread mDriverThread;
-    CommandBufferQueue mCommandBufferQueue;
+    driver::CommandBufferQueue mCommandBufferQueue;
     DriverApi mCommandStream;
 
     LinearAllocatorArena mPerRenderPassAllocator;
@@ -330,7 +337,7 @@ private:
     mutable FTexture* mDefaultIblTexture = nullptr;
     mutable FIndirectLight* mDefaultIbl = nullptr;
 
-    mutable Handle<HwProgram> mPostProcessPrograms[POST_PROCESS_STAGES_COUNT];
+    mutable driver::Handle<driver::HwProgram> mPostProcessPrograms[POST_PROCESS_STAGES_COUNT];
     mutable std::unique_ptr<MaterialParser> mPostProcessParser;
 
     mutable utils::CountDownLatch mDriverBarrier;

--- a/filament/src/details/Fence.h
+++ b/filament/src/details/Fence.h
@@ -63,7 +63,7 @@ private:
     };
 
     FEngine& mEngine;
-    Handle<HwFence> mFenceHandle;
+    driver::Handle<driver::HwFence> mFenceHandle;
     // TODO: use custom allocator for these small objects
     std::shared_ptr<FenceSignal> mFenceSignal;
 };

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -37,7 +37,7 @@ public:
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    Handle<HwIndexBuffer> getHwHandle() const noexcept { return mHandle; }
+    driver::Handle<driver::HwIndexBuffer> getHwHandle() const noexcept { return mHandle; }
 
     size_t getIndexCount() const noexcept { return mIndexCount; }
 
@@ -45,7 +45,7 @@ public:
 
 private:
     friend class IndexBuffer;
-    Handle<HwIndexBuffer> mHandle;
+    driver::Handle<driver::HwIndexBuffer> mHandle;
     uint32_t mIndexCount;
 };
 

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -40,8 +40,8 @@ public:
 
     void terminate(FEngine& engine);
 
-    Handle<HwTexture> getReflectionMap() const noexcept { return mReflectionsMapHandle; }
-    Handle<HwTexture> getIrradianceMap() const noexcept { return mIrradianceMapHandle; }
+    driver::Handle<driver::HwTexture> getReflectionMap() const noexcept { return mReflectionsMapHandle; }
+    driver::Handle<driver::HwTexture> getIrradianceMap() const noexcept { return mIrradianceMapHandle; }
     math::float3 const* getSH() const noexcept{ return mIrradianceCoefs.data(); }
     float getIntensity() const noexcept { return mIntensity; }
     void setIntensity(float intensity) noexcept { mIntensity = intensity; }
@@ -49,8 +49,8 @@ public:
     const math::mat3f& getRotation() const { return mRotation; }
 
 private:
-    Handle<HwTexture> mReflectionsMapHandle;
-    Handle<HwTexture> mIrradianceMapHandle;
+    driver::Handle<driver::HwTexture> mReflectionsMapHandle;
+    driver::Handle<driver::HwTexture> mIrradianceMapHandle;
     std::array<math::float3, 9> mIrradianceCoefs;
     float mIntensity = DEFAULT_INTENSITY;
     math::mat3f mRotation;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -86,7 +86,7 @@ public:
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 
     const utils::CString& getName() const noexcept { return mName; }
-    driver::Driver::RasterState getRasterState() const noexcept  { return mRasterState; }
+    driver::RasterState getRasterState() const noexcept  { return mRasterState; }
     uint32_t getId() const noexcept { return mMaterialId; }
 
     Shading getShading() const noexcept { return mShading; }
@@ -99,7 +99,7 @@ public:
     bool isColorWriteEnabled() const noexcept { return mRasterState.colorWrite; }
     bool isDepthWriteEnabled() const noexcept { return mRasterState.depthWrite; }
     bool isDepthCullingEnabled() const noexcept {
-        return mRasterState.depthFunc != driver::Driver::RasterState::DepthFunc::A;
+        return mRasterState.depthFunc != driver::RasterState::DepthFunc::A;
     }
     bool isDoubleSided() const noexcept { return mDoubleSided; }
     float getMaskThreshold() const noexcept { return mMaskThreshold; }
@@ -118,7 +118,7 @@ private:
     // try to order by frequency of use
     mutable std::array<driver::Handle<driver::HwProgram>, VARIANT_COUNT> mCachedPrograms;
 
-    driver::Driver::RasterState mRasterState;
+    driver::RasterState mRasterState;
     BlendingMode mRenderBlendingMode;
     TransparencyMode mTransparencyMode;
     bool mIsVariantLit;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -73,20 +73,20 @@ public:
 
     FEngine& getEngine() const noexcept  { return mEngine; }
 
-    Handle<HwProgram> getProgramSlow(uint8_t variantKey) const noexcept;
-    Handle<HwProgram> getProgram(uint8_t variantKey) const noexcept {
+    driver::Handle<driver::HwProgram> getProgramSlow(uint8_t variantKey) const noexcept;
+    driver::Handle<driver::HwProgram> getProgram(uint8_t variantKey) const noexcept {
 
         // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
         assert( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );
 
-        Handle<HwProgram> const entry = mCachedPrograms[variantKey];
+        driver::Handle<driver::HwProgram> const entry = mCachedPrograms[variantKey];
         return UTILS_LIKELY(entry) ? entry : getProgramSlow(variantKey);
     }
 
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 
     const utils::CString& getName() const noexcept { return mName; }
-    Driver::RasterState getRasterState() const noexcept  { return mRasterState; }
+    driver::Driver::RasterState getRasterState() const noexcept  { return mRasterState; }
     uint32_t getId() const noexcept { return mMaterialId; }
 
     Shading getShading() const noexcept { return mShading; }
@@ -99,7 +99,7 @@ public:
     bool isColorWriteEnabled() const noexcept { return mRasterState.colorWrite; }
     bool isDepthWriteEnabled() const noexcept { return mRasterState.depthWrite; }
     bool isDepthCullingEnabled() const noexcept {
-        return mRasterState.depthFunc != Driver::RasterState::DepthFunc::A;
+        return mRasterState.depthFunc != driver::Driver::RasterState::DepthFunc::A;
     }
     bool isDoubleSided() const noexcept { return mDoubleSided; }
     float getMaskThreshold() const noexcept { return mMaskThreshold; }
@@ -116,9 +116,9 @@ public:
 
 private:
     // try to order by frequency of use
-    mutable std::array<Handle<HwProgram>, VARIANT_COUNT> mCachedPrograms;
+    mutable std::array<driver::Handle<driver::HwProgram>, VARIANT_COUNT> mCachedPrograms;
 
-    Driver::RasterState mRasterState;
+    driver::Driver::RasterState mRasterState;
     BlendingMode mRenderBlendingMode;
     TransparencyMode mTransparencyMode;
     bool mIsVariantLit;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -94,7 +94,7 @@ public:
         mPolygonOffset = { scale, constant };
     }
 
-    driver::Driver::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
+    driver::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
 
 private:
     friend class FMaterial;
@@ -112,7 +112,7 @@ private:
 
     UniformBuffer mUniforms;
     driver::SamplerGroup mSamplers;
-    driver::Driver::PolygonOffset mPolygonOffset;
+    driver::PolygonOffset mPolygonOffset;
 
     uint64_t mMaterialSortingKey = 0;
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -74,7 +74,7 @@ public:
     uint64_t getSortingKey() const noexcept { return mMaterialSortingKey; }
 
     UniformBuffer const& getUniformBuffer() const noexcept { return mUniforms; }
-    SamplerGroup const& getSamplerGroup() const noexcept { return mSamplers; }
+    driver::SamplerGroup const& getSamplerGroup() const noexcept { return mSamplers; }
 
     void setScissor(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept {
         mScissorRect = { left, bottom,
@@ -94,7 +94,7 @@ public:
         mPolygonOffset = { scale, constant };
     }
 
-    Driver::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
+    driver::Driver::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
 
 private:
     friend class FMaterial;
@@ -107,12 +107,12 @@ private:
 
     // keep these grouped, they're accessed together in the render-loop
     FMaterial const* mMaterial = nullptr;
-    Handle<HwUniformBuffer> mUbHandle;
-    Handle<HwSamplerGroup> mSbHandle;
+    driver::Handle<driver::HwUniformBuffer> mUbHandle;
+    driver::Handle<driver::HwSamplerGroup> mSbHandle;
 
     UniformBuffer mUniforms;
-    SamplerGroup mSamplers;
-    Driver::PolygonOffset mPolygonOffset;
+    driver::SamplerGroup mSamplers;
+    driver::Driver::PolygonOffset mPolygonOffset;
 
     uint64_t mMaterialSortingKey = 0;
 

--- a/filament/src/details/RenderPrimitive.h
+++ b/filament/src/details/RenderPrimitive.h
@@ -50,7 +50,7 @@ public:
     void terminate(FEngine& engine);
 
     const FMaterialInstance* getMaterialInstance() const noexcept { return mMaterialInstance; }
-    Handle<HwRenderPrimitive> getHwHandle() const noexcept { return mHandle; }
+    driver::Handle<driver::HwRenderPrimitive> getHwHandle() const noexcept { return mHandle; }
     driver::PrimitiveType getPrimitiveType() const noexcept { return mPrimitiveType; }
     AttributeBitset getEnabledAttributes() const noexcept { return mEnabledAttributes; }
     uint16_t getBlendOrder() const noexcept { return mBlendOrder; }
@@ -62,7 +62,7 @@ public:
 
 private:
     FMaterialInstance const* mMaterialInstance = nullptr;
-    Handle<HwRenderPrimitive> mHandle;
+    driver::Handle<driver::HwRenderPrimitive> mHandle;
     driver::PrimitiveType mPrimitiveType = driver::PrimitiveType::NONE;
     AttributeBitset mEnabledAttributes;
     uint16_t mBlendOrder = 0;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -39,7 +39,10 @@
 
 namespace filament {
 
+namespace driver {
 class Driver;
+} // namespace driver
+
 class View;
 
 namespace details {
@@ -90,15 +93,15 @@ private:
         utils::JobSystem& js;
         utils::JobSystem::Job* jobFroxelize = nullptr;
         FView const& view;
-        Handle<HwRenderTarget> const rth;
+        driver::Handle<driver::HwRenderTarget> const rth;
         void beginRenderPass(driver::DriverApi& driver, Viewport const& viewport, const CameraInfo& camera) noexcept override;
         void endRenderPass(DriverApi& driver, Viewport const& viewport) noexcept override;
     public:
         ColorPass(const char* name, utils::JobSystem& js, utils::JobSystem::Job* jobFroxelize,
-                FView& view, Handle<HwRenderTarget> rth);
+                FView& view, driver::Handle<driver::HwRenderTarget> rth);
         static void renderColorPass(FEngine& engine,
                 utils::JobSystem& js, utils::JobSystem::Job* sync,
-                Handle<HwRenderTarget> rth,
+                driver::Handle<driver::HwRenderTarget> rth,
                 FView& view, Viewport const& scaledViewport,
                 utils::GrowingSlice<Command>& commands) noexcept;
     };
@@ -115,7 +118,7 @@ private:
                 FView& view, utils::GrowingSlice<Command>& commands) noexcept;
     };
 
-    Handle<HwRenderTarget> getRenderTarget() const noexcept { return mRenderTarget; }
+    driver::Handle<driver::HwRenderTarget> getRenderTarget() const noexcept { return mRenderTarget; }
 
     void recordHighWatermark(utils::Slice<Command> const& commands) noexcept {
 #ifndef NDEBUG
@@ -142,7 +145,7 @@ private:
     // keep a reference to our engine
     FEngine& mEngine;
     FrameSkipper mFrameSkipper;
-    Handle<HwRenderTarget> mRenderTarget;
+    driver::Handle<driver::HwRenderTarget> mRenderTarget;
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -83,11 +83,11 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(const math::mat4f& worldOriginTransform);
-    void prepareDynamicLights(const CameraInfo& camera, ArenaScope& arena, Handle<HwUniformBuffer> lightUbh) noexcept;
+    void prepareDynamicLights(const CameraInfo& camera, ArenaScope& arena, driver::Handle<driver::HwUniformBuffer> lightUbh) noexcept;
     void computeBounds(Aabb& castersBox, Aabb& receiversBox, uint32_t visibleLayers) const noexcept;
 
 
-    filament::Handle<HwUniformBuffer> getRenderableUBO() const noexcept {
+    filament::driver::Handle<driver::HwUniformBuffer> getRenderableUBO() const noexcept {
         return mRenderableViewUbh;
     }
 
@@ -116,7 +116,7 @@ public:
             utils::EntityInstance<RenderableManager>,
             math::mat4f,
             FRenderableManager::Visibility,
-            Handle<HwUniformBuffer>,
+            driver::Handle<driver::HwUniformBuffer>,
             math::float3,
             Culler::result_type,
             uint8_t,
@@ -163,7 +163,7 @@ public:
     LightSoa const& getLightData() const noexcept { return mLightData; }
     LightSoa& getLightData() noexcept { return mLightData; }
 
-    void updateUBOs(utils::Range<uint32_t> visibleRenderables, Handle<HwUniformBuffer> renderableUbh) noexcept;
+    void updateUBOs(utils::Range<uint32_t> visibleRenderables, driver::Handle<driver::HwUniformBuffer> renderableUbh) noexcept;
 
 private:
     static inline void computeLightRanges(math::float2* zrange,
@@ -192,7 +192,7 @@ private:
      */
     RenderableSoa mRenderableData;
     LightSoa mLightData;
-    Handle<HwUniformBuffer> mRenderableViewUbh; // This is actually owned by the view.
+    driver::Handle<driver::HwUniformBuffer> mRenderableViewUbh; // This is actually owned by the view.
 };
 
 FILAMENT_UPCAST(Scene)

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -50,7 +50,7 @@ public:
     bool hasVisibleShadows() const noexcept { return mHasVisibleShadows; }
 
     // Allocates shadow texture based on user parameters (e.g. dimensions)
-    void prepare(driver::DriverApi& driver, SamplerGroup& buffer) noexcept;
+    void prepare(driver::DriverApi& driver, driver::SamplerGroup& buffer) noexcept;
 
     // Returns the shadow map's viewport. Valid after prepare().
     Viewport const& getViewport() const noexcept { return mViewport; }
@@ -175,8 +175,8 @@ private:
 
     // set-up in prepare()
     Viewport mViewport;
-    Handle<HwTexture> mShadowMapHandle;
-    Handle<HwRenderTarget> mShadowMapRenderTarget;
+    driver::Handle<driver::HwTexture> mShadowMapHandle;
+    driver::Handle<driver::HwRenderTarget> mShadowMapRenderTarget;
 
     // set-up in update()
     uint32_t mShadowMapDimension = 0;

--- a/filament/src/details/Stream.h
+++ b/filament/src/details/Stream.h
@@ -38,7 +38,7 @@ public:
     FStream(FEngine& engine, const Builder& builder) noexcept;
     void terminate(FEngine& engine) noexcept;
 
-    Handle<HwStream> getHandle() const noexcept { return mStreamHandle; }
+    driver::Handle<driver::HwStream> getHandle() const noexcept { return mStreamHandle; }
 
     void setDimensions(uint32_t width, uint32_t height) noexcept;
 
@@ -57,7 +57,7 @@ public:
 
 private:
     FEngine& mEngine;
-    Handle<HwStream> mStreamHandle;
+    driver::Handle<driver::HwStream> mStreamHandle;
     void* mNativeStream = nullptr;
     intptr_t mExternalTextureId;
     uint32_t mWidth;

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -55,12 +55,12 @@ public:
         return (mConfigFlags & CONFIG_READABLE) != 0;
     }
 
-    Handle<HwSwapChain> getHwHandle() const noexcept {
+    driver::Handle<driver::HwSwapChain> getHwHandle() const noexcept {
       return mSwapChain;
     }
 
 private:
-    Handle<HwSwapChain> mSwapChain;
+    driver::Handle<driver::HwSwapChain> mSwapChain;
     void* mNativeWindow = nullptr;
     uint64_t mConfigFlags = 0;
 };

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -42,7 +42,7 @@ public:
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    Handle<HwTexture> getHwHandle() const noexcept { return mHandle; }
+    driver::Handle<driver::HwTexture> getHwHandle() const noexcept { return mHandle; }
 
     size_t getWidth(size_t level = 0) const noexcept;
     size_t getHeight(size_t level = 0) const noexcept;
@@ -76,7 +76,7 @@ public:
 
 private:
     friend class Texture;
-    Handle<HwTexture> mHandle;
+    driver::Handle<driver::HwTexture> mHandle;
     uint32_t mWidth = 1;
     uint32_t mHeight = 1;
     uint32_t mDepth = 1;

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -19,7 +19,6 @@
 
 #include "upcast.h"
 
-#include "private/backend/Driver.h"
 #include "private/backend/Handle.h"
 
 #include <private/filament/EngineEnums.h>
@@ -58,8 +57,8 @@ public:
 private:
     friend class VertexBuffer;
 
-    struct AttributeData : driver::Driver::Attribute {
-        AttributeData() : driver::Driver::Attribute{ .type = driver::ElementType::FLOAT4 } {}
+    struct AttributeData : driver::Attribute {
+        AttributeData() : driver::Attribute{ .type = driver::ElementType::FLOAT4 } {}
     };
 
     driver::Handle<driver::HwVertexBuffer> mHandle;

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -43,7 +43,7 @@ public:
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    Handle<HwVertexBuffer> getHwHandle() const noexcept { return mHandle; }
+    driver::Handle<driver::HwVertexBuffer> getHwHandle() const noexcept { return mHandle; }
 
     size_t getVertexCount() const noexcept;
 
@@ -58,11 +58,11 @@ public:
 private:
     friend class VertexBuffer;
 
-    struct AttributeData : Driver::Attribute {
-        AttributeData() : Driver::Attribute{ .type = Driver::ElementType::FLOAT4 } {}
+    struct AttributeData : driver::Driver::Attribute {
+        AttributeData() : driver::Driver::Attribute{ .type = driver::ElementType::FLOAT4 } {}
     };
 
-    Handle<HwVertexBuffer> mHandle;
+    driver::Handle<driver::HwVertexBuffer> mHandle;
     std::array<AttributeData, MAX_ATTRIBUTE_BUFFERS_COUNT> mAttributes;
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -266,14 +266,14 @@ private:
             FScene::RenderableSoa::iterator begin, FScene::RenderableSoa::iterator end, uint8_t mask) noexcept;
 
     // these are accessed in the render loop, keep together
-    Handle<HwSamplerGroup> mPerViewSbh;
-    Handle<HwUniformBuffer> mPerViewUbh;
-    Handle<HwUniformBuffer> mLightUbh;
-    Handle<HwUniformBuffer> mRenderableUbh;
+    driver::Handle<driver::HwSamplerGroup> mPerViewSbh;
+    driver::Handle<driver::HwUniformBuffer> mPerViewUbh;
+    driver::Handle<driver::HwUniformBuffer> mLightUbh;
+    driver::Handle<driver::HwUniformBuffer> mRenderableUbh;
 
-    Handle<HwSamplerGroup> getUsh() const noexcept { return mPerViewSbh; }
-    Handle<HwUniformBuffer> getUbh() const noexcept { return mPerViewUbh; }
-    Handle<HwUniformBuffer> getLightUbh() const noexcept { return mLightUbh; }
+    driver::Handle<driver::HwSamplerGroup> getUsh() const noexcept { return mPerViewSbh; }
+    driver::Handle<driver::HwUniformBuffer> getUbh() const noexcept { return mPerViewUbh; }
+    driver::Handle<driver::HwUniformBuffer> getLightUbh() const noexcept { return mLightUbh; }
 
     FScene* mScene = nullptr;
     FCamera* mCullingCamera = nullptr;
@@ -313,7 +313,7 @@ private:
     RenderQuality mRenderQuality;
 
     mutable UniformBuffer mPerViewUb;
-    mutable SamplerGroup mPerViewSb;
+    mutable driver::SamplerGroup mPerViewSb;
 
     utils::CString mName;
 

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -18,7 +18,6 @@
 
 #include "FrameGraphPassResources.h"
 
-#include "private/backend/Driver.h"
 #include "private/backend/Handle.h"
 #include "private/backend/CommandStream.h"
 
@@ -89,7 +88,7 @@ struct Resource final : public VirtualResource { // 72
     uint32_t refs = 0;                      // final reference count
 
     // set during execute(), as needed
-    Handle<HwTexture> texture;
+    driver::Handle<driver::HwTexture> texture;
 };
 
 struct ResourceNode { // 24
@@ -153,7 +152,7 @@ struct RenderTargetResource final : public VirtualResource {  // 104
 
                 // devirtualize our texture handles. By this point these handles have been
                 // remapped to their alias if any.
-                Handle<HwTexture> textures[FrameGraphRenderTarget::Attachments::COUNT];
+                driver::Handle<driver::HwTexture> textures[FrameGraphRenderTarget::Attachments::COUNT];
                 for (size_t i = 0, c = desc.attachments.textures.size(); i < c; i++) {
                     FrameGraphResource r = desc.attachments.textures[i];
                     if (r.isValid()) {
@@ -224,7 +223,7 @@ struct RenderTarget { // 32
             uint32_t width = 0;
             uint32_t height = 0;
             TextureFormat colorFormat = {};
-            Handle<HwTexture> textures[FrameGraphRenderTarget::Attachments::COUNT];
+            driver::Handle<driver::HwTexture> textures[FrameGraphRenderTarget::Attachments::COUNT];
 
             static constexpr TargetBufferFlags flags[] = {
                     TargetBufferFlags::COLOR,
@@ -562,7 +561,7 @@ FrameGraphPassResources::FrameGraphPassResources(FrameGraph& fg, fg::PassNode co
         : mFrameGraph(fg), mPass(pass) {
 }
 
-Handle <HwTexture> FrameGraphPassResources::getTexture(FrameGraphResource r) const noexcept {
+driver::Handle<driver::HwTexture> FrameGraphPassResources::getTexture(FrameGraphResource r) const noexcept {
     Resource const* const pResource = mFrameGraph.mResourceNodes[r.index].resource;
     assert(pResource);
 
@@ -752,7 +751,7 @@ bool FrameGraph::equals(FrameGraphRenderTarget::Descriptor const& lhs,
 
 FrameGraphResource FrameGraph::importResource(const char* name,
         FrameGraphRenderTarget::Descriptor descriptor,
-        Handle<HwRenderTarget> target, uint32_t width, uint32_t height,
+        driver::Handle<driver::HwRenderTarget> target, uint32_t width, uint32_t height,
         TargetBufferFlags discardStart, TargetBufferFlags discardEnd) {
 
     // TODO: for now we don't allow imported targets to specify textures
@@ -783,7 +782,7 @@ FrameGraphResource FrameGraph::importResource(const char* name,
 
 FrameGraphResource FrameGraph::importResource(
         const char* name, FrameGraphResource::Descriptor const& descriptor,
-        Handle<HwTexture> color) {
+        driver::Handle<driver::HwTexture> color) {
     Resource* resource = createResource(name, descriptor, true);
     resource->texture = color;
     return createResourceNode(resource);

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -157,14 +157,14 @@ public:
     // Import a write-only render target from outside the framegraph and returns a handle to it.
     FrameGraphResource importResource(const char* name,
             FrameGraphRenderTarget::Descriptor descriptor,
-            Handle<HwRenderTarget> target, uint32_t width, uint32_t height,
+            driver::Handle<driver::HwRenderTarget> target, uint32_t width, uint32_t height,
             driver::TargetBufferFlags discardStart = driver::TargetBufferFlags::NONE,
             driver::TargetBufferFlags discardEnd = driver::TargetBufferFlags::NONE);
 
     // Import a read-only render target from outside the framegraph and returns a handle to it.
     FrameGraphResource importResource(
             const char* name, FrameGraphResource::Descriptor const& descriptor,
-            Handle<HwTexture> color);
+            driver::Handle<driver::HwTexture> color);
 
 
     // Moves the resource associated to the handle 'from' to the handle 'to'. After this call,

--- a/filament/src/fg/FrameGraphPassResources.h
+++ b/filament/src/fg/FrameGraphPassResources.h
@@ -35,11 +35,11 @@ class FrameGraphPassResources {
 public:
 
     struct RenderTargetInfo {
-        Handle<HwRenderTarget> target;
+        driver::Handle<driver::HwRenderTarget> target;
         driver::RenderPassParams params;
     };
 
-    Handle <HwTexture> getTexture(FrameGraphResource r) const noexcept;
+    driver::Handle<driver::HwTexture> getTexture(FrameGraphResource r) const noexcept;
 
     RenderTargetInfo getRenderTarget(FrameGraphResource r) const noexcept;
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -49,7 +49,7 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
         "Dynamically sized sampler buffer must be the last binding point.");
 
 constexpr uint32_t ATTRIBUTE_INDEX_COUNT = 7;
-constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8; // FIXME: should match Driver::MAX_ATTRIBUTE_BUFFER_COUNT
+constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8; // FIXME: should match driver::MAX_ATTRIBUTE_BUFFER_COUNT
 constexpr size_t MAX_SAMPLER_COUNT = 16; // Matches the Adreno Vulkan driver.
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.


### PR DESCRIPTION
- get rid of type aliases in Driver:: we use the driver:: version instead.

- Only use the Handle<> aliases in DriverAPI.inc -- they exist only
  because of the macro hackery we have to do.

- move all public-ish types of libbackend into the 'driver' namespace
  (later to be renamed to 'backend')