### PR TITLE
backend textures can now represent a renderbuffer

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -117,6 +117,8 @@ struct Viewport {
     int32_t bottom;
     uint32_t width;
     uint32_t height;
+    int32_t right() const noexcept { return left + width; }
+    int32_t top() const noexcept { return bottom + height; }
 };
 
 struct RenderPassFlags {
@@ -487,7 +489,7 @@ enum TextureUsage : uint8_t {
 
 // implement requirement of BitmaskType
 inline constexpr TextureUsage operator~(TextureUsage rhs) noexcept {
-    return TextureUsage(~uint8_t(rhs) & uint8_t(TargetBufferFlags::ALL));
+    return TextureUsage(~uint8_t(rhs) & 0x1Fu);
 }
 inline constexpr TextureUsage operator|=(TextureUsage& lhs, TextureUsage rhs) noexcept {
     return lhs = TextureUsage(uint8_t(lhs) | uint8_t(rhs));

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -481,8 +481,32 @@ enum TextureUsage : uint8_t {
     DEPTH_ATTACHMENT    = 0x2,
     STENCIL_ATTACHMENT  = 0x4,
     UPLOADABLE          = 0x8,
-    DEFAULT = UPLOADABLE
+    SAMPLEABLE          = 0x10,
+    DEFAULT = UPLOADABLE | SAMPLEABLE
 };
+
+// implement requirement of BitmaskType
+inline constexpr TextureUsage operator~(TextureUsage rhs) noexcept {
+    return TextureUsage(~uint8_t(rhs) & uint8_t(TargetBufferFlags::ALL));
+}
+inline constexpr TextureUsage operator|=(TextureUsage& lhs, TextureUsage rhs) noexcept {
+    return lhs = TextureUsage(uint8_t(lhs) | uint8_t(rhs));
+}
+inline constexpr TextureUsage operator&=(TextureUsage& lhs, TextureUsage rhs) noexcept {
+    return lhs = TextureUsage(uint8_t(lhs) & uint8_t(rhs));
+}
+inline constexpr TextureUsage operator^=(TextureUsage& lhs, TextureUsage rhs) noexcept {
+    return lhs = TextureUsage(uint8_t(lhs) ^ uint8_t(rhs));
+}
+inline constexpr TextureUsage operator|(TextureUsage lhs, TextureUsage rhs) noexcept {
+    return TextureUsage(uint8_t(lhs) | uint8_t(rhs));
+}
+inline constexpr TextureUsage operator&(TextureUsage lhs, TextureUsage rhs) noexcept {
+    return TextureUsage(uint8_t(lhs) & uint8_t(rhs));
+}
+inline constexpr TextureUsage operator^(TextureUsage lhs, TextureUsage rhs) noexcept {
+    return TextureUsage(uint8_t(lhs) ^ uint8_t(rhs));
+}
 
 //! returns whether this format is an ETC2 compressed format
 static constexpr bool isETC2Compression(TextureFormat format) noexcept {

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -259,12 +259,11 @@ DECL_DRIVER_API_R_1(backend::ProgramHandle, createProgram,
 
 DECL_DRIVER_API_R_0(backend::RenderTargetHandle, createDefaultRenderTarget)
 
-DECL_DRIVER_API_R_8(backend::RenderTargetHandle, createRenderTarget,
+DECL_DRIVER_API_R_7(backend::RenderTargetHandle, createRenderTarget,
         backend::TargetBufferFlags, targetBufferFlags,
         uint32_t, width,
         uint32_t, height,
         uint8_t, samples,
-        backend::TextureFormat, format,
         backend::TargetBufferInfo, color,
         backend::TargetBufferInfo, depth,
         backend::TargetBufferInfo, stencil)
@@ -383,11 +382,6 @@ DECL_DRIVER_API_6(discardSubRenderTargetBuffers,
         backend::TargetBufferFlags, targetBufferFlags,
         uint32_t, left,
         uint32_t, bottom,
-        uint32_t, width,
-        uint32_t, height)
-
-DECL_DRIVER_API_3(resizeRenderTarget,
-        backend::RenderTargetHandle, rth,
         uint32_t, width,
         uint32_t, height)
 

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -103,9 +103,9 @@ struct HwUniformBuffer : public HwBase {
 
 struct HwTexture : public HwBase {
     HwTexture(backend::SamplerType target, uint8_t levels, uint8_t samples,
-              uint32_t width, uint32_t height, uint32_t depth, TextureFormat fmt) noexcept
+              uint32_t width, uint32_t height, uint32_t depth, TextureFormat fmt, TextureUsage usage) noexcept
             : width(width), height(height), depth(depth),
-              target(target), levels(levels), samples(samples), format(fmt) { }
+              target(target), levels(levels), samples(samples), format(fmt), usage(usage) { }
     uint32_t width;
     uint32_t height;
     uint32_t depth;
@@ -113,6 +113,7 @@ struct HwTexture : public HwBase {
     uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
     uint8_t samples : 4; // In practice this is always 1.
     TextureFormat format;
+    TextureUsage usage;
     HwStream* hwStream = nullptr;
 };
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -149,7 +149,7 @@ void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int dum
 
 void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, TextureFormat format, TargetBufferInfo color,
+        uint8_t samples, TargetBufferInfo color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
 
     auto getColorTexture = [&]() -> id<MTLTexture> {
@@ -179,8 +179,8 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         return nil;
     };
 
-    construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples, format,
-            getColorTexture(), getDepthTexture());
+//    construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples, format,
+//            getColorTexture(), getDepthTexture());
 
     ASSERT_POSTCONDITION(
             !stencil.handle && !(targetBufferFlags & TargetBufferFlags::STENCIL),
@@ -539,11 +539,6 @@ void MetalDriver::endRenderPass(int dummy) {
 
 void MetalDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t left, uint32_t bottom, uint32_t width,
-        uint32_t height) {
-
-}
-
-void MetalDriver::resizeRenderTarget(Handle<HwRenderTarget> rth, uint32_t width,
         uint32_t height) {
 
 }

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -157,7 +157,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             auto colorTexture = handle_cast<MetalTexture>(mHandleMap, color.handle);
             return colorTexture->texture;
         } else if (targetBufferFlags & TargetBufferFlags::COLOR) {
-            ASSERT_POSTCONDITION(false, "A color buffer is required for a render target.");
+            ASSERT_POSTCONDITION(false, "The COLOR flag was specified, but no color texture provided.");
         }
         return nil;
     };
@@ -167,20 +167,13 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             auto depthTexture = handle_cast<MetalTexture>(mHandleMap, depth.handle);
             return depthTexture->texture;
         } else if (targetBufferFlags & TargetBufferFlags::DEPTH) {
-            MTLTextureDescriptor *depthTextureDesc =
-                    [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatDepth32Float
-                                                                       width:width
-                                                                      height:height
-                                                                   mipmapped:NO];
-            depthTextureDesc.usage = MTLTextureUsageRenderTarget;
-            depthTextureDesc.resourceOptions = MTLResourceStorageModePrivate;
-            return [[mContext->device newTextureWithDescriptor:depthTextureDesc] autorelease];
+            ASSERT_POSTCONDITION(false, "The DEPTH flag was specified, but no depth texture provided.");
         }
         return nil;
     };
 
-//    construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples, format,
-//            getColorTexture(), getDepthTexture());
+    construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples,
+            getColorTexture(), getDepthTexture());
 
     ASSERT_POSTCONDITION(
             !stencil.handle && !(targetBufferFlags & TargetBufferFlags::STENCIL),

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -143,7 +143,7 @@ struct MetalSamplerGroup : public HwSamplerGroup {
 class MetalRenderTarget : public HwRenderTarget {
 public:
     MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height, uint8_t samples,
-            TextureFormat format, id<MTLTexture> color, id<MTLTexture> depth);
+            id<MTLTexture> color, id<MTLTexture> depth);
     explicit MetalRenderTarget(MetalContext* context)
             : HwRenderTarget(0, 0), context(context), defaultRenderTarget(true) {}
     ~MetalRenderTarget();
@@ -158,7 +158,7 @@ public:
     id<MTLTexture> getDepthResolve();
 
 private:
-    static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, TextureFormat format,
+    static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, MTLPixelFormat format,
             uint32_t width, uint32_t height, uint8_t samples);
 
     MetalContext* context;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -28,17 +28,23 @@ namespace backend {
 namespace metal {
 
 static inline MTLTextureUsage getMetalTextureUsage(TextureUsage usage) {
-    switch (usage) {
-        case TextureUsage::DEFAULT:
-            return MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
-
-        case TextureUsage::COLOR_ATTACHMENT:
-            return MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
-
-        case TextureUsage::DEPTH_ATTACHMENT:
-        case TextureUsage::STENCIL_ATTACHMENT:
-            return MTLTextureUsageShaderRead | MTLTextureUsageRenderTarget;
+    int u = 0;
+    if (usage & TextureUsage::COLOR_ATTACHMENT) {
+        u |= MTLTextureUsageRenderTarget;
     }
+    if (usage & TextureUsage::DEPTH_ATTACHMENT) {
+        u |= MTLTextureUsageRenderTarget;
+    }
+    if (usage & TextureUsage::STENCIL_ATTACHMENT) {
+        u |= MTLTextureUsageRenderTarget;
+    }
+    if (usage & TextureUsage::UPLOADABLE) {
+        u |= MTLTextureUsageShaderWrite;
+    }
+    if (usage & TextureUsage::SAMPLEABLE) {
+        u |= MTLTextureUsageShaderRead;
+    }
+    return MTLTextureUsage(u);
 }
 
 static inline MTLStorageMode getMetalStorageMode(TextureFormat format) {
@@ -262,7 +268,7 @@ MetalProgram::~MetalProgram() {
 MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
         TextureUsage usage) noexcept
-    : HwTexture(target, levels, samples, width, height, depth, format), context(context),
+    : HwTexture(target, levels, samples, width, height, depth, format, usage), context(context),
         externalImage(context), reshaper(format) {
 
     // Metal does not natively support 3 component textures. We'll emulate support by reshaping the

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -384,7 +384,7 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
-        TextureFormat format, TargetBufferInfo color, TargetBufferInfo depth,
+        TargetBufferInfo color, TargetBufferInfo depth,
         TargetBufferInfo stencil) {
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
             width, height, color.level);
@@ -396,7 +396,7 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             .format = colorTexture->vkformat
         });
     } else if (targets & TargetBufferFlags::COLOR) {
-        renderTarget->createColorImage(getVkFormat(format));
+//        renderTarget->createColorImage(getVkFormat(format));
     }
     if (depth.handle) {
         auto depthTexture = handle_cast<VulkanTexture>(mHandleMap, depth.handle);
@@ -775,10 +775,6 @@ void VulkanDriver::endRenderPass(int) {
 void VulkanDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
         TargetBufferFlags buffers,
         uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
-}
-
-void VulkanDriver::resizeRenderTarget(Handle<HwRenderTarget> rth,
-        uint32_t width, uint32_t height) {
 }
 
 void VulkanDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -370,7 +370,7 @@ VulkanUniformBuffer::~VulkanUniformBuffer() {
 VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t levels,
         TextureFormat tformat, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage usage, VulkanStagePool& stagePool) :
-        HwTexture(target, levels, samples, w, h, depth, tformat),
+        HwTexture(target, levels, samples, w, h, depth, tformat, usage),
         vkformat(getVkFormat(tformat)), mContext(context), mStagePool(stagePool) {
     // Create an appropriately-sized device-only VkImage, but do not fill it yet.
     VkImageCreateInfo imageInfo {

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -290,12 +290,13 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             (FrameGraph::Builder& builder, ColorPassData& data) {
 
                 data.color = builder.createTexture("color buffer",
-                        { .width = svp.width, .height = svp.height, .format = hdrFormat });
+                        { .width = svp.width, .height = svp.height, .format = hdrFormat, .samples = msaa });
 
                 if (colorPassNeedsDepthBuffer) {
                     data.depth = builder.createTexture("depth buffer",
                             { .width = svp.width, .height = svp.height,
-                              .format = TextureFormat::DEPTH24 // TODO: fg should figure that out automatically
+                              .format = TextureFormat::DEPTH24,
+                              .samples = msaa
                             });
                 }
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -128,7 +128,7 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
 
     mShadowMapHandle = driver.createTexture(
             SamplerType::SAMPLER_2D, 1, format, 1, dim, dim, 1,
-            TextureUsage::DEPTH_ATTACHMENT);
+            TextureUsage::DEPTH_ATTACHMENT | TextureUsage::SAMPLEABLE);
 
     mShadowMapRenderTarget = driver.createRenderTarget(
             TargetBufferFlags::DEPTH, dim, dim, 1, format,

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -131,7 +131,7 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
             TextureUsage::DEPTH_ATTACHMENT | TextureUsage::SAMPLEABLE);
 
     mShadowMapRenderTarget = driver.createRenderTarget(
-            TargetBufferFlags::DEPTH, dim, dim, 1, format,
+            TargetBufferFlags::DEPTH, dim, dim, 1,
             {}, { mShadowMapHandle }, {});
 
     SamplerParams s;

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -84,7 +84,8 @@ Texture::Builder& Texture::Builder::rgbm(bool enabled) noexcept {
 }
 
 Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
-    mImpl->mUsage = usage;
+    // for now, the public API only allows UPLOADABLE and SAMPLEABLE textures
+    mImpl->mUsage = Texture::Usage(Texture::Usage::DEFAULT | usage);
     return *this;
 }
 

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -220,15 +220,15 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
         uint32_t srcw = mWidth;
         uint32_t srch = mHeight;
         backend::Handle<backend::HwRenderTarget> srcrth = driver.createRenderTarget(TargetBufferFlags::COLOR,
-                srcw, srch, mSampleCount, mFormat, { mHandle, level++, layer }, {}, {});
+                srcw, srch, mSampleCount, { mHandle, level++, layer }, {}, {});
 
         // Perform a blit for all miplevels down to 1x1.
         backend::Handle<backend::HwRenderTarget> dstrth;
         do {
-            uint32_t dstw = std::max(srcw >> 1, 1u);
-            uint32_t dsth = std::max(srch >> 1, 1u);
+            uint32_t dstw = std::max(srcw >> 1u, 1u);
+            uint32_t dsth = std::max(srch >> 1u, 1u);
             dstrth = driver.createRenderTarget(TargetBufferFlags::COLOR, dstw, dsth, mSampleCount,
-                    mFormat, { mHandle, level++, layer }, {}, {});
+                    { mHandle, level++, layer }, {}, {});
             driver.blit(TargetBufferFlags::COLOR,
                     dstrth, { 0, 0, dstw, dsth },
                     srcrth, { 0, 0, srcw, srch },

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -79,7 +79,7 @@ struct Resource final : public VirtualResource { // 72
 
     // updated by builder
     uint8_t version = 0;
-    TextureUsage usage = (TextureUsage)0;
+    TextureUsage usage = TextureUsage::DEFAULT;
     bool needsTexture = false;
     FrameGraphResource::Descriptor desc;
 

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -63,6 +63,7 @@ public:
         uint32_t height = 1;    // height of resource in pixel
         uint32_t depth = 1;     // # of images for 3D textures
         uint8_t levels = 1;     // # of levels for textures
+        uint8_t samples = 1;
         backend::SamplerType type = backend::SamplerType::SAMPLER_2D;     // texture target type
         backend::TextureFormat format = backend::TextureFormat::RGBA8;    // resource internal format
         bool relaxed = false; // dimensions can be slightly adjusted


### PR DESCRIPTION
We have a new TextureUsage::SAMPLEABLE flag, that is the default,
used for "regular" textures that can be sampled.
When this flag is not set, a RenderBuffer (in GL parlance) is
created instead.

This will be needed in an upcoming PR for creating RenderTarget more
explicitly.