### PR TITLE
Additional validation in VertexBuffer::Builder::build.

### DIFF
--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -124,6 +124,10 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount > 0, "bufferCount cannot be 0")) {
         return nullptr;
     }
+    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount <= MAX_ATTRIBUTE_BUFFER_COUNT,
+            "bufferCount cannot be more than %d", MAX_ATTRIBUTE_BUFFER_COUNT)) {
+        return nullptr;
+    }
 
     return upcast(engine).createVertexBuffer(*this);
 }


### PR DESCRIPTION
If a client asks for more than 8 buffers in a VertexBuffer, they will
either crash (release) or hit an assert in OpenGLDriver (debug). It's
better to catch this earlier.

This was noticed while investigating #1256.