### PR TITLE
Add replaceOcclusion() to AssetPipeline.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -104,6 +104,11 @@ public:
     AssetHandle generatePreview(AssetHandle source, const utils::Path& texture);
 
     /**
+     * Replaces or adds the given occlusion texture to all primitives that have BAKED_UV_ATTRIB.
+     */
+    AssetHandle replaceOcclusion(AssetHandle source, const utils::Path& texture);
+
+    /**
      * Signals that a region of a path-traced image is available (used for progress notification).
      * This can be called from any thread.
      */

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -93,6 +93,7 @@ struct App {
     AppState pushedState;
     gltfio::AssetPipeline* pipeline;
     uint32_t bakeResolution = 1024;
+    bool preserveMaterialsForExport = true;
 
     // Secondary threads might write to the following fields.
     std::shared_ptr<std::string> statusText;
@@ -626,8 +627,8 @@ int main(int argc, char** argv) {
             // Export action
             const bool canExport = app.state == BAKED;
             ImGui::PushStyleColor(ImGuiCol_Text, canExport ? enabled : disabled);
-            if (ImGui::Button("Export", ImVec2(100, 50)) && canExport) {
-                exportAsset(app);
+            if (ImGui::Button("Export...", ImVec2(100, 50)) && canExport) {
+                ImGui::OpenPopup("Export options");
             }
             if (ImGui::IsItemHovered()) {
                 ImGui::SetTooltip("Saves the baked result to disk.");
@@ -677,6 +678,16 @@ int main(int argc, char** argv) {
                     ImGui::EndPopup();
                 }
                 ImGui::PopStyleVar();
+            }
+
+            if (ImGui::BeginPopupModal("Export options", nullptr,
+                    ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar)) {
+                ImGui::Checkbox("Preserve materials", &app.preserveMaterialsForExport);
+                if (ImGui::Button("OK", ImVec2(120,0))) {
+                    ImGui::CloseCurrentPopup();
+                    exportAsset(app);
+                }
+                ImGui::EndPopup();
             }
         });
 

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -519,7 +519,11 @@ static void exportAsset(App& app) {
 
     gltfio::AssetPipeline::AssetHandle asset = app.asset->getSourceAsset();
     gltfio::AssetPipeline pipeline;
-    asset = pipeline.generatePreview(asset, "baked.png");
+    if (app.preserveMaterialsForExport) {
+        asset = pipeline.replaceOcclusion(asset, "baked.png");
+    } else {
+        asset = pipeline.generatePreview(asset, "baked.png");
+    }
     pipeline.save(asset, outPath, binPath);
 
     std::cout << "Generated " << outPath << ", " << binPath << ", and " << texPath << std::endl;


### PR DESCRIPTION
This preserves original materials but substitutes (or adds) the occlusion texture with generated AO map.  Before baking / after bake for the glTF buggy model shown below.

SSAO is disabled in both screenshots.

<img height="300" alt="Screen Shot 2019-05-23 at 9 59 38 PM" src="https://user-images.githubusercontent.com/1288904/58304011-6cce9880-7da7-11e9-9e67-8e2e870a2006.png"><img height="300" alt="Screen Shot 2019-05-23 at 10 01 00 PM" src="https://user-images.githubusercontent.com/1288904/58304012-6cce9880-7da7-11e9-9de6-3cd151ca68ed.png">
