### PR TITLE
gltf_baker: allow users to adjust to seed iterations.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetPipeline.h
+++ b/libs/gltfio/include/gltfio/AssetPipeline.h
@@ -94,8 +94,11 @@ public:
      * The topology of the meshes in the resulting asset is potentially different from the source
      * asset (e.g., new vertices might be inserted). The newly generated UV set is placed into the
      * attribute slot named BAKED_UV_ATTRIB.
+     *
+     * If some of the generated charts are badly sized, increasing the maxIterations argument can
+     * help by allowing xatlas to try different seed points.
      */
-    AssetHandle parameterize(AssetHandle source);
+    AssetHandle parameterize(AssetHandle source, int maxIterations = 2);
 
     /**
      * Strips all textures and materials from a flattened asset, replacing them with a nonlit


### PR DESCRIPTION
The shader ball AO was splotchy because of badly located seed points during segmentation. This improves dramatically by allowing the seed heuristic to make a second attempt, as seen in the below before / after montage.

![output](https://user-images.githubusercontent.com/1288904/58920147-bf804c80-86e5-11e9-89e2-2a745bd579cc.png)
