### PR TITLE
Fix MaterialInstance Java color bindings

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
@@ -130,12 +130,14 @@ public class MaterialInstance {
 
     public void setParameter(@NonNull String name, @NonNull Colors.RgbType type,
             float r, float g, float b) {
-        setParameter(name, FloatElement.FLOAT3, Colors.toLinear(type, r, g, b), 0, 1);
+        float[] color = Colors.toLinear(type, r, g, b);
+        nSetParameterFloat3(getNativeObject(), name, color[0], color[1], color[2]);
     }
 
     public void setParameter(@NonNull String name, @NonNull Colors.RgbaType type,
             float r, float g, float b, float a) {
-        setParameter(name, FloatElement.FLOAT4, Colors.toLinear(type, r, g, b, a), 0, 1);
+        float[] color = Colors.toLinear(type, r, g, b, a);
+        nSetParameterFloat4(getNativeObject(), name, color[0], color[1], color[2], color[3]);
     }
 
     public void setScissor(@IntRange(from = 0) int left, @IntRange(from = 0) int bottom,


### PR DESCRIPTION
This changes addresses issue #1307. We recently fixed the way we support arrays
of parameters to allow arrays of 1 element. Previously single elements (e.g. float)
were treated as an array of 1 element and the other way around. Unfortunately our
Java bindings relied on this behavior to set colors. This change simply directly
calls the float3 and float4 variants of setParameter() when setting a color.