### PR TITLE
 debug option to fill the shadowmap with a checkerboard

### DIFF
--- a/filament/src/GPUBuffer.h
+++ b/filament/src/GPUBuffer.h
@@ -81,7 +81,6 @@ public:
 private:
     // this is really hidden implementation details (the fact we're using a texture should be
     // exposed as little as possible)
-    friend class SamplerGroup;
     backend::Handle<backend::HwTexture> getHandle() const noexcept { return mTexture; }
     backend::SamplerParams getSamplerParams() const noexcept { return backend::SamplerParams{}; }
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -54,10 +54,6 @@ void RenderPass::setCamera(const CameraInfo& camera) noexcept {
     mCamera = camera;
 }
 
-void RenderPass::setCommandType(RenderPass::CommandTypeFlags commandType) noexcept {
-    mCommandType = commandType;
-}
-
 void RenderPass::setRenderFlags(RenderPass::RenderFlags flags) noexcept {
     mFlags = flags;
 }
@@ -66,13 +62,12 @@ void RenderPass::setExecuteSync(JobSystem::Job* sync) noexcept {
     mSync = sync;
 }
 
-void RenderPass::generateSortedCommands() noexcept {
+void RenderPass::generateSortedCommands(CommandTypeFlags const commandTypeFlags) noexcept {
     SYSTRACE_CONTEXT();
 
     FEngine& engine = mEngine;
     JobSystem& js = engine.getJobSystem();
     GrowingSlice<Command>& commands = mCommands;
-    const CommandTypeFlags commandTypeFlags = mCommandType;
     const RenderFlags renderFlags = mFlags;
     CameraInfo const& camera = mCamera;
     FScene& scene = *mScene;

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -205,14 +205,15 @@ public:
     RenderPass(FEngine& engine, utils::GrowingSlice<Command>& commands) noexcept;
     void setGeometry(FScene& scene, utils::Range<uint32_t> vr) noexcept;
     void setCamera(const CameraInfo& camera) noexcept;
-    void setCommandType(CommandTypeFlags commandType) noexcept;
     void setRenderFlags(RenderFlags flags) noexcept;
     void setExecuteSync(utils::JobSystem::Job* sync) noexcept;
-    void generateSortedCommands() noexcept;
+    void generateSortedCommands(CommandTypeFlags commandType) noexcept;
     void execute(const char* name,
             backend::Handle <backend::HwRenderTarget> renderTarget,
             backend::RenderPassParams params,
             Command const* first, Command const* last) const noexcept;
+
+    utils::GrowingSlice<Command>& getCommands() { return mCommands; }
 
     size_t getCommandsHighWatermark() const noexcept {
         return mCommandsHighWatermark * sizeof(Command);
@@ -254,7 +255,6 @@ private:
     FScene* mScene = nullptr;
     utils::Range<uint32_t> mVisibleRenderables{};
     CameraInfo mCamera;
-    CommandTypeFlags mCommandType{};
     RenderFlags mFlags{};
     utils::JobSystem::Job* mSync = nullptr;
     size_t mCommandsHighWatermark = 0;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -355,6 +355,7 @@ public:
         struct {
             bool far_uses_shadowcasters = true;
             bool focus_shadowcasters = true;
+            bool checkerboard = false;
             bool lispsm = true;
             float dzn = -1.0f;
             float dzf =  1.0f;

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -78,6 +78,8 @@ public:
 
     void render(backend::DriverApi& driver, RenderPass& pass, FView& view) noexcept;
 
+    void fillWithDebugPattern(backend::DriverApi& driverApi) const noexcept;
+
 private:
     struct CameraInfo {
         math::mat4f projection;

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -33,6 +33,9 @@
 namespace filament {
 namespace details {
 
+class FView;
+class RenderPass;
+
 class ShadowMap {
 public:
     explicit ShadowMap(FEngine& engine) noexcept;
@@ -72,6 +75,8 @@ public:
 
     // use only for debugging
     FCamera const& getDebugCamera() const noexcept { return *mDebugCamera; }
+
+    void render(backend::DriverApi& driver, RenderPass& pass, FView& view) noexcept;
 
 private:
     struct CameraInfo {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -138,6 +138,7 @@ public:
     void setShadowsEnabled(bool enabled) noexcept { mShadowingEnabled = enabled; }
 
     ShadowMap const& getShadowMap() const { return mDirectionalShadowMap; }
+    ShadowMap& getShadowMap() { return mDirectionalShadowMap; }
 
     FCamera const* getDirectionalLightCamera() const noexcept {
         return &mDirectionalShadowMap.getDebugCamera();

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -341,6 +341,8 @@ static void gui(filament::Engine* engine, filament::View*) {
                     debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
             ImGui::Checkbox("Focus shadow casters",
                     debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
+            ImGui::Checkbox("Show checker board",
+                    debug.getPropertyAddress<bool>("d.shadowmap.checkerboard"));
             bool* lispsm;
             if (debug.getPropertyAddress<bool>("d.shadowmap.lispsm", &lispsm)) {
                 ImGui::Checkbox("Enable LiSPSM", lispsm);


### PR DESCRIPTION
<img width="836" alt="checkerboard" src="https://user-images.githubusercontent.com/1240896/55653528-b1748500-57a3-11e9-9031-dbb44e71f63b.png">

Each tile of the checker board corresponds to 8x8 texels in the shadow map.