### PR TITLE
Add material domains boilerplate

### DIFF
--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -137,6 +137,9 @@ public:
     //! Returns the vertex domain of this material.
     VertexDomain getVertexDomain() const noexcept;
 
+    //! Returns the material domain of this material.
+    MaterialDomain getMaterialDomain() const noexcept;
+
     //! Returns the culling mode of this material.
     CullingMode getCullingMode() const noexcept;
 

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -138,6 +138,7 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     parser->getBlendingMode(&mBlendingMode);
     parser->getInterpolation(&mInterpolation);
     parser->getVertexDomain(&mVertexDomain);
+    parser->getMaterialDomain(&mMaterialDomain);
     parser->getRequiredAttributes(&mRequiredAttributes);
 
     if (mBlendingMode == BlendingMode::MASKED) {
@@ -425,6 +426,10 @@ BlendingMode Material::getBlendingMode() const noexcept {
 
 VertexDomain Material::getVertexDomain() const noexcept {
     return upcast(this)->getVertexDomain();
+}
+
+MaterialDomain Material::getMaterialDomain() const noexcept {
+    return upcast(this)->getMaterialDomain();
 }
 
 CullingMode Material::getCullingMode() const noexcept {

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -212,6 +212,12 @@ bool MaterialParser::getVertexDomain(VertexDomain* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialVertexDomain, reinterpret_cast<uint8_t*>(value));
 }
 
+bool MaterialParser::getMaterialDomain(MaterialDomain* value) const noexcept {
+    static_assert(sizeof(MaterialDomain) == sizeof(uint8_t),
+            "MaterialDomain expected size is wrong");
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialDomain, reinterpret_cast<uint8_t*>(value));
+}
+
 bool MaterialParser::getBlendingMode(BlendingMode* value) const noexcept {
     static_assert(sizeof(BlendingMode) == sizeof(uint8_t),
             "BlendingMode expected size is wrong");

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -70,6 +70,7 @@ public:
     bool getDepthTest(bool* value) const noexcept;
     bool getInterpolation(Interpolation* value) const noexcept;
     bool getVertexDomain(VertexDomain* value) const noexcept;
+    bool getMaterialDomain(MaterialDomain* domain) const noexcept;
 
     bool getShading(Shading*) const noexcept;
     bool getBlendingMode(BlendingMode*) const noexcept;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -94,6 +94,7 @@ public:
     BlendingMode getBlendingMode() const noexcept { return mBlendingMode; }
     BlendingMode getRenderBlendingMode() const noexcept { return mRenderBlendingMode; }
     VertexDomain getVertexDomain() const noexcept { return mVertexDomain; }
+    MaterialDomain getMaterialDomain() const noexcept { return mMaterialDomain; }
     CullingMode getCullingMode() const noexcept { return mCullingMode; }
     TransparencyMode getTransparencyMode() const noexcept { return mTransparencyMode; }
     bool isColorWriteEnabled() const noexcept { return mRasterState.colorWrite; }
@@ -132,6 +133,7 @@ private:
     BlendingMode mBlendingMode;
     Interpolation mInterpolation;
     VertexDomain mVertexDomain;
+    MaterialDomain mMaterialDomain;
     CullingMode mCullingMode;
     AttributeBitset mRequiredAttributes;
 

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -57,6 +57,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialSpecularAntiAliasingVariance = charTo64bitNum("MAT_SVAR"),
     MaterialSpecularAntiAliasingThreshold = charTo64bitNum("MAT_STHR"),
     MaterialClearCoatIorChange = charTo64bitNum("MAT_CIOR"),
+    MaterialDomain = charTo64bitNum("MAT_DOMN"),
 
     MaterialRequiredAttributes = charTo64bitNum("MAT_REQA"),
     MaterialDepthWriteSet = charTo64bitNum("MAT_DEWS"),

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -118,6 +118,14 @@ enum VertexAttribute : uint8_t {
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 
+/**
+ * Material domains
+ */
+enum MaterialDomain : uint8_t {
+    SURFACE         = 0, //!< shaders applied to renderables
+    POST_PROCESS    = 1, //!< shaders applied to rendered buffers
+};
+
 // can't really use std::underlying_type<AttributeIndex>::type because the driver takes a uint32_t
 using AttributeBitset = utils::bitset32;
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -153,6 +153,7 @@ public:
     MaterialBuilder& name(const char* name) noexcept;
 
     // set the shading model
+    using MaterialDomain = filament::MaterialDomain;
     MaterialBuilder& shading(Shading shading) noexcept;
 
     // set the interpolation mode
@@ -181,13 +182,22 @@ public:
     // depends on the shading model
     MaterialBuilder& require(filament::VertexAttribute attribute) noexcept;
 
+    // specify the domain that this material will operate in
+    MaterialBuilder& materialDomain(MaterialDomain materialDomain) noexcept;
+
     // set the code content of this material
-    // must declare a function "void material(inout MaterialInputs material)"
-    // this function *must* call "prepareMaterial(material)" before it returns
+    // for materials in the SURFACE domain:
+    //     must declare a function "void material(inout MaterialInputs material)"
+    //     this function *must* call "prepareMaterial(material)" before it returns
+    // for materials in the POST_PROCESS domain:
+    //     must declare a function "void postProcess(inout PostProcessInputs postProcess)"
     MaterialBuilder& material(const char* code, size_t line = 0) noexcept;
 
     // set the vertex code content of this material
-    // must declare a function "void materialVertex(inout MaterialVertexInputs material)"
+    // for materials in the SURFACE domain:
+    //     must declare a function "void materialVertex(inout MaterialVertexInputs material)"
+    // for materials in the POST_PROCESS domain:
+    //     must declare a function "void postProcessVertex(inout PostProcessVertexInputs postProcess)"
     MaterialBuilder& materialVertex(const char* code, size_t line = 0) noexcept;
 
     // set blending mode for this material
@@ -363,6 +373,7 @@ private:
     BlendingMode mPostLightingBlendingMode = BlendingMode::TRANSPARENT;
     CullingMode mCullingMode = CullingMode::BACK;
     Shading mShading = Shading::LIT;
+    MaterialDomain mMaterialDomain = MaterialDomain::SURFACE;
     Interpolation mInterpolation = Interpolation::SMOOTH;
     VertexDomain mVertexDomain = VertexDomain::OBJECT;
     TransparencyMode mTransparencyMode = TransparencyMode::DEFAULT;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -657,6 +657,7 @@ void MaterialBuilder::writeChunks(ChunkContainer& container, MaterialInfo& info)
     container.addSimpleChild<const char*>(ChunkType::MaterialName, mMaterialName.c_str_safe());
     container.addSimpleChild<uint8_t>(ChunkType::MaterialShading, static_cast<uint8_t>(mShading));
     container.addSimpleChild<uint8_t>(ChunkType::MaterialBlendingMode, static_cast<uint8_t>(mBlendingMode));
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialDomain, static_cast<uint8_t>(mMaterialDomain));
 
     if (mBlendingMode == BlendingMode::MASKED) {
         container.addSimpleChild<float>(ChunkType::MaterialMaskThreshold, mMaskThreshold);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -193,6 +193,11 @@ MaterialBuilder& MaterialBuilder::require(filament::VertexAttribute attribute) n
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::materialDomain(MaterialDomain materialDomain) noexcept {
+    mMaterialDomain = materialDomain;
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::blending(BlendingMode blending) noexcept {
     mBlendingMode = blending;
     return *this;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -441,6 +441,20 @@ static bool processShading(MaterialBuilder& builder, const JsonishValue& value) 
     return true;
 }
 
+static bool processDomain(MaterialBuilder& builder, const JsonishValue& value) {
+    static const std::unordered_map<std::string, MaterialBuilder::MaterialDomain> strToEnum {
+        { "surface",            MaterialBuilder::MaterialDomain::SURFACE },
+        { "postprocess",        MaterialBuilder::MaterialDomain::POST_PROCESS },
+    };
+    auto jsonString = value.toJsonString();
+    if (!isStringValidEnum(strToEnum, jsonString->getString())) {
+        return logEnumIssue("domain", *jsonString, strToEnum);
+    }
+
+    builder.materialDomain(stringToEnum(strToEnum, jsonString->getString()));
+    return true;
+}
+
 static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& value) {
     // We avoid using an initializer list for this particular map to avoid build errors that are
     // due to static initialization ordering.
@@ -505,6 +519,7 @@ ParametersProcessor::ParametersProcessor() {
     mParameters["flipUV"]                        = { &processFlipUV, Type::BOOL };
     mParameters["multiBounceAmbientOcclusion"]   = { &processMultiBounceAO, Type::BOOL };
     mParameters["specularAmbientOcclusion"]      = { &processSpecularAmbientOcclusion, Type::BOOL };
+    mParameters["domain"]                        = { &processDomain, Type::STRING };
 }
 
 bool ParametersProcessor::process(MaterialBuilder& builder, const JsonishObject& jsonObject) {


### PR DESCRIPTION
First installment for material domain changes. This adds support for the `domain` keyword in Filament materials and adds a new material domain chunk to material files.