### PR TITLE
gltfio: remove alpha cutoff from MaterialKey.

### DIFF
--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -59,11 +59,9 @@ struct alignas(4) MaterialKey {
     uint8_t aoUV;
     uint8_t normalUV;
     bool hasTextureTransforms : 8;
-    // -- 32 bit boundary --
-    float alphaMaskThreshold;
 };
 
-static_assert(sizeof(MaterialKey) == 12, "MaterialKey has unexpected padding.");
+static_assert(sizeof(MaterialKey) == 8, "MaterialKey has unexpected padding.");
 
 bool operator==(const MaterialKey& k1, const MaterialKey& k2);
 

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -616,7 +616,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
         .aoUV = (uint8_t) inputMat->occlusion_texture.texcoord,
         .normalUV = (uint8_t) inputMat->normal_texture.texcoord,
         .hasTextureTransforms = hasTextureTransforms,
-        .alphaMaskThreshold = 0.5f
     };
 
     if (inputMat->has_pbr_specular_glossiness) {
@@ -639,7 +638,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
             break;
         case cgltf_alpha_mode_mask:
             matkey.alphaMode = AlphaMode::MASK;
-            matkey.alphaMaskThreshold = inputMat->alpha_cutoff;
             break;
         case cgltf_alpha_mode_blend:
             matkey.alphaMode = AlphaMode::BLEND;
@@ -650,6 +648,10 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
     // rendering constraints. For example, Filament only supports 2 sets of texture coordinates.
     MaterialInstance* mi = mMaterials->createMaterialInstance(&matkey, uvmap, inputMat->name);
     mResult->mMaterialInstances.push_back(mi);
+
+    if (inputMat->alpha_mode == cgltf_alpha_mode_mask) {
+        mi->setMaskThreshold(inputMat->alpha_cutoff);
+    }
 
     const float* e = inputMat->emissive_factor;
     mi->setParameter("emissiveFactor", float3(e[0], e[1], e[2]));

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -277,7 +277,6 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
             break;
         case AlphaMode::MASK:
             builder.blending(MaterialBuilder::BlendingMode::MASKED);
-            builder.maskThreshold(config.alphaMaskThreshold);
             break;
         case AlphaMode::BLEND:
             builder.blending(MaterialBuilder::BlendingMode::TRANSPARENT);

--- a/libs/gltfio/src/MaterialProvider.cpp
+++ b/libs/gltfio/src/MaterialProvider.cpp
@@ -33,8 +33,7 @@ bool gltfio::operator==(const MaterialKey& k1, const MaterialKey& k2) {
         (k1.metallicRoughnessUV == k2.metallicRoughnessUV) &&
         (k1.emissiveUV == k2.emissiveUV) &&
         (k1.aoUV == k2.aoUV) &&
-        (k1.normalUV == k2.normalUV) &&
-        (k1.alphaMaskThreshold == k2.alphaMaskThreshold);
+        (k1.normalUV == k2.normalUV);
 }
 
 // Filament supports up to 2 UV sets. glTF has arbitrary texcoord set indices, but it allows

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -129,10 +129,6 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
     mi->setParameter("aoIndex", getUvIndex(config->aoUV, config->hasOcclusionTexture));
     mi->setParameter("emissiveIndex", getUvIndex(config->emissiveUV, config->hasEmissiveTexture));
 
-    if (config->alphaMode == AlphaMode::MASK) {
-        mi->setMaskThreshold(config->alphaMaskThreshold);
-    }
-
     mi->setDoubleSided(config->doubleSided);
 
     mat3f identity;


### PR DESCRIPTION
Harmless cleanup. The cutoff value is a uniform and therefore does not
need to be a part of the material configuration structure.