### PR TITLE
Accept MSAA render targets in MetalBlitter

### DIFF
--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -158,9 +158,11 @@ public:
 
     id<MTLTexture> getColor();
     id<MTLTexture> getColorResolve();
-    uint8_t getColorLevel() { return level; }
     id<MTLTexture> getDepth();
     id<MTLTexture> getDepthResolve();
+    id<MTLTexture> getBlitColorSource();
+    id<MTLTexture> getBlitDepthSource();
+    uint8_t getColorLevel() { return level; }
 
 private:
     static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, MTLPixelFormat format,

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -435,6 +435,20 @@ id<MTLTexture> MetalRenderTarget::getDepthResolve() {
     return shouldResolveDepth ? depth : nil;
 }
 
+id<MTLTexture> MetalRenderTarget::getBlitColorSource() {
+    if (color) {
+        return color;
+    }
+    return multisampledColor;
+}
+
+id<MTLTexture> MetalRenderTarget::getBlitDepthSource() {
+    if (depth) {
+        return depth;
+    }
+    return multisampledDepth;
+}
+
 MTLLoadAction MetalRenderTarget::getLoadAction(const RenderPassParams& params,
         TargetBufferFlags buffer) {
     const auto clearFlags = (TargetBufferFlags) params.flags.clear;


### PR DESCRIPTION
Implement bliting from MSAA render targets to non-MSAA targets, which also resolves the samples. Also clean up `MetalBlitter` by using preprocessor macros to generate blit shaders on the fly.
