### PR TITLE
fix ssao issue and rework RenderPass commandTypeFlags

### DIFF
--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -84,11 +84,27 @@ public:
     };
 
     enum CommandTypeFlags : uint8_t {
-        COLOR  = 0x1, // generate the color pass
-        DEPTH  = 0x2, // generate the depth pass
-        SHADOW = 0x4, // generate the shadow-map pass
-        DEPTH_AND_COLOR = DEPTH | COLOR, // generate both depth and color pass
+        COLOR = 0x1,    // generate the color pass only (e.g. no depth-prepass)
+        DEPTH = 0x2,    // generate the depth pass only ( e.g. shadowmap)
+        COLOR_AND_DEPTH = COLOR | DEPTH,
+
+
+        // shadow-casters are rendered in the depth buffer, regardless of blending (or alpha masking)
+        DEPTH_CONTAINS_SHADOW_CASTERS = 0x4,
+        // alpha-blended objects are not rendered in the depth buffer
+        DEPTH_FILTER_TRANSLUCENT_OBJECTS = 0x8,
+        // alpha-tested objects are not rendered in the depth buffer
+        DEPTH_FILTER_ALPHA_MASKED_OBJECTS = 0x10,
+
+
+        // generate commands for color with depth pre-pass -- in this case, we want to put
+        // objects that use alpha-testing or blending in the depth prepass.
+        COLOR_WITH_DEPTH_PREPASS = DEPTH | COLOR | DEPTH_FILTER_TRANSLUCENT_OBJECTS | DEPTH_FILTER_ALPHA_MASKED_OBJECTS,
+        // generate commands for shadow map
+        SHADOW = DEPTH | DEPTH_CONTAINS_SHADOW_CASTERS
     };
+
+
 
     // Command key encoding
     // --------------------


### PR DESCRIPTION
There are now only 2 main commandTypeFlags, COLOR and DEPTH,
indicating if we need to generate respectively COLOR and DEPTH commands.
The command generation code, only has 3 implementations: DEPTH, COLOR and
DEPTH + COLOR.

We also add "options" flags that get passed along, used to control what
goes into the the depth pass -- this because sometimes we don't want
translucent or alpha masked objects. e.g. when rendering the shadow pass,
we want the DEPTH + shadow casters regardless of if they're translucent.


With this, we can fix a SSAO problem where alpha-masked objects where
not participating when the depth pre-pass was used. Now, we add those
objects to the DEPTH if SSAO is active and MSAA is not.