### PR TITLE
Add spherical harmonics parser, reduce code duplication.

### DIFF
--- a/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
+++ b/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
@@ -99,7 +99,7 @@ void FilamentApp::setupIbl() {
     image::KtxBundle* iblBundle = new image::KtxBundle(RESOURCES_VENETIAN_CROSSROADS_IBL_DATA,
                                                        RESOURCES_VENETIAN_CROSSROADS_IBL_SIZE);
     float3 harmonics[9];
-    parseSphereHarmonics(iblBundle->getMetadata("sh"), harmonics);
+    iblBundle->getSphericalHarmonics(harmonics);
     app.iblTexture = image::KtxUtility::createTexture(engine, iblBundle, false, true);
 
     app.indirectLight = IndirectLight::Builder()
@@ -152,19 +152,4 @@ void FilamentApp::setupView() {
 void FilamentApp::setupCameraFeedTriangle() {
     app.cameraFeedTriangle = new FullScreenTriangle(engine);
     scene->addEntity(app.cameraFeedTriangle->getEntity());
-}
-
-void FilamentApp::parseSphereHarmonics(const char* str, float3 harmonics[9]) {
-    std::istringstream iss(str);
-    std::string read;
-    for (int i = 0; i < 9; i++) {
-        float3 harmonic;
-        iss >> read;
-        harmonic.x = std::stof(read);
-        iss >> read;
-        harmonic.y = std::stof(read);
-        iss >> read;
-        harmonic.z = std::stof(read);
-        harmonics[i] = std::move(harmonic);
-    }
 }

--- a/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.h
+++ b/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.h
@@ -60,8 +60,6 @@ private:
     void setupView();
     void setupCameraFeedTriangle();
 
-    static void parseSphereHarmonics(const char* str, float3 harmonics[9]);
-
     void* nativeLayer = nullptr;
     uint32_t width, height;
 

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
@@ -87,7 +87,7 @@ void App::setupIbl() {
     image::KtxBundle* iblBundle = new image::KtxBundle(RESOURCES_VENETIAN_CROSSROADS_IBL_DATA,
                                                        RESOURCES_VENETIAN_CROSSROADS_IBL_SIZE);
     float3 harmonics[9];
-    parseSphereHarmonics(iblBundle->getMetadata("sh"), harmonics);
+    iblBundle->getSphericalHarmonics(harmoncs);
     app.iblTexture = image::KtxUtility::createTexture(engine, iblBundle, false, true);
 
     image::KtxBundle* skyboxBundle = new image::KtxBundle(RESOURCES_VENETIAN_CROSSROADS_SKYBOX_DATA,
@@ -148,19 +148,4 @@ void App::setupView() {
 
     // Even FXAA anti-aliasing is overkill on iOS retina screens. This saves a few ms.
     view->setAntiAliasing(View::AntiAliasing::NONE);
-}
-
-void App::parseSphereHarmonics(const char* str, float3 harmonics[9]) {
-    std::istringstream iss(str);
-    std::string read;
-    for (int i = 0; i < 9; i++) {
-        float3 harmonic;
-        iss >> read;
-        harmonic.x = std::stof(read);
-        iss >> read;
-        harmonic.y = std::stof(read);
-        iss >> read;
-        harmonic.z = std::stof(read);
-        harmonics[i] = std::move(harmonic);
-    }
 }

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
@@ -60,8 +60,6 @@ private:
     void setupMesh();
     void setupView();
 
-    static void parseSphereHarmonics(const char* str, float3 harmonics[9]);
-
     void* nativeLayer = nullptr;
     uint32_t width, height;
     const utils::Path resourcePath;

--- a/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
+++ b/ios/samples/hello-pbr/hello-pbr/FilamentApp.cpp
@@ -46,7 +46,7 @@ void FilamentApp::initialize() {
     image::KtxBundle* iblBundle = new image::KtxBundle(RESOURCES_VENETIAN_CROSSROADS_IBL_DATA,
             RESOURCES_VENETIAN_CROSSROADS_IBL_SIZE);
     filament::math::float3 harmonics[9];
-    parseSphereHarmonics(iblBundle->getMetadata("sh"), harmonics);
+    iblBundle->getSphericalHarmonics(harmonics);
     app.iblTexture = image::KtxUtility::createTexture(engine, iblBundle, false, true);
 
     image::KtxBundle* skyboxBundle = new image::KtxBundle(RESOURCES_VENETIAN_CROSSROADS_SKYBOX_DATA,
@@ -127,19 +127,4 @@ FilamentApp::~FilamentApp() {
     engine->destroy(camera);
     engine->destroy(swapChain);
     engine->destroy(&engine);
-}
-
-void FilamentApp::parseSphereHarmonics(const char* str, filament::math::float3 harmonics[9]) {
-    std::istringstream iss(str);
-    std::string read;
-    for (int i = 0; i < 9; i++) {
-        filament::math::float3 harmonic;
-        iss >> read;
-        harmonic.x = std::stof(read);
-        iss >> read;
-        harmonic.y = std::stof(read);
-        iss >> read;
-        harmonic.z = std::stof(read);
-        harmonics[i] = std::move(harmonic);
-    }
 }

--- a/ios/samples/hello-pbr/hello-pbr/FilamentApp.h
+++ b/ios/samples/hello-pbr/hello-pbr/FilamentApp.h
@@ -48,8 +48,6 @@ private:
 
     void updateRotation();
 
-    static void parseSphereHarmonics(const char* str, filament::math::float3 harmonics[9]);
-
     void* nativeLayer = nullptr;
     uint32_t width, height;
 

--- a/libs/image/include/image/KtxBundle.h
+++ b/libs/image/include/image/KtxBundle.h
@@ -17,6 +17,8 @@
 #ifndef IMAGE_KTXBUNDLE_H
 #define IMAGE_KTXBUNDLE_H
 
+#include <math/vec3.h>
+
 #include <cstdint>
 #include <memory>
 
@@ -100,6 +102,14 @@ public:
      */
     const char* getMetadata(const char* key, size_t* valueSize = nullptr) const;
     void setMetadata(const char* key, const char* value);
+
+    /**
+     * Parses the key="sh" metadata and returns 3 bands of data.
+     *
+     * Assumes 3 bands for a total of 9 coefficients.
+     * Returns true if successful.
+     */
+    bool getSphericalHarmonics(filament::math::float3* result);
 
     /**
      * Gets the number of miplevels (this is never zero).

--- a/libs/image/src/KtxBundle.cpp
+++ b/libs/image/src/KtxBundle.cpp
@@ -286,6 +286,23 @@ void KtxBundle::setMetadata(const char* key, const char* value) {
     mMetadata->keyvals.insert({key, value});
 }
 
+bool KtxBundle::getSphericalHarmonics(filament::math::float3* result) {
+    char const* src = getMetadata("sh");
+    if (!src) {
+        return false;
+    }
+    float* flat = &result->x;
+    for (int i = 0; i < 9; i++) {
+        char* next;
+        *flat++ = std::strtof(src, &next);
+        if (next == src) {
+            return false;
+        }
+        src = next;
+    }
+    return true;
+}
+
 bool KtxBundle::getBlob(KtxBlobIndex index, uint8_t** data, uint32_t* size) const {
     if (index.mipLevel >= mNumMipLevels || index.arrayIndex >= mArrayLength ||
             index.cubeFace >= mNumCubeFaces) {

--- a/samples/app/IBL.cpp
+++ b/samples/app/IBL.cpp
@@ -17,7 +17,6 @@
 #include "IBL.h"
 
 #include <fstream>
-#include <sstream>
 #include <string>
 
 #include <filament/Engine.h>
@@ -81,9 +80,8 @@ bool IBL::loadFromKtx(const std::string& prefix) {
     mSkyboxTexture = KtxUtility::createTexture(&mEngine, skyKtx, false);
     mTexture = KtxUtility::createTexture(&mEngine, iblKtx, false);
 
-    std::istringstream shstring(iblKtx->getMetadata("sh"));
-    for (float3& band : mBands) {
-        shstring >> band.x >> band.y >> band.z;
+    if (!iblKtx->getSphericalHarmonics(mBands)) {
+        return false;
     }
 
     mIndirectLight = IndirectLight::Builder()


### PR DESCRIPTION
This uses strtof rather than stringstream and provides a common location
that can be leveraged by the upcoming JNI bindings.

Note that this new method lives in KtxBundle rather than KtxUtility. The
latter creates Filament textures and therefore does not get built into
libimage.