### PR TITLE
MATERIAL BREAK: VulkanBinder now binds 2 descriptor sets at a time.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1067,12 +1067,12 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
         }
     }
 
-    // Bind a new descriptor set if it needs to change.
-    VkDescriptorSet descriptor;
+    // Bind new descriptor sets if they need to change.
+    VkDescriptorSet descriptors[2];
     VkPipelineLayout pipelineLayout;
-    if (mBinder.getOrCreateDescriptor(&descriptor, &pipelineLayout)) {
-        vkCmdBindDescriptorSets(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1,
-                &descriptor, 0, nullptr);
+    if (mBinder.getOrCreateDescriptors(descriptors, &pipelineLayout)) {
+        vkCmdBindDescriptorSets(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 2,
+                descriptors, 0, nullptr);
     }
 
     // Bind the pipeline if it changed. This can happen, for example, if the raster state changed.

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -26,7 +26,7 @@
 
 namespace filament {
 
-static constexpr size_t MATERIAL_VERSION = 2;
+static constexpr size_t MATERIAL_VERSION = 3;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -54,18 +54,7 @@ struct PostProcessSib {
 
 // Returns the binding point of the first sampler for the given backend API.
 inline constexpr uint8_t getSamplerBindingsStart(backend::Backend api) noexcept {
-    switch (api) {
-        default:
-        case backend::Backend::VULKAN:
-            // The Vulkan backend has single namespace for uniforms and samplers.
-            // To avoid collision, the sampler bindings start after the last UBO binding.
-            return backend::CONFIG_UNIFORM_BINDING_COUNT;
-
-        case backend::Backend::OPENGL:
-        case backend::Backend::METAL:
-            // Metal has a separate namespace for uniforms and samplers- collisions aren't an issue.
-            return 0;
-    }
+    return 0;
 }
 
 }

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -296,7 +296,17 @@ std::ostream& CodeGenerator::generateSamplers(
         char const* const precision = getPrecisionQualifier(info.precision, Precision::DEFAULT);
         if (mTargetLanguage == TargetLanguage::SPIRV) {
             const uint32_t bindingIndex = (uint32_t) firstBinding + info.offset;
-            out << "layout(binding = " << bindingIndex << ") ";
+            out << "layout(binding = " << bindingIndex;
+
+            // For Vulkan, we place uniforms in set 0 (the default set) and samplers in set 1. This
+            // allows the sampler bindings to live in a separate "namespace" that starts at zero.
+            // Note that the set specifier is not covered by the desktop GLSL spec, including
+            // recent versions. It is only documented in the GL_KHR_vulkan_glsl extension.
+            if (mTargetApi == TargetApi::VULKAN) {
+                out << ", set = 1";
+            }
+
+            out << ") ";
         }
         out << "uniform " << precision << " " << typeName << " " << uniformName.c_str();
         out << ";\n";


### PR DESCRIPTION
This allows us to start Vulkan sampler bindings at zero, similar
to uniforms. Further cleanup will be implemented in a subsequent pull
request.