### PR TITLE
Use depth culling when computing SSAO

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -339,7 +339,9 @@ FrameGraphResource PostProcessManager::ssao(FrameGraph& fg, RenderPass& pass,
                         .format = TextureFormat::R8 });
 
                 data.ssao = builder.useRenderTarget("SSAO Target",
-                        { .attachments.color = data.ssao }, TargetBufferFlags::NONE).color;
+                        { .attachments.color = data.ssao,
+                          .attachments.depth = { data.depth, FrameGraphRenderTarget::Attachments::READ }
+                        }, TargetBufferFlags::NONE).color;
             },
             [this, fullScreenRenderPrimitive](FrameGraphPassResources const& resources,
                     SSAOPassData const& data, DriverApi& driver) {
@@ -363,6 +365,7 @@ FrameGraphResource PostProcessManager::ssao(FrameGraph& fg, RenderPass& pass,
                 PipelineState pipeline;
                 pipeline.program = mSSAOProgram;
                 pipeline.rasterState = mSSAOMaterial->getRasterState();
+                pipeline.rasterState.depthFunc = RasterState::DepthFunc::G;
 
                 driver.beginRenderPass(ssao.target, ssao.params);
                 driver.draw(pipeline, fullScreenRenderPrimitive);

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -36,7 +36,7 @@ material {
     ],
     vertexDomain : device,
     depthWrite : false,
-    depthCulling : false,
+    depthCulling : true,
     shadingModel : unlit,
     variantFilter : [ skinning ],
     culling: none
@@ -46,6 +46,7 @@ vertex {
     void materialVertex(inout MaterialVertexInputs material) {
         // far-plane in view space
         vec4 position = getPosition(); // clip-space
+        position.z = 1.0; // far plane
         material.vertex.xy = (position.xy * 0.5 + 0.5);
         material.vertex.zw = position.xy;
     }

--- a/filament/src/materials/ssao.mat
+++ b/filament/src/materials/ssao.mat
@@ -36,7 +36,7 @@ material {
     ],
     vertexDomain : device,
     depthWrite : false,
-    depthCulling : false,
+    depthCulling : true,
     shadingModel : unlit,
     variantFilter : [ skinning ],
     culling: none
@@ -46,6 +46,7 @@ vertex {
     void materialVertex(inout MaterialVertexInputs material) {
         // far-plane in view space
         vec4 position = getPosition(); // clip-space
+        position.z = 1.0; // far plane
         material.vertex.xy = (position.xy * 0.5 + 0.5);
         material.vertex.zw = position.xy;
     }


### PR DESCRIPTION
Since we have a depth buffer, we might as well use it for depth-culling,
this automatically discards the skybox's fragments -- which we can
assume won't participate in SSAO.