### PR TITLE
Add external image support to Metal backend

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -261,7 +261,7 @@ if (FILAMENT_SUPPORTS_VULKAN)
 endif()
 
 if (FILAMENT_SUPPORTS_METAL)
-    target_link_libraries(${TARGET} PUBLIC "-framework Metal")
+    target_link_libraries(${TARGET} PUBLIC "-framework Metal -framework CoreVideo")
 endif()
 
 if (LINUX)

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -95,6 +95,7 @@ if (FILAMENT_SUPPORTS_METAL)
             src/metal/MetalBufferPool.mm
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm
+            src/metal/MetalExternalImage.mm
             src/metal/MetalHandles.mm
             src/metal/MetalResourceTracker.cpp
             src/metal/MetalState.mm

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -318,6 +318,8 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 
+DECL_DRIVER_API_SYNCHRONOUS_2(void, setExternalImageS, backend::TextureHandle, th, void*, image)
+
 /*
  * Updating driver objects
  * -----------------------

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -318,7 +318,9 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 
-DECL_DRIVER_API_SYNCHRONOUS_2(void, setExternalImageS, backend::TextureHandle, th, void*, image)
+DECL_DRIVER_API_SYNCHRONOUS_1(void, setupExternalImage, void*, image)
+
+DECL_DRIVER_API_SYNCHRONOUS_1(void, cancelExternalImage, void*, image)
 
 /*
  * Updating driver objects

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -21,6 +21,7 @@
 #include "MetalResourceTracker.h"
 #include "MetalState.h"
 
+#include <CoreVideo/CVMetalTextureCache.h>
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
 
@@ -76,12 +77,17 @@ struct MetalContext {
     id<CAMetalDrawable> currentDrawable = nullptr;
     MTLPixelFormat currentSurfacePixelFormat = MTLPixelFormatInvalid;
     MTLPixelFormat currentDepthPixelFormat = MTLPixelFormatInvalid;
+
+    // External textures.
+    CVMetalTextureCacheRef textureCache = nullptr;
 };
 
 // Acquire the current surface's CAMetalDrawable for the current frame if it has not already been
 // acquired.
 // This method returns the drawable and stores it in the context's currentDrawable field.
 id<CAMetalDrawable> acquireDrawable(MetalContext* context);
+
+id<MTLCommandBuffer> acquireCommandBuffer(MetalContext* context);
 
 } // namespace metal
 } // namespace backend

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -32,6 +32,13 @@ id<CAMetalDrawable> acquireDrawable(MetalContext* context) {
     return context->currentDrawable;
 }
 
+id<MTLCommandBuffer> acquireCommandBuffer(MetalContext* context) {
+    id<MTLCommandBuffer> commandBuffer = [context->commandQueue commandBuffer];
+    ASSERT_POSTCONDITION(commandBuffer != nil, "Could not obtain command buffer.");
+    context->currentCommandBuffer = commandBuffer;
+    return commandBuffer;
+}
+
 } // namespace metal
 } // namespace backend
 } // namespace filament

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -23,6 +23,8 @@
 #include "MetalHandles.h"
 #include "MetalState.h"
 
+#include <CoreVideo/CVMetalTexture.h>
+#include <CoreVideo/CVPixelBuffer.h>
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
 
@@ -56,10 +58,15 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
     mContext->depthStencilStateCache.setDevice(mContext->device);
     mContext->samplerStateCache.setDevice(mContext->device);
     mContext->bufferPool = new MetalBufferPool(*mContext);
+
+    CVReturn success = CVMetalTextureCacheCreate(kCFAllocatorDefault, nullptr, mContext->device,
+            nullptr, &mContext->textureCache);
+    ASSERT_POSTCONDITION(success == kCVReturnSuccess, "Could not create Metal texture cache.");
 }
 
 MetalDriver::~MetalDriver() noexcept {
     [mContext->device release];
+    CFRelease(mContext->textureCache);
     delete mContext->bufferPool;
     delete mContext;
 }
@@ -75,9 +82,9 @@ void MetalDriver::debugCommand(const char *methodName) {
 
 void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     mContext->framePool = [[NSAutoreleasePool alloc] init];
-    mContext->currentCommandBuffer = [mContext->commandQueue commandBuffer];
 
-    [mContext->currentCommandBuffer addCompletedHandler:^(id <MTLCommandBuffer> buffer) {
+    id<MTLCommandBuffer> commandBuffer = acquireCommandBuffer(mContext);
+    [commandBuffer addCompletedHandler:^(id <MTLCommandBuffer> buffer) {
         mContext->resourceTracker.clearResources(buffer);
     }];
 }
@@ -90,6 +97,8 @@ void MetalDriver::endFrame(uint32_t frameId) {
     // Release resources created during frame execution- like commandBuffer and currentDrawable.
     [mContext->framePool drain];
     mContext->bufferPool->gc();
+
+    CVMetalTextureCacheFlush(mContext->textureCache, 0);
 }
 
 void MetalDriver::flush(int dummy) {
@@ -113,7 +122,7 @@ void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elem
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
         uint32_t depth, TextureUsage usage) {
-    construct_handle<MetalTexture>(mHandleMap, th, mContext->device, target, levels, format, samples,
+    construct_handle<MetalTexture>(mHandleMap, th, *mContext, target, levels, format, samples,
             width, height, depth, usage);
 }
 
@@ -313,6 +322,8 @@ void MetalDriver::terminate() {
     mContext->bufferPool->reset();
     [mContext->commandQueue release];
     [mContext->driverPool drain];
+
+    MetalExternalImage::shutdown();
 }
 
 ShaderModel MetalDriver::getShaderModel() const noexcept {
@@ -394,8 +405,16 @@ void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
+void MetalDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+    // Take ownership of the passed in buffer. It will be released the next time
+    // setExternalImage is called, or when the texture is destroyed.
+    CVPixelBufferRef pixelBuffer = (CVPixelBufferRef) image;
+    CVPixelBufferRetain(pixelBuffer);
+}
 
+void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
+    auto texture = handle_cast<MetalTexture>(mHandleMap, th);
+    texture->externalImage.set((CVPixelBufferRef) image);
 }
 
 void MetalDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
@@ -558,6 +577,7 @@ void MetalDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> s
 void MetalDriver::commit(Handle<HwSwapChain> sch) {
     [mContext->currentCommandBuffer presentDrawable:mContext->currentDrawable];
     [mContext->currentCommandBuffer commit];
+    mContext->currentCommandBuffer = nil;
     mContext->currentDrawable = nil;
 }
 
@@ -729,6 +749,10 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             uint8_t binding) {
         const auto metalTexture = handle_const_cast<MetalTexture>(mHandleMap, sampler->t);
         texturesToBind[binding] = metalTexture->texture;
+
+        if (metalTexture->externalImage.isValid()) {
+            texturesToBind[binding] = metalTexture->externalImage.getMetalTextureForDraw();
+        }
 
         id <MTLSamplerState> samplerState = mContext->samplerStateCache.getOrCreateState(sampler->s);
         samplersToBind[binding] = samplerState;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -405,11 +405,16 @@ void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+void MetalDriver::setupExternalImage(void* image) {
     // Take ownership of the passed in buffer. It will be released the next time
     // setExternalImage is called, or when the texture is destroyed.
     CVPixelBufferRef pixelBuffer = (CVPixelBufferRef) image;
     CVPixelBufferRetain(pixelBuffer);
+}
+
+void MetalDriver::cancelExternalImage(void* image) {
+    CVPixelBufferRef pixelBuffer = (CVPixelBufferRef) image;
+    CVPixelBufferRelease(pixelBuffer);
 }
 
 void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {

--- a/filament/backend/src/metal/MetalExternalImage.h
+++ b/filament/backend/src/metal/MetalExternalImage.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_METALEXTERNALIMAGE_H
+#define TNT_METALEXTERNALIMAGE_H
+
+#include <CoreVideo/CoreVideo.h>
+#include <Metal/Metal.h>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+struct MetalContext;
+
+/**
+ * MetalExternalImage holds necessary handles for converting a single CVPixelBuffer to a Metal
+ * texture.
+ */
+class MetalExternalImage {
+
+public:
+
+    MetalExternalImage(MetalContext& context) noexcept;
+
+    /**
+     * @return true, if this MetalExternalImage is holding a live external image. Returns false
+     * until set has been called with a valid CVPixelBuffer. The image can be cleared via
+     * set(nullptr), and isValid will return false again.
+     */
+    bool isValid() const noexcept;
+
+    /**
+     * Set this external image to the passed-in CVPixelBuffer. Future calls to
+     * getMetalTextureForDraw will return a texture backed by this CVPixelBuffer. Previous
+     * CVPixelBuffers and related resources will be released when all GPU work using them has
+     * finished.
+     *
+     * Calling set with a YCbCr image will encode a compute pass to convert the image from YCbCr to
+     * RGB.
+     */
+    void set(CVPixelBufferRef image) noexcept;
+
+    /**
+     * Get a Metal texture used to draw this image and denote that it is used for the current frame.
+     * For future frames that use this external image, getMetalTextureForDraw must be called again.
+     */
+    id<MTLTexture> getMetalTextureForDraw() const noexcept;
+
+    /**
+     * Free global resources. Should be called at least once per process when no further calls to
+     * set will occur.
+     */
+    static void shutdown() noexcept;
+
+private:
+
+    CVMetalTextureRef createTextureFromImage(CVPixelBufferRef image, MTLPixelFormat format,
+            size_t plane);
+    id<MTLTexture> createRgbTexture(size_t width, size_t height);
+    void ensureComputePipelineState();
+    id<MTLCommandBuffer> encodeColorConversionPass(id<MTLTexture> inYPlane, id<MTLTexture>
+            inCbCrTexture, id<MTLTexture> outTexture);
+
+    static constexpr size_t Y_PLANE = 0;
+    static constexpr size_t CBCR_PLANE = 1;
+
+    MetalContext& mContext;
+
+    // If the external image has a single plane, mImage and mTexture hold references to the image
+    // and created Metal texture, respectively.
+    CVPixelBufferRef mImage = nullptr;
+    CVMetalTextureRef mTexture = nullptr;
+
+    // If the external image is in the YCbCr format, this holds the result of the converted RGB
+    // texture.
+    id<MTLTexture> mRgbTexture = nil;
+
+};
+
+#endif //TNT_METALEXTERNALIMAGE_H
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalExternalImage.mm
+++ b/filament/backend/src/metal/MetalExternalImage.mm
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalExternalImage.h"
+
+#include "MetalContext.h"
+
+#include <utils/Panic.h>
+#include <utils/trap.h>
+
+#define NSERROR_CHECK(message)                                                                     \
+    if (error) {                                                                                   \
+        auto description = [error.localizedDescription cStringUsingEncoding:NSUTF8StringEncoding]; \
+        utils::slog.e << description << utils::io::endl;                                           \
+    }                                                                                              \
+    ASSERT_POSTCONDITION(error == nil, message);
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+static id<MTLComputePipelineState> gComputePipelineState = nil;
+
+static const auto cvBufferDeleter = [](const void* buffer) {
+    CVBufferRelease((CVMetalTextureRef) buffer);
+};
+
+static std::string kernel (R"(
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+kernel void
+ycbcrToRgb(texture2d<half, access::read>  inYTexture    [[texture(0)]],
+           texture2d<half, access::read>  inCbCrTexture [[texture(1)]],
+           texture2d<half, access::write> outTexture    [[texture(2)]],
+           uint2                           gid          [[thread_position_in_grid]])
+{
+    if (gid.x >= outTexture.get_width() || gid.y >= outTexture.get_height()) {
+        return;
+    }
+
+    half luminance = inYTexture.read(gid).r;
+    // The color plane is half the size of the luminance plane.
+    half2 color = inCbCrTexture.read(gid / 2).rg;
+
+    half4 ycbcr = half4(luminance, color, 1.0);
+
+    const half4x4 ycbcrToRGBTransform = half4x4(
+        half4(+1.0000f, +1.0000f, +1.0000f, +0.0000f),
+        half4(+0.0000f, -0.3441f, +1.7720f, +0.0000f),
+        half4(+1.4020f, -0.7141f, +0.0000f, +0.0000f),
+        half4(-0.7010f, +0.5291f, -0.8860f, +1.0000f)
+    );
+
+    outTexture.write(ycbcrToRGBTransform * ycbcr, gid);
+}
+)");
+
+MetalExternalImage::MetalExternalImage(MetalContext& context) noexcept : mContext(context) { }
+
+bool MetalExternalImage::isValid() const noexcept {
+    return mRgbTexture != nil || mImage != nullptr;
+}
+
+void MetalExternalImage::set(CVPixelBufferRef image) noexcept {
+    // This pool is necessary because set is called outside of a frame.
+    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
+
+    CVPixelBufferRelease(mImage);
+    CVBufferRelease(mTexture);
+    [mRgbTexture release];
+
+    mImage = nullptr;
+    mTexture = nullptr;
+    mRgbTexture = nil;
+
+    if (!image) {
+        return;
+    }
+
+    OSType formatType = CVPixelBufferGetPixelFormatType(image);
+    ASSERT_POSTCONDITION(formatType == kCVPixelFormatType_32BGRA ||
+                         formatType == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+            "Metal external images must be in either 32BGRA or 420f format.");
+
+    size_t planeCount = CVPixelBufferGetPlaneCount(image);
+    ASSERT_POSTCONDITION(planeCount == 0 || planeCount == 2,
+            "The Metal backend does not support images with plane counts of %d.", planeCount);
+
+    if (planeCount == 0) {
+        mImage = image;
+        mTexture = createTextureFromImage(image, MTLPixelFormatBGRA8Unorm, 0);
+    }
+
+    if (planeCount == 2) {
+        CVMetalTextureRef yPlane = createTextureFromImage(image, MTLPixelFormatR8Unorm, Y_PLANE);
+        CVMetalTextureRef cbcrPlane = createTextureFromImage(image, MTLPixelFormatRG8Unorm,
+                CBCR_PLANE);
+
+        // Get the size of luminance plane.
+        size_t width = CVPixelBufferGetWidthOfPlane(image, Y_PLANE);
+        size_t height = CVPixelBufferGetHeightOfPlane(image, Y_PLANE);
+
+        mRgbTexture = createRgbTexture(width, height);
+
+        id <MTLCommandBuffer> commandBuffer = encodeColorConversionPass(
+                CVMetalTextureGetTexture(yPlane),
+                CVMetalTextureGetTexture(cbcrPlane),
+                mRgbTexture);
+
+        [commandBuffer addCompletedHandler:^(id <MTLCommandBuffer> o) {
+            CVBufferRelease(yPlane);
+            CVBufferRelease(cbcrPlane);
+            CVPixelBufferRelease(image);
+        }];
+
+        [commandBuffer commit];
+    }
+
+    [pool drain];
+}
+
+id<MTLTexture> MetalExternalImage::getMetalTextureForDraw() const noexcept {
+    if (mRgbTexture) {
+        return mRgbTexture;
+    }
+
+    // Retain the image and Metal texture until the GPU has finished with this frame. This does
+    // not need to be done for the RGB texture, because it is an Objective-C object whose
+    // lifetime is automatically managed by Metal.
+    auto& tracker = mContext.resourceTracker;
+    auto commandBuffer = mContext.currentCommandBuffer;
+    if (tracker.trackResource(commandBuffer, mImage, cvBufferDeleter)) {
+        CVPixelBufferRetain(mImage);
+    }
+    if (tracker.trackResource(commandBuffer, mTexture, cvBufferDeleter)) {
+        CVBufferRetain(mTexture);
+    }
+
+    return CVMetalTextureGetTexture(mTexture);
+}
+
+CVMetalTextureRef MetalExternalImage::createTextureFromImage(CVPixelBufferRef image,
+        MTLPixelFormat format, size_t plane) {
+    size_t width = CVPixelBufferGetWidthOfPlane(image, plane);
+    size_t height = CVPixelBufferGetHeightOfPlane(image, plane);
+
+    CVMetalTextureRef texture;
+    CVReturn result = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+            mContext.textureCache, image, nullptr, format, width, height, plane, &texture);
+    ASSERT_POSTCONDITION(result == kCVReturnSuccess,
+            "Could not create a CVMetalTexture from CVPixelBuffer.");
+
+    return texture;
+}
+
+void MetalExternalImage::shutdown() noexcept {
+    [gComputePipelineState release];
+    gComputePipelineState = nil;
+}
+
+id<MTLTexture> MetalExternalImage::createRgbTexture(size_t width, size_t height) {
+    MTLTextureDescriptor *descriptor =
+            [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+                                                               width:width
+                                                              height:height
+                                                           mipmapped:NO];
+    descriptor.usage = MTLTextureUsageShaderWrite | MTLTextureUsageShaderRead;
+    return [mContext.device newTextureWithDescriptor:descriptor];
+}
+
+
+void MetalExternalImage::ensureComputePipelineState() {
+    if (gComputePipelineState != nil) {
+        return;
+    }
+
+    NSError* error = nil;
+
+    NSString* objcSource = [NSString stringWithCString:kernel.data()
+                                              encoding:NSUTF8StringEncoding];
+    id<MTLLibrary> library = [mContext.device newLibraryWithSource:objcSource
+                                                            options:nil
+                                                              error:&error];
+    NSERROR_CHECK("Unable to compile Metal shading library.");
+
+    id<MTLFunction> kernelFunction = [library newFunctionWithName:@"ycbcrToRgb"];
+    [library release];
+
+    gComputePipelineState = [mContext.device newComputePipelineStateWithFunction:kernelFunction
+                                                                           error:&error];
+    NSERROR_CHECK("Unable to create Metal compute pipeline state.");
+    [kernelFunction release];
+}
+
+id<MTLCommandBuffer> MetalExternalImage::encodeColorConversionPass(id<MTLTexture> inYPlane,
+        id<MTLTexture> inCbCrTexture, id<MTLTexture> outTexture) {
+    ensureComputePipelineState();
+
+    id<MTLCommandBuffer> commandBuffer = [mContext.commandQueue commandBuffer];
+    commandBuffer.label = @"YCbCr to RGB conversion";
+
+    id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+
+    [computeEncoder setComputePipelineState:gComputePipelineState];
+    [computeEncoder setTexture:inYPlane atIndex:0];
+    [computeEncoder setTexture:inCbCrTexture atIndex:1];
+    [computeEncoder setTexture:outTexture atIndex:2];
+
+    MTLSize tgSize = MTLSizeMake(16, 16, 1);
+    MTLSize tgCount;
+    tgCount.width = (outTexture.width  + tgSize.width -  1) / tgSize.width;
+    tgCount.height = (outTexture.height + tgSize.height - 1) / tgSize.height;
+    tgCount.depth = 1;
+
+    [computeEncoder dispatchThreadgroups:tgCount threadsPerThreadgroup:tgSize];
+
+    [computeEncoder endEncoding];
+
+    return commandBuffer;
+}
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -19,11 +19,13 @@
 
 #include "metal/MetalDriver.h"
 
+#include <CoreVideo/CVPixelBuffer.h>
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h> // for CAMetalLayer
 
 #include "MetalContext.h"
 #include "MetalEnums.h"
+#include "MetalExternalImage.h"
 #include "MetalState.h" // for MetalState::VertexDescription
 #include "TextureReshaper.h"
 
@@ -119,7 +121,7 @@ struct MetalProgram : public HwProgram {
 };
 
 struct MetalTexture : public HwTexture {
-    MetalTexture(id<MTLDevice> device, backend::SamplerType target, uint8_t levels,
+    MetalTexture(MetalContext& context, backend::SamplerType target, uint8_t levels,
             TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
             TextureUsage usage) noexcept;
     ~MetalTexture();
@@ -129,7 +131,9 @@ struct MetalTexture : public HwTexture {
     void loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
             int miplevel);
 
-    id<MTLTexture> texture;
+    MetalContext& context;
+    MetalExternalImage externalImage;
+    id<MTLTexture> texture = nil;
     uint8_t bytesPerPixel;
     TextureReshaper reshaper;
 };

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2045,6 +2045,9 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
     CHECK_GL_ERROR(utils::slog.e)
 }
 
+void OpenGLDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+}
+
 void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     if (ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2045,7 +2045,10 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+void OpenGLDriver::setupExternalImage(void* image) {
+}
+
+void OpenGLDriver::cancelExternalImage(void* image) {
 }
 
 void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -619,7 +619,10 @@ void VulkanDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     scheduleDestroy(std::move(data));
 }
 
-void VulkanDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+void VulkanDriver::setupExternalImage(void* image) {
+}
+
+void VulkanDriver::cancelExternalImage(void* image) {
 }
 
 void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -619,6 +619,9 @@ void VulkanDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     scheduleDestroy(std::move(data));
 }
 
+void VulkanDriver::setExternalImageS(Handle<HwTexture> th, void* image) {
+}
+
 void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -324,8 +324,12 @@ public:
      *   - the size and format of the texture is defined by the external image
      *
      * @param engine        Engine this texture is associated to.
-     * @param image         An opaque handle to a platform specific image. The only supported
-     *                      type is eglImageOES.
+     * @param image         An opaque handle to a platform specific image. Supported types are
+     *                      eglImageOES on Android and CVPixelBufferRef on iOS.
+     *
+     *                      On iOS the following pixel formats are supported:
+     *                        - kCVPixelFormatType_32BGRA
+     *                        - kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
      *
      * @attention \p engine must be the instance passed to Builder::build()
      * @attention This Texture instance must use backend::SamplerType::SAMPLER_EXTERNAL or it has no effect

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -161,6 +161,9 @@ void FTexture::setImage(FEngine& engine, size_t level,
 
 void FTexture::setExternalImage(FEngine& engine, void* image) noexcept {
     if (mTarget == Sampler::SAMPLER_EXTERNAL) {
+        // The first call to setExternalImageS is synchronous, and allows the driver to take
+        // ownership of the external image on this thread, if necessary.
+        engine.getDriverApi().setExternalImageS(mHandle, image);
         engine.getDriverApi().setExternalImage(mHandle, image);
     }
 }

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -161,9 +161,9 @@ void FTexture::setImage(FEngine& engine, size_t level,
 
 void FTexture::setExternalImage(FEngine& engine, void* image) noexcept {
     if (mTarget == Sampler::SAMPLER_EXTERNAL) {
-        // The first call to setExternalImageS is synchronous, and allows the driver to take
-        // ownership of the external image on this thread, if necessary.
-        engine.getDriverApi().setExternalImageS(mHandle, image);
+        // The call to setupExternalImage is synchronous, and allows the driver to take ownership of
+        // the external image on this thread, if necessary.
+        engine.getDriverApi().setupExternalImage(image);
         engine.getDriverApi().setExternalImage(mHandle, image);
     }
 }


### PR DESCRIPTION
Add external image support to Metal through the `MetalExternalImage` class. A new synchronous driver method, `setExternalImageS` is necessary because the `CVPixelBufferRef ` must be retained on the same thread that `setExternalImage` is called.