### PR TITLE
Fix #477, add a way to set the intensity of the skybox

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -105,6 +105,22 @@ public:
          */
         Builder& showSun(bool show) noexcept;
 
+
+        /**
+         * Skybox intensity when no IndirectLight is set
+         *
+         * This call is ignored when an IndirectLight is set, otherwise it is used in its place.
+         *
+         *
+         * @param envIntensity  Scale factor applied to the skybox texel values such that
+         *                      the result is in cd/m^2 (lux) units (default = 30000)
+         *
+         * @return This Builder, for chaining calls.
+         *
+         * @See IndirectLight::Builder::intensity
+         */
+        Builder& intensity(float envIntensity) noexcept;
+
         /**
          * Creates the Skybox object and returns a pointer to it.
          *
@@ -121,6 +137,11 @@ public:
     void setLayerMask(uint8_t select, uint8_t values) noexcept;
 
     uint8_t getLayerMask() const noexcept;
+
+    /**
+     * Returns the skybox's intensity in cd/m^2.
+     */
+    float getIntensity() const noexcept;
 };
 
 } // namespace filament

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -20,6 +20,7 @@
 #include "details/Texture.h"
 #include "details/VertexBuffer.h"
 #include "details/IndexBuffer.h"
+#include "details/IndirectLight.h"
 #include "details/Material.h"
 #include "details/MaterialInstance.h"
 
@@ -39,6 +40,7 @@ using namespace details;
 
 struct Skybox::BuilderDetails {
     Texture* mEnvironmentMap = nullptr;
+    float mIntensity = FIndirectLight::DEFAULT_INTENSITY;
     bool mShowSun = false;
 };
 
@@ -53,6 +55,11 @@ BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs
 
 Skybox::Builder& Skybox::Builder::environment(Texture* cubemap) noexcept {
     mImpl->mEnvironmentMap = cubemap;
+    return *this;
+}
+
+Skybox::Builder& Skybox::Builder::intensity(float envIntensity) noexcept {
+    mImpl->mIntensity = envIntensity;
     return *this;
 }
 
@@ -81,7 +88,8 @@ namespace details {
 
 FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
         : mSkyboxTexture(upcast(builder->mEnvironmentMap)),
-          mRenderableManager(engine.getRenderableManager()) {
+          mRenderableManager(engine.getRenderableManager()),
+          mIntensity(builder->mIntensity) {
 
     FMaterial const* material = engine.getSkyboxMaterial(mSkyboxTexture->isRgbm());
     mSkyboxMaterialInstance = material->createInstance();
@@ -150,6 +158,10 @@ void Skybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
 
 uint8_t Skybox::getLayerMask() const noexcept {
     return upcast(this)->getLayerMask();
+}
+
+float Skybox::getIntensity() const noexcept {
+    return upcast(this)->getIntensity();
 }
 
 } // namespace filament

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -339,7 +339,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 
     // IBL
     FIndirectLight const* const ibl = scene->getIndirectLight();
-    if (ibl) {
+    if (UTILS_LIKELY(ibl)) {
         u.setUniform(offsetof(PerViewUib, iblLuminance), ibl->getIntensity() * exposure);
         u.setUniformArray(offsetof(PerViewUib, iblSH), ibl->getSH(), 9);
         if (ibl->getReflectionMap()) {
@@ -350,8 +350,9 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
                     { ibl->getReflectionMap(), reflectionSamplerParams });
         }
     } else {
-        u.setUniform(offsetof(PerViewUib, iblLuminance),
-                FIndirectLight::DEFAULT_INTENSITY * exposure);
+        FSkybox const* const skybox = scene->getSkybox();
+        const float intensity = skybox ? skybox->getIntensity() : FIndirectLight::DEFAULT_INTENSITY;
+        u.setUniform(offsetof(PerViewUib, iblLuminance), intensity * exposure);
     }
 
     // Directional light (always at index 0)

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -16,13 +16,7 @@
 
 #include "upcast.h"
 
-#include <backend/Handle.h>
-
-#include <components/RenderableManager.h>
-
 #include <filament/Skybox.h>
-
-#include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
 #include <utils/Entity.h>
@@ -37,6 +31,7 @@ class FEngine;
 class FTexture;
 class FMaterial;
 class FMaterialInstance;
+class FRenderableManager;
 
 class FSkybox : public Skybox {
 public:
@@ -52,6 +47,8 @@ public:
 
     uint8_t getLayerMask() const noexcept { return mLayerMask; }
 
+    float getIntensity() const noexcept { return mIntensity; }
+
 private:
     // we don't own these
     FTexture const* mSkyboxTexture = nullptr;
@@ -60,6 +57,7 @@ private:
     FMaterialInstance* mSkyboxMaterialInstance = nullptr;
     utils::Entity mSkybox;
     FRenderableManager& mRenderableManager;
+    float mIntensity = 0.0f;
     uint8_t mLayerMask = 0x1;
 };
 


### PR DESCRIPTION
When there is no indirect light it wasn't possible to control the
skybox's intensity. Now the skybox has its own intensity that
is used in that case.