### PR TITLE
fix our ostream << hex << char

### DIFF
--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -73,8 +73,8 @@ const char* ostream::getFormat(ostream::type t) const noexcept {
     switch (t) {
         case type::SHORT:       return mShowHex ? "0x%hx"  : "%hd";
         case type::USHORT:      return mShowHex ? "0x%hx"  : "%hu";
-        case type::CHAR:        return mShowHex ? "0x%x"   : "%c";
-        case type::UCHAR:       return mShowHex ? "0x%x"   : "%c";
+        case type::CHAR:        return "%c";
+        case type::UCHAR:       return "%c";
         case type::INT:         return mShowHex ? "0x%x"   : "%d";
         case type::UINT:        return mShowHex ? "0x%x"   : "%u";
         case type::LONG:        return mShowHex ? "0x%lx"  : "%ld";


### PR DESCRIPTION
Even when hex modifier is used, 'char' should be printed as characters,
this is particularly relevant with 0.
e.g. out << (char)0, should write a nul terminator, not "0".