### PR TITLE
Expose texture usage flags to Java / Kotlin.

### DIFF
--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -113,6 +113,13 @@ Java_com_google_android_filament_Texture_nBuilderRgbm(JNIEnv*, jclass,
     builder->rgbm(enable);
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Texture_nBuilderUsage(JNIEnv*, jclass,
+        jlong nativeBuilder, jint flags) {
+    Texture::Builder *builder = (Texture::Builder *) nativeBuilder;
+    builder->usage((Texture::Usage) flags);
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_Texture_nBuilderBuild(JNIEnv*, jclass,
         jlong nativeBuilder, jlong nativeEngine) {

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -341,6 +341,17 @@ public class Texture {
             return this;
         }
 
+        /**
+         * Sets the usage flags, which is necessary when attaching to {@link RenderTarget}.
+         *
+         * The flags argument much be a combination of {@link Usage} flags.
+         */
+        @NonNull
+        public Builder usage(int flags) {
+            nBuilderUsage(mNativeBuilder, flags);
+            return this;
+        }
+
         @NonNull
         public Texture build(@NonNull Engine engine) {
             long nativeTexture = nBuilderBuild(mNativeBuilder, engine.getNativeObject());
@@ -365,6 +376,15 @@ public class Texture {
                 }
             }
         }
+    }
+
+    public static class Usage {
+        public static final int COLOR_ATTACHMENT = 0x1;
+        public static final int DEPTH_ATTACHMENT = 0x2;
+        public static final int STENCIL_ATTACHMENT = 0x4;
+        public static final int UPLOADABLE = 0x8;
+        public static final int SAMPLEABLE = 0x10;
+        public static final int DEFAULT = UPLOADABLE | SAMPLEABLE;
     }
 
     public static final int BASE_LEVEL = 0;
@@ -496,6 +516,7 @@ public class Texture {
     private static native void nBuilderSampler(long nativeBuilder, int sampler);
     private static native void nBuilderFormat(long nativeBuilder, int format);
     private static native void nBuilderRgbm(long nativeBuilder, boolean enabled);
+    private static native void nBuilderUsage(long nativeBuilder, int flags);
     private static native long nBuilderBuild(long nativeBuilder, long nativeEngine);
 
     private static native int nGetWidth(long nativeTexture, int level);


### PR DESCRIPTION
Clients need this ability in order to use the new RenderTarget API.