### PR TITLE
Add new shading model to Filament for specularGlossiness.

### DIFF
--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -34,7 +34,8 @@ public class MaterialBuilder {
         UNLIT,                  // no lighting applied, emissive possible
         LIT,                    // default, standard lighting
         SUBSURFACE,             // subsurface lighting model
-        CLOTH                   // cloth lighting model
+        CLOTH,                  // cloth lighting model
+        SPECULAR_GLOSSINESS     // legacy lighting model
     }
 
     public enum Interpolation {

--- a/android/filament-android/src/main/java/com/google/android/filament/Material.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Material.java
@@ -37,7 +37,8 @@ public class Material {
         UNLIT,
         LIT,
         SUBSURFACE,
-        CLOTH
+        CLOTH,
+        SPECULAR_GLOSSINESS
     }
 
     public enum Interpolation {

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -55,10 +55,11 @@ Material instance
 # Material models
 
 Filament materials can use one of the following material models:
-- Lit (or standard)
-- Subsurface
-- Cloth
-- Unlit
+- `lit` (or standard)
+- `subsurface`
+- `cloth`
+- `unlit`
+- `specularGlossiness` (legacy)
 
 ## Lit model
 
@@ -521,6 +522,13 @@ Figure [materialUnlit] shows an example of the unlit material model
 (click on the image to see a larger version).
 
 ![Figure [materialUnlit]: The unlit model is used to render debug information](images/screenshot_unlit.jpg)
+
+## Specular glossiness
+
+This alternative lighting model exists to comply with legacy standards.
+
+Similar to cloth, it encompasses all the parameters previously defined for the standard
+lit mode except for _metallic_ and _reflectance_, and adds a _sheenColor_ parameter.
 
 # Material definitions
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -55,11 +55,11 @@ Material instance
 # Material models
 
 Filament materials can use one of the following material models:
-- `lit` (or standard)
-- `subsurface`
-- `cloth`
-- `unlit`
-- `specularGlossiness` (legacy)
+- Lit (or standard)
+- Subsurface
+- Cloth
+- Unlit
+- Specular glossiness (legacy)
 
 ## Lit model
 
@@ -528,7 +528,30 @@ Figure [materialUnlit] shows an example of the unlit material model
 This alternative lighting model exists to comply with legacy standards.
 
 Similar to cloth, it encompasses all the parameters previously defined for the standard
-lit mode except for _metallic_ and _reflectance_, and adds a _sheenColor_ parameter.
+lit mode except for _metallic_ and _reflectance_, and adds a _sheenColor_ parameter. The sheen
+color is used to formulate the BRDF inputs as follows.
+
+```glsl
+pixel.diffuseColor = baseColor * (1.0 - max(sheen.r, sheen.g, sheen.b));
+pixel.f0 = sheen;
+```
+
+This is not a physically-based formulation, so we do not recommend using the `specularGlossiness`
+model except when loading legacy assets.
+
+Parameter      |      Definition
+---------------------:|:---------------------
+**baseColor**         | Surface diffuse color
+**sheenColor**        | Specular tint (defaults to $\sqrt{baseColor}$)
+[Table [glossinessProperties]: Properties of the specular-glossiness shading model]
+
+The type and range of each property is described in table [glossinessPropertiesTypes].
+
+       Property       |   Type   |            Range         |           Note
+---------------------:|:--------:|:------------------------:|:-------------------------
+**baseColor**         | float4   |  [0..1]                  | Pre-multiplied linear RGB
+**sheenColor**        | float3   |  [0..1]                  | Linear RGB
+[Table [glossinessPropertiesTypes]: Range and type of the specular-glossiness model's properties]
 
 # Material definitions
 
@@ -664,7 +687,7 @@ Type
 :    `string`
 
 Value
-:     Any of `lit`, `subsurface`, `cloth`, `unlit`. Defaults to `lit`.
+:     Any of `lit`, `subsurface`, `cloth`, `unlit`, `specularGlossiness`. Defaults to `lit`.
 
 Description
 :     Selects the material model as described in the Material models section.
@@ -1395,8 +1418,8 @@ struct MaterialInputs {
 
     // no other field is available with the unlit shading model
     float  roughness;           // default: 1.0
-    float  metallic;            // default: 0.0, not available with cloth
-    float  reflectance;         // default: 0.5, not available with cloth
+    float  metallic;            // default: 0.0, not available with cloth or specularGlossiness
+    float  reflectance;         // default: 0.5, not available with cloth or specularGlossiness
     float  ambientOcclusion;    // default: 0.0
 
     // not available when the shading model is subsurface or cloth
@@ -1414,6 +1437,9 @@ struct MaterialInputs {
     // only available when the shading model is cloth
     float3 sheenColor;          // default: sqrt(baseColor)
     float3 subsurfaceColor;     // default: float3(0.0)
+
+    // only available when the shading model is specularGlossiness
+    float3 sheenColor;          // default: sqrt(baseColor)
 
     // not available when the shading model is unlit
     // must be set before calling prepareMaterial()

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -36,6 +36,7 @@ enum class Shading : uint8_t {
     LIT,                    //!< default, standard lighting
     SUBSURFACE,             //!< subsurface lighting model
     CLOTH,                  //!< cloth lighting model
+    SPECULAR_GLOSSINESS,    //!< legacy lighting model
 };
 
 /**

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -126,7 +126,7 @@ public:
         THICKNESS,               // float,  subsurface shading model only
         SUBSURFACE_POWER,        // float,  subsurface shading model only
         SUBSURFACE_COLOR,        // float3, subsurface and cloth shading models only
-        SHEEN_COLOR,             // float3, cloth shading model only
+        SHEEN_COLOR,             // float3, cloth and specular-glossiness shading models only
         EMISSIVE,                // float4, all shading models
         NORMAL,                  // float3, all shading models only, except unlit
         POST_LIGHTING_COLOR,     // float4, all shading models

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -450,6 +450,7 @@ std::ostream& CodeGenerator::generateShaderLit(std::ostream& out, ShaderType typ
             case Shading::UNLIT:
                 assert("Lit shader generated with unlit shading model");
                 break;
+            case Shading::SPECULAR_GLOSSINESS:
             case Shading::LIT:
                 out << SHADERS_SHADING_MODEL_STANDARD_FS_DATA;
                 break;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -38,10 +38,11 @@ namespace filamat {
 
 static const char* getShadingDefine(filament::Shading shading) noexcept {
     switch (shading) {
-        case filament::Shading::LIT:         return "SHADING_MODEL_LIT";
-        case filament::Shading::UNLIT:       return "SHADING_MODEL_UNLIT";
-        case filament::Shading::SUBSURFACE:  return "SHADING_MODEL_SUBSURFACE";
-        case filament::Shading::CLOTH:       return "SHADING_MODEL_CLOTH";
+        case filament::Shading::LIT:                 return "SHADING_MODEL_LIT";
+        case filament::Shading::UNLIT:               return "SHADING_MODEL_UNLIT";
+        case filament::Shading::SUBSURFACE:          return "SHADING_MODEL_SUBSURFACE";
+        case filament::Shading::CLOTH:               return "SHADING_MODEL_CLOTH";
+        case filament::Shading::SPECULAR_GLOSSINESS: return "SHADING_MODEL_SPECULAR_GLOSSINESS";
     }
 }
 

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -46,7 +46,7 @@ struct PixelParams {
     float subsurfacePower;
 #endif
 
-#if defined(SHADING_MODEL_CLOTH) && defined(MATERIAL_HAS_SUBSURFACE_COLOR)
+#if (defined(SHADING_MODEL_CLOTH) || defined(SHADING_MODEL_SPECULAR_GLOSSINESS)) && defined(MATERIAL_HAS_SUBSURFACE_COLOR)
     vec3  subsurfaceColor;
 #endif
 };

--- a/shaders/src/common_material.fs
+++ b/shaders/src/common_material.fs
@@ -61,7 +61,7 @@ struct MaterialInputs {
     vec4  baseColor;
 #if !defined(SHADING_MODEL_UNLIT)
     float roughness;
-#if !defined(SHADING_MODEL_CLOTH)
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     float metallic;
     float reflectance;
 #endif
@@ -81,7 +81,7 @@ struct MaterialInputs {
     vec3  subsurfaceColor;
 #endif
 
-#if defined(SHADING_MODEL_CLOTH)
+#if defined(SHADING_MODEL_CLOTH) || defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     vec3  sheenColor;
 #if defined(MATERIAL_HAS_SUBSURFACE_COLOR)
     vec3  subsurfaceColor;
@@ -104,7 +104,7 @@ void initMaterial(out MaterialInputs material) {
     material.baseColor = vec4(1.0);
 #if !defined(SHADING_MODEL_UNLIT)
     material.roughness = 1.0;
-#if !defined(SHADING_MODEL_CLOTH)
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     material.metallic = 0.0;
     material.reflectance = 0.5;
 #endif
@@ -128,7 +128,7 @@ void initMaterial(out MaterialInputs material) {
     material.subsurfaceColor = vec3(1.0);
 #endif
 
-#if defined(SHADING_MODEL_CLOTH)
+#if defined(SHADING_MODEL_CLOTH) || defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     material.sheenColor = sqrt(material.baseColor.rgb);
 #if defined(MATERIAL_HAS_SUBSURFACE_COLOR)
     material.subsurfaceColor = vec3(0.0);

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -27,7 +27,13 @@ void getPixelParams(const MaterialInputs material, out PixelParams pixel) {
     baseColor.rgb /= max(baseColor.a, FLT_EPS);
 #endif
 
-#if !defined(SHADING_MODEL_CLOTH)
+#if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
+    // This is from KHR_materials_pbrSpecularGlossiness.
+    vec3 specular = material.sheenColor;
+    float maxSpecularComponent = max(max(specular.r, specular.g), specular.b);
+    pixel.diffuseColor =  baseColor.rgb * (1.0 - maxSpecularComponent);
+    pixel.f0 = specular;
+#elif !defined(SHADING_MODEL_CLOTH)
     float metallic = material.metallic;
     float reflectance = material.reflectance;
 

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -31,7 +31,7 @@ void getPixelParams(const MaterialInputs material, out PixelParams pixel) {
     // This is from KHR_materials_pbrSpecularGlossiness.
     vec3 specular = material.sheenColor;
     float maxSpecularComponent = max(max(specular.r, specular.g), specular.b);
-    pixel.diffuseColor =  baseColor.rgb * (1.0 - maxSpecularComponent);
+    pixel.diffuseColor = baseColor.rgb * (1.0 - maxSpecularComponent);
     pixel.f0 = specular;
 #elif !defined(SHADING_MODEL_CLOTH)
     float metallic = material.metallic;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -136,6 +136,7 @@ ParametersProcessor::ParametersProcessor() {
     mStringToShading["lit"] = MaterialBuilder::Shading::LIT;
     mStringToShading["subsurface"] = MaterialBuilder::Shading::SUBSURFACE;
     mStringToShading["unlit"] = MaterialBuilder::Shading::UNLIT;
+    mStringToShading["specularGlossiness"] = MaterialBuilder::Shading::SPECULAR_GLOSSINESS;
 
     mStringToVariant["directionalLighting"] = filament::Variant::DIRECTIONAL_LIGHTING;
     mStringToVariant["dynamicLighting"] = filament::Variant::DYNAMIC_LIGHTING;

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -243,6 +243,7 @@ const char* toString(Shading shadingModel) {
         case Shading::LIT: return "lit";
         case Shading::SUBSURFACE: return "subsurface";
         case Shading::CLOTH: return "cloth";
+        case Shading::SPECULAR_GLOSSINESS: return "specularGlossiness";
     }
 }
 


### PR DESCRIPTION
This adds a shading model based on KHR_materials_pbrSpecularGlossiness.
The corollary gltfio change will be in an upcoming PR.