### PR TITLE
Fix Vulkan sampler enumeration to be similar to MetalDriver.

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -74,7 +74,7 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
     }
 
     // Make a copy of the binding map
-    samplerBindings = builder.getSamplerGroupInfo();
+    samplerGroupInfo = builder.getSamplerGroupInfo();
 #if FILAMENT_VULKAN_VERBOSE
     utils::slog.d << "Created VulkanProgram " << builder.getName().c_str()
                 << ", variants = (0x" << utils::io::hex

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -31,7 +31,7 @@ struct VulkanProgram : public HwProgram {
     ~VulkanProgram();
     VulkanContext& context;
     VulkanBinder::ProgramBundle bundle;
-    Program::SamplerGroupInfo samplerBindings;
+    Program::SamplerGroupInfo samplerGroupInfo;
 };
 
 struct VulkanTexture;


### PR DESCRIPTION
There will (probably) be a follow-up change that makes this even
simpler.