### PR TITLE
gltfio: improve robustness for missing attributes.

### DIFF
--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -70,6 +70,13 @@ bool operator==(const MaterialKey& k1, const MaterialKey& k2);
 enum UvSet : uint8_t { UNUSED, UV0, UV1 };
 using UvMap = std::array<UvSet, 8>;
 
+inline uint8_t getNumUvSets(const UvMap& uvmap) {
+    return std::max({
+        uvmap[0], uvmap[1], uvmap[2], uvmap[3],
+        uvmap[4], uvmap[5], uvmap[6], uvmap[7],
+    });
+};
+
 enum MaterialSource {
     GENERATE_SHADERS,
     LOAD_UBERSHADERS,

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -495,17 +495,19 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
     if (mMaterials->getSource() == LOAD_UBERSHADERS) {
         if (!hasUv0) {
             needsDummyData = true;
-            vbb.attribute(VertexAttribute::UV0, slot++, VertexBuffer::AttributeType::USHORT2);
+            vbb.attribute(VertexAttribute::UV0, slot, VertexBuffer::AttributeType::USHORT2);
         }
         if (!hasUv1) {
             needsDummyData = true;
-            vbb.attribute(VertexAttribute::UV1, slot++, VertexBuffer::AttributeType::USHORT2);
+            vbb.attribute(VertexAttribute::UV1, slot, VertexBuffer::AttributeType::USHORT2);
         }
         if (!hasVertexColor) {
             needsDummyData = true;
-            vbb.attribute(VertexAttribute::COLOR, slot++, VertexBuffer::AttributeType::UBYTE4);
+            vbb.attribute(VertexAttribute::COLOR, slot, VertexBuffer::AttributeType::UBYTE4);
             vbb.normalized(VertexAttribute::COLOR);
         }
+    if (needsDummyData) {
+        slot++;
     }
 
     int bufferCount = slot;

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -221,14 +221,11 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
     }
 
     static_assert(std::tuple_size<UvMap>::value == 8, "Badly sized uvset.");
-    int numTextures = std::max({
-        uvmap[0], uvmap[1], uvmap[2], uvmap[3],
-        uvmap[4], uvmap[5], uvmap[6], uvmap[7],
-    });
-    if (numTextures > 0) {
+    int numUvSets = getNumUvSets(uvmap);
+    if (numUvSets > 0) {
         builder.require(VertexAttribute::UV0);
     }
-    if (numTextures > 1) {
+    if (numUvSets > 1) {
         builder.require(VertexAttribute::UV1);
     }
 


### PR DESCRIPTION
The bistro model has some UV-free primitives associated with textured materials. This caused Filament to emit warnings like:

    [entity=445, primitive @ 0] missing required attributes (0xb), declared=0x3

We now catch these in gltfio, which enables a friendlier warning so that the artist can go make a fix. These new warnings contain the mesh name, e.g.:

    Missing UV0 data in Bistro_Research_Exterior_Paris_Building_01_paris_building_01_bottom_4669