### PR TITLE
gltfio: allow clients to pass in EntityManager.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -33,6 +33,7 @@ struct AssetConfiguration {
     class filament::Engine* engine;
     MaterialProvider* materials;
     utils::NameComponentManager* names = nullptr;
+    utils::EntityManager* entities = nullptr;
 };
 
 /**

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -100,7 +100,7 @@ static uint32_t computeBindingOffset(const cgltf_accessor* accessor) {
 
 struct FAssetLoader : public AssetLoader {
     FAssetLoader(const AssetConfiguration& config) :
-            mEntityManager(EntityManager::get()),
+            mEntityManager(config.entities ? *config.entities : EntityManager::get()),
             mRenderableManager(config.engine->getRenderableManager()),
             mNameManager(config.names),
             mTransformManager(config.engine->getTransformManager()),


### PR DESCRIPTION
**NOTE:** Should we expose `Engine::getEntityManager()` to help with issues like this? e.g. it would allow gltfio to extract it from the engine rather than consuming an additional argument.

This fixes an entity id collision that I saw when building gltfio into its own DSO (e.g. on Android). Since it is a separate executable it has its own EntityManager singleton. This id collision was causing unwanted entities to be added to the scene.