### PR TITLE
lucy_bloom: use LINEAR to reduce texture lookups

### DIFF
--- a/samples/lucy_bloom.cpp
+++ b/samples/lucy_bloom.cpp
@@ -214,6 +214,7 @@ static void setup(LucyApp& app, Engine* engine, View* finalView, Scene* finalSce
     app.reflection.view->setScene(app.reflection.scene);
     app.reflection.view->setCamera(app.reflection.camera);
     app.reflection.view->setToneMapping(View::ToneMapping::LINEAR);
+    app.reflection.view->setDithering(View::Dithering::NONE);
     FilamentApp::get().addOffscreenView(app.reflection.view);
 
     app.primary.camera = engine->createCamera();
@@ -224,6 +225,7 @@ static void setup(LucyApp& app, Engine* engine, View* finalView, Scene* finalSce
     app.primary.view->setScene(app.primary.scene);
     app.primary.view->setCamera(app.primary.camera);
     app.primary.view->setToneMapping(View::ToneMapping::LINEAR);
+    app.reflection.view->setDithering(View::Dithering::NONE);
     FilamentApp::get().addOffscreenView(app.primary.view);
 
     app.hblur.camera = engine->createCamera();

--- a/samples/lucy_utils.cpp
+++ b/samples/lucy_utils.cpp
@@ -37,7 +37,7 @@ using namespace utils;
 
 using filament::geometry::SurfaceOrientation;
 
-#define FILTER_SIZE 9
+#define FILTER_SIZE 17
 
 namespace LucyUtils {
 
@@ -139,7 +139,7 @@ Entity createQuad(Engine* engine, Texture* tex, ImageOp op, Texture* secondary) 
         static float4 weights[FILTER_SIZE * 2];
         float4* hweights = weights;
         float4* vweights = weights + FILTER_SIZE;
-        static const float radius = 2;
+        static const float radius = 1;
         const auto filter = [](float t) {
             t /= 2.0;
             if (t >= 1.0) return 0.0f;

--- a/samples/lucy_utils.cpp
+++ b/samples/lucy_utils.cpp
@@ -132,6 +132,9 @@ Entity createQuad(Engine* engine, Texture* tex, ImageOp op, Texture* secondary) 
         return Material::Builder().package(pkg.getData(), pkg.getSize()).build(engine);
     }(*engine);
 
+    // Compute the "weights" array, which is composed of two consective sequences of 4-tuples:
+    //       [WEIGHT, OFFSET_X, OFFSET_Y, DONT_CARE]
+    // The first sequence is for the horizontal pass, the second sequence is for the vertical pass.
     static const float4* weights = []() {
         static float4 weights[FILTER_SIZE * 2];
         float4* hweights = weights;


### PR DESCRIPTION
By carefully sampling between texel centers during each 1D pass, this achieves a higher quality blur without increasing the number of texture lookups.