### PR TITLE
Refactor MaterialBuilder chunks, findProperties

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -36,6 +36,7 @@
 namespace filamat {
 
 struct MaterialInfo;
+class ChunkContainer;
 
 class UTILS_PUBLIC MaterialBuilderBase {
 public:
@@ -337,6 +338,8 @@ private:
     bool runStaticCodeAnalysis() noexcept;
 
     bool checkLiteRequirements() noexcept;
+
+    void writeChunks(ChunkContainer& container, MaterialInfo& info) const noexcept;
 
     bool isLit() const noexcept { return mShading != filament::Shading::UNLIT; }
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -376,13 +376,20 @@ bool MaterialBuilder::runStaticCodeAnalysis() noexcept {
 #ifndef FILAMAT_LITE
     GLSLTools glslTools;
 
+    // Some fields in MaterialInputs only exist if the property is set (e.g: normal, subsurface
+    // for cloth shading model). Give our shader all properties. This will enable us to parse and
+    // static code analyse the AST.
+    MaterialBuilder::PropertyList allProperties;
+    std::fill_n(allProperties, MATERIAL_PROPERTIES_COUNT, true);
+    ShaderModel model;
+    std::string shaderCodeAllProperties = peek(ShaderType::FRAGMENT, model, allProperties);
+
     // Populate mProperties with the properties set in the shader.
-    if (!glslTools.findProperties(*this, mProperties, mTargetApi)) {
+    if (!glslTools.findProperties(shaderCodeAllProperties, mProperties, mTargetApi, model)) {
         return false;
     }
 
     // At this point the shader is syntactically correct. Perform semantic analysis now.
-    ShaderModel model;
 
     std::string shaderCode = peek(ShaderType::VERTEX, model, mProperties);
     bool result = glslTools.analyzeVertexShader(shaderCode, model, mTargetApi);

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -51,9 +51,7 @@ Package PostprocessMaterialBuilder::build() {
     // Create chunk tree.
     ChunkContainer container;
 
-    auto version = std::make_unique<SimpleFieldChunk<uint32_t>>(
-            ChunkType::PostProcessVersion, filament::MATERIAL_VERSION);
-    container.addChild(std::move(version));
+    container.addSimpleChild<uint32_t>(ChunkType::PostProcessVersion, filament::MATERIAL_VERSION);
 
     std::vector<TextEntry> glslEntries;
     std::vector<SpirvEntry> spirvEntries;
@@ -189,29 +187,22 @@ Package PostprocessMaterialBuilder::build() {
     }
 
     // Emit GLSL chunks
-    using namespace std;
-    auto dicGlslChunk = make_unique<filamat::DictionaryTextChunk>(std::move(glslDictionary), ChunkType::DictionaryGlsl);
-    auto glslChunk = make_unique<MaterialTextChunk>(std::move(glslEntries), std::move(glslDictionary), ChunkType::MaterialGlsl);
     if (!glslEntries.empty()) {
-        container.addChild(std::move(dicGlslChunk));
-        container.addChild(std::move(glslChunk));
+        container.addChild<filamat::DictionaryTextChunk>(std::move(glslDictionary), ChunkType::DictionaryGlsl);
+        container.addChild<MaterialTextChunk>(std::move(glslEntries), std::move(glslDictionary), ChunkType::MaterialGlsl);
     }
 
 #ifndef FILAMAT_LITE
     // Emit SPIRV chunks
-    auto dicSpirvChunk = make_unique<filamat::DictionarySpirvChunk>(std::move(spirvDictionary));
-    auto spirvChunk = make_unique<MaterialSpirvChunk>(std::move(spirvEntries));
     if (!spirvEntries.empty()) {
-        container.addChild(std::move(dicSpirvChunk));
-        container.addChild(std::move(spirvChunk));
+        container.addChild<filamat::DictionarySpirvChunk>(std::move(spirvDictionary));
+        container.addChild<MaterialSpirvChunk>(std::move(spirvEntries));
     }
 
     // Emit Metal chunks
-    auto dicMetalChunk = make_unique<filamat::DictionaryTextChunk>(std::move(metalDictionary), ChunkType::DictionaryMetal);
-    auto metalChunk = make_unique<MaterialTextChunk>(std::move(metalEntries), std::move(metalDictionary), ChunkType::MaterialMetal);
     if (!metalEntries.empty()) {
-        container.addChild(std::move(dicMetalChunk));
-        container.addChild(std::move(metalChunk));
+        container.addChild<filamat::DictionaryTextChunk>(std::move(metalDictionary), ChunkType::DictionaryMetal);
+        container.addChild<MaterialTextChunk>(std::move(metalEntries), std::move(metalDictionary), ChunkType::MaterialMetal);
     }
 #endif
 

--- a/libs/filamat/src/eiff/ChunkContainer.cpp
+++ b/libs/filamat/src/eiff/ChunkContainer.cpp
@@ -18,10 +18,6 @@
 
 namespace filamat {
 
-void ChunkContainer::addChild(ChunkPtr&& chunk) {
-    mChildren.push_back(std::move(chunk));
-}
-
 // This calls is relatively expensive since it performs a dry run of the flattering process,
 // using a flattener that will calculate offets but will not write. It should be used only once
 // when the container is about to be flattened.
@@ -30,7 +26,7 @@ size_t ChunkContainer::getSize() const {
 }
 
 size_t ChunkContainer::flatten(Flattener& f) const {
-    for (auto& chunk: mChildren) {
+    for (const auto& chunk: mChildren) {
         f.writeUint64(static_cast<uint64_t>(chunk->getType()));
         f.writeSizePlaceholder();
         chunk->flatten(f);

--- a/libs/filamat/src/eiff/ChunkContainer.cpp
+++ b/libs/filamat/src/eiff/ChunkContainer.cpp
@@ -18,8 +18,8 @@
 
 namespace filamat {
 
-void ChunkContainer::addChild(Chunk* chunk) {
-    mChildren.push_back(chunk);
+void ChunkContainer::addChild(ChunkPtr&& chunk) {
+    mChildren.push_back(std::move(chunk));
 }
 
 // This calls is relatively expensive since it performs a dry run of the flattering process,
@@ -30,7 +30,7 @@ size_t ChunkContainer::getSize() const {
 }
 
 size_t ChunkContainer::flatten(Flattener& f) const {
-    for (Chunk* chunk: mChildren) {
+    for (auto& chunk: mChildren) {
         f.writeUint64(static_cast<uint64_t>(chunk->getType()));
         f.writeSizePlaceholder();
         chunk->flatten(f);

--- a/libs/filamat/src/eiff/ChunkContainer.h
+++ b/libs/filamat/src/eiff/ChunkContainer.h
@@ -25,19 +25,33 @@
 
 #include <filament/MaterialChunkType.h>
 
+#include "SimpleFieldChunk.h"
+
 namespace filamat {
 
 class ChunkContainer {
 public:
-    using ChunkPtr = std::unique_ptr<Chunk>;
-
     ChunkContainer() = default;
     ~ChunkContainer() = default;
-    void addChild(ChunkPtr&& chunk);
-    size_t getSize() const;
 
+    template <typename T,
+             std::enable_if_t<std::is_base_of<Chunk, T>::value, int> = 0,
+             typename... Args>
+    void addChild(Args&&... args) {
+        mChildren.emplace_back(new T(std::forward<Args>(args)...));
+    }
+
+    // Helper method to add a SimpleFieldChunk to this ChunkContainer.
+    template <typename T, typename... Args>
+    void addSimpleChild(Args&&... args) {
+        addChild<SimpleFieldChunk<T>>(std::forward<Args>(args)...);
+    }
+
+    size_t getSize() const;
     size_t flatten(Flattener& f) const;
+
 private:
+    using ChunkPtr = std::unique_ptr<Chunk>;
     std::vector<ChunkPtr> mChildren;
 };
 

--- a/libs/filamat/src/eiff/ChunkContainer.h
+++ b/libs/filamat/src/eiff/ChunkContainer.h
@@ -17,6 +17,7 @@
 #ifndef TNT_FILAMAT_CHUNK_CONTAINER_H
 #define TNT_FILAMAT_CHUNK_CONTAINER_H
 
+#include <memory>
 #include <vector>
 
 #include "Chunk.h"
@@ -28,15 +29,16 @@ namespace filamat {
 
 class ChunkContainer {
 public:
+    using ChunkPtr = std::unique_ptr<Chunk>;
+
     ChunkContainer() = default;
     ~ChunkContainer() = default;
-    // Copy the POINTER to the chunk and doesn't make a copy. The Chunk* is used later when flattening
-    // The Chunk object must be valid until flatten is called (so for the life duration of ChunkContainer).
-    void addChild(Chunk* chunk);
+    void addChild(ChunkPtr&& chunk);
     size_t getSize() const;
+
     size_t flatten(Flattener& f) const;
 private:
-    std::vector<Chunk*> mChildren;
+    std::vector<ChunkPtr> mChildren;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/DictionarySpirvChunk.cpp
+++ b/libs/filamat/src/eiff/DictionarySpirvChunk.cpp
@@ -20,7 +20,7 @@
 
 namespace filamat {
 
-DictionarySpirvChunk::DictionarySpirvChunk(BlobDictionary& dictionary) :
+DictionarySpirvChunk::DictionarySpirvChunk(BlobDictionary&& dictionary) :
         Chunk(ChunkType::DictionarySpirv), mDictionary(dictionary){
 }
 

--- a/libs/filamat/src/eiff/DictionarySpirvChunk.h
+++ b/libs/filamat/src/eiff/DictionarySpirvChunk.h
@@ -28,13 +28,13 @@ namespace filamat {
 
 class DictionarySpirvChunk final : public Chunk {
 public:
-    explicit DictionarySpirvChunk(BlobDictionary& dictionary);
+    explicit DictionarySpirvChunk(BlobDictionary&& dictionary);
     ~DictionarySpirvChunk() = default;
 
 private:
     void flatten(Flattener& f) override;
 
-    BlobDictionary& mDictionary;
+    BlobDictionary mDictionary;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/DictionaryTextChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.cpp
@@ -18,7 +18,7 @@
 
 namespace filamat {
 
-DictionaryTextChunk::DictionaryTextChunk(LineDictionary& dictionary, ChunkType chunkType) :
+DictionaryTextChunk::DictionaryTextChunk(LineDictionary&& dictionary, ChunkType chunkType) :
         Chunk(chunkType), mDictionary(dictionary) {
 }
 

--- a/libs/filamat/src/eiff/DictionaryTextChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.cpp
@@ -18,7 +18,7 @@
 
 namespace filamat {
 
-DictionaryTextChunk::DictionaryTextChunk(LineDictionary&& dictionary, ChunkType chunkType) :
+DictionaryTextChunk::DictionaryTextChunk(const LineDictionary& dictionary, ChunkType chunkType) :
         Chunk(chunkType), mDictionary(dictionary) {
 }
 

--- a/libs/filamat/src/eiff/DictionaryTextChunk.h
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.h
@@ -28,7 +28,7 @@ namespace filamat {
 
 class DictionaryTextChunk final : public Chunk {
 public:
-    DictionaryTextChunk(LineDictionary&& dictionary, ChunkType chunkType);
+    DictionaryTextChunk(const LineDictionary& dictionary, ChunkType chunkType);
     ~DictionaryTextChunk() = default;
 
 private:

--- a/libs/filamat/src/eiff/DictionaryTextChunk.h
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.h
@@ -28,13 +28,13 @@ namespace filamat {
 
 class DictionaryTextChunk final : public Chunk {
 public:
-    DictionaryTextChunk(LineDictionary& dictionary, ChunkType chunkType);
+    DictionaryTextChunk(LineDictionary&& dictionary, ChunkType chunkType);
     ~DictionaryTextChunk() = default;
 
 private:
     void flatten(Flattener& f) override;
 
-    LineDictionary& mDictionary;
+    LineDictionary mDictionary;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/LineDictionary.cpp
+++ b/libs/filamat/src/eiff/LineDictionary.cpp
@@ -39,7 +39,9 @@ size_t LineDictionary::getIndex(const std::string& s) const noexcept {
     return mLineIndices.at(s);
 }
 
-void LineDictionary::addText(const char* s) noexcept {
+void LineDictionary::addText(const std::string& line) noexcept {
+    const char* s = line.c_str();
+
     assert(s != nullptr);
 
     size_t cur = 0;

--- a/libs/filamat/src/eiff/LineDictionary.h
+++ b/libs/filamat/src/eiff/LineDictionary.h
@@ -30,8 +30,7 @@ public:
     LineDictionary();
     ~LineDictionary() = default;
 
-    void addText(const char* s) noexcept;
-    void addLine(const std::string&& line) noexcept;
+    void addText(const std::string& text) noexcept;
     size_t getLineCount() const;
 
     constexpr size_t getSize() const noexcept {
@@ -46,6 +45,8 @@ public:
     size_t getIndex(const std::string& s) const noexcept;
 
 private:
+    void addLine(const std::string&& line) noexcept;
+
     std::unordered_map<std::string, size_t> mLineIndices;
     std::vector<std::string> mStrings;
     size_t mStorageSize;

--- a/libs/filamat/src/eiff/MaterialSpirvChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialSpirvChunk.cpp
@@ -18,7 +18,7 @@
 
 namespace filamat {
 
-MaterialSpirvChunk::MaterialSpirvChunk(const std::vector<SpirvEntry>& entries) :
+MaterialSpirvChunk::MaterialSpirvChunk(const std::vector<SpirvEntry>&& entries) :
         Chunk(ChunkType::MaterialSpirv), mEntries(entries) {}
 
 void MaterialSpirvChunk::flatten(Flattener &f) {

--- a/libs/filamat/src/eiff/MaterialSpirvChunk.h
+++ b/libs/filamat/src/eiff/MaterialSpirvChunk.h
@@ -26,13 +26,13 @@ namespace filamat {
 
 class MaterialSpirvChunk final : public Chunk {
 public:
-    explicit MaterialSpirvChunk(const std::vector<SpirvEntry>& entries);
+    explicit MaterialSpirvChunk(const std::vector<SpirvEntry>&& entries);
     ~MaterialSpirvChunk() = default;
 
 private:
     void flatten(Flattener& f) override;
 
-    const std::vector<SpirvEntry>& mEntries;
+    const std::vector<SpirvEntry> mEntries;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/MaterialTextChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialTextChunk.cpp
@@ -26,7 +26,7 @@ void MaterialTextChunk::writeEntryAttributes(size_t entryIndex, Flattener& f) co
 }
 
 const char* MaterialTextChunk::getShaderText(size_t entryIndex) const noexcept {
-    return mEntries[entryIndex].shader;
+    return mEntries[entryIndex].shader.c_str();
 }
 
 void compressShader(const char *s, Flattener &f, const LineDictionary& dictionary) {

--- a/libs/filamat/src/eiff/MaterialTextChunk.h
+++ b/libs/filamat/src/eiff/MaterialTextChunk.h
@@ -27,7 +27,7 @@ namespace filamat {
 
 class MaterialTextChunk final : public Chunk {
 public:
-    MaterialTextChunk(const std::vector<TextEntry> &entries, LineDictionary &dictionary,
+    MaterialTextChunk(const std::vector<TextEntry>&& entries, LineDictionary&& dictionary,
             ChunkType type) : Chunk(type), mDictionary(dictionary), mEntries(entries) {
     }
     ~MaterialTextChunk() = default;
@@ -45,8 +45,8 @@ private:
     };
     std::vector<ShaderAttribute> mDuplicateMap;
 
-    const std::vector<TextEntry>& mEntries;
-    const LineDictionary& mDictionary;
+    const std::vector<TextEntry> mEntries;
+    const LineDictionary mDictionary;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/MaterialTextChunk.h
+++ b/libs/filamat/src/eiff/MaterialTextChunk.h
@@ -27,7 +27,7 @@ namespace filamat {
 
 class MaterialTextChunk final : public Chunk {
 public:
-    MaterialTextChunk(const std::vector<TextEntry>&& entries, LineDictionary&& dictionary,
+    MaterialTextChunk(const std::vector<TextEntry>&& entries, const LineDictionary& dictionary,
             ChunkType type) : Chunk(type), mDictionary(dictionary), mEntries(entries) {
     }
     ~MaterialTextChunk() = default;

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -27,7 +27,6 @@ struct TextEntry {
     uint8_t variant;
     uint8_t stage;
     std::string shader;
-    size_t shaderSize;
 };
 
 struct SpirvEntry {

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMAT_SHADER_ENTRY_H
 #define TNT_FILAMAT_SHADER_ENTRY_H
 
+#include <string>
+
 namespace filamat {
 
 // TextEntry stores a shader in ASCII text format, like GLSL.
@@ -24,7 +26,7 @@ struct TextEntry {
     uint8_t shaderModel;
     uint8_t variant;
     uint8_t stage;
-    char* shader;
+    std::string shader;
     size_t shaderSize;
 };
 

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -140,19 +140,10 @@ void GLSLTools::shutdown() {
     FinalizeProcess();
 }
 
-bool GLSLTools::findProperties(const filamat::MaterialBuilder& builderIn,
+bool GLSLTools::findProperties(const std::string& shaderCode,
         MaterialBuilder::PropertyList& properties,
-        MaterialBuilder::TargetApi targetApi) const noexcept {
-    filamat::MaterialBuilder builder(builderIn);
-
-    // Some fields in MaterialInputs only exist if the property is set (e.g: normal, subsurface
-    // for cloth shading model). Give our shader all properties. This will enable us to parse and
-    // static code analyse the AST.
-    MaterialBuilder::PropertyList allProperties;
-    std::fill_n(allProperties, MaterialBuilder::MATERIAL_PROPERTIES_COUNT, true);
-
-    ShaderModel model;
-    std::string shaderCode = builder.peek(ShaderType::FRAGMENT, model, allProperties);
+        MaterialBuilder::TargetApi targetApi,
+        ShaderModel model) const noexcept {
     const char* shaderCString = shaderCode.c_str();
 
     TShader tShader(EShLanguage::EShLangFragment);

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -130,11 +130,13 @@ public:
 
     // Public for unit tests.
     using Property = MaterialBuilder::Property;
+    using ShaderModel = filament::backend::ShaderModel;
     // Use static code analysis on the fragment shader AST to guess properties used in user provided
     // glgl code. Populate properties accordingly.
-    bool findProperties(const MaterialBuilder& builder,
+    bool findProperties(const std::string& shaderCode,
             MaterialBuilder::PropertyList& properties,
-            MaterialBuilder::TargetApi targetApi = MaterialBuilder::TargetApi::OPENGL) const noexcept;
+            MaterialBuilder::TargetApi targetApi = MaterialBuilder::TargetApi::OPENGL,
+            ShaderModel model = ShaderModel::GL_CORE_41) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::backend::ShaderModel model);
 


### PR DESCRIPTION
This is the first of a few `MaterialBuilder` refactorings that pave the way for post-process
material domains.

Two main changes:

- Pass shader code directly to `GLSLTools::findProperties`, instead of the `MaterialBuilder`
  instance.
- Moved material chunk emission to a separate method. Doing so required some changes in how
  `ChunkContainer` temporarily stores chunks before flattening.

Compiled materials are bit-for-bit the same before and after this change.
