### PR TITLE
 handle levels of textures in the framegraph 

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1281,12 +1281,17 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
 
     rt->gl.samples = samples;
 
+    auto valueForLevel = [](size_t level, size_t value) {
+        return std::max(size_t(1), value >> level);
+    };
+
     if (targets & TargetBufferFlags::COLOR) {
         // TODO: handle multiple color attachments
         assert(color.handle);
         rt->gl.color.texture = handle_cast<GLTexture*>(color.handle);
         rt->gl.color.level = color.level;
-        assert(width == rt->gl.color.texture->width && height == rt->gl.color.texture->height);
+        assert(width == valueForLevel(color.level, rt->gl.color.texture->width) &&
+               height == valueForLevel(color.level, rt->gl.color.texture->height));
         if (rt->gl.color.texture->usage & TextureUsage::SAMPLEABLE) {
             framebufferTexture(color, rt, GL_COLOR_ATTACHMENT0);
         } else {
@@ -1308,7 +1313,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         assert(!stencil.handle || stencil.handle == depth.handle);
         rt->gl.depth.texture = handle_cast<GLTexture*>(depth.handle);
         rt->gl.depth.level = depth.level;
-        assert(width == rt->gl.depth.texture->width && height == rt->gl.depth.texture->height);
+        assert(width == valueForLevel(depth.level, rt->gl.depth.texture->width) &&
+               height == valueForLevel(depth.level, rt->gl.depth.texture->height));
         if (rt->gl.depth.texture->usage & TextureUsage::SAMPLEABLE) {
             // special case: depth & stencil requested, and both provided as the same texture
             specialCased = true;
@@ -1325,7 +1331,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             assert(depth.handle);
             rt->gl.depth.texture = handle_cast<GLTexture*>(depth.handle);
             rt->gl.depth.level = depth.level;
-            assert(width == rt->gl.depth.texture->width && height == rt->gl.depth.texture->height);
+            assert(width == valueForLevel(depth.level, rt->gl.depth.texture->width) &&
+                   height == valueForLevel(depth.level, rt->gl.depth.texture->height));
             if (rt->gl.depth.texture->usage & TextureUsage::SAMPLEABLE) {
                 framebufferTexture(depth, rt, GL_DEPTH_ATTACHMENT);
             } else {
@@ -1336,7 +1343,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             assert(stencil.handle);
             rt->gl.stencil.texture = handle_cast<GLTexture*>(stencil.handle);
             rt->gl.stencil.level = stencil.level;
-            assert(width == rt->gl.stencil.texture->width && height == rt->gl.stencil.texture->height);
+            assert(width == valueForLevel(stencil.level, rt->gl.stencil.texture->width) &&
+                   height == valueForLevel(stencil.level, rt->gl.stencil.texture->height));
             if (rt->gl.stencil.texture->usage & TextureUsage::SAMPLEABLE) {
                 framebufferTexture(stencil, rt, GL_STENCIL_ATTACHMENT);
             } else {

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -123,10 +123,6 @@ void FTexture::terminate(FEngine& engine) {
     driver.destroyTexture(mHandle);
 }
 
-static inline size_t valueForLevel(size_t level, size_t value) {
-    return std::max(size_t(1), value >> level);
-}
-
 size_t FTexture::getWidth(size_t level) const noexcept {
     return valueForLevel(level, mWidth);
 }

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -74,6 +74,10 @@ public:
 
     static size_t getFormatSize(InternalFormat format) noexcept;
 
+    static inline size_t valueForLevel(size_t level, size_t value) {
+        return std::max(size_t(1), value >> level);
+    }
+
 private:
     friend class Texture;
     backend::Handle<backend::HwTexture> mHandle;

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -59,7 +59,7 @@ public:
 
     class Builder {
     public:
-        using Attachments = FrameGraphRenderTarget::Attachments;
+        using Attachments = FrameGraphRenderTarget::AttachmentResult;
 
         Builder(Builder const&) = delete;
         Builder& operator=(Builder const&) = delete;
@@ -77,6 +77,12 @@ public:
 
         FrameGraphResource::Descriptor const& getDescriptor(FrameGraphResource const& r);
 
+        // get resource's name
+        const char* getName(FrameGraphResource const& r) const noexcept;
+
+        // return resource's sample count
+        uint8_t getSamples(FrameGraphResource const& r) const noexcept;
+
         /*
          * Use this resource as a render target.
          * This implies both reading and writing to the resource -- but unlike Builder::read()
@@ -91,8 +97,8 @@ public:
                 FrameGraphRenderTarget::Descriptor const& desc,
                 backend::TargetBufferFlags clearFlags = {}) noexcept;
 
-        // helper for single color attachment
-        Attachments useRenderTarget(FrameGraphResource texture,
+        // helper for single color attachment with WRITE access
+        FrameGraphResource useRenderTarget(FrameGraphResource texture,
                 backend::TargetBufferFlags clearFlags = {}) noexcept;
 
         // Declare that this pass has side effects outside the framegraph (i.e. it can't be culled)

--- a/filament/src/fg/FrameGraphPassResources.h
+++ b/filament/src/fg/FrameGraphPassResources.h
@@ -43,7 +43,7 @@ public:
 
     backend::Handle<backend::HwTexture> getTexture(FrameGraphResource r) const noexcept;
 
-    RenderTargetInfo getRenderTarget(FrameGraphResource r) const noexcept;
+    RenderTargetInfo getRenderTarget(FrameGraphResource r, uint8_t level = 0) const noexcept;
 
     FrameGraphResource::Descriptor const& getDescriptor(FrameGraphResource r) const noexcept;
 

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -66,7 +66,6 @@ public:
         uint8_t samples = 1;
         backend::SamplerType type = backend::SamplerType::SAMPLER_2D;     // texture target type
         backend::TextureFormat format = backend::TextureFormat::RGBA8;    // resource internal format
-        bool relaxed = false; // dimensions can be slightly adjusted
     };
 
     bool isValid() const noexcept { return index != UNINITIALIZED; }
@@ -94,18 +93,29 @@ struct Attachments {
         READ_WRITE = READ | WRITE
     };
     struct AttachmentInfo {
-        AttachmentInfo() noexcept = default;
+        // auto convert from FrameGraphResource
         AttachmentInfo(FrameGraphResource handle) noexcept : mHandle(handle) {} // NOLINT
+
+        // auto convert to FrameGraphResource
+        operator FrameGraphResource() const noexcept { return mHandle; } // NOLINT
+
+        AttachmentInfo() noexcept = default;
+
         AttachmentInfo(FrameGraphResource handle, Access access) noexcept
                 : mHandle(handle), mAccess(access) {}
 
-        operator FrameGraphResource() const noexcept { return mHandle; } // NOLINT
+        AttachmentInfo(FrameGraphResource handle, uint8_t level, Access access) noexcept
+                : mHandle(handle), mLevel(level), mAccess(access) {}
 
         bool isValid() const noexcept { return mHandle.isValid(); }
+
         FrameGraphResource getHandle() const noexcept { return mHandle; }
+        uint8_t getLevel() const noexcept { return mLevel; }
         Access getAccess() const noexcept { return mAccess; }
+
     private:
         FrameGraphResource mHandle{};
+        uint8_t mLevel = 0;
         Access mAccess = Access::READ_WRITE;
     };
 

--- a/filament/src/fg/FrameGraphResource.h
+++ b/filament/src/fg/FrameGraphResource.h
@@ -126,6 +126,18 @@ struct Descriptor {
     uint8_t samples = 1;            // # of samples
 };
 
+struct AttachmentResult {
+    enum { COLOR = 0, DEPTH = 1 };
+    static constexpr size_t COUNT = 2;
+    union {
+        std::array<FrameGraphResource, COUNT> textures = {};
+        struct {
+            FrameGraphResource color;
+            FrameGraphResource depth;
+        };
+    };
+};
+
 } // namespace FrameGraphRenderTarget
 
 

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -47,7 +47,7 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                         .format = TextureFormat::RGBA16F
                 };
                 data.output = builder.createTexture("color buffer", desc);
-                data.output = builder.useRenderTarget(data.output).textures[0];
+                data.output = builder.useRenderTarget(data.output);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &renderPassExecuted](
@@ -210,7 +210,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
     auto& renderPass = fg.addPass<RenderPassData>("Render",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
                 data.output = builder.createTexture("renderTarget");
-                data.output = builder.useRenderTarget(data.output).textures[0];
+                data.output = builder.useRenderTarget(data.output);
             },
             [=, &renderPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -233,7 +233,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
             [&](FrameGraph::Builder& builder, PostProcessPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
                 data.output = builder.createTexture("postprocess-renderTarget");
-                data.output = builder.useRenderTarget(data.output).textures[0];
+                data.output = builder.useRenderTarget(data.output);
             },
             [=, &postProcessPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -256,7 +256,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
             [&](FrameGraph::Builder& builder, CulledPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
                 data.output = builder.createTexture("unused-rendertarget");
-                data.output = builder.useRenderTarget(data.output).textures[0];
+                data.output = builder.useRenderTarget(data.output);
             },
             [=, &culledPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -300,7 +300,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                         .format = TextureFormat::RGBA16F
                 };
                 data.output = builder.createTexture("color buffer", desc);
-                data.output = builder.useRenderTarget(data.output, (TargetBufferFlags)0x80).textures[0];
+                data.output = builder.useRenderTarget(data.output, (TargetBufferFlags)0x80);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &rt1, &renderPassExecuted1](
@@ -317,7 +317,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
 
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
-                data.output = builder.useRenderTarget(renderPass1.getData().output, (TargetBufferFlags)0x40).textures[0];
+                data.output = builder.useRenderTarget(renderPass1.getData().output, (TargetBufferFlags)0x40);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &rt1, &renderPassExecuted2](


### PR DESCRIPTION
- Fix wrong assert in createRenderTarget() 

- useRenderTarget() has a helper for simple cases, make it even more
easy to use. It assumes a single color attachment w/ WRITE access,
which is a common case.

- it's now possible to use a level of a texture as an attachment of
  a rendertarget in the framegraph, by simply setting the desired level
  when specifying an attachment.

- for now, removed the (never used) feature where the framegraph could
  resize a resource under-the-hood.

- when requesting the physical renderder target by calling
  getRenderTarget(), we now must specify the same level that was used
  when the rendertarget was created. This is not ideal, and we hope
  to fix that in the future, but it'll require some serious internal
  changes (and maybe API changes)