### PR TITLE
Add MetalBufferPool to Metal backend

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -92,6 +92,7 @@ endif()
 
 if (FILAMENT_SUPPORTS_METAL)
     list(APPEND SRCS
+            src/metal/MetalBufferPool.mm
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm
             src/metal/MetalHandles.mm

--- a/filament/backend/src/metal/MetalBufferPool.h
+++ b/filament/backend/src/metal/MetalBufferPool.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_METALSTAGEPOOL_H
+#define TNT_FILAMENT_DRIVER_METALSTAGEPOOL_H
+
+#include <Metal/Metal.h>
+
+#include <map>
+#include <mutex>
+#include <unordered_set>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+struct MetalContext;
+
+// Immutable POD representing a shared CPU-GPU buffer.
+struct MetalBufferPoolEntry {
+    id<MTLBuffer> buffer;
+    size_t capacity;
+    mutable uint64_t lastAccessed;
+};
+
+// Manages a pool of Metal buffers, periodically releasing ones that have been unused for awhile.
+class MetalBufferPool {
+public:
+    explicit MetalBufferPool(MetalContext& context) noexcept : mContext(context) {}
+
+    // Finds or creates a buffer whose capacity is at least the given number of bytes.
+    MetalBufferPoolEntry const* acquireBuffer(size_t numBytes);
+
+    // Returns the given buffer back to the pool.
+    void releaseBuffer(MetalBufferPoolEntry const *stage) noexcept;
+
+    // Evicts old unused buffers and bumps the current frame number.
+    void gc() noexcept;
+
+    // Destroys all unused buffers.
+    void reset() noexcept;
+
+private:
+    MetalContext& mContext;
+
+    // Synchronize access to mFreeStages and mUsedStages. acquireBuffer and releaseBuffer may be
+    // called on separate threads (the engine thread and a Metal callback thread, for example).
+    std::mutex mMutex;
+
+    // Use an ordered multimap for quick (capacity => stage) lookups using lower_bound().
+    std::multimap<size_t, MetalBufferPoolEntry const*> mFreeStages;
+
+    // Simple unordered set for stashing a list of in-use stages that can be reclaimed later.
+    // In theory this need not exist, but is useful for validation and ensuring no leaks.
+    std::unordered_set<MetalBufferPoolEntry const*> mUsedStages;
+
+    // Store the current "time" (really just a frame count) and LRU eviction parameters.
+    uint64_t mCurrentFrame = 0;
+    static constexpr uint32_t TIME_BEFORE_EVICTION = 10;
+};
+
+} // namespace metal
+} // namespace backend
+} // namespace filament
+
+#endif // TNT_FILAMENT_DRIVER_METALSTAGEPOOL_H

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalBufferPool.h"
+
+#include "MetalContext.h"
+
+#include <utils/Panic.h>
+
+#include <thread>
+#include <chrono>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+MetalBufferPoolEntry const* MetalBufferPool::acquireBuffer(size_t numBytes) {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    // First check if a stage exists whose capacity is greater than or equal to the requested size.
+    auto iter = mFreeStages.lower_bound(numBytes);
+    if (iter != mFreeStages.end()) {
+        auto stage = iter->second;
+        mFreeStages.erase(iter);
+        mUsedStages.insert(stage);
+        return stage;
+    }
+
+    // We were not able to find a sufficiently large stage, so create a new one.
+    id<MTLBuffer> buffer = [mContext.device newBufferWithLength:numBytes
+                                                        options:MTLResourceStorageModeShared];
+    MetalBufferPoolEntry* stage = new MetalBufferPoolEntry({
+        .buffer = buffer,
+        .capacity = numBytes,
+        .lastAccessed = mCurrentFrame
+    });
+    mUsedStages.insert(stage);
+
+    return stage;
+}
+
+void MetalBufferPool::releaseBuffer(MetalBufferPoolEntry const *stage) noexcept {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    auto iter = mUsedStages.find(stage);
+    if (iter == mUsedStages.end()) {
+        utils::slog.e << "Unknown Metal buffer: " << stage->capacity << " bytes"
+                << utils::io::endl;
+        return;
+    }
+    stage->lastAccessed = mCurrentFrame;
+    mUsedStages.erase(iter);
+    mFreeStages.insert(std::make_pair(stage->capacity, stage));
+}
+
+void MetalBufferPool::gc() noexcept {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    mCurrentFrame++;
+    decltype(mFreeStages) stages;
+    stages.swap(mFreeStages);
+    const uint64_t evictionTime = mCurrentFrame - TIME_BEFORE_EVICTION;
+    for (auto pair : stages) {
+        if (pair.second->lastAccessed < evictionTime) {
+            [pair.second->buffer release];
+            delete pair.second;
+        } else {
+            mFreeStages.insert(pair);
+        }
+    }
+}
+
+void MetalBufferPool::reset() noexcept {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    assert(mUsedStages.empty());
+    for (auto pair : mFreeStages) {
+        [pair.second->buffer release];
+        delete pair.second;
+    }
+    mFreeStages.clear();
+}
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -17,18 +17,22 @@
 #ifndef TNT_METALCONTEXT_H
 #define TNT_METALCONTEXT_H
 
+#include "MetalBufferPool.h"
+#include "MetalState.h"
+
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
-
-#include "MetalState.h"
 
 namespace filament {
 namespace backend {
 namespace metal {
 
 class MetalRenderTarget;
+class MetalUniformBuffer;
+struct MetalIndexBuffer;
 struct MetalSamplerGroup;
 struct MetalSwapChain;
+struct MetalVertexBuffer;
 
 struct MetalContext {
     id<MTLDevice> device = nullptr;
@@ -51,7 +55,7 @@ struct MetalContext {
     // State trackers.
     PipelineStateTracker pipelineState;
     DepthStencilStateTracker depthStencilState;
-    UniformBufferStateTracker uniformState[VERTEX_BUFFER_START];
+    UniformBufferState uniformState[VERTEX_BUFFER_START];
     CullModeStateTracker cullModeState;
 
     // State caches.
@@ -60,6 +64,8 @@ struct MetalContext {
     SamplerStateCache samplerStateCache;
 
     MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
+
+    MetalBufferPool* bufferPool;
 
     // Surface-related properties.
     MetalSwapChain* currentSurface = nullptr;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -34,9 +34,10 @@ class MetalPlatform;
 
 namespace metal {
 
+class MetalUniformBuffer;
 struct MetalContext;
-
 struct MetalProgram;
+struct UniformBufferState;
 
 class MetalDriver final : public DriverBase {
     MetalDriver(backend::MetalPlatform* platform) noexcept;
@@ -143,6 +144,9 @@ private:
 
     void enumerateSamplerGroups(const MetalProgram* program,
             const std::function<void(const SamplerGroup::Sampler*, size_t)>& f);
+    void enumerateBoundUniforms(const std::function<void(const UniformBufferState&,
+            const MetalUniformBuffer*, uint32_t)>& f);
+
 };
 
 } // namespace metal

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -144,7 +144,7 @@ private:
 
     void enumerateSamplerGroups(const MetalProgram* program,
             const std::function<void(const SamplerGroup::Sampler*, size_t)>& f);
-    void enumerateBoundUniforms(const std::function<void(const UniformBufferState&,
+    void enumerateBoundUniformBuffers(const std::function<void(const UniformBufferState&,
             const MetalUniformBuffer*, uint32_t)>& f);
 
 };

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -677,7 +677,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     id<MTLBuffer> uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
     NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
 
-    enumerateBoundUniforms([&uniformsToBind, &offsets](const UniformBufferState& state,
+    enumerateBoundUniformBuffers([&uniformsToBind, &offsets](const UniformBufferState& state,
             const MetalUniformBuffer* uniform, uint32_t index) {
         // getGpuBuffer() might return nil, which means there isn't a device allocation for this
         // uniform. In this case, we'll update the uniform below with our CPU-side buffer via
@@ -698,7 +698,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                                                 offsets:offsets
                                               withRange:uniformRange];
 
-    enumerateBoundUniforms([commandEncoder = mContext->currentCommandEncoder](
+    enumerateBoundUniformBuffers([commandEncoder = mContext->currentCommandEncoder](
             const UniformBufferState& state, const MetalUniformBuffer* uniform, uint32_t index) {
         void* cpuBuffer = uniform->getCpuBuffer();
         if (!cpuBuffer) {
@@ -788,15 +788,15 @@ void MetalDriver::enumerateSamplerGroups(
     }
 }
 
-void MetalDriver::enumerateBoundUniforms(
+void MetalDriver::enumerateBoundUniformBuffers(
         const std::function<void(const UniformBufferState&, const MetalUniformBuffer*,
         uint32_t)>& f) {
     for (uint32_t i = 0; i < Program::UNIFORM_BINDING_COUNT; i++) {
-        auto &thisUniform = mContext->uniformState[i];
+        auto& thisUniform = mContext->uniformState[i];
         if (!thisUniform.bound) {
             continue;
         }
-        const auto *uniform = handle_const_cast<MetalUniformBuffer>(mHandleMap, thisUniform.ubh);
+        const auto* uniform = handle_const_cast<MetalUniformBuffer>(mHandleMap, thisUniform.ubh);
         f(thisUniform, uniform, i);
     }
 }

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -51,10 +51,12 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
     mContext->pipelineStateCache.setDevice(mContext->device);
     mContext->depthStencilStateCache.setDevice(mContext->device);
     mContext->samplerStateCache.setDevice(mContext->device);
+    mContext->bufferPool = new MetalBufferPool(*mContext);
 }
 
 MetalDriver::~MetalDriver() noexcept {
     [mContext->device release];
+    delete mContext->bufferPool;
     delete mContext;
 }
 
@@ -79,6 +81,7 @@ void MetalDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 void MetalDriver::endFrame(uint32_t frameId) {
     // Release resources created during frame execution- like commandBuffer and currentDrawable.
     [mContext->framePool drain];
+    mContext->bufferPool->gc();
 }
 
 void MetalDriver::flush(int dummy) {
@@ -112,7 +115,7 @@ void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
 
 void MetalDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
         BufferUsage usage) {
-    construct_handle<MetalUniformBuffer>(mHandleMap, ubh, mContext->device, size);
+    construct_handle<MetalUniformBuffer>(mHandleMap, ubh, *mContext, size);
 }
 
 void MetalDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int dummy) {
@@ -262,6 +265,11 @@ void MetalDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
 void MetalDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
     if (ubh) {
         destruct_handle<MetalUniformBuffer>(mHandleMap, ubh);
+        for (auto& thisUniform : mContext->uniformState) {
+            if (thisUniform.ubh == ubh) {
+                thisUniform.bound = false;
+            }
+        }
     }
 }
 
@@ -288,6 +296,13 @@ void MetalDriver::destroyStream(Handle<HwStream> sh) {
 }
 
 void MetalDriver::terminate() {
+    // Wait for all frames to finish by submitting and waiting on a dummy command buffer.
+    // This must be done before calling bufferPool->reset() to ensure no buffers are in flight.
+    id<MTLCommandBuffer> oneOffBuffer = [mContext->commandQueue commandBuffer];
+    [oneOffBuffer commit];
+    [oneOffBuffer waitUntilCompleted];
+
+    mContext->bufferPool->reset();
     [mContext->commandQueue release];
     [mContext->driverPool drain];
 }
@@ -401,7 +416,12 @@ bool MetalDriver::canGenerateMipmaps() {
 
 void MetalDriver::updateUniformBuffer(Handle<HwUniformBuffer> ubh,
         BufferDescriptor&& data) {
-    auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);
+   if (data.size <= 0) {
+       return;
+   }
+
+   auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);
+
     buffer->copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));
 }
@@ -476,9 +496,6 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     // Metal requires a new command encoder for each render pass, and they cannot be reused.
     // We must bind certain states for each command encoder, so we dirty the states here to force a
     // rebinding at the first the draw call of this pass.
-    for (auto& i : mContext->uniformState) {
-        i.invalidate();
-    }
     mContext->pipelineState.invalidate();
     mContext->depthStencilState.invalidate();
     mContext->cullModeState.invalidate();
@@ -540,20 +557,20 @@ void MetalDriver::commit(Handle<HwSwapChain> sch) {
 }
 
 void MetalDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
-    mContext->uniformState[index].updateState(UniformBufferState {
+    mContext->uniformState[index] = UniformBufferState {
         .bound = true,
         .ubh = ubh,
         .offset = 0
-    });
+    };
 }
 
 void MetalDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
         size_t offset, size_t size) {
-    mContext->uniformState[index].updateState(UniformBufferState {
+    mContext->uniformState[index] = UniformBufferState {
         .bound = true,
         .ubh = ubh,
         .offset = offset
-    });
+    };
 }
 
 void MetalDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
@@ -656,41 +673,45 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                                               clamp:0.0];
     }
 
-    // Bind any uniform buffers that have changed since the last draw call.
-    for (uint32_t i = 0; i < VERTEX_BUFFER_START; i++) {
-        auto& thisUniform = mContext->uniformState[i];
-        if (thisUniform.stateChanged()) {
-            const auto& uniformState = thisUniform.getState();
-            if (!uniformState.bound) {
-                continue;
-            }
+    // Bind uniform buffers.
+    id<MTLBuffer> uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
+    NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
 
-            const auto* uniform = handle_const_cast<MetalUniformBuffer>(mHandleMap,
-                    uniformState.ubh);
-
-            // We have no way of knowing which uniform buffers will be used by which shader stage
-            // so for now, bind the uniform buffer to both the vertex and fragment stages.
-
-            if (uniform->buffer) {
-                [mContext->currentCommandEncoder setVertexBuffer:uniform->buffer
-                                                        offset:uniformState.offset
-                                                       atIndex:i];
-
-                [mContext->currentCommandEncoder setFragmentBuffer:uniform->buffer
-                                                          offset:uniformState.offset
-                                                         atIndex:i];
-            } else {
-                assert(uniform->cpuBuffer);
-                uint8_t* bytes = static_cast<uint8_t*>(uniform->cpuBuffer) + uniformState.offset;
-                [mContext->currentCommandEncoder setVertexBytes:bytes
-                                                       length:(uniform->size - uniformState.offset)
-                                                      atIndex:i];
-                [mContext->currentCommandEncoder setFragmentBytes:bytes
-                                                         length:(uniform->size - uniformState.offset)
-                                                        atIndex:i];
-            }
+    enumerateBoundUniforms([&uniformsToBind, &offsets](const UniformBufferState& state,
+            const MetalUniformBuffer* uniform, uint32_t index) {
+        // getGpuBuffer() might return nil, which means there isn't a device allocation for this
+        // uniform. In this case, we'll update the uniform below with our CPU-side buffer via
+        // setVertexBytes and setFragmentBytes.
+        id<MTLBuffer> gpuBuffer = uniform->getGpuBuffer();
+        if (gpuBuffer == nil) {
+            return;
         }
-    }
+        uniformsToBind[index] = gpuBuffer;
+        offsets[index] = state.offset;
+    });
+
+    NSRange uniformRange = NSMakeRange(0, Program::UNIFORM_BINDING_COUNT);
+    [mContext->currentCommandEncoder setVertexBuffers:uniformsToBind
+                                              offsets:offsets
+                                            withRange:uniformRange];
+    [mContext->currentCommandEncoder setFragmentBuffers:uniformsToBind
+                                                offsets:offsets
+                                              withRange:uniformRange];
+
+    enumerateBoundUniforms([commandEncoder = mContext->currentCommandEncoder](
+            const UniformBufferState& state, const MetalUniformBuffer* uniform, uint32_t index) {
+        void* cpuBuffer = uniform->getCpuBuffer();
+        if (!cpuBuffer) {
+            return;
+        }
+        uint8_t* bytes = static_cast<uint8_t*>(cpuBuffer) + state.offset;
+        [commandEncoder setVertexBytes:bytes
+                                length:(uniform->getSize() - state.offset)
+                               atIndex:index];
+        [commandEncoder setFragmentBytes:bytes
+                                  length:(uniform->getSize() - state.offset)
+                                 atIndex:index];
+    });
 
     // Enumerate all the sampler buffers for the program and check which textures and samplers need
     // to be bound.
@@ -711,18 +732,15 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     // Similar to uniforms, we can't tell which stage will use the textures / samplers, so bind
     // to both the vertex and fragment stages.
 
-    NSRange range {
-        .length = SAMPLER_BINDING_COUNT,
-        .location = 0
-    };
+    NSRange samplerRange = NSMakeRange(0, SAMPLER_BINDING_COUNT);
     [mContext->currentCommandEncoder setFragmentTextures:texturesToBind
-                                             withRange:range];
+                                             withRange:samplerRange];
     [mContext->currentCommandEncoder setVertexTextures:texturesToBind
-                                           withRange:range];
+                                           withRange:samplerRange];
     [mContext->currentCommandEncoder setFragmentSamplerStates:samplersToBind
-                                                  withRange:range];
+                                                  withRange:samplerRange];
     [mContext->currentCommandEncoder setVertexSamplerStates:samplersToBind
-                                                withRange:range];
+                                                withRange:samplerRange];
 
     // Bind the vertex buffers.
     NSRange bufferRange = NSMakeRange(VERTEX_BUFFER_START, primitive->buffers.size());
@@ -767,6 +785,19 @@ void MetalDriver::enumerateSamplerGroups(
 
             f(boundSampler, bindingPoint);
         }
+    }
+}
+
+void MetalDriver::enumerateBoundUniforms(
+        const std::function<void(const UniformBufferState&, const MetalUniformBuffer*,
+        uint32_t)>& f) {
+    for (uint32_t i = 0; i < Program::UNIFORM_BINDING_COUNT; i++) {
+        auto &thisUniform = mContext->uniformState[i];
+        if (!thisUniform.bound) {
+            continue;
+        }
+        const auto *uniform = handle_const_cast<MetalUniformBuffer>(mHandleMap, thisUniform.ubh);
+        f(thisUniform, uniform, i);
     }
 }
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -59,20 +59,35 @@ struct MetalIndexBuffer : public HwIndexBuffer {
     id<MTLBuffer> buffer;
 };
 
-struct MetalUniformBuffer : public HwUniformBuffer {
-    // TODO: We aren't implementing triple-buffering for uniform buffers yet- i.e., a single
-    // Filament uniform buffer maps to a single MetalUniformBuffer. This could cause access
-    // conflicts between CPU / GPU.
-
-    MetalUniformBuffer(id<MTLDevice> device, size_t size);
+class MetalUniformBuffer : public HwUniformBuffer {
+public:
+    MetalUniformBuffer(MetalContext& context, size_t size);
     ~MetalUniformBuffer();
 
+    size_t getSize() const { return size; }
+
+    /**
+     * Update the uniform with data inside src. Potentially allocates a new buffer allocation to
+     * hold the bytes which will be released when the current frame is finished.
+     */
     void copyIntoBuffer(void* src, size_t size);
 
-    size_t size = 0;
+    /**
+     * @return The MTLBuffer representing the current state of the uniform to bind, or nil if there
+     * is no device allocation.
+     */
+    id<MTLBuffer> getGpuBuffer() const;
 
-    id <MTLBuffer> buffer;
-    void* cpuBuffer;
+    /**
+     * @return A pointer to the CPU buffer holding the uniform data or nullptr if there isn't one.
+     */
+    void* getCpuBuffer() const;
+
+private:
+    size_t size = 0;
+    const MetalBufferPoolEntry* bufferPoolEntry = nullptr;
+    void* cpuBuffer = nullptr;
+    MetalContext& context;
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -164,7 +164,6 @@ void MetalUniformBuffer::copyIntoBuffer(void* src, size_t size) {
     }];
 }
 
-
 id<MTLBuffer> MetalUniformBuffer::getGpuBuffer() const {
     if (bufferPoolEntry) {
         return bufferPoolEntry->buffer;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -96,8 +96,11 @@ MetalVertexBuffer::MetalVertexBuffer(id<MTLDevice> device, uint8_t bufferCount, 
             }
         }
 
-        id<MTLBuffer> buffer = [device newBufferWithLength:size
-                                                   options:MTLResourceStorageModeShared];
+        id<MTLBuffer> buffer = nil;
+        if (size > 0) {
+            buffer = [device newBufferWithLength:size
+                                         options:MTLResourceStorageModeShared];
+        }
         buffers.push_back(buffer);
     }
 }
@@ -116,38 +119,61 @@ MetalIndexBuffer::MetalIndexBuffer(id<MTLDevice> device, uint8_t elementSize, ui
 
 MetalIndexBuffer::~MetalIndexBuffer() {
     [buffer release];
-};
+}
 
-MetalUniformBuffer::MetalUniformBuffer(id<MTLDevice> device, size_t size) : HwUniformBuffer(),
-        size(size) {
+MetalUniformBuffer::MetalUniformBuffer(MetalContext& context, size_t size) : HwUniformBuffer(),
+        size(size), context(context) {
+    ASSERT_PRECONDITION(size > 0, "Cannot create Metal uniform with size %d.", size);
     // If the buffer is less than 4K in size, we don't use an explicit buffer and instead use
     // immediate command encoder methods like setVertexBytes:length:atIndex:.
     if (size <= 4 * 1024) {   // 4K
-        buffer = nil;
+        bufferPoolEntry = nullptr;
         cpuBuffer = malloc(size);
-    } else {
-        buffer = [device newBufferWithLength:size
-                                     options:MTLResourceStorageModeShared];
-        cpuBuffer = nullptr;
     }
 }
 
 MetalUniformBuffer::~MetalUniformBuffer() {
-    if (buffer) {
-        [buffer release];
-    } else if (cpuBuffer) {
+    if (cpuBuffer) {
         free(cpuBuffer);
     }
 }
 
 void MetalUniformBuffer::copyIntoBuffer(void* src, size_t size) {
-    // Either copy into the Metal buffer or into our cpu buffer.
-    if (buffer) {
-        memcpy(buffer.contents, src, size);
-    } else {
-        assert(cpuBuffer);
-        memcpy(cpuBuffer, src, size);
+    if (size <= 0) {
+        return;
     }
+    ASSERT_PRECONDITION(size <= this->size, "Attempting to copy %d bytes into a uniform of size %d",
+            size, this->size);
+
+    // Either copy into the Metal buffer or into our cpu buffer.
+    if (cpuBuffer) {
+        memcpy(cpuBuffer, src, size);
+        return;
+    }
+
+    bufferPoolEntry = context.bufferPool->acquireBuffer(size);
+    memcpy(static_cast<uint8_t*>(bufferPoolEntry->buffer.contents), src, size);
+
+    const MetalBufferPoolEntry* entry = this->bufferPoolEntry;
+    MetalBufferPool* pool = context.bufferPool;
+    // Important to copy the bufferPool and entry pointers into separate variables so that the block
+    // does not capture "this", which may not be valid by the time the frame has completed (if this
+    // uniform is destroyed, for example).
+    [context.currentCommandBuffer addCompletedHandler:^(id<MTLCommandBuffer> commandBuffer) {
+        pool->releaseBuffer(entry);
+    }];
+}
+
+
+id<MTLBuffer> MetalUniformBuffer::getGpuBuffer() const {
+    if (bufferPoolEntry) {
+        return bufferPoolEntry->buffer;
+    }
+    return nil;
+}
+
+void* MetalUniformBuffer::getCpuBuffer() const {
+    return cpuBuffer;
 }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*


### PR DESCRIPTION
Before this change, there was a 1:1 mapping between a Filament uniform buffer and a Metal buffer. This causes conflicts if the CPU attempts to perform a uniform update while the buffer is being used by the GPU. To solve this, the Metal backend now has a pool of buffers which are used to avoid access conflicts along with allowing multiple uniform updates per frame.

`MetalBufferPool` is copied from `VulkanStagePool` with modifications made for Metal.
