### PR TITLE
 API BREAK: Make all subclasses of Platform private 

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -10,8 +10,8 @@ set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 # ==================================================================================================
 set(PUBLIC_HDRS
         include/backend/BufferDescriptor.h
-        include/backend/PixelBufferDescriptor.h
         include/backend/PipelineState.h
+        include/backend/PixelBufferDescriptor.h
         include/backend/Platform.h
         include/backend/TargetBufferInfo.h
 )
@@ -24,11 +24,6 @@ set(SRCS
         src/Handle.cpp
         src/noop/NoopDriver.cpp
         src/noop/PlatformNoop.cpp
-        src/opengl/gl_headers.cpp
-        src/opengl/GLUtils.cpp
-        src/opengl/OpenGLBlitter.cpp
-        src/opengl/OpenGLDriver.cpp
-        src/opengl/OpenGLProgram.cpp
         src/Platform.cpp
         src/Program.cpp
         src/SamplerGroup.cpp
@@ -53,29 +48,42 @@ set(PRIVATE_HDRS
 )
 
 # ==================================================================================================
-# OS specific
+# OpenGL / OpenGL ES Sources
 # ==================================================================================================
 
-# Here set the architecture specific sources
-if (USE_EXTERNAL_GLES3)
-    # Experimental feature; clients provide their own Context Manager.
-elseif (ANDROID)
-    list(APPEND SRCS src/android/ExternalStreamManagerAndroid.cpp)
-    list(APPEND SRCS src/android/ExternalTextureManagerAndroid.cpp)
-    list(APPEND SRCS src/android/VirtualMachineEnv.cpp)
-    list(APPEND SRCS src/opengl/PlatformEGL.cpp)
-elseif (IOS)
-    list(APPEND SRCS src/opengl/PlatformCocoaTouchGL.mm)
-elseif (APPLE)
-    list(APPEND SRCS src/opengl/PlatformCocoaGL.mm)
-elseif (WEBGL)
-    list(APPEND SRCS src/opengl/PlatformWebGL.cpp)
-elseif (LINUX)
-    list(APPEND SRCS src/opengl/PlatformGLX.cpp)
-elseif (WIN32)
-    list(APPEND SRCS src/opengl/PlatformWGL.cpp)
-else()
-    list(APPEND SRCS src/opengl/PlatformDummyGL.cpp)
+if (NOT USE_EXTERNAL_GLES3)
+    list(APPEND SRCS
+            src/opengl/gl_headers.cpp
+            src/opengl/gl_headers.h
+            src/opengl/GLUtils.cpp
+            src/opengl/GLUtils.h
+            src/opengl/OpenGLBlitter.cpp
+            src/opengl/OpenGLBlitter.h
+            src/opengl/OpenGLDriver.cpp
+            src/opengl/OpenGLDriver.h
+            src/opengl/OpenGLProgram.cpp
+            src/opengl/OpenGLProgram.h
+            src/opengl/OpenGLPlatform.cpp
+            src/opengl/OpenGLPlatform.h
+    )
+    if (ANDROID)
+        list(APPEND SRCS src/android/ExternalStreamManagerAndroid.cpp)
+        list(APPEND SRCS src/android/ExternalTextureManagerAndroid.cpp)
+        list(APPEND SRCS src/android/VirtualMachineEnv.cpp)
+        list(APPEND SRCS src/opengl/PlatformEGL.cpp)
+    elseif (IOS)
+        list(APPEND SRCS src/opengl/PlatformCocoaTouchGL.mm)
+    elseif (APPLE)
+        list(APPEND SRCS src/opengl/PlatformCocoaGL.mm)
+    elseif (WEBGL)
+        list(APPEND SRCS src/opengl/PlatformWebGL.cpp)
+    elseif (LINUX)
+        list(APPEND SRCS src/opengl/PlatformGLX.cpp)
+    elseif (WIN32)
+        list(APPEND SRCS src/opengl/PlatformWGL.cpp)
+    else()
+        list(APPEND SRCS src/opengl/PlatformDummyGL.cpp)
+    endif()
 endif()
 
 # ==================================================================================================
@@ -113,6 +121,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanFboCache.h
             src/vulkan/VulkanHandles.cpp
             src/vulkan/VulkanHandles.h
+            src/vulkan/VulkanPlatform.cpp
+            src/vulkan/VulkanPlatform.h
             src/vulkan/VulkanSamplerCache.cpp
             src/vulkan/VulkanSamplerCache.h
             src/vulkan/VulkanStagePool.cpp

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -30,9 +30,9 @@ namespace driver {
 class Program {
 public:
 
-    static constexpr size_t NUM_SHADER_TYPES = 2;
-    static constexpr size_t NUM_UNIFORM_BINDINGS = 6; //BindingPoints::COUNT;
-    static constexpr size_t NUM_SAMPLER_BINDINGS = 6; //BindingPoints::COUNT;
+    static constexpr size_t SHADER_TYPE_COUNT = 2;
+    static constexpr size_t UNIFORM_BINDING_COUNT = 6; //BindingPoints::COUNT;
+    static constexpr size_t SAMPLER_BINDING_COUNT = 6; //BindingPoints::COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,
@@ -44,8 +44,8 @@ public:
         size_t binding = 0;         // binding point of the sampler in the shader
     };
 
-    using SamplerGroupInfo = std::array<std::vector<Sampler>, NUM_SAMPLER_BINDINGS>;
-    using UniformBlockInfo = std::array<utils::CString, NUM_UNIFORM_BINDINGS>;
+    using SamplerGroupInfo = std::array<std::vector<Sampler>, SAMPLER_BINDING_COUNT>;
+    using UniformBlockInfo = std::array<utils::CString, UNIFORM_BINDING_COUNT>;
 
     Program() noexcept;
     Program(const Program& rhs) = delete;
@@ -83,7 +83,7 @@ public:
         return shader(Shader::FRAGMENT, data, size);
     }
 
-    std::array<std::vector<uint8_t>, NUM_SHADER_TYPES> const& getShadersSource() const noexcept {
+    std::array<std::vector<uint8_t>, SHADER_TYPE_COUNT> const& getShadersSource() const noexcept {
         return mShadersSource;
     }
 
@@ -105,7 +105,7 @@ private:
     // FIXME: none of these fields should be public as this is a public API
     UniformBlockInfo mUniformBlocks = {};
     SamplerGroupInfo mSamplerGroups = {};
-    std::array<std::vector<uint8_t>, NUM_SHADER_TYPES> mShadersSource;
+    std::array<std::vector<uint8_t>, SHADER_TYPE_COUNT> mShadersSource;
     utils::CString mName;
     bool mHasSamplers = false;
     uint8_t mVariant;

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -17,8 +17,6 @@
 #ifndef TNT_FILAMENT_DRIVER_PROGRAM_H
 #define TNT_FILAMENT_DRIVER_PROGRAM_H
 
-#include <private/filament/EngineEnums.h>
-
 #include <utils/compiler.h>
 #include <utils/CString.h>
 #include <utils/Log.h>
@@ -33,16 +31,12 @@ class Program {
 public:
 
     static constexpr size_t NUM_SHADER_TYPES = 2;
-    static constexpr size_t NUM_UNIFORM_BINDINGS = BindingPoints::COUNT;
-    static constexpr size_t NUM_SAMPLER_BINDINGS = BindingPoints::COUNT;
+    static constexpr size_t NUM_UNIFORM_BINDINGS = 6; //BindingPoints::COUNT;
+    static constexpr size_t NUM_SAMPLER_BINDINGS = 6; //BindingPoints::COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,
         FRAGMENT = 1
-    };
-
-    struct UniformBlock {
-        utils::CString name = {};   // name of the uniform block in the shader
     };
 
     struct Sampler {

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -91,7 +91,7 @@ private:
     friend utils::io::ostream& operator<<(utils::io::ostream& out, const SamplerGroup& rhs);
 #endif
 
-    std::array<Sampler, 16> mBuffer;    // 128 bytes
+    std::array<Sampler, driver::MAX_SAMPLER_COUNT> mBuffer;    // 128 bytes
     mutable utils::bitset32 mDirty;
     uint8_t mSize = 0;
 };

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -71,16 +71,10 @@ namespace driver {
 // this generates the vtable in this translation unit
 Platform::~Platform() noexcept = default;
 
-OpenGLPlatform::~OpenGLPlatform() noexcept = default;
-
-VulkanPlatform::~VulkanPlatform() noexcept = default;
-
-MetalPlatform::~MetalPlatform() noexcept = default;
-
 // Creates the platform-specific Platform object. The caller takes ownership and is
 // responsible for destroying it. Initialization of the backend API is deferred until
 // createDriver(). The passed-in backend hint is replaced with the resolved backend.
-Platform* Platform::create(Backend* backend) noexcept {
+DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
     assert(backend);
     if (*backend == Backend::DEFAULT) {
         *backend = Backend::OPENGL;
@@ -135,10 +129,12 @@ Platform* Platform::create(Backend* backend) noexcept {
 }
 
 // destroys an Platform create by create()
-void Platform::destroy(Platform** context) noexcept {
-    delete *context;
-    *context = nullptr;
+void DefaultPlatform::destroy(DefaultPlatform** platform) noexcept {
+    delete *platform;
+    *platform = nullptr;
 }
+
+DefaultPlatform::~DefaultPlatform() noexcept = default;
 
 } // namespace driver
 } // namespace filament

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -59,7 +59,7 @@ struct MetalContext {
     PipelineStateCache pipelineStateCache;
     SamplerStateCache samplerStateCache;
 
-    MetalSamplerGroup* samplerBindings[NUM_SAMPLER_BINDINGS] = {};
+    MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
 
     // Surface-related properties.
     MetalSwapChain* currentSurface = nullptr;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -29,6 +29,9 @@
 
 namespace filament {
 namespace driver {
+
+class MetalPlatform;
+
 namespace metal {
 
 struct MetalContext;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -695,8 +695,8 @@ void MetalDriver::draw(driver::PipelineState ps, Handle<HwRenderPrimitive> rph) 
     // Enumerate all the sampler buffers for the program and check which textures and samplers need
     // to be bound.
 
-    id<MTLTexture> texturesToBind[NUM_SAMPLER_BINDINGS] = {};
-    id<MTLSamplerState> samplersToBind[NUM_SAMPLER_BINDINGS] = {};
+    id<MTLTexture> texturesToBind[SAMPLER_BINDING_COUNT] = {};
+    id<MTLSamplerState> samplersToBind[SAMPLER_BINDING_COUNT] = {};
 
     enumerateSamplerGroups(program, [this, &texturesToBind, &samplersToBind](
             const SamplerGroup::Sampler* sampler,
@@ -712,7 +712,7 @@ void MetalDriver::draw(driver::PipelineState ps, Handle<HwRenderPrimitive> rph) 
     // to both the vertex and fragment stages.
 
     NSRange range {
-        .length = NUM_SAMPLER_BINDINGS,
+        .length = SAMPLER_BINDING_COUNT,
         .location = 0
     };
     [mContext->currentCommandEncoder setFragmentTextures:texturesToBind
@@ -742,7 +742,7 @@ void MetalDriver::draw(driver::PipelineState ps, Handle<HwRenderPrimitive> rph) 
 void MetalDriver::enumerateSamplerGroups(
         const MetalProgram* program,
         const std::function<void(const SamplerGroup::Sampler*, size_t)>& f) {
-    for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < NUM_SAMPLER_GROUPS; samplerGroupIdx++) {
+    for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < SAMPLER_GROUP_COUNT; samplerGroupIdx++) {
         const auto& samplerGroup = program->samplerGroupInfo[samplerGroupIdx];
         if (samplerGroup.empty()) {
             continue;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -194,11 +194,11 @@ MetalProgram::MetalProgram(id<MTLDevice> device, const Program& program) noexcep
 
     using MetalFunctionPtr = id<MTLFunction>*;
 
-    static_assert(Program::NUM_SHADER_TYPES == 2, "Only vertex and fragment shaders expected.");
+    static_assert(Program::SHADER_TYPE_COUNT == 2, "Only vertex and fragment shaders expected.");
     MetalFunctionPtr shaderFunctions[2] = { &vertexFunction, &fragmentFunction };
 
     const auto& sources = program.getShadersSource();
-    for (size_t i = 0; i < Program::NUM_SHADER_TYPES; i++) {
+    for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         const auto& source = sources[i];
         // It's okay for some shaders to be empty, they shouldn't be used in any draw calls.
         if (source.empty()) {

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -20,8 +20,9 @@
 #include <Metal/Metal.h>
 
 #include "private/backend/Driver.h"
+#include "private/backend/Program.h"
 
-#include <private/filament/EngineEnums.h>
+#include <filament/backend/DriverEnums.h>
 
 #include <memory>
 #include <tsl/robin_map.h>
@@ -36,10 +37,10 @@ inline bool operator==(const driver::SamplerParams& lhs, const driver::SamplerPa
 
 namespace metal {
 
-static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = filament::ATTRIBUTE_INDEX_COUNT;
-static constexpr uint32_t NUM_SAMPLER_GROUPS = BindingPoints::COUNT;
-static constexpr uint32_t NUM_SAMPLER_BINDINGS = filament::MAX_SAMPLER_COUNT;
-static constexpr uint32_t VERTEX_BUFFER_START = BindingPoints::COUNT;
+static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
+static constexpr uint32_t NUM_SAMPLER_GROUPS = Program::NUM_UNIFORM_BINDINGS;
+static constexpr uint32_t NUM_SAMPLER_BINDINGS = driver::MAX_SAMPLER_COUNT;
+static constexpr uint32_t VERTEX_BUFFER_START = Program::NUM_UNIFORM_BINDINGS;
 
 // Forward declarations necessary here, definitions at end of file.
 inline bool operator==(const MTLViewport& lhs, const MTLViewport& rhs);

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -37,10 +37,10 @@ inline bool operator==(const driver::SamplerParams& lhs, const driver::SamplerPa
 
 namespace metal {
 
-static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
-static constexpr uint32_t NUM_SAMPLER_GROUPS = Program::NUM_UNIFORM_BINDINGS;
-static constexpr uint32_t NUM_SAMPLER_BINDINGS = driver::MAX_SAMPLER_COUNT;
-static constexpr uint32_t VERTEX_BUFFER_START = Program::NUM_UNIFORM_BINDINGS;
+static constexpr uint32_t MAX_VERTEX_ATTRIBUTE_COUNT = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
+static constexpr uint32_t SAMPLER_GROUP_COUNT = Program::UNIFORM_BINDING_COUNT;
+static constexpr uint32_t SAMPLER_BINDING_COUNT = driver::MAX_SAMPLER_COUNT;
+static constexpr uint32_t VERTEX_BUFFER_START = Program::UNIFORM_BINDING_COUNT;
 
 // Forward declarations necessary here, definitions at end of file.
 inline bool operator==(const MTLViewport& lhs, const MTLViewport& rhs);
@@ -59,19 +59,19 @@ struct VertexDescription {
     struct Layout {
         uint32_t stride;
     };
-    Attribute attributes[MAX_VERTEX_ATTRIBUTES] = {};
-    Layout layouts[MAX_VERTEX_ATTRIBUTES] = {};
+    Attribute attributes[MAX_VERTEX_ATTRIBUTE_COUNT] = {};
+    Layout layouts[MAX_VERTEX_ATTRIBUTE_COUNT] = {};
 
     bool operator==(const VertexDescription& rhs) const noexcept {
         bool result = true;
-        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTE_COUNT; i++) {
             result &= (
                     this->attributes[i].format == rhs.attributes[i].format &&
                     this->attributes[i].buffer == rhs.attributes[i].buffer &&
                     this->attributes[i].offset == rhs.attributes[i].offset
             );
         }
-        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+        for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTE_COUNT; i++) {
             result &= this->layouts[i].stride == rhs.layouts[i].stride;
         }
         return result;

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -39,7 +39,7 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
 
     const auto& vertexDescription = state.vertexDescription;
 
-    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTE_COUNT; i++) {
         if (vertexDescription.attributes[i].format > MTLVertexFormatInvalid) {
             const auto& attribute = vertexDescription.attributes[i];
             vertex.attributes[i].format = attribute.format;
@@ -48,7 +48,7 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
         }
     }
 
-    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
+    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTE_COUNT; i++) {
         if (vertexDescription.layouts[i].stride > 0) {
             const auto& layout = vertexDescription.layouts[i];
             vertex.layouts[VERTEX_BUFFER_START + i].stride = layout.stride;

--- a/filament/backend/src/metal/PlatformMetal.h
+++ b/filament/backend/src/metal/PlatformMetal.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H
-#define TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H
+#ifndef TNT_FILAMENT_DRIVER_PLATFORM_METAL_H
+#define TNT_FILAMENT_DRIVER_PLATFORM_METAL_H
 
 #include <stdint.h>
 
@@ -23,13 +23,22 @@
 #include <backend/Platform.h>
 
 namespace filament {
+namespace driver {
+
+class MetalPlatform : public DefaultPlatform {
+public:
+    ~MetalPlatform() override;
+};
+
+} // namespace driver
 
 class PlatformMetal final : public driver::MetalPlatform {
 public:
     driver::Driver* createDriver(void* sharedContext) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
+    ~PlatformMetal() override;
 };
 
 } // namespace filament
 
-#endif // TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_METAL_H
+#endif // TNT_FILAMENT_DRIVER_PLATFORM_METAL_H

--- a/filament/backend/src/metal/PlatformMetal.mm
+++ b/filament/backend/src/metal/PlatformMetal.mm
@@ -19,10 +19,18 @@
 
 namespace filament {
 
+namespace driver {
+MetalPlatform::~MetalPlatform() = default;
+} // namespace driver
+
+
 using namespace driver;
 
 Driver* PlatformMetal::createDriver(void* sharedContext) noexcept {
     return metal::MetalDriver::create(this);
 }
+
+PlatformMetal::~PlatformMetal() = default;
+
 
 } // namespace filament

--- a/filament/backend/src/opengl/GLUtils.cpp
+++ b/filament/backend/src/opengl/GLUtils.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/GLUtils.h"
+#include "GLUtils.h"
 
 #include <ostream>
 

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -22,7 +22,7 @@
 
 #include <filament/backend/DriverEnums.h>
 
-#include "opengl/gl_headers.h"
+#include "gl_headers.h"
 
 namespace filament {
 namespace GLUtils {

--- a/filament/backend/src/opengl/OpenGLBlitter.cpp
+++ b/filament/backend/src/opengl/OpenGLBlitter.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/OpenGLBlitter.h"
+#include "OpenGLBlitter.h"
 
 #include <assert.h>
 
@@ -23,8 +23,8 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
-#include "opengl/OpenGLDriver.h"
-#include "opengl/GLUtils.h"
+#include "OpenGLDriver.h"
+#include "GLUtils.h"
 
 using namespace filament::math;
 using namespace utils;

--- a/filament/backend/src/opengl/OpenGLBlitter.h
+++ b/filament/backend/src/opengl/OpenGLBlitter.h
@@ -18,7 +18,7 @@
 #define TNT_FILAMENT_DRIVER_OPENGLBLITTER_H
 
 #include <utils/compiler.h>
-#include "opengl/gl_headers.h"
+#include "gl_headers.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 #include <set>
 
@@ -25,10 +25,10 @@
 
 #include "private/backend/DriverApi.h"
 #include "CommandStreamDispatcher.h"
-#include "opengl/OpenGLProgram.h"
-#include "opengl/OpenGLBlitter.h"
+#include "OpenGLBlitter.h"
+#include "OpenGLPlatform.h"
+#include "OpenGLProgram.h"
 
-#include <backend/Platform.h>
 
 // change to true to display all GL extensions in the console on start-up
 #define DEBUG_PRINT_EXTENSIONS false

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -385,7 +385,7 @@ void OpenGLDriver::unbindTexture(GLenum target, GLuint texture_id) noexcept {
     // no need unbind the texture from FBOs because we're not tracking that state (and there is
     // no need to).
     const size_t index = getIndexForTextureTarget(target);
-    for (GLuint unit = 0; unit < MAX_TEXTURE_UNITS; unit++) {
+    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
         if (state.textures.units[unit].targets[index].texture_id == texture_id) {
             bindTexture(unit, target, (GLuint)0, index);
         }
@@ -395,7 +395,7 @@ void OpenGLDriver::unbindTexture(GLenum target, GLuint texture_id) noexcept {
 void OpenGLDriver::unbindSampler(GLuint sampler) noexcept {
     // unbind this sampler from all the units it might be bound to
     #pragma nounroll    // clang generates >800B of code!!!
-    for (GLuint unit = 0; unit < MAX_TEXTURE_UNITS; unit++) {
+    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
         if (state.textures.units[unit].sampler == sampler) {
             bindSampler(unit, 0);
         }
@@ -945,8 +945,8 @@ UTILS_NOINLINE
 void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
         uint32_t width, uint32_t height, uint32_t depth) noexcept {
 
-    bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t, t->gl.targetIndex);
-    activeTexture(MAX_TEXTURE_UNITS - 1);
+    bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t->gl.target, t, t->gl.targetIndex);
+    activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
 
     switch (t->gl.target) {
         case GL_TEXTURE_2D:
@@ -1859,8 +1859,8 @@ void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     assert(t->gl.target != GL_TEXTURE_2D_MULTISAMPLE);
     // Note: glGenerateMimap can also fail if the internal format is not both
     // color-renderable and filterable (i.e.: doesn't work for depth)
-    bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t, t->gl.targetIndex);
-    activeTexture(MAX_TEXTURE_UNITS - 1);
+    bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t->gl.target, t, t->gl.targetIndex);
+    activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
 
     t->gl.baseLevel = 0;
     t->gl.maxLevel = static_cast<uint8_t>(t->levels - 1);
@@ -1909,8 +1909,8 @@ void OpenGLDriver::setTextureData(GLTexture* t,
             // fallthrough...
         case SamplerType::SAMPLER_2D:
             // NOTE: GL_TEXTURE_2D_MULTISAMPLE is not allowed
-            bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t);
-            activeTexture(MAX_TEXTURE_UNITS - 1);
+            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t->gl.target, t);
+            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
             switch (t->gl.target) {
                 case GL_TEXTURE_2D:
                     glTexSubImage2D(t->gl.target, GLint(level),
@@ -1929,8 +1929,8 @@ void OpenGLDriver::setTextureData(GLTexture* t,
             break;
         case SamplerType::SAMPLER_CUBEMAP: {
             assert(t->gl.target == GL_TEXTURE_CUBE_MAP);
-            bindTexture(MAX_TEXTURE_UNITS - 1, GL_TEXTURE_CUBE_MAP, t);
-            activeTexture(MAX_TEXTURE_UNITS - 1);
+            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, GL_TEXTURE_CUBE_MAP, t);
+            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
 #pragma nounroll
             for (size_t face = 0; face < 6; face++) {
@@ -1990,8 +1990,8 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
             // fallthrough...
         case SamplerType::SAMPLER_2D:
             // NOTE: GL_TEXTURE_2D_MULTISAMPLE is not allowed
-            bindTexture(MAX_TEXTURE_UNITS - 1, t->gl.target, t);
-            activeTexture(MAX_TEXTURE_UNITS - 1);
+            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t->gl.target, t);
+            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
             switch (t->gl.target) {
                 case GL_TEXTURE_2D:
                     glCompressedTexSubImage2D(t->gl.target, GLint(level),
@@ -2011,8 +2011,8 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
         case SamplerType::SAMPLER_CUBEMAP: {
             assert(faceOffsets);
             assert(t->gl.target == GL_TEXTURE_CUBE_MAP);
-            bindTexture(MAX_TEXTURE_UNITS - 1, GL_TEXTURE_CUBE_MAP, t);
-            activeTexture(MAX_TEXTURE_UNITS - 1);
+            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, GL_TEXTURE_CUBE_MAP, t);
+            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
 #pragma nounroll
             for (size_t face = 0; face < 6; face++) {
@@ -2051,8 +2051,8 @@ void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
         assert(t->target == SamplerType::SAMPLER_EXTERNAL);
         assert(t->gl.target == GL_TEXTURE_EXTERNAL_OES);
 
-        bindTexture(MAX_TEXTURE_UNITS - 1, GL_TEXTURE_EXTERNAL_OES, t);
-        activeTexture(MAX_TEXTURE_UNITS - 1);
+        bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, GL_TEXTURE_EXTERNAL_OES, t);
+        activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
 
 #ifdef GL_OES_EGL_image
         glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, static_cast<GLeglImageOES>(image));
@@ -2617,7 +2617,7 @@ void OpenGLDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
 
     GLSamplerGroup* sb = handle_cast<GLSamplerGroup *>(sbh);
-    assert(index < Program::NUM_SAMPLER_BINDINGS);
+    assert(index < Program::SAMPLER_BINDING_COUNT);
     mSamplerBindings[index] = sb;
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -2903,8 +2903,8 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
             int8_t targetLevel = d->gl.colorLevel;
             if (targetLevel < baseLevel || targetLevel > maxLevel) {
                 GLenum target = dtexture->gl.target;
-                bindTexture(MAX_TEXTURE_UNITS - 1, target, dtexture, dtexture->gl.targetIndex);
-                activeTexture(MAX_TEXTURE_UNITS - 1);
+                bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, target, dtexture, dtexture->gl.targetIndex);
+                activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
                 if (targetLevel < baseLevel) {
                     dtexture->gl.baseLevel = targetLevel;
                     glTexParameteri(target, GL_TEXTURE_BASE_LEVEL, targetLevel);

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -377,14 +377,14 @@ private:
         return pos->second;
     }
 
-    const std::array<driver::HwSamplerGroup*, driver::Program::NUM_SAMPLER_BINDINGS>& getSamplerBindings() const {
+    const std::array<driver::HwSamplerGroup*, driver::Program::SAMPLER_BINDING_COUNT>& getSamplerBindings() const {
         return mSamplerBindings;
     }
 
     GLsizei getAttachments(std::array<GLenum, 3>& attachments,
             GLRenderTarget const* rt, uint8_t buffers) const noexcept;
 
-    static constexpr const size_t MAX_TEXTURE_UNITS = 16;   // All mobile GPUs as of 2016
+    static constexpr const size_t MAX_TEXTURE_UNIT_COUNT = 16;   // All mobile GPUs as of 2016
     static constexpr const size_t MAX_BUFFER_BINDINGS = 32;
 
     GLRenderPrimitive mDefaultVAO;
@@ -454,7 +454,7 @@ private:
                 struct {
                     GLuint texture_id = 0;
                 } targets[5];
-            } units[MAX_TEXTURE_UNITS];
+            } units[MAX_TEXTURE_UNIT_COUNT];
         } textures;
 
         struct {
@@ -513,7 +513,7 @@ private:
             bool clearStencil, uint32_t stencil) noexcept;
 
     // sampler buffer binding points (nullptr if not used)
-    std::array<driver::HwSamplerGroup*, driver::Program::NUM_SAMPLER_BINDINGS> mSamplerBindings;   // 8 pointers
+    std::array<driver::HwSamplerGroup*, driver::Program::SAMPLER_BINDING_COUNT> mSamplerBindings;   // 8 pointers
 
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
     mutable std::vector<GLTexture*> mExternalStreams;
@@ -634,7 +634,7 @@ constexpr size_t OpenGLDriver::getIndexForBufferTarget(GLenum target) noexcept {
 }
 
 void OpenGLDriver::activeTexture(GLuint unit) noexcept {
-    assert(unit < MAX_TEXTURE_UNITS);
+    assert(unit < MAX_TEXTURE_UNIT_COUNT);
     update_state(state.textures.active, unit, [&]() {
         glActiveTexture(GL_TEXTURE0 + unit);
     });
@@ -654,7 +654,7 @@ void UTILS_UNUSED OpenGLDriver::bindTexture(GLuint unit, GLuint target, GLuint t
 }
 
 void OpenGLDriver::bindSampler(GLuint unit, GLuint sampler) noexcept {
-    assert(unit < MAX_TEXTURE_UNITS);
+    assert(unit < MAX_TEXTURE_UNIT_COUNT);
     update_state(state.textures.units[unit].sampler, sampler, [&]() {
         glBindSampler(unit, sampler);
     });

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -19,7 +19,7 @@
 
 #include "private/backend/Driver.h"
 #include "DriverBase.h"
-#include "opengl/GLUtils.h"
+#include "GLUtils.h"
 
 #include <utils/compiler.h>
 #include <utils/Allocator.h>
@@ -36,6 +36,7 @@
 namespace filament {
 
 namespace driver {
+class OpenGLPlatform;
 class PixelBufferDescriptor;
 class TargetBufferInfo;
 } // namespace driver

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-#include "PlatformDummyGL.h"
-
-#include "OpenGLDriver.h"
+#include "OpenGLPlatform.h"
 
 namespace filament {
+namespace driver {
 
-Driver* PlatformDummyGL::createDriver(void* const sharedGLContext) noexcept {
-    return nullptr;
-}
+OpenGLPlatform::~OpenGLPlatform() noexcept = default;
 
+} // namespace driver
 } // namespace filament
-
-// ---------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLPlatform.h
+++ b/filament/backend/src/opengl/OpenGLPlatform.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_OPENGL_PLATFORM_H
+#define TNT_FILAMENT_DRIVER_OPENGL_PLATFORM_H
+
+#include <backend/Platform.h>
+
+namespace filament {
+namespace driver {
+
+class Driver;
+
+class OpenGLPlatform : public DefaultPlatform {
+public:
+    ~OpenGLPlatform() noexcept override;
+
+    // Called to destroy the OpenGL context. This should clean up any windows
+    // or buffers from initialization.
+    virtual void terminate() noexcept = 0;
+
+    virtual SwapChain* createSwapChain(void* nativeWindow, uint64_t& flags) noexcept = 0;
+    virtual void destroySwapChain(SwapChain* swapChain) noexcept = 0;
+
+    virtual void createDefaultRenderTarget(uint32_t& framebuffer, uint32_t& colorbuffer,
+            uint32_t& depthbuffer) noexcept {
+        framebuffer = 0;
+        colorbuffer = 0;
+        depthbuffer = 0;
+    }
+
+    // Called to make the OpenGL context active on the calling thread.
+    virtual void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept = 0;
+
+    // Called once the current frame finishes drawing. Typically this should
+    // swap draw buffers (i.e. for double-buffered rendering).
+    virtual void commit(SwapChain* swapChain) noexcept = 0;
+
+    virtual void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept = 0;
+
+    virtual bool canCreateFence() noexcept { return false; }
+    virtual Fence* createFence() noexcept = 0;
+    virtual void destroyFence(Fence* fence) noexcept = 0;
+    virtual driver::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept = 0;
+
+    // this is called synchronously in the application thread (NOT the Driver thread)
+    virtual Stream* createStream(void* nativeStream) noexcept = 0;
+
+    virtual void destroyStream(Stream* stream) noexcept = 0;
+
+    // attach takes ownership of the texture (tname) object
+    virtual void attach(Stream* stream, intptr_t tname) noexcept = 0;
+
+    // detach destroys the texture associated to the stream
+    virtual void detach(Stream* stream) noexcept = 0;
+    virtual void updateTexImage(Stream* stream, int64_t* timestamp) noexcept = 0;
+
+    // external texture storage
+    virtual ExternalTexture* createExternalTextureStorage() noexcept = 0;
+
+    // this is called synchronously in the application thread (NOT the Driver thread)
+    virtual void reallocateExternalStorage(ExternalTexture* ets,
+            uint32_t w, uint32_t h, TextureFormat format) noexcept = 0;
+
+    virtual void destroyExternalTextureStorage(ExternalTexture* ets) noexcept = 0;
+};
+
+} // namespace driver
+} // namespace filament
+
+#endif // TNT_FILAMENT_DRIVER_OPENGL_PLATFORM_H

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "opengl/OpenGLProgram.h"
+#include "OpenGLProgram.h"
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 #include <utils/Log.h>
 #include <utils/compiler.h>

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -39,7 +39,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
 
     // build all shaders
     #pragma nounroll
-    for (size_t i = 0; i < Program::NUM_SHADER_TYPES; i++) {
+    for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         GLenum glShaderType;
         Shader type = (Shader)i;
         switch (type) {
@@ -76,7 +76,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
     if (UTILS_LIKELY((mValidShaderSet & mask) == mask)) {
         GLint status;
         GLuint program = glCreateProgram();
-        for (size_t i = 0; i < Program::NUM_SHADER_TYPES; i++) {
+        for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
             if (validShaderSet & (1U << i)) {
                 glAttachShader(program, this->gl.shaders[i]);
             }
@@ -164,7 +164,7 @@ OpenGLProgram::~OpenGLProgram() noexcept {
     GLuint program = gl.program;
     if (validShaderSet) {
         #pragma nounroll
-        for (size_t i = 0; i < Program::NUM_SHADER_TYPES; i++) {
+        for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
             if (validShaderSet & (1U << i)) {
                 const GLuint shader = gl.shaders[i];
                 if (isValid) {

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -61,14 +61,14 @@ public:
     }
 
     struct {
-        GLuint shaders[driver::Program::NUM_SHADER_TYPES];
+        GLuint shaders[driver::Program::SHADER_TYPE_COUNT];
         GLuint program;
     } gl; // 12 bytes
 
     static void logCompilationError(utils::io::ostream& out, GLuint shaderId, char const* source) noexcept;
 
 private:
-    static constexpr uint8_t NUM_TEXTURE_UNITS = OpenGLDriver::MAX_TEXTURE_UNITS;
+    static constexpr uint8_t TEXTURE_UNIT_COUNT = OpenGLDriver::MAX_TEXTURE_UNIT_COUNT;
     static constexpr uint8_t VERTEX_SHADER_BIT   = uint8_t(1) << size_t(driver::Program::Shader::VERTEX);
     static constexpr uint8_t FRAGMENT_SHADER_BIT = uint8_t(1) << size_t(driver::Program::Shader::FRAGMENT);
 
@@ -77,11 +77,11 @@ private:
         uint8_t unused  : 1;    // padding / available
         uint8_t count   : 4;    // number of TMUs actually used minus 1
 
-        // if NUM_TEXTURE_UNITS > 16, the count bitfield must be increased accordingly
-        static_assert(NUM_TEXTURE_UNITS <= 16, "NUM_TEXTURE_UNITS must be <= 16");
+        // if TEXTURE_UNIT_COUNT > 16, the count bitfield must be increased accordingly
+        static_assert(TEXTURE_UNIT_COUNT <= 16, "TEXTURE_UNIT_COUNT must be <= 16");
 
-        // if NUM_SAMPLER_BINDINGS > 8, the binding bitfield must be increased accordingly
-        static_assert(driver::Program::NUM_SAMPLER_BINDINGS <= 8, "NUM_SAMPLER_BINDINGS must be <= 8");
+        // if SAMPLER_BINDING_COUNT > 8, the binding bitfield must be increased accordingly
+        static_assert(driver::Program::SAMPLER_BINDING_COUNT <= 8, "SAMPLER_BINDING_COUNT must be <= 8");
     };
 
     uint8_t mUsedBindingsCount = 0;
@@ -89,10 +89,10 @@ private:
     bool mIsValid = false;
 
     // information about each USED sampler buffer (no gaps)
-    std::array<BlockInfo, driver::Program::NUM_SAMPLER_BINDINGS> mBlockInfos;   // 8 bytes
+    std::array<BlockInfo, driver::Program::SAMPLER_BINDING_COUNT> mBlockInfos;   // 8 bytes
 
     // runs of indices into SamplerGroup -- run start index and size given by BlockInfo
-    std::array<uint8_t, NUM_TEXTURE_UNITS> mIndicesRuns;    // 16 bytes
+    std::array<uint8_t, TEXTURE_UNIT_COUNT> mIndicesRuns;    // 16 bytes
 
     void updateSamplers(OpenGLDriver* gl) noexcept;
 };

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -25,11 +25,12 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
-#include "opengl/gl_headers.h"
-#include "private/backend/Driver.h"
 #include "DriverBase.h"
+#include "gl_headers.h"
+#include "OpenGLDriver.h"
+
+#include "private/backend/Driver.h"
 #include "private/backend/Program.h"
-#include "opengl/OpenGLDriver.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -20,7 +20,8 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -17,7 +17,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-#include "opengl/PlatformCocoaGL.h"
+#include "PlatformCocoaGL.h"
 
 #include <OpenGL/OpenGL.h>
 #include <Cocoa/Cocoa.h>
@@ -28,7 +28,7 @@
 
 #include <utils/Panic.h>
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -20,7 +20,8 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/PlatformCocoaTouchGL.h"
+#include "PlatformCocoaTouchGL.h"
 
 #include <OpenGLES/EAGL.h>
 #include <OpenGLES/ES3/gl.h>
@@ -28,7 +28,7 @@
 
 #include <utils/Panic.h>
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/PlatformDummyGL.h
@@ -20,7 +20,8 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/PlatformEGL.h"
+#include "PlatformEGL.h"
 
 #include <jni.h>
 
@@ -33,7 +33,7 @@
 #include "android/ExternalStreamManagerAndroid.h"
 #include "android/VirtualMachineEnv.h"
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 #include <android/api-level.h>
 #include <sys/system_properties.h>

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -23,7 +23,8 @@
 #include <EGL/eglext.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 struct AHardwareBuffer;
 

--- a/filament/backend/src/opengl/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/PlatformGLX.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "opengl/PlatformGLX.h"
+#include "PlatformGLX.h"
 
 #include <utils/Log.h>
 #include <utils/Panic.h>
@@ -23,7 +23,7 @@
 #include <GL/glx.h>
 #include <GL/glxext.h>
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 #include <dlfcn.h>
 

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -23,7 +23,8 @@
 #include <GL/glx.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/PlatformWGL.cpp
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#include "opengl/PlatformWGL.h"
+#include "PlatformWGL.h"
 
 #include <Wingdi.h>
 
-#include "opengl/OpenGLDriver.h"
+#include "OpenGLDriver.h"
 
 #include "Windows.h"
 #include <GL/gl.h>

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -23,7 +23,8 @@
 #include <utils/unwindows.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/PlatformWebGL.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "opengl/PlatformWebGL.h"
-#include "opengl/OpenGLDriver.h"
+#include "PlatformWebGL.h"
+#include "OpenGLDriver.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -20,7 +20,8 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+
+#include "OpenGLPlatform.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -80,7 +80,7 @@
 #define GL_TEXTURE_EXTERNAL_OES           0x8D65
 #endif
 
-#include "opengl/NullGLES.h"
+#include "NullGLES.h"
 
 #if (!defined(GL_ES_VERSION_3_1) && !defined(GL_VERSION_4_1))
 #error "Minimum header version must be OpenGL ES 3.1 or OpenGL 4.1"

--- a/filament/backend/src/vulkan/PlatformVkAndroid.h
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+#include "VulkanPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+#include "VulkanPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/vulkan/PlatformVkLinux.h
+++ b/filament/backend/src/vulkan/PlatformVkLinux.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+#include "VulkanPlatform.h"
 
 #include <X11/Xlib.h>
 

--- a/filament/backend/src/vulkan/PlatformVkWindows.h
+++ b/filament/backend/src/vulkan/PlatformVkWindows.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #include <filament/backend/DriverEnums.h>
-#include <backend/Platform.h>
+#include "VulkanPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -17,7 +17,9 @@
 #ifndef TNT_FILAMENT_DRIVER_VULKANBINDER_H
 #define TNT_FILAMENT_DRIVER_VULKANBINDER_H
 
-#include <private/filament/EngineEnums.h>
+#include <filament/backend/DriverEnums.h>
+
+#include <private/backend/Program.h>
 
 #include <bluevk/BlueVK.h>
 #include <utils/Hash.h>
@@ -69,10 +71,10 @@ namespace driver {
 //
 class VulkanBinder {
 public:
-    static constexpr uint32_t NUM_UBUFFER_BINDINGS = filament::BindingPoints::COUNT;
-    static constexpr uint32_t NUM_SAMPLER_BINDINGS = filament::MAX_SAMPLER_COUNT;
+    static constexpr uint32_t NUM_UBUFFER_BINDINGS = Program::NUM_UNIFORM_BINDINGS;
+    static constexpr uint32_t NUM_SAMPLER_BINDINGS = driver::MAX_SAMPLER_COUNT;
     static constexpr uint32_t NUM_SHADER_MODULES = 2;
-    static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = filament::ATTRIBUTE_INDEX_COUNT;
+    static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
 
     // The VertexArray POD is an array of buffer targets and an array of attributes that refer to
     // those targets. It does not include any references to actual buffers, so you can think of it

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -71,18 +71,18 @@ namespace driver {
 //
 class VulkanBinder {
 public:
-    static constexpr uint32_t NUM_UBUFFER_BINDINGS = Program::NUM_UNIFORM_BINDINGS;
-    static constexpr uint32_t NUM_SAMPLER_BINDINGS = driver::MAX_SAMPLER_COUNT;
-    static constexpr uint32_t NUM_SHADER_MODULES = 2;
-    static constexpr uint32_t MAX_VERTEX_ATTRIBUTES = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
+    static constexpr uint32_t UBUFFER_BINDING_COUNT = Program::UNIFORM_BINDING_COUNT;
+    static constexpr uint32_t SAMPLER_BINDING_COUNT = driver::MAX_SAMPLER_COUNT;
+    static constexpr uint32_t SHADER_MODULE_COUNT = 2;
+    static constexpr uint32_t VERTEX_ATTRIBUTE_COUNT = driver::MAX_VERTEX_ATTRIBUTE_COUNT;
 
     // The VertexArray POD is an array of buffer targets and an array of attributes that refer to
     // those targets. It does not include any references to actual buffers, so you can think of it
     // as a vertex assembler configuration. For simplicity it contains fixed-size arrays and does
     // not store sizes; all unused entries are simply zeroed out.
     struct VertexArray {
-        VkVertexInputAttributeDescription attributes[MAX_VERTEX_ATTRIBUTES];
-        VkVertexInputBindingDescription buffers[MAX_VERTEX_ATTRIBUTES];
+        VkVertexInputAttributeDescription attributes[VERTEX_ATTRIBUTE_COUNT];
+        VkVertexInputBindingDescription buffers[VERTEX_ATTRIBUTE_COUNT];
     };
 
     // The ProgramBundle contains weak references to the compiled vertex and fragment shaders.
@@ -105,7 +105,7 @@ public:
     // Encapsulates the arguments passed to vkUpdateDescriptorSets.
     struct DescriptorUpdateOp {
         uint32_t count;
-        VkWriteDescriptorSet writes[NUM_UBUFFER_BINDINGS + NUM_SAMPLER_BINDINGS];
+        VkWriteDescriptorSet writes[UBUFFER_BINDING_COUNT + SAMPLER_BINDING_COUNT];
     };
 
     // Upon construction, the binder initializes some internal state but does not make any Vulkan
@@ -167,12 +167,12 @@ private:
     // VkPipeline object. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreatePipeline.
     struct alignas(8) PipelineKey {
-        VkShaderModule shaders[NUM_SHADER_MODULES]; // 8*2 bytes
+        VkShaderModule shaders[SHADER_MODULE_COUNT]; // 8*2 bytes
         RasterState rasterState; // 248 bytes
         VkRenderPass renderPass; // 8 bytes
         VkPrimitiveTopology topology; // 4 bytes
-        VkVertexInputAttributeDescription vertexAttributes[MAX_VERTEX_ATTRIBUTES]; // 16*5 bytes
-        VkVertexInputBindingDescription vertexBuffers[MAX_VERTEX_ATTRIBUTES]; // 12*5 bytes
+        VkVertexInputAttributeDescription vertexAttributes[VERTEX_ATTRIBUTE_COUNT]; // 16*5 bytes
+        VkVertexInputBindingDescription vertexBuffers[VERTEX_ATTRIBUTE_COUNT]; // 12*5 bytes
     };
 
     static_assert(sizeof(PipelineKey) ==
@@ -207,10 +207,10 @@ private:
     // descriptor set. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreateDescriptor.
     struct alignas(8) DescriptorKey {
-        VkBuffer uniformBuffers[NUM_UBUFFER_BINDINGS];
-        VkDescriptorImageInfo samplers[NUM_SAMPLER_BINDINGS];
-        VkDeviceSize uniformBufferOffsets[NUM_UBUFFER_BINDINGS];
-        VkDeviceSize uniformBufferSizes[NUM_UBUFFER_BINDINGS];
+        VkBuffer uniformBuffers[UBUFFER_BINDING_COUNT];
+        VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT];
+        VkDeviceSize uniformBufferOffsets[UBUFFER_BINDING_COUNT];
+        VkDeviceSize uniformBufferSizes[UBUFFER_BINDING_COUNT];
     };
 
     static_assert(sizeof(DescriptorKey) ==
@@ -247,10 +247,10 @@ private:
     const RasterState mDefaultRasterState;
 
     // Info structs used only in a transient way but they are stored for convenience.
-    VkPipelineShaderStageCreateInfo mShaderStages[NUM_SHADER_MODULES];
+    VkPipelineShaderStageCreateInfo mShaderStages[SHADER_MODULE_COUNT];
     VkPipelineColorBlendStateCreateInfo mColorBlendState;
-    VkDescriptorBufferInfo mDescriptorBuffers[NUM_UBUFFER_BINDINGS];
-    VkDescriptorImageInfo mDescriptorSamplers[NUM_SAMPLER_BINDINGS];
+    VkDescriptorBufferInfo mDescriptorBuffers[UBUFFER_BINDING_COUNT];
+    VkDescriptorImageInfo mDescriptorSamplers[SAMPLER_BINDING_COUNT];
     DescriptorUpdateOp mDescriptorUpdateOp;
 
     // Current bindings are divided into two "keys" which are composed of a mix of actual values

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -20,6 +20,7 @@
 
 #include "VulkanBuffer.h"
 #include "VulkanHandles.h"
+#include "VulkanPlatform.h"
 
 #include <utils/Panic.h>
 #include <utils/CString.h>

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1017,7 +1017,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     // Query the program for the mapping from (SamplerBufferBinding,Offset) to (SamplerBinding),
     // where "SamplerBinding" is the integer in the GLSL, and SamplerBufferBinding is the abstract
     // Filament concept used to form groups of samplers.
-    for (uint8_t bufferIdx = 0; bufferIdx < VulkanBinder::NUM_SAMPLER_BINDINGS; bufferIdx++) {
+    for (uint8_t bufferIdx = 0; bufferIdx < VulkanBinder::SAMPLER_BINDING_COUNT; bufferIdx++) {
         VulkanSamplerGroup* vksb = mSamplerBindings[bufferIdx];
         if (!vksb) {
             continue;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -148,7 +148,7 @@ private:
     VulkanFboCache mFramebufferCache;
     VulkanSamplerCache mSamplerCache;
     VulkanRenderTarget* mCurrentRenderTarget = nullptr;
-    VulkanSamplerGroup* mSamplerBindings[VulkanBinder::NUM_SAMPLER_BINDINGS] = {};
+    VulkanSamplerGroup* mSamplerBindings[VulkanBinder::SAMPLER_BINDING_COUNT] = {};
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
 };
 

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -37,6 +37,7 @@
 namespace filament {
 namespace driver {
 
+class VulkanPlatform;
 struct VulkanRenderTarget;
 struct VulkanSamplerGroup;
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -51,7 +51,7 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
     auto const& blobs = builder.getShadersSource();
     VkShaderModule* modules[2] = { &bundle.vertex, &bundle.fragment };
     bool missing = false;
-    for (size_t i = 0; i < Program::NUM_SHADER_TYPES; i++) {
+    for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         const auto& blob = blobs[i];
         VkShaderModule* module = modules[i];
         if (blob.empty()) {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -21,7 +21,6 @@
 #include "VulkanBinder.h"
 #include "VulkanBuffer.h"
 
-#include <private/filament/EngineEnums.h>
 #include <private/filament/SamplerBindingMap.h>
 
 namespace filament {

--- a/filament/backend/src/vulkan/VulkanPlatform.cpp
+++ b/filament/backend/src/vulkan/VulkanPlatform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_VK_COCOA_H
-#define TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_VK_COCOA_H
-
-#include <stdint.h>
-
-#include <filament/backend/DriverEnums.h>
 #include "VulkanPlatform.h"
 
 namespace filament {
+namespace driver {
 
-class PlatformVkCocoa final : public driver::VulkanPlatform {
-public:
-    driver::Driver* createDriver(void* sharedContext) noexcept override;
-    void* createVkSurfaceKHR(void* nativeWindow, void* instance,
-            uint32_t* width, uint32_t* height) noexcept override;
-    int getOSVersion() const noexcept override { return 0; }
-};
+VulkanPlatform::~VulkanPlatform() = default;
 
+} // namespace driver
 } // namespace filament
-
-#endif // TNT_FILAMENT_DRIVER_VULKAN_PLATFORM_VK_COCOA_H

--- a/filament/backend/src/vulkan/VulkanPlatform.h
+++ b/filament/backend/src/vulkan/VulkanPlatform.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,26 +14,29 @@
  * limitations under the License.
  */
 
-#ifndef TNT_FILAMENT_DRIVER_NOOP_PLATFORM_NOOP_H
-#define TNT_FILAMENT_DRIVER_NOOP_PLATFORM_NOOP_H
+#ifndef TNT_FILAMENT_DRIVER_VULKANPLATFORM_H
+#define TNT_FILAMENT_DRIVER_VULKANPLATFORM_H
 
-#include <filament/backend/DriverEnums.h>
 #include <backend/Platform.h>
 
 namespace filament {
 
-class PlatformNoop final : public driver::DefaultPlatform {
+namespace driver {
+class Driver;
+} // namespace driver
+
+namespace driver {
+
+class VulkanPlatform : public DefaultPlatform {
 public:
+    // Given a Vulkan instance and native window handle, creates the platform-specific surface.
+    virtual void* createVkSurfaceKHR(void* nativeWindow, void* instance,
+            uint32_t* width, uint32_t* height) noexcept = 0;
 
-    int getOSVersion() const noexcept final { return 0; }
-
-    ~PlatformNoop() noexcept override = default;
-
-protected:
-
-    driver::Driver* createDriver(void* sharedContext) noexcept override;
+   ~VulkanPlatform() override;
 };
 
+} // namespace driver
 } // namespace filament
 
-#endif // TNT_FILAMENT_DRIVER_NOOP_PLATFORM_NOOP_H
+#endif //TNT_FILAMENT_DRIVER_VULKANPLATFORM_H

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -17,8 +17,6 @@
 #ifndef TNT_FILAMENT_MATERIAL_PARSER_H
 #define TNT_FILAMENT_MATERIAL_PARSER_H
 
-#include <private/filament/EngineEnums.h>
-
 #include <filaflat/BlobDictionary.h>
 #include <filaflat/ChunkContainer.h>
 #include <filaflat/MaterialChunk.h>

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -37,7 +37,7 @@ using namespace driver;
 using namespace filament::math;
 
 struct VertexBuffer::BuilderDetails {
-    FVertexBuffer::AttributeData mAttributes[MAX_ATTRIBUTE_BUFFERS_COUNT];
+    FVertexBuffer::AttributeData mAttributes[MAX_ATTRIBUTE_BUFFER_COUNT];
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
@@ -76,8 +76,8 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         byteStride = (uint8_t)attributeSize;
     }
 
-    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFERS_COUNT &&
-        size_t(bufferIndex) < MAX_ATTRIBUTE_BUFFERS_COUNT) {
+    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFER_COUNT &&
+        size_t(bufferIndex) < MAX_ATTRIBUTE_BUFFER_COUNT) {
 
 #ifndef NDEBUG
         if (byteOffset & 0x3) {
@@ -105,7 +105,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
 
 VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribute,
         bool normalized) noexcept {
-    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFERS_COUNT) {
+    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFER_COUNT) {
         FVertexBuffer::AttributeData& entry = mImpl->mAttributes[attribute];
         if (normalized) {
             entry.flags |= Attribute::FLAG_NORMALIZED;
@@ -141,7 +141,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     AttributeArray attributeArray;
 
-    static_assert(attributeArray.size() == MAX_ATTRIBUTE_BUFFERS_COUNT,
+    static_assert(attributeArray.size() == MAX_ATTRIBUTE_BUFFER_COUNT,
             "Attribute and Builder::Attribute arrays must match");
 
     static_assert(sizeof(Attribute) == sizeof(AttributeData),

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -286,6 +286,7 @@ private:
 
     Backend mBackend;
     Platform* mPlatform = nullptr;
+    bool mOwnPlatform = false;
     void* mSharedGLContext = nullptr;
     bool mTerminated = false;
     driver::Handle<driver::HwRenderPrimitive> mFullScreenTriangleRph;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -35,6 +35,8 @@
 #include "private/backend/CommandBufferQueue.h"
 #include "private/backend/DriverApi.h"
 
+#include <private/filament/EngineEnums.h>
+
 #include <filament/Engine.h>
 #include <filament/VertexBuffer.h>
 #include <filament/IndirectLight.h>

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -21,7 +21,7 @@
 
 #include "private/backend/Handle.h"
 
-#include <private/filament/EngineEnums.h>
+#include <filament/backend/DriverEnums.h>
 #include <filament/VertexBuffer.h>
 
 #include <utils/bitset.h>
@@ -62,7 +62,7 @@ private:
     };
 
     driver::Handle<driver::HwVertexBuffer> mHandle;
-    std::array<AttributeData, MAX_ATTRIBUTE_BUFFERS_COUNT> mAttributes;
+    std::array<AttributeData, driver::MAX_ATTRIBUTE_BUFFER_COUNT> mAttributes;
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -28,7 +28,7 @@ using namespace driver;
 
 static CircularBuffer buffer(8192);
 static Backend backend = Backend::NOOP;
-static Platform* platform = Platform::create(&backend);
+static DefaultPlatform* platform = DefaultPlatform::create(&backend);
 static CommandStream driverApi(*platform->createDriver(nullptr), buffer);
 
 TEST(FrameGraphTest, SimpleRenderPass) {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -110,6 +110,7 @@ enum VertexAttribute : uint8_t {
     UV1             = 4, //!< texture coordinates (float2)
     BONE_INDICES    = 5, //!< indices of 4 bones, as unsigned integers (uvec4)
     BONE_WEIGHTS    = 6, //!< weights of the 4 bones (normalized float4)
+    // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 
 // can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t

--- a/libs/filabridge/include/filament/backend/DriverEnums.h
+++ b/libs/filabridge/include/filament/backend/DriverEnums.h
@@ -42,7 +42,9 @@ namespace driver {
 static constexpr uint64_t SWAP_CHAIN_CONFIG_TRANSPARENT = 0x1;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_READABLE = 0x2;
 
-static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8;
+static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8; // FIXME: what should this be?
+static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 7; // FIXME: what should this be?
+static constexpr size_t MAX_SAMPLER_COUNT = 16;         // Matches the Adreno Vulkan driver.
 
 /**
  * Selects which driver a particular Engine should use.

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -40,7 +40,7 @@ namespace BindingPoints {
     constexpr uint8_t POST_PROCESS            = 4;    // samplers for the post process pass
     constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                   = 6;
-    // These are limited by Program::NUM_UNIFORM_BINDINGS (currently 6)
+    // These are limited by Program::UNIFORM_BINDING_COUNT (currently 6)
 }
 
 static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -22,8 +22,6 @@
 
 namespace filament {
 
-static constexpr size_t VERTEX_DOMAIN_COUNT = 4;
-
 static constexpr size_t POST_PROCESS_STAGES_COUNT = 4;
 enum class PostProcessStage : uint8_t {
     TONE_MAPPING_OPAQUE,           // Tone mapping post-process
@@ -34,7 +32,6 @@ enum class PostProcessStage : uint8_t {
 
 // Binding points for uniform buffers and sampler buffers.
 // Effectively, these are just names.
-// These are limited by Program::NUM_UNIFORM_BINDINGS (currently 6)
 namespace BindingPoints {
     constexpr uint8_t PER_VIEW                = 0;    // uniforms/samplers updated per view
     constexpr uint8_t PER_RENDERABLE          = 1;    // uniforms/samplers updated per renderable
@@ -43,14 +40,11 @@ namespace BindingPoints {
     constexpr uint8_t POST_PROCESS            = 4;    // samplers for the post process pass
     constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                   = 6;
+    // These are limited by Program::NUM_UNIFORM_BINDINGS (currently 6)
 }
 
 static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
         "Dynamically sized sampler buffer must be the last binding point.");
-
-constexpr uint32_t ATTRIBUTE_INDEX_COUNT = 7;
-constexpr size_t MAX_ATTRIBUTE_BUFFERS_COUNT = 8; // FIXME: should match driver::MAX_ATTRIBUTE_BUFFER_COUNT
-constexpr size_t MAX_SAMPLER_COUNT = 16; // Matches the Adreno Vulkan driver.
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
 // Values <= 256, use less CPU and GPU resources.

--- a/libs/filabridge/src/SamplerBindingMap.cpp
+++ b/libs/filabridge/src/SamplerBindingMap.cpp
@@ -27,7 +27,7 @@ namespace filament {
 void SamplerBindingMap::populate(uint8_t firstSamplerBinding,
         const SamplerInterfaceBlock* perMaterialSib, const char* materialName) {
     uint8_t offset = firstSamplerBinding;
-    size_t maxSamplerIndex = firstSamplerBinding + filament::MAX_SAMPLER_COUNT - 1;
+    size_t maxSamplerIndex = firstSamplerBinding + driver::MAX_SAMPLER_COUNT - 1;
     bool overflow = false;
     for (uint8_t blockIndex = 0; blockIndex < filament::BindingPoints::COUNT; blockIndex++) {
         mSamplerBlockOffsets[blockIndex] = offset;
@@ -57,7 +57,7 @@ void SamplerBindingMap::populate(uint8_t firstSamplerBinding,
     // If an overflow occurred, go back through and list all sampler names. This is helpful to
     // material authors who need to understand where the samplers are coming from.
     if (overflow) {
-        utils::slog.e << "WARNING: Exceeded max sampler count of " << filament::MAX_SAMPLER_COUNT;
+        utils::slog.e << "WARNING: Exceeded max sampler count of " << driver::MAX_SAMPLER_COUNT;
         if (materialName) {
             utils::slog.e << " (" << materialName << ")";
         }

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -18,7 +18,6 @@
 
 #include <filament/backend/DriverEnums.h>
 
-#include <private/filament/EngineEnums.h>
 #include <private/filament/SamplerInterfaceBlock.h>
 
 namespace filament {

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -18,7 +18,6 @@
 
 #include <cstring>
 
-#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -19,7 +19,6 @@
 
 #include <filament/backend/DriverEnums.h>
 #include <filament/MaterialEnums.h>
-#include <private/filament/EngineEnums.h>
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerBindingMap.h>
 #include <private/filament/SamplerInterfaceBlock.h>

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 
-#include <private/filament/EngineEnums.h>
 #include <filament/MaterialEnums.h>
 
 #include <filamat/MaterialBuilder.h>

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -28,8 +28,6 @@
 
 #include <filament/backend/DriverEnums.h>
 
-#include <private/filament/EngineEnums.h>
-
 #include <utils/Path.h>
 
 #include <spirv_glsl.hpp>


### PR DESCRIPTION
also
- libbackend header cleanup 
- naming convention NUM_FOOS -> FOO_COUNT