### PR TITLE
Add link_library(libc++.a)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,20 +143,9 @@ endif()
 
 if (LINUX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    if (FILAMENT_REQUIRES_CXXABI)
-        # Required in CI environment with custom libc++ and libc++abi
-        link_libraries(libc++abi.a)
-    endif()
-    # To distribute our binaries, we must remove the dependency on libc++ and libgcc.
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        link_libraries("-static-libgcc -static-libstdc++")
-        # Some Linux distributions require explicit static linking against libc++:
-        link_libraries(libc++.a)
-    endif()
-else()
-    if (FILAMENT_REQUIRES_CXXABI)
-        message("The option FILAMENT_REQUIRES_CXXABI is unsupported on this platform")
-    endif()
+    link_libraries("-static-libgcc -static-libstdc++")
+    link_libraries(libc++.a)
+    link_libraries(libc++abi.a)
 endif()
 
 if (CYGWIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ if (LINUX)
     # To distribute our binaries, we must remove the dependency on libc++ and libgcc.
     if (CMAKE_BUILD_TYPE STREQUAL "Release")
         link_libraries("-static-libgcc -static-libstdc++")
+        # Some Linux distributions require explicit static linking against libc++:
+        link_libraries(libc++.a)
     endif()
 else()
     if (FILAMENT_REQUIRES_CXXABI)

--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ If you use CMake directly instead of the build script, pass `-DENABLE_JAVA=OFF` 
 
 Make sure you've installed the following dependencies:
 
-- `clang-7`
+- `clang-7` or higher
 - `libglu1-mesa-dev`
-- `libc++-7-dev` (`libcxx-devel` and `libcxx-static` on Fedora)
-- `libc++abi-7-dev` (`libcxxabi-static` on Fedora)
+- `libc++-7-dev` (`libcxx-devel` and `libcxx-static` on Fedora) or higher
+- `libc++abi-7-dev` (`libcxxabi-static` on Fedora) or higher
 - `ninja-build`
 - `libxi-dev`
 
@@ -258,13 +258,6 @@ follows, with some caveats that are explained further down.
 $ mkdir out/cmake-release
 $ cd out/cmake-release
 $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../release/filament ../..
-```
-
-If you experience link errors you must ensure that you are using `libc++abi` by passing this
-extra parameter to `cmake`:
-
-```
--DFILAMENT_REQUIRES_CXXABI=true
 ```
 
 Your Linux distribution might default to `gcc` instead of `clang`, if that's the case invoke

--- a/build.sh
+++ b/build.sh
@@ -142,7 +142,6 @@ function build_desktop_target {
             -DIMPORT_EXECUTABLES_DIR=out \
             -DCMAKE_BUILD_TYPE=$1 \
             -DCMAKE_INSTALL_PREFIX=../${lc_target}/filament \
-            -DFILAMENT_REQUIRES_CXXABI=${FILAMENT_REQUIRES_CXXABI} \
             -DENABLE_JAVA=${ENABLE_JAVA} \
             ../..
     fi

--- a/build/linux/ci-common.sh
+++ b/build/linux/ci-common.sh
@@ -93,9 +93,6 @@ if [[ "$KOKORO_BUILD_ID" ]]; then
 
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     export LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH
-
-    # set to true to link against libc++abi
-    export FILAMENT_REQUIRES_CXXABI=false
 fi
 
 wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip


### PR DESCRIPTION
Fixes #1239 

If this works everywhere, we may not need `FILAMENT_REQUIRES_CXXABI` anymore.