### PR TITLE
Correct JS bindings for 

### DIFF
--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -776,8 +776,8 @@ class_<VertexBuilder>("VertexBuffer$Builder")
             VertexAttribute attr,
             uint8_t bufferIndex,
             VertexBuffer::AttributeType attrType,
-            size_t byteOffset,
-            size_t byteStride), {
+            uint32_t byteOffset,
+            uint8_t byteStride), {
         return &builder->attribute(attr, bufferIndex, attrType, byteOffset, byteStride); })
     .BUILDER_FUNCTION("vertexCount", VertexBuilder, (VertexBuilder* builder, int count), {
         return &builder->vertexCount(count); })

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -695,7 +695,11 @@ class_<TransformManager>("TransformManager")
     /// ::retval:: a transform component that can be passed to `setTransform`.
     .function("getInstance", &TransformManager::getInstance)
 
-    .function("create", &TransformManager::create)
+    .function("create", EMBIND_LAMBDA(void,
+            (TransformManager* self, utils::Entity entity), {
+        self->create(entity);
+    }), allow_raw_pointers())
+
     .function("destroy", &TransformManager::destroy)
     .function("setParent", &TransformManager::setParent)
     .function("getParent", &TransformManager::getParent)
@@ -772,8 +776,8 @@ class_<VertexBuilder>("VertexBuffer$Builder")
             VertexAttribute attr,
             uint8_t bufferIndex,
             VertexBuffer::AttributeType attrType,
-            uint8_t byteOffset,
-            uint8_t byteStride), {
+            size_t byteOffset,
+            size_t byteStride), {
         return &builder->attribute(attr, bufferIndex, attrType, byteOffset, byteStride); })
     .BUILDER_FUNCTION("vertexCount", VertexBuilder, (VertexBuilder* builder, int count), {
         return &builder->vertexCount(count); })


### PR DESCRIPTION
Both TransformManager::create and VertexBuffer::Builder::attribute were bound incorrectly in jsbindings.cpp, so calling them would cause a crash (VertexBuffer::Builder::attribute would crash if the offset was > 255,  TransformManager::create would always crash).  Corrected bindings so both will work.