### PR TITLE
math::half is an arithmetic type even on msvc

### DIFF
--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -167,10 +167,13 @@ inline constexpr half operator "" _h(long double v) {
 
 namespace std {
 
-template<> struct is_floating_point< filament::math::half> : public std::true_type {};
+template<> struct is_floating_point<filament::math::half> : public std::true_type {};
+
+// note: this shouldn't be needed (is_floating_point<> is enough) but some version of msvc need it
+template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
 
 template<>
-class numeric_limits< filament::math::half> {
+class numeric_limits<filament::math::half> {
 public:
     typedef filament::math::half type;
 


### PR DESCRIPTION
This addresses some of #1274 