### PR TITLE
Fixed enum scoping in DriverEnums.h to allow compilation with gcc

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -679,10 +679,11 @@ struct PolygonOffset {
 };
 
 struct RasterState {
-    using CullingMode = CullingMode;
-    using DepthFunc = SamplerCompareFunc;
-    using BlendEquation = BlendEquation;
-    using BlendFunction = BlendFunction;
+
+    using CullingMode = filament::backend::CullingMode;
+    using DepthFunc = filament::backend::SamplerCompareFunc;
+    using BlendEquation = filament::backend::BlendEquation;
+    using BlendFunction = filament::backend::BlendFunction;
 
     RasterState() noexcept { // NOLINT(cppcoreguidelines-pro-type-member-init)
         static_assert(sizeof(RasterState) == sizeof(uint32_t),


### PR DESCRIPTION
GCC complains about these enums when the DriverEnums.h header is included
```
filament/out/debug/filament/include/backend/DriverEnums.h:683:36: error: declaration of ‘using CullingMode = enum class filament::backend::CullingMode’ [-fpermissive]
     using CullingMode = CullingMode;
                                    ^
filament/include/backend/DriverEnums.h:252:12: error: changes meaning of ‘CullingMode’ from ‘enum class filament::backend::CullingMode’ [-fpermissive]
 enum class CullingMode : uint8_t {
            ^~~~~~~~~~~
filament/include/backend/DriverEnums.h:685:40: error: declaration of ‘using BlendEquation = enum class filament::backend::BlendEquation’ [-fpermissive]
     using BlendEquation = BlendEquation;
                                        ^
filament/include/backend/DriverEnums.h:644:12: error: changes meaning of ‘BlendEquation’ from ‘enum class filament::backend::BlendEquation’ [-fpermissive]
 enum class BlendEquation : uint8_t {
            ^~~~~~~~~~~~~
filament/out/debug/filament/include/backend/DriverEnums.h:686:40: error: declaration of ‘using BlendFunction = enum class filament::backend::BlendFunction’ [-fpermissive]
     using BlendFunction = BlendFunction;
                                        ^
filament/out/debug/filament/include/backend/DriverEnums.h:648:12: error: changes meaning of ‘BlendFunction’ from ‘enum class filament::backend::BlendFunction’ [-fpermissive]
 enum class BlendFunction : uint8_t {

```
Using the explicit scoping fixes this and allows compilation of projects with GCC.