### PR TITLE
Fix msan use-of-uninitialized-value in destroyVertexBuffer

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1402,13 +1402,14 @@ void OpenGLDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     if (vbh) {
         GLVertexBuffer const* eb = handle_cast<const GLVertexBuffer*>(vbh);
         GLsizei n = GLsizei(eb->bufferCount);
-        glDeleteBuffers(n, eb->gl.buffers.data());
+        auto& buffers = eb->gl.buffers;
+        glDeleteBuffers(n, buffers.data());
         // bindings of bound buffers are reset to 0
         const size_t targetIndex = getIndexForBufferTarget(GL_ARRAY_BUFFER);
         auto& target = state.buffers.genericBinding[targetIndex];
         #pragma nounroll
-        for (GLuint b : eb->gl.buffers) {
-            if (target == b) {
+        for (GLsizei i = 0; i < n; ++i) {
+            if (target == buffers[i]) {
                 target = 0;
             }
         }


### PR DESCRIPTION
GLVertexBuffer.gl.buffers is a std::array which is not
default-initialized, and createVertexBuffer only initializes the first
bufferCount fields of the array.

When destructing, destroyVertexBuffer iterated over all buffers to unset
bindings, but it was erroneously iterating over the entire array instead
of the initialized values.  Update the loop to only iterate over known
initialized values.