### PR TITLE
Fixed the move constructor and assignment operator for MeshReader::MaterialRegistry

### DIFF
--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -72,9 +72,7 @@ MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::operator=(const Mate
 }
 // Delete the implementation
 MeshReader::MaterialRegistry::~MaterialRegistry() {
-    if (mImpl != nullptr) {
-        delete mImpl;
-    }
+    delete mImpl;
 }
 
 // Default move construction

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -105,8 +105,7 @@ filament::MaterialInstance* MeshReader::MaterialRegistry::getMaterialInstance(
 void MeshReader::MaterialRegistry::registerMaterialInstance(const utils::CString& name,
         filament::MaterialInstance* materialInstance) {
     // Add the material to our map
-    //mImpl->materialMap[name] = materialInstance;
-    mImpl->materialMap.insert({name, materialInstance});
+    mImpl->materialMap[name] = materialInstance;
 }
 
 void MeshReader::MaterialRegistry::unregisterMaterialInstance(const utils::CString& name) {

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -58,26 +58,35 @@ struct MeshReader::MaterialRegistry::MaterialRegistryImpl {
 
 // Create the implementation
 MeshReader::MaterialRegistry::MaterialRegistry()
-    : mImpl(new MaterialRegistryImpl) {
+    : mImpl(new MaterialRegistryImpl()) {
 }
+
 // Deep copy the implementation
 MeshReader::MaterialRegistry::MaterialRegistry(const MaterialRegistry& rhs)
     : mImpl(new MaterialRegistryImpl(*rhs.mImpl)) {
 }
+
 MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::operator=(const MaterialRegistry& rhs) {
     *mImpl = *rhs.mImpl;
     return *this;
 }
 // Delete the implementation
 MeshReader::MaterialRegistry::~MaterialRegistry() {
-    delete mImpl;
+    if (mImpl != nullptr) {
+        delete mImpl;
+    }
 }
 
 // Default move construction
-MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&&) = default;
+MeshReader::MaterialRegistry::MaterialRegistry(MaterialRegistry&& rhs) 
+    : mImpl(nullptr) {
+    std::swap(mImpl, rhs.mImpl);
+}
 
 MeshReader::MaterialRegistry& MeshReader::MaterialRegistry::operator=(MaterialRegistry&& rhs) {
-    *mImpl = std::move(*rhs.mImpl);
+    delete mImpl;
+    mImpl = nullptr;
+    std::swap(mImpl, rhs.mImpl);
     return *this;
 }
 
@@ -96,7 +105,8 @@ filament::MaterialInstance* MeshReader::MaterialRegistry::getMaterialInstance(
 void MeshReader::MaterialRegistry::registerMaterialInstance(const utils::CString& name,
         filament::MaterialInstance* materialInstance) {
     // Add the material to our map
-    mImpl->materialMap[name] = materialInstance;
+    //mImpl->materialMap[name] = materialInstance;
+    mImpl->materialMap.insert({name, materialInstance});
 }
 
 void MeshReader::MaterialRegistry::unregisterMaterialInstance(const utils::CString& name) {


### PR DESCRIPTION
Was getting segmentation faults in my test project, due to the current move constructor not nullifying the rhs implementation pointer. This leads to it being deleted when the moved from object is destroyed.
Fix makes sure to nullify the moved from objects implementation pointer.