### PR TITLE
Manually define PI to fix MSVC issue

### DIFF
--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -33,6 +33,8 @@ namespace math {
 // -------------------------------------------------------------------------------------
 namespace details {
 
+constexpr double PI = 3.14159265358979323846;
+
 template<typename T>
 class TQuaternion;
 
@@ -492,10 +494,10 @@ constexpr TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat4
     T w;
 
     if (direction == TMat44::Fov::VERTICAL) {
-        h = std::tan(fov * M_PI / 360.0f) * near;
+        h = std::tan(fov * PI / 360.0f) * near;
         w = h * aspect;
     } else {
-        w = std::tan(fov * M_PI / 360.0f) * near;
+        w = std::tan(fov * PI / 360.0f) * near;
         h = w / aspect;
     }
     return frustum(-w, w, -h, h, near, far);

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -33,7 +33,7 @@ namespace math {
 // -------------------------------------------------------------------------------------
 namespace details {
 
-constexpr double PI = 3.14159265358979323846;
+static constexpr double PI = 3.14159265358979323846;
 
 template<typename T>
 class TQuaternion;

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -33,6 +33,7 @@ namespace math {
 // -------------------------------------------------------------------------------------
 namespace details {
 
+// Define PI here for compatibility with MSVC.
 static constexpr double PI = 3.14159265358979323846;
 
 template<typename T>


### PR DESCRIPTION
MSVC doesn't have `M_PI`. We could define `_USE_MATH_DEFINES` and include `math.h`, but IMO just defining `PI` is a cleaner solution given this is a public header file.