### PR TITLE
Add correct Metal load and store actions

### DIFF
--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -144,7 +144,10 @@ constexpr inline MTLPixelFormat getMetalFormat(TextureFormat format) noexcept {
         case TextureFormat::RG8UI: return MTLPixelFormatRG8Uint;
         case TextureFormat::RG8I: return MTLPixelFormatRG8Sint;
 
-#if !defined(IOS)
+#if defined(IOS)
+        // iOS does not support 16 bit depth textures.
+        case TextureFormat::DEPTH16: return MTLPixelFormatDepth32Float;
+#else
         case TextureFormat::DEPTH16: return MTLPixelFormatDepth16Unorm;
 #endif
 

--- a/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
+++ b/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
@@ -65,6 +65,14 @@ void FilamentApp::initialize() {
     scene->setIndirectLight(app.indirectLight);
     scene->setSkybox(app.skybox);
 
+    app.sun = EntityManager::get().create();
+    LightManager::Builder(LightManager::Type::SUN)
+        .castShadows(true)
+        // The direction is calibrated to match the IBL's sun.
+        .direction({0.548267, -0.473983, -0.689016})
+        .build(*engine, app.sun);
+    scene->addEntity(app.sun);
+
     app.mat = Material::Builder()
         .package(RESOURCES_CLEAR_COAT_DATA, RESOURCES_CLEAR_COAT_SIZE)
         .build(*engine);
@@ -76,6 +84,8 @@ void FilamentApp::initialize() {
 
     app.renderable = mesh.renderable;
     scene->addEntity(app.renderable);
+    auto& rcm = engine->getRenderableManager();
+    rcm.setCastShadows(rcm.getInstance(app.renderable), true);
 
     filaView->setScene(scene);
     filaView->setCamera(camera);
@@ -109,6 +119,7 @@ FilamentApp::~FilamentApp() {
     engine->destroy(app.skyboxTexture);
     engine->destroy(app.skybox);
     engine->destroy(app.renderable);
+    engine->destroy(app.sun);
 
     engine->destroy(renderer);
     engine->destroy(scene);

--- a/ios/samples/hello-pbr/hello-pbr/FilamentApp.h
+++ b/ios/samples/hello-pbr/hello-pbr/FilamentApp.h
@@ -19,6 +19,7 @@
 
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
+#include <filament/LightManager.h>
 #include <filament/RenderableManager.h>
 #include <filament/Renderer.h>
 #include <filament/Scene.h>
@@ -73,6 +74,7 @@ private:
         Texture* skyboxTexture = nullptr;
         Skybox* skybox = nullptr;
         Entity renderable;
+        Entity sun;
     } app;
 
     CameraManipulator cameraManipulator;


### PR DESCRIPTION
There was an issue with shadow maps on iOS (and possibly desktops) because the `storeAction` of the shadow buffer wasn't set correctly. This implements correct load and store actions for render passes.