### PR TITLE
Fix JNI for parameter arrays in MaterialInstance.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 
 # Release notes
 
+- Fix JNI bindings for setting values in parameter arrays.
 - Added JNI bindings for the gltfio library.
 - Fix support for parameter arrays in `.mat` files.
 - Added support for `RGB_11_11_10`


### PR DESCRIPTION
Previously we used the <T=float> template instantiation of setParameter
when the client specified FLOAT4. This resulted in the lower layer
adding needless padding, thus causing a buffer overflow.

Moreover the JNI code for this was somewhat cryptic because it casted an
enum value to an int, then added 1 to compute the size. We now use
a switch statement to improve readability.

This issue was discovered (and the fix was verified) with the upcoming
Android port of the bloom demo.