### PR TITLE
Fix incomplete FBO when rendering to cubemap.

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1114,6 +1114,12 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         // still work, albeit without MSAA.
         bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
         switch (target) {
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_Y:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_Y:
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_Z:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_Z:
             case GL_TEXTURE_2D:
             case GL_TEXTURE_2D_MULTISAMPLE:
                 glFramebufferTexture2D(GL_FRAMEBUFFER, attachment,
@@ -1162,6 +1168,12 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         }
         bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo_read);
         switch (target) {
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_Y:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_Y:
+            case GL_TEXTURE_CUBE_MAP_POSITIVE_Z:
+            case GL_TEXTURE_CUBE_MAP_NEGATIVE_Z:
             case GL_TEXTURE_2D:
                 glFramebufferTexture2D(GL_FRAMEBUFFER, attachment,
                         target, t->gl.id, binfo.level);


### PR DESCRIPTION
The bug was reproduced and the fix was verified by making the following
changes to the `lucy_bloom` demo.

Fixes #1300.

```
diff --git a/samples/lucy_bloom.cpp b/samples/lucy_bloom.cpp
index c3a887ca..98f19c53 100644
--- a/samples/lucy_bloom.cpp
+++ b/samples/lucy_bloom.cpp
@@ -87,6 +87,7 @@ static void setup(LucyApp& app, Engine* engine, View* finalView, Scene* finalSce

     app.reflection.color = Texture::Builder()
         .width(FBO_WIDTH).height(FBO_HEIGHT).levels(1)
+        .sampler(Texture::Sampler::SAMPLER_CUBEMAP)
         .usage(Texture::Usage::COLOR_ATTACHMENT | Texture::Usage::SAMPLEABLE)
         .format(Texture::InternalFormat::RGBA8).build(*engine);
     app.reflection.depth = Texture::Builder()
@@ -96,6 +97,7 @@ static void setup(LucyApp& app, Engine* engine, View* finalView, Scene* finalSce
     app.reflection.target = RenderTarget::Builder()
         .texture(RenderTarget::COLOR, app.reflection.color)
         .texture(RenderTarget::DEPTH, app.reflection.depth)
+        .face(RenderTarget::COLOR, RenderTarget::CubemapFace::POSITIVE_Y)
         .build(*engine);

     app.primary.color = Texture::Builder()
diff --git a/samples/lucy_utils.cpp b/samples/lucy_utils.cpp
index 647a97f2..59a0135b 100644
--- a/samples/lucy_utils.cpp
+++ b/samples/lucy_utils.cpp
@@ -300,7 +300,8 @@ Entity createDisk(Engine* engine, Texture* reflection) {
                 material.ambientOcclusion = texture(materialParams_ao, getUV0()).r;

                 float2 uv = gl_FragCoord.xy * getResolution().zw; uv.y = 1.0 - uv.y;
-                vec3 reflection = texture(materialParams_reflection, uv).xyz;
+                float3 dir = float3(uv.x * 2.0 - 1.0, 1.0, uv.y * 2.0 - 1.0); // select POSITIVE_Y
+                vec3 reflection = texture(materialParams_reflection, dir).xyz;

                 // HACK: blend the reflection with the baseColor.
                 material.baseColor.rgb = mix(reflection, material.baseColor.rgb, 0.75);
@@ -311,7 +312,7 @@ Entity createDisk(Engine* engine, Texture* reflection) {
         .parameter(filamat::MaterialBuilder::SamplerType::SAMPLER_2D, "color")
         .parameter(filamat::MaterialBuilder::SamplerType::SAMPLER_2D, "roughness")
         .parameter(filamat::MaterialBuilder::SamplerType::SAMPLER_2D, "ao")
-        .parameter(filamat::MaterialBuilder::SamplerType::SAMPLER_2D, "reflection")
+        .parameter(filamat::MaterialBuilder::SamplerType::SAMPLER_CUBEMAP, "reflection")
         .targetApi(filamat::MaterialBuilder::TargetApi::OPENGL)
         .specularAntiAliasing(true)
         .shading(Shading::LIT)
```
