### PR TITLE
Some matinfo fixes.

### DIFF
--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -604,7 +604,7 @@ inline utils::CString typeToString(uint64_t v) {
         str[7 - i] = raw[i];
     }
     str[8] = '\0';
-    return utils::CString(str, 7);
+    return utils::CString(str, strnlen(str, 8));
 }
 
 static void printChunks(const ChunkContainer& container) {
@@ -904,7 +904,9 @@ static bool parseChunks(Config config, void* data, size_t size) {
 
             const auto& item = info[config.shaderIndex];
             parser.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
-            std::cout << builder.data();
+
+            // Casted to char* to print as a string rather than hex value.
+            std::cout << (const char*) builder.data();
 
             return true;
         }


### PR DESCRIPTION
- Fix the "CString size mismatch" assert seen in debug config.
- Fix the --print-glsl option, which was printing junk.