### PR TITLE
Overhaul UI for gltf_baker.

### DIFF
--- a/libs/filagui/CMakeLists.txt
+++ b/libs/filagui/CMakeLists.txt
@@ -9,7 +9,8 @@ set(PUBLIC_HDR_DIR include)
 # ==================================================================================================
 set(PUBLIC_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/ImGuiExtensions.h
-        ${PUBLIC_HDR_DIR}/${TARGET}/ImGuiHelper.h)
+        ${PUBLIC_HDR_DIR}/${TARGET}/ImGuiHelper.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/ImGuiMath.h)
 
 set(SRCS
         src/ImGuiHelper.cpp

--- a/libs/filagui/include/filagui/ImGuiMath.h
+++ b/libs/filagui/include/filagui/ImGuiMath.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FILAGUI_IMGUIMATH_H_
+#define FILAGUI_IMGUIMATH_H_
+
+#include <imgui.h>
+
+static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs) {
+    return { lhs.x+rhs.x, lhs.y+rhs.y };
+}
+
+static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs) {
+    return { lhs.x-rhs.x, lhs.y-rhs.y };
+}
+
+#endif /* FILAGUI_IMGUIMATH_H_ */

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -120,6 +120,14 @@ public:
      */
     FilamentAsset* createAssetFromBinary(const uint8_t* bytes, uint32_t nbytes);
 
+    /**
+     * Takes a pointer to an opaque pipeline object and returns a bundle of Filament objects.
+     *
+     * This exists solely for interop with AssetPipeline, which is optional according to the build
+     * configuration.
+     */
+    FilamentAsset* createAssetFromHandle(const void* cgltf);
+
     /** Destroys the given asset and all of its associated Filament objects. */
     void destroyAsset(const FilamentAsset* asset);
 

--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -109,6 +109,11 @@ public:
     AssetHandle replaceOcclusion(AssetHandle source, const utils::Path& texture);
 
     /**
+     * Modifies the occlusion texture URI for all primitives that have BAKED_UV_ATTRIB.
+     */
+    void setOcclusionUri(AssetHandle source, const utils::Path& texture);
+
+    /**
      * Signals that a region of a path-traced image is available (used for progress notification).
      * This can be called from any thread.
      */
@@ -147,6 +152,13 @@ public:
     void bakeAllOutputs(AssetHandle source,
             image::LinearImage targets[filament::rays::OUTPUTPLANE_COUNT],
             RenderTileCallback progress, RenderDoneCallback done, void* userData);
+
+    /**
+     * Sets the number of occlusion rays emitted for each pixel in the target image.
+     *
+     * This has an effect on subsequent calls to bake*() and render*().
+     */
+    void setSamplesPerPixel(size_t spp);
 
     static bool isFlattened(AssetHandle source);
     static bool isParameterized(AssetHandle source);

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -50,6 +50,7 @@ class SimpleViewer {
 public:
 
     static constexpr uint32_t FLAG_COLLAPSED = (1 << 0);
+    static constexpr int DEFAULT_SIDEBAR_WIDTH = 350;
 
     /**
      * Constructs a SimpleViewer that has a fixed association with the given Filament objects.
@@ -58,7 +59,7 @@ public:
      * light sources) that it owns.
      */
     SimpleViewer(filament::Engine* engine, filament::Scene* scene, filament::View* view,
-            uint32_t flags = 0);
+            uint32_t flags = 0, int sidebarWidth = DEFAULT_SIDEBAR_WIDTH);
 
     /**
      * Destroys the SimpleViewer and any Filament entities that it owns.
@@ -118,7 +119,14 @@ public:
      */
     void setUiCallback(std::function<void()> callback) { mCustomUI = callback; }
 
-    static constexpr int INITIAL_SIDEBAR_WIDTH = 350;
+    void enableWireframe(bool b) { mEnableWireframe = b; }
+    void enableSunlight(bool b) { mEnableSunlight = b; }
+    void enableDithering(bool b) { mEnableDithering = b; }
+    void enablePrepass(bool b) { mEnablePrepass = b; }
+    void enableFxaa(bool b) { mEnableFxaa = b; }
+    void enableMsaa(bool b) { mEnableMsaa = b; }
+    void enableSSAO(bool b) { mEnableSsao = b; }
+    void setIBLIntensity(float brightness) { mIblIntensity = brightness; }
 
 private:
     // Immutable properties set from the constructor.
@@ -141,14 +149,14 @@ private:
     float mIblRotation = 0.0f;
     float mSunlightIntensity = 100000.0f;
     filament::math::float3 mSunlightDirection = {0.6, -1.0, -0.8};
-    bool mShowWireframe = false;
+    bool mEnableWireframe = false;
     bool mEnableSunlight = true;
     bool mEnableDithering = true;
     bool mEnablePrepass = true;
     bool mEnableFxaa = true;
     bool mEnableMsaa = true;
     bool mEnableSsao = true;
-    int mSidebarWidth = INITIAL_SIDEBAR_WIDTH;
+    int mSidebarWidth;
     uint32_t mFlags;
 };
 
@@ -187,11 +195,11 @@ filament::math::mat4f fitIntoUnitCube(const filament::Aabb& bounds) {
 }
 
 SimpleViewer::SimpleViewer(filament::Engine* engine, filament::Scene* scene, filament::View* view,
-        uint32_t flags) :
+        uint32_t flags, int sidebarWidth) :
         mEngine(engine), mScene(scene), mView(view),
         mNames(new utils::NameComponentManager(utils::EntityManager::get())),
         mSunlight(utils::EntityManager::get().create()),
-        mFlags(flags) {
+        mFlags(flags), mSidebarWidth(sidebarWidth) {
     using namespace filament;
     LightManager::Builder(LightManager::Type::SUN)
         .color(Color::toLinear<ACCURATE>({0.98, 0.92, 0.89}))
@@ -346,7 +354,7 @@ void SimpleViewer::updateUserInterface() {
 
     const float width = ImGui::GetIO().DisplaySize.x;
     const float height = ImGui::GetIO().DisplaySize.y;
-    ImGui::SetNextWindowSize(ImVec2(INITIAL_SIDEBAR_WIDTH, height), ImGuiCond_Once);
+    ImGui::SetNextWindowSize(ImVec2(mSidebarWidth, height), ImGuiCond_Once);
     ImGui::SetNextWindowSizeConstraints(ImVec2(20, height), ImVec2(width, height));
 
     ImGui::Begin("Filament", nullptr, ImGuiWindowFlags_NoTitleBar);
@@ -397,11 +405,11 @@ void SimpleViewer::updateUserInterface() {
                     ImGui::TreePop();
                 }
             }
-            ImGui::Checkbox("Wireframe", &mShowWireframe);
+            ImGui::Checkbox("Wireframe", &mEnableWireframe);
             treeNode(mAsset->getRoot());
         }
 
-        if (mShowWireframe) {
+        if (mEnableWireframe) {
             mScene->addEntity(mAsset->getWireframe());
         } else {
             mScene->remove(mAsset->getWireframe());

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -805,6 +805,12 @@ FilamentAsset* AssetLoader::createAssetFromBinary(uint8_t const* bytes, uint32_t
     return upcast(this)->createAssetFromBinary(bytes, nbytes);
 }
 
+FilamentAsset* AssetLoader::createAssetFromHandle(const void* handle) {
+    const cgltf_data* sourceAsset = (const cgltf_data*) handle;
+    upcast(this)->createAsset(sourceAsset);
+    return upcast(this)->mResult;
+}
+
 void AssetLoader::destroyAsset(const FilamentAsset* asset) {
     upcast(this)->destroyAsset(upcast(asset));
 }

--- a/samples/app/FilamentApp.cpp
+++ b/samples/app/FilamentApp.cpp
@@ -72,6 +72,7 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
         CleanupCallback cleanupCallback, ImGuiCallback imguiCallback,
         PreRenderCallback preRender, PostRenderCallback postRender,
         size_t width, size_t height) {
+    mWindowTitle = config.title;
     std::unique_ptr<FilamentApp::Window> window(
             new FilamentApp::Window(this, config, config.title, width, height));
 
@@ -199,8 +200,13 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
     int sidebarWidth = mSidebarWidth;
 
     SDL_EventState(SDL_DROPFILE, SDL_ENABLE);
+    SDL_Window* sdlWindow = window->getSDLWindow();
 
     while (!mClosed) {
+
+        if (mWindowTitle != SDL_GetWindowTitle(sdlWindow)) {
+            SDL_SetWindowTitle(sdlWindow, mWindowTitle.c_str());
+        }
 
         if (mSidebarWidth != sidebarWidth) {
             window->configureCamerasForWindow();

--- a/samples/app/FilamentApp.h
+++ b/samples/app/FilamentApp.h
@@ -80,6 +80,7 @@ public:
     void close() { mClosed = true; }
 
     void setSidebarWidth(int width) { mSidebarWidth = width; }
+    void setWindowTitle(const char* title) { mWindowTitle = title; }
 
     size_t getSkippedFrameCount() const { return mSkippedFrames; }
 
@@ -212,6 +213,7 @@ private:
     DropCallback mDropHandler;
     int mSidebarWidth = 0;
     size_t mSkippedFrames = 0;
+    std::string mWindowTitle;
 };
 
 #endif // TNT_FILAMENT_SAMPLE_FILAMENTAPP_H

--- a/samples/materials/aoPreview.mat
+++ b/samples/materials/aoPreview.mat
@@ -4,6 +4,10 @@ material {
         {
             type : sampler2d,
             name : luma
+        },
+        {
+            type : bool,
+            name : grayscale
         }
     ],
     requires : [
@@ -11,17 +15,17 @@ material {
     ],
     shadingModel : unlit,
     culling : none,
-    depthCulling: false,
-    blending : transparent
+    depthCulling: false
 }
 
 fragment {
     void material(inout MaterialInputs material) {
         prepareMaterial(material);
-        float L = texture(materialParams_luma, getUV0()).r;
-        if (L == 0.0) {
-            discard;
+        if (materialParams.grayscale) {
+            float L = texture(materialParams_luma, getUV0()).r;
+            material.baseColor.rgb = vec3(L);
+        } else {
+            material.baseColor = texture(materialParams_luma, getUV0());
         }
-        material.baseColor.rgb = vec3(L);
     }
 }


### PR DESCRIPTION
This is complete rewrite of the baking UI although the AssetPipeline implementation is largely untouched.

As per the design doc, this makes the app somewhat usable by adding an "export options" dialog box, eliminating hardcoded filenames, removing the hidden state machine, etc.

![corset](https://user-images.githubusercontent.com/1288904/58736785-f1c33e80-83b3-11e9-92c7-3b6084e765af.png)
![shaderball](https://user-images.githubusercontent.com/1288904/58736920-6e561d00-83b4-11e9-859d-6dfdff76e53e.png)
