### PR TITLE
Switch desktop to interleaved RGB noise

### DIFF
--- a/shaders/src/dithering.fs
+++ b/shaders/src/dithering.fs
@@ -10,9 +10,9 @@
 #define DITHERING_TRIANGLE_NOISE_RGB   4
 
 #ifdef TARGET_MOBILE
-  #define DITHERING_OPERATOR           DITHERING_INTERLEAVED_NOISE
+    #define DITHERING_OPERATOR         DITHERING_INTERLEAVED_NOISE
 #else
-  #define DITHERING_OPERATOR           DITHERING_TRIANGLE_NOISE_RGB
+    #define DITHERING_OPERATOR         DITHERING_VLACHOS
 #endif
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This eliminates the flicker caused by triangle noise based dithering
when FXAA is turned on. This will require further investigation to
see if we can use triangle noise with FXAA without such artifacts.