### PR TITLE
fix FBO leak when using MSAA in some cases

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -209,7 +209,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
                 t->gl.fence = nullptr;
             }
 
-            gl->bindTexture(tmu, t->gl.target, t, t->gl.targetIndex);
+            gl->bindTexture(tmu, t);
 
             // FIXME: getSampler() is expensive because it's a hashmap lookup
             GLuint sampler = gl->getSampler(samplers[index].s);


### PR DESCRIPTION
We would leak an FBO when using the same texture with multiple FBOs 
and MSAA, this is because we have to allocate a sidecar FBO in this case
and we were doing so even if it was already existing.

Also store the sidecar fbo with the texture instead of the RenderTarget,
because it has nothing to do with the later. In fact we could have
several textures (e.g. color + depth) who both need a sidecar fbo,
so it can't be stored in the RenderTarget structure.

Also clean-up bindTexture().