### PR TITLE
Removing STL headers from filameshio

### DIFF
--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -28,7 +28,7 @@ namespace filament {
 }
 
 namespace utils {
-  class Path;
+    class Path;
 }
 
 namespace filamesh {

--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -44,8 +44,7 @@ public:
     using Callback = void(*)(void* buffer, size_t size, void* user);
 
     // Class to track material instances
-    class MaterialRegistry
-    {
+    class MaterialRegistry {
     public:
          MaterialRegistry();
          MaterialRegistry(const MaterialRegistry& rhs);

--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -47,31 +47,34 @@ public:
     class MaterialRegistry
     {
     public:
-       MaterialRegistry();
-       MaterialRegistry(const MaterialRegistry& rhs);
-       MaterialRegistry& operator=(const MaterialRegistry& rhs);
-       ~MaterialRegistry();
-       MaterialRegistry(MaterialRegistry&&);
-       MaterialRegistry& operator=(MaterialRegistry&&);
+         MaterialRegistry();
+         MaterialRegistry(const MaterialRegistry& rhs);
+         MaterialRegistry& operator=(const MaterialRegistry& rhs);
+         ~MaterialRegistry();
+         MaterialRegistry(MaterialRegistry&&);
+         MaterialRegistry& operator=(MaterialRegistry&&);
 
-       filament::MaterialInstance* getMaterialInstance(const utils::CString& name);
-       void
-       registerMaterialInstance(const utils::CString& name,
-                                filament::MaterialInstance* materialInstance);
-       void unregisterMaterialInstance(const utils::CString& name);
-       void unregisterAll();
+         filament::MaterialInstance* getMaterialInstance(const utils::CString& name);
 
-       std::size_t numRegistered() const noexcept;
+         void registerMaterialInstance(const utils::CString& name,
+                 filament::MaterialInstance* materialInstance);
 
-       void getRegisteredMaterials(filament::MaterialInstance** materialList,
-                                   utils::CString* materialNameList) const;
-       void
-       getRegisteredMaterials(filament::MaterialInstance** materialList) const;
-       void getRegisteredMaterialNames(utils::CString* materialNameList) const;
+         void unregisterMaterialInstance(const utils::CString& name);
+
+         void unregisterAll();
+
+         std::size_t numRegistered() const noexcept;
+
+         void getRegisteredMaterials(filament::MaterialInstance** materialList,
+                 utils::CString* materialNameList) const;
+
+         void getRegisteredMaterials(filament::MaterialInstance** materialList) const;
+
+         void getRegisteredMaterialNames(utils::CString* materialNameList) const;
 
      private:
-       struct MaterialRegistryImpl;
-       MaterialRegistryImpl* impl;
+         struct MaterialRegistryImpl;
+         MaterialRegistryImpl* mImpl;
     };
 
     struct Mesh {

--- a/libs/filameshio/include/filameshio/MeshReader.h
+++ b/libs/filameshio/include/filameshio/MeshReader.h
@@ -18,10 +18,7 @@
 #define TNT_FILAMENT_FILAMESHIO_MESHREADER_H
 
 #include <utils/Entity.h>
-#include <utils/Path.h>
-
-#include <map>
-#include <string>
+#include <utils/CString.h>
 
 namespace filament {
     class Engine;
@@ -30,7 +27,12 @@ namespace filament {
     class MaterialInstance;
 }
 
+namespace utils {
+  class Path;
+}
+
 namespace filamesh {
+
 
 /**
  * This API can be used to read meshes stored in the "filamesh" format produced
@@ -40,7 +42,37 @@ namespace filamesh {
 class MeshReader {
 public:
     using Callback = void(*)(void* buffer, size_t size, void* user);
-    using MaterialRegistry = std::map<std::string, filament::MaterialInstance*>;
+
+    // Class to track material instances
+    class MaterialRegistry
+    {
+    public:
+       MaterialRegistry();
+       MaterialRegistry(const MaterialRegistry& rhs);
+       MaterialRegistry& operator=(const MaterialRegistry& rhs);
+       ~MaterialRegistry();
+       MaterialRegistry(MaterialRegistry&&);
+       MaterialRegistry& operator=(MaterialRegistry&&);
+
+       filament::MaterialInstance* getMaterialInstance(const utils::CString& name);
+       void
+       registerMaterialInstance(const utils::CString& name,
+                                filament::MaterialInstance* materialInstance);
+       void unregisterMaterialInstance(const utils::CString& name);
+       void unregisterAll();
+
+       std::size_t numRegistered() const noexcept;
+
+       void getRegisteredMaterials(filament::MaterialInstance** materialList,
+                                   utils::CString* materialNameList) const;
+       void
+       getRegisteredMaterials(filament::MaterialInstance** materialList) const;
+       void getRegisteredMaterialNames(utils::CString* materialNameList) const;
+
+     private:
+       struct MaterialRegistryImpl;
+       MaterialRegistryImpl* impl;
+    };
 
     struct Mesh {
         utils::Entity renderable;

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -52,111 +52,88 @@ using namespace filament::math;
 //-------------------------Begin Material Registry------------------------------
 //------------------------------------------------------------------------------
 
-struct MeshReader::MaterialRegistry::MaterialRegistryImpl
-{
-  std::map<utils::CString, filament::MaterialInstance*> materialMap;
+struct MeshReader::MaterialRegistry::MaterialRegistryImpl {
+    std::map<utils::CString, filament::MaterialInstance*> materialMap;
 };
 
 // Create the implementation
 MeshReader::MaterialRegistry::MaterialRegistry()
-  : impl(new MaterialRegistryImpl)
-{
+    : mImpl(new MaterialRegistryImpl) {
 }
 // Deep copy the implementation
 MeshReader::MaterialRegistry::MaterialRegistry(const MaterialRegistry& rhs)
-  : impl(new MaterialRegistryImpl(*rhs.impl))
-{
+    : mImpl(new MaterialRegistryImpl(*rhs.mImpl)) {
 }
-MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
-operator=(const MaterialRegistry& rhs)
-{
-  *impl = *rhs.impl;
-  return *this;
+MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::operator=(const MaterialRegistry& rhs) {
+    *mImpl = *rhs.mImpl;
+    return *this;
 }
 // Delete the implementation
-MeshReader::MaterialRegistry::~MaterialRegistry()
-{
-  delete impl;
+MeshReader::MaterialRegistry::~MaterialRegistry() {
+    delete mImpl;
 }
 
 // Default move construction
 MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&&) = default;
 
-MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
-operator=(MaterialRegistry&& rhs)
-{
-  *impl = std::move(*rhs.impl);
-  return *this;
+MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::operator=(MaterialRegistry&& rhs) {
+    *mImpl = std::move(*rhs.mImpl);
+    return *this;
 }
 
-filament::MaterialInstance*
-MeshReader::MaterialRegistry::getMaterialInstance(const utils::CString& name)
-{
-  // Try to find the requested material
-  auto miter = impl->materialMap.find(name);
-  // If it exists, return it
-  if (miter != impl->materialMap.end())
-  {
-    return miter->second;
-  }
-  // If it doesn't exist, give a dummy value
-  return nullptr;
+filament::MaterialInstance* MeshReader::MaterialRegistry::getMaterialInstance(
+        const utils::CString& name) {
+    // Try to find the requested material
+    auto miter = mImpl->materialMap.find(name);
+    // If it exists, return it
+    if (miter != mImpl->materialMap.end()) {
+        return miter->second;
+    }
+    // If it doesn't exist, give a dummy value
+    return nullptr;
 }
 
-void MeshReader::MaterialRegistry::registerMaterialInstance(
-  const utils::CString& name, filament::MaterialInstance* materialInstance)
-{
-  // Add the material to our map
-  impl->materialMap[name] = materialInstance;
+void MeshReader::MaterialRegistry::registerMaterialInstance(const utils::CString& name,
+        filament::MaterialInstance* materialInstance) {
+    // Add the material to our map
+    mImpl->materialMap[name] = materialInstance;
 }
 
-void MeshReader::MaterialRegistry::unregisterMaterialInstance(
-  const utils::CString& name)
-{
-  auto miter = impl->materialMap.find(name);
-  // Remove it from the map if it existed
-  if (miter != impl->materialMap.end())
-  {
-    impl->materialMap.erase(miter);
-  }
+void MeshReader::MaterialRegistry::unregisterMaterialInstance(const utils::CString& name) {
+    auto miter = mImpl->materialMap.find(name);
+    // Remove it from the map if it existed
+    if (miter != mImpl->materialMap.end()) {
+        mImpl->materialMap.erase(miter);
+    }
 }
-void MeshReader::MaterialRegistry::unregisterAll()
-{
-  impl->materialMap.clear();
+void MeshReader::MaterialRegistry::unregisterAll() {
+    mImpl->materialMap.clear();
 }
 
-std::size_t MeshReader::MaterialRegistry::numRegistered() const noexcept
-{
-  return impl->materialMap.size();
+std::size_t MeshReader::MaterialRegistry::numRegistered() const noexcept {
+    return mImpl->materialMap.size();
+}
+
+void MeshReader::MaterialRegistry::getRegisteredMaterials(filament::MaterialInstance** materialList,
+        utils::CString* materialNameList) const {
+    for (const auto& materialPair : mImpl->materialMap) {
+        (*materialNameList++) = materialPair.first;
+        (*materialList++) = materialPair.second;
+    }
 }
 
 void MeshReader::MaterialRegistry::getRegisteredMaterials(
-  filament::MaterialInstance** materialList,
-  utils::CString* materialNameList) const
-{
-  for (const auto& materialPair : impl->materialMap)
-  {
-    (*materialNameList++) = materialPair.first;
-    (*materialList++) = materialPair.second;
-  }
-}
-
-void MeshReader::MaterialRegistry::getRegisteredMaterials(
-  filament::MaterialInstance** materialList) const
-{
-  for (const auto& materialPair : impl->materialMap)
-  {
-    (*materialList++) = materialPair.second;
-  }
+        filament::MaterialInstance** materialList) const {
+    for (const auto& materialPair : mImpl->materialMap) {
+        (*materialList++) = materialPair.second;
+    }
 }
 
 void MeshReader::MaterialRegistry::getRegisteredMaterialNames(
-  utils::CString* materialNameList) const
-{
-  for (const auto& materialPair : impl->materialMap)
-  {
-    (*materialNameList++) = materialPair.first;
-  }
+        utils::CString* materialNameList) const {
+    for (const auto& materialPair : mImpl->materialMap) {
+        (*materialNameList++) = materialPair.first;
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -70,7 +70,7 @@ MeshReader::MaterialRegistry::MaterialRegistry(const MaterialRegistry& rhs)
 MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
 operator=(const MaterialRegistry& rhs)
 {
-  impl = new MaterialRegistryImpl(*rhs.impl);
+  *impl = *rhs.impl;
   return *this;
 }
 // Delete the implementation
@@ -79,10 +79,15 @@ MeshReader::MaterialRegistry::~MaterialRegistry()
   delete impl;
 }
 
-// Default move semantics
+// Default move construction
 MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&&) = default;
+
 MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
-operator=(MaterialRegistry&&) = default;
+operator=(MaterialRegistry&& rhs)
+{
+  *impl = std::move(*rhs.impl);
+  return *this;
+}
 
 filament::MaterialInstance*
 MeshReader::MaterialRegistry::getMaterialInstance(const utils::CString& name)

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -32,6 +32,8 @@
 
 #include <string>
 #include <vector>
+#include <map>
+#include <string>
 
 #include <fcntl.h>
 #if !defined(WIN32)
@@ -45,6 +47,117 @@ using namespace filamesh;
 using namespace filament::math;
 
 #define DEFAULT_MATERIAL "DefaultMaterial"
+
+//------------------------------------------------------------------------------
+//-------------------------Begin Material Registry------------------------------
+//------------------------------------------------------------------------------
+
+struct MeshReader::MaterialRegistry::MaterialRegistryImpl
+{
+  std::map<utils::CString, filament::MaterialInstance*> materialMap;
+};
+
+// Create the implementation
+MeshReader::MaterialRegistry::MaterialRegistry()
+  : impl(new MaterialRegistryImpl)
+{
+}
+// Deep copy the implementation
+MeshReader::MaterialRegistry::MaterialRegistry(const MaterialRegistry& rhs)
+  : impl(new MaterialRegistryImpl(*rhs.impl))
+{
+}
+MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
+operator=(const MaterialRegistry& rhs)
+{
+  impl = new MaterialRegistryImpl(*rhs.impl);
+  return *this;
+}
+// Delete the implementation
+MeshReader::MaterialRegistry::~MaterialRegistry()
+{
+  delete impl;
+}
+
+// Default move semantics
+MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&&) = default;
+MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::
+operator=(MaterialRegistry&&) = default;
+
+filament::MaterialInstance*
+MeshReader::MaterialRegistry::getMaterialInstance(const utils::CString& name)
+{
+  // Try to find the requested material
+  auto miter = impl->materialMap.find(name);
+  // If it exists, return it
+  if (miter != impl->materialMap.end())
+  {
+    return miter->second;
+  }
+  // If it doesn't exist, give a dummy value
+  return nullptr;
+}
+
+void MeshReader::MaterialRegistry::registerMaterialInstance(
+  const utils::CString& name, filament::MaterialInstance* materialInstance)
+{
+  // Add the material to our map
+  impl->materialMap[name] = materialInstance;
+}
+
+void MeshReader::MaterialRegistry::unregisterMaterialInstance(
+  const utils::CString& name)
+{
+  auto miter = impl->materialMap.find(name);
+  // Remove it from the map if it existed
+  if (miter != impl->materialMap.end())
+  {
+    impl->materialMap.erase(miter);
+  }
+}
+void MeshReader::MaterialRegistry::unregisterAll()
+{
+  impl->materialMap.clear();
+}
+
+std::size_t MeshReader::MaterialRegistry::numRegistered() const noexcept
+{
+  return impl->materialMap.size();
+}
+
+void MeshReader::MaterialRegistry::getRegisteredMaterials(
+  filament::MaterialInstance** materialList,
+  utils::CString* materialNameList) const
+{
+  for (const auto& materialPair : impl->materialMap)
+  {
+    (*materialNameList++) = materialPair.first;
+    (*materialList++) = materialPair.second;
+  }
+}
+
+void MeshReader::MaterialRegistry::getRegisteredMaterials(
+  filament::MaterialInstance** materialList) const
+{
+  for (const auto& materialPair : impl->materialMap)
+  {
+    (*materialList++) = materialPair.second;
+  }
+}
+
+void MeshReader::MaterialRegistry::getRegisteredMaterialNames(
+  utils::CString* materialNameList) const
+{
+  for (const auto& materialPair : impl->materialMap)
+  {
+    (*materialNameList++) = materialPair.first;
+  }
+}
+
+//------------------------------------------------------------------------------
+//---------------------------End Material Registry------------------------------
+//------------------------------------------------------------------------------
+
 
 static size_t fileSize(int fd) {
     size_t filesize;
@@ -87,7 +200,7 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
         void const* data, Callback destructor, void* user,
         MaterialInstance* defaultMaterial) {
     MaterialRegistry reg;
-    reg[DEFAULT_MATERIAL] = defaultMaterial;
+    reg.registerMaterialInstance(utils::CString(DEFAULT_MATERIAL), defaultMaterial);
     return loadMeshFromBuffer(engine, data, destructor, user, reg);
 }
 
@@ -249,18 +362,18 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
     RenderableManager::Builder builder(header->parts);
     builder.boundingBox(header->aabb);
-    const auto defaultmi = materials.at(DEFAULT_MATERIAL);
+    const auto defaultmi = materials.getMaterialInstance(utils::CString(DEFAULT_MATERIAL));
     for (size_t i = 0; i < header->parts; i++) {
         builder.geometry(i, RenderableManager::PrimitiveType::TRIANGLES,
                             mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
                             parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
-        const auto& materialName = partsMaterial[i];
-        const auto miter = materials.find(materialName);
-        if (miter == materials.end()) {
+        const utils::CString materialName(partsMaterial[i].c_str(), partsMaterial[i].size());
+        const auto mat = materials.getMaterialInstance(materialName);
+        if (mat == nullptr) {
             builder.material(i, defaultmi);
-            materials[materialName] = defaultmi;
+            materials.registerMaterialInstance(materialName, defaultmi);
         } else {
-            builder.material(i, miter->second);
+            builder.material(i, mat);
         }
     }
     builder.build(*engine, mesh.renderable);

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -52,7 +52,7 @@ using namespace utils;
 
 static std::vector<Path> g_filenames;
 
-static std::map<std::string, MaterialInstance*> g_materialInstances;
+static MeshReader::MaterialRegistry g_materialInstances;
 static std::vector<MeshReader::Mesh> g_meshes;
 static const Material* g_material;
 static Entity g_light;
@@ -150,9 +150,12 @@ static int handleCommandLineArgments(int argc, char* argv[], Config* config) {
 static void cleanup(Engine* engine, View*, Scene*) {
     engine->destroy(g_normalMap);
     engine->destroy(g_clearCoatNormalMap);
-    for (auto material : g_materialInstances) {
-        engine->destroy(material.second);
+    std::vector<filament::MaterialInstance*> materialList(g_materialInstances.numRegistered());
+    g_materialInstances.getRegisteredMaterials(materialList.data());
+    for (auto material : materialList) {
+        engine->destroy(material);
     }
+    g_materialInstances.unregisterAll();
     engine->destroy(g_material);
     EntityManager& em = EntityManager::get();
     for (auto mesh : g_meshes) {
@@ -297,21 +300,22 @@ static void setup(Engine* engine, View*, Scene* scene) {
 
     g_material = Material::Builder().package(pkg.getData(), pkg.getSize())
             .build(*engine);
-    g_materialInstances["DefaultMaterial"] = g_material->createInstance();
+    const utils::CString defaultMaterialName("DefaultMaterial");
+    g_materialInstances.registerMaterialInstance(defaultMaterialName, g_material->createInstance());
 
     TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
             TextureSampler::MagFilter::LINEAR, TextureSampler::WrapMode::REPEAT);
     sampler.setAnisotropy(8.0f);
 
     if (hasNormalMap) {
-        g_materialInstances["DefaultMaterial"]->setParameter("normalMap", g_normalMap, sampler);
+        g_materialInstances.getMaterialInstance(defaultMaterialName)->setParameter("normalMap", g_normalMap, sampler);
     }
     if (hasClearCoatNormalMap) {
-        g_materialInstances["DefaultMaterial"]->setParameter(
+        g_materialInstances.getMaterialInstance(defaultMaterialName)->setParameter(
                 "clearCoatNormalMap", g_clearCoatNormalMap, sampler);
     }
     if (hasBaseColorMap) {
-        g_materialInstances["DefaultMaterial"]->setParameter(
+        g_materialInstances.getMaterialInstance(defaultMaterialName)->setParameter(
                 "baseColorMap", g_baseColorMap, sampler);
     }
 


### PR DESCRIPTION
Removing STL headers from the filamesh reader. Not sure that the jsbindings were amended correctly. Also still has `<functional>` from the `CString` header using it for `std::hash` specialisation, maybe that could be moved to another header to be included only by internal source files, as `std::hash` should only be used by STL headers anyway? (I think).