### PR TITLE
Rename CodeGenTargetApi to TargetLanguage.

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -54,6 +54,11 @@ public:
         METAL
     };
 
+    enum class TargetLanguage {
+        GLSL,
+        SPIRV
+    };
+
     enum class Optimization {
         NONE,
         PREPROCESSOR,
@@ -81,7 +86,7 @@ protected:
     struct CodeGenParams {
         int shaderModel;
         TargetApi targetApi;
-        TargetApi codeGenTargetApi;
+        TargetLanguage targetLanguage;
     };
     std::vector<CodeGenParams> mCodeGenPermutations;
     uint8_t mVariantFilter = 0;

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -64,7 +64,7 @@ Package PostprocessMaterialBuilder::build() {
     for (const auto& params : mCodeGenPermutations) {
         const ShaderModel shaderModel = ShaderModel(params.shaderModel);
         const TargetApi targetApi = params.targetApi;
-        const TargetApi codeGenTargetApi = params.codeGenTargetApi;
+        const TargetLanguage targetLanguage = params.targetLanguage;
 
         // Populate a SamplerBindingMap for the sole purpose of finding where the post-process bindings
         // live within the global namespace of samplers.
@@ -97,7 +97,7 @@ Package PostprocessMaterialBuilder::build() {
 
             // Vertex Shader
             std::string vs = ShaderPostProcessGenerator::createPostProcessVertexProgram(
-                    shaderModel, targetApi, codeGenTargetApi,
+                    shaderModel, targetApi, targetLanguage,
                     filament::PostProcessStage(k), firstSampler);
 
             bool ok = postProcessor.process(vs, filament::backend::ShaderType::VERTEX, shaderModel,
@@ -138,7 +138,7 @@ Package PostprocessMaterialBuilder::build() {
 
             // Fragment Shader
             std::string fs = ShaderPostProcessGenerator::createPostProcessFragmentProgram(
-                    shaderModel, targetApi, codeGenTargetApi,
+                    shaderModel, targetApi, targetLanguage,
                     filament::PostProcessStage(k), firstSampler);
 
             ok = postProcessor.process(fs, filament::backend::ShaderType::FRAGMENT, shaderModel, &fs,

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -41,7 +41,7 @@ std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
             break;
         case ShaderModel::GL_ES_30:
             // Vulkan requires version 310 or higher
-            if (mCodeGenTargetApi == TargetApi::VULKAN) {
+            if (mTargetLanguage == TargetLanguage::SPIRV) {
                 // Vulkan requires layout locations on ins and outs, which were not supported
                 // in the OpenGL 4.1 GLSL profile.
                 out << "#version 310 es\n\n";
@@ -54,7 +54,7 @@ std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
             out << "#define TARGET_MOBILE\n";
             break;
         case ShaderModel::GL_CORE_41:
-            if (mCodeGenTargetApi == TargetApi::VULKAN) {
+            if (mTargetLanguage == TargetLanguage::SPIRV) {
                 // Vulkan requires binding specifiers on uniforms and samplers, which were not
                 // supported in the OpenGL 4.1 GLSL profile.
                 out << "#version 450 core\n\n";
@@ -70,8 +70,8 @@ std::ostream& CodeGenerator::generateProlog(std::ostream& out, ShaderType type,
     if (mTargetApi == TargetApi::METAL) {
         out << "#define TARGET_METAL_ENVIRONMENT\n";
     }
-    if (mCodeGenTargetApi == TargetApi::VULKAN) {
-        out << "#define CODEGEN_TARGET_VULKAN_ENVIRONMENT\n";
+    if (mTargetLanguage == TargetLanguage::SPIRV) {
+        out << "#define TARGET_LANGUAGE_SPIRV\n";
     }
 
     Precision defaultPrecision = getDefaultPrecision(type);
@@ -251,7 +251,7 @@ std::ostream& CodeGenerator::generateUniforms(std::ostream& out, ShaderType shad
     Precision defaultPrecision = getDefaultPrecision(shaderType);
 
     out << "\nlayout(";
-    if (mCodeGenTargetApi == TargetApi::VULKAN) {
+    if (mTargetLanguage == TargetLanguage::SPIRV) {
         uint32_t bindingIndex = (uint32_t) binding; // avoid char output
         out << "binding = " << bindingIndex << ", ";
     }
@@ -294,7 +294,7 @@ std::ostream& CodeGenerator::generateSamplers(
         }
         char const* const typeName = getSamplerTypeName(type, info.format, info.multisample);
         char const* const precision = getPrecisionQualifier(info.precision, Precision::DEFAULT);
-        if (mCodeGenTargetApi == TargetApi::VULKAN) {
+        if (mTargetLanguage == TargetLanguage::SPIRV) {
             const uint32_t bindingIndex = (uint32_t) firstBinding + info.offset;
             out << "layout(binding = " << bindingIndex << ") ";
         }
@@ -561,7 +561,7 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
             // Vulkan doesn't have external textures in the sense as GL. Vulkan external textures
             // are created via VK_ANDROID_external_memory_android_hardware_buffer, but they are
             // backed by VkImage just like a normal texture, and sampled from normally.
-            return (mCodeGenTargetApi == TargetApi::VULKAN) ? "sampler2D" : "samplerExternalOES";
+            return (mTargetLanguage == TargetLanguage::SPIRV) ? "sampler2D" : "samplerExternalOES";
     }
 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -38,10 +38,11 @@ namespace filamat {
 class UTILS_PRIVATE CodeGenerator {
     using ShaderType = filament::backend::ShaderType;
     using TargetApi = MaterialBuilder::TargetApi;
+    using TargetLanguage = MaterialBuilder::TargetLanguage;
 public:
     CodeGenerator(filament::backend::ShaderModel shaderModel,
-            TargetApi targetApi, TargetApi codeGenTargetApi) noexcept
-            : mShaderModel(shaderModel), mTargetApi(targetApi), mCodeGenTargetApi(codeGenTargetApi) {
+            TargetApi targetApi, TargetLanguage targetLanguage) noexcept
+            : mShaderModel(shaderModel), mTargetApi(targetApi), mTargetLanguage(targetLanguage) {
         if (targetApi == TargetApi::ALL) {
             utils::slog.e << "Must resolve target API before codegen." << utils::io::endl;
             std::terminate();
@@ -133,7 +134,7 @@ private:
 
     filament::backend::ShaderModel mShaderModel;
     TargetApi mTargetApi;
-    TargetApi mCodeGenTargetApi;
+    TargetLanguage mTargetLanguage;
 
     // return type name of uniform  (e.g.: "vec3", "vec4", "float")
     static char const* getUniformTypeName(filament::UniformInterfaceBlock::Type uniformType) noexcept;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -142,12 +142,12 @@ ShaderGenerator::ShaderGenerator(
 }
 
 const std::string ShaderGenerator::createVertexProgram(filament::backend::ShaderModel shaderModel,
-        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
         MaterialInfo const& material, uint8_t variantKey, filament::Interpolation interpolation,
         filament::VertexDomain vertexDomain) const noexcept {
     std::stringstream vs;
 
-    const CodeGenerator cg(shaderModel, targetApi, codeGenTargetApi);
+    const CodeGenerator cg(shaderModel, targetApi, targetLanguage);
     const bool lit = material.isLit;
     const filament::Variant variant(variantKey);
 
@@ -230,11 +230,11 @@ bool ShaderGenerator::hasCustomDepthShader() const noexcept {
 }
 
 const std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderModel shaderModel,
-        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
         MaterialInfo const& material, uint8_t variantKey,
         filament::Interpolation interpolation) const noexcept {
 
-    const CodeGenerator cg(shaderModel, targetApi, codeGenTargetApi);
+    const CodeGenerator cg(shaderModel, targetApi, targetLanguage);
     const bool lit = material.isLit;
     const filament::Variant variant(variantKey);
 
@@ -352,9 +352,9 @@ void ShaderGenerator::fixupExternalSamplers(filament::backend::ShaderModel sm,
 
 const std::string ShaderPostProcessGenerator::createPostProcessVertexProgram(
         filament::backend::ShaderModel sm, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetApi codeGenTargetApi, filament::PostProcessStage variant,
+        MaterialBuilder::TargetLanguage targetLanguage, filament::PostProcessStage variant,
         uint8_t firstSampler) noexcept {
-    const CodeGenerator cg(sm, targetApi, codeGenTargetApi);
+    const CodeGenerator cg(sm, targetApi, targetLanguage);
     std::stringstream vs;
     cg.generateProlog(vs, ShaderType::VERTEX, false);
     cg.generateDefine(vs, "LOCATION_POSITION", uint32_t(VertexAttribute::POSITION));
@@ -375,9 +375,9 @@ const std::string ShaderPostProcessGenerator::createPostProcessVertexProgram(
 
 const std::string ShaderPostProcessGenerator::createPostProcessFragmentProgram(
         filament::backend::ShaderModel sm, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetApi codeGenTargetApi, filament::PostProcessStage variant,
+        MaterialBuilder::TargetLanguage targetLanguage, filament::PostProcessStage variant,
         uint8_t firstSampler) noexcept {
-    const CodeGenerator cg(sm, targetApi, codeGenTargetApi);
+    const CodeGenerator cg(sm, targetApi, targetLanguage);
     std::stringstream fs;
     cg.generateProlog(fs, ShaderType::FRAGMENT, false);
     generatePostProcessStageDefines(fs, cg, variant);

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -42,12 +42,12 @@ public:
             size_t vertexLineOffset) noexcept;
 
     const std::string createVertexProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialInfo const& material, uint8_t variantKey,
             filament::Interpolation interpolation,
             filament::VertexDomain vertexDomain) const noexcept;
     const std::string createFragmentProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialInfo const& material, uint8_t variantKey,
             filament::Interpolation interpolation) const noexcept;
 
@@ -74,10 +74,10 @@ private:
 
 struct ShaderPostProcessGenerator {
     static const std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             filament::PostProcessStage variant, uint8_t firstSampler) noexcept;
     static const std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetApi codeGenTargetApi,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             filament::PostProcessStage variant, uint8_t firstSampler) noexcept;
     static void generatePostProcessStageDefines(std::stringstream& vs, CodeGenerator const& cg,
             filament::PostProcessStage variant) noexcept;

--- a/shaders/src/common_types.fs
+++ b/shaders/src/common_types.fs
@@ -6,7 +6,7 @@
 #define MEDIUMP
 #endif
 
-#if !defined(TARGET_MOBILE) || defined(CODEGEN_TARGET_VULKAN_ENVIRONMENT)
+#if !defined(TARGET_MOBILE) || defined(TARGET_LANGUAGE_SPIRV)
 #define LAYOUT_LOCATION(x) layout(location = x)
 #else
 #define LAYOUT_LOCATION(x)


### PR DESCRIPTION
This is just a cleanup and does not change any behavior. The old code
was a little strange because we'd generate code designed for OpenGL but
we'd pass VULKAN to the code generator. This was a little white lie that
really meant: "I will need SPIRV (for optimization purposes only)"