### PR TITLE
Add missing getter in IndirectLight

### DIFF
--- a/android/filament-android/src/main/cpp/IndirectLight.cpp
+++ b/android/filament-android/src/main/cpp/IndirectLight.cpp
@@ -92,8 +92,6 @@ Java_com_google_android_filament_IndirectLight_nRotation(JNIEnv *, jclass, jlong
     builder->rotation(filament::math::mat3f{v0, v1, v2, v3, v4, v5, v6, v7, v8});
 }
 
-
-
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_IndirectLight_nSetIntensity(JNIEnv*, jclass,
         jlong nativeIndirectLight, jfloat intensity) {
@@ -109,9 +107,19 @@ Java_com_google_android_filament_IndirectLight_nGetIntensity(JNIEnv*, jclass,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_IndirectLight_nSetRotation(JNIEnv *env, jclass type,
-        jlong nativeIndirectLight, jfloat v0, jfloat v1, jfloat v2, jfloat v3, jfloat v4, jfloat v5,
-        jfloat v6, jfloat v7, jfloat v8) {
+Java_com_google_android_filament_IndirectLight_nSetRotation(JNIEnv*, jclass,
+        jlong nativeIndirectLight, jfloat v0, jfloat v1, jfloat v2,
+        jfloat v3, jfloat v4, jfloat v5, jfloat v6, jfloat v7, jfloat v8) {
     IndirectLight *indirectLight = (IndirectLight *) nativeIndirectLight;
     indirectLight->setRotation(filament::math::mat3f{v0, v1, v2, v3, v4, v5, v6, v7, v8});
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_IndirectLight_nGetRotation(JNIEnv* env, jclass,
+        jlong nativeIndirectLight, jfloatArray outRotation_) {
+    IndirectLight *indirectLight = (IndirectLight *) nativeIndirectLight;
+    jfloat *outRotation = env->GetFloatArrayElements(outRotation_, NULL);
+    *reinterpret_cast<filament::math::mat3f*>(outRotation) = indirectLight->getRotation();
+    env->ReleaseFloatArrayElements(outRotation_, outRotation, 0);
+
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/Asserts.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Asserts.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament;
+
+import android.support.annotation.IntRange;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+
+final class Asserts {
+    private Asserts() {
+    }
+
+    @NonNull @Size(min = 9)
+    static float[] assertMat3f(@Nullable float[] out) {
+        if (out == null) out = new float[9];
+        else if (out.length < 9) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 9");
+        }
+        return out;
+    }
+
+    static void assertMat3fIn(@NonNull @Size(min = 9) float[] in) {
+        if (in.length < 9) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 9");
+        }
+    }
+
+    @NonNull @Size(min = 16)
+    static double[] assertMat4d(@Nullable double[] out) {
+        if (out == null) out = new double[16];
+        else if (out.length < 16) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
+        }
+        return out;
+    }
+
+    static void assertMat4dIn(@NonNull @Size(min = 16) double[] in) {
+        if (in.length < 16) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
+        }
+    }
+
+    @NonNull @Size(min = 16)
+    static float[] assertMat4f(@Nullable float[] out) {
+        if (out == null) out = new float[16];
+        else if (out.length < 16) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
+        }
+        return out;
+    }
+
+    static void assertMat4fIn(@NonNull @Size(min = 16) float[] in) {
+        if (in.length < 16) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
+        }
+    }
+
+    @NonNull @Size(min = 3)
+    static float[] assertFloat3(@Nullable float[] out) {
+        if (out == null) out = new float[3];
+        else if (out.length < 3) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 3");
+        }
+        return out;
+    }
+
+    @NonNull @Size(min = 4)
+    static float[] assertFloat4(@Nullable float[] out) {
+        if (out == null) out = new float[4];
+        else if (out.length < 4) {
+            throw new ArrayIndexOutOfBoundsException("Array length must be at least 4");
+        }
+        return out;
+    }
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/Camera.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Camera.java
@@ -219,7 +219,7 @@ public class Camera {
      */
     public void setCustomProjection(@NonNull @Size(min = 16) double inMatrix[],
             double near, double far) {
-        assertMat4dIn(inMatrix);
+        Asserts.assertMat4dIn(inMatrix);
         nSetCustomProjection(getNativeObject(), inMatrix, near, far);
     }
 
@@ -228,7 +228,7 @@ public class Camera {
      * @param in
      */
     public void setModelMatrix(@NonNull @Size(min = 16) float in[]) {
-        assertMat4fIn(in);
+        Asserts.assertMat4fIn(in);
         nSetModelMatrix(getNativeObject(), in);
     }
 
@@ -273,7 +273,7 @@ public class Camera {
      */
     @NonNull @Size(min = 16)
     public double[] getProjectionMatrix(@Nullable @Size(min = 16) double out[]) {
-        out = assertMat4d(out);
+        out = Asserts.assertMat4d(out);
         nGetProjectionMatrix(getNativeObject(), out);
         return out;
     }
@@ -287,7 +287,7 @@ public class Camera {
      */
     @NonNull @Size(min = 16)
     public float[] getModelMatrix(@Nullable @Size(min = 16) float out[]) {
-        out = assertMat4f(out);
+        out = Asserts.assertMat4f(out);
         nGetModelMatrix(getNativeObject(), out);
         return out;
     }
@@ -301,7 +301,7 @@ public class Camera {
      */
     @NonNull @Size(min = 16)
     public float[] getViewMatrix(@Nullable @Size(min = 16) float out[]) {
-        out = assertMat4f(out);
+        out = Asserts.assertMat4f(out);
         nGetViewMatrix(getNativeObject(), out);
         return out;
     }
@@ -314,7 +314,7 @@ public class Camera {
      */
     @NonNull @Size(min = 3)
     public float[] getPosition(@Nullable @Size(min = 3) float out[]) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetPosition(getNativeObject(), out);
         return out;
     }
@@ -328,7 +328,7 @@ public class Camera {
      */
     @NonNull @Size(min = 3)
     public float[] getLeftVector(@Nullable @Size(min = 3) float out[]) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetLeftVector(getNativeObject(), out);
         return out;
     }
@@ -342,7 +342,7 @@ public class Camera {
      */
     @NonNull @Size(min = 3)
     public float[] getUpVector(@Nullable @Size(min = 3) float out[]) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetUpVector(getNativeObject(), out);
         return out;
     }
@@ -356,7 +356,7 @@ public class Camera {
      */
     @NonNull @Size(min = 3)
     public float[] getForwardVector(@Nullable @Size(min = 3) float out[]) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetForwardVector(getNativeObject(), out);
         return out;
     }
@@ -404,45 +404,6 @@ public class Camera {
 
     void clearNativeObject() {
         mNativeObject = 0;
-    }
-
-    @NonNull @Size(min = 16)
-    private static double[] assertMat4d(@Nullable double[] out) {
-        if (out == null) out = new double[16];
-        else if (out.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
-        return out;
-    }
-
-    @NonNull @Size(min = 16)
-    private static float[] assertMat4f(@Nullable float[] out) {
-        if (out == null) out = new float[16];
-        else if (out.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
-        return out;
-    }
-
-    private static void assertMat4dIn(@NonNull @Size(min = 16) double[] in) {
-        if (in.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
-    }
-
-    private static void assertMat4fIn(@NonNull @Size(min = 16) float[] in) {
-        if (in.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
-    }
-
-    @NonNull @Size(min = 3)
-    private static float[] assertFloat3(@Nullable float[] out) {
-        if (out == null) out = new float[3];
-        else if (out.length < 3) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 3");
-        }
-        return out;
     }
 
     private static native void nSetProjection(long nativeCamera, int projection, double left, double right, double bottom, double top, double near, double far);

--- a/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
@@ -18,6 +18,7 @@ package com.google.android.filament;
 
 import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.Size;
 
 public class IndirectLight {
@@ -133,10 +134,18 @@ public class IndirectLight {
     }
 
     public void setRotation(@NonNull @Size(min = 9) float[] rotation) {
+        Asserts.assertMat3fIn(rotation);
         nSetRotation(getNativeObject(),
                 rotation[0], rotation[1], rotation[2],
                 rotation[3], rotation[4], rotation[5],
                 rotation[6], rotation[7], rotation[8]);
+    }
+
+    @NonNull @Size(min = 9)
+    public float[] getRotation(@Nullable @Size(min = 9) float[] rotation) {
+        rotation = Asserts.assertMat3f(rotation);
+        nGetRotation(getNativeObject(), rotation);
+        return rotation;
     }
 
     long getNativeObject() {
@@ -164,4 +173,5 @@ public class IndirectLight {
     private static native void nSetIntensity(long nativeIndirectLight, float intensity);
     private static native float nGetIntensity(long nativeIndirectLight);
     private static native void nSetRotation(long nativeIndirectLight, float v0, float v1, float v2, float v3, float v4, float v5, float v6, float v7, float v8);
+    private static native void nGetRotation(long nativeIndirectLight, float[] outRotation);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -187,7 +187,7 @@ public class LightManager {
 
     @NonNull
     public float[] getPosition(@EntityInstance int i, @Nullable @Size(min = 3) float[] out) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetPosition(mNativeObject, i, out);
         return out;
     }
@@ -198,7 +198,7 @@ public class LightManager {
 
     @NonNull
     public float[] getDirection(@EntityInstance int i, @Nullable @Size(min = 3) float[] out) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetDirection(mNativeObject, i, out);
         return out;
     }
@@ -209,7 +209,7 @@ public class LightManager {
 
     @NonNull
     public float[] getColor(@EntityInstance int i, @Nullable @Size(min = 3) float[] out) {
-        out = assertFloat3(out);
+        out = Asserts.assertFloat3(out);
         nGetColor(mNativeObject, i, out);
         return out;
     }
@@ -260,15 +260,6 @@ public class LightManager {
 
     public float getSunHaloFalloff(@EntityInstance int i) {
         return nGetSunHaloFalloff(mNativeObject, i);
-    }
-
-    @NonNull @Size(min = 3)
-    private static float[] assertFloat3(@Nullable float[] out) {
-        if (out == null) out = new float[3];
-        else if (out.length < 3) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 3");
-        }
-        return out;
     }
 
     private static native boolean nHasComponent(long nativeLightManager, int entity);

--- a/android/filament-android/src/main/java/com/google/android/filament/TransformManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/TransformManager.java
@@ -57,9 +57,7 @@ public class TransformManager {
 
     public void setTransform(@EntityInstance int i,
             @NonNull @Size(min = 16) float[] localTransform) {
-        if (localTransform.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
+        Asserts.assertMat4fIn(localTransform);
         nSetTransform(mNativeObject, i, localTransform);
     }
 
@@ -67,7 +65,7 @@ public class TransformManager {
     @Size(min = 16)
     public float[] getTransform(@EntityInstance int i,
             @Nullable @Size(min = 16) float[] outLocalTransform) {
-        outLocalTransform = assertMat4f(outLocalTransform);
+        outLocalTransform = Asserts.assertMat4f(outLocalTransform);
         nGetTransform(mNativeObject, i, outLocalTransform);
         return outLocalTransform;
     }
@@ -76,7 +74,7 @@ public class TransformManager {
     @Size(min = 16)
     public float[] getWorldTransform(@EntityInstance int i,
             @Nullable @Size(min = 16) float[] outWorldTransform) {
-        outWorldTransform = assertMat4f(outWorldTransform);
+        outWorldTransform = Asserts.assertMat4f(outWorldTransform);
         nGetWorldTransform(mNativeObject, i, outWorldTransform);
         return outWorldTransform;
     }
@@ -87,15 +85,6 @@ public class TransformManager {
 
     public void commitLocalTransformTransaction() {
         nCommitLocalTransformTransaction(mNativeObject);
-    }
-
-    @NonNull @Size(min = 16)
-    private static float[] assertMat4f(@Nullable float[] out) {
-        if (out == null) out = new float[16];
-        else if (out.length < 16) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 16");
-        }
-        return out;
     }
 
     private static native boolean nHasComponent(long nativeTransformManager, int entity);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -148,7 +148,7 @@ public class View {
 
     @NonNull @Size(min = 4)
     public float[] getClearColor(@NonNull @Size(min = 4) float[] out) {
-        out = assertFloat4(out);
+        out = Asserts.assertFloat4(out);
         nGetClearColor(getNativeObject(), out);
         return out;
     }
@@ -307,15 +307,6 @@ public class View {
 
     void clearNativeObject() {
         mNativeObject = 0;
-    }
-
-    @NonNull @Size(min = 4)
-    private static float[] assertFloat4(@Nullable float[] out) {
-        if (out == null) out = new float[4];
-        else if (out.length < 4) {
-            throw new ArrayIndexOutOfBoundsException("Array length must be at least 4");
-        }
-        return out;
     }
 
     private static native void nSetName(long nativeView, String name);

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -280,6 +280,11 @@ public:
      * @param rotation 3x3 rotation matrix. Must be a rigid-body transform.
      */
     void setRotation(math::mat3f const& rotation) noexcept;
+
+    /**
+     * Returns the rigid-body transformation applied to the IBL.
+     */
+    const math::mat3f& getRotation() const noexcept;
 };
 
 } // namespace filament

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -184,4 +184,9 @@ void IndirectLight::setRotation(mat3f const& rotation) noexcept {
     upcast(this)->setRotation(rotation);
 }
 
+const math::mat3f& IndirectLight::getRotation() const noexcept {
+    return upcast(this)->getRotation();
+}
+
+
 } // namespace filament

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -47,7 +47,7 @@ public:
     float getIntensity() const noexcept { return mIntensity; }
     void setIntensity(float intensity) noexcept { mIntensity = intensity; }
     void setRotation(math::mat3f const& rotation) noexcept { mRotation = rotation; }
-    const math::mat3f& getRotation() const { return mRotation; }
+    const math::mat3f& getRotation() const noexcept { return mRotation; }
     size_t getMaxMipLevel() const noexcept { return mMaxMipLevel; }
 
 private:

--- a/java/filament/CMakeLists.txt
+++ b/java/filament/CMakeLists.txt
@@ -112,6 +112,7 @@ set(FILAMENT_JAVA_DIR ${FILAMENT_DIR}/src/main/java/)
 get_filename_component(FILAMENT_JAVA_DIR ${FILAMENT_JAVA_DIR} ABSOLUTE)
 
 set(JAVA_SOURCE_FILES
+        ${FILAMENT_JAVA_DIR}/com/google/android/filament/Asserts.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Box.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Camera.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Colors.java


### PR DESCRIPTION
This change also factors a bunch of assert methods in a single place
which should slightly decrease binary size.