### PR TITLE
jsbindings: add setColor4Parameter and rename setColorParam.

### DIFF
--- a/docs/webgl/tutorial_redball.html
+++ b/docs/webgl/tutorial_redball.html
@@ -130,7 +130,7 @@ Replace the <strong>create material</strong> comment with the following snippet.
 <span style="color: #008000; font-weight: bold">const</span> matinstance <span style="color: #666666">=</span> material.createInstance();
 
 <span style="color: #008000; font-weight: bold">const</span> red <span style="color: #666666">=</span> [<span style="color: #666666">0.8</span>, <span style="color: #666666">0.0</span>, <span style="color: #666666">0.0</span>];
-matinstance.setColorParameter(<span style="color: #BA2121">&#39;baseColor&#39;</span>, Filament.RgbType.sRGB, red);
+matinstance.setColor3Parameter(<span style="color: #BA2121">&#39;baseColor&#39;</span>, Filament.RgbType.sRGB, red);
 matinstance.setFloatParameter(<span style="color: #BA2121">&#39;roughness&#39;</span>, <span style="color: #666666">0.5</span>);
 matinstance.setFloatParameter(<span style="color: #BA2121">&#39;clearCoat&#39;</span>, <span style="color: #666666">1.0</span>);
 matinstance.setFloatParameter(<span style="color: #BA2121">&#39;clearCoatRoughness&#39;</span>, <span style="color: #666666">0.3</span>);

--- a/docs/webgl/tutorial_redball.js
+++ b/docs/webgl/tutorial_redball.js
@@ -22,7 +22,7 @@ class App {
     const material = engine.createMaterial(filamat_url);
     const matinstance = material.createInstance();
     const red = [0.8, 0.0, 0.0];
-    matinstance.setColorParameter('baseColor', Filament.RgbType.sRGB, red);
+    matinstance.setColor3Parameter('baseColor', Filament.RgbType.sRGB, red);
     matinstance.setFloatParameter('roughness', 0.5);
     matinstance.setFloatParameter('clearCoat', 1.0);
     matinstance.setFloatParameter('clearCoatRoughness', 0.3);

--- a/web/docs/tutorial_redball.md
+++ b/web/docs/tutorial_redball.md
@@ -144,7 +144,7 @@ const material = engine.createMaterial(filamat_url);
 const matinstance = material.createInstance();
 
 const red = [0.8, 0.0, 0.0];
-matinstance.setColorParameter('baseColor', Filament.RgbType.sRGB, red);
+matinstance.setColor3Parameter('baseColor', Filament.RgbType.sRGB, red);
 matinstance.setFloatParameter('roughness', 0.5);
 matinstance.setFloatParameter('clearCoat', 1.0);
 matinstance.setFloatParameter('clearCoatRoughness', 0.3);

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -70,7 +70,8 @@ export class MaterialInstance {
     public setFloat3Parameter(name: string, value: float3): void;
     public setFloat4Parameter(name: string, value: float4): void;
     public setTextureParameter(name: string, value: Texture, sampler: TextureSampler): void;
-    public setColorParameter(name: string, ctype: RgbType, value: float3): void;
+    public setColor3Parameter(name: string, ctype: RgbType, value: float3): void;
+    public setColor4Parameter(name: string, ctype: RgbaType, value: float4): void;
     public setPolygonOffset(scale: number, constant: number): void;
     public setMaskThreshold(threshold: number): void;
     public setDoubleSided(doubleSided: boolean): void;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -838,8 +838,11 @@ class_<MaterialInstance>("MaterialInstance")
     .function("setTextureParameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, Texture* value, TextureSampler sampler), {
         self->setParameter(name.c_str(), value, sampler); }), allow_raw_pointers())
-    .function("setColorParameter", EMBIND_LAMBDA(void,
+    .function("setColor3Parameter", EMBIND_LAMBDA(void,
             (MaterialInstance* self, std::string name, RgbType type, filament::math::float3 value), {
+        self->setParameter(name.c_str(), type, value); }), allow_raw_pointers())
+    .function("setColor4Parameter", EMBIND_LAMBDA(void,
+            (MaterialInstance* self, std::string name, RgbaType type, filament::math::float4 value), {
         self->setParameter(name.c_str(), type, value); }), allow_raw_pointers())
     .function("setPolygonOffset", &MaterialInstance::setPolygonOffset)
     .function("setMaskThreshold", &MaterialInstance::setMaskThreshold)


### PR DESCRIPTION
JavaScript does not have overloading so we generally use a numeric
suffix to distinguish overloads.

Fixes #1202