### PR TITLE
Fix and optimize shadow bias calculation

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -444,11 +444,16 @@ void ShadowMap::computeShadowCameraDirectional(
 
         mTexelSizeWs = texelSizeWorldSpace(St, float3{ 0.5f });
         mLightSpace = St;
-        mSceneRange = (zfar - znear);
-        mCamera->setCustomProjection(mat4(S), znear, zfar);
+
+        // We apply the constant bias in world space (as opposed to light-space) to account
+        // for perspective and lispsm shadow maps. This also allows us to do this at zero-cost
+        // by baking it in the shadow-map itself.
+
+        const mat4f Sb = S * mat4f::translation(dir * params.options.constantBias);
+        mCamera->setCustomProjection(mat4(Sb), znear, zfar);
 
         // for the debug camera, we need to undo the world origin
-        mDebugCamera->setCustomProjection(mat4(S * camera.worldOrigin), znear, zfar);
+        mDebugCamera->setCustomProjection(mat4(Sb * camera.worldOrigin), znear, zfar);
     }
 }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -305,14 +305,11 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
             mat4f const& lightFromWorldMatrix = shadowMap.getLightSpaceMatrix();
             u.setUniform(offsetof(PerViewUib, lightFromWorldMatrix), lightFromWorldMatrix);
 
-            // the 2x bias is needed in opengl because the depth maps to -1/1. It may not be
-            // needed with other APIs, but at least it won't worsen the acnee there.
-            const float sceneRange = shadowMap.getSceneRange();
             const float texelSizeWorldSpace = shadowMap.getTexelSizeWorldSpace();
             const float constantBias = lcm.getShadowConstantBias(directionalLight);
             const float normalBias = lcm.getShadowNormalBias(directionalLight);
             u.setUniform(offsetof(PerViewUib, shadowBias),
-                    float3{ 2 * constantBias / sceneRange, normalBias * texelSizeWorldSpace, 0 });
+                    float3{ constantBias, normalBias * texelSizeWorldSpace, 0 });
         }
     }
 }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -306,10 +306,9 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
             u.setUniform(offsetof(PerViewUib, lightFromWorldMatrix), lightFromWorldMatrix);
 
             const float texelSizeWorldSpace = shadowMap.getTexelSizeWorldSpace();
-            const float constantBias = lcm.getShadowConstantBias(directionalLight);
             const float normalBias = lcm.getShadowNormalBias(directionalLight);
             u.setUniform(offsetof(PerViewUib, shadowBias),
-                    float3{ constantBias, normalBias * texelSizeWorldSpace, 0 });
+                    float3{ 0, normalBias * texelSizeWorldSpace, 0 });
         }
     }
 }

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -67,9 +67,6 @@ public:
     // return the size of a texel in world space (pre-warping)
     float getTexelSizeWorldSpace() const noexcept { return mTexelSizeWs; }
 
-    // Returns the shadow map's depth range. Valid after init().
-    float getSceneRange() const noexcept { return mSceneRange; }
-
     // Returns the light's projection. Valid after calling update().
     FCamera const& getCamera() const noexcept { return *mCamera; }
 
@@ -181,7 +178,6 @@ private:
     FCamera* mCamera = nullptr;
     FCamera* mDebugCamera = nullptr;
     math::mat4f mLightSpace;
-    float mSceneRange = 0.0f;
     float mTexelSizeWs = 0.0f;
 
     // set-up in prepare()

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -64,7 +64,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     filament::math::float3 lightDirection;
     uint32_t fParamsX; // stride-x
 
-    filament::math::float3 shadowBias; // constant bias, normal bias, unused
+    filament::math::float3 shadowBias; // unused, normal bias, unused
     float oneOverFroxelDimensionY;
 
     filament::math::float4 zParams; // froxel Z parameters

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -349,6 +349,10 @@ static void gui(filament::Engine* engine, filament::View*) {
                     debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
             ImGui::Checkbox("Show checker board",
                     debug.getPropertyAddress<bool>("d.shadowmap.checkerboard"));
+            ImGui::SliderFloat("Normal bias",
+                    &params.normalBias, 0.0f, 3.0f);
+            ImGui::SliderFloat("Constant bias",
+                    &params.constantBias, 0.0f, 2.0f);
             bool* lispsm;
             if (debug.getPropertyAddress<bool>("d.shadowmap.lispsm", &lispsm)) {
                 ImGui::Checkbox("Enable LiSPSM", lispsm);
@@ -384,10 +388,19 @@ static void gui(filament::Engine* engine, filament::View*) {
     }
 
     auto& lcm = engine->getLightManager();
-    auto instance = lcm.getInstance(params.light);
-    LightManager::ShadowOptions options = lcm.getShadowOptions(instance);
+    auto lightInstance = lcm.getInstance(params.light);
+    lcm.setColor(lightInstance, params.lightColor);
+    lcm.setIntensity(lightInstance, params.lightIntensity);
+    lcm.setDirection(lightInstance, params.lightDirection);
+    lcm.setSunAngularRadius(lightInstance, params.sunAngularRadius);
+    lcm.setSunHaloSize(lightInstance, params.sunHaloSize);
+    lcm.setSunHaloFalloff(lightInstance, params.sunHaloFalloff);
+
+    LightManager::ShadowOptions options = lcm.getShadowOptions(lightInstance);
     options.stable = params.stableShadowMap;
-    lcm.setShadowOptions(instance, options);
+    options.normalBias = params.normalBias;
+    options.constantBias = params.constantBias;
+    lcm.setShadowOptions(lightInstance, options);
 
     auto* ibl = FilamentApp::get().getIBL();
     if (ibl) {

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -85,6 +85,8 @@ struct SandboxParameters {
     bool msaa = false;
     bool dithering = true;
     bool stableShadowMap = false;
+    float normalBias = 0.4;
+    float constantBias = 0.01;
 };
 
 inline void createInstances(SandboxParameters& params, filament::Engine& engine) {
@@ -193,14 +195,6 @@ inline filament::MaterialInstance* updateInstances(SandboxParameters& params,
         materialInstance->setParameter("subsurfaceColor", RgbType::sRGB, params.subsurfaceColor);
     }
 
-    auto& lcm = engine.getLightManager();
-    auto lightInstance = lcm.getInstance(params.light);
-    lcm.setColor(lightInstance, params.lightColor);
-    lcm.setIntensity(lightInstance, params.lightIntensity);
-    lcm.setDirection(lightInstance, params.lightDirection);
-    lcm.setSunAngularRadius(lightInstance, params.sunAngularRadius);
-    lcm.setSunHaloSize(lightInstance, params.sunHaloSize);
-    lcm.setSunHaloFalloff(lightInstance, params.sunHaloFalloff);
     return materialInstance;
 }
 

--- a/shaders/src/shadowing.vs
+++ b/shaders/src/shadowing.vs
@@ -10,12 +10,18 @@
  * normal at the point must also be passed to this function.
  */
 vec4 getLightSpacePosition(const vec3 p, const vec3 n) {
-    float NoL = saturate(dot(n, frameUniforms.lightDirection));
+    vec3 l = frameUniforms.lightDirection;
+    float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
 
-    vec3 offsetPosition = p + n * (sinTheta * frameUniforms.shadowBias.y);
+    vec3 offsetPosition = p;
+    // normal bias
+    offsetPosition += n * (sinTheta * frameUniforms.shadowBias.y);
+    // constant bias (note this could be a uniform). We apply the constant bias in
+    // world space (as opposed to light-space) to account for perspective and lispsm shadow maps.
+    offsetPosition += l * frameUniforms.shadowBias.x;
+
     vec4 lightSpacePosition = (getLightFromWorldMatrix() * vec4(offsetPosition, 1.0));
-    lightSpacePosition.z -= frameUniforms.shadowBias.x;
 
     return lightSpacePosition;
 }

--- a/shaders/src/shadowing.vs
+++ b/shaders/src/shadowing.vs
@@ -13,16 +13,8 @@ vec4 getLightSpacePosition(const vec3 p, const vec3 n) {
     vec3 l = frameUniforms.lightDirection;
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
-
-    vec3 offsetPosition = p;
-    // normal bias
-    offsetPosition += n * (sinTheta * frameUniforms.shadowBias.y);
-    // constant bias (note this could be a uniform). We apply the constant bias in
-    // world space (as opposed to light-space) to account for perspective and lispsm shadow maps.
-    offsetPosition += l * frameUniforms.shadowBias.x;
-
+    vec3 offsetPosition = p + n * (sinTheta * frameUniforms.shadowBias.y);
     vec4 lightSpacePosition = (getLightFromWorldMatrix() * vec4(offsetPosition, 1.0));
-
     return lightSpacePosition;
 }
 #endif

--- a/shaders/src/shadowing.vs
+++ b/shaders/src/shadowing.vs
@@ -11,14 +11,9 @@
  */
 vec4 getLightSpacePosition(const vec3 p, const vec3 n) {
     float NoL = saturate(dot(n, frameUniforms.lightDirection));
+    float sinTheta = sqrt(1.0 - NoL * NoL);
 
-#ifdef TARGET_MOBILE
-    float normalBias = 1.0 - NoL * NoL;
-#else
-    float normalBias = sqrt(1.0 - NoL * NoL);
-#endif
-
-    vec3 offsetPosition = p + n * (normalBias * frameUniforms.shadowBias.y);
+    vec3 offsetPosition = p + n * (sinTheta * frameUniforms.shadowBias.y);
     vec4 lightSpacePosition = (getLightFromWorldMatrix() * vec4(offsetPosition, 1.0));
     lightSpacePosition.z -= frameUniforms.shadowBias.x;
 


### PR DESCRIPTION
- add normal/constant bias slider to debug ui
- remove sin(x) approximation by sin(x)^2, not worth it.
- fix calculation of constant bias so it works with non-ortho projections
- optimize constant bias calculation out, by backing it into the shadow map