### PR TITLE
gltf_baker: add more options and visualizations.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -168,6 +168,13 @@ public:
      */
     void setAoRayNear(float tmin);
 
+    /**
+     * If false, disables the flood-fill that the baker performs after generating charts.
+     *
+     * This has an effect on subsequent calls to bake*().
+     */
+    void setChartDilation(bool dilate);
+
     static bool isFlattened(AssetHandle source);
     static bool isParameterized(AssetHandle source);
 

--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -160,6 +160,14 @@ public:
      */
     void setSamplesPerPixel(size_t spp);
 
+    /**
+     * Sets the ray "tmin" for occlusion rays; if this value is too small, self-intersections can
+     * occur. If it is too large then nearby surfaces might be skipped over.
+     *
+     * This has an effect on subsequent calls to bake*() and render*().
+     */
+    void setAoRayNear(float tmin);
+
     static bool isFlattened(AssetHandle source);
     static bool isParameterized(AssetHandle source);
 

--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -175,6 +175,13 @@ public:
      */
     void setChartDilation(bool dilate);
 
+    /**
+     * If false, disables the denoise pass after path tracing.
+     *
+     * This has an effect on subsequent calls to bake*() and render*().
+     */
+    void setDenoiser(bool denoise);
+
     static bool isFlattened(AssetHandle source);
     static bool isParameterized(AssetHandle source);
 

--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -125,6 +125,16 @@ public:
      */
     using RenderDoneCallback = filament::rays::DoneCallback;
 
+    struct RenderOptions {
+        RenderTileCallback progress = nullptr;
+        RenderDoneCallback done = nullptr;
+        void* userData = nullptr;
+        size_t samplesPerPixel = 256;
+        float aoRayNear = std::numeric_limits<float>::epsilon() * 100.0f;
+        bool enableDenoise = true;
+        bool enableDilation = true;
+    };
+
     /**
      * Consumes a parameterized glTF asset and produces a single-channel image with ambient
      * occlusion. Requires the presence of BAKED_UV_ATTRIB in the source asset.
@@ -134,7 +144,7 @@ public:
      * Clients should not destroy the AssetPipeline before the done callback is triggered.
      */
     void bakeAmbientOcclusion(AssetHandle source, image::LinearImage target,
-            RenderTileCallback progress, RenderDoneCallback done, void* userData);
+            const RenderOptions& options);
 
     /**
      * Consumes a glTF asset and produces a single-channel image with ambient occlusion rendered
@@ -145,42 +155,13 @@ public:
      * Clients should not destroy the AssetPipeline before the done callback is triggered.
      */
     void renderAmbientOcclusion(AssetHandle source, image::LinearImage target,
-            const filament::rays::SimpleCamera& camera, RenderTileCallback progress,
-            RenderDoneCallback done, void* userData);
+            const filament::rays::SimpleCamera& camera,
+            const RenderOptions& options);
 
     /** Similar to bakeAmbientOcclusion but produces all outputs. */
     void bakeAllOutputs(AssetHandle source,
             image::LinearImage targets[filament::rays::OUTPUTPLANE_COUNT],
-            RenderTileCallback progress, RenderDoneCallback done, void* userData);
-
-    /**
-     * Sets the number of occlusion rays emitted for each pixel in the target image.
-     *
-     * This has an effect on subsequent calls to bake*() and render*().
-     */
-    void setSamplesPerPixel(size_t spp);
-
-    /**
-     * Sets the ray "tmin" for occlusion rays; if this value is too small, self-intersections can
-     * occur. If it is too large then nearby surfaces might be skipped over.
-     *
-     * This has an effect on subsequent calls to bake*() and render*().
-     */
-    void setAoRayNear(float tmin);
-
-    /**
-     * If false, disables the flood-fill that the baker performs after generating charts.
-     *
-     * This has an effect on subsequent calls to bake*().
-     */
-    void setChartDilation(bool dilate);
-
-    /**
-     * If false, disables the denoise pass after path tracing.
-     *
-     * This has an effect on subsequent calls to bake*() and render*().
-     */
-    void setDenoiser(bool denoise);
+            const RenderOptions& options);
 
     static bool isFlattened(AssetHandle source);
     static bool isParameterized(AssetHandle source);

--- a/libs/gltfio/src/AssetPipeline.cpp
+++ b/libs/gltfio/src/AssetPipeline.cpp
@@ -118,6 +118,7 @@ public:
             void* userData);
 
     void setSamplesPerPixel(size_t spp) { mSamplesPerPixel = spp; }
+    void setAoRayNear(float tmin) { mAoRayNear = tmin; }
 
     ~Pipeline();
 
@@ -136,6 +137,7 @@ private:
     uint32_t mFlattenFlags;
     vector<cgltf_data*> mSourceAssets;
     size_t mSamplesPerPixel = 256;
+    float mAoRayNear = std::numeric_limits<float>::epsilon() * 10.0f;
 
     struct {
         ArrayHolder<cgltf_data> resultAssets;
@@ -754,6 +756,7 @@ void Pipeline::bakeAmbientOcclusion(const cgltf_data* sourceAsset, image::Linear
         .uvCamera()
         .denoise()
         .samplesPerPixel(mSamplesPerPixel)
+        .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
         .tileCallback(onTile, userData)
         .doneCallback(onDone, userData);
 
@@ -774,6 +777,7 @@ void Pipeline::renderAmbientOcclusion(const cgltf_data* sourceAsset, image::Line
         .filmCamera(camera)
         .denoise()
         .samplesPerPixel(mSamplesPerPixel)
+        .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
         .tileCallback(onTile, userData)
         .doneCallback(onDone, userData);
 
@@ -798,6 +802,7 @@ void Pipeline::bakeAllOutputs(const cgltf_data* sourceAsset,
         .uvCamera()
         .denoise()
         .samplesPerPixel(mSamplesPerPixel)
+        .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
         .tileCallback(onTile, userData)
         .doneCallback(onDone, userData);
 
@@ -1732,6 +1737,11 @@ void AssetPipeline::bakeAllOutputs(AssetHandle source,
 void AssetPipeline::setSamplesPerPixel(size_t spp) {
     Pipeline* impl = (Pipeline*) mImpl;
     impl->setSamplesPerPixel(spp);
+}
+
+void AssetPipeline::setAoRayNear(float tmin) {
+    Pipeline* impl = (Pipeline*) mImpl;
+    impl->setAoRayNear(tmin);
 }
 
 bool AssetPipeline::isFlattened(AssetHandle source) {

--- a/libs/gltfio/src/AssetPipeline.cpp
+++ b/libs/gltfio/src/AssetPipeline.cpp
@@ -119,6 +119,7 @@ public:
 
     void setSamplesPerPixel(size_t spp) { mSamplesPerPixel = spp; }
     void setAoRayNear(float tmin) { mAoRayNear = tmin; }
+    void setChartDilation(bool dilate) { mChartDilation = dilate; }
 
     ~Pipeline();
 
@@ -138,6 +139,7 @@ private:
     vector<cgltf_data*> mSourceAssets;
     size_t mSamplesPerPixel = 256;
     float mAoRayNear = std::numeric_limits<float>::epsilon() * 10.0f;
+    bool mChartDilation = true;
 
     struct {
         ArrayHolder<cgltf_data> resultAssets;
@@ -753,7 +755,7 @@ void Pipeline::bakeAmbientOcclusion(const cgltf_data* sourceAsset, image::Linear
     builder
         .meshes(meshes, numMeshes)
         .outputPlane(filament::rays::AMBIENT_OCCLUSION, target)
-        .uvCamera()
+        .uvCamera(mChartDilation)
         .denoise()
         .samplesPerPixel(mSamplesPerPixel)
         .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
@@ -799,7 +801,7 @@ void Pipeline::bakeAllOutputs(const cgltf_data* sourceAsset,
         .outputPlane(BENT_NORMALS, targets[(int) BENT_NORMALS])
         .outputPlane(MESH_NORMALS, targets[(int) MESH_NORMALS])
         .outputPlane(MESH_POSITIONS, targets[(int) MESH_POSITIONS])
-        .uvCamera()
+        .uvCamera(mChartDilation)
         .denoise()
         .samplesPerPixel(mSamplesPerPixel)
         .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
@@ -1742,6 +1744,11 @@ void AssetPipeline::setSamplesPerPixel(size_t spp) {
 void AssetPipeline::setAoRayNear(float tmin) {
     Pipeline* impl = (Pipeline*) mImpl;
     impl->setAoRayNear(tmin);
+}
+
+void AssetPipeline::setChartDilation(bool dilate) {
+    Pipeline* impl = (Pipeline*) mImpl;
+    impl->setChartDilation(dilate);
 }
 
 bool AssetPipeline::isFlattened(AssetHandle source) {

--- a/libs/gltfio/src/AssetPipeline.cpp
+++ b/libs/gltfio/src/AssetPipeline.cpp
@@ -120,6 +120,7 @@ public:
     void setSamplesPerPixel(size_t spp) { mSamplesPerPixel = spp; }
     void setAoRayNear(float tmin) { mAoRayNear = tmin; }
     void setChartDilation(bool dilate) { mChartDilation = dilate; }
+    void setDenoiser(bool denoise) { mApplyDenoiser = denoise; }
 
     ~Pipeline();
 
@@ -140,6 +141,7 @@ private:
     size_t mSamplesPerPixel = 256;
     float mAoRayNear = std::numeric_limits<float>::epsilon() * 10.0f;
     bool mChartDilation = true;
+    bool mApplyDenoiser = true;
 
     struct {
         ArrayHolder<cgltf_data> resultAssets;
@@ -756,7 +758,7 @@ void Pipeline::bakeAmbientOcclusion(const cgltf_data* sourceAsset, image::Linear
         .meshes(meshes, numMeshes)
         .outputPlane(filament::rays::AMBIENT_OCCLUSION, target)
         .uvCamera(mChartDilation)
-        .denoise()
+        .denoise(mApplyDenoiser)
         .samplesPerPixel(mSamplesPerPixel)
         .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
         .tileCallback(onTile, userData)
@@ -777,7 +779,7 @@ void Pipeline::renderAmbientOcclusion(const cgltf_data* sourceAsset, image::Line
         .meshes(meshes, numMeshes)
         .outputPlane(filament::rays::AMBIENT_OCCLUSION, target)
         .filmCamera(camera)
-        .denoise()
+        .denoise(mApplyDenoiser)
         .samplesPerPixel(mSamplesPerPixel)
         .occlusionRayBounds(mAoRayNear, std::numeric_limits<float>::infinity())
         .tileCallback(onTile, userData)
@@ -1749,6 +1751,11 @@ void AssetPipeline::setAoRayNear(float tmin) {
 void AssetPipeline::setChartDilation(bool dilate) {
     Pipeline* impl = (Pipeline*) mImpl;
     impl->setChartDilation(dilate);
+}
+
+void AssetPipeline::setDenoiser(bool denoise) {
+    Pipeline* impl = (Pipeline*) mImpl;
+    impl->setDenoiser(denoise);
 }
 
 bool AssetPipeline::isFlattened(AssetHandle source) {

--- a/libs/rays/include/rays/PathTracer.h
+++ b/libs/rays/include/rays/PathTracer.h
@@ -132,6 +132,11 @@ public:
          */
         Builder& samplesPerPixel(size_t numSamples);
 
+        /**
+         * Sets the tmin and tfar for secondary rays.
+         */
+        Builder& occlusionRayBounds(float aoRayNear, float aoRayFar);
+
         PathTracer build();
     private:
         Config mConfig;

--- a/libs/rays/include/rays/PathTracer.h
+++ b/libs/rays/include/rays/PathTracer.h
@@ -77,6 +77,7 @@ public:
         size_t samplesPerPixel = 256;
         SimpleCamera filmCamera;
         bool uvCamera = false;
+        bool dilate = true;
         bool denoise = false;
         TileCallback tileCallback = nullptr;
         void* tileUserData = nullptr;
@@ -109,7 +110,7 @@ public:
         /**
          * Enables a UV-based cameras used for light map baking.
          */
-        Builder& uvCamera();
+        Builder& uvCamera(bool dilate = true);
 
         /**
          * Executes OpenImageDenoise after rendering the complete image.

--- a/libs/rays/include/rays/PathTracer.h
+++ b/libs/rays/include/rays/PathTracer.h
@@ -115,7 +115,7 @@ public:
         /**
          * Executes OpenImageDenoise after rendering the complete image.
          */
-        Builder& denoise();
+        Builder& denoise(bool enable = true);
 
         /**
          * Signals that a region within each render target has become available, typically used for

--- a/libs/rays/src/PathTracer.cpp
+++ b/libs/rays/src/PathTracer.cpp
@@ -304,12 +304,15 @@ static void renderTileToGbuffer(EmbreeContext* context, PixelRectangle rect) {
 static void dilateCharts(EmbreeContext* context) {
     LinearImage& ao = context->config.renderTargets[(int) AMBIENT_OCCLUSION];
     LinearImage& meshNormals = context->config.renderTargets[(int) MESH_NORMALS];
+    LinearImage& bentNormals = context->config.renderTargets[(int) BENT_NORMALS];
     auto presence = [] (const LinearImage& normals, uint32_t col, uint32_t row, void*) {
         return normals.getPixelRef(col, row)[0] != EMPTY_SENTINEL;
     };
-    auto coords = image::computeCoordField(meshNormals, presence, nullptr);
-    auto dilated = image::voronoiFromCoordField(coords, ao);
+    LinearImage coords = image::computeCoordField(meshNormals, presence, nullptr);
+    LinearImage dilated = image::voronoiFromCoordField(coords, ao);
     blitImage(ao, dilated);
+    dilated = image::voronoiFromCoordField(coords, bentNormals);
+    blitImage(bentNormals, dilated);
 }
 
 static void denoise(EmbreeContext* context) {

--- a/libs/rays/src/PathTracer.cpp
+++ b/libs/rays/src/PathTracer.cpp
@@ -99,8 +99,9 @@ PathTracer::Builder& PathTracer::Builder::filmCamera(const SimpleCamera& filmCam
     return *this;
 }
 
-PathTracer::Builder& PathTracer::Builder::uvCamera() {
+PathTracer::Builder& PathTracer::Builder::uvCamera(bool dilate) {
     mConfig.uvCamera = true;
+    mConfig.dilate = dilate;
     return *this;
 }
 
@@ -549,7 +550,9 @@ bool PathTracer::render() {
                 context->config.tileCallback(rect.topLeft, rect.bottomRight,
                         context->config.tileUserData);
             }, [](EmbreeContext* context) {
-                dilateCharts(context);
+                if (context->config.dilate) {
+                    dilateCharts(context);
+                }
                 if (context->config.denoise) {
                     denoise(context);
                 }

--- a/libs/rays/src/PathTracer.cpp
+++ b/libs/rays/src/PathTracer.cpp
@@ -105,8 +105,8 @@ PathTracer::Builder& PathTracer::Builder::uvCamera(bool dilate) {
     return *this;
 }
 
-PathTracer::Builder& PathTracer::Builder::denoise() {
-    mConfig.denoise = true;
+PathTracer::Builder& PathTracer::Builder::denoise(bool enable) {
+    mConfig.denoise = enable;
     return *this;
 }
 

--- a/libs/rays/src/PathTracer.cpp
+++ b/libs/rays/src/PathTracer.cpp
@@ -126,6 +126,12 @@ PathTracer::Builder& PathTracer::Builder::samplesPerPixel(size_t numSamples) {
     return *this;
 }
 
+PathTracer::Builder& PathTracer::Builder::occlusionRayBounds(float aoRayNear, float aoRayFar) {
+    mConfig.aoRayNear = aoRayNear;
+    mConfig.aoRayFar = aoRayFar;
+    return *this;
+}
+
 PathTracer PathTracer::Builder::build() {
     // TODO: check for valid configuration (consistent sizes etc)
     return PathTracer(mConfig);

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -755,6 +755,14 @@ int main(int argc, char** argv) {
             ImGui::GetStyle().FrameRounding = 20;
             ImGui::GetStyle().ItemSpacing.x = 8;
 
+            // Model stats
+            if (app.viewerAsset) {
+                filament::Aabb aabb = app.viewerAsset->getBoundingBox();
+                ImGui::TextColored({1, 0, 1, 1}, "min (%g, %g, %g)", aabb.min.x, aabb.min.y, aabb.min.z);
+                ImGui::TextColored({1, 0, 1, 1}, "max (%g, %g, %g)", aabb.max.x, aabb.max.y, aabb.max.z);
+                ImGui::Spacing();
+            }
+
             // Status text
             if (app.statusText.size()) {
                 ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, {10, 10} );

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -126,6 +126,7 @@ struct BakerApp {
         int samplesPerPixel = 256;
         float aoRayNear = std::numeric_limits<float>::epsilon() * 10.0f;
         bool dilateCharts = true;
+        bool applyDenoiser = true;
     } bakeOptions;
 
     struct {
@@ -476,6 +477,7 @@ static void executeTestRender(BakerApp& app) {
     });
     app.pipeline->setSamplesPerPixel(app.bakeOptions.samplesPerPixel);
     app.pipeline->setAoRayNear(app.bakeOptions.aoRayNear);
+    app.pipeline->setDenoiser(app.bakeOptions.applyDenoiser);
     app.pipeline->renderAmbientOcclusion(currentAsset, app.ambientOcclusion, camera, onRenderTile,
             onRenderDone, &app);
 }
@@ -546,6 +548,7 @@ static void executeBakeAo(BakerApp& app) {
         app.pipeline->setSamplesPerPixel(app.bakeOptions.samplesPerPixel);
         app.pipeline->setAoRayNear(app.bakeOptions.aoRayNear);
         app.pipeline->setChartDilation(app.bakeOptions.dilateCharts);
+        app.pipeline->setDenoiser(app.bakeOptions.applyDenoiser);
         app.pipeline->bakeAllOutputs(app.currentAsset, outputs, onRenderTile, onRenderDone, &app);
     };
 
@@ -844,6 +847,7 @@ int main(int argc, char** argv) {
                         std::numeric_limits<float>::epsilon() * 10.0f, 10);
 
                 ImGui::Checkbox("Dilate charts", &app.bakeOptions.dilateCharts);
+                ImGui::Checkbox("Apply denoiser", &app.bakeOptions.applyDenoiser);
             }
 
             // Modals

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -346,7 +346,7 @@ static void updateViewerImage(BakerApp& app) {
     const int channels = image.getChannels();
     const void* data = image.getPixelRef();
     const Texture::InternalFormat internalFormat = channels == 1 ?
-            Texture::InternalFormat::R8 : Texture::InternalFormat::RGB8;
+            Texture::InternalFormat::R32F : Texture::InternalFormat::RGB32F;
     const Texture::Format format = channels == 1 ? Texture::Format::R : Texture::Format::RGB;
 
     // Create a brand new texture object if necessary.
@@ -502,11 +502,6 @@ static void executeBakeAo(BakerApp& app) {
 
     auto onRenderDone = makeDoneCallback([](BakerApp* app) {
         app->requestViewerUpdate = true;
-
-        // TODO: users can preview bent normals as they are being rendered so we should
-        // consider doing the vector-to-colors conversion in real time rather than waiting
-        // till the end.
-        app->bentNormals = vectorsToColors(app->bentNormals);
 
         // Generate a simple red-green UV visualization texture.
         const utils::Path folder = app->filename.getAbsolutePath().getParent();

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -63,7 +63,8 @@ enum class Visualization : int {
     MESH_PREVIEW_AO,
     MESH_PREVIEW_UV,
     IMAGE_OCCLUSION,
-    IMAGE_BENT_NORMALS
+    IMAGE_BENT_NORMALS,
+    IMAGE_MESH_NORMALS
 };
 
 static const char* DEFAULT_IBL = "envs/venetian_crossroads";
@@ -334,6 +335,9 @@ static void updateViewerImage(BakerApp& app) {
         case Visualization::IMAGE_BENT_NORMALS:
             image = app.bentNormals;
             break;
+        case Visualization::IMAGE_MESH_NORMALS:
+            image = app.meshNormals;
+            break;
         default:
             return;
     }
@@ -378,6 +382,7 @@ static void updateViewer(BakerApp& app) {
             break;
         case Visualization::IMAGE_OCCLUSION:
         case Visualization::IMAGE_BENT_NORMALS:
+        case Visualization::IMAGE_MESH_NORMALS:
             updateViewerImage(app);
             break;
     }
@@ -796,12 +801,14 @@ int main(int argc, char** argv) {
                 } else if (!app.modifiedAsset) {
                     addOption("2D texture with occlusion", '2', RV::IMAGE_OCCLUSION);
                     addOption("2D texture with bent normals", '3', RV::IMAGE_BENT_NORMALS);
+                    addOption("2D texture with mesh normals", '4', RV::IMAGE_MESH_NORMALS);
                 } else {
                     addOption("3D model with modified materials", '2', RV::MESH_MODIFIED);
                     addOption("3D model with new occlusion only", '3', RV::MESH_PREVIEW_AO);
                     addOption("3D model with UV visualization", '4', RV::MESH_PREVIEW_UV);
                     addOption("2D texture with occlusion", '5', RV::IMAGE_OCCLUSION);
                     addOption("2D texture with bent normals", '6', RV::IMAGE_BENT_NORMALS);
+                    addOption("2D texture with mesh normals", '7', RV::IMAGE_MESH_NORMALS);
                 }
                 if (app.visualization != previousVisualization) {
                     app.requestViewerUpdate = true;
@@ -901,7 +908,8 @@ int main(int argc, char** argv) {
         app.overlayQuad.scene = app.overlayQuad.view->getScene();
         app.overlayQuad.scene->remove(app.overlayQuad.entity);
         const bool showOverlay = app.visualization == Visualization::IMAGE_OCCLUSION
-                || app.visualization == Visualization::IMAGE_BENT_NORMALS;
+                || app.visualization == Visualization::IMAGE_BENT_NORMALS
+                || app.visualization == Visualization::IMAGE_MESH_NORMALS;
         if (showOverlay) {
             createQuadRenderable(app);
             app.overlayQuad.scene->addEntity(app.overlayQuad.entity);

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -125,6 +125,7 @@ struct BakerApp {
         uint32_t resolution = 1024;
         int samplesPerPixel = 256;
         float aoRayNear = std::numeric_limits<float>::epsilon() * 10.0f;
+        bool dilateCharts = true;
     } bakeOptions;
 
     struct {
@@ -544,6 +545,7 @@ static void executeBakeAo(BakerApp& app) {
         };
         app.pipeline->setSamplesPerPixel(app.bakeOptions.samplesPerPixel);
         app.pipeline->setAoRayNear(app.bakeOptions.aoRayNear);
+        app.pipeline->setChartDilation(app.bakeOptions.dilateCharts);
         app.pipeline->bakeAllOutputs(app.currentAsset, outputs, onRenderTile, onRenderDone, &app);
     };
 
@@ -840,6 +842,8 @@ int main(int argc, char** argv) {
                 ImGui::InputFloat("Secondary ray tmin", &app.bakeOptions.aoRayNear,
                         std::numeric_limits<float>::epsilon(),
                         std::numeric_limits<float>::epsilon() * 10.0f, 10);
+
+                ImGui::Checkbox("Dilate charts", &app.bakeOptions.dilateCharts);
             }
 
             // Modals

--- a/samples/materials/aoPreview.mat
+++ b/samples/materials/aoPreview.mat
@@ -25,7 +25,8 @@ fragment {
             float L = texture(materialParams_luma, getUV0()).r;
             material.baseColor.rgb = vec3(L);
         } else {
-            material.baseColor = texture(materialParams_luma, getUV0());
+            float3 v = texture(materialParams_luma, getUV0()).rgb;
+            material.baseColor.rgb = v * 0.5 + 0.5;
         }
     }
 }


### PR DESCRIPTION
The new normals visualizer reveals why the shader ball is splotchy in one area:

![Screen Shot 2019-06-03 at 11 35 48 AM](https://user-images.githubusercontent.com/1288904/58825652-c62e9700-85f3-11e9-94f5-9e9029b0c7ca.png)


