### PR TITLE
Properly inverse the projection matrix for the shader

### DIFF
--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -609,7 +609,7 @@ void FView::prepareCamera(const CameraInfo& camera, const filament::Viewport& vi
     const mat4f projectionMatrix(camera.projection);
 
     const mat4f clipFromView(projectionMatrix);
-    const mat4f viewFromClip(Camera::inverseProjection(clipFromView));
+    const mat4f viewFromClip(inverse(clipFromView));
     const mat4f clipFromWorld(clipFromView * viewFromWorld);
     const mat4f worldFromClip(worldFromView * viewFromClip);
 


### PR DESCRIPTION
Some projections matrices were incorrectly inverted. 
This also fix #1281, fortunately, the incorrect matrix wasn't used
in that case.

Camera::inverseProjection only handles projection matrices it
created (as opposed to custom ones, which is what the shadowmap
code uses)