### PR TITLE
better command queue flushing

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -150,9 +150,6 @@ void RenderPass::execute(const char* name,
     RenderPass::recordDriverCommands(driver, scene, first, last);
     driver.endRenderPass();
     driver.popGroupMarker();
-
-    driver.flush(); // Kick the GPU since we're done with this render target
-    engine.flush(); // Wake-up the driver thread
 }
 
 UTILS_NOINLINE // no need to be inlined

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -219,6 +219,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     if (view.hasShadowing()) {
         view.getShadowMap().render(driver, pass, view);
+        driver.flush(); // Kick the GPU since we're done with this render target
+        engine.flush(); // Wake-up the driver thread
         commands.clear();
     }
 
@@ -389,7 +391,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     fg.compile();
     //fg.export_graphviz(slog.d);
 
-    fg.execute(driver);
+    fg.execute(engine, driver);
 
     commands.clear();
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -43,6 +43,10 @@
 
 namespace filament {
 
+namespace details {
+class FEngine;
+} // namespace details
+
 namespace fg {
 struct Resource;
 struct ResourceNode;
@@ -189,10 +193,19 @@ public:
     // allocates concrete resources and culls unreferenced passes
     FrameGraph& compile() noexcept;
 
-    // execute all referenced passes
+    // execute all referenced passes and flush the command queue after each pass
+    void execute(details::FEngine& engine, backend::DriverApi& driver) noexcept;
+
+
+    /*
+     * Debugging...
+     */
+
+    // execute all referenced passes -- this version is for unit-testing, where we don't have
+    // an engine necessarily.
     void execute(backend::DriverApi& driver) noexcept;
 
-    // for debugging
+    // print the frame graph as a graphviz file in the log
     void export_graphviz(utils::io::ostream& out);
 
 private:
@@ -233,6 +246,10 @@ private:
 
     bool equals(FrameGraphRenderTarget::Descriptor const& lhs,
             FrameGraphRenderTarget::Descriptor const& rhs) const noexcept;
+
+    void executeInternal(fg::PassNode const& node, backend::DriverApi& driver) noexcept;
+
+    void reset() noexcept;
 
     details::LinearAllocatorArena mArena;
     Vector<fg::PassNode> mPassNodes;                    // list of frame graph passes


### PR DESCRIPTION
Instead of flushing the driver and command queue in RenderPass, we now
do that in the framegraph.

We flush the command queue after each pass -- which reduces memory
pressure on the command queue and improves parallel execution
with the backend thread. We flush the driver only after the last
pass -- maybe we could improve this in the future as the framegraph
gain more knowledge about what's going on.