### PR TITLE
Use SAO style ambient occlusion

### DIFF
--- a/android/samples/image-based-lighting/app/src/main/java/com/google/android/filament/ibl/MainActivity.kt
+++ b/android/samples/image-based-lighting/app/src/main/java/com/google/android/filament/ibl/MainActivity.kt
@@ -117,6 +117,8 @@ class MainActivity : Activity() {
         // unnecessary when using a skybox
         view.setClearColor(0.035f, 0.035f, 0.035f, 1.0f)
 
+        view.ambientOcclusion = View.AmbientOcclusion.SSAO
+
         // NOTE: Try to disable post-processing (tone-mapping, etc.) to see the difference
         // view.isPostProcessingEnabled = false
 

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -126,6 +126,7 @@ set(MATERIAL_SRCS
         src/materials/defaultMaterial.mat
         src/materials/skybox.mat
         src/materials/skyboxRGBM.mat
+        src/materials/sao.mat
         src/materials/ssao.mat
 )
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -59,7 +59,7 @@ void PostProcessManager::init(FEngine& engine) noexcept {
     driver.update2DImage(mNoSSAOTexture, 0, 0, 0, 1, 1, std::move(data));
 
     mSSAOMaterial = upcast(Material::Builder().package(
-            MATERIALS_SSAO_DATA, MATERIALS_SSAO_SIZE).build(engine));
+            MATERIALS_SAO_DATA, MATERIALS_SAO_SIZE).build(engine));
 
     mSSAOMaterialInstance = mSSAOMaterial->getDefaultInstance();
 
@@ -321,6 +321,8 @@ FrameGraphResource PostProcessManager::ssao(FrameGraph& fg, FrameGraphResource d
                 FMaterialInstance* const pInstance = mSSAOMaterialInstance;
                 pInstance->setParameter("depth", depth, params);
                 pInstance->setParameter("radius", data.options.radius);
+                pInstance->setParameter("invRadiusSquared", 1.0f / (data.options.radius * data.options.radius));
+                pInstance->setParameter("projectionScaleRadius", 500.0f * data.options.radius);
                 pInstance->setParameter("bias", data.options.bias);
                 pInstance->setParameter("power", data.options.power);
                 pInstance->commit(driver);

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -2,8 +2,9 @@ material {
     name : ssao,
     parameters : [
         {
-           type : sampler2d,
-           name : depth
+            type : sampler2d,
+            name : depth,
+            precision: high
         },
         {
             type : float,
@@ -71,12 +72,12 @@ fragment {
     }
 
     // remaps to -1 and 1, repeating
-    float reduce(float x) {
+    float reduce(highp float x) {
         return fract(0.5 * x + 0.5) * 2.0 - 1.0;
     }
 
     // very crude and fast sin/cos approximation
-    vec2 fast_cossin(float x) {
+    vec2 fast_cossin(highp float x) {
         x *= 1.0/3.1415926;
         vec2 a = vec2(reduce(x + 0.5), reduce(x));
         vec2 xn = sq(a * 2.0 + 1.0) - 1.0;
@@ -85,10 +86,10 @@ fragment {
     }
 
     // random number between 0 and 1
-    float random(HIGHP vec2 n) {
+    float random(highp vec2 n) {
         n  = fract(n * vec2(5.3987, 5.4421));
         n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
-        HIGHP float xy = n.x * n.y;
+        highp float xy = n.x * n.y;
         // compute in [0..2[ and remap to [0.0..1.0[
         return fract(xy * 95.4307) + fract(xy * 75.04961) * 0.5;
     }
@@ -100,8 +101,8 @@ fragment {
             const float dalpha = 1.0f / (float(kSpiralSampleCount) - 0.5f);
             float phi = random(uv);
             float dr = phi * dalpha;
-            float dalpha2 = sq(dalpha);
-            float dphi = (6.28318 * kSpiralTurns) * sq(phi) * dalpha2
+            highp float dalpha2 = sq(dalpha);
+            highp float dphi = (6.28318 * kSpiralTurns) * sq(phi) * dalpha2
                 + phi * 6.28318 * (1.0 + kSpiralTurns * dalpha2)
                 + phi * (2.0 * 6.28318 * kSpiralTurns) * dalpha2;
             return vec3(fast_cossin(dphi), dr);
@@ -114,24 +115,24 @@ fragment {
         #endif
     }
 
-    vec3 computeViewSpaceNormalNotNormalized(const vec3 position) {
-        vec3 dpdx = dFdx(position);
-        vec3 dpdy = dFdy(position);
+    highp vec3 computeViewSpaceNormalNotNormalized(const highp vec3 position) {
+        highp vec3 dpdx = dFdx(position);
+        highp vec3 dpdy = dFdy(position);
         return cross(dpdx, dpdy);
     }
 
-    float linearizeDepth(float depth) {
-        mat4 projection = getClipFromViewMatrix();
-        float z = depth * 2.0 - 1.0; // depth in clip space
+    highp float linearizeDepth(highp float depth) {
+        highp mat4 projection = getClipFromViewMatrix();
+        highp float z = depth * 2.0 - 1.0; // depth in clip space
         return -projection[3].z / (z + projection[2].z);
     }
 
-    float sampleDepthLinear(const vec2 uv) {
+    highp float sampleDepthLinear(const vec2 uv) {
         return linearizeDepth(texture(materialParams_depth, uv, 0.0).r);
     }
 
-    vec3 computeViewSpacePositionFromDepth(in vec2 p, float linearDepth) {
-        mat4 invProjection = getViewFromClipMatrix();
+    highp vec3 computeViewSpacePositionFromDepth(in vec2 p, highp float linearDepth) {
+        highp mat4 invProjection = getViewFromClipMatrix();
         p.x *= invProjection[0].x;
         p.y *= invProjection[1].y;
         return vec3(p * -linearDepth, linearDepth);
@@ -160,15 +161,14 @@ fragment {
         return clamp(uv, ivec2(0), textureSize(materialParams_depth, 0) - ivec2(1));
     }
 
-    float computeAmbientOcclusionSAO(uint i, float ssDiskRadius, const ivec2 ssOrigin, const vec3 origin, const vec3 normal, const vec3 noise) {
+    float computeAmbientOcclusionSAO(uint i, float ssDiskRadius, const ivec2 ssOrigin, const highp vec3 origin, const vec3 normal, const vec3 noise) {
         vec3 tap = tapLocation(i, noise);
         float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
+
         ivec2 ssSamplePos = ssOrigin + ivec2(ssRadius * tap.xy);
-
-        float occlusionDepth = linearizeDepth(texelFetch(materialParams_depth, clampToEdge(ssSamplePos), 0).r);
-
         vec2 uvSamplePos = (vec2(ssSamplePos) + vec2(0.5)) * frameUniforms.resolution.zw;
-        vec3 p = computeViewSpacePositionFromDepth(uvSamplePos * 2.0 - 1.0, occlusionDepth);
+        highp float occlusionDepth = linearizeDepth(texelFetch(materialParams_depth, clampToEdge(ssSamplePos), 0).r);
+        highp vec3 p = computeViewSpacePositionFromDepth(uvSamplePos * 2.0 - 1.0, occlusionDepth);
 
         // now we have the sample, compute AO
         vec3 v = p - origin;        // sample vector
@@ -185,11 +185,11 @@ fragment {
 
         vec2 uv = variable_vertex.xy; // interpolated to pixel center
 
+        highp float depth = sampleDepthLinear(uv);
+        highp vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
+        highp vec3 normal = computeViewSpaceNormalNotNormalized(origin);
         vec3 noise = getTrigNoise(uv);
-        float depth = sampleDepthLinear(uv);
-        vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
-        ivec2 ssOrigin = ivec2(uv * frameUniforms.resolution.xy);
-        vec3 normal = computeViewSpaceNormalNotNormalized(origin);
+
 
         // attempt to reject "bad" normals that were reconstructed at an edge that cause
         // false occlusion (black spots)
@@ -211,6 +211,7 @@ fragment {
         }
 
         normal = normalize(normal);
+        ivec2 ssOrigin = ivec2(uv * frameUniforms.resolution.xy);
         float occlusion = 0.0;
         for (uint i = 0u; i < kSpiralSampleCount; i++) {
             occlusion += computeAmbientOcclusionSAO(i, ssDiskRadius, ssOrigin, origin, normal, noise);

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -1,0 +1,224 @@
+material {
+    name : ssao,
+    parameters : [
+        {
+           type : sampler2d,
+           name : depth
+        },
+        {
+            type : float,
+            name : radius
+        },
+        {
+            type : float,
+            name : invRadiusSquared
+        },
+        {
+            type : float,
+            name : projectionScaleRadius
+        },
+        {
+            type : float,
+            name : bias
+        },
+        {
+            type : float,
+            name : power
+        }
+    ],
+    variables : [
+         vertex
+    ],
+    vertexDomain : device,
+    depthWrite : false,
+    depthCulling : false,
+    shadingModel : unlit,
+    variantFilter : [ skinning ],
+    culling: none
+}
+
+vertex {
+    void materialVertex(inout MaterialVertexInputs material) {
+        // far-plane in view space
+        vec4 position = getPosition(); // clip-space
+        material.vertex.xy = (position.xy * 0.5 + 0.5);
+        material.vertex.zw = position.xy;
+    }
+}
+
+fragment {
+    #define NOISE_NONE      0
+    #define NOISE_PATTERN   1
+    #define NOISE_RANDOM    2
+    #define NOISE_TYPE      NOISE_PATTERN
+
+    const uint kSpiralSampleCount = 7u;
+    const vec3 kSipralSamples[kSpiralSampleCount] = vec3[](
+        vec3(0.885456,0.464723,0.0769231), vec3(0.120537,0.992709,0.230769), vec3(-0.748511,0.663123,0.384615), vec3(-0.970942,-0.239316,0.538462),
+        vec3(-0.354605,-0.935016,0.692308), vec3(0.568065,-0.822984,0.846154), vec3(1,1.74846e-07,1)
+    );
+
+    const uint kTrigNoiseSampleCount = 16u;
+    const vec3 kTrigNoiseSamples[kTrigNoiseSampleCount] = vec3[](
+        vec3(0.0759449,0.997112,0.0317202), vec3(-0.53898,-0.842318,0.0879207), vec3(0.672069,0.740488,0.0176937), vec3(-0.323441,-0.946248,0.0930107),
+        vec3(0.330969,0.943642,0.026175), vec3(0.341023,-0.940055,0.107385), vec3(-0.197094,0.980384,0.0375434), vec3(0.106268,-0.994338,0.102259),
+        vec3(0.955394,0.295335,0.00636207), vec3(0.306817,0.951768,0.0267157), vec3(-0.882675,0.469983,0.056284), vec3(0.671194,-0.741282,0.115615),
+        vec3(-0.958342,0.285624,0.0605199), vec3(0.954541,-0.298078,0.12691), vec3(-0.586924,-0.809642,0.0866893), vec3(0.679755,-0.73344,0.115861)
+    );
+
+    vec2 sq(const vec2 a) {
+        return a * a;
+    }
+
+    // remaps to -1 and 1, repeating
+    float reduce(float x) {
+        return fract(0.5 * x + 0.5) * 2.0 - 1.0;
+    }
+
+    // very crude and fast sin/cos approximation
+    vec2 fast_cossin(float x) {
+        x *= 1.0/3.1415926;
+        vec2 a = vec2(reduce(x + 0.5), reduce(x));
+        vec2 xn = sq(a * 2.0 + 1.0) - 1.0;
+        vec2 xp = 1.0 - sq(a * 2.0 - 1.0);
+        return vec2(a.x < 0.0 ? xn.x : xp.x, a.y < 0.0 ? xn.y : xp.y);
+    }
+
+    // random number between 0 and 1
+    float random(HIGHP vec2 n) {
+        n  = fract(n * vec2(5.3987, 5.4421));
+        n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
+        HIGHP float xy = n.x * n.y;
+        // compute in [0..2[ and remap to [0.0..1.0[
+        return fract(xy * 95.4307) + fract(xy * 75.04961) * 0.5;
+    }
+
+    // see ssaogen.cpp
+    vec3 getTrigNoise(const vec2 uv) {
+        #if NOISE_TYPE == NOISE_RANDOM
+            const float kSpiralTurns = 7.0; // must match ssaogen.cpp
+            const float dalpha = 1.0f / (float(kSpiralSampleCount) - 0.5f);
+            float phi = random(uv);
+            float dr = phi * dalpha;
+            float dalpha2 = sq(dalpha);
+            float dphi = (6.28318 * kSpiralTurns) * sq(phi) * dalpha2
+                + phi * 6.28318 * (1.0 + kSpiralTurns * dalpha2)
+                + phi * (2.0 * 6.28318 * kSpiralTurns) * dalpha2;
+            return vec3(fast_cossin(dphi), dr);
+        #elif NOISE_TYPE == NOISE_PATTERN
+            uint ix = uint(gl_FragCoord.x) & 3u;
+            uint iy = uint(gl_FragCoord.y) & 3u;
+            return kTrigNoiseSamples[ix + iy * 4u];
+        #else
+            return vec3(0.0);
+        #endif
+    }
+
+    vec3 computeViewSpaceNormalNotNormalized(const vec3 position) {
+        vec3 dpdx = dFdx(position);
+        vec3 dpdy = dFdy(position);
+        return cross(dpdx, dpdy);
+    }
+
+    float linearizeDepth(float depth) {
+        mat4 projection = getClipFromViewMatrix();
+        float z = depth * 2.0 - 1.0; // depth in clip space
+        return -projection[3].z / (z + projection[2].z);
+    }
+
+    float sampleDepthLinear(const vec2 uv) {
+        return linearizeDepth(texture(materialParams_depth, uv, 0.0).r);
+    }
+
+    vec3 computeViewSpacePositionFromDepth(in vec2 p, float linearDepth) {
+        mat4 invProjection = getViewFromClipMatrix();
+        p.x *= invProjection[0].x;
+        p.y *= invProjection[1].y;
+        return vec3(p * -linearDepth, linearDepth);
+    }
+
+    // Ambient Occlusion, largely inspired from:
+    // "The Alchemy Screen-Space Ambient Obscurance Algorithm" by Morgan McGuire
+    // "Scalable Ambient Obscurance" by Morgan McGuire, Michael Mara and David Luebke
+
+    vec3 tapLocationReference(uint i) {
+        const float dalpha = 1.0f / (float(kSpiralSampleCount) - 0.5f);
+        float phi = random(variable_vertex.xy) * 0.5 + 0.5;
+        float radius = (float(i) + phi + 0.5) * dalpha;
+        radius *= radius;
+        float angle = radius * (7.0 * 6.28318) + phi * 6.28318;
+        return vec3(cos(angle), sin(angle), radius);
+    }
+
+    vec3 tapLocation(uint i, const vec3 noise) {
+        mat2 M = mat2(noise.xy, vec2(-noise.y, noise.x));
+        float radius = kSipralSamples[i].z + noise.z;
+        return vec3(M * kSipralSamples[i].xy, radius * radius);
+    }
+
+    ivec2 clampToEdge(ivec2 uv) {
+        return clamp(uv, ivec2(0), textureSize(materialParams_depth, 0) - ivec2(1));
+    }
+
+    float computeAmbientOcclusionSAO(uint i, float ssDiskRadius, const ivec2 ssOrigin, const vec3 origin, const vec3 normal, const vec3 noise) {
+        vec3 tap = tapLocation(i, noise);
+        float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
+        ivec2 ssSamplePos = ssOrigin + ivec2(ssRadius * tap.xy);
+
+        float occlusionDepth = linearizeDepth(texelFetch(materialParams_depth, clampToEdge(ssSamplePos), 0).r);
+
+        vec2 uvSamplePos = (vec2(ssSamplePos) + vec2(0.5)) * frameUniforms.resolution.zw;
+        vec3 p = computeViewSpacePositionFromDepth(uvSamplePos * 2.0 - 1.0, occlusionDepth);
+
+        // now we have the sample, compute AO
+        vec3 v = p - origin;        // sample vector
+        float vv = dot(v, v);       // squared distance
+        float vn = dot(v, normal);  // distance * cos(v, normal)
+        const float uu = 0.015;
+        float falloff = saturate(1.0 - vv * materialParams.invRadiusSquared);
+        float occlusion = falloff * max(0.0, vn - materialParams.bias) / (vv + uu);
+        return occlusion;
+    }
+
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+
+        vec2 uv = variable_vertex.xy; // interpolated to pixel center
+
+        vec3 noise = getTrigNoise(uv);
+        float depth = sampleDepthLinear(uv);
+        vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
+        ivec2 ssOrigin = ivec2(uv * frameUniforms.resolution.xy);
+        vec3 normal = computeViewSpaceNormalNotNormalized(origin);
+
+        // attempt to reject "bad" normals that were reconstructed at an edge that cause
+        // false occlusion (black spots)
+        // Normal's length should be small before they're normalized, unless they're bad ones.
+        if (dot(normal, normal) >= (sq(origin.z * origin.z * 0.000061))) {
+            // For now we assume no occlusion, which is wrong in some case, but overall seem to
+            // look better.  Maybe those could be handled in the blur pass instead?
+            material.baseColor.r = 1.0;
+            return;
+        }
+
+        // Choose the screen-space sample radius
+        // proportional to the projected area of the sphere
+        float ssDiskRadius = -materialParams.projectionScaleRadius / origin.z;
+        if (ssDiskRadius <= 1.0) {
+            // There is no way to compute AO at this radius
+            material.baseColor.r = 1.0;
+            return;
+        }
+
+        normal = normalize(normal);
+        float occlusion = 0.0;
+        for (uint i = 0u; i < kSpiralSampleCount; i++) {
+            occlusion += computeAmbientOcclusionSAO(i, ssDiskRadius, ssOrigin, origin, normal, noise);
+        }
+        float ao = 1.0 - occlusion / float(kSpiralSampleCount);
+
+        // simulate user-controled ao^n with n[1, 2]
+        ao = mix(ao, ao * ao, materialParams.power);
+        material.baseColor.r = ao;
+    }
+}

--- a/filament/src/materials/ssao.mat
+++ b/filament/src/materials/ssao.mat
@@ -2,8 +2,9 @@ material {
     name : ssao,
     parameters : [
         {
-           type : sampler2d,
-           name : depth
+            type : sampler2d,
+            name : depth,
+            precision: high
         },
         {
             type : float,
@@ -73,10 +74,10 @@ fragment {
     );
 
     // random number between 0 and 1
-    float random(HIGHP vec2 n) {
+    float random(highp vec2 n) {
         n  = fract(n * vec2(5.3987, 5.4421));
         n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
-        HIGHP float xy = n.x * n.y;
+        highp float xy = n.x * n.y;
         // compute in [0..2[ and remap to [0.0..1.0[
         return fract(xy * 95.4307) + fract(xy * 75.04961) * 0.5;
     }
@@ -94,24 +95,24 @@ fragment {
         #endif
     }
 
-    vec3 computeViewSpaceNormalNotNormalized(const vec3 position) {
-        vec3 dpdx = dFdx(position);
-        vec3 dpdy = dFdy(position);
+    highp vec3 computeViewSpaceNormalNotNormalized(const highp vec3 position) {
+        highp vec3 dpdx = dFdx(position);
+        highp vec3 dpdy = dFdy(position);
         return cross(dpdx, dpdy);
     }
 
-    float linearizeDepth(float depth) {
-        mat4 projection = getClipFromViewMatrix();
-        float z = depth * 2.0 - 1.0; // depth in clip space
+    highp float linearizeDepth(highp float depth) {
+        highp mat4 projection = getClipFromViewMatrix();
+        highp float z = depth * 2.0 - 1.0; // depth in clip space
         return -projection[3].z / (z + projection[2].z);
     }
 
-    float sampleDepthLinear(const vec2 uv) {
+    highp float sampleDepthLinear(const vec2 uv) {
         return linearizeDepth(texture(materialParams_depth, uv, 0.0).r);
     }
 
-    vec3 computeViewSpacePositionFromDepth(in vec2 p, float linearDepth) {
-        mat4 invProjection = getViewFromClipMatrix();
+    highp vec3 computeViewSpacePositionFromDepth(in vec2 p, highp float linearDepth) {
+        highp mat4 invProjection = getViewFromClipMatrix();
         p.x *= invProjection[0].x;
         p.y *= invProjection[1].y;
         return vec3(p * -linearDepth, linearDepth);
@@ -120,19 +121,19 @@ fragment {
     // Ambient Occlusion, largely inspired from:
     // Hemisphere Crysis-style SSAO. See "Screen Space Ambient Occlusion" by John Chapman
 
-    float computeAmbientOcclusionSSAO(const vec3 origin, const vec3 normal, const vec3 noise, const vec3 sphereSample) {
-        mat4 projection = getClipFromViewMatrix();
+    float computeAmbientOcclusionSSAO(const highp vec3 origin, const vec3 normal, const vec3 noise, const vec3 sphereSample) {
+        highp mat4 projection = getClipFromViewMatrix();
         float radius = materialParams.radius;
         float bias = materialParams.bias;
 
         vec3 r = sphereSample * radius;
         r = reflect(r, noise);
         r = sign(dot(r, normal)) * r;
-        vec3 samplePos = origin + r;
+        highp vec3 samplePos = origin + r;
 
-        vec4 samplePosScreen = projection * vec4(samplePos, 1.0);
+        highp vec4 samplePosScreen = projection * vec4(samplePos, 1.0);
         samplePosScreen.xy = samplePosScreen.xy * (0.5 / samplePosScreen.w) + 0.5;
-        float occlusionDepth = sampleDepthLinear(samplePosScreen.xy);
+        highp float occlusionDepth = sampleDepthLinear(samplePosScreen.xy);
         // smoothstep() optimized for range 0 to 1
         float t = saturate(radius / abs(origin.z - occlusionDepth));
         float rangeCheck = t * t * (3.0 - 2.0 * t);
@@ -145,10 +146,10 @@ fragment {
 
         vec2 uv = variable_vertex.xy; // interpolated to pixel center
 
+        highp float depth = sampleDepthLinear(uv);
+        highp vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
+        highp vec3 normal = computeViewSpaceNormalNotNormalized(origin);
         vec3 noise = getNoise(uv);
-        float depth = sampleDepthLinear(uv);
-        vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
-        vec3 normal = computeViewSpaceNormalNotNormalized(origin);
 
         // attempt to reject "bad" normals that were reconstructed at an edge that cause
         // false occlusion (black spots)

--- a/filament/src/materials/ssao.mat
+++ b/filament/src/materials/ssao.mat
@@ -11,6 +11,14 @@ material {
         },
         {
             type : float,
+            name : invRadiusSquared
+        },
+        {
+            type : float,
+            name : projectionScaleRadius
+        },
+        {
+            type : float,
             name : bias
         },
         {
@@ -39,6 +47,11 @@ vertex {
 }
 
 fragment {
+    #define NOISE_NONE      0
+    #define NOISE_PATTERN   1
+    #define NOISE_RANDOM    2
+    #define NOISE_TYPE      NOISE_PATTERN
+
     const uint kSphereSampleCount = 16u;
     const vec3 kSphereSamples[16] = vec3[](
         vec3(-1.60954e-06,3.93118e-07,1.51895e-06), vec3(-0.0950889,0.00458908,-0.0312535),
@@ -59,16 +72,26 @@ fragment {
         vec3(-0.57093,-0.531056,-0.626114), vec3(0.699014,0.0632826,-0.712303), vec3(0.207495,0.976129,-0.0641723), vec3(-0.0609008,-0.869738,-0.489742)
     );
 
-    float random(const vec2 st) {
-        return fract(sin(dot(st.xy, vec2(12.9898,78.233)))* 43758.5453123);
+    // random number between 0 and 1
+    float random(HIGHP vec2 n) {
+        n  = fract(n * vec2(5.3987, 5.4421));
+        n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
+        HIGHP float xy = n.x * n.y;
+        // compute in [0..2[ and remap to [0.0..1.0[
+        return fract(xy * 95.4307) + fract(xy * 75.04961) * 0.5;
     }
 
+    // noise vector between -1 and 1
     vec3 getNoise(const vec2 uv) {
-        uint ix = uint(gl_FragCoord.x) & 3u;
-        uint iy = uint(gl_FragCoord.y) & 3u;
-        //vec3 noise = kNoiseSamples[ix + iy * 4];
-        vec3 noise = normalize(vec3(random(uv), random(uv*2.0), random(uv*4.0)));
-        return noise;
+        #if NOISE_TYPE == NOISE_RANDOM
+            return normalize(2.0 * vec3(random(uv), random(uv * 2.0), random(uv * 4.0)) - vec3(1.0));
+        #elif NOISE_TYPE == NOISE_PATTERN
+            uint ix = uint(gl_FragCoord.x) & 3u;
+            uint iy = uint(gl_FragCoord.y) & 3u;
+            return kNoiseSamples[ix + iy * 4u];
+        #else
+            return vec3(0.0);
+        #endif
     }
 
     vec3 computeViewSpaceNormalNotNormalized(const vec3 position) {
@@ -88,13 +111,16 @@ fragment {
     }
 
     vec3 computeViewSpacePositionFromDepth(in vec2 p, float linearDepth) {
-        mat4 projection = getClipFromViewMatrix();
-        p.x = p.x * (-1.0 / projection[0].x);   // could be in a ubo
-        p.y = p.y * (-1.0 / projection[1].y);   // could be in a ubo
-        return vec3(p * linearDepth, linearDepth);
+        mat4 invProjection = getViewFromClipMatrix();
+        p.x *= invProjection[0].x;
+        p.y *= invProjection[1].y;
+        return vec3(p * -linearDepth, linearDepth);
     }
 
-    float computeAmbientOcclusion(const vec3 origin, const vec3 normal, const vec3 noise, const vec3 sphereSample) {
+    // Ambient Occlusion, largely inspired from:
+    // Hemisphere Crysis-style SSAO. See "Screen Space Ambient Occlusion" by John Chapman
+
+    float computeAmbientOcclusionSSAO(const vec3 origin, const vec3 normal, const vec3 noise, const vec3 sphereSample) {
         mat4 projection = getClipFromViewMatrix();
         float radius = materialParams.radius;
         float bias = materialParams.bias;
@@ -106,13 +132,10 @@ fragment {
 
         vec4 samplePosScreen = projection * vec4(samplePos, 1.0);
         samplePosScreen.xy = samplePosScreen.xy * (0.5 / samplePosScreen.w) + 0.5;
-
         float occlusionDepth = sampleDepthLinear(samplePosScreen.xy);
-
         // smoothstep() optimized for range 0 to 1
         float t = saturate(radius / abs(origin.z - occlusionDepth));
         float rangeCheck = t * t * (3.0 - 2.0 * t);
-
         float d = samplePos.z - occlusionDepth; // distance from depth to sample
         return (d >= -bias ? 0.0 : rangeCheck);
     }
@@ -121,6 +144,7 @@ fragment {
         prepareMaterial(material);
 
         vec2 uv = variable_vertex.xy; // interpolated to pixel center
+
         vec3 noise = getNoise(uv);
         float depth = sampleDepthLinear(uv);
         vec3 origin = computeViewSpacePositionFromDepth(variable_vertex.zw, depth);
@@ -139,14 +163,12 @@ fragment {
         normal = normalize(normal);
         float occlusion = 0.0;
         for (uint i = 0u; i < kSphereSampleCount; i++) {
-            occlusion += computeAmbientOcclusion(origin, normal, noise, kSphereSamples[i]);
+            occlusion += computeAmbientOcclusionSSAO(origin, normal, noise, kSphereSamples[i]);
         }
-
         float ao = 1.0 - occlusion / float(kSphereSampleCount);
 
         // simulate user-controled ao^n with n[1, 2]
         ao = mix(ao, ao * ao, materialParams.power);
-
         material.baseColor.r = ao;
     }
 }

--- a/filament/tools/ssaogen.cpp
+++ b/filament/tools/ssaogen.cpp
@@ -32,8 +32,8 @@ int main(int argc, char** argv) {
     std::default_random_engine generator;
 
     size_t sphereSampleCount = 16;
-    std::cout << "const uint kSphereSampleCount = " << sphereSampleCount << ";" << std::endl;
-    std::cout << "const vec3 kSphereSamples[kSampleCount] = vec3[](" << std::endl;
+    std::cout << "const uint kSphereSampleCount = " << sphereSampleCount << "u;" << std::endl;
+    std::cout << "const vec3 kSphereSamples[kSphereSampleCount] = vec3[](" << std::endl;
     for (size_t i = 0; i < sphereSampleCount; i++) {
         float s = float(i) / sphereSampleCount;
         float r = random(generator);
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
         if (!(i & 1)) {
             std::cout << "   ";
         }
-        std::cout << " vec3(" << d.x << "," << d.y << "," << d.z << "),";
+        std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
         if (i & 1) {
             std::cout << std::endl;
         }
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
 
 
     size_t noiseSampleCount = 16;
-    std::cout << "const uint kNoiseSampleCount = " << sphereSampleCount << ";" << std::endl;
+    std::cout << "const uint kNoiseSampleCount = " << sphereSampleCount << "u;" << std::endl;
     std::cout << "const vec3 kNoiseSamples[kNoiseSampleCount] = vec3[](" << std::endl;
     for (size_t i = 0; i < noiseSampleCount; i++) {
         float3 d = {
@@ -68,7 +68,86 @@ int main(int argc, char** argv) {
         if ((i & 0x3) == 0) {
             std::cout << "   ";
         }
-        std::cout << " vec3(" << d.x << "," << d.y << "," << d.z << "),";
+        std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
+        if ((i & 0x3) == 0x3) {
+            std::cout << std::endl;
+        }
+    }
+    std::cout << ");" << std::endl;
+
+
+    /*
+     * This calculates a modified version of the "spiral" pattern from
+     * "Scalable Ambient Obscurance" by Morgan McGuire, that is used in g3d
+     * (https://casual-effects.com/g3d/www/index.html).
+     *
+     * We modify it further here to avoid the sin/cos per sample. The original algorithm is as
+     * follows:
+     *
+     *  s: sample count
+     *  i: sample index
+     *  phi: random angle
+     *
+     *  radius = (i + phi + 0.5) / (s - 0.5)
+     *  radius = radius^2
+     *  angle = radius * (t * 2pi) + phi * 2pi
+     *  result = { cos(angle), sin(angle), radius }
+     *
+     * The idea below is to express the above result as:
+     *
+     *     cos(angle + f(phi)), sin(angle + f(phi), radius + g(phi)
+     *
+     * This way, we can precompute cos/sin/radius that doesn't depend on phi, and also
+     * precompute a "noise" table that depend only on phi (but not i). At runtime, we can
+     * recombine both expressions using the trigonometric identities for cos(a+b) and sin(a+b).
+     *
+     *
+     * Unfortunately, because angle depends on radius^2, it's not possible to separate phi and i,
+     * as the final expression is:
+     *
+     *   g(phi) = phi^2   * 2.0 * M_PI * kSpiralTurns * K
+     *          + phi     * 2.0 * M_PI * (1.0 + kSpiralTurns * K)
+     *          + i * phi * 4.0 * M_PI * kSpiralTurns * K;   // K is a constant
+     *
+     * g(phi) has a term in "i * phi" which links both expressions.
+     *
+     * In the code below we simply assume i=1, which seems to give good results.
+     *
+     */
+
+    const float kSpiralTurns = 7.0;
+    const size_t spiralSampleCount = 7;
+    std::cout << "const uint kSpiralSampleCount = " << spiralSampleCount << "u;" << std::endl;
+    std::cout << "const vec3 kSipralSamples[kSpiralSampleCount] = vec3[](" << std::endl;
+    const float dalpha = 1.0f / (spiralSampleCount - 0.5f);
+    for (size_t i = 0; i < spiralSampleCount; i++) {
+        float radius = 0.5f * dalpha + i * dalpha;
+        float angle = radius * radius * (2 * M_PI * kSpiralTurns);
+        if ((i & 0x3) == 0) {
+            std::cout << "   ";
+        }
+        std::cout << " vec3(" << std::cos(angle) << ", " << std::sin(angle) << ", " << radius << "),";
+        if ((i & 0x3) == 0x3) {
+            std::cout << std::endl;
+        }
+    }
+    std::cout << ");" << std::endl;
+
+
+    size_t trigNoiseSampleCount = 16;
+    std::cout << "const uint kTrigNoiseSampleCount = " << sphereSampleCount << "u;" << std::endl;
+    std::cout << "const vec3 kTrigNoiseSamples[kTrigNoiseSampleCount] = vec3[](" << std::endl;
+    for (size_t i = 0; i < trigNoiseSampleCount; i++) {
+        float phi = random(generator);
+        float dr = phi * dalpha;
+        float dphi =    2.0 * M_PI * kSpiralTurns * phi * phi * dalpha * dalpha
+                + phi * 2.0 * M_PI * (1.0 + kSpiralTurns * dalpha * dalpha)
+                + phi * 4.0 * M_PI * kSpiralTurns * dalpha * dalpha;
+        float3 d = { std::cos(dphi), std::sin(dphi), dr };
+        if ((i & 0x3) == 0) {
+            std::cout << "   ";
+        }
+        std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
         if ((i & 0x3) == 0x3) {
             std::cout << std::endl;
         }


### PR DESCRIPTION
Both SSAO and SAO are available, but currently only
SSAO can be used.
SAO is more correct and produces less "halos", but
SSAO is sometimes more pleasant.

Note that this doesn't implement all the SAO optimizations
yet.