### PR TITLE
(affects OpenGL) Move beginFrame calls to fix fence lifetime.

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -368,9 +368,6 @@ bool FRenderer::beginFrame(FSwapChain* swapChain) {
     assert(swapChain);
 
     mFrameId++;
-    if (UTILS_HAS_THREADING) {
-        mFrameInfoManager.beginFrame(mFrameId);
-    }
 
     { // scope for frame id trace
         char buf[64];
@@ -389,6 +386,12 @@ bool FRenderer::beginFrame(FSwapChain* swapChain) {
 
     int64_t monotonic_clock_ns (std::chrono::steady_clock::now().time_since_epoch().count());
     driver.beginFrame(monotonic_clock_ns, mFrameId);
+
+    // This need to occur after the backend beginFrame() because some backends need to start
+    // a command buffer before creating a fence.
+    if (UTILS_HAS_THREADING) {
+        mFrameInfoManager.beginFrame(mFrameId);
+    }
 
     if (!mFrameSkipper.beginFrame()) {
         mFrameInfoManager.cancelFrame();


### PR DESCRIPTION
There are a couple reasons for this change. First of all, creating a
Vulkan fence outside of beginFrame / endFrame is not ideal because
the backend does not know yet which command buffer will be chosen
during swap chain acquisition.

Secondly, the Renderer currently calls endFrame in this order:

    frameInfoManager.endFrame
    mFrameSkipper.endFrame
    driver.endFrame

However the beginFrame calls were ordered like this:

    frameInfoManager.beginFrame
    driver.beginFrame
    mFrameSkipper.beginFrame

This change makes it such that the beginFrame calls have the reverse
ordering of the endFrame calls, which is less surprising.

I did a poor man's sanity check by running textured-object on a Pixel 2,
(which enables dynamic resolution) and hacking PostProcessManager to
make it visually obvious if anything were amiss.