### PR TITLE
Allow configurable attribute and binding counts.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -46,6 +46,9 @@ static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8; // FIXME: what should th
 static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 7; // FIXME: what should this be?
 static constexpr size_t MAX_SAMPLER_COUNT = 16;         // Matches the Adreno Vulkan driver.
 
+static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
+static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;
+
 /**
  * Selects which driver a particular Engine should use.
  */

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -21,6 +21,8 @@
 #include <utils/CString.h>
 #include <utils/Log.h>
 
+#include <private/filament/EngineEnums.h>
+
 #include <array>
 #include <vector>
 
@@ -31,8 +33,8 @@ class Program {
 public:
 
     static constexpr size_t SHADER_TYPE_COUNT = 2;
-    static constexpr size_t UNIFORM_BINDING_COUNT = 6; //BindingPoints::COUNT;
-    static constexpr size_t SAMPLER_BINDING_COUNT = 6; //BindingPoints::COUNT;
+    static constexpr size_t UNIFORM_BINDING_COUNT = filament::CONFIG_UNIFORM_BINDING_COUNT;
+    static constexpr size_t SAMPLER_BINDING_COUNT = filament::CONFIG_SAMPLER_BINDING_COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -21,7 +21,7 @@
 #include <utils/CString.h>
 #include <utils/Log.h>
 
-#include <private/filament/EngineEnums.h>
+#include <backend/DriverEnums.h>
 
 #include <array>
 #include <vector>
@@ -33,8 +33,8 @@ class Program {
 public:
 
     static constexpr size_t SHADER_TYPE_COUNT = 2;
-    static constexpr size_t UNIFORM_BINDING_COUNT = filament::CONFIG_UNIFORM_BINDING_COUNT;
-    static constexpr size_t SAMPLER_BINDING_COUNT = filament::CONFIG_SAMPLER_BINDING_COUNT;
+    static constexpr size_t UNIFORM_BINDING_COUNT = CONFIG_UNIFORM_BINDING_COUNT;
+    static constexpr size_t SAMPLER_BINDING_COUNT = CONFIG_SAMPLER_BINDING_COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -166,7 +166,8 @@ private:
     // The pipeline key is a POD that represents all currently bound states that form the immutable
     // VkPipeline object. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreatePipeline.
-    struct alignas(8) PipelineKey {
+    #pragma pack(push, 1)
+    struct PipelineKey {
         VkShaderModule shaders[SHADER_MODULE_COUNT]; // 8*2 bytes
         RasterState rasterState; // 248 bytes
         VkRenderPass renderPass; // 8 bytes
@@ -174,15 +175,7 @@ private:
         VkVertexInputAttributeDescription vertexAttributes[VERTEX_ATTRIBUTE_COUNT]; // 16*5 bytes
         VkVertexInputBindingDescription vertexBuffers[VERTEX_ATTRIBUTE_COUNT]; // 12*5 bytes
     };
-
-    static_assert(sizeof(PipelineKey) ==
-        sizeof(PipelineKey::shaders) +
-        sizeof(PipelineKey::rasterState) +
-        sizeof(PipelineKey::renderPass) +
-        sizeof(PipelineKey::topology) +
-        sizeof(PipelineKey::vertexAttributes) +
-        sizeof(PipelineKey::vertexBuffers),
-        "Implicit padding is not allowed for fast hashing");
+    #pragma pack(pop)
 
     static_assert(std::is_pod<PipelineKey>::value, "PipelineKey must be a POD for fast hashing.");
 
@@ -206,19 +199,14 @@ private:
     // The descriptor key is a POD that represents all currently bound states that go into the
     // descriptor set. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreateDescriptor.
-    struct alignas(8) DescriptorKey {
+    #pragma pack(push, 1)
+    struct DescriptorKey {
         VkBuffer uniformBuffers[UBUFFER_BINDING_COUNT];
         VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT];
         VkDeviceSize uniformBufferOffsets[UBUFFER_BINDING_COUNT];
         VkDeviceSize uniformBufferSizes[UBUFFER_BINDING_COUNT];
     };
-
-    static_assert(sizeof(DescriptorKey) ==
-        sizeof(DescriptorKey::uniformBuffers) +
-        sizeof(DescriptorKey::samplers) +
-        sizeof(DescriptorKey::uniformBufferOffsets) +
-        sizeof(DescriptorKey::uniformBufferSizes),
-        "Implicit padding is not allowed for fast hashing");
+    #pragma pack(pop)
 
     static_assert(std::is_pod<DescriptorKey>::value, "DescriptorKey must be a POD.");
 

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -22,6 +22,8 @@
 #include <private/backend/Program.h>
 
 #include <bluevk/BlueVK.h>
+
+#include <utils/compiler.h>
 #include <utils/Hash.h>
 
 #include <tsl/robin_map.h>
@@ -166,8 +168,7 @@ private:
     // The pipeline key is a POD that represents all currently bound states that form the immutable
     // VkPipeline object. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreatePipeline.
-    #pragma pack(push, 1)
-    struct PipelineKey {
+    struct UTILS_PACKED PipelineKey {
         VkShaderModule shaders[SHADER_MODULE_COUNT]; // 8*2 bytes
         RasterState rasterState; // 248 bytes
         VkRenderPass renderPass; // 8 bytes
@@ -175,7 +176,6 @@ private:
         VkVertexInputAttributeDescription vertexAttributes[VERTEX_ATTRIBUTE_COUNT]; // 16*5 bytes
         VkVertexInputBindingDescription vertexBuffers[VERTEX_ATTRIBUTE_COUNT]; // 12*5 bytes
     };
-    #pragma pack(pop)
 
     static_assert(std::is_pod<PipelineKey>::value, "PipelineKey must be a POD for fast hashing.");
 
@@ -199,14 +199,12 @@ private:
     // The descriptor key is a POD that represents all currently bound states that go into the
     // descriptor set. We apply a hash function to its contents only if has been mutated since
     // the previous call to getOrCreateDescriptor.
-    #pragma pack(push, 1)
-    struct DescriptorKey {
+    struct UTILS_PACKED DescriptorKey {
         VkBuffer uniformBuffers[UBUFFER_BINDING_COUNT];
         VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT];
         VkDeviceSize uniformBufferOffsets[UBUFFER_BINDING_COUNT];
         VkDeviceSize uniformBufferSizes[UBUFFER_BINDING_COUNT];
     };
-    #pragma pack(pop)
 
     static_assert(std::is_pod<DescriptorKey>::value, "DescriptorKey must be a POD.");
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -59,6 +59,9 @@ constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 static constexpr bool   CONFIG_IBL_RGBM  = true;
 static constexpr size_t CONFIG_IBL_SIZE  = 256;
 
+static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
+static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;
+
 } // namespace filament
 
 #endif // TNT_FILAMENT_driver/EngineEnums.h

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -59,9 +59,6 @@ constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 static constexpr bool   CONFIG_IBL_RGBM  = true;
 static constexpr size_t CONFIG_IBL_SIZE  = 256;
 
-static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
-static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;
-
 } // namespace filament
 
 #endif // TNT_FILAMENT_driver/EngineEnums.h

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -59,7 +59,7 @@ inline constexpr uint8_t getSamplerBindingsStart(backend::Backend api) noexcept 
         case backend::Backend::VULKAN:
             // The Vulkan backend has single namespace for uniforms and samplers.
             // To avoid collision, the sampler bindings start after the last UBO binding.
-            return filament::BindingPoints::COUNT;
+            return CONFIG_UNIFORM_BINDING_COUNT;
 
         case backend::Backend::OPENGL:
         case backend::Backend::METAL:

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -59,7 +59,7 @@ inline constexpr uint8_t getSamplerBindingsStart(backend::Backend api) noexcept 
         case backend::Backend::VULKAN:
             // The Vulkan backend has single namespace for uniforms and samplers.
             // To avoid collision, the sampler bindings start after the last UBO binding.
-            return CONFIG_UNIFORM_BINDING_COUNT;
+            return backend::CONFIG_UNIFORM_BINDING_COUNT;
 
         case backend::Backend::OPENGL:
         case backend::Backend::METAL:

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -36,6 +36,14 @@
 #    define UTILS_PUBLIC  
 #endif
 
+#if __has_attribute(packed)
+#   define UTILS_PACKED __attribute__((packed))
+#else
+// If this happens, we may need to use "#pragma pack(push, 1)" instead.
+#   error Compiler does not support the packed attribute.
+#   define UTILS_PACKED
+#endif
+
 #if __has_attribute(visibility)
 #    ifndef TNT_DEV
 #        define UTILS_PRIVATE __attribute__((visibility("hidden")))


### PR DESCRIPTION
This fixes two issues related to the Vulkan backend, one being a build
issue and the other being a run-time issue:

(1) Compile-Time Issue

To prevent accidental introduction of padding into hashed structures,
the Vulkan backend was static-asserting the size of the hash input. I
think it's fine to simply use a pragma pack instead.

(2) Run-Time Issue

SibGenerator was erroneuously using BindingPoints::COUNT instead of
UNIFORM_BINDING_COUNT for determining the first sampler binding index.
(Hopefully this logic will go away after some upcoming Vulkan cleanup.)
Since SibGenerator does not include Program, this moves the uniform and
sampler counts into EngineEnums, which might be a good place anyway
since they are ideally "config" constants.