### PR TITLE
Stop using DXT5 in web samples for the IBL.

### DIFF
--- a/web/filament-js/utilities.js
+++ b/web/filament-js/utilities.js
@@ -260,6 +260,13 @@ Filament._createTextureFromKtx = function(ktxdata, engine, options) {
 Filament._createIblFromKtx = function(ktxdata, engine, options) {
     options = options || {};
     const iblktx = options['ktx'] = new Filament.KtxBundle(ktxdata);
+
+    const format = iblktx.info().glInternalFormat;
+    if (format != this.ctx.R11F_G11F_B10F && format != this.ctx.RGB16F && format != this.ctx.RGB32F) {
+        console.warning('IBL texture format is 0x' + internalFormat.toString(16) +
+            ' which is not an expected floating-point format. Please use cmgen to generate IBL.');
+    }
+
     const ibltex = Filament._createTextureFromKtx(ktxdata, engine, options);
     const shstring = iblktx.getMetadata("sh");
     const shfloats = shstring.split(/\s/, 9 * 3).map(parseFloat);

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -121,8 +121,6 @@ add_mesh("third_party/models/shader_ball/shader_ball.obj" "shader_ball.filamesh"
 # Generate IBL and skybox images using cmgen.
 set(CMGEN_ARGS -x . --format=ktx --size=256 --extract-blur=0.1)
 set(CMGEN_ARGS_TINY -x . --format=ktx --size=64 --extract-blur=0.1)
-set(CMGEN_ARGS_S3TC ${CMGEN_ARGS} --compression=s3tc_rgba_dxt5)
-set(CMGEN_ARGS_ETC ${CMGEN_ARGS} --compression=etc_rgba8_rgba_40)
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${ROOT_DIR}/${SOURCE}")
 
@@ -130,9 +128,6 @@ function(add_envmap SOURCE TARGET)
 
     set(target_skybox "${SERVER_DIR}/${TARGET}/${TARGET}_skybox.ktx")
     set(target_envmap "${SERVER_DIR}/${TARGET}/${TARGET}_ibl.ktx")
-
-    set(target_envmap_etc "${SERVER_DIR}/${TARGET}/${TARGET}_ibl_etc.ktx")
-    set(target_envmap_s3tc "${SERVER_DIR}/${TARGET}/${TARGET}_ibl_s3tc.ktx")
 
     set(target_skybox_tiny "${SERVER_DIR}/${TARGET}/${TARGET}_skybox_tiny.ktx")
 
@@ -143,14 +138,6 @@ function(add_envmap SOURCE TARGET)
 
     add_custom_command(OUTPUT ${target_skybox} ${target_skybox_tiny}
                 ${target_envmap} ${target_envmap_etc} ${target_envmap_s3tc}
-
-        # First create an S3TC-encoded envmap, then rename it.
-        COMMAND cmgen ${CMGEN_ARGS_S3TC} ${source_envmap}
-        COMMAND mv ${target_envmap} ${target_envmap_s3tc}
-
-        # Now create an ETC-encoded envmap, then rename it.
-        COMMAND cmgen ${CMGEN_ARGS_ETC} ${source_envmap}
-        COMMAND mv ${target_envmap} ${target_envmap_etc}
 
         # Create a low-resolution skybox, then rename it.
         COMMAND cmgen ${CMGEN_ARGS_TINY} ${source_envmap}

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -23,9 +23,8 @@ canvas     { position: absolute; width: 100%; height: 100%; }
 <script src="https://unpkg.com/gltumble"></script>
 <script>
 
-const ibl_suffix = Filament.getSupportedFormatSuffix('etc s3tc');
 const env = 'syferfontein_18d_clear_2k';
-const ibl_url = `${env}/${env}_ibl${ibl_suffix}.ktx`;
+const ibl_url = `${env}/${env}_ibl.ktx`;
 const sky_url = `${env}/${env}_skybox.ktx`;
 const mesh_url = 'helmet.gltf';
 

--- a/web/samples/suzanne.html
+++ b/web/samples/suzanne.html
@@ -16,12 +16,11 @@ canvas { touch-action: none; width: 100%; height: 100%; }
 <script src="gl-matrix-min.js"></script>
 <script>
 
-const ibl_suffix = Filament.getSupportedFormatSuffix('etc s3tc');
 const albedo_suffix = Filament.getSupportedFormatSuffix('astc s3tc');
 const texture_suffix = Filament.getSupportedFormatSuffix('etc');
 
 const env = 'syferfontein_18d_clear_2k'
-const ibl_url = `${env}/${env}_ibl${ibl_suffix}.ktx`;
+const ibl_url = `${env}/${env}_ibl.ktx`;
 const sky_url = `${env}/${env}_skybox.ktx`;
 const albedo_url = `albedo${albedo_suffix}.ktx`;
 const ao_url = `ao${texture_suffix}.ktx`;


### PR DESCRIPTION
Filament no longer decodes RGBM, so it's better to use a
floating-point format such as R11F_G11F_B10F.