### PR TITLE
Fix crasher in framegraph

### DIFF
--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -874,10 +874,12 @@ FrameGraph& FrameGraph::compile() noexcept {
             //  attachment would be missing).
             for (fg::RenderTarget& rt : renderTargets) {
                 auto& textures = rt.desc.attachments.textures;
-                ResourceNode const& node = resourceNodes[textures[0].index];
-                if (node.resource->imported && node.resource == from.resource) {
-                    for (size_t i = 1; i < textures.size(); ++i) {
-                        textures[i] = {};
+                if (textures[0].isValid()) {
+                    ResourceNode const& node = resourceNodes[textures[0].index];
+                    if (node.resource->imported && node.resource == from.resource) {
+                        for (size_t i = 1; i < textures.size(); ++i) {
+                            textures[i] = {};
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It would happen when using a rendertarget without a color buffer and 
a moveResource operation was set. We would incorrectly dereference the
color texture (which didn't exist).