### PR TITLE
Better frustum/box intersection, make code more robust

### DIFF
--- a/filament/include/filament/Box.h
+++ b/filament/include/filament/Box.h
@@ -175,6 +175,13 @@ struct Aabb {
      * Return the 8 corner vertices of the AABB
      */
     Corners getCorners() const;
+
+    /**
+     * Returns whether the box contains a given point.
+     * @param p the point to test
+     * @return the maximum signed distance to the box. Negative if p is in the box
+     */
+    float contains(math::float3 p) const noexcept;
 };
 
 } // namespace filament

--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -104,6 +104,13 @@ public:
      */
     bool intersects(const math::float4& sphere) const noexcept;
 
+    /**
+     * Returns whether the frustum contains a given point.
+     * @param p the point to test
+     * @return the maximum signed distance to the frustum. Negative if p is inside.
+     */
+    float contains(math::float3 p) const noexcept;
+
 private:
     friend class details::Culler;
     math::float4 mPlanes[6];

--- a/filament/src/Box.cpp
+++ b/filament/src/Box.cpp
@@ -42,4 +42,14 @@ Aabb::Corners Aabb::getCorners() const {
             }};
 }
 
+float Aabb::contains(math::float3 p) const noexcept {
+    float d = min.x - p.x;
+    d = std::max(d, min.y - p.y);
+    d = std::max(d, min.z - p.z);
+    d = std::max(d, p.x - max.x);
+    d = std::max(d, p.y - max.y);
+    d = std::max(d, p.z - max.z);
+    return d;
+}
+
 } // namespace filament

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -83,4 +83,20 @@ bool Frustum::intersects(const float4& sphere) const noexcept {
     return Culler::intersects(*this, sphere);
 }
 
+float Frustum::contains(math::float3 p) const noexcept {
+    float l = dot(mPlanes[0].xyz, p) + mPlanes[0].w;
+    float b = dot(mPlanes[1].xyz, p) + mPlanes[1].w;
+    float r = dot(mPlanes[2].xyz, p) + mPlanes[2].w;
+    float t = dot(mPlanes[3].xyz, p) + mPlanes[3].w;
+    float f = dot(mPlanes[4].xyz, p) + mPlanes[4].w;
+    float n = dot(mPlanes[5].xyz, p) + mPlanes[5].w;
+    float d = l;
+    d = std::max(d, b);
+    d = std::max(d, r);
+    d = std::max(d, t);
+    d = std::max(d, f);
+    d = std::max(d, n);
+    return d;
+}
+
 } // namespace filament

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -122,10 +122,10 @@ private:
     static inline void computeFrustumCorners(math::float3* out,
             const math::mat4f& projectionViewInverse) noexcept;
 
-    static inline math::float2 computeNearFar(math::mat4f const& lightView,
+    static inline math::float2 computeNearFar(math::mat4f const& view,
             Aabb const& wsShadowCastersVolume) noexcept;
 
-    static inline math::float2 computeNearFar(math::mat4f const& lightView,
+    static inline math::float2 computeNearFar(math::mat4f const& view,
             math::float3 const* wsVertices, size_t count) noexcept;
 
     static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
@@ -135,16 +135,17 @@ private:
             math::float3 const* wsViewFrustumCorners, size_t count) noexcept;
 
     static inline bool intersectSegmentWithPlane(math::float3& p,
-            math::float3 s0, math::float3 s1,
-            math::float3 pn, math::float3 p0) noexcept;
+            math::double3 s0, math::double3 s1,
+            math::double3 pn, math::double3 p0) noexcept;
 
     static inline bool intersectSegmentWithPlanarQuad(math::float3& p,
-            math::float3 s0, math::float3 s1,
-            math::float3 t0, math::float3 t1,
-            math::float3 t2, math::float3 t3) noexcept;
+            math::double3 s0, math::double3 s1,
+            math::double3 t0, math::double3 t1,
+            math::double3 t2, math::double3 t3) noexcept;
 
-    static size_t intersectFrustums(math::float3* out, size_t vertexCount,
-            math::float3 const* segmentsVertices, math::float3 const* quadsVertices) noexcept;
+    static size_t intersectFrustum(math::float3* out, size_t vertexCount,
+            math::float3 const* segmentsVertices, math::float3 const* quadsVertices,
+            Frustum const& frustum) noexcept;
 
     static size_t intersectFrustumWithBox(
             FrustumBoxIntersection& outVertices,

--- a/libs/math/include/math/scalar.h
+++ b/libs/math/include/math/scalar.h
@@ -45,8 +45,8 @@ inline constexpr T MATH_PURE lerp(T x, T y, T a) noexcept {
 }
 
 template <typename T>
-inline constexpr int sign(T val) noexcept {
-    return (T(0) < val) - (val < T(0));
+inline constexpr T sign(T x) noexcept {
+    return x < T(0) ? T(-1) : T(1);
 }
 
 } // namespace math


### PR DESCRIPTION
- switched the frustum/box intersection code to double. With large 
scenes, we were getting very wrong intersection points (up to 1m off).
This doesn't seem to happen with doubles. 

- reject points that end-up outside the frustum

- made LiSPSM code more robust against the problem above. When points
were falsely placed behind the near plane (due to bad intersections),
we could end-up with NaN (sqrt of negative numbers).