### PR TITLE
Split runStaticCodeAnalysis into separate methods

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -336,7 +336,8 @@ private:
 
     // Return true if:
     // The shader is syntactically and semantically valid
-    bool runStaticCodeAnalysis() noexcept;
+    bool findProperties() noexcept;
+    bool runSemanticAnalysis() noexcept;
 
     bool checkLiteRequirements() noexcept;
 

--- a/libs/filamat/include/filamat/Package.h
+++ b/libs/filamat/include/filamat/Package.h
@@ -84,6 +84,12 @@ public:
         return mValid;
     }
 
+    static Package invalidPackage() {
+        Package package(0);
+        package.setValid(false);
+        return package;
+    }
+
 private:
     uint8_t* mPayload = nullptr;
     size_t mSize = 0;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -371,10 +371,9 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.specularAO = mSpecularAO;
 }
 
-bool MaterialBuilder::runStaticCodeAnalysis() noexcept {
-    using namespace filament::backend;
-
+bool MaterialBuilder::findProperties() noexcept {
 #ifndef FILAMAT_LITE
+    using namespace filament::backend;
     GLSLTools glslTools;
 
     // Some fields in MaterialInputs only exist if the property is set (e.g: normal, subsurface
@@ -390,8 +389,19 @@ bool MaterialBuilder::runStaticCodeAnalysis() noexcept {
         return false;
     }
 
-    // At this point the shader is syntactically correct. Perform semantic analysis now.
+    return true;
+#else
+    GLSLToolsLite glslTools;
+    return glslTools.findProperties(mMaterialCode, mProperties);
+#endif
+}
 
+bool MaterialBuilder::runSemanticAnalysis() noexcept {
+#ifndef FILAMAT_LITE
+    using namespace filament::backend;
+    GLSLTools glslTools;
+
+    ShaderModel model;
     std::string shaderCode = peek(ShaderType::VERTEX, model, mProperties);
     bool result = glslTools.analyzeVertexShader(shaderCode, model, mTargetApi);
     if (!result) return false;
@@ -400,8 +410,7 @@ bool MaterialBuilder::runStaticCodeAnalysis() noexcept {
     result = glslTools.analyzeFragmentShader(shaderCode, model, mTargetApi);
     return result;
 #else
-    GLSLToolsLite glslTools;
-    return glslTools.findProperties(mMaterialCode, mProperties);
+    return true;
 #endif
 }
 
@@ -580,7 +589,8 @@ Package MaterialBuilder::build() noexcept {
     }
 
     if (!checkLiteRequirements() ||
-        !runStaticCodeAnalysis()) {
+        !findProperties() ||
+        !runSemanticAnalysis()) {
         // Return an empty package to signal a failure to build the material.
         Package package(0);
         package.setValid(false);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -583,18 +583,14 @@ Package MaterialBuilder::build() noexcept {
         utils::slog.e << "Error: MaterialBuilder::init() must be called before build()."
             << utils::io::endl;
         // Return an empty package to signal a failure to build the material.
-        Package package(0);
-        package.setValid(false);
-        return package;
+        return Package::invalidPackage();
     }
 
     if (!checkLiteRequirements() ||
         !findProperties() ||
         !runSemanticAnalysis()) {
         // Return an empty package to signal a failure to build the material.
-        Package package(0);
-        package.setValid(false);
-        return package;
+        return Package::invalidPackage();
     }
 
     MaterialInfo info;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -586,6 +586,8 @@ Package MaterialBuilder::build() noexcept {
         return Package::invalidPackage();
     }
 
+    // Run checks, in order.
+    // The call to findProperties populates mProperties and must come before runSemanticAnalysis.
     if (!checkLiteRequirements() ||
         !findProperties() ||
         !runSemanticAnalysis()) {


### PR DESCRIPTION
Two small additional changes to `MaterialBuilder`:

- split `runStaticCodeAnalysis` into `findProperties` and `runSemanticAnalysis`
- add `invalidPackage` convenience method
