### PR TITLE
Remove unneeded yOffset uniform

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -142,11 +142,6 @@ void PostProcessManager::setSource(uint32_t viewportWidth, uint32_t viewportHeig
     ub.setUniform(offsetof(PostProcessingUib, time), fraction);
     ub.setUniform(offsetof(PostProcessingUib, uvScale), uvScale);
 
-    // The shader may need to know the offset between the top of the texture and the top
-    // of the rectangle that it actually needs to sample from.
-    const float yOffset = textureHeight - viewportHeight;
-    ub.setUniform(offsetof(PostProcessingUib, yOffset), yOffset);
-
     driver.updateSamplerGroup(mPostProcessSbh, std::move(group));
     driver.loadUniformBuffer(mPostProcessUbh, ub.toBufferDescriptor(driver));
 }

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -111,7 +111,6 @@ struct PostProcessingUib {
     }
     filament::math::float2 uvScale;
     float time;             // time in seconds, with a 1 second period, used for dithering
-    float yOffset;
     int dithering;          // type of dithering 0=none, 1=enabled
 };
 

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -104,7 +104,6 @@ UniformInterfaceBlock const& UibGenerator::getPostProcessingUib() noexcept {
             .name("PostProcessUniforms")
             .add("uvScale",   1, UniformInterfaceBlock::Type::FLOAT2)
             .add("time",      1, UniformInterfaceBlock::Type::FLOAT)
-            .add("yOffset",   1, UniformInterfaceBlock::Type::FLOAT)
             .add("dithering", 1, UniformInterfaceBlock::Type::INT)
             .build();
     return uib;

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -6,16 +6,6 @@ LAYOUT_LOCATION(0) out vec2 vertex_uv;
 void main() {
     vertex_uv = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
 
-#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
-    // In Vulkan and Metal, drawing the top row of pixels occurs when position.y = -1.0 (1.0 for
-    // Metal), but we're sampling from a rectangle the sits in the lower-left corner of the texture.
-    // Therefore we need to apply an offset to get the correct texture coordinate.
-    //
-    // For example, if the sampled area height is 180 and the texture height is 200,
-    // we need to sample the texture in the range [20,200) rather than [0,180).
-    vertex_uv.y += postProcessUniforms.yOffset;
-#endif
-
 #if POST_PROCESS_ANTI_ALIASING
     // texel to uv, accounting for the texture actual size
     vertex_uv *= frameUniforms.resolution.zw * postProcessUniforms.uvScale;


### PR DESCRIPTION
The `yOffset` uniform is no longer needed by post-process shaders (it's currently always 0). Previously, post-process passes needed to know the offset because the framebuffer size didn't always match the size of the viewport. Removing it simplifies post-process materials.