### PR TITLE
Add multi-bounce AO based on GTAO

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -463,6 +463,7 @@ std::ostream& CodeGenerator::generateShaderLit(std::ostream& out, ShaderType typ
         }
 
         if (shading != Shading::UNLIT) {
+            out << SHADERS_AMBIENT_OCCLUSION_FS_DATA;
             out << SHADERS_LIGHT_INDIRECT_FS_DATA;
         }
         if (variant.hasDirectionalLighting()) {

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 # Sources and headers
 # ==================================================================================================
 set(SHADERS
+        src/ambient_occlusion.fs
         src/brdf.fs
         src/common_getters.fs
         src/common_graphics.fs

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// Ambient occlusion helpers
+//------------------------------------------------------------------------------
+
+#ifndef TARGET_MOBILE
+#if !defined(SPECULAR_OCCLUSION)
+    #define SPECULAR_OCCLUSION
+#endif
+#if !defined(MULTI_BOUNCE_AMBIENT_OCCLUSION)
+    #define MULTI_BOUNCE_AMBIENT_OCCLUSION
+#endif
+#endif
+
+/**
+ * Computes a specular occlusion term from the ambient occlusion term.
+ */
+float computeSpecularAO(float NoV, float visibility, float roughness) {
+#if defined(SPECULAR_OCCLUSION)
+    return saturate(pow(NoV + visibility, exp2(-16.0 * roughness - 1.0)) - 1.0 + visibility);
+#else
+    return 1.0;
+#endif
+}
+
+#if defined(MULTI_BOUNCE_AMBIENT_OCCLUSION)
+/**
+ * Returns a color ambient occlusion based on a pre-computed visibility term.
+ * The albedo term is meant to be the diffuse color or f0 for the diffuse and
+ * specular terms respectively.
+ */
+vec3 gtaoMultiBounce(float visibility, const vec3 albedo) {
+    // Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"
+    vec3 a =  2.0404 * albedo - 0.3324;
+    vec3 b = -4.7951 * albedo + 0.6417;
+    vec3 c =  2.7552 * albedo + 0.6903;
+
+    return max(vec3(visibility), ((visibility * a + b) * visibility + c) * visibility);
+}
+#endif
+
+void multiBounceAO(float visibility, const vec3 albedo, inout vec3 color) {
+#if defined(MULTI_BOUNCE_AMBIENT_OCCLUSION)
+    color *= gtaoMultiBounce(visibility, albedo);
+#endif
+}
+
+void multiBounceSpecularAO(float visibility, const vec3 albedo, inout vec3 color) {
+#if defined(MULTI_BOUNCE_AMBIENT_OCCLUSION) && defined(SPECULAR_OCCLUSION)
+    color *= gtaoMultiBounce(visibility, albedo);
+#endif
+}
+
+float singleBounceAO(float visibility) {
+#if defined(MULTI_BOUNCE_AMBIENT_OCCLUSION)
+    return 1.0;
+#else
+    return visibility;
+#endif
+}


### PR DESCRIPTION
Implements multi-bounced colored AO as described in "Practical Realtime Strategies for Accurate Indirect Occlusion" by Jimenez et al. This effects lightens ambient occlusion and preserves hue/saturation in occluded area. It's a limited form of local GI.

The screenshots below shows the model Littlest Tokyo from Sketchfab with and without multi-bounce AO.

This effect is currently always enabled on desktop, but never on mobile. A future PR will add the ability to turn this effect on in a material.

![Screen Shot 2019-05-13 at 2 50 10 PM](https://user-images.githubusercontent.com/869684/57658004-15a01b00-7592-11e9-8874-26010621ff9c.png)
