### PR TITLE
fix typo in ashmem fallback code

### DIFF
--- a/filament/backend/include/private/backend/CircularBuffer.h
+++ b/filament/backend/include/private/backend/CircularBuffer.h
@@ -69,6 +69,7 @@ public:
 
 private:
     void* alloc(size_t size) noexcept;
+    void dealloc() noexcept;
 
     // pointer to the beginning of the circular buffer (constant)
     void* mData = nullptr;


### PR DESCRIPTION
There was typo that prevented the ashmem fallback code to work.
This became briefly a problem on Android Q before we fixed our
use of private APIs.