### PR TITLE
Add MetalResourceTracker to Metal backend

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -96,6 +96,7 @@ if (FILAMENT_SUPPORTS_METAL)
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm
             src/metal/MetalHandles.mm
+            src/metal/MetalResourceTracker.cpp
             src/metal/MetalState.mm
             src/metal/PlatformMetal.mm
     )

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -19,6 +19,7 @@
 #include "MetalContext.h"
 
 #include <utils/Panic.h>
+#include <utils/trap.h>
 
 #include <thread>
 #include <chrono>

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -20,7 +20,6 @@
 #include "MetalBufferPool.h"
 #include "MetalResourceTracker.h"
 #include "MetalState.h"
-#include "MetalState.h"
 
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -18,6 +18,8 @@
 #define TNT_METALCONTEXT_H
 
 #include "MetalBufferPool.h"
+#include "MetalResourceTracker.h"
+#include "MetalState.h"
 #include "MetalState.h"
 
 #include <Metal/Metal.h>
@@ -48,6 +50,9 @@ struct MetalContext {
     // Single use, re-created each frame.
     id<MTLCommandBuffer> currentCommandBuffer = nullptr;
     id<MTLRenderCommandEncoder> currentCommandEncoder = nullptr;
+
+    // Tracks resources used by command buffers.
+    MetalResourceTracker resourceTracker;
 
     RenderPassFlags currentRenderPassFlags;
     MetalRenderTarget* currentRenderTarget = nullptr;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -145,7 +145,7 @@ private:
     void enumerateSamplerGroups(const MetalProgram* program,
             const std::function<void(const SamplerGroup::Sampler*, size_t)>& f);
     void enumerateBoundUniformBuffers(const std::function<void(const UniformBufferState&,
-            const MetalUniformBuffer*, uint32_t)>& f);
+            MetalUniformBuffer*, uint32_t)>& f);
 
 };
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -73,10 +73,13 @@ public:
     void copyIntoBuffer(void* src, size_t size);
 
     /**
+     * Denotes that this uniform is used for a draw call ensuring that its allocation remains valid
+     * until the end of the current frame.
+     *
      * @return The MTLBuffer representing the current state of the uniform to bind, or nil if there
      * is no device allocation.
      */
-    id<MTLBuffer> getGpuBuffer() const;
+    id<MTLBuffer> getGpuBufferForDraw();
 
     /**
      * @return A pointer to the CPU buffer holding the uniform data or nullptr if there isn't one.

--- a/filament/backend/src/metal/MetalResourceTracker.cpp
+++ b/filament/backend/src/metal/MetalResourceTracker.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalResourceTracker.h"
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+bool MetalResourceTracker::trackResource(CommandBuffer buffer, Resource resource,
+        ResourceDeleter deleter) {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    auto found = mResources.find(buffer);
+    if (found == mResources.end()) {
+        Resources& resourcesForBuffer = mResources[buffer] = {};
+        resourcesForBuffer.insert({resource, deleter});
+        return true;
+    }
+
+    assert(found != mResources.end());
+    Resources& resources = found.value();
+    auto inserted = resources.insert({resource, deleter});
+    return inserted.second;
+}
+
+void MetalResourceTracker::clearResources(CommandBuffer buffer) {
+    std::lock_guard<std::mutex> lock(mMutex);
+
+    auto found = mResources.find(buffer);
+    if (found == mResources.end()) {
+        return;
+    }
+
+    for (const auto& resource : found.value()) {
+        resource.deleter(resource.resource);
+    }
+    mResources.erase(found);
+}
+
+}; // namespace metal
+}; // namespace backend
+}; // namespace filament

--- a/filament/backend/src/metal/MetalResourceTracker.cpp
+++ b/filament/backend/src/metal/MetalResourceTracker.cpp
@@ -51,6 +51,6 @@ void MetalResourceTracker::clearResources(CommandBuffer buffer) {
     mResources.erase(found);
 }
 
-}; // namespace metal
-}; // namespace backend
-}; // namespace filament
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalResourceTracker.h
+++ b/filament/backend/src/metal/MetalResourceTracker.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_METALRESOURCETRACKER_H
+#define TNT_METALRESOURCETRACKER_H
+
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
+
+#include <functional>
+#include <mutex>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+/**
+ * MetalResourceTracker is a simple utility that maps individual command buffers to a set of
+ * associated resources.
+ */
+class MetalResourceTracker {
+
+public:
+
+    using CommandBuffer = void*;
+    using Resource = const void*;
+    using ResourceDeleter = std::function<void(Resource)>;
+
+    /**
+     * Associate the given resource with a command buffer. When clearResources is called, the given
+     * deleter will be called for each resource.
+     * @return true, if this is the first time tracking the resource.
+     */
+    bool trackResource(CommandBuffer buffer, Resource resource, ResourceDeleter deleter);
+
+    /**
+     * Calls the deleter for each resource associated with the command buffer, and removes them from
+     * tracking.
+     */
+    void clearResources(CommandBuffer buffer);
+
+private:
+
+    struct ResourceEntry {
+        Resource resource;
+        ResourceDeleter deleter;
+
+        bool operator==(const ResourceEntry& rhs) const noexcept {
+            return resource == rhs.resource;
+        }
+    };
+
+    struct ResourceEntryHash {
+        size_t operator()(const ResourceEntry& entry) const noexcept {
+            return std::hash<Resource>{}(entry.resource);
+        }
+    };
+
+    using ResourcesKey = CommandBuffer;
+    using Resources = tsl::robin_set<ResourceEntry, ResourceEntryHash>;
+    tsl::robin_map<ResourcesKey, Resources> mResources;
+
+    // Synchronizes access to the map.
+    // trackResource and clearResources may be called on separate threads (the engine thread and a
+    // Metal callback thread, for example).
+    std::mutex mMutex;
+
+};
+
+}; // namespace metal
+}; // namespace backend
+}; // namespace filament
+
+#endif //TNT_METALRESOURCETRACKER_H


### PR DESCRIPTION
This adds a new class, `MetalResourceTracker`, which helps the Metal driver track resources that are used per command buffer.

This also fixes an issue with releasing uniform buffers too early in scenarios such as the following:

**Frame N:**
update uniform
draw
frame completes on GPU

**Frame N + 1**
draw
update uniform

The uniform would be released back into the pool at the time of the second update, which isn't correct. Uniforms need to persist until the end of _each_ frame that utilizes them in a draw call.
