### PR TITLE
Add an extra clean task to Android samples.

### DIFF
--- a/android/samples/hello-triangle/app/build.gradle
+++ b/android/samples/hello-triangle/app/build.gradle
@@ -14,6 +14,10 @@ compileMaterials {
 
 preBuild.dependsOn compileMaterials
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/android/samples/image-based-lighting/app/build.gradle
+++ b/android/samples/image-based-lighting/app/build.gradle
@@ -32,6 +32,10 @@ preBuild.dependsOn compileMaterials
 preBuild.dependsOn compileMesh
 preBuild.dependsOn generateIbl
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/android/samples/lit-cube/app/build.gradle
+++ b/android/samples/lit-cube/app/build.gradle
@@ -14,6 +14,10 @@ compileMaterials {
 
 preBuild.dependsOn compileMaterials
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/android/samples/texture-view/app/build.gradle
+++ b/android/samples/texture-view/app/build.gradle
@@ -14,6 +14,10 @@ compileMaterials {
 
 preBuild.dependsOn compileMaterials
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/android/samples/textured-object/app/build.gradle
+++ b/android/samples/textured-object/app/build.gradle
@@ -32,6 +32,10 @@ preBuild.dependsOn compileMaterials
 preBuild.dependsOn compileMesh
 preBuild.dependsOn generateIbl
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {

--- a/android/samples/transparent-view/app/build.gradle
+++ b/android/samples/transparent-view/app/build.gradle
@@ -14,6 +14,10 @@ compileMaterials {
 
 preBuild.dependsOn compileMaterials
 
+clean.doFirst {
+    delete "src/main/assets"
+}
+
 android {
     compileSdkVersion 28
     defaultConfig {


### PR DESCRIPTION
It is easy to run into our new material version error if a stale
filamat file is sitting around, this helps with that.