### PR TITLE
fix a "shadow disappear" bug introduced recently

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -856,14 +856,7 @@ size_t ShadowMap::intersectFrustumWithBox(
         }
     }
 
-#ifdef NDEBUG
-    // Sanity check: all vertices should be inside the Frustum and inside the Box
     assert(vertexCount <= outVertices.size());
-    for (size_t i = 0; i < vertexCount; i++) {
-        assert(frustum.contains(outVertices[i]) <= EPSILON);
-        assert(wsBox.contains(outVertices[i]) <= 0);
-    }
-#endif
 
     return vertexCount;
 }
@@ -879,7 +872,7 @@ size_t ShadowMap::intersectFrustum(
         float3 const* quadsVertices,
         Frustum const& frustum) noexcept {
 
-#pragma nounroll
+    #pragma nounroll
     for (const Segment segment : sBoxSegments) {
         const double3 s0{ segmentsVertices[segment.v0] };
         const double3 s1{ segmentsVertices[segment.v1] };
@@ -892,12 +885,7 @@ size_t ShadowMap::intersectFrustum(
             const double3 t2{ quadsVertices[quad.v2] };
             const double3 t3{ quadsVertices[quad.v3] };
             if (intersectSegmentWithPlanarQuad(out[vertexCount], s0, s1, t0, t1, t2, t3)) {
-                // the test below shouldn't be necessary, but due to rounding errors, we've seen
-                // it happen -- and this breaks an invariant, so we discard those points
-                constexpr const float EPSILON = 1.0f / 8192.0f; // ~0.012 mm
-                if (frustum.contains(out[vertexCount]) <= EPSILON) {
-                    vertexCount++;
-                }
+                vertexCount++;
             }
         }
     }


### PR DESCRIPTION
We were too aggressive removing vertices resulting from
the triangle/segment intersection test, that were not
contained in the frustum (this invariant should hold).
This happens because our triangle/segment intersection
is not watertight. Removing those vertices entirely would lead
to wrongly reduced light frustum.

Now that the lispsm code is more robust to these invalid vertices,
we can keep them. Most of the time they're harmless, because they're
close to the correct solution.