### PR TITLE
Don't flip the normals

### DIFF
--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -84,7 +84,6 @@ static std::string shaderFromKey(const MaterialKey& config) {
         }
         shader += R"SHADER(
             material.normal = texture(materialParams_normalMap, normalUV).xyz * 2.0 - 1.0;
-            material.normal.y = -material.normal.y;
             material.normal.xy *= materialParams.normalScale;
         )SHADER";
     }


### PR DESCRIPTION
We were not passing the glTF tests anymore. I'm not sure why we were flipping the normal map normal here. Here's before:

<img width="1136" alt="Screen Shot 2019-03-29 at 4 53 21 PM" src="https://user-images.githubusercontent.com/869684/55268079-f64c6900-5243-11e9-9829-f3626f3b8401.png">

And after:

<img width="1136" alt="Screen Shot 2019-03-29 at 4 56 46 PM" src="https://user-images.githubusercontent.com/869684/55268081-f9dff000-5243-11e9-8fb9-ddbdc84dce9b.png">
