### PR TITLE
Allow MSAA textures in Metal backend

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -45,10 +45,6 @@ Driver* MetalDriverFactory::create(MetalPlatform* const platform) {
 
 namespace metal {
 
-static MTLLoadAction determineLoadAction(const RenderPassParams& params, TargetBufferFlags buffer);
-static MTLStoreAction determineStoreAction(const RenderPassParams& params, TargetBufferFlags buffer,
-        bool isMultisampled);
-
 UTILS_NOINLINE
 Driver* MetalDriver::create(MetalPlatform* const platform) {
     assert(platform);
@@ -500,33 +496,33 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
 
     MTLRenderPassDescriptor* descriptor = [MTLRenderPassDescriptor renderPassDescriptor];
 
-    const auto discardFlags = (TargetBufferFlags) params.flags.discardEnd;
+    const auto discardFlags = params.flags.discardEnd;
     const auto discardColor = (discardFlags & TargetBufferFlags::COLOR);
     const auto discardDepth = (discardFlags & TargetBufferFlags::DEPTH);
 
     // Color
 
-    descriptor.colorAttachments[0].texture = renderTarget->getColor();
-    descriptor.colorAttachments[0].resolveTexture = discardColor ? nil : renderTarget->getColorResolve();
-    mContext->currentSurfacePixelFormat = descriptor.colorAttachments[0].texture.pixelFormat;
+    const auto& colorAttachment = descriptor.colorAttachments[0];
+    colorAttachment.texture = renderTarget->getColor();
+    colorAttachment.resolveTexture = discardColor ? nil : renderTarget->getColorResolve();
+    mContext->currentSurfacePixelFormat = colorAttachment.texture.pixelFormat;
 
     // Metal clears the entire attachment without respect to viewport or scissor.
     // TODO: Might need to clear the scissor area manually via a draw if we need that functionality.
 
-    descriptor.colorAttachments[0].loadAction = determineLoadAction(params, TargetBufferFlags::COLOR);
-    descriptor.colorAttachments[0].storeAction = determineStoreAction(params, TargetBufferFlags::COLOR,
-            renderTarget->isMultisampled());
-    descriptor.colorAttachments[0].clearColor = MTLClearColorMake(
+    colorAttachment.loadAction = renderTarget->getLoadAction(params, TargetBufferFlags::COLOR);
+    colorAttachment.storeAction = renderTarget->getStoreAction(params, TargetBufferFlags::COLOR);
+    colorAttachment.clearColor = MTLClearColorMake(
             params.clearColor.r, params.clearColor.g, params.clearColor.b, params.clearColor.a);
 
     // Depth
 
-    descriptor.depthAttachment.texture = renderTarget->getDepth();
-    descriptor.depthAttachment.resolveTexture = discardDepth ? nil : renderTarget->getDepthResolve();
-    descriptor.depthAttachment.loadAction = determineLoadAction(params, TargetBufferFlags::DEPTH);
-    descriptor.depthAttachment.storeAction = determineStoreAction(params, TargetBufferFlags::DEPTH,
-            renderTarget->isMultisampled());
-    descriptor.depthAttachment.clearDepth = params.clearDepth;
+    const auto& depthAttachment = descriptor.depthAttachment;
+    depthAttachment.texture = renderTarget->getDepth();
+    depthAttachment.resolveTexture = discardDepth ? nil : renderTarget->getDepthResolve();
+    depthAttachment.loadAction = renderTarget->getLoadAction(params, TargetBufferFlags::DEPTH);
+    depthAttachment.storeAction = renderTarget->getStoreAction(params, TargetBufferFlags::DEPTH);
+    depthAttachment.clearDepth = params.clearDepth;
     mContext->currentDepthPixelFormat = descriptor.depthAttachment.texture.pixelFormat;
 
     mContext->currentCommandEncoder =
@@ -900,26 +896,6 @@ void MetalDriver::enumerateBoundUniformBuffers(
         auto* uniform = handle_cast<MetalUniformBuffer>(mHandleMap, thisUniform.ubh);
         f(thisUniform, uniform, i);
     }
-}
-
-MTLLoadAction determineLoadAction(const RenderPassParams& params, TargetBufferFlags buffer) {
-    const auto clearFlags = (TargetBufferFlags) params.flags.clear;
-    const auto discardStartFlags = (TargetBufferFlags) params.flags.discardStart;
-    if (clearFlags & buffer) {
-        return MTLLoadActionClear;
-    } else if (discardStartFlags & buffer) {
-        return MTLLoadActionDontCare;
-    }
-    return MTLLoadActionLoad;
-}
-
-static MTLStoreAction determineStoreAction(const RenderPassParams& params, TargetBufferFlags buffer,
-        bool isMultisampled) {
-    const auto discardEndFlags = (TargetBufferFlags) params.flags.discardEnd;
-    if (discardEndFlags & buffer) {
-        return MTLStoreActionDontCare;
-    }
-    return isMultisampled ? MTLStoreActionMultisampleResolve : MTLStoreActionStore;
 }
 
 } // namespace metal

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -152,8 +152,9 @@ public:
     ~MetalRenderTarget();
 
     bool isDefaultRenderTarget() const { return defaultRenderTarget; }
-    bool isMultisampled() const { return samples > 1; }
     uint8_t getSamples() const { return samples; }
+    MTLLoadAction getLoadAction(const RenderPassParams& params, TargetBufferFlags buffer);
+    MTLStoreAction getStoreAction(const RenderPassParams& params, TargetBufferFlags buffer);
 
     id<MTLTexture> getColor();
     id<MTLTexture> getColorResolve();
@@ -166,16 +167,14 @@ private:
             uint32_t width, uint32_t height, uint8_t samples);
 
     MetalContext* context;
-    id<MTLTexture> color = nil;
-    id<MTLTexture> depth = nil;
     bool defaultRenderTarget = false;
     uint8_t samples = 1;
     uint8_t level = 0;
 
-    // These textures are only used if this render target is multisampled.
+    id<MTLTexture> color = nil;
+    id<MTLTexture> depth = nil;
     id<MTLTexture> multisampledColor = nil;
     id<MTLTexture> multisampledDepth = nil;
-
 };
 
 class MetalFence : public HwFence {


### PR DESCRIPTION
The Metal backend now supports creating MSAA textures and attaching them to render targets. If a
MSAA render target is created with a single-sampled texture, an automatic resolve into the attached
texture at the end of the render pass is performed.
