### PR TITLE
fix LISPSM warping frustum computation

### DIFF
--- a/android/filament-android/src/main/cpp/LightManager.cpp
+++ b/android/filament-android/src/main/cpp/LightManager.cpp
@@ -64,10 +64,17 @@ Java_com_google_android_filament_LightManager_nBuilderCastShadows(JNIEnv *env, j
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_LightManager_nBuilderShadowOptions(JNIEnv *env, jclass type,
-        jlong nativeBuilder, jint mapSize, jfloat constantBias, jfloat normalBias, jfloat shadowFar) {
+        jlong nativeBuilder, jint mapSize, jfloat constantBias, jfloat normalBias, jfloat shadowFar,
+        jfloat shadowNearHint, jfloat shadowFarHint, jboolean stable) {
     LightManager::Builder *builder = (LightManager::Builder *) nativeBuilder;
     builder->shadowOptions(
-            LightManager::ShadowOptions{(uint32_t) mapSize, constantBias, normalBias, shadowFar});
+            LightManager::ShadowOptions{.mapSize = (uint32_t)mapSize,
+                                        .constantBias = constantBias,
+                                        .normalBias = normalBias,
+                                        .shadowFar = shadowFar,
+                                        .shadowNearHint = shadowNearHint,
+                                        .shadowFarHint = shadowFarHint,
+                                        .stable = (bool)stable});
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -53,6 +53,9 @@ public class LightManager {
         public float constantBias = 0.05f;
         public float normalBias = 0.4f;
         public float shadowFar = 0.0f;
+        public float shadowNearHint = 1.0f;
+        public float shadowFarHint = 100.0f;
+        public boolean stable = true;
     }
 
     public static final float EFFICIENCY_INCANDESCENT = 0.0220f;
@@ -79,7 +82,8 @@ public class LightManager {
         @NonNull
         public Builder shadowOptions(@NonNull ShadowOptions options) {
             nBuilderShadowOptions(mNativeBuilder,
-                    options.mapSize, options.constantBias, options.normalBias, options.shadowFar);
+                    options.mapSize, options.constantBias, options.normalBias, options.shadowFar,
+                    options.shadowNearHint, options.shadowFarHint, options.stable);
             return this;
         }
 
@@ -275,7 +279,7 @@ public class LightManager {
     private static native void nDestroyBuilder(long nativeBuilder);
     private static native boolean nBuilderBuild(long nativeBuilder, long nativeEngine, int entity);
     private static native void nBuilderCastShadows(long nativeBuilder, boolean enable);
-    private static native void nBuilderShadowOptions(long nativeBuilder, int mapSize, float constantBias, float normalBias, float shadowFar);
+    private static native void nBuilderShadowOptions(long nativeBuilder, int mapSize, float constantBias, float normalBias, float shadowFar, float shadowNearHint, float shadowFarhint, boolean stable);
     private static native void nBuilderCastLight(long nativeBuilder, boolean enabled);
     private static native void nBuilderPosition(long nativeBuilder, float x, float y, float z);
     private static native void nBuilderDirection(long nativeBuilder, float x, float y, float z);

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -210,6 +210,13 @@ public:
          * use the camera far distance.
          */
         float shadowFarHint = 100.0f;
+
+        /**
+         * Controls whether the shadow map should be optimized for resolution or stability.
+         * When set to true, all resolution enhancing features that can affect stability are
+         * disabling, resulting in significantly lower resolution shadows, albeit stable ones.
+         */
+        bool stable = false;
     };
 
     //! Use Builder to construct a Light object instance
@@ -638,6 +645,20 @@ public:
      * @return the halo falloff
      */
     float getSunHaloFalloff(Instance i) const noexcept;
+
+    /**
+     * returns the shadow-map options for a given light
+     * @param i     Instance of the component obtained from getInstance().
+     * @return      A ShadowOption structure
+     */
+    ShadowOptions const& getShadowOptions(Instance i) const noexcept;
+
+    /**
+     * sets the shadow-map options for a given light
+     * @param i     Instance of the component obtained from getInstance().
+     * @param options  A ShadowOption structure
+     */
+    void setShadowOptions(Instance i, ShadowOptions const& options) noexcept;
 };
 
 } // namespace filament

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -35,7 +35,7 @@ using namespace details;
 // ------------------------------------------------------------------------------------------------
 
 struct LightManager::BuilderDetails {
-    Type mType;
+    Type mType = Type::DIRECTIONAL;
     bool mCastShadows = false;
     bool mCastLight = true;
     float3 mPosition = {};
@@ -165,14 +165,14 @@ void FLightManager::create(const FLightManager::Builder& builder, utils::Entity 
         lightType.type = builder->mType;
         lightType.shadowCaster = builder->mCastShadows;
         lightType.lightCaster = builder->mCastLight;
-        lightType.shadowMapBits = uint8_t(std::min(15, std::ilogbf(builder->mShadowOptions.mapSize)));
 
         ShadowParams& shadowParams = manager[i].shadowParams;
-        shadowParams.shadowConstantBias = clamp(builder->mShadowOptions.constantBias, 0.0f, 2.0f);
-        shadowParams.shadowNormalBias = clamp(builder->mShadowOptions.normalBias, 0.0f, 3.0f);
-        shadowParams.shadowFar = std::max(builder->mShadowOptions.shadowFar, 0.0f);
-        shadowParams.shadowNearHint = std::max(builder->mShadowOptions.shadowNearHint, 0.0f);
-        shadowParams.shadowFarHint = std::max(builder->mShadowOptions.shadowFarHint, 0.0f);
+        shadowParams.options.mapSize        = clamp(builder->mShadowOptions.mapSize, 0u, 2048u);
+        shadowParams.options.constantBias   = clamp(builder->mShadowOptions.constantBias, 0.0f, 2.0f);
+        shadowParams.options.normalBias     = clamp(builder->mShadowOptions.normalBias, 0.0f, 3.0f);
+        shadowParams.options.shadowFar      = std::max(builder->mShadowOptions.shadowFar, 0.0f);
+        shadowParams.options.shadowNearHint = std::max(builder->mShadowOptions.shadowNearHint, 0.0f);
+        shadowParams.options.shadowFarHint  = std::max(builder->mShadowOptions.shadowFarHint, 0.0f);
 
         // set default values by calling the setters
         setLocalPosition(i, builder->mPosition);
@@ -427,6 +427,14 @@ float LightManager::getSunHaloFalloff(Instance i) const noexcept {
 
 LightManager::Type LightManager::getType(LightManager::Instance i) const noexcept {
     return upcast(this)->getType(i);
+}
+
+const LightManager::ShadowOptions& LightManager::getShadowOptions(Instance i) const noexcept {
+    return upcast(this)->getShadowOptions(i);
+}
+
+void LightManager::setShadowOptions(Instance i, ShadowOptions const& options) noexcept {
+    upcast(this)->setShadowOptions(i, options);
 }
 
 } // namespace filament

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -65,7 +65,6 @@ public:
 
     struct LightType {
         Type type : 3;
-        uint8_t shadowMapBits : 4;
         bool shadowCaster : 1;
         bool lightCaster : 1;
     };
@@ -79,11 +78,7 @@ public:
     };
 
     struct ShadowParams {
-        float shadowConstantBias;
-        float shadowNormalBias;
-        float shadowFar;
-        float shadowNearHint;
-        float shadowFarHint;
+        LightManager::ShadowOptions options;
     };
 
     UTILS_NOINLINE void setLocalPosition(Instance i, const math::float3& position) noexcept;
@@ -135,7 +130,7 @@ public:
     }
 
     constexpr uint32_t getShadowMapSize(Instance i) const noexcept {
-        return 1u << getLightType(i).shadowMapBits;
+        return getShadowParams(i).options.mapSize;
     }
 
     constexpr ShadowParams const& getShadowParams(Instance i) const noexcept {
@@ -143,15 +138,15 @@ public:
     }
 
     constexpr float getShadowConstantBias(Instance i) const noexcept {
-        return getShadowParams(i).shadowConstantBias;
+        return getShadowParams(i).options.constantBias;
     }
 
     constexpr float getShadowNormalBias(Instance i) const noexcept {
-        return getShadowParams(i).shadowNormalBias;
+        return getShadowParams(i).options.normalBias;
     }
 
     constexpr float getShadowFar(Instance i) const noexcept {
-        return getShadowParams(i).shadowFar;
+        return getShadowParams(i).options.shadowFar;
     }
 
     constexpr const math::float3& getColor(Instance i) const noexcept {
@@ -200,6 +195,14 @@ public:
 
     constexpr const math::float3& getLocalDirection(Instance i) const noexcept {
         return mManager[i].direction;
+    }
+
+    const ShadowOptions& getShadowOptions(Instance i) const noexcept {
+        return getShadowParams(i).options;
+    }
+
+    void setShadowOptions(Instance i, ShadowOptions const& options) noexcept {
+        static_cast<ShadowParams&>(mManager[i].shadowParams).options = options;
     }
 
 private:

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -108,8 +108,8 @@ private:
             uint8_t visibleLayers) noexcept;
 
     static math::mat4f applyLISPSM(
-            CameraInfo const& camera, float dzn, float dzf, const math::mat4f& LMpMv,
-            Aabb const& wsShadowReceiversVolume, const math::float3 wsViewFrustumCorners[8],
+            CameraInfo const& camera, const math::mat4f& LMpMv,
+            FrustumBoxIntersection const& wsShadowReceiverVolume, size_t vertexCount,
             const math::float3& dir);
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,
@@ -121,11 +121,14 @@ private:
     static inline math::float2 computeNearFar(math::mat4f const& lightView,
             Aabb const& wsShadowCastersVolume) noexcept;
 
-    static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
+    static inline math::float2 computeNearFar(math::mat4f const& lightView,
+            math::float3 const* wsVertices, size_t count) noexcept;
+
+        static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
             Aabb const& wsShadowCastersVolume) noexcept;
 
     static inline math::float2 computeWpNearFarOfWarpSpace(math::mat4f const& lightView,
-            math::float3 const wsViewFrustumCorners[8]) noexcept;
+            math::float3 const* wsViewFrustumCorners, size_t count) noexcept;
 
     static inline bool intersectSegmentWithPlane(math::float3& p,
             math::float3 s0, math::float3 s1,

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -150,7 +150,9 @@ private:
 
     static math::mat4f warpFrustum(float n, float f) noexcept;
 
-    math::mat4f getTextureCoordsMapping() const noexcept;
+    static math::mat4f directionalLightFrustum(float n, float f) noexcept;
+
+    math::mat4f getTextureCoordsMapping(math::mat4f const& S) const noexcept;
 
     float texelSizeWorldSpace(const math::mat4f& lightSpaceMatrix) const noexcept;
     float texelSizeWorldSpace(const math::mat4f& lightSpaceMatrix, math::float3 const& str) const noexcept;

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -81,8 +81,6 @@ private:
         math::mat4f worldOrigin;
         float zn = 0;
         float zf = 0;
-        float dzn = 0;
-        float dzf = 0;
         Frustum frustum;
         float getNear() const noexcept { return zn; }
         float getFar() const noexcept { return zf; }
@@ -104,11 +102,13 @@ private:
     using FrustumBoxIntersection = std::array<math::float3, 64>;
 
     void computeShadowCameraDirectional(
-            math::float3 const& direction, FScene const* scene, CameraInfo const& camera,
+            math::float3 const& direction, FScene const* scene,
+            CameraInfo const& camera, FLightManager::ShadowParams const& params,
             uint8_t visibleLayers) noexcept;
 
     static math::mat4f applyLISPSM(
-            CameraInfo const& camera, const math::mat4f& LMpMv,
+            CameraInfo const& camera, FLightManager::ShadowParams const& params,
+            const math::mat4f& LMpMv,
             FrustumBoxIntersection const& wsShadowReceiverVolume, size_t vertexCount,
             const math::float3& dir);
 

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -124,7 +124,7 @@ private:
     static inline math::float2 computeNearFar(math::mat4f const& lightView,
             math::float3 const* wsVertices, size_t count) noexcept;
 
-        static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
+    static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
             Aabb const& wsShadowCastersVolume) noexcept;
 
     static inline math::float2 computeWpNearFarOfWarpSpace(math::mat4f const& lightView,

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -335,6 +335,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             DebugRegistry& debug = engine->getDebugRegistry();
             ImGui::Checkbox("Camera at origin",
                     debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
+            ImGui::Checkbox("Stable Shadow Map", &params.stableShadowMap);
             ImGui::Checkbox("Light Far uses shadow casters",
                     debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
             ImGui::Checkbox("Focus shadow casters",
@@ -372,6 +373,12 @@ static void gui(filament::Engine* engine, filament::View*) {
         g_scene->remove(params.light);
         params.hasDirectionalLight = false;
     }
+
+    auto& lcm = engine->getLightManager();
+    auto instance = lcm.getInstance(params.light);
+    LightManager::ShadowOptions options = lcm.getShadowOptions(instance);
+    options.stable = params.stableShadowMap;
+    lcm.setShadowOptions(instance, options);
 
     auto* ibl = FilamentApp::get().getIBL();
     if (ibl) {

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -80,6 +80,7 @@ struct SandboxParameters {
     bool tonemapping = true;
     bool msaa = false;
     bool dithering = true;
+    bool stableShadowMap = false;
 };
 
 inline void createInstances(SandboxParameters& params, filament::Engine& engine) {


### PR DESCRIPTION
We were using the view frustum as a basis instead of the shadow 
receivers volume which didn't give a good warping for the scene, we
were working around it by setting a virtual near plane dynamically.

Now that the warping frustum is tight, the virtual near plane is 
no longer needed -- it's still needed for the user to adjust the
precision and the default is still 1m.