### PR TITLE
Add mipmap level selection to Metal render targets

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -189,7 +189,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     };
 
     construct_handle<MetalRenderTarget>(mHandleMap, rth, mContext, width, height, samples,
-            getColorTexture(), getDepthTexture(), color.level);
+            getColorTexture(), getDepthTexture(), color.level, depth.level);
 
     ASSERT_POSTCONDITION(
             !stencil.handle && !(targetBufferFlags & TargetBufferFlags::STENCIL),
@@ -526,6 +526,7 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     const auto& colorAttachment = descriptor.colorAttachments[0];
     colorAttachment.texture = renderTarget->getColor();
     colorAttachment.resolveTexture = discardColor ? nil : renderTarget->getColorResolve();
+    colorAttachment.level = renderTarget->getColorLevel();
     mContext->currentSurfacePixelFormat = colorAttachment.texture.pixelFormat;
 
     // Metal clears the entire attachment without respect to viewport or scissor.
@@ -544,6 +545,7 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     depthAttachment.loadAction = renderTarget->getLoadAction(params, TargetBufferFlags::DEPTH);
     depthAttachment.storeAction = renderTarget->getStoreAction(params, TargetBufferFlags::DEPTH);
     depthAttachment.clearDepth = params.clearDepth;
+    depthAttachment.level = renderTarget->getDepthLevel();
     mContext->currentDepthPixelFormat = descriptor.depthAttachment.texture.pixelFormat;
 
     mContext->currentCommandEncoder =

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -146,7 +146,7 @@ struct MetalSamplerGroup : public HwSamplerGroup {
 class MetalRenderTarget : public HwRenderTarget {
 public:
     MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height, uint8_t samples,
-            id<MTLTexture> color, id<MTLTexture> depth, uint8_t level);
+            id<MTLTexture> color, id<MTLTexture> depth, uint8_t colorLevel, uint8_t depthLevel);
     explicit MetalRenderTarget(MetalContext* context)
             : HwRenderTarget(0, 0), context(context), defaultRenderTarget(true) {}
     ~MetalRenderTarget();
@@ -162,7 +162,8 @@ public:
     id<MTLTexture> getDepthResolve();
     id<MTLTexture> getBlitColorSource();
     id<MTLTexture> getBlitDepthSource();
-    uint8_t getColorLevel() { return level; }
+    uint8_t getColorLevel() { return colorLevel; }
+    uint8_t getDepthLevel() { return depthLevel; }
 
 private:
     static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, MTLPixelFormat format,
@@ -171,7 +172,8 @@ private:
     MetalContext* context;
     bool defaultRenderTarget = false;
     uint8_t samples = 1;
-    uint8_t level = 0;
+    uint8_t colorLevel;
+    uint8_t depthLevel;
 
     id<MTLTexture> color = nil;
     id<MTLTexture> depth = nil;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -172,8 +172,8 @@ private:
     MetalContext* context;
     bool defaultRenderTarget = false;
     uint8_t samples = 1;
-    uint8_t colorLevel;
-    uint8_t depthLevel;
+    uint8_t colorLevel = 0;
+    uint8_t depthLevel = 0;
 
     id<MTLTexture> color = nil;
     id<MTLTexture> depth = nil;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -368,8 +368,9 @@ void MetalTexture::loadCubeImage(const PixelBufferDescriptor& data, const FaceOf
 }
 
 MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height,
-        uint8_t samples, id<MTLTexture> color, id<MTLTexture> depth, uint8_t level)
-        : HwRenderTarget(width, height), context(context), samples(samples), level(level) {
+        uint8_t samples, id<MTLTexture> color, id<MTLTexture> depth, uint8_t colorLevel,
+        uint8_t depthLevel) : HwRenderTarget(width, height), context(context), samples(samples),
+        colorLevel(colorLevel), depthLevel(depthLevel) {
     ASSERT_PRECONDITION(color || depth, "Must provide either a color or depth texture.");
 
     [color retain];


### PR DESCRIPTION
Implement mipmap selection for Metal render targets. This is in preparation for Metal supporting SSAO, where a chain of depth mipmaps need to be generated.