### PR TITLE
Fix windows build

### DIFF
--- a/libs/imageio/src/BlockCompression.cpp
+++ b/libs/imageio/src/BlockCompression.cpp
@@ -18,6 +18,7 @@
 
 #include <image/ImageOps.h>
 
+#include <algorithm>
 #include <cmath>
 #include <thread>
 


### PR DESCRIPTION
`algorithm` header necessary for `std::min` and `std::max`.