### PR TITLE
Add micro-shadowing feature

### DIFF
--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -354,6 +354,8 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             auto ti = tcm.getInstance(renderable);
             tcm.setTransform(ti, mat4f{ mat3f(g_config.scale), float3(0.0f, 0.0f, -4.0f) } *
                     tcm.getWorldTransform(ti));
+            rcm.setReceiveShadows(rcm.getInstance(renderable), true);
+            rcm.setCastShadows(rcm.getInstance(renderable), true);
             scene->addEntity(renderable);
         }
     }
@@ -363,6 +365,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             .color(Color::toLinear<ACCURATE>({0.98f, 0.92f, 0.89f}))
             .intensity(110000)
             .direction({0.6, -1, -0.8})
+            .castShadows(true)
             .build(*engine, g_light);
     scene->addEntity(g_light);
 }

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -11,12 +11,18 @@
 #endif
 #endif
 
+float evaluateSSAO() {
+    // TODO: Don't use gl_FragCoord.xy, use the view bounds
+    vec2 uv = gl_FragCoord.xy * frameUniforms.resolution.zw;
+    return texture(light_ssao, uv, 0.0).r;
+}
+
 /**
  * Computes a specular occlusion term from the ambient occlusion term.
  */
-float computeSpecularAO(float NoV, float visibility, float roughness) {
+float computeSpecularAO(float NoV, float visibility, float linearRoughness) {
 #if defined(SPECULAR_OCCLUSION)
-    return saturate(pow(NoV + visibility, exp2(-16.0 * roughness - 1.0)) - 1.0 + visibility);
+    return saturate(pow(NoV + visibility, exp2(-16.0 * linearRoughness - 1.0)) - 1.0 + visibility);
 #else
     return 1.0;
 #endif
@@ -56,4 +62,10 @@ float singleBounceAO(float visibility) {
 #else
     return visibility;
 #endif
+}
+
+float computeMicroShadowing(float NoL, float visibility) {
+    // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+    float aperture = 2.0 * visibility * visibility;
+    return saturate(NoL + aperture - 1.0);
 }

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -63,9 +63,3 @@ float singleBounceAO(float visibility) {
     return visibility;
 #endif
 }
-
-float computeMicroShadowing(float NoL, float visibility) {
-    // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
-    float aperture = 2.0 * visibility * visibility;
-    return saturate(NoL + aperture - 1.0);
-}

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -26,6 +26,7 @@ struct PixelParams {
     vec3  f0;
     float linearRoughness;
     vec3  dfg;
+    float diffuseAO;
     vec3  energyCompensation;
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)
@@ -50,9 +51,3 @@ struct PixelParams {
     vec3  subsurfaceColor;
 #endif
 };
-
-float computeMicroShadowing(float NoL, float ao) {
-    // Brinck and Maximov 2016, "Technical Art of Uncharted 4"
-    float aperture = 2.0 * ao * ao;
-    return saturate(NoL + aperture - 1.0);
-}

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -51,8 +51,9 @@ struct PixelParams {
 #endif
 };
 
-float computeMicroShadowing(float NoL, float visibility) {
+float computeMicroShadowing(float NoL, float visibility, float opacity) {
     // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
     float aperture = 2.0 * visibility * visibility;
-    return saturate(NoL + aperture - 1.0);
+    float microShadow = saturate(NoL + aperture - 1.0);
+    return microShadow * opacity + opacity;
 }

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -26,7 +26,6 @@ struct PixelParams {
     vec3  f0;
     float linearRoughness;
     vec3  dfg;
-    float diffuseAO;
     vec3  energyCompensation;
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -51,3 +51,9 @@ struct PixelParams {
     vec3  subsurfaceColor;
 #endif
 };
+
+float computeMicroShadowing(float NoL, float visibility) {
+    // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
+    float aperture = 2.0 * visibility * visibility;
+    return saturate(NoL + aperture - 1.0);
+}

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -55,5 +55,5 @@ float computeMicroShadowing(float NoL, float visibility, float opacity) {
     // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
     float aperture = 2.0 * visibility * visibility;
     float microShadow = saturate(NoL + aperture - 1.0);
-    return microShadow * opacity + opacity;
+    return microShadow * opacity + (1.0 - opacity);
 }

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -51,9 +51,9 @@ struct PixelParams {
 #endif
 };
 
-float computeMicroShadowing(float NoL, float visibility, float opacity) {
-    // Brinck and Maximov 2016, "The Technical Art of Uncharted 4"
-    float aperture = 2.0 * visibility * visibility;
-    float microShadow = saturate(NoL + aperture - 1.0);
-    return microShadow * opacity + (1.0 - opacity);
+float computeMicroShadowing(float NoL, float visibility) {
+    // Chan 2018, "Material Advances in Call of Duty: WWII"
+    float aperture = inversesqrt(1.0 - visibility);
+    float microShadow = saturate(NoL * aperture);
+    return microShadow * microShadow;
 }

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -33,6 +33,9 @@ void evaluateDirectionalLight(const PixelParams pixel, inout vec3 color) {
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
         visibility = shadow(light_shadowMap, getLightSpacePosition());
+        if (gl_FragCoord.x < frameUniforms.resolution.x * 0.5) {
+            visibility *= computeMicroShadowing(light.NoL, pixel.diffuseAO);
+        }
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -30,16 +30,20 @@ Light getDirectionalLight() {
     return light;
 }
 
-void evaluateDirectionalLight(const PixelParams pixel, inout vec3 color) {
+void evaluateDirectionalLight(const MaterialInputs material,
+        const PixelParams pixel, inout vec3 color) {
+
     Light light = getDirectionalLight();
 
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
         visibility = shadow(light_shadowMap, getLightSpacePosition());
+        #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
         if (gl_FragCoord.x < frameUniforms.resolution.x * 0.5) {
-            visibility *= computeMicroShadowing(light.NoL, pixel.diffuseAO);
+            visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
         }
+        #endif
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -2,8 +2,12 @@
 // Directional light evaluation
 //------------------------------------------------------------------------------
 
-vec3 sampleSunAreaLight(const vec3 lightDirection) {
 #if !defined(TARGET_MOBILE)
+#define SUN_AS_AREA_LIGHT
+#endif
+
+vec3 sampleSunAreaLight(const vec3 lightDirection) {
+#if defined(SUN_AS_AREA_LIGHT)
     if (frameUniforms.sun.w >= 0.0) {
         // simulate sun as disc area light
         float LoR = dot(lightDirection, shading_reflected);

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -40,8 +40,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
     if (light.NoL > 0.0) {
         visibility = shadow(light_shadowMap, getLightSpacePosition());
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
-        // TODO: Add microShadowOpacity uniform
-        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion, 1.0);
+        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
         #endif
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -40,7 +40,8 @@ void evaluateDirectionalLight(const MaterialInputs material,
     if (light.NoL > 0.0) {
         visibility = shadow(light_shadowMap, getLightSpacePosition());
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
-        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
+        // TODO: Add microShadowOpacity uniform
+        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion, 1.0);
         #endif
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -40,9 +40,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
     if (light.NoL > 0.0) {
         visibility = shadow(light_shadowMap, getLightSpacePosition());
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
-        if (gl_FragCoord.x < frameUniforms.resolution.x * 0.5) {
-            visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
-        }
+        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
         #endif
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -350,19 +350,12 @@ void evaluateSubsurfaceIBL(const PixelParams pixel, const vec3 diffuseIrradiance
 #endif
 }
 
-float evaluateSSAO() {
-    // TODO: Don't use gl_FragCoord.xy, use the view bounds
-    vec2 uv = gl_FragCoord.xy * frameUniforms.resolution.zw;
-    return texture(light_ssao, uv, 0.0).r;
-}
-
 void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout vec3 color) {
     // Apply transform here if we wanted to rotate the IBL
     vec3 n = shading_normal;
     vec3 r = getReflectedVector(pixel, n);
 
-    float ssao = evaluateSSAO();
-    float diffuseAO = min(material.ambientOcclusion, ssao);
+    float diffuseAO = pixel.diffuseAO;
     float specularAO = computeSpecularAO(shading_NoV, diffuseAO, pixel.linearRoughness);
 
     // diffuse indirect

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -355,7 +355,8 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     vec3 n = shading_normal;
     vec3 r = getReflectedVector(pixel, n);
 
-    float diffuseAO = pixel.diffuseAO;
+    float ssao = evaluateSSAO();
+    float diffuseAO = min(material.ambientOcclusion, ssao);
     float specularAO = computeSpecularAO(shading_NoV, diffuseAO, pixel.linearRoughness);
 
     // diffuse indirect

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -128,11 +128,6 @@ void getEnergyCompensationPixelParams(inout PixelParams pixel) {
 #endif
 }
 
-void getAmbientOcclusionPixelParams(const MaterialInputs material, inout PixelParams pixel) {
-    float ssao = evaluateSSAO();
-    pixel.diffuseAO = min(material.ambientOcclusion, ssao);
-}
-
 /**
  * Computes all the parameters required to shade the current pixel/fragment.
  * These parameters are derived from the MaterialInputs structure computed
@@ -148,7 +143,6 @@ void getPixelParams(const MaterialInputs material, out PixelParams pixel) {
     getSubsurfacePixelParams(material, pixel);
     getAnisotropyPixelParams(material, pixel);
     getEnergyCompensationPixelParams(pixel);
-    getAmbientOcclusionPixelParams(material, pixel);
 }
 
 float getDiffuseAlpha(float a) {
@@ -183,7 +177,7 @@ vec4 evaluateLights(const MaterialInputs material) {
     evaluateIBL(material, pixel, color);
 
 #if defined(HAS_DIRECTIONAL_LIGHTING)
-    evaluateDirectionalLight(pixel, color);
+    evaluateDirectionalLight(material, pixel, color);
 #endif
 
 #if defined(HAS_DYNAMIC_LIGHTING)


### PR DESCRIPTION
Micro-shadowing is derived from ambient occlusion maps and applies to directional lighting. The implementation comes from Chan 2018, _Material Advances in Call of Duty: WWII_. It's an approximation that estimates the visibility cone at any given point based on the local ambient occlusion value.

![micro-shadowing](https://user-images.githubusercontent.com/869684/57879638-c5af9700-77d1-11e9-94eb-a04931b9b7a9.png)
