### PR TITLE
Post-process materials: add post-process variant enum, split writeChunks function

### DIFF
--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -30,6 +30,12 @@ enum class PostProcessStage : uint8_t {
     ANTI_ALIASING_TRANSLUCENT,     // Anti-aliasing stage
 };
 
+static constexpr size_t POST_PROCESS_VARIANT_COUNT = 2;
+enum class PostProcessVariant : uint8_t {
+    OPAQUE,
+    TRANSLUCENT
+};
+
 // Binding points for uniform buffers and sampler buffers.
 // Effectively, these are just names.
 namespace BindingPoints {

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -367,7 +367,8 @@ private:
 
     bool checkLiteRequirements() noexcept;
 
-    void writeChunks(ChunkContainer& container, MaterialInfo& info) const noexcept;
+    void writeCommonChunks(ChunkContainer& container, MaterialInfo& info) const noexcept;
+    void writeSurfaceChunks(ChunkContainer& container) const noexcept;
 
     bool generateShaders(const std::vector<Variant>& variants, ChunkContainer& container,
             const MaterialInfo& info) const noexcept;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -639,7 +639,7 @@ Package MaterialBuilder::build() noexcept {
     }
 
     // Generate all shaders and write the shader chunks.
-    auto variants = determineVariants(mVariantFilter, isLit(), mShadowMultiplier);
+    auto variants = determineSurfaceVariants(mVariantFilter, isLit(), mShadowMultiplier);
     bool success = generateShaders(variants, container, info);
 
     // Flatten all chunks in the container into a Package.

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -633,7 +633,10 @@ Package MaterialBuilder::build() noexcept {
 
     // Create chunk tree.
     ChunkContainer container;
-    writeChunks(container, info);
+    writeCommonChunks(container, info);
+    if (mMaterialDomain == MaterialDomain::SURFACE) {
+        writeSurfaceChunks(container);
+    }
 
     // Generate all shaders and write the shader chunks.
     auto variants = determineVariants(mVariantFilter, isLit(), mShadowMultiplier);
@@ -672,27 +675,11 @@ const std::string MaterialBuilder::peek(filament::backend::ShaderType type,
     return std::string("");
 }
 
-void MaterialBuilder::writeChunks(ChunkContainer& container, MaterialInfo& info) const noexcept {
+void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo& info) const noexcept {
     container.addSimpleChild<uint32_t>(ChunkType::MaterialVersion, filament::MATERIAL_VERSION);
     container.addSimpleChild<const char*>(ChunkType::MaterialName, mMaterialName.c_str_safe());
-    container.addSimpleChild<uint8_t>(ChunkType::MaterialShading, static_cast<uint8_t>(mShading));
-    container.addSimpleChild<uint8_t>(ChunkType::MaterialBlendingMode, static_cast<uint8_t>(mBlendingMode));
+    container.addSimpleChild<uint32_t>(ChunkType::MaterialShaderModels, mShaderModels.getValue());
     container.addSimpleChild<uint8_t>(ChunkType::MaterialDomain, static_cast<uint8_t>(mMaterialDomain));
-
-    if (mBlendingMode == BlendingMode::MASKED) {
-        container.addSimpleChild<float>(ChunkType::MaterialMaskThreshold, mMaskThreshold);
-    }
-
-    if (mShading == Shading::UNLIT) {
-        container.addSimpleChild<bool>(ChunkType::MaterialShadowMultiplier, mShadowMultiplier);
-    }
-
-    container.addSimpleChild<bool>(ChunkType::MaterialSpecularAntiAliasing, mSpecularAntiAliasing);
-    container.addSimpleChild<float>(ChunkType::MaterialSpecularAntiAliasingVariance, mSpecularAntiAliasingVariance);
-    container.addSimpleChild<float>(ChunkType::MaterialSpecularAntiAliasingThreshold, mSpecularAntiAliasingThreshold);
-    container.addSimpleChild<bool>(ChunkType::MaterialClearCoatIorChange, mClearCoatIorChange);
-    container.addSimpleChild<uint8_t>(ChunkType::MaterialTransparencyMode, static_cast<uint8_t>(mTransparencyMode));
-    container.addSimpleChild<uint32_t>(ChunkType::MaterialRequiredAttributes, mRequiredAttributes.getValue());
 
     // UIB
     container.addChild<MaterialUniformInterfaceBlockChunk>(info.uib);
@@ -700,16 +687,36 @@ void MaterialBuilder::writeChunks(ChunkContainer& container, MaterialInfo& info)
     // SIB
     container.addChild<MaterialSamplerInterfaceBlockChunk>(info.sib);
 
-    container.addSimpleChild<bool>(ChunkType::MaterialDepthWriteSet, mDepthWriteSet);
     container.addSimpleChild<bool>(ChunkType::MaterialDoubleSidedSet, mDoubleSidedCapability);
     container.addSimpleChild<bool>(ChunkType::MaterialDoubleSided, mDoubleSided);
+
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialBlendingMode, static_cast<uint8_t>(mBlendingMode));
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialTransparencyMode, static_cast<uint8_t>(mTransparencyMode));
+    container.addSimpleChild<bool>(ChunkType::MaterialDepthWriteSet, mDepthWriteSet);
     container.addSimpleChild<bool>(ChunkType::MaterialColorWrite, mColorWrite);
     container.addSimpleChild<bool>(ChunkType::MaterialDepthWrite, mDepthWrite);
     container.addSimpleChild<bool>(ChunkType::MaterialDepthTest, mDepthTest);
     container.addSimpleChild<uint8_t>(ChunkType::MaterialCullingMode, static_cast<uint8_t>(mCullingMode));
+}
+
+void MaterialBuilder::writeSurfaceChunks(ChunkContainer& container) const noexcept {
+    if (mBlendingMode == BlendingMode::MASKED) {
+        container.addSimpleChild<float>(ChunkType::MaterialMaskThreshold, mMaskThreshold);
+    }
+
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialShading, static_cast<uint8_t>(mShading));
+
+    if (mShading == Shading::UNLIT) {
+        container.addSimpleChild<bool>(ChunkType::MaterialShadowMultiplier, mShadowMultiplier);
+    }
+
+    container.addSimpleChild<bool>(ChunkType::MaterialClearCoatIorChange, mClearCoatIorChange);
+    container.addSimpleChild<uint32_t>(ChunkType::MaterialRequiredAttributes, mRequiredAttributes.getValue());
+    container.addSimpleChild<bool>(ChunkType::MaterialSpecularAntiAliasing, mSpecularAntiAliasing);
+    container.addSimpleChild<float>(ChunkType::MaterialSpecularAntiAliasingVariance, mSpecularAntiAliasingVariance);
+    container.addSimpleChild<float>(ChunkType::MaterialSpecularAntiAliasingThreshold, mSpecularAntiAliasingThreshold);
     container.addSimpleChild<uint8_t>(ChunkType::MaterialVertexDomain, static_cast<uint8_t>(mVertexDomain));
     container.addSimpleChild<uint8_t>(ChunkType::MaterialInterpolation, static_cast<uint8_t>(mInterpolation));
-    container.addSimpleChild<uint32_t>(ChunkType::MaterialShaderModels, mShaderModels.getValue());
 }
 
 } // namespace filamat

--- a/libs/filamat/src/MaterialVariants.cpp
+++ b/libs/filamat/src/MaterialVariants.cpp
@@ -46,6 +46,8 @@ std::vector<Variant> determineSurfaceVariants(uint8_t variantFilter, bool isLit,
 
 std::vector<Variant> determinePostProcessVariants() {
     std::vector<Variant> variants;
+    // TODO: add a way to filter out post-process variants (e.g., the transparent variant if only
+    // opaque is needed)
     for (size_t k = 0; k < filament::POST_PROCESS_VARIANT_COUNT; k++) {
         variants.emplace_back(k, filament::backend::ShaderType::VERTEX);
         variants.emplace_back(k, filament::backend::ShaderType::FRAGMENT);

--- a/libs/filamat/src/MaterialVariants.cpp
+++ b/libs/filamat/src/MaterialVariants.cpp
@@ -16,9 +16,11 @@
 
 #include "MaterialVariants.h"
 
+#include <private/filament/EngineEnums.h>
+
 namespace filamat {
 
-std::vector<Variant> determineVariants(uint8_t variantFilter, bool isLit,
+std::vector<Variant> determineSurfaceVariants(uint8_t variantFilter, bool isLit,
         bool shadowMultiplier) {
     std::vector<Variant> variants;
     uint8_t variantMask = ~variantFilter;
@@ -38,6 +40,15 @@ std::vector<Variant> determineVariants(uint8_t variantFilter, bool isLit,
         if (filament::Variant::filterVariantFragment(v) == k) {
             variants.emplace_back(k, filament::backend::ShaderType::FRAGMENT);
         }
+    }
+    return variants;
+}
+
+std::vector<Variant> determinePostProcessVariants() {
+    std::vector<Variant> variants;
+    for (size_t k = 0; k < filament::POST_PROCESS_VARIANT_COUNT; k++) {
+        variants.emplace_back(k, filament::backend::ShaderType::VERTEX);
+        variants.emplace_back(k, filament::backend::ShaderType::FRAGMENT);
     }
     return variants;
 }

--- a/libs/filamat/src/MaterialVariants.h
+++ b/libs/filamat/src/MaterialVariants.h
@@ -34,7 +34,10 @@ struct Variant {
     Stage stage;
 };
 
-std::vector<Variant> determineVariants(uint8_t variantFilter, bool isLit, bool shadowMultiplier);
+std::vector<Variant> determineSurfaceVariants(uint8_t variantFilter, bool isLit,
+        bool shadowMultiplier);
+
+std::vector<Variant> determinePostProcessVariants();
 
 } // namespace filamat
 


### PR DESCRIPTION
Post-process materials will have two variants: opaque and translucent. This PR adds a new function to
calculate post-process variant combinations. The `PostProcessStage` enum will eventually be removed.

Also split `writeChunks` into `writeCommonChunks` and `writeSurfaceChunks`, only writing out surface chunks for surface materials.

