### PR TITLE
gltfio: Disable file formats that we do not need.

### DIFF
--- a/third_party/stb/stb.c
+++ b/third_party/stb/stb.c
@@ -14,5 +14,13 @@
  * limitations under the License.
  */
 
+#define STBI_NO_BMP
+#define STBI_NO_PSD
+#define STBI_NO_TGA
+#define STBI_NO_GIF
+#define STBI_NO_HDR
+#define STBI_NO_PIC
+#define STBI_NO_PNM
+
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>


### PR DESCRIPTION
This only removes 40k but at least it is easy.