### PR TITLE
rename mirrorFrame() to copyFrame()

### DIFF
--- a/android/filament-android/src/main/cpp/Renderer.cpp
+++ b/android/filament-android/src/main/cpp/Renderer.cpp
@@ -51,7 +51,7 @@ Java_com_google_android_filament_Renderer_nRender(JNIEnv *, jclass, jlong native
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_Renderer_nMirrorFrame(JNIEnv *, jclass, jlong nativeRenderer,
+Java_com_google_android_filament_Renderer_nCopyFrame(JNIEnv *, jclass, jlong nativeRenderer,
         jlong nativeDstSwapChain,
         jint dstLeft, jint dstBottom, jint dstWidth, jint dstHeight,
         jint srcLeft, jint srcBottom, jint srcWidth, jint srcHeight,
@@ -60,7 +60,7 @@ Java_com_google_android_filament_Renderer_nMirrorFrame(JNIEnv *, jclass, jlong n
     SwapChain *dstSwapChain = (SwapChain *) nativeDstSwapChain;
     const filament::Viewport dstViewport {dstLeft, dstBottom, (uint32_t) dstWidth, (uint32_t) dstHeight};
     const filament::Viewport srcViewport {srcLeft, srcBottom, (uint32_t) srcWidth, (uint32_t) srcHeight};
-    renderer->mirrorFrame(dstSwapChain, dstViewport, srcViewport, (uint32_t) flags);
+    renderer->copyFrame(dstSwapChain, dstViewport, srcViewport, (uint32_t) flags);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -56,13 +56,20 @@ public class Renderer {
     /**
      * This method MUST be called before endFrame.
      */
-    public void mirrorFrame(
+    public void copyFrame(
             @NonNull SwapChain dstSwapChain, @NonNull Viewport dstViewport,
             @NonNull Viewport srcViewport, int flags) {
-        nMirrorFrame(getNativeObject(), dstSwapChain.getNativeObject(),
+        nCopyFrame(getNativeObject(), dstSwapChain.getNativeObject(),
                 dstViewport.left, dstViewport.bottom, dstViewport.width, dstViewport.height,
                 srcViewport.left, srcViewport.bottom, srcViewport.width, srcViewport.height,
                 flags);
+    }
+
+    /** @deprecated */
+    public void mirrorFrame(
+            @NonNull SwapChain dstSwapChain, @NonNull Viewport dstViewport,
+            @NonNull Viewport srcViewport, int flags) {
+        copyFrame(dstSwapChain, dstViewport, srcViewport, flags);
     }
 
     /**
@@ -111,7 +118,7 @@ public class Renderer {
     private static native boolean nBeginFrame(long nativeRenderer, long nativeSwapChain);
     private static native void nEndFrame(long nativeRenderer);
     private static native void nRender(long nativeRenderer, long nativeView);
-    private static native void nMirrorFrame(long nativeRenderer, long nativeDstSwapChain,
+    private static native void nCopyFrame(long nativeRenderer, long nativeDstSwapChain,
             int dstLeft, int dstBottom, int dstWidth, int dstHeight,
             int srcLeft, int srcBottom, int srcWidth, int srcHeight,
             int flags);

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -138,54 +138,54 @@ public:
     void render(View const* view);
 
     /**
-     * Flags used to configure the behavior of mirrorFrame().
+     * Flags used to configure the behavior of copyFrame().
      *
      * @see
-     * mirrorFrame()
+     * copyFrame()
      */
-    using MirrorFrameFlag = uint32_t;
+    using CopyFrameFlag = uint32_t;
 
     /**
-     * Indicates that the dstSwapChain passed into mirrorFrame() should be
-     * committed after the frame has been mirrored.
+     * Indicates that the dstSwapChain passed into copyFrame() should be
+     * committed after the frame has been copied.
      *
      * @see
-     * mirrorFrame()
+     * copyFrame()
      */
-    static constexpr MirrorFrameFlag COMMIT = 0x1;
+    static constexpr CopyFrameFlag COMMIT = 0x1;
     /**
      * Indicates that the presentation time should be set on the dstSwapChain
-     * passed into mirrorFrame to the monotonic clock time when the frame is
-     * mirrored.
+     * passed into copyFrame to the monotonic clock time when the frame is
+     * copied.
      *
      * @see
-     * mirrorFrame()
+     * copyFrame()
      */
-    static constexpr MirrorFrameFlag SET_PRESENTATION_TIME = 0x2;
+    static constexpr CopyFrameFlag SET_PRESENTATION_TIME = 0x2;
     /**
-     * Indicates that the dstSwapChain passed into mirrorFrame() should be
-     * cleared to black before the frame is mirrored into the specified viewport.
+     * Indicates that the dstSwapChain passed into copyFrame() should be
+     * cleared to black before the frame is copied into the specified viewport.
      *
      * @see
-     * mirrorFrame()
+     * copyFrame()
      */
-    static constexpr MirrorFrameFlag CLEAR = 0x4;
+    static constexpr CopyFrameFlag CLEAR = 0x4;
 
     /**
-     * Mirror the currently rendered view to the indicated swap chain, using the
+     * Copy the currently rendered view to the indicated swap chain, using the
      * indicated source and destination rectangle.
      *
-     * @param dstSwapChain The swap chain into which the frame should be mirrored.
+     * @param dstSwapChain The swap chain into which the frame should be copied.
      * @param dstViewport The destination rectangle in which to draw the view.
-     * @param srcViewport The source rectangle to be mirrored.
-     * @param flags One or more MirrorFrameFlag behavior configuration flags.
+     * @param srcViewport The source rectangle to be copied.
+     * @param flags One or more CopyFrameFlag behavior configuration flags.
      *
      * @remark
-     * mirrorFrame() should be called after a frame is rendered using render()
+     * copyFrame() should be called after a frame is rendered using render()
      * but before endFrame() is called.
      */
-    void mirrorFrame(SwapChain* dstSwapChain, Viewport const& dstViewport, Viewport const& srcViewport,
-                     uint32_t flags=0);
+    void copyFrame(SwapChain* dstSwapChain, Viewport const& dstViewport,
+            Viewport const& srcViewport, uint32_t flags = 0);
 
     /**
      * Read-back the content of the SwapChain associated with this Renderer.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -396,8 +396,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     recordHighWatermark(pass.getCommandsHighWatermark());
 }
 
-void FRenderer::mirrorFrame(FSwapChain* dstSwapChain, filament::Viewport const& dstViewport,
-        filament::Viewport const& srcViewport, MirrorFrameFlag flags) {
+void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& dstViewport,
+        filament::Viewport const& srcViewport, CopyFrameFlag flags) {
     SYSTRACE_CALL();
 
     assert(mSwapChain);
@@ -625,9 +625,9 @@ bool Renderer::beginFrame(SwapChain* swapChain) {
     return upcast(this)->beginFrame(upcast(swapChain));
 }
 
-void Renderer::mirrorFrame(SwapChain* dstSwapChain, filament::Viewport const& dstViewport,
-        filament::Viewport const& srcViewport, MirrorFrameFlag flags) {
-    upcast(this)->mirrorFrame(upcast(dstSwapChain), dstViewport, srcViewport, flags);
+void Renderer::copyFrame(SwapChain* dstSwapChain, filament::Viewport const& dstViewport,
+        filament::Viewport const& srcViewport, CopyFrameFlag flags) {
+    upcast(this)->copyFrame(upcast(dstSwapChain), dstViewport, srcViewport, flags);
 }
 
 void Renderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -71,8 +71,8 @@ public:
     void render(FView const* view);
     void renderJob(ArenaScope& arena, FView& view);
 
-    void mirrorFrame(FSwapChain* dstSwapChain, Viewport const& dstViewport, Viewport const& srcViewport,
-                     MirrorFrameFlag flags);
+    void copyFrame(FSwapChain* dstSwapChain, Viewport const& dstViewport,
+            Viewport const& srcViewport, CopyFrameFlag flags);
 
     bool beginFrame(FSwapChain* swapChain);
     void endFrame();


### PR DESCRIPTION
"mirror" was misleading, like it would apply a symmetry to the frame.
mirrorFrame() is just a blit from a swapchain to another, so it's a
copy.

The Java language API is kept for compatibility.