### PR TITLE
Slight Metal improvements

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -580,7 +580,9 @@ void MetalDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> s
 }
 
 void MetalDriver::commit(Handle<HwSwapChain> sch) {
-    [mContext->currentCommandBuffer presentDrawable:mContext->currentDrawable];
+    if (mContext->currentDrawable != nil) {
+        [mContext->currentCommandBuffer presentDrawable:mContext->currentDrawable];
+    }
     [mContext->currentCommandBuffer commit];
     mContext->currentCommandBuffer = nil;
     mContext->currentDrawable = nil;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -39,10 +39,8 @@ namespace metal {
 
 struct MetalSwapChain : public HwSwapChain {
     MetalSwapChain(id<MTLDevice> device, CAMetalLayer* nativeWindow);
-    ~MetalSwapChain();
 
     CAMetalLayer* layer = nullptr;
-    id<MTLTexture> depthTexture = nullptr;
     NSUInteger surfaceHeight = 0;
 };
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -63,22 +63,8 @@ static inline MTLStorageMode getMetalStorageMode(TextureFormat format) {
 MetalSwapChain::MetalSwapChain(id<MTLDevice> device, CAMetalLayer* nativeWindow)
         : layer(nativeWindow) {
     layer.device = device;
-
-    // Create a depth buffer for the swap chain.
     CGSize size = layer.drawableSize;
-    MTLTextureDescriptor* depthTextureDesc =
-            [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatDepth32Float
-                                                               width:(NSUInteger)(size.width)
-                                                              height:(NSUInteger)(size.height)
-                                                           mipmapped:NO];
-    depthTextureDesc.usage = MTLTextureUsageRenderTarget;
-    depthTextureDesc.resourceOptions = MTLResourceStorageModePrivate;
-    depthTexture = [device newTextureWithDescriptor:depthTextureDesc];
     surfaceHeight = (NSUInteger)(size.height);
-}
-
-MetalSwapChain::~MetalSwapChain() {
-    [depthTexture release];
 }
 
 MetalVertexBuffer::MetalVertexBuffer(id<MTLDevice> device, uint8_t bufferCount, uint8_t attributeCount,
@@ -399,9 +385,6 @@ id<MTLTexture> MetalRenderTarget::getDepthResolve() {
 }
 
 id<MTLTexture> MetalRenderTarget::getDepth() {
-    if (defaultRenderTarget) {
-        return context->currentSurface->depthTexture;
-    }
     return isMultisampled() ? multisampledDepth : depth;
 }
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -230,12 +230,15 @@ MetalProgram::MetalProgram(id<MTLDevice> device, const Program& program) noexcep
         if (source.empty()) {
             continue;
         }
-        NSString* objcSource = [NSString stringWithCString:(const char*)source.data()
-                                                  encoding:NSUTF8StringEncoding];
+
+        NSString* objcSource = [[NSString alloc] initWithBytes:source.data()
+                                                        length:source.size()
+                                                      encoding:NSUTF8StringEncoding];
         NSError* error = nil;
         id<MTLLibrary> library = [device newLibraryWithSource:objcSource
                                                       options:nil
                                                         error:&error];
+        [objcSource release];
         if (error) {
             auto description =
                     [error.localizedDescription cStringUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
- No need to create a depth buffer automatically for Metal swap chains
- A potential bug when loading shader text if the data isn’t null-terminated
- Check that we've rendered to the default render target before trying to present it at the end of a frame