### PR TITLE
ssao is now done in quarter resolution

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -33,6 +33,7 @@ class FMaterial;
 class FMaterialInstance;
 class FEngine;
 class FView;
+class RenderPass;
 } // namespace details
 
 class PostProcessManager {
@@ -58,7 +59,8 @@ public:
             FrameGraph& fg, FrameGraphResource input) noexcept;
 
 
-    FrameGraphResource ssao(FrameGraph& fg, FrameGraphResource depth,
+    FrameGraphResource ssao(FrameGraph& fg, details::RenderPass& pass,
+            filament::Viewport const& svp,
             View::AmbientOcclusionOptions const& options) noexcept;
 
     backend::Handle<backend::HwTexture> getNoSSAOTexture() const {

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -225,7 +225,7 @@ public:
     void setRenderFlags(RenderFlags flags) noexcept;
     Command const* appendSortedCommands(CommandTypeFlags const commandTypeFlags) noexcept;
     void execute(const char* name,
-            backend::Handle <backend::HwRenderTarget> renderTarget,
+            backend::Handle<backend::HwRenderTarget> renderTarget,
             backend::RenderPassParams params,
             Command const* first, Command const* last) const noexcept;
 

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -7,6 +7,10 @@ material {
             precision: high
         },
         {
+            type : float4,
+            name : resolution
+        },
+        {
             type : float,
             name : radius
         },
@@ -166,7 +170,7 @@ fragment {
         float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
 
         ivec2 ssSamplePos = ssOrigin + ivec2(ssRadius * tap.xy);
-        vec2 uvSamplePos = (vec2(ssSamplePos) + vec2(0.5)) * frameUniforms.resolution.zw;
+        vec2 uvSamplePos = (vec2(ssSamplePos) + vec2(0.5)) * materialParams.resolution.zw;
         highp float occlusionDepth = linearizeDepth(texelFetch(materialParams_depth, clampToEdge(ssSamplePos), 0).r);
         highp vec3 p = computeViewSpacePositionFromDepth(uvSamplePos * 2.0 - 1.0, occlusionDepth);
 
@@ -211,7 +215,7 @@ fragment {
         }
 
         normal = normalize(normal);
-        ivec2 ssOrigin = ivec2(uv * frameUniforms.resolution.xy);
+        ivec2 ssOrigin = ivec2(uv * materialParams.resolution.xy);
         float occlusion = 0.0;
         for (uint i = 0u; i < kSpiralSampleCount; i++) {
             occlusion += computeAmbientOcclusionSAO(i, ssDiskRadius, ssOrigin, origin, normal, noise);

--- a/filament/src/materials/ssao.mat
+++ b/filament/src/materials/ssao.mat
@@ -7,6 +7,10 @@ material {
             precision: high
         },
         {
+            type : float4,
+            name : resolution
+        },
+        {
             type : float,
             name : radius
         },


### PR DESCRIPTION
- this means that we cannot share the depth pass between ssao and color
passes, so all this code is removed, which simplify things a lot.

- the depth pass code is moved into the ssao codepath since they're now
intimately linked.

- and finals ssao shader can't rely on frameUniform which is set up with
the main buffer's size (instead of 1/4 res).