### PR TITLE
Fix #1270 Inconsistent setParameter behavior for arrays

### DIFF
--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -128,10 +128,8 @@ public:
         constexpr size_t stride = (sizeof(T) + 0xF) & ~0xF;
         T* UTILS_RESTRICT p = static_cast<T*>(invalidateUniforms(offset, stride * count));
         for (size_t i = 0; i < count; i++) {
-            *p++ = begin[i];
-            if (sizeof(T) & 0xF) {
-                p = utils::pointermath::align(p, 0x10);
-            }
+            *p = begin[i];
+            p = utils::pointermath::add(p, stride);
         }
     }
 
@@ -191,19 +189,6 @@ private:
     uint32_t mSize = 0;
     mutable bool mSomethingDirty = false;
 };
-
-// specialization for float3 (which has a different alignment)
-template<>
-inline void
-UniformBuffer::setUniformArray(size_t offset, math::float3 const* begin, size_t count) noexcept {
-    math::float4* p = static_cast<math::float4*>(invalidateUniforms(offset,
-            sizeof(math::float4) * count));
-    math::float3 const* const end = begin + count;
-    while (begin != end) {
-        p->xyz = *begin++;
-        ++p;
-    }
-}
 
 // specialization for mat3f (which has a different alignment, see std140 layout rules)
 template<>

--- a/libs/filabridge/src/UniformInterfaceBlock.cpp
+++ b/libs/filabridge/src/UniformInterfaceBlock.cpp
@@ -91,7 +91,7 @@ UniformInterfaceBlock::UniformInterfaceBlock(Builder const& builder) noexcept
         size_t alignment = baseAlignmentForType(e.type);
         uint8_t stride = strideForType(e.type);
         if (e.size > 1) { // this is an array
-            // round the alignment up to that of a double4
+            // round the alignment up to that of a float4
             alignment = (alignment + 3) & ~3;
             stride = (stride + uint8_t(3)) & ~uint8_t(3);
         }


### PR DESCRIPTION
Arrays in unform buffers are stored in std140, i.e. they have an
alignment of float4. This wasn't taken into account when setting
arrays (other than mat3)