### PR TITLE
make OpenGLPlatform semi-public again

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -64,7 +64,7 @@ if (NOT USE_EXTERNAL_GLES3)
             src/opengl/OpenGLProgram.cpp
             src/opengl/OpenGLProgram.h
             src/opengl/OpenGLPlatform.cpp
-            src/opengl/OpenGLPlatform.h
+            include/private/backend/OpenGLPlatform.h
     )
     if (ANDROID)
         list(APPEND SRCS src/android/ExternalStreamManagerAndroid.cpp)

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -25,6 +25,14 @@ namespace backend {
 class Driver;
 
 class OpenGLPlatform : public DefaultPlatform {
+protected:
+
+    /*
+     * Derived classes can use this to instantiate the default OpenGLDriver backend.
+     * This is typically called from your implementation of createDriver()
+     */
+    static Driver* createDefaultDriver(OpenGLPlatform* platform, void* sharedContext);
+
 public:
     ~OpenGLPlatform() noexcept override;
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -24,9 +24,9 @@
 #include <utils/Systrace.h>
 
 #include "private/backend/DriverApi.h"
+#include "private/backend/OpenGLPlatform.h"
 #include "CommandStreamDispatcher.h"
 #include "OpenGLBlitter.h"
-#include "OpenGLPlatform.h"
 #include "OpenGLProgram.h"
 
 

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
+
+#include "OpenGLDriver.h"
 
 namespace filament {
 namespace backend {
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
+
+Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform, void* sharedContext) {
+    return OpenGLDriver::create(platform, sharedContext);
+}
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -21,7 +21,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -21,7 +21,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/PlatformDummyGL.h
@@ -21,7 +21,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -24,7 +24,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 struct AHardwareBuffer;
 

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -24,7 +24,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -24,7 +24,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 namespace filament {
 

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -21,7 +21,7 @@
 
 #include <backend/DriverEnums.h>
 
-#include "OpenGLPlatform.h"
+#include "private/backend/OpenGLPlatform.h"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>


### PR DESCRIPTION
There is a new static method that can be used by derived classes to
instantiate an OpenGLDriver.

This is to support existing clients that use their own implementation
of OpenGLPlatform with filament's OpenGLDriver implementation.