### PR TITLE
AssetPipeline: renormalize after baking transforms.

### DIFF
--- a/libs/gltfio/src/AssetPipeline.cpp
+++ b/libs/gltfio/src/AssetPipeline.cpp
@@ -833,7 +833,7 @@ void Pipeline::bakeTransform(BakedPrim* prim, const mat4f& transform, const mat3
         float3* bakedNormals = prim->bakedNormals;
         for (cgltf_size index = 0; index < numNormals; ++index) {
             float3& n = bakedNormals[index];
-            n = normalMatrix * n;
+            n = normalize(normalMatrix * n);
         }
     }
 


### PR DESCRIPTION
The rubber ducky model has non-uniform scale so it exposed a bug in the flattener. Screenshots below to see the bug and the fix.  :) 

![Screen Shot 2019-05-30 at 2 11 00 PM](https://user-images.githubusercontent.com/1288904/58665142-113f6600-82e5-11e9-8d76-5985cc623416.png)![Screen Shot 2019-05-30 at 2 10 45 PM](https://user-images.githubusercontent.com/1288904/58665146-156b8380-82e5-11e9-8365-0801eacfdf18.png)
