### PR TITLE
compute the projection scale properly.

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -34,6 +34,7 @@ class FMaterialInstance;
 class FEngine;
 class FView;
 class RenderPass;
+struct CameraInfo;
 } // namespace details
 
 class PostProcessManager {
@@ -61,6 +62,7 @@ public:
 
     FrameGraphResource ssao(FrameGraph& fg, details::RenderPass& pass,
             filament::Viewport const& svp,
+            details::CameraInfo const& cameraInfo,
             View::AmbientOcclusionOptions const& options) noexcept;
 
     backend::Handle<backend::HwTexture> getNoSSAOTexture() const {

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -264,7 +264,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         pass.appendSortedCommands(RenderPass::CommandTypeFlags::DEPTH);
     }
 
-    FrameGraphResource ssao = ppm.ssao(fg, pass, svp, view.getAmbientOcclusionOptions());
+    FrameGraphResource ssao = ppm.ssao(fg, pass, svp, cameraInfo, view.getAmbientOcclusionOptions());
 
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
It used to be hard-coded, which meant the size SAO radius changed with
the screen resolution.