### PR TITLE
simplify RenderPass

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -60,10 +60,6 @@ void RenderPass::setRenderFlags(RenderPass::RenderFlags flags) noexcept {
     mFlags = flags;
 }
 
-void RenderPass::setExecuteSync(std::function<void(DriverApi& driver)> sync) noexcept {
-    mSync = std::move(sync);
-}
-
 void RenderPass::overridePolygonOffset(backend::PolygonOffset* polygonOffset) noexcept {
     if ((mPolygonOffsetOverride = (polygonOffset != nullptr))) {
         mPolygonOffset = *polygonOffset;
@@ -147,12 +143,6 @@ void RenderPass::execute(const char* name,
 
     // Take care not to upload data within the render pass (synchronize can commit froxel data)
     DriverApi& driver = engine.getDriverApi();
-
-    // give a chance to dependant jobs to finish
-    if (mSync) {
-        mSync(driver);
-        mSync = nullptr;
-    }
 
     // Now, execute all commands
     driver.pushGroupMarker(name);

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -207,7 +207,6 @@ public:
     void setGeometry(FScene& scene, utils::Range<uint32_t> vr) noexcept;
     void setCamera(const CameraInfo& camera) noexcept;
     void setRenderFlags(RenderFlags flags) noexcept;
-    void setExecuteSync(std::function<void(backend::DriverApi& driver)> sync) noexcept;
     void generateSortedCommands(CommandTypeFlags commandType) noexcept;
     void execute(const char* name,
             backend::Handle <backend::HwRenderTarget> renderTarget,
@@ -215,6 +214,7 @@ public:
             Command const* first, Command const* last) const noexcept;
 
     utils::GrowingSlice<Command>& getCommands() { return mCommands; }
+    utils::Slice<Command> const& getCommands() const { return mCommands; }
 
     size_t getCommandsHighWatermark() const noexcept {
         return mCommandsHighWatermark * sizeof(Command);
@@ -259,7 +259,6 @@ private:
     RenderFlags mFlags{};
     bool mPolygonOffsetOverride = false;
     backend::PolygonOffset mPolygonOffset{};
-    mutable std::function<void(backend::DriverApi&)> mSync;
     size_t mCommandsHighWatermark = 0;
 };
 


### PR DESCRIPTION
Now that generate and execute commands are separate, we don’t need the
setExecuteSync() functionality — it can just be done explicitly when
needed.