### PR TITLE
 Fix incorrect depth comparisons with floating point depth formats

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -103,6 +103,10 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
     // we set a viewport with a 1-texel border for when we index outside of the texture
     // DON'T CHANGE this unless computeLightSpaceMatrix() is updated too.
     // see: computeLightSpaceMatrix()
+    // For floating-point depth textures, the 1-texel border could be set to FLOAT_MAX to avoid
+    // clamping in the shadow shader (see sampleDepth inside shadowing.fs). Unfortunately, the APIs
+    // don't seem let us clear depth attachments to anything greater than 1.0, so we'd need a way to
+    // do this other than clearing.
     mViewport = { 1, 1, dim - 2, dim - 2 };
     mShadowMapResolution.xy = 1.0f / (dim - 2);
 

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -70,14 +70,17 @@ float sampleDepth(const lowp sampler2DShadow map, vec2 base, vec2 dudv, float de
     depth += dot(dudv, rpdb);
  #endif
 #endif
-    return texture(map, vec3(base + dudv, depth));
+    // depth must be clamped to support floating-point depth formats. This is to avoid comparing a
+    // value from the depth texture (which is never greater than 1.0) with a greater-than-one
+    // comparison value (which is possible with floating-point formats).
+    return texture(map, vec3(base + dudv, clamp(depth, 0.0, 1.0)));
 }
 
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HARD
 float ShadowSample_Hard(const lowp sampler2DShadow map, const vec2 size, const vec3 position) {
     vec2 rpdb = computeReceiverPlaneDepthBias(position);
     float depth = samplingBias(position.z, rpdb, vec2(1.0) / size);
-    return texture(map, vec3(position.xy, depth));
+    return texture(map, vec3(position.xy, clamp(depth, 0.0, 1.0)));
 }
 #endif
 


### PR DESCRIPTION
Found this shadow issue when testing shadows on iOS (which does not have fixed-point depth texture
support).

To reproduce on Mac, set `g_shadowPlane` to `true` in `material_sandbox` and force the depth texture
in `ShadowMap.cpp` to be 32 bit:

```
     mShadowMapHandle = driver.createTexture(
-            SamplerType::SAMPLER_2D, 1, format, 1, dim, dim, 1,
+            SamplerType::SAMPLER_2D, 1, TextureFormat::DEPTH32F, 1, dim, dim, 1,
             TextureUsage::DEPTH_ATTACHMENT);
```

![shadow-issue](https://user-images.githubusercontent.com/5298046/56540700-591ce180-651e-11e9-9722-9a750b3aa290.png)

The fix is to clamp the depth comparison value between 0 and 1. spirv-opt optimizes the `clamp` and
does it only once, even though we may be calling `sampleDepth` multiple times.
