### PR TITLE
Implement Metal blitting

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -93,6 +93,7 @@ endif()
 
 if (FILAMENT_SUPPORTS_METAL)
     list(APPEND SRCS
+            src/metal/MetalBlitter.mm
             src/metal/MetalBufferPool.mm
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm

--- a/filament/backend/src/metal/MetalBlitter.h
+++ b/filament/backend/src/metal/MetalBlitter.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_METALBLITTER_H
+#define TNT_METALBLITTER_H
+
+#include <Metal/Metal.h>
+
+#include <backend/DriverEnums.h>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+struct MetalContext;
+
+class MetalBlitter {
+
+public:
+
+    explicit MetalBlitter(MetalContext& context) noexcept;
+
+    struct BlitArgs {
+        struct Attachment {
+            id<MTLTexture> color = nil;
+            id<MTLTexture> depth = nil;
+            MTLRegion region;
+            uint8_t level = 0;
+        };
+
+        Attachment source, destination;
+        SamplerMagFilter filter;
+
+        bool colorDestinationIsFullAttachment() const {
+            return destination.color.width == destination.region.size.width &&
+                   destination.color.height == destination.region.size.height;
+        }
+
+        bool depthDestinationIsFullAttachment() const {
+            return destination.depth.width == destination.region.size.width &&
+                   destination.depth.height == destination.region.size.height;
+        }
+    };
+
+    void blit(const BlitArgs& args);
+
+    /**
+     * Free global resources. Should be called at least once per process when no further calls to
+     * blit will occur.
+     */
+    static void shutdown() noexcept;
+
+private:
+
+    static void setupColorAttachment(const BlitArgs& args, MTLRenderPassDescriptor* descriptor);
+    static void setupDepthAttachment(const BlitArgs& args, MTLRenderPassDescriptor* descriptor);
+    void ensureFunctions();
+
+    MetalContext& mContext;
+
+};
+
+} // namespace metal
+} // namespace backend
+} // namespace filament
+
+#endif //TNT_METALBLITTER_H

--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalBlitter.h"
+
+#include "MetalContext.h"
+
+#include <math/vec4.h>
+#include <utils/Panic.h>
+
+#define NSERROR_CHECK(message)                                                                     \
+    if (error) {                                                                                   \
+        auto description = [error.localizedDescription cStringUsingEncoding:NSUTF8StringEncoding]; \
+        utils::slog.e << description << utils::io::endl;                                           \
+    }                                                                                              \
+    ASSERT_POSTCONDITION(error == nil, message);
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+static id<MTLFunction> gVertexFunction = nil;
+static id<MTLFunction> gFragmentColor = nil;
+static id<MTLFunction> gFragmentDepth = nil;
+static id<MTLFunction> gFragmentColorDepth = nil;
+
+static std::string functionLibrary (R"(
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using namespace metal;
+
+struct VertexOut
+{
+    float4 vertexPosition [[position]];
+    float2 uv;
+};
+
+struct ColorFragmentOut
+{
+    float4 color [[color(0)]];
+};
+
+struct DepthFragmentOut
+{
+    float depth [[depth(any)]];
+};
+
+struct ColorDepthFragmentOut
+{
+    float4 color [[color(0)]];
+    float depth [[depth(any)]];
+};
+
+vertex VertexOut
+blitterVertex(uint vid [[vertex_id]],
+              constant float4* vertices [[buffer(0)]])
+{
+    VertexOut out = {};
+    out.vertexPosition = float4(vertices[vid].xy, 0.0, 1.0);
+    out.uv = vertices[vid].zw;
+    return out;
+}
+
+fragment ColorFragmentOut
+blitterFragColor(VertexOut in [[stage_in]],
+                 sampler sourceSampler [[sampler(0)]],
+                 texture2d<float, access::sample> sourceColor [[texture(0)]],
+                 constant uint8_t* lod [[buffer(0)]])
+{
+    ColorFragmentOut out = {};
+    out.color = sourceColor.sample(sourceSampler, in.uv, level(*lod));
+    return out;
+}
+
+fragment DepthFragmentOut
+blitterFragDepth(VertexOut in [[stage_in]],
+                 sampler sourceSampler [[sampler(0)]],
+                 texture2d<float, access::sample> sourceDepth [[texture(1)]],
+                 constant uint8_t* lod [[buffer(0)]])
+{
+    DepthFragmentOut out = {};
+    out.depth = sourceDepth.sample(sourceSampler, in.uv, level(*lod)).r;
+    return out;
+}
+
+fragment ColorDepthFragmentOut
+blitterFragColorDepth(VertexOut in [[stage_in]],
+                      sampler sourceSampler [[sampler(0)]],
+                      texture2d<float, access::sample> sourceColor [[texture(0)]],
+                      texture2d<float, access::sample> sourceDepth [[texture(1)]],
+                      constant uint8_t* lod [[buffer(0)]])
+{
+    ColorDepthFragmentOut out = {};
+    out.color = sourceColor.sample(sourceSampler, in.uv, level(*lod));
+    out.depth = sourceDepth.sample(sourceSampler, in.uv, level(*lod)).r;
+    return out;
+}
+)");
+
+MetalBlitter::MetalBlitter(MetalContext& context) noexcept : mContext(context) { }
+
+void MetalBlitter::blit(const BlitArgs& args) {
+    const bool blitColor = args.source.color != nil && args.destination.color != nil;
+    const bool blitDepth = args.source.depth != nil && args.destination.depth != nil;
+
+    if (!blitColor && !blitDepth) {
+        return;
+    }
+
+    ensureFunctions();
+
+    MTLRenderPassDescriptor* descriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+
+    if (blitColor) {
+        setupColorAttachment(args, descriptor);
+    }
+
+    if (blitDepth) {
+        setupDepthAttachment(args, descriptor);
+    }
+
+    id<MTLRenderCommandEncoder> encoder =
+            [mContext.currentCommandBuffer renderCommandEncoderWithDescriptor:descriptor];
+    encoder.label = @"Blit";
+
+    id<MTLFunction> fragmentFunction = nil;
+    if (blitColor && blitDepth) {
+        fragmentFunction = gFragmentColorDepth;
+    } else if (blitColor) {
+        fragmentFunction = gFragmentColor;
+    } else if (blitDepth) {
+        fragmentFunction = gFragmentDepth;
+    }
+
+    PipelineState pipelineState {
+        .vertexFunction = gVertexFunction,
+        .fragmentFunction = fragmentFunction,
+        .vertexDescription = {},
+        .colorAttachmentPixelFormat = args.destination.color.pixelFormat,
+        .depthAttachmentPixelFormat =
+                blitDepth ? args.destination.depth.pixelFormat : MTLPixelFormatInvalid,
+        .sampleCount = 1,
+        .blendState = {}
+    };
+    id<MTLRenderPipelineState> pipeline = mContext.pipelineStateCache.getOrCreateState(pipelineState);
+    [encoder setRenderPipelineState:pipeline];
+
+    if (blitColor) {
+        [encoder setFragmentTexture:args.source.color atIndex:0];
+    }
+
+    if (blitDepth) {
+        [encoder setFragmentTexture:args.source.depth atIndex:1];
+    }
+
+    SamplerParams samplerState;
+    samplerState.filterMin = static_cast<SamplerMinFilter>(args.filter);
+    samplerState.filterMag = args.filter;
+    id<MTLSamplerState> sampler = mContext.samplerStateCache.getOrCreateState(samplerState);
+    [encoder setFragmentSamplerState:sampler atIndex:0];
+
+    MTLViewport viewport;
+    viewport.originX = args.destination.region.origin.x;
+    viewport.originY = args.destination.region.origin.y;
+    viewport.height = args.destination.region.size.height;
+    viewport.width = args.destination.region.size.width;
+    viewport.znear = 0.0;
+    viewport.zfar = 1.0;
+    [encoder setViewport:viewport];
+
+    DepthStencilState depthStencilState {
+        .compareFunction = MTLCompareFunctionAlways,
+        .depthWriteEnabled = blitDepth
+    };
+    id<MTLDepthStencilState> depthStencil =
+            mContext.depthStencilStateCache.getOrCreateState(depthStencilState);
+    [encoder setDepthStencilState:depthStencil];
+
+    /*
+     *  We blit by rendering a single triangle that covers the entire viewport. The UV coordinates
+     *  are chosen so that, when interpolated across the viewport, they correctly sample the
+     *  desired region of the source texture:
+     *
+     *  (the Xs denote the 3 vertices)
+     *
+     *  (l, 2 * t - b)
+     *  X
+     *
+     *
+     *
+     *  (l, t)     (r, t)
+     *  . . . . . .
+     *  . . . . . .
+     *  . . . . . .
+     *  . . . . . .
+     *  X . . . . .           X
+     *  (l, b)     (r, b)     (2 * r - l, b)
+     *
+     */
+
+    if (blitColor && blitDepth) {
+        // To keep the math simple, for now we'll assume the color and depth attachments of the
+        // source render target have the same dimensions.
+        ASSERT_PRECONDITION(args.source.color.width == args.source.depth.width &&
+                            args.source.color.height == args.source.depth.height,
+                            "Source color and depth attachments must be same dimensions.");
+    }
+
+    const NSUInteger sourceWidth = blitColor ? args.source.color.width : args.source.depth.width;
+    const NSUInteger sourceHeight = blitColor ? args.source.color.height : args.source.depth.height;
+
+    const float u = 1.0f / sourceWidth;
+    const float v = 1.0f / sourceHeight;
+
+    const auto& sourceRegion = args.source.region;
+    const float left   = sourceRegion.origin.x * u;
+    const float top    = sourceRegion.origin.y * v;
+    const float right  = (sourceRegion.origin.x + sourceRegion.size.width) * u;
+    const float bottom = (sourceRegion.origin.y + sourceRegion.size.height) * v;
+
+    const math::float4 vertices[3] = {
+        { -1.0f, -1.0f,  left,  bottom },
+        { -1.0f,  3.0f,  left, 2.0f * top - bottom },
+        {  3.0f, -1.0f,  2.0f * right - left,  bottom },
+    };
+
+    [encoder setVertexBytes:vertices length:(sizeof(math::float4) * 3) atIndex:0];
+    [encoder setFragmentBytes:&args.source.level length:sizeof(uint8_t) atIndex:0];
+    [encoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+    [encoder endEncoding];
+}
+
+void MetalBlitter::shutdown() noexcept {
+    [gVertexFunction release];
+    [gFragmentColor release];
+    [gFragmentDepth release];
+    [gFragmentColorDepth release];
+    gFragmentColor = nil;
+    gFragmentColorDepth = nil;
+    gVertexFunction = nil;
+}
+
+void MetalBlitter::setupColorAttachment(const BlitArgs& args,
+        MTLRenderPassDescriptor* descriptor) {
+    descriptor.colorAttachments[0].texture = args.destination.color;
+    descriptor.colorAttachments[0].level = args.destination.level;
+
+    descriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
+    // We don't need to load the contents of the attachment if we're only blitting to part of it.
+    if (args.colorDestinationIsFullAttachment()) {
+        descriptor.colorAttachments[0].loadAction = MTLLoadActionDontCare;
+    }
+
+    descriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+}
+
+void MetalBlitter::setupDepthAttachment(const BlitArgs& args, MTLRenderPassDescriptor* descriptor) {
+    descriptor.depthAttachment.texture = args.destination.depth;
+    descriptor.depthAttachment.level = args.destination.level;
+
+    descriptor.depthAttachment.loadAction = MTLLoadActionLoad;
+    // We don't need to load the contents of the attachment if we're only blitting to part of it.
+    if (args.depthDestinationIsFullAttachment()) {
+        descriptor.depthAttachment.loadAction = MTLLoadActionDontCare;
+    }
+
+    descriptor.depthAttachment.storeAction = MTLStoreActionStore;
+}
+
+void MetalBlitter::ensureFunctions() {
+    if (gFragmentColor != nil && gFragmentDepth != nil && gFragmentColorDepth != nil &&
+        gVertexFunction != nil) {
+        return;
+    }
+
+    NSError* error = nil;
+    NSString* objcSource = [NSString stringWithCString:functionLibrary.data()
+                                              encoding:NSUTF8StringEncoding];
+    id<MTLLibrary> library = [mContext.device newLibraryWithSource:objcSource
+                                                            options:nil
+                                                              error:&error];
+    NSERROR_CHECK("Unable to compile shading library for MetalBlitter.");
+
+    gVertexFunction = [library newFunctionWithName:@"blitterVertex"];
+    gFragmentColor = [library newFunctionWithName:@"blitterFragColor"];
+    gFragmentDepth = [library newFunctionWithName:@"blitterFragDepth"];
+    gFragmentColorDepth = [library newFunctionWithName:@"blitterFragColorDepth"];
+    [library release];
+}
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -17,6 +17,7 @@
 #ifndef TNT_METALCONTEXT_H
 #define TNT_METALCONTEXT_H
 
+#include "MetalBlitter.h"
 #include "MetalBufferPool.h"
 #include "MetalResourceTracker.h"
 #include "MetalState.h"
@@ -80,6 +81,8 @@ struct MetalContext {
 
     // External textures.
     CVMetalTextureCacheRef textureCache = nullptr;
+
+    MetalBlitter* blitter = nullptr;
 };
 
 // Acquire the current surface's CAMetalDrawable for the current frame if it has not already been

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -65,6 +65,7 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
     mContext->depthStencilStateCache.setDevice(mContext->device);
     mContext->samplerStateCache.setDevice(mContext->device);
     mContext->bufferPool = new MetalBufferPool(*mContext);
+    mContext->blitter = new MetalBlitter(*mContext);
 
     CVReturn success = CVMetalTextureCacheCreate(kCFAllocatorDefault, nullptr, mContext->device,
             nullptr, &mContext->textureCache);
@@ -180,7 +181,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     };
 
     construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples,
-            getColorTexture(), getDepthTexture());
+            getColorTexture(), getDepthTexture(), color.level);
 
     ASSERT_POSTCONDITION(
             !stencil.handle && !(targetBufferFlags & TargetBufferFlags::STENCIL),
@@ -324,6 +325,7 @@ void MetalDriver::terminate() {
     [mContext->driverPool drain];
 
     MetalExternalImage::shutdown();
+    MetalBlitter::shutdown();
 }
 
 ShaderModel MetalDriver::getShaderModel() const noexcept {
@@ -631,7 +633,57 @@ void MetalDriver::blit(TargetBufferFlags buffers,
         Handle<HwRenderTarget> dst, backend::Viewport dstRect,
         Handle<HwRenderTarget> src, backend::Viewport srcRect,
         SamplerMagFilter filter) {
-    ASSERT_POSTCONDITION(false, "Blitting not implemented.");
+    ASSERT_PRECONDITION(mContext->currentCommandBuffer != nil &&
+                        mContext->currentCommandEncoder == nil,
+                        "Blitting must be done during a frame, but outside of a render pass.");
+
+    auto srcTarget = handle_cast<MetalRenderTarget>(mHandleMap, src);
+    auto dstTarget = handle_cast<MetalRenderTarget>(mHandleMap, dst);
+
+    ASSERT_PRECONDITION(srcRect.left >= 0 && srcRect.bottom >= 0 &&
+                        dstRect.left >= 0 && dstRect.bottom >= 0,
+            "Source and destination rects must be positive.");
+
+    id<MTLTexture> srcTexture = srcTarget->getColor();
+    id<MTLTexture> dstTexture = dstTarget->getColor();
+
+    // Metal's texture coordinates have (0, 0) at the top-left of the texture, but Filament's
+    // coordinates have (0, 0) at bottom-left.
+    MTLRegion srcRegion = MTLRegionMake2D(
+            (NSUInteger) srcRect.left,
+            srcTexture.height - (NSUInteger) srcRect.bottom - srcRect.height,
+            srcRect.width, srcRect.height);
+
+    MTLRegion dstRegion = MTLRegionMake2D(
+            (NSUInteger) dstRect.left,
+            dstTexture.height - (NSUInteger) dstRect.bottom - dstRect.height,
+            dstRect.width, dstRect.height);
+
+    const uint8_t srcLevel = srcTarget->getColorLevel();
+    const uint8_t dstLevel = dstTarget->getColorLevel();
+
+    ASSERT_PRECONDITION(srcTexture.textureType == MTLTextureType2D &&
+                        dstTexture.textureType == MTLTextureType2D,
+                        "Metal does not support blitting to/from non-2D textures.");
+
+    MetalBlitter::BlitArgs args;
+    args.filter = filter;
+    args.source.level = srcLevel;
+    args.source.region = srcRegion;
+    args.destination.level = dstLevel;
+    args.destination.region = dstRegion;
+
+    if (buffers & TargetBufferFlags::COLOR) {
+        args.source.color = srcTexture;
+        args.destination.color = dstTexture;
+    }
+
+    if (buffers & TargetBufferFlags::DEPTH) {
+        args.source.depth = srcTarget->getDepth();
+        args.destination.depth = dstTarget->getDepth();
+    }
+
+    mContext->blitter->blit(args);
 }
 
 void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph) {

--- a/filament/backend/src/metal/MetalExternalImage.h
+++ b/filament/backend/src/metal/MetalExternalImage.h
@@ -91,8 +91,8 @@ private:
 
 };
 
-#endif //TNT_METALEXTERNALIMAGE_H
-
 } // namespace metal
 } // namespace backend
 } // namespace filament
+
+#endif //TNT_METALEXTERNALIMAGE_H

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -143,7 +143,7 @@ struct MetalSamplerGroup : public HwSamplerGroup {
 class MetalRenderTarget : public HwRenderTarget {
 public:
     MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height, uint8_t samples,
-            id<MTLTexture> color, id<MTLTexture> depth);
+            id<MTLTexture> color, id<MTLTexture> depth, uint8_t level);
     explicit MetalRenderTarget(MetalContext* context)
             : HwRenderTarget(0, 0), context(context), defaultRenderTarget(true) {}
     ~MetalRenderTarget();
@@ -154,6 +154,7 @@ public:
 
     id<MTLTexture> getColor();
     id<MTLTexture> getColorResolve();
+    uint8_t getColorLevel() { return level; }
     id<MTLTexture> getDepth();
     id<MTLTexture> getDepthResolve();
 
@@ -166,6 +167,7 @@ private:
     id<MTLTexture> depth = nil;
     bool defaultRenderTarget = false;
     uint8_t samples = 1;
+    uint8_t level = 0;
 
     // These textures are only used if this render target is multisampled.
     id<MTLTexture> multisampledColor = nil;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -351,9 +351,9 @@ void MetalTexture::loadCubeImage(const PixelBufferDescriptor& data, const FaceOf
 }
 
 MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height,
-        uint8_t samples, id<MTLTexture> color, id<MTLTexture> depth)
+        uint8_t samples, id<MTLTexture> color, id<MTLTexture> depth, uint8_t level)
         : HwRenderTarget(width, height), context(context), color(color), depth(depth),
-        samples(samples) {
+        samples(samples), level(level) {
     [color retain];
     [depth retain];
 

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -18,10 +18,6 @@
 
 #include "MetalEnums.h"
 
-#include <tsl/robin_map.h>
-#include <utils/Hash.h>
-#include <utils/compiler.h>
-
 namespace filament {
 namespace backend {
 namespace metal {
@@ -79,7 +75,11 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
     NSError* error = nullptr;
     id<MTLRenderPipelineState> pipeline = [device newRenderPipelineStateWithDescriptor:descriptor
                                                                                  error:&error];
-    assert(error == nullptr);
+    if (error) {
+        auto description = [error.localizedDescription cStringUsingEncoding:NSUTF8StringEncoding];
+        utils::slog.e << description << utils::io::endl;
+    }
+    ASSERT_POSTCONDITION(error == nil, "Could not create Metal pipeline state.");
 
     [descriptor release];
 


### PR DESCRIPTION
Blitting color / depth now supported via the rasterization pipeline. This is to overcome Metal's
native blitting limitations (pixel formats must match, scaling is not allowed). An optimization
might be to opt to use Metal's blitting methods if the limitations are met.