### PR TITLE
Fix GL_INVALID_OPERATION in the default IBL.

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -202,8 +202,8 @@ void FEngine::init() {
             .build(*this));
     static uint32_t pixel = 0;
     Texture::PixelBufferDescriptor buffer(
-            &pixel, 4, // 4 bytes in 1 RGB pixel
-            Texture::Format::RGB, Texture::Type::UBYTE);
+            &pixel, 4, // 4 bytes in 1 RGBA pixel
+            Texture::Format::RGBA, Texture::Type::UBYTE);
     Texture::FaceOffsets offsets = {};
     mDefaultIblTexture->setImage(*this, 0, std::move(buffer), offsets);
 


### PR DESCRIPTION
In commit d955e73 we changed the default IBL from RGBM to RGB, but we
kept its internal format of RGBA8. Since the internal format is not
compatible with the data format, we see GL_INVALID_OPERATION during the
texture upload.

This is a single-pixel black texture, so the format does not really
matter, but this clears up a GL error seen on some platforms.