### PR TITLE
gltfio: fix file path bug.

### DIFF
--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -36,7 +36,7 @@ namespace details {
 
 struct ResourceConfiguration {
     class filament::Engine* engine;
-    utils::Path basePath;
+    utils::Path gltfPath;
     bool normalizeSkinningWeights;
     bool recomputeBoundingBoxes;
 };

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -178,7 +178,7 @@ bool ResourceLoader::loadResources(FilamentAsset* asset) {
     #else
 
     // Read data from the file system and base64 URLs.
-    cgltf_result result = cgltf_load_buffers(&options, gltf, mConfig.basePath.c_str());
+    cgltf_result result = cgltf_load_buffers(&options, gltf, mConfig.gltfPath.c_str());
     if (result != cgltf_result_success) {
         slog.e << "Unable to load resources." << io::endl;
         return false;
@@ -319,7 +319,7 @@ bool ResourceLoader::createTextures(details::FFilamentAsset* asset) const {
                 slog.e << "Unable to load texture: " << tb.uri << io::endl;
                 return false;
             #else
-                utils::Path fullpath = this->mConfig.basePath + tb.uri;
+                utils::Path fullpath = this->mConfig.gltfPath.getParent() + tb.uri;
                 texels = stbi_load(fullpath.c_str(), &width, &height, &comp, 4);
             #endif
         }

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -193,8 +193,12 @@ int main(int argc, char** argv) {
 
     auto loadResources = [&app] (utils::Path filename) {
         // Load external textures and buffers.
-        utils::Path assetFolder = filename.getParent();
-        gltfio::ResourceLoader({app.engine, assetFolder, true, false}).loadResources(app.asset);
+        gltfio::ResourceLoader({
+            .engine = app.engine,
+            .gltfPath = filename.getAbsolutePath(),
+            .normalizeSkinningWeights = true,
+            .recomputeBoundingBoxes = false
+        }).loadResources(app.asset);
 
         // Load animation data then free the source hierarchy.
         app.asset->getAnimator();


### PR DESCRIPTION
The cgltf "base path" that gets passed to cgltf_load_buffers should
actually be the path to original glTF file, otherwise bin filepaths
are resolved incorrectly.