### PR TITLE
Add `postLightingColor` property to materials

### DIFF
--- a/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
+++ b/android/filamat-android/src/main/cpp/MaterialBuilder.cpp
@@ -22,39 +22,36 @@ using namespace filament;
 using namespace filamat;
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderInit(JNIEnv *env,
-        jclass type) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderInit(JNIEnv*, jclass) {
     MaterialBuilder::init();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShutdown(JNIEnv *env,
-        jclass type) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShutdown(JNIEnv*, jclass) {
     MaterialBuilder::shutdown();
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nCreateMaterialBuilder(JNIEnv *env,
-        jclass type) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nCreateMaterialBuilder(JNIEnv*, jclass) {
     return (jlong) new MaterialBuilder();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nDestroyMaterialBuilder(JNIEnv *env,
-        jclass type, jlong nativeBuilder) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nDestroyMaterialBuilder(JNIEnv*, jclass,
+        jlong nativeBuilder) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     delete builder;
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nBuilderBuild(JNIEnv* env, jclass type,
+Java_com_google_android_filament_filamat_MaterialBuilder_nBuilderBuild(JNIEnv*, jclass,
         jlong nativeBuilder) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     return (jlong) new Package(builder->build());
 }
 
 extern "C" JNIEXPORT jbyteArray JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nGetPackageBytes(JNIEnv* env, jclass type,
+Java_com_google_android_filament_filamat_MaterialBuilder_nGetPackageBytes(JNIEnv* env, jclass,
         jlong nativePackage) {
     auto package = (Package*) nativePackage;
     auto size = jsize(package->getSize());
@@ -65,14 +62,14 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nGetPackageBytes(JNIEnv
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nGetPackageIsValid(JNIEnv* env,
-        jclass type, jlong nativePackage) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nGetPackageIsValid(JNIEnv*, jclass,
+        jlong nativePackage) {
     auto* package = (Package*) nativePackage;
     return jboolean(package->isValid());
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nDestroyPackage(JNIEnv* env, jclass type,
+Java_com_google_android_filament_filamat_MaterialBuilder_nDestroyPackage(JNIEnv*, jclass,
         jlong nativePackage) {
     Package* package = (Package*) nativePackage;
     delete package;
@@ -80,29 +77,29 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nDestroyPackage(JNIEnv*
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderName(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jstring name_) {
+        jclass, jlong nativeBuilder, jstring name_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* name = env->GetStringUTFChars(name_, nullptr);
     builder->name(name);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShading(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint shading) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShading(JNIEnv*,
+        jclass, jlong nativeBuilder, jint shading) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->shading((MaterialBuilder::Shading) shading);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderInterpolation(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint interpolation) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderInterpolation(JNIEnv*,
+        jclass, jlong nativeBuilder, jint interpolation) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->interpolation((MaterialBuilder::Interpolation) interpolation);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderUniformParameter(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jint uniformType, jstring name_) {
+        JNIEnv* env, jclass, jlong nativeBuilder, jint uniformType, jstring name_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* name = env->GetStringUTFChars(name_, nullptr);
     builder->parameter((MaterialBuilder::UniformType) uniformType, name);
@@ -110,7 +107,7 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderUniform
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderUniformParameterArray(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jint uniformType, jint size, jstring name_) {
+        JNIEnv* env, jclass, jlong nativeBuilder, jint uniformType, jint size, jstring name_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* name = env->GetStringUTFChars(name_, nullptr);
     builder->parameter((MaterialBuilder::UniformType) uniformType, (size_t) size, name);
@@ -118,7 +115,7 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderUniform
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderSamplerParameter(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jint samplerType, jint format,
+        JNIEnv* env, jclass, jlong nativeBuilder, jint samplerType, jint format,
         jint precision, jstring name_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* name = env->GetStringUTFChars(name_, nullptr);
@@ -129,22 +126,22 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderSampler
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderVariable(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jint variable, jstring name_) {
+        JNIEnv* env, jclass, jlong nativeBuilder, jint variable, jstring name_) {
     const char* name = env->GetStringUTFChars(name_, nullptr);
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->variable((MaterialBuilder::Variable) variable, name);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderRequire(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint attribute) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderRequire(JNIEnv*,
+        jclass, jlong nativeBuilder, jint attribute) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->require((VertexAttribute) attribute);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderMaterial(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jstring code_) {
+        jclass, jlong nativeBuilder, jstring code_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* code = env->GetStringUTFChars(code_, nullptr);
     builder->material(code);
@@ -152,134 +149,141 @@ Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderMateria
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderMaterialVertex(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jstring code_) {
+        jclass, jlong nativeBuilder, jstring code_) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     const char* code = env->GetStringUTFChars(code_, nullptr);
     builder->materialVertex(code);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderBlending(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint mode) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderBlending(JNIEnv*,
+        jclass, jlong nativeBuilder, jint mode) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->blending((MaterialBuilder::BlendingMode) mode);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderVertexDomain(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint vertexDomain) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderPostLightingBlending(
+        JNIEnv*, jclass, jlong nativeBuilder, jint mode) {
+    auto builder = (MaterialBuilder*) nativeBuilder;
+    builder->postLightingBlending((MaterialBuilder::BlendingMode) mode);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderVertexDomain(JNIEnv*,
+        jclass, jlong nativeBuilder, jint vertexDomain) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->vertexDomain((MaterialBuilder::VertexDomain) vertexDomain);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderCulling(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint mode) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderCulling(JNIEnv*,
+        jclass, jlong nativeBuilder, jint mode) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->culling((MaterialBuilder::CullingMode) mode);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderColorWrite(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jboolean enable) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderColorWrite(JNIEnv*,
+        jclass, jlong nativeBuilder, jboolean enable) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->colorWrite(enable);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDepthWrite(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jboolean depthWrite) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDepthWrite(JNIEnv*,
+        jclass, jlong nativeBuilder, jboolean depthWrite) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->depthWrite(depthWrite);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDepthCulling(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jboolean depthCulling) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDepthCulling(JNIEnv*,
+        jclass, jlong nativeBuilder, jboolean depthCulling) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->depthCulling(depthCulling);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDoubleSided(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jboolean doubleSided) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderDoubleSided(JNIEnv*,
+        jclass, jlong nativeBuilder, jboolean doubleSided) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->doubleSided(doubleSided);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderMaskThreshold(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jfloat maskThreshold) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderMaskThreshold(JNIEnv*,
+        jclass, jlong nativeBuilder, jfloat maskThreshold) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->maskThreshold(maskThreshold);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderShadowMultiplier(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jboolean shadowMultiplier) {
+        JNIEnv*, jclass, jlong nativeBuilder, jboolean shadowMultiplier) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->shadowMultiplier(shadowMultiplier);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderCurvatureToRoughness(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jboolean curvatureToRoughness) {
+        JNIEnv*, jclass, jlong nativeBuilder, jboolean curvatureToRoughness) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->curvatureToRoughness(curvatureToRoughness);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderLimitOverInterpolation(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jboolean limitOverInterpolation) {
+        JNIEnv*, jclass, jlong nativeBuilder, jboolean limitOverInterpolation) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->limitOverInterpolation(limitOverInterpolation);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderClearCoatIorChange(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jboolean clearCoatIorChange) {
+        JNIEnv*, jclass, jlong nativeBuilder, jboolean clearCoatIorChange) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->clearCoatIorChange(clearCoatIorChange);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderFlipUV(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jboolean flipUV) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderFlipUV(JNIEnv*,
+        jclass, jlong nativeBuilder, jboolean flipUV) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->flipUV(flipUV);
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderTransparencyMode(
-        JNIEnv* env, jclass type, jlong nativeBuilder, jint mode) {
+        JNIEnv* env, jclass, jlong nativeBuilder, jint mode) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->transparencyMode((MaterialBuilder::TransparencyMode) mode);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderPlatform(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint platform) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderPlatform(JNIEnv*,
+        jclass, jlong nativeBuilder, jint platform) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->platform((MaterialBuilder::Platform) platform);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderTargetApi(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint targetApi) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderTargetApi(JNIEnv*,
+        jclass, jlong nativeBuilder, jint targetApi) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->targetApi((MaterialBuilder::TargetApi) targetApi);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderOptimization(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jint optimization) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderOptimization(JNIEnv*,
+        jclass, jlong nativeBuilder, jint optimization) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->optimization((MaterialBuilder::Optimization) optimization);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderVariantFilter(JNIEnv* env,
-        jclass type, jlong nativeBuilder, jbyte variantFilter) {
+Java_com_google_android_filament_filamat_MaterialBuilder_nMaterialBuilderVariantFilter(JNIEnv*,
+        jclass, jlong nativeBuilder, jbyte variantFilter) {
     auto builder = (MaterialBuilder*) nativeBuilder;
     builder->variantFilter((uint8_t) variantFilter);
 }

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -235,6 +235,12 @@ public class MaterialBuilder {
     }
 
     @NonNull
+    public MaterialBuilder postLightingBlending(@NonNull BlendingMode mode) {
+        nMaterialBuilderPostLightingBlending(mNativeObject, mode.ordinal());
+        return this;
+    }
+
+    @NonNull
     public MaterialBuilder vertexDomain(@NonNull VertexDomain vertexDomain) {
         nMaterialBuilderVertexDomain(mNativeObject, vertexDomain.ordinal());
         return this;
@@ -390,6 +396,7 @@ public class MaterialBuilder {
     private static native void nMaterialBuilderMaterial(long nativeBuilder, String code);
     private static native void nMaterialBuilderMaterialVertex(long nativeBuilder, String code);
     private static native void nMaterialBuilderBlending(long nativeBuilder, int mode);
+    private static native void nMaterialBuilderPostLightingBlending(long nativeBuilder, int mode);
     private static native void nMaterialBuilderVertexDomain(long nativeBuilder, int vertexDomain);
     private static native void nMaterialBuilderCulling(long nativeBuilder, int mode);
     private static native void nMaterialBuilderColorWrite(long nativeBuilder, boolean enable);

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -1205,7 +1205,7 @@ non-shader data.
 
 </p><dl><dt>Type</dt><dd><p>     <code>string</code>
 
-</p></dd><dt>Value</dt><dd><p>      Any of <code>opaque</code>, <code>transparent</code>, <code>add</code>. Defaults to <code>opaque</code>.
+</p></dd><dt>Value</dt><dd><p>      Any of <code>opaque</code>, <code>transparent</code>, <code>add</code>. Defaults to <code>transparent</code>.
 
 </p></dd><dt>Description</dt><dd><p>      Defines how the <code>postLightingColor</code> material property is blended with the result of the
       lighting computations. The possible blending modes are:
@@ -1222,7 +1222,7 @@ non-shader data.
     <li class="minus"><strong class="asterisk">Add</strong>: blending is enabled. The material&apos;s computed color is added to <code>postLightingColor</code>.</li></ul>
 
 <p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
-<span class="line">    postLightingBlending : transparent</span>
+<span class="line">    postLightingBlending : add</span>
 <span class="line">}</span></code></pre>
 <a class="target" name="vertexdomain">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/vertexdomain">&#xA0;</a><a class="target" name="toc4.2.8">&#xA0;</a><h3>vertexDomain</h3>
 <p>
@@ -1673,7 +1673,7 @@ plastic with bump mapping:
 <pre class="listing tilde"><code><span class="line">struct MaterialInputs {</span>
 <span class="line">    float4 baseColor;           <span class="hljs-comment">// default: float4(1.0)</span></span>
 <span class="line">    float4 emissive;            <span class="hljs-comment">// default: float4(0.0)</span></span>
-<span class="line">    float4 postLightingColor;   <span class="hljs-comment">// default: float4(1.0)</span></span>
+<span class="line">    float4 postLightingColor;   <span class="hljs-comment">// default: float4(0.0)</span></span>
 <span class="line"></span>
 <span class="line">    <span class="hljs-comment">// no other field is available with the unlit shading model</span></span>
 <span class="line">    <span class="hljs-type">float</span>  roughness;           <span class="hljs-comment">// default: 1.0</span></span>

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -1673,6 +1673,7 @@ plastic with bump mapping:
 <pre class="listing tilde"><code><span class="line">struct MaterialInputs {</span>
 <span class="line">    float4 baseColor;           <span class="hljs-comment">// default: float4(1.0)</span></span>
 <span class="line">    float4 emissive;            <span class="hljs-comment">// default: float4(0.0)</span></span>
+<span class="line">    float4 postLightingColor;   <span class="hljs-comment">// default: float4(1.0)</span></span>
 <span class="line"></span>
 <span class="line">    <span class="hljs-comment">// no other field is available with the unlit shading model</span></span>
 <span class="line">    <span class="hljs-type">float</span>  roughness;           <span class="hljs-comment">// default: 1.0</span></span>
@@ -1693,12 +1694,12 @@ plastic with bump mapping:
 <span class="line">    float3 subsurfaceColor;     <span class="hljs-comment">// default: float3(1.0)</span></span>
 <span class="line"></span>
 <span class="line">    <span class="hljs-comment">// only available when the shading model is cloth</span></span>
-<span class="line">    float3 sheenColor;         <span class="hljs-comment">// default: sqrt(baseColor)</span></span>
-<span class="line">    float3 subsurfaceColor;    <span class="hljs-comment">// default: float3(0.0)</span></span>
+<span class="line">    float3 sheenColor;          <span class="hljs-comment">// default: sqrt(baseColor)</span></span>
+<span class="line">    float3 subsurfaceColor;     <span class="hljs-comment">// default: float3(0.0)</span></span>
 <span class="line"></span>
 <span class="line">    <span class="hljs-comment">// not available when the shading model is unlit</span></span>
 <span class="line">    <span class="hljs-comment">// must be set before calling prepareMaterial()</span></span>
-<span class="line">    float3 normal;             <span class="hljs-comment">// default: float3(0.0, 0.0, 1.0)</span></span>
+<span class="line">    float3 normal;              <span class="hljs-comment">// default: float3(0.0, 0.0, 1.0)</span></span>
 <span class="line">}</span></code></pre>
 <a class="target" name="shaderpublicapis">&#xA0;</a><a class="target" name="materialdefinitions/shaderpublicapis">&#xA0;</a><a class="target" name="toc4.5">&#xA0;</a><h2>Shader public APIs</h2>
 

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -49,6 +49,7 @@ counter-increment: h6;margin-right:10px}</style><style>.hljs{display:block;overf
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/normal" class="level3"><span class="tocNumber">3.1.12&#xA0; </span>Normal</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/clearcoatnormal" class="level3"><span class="tocNumber">3.1.13&#xA0; </span>Clear coat normal</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/emissive" class="level3"><span class="tocNumber">3.1.14&#xA0; </span>Emissive</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/litmodel/post-lightingcolor" class="level3"><span class="tocNumber">3.1.15&#xA0; </span>Post-lighting color</a><br>
 &#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel" class="level2"><span class="tocNumber">3.2&#xA0; </span>Subsurface model</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel/thickness" class="level3"><span class="tocNumber">3.2.1&#xA0; </span>Thickness</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialmodels/subsurfacemodel/subsurfacecolor" class="level3"><span class="tocNumber">3.2.2&#xA0; </span>Subsurface color</a><br>
@@ -68,21 +69,22 @@ counter-increment: h6;margin-right:10px}</style><style>.hljs{display:block;overf
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/requires" class="level3"><span class="tocNumber">4.2.4&#xA0; </span>requires</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/variables" class="level3"><span class="tocNumber">4.2.5&#xA0; </span>variables</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/blending" class="level3"><span class="tocNumber">4.2.6&#xA0; </span>blending</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/vertexdomain" class="level3"><span class="tocNumber">4.2.7&#xA0; </span>vertexDomain</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/interpolation" class="level3"><span class="tocNumber">4.2.8&#xA0; </span>interpolation</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/culling" class="level3"><span class="tocNumber">4.2.9&#xA0; </span>culling</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/colorwrite" class="level3"><span class="tocNumber">4.2.10&#xA0; </span>colorWrite</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthwrite" class="level3"><span class="tocNumber">4.2.11&#xA0; </span>depthWrite</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthculling" class="level3"><span class="tocNumber">4.2.12&#xA0; </span>depthCulling</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/doublesided" class="level3"><span class="tocNumber">4.2.13&#xA0; </span>doubleSided</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/transparency" class="level3"><span class="tocNumber">4.2.14&#xA0; </span>transparency</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/maskthreshold" class="level3"><span class="tocNumber">4.2.15&#xA0; </span>maskThreshold</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/shadowmultiplier" class="level3"><span class="tocNumber">4.2.16&#xA0; </span>shadowMultiplier</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/curvaturetoroughness" class="level3"><span class="tocNumber">4.2.17&#xA0; </span>curvatureToRoughness</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/limitoverinterpolation" class="level3"><span class="tocNumber">4.2.18&#xA0; </span>limitOverInterpolation</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/clearcoatiorchange" class="level3"><span class="tocNumber">4.2.19&#xA0; </span>clearCoatIorChange</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/variantfilter" class="level3"><span class="tocNumber">4.2.20&#xA0; </span>variantFilter</a><br>
-&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/flipuv" class="level3"><span class="tocNumber">4.2.21&#xA0; </span>flipUV</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/postlightingblending" class="level3"><span class="tocNumber">4.2.7&#xA0; </span>postLightingBlending</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/vertexdomain" class="level3"><span class="tocNumber">4.2.8&#xA0; </span>vertexDomain</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/interpolation" class="level3"><span class="tocNumber">4.2.9&#xA0; </span>interpolation</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/culling" class="level3"><span class="tocNumber">4.2.10&#xA0; </span>culling</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/colorwrite" class="level3"><span class="tocNumber">4.2.11&#xA0; </span>colorWrite</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthwrite" class="level3"><span class="tocNumber">4.2.12&#xA0; </span>depthWrite</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/depthculling" class="level3"><span class="tocNumber">4.2.13&#xA0; </span>depthCulling</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/doublesided" class="level3"><span class="tocNumber">4.2.14&#xA0; </span>doubleSided</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/transparency" class="level3"><span class="tocNumber">4.2.15&#xA0; </span>transparency</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/maskthreshold" class="level3"><span class="tocNumber">4.2.16&#xA0; </span>maskThreshold</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/shadowmultiplier" class="level3"><span class="tocNumber">4.2.17&#xA0; </span>shadowMultiplier</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/curvaturetoroughness" class="level3"><span class="tocNumber">4.2.18&#xA0; </span>curvatureToRoughness</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/limitoverinterpolation" class="level3"><span class="tocNumber">4.2.19&#xA0; </span>limitOverInterpolation</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/clearcoatiorchange" class="level3"><span class="tocNumber">4.2.20&#xA0; </span>clearCoatIorChange</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/variantfilter" class="level3"><span class="tocNumber">4.2.21&#xA0; </span>variantFilter</a><br>
+&#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/materialblock/flipuv" class="level3"><span class="tocNumber">4.2.22&#xA0; </span>flipUV</a><br>
 &#xA0;&#xA0;<a href="#materialdefinitions/vertexblock" class="level2"><span class="tocNumber">4.3&#xA0; </span>Vertex block</a><br>
 &#xA0;&#xA0;&#xA0;&#xA0;<a href="#materialdefinitions/vertexblock/materialvertexinputs" class="level3"><span class="tocNumber">4.3.1&#xA0; </span>Material vertex inputs</a><br>
 &#xA0;&#xA0;<a href="#materialdefinitions/fragmentblock" class="level2"><span class="tocNumber">4.4&#xA0; </span>Fragment block</a><br>
@@ -221,6 +223,7 @@ in <a href="#table_standardproperties">table&#xA0;1</a>.
 <tr><td style="text-align:right"> <strong class="asterisk">normal</strong> </td><td style="text-align:left"> A detail normal used to perturb the surface using <em class="underscore">bump mapping</em> (<em class="underscore">normal mapping</em>) </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:left"> A detail normal used to perturb the clear coat layer using <em class="underscore">bump mapping</em> (<em class="underscore">normal mapping</em>) </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:left"> Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:left"> Additional color that can be blended with the result of the lighting computations. See <code>postLightingBlending</code> </td></tr>
 </tbody></table><div class="tablecaption"><a class="target" name="table_standardproperties">&#xA0;</a><b style="font-style:normal;">Table&#xA0;1:</b> Properties of the standard model</div></div>
 
 <p></p><p>
@@ -240,6 +243,7 @@ The type and range of each property is described in <a href="#table_standardprop
 <tr><td style="text-align:right"> <strong class="asterisk">normal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=[-n..n] </td><td style="text-align:left"> Alpha is the exposure compensation </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
 </tbody></table><div class="tablecaption"><a class="target" name="table_standardpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;2:</b> Range and type of the standard model&apos;s properties</div></div>
 
 <p></p><p>
@@ -631,6 +635,27 @@ to be brighter (positive values) or darker (negative values) than the current ex
 effect is enabled, using a positive exposure compensation can force the surface to bloom.
 
 </p>
+<a class="target" name="post-lightingcolor">&#xA0;</a><a class="target" name="materialmodels/litmodel/post-lightingcolor">&#xA0;</a><a class="target" name="toc3.1.15">&#xA0;</a><h3>Post-lighting color</h3>
+<p>
+
+
+The <code>postLightingColor</code> can be used to modify the surface color after lighting computations. This
+property has no physical meaning and only exists to implement specific effects or to help with
+debugging. This property is defined as a <code>float4</code> value containing a pre-multiplied RGB color in
+linear space.
+
+</p><p>
+
+The post-lighting color is blended with the result of lighting according to the blending mode
+specified by the <code>postLightingBlending</code> material option. Please refer to the documentation of
+this option for more information.
+
+</p><p>
+
+</p><div class="admonition tip"><code>postLightingColor</code> can be used as a simpler <code>emissive</code> property by setting
+    <code>postLightingBlending</code> to <code>add</code> and by providing an RGB color with alpha set to <code>0.0</code>.</div>
+
+<p></p>
 <a class="target" name="subsurfacemodel">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel">&#xA0;</a><a class="target" name="toc3.2">&#xA0;</a><h2>Subsurface model</h2>
 
 <a class="target" name="thickness">&#xA0;</a><a class="target" name="materialmodels/subsurfacemodel/thickness">&#xA0;</a><a class="target" name="toc3.2.1">&#xA0;</a><h3>Thickness</h3>
@@ -778,6 +803,7 @@ in <a href="#table_unlitproperties">table&#xA0;8</a>.
 <table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:left"> Definition </th></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:left"> Surface diffuse color </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:left"> Additional diffuse color to simulate emissive surfaces. This property is mostly useful in an HDR pipeline with a bloom pass </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:left"> Additional color to blend with base color and emissive </td></tr>
 </tbody></table><div class="tablecaption"><a class="target" name="table_unlitproperties">&#xA0;</a><b style="font-style:normal;">Table&#xA0;8:</b> Properties of the standard model</div></div>
 
 <p></p><p>
@@ -787,12 +813,15 @@ The type and range of each property is described in <a href="#table_unlitpropert
 <table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:center"> Type </th><th style="text-align:center"> Range </th><th style="text-align:left"> Note </th></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=N/A </td><td style="text-align:left"> Pre-multiplied linear RGB, alpha is ignored </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
 </tbody></table><div class="tablecaption"><a class="target" name="table_unlitpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;9:</b> Range and type of the unlit model&apos;s properties</div></div>
 
 <p></p><p>
 
 The value of <code>emissive</code> is simply added to <code>baseColor</code> when present. The main use of <code>emissive</code>
-is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass.
+is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass. The value
+of <code>postLightingColor</code> is blended with the sum of <code>emissive</code> and <code>baseColor</code> according to the
+blending mode specified by the <code>postLightingBlending</code> material option.
 
 </p><p>
 
@@ -1170,7 +1199,32 @@ non-shader data.
 <p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    blending : transparent</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="vertexdomain">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/vertexdomain">&#xA0;</a><a class="target" name="toc4.2.7">&#xA0;</a><h3>vertexDomain</h3>
+<a class="target" name="postlightingblending">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/postlightingblending">&#xA0;</a><a class="target" name="toc4.2.7">&#xA0;</a><h3>postLightingBlending</h3>
+<p>
+
+
+</p><dl><dt>Type</dt><dd><p>     <code>string</code>
+
+</p></dd><dt>Value</dt><dd><p>      Any of <code>opaque</code>, <code>transparent</code>, <code>add</code>. Defaults to <code>opaque</code>.
+
+</p></dd><dt>Description</dt><dd><p>      Defines how the <code>postLightingColor</code> material property is blended with the result of the
+      lighting computations. The possible blending modes are:
+
+</p><p>
+
+</p><ul>
+    <li class="minus"><strong class="asterisk">Opaque</strong>: blending is disabled, the material will output <code>postLightingColor</code> directly.
+</li>
+    <li class="minus"><strong class="asterisk">Transparent</strong>: blending is enabled. The material&apos;s computed color is alpha composited with
+          the <code>postLightingColor</code>, using Porter-Duff&apos;s <code>source over</code> rule. This blending mode assumes
+          pre-multiplied alpha.
+</li>
+    <li class="minus"><strong class="asterisk">Add</strong>: blending is enabled. The material&apos;s computed color is added to <code>postLightingColor</code>.</li></ul>
+
+<p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
+<span class="line">    postLightingBlending : transparent</span>
+<span class="line">}</span></code></pre>
+<a class="target" name="vertexdomain">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/vertexdomain">&#xA0;</a><a class="target" name="toc4.2.8">&#xA0;</a><h3>vertexDomain</h3>
 <p>
 
 
@@ -1199,7 +1253,7 @@ non-shader data.
 <p></p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    vertexDomain : device</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="interpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/interpolation">&#xA0;</a><a class="target" name="toc4.2.8">&#xA0;</a><h3>interpolation</h3>
+<a class="target" name="interpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/interpolation">&#xA0;</a><a class="target" name="toc4.2.9">&#xA0;</a><h3>interpolation</h3>
 <p>
 
 
@@ -1215,7 +1269,7 @@ non-shader data.
 </p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    interpolation : flat</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="culling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/culling">&#xA0;</a><a class="target" name="toc4.2.9">&#xA0;</a><h3>culling</h3>
+<a class="target" name="culling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/culling">&#xA0;</a><a class="target" name="toc4.2.10">&#xA0;</a><h3>culling</h3>
 <p>
 
 
@@ -1229,7 +1283,7 @@ non-shader data.
 </p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    culling : none</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="colorwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/colorwrite">&#xA0;</a><a class="target" name="toc4.2.10">&#xA0;</a><h3>colorWrite</h3>
+<a class="target" name="colorwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/colorwrite">&#xA0;</a><a class="target" name="toc4.2.11">&#xA0;</a><h3>colorWrite</h3>
 <p>
 
 
@@ -1242,7 +1296,7 @@ non-shader data.
 </p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    colorWrite : false</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="depthwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthwrite">&#xA0;</a><a class="target" name="toc4.2.11">&#xA0;</a><h3>depthWrite</h3>
+<a class="target" name="depthwrite">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthwrite">&#xA0;</a><a class="target" name="toc4.2.12">&#xA0;</a><h3>depthWrite</h3>
 <p>
 
 
@@ -1255,7 +1309,7 @@ non-shader data.
 </p></dd></td></tr></tbody></table></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    depthWrite : false</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="depthculling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthculling">&#xA0;</a><a class="target" name="toc4.2.12">&#xA0;</a><h3>depthCulling</h3>
+<a class="target" name="depthculling">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/depthculling">&#xA0;</a><a class="target" name="toc4.2.13">&#xA0;</a><h3>depthCulling</h3>
 <p>
 
 
@@ -1269,7 +1323,7 @@ non-shader data.
 </p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    depthCulling : false</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="doublesided">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/doublesided">&#xA0;</a><a class="target" name="toc4.2.13">&#xA0;</a><h3>doubleSided</h3>
+<a class="target" name="doublesided">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/doublesided">&#xA0;</a><a class="target" name="toc4.2.14">&#xA0;</a><h3>doubleSided</h3>
 <p>
 
 
@@ -1284,7 +1338,7 @@ non-shader data.
 </p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    doubleSided : true</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="transparency">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/transparency">&#xA0;</a><a class="target" name="toc4.2.14">&#xA0;</a><h3>transparency</h3>
+<a class="target" name="transparency">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/transparency">&#xA0;</a><a class="target" name="toc4.2.15">&#xA0;</a><h3>transparency</h3>
 <p>
 
 
@@ -1331,7 +1385,7 @@ and correctly sorted</div></div></center>
 and sorting issues are minimized or eliminated</div></div></center>
 
 <p></p>
-<a class="target" name="maskthreshold">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/maskthreshold">&#xA0;</a><a class="target" name="toc4.2.15">&#xA0;</a><h3>maskThreshold</h3>
+<a class="target" name="maskthreshold">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/maskthreshold">&#xA0;</a><a class="target" name="toc4.2.16">&#xA0;</a><h3>maskThreshold</h3>
 <p>
 
 
@@ -1347,7 +1401,7 @@ and sorting issues are minimized or eliminated</div></div></center>
 <span class="line">    blending : masked,</span>
 <span class="line">    maskThreshold : 0.5</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="shadowmultiplier">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/shadowmultiplier">&#xA0;</a><a class="target" name="toc4.2.16">&#xA0;</a><h3>shadowMultiplier</h3>
+<a class="target" name="shadowmultiplier">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/shadowmultiplier">&#xA0;</a><a class="target" name="toc4.2.17">&#xA0;</a><h3>shadowMultiplier</h3>
 <p>
 
 
@@ -1373,7 +1427,7 @@ and sorting issues are minimized or eliminated</div></div></center>
 <span class="line">        material.baseColor = vec4(0.0, 0.0, 0.0, 0.7);</span>
 <span class="line">    }</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="curvaturetoroughness">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/curvaturetoroughness">&#xA0;</a><a class="target" name="toc4.2.17">&#xA0;</a><h3>curvatureToRoughness</h3>
+<a class="target" name="curvaturetoroughness">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/curvaturetoroughness">&#xA0;</a><a class="target" name="toc4.2.18">&#xA0;</a><h3>curvatureToRoughness</h3>
 <p>
 
 
@@ -1392,7 +1446,7 @@ and sorting issues are minimized or eliminated</div></div></center>
 with <code>curvatureToRoughness</code> (right).</div></div></center>
 
 <p></p>
-<a class="target" name="limitoverinterpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/limitoverinterpolation">&#xA0;</a><a class="target" name="toc4.2.18">&#xA0;</a><h3>limitOverInterpolation</h3>
+<a class="target" name="limitoverinterpolation">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/limitoverinterpolation">&#xA0;</a><a class="target" name="toc4.2.19">&#xA0;</a><h3>limitOverInterpolation</h3>
 <p>
 
 
@@ -1409,7 +1463,7 @@ with <code>curvatureToRoughness</code> (right).</div></div></center>
 </p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    limitOverInterpolation : true</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="clearcoatiorchange">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/clearcoatiorchange">&#xA0;</a><a class="target" name="toc4.2.19">&#xA0;</a><h3>clearCoatIorChange</h3>
+<a class="target" name="clearcoatiorchange">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/clearcoatiorchange">&#xA0;</a><a class="target" name="toc4.2.20">&#xA0;</a><h3>clearCoatIorChange</h3>
 <p>
 
 
@@ -1431,7 +1485,7 @@ with <code>clearCoatIorChange</code> enabled (left) and disabled
 (right).</div></div></center>
 
 <p></p>
-<a class="target" name="variantfilter">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/variantfilter">&#xA0;</a><a class="target" name="toc4.2.20">&#xA0;</a><h3>variantFilter</h3>
+<a class="target" name="variantfilter">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/variantfilter">&#xA0;</a><a class="target" name="toc4.2.21">&#xA0;</a><h3>variantFilter</h3>
 <p>
 
 
@@ -1467,7 +1521,7 @@ with <code>clearCoatIorChange</code> enabled (left) and disabled
 <span class="line">    blending : transparent,</span>
 <span class="line">    variantFilter : [ skinning ]</span>
 <span class="line">}</span></code></pre>
-<a class="target" name="flipuv">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/flipuv">&#xA0;</a><a class="target" name="toc4.2.21">&#xA0;</a><h3>flipUV</h3>
+<a class="target" name="flipuv">&#xA0;</a><a class="target" name="materialdefinitions/materialblock/flipuv">&#xA0;</a><a class="target" name="toc4.2.22">&#xA0;</a><h3>flipUV</h3>
 <p>
 
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -87,6 +87,7 @@ in table [standardProperties].
 **normal**              | A detail normal used to perturb the surface using _bump mapping_ (_normal mapping_)
 **clearCoatNormal**     | A detail normal used to perturb the clear coat layer using _bump mapping_ (_normal mapping_)
 **emissive**            | Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass
+**postLightingColor**   | Additional color that can be blended with the result of the lighting computations. See `postLightingBlending`
 [Table [standardProperties]: Properties of the standard model]
 
 The type and range of each property is described in table [standardPropertiesTypes].
@@ -105,6 +106,7 @@ The type and range of each property is described in table [standardPropertiesTyp
 **normal**              | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
 **clearCoatNormal**     | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
 **emissive**            | float4   |  rgb=[0..1], a=[-n..n]   | Alpha is the exposure compensation
+**postLightingColor**   | float4   |  [0..1]                  | Pre-multiplied linear RGB
 [Table [standardPropertiesTypes]: Range and type of the standard model's properties]
 
 
@@ -373,6 +375,21 @@ The exposure compensation value of the emissive property can be used to force th
 to be brighter (positive values) or darker (negative values) than the current exposure. If the bloom
 effect is enabled, using a positive exposure compensation can force the surface to bloom.
 
+### Post-lighting color
+
+The `postLightingColor` can be used to modify the surface color after lighting computations. This
+property has no physical meaning and only exists to implement specific effects or to help with
+debugging. This property is defined as a `float4` value containing a pre-multiplied RGB color in
+linear space.
+
+The post-lighting color is blended with the result of lighting according to the blending mode
+specified by the `postLightingBlending` material option. Please refer to the documentation of
+this option for more information.
+
+!!! Tip
+    `postLightingColor` can be used as a simpler `emissive` property by setting
+    `postLightingBlending` to `add` and by providing an RGB color with alpha set to `0.0`.
+
 ## Subsurface model
 
 ### Thickness
@@ -483,6 +500,7 @@ in table [unlitProperties].
 ---------------------:|:---------------------
 **baseColor**         | Surface diffuse color
 **emissive**          | Additional diffuse color to simulate emissive surfaces. This property is mostly useful in an HDR pipeline with a bloom pass
+**postLightingColor** | Additional color to blend with base color and emissive
 [Table [unlitProperties]: Properties of the standard model]
 
 The type and range of each property is described in table [unlitPropertiesTypes].
@@ -491,10 +509,13 @@ The type and range of each property is described in table [unlitPropertiesTypes]
 ---------------------:|:--------:|:------------------------:|:-------------------------
 **baseColor**         | float4   |  [0..1]                  | Pre-multiplied linear RGB
 **emissive**          | float4   |  rgb=[0..1], a=N/A       | Pre-multiplied linear RGB, alpha is ignored
+**postLightingColor** | float4   |  [0..1]                  | Pre-multiplied linear RGB
 [Table [unlitPropertiesTypes]: Range and type of the unlit model's properties]
 
 The value of `emissive` is simply added to `baseColor` when present. The main use of `emissive`
-is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass.
+is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass. The value
+of `postLightingColor` is blended with the sum of `emissive` and `baseColor` according to the
+blending mode specified by the `postLightingBlending` material option.
 
 Figure [materialUnlit] shows an example of the unlit material model
 (click on the image to see a larger version).
@@ -855,6 +876,30 @@ Description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {
     blending : transparent
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+### postLightingBlending
+
+Type
+:    `string`
+
+Value
+:     Any of `opaque`, `transparent`, `add`. Defaults to `opaque`.
+
+Description
+:     Defines how the `postLightingColor` material property is blended with the result of the
+      lighting computations. The possible blending modes are:
+
+    - **Opaque**: blending is disabled, the material will output `postLightingColor` directly.
+    - **Transparent**: blending is enabled. The material's computed color is alpha composited with
+      the `postLightingColor`, using Porter-Duff's `source over` rule. This blending mode assumes
+      pre-multiplied alpha.
+    - **Add**: blending is enabled. The material's computed color is added to `postLightingColor`.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
+material {
+    postLightingBlending : transparent
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1382,6 +1382,7 @@ fragment {
 struct MaterialInputs {
     float4 baseColor;           // default: float4(1.0)
     float4 emissive;            // default: float4(0.0)
+    float4 postLightingColor;   // default: float4(1.0)
 
     // no other field is available with the unlit shading model
     float  roughness;           // default: 1.0
@@ -1402,12 +1403,12 @@ struct MaterialInputs {
     float3 subsurfaceColor;     // default: float3(1.0)
 
     // only available when the shading model is cloth
-    float3 sheenColor;         // default: sqrt(baseColor)
-    float3 subsurfaceColor;    // default: float3(0.0)
+    float3 sheenColor;          // default: sqrt(baseColor)
+    float3 subsurfaceColor;     // default: float3(0.0)
 
     // not available when the shading model is unlit
     // must be set before calling prepareMaterial()
-    float3 normal;             // default: float3(0.0, 0.0, 1.0)
+    float3 normal;              // default: float3(0.0, 0.0, 1.0)
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -885,7 +885,7 @@ Type
 :    `string`
 
 Value
-:     Any of `opaque`, `transparent`, `add`. Defaults to `opaque`.
+:     Any of `opaque`, `transparent`, `add`. Defaults to `transparent`.
 
 Description
 :     Defines how the `postLightingColor` material property is blended with the result of the
@@ -899,7 +899,7 @@ Description
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {
-    postLightingBlending : transparent
+    postLightingBlending : add
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1382,7 +1382,7 @@ fragment {
 struct MaterialInputs {
     float4 baseColor;           // default: float4(1.0)
     float4 emissive;            // default: float4(0.0)
-    float4 postLightingColor;   // default: float4(1.0)
+    float4 postLightingColor;   // default: float4(0.0)
 
     // no other field is available with the unlit shading model
     float  roughness;           // default: 1.0

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -111,7 +111,7 @@ public:
         // when adding more variables, make sure to update MATERIAL_VARIABLES_COUNT
     };
 
-    static constexpr size_t MATERIAL_PROPERTIES_COUNT = 16;
+    static constexpr size_t MATERIAL_PROPERTIES_COUNT = 17;
     enum class Property : uint8_t {
         BASE_COLOR,              // float4, all shading models
         ROUGHNESS,               // float,  lit shading models only
@@ -129,6 +129,7 @@ public:
         SHEEN_COLOR,             // float3, cloth shading model only
         EMISSIVE,                // float4, all shading models
         NORMAL,                  // float3, all shading models only, except unlit
+        POST_LIGHTING_COLOR,     // float4, all shading models
         // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
     };
 
@@ -187,6 +188,11 @@ public:
 
     // set blending mode for this material
     MaterialBuilder& blending(BlendingMode blending) noexcept;
+
+    // set blending mode of the post lighting color for this material
+    // only OPAQUE, TRANSPARENT and ADD are supported
+    // this setting requires the material property "postLightingColor" to be set
+    MaterialBuilder& postLightingBlending(BlendingMode blending) noexcept;
 
     // set vertex domain for this material
     MaterialBuilder& vertexDomain(VertexDomain domain) noexcept;
@@ -321,6 +327,7 @@ private:
     VariableList mVariables;
 
     BlendingMode mBlendingMode = BlendingMode::OPAQUE;
+    BlendingMode mPostLightingBlendingMode = BlendingMode::OPAQUE;
     CullingMode mCullingMode = CullingMode::BACK;
     Shading mShading = Shading::LIT;
     Interpolation mInterpolation = Interpolation::SMOOTH;

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -190,7 +190,7 @@ public:
     MaterialBuilder& blending(BlendingMode blending) noexcept;
 
     // set blending mode of the post lighting color for this material
-    // only OPAQUE, TRANSPARENT and ADD are supported
+    // only OPAQUE, TRANSPARENT and ADD are supported, the default is TRANSPARENT
     // this setting requires the material property "postLightingColor" to be set
     MaterialBuilder& postLightingBlending(BlendingMode blending) noexcept;
 
@@ -327,7 +327,7 @@ private:
     VariableList mVariables;
 
     BlendingMode mBlendingMode = BlendingMode::OPAQUE;
-    BlendingMode mPostLightingBlendingMode = BlendingMode::OPAQUE;
+    BlendingMode mPostLightingBlendingMode = BlendingMode::TRANSPARENT;
     CullingMode mCullingMode = CullingMode::BACK;
     Shading mShading = Shading::LIT;
     Interpolation mInterpolation = Interpolation::SMOOTH;

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -36,7 +36,8 @@ std::unordered_map<std::string, Property> Enums::mStringToProperty = {
         { "subsurfaceColor",     Property::SUBSURFACE_COLOR },
         { "sheenColor",          Property::SHEEN_COLOR },
         { "emissive",            Property::EMISSIVE },
-        { "normal",              Property::NORMAL }
+        { "normal",              Property::NORMAL },
+        { "postLightingColor",   Property::POST_LIGHTING_COLOR },
 };
 
 template <>

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -190,6 +190,11 @@ MaterialBuilder& MaterialBuilder::blending(BlendingMode blending) noexcept {
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::postLightingBlending(BlendingMode blending) noexcept {
+    mPostLightingBlendingMode = blending;
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::vertexDomain(VertexDomain domain) noexcept {
     mVertexDomain = domain;
     return *this;
@@ -328,6 +333,7 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.flipUV = mFlipUV;
     info.requiredAttributes = mRequiredAttributes;
     info.blendingMode = mBlendingMode;
+    info.postLightingBlendingMode = mPostLightingBlendingMode;
     info.shading = mShading;
     info.hasShadowMultiplier = mShadowMultiplier;
 }

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -510,6 +510,7 @@ char const* CodeGenerator::getConstantName(MaterialBuilder::Property property) n
         case Property::SHEEN_COLOR:          return "SHEEN_COLOR";
         case Property::EMISSIVE:             return "EMISSIVE";
         case Property::NORMAL:               return "NORMAL";
+        case Property::POST_LIGHTING_COLOR:  return "POST_LIGHTING_COLOR";
     }
 }
 

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -42,6 +42,7 @@ struct UTILS_PUBLIC MaterialInfo {
     bool flipUV;
     filament::AttributeBitset requiredAttributes;
     filament::BlendingMode blendingMode;
+    filament::BlendingMode postLightingBlendingMode;
     filament::Shading shading;
     filament::UniformInterfaceBlock uib;
     filament::SamplerInterfaceBlock sib;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -47,23 +47,9 @@ static const char* getShadingDefine(filament::Shading shading) noexcept {
 
 static void generateMaterialDefines(std::ostream& os, const CodeGenerator& cg,
         MaterialBuilder::PropertyList const properties) noexcept {
-    using Property = MaterialBuilder::Property;
-    cg.generateMaterialProperty(os, Property::BASE_COLOR,           properties[ 0]);
-    cg.generateMaterialProperty(os, Property::ROUGHNESS,            properties[ 1]);
-    cg.generateMaterialProperty(os, Property::METALLIC,             properties[ 2]);
-    cg.generateMaterialProperty(os, Property::REFLECTANCE,          properties[ 3]);
-    cg.generateMaterialProperty(os, Property::AMBIENT_OCCLUSION,    properties[ 4]);
-    cg.generateMaterialProperty(os, Property::CLEAR_COAT,           properties[ 5]);
-    cg.generateMaterialProperty(os, Property::CLEAR_COAT_ROUGHNESS, properties[ 6]);
-    cg.generateMaterialProperty(os, Property::CLEAR_COAT_NORMAL,    properties[ 7]);
-    cg.generateMaterialProperty(os, Property::ANISOTROPY,           properties[ 8]);
-    cg.generateMaterialProperty(os, Property::ANISOTROPY_DIRECTION, properties[ 9]);
-    cg.generateMaterialProperty(os, Property::THICKNESS,            properties[10]);
-    cg.generateMaterialProperty(os, Property::SUBSURFACE_POWER,     properties[11]);
-    cg.generateMaterialProperty(os, Property::SUBSURFACE_COLOR,     properties[12]);
-    cg.generateMaterialProperty(os, Property::SHEEN_COLOR,          properties[13]);
-    cg.generateMaterialProperty(os, Property::EMISSIVE,             properties[14]);
-    cg.generateMaterialProperty(os, Property::NORMAL,               properties[15]);
+    for (size_t i = 0; i < MaterialBuilder::MATERIAL_PROPERTIES_COUNT; i++) {
+        cg.generateMaterialProperty(os, static_cast<MaterialBuilder::Property>(i), properties[i]);
+    }
 }
 
 static void generateVertexDomain(const CodeGenerator& cg, std::stringstream& vs,
@@ -278,6 +264,19 @@ const std::string ShaderGenerator::createFragmentProgram(filament::backend::Shad
             break;
         case BlendingMode::MASKED:
             cg.generateDefine(fs, "BLEND_MODE_MASKED", true);
+            break;
+    }
+    switch (material.postLightingBlendingMode) {
+        case BlendingMode::OPAQUE:
+            cg.generateDefine(fs, "POST_LIGHTING_BLEND_MODE_OPAQUE", true);
+            break;
+        case BlendingMode::TRANSPARENT:
+            cg.generateDefine(fs, "POST_LIGHTING_BLEND_MODE_TRANSPARENT", true);
+            break;
+        case BlendingMode::ADD:
+            cg.generateDefine(fs, "POST_LIGHTING_BLEND_MODE_ADD", true);
+            break;
+        default:
             break;
     }
     cg.generateDefine(fs, getShadingDefine(material.shading), true);

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -496,6 +496,24 @@ TEST_F(MaterialCompiler, StaticCodeAnalyzerNormal) {
     expected[size_t(filamat::MaterialBuilder::Property::NORMAL)] = true;
     EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
+
+TEST_F(MaterialCompiler, StaticCodeAnalyzerOutputFactor) {
+    std::string shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.postLightingColor = vec4(1.0);
+        }
+    )");
+
+    filamat::MaterialBuilder builder = makeBuilder(shaderCode);
+    GLSLTools glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(builder, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(filamat::MaterialBuilder::Property::POST_LIGHTING_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
 TEST_F(MaterialCompiler, EmptyName) {
     std::string shaderCode(R"(
         void material(inout MaterialInputs material) {

--- a/samples/materials/sandboxLit.mat
+++ b/samples/materials/sandboxLit.mat
@@ -30,8 +30,7 @@ material {
             type : float,
             name : anisotropy
         }
-    ],
-    postLightingBlending : opaque
+    ]
 }
 
 fragment {
@@ -44,6 +43,5 @@ fragment {
         material.clearCoat = materialParams.clearCoat;
         material.clearCoatRoughness = materialParams.clearCoatRoughness;
         material.anisotropy = materialParams.anisotropy;
-        material.postLightingColor = vec4(0.5, 0.0, 0.0, 0.5);
     }
 }

--- a/samples/materials/sandboxLit.mat
+++ b/samples/materials/sandboxLit.mat
@@ -31,6 +31,7 @@ material {
             name : anisotropy
         }
     ],
+    postLightingBlending : opaque
 }
 
 fragment {
@@ -43,5 +44,6 @@ fragment {
         material.clearCoat = materialParams.clearCoat;
         material.clearCoatRoughness = materialParams.clearCoatRoughness;
         material.anisotropy = materialParams.anisotropy;
+        material.postLightingColor = vec4(0.5, 0.0, 0.0, 0.5);
     }
 }

--- a/shaders/src/common_material.fs
+++ b/shaders/src/common_material.fs
@@ -94,6 +94,10 @@ struct MaterialInputs {
 #if defined(MATERIAL_HAS_CLEAR_COAT) && defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     vec3  clearCoatNormal;
 #endif
+
+#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
+    vec4  postLightingColor;
+#endif
 };
 
 void initMaterial(out MaterialInputs material) {
@@ -136,5 +140,9 @@ void initMaterial(out MaterialInputs material) {
 #endif
 #if defined(MATERIAL_HAS_CLEAR_COAT) && defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     material.clearCoatNormal = vec3(0.0, 0.0, 1.0);
+#endif
+
+#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
+    material.postLightingColor = vec4(1.0);
 #endif
 }

--- a/shaders/src/common_material.fs
+++ b/shaders/src/common_material.fs
@@ -143,6 +143,6 @@ void initMaterial(out MaterialInputs material) {
 #endif
 
 #if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
-    material.postLightingColor = vec4(1.0);
+    material.postLightingColor = vec4(0.0);
 #endif
 }

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -1,3 +1,15 @@
+#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
+void blendPostLightingColor(const MaterialInputs material, inout vec4 color) {
+#if defined(POST_LIGHTING_BLEND_MODE_OPAQUE)
+    color = material.postLightingColor;
+#elif defined(POST_LIGHTING_BLEND_MODE_TRANSPARENT)
+    color = material.postLightingColor + color * (1.0 - material.postLightingColor.a);
+#elif defined(POST_LIGHTING_BLEND_MODE_ADD)
+    color += material.postLightingColor;
+#endif
+}
+#endif
+
 void main() {
     // See shading_parameters.fs
     // Computes global variables we need to evaluate material and lighting
@@ -11,4 +23,8 @@ void main() {
     material(inputs);
 
     fragColor = evaluateMaterial(inputs);
+
+#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
+    blendPostLightingColor(inputs, fragColor);
+#endif
 }

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -35,6 +35,7 @@ static constexpr const char* PARAM_KEY_PARAMETERS               = "parameters";
 static constexpr const char* PARAM_KEY_VARIABLES                = "variables";
 static constexpr const char* PARAM_KEY_REQUIRES                 = "requires";
 static constexpr const char* PARAM_KEY_BLENDING                 = "blending";
+static constexpr const char* PARAM_KEY_POST_LIGHTING_BLENDING   = "postLightingBlending";
 static constexpr const char* PARAM_KEY_VERTEX_DOMAIN            = "vertexDomain";
 static constexpr const char* PARAM_KEY_CULLING                  = "culling";
 static constexpr const char* PARAM_KEY_COLOR_WRITE              = "colorWrite";
@@ -58,6 +59,8 @@ ParametersProcessor::ParametersProcessor() {
     mConfigProcessor[PARAM_KEY_VARIABLES]         = &ParametersProcessor::processVariables;
     mConfigProcessor[PARAM_KEY_REQUIRES]          = &ParametersProcessor::processRequires;
     mConfigProcessor[PARAM_KEY_BLENDING]          = &ParametersProcessor::processBlending;
+    mConfigProcessor[PARAM_KEY_POST_LIGHTING_BLENDING]
+            = &ParametersProcessor::processPostLightingBlending;
     mConfigProcessor[PARAM_KEY_VERTEX_DOMAIN]     = &ParametersProcessor::processVertexDomain;
     mConfigProcessor[PARAM_KEY_CULLING]           = &ParametersProcessor::processCulling;
     mConfigProcessor[PARAM_KEY_COLOR_WRITE]       = &ParametersProcessor::processColorWrite;
@@ -83,6 +86,7 @@ ParametersProcessor::ParametersProcessor() {
     mRootAsserts[PARAM_KEY_VARIABLES]                = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_REQUIRES]                 = JsonishValue::Type::ARRAY;
     mRootAsserts[PARAM_KEY_BLENDING]                 = JsonishValue::Type::STRING;
+    mRootAsserts[PARAM_KEY_POST_LIGHTING_BLENDING]   = JsonishValue::Type::STRING;
     mRootAsserts[PARAM_KEY_VERTEX_DOMAIN]            = JsonishValue::Type::STRING;
     mRootAsserts[PARAM_KEY_CULLING]                  = JsonishValue::Type::STRING;
     mRootAsserts[PARAM_KEY_COLOR_WRITE]              = JsonishValue::Type::BOOL;
@@ -384,6 +388,30 @@ bool ParametersProcessor::processBlending(filamat::MaterialBuilder& builder,
     }
 
     builder.blending(stringToEnum(mStringToBlendingMode, jsonString->getString()));
+    return true;
+}
+
+bool ParametersProcessor::processPostLightingBlending(filamat::MaterialBuilder& builder,
+        const JsonishValue& value) {
+    auto jsonString = value.toJsonString();
+    if (!isStringValidEnum(mStringToBlendingMode, jsonString->getString())) {
+        std::cerr << PARAM_KEY_BLENDING << ": value is not a valid BlendMode." << std::endl;
+        return false;
+    }
+
+    filament::BlendingMode postLightingBlending =
+            stringToEnum(mStringToBlendingMode, jsonString->getString());
+    switch (postLightingBlending) {
+        case filament::BlendingMode::FADE:
+        case filament::BlendingMode::MASKED:
+            std::cerr << PARAM_KEY_BLENDING <<
+                    ": value is not a valid post-lighting BlendMode."
+                    " Only OPAQUE, TRANSPARENT and FADE are supported." << std::endl;
+            return false;
+        default:
+            break;
+    }
+    builder.postLightingBlending(postLightingBlending);
     return true;
 }
 

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -406,7 +406,7 @@ bool ParametersProcessor::processPostLightingBlending(filamat::MaterialBuilder& 
         case filament::BlendingMode::MASKED:
             std::cerr << PARAM_KEY_BLENDING <<
                     ": value is not a valid post-lighting BlendMode."
-                    " Only OPAQUE, TRANSPARENT and FADE are supported." << std::endl;
+                    " Only OPAQUE, TRANSPARENT and ADD are supported." << std::endl;
             return false;
         default:
             break;

--- a/tools/matc/src/matc/ParametersProcessor.h
+++ b/tools/matc/src/matc/ParametersProcessor.h
@@ -42,6 +42,7 @@ private:
     bool processVariables(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processRequires(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processBlending(filamat::MaterialBuilder &builder, const JsonishValue &value);
+    bool processPostLightingBlending(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processVertexDomain(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processCulling(filamat::MaterialBuilder &builder, const JsonishValue &value);
     bool processColorWrite(filamat::MaterialBuilder &builder, const JsonishValue &value);


### PR DESCRIPTION
This property can be used to modify the color computed in the lighting
passes of the materials. That color is blended with the computed color
according to the postLightingBlending option (add, transparent or opaque).