### PR TITLE
Use 64x64 DFG LUT on mobile targets

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -135,10 +135,28 @@ list(APPEND PRIVATE_HDRS ${RESGEN_HEADER})
 list(APPEND SRCS ${RESGEN_SOURCE})
 
 # ==================================================================================================
+# Configuration
+# ==================================================================================================
+if (ANDROID OR WEBGL OR IOS)
+    set(IS_MOBILE_TARGET TRUE)
+endif()
+
+# Size of the DFG lookup table
+if (NOT DFG_LUT_SIZE)
+    if (IS_MOBILE_TARGET)
+        set(DFG_LUT_SIZE 64)
+    else()
+        set(DFG_LUT_SIZE 128)
+    endif()
+endif()
+message(STATUS "DFG LUT size set to ${DFG_LUT_SIZE}x${DFG_LUT_SIZE}")
+
+# ==================================================================================================
 # Definitions
 # ==================================================================================================
 # "2" corresponds to SYSTRACE_TAG_FILEMENT (See: utils/Systrace.h)
-add_definitions(-DSYSTRACE_TAG=2 )
+add_definitions(-DSYSTRACE_TAG=2)
+add_definitions(-DFILAMENT_DFG_LUT_SIZE=${DFG_LUT_SIZE})
 
 # ==================================================================================================
 # Generate all .filamat: default material, skyboxes, and post-process
@@ -152,7 +170,7 @@ set(MATERIAL_BINS)
 file(MAKE_DIRECTORY ${MATERIAL_DIR})
 
 # Target system.
-if (ANDROID OR WEBGL OR IOS)
+if (IS_MOBILE_TARGET)
     set(MATC_TARGET mobile)
 else()
     set(MATC_TARGET desktop)
@@ -212,7 +230,7 @@ file(MAKE_DIRECTORY "${GENERATION_ROOT}/generated/data/")
 set(output_path "${GENERATION_ROOT}/generated/data/dfg.inc")
 add_custom_command(
         OUTPUT ${output_path}
-        COMMAND cmgen --quiet --ibl-dfg-multiscatter --ibl-dfg-cloth --ibl-dfg=${output_path}
+        COMMAND cmgen --quiet --size=${DFG_LUT_SIZE} --ibl-dfg-multiscatter --ibl-dfg-cloth --ibl-dfg=${output_path}
         DEPENDS cmgen
         COMMENT "Generating DFG LUT ${output_path}"
 )

--- a/filament/src/details/DFG.h
+++ b/filament/src/details/DFG.h
@@ -29,6 +29,10 @@ namespace details {
 class FEngine;
 class FTexture;
 
+#if !defined(FILAMENT_DFG_LUT_SIZE)
+#define FILAMENT_DFG_LUT_SIZE 128
+#endif
+
 class DFG {
 public:
     explicit DFG(FEngine& engine) noexcept;
@@ -57,11 +61,13 @@ private:
     FTexture* mLUT = nullptr;
 
     // make sure to use the right size here
-    static constexpr size_t DFG_LUT_SIZE = 128;
+    static constexpr size_t DFG_LUT_SIZE = FILAMENT_DFG_LUT_SIZE;
 
     // this lookup table is generated with cmgen
     static const uint16_t DFG_LUT[];
 };
+
+#undef FILAMENT_DFG_LUT_SIZE
 
 } // namespace details
 } // namespace filament


### PR DESCRIPTION
The size of the LUT is now configurable at build-time with -DDFG_LUT_SIZE=XX. It is 128x128 on desktop, 64x64 on Android, WebGL and iOS.

With this new default, the LUT uses 25 KiB per ABI instead of 94 KiB. For further savings a 32x32 LUT can be used (6 KiB).