### PR TITLE
Use std::move in MeshAssimp.

### DIFF
--- a/samples/app/MeshAssimp.cpp
+++ b/samples/app/MeshAssimp.cpp
@@ -305,7 +305,7 @@ MeshAssimp::~MeshAssimp() {
 template<typename T>
 struct State {
     std::vector<T> state;
-    explicit State(std::vector<T>&& state) : state(state) { }
+    explicit State(std::vector<T>&& state) : state(std::move(state)) { }
     static void free(void* buffer, size_t size, void* user) {
         auto* const that = static_cast<State<T>*>(user);
         delete that;


### PR DESCRIPTION
Tested this via material_sandbox, seems to be fine.

Fixes #1366.