### PR TITLE
Add new filamat_lite target to filamat

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ A new header is inserted each time a *tag* is created.
 
 # Release notes
 
+- Added a new, smaller, version of the `filamat` library, `filamat_lite`. Material optimization and
+  compiling for non-OpenGL backends have been removed in favor of a smaller binary size.
 - Created a `RELEASE_NOTES.md` file, to be updated with significant PRs.
 
 ## sceneform-1.9pr2

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
 
-set(FILAMAT_VERSION "filamat")
+set(FILAMAT_FLAVOR "filamat")
 if(FILAMAT_LITE)
-    set(FILAMAT_VERSION "filamat_lite")
+    set(FILAMAT_FLAVOR "filamat_lite")
 endif()
 
-add_library(${FILAMAT_VERSION} STATIC IMPORTED)
-set_target_properties(${FILAMAT_VERSION} PROPERTIES IMPORTED_LOCATION
-        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/lib${FILAMAT_VERSION}.a)
+add_library(${FILAMAT_FLAVOR} STATIC IMPORTED)
+set_target_properties(${FILAMAT_FLAVOR} PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/lib${FILAMAT_FLAVOR}.a)
 
 add_library(utils STATIC IMPORTED)
 set_target_properties(utils PROPERTIES IMPORTED_LOCATION
@@ -45,7 +45,7 @@ add_library(filamat-jni SHARED
 )
 
 target_link_libraries(filamat-jni
-        ${FILAMAT_VERSION}
+        ${FILAMAT_FLAVOR}
         filabridge
         shaders
         utils

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
 
-add_library(filamat STATIC IMPORTED)
-set_target_properties(filamat PROPERTIES IMPORTED_LOCATION
-        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilamat.a)
+set(FILAMAT_VERSION "filamat")
+if(FILAMAT_LITE)
+    set(FILAMAT_VERSION "filamat_lite")
+endif()
+
+add_library(${FILAMAT_VERSION} STATIC IMPORTED)
+set_target_properties(${FILAMAT_VERSION} PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/lib${FILAMAT_VERSION}.a)
 
 add_library(utils STATIC IMPORTED)
 set_target_properties(utils PROPERTIES IMPORTED_LOCATION
@@ -40,7 +45,7 @@ add_library(filamat-jni SHARED
 )
 
 target_link_libraries(filamat-jni
-        filamat
+        ${FILAMAT_VERSION}
         filabridge
         shaders
         utils

--- a/android/filamat-android/build.gradle
+++ b/android/filamat-android/build.gradle
@@ -65,6 +65,23 @@ android {
         }
     }
 
+    flavorDimensions "functionality"
+    productFlavors {
+        full {
+            dimension "functionality"
+        }
+
+        lite {
+            dimension "functionality"
+
+            externalNativeBuild {
+                cmake {
+                    arguments.add("-DFILAMAT_LITE=ON")
+                }
+            }
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"

--- a/build.sh
+++ b/build.sh
@@ -395,7 +395,8 @@ function build_android {
 
         if [[ "$INSTALL_COMMAND" ]]; then
             echo "Installing out/filamat-android-debug.aar..."
-            cp build/outputs/aar/filamat-android-debug.aar ../../out/
+            cp build/outputs/aar/filamat-android-full-debug.aar ../../out/
+            cp build/outputs/aar/filamat-android-lite-debug.aar ../../out/
         fi
     fi
 
@@ -404,7 +405,8 @@ function build_android {
 
         if [[ "$INSTALL_COMMAND" ]]; then
             echo "Installing out/filamat-android-release.aar..."
-            cp build/outputs/aar/filamat-android-release.aar ../../out/
+            cp build/outputs/aar/filamat-android-full-release.aar ../../out/
+            cp build/outputs/aar/filamat-android-lite-release.aar ../../out/
         fi
     fi
 

--- a/build/common/test_list.txt
+++ b/build/common/test_list.txt
@@ -3,6 +3,7 @@ libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils
 libs/filamat/test_filamat
+libs/filamat/test_filamat_lite
 tools/matc/test_matc
 tools/cmgen/test_cmgen compare
 tools/glslminifier/test_glslminifier

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -4,6 +4,11 @@ project(filamat)
 set(TARGET         filamat)
 set(PUBLIC_HDR_DIR include)
 
+# filamat is split into two targets: filamat, and filamat_lite.
+# filamat_lite forgoes SPIRV-V / MSL output, static analysis, and optimization in favor of a smaller
+# binary size.
+# Both libraries use the same public header files.
+
 # ==================================================================================================
 # Sources and headers
 # ==================================================================================================
@@ -13,43 +18,61 @@ set(HDRS
         include/filamat/Package.h
         include/filamat/PostprocessMaterialBuilder.h)
 
-set(PRIVATE_HDRS
-        src/eiff/BlobDictionary.h
+set(COMMON_PRIVATE_HDRS
         src/eiff/Chunk.h
         src/eiff/ChunkContainer.h
         src/eiff/DictionaryTextChunk.h
-        src/eiff/DictionarySpirvChunk.h
         src/eiff/Flattener.h
         src/eiff/LineDictionary.h
         src/eiff/MaterialTextChunk.h
         src/eiff/MaterialInterfaceBlockChunk.h
-        src/eiff/MaterialSpirvChunk.h
         src/eiff/ShaderEntry.h
-        src/eiff/SimpleFieldChunk.h
-        src/sca/ASTHelpers.h
-        src/sca/GLSLTools.h
-        src/sca/builtinResource.h
-        src/GLSLPostProcessor.h)
+        src/eiff/SimpleFieldChunk.h)
 
-set(SRCS
-        src/eiff/BlobDictionary.cpp
+set(COMMON_SRCS
         src/eiff/Chunk.cpp
         src/eiff/ChunkContainer.cpp
         src/eiff/DictionaryTextChunk.cpp
-        src/eiff/DictionarySpirvChunk.cpp
         src/eiff/LineDictionary.cpp
         src/eiff/MaterialTextChunk.cpp
-        src/eiff/MaterialSpirvChunk.cpp
         src/eiff/MaterialInterfaceBlockChunk.cpp
         src/eiff/SimpleFieldChunk.cpp
-        src/sca/ASTHelpers.cpp
-        src/sca/GLSLTools.cpp
         src/shaders/CodeGenerator.cpp
         src/shaders/ShaderGenerator.cpp
         src/Enums.cpp
-        src/GLSLPostProcessor.cpp
         src/MaterialBuilder.cpp
         src/PostprocessMaterialBuilder.cpp)
+
+# Sources and headers for filamat
+
+set(PRIVATE_HDRS
+        ${COMMON_PRIVATE_HDRS}
+        src/eiff/BlobDictionary.h
+        src/eiff/DictionarySpirvChunk.h
+        src/eiff/MaterialSpirvChunk.h
+        src/GLSLPostProcessor.h
+        src/sca/ASTHelpers.h
+        src/sca/GLSLTools.h
+        src/sca/builtinResource.h)
+
+set(SRCS
+        ${COMMON_SRCS}
+        src/eiff/BlobDictionary.cpp
+        src/eiff/DictionarySpirvChunk.cpp
+        src/eiff/MaterialSpirvChunk.cpp
+        src/sca/ASTHelpers.cpp
+        src/sca/GLSLTools.cpp
+        src/GLSLPostProcessor.cpp)
+
+# Sources and headers for filamat lite
+
+set(LITE_PRIVATE_HDRS
+        ${COMMON_PRIVATE_HDRS}
+        src/sca/GLSLToolsLite.h)
+
+set(LITE_SRCS
+        ${COMMON_SRCS}
+        src/sca/GLSLToolsLite.cpp)
 
 # ==================================================================================================
 # Include and target definitions
@@ -57,10 +80,15 @@ set(SRCS
 include_directories(${PUBLIC_HDR_DIR})
 include_directories(${CMAKE_BINARY_DIR})
 
+# Filamat
 add_library(${TARGET} STATIC ${HDRS} ${PRIVATE_HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
-
 target_link_libraries(${TARGET} shaders filabridge utils smol-v)
+
+# Filamat Lite
+add_library(filamat_lite STATIC ${HDRS} ${LITE_PRIVATE_HDRS} ${LITE_SRCS})
+target_include_directories(filamat_lite PUBLIC ${PUBLIC_HDR_DIR})
+target_link_libraries(filamat_lite shaders filabridge utils)
 
 # We are being naughty and accessing private headers here
 # For spirv-tools, we're just following glslang's example
@@ -87,6 +115,14 @@ target_compile_options(${TARGET} PRIVATE
 #        -fvisibility=hidden
         $<$<PLATFORM_ID:Linux>:-fPIC>
 )
+
+target_compile_options(filamat_lite PRIVATE
+# TODO: use hidden by default and expose what we need (we'll need to do the same in dependencies)
+#        -fvisibility=hidden
+        $<$<PLATFORM_ID:Linux>:-fPIC>
+)
+
+target_compile_definitions(filamat_lite PRIVATE FILAMAT_LITE)
 
 # ==================================================================================================
 # Installation
@@ -134,6 +170,8 @@ set(FILAMAT_LIB_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}filamat${CMAKE_STATIC_LIBRARY
 install(FILES "${FILAMAT_COMBINED_OUTPUT}" DESTINATION lib/${DIST_DIR} RENAME ${FILAMAT_LIB_NAME})
 install(DIRECTORY ${PUBLIC_HDR_DIR}/filamat DESTINATION include)
 
+install(TARGETS filamat_lite ARCHIVE DESTINATION lib/${DIST_DIR})
+
 # ==================================================================================================
 # Tests
 # ==================================================================================================
@@ -147,3 +185,13 @@ add_executable(${TARGET} ${SRCS})
 target_include_directories(${TARGET} PRIVATE src)
 
 target_link_libraries(${TARGET} filamat gtest)
+
+set(TARGET test_filamat_lite)
+set(SRCS
+        tests/test_filamat_lite.cpp)
+
+add_executable(${TARGET} ${SRCS})
+
+target_include_directories(${TARGET} PRIVATE src)
+
+target_link_libraries(${TARGET} filamat_lite gtest)

--- a/libs/filamat/README.md
+++ b/libs/filamat/README.md
@@ -184,7 +184,7 @@ The `filamat_lite` library is interchangeable with `filamat`, with a few caveats
 
 In addition, `filamat_lite` only performs a simple text match to determine which properties on the
 `MaterialInputs` structure are set. It does this by looking for instances of `material.`. Because of
-this, shaders must be careful with whitespace and comments. The `material` input variable must also
+this, shaders must be careful with whitespace. The `material` input variable must also
 always be refered to by the name `material`.
 
 ```
@@ -209,10 +209,6 @@ void material(inout MaterialInputs material) {
     // Incorrect! While this line is technically correct GLSL code, the simple parser inside
     // filamat_lite will not pick up the set to clearCoat due to the additional whitespace.
     material . clearCoat  = 1.0;
-
-    // Warning! The code is commented-out, but the parser still consideres the anisotropy
-    // parameter to be set. This may affect shader performance.
-    // material.anisotropy = 0.8;
 
     aFunction(material);
     anotherFunction(material);

--- a/libs/filamat/README.md
+++ b/libs/filamat/README.md
@@ -4,7 +4,7 @@ Filamat allows for generating materials programatically on the device as opposed
 tool on the host machine. The cost is a binary size increase of your app due to the relatively
 larger size of the `filamat` library.
 
-For a smaller-sized library, see [`filamat_lite`](#filamat-lite). It has no no dependencies on
+For a smaller-sized library, see [`filamat_lite`](#filamat-lite). It has no dependencies on
 `glslang`, but can only compile materials for OpenGL and does no shader code optimization.
 
 The filamat package is included in the releases available on

--- a/libs/filamat/README.md
+++ b/libs/filamat/README.md
@@ -183,9 +183,8 @@ The `filamat_lite` library is interchangeable with `filamat`, with a few caveats
 1. GLSL correctness is not checked.
 
 In addition, `filamat_lite` only performs a simple text match to determine which properties on the
-`MaterialInputs` structure are set. It does this by looking for instances of `material.`. Because of
-this, shaders must be careful with whitespace. The `material` input variable must also
-always be refered to by the name `material`.
+`MaterialInputs` structure are set. The `material` input variable must also always be refered to by
+the name `material`.
 
 ```
 void anotherFunction(inout MaterialInputs m) {
@@ -205,10 +204,6 @@ void material(inout MaterialInputs material) {
     // Good.
     material.roughness = materialParams.roughness;
     material.baseColor.rgb = vec3(1.0, 0.0, 1.0);
-
-    // Incorrect! While this line is technically correct GLSL code, the simple parser inside
-    // filamat_lite will not pick up the set to clearCoat due to the additional whitespace.
-    material . clearCoat  = 1.0;
 
     aFunction(material);
     anotherFunction(material);

--- a/libs/filamat/README.md
+++ b/libs/filamat/README.md
@@ -4,6 +4,9 @@ Filamat allows for generating materials programatically on the device as opposed
 tool on the host machine. The cost is a binary size increase of your app due to the relatively
 larger size of the `filamat` library.
 
+For a smaller-sized library, see [`filamat_lite`](#filamat-lite). It has no no dependencies on
+`glslang`, but can only compile materials for OpenGL and does no shader code optimization.
+
 The filamat package is included in the releases available on
 [GitHub](https://github.com/google/filament/releases).
 
@@ -170,3 +173,48 @@ material with Filament, pass the material package's data into a Filament Materia
 
 Note that this will require [linking against Filament's libraries](../../filament/README.md) in
 addition to Filamat's.
+
+## Filamat Lite
+
+The `filamat_lite` library is interchangeable with `filamat`, with a few caveats:
+
+1. Material compilation is only supported for the OpenGL backend.
+1. No shader-level optimization is performed.
+1. GLSL correctness is not checked.
+
+In addition, `filamat_lite` only performs a simple text match to determine which properties on the
+`MaterialInputs` structure are set. It does this by looking for instances of `material.`. Because of
+this, shaders must be careful with whitespace and comments. The `material` input variable must also
+always be refered to by the name `material`.
+
+```
+void anotherFunction(inout MaterialInputs m) {
+    // Incorrect! The MaterialInputs is being referred to by the name "m".
+    m.metallic = 0.0;
+}
+
+void aFunction(inout MaterialInputs material) {
+    // Works, but only because the variable name "material" is used.
+    material.reflectance = 0.5;
+}
+
+// The MaterialInputs variable must be named material.
+void material(inout MaterialInputs material) {
+    prepareMaterial(material);
+
+    // Good.
+    material.roughness = materialParams.roughness;
+    material.baseColor.rgb = vec3(1.0, 0.0, 1.0);
+
+    // Incorrect! While this line is technically correct GLSL code, the simple parser inside
+    // filamat_lite will not pick up the set to clearCoat due to the additional whitespace.
+    material . clearCoat  = 1.0;
+
+    // Warning! The code is commented-out, but the parser still consideres the anisotropy
+    // parameter to be set. This may affect shader performance.
+    // material.anisotropy = 0.8;
+
+    aFunction(material);
+    anotherFunction(material);
+}
+```

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -246,11 +246,13 @@ public:
     // (used to generate code) and final output representations (spirv and/or text).
     MaterialBuilder& platform(Platform platform) noexcept;
 
-    // specifies vulkan vs opengl; works in concert with Platform to determine the shader models
+    // specifies opengl, vulkan, or metal; works in concert with Platform to determine the shader models
     // (used to generate code) and final output representations (spirv and/or text).
+    // if linking against filamat_lite, only "opengl" is allowed.
     MaterialBuilder& targetApi(TargetApi targetApi) noexcept;
 
     // specifies the level of optimization to apply to the shaders (default is PERFORMANCE)
+    // if linking against filamat_lite, this _must_ be called with Optimization::NONE.
     MaterialBuilder& optimization(Optimization optimization) noexcept;
 
     // if true, will output the generated GLSL shader code to stdout
@@ -315,6 +317,8 @@ private:
     // Return true if:
     // The shader is syntactically and semantically valid
     bool runStaticCodeAnalysis() noexcept;
+
+    bool checkLiteRequirements() noexcept;
 
     bool isLit() const noexcept { return mShading != filament::Shading::UNLIT; }
 

--- a/libs/filamat/src/sca/GLSLToolsLite.cpp
+++ b/libs/filamat/src/sca/GLSLToolsLite.cpp
@@ -29,9 +29,49 @@ static bool isVariableCharacter(char c) {
            (c == '_');
 }
 
+static std::string stripComments(const std::string& code) {
+    char* temp = (char*) malloc(code.size() + 1);
+
+    size_t r = 0;
+    bool insideSlashSlashComment = false, insideMultilineComment = false;
+
+    for (size_t loc = 0; loc < code.size(); loc++) {
+        char c = code[loc];
+        char lookahead = (loc + 1) < code.size() ? code[loc + 1] : 0;
+
+        // Handle slash slash comments.
+        if (!insideSlashSlashComment && c == '/' && lookahead == '/') {
+            insideSlashSlashComment = true;
+        }
+        if (insideSlashSlashComment && c == '\n') {
+            insideSlashSlashComment = false;
+        }
+
+        // Handle multiline comments.
+        if (!insideMultilineComment && c == '/' && lookahead == '*') {
+            insideMultilineComment = true;
+        }
+        if (insideMultilineComment && c == '*' && lookahead == '/') {
+            insideMultilineComment = false;
+        }
+
+        if (insideSlashSlashComment || insideMultilineComment) {
+            continue;
+        }
+
+        temp[r++] = c;
+    }
+
+    temp[r] = 0;
+    std::string result(temp);
+    free(temp);
+
+    return result;
+}
+
 bool GLSLToolsLite::findProperties(const utils::CString& material,
                     MaterialBuilder::PropertyList& properties) const noexcept {
-    const std::string shaderCode(material.c_str());
+    const std::string shaderCode = stripComments(material.c_str());
 
     size_t start = 0, end = 0;
 

--- a/libs/filamat/src/sca/GLSLToolsLite.cpp
+++ b/libs/filamat/src/sca/GLSLToolsLite.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GLSLToolsLite.h"
+
+#include <filamat/Enums.h>
+
+using namespace filament::backend;
+
+namespace filamat {
+
+static bool isVariableCharacter(char c) {
+    return (c >= 'A' && c <= 'Z') ||
+           (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+           (c == '_');
+}
+
+bool GLSLToolsLite::findProperties(const utils::CString& material,
+                    MaterialBuilder::PropertyList& properties) const noexcept {
+    const std::string shaderCode(material.c_str());
+
+    size_t start = 0, end = 0;
+
+    const auto p = Enums::map<Property>();
+
+    // Find all occurrences of "material.someProperty" in the shader string.
+    size_t loc;
+    while ((loc = shaderCode.find("material.", start)) != std::string::npos) {
+        // Set start and end to the index of the first character after "material."
+        start = loc + 9;
+        end = start;
+
+        // Increment end until we reach a non-variable character.
+        while (end != shaderCode.length() && isVariableCharacter(shaderCode[end])) {
+            end++;
+        }
+
+        std::string foundProperty = shaderCode.substr(start, end - start);
+
+        // Check to see if this property matches any in the property list.
+        for (const auto& i : p) {
+            const std::string& propertySymbol = i.first;
+            Property prop = i.second;
+
+            if (foundProperty == propertySymbol) {
+                properties[size_t(prop)] = true;
+            }
+        }
+    }
+
+    return true;
+}
+
+} // namespace filamat

--- a/libs/filamat/src/sca/GLSLToolsLite.cpp
+++ b/libs/filamat/src/sca/GLSLToolsLite.cpp
@@ -29,6 +29,10 @@ static bool isVariableCharacter(char c) {
            (c == '_');
 }
 
+static bool isWhitespace(char c) {
+    return (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v');
+}
+
 static std::string stripComments(const std::string& code) {
     char* temp = (char*) malloc(code.size() + 1);
 
@@ -79,12 +83,28 @@ bool GLSLToolsLite::findProperties(const utils::CString& material,
 
     // Find all occurrences of "material.someProperty" in the shader string.
     size_t loc;
-    while ((loc = shaderCode.find("material.", start)) != std::string::npos) {
-        // Set start and end to the index of the first character after "material."
-        start = loc + 9;
-        end = start;
+    while ((loc = shaderCode.find("material", start)) != std::string::npos) {
+        // Set start to the index of the first character after "material"
+        start = loc + 8;
+
+        // Eat up any whitespace after "material"
+        while (start != shaderCode.length() && isWhitespace(shaderCode[start])) {
+            start++;
+        }
+
+        // If the next character isn't a '.', then this isn't a property set.
+        if (start == shaderCode.length() || shaderCode[start] != '.') {
+            continue;
+        }
+        start++;
+
+        // Eat up any whitespace after the '.'.
+        while (start != shaderCode.length() && isWhitespace(shaderCode[start])) {
+            start++;
+        }
 
         // Increment end until we reach a non-variable character.
+        end = start;
         while (end != shaderCode.length() && isVariableCharacter(shaderCode[end])) {
             end++;
         }

--- a/libs/filamat/src/sca/GLSLToolsLite.h
+++ b/libs/filamat/src/sca/GLSLToolsLite.h
@@ -41,8 +41,6 @@ public:
      *
      *  Incorrect:
      *     material . baseColor = vec4(1.0, 0.0, 0.0, 1.0);
-     *
-     * Also note that this method does not discount property sets that are inside commented-out code.
      */
     bool findProperties(const utils::CString& material,
             MaterialBuilder::PropertyList& properties) const noexcept;

--- a/libs/filamat/src/sca/GLSLToolsLite.h
+++ b/libs/filamat/src/sca/GLSLToolsLite.h
@@ -34,13 +34,6 @@ public:
      *  2. The properties on "material" should be set directly, i.e., not passed via an inout qualifier
      *     to another function which sets properties (this only works if the argument to the
      *     function is also named "material").
-     *  3. The property access must not contain whitespace between tokens:
-     *
-     *  Correct:
-     *     material.baseColor = vec4(1.0, 0.0, 0.0, 1.0);
-     *
-     *  Incorrect:
-     *     material . baseColor = vec4(1.0, 0.0, 0.0, 1.0);
      */
     bool findProperties(const utils::CString& material,
             MaterialBuilder::PropertyList& properties) const noexcept;

--- a/libs/filamat/src/sca/GLSLToolsLite.h
+++ b/libs/filamat/src/sca/GLSLToolsLite.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_GLSLTOOLSLITE_H
+#define TNT_GLSLTOOLSLITE_H
+
+#include <filamat/MaterialBuilder.h>
+
+namespace filamat {
+
+class GLSLToolsLite {
+public:
+
+    // Public for unit tests.
+    using Property = MaterialBuilder::Property;
+
+    /* Guess the properties that the material is using based on a naive text-based search.
+     *
+     * In order for this method to detect the usage of a property:
+     *  1. The MaterialInputs argument to the user-defined material function must be named "material".
+     *  2. The properties on "material" should be set directly, i.e., not passed via an inout qualifier
+     *     to another function which sets properties (this only works if the argument to the
+     *     function is also named "material").
+     *  3. The property access must not contain whitespace between tokens:
+     *
+     *  Correct:
+     *     material.baseColor = vec4(1.0, 0.0, 0.0, 1.0);
+     *
+     *  Incorrect:
+     *     material . baseColor = vec4(1.0, 0.0, 0.0, 1.0);
+     *
+     * Also note that this method does not discount property sets that are inside commented-out code.
+     */
+    bool findProperties(const utils::CString& material,
+            MaterialBuilder::PropertyList& properties) const noexcept;
+
+};
+
+} // namespace filamat
+
+#endif // TNT_GLSLTOOLSLITE_H

--- a/libs/filamat/tests/test_filamat_lite.cpp
+++ b/libs/filamat/tests/test_filamat_lite.cpp
@@ -131,6 +131,27 @@ TEST_F(FilamatLite, StaticCodeAnalyzerNoSpace) {
     EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
+TEST_F(FilamatLite, StaticCodeAnalyzerWhitespace) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material  .subsurfaceColor = vec3(1.0);
+            material    .   ambientOcclusion  = vec3(1.0);
+            material
+                .   baseColor  = vec3(1.0);
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::SUBSURFACE_COLOR)] = true;
+    expected[size_t(MaterialBuilder::Property::AMBIENT_OCCLUSION)] = true;
+    expected[size_t(MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
 TEST_F(FilamatLite, StaticCodeAnalyzerEndOfShader) {
     utils::CString shaderCode(R"(
         void material(inout MaterialInputs material) {

--- a/libs/filamat/tests/test_filamat_lite.cpp
+++ b/libs/filamat/tests/test_filamat_lite.cpp
@@ -143,6 +143,50 @@ TEST_F(FilamatLite, StaticCodeAnalyzerEndOfShader) {
     EXPECT_TRUE(PropertyListsMatch(expected, properties));
 }
 
+TEST_F(FilamatLite, StaticCodeAnalyzerSlashComments) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.metallic = 1.0;
+            // material.baseColor = vec4(1.0); // material.baseColor = vec4(1.0);
+            // material.ambientOcclusion = vec3(1.0);
+            material.clearCoat = 0.5;
+            material.anisotropy = -1.0;
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::METALLIC)] = true;
+    expected[size_t(MaterialBuilder::Property::CLEAR_COAT)] = true;
+    expected[size_t(MaterialBuilder::Property::ANISOTROPY)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerMultilineComments) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.metallic = 1.0;
+            /*
+            material.baseColor = vec4(1.0); // material.baseColor = vec4(1.0);
+            material.ambientOcclusion = vec3(1.0);
+            */
+            material.clearCoat = 0.5;
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::METALLIC)] = true;
+    expected[size_t(MaterialBuilder::Property::CLEAR_COAT)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/libs/filamat/tests/test_filamat_lite.cpp
+++ b/libs/filamat/tests/test_filamat_lite.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "sca/GLSLToolsLite.h"
+
+#include <filamat/MaterialBuilder.h>
+#include <filamat/Enums.h>
+
+using namespace filamat;
+
+static ::testing::AssertionResult PropertyListsMatch(const MaterialBuilder::PropertyList& expected,
+        const MaterialBuilder::PropertyList& actual) {
+    for (size_t i = 0; i < MaterialBuilder::MATERIAL_PROPERTIES_COUNT; i++) {
+        if (expected[i] != actual[i]) {
+            const auto& propString = Enums::toString<Property>(Property(i));
+            return ::testing::AssertionFailure()
+                    << "actual[" << propString << "] (" << actual[i]
+                    << ") != expected[" << propString << "] (" << expected[i] << ")";
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
+class FilamatLite : public ::testing::Test {
+protected:
+    FilamatLite() {
+    }
+
+    virtual ~FilamatLite() {
+    }
+
+    virtual void SetUp() {
+        MaterialBuilder::init();
+    }
+};
+
+TEST_F(FilamatLite, StaticCodeAnalyzerNothingDetected) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerDirectAssign) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.baseColor = vec4(0.8);
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::BASE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerAssignMultiple) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            material.clearCoat = 1.0;
+            prepareMaterial(material);
+            material.baseColor = vec4(0.8);
+            material.metallic = 1.0;
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::CLEAR_COAT)] = true;
+    expected[size_t(MaterialBuilder::Property::BASE_COLOR)] = true;
+    expected[size_t(MaterialBuilder::Property::METALLIC)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerDirectAssignWithSwizzling) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.subsurfaceColor.rgb = vec3(1.0, 0.4, 0.8);
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::SUBSURFACE_COLOR)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerNoSpace) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            prepareMaterial(material);
+            material.ambientOcclusion=vec3(1.0);
+        }
+    )");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    expected[size_t(MaterialBuilder::Property::AMBIENT_OCCLUSION)] = true;
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+TEST_F(FilamatLite, StaticCodeAnalyzerEndOfShader) {
+    utils::CString shaderCode(R"(
+        void material(inout MaterialInputs material) {
+            material.)");
+
+    GLSLToolsLite glslTools;
+    MaterialBuilder::PropertyList properties {false};
+    glslTools.findProperties(shaderCode, properties);
+    MaterialBuilder::PropertyList expected {false};
+    EXPECT_TRUE(PropertyListsMatch(expected, properties));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is the first pass at reducing the size of the `filamat` library. This adds a new target
`filamat_lite`, which has fewer dependencies and a smaller binary size. Its restrictions:

1. Only supports OpenGL backend
1. No material optimizatione
1. No compile-time static analysis of shader code
1. Stricter requirements for setting properties in the `material` function (see
   `GLSLToolsLite.h`)

Size reduction:

| Architecture | filamat | filamat_lite | % reduction |
| -- | -- | -- | -- |
| arm64-v8a/libfilamat-jni.so | 5107 KiB | 842 KiB | 16.5% |
| armeabi-v7a/libfilamat-jni.so | 3466 KiB | 462 KiB | 13.3% |
| x86/libfilamat-jni.so | 5358 KiB | 874 KiB | 16.3% |
| x86_64/libfilamat-jni.so | 5547 KiB | 879 KiB | 15.8% |

How including filamat_lite in the filament-jni library affects binary size:

| Architecture | Size without filamat_lite | Size increase with filamat_lite | % Size increase |
| -- | -- | -- | -- |
| arm64-v8a/libfilament-jni.so | 742 KiB | +580 KiB | 78.1% |
| armeabi-v7a/libfilament-jni.so | 522 KiB | +336 KiB | 64.4% |
| x86/libfilament-jni.so | 810 KiB | +624 KiB | 77.1% |
| x86_64/libfilament-jni.so | 787 KiB | +612 KiB | 77.8% |

