### PR TITLE
Fix a FrameGraph discard bug with imported rendertargets

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -235,7 +235,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     const backend::Handle<backend::HwRenderTarget> viewRenderTarget = getRenderTarget();
     FrameGraphResource output = fg.importResource("viewRenderTarget",
-            { .viewport = vp }, viewRenderTarget, vp.width, vp.height);
+            { .viewport = vp }, viewRenderTarget, vp.width, vp.height,
+            view.getDiscardedTargetBuffers());
 
     /*
      * Depth + Color passes

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -211,7 +211,7 @@ private:
     fg::ResourceNode& getResource(FrameGraphResource r);
 
     fg::RenderTarget& createRenderTarget(const char* name,
-            FrameGraphRenderTarget::Descriptor const& desc, bool imported) noexcept;
+            FrameGraphRenderTarget::Descriptor const& desc) noexcept;
 
     FrameGraphResource createResourceNode(fg::Resource* resource) noexcept;
 


### PR DESCRIPTION
Imported render target's discard flags (i.e. the imported flags)
were ignored, which means we were discarding the imported buffer
each time we were drawing into it, especially the 2nd time when
drawing the ImGUI.