### PR TITLE
Compile gltfio with -fPIC

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -114,6 +114,7 @@ link_libraries(math utils filament cgltf stb geometry gltfio_resources)
 add_library(gltfio_core STATIC ${PUBLIC_HDRS} ${SRCS})
 
 target_include_directories(gltfio_core PUBLIC ${PUBLIC_HDR_DIR})
+target_compile_options(gltfio_core PRIVATE $<$<PLATFORM_ID:Linux>:-fPIC>)
 
 if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
 
@@ -141,6 +142,7 @@ if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
     else()
         target_compile_options(${TARGET} PRIVATE $<$<CONFIG:Release>:-ffast-math>)
     endif()
+    target_compile_options(${TARGET} PRIVATE $<$<PLATFORM_ID:Linux>:-fPIC>)
 
     # ==================================================================================================
     # Installation


### PR DESCRIPTION
Attempting to create a shared library linking in gltfio results in the following.

/usr/bin/ld.gold: error: /home/joetoth/projects/psycho/third_party/filament/out/release/filament/lib/x86_64/libgltfio.a(MaterialGenerator.cpp.o): requires unsupported dynamic reloc 11; recompile with -fPIC

After adding -fPIC for CXX I then got...

/usr/bin/ld.gold: error: /home/joetoth/projects/psycho/third_party/filament/out/release/filament/lib/x86_64/libgltfio_core.a(stb.c.o): requires dynamic R_X86_64_32 reloc which may overflow at runtime; recompile with -fPIC

added -fPIC to CMAKE_C_FLAGS fixed this.