### PR TITLE
gltfio: consolidate buffer slots.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ toolchains
 filament/docs/html/**
 .vscode
 gltf_baker.ini
+*tmp*.png

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -148,6 +148,7 @@ struct BufferBinding {
     bool convertBytesToShorts;   // the resource loader must convert the buffer from u8 to u16
     bool generateTrivialIndices; // the resource loader must generate indices like: 0, 1, 2, ...
     bool generateDummyData;      // the resource loader should generate a sequence of 1.0 values
+    bool generateTangents;       // the resource loader should generate tangents
 };
 
 /** Describes a binding from a Texture to a MaterialInstance. */

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -80,7 +80,7 @@ public:
 
 private:
     bool createTextures(details::FFilamentAsset* asset) const;
-    void computeTangents(details::FFilamentAsset* asset) const;
+    void computeTangents(details::FFilamentAsset* asset, int tangentsSlot) const;
     void normalizeSkinningWeights(details::FFilamentAsset* asset) const;
     void updateBoundingBoxes(details::FFilamentAsset* asset) const;
     details::AssetPool* mPool;


### PR DESCRIPTION
Instead of using the actual glTF attribute indices, we now pack them
so that unused indices do not take up any VertexBuffer slots.

Fixes #1256.