### PR TITLE
Add support for custom vertex attributes.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 This file contains one line summaries of commits that are worthy of mentioning in release notes.
 A new header is inserted each time a *tag* is created.
 
+- Introduced custom attributes, accessible from the vertex shader.
 - Added Java / Kotlin bindings for KtxLoader.
 - Added JavaScript / Typescript bindings for the new `RenderTarget` class.
 

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -98,7 +98,8 @@ public class MaterialBuilder {
         UV0,                    // texture coordinates (float2)
         UV1,                    // texture coordinates (float2)
         BONE_INDICES,           // indices of 4 bones (uvec4)
-        BONE_WEIGHTS            // weights of the 4 bones (normalized float4)
+        BONE_WEIGHTS,           // weights of the 4 bones (normalized float4)
+        CUSTOM0,                // the first user-defined attributes (must be last in the enum)
     }
 
     public enum BlendingMode {

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -99,7 +99,14 @@ public class MaterialBuilder {
         UV1,                    // texture coordinates (float2)
         BONE_INDICES,           // indices of 4 bones (uvec4)
         BONE_WEIGHTS,           // weights of the 4 bones (normalized float4)
-        CUSTOM0,                // the first user-defined attributes (must be last in the enum)
+        CUSTOM0,
+        CUSTOM1,
+        CUSTOM2,
+        CUSTOM3,
+        CUSTOM4,
+        CUSTOM5,
+        CUSTOM6,
+        CUSTOM7
     }
 
     public enum BlendingMode {

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1580,11 +1580,12 @@ type aliases:
 
 The following APIs are only available from the vertex block:
 
-                 Name               |   Type   |            Description
-:-----------------------------------|:--------:|:------------------------------------
-**getPosition()**                   | float4   |  Vertex position in the domain defined by the material (default: object/model space)
-**getWorldFromModelMatrix()**       | float4x4 |  Matrix that converts from model (object) space to world space
-**getWorldFromModelNormalMatrix()** | float3x3 |  Matrix that converts normals from model (object) space to world space
+                 Name                |   Type   |            Description
+:------------------------------------|:--------:|:------------------------------------
+**getPosition()**                    | float4   |  Vertex position in the domain defined by the material (default: object/model space)
+**getCustom0()** to **getCustom7()** | float4   |  Custom vertex attribute
+**getWorldFromModelMatrix()**        | float4x4 |  Matrix that converts from model (object) space to world space
+**getWorldFromModelNormalMatrix()**  | float3x3 |  Matrix that converts normals from model (object) space to world space
 
 ### Fragment only
 

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -115,7 +115,14 @@ enum VertexAttribute : uint8_t {
     UV1             = 4, //!< texture coordinates (float2)
     BONE_INDICES    = 5, //!< indices of 4 bones, as unsigned integers (uvec4)
     BONE_WEIGHTS    = 6, //!< weights of the 4 bones (normalized float4)
-    CUSTOM0         = 7, //!< the first custom attribute (this is always last in the enum)
+    CUSTOM0         = 7,
+    CUSTOM1         = 8,
+    CUSTOM2         = 9,
+    CUSTOM3         = 10,
+    CUSTOM4         = 11,
+    CUSTOM5         = 12,
+    CUSTOM6         = 13,
+    CUSTOM7         = 14,
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -115,8 +115,11 @@ enum VertexAttribute : uint8_t {
     UV1             = 4, //!< texture coordinates (float2)
     BONE_INDICES    = 5, //!< indices of 4 bones, as unsigned integers (uvec4)
     BONE_WEIGHTS    = 6, //!< weights of the 4 bones (normalized float4)
+    CUSTOM0         = 7, //!< the first custom attribute (this is always last in the enum)
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
+
+static constexpr size_t MAX_CUSTOM_ATTRIBUTES = 8;
 
 /**
  * Material domains

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -189,6 +189,13 @@ io::sstream& CodeGenerator::generateShaderInputs(io::sstream& out, ShaderType ty
     bool hasBoneWeights = attributes.test(VertexAttribute::BONE_WEIGHTS);
     generateDefine(out, "HAS_ATTRIBUTE_BONE_WEIGHTS", hasBoneWeights);
 
+    for (int i = 0; i < MAX_CUSTOM_ATTRIBUTES; i++) {
+        bool hasCustom = attributes.test(VertexAttribute::CUSTOM0 + i);
+        if (hasCustom) {
+            generateIndexedDefine(out, "HAS_ATTRIBUTE_CUSTOM", i, 1);
+        }
+    }
+
     if (type == ShaderType::VERTEX) {
         out << "\n";
         generateDefine(out, "LOCATION_POSITION", uint32_t(VertexAttribute::POSITION));
@@ -209,6 +216,13 @@ io::sstream& CodeGenerator::generateShaderInputs(io::sstream& out, ShaderType ty
         }
         if (hasBoneWeights) {
             generateDefine(out, "LOCATION_BONE_WEIGHTS", uint32_t(VertexAttribute::BONE_WEIGHTS));
+        }
+
+        for (int i = 0; i < MAX_CUSTOM_ATTRIBUTES; i++) {
+            if (attributes.test(VertexAttribute::CUSTOM0 + i)) {
+                generateIndexedDefine(out, "LOCATION_CUSTOM", i,
+                        uint32_t(VertexAttribute::CUSTOM0) + i);
+            }
         }
 
         out << SHADERS_INPUTS_VS_DATA;
@@ -393,6 +407,12 @@ io::sstream& CodeGenerator::generateFunction(io::sstream& out, const char* retur
     out << "\n" << returnType << " " << name << "()";
     out << " {\n" << body;
     out << "\n}\n";
+    return out;
+}
+
+io::sstream& CodeGenerator::generateIndexedDefine(io::sstream& out, const char* name,
+        uint32_t index, uint32_t value) const {
+    out << "#define " << name << index << " " << value << "\n";
     return out;
 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -108,6 +108,8 @@ public:
     utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, float value) const;
     utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, uint32_t value) const;
     utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, const char* string) const;
+    utils::io::sstream& generateIndexedDefine(utils::io::sstream& out, const char* name,
+            uint32_t index, uint32_t value) const;
 
     utils::io::sstream& generateGetters(utils::io::sstream& out, ShaderType type) const;
     utils::io::sstream& generateParameters(utils::io::sstream& out, ShaderType type) const;

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -76,6 +76,31 @@ vec4 getSkinnedPosition() {
     return pos;
 }
 
+#if defined(HAS_ATTRIBUTE_CUSTOM0)
+vec4 getCustom0() { return mesh_custom0; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM1)
+vec4 getCustom1() { return mesh_custom1; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM2)
+vec4 getCustom2() { return mesh_custom2; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM3)
+vec4 getCustom3() { return mesh_custom3; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM4)
+vec4 getCustom4() { return mesh_custom4; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM5)
+vec4 getCustom5() { return mesh_custom5; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM6)
+vec4 getCustom6() { return mesh_custom6; }
+#endif
+#if defined(HAS_ATTRIBUTE_CUSTOM7)
+vec4 getCustom7() { return mesh_custom7; }
+#endif
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------

--- a/shaders/src/inputs.vs
+++ b/shaders/src/inputs.vs
@@ -24,6 +24,38 @@ layout(location = LOCATION_BONE_INDICES) in uvec4 mesh_bone_indices;
 layout(location = LOCATION_BONE_WEIGHTS) in vec4 mesh_bone_weights;
 #endif
 
+#if defined(HAS_ATTRIBUTE_CUSTOM0)
+layout(location = LOCATION_CUSTOM0) in vec4 mesh_custom0;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM1)
+layout(location = LOCATION_CUSTOM1) in vec4 mesh_custom1;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM2)
+layout(location = LOCATION_CUSTOM2) in vec4 mesh_custom2;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM3)
+layout(location = LOCATION_CUSTOM3) in vec4 mesh_custom3;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM4)
+layout(location = LOCATION_CUSTOM4) in vec4 mesh_custom4;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM5)
+layout(location = LOCATION_CUSTOM5) in vec4 mesh_custom5;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM6)
+layout(location = LOCATION_CUSTOM6) in vec4 mesh_custom6;
+#endif
+
+#if defined(HAS_ATTRIBUTE_CUSTOM7)
+layout(location = LOCATION_CUSTOM7) in vec4 mesh_custom7;
+#endif
+
 LAYOUT_LOCATION(4) out highp vec3 vertex_worldPosition;
 #if defined(HAS_ATTRIBUTE_TANGENTS)
 LAYOUT_LOCATION(5) SHADING_INTERPOLATION out mediump vec3 vertex_worldNormal;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -252,12 +252,21 @@ static bool processVariables(MaterialBuilder& builder, const JsonishValue& value
 }
 
 static bool processRequires(MaterialBuilder& builder, const JsonishValue& value) {
-    static const std::unordered_map<std::string, filament::VertexAttribute> strToEnum {
-        { "color", filament::VertexAttribute::COLOR },
-        { "position", filament::VertexAttribute::POSITION },
-        { "tangents", filament::VertexAttribute::TANGENTS },
-        { "uv0", filament::VertexAttribute::UV0 },
-        { "uv1", filament::VertexAttribute::UV1 },
+    using Attribute = filament::VertexAttribute;
+    static const std::unordered_map<std::string, Attribute> strToEnum {
+        { "color", Attribute::COLOR },
+        { "position", Attribute::POSITION },
+        { "tangents", Attribute::TANGENTS },
+        { "uv0", Attribute::UV0 },
+        { "uv1", Attribute::UV1 },
+        { "custom0", Attribute::CUSTOM0 },
+        { "custom1", Attribute(Attribute::CUSTOM0 + 1) },
+        { "custom2", Attribute(Attribute::CUSTOM0 + 2) },
+        { "custom3", Attribute(Attribute::CUSTOM0 + 3) },
+        { "custom4", Attribute(Attribute::CUSTOM0 + 4) },
+        { "custom5", Attribute(Attribute::CUSTOM0 + 5) },
+        { "custom6", Attribute(Attribute::CUSTOM0 + 6) },
+        { "custom7", Attribute(Attribute::CUSTOM0 + 7) },
     };
     for (auto v : value.toJsonArray()->getElements()) {
         if (v->getType() != JsonishValue::Type::STRING) {

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -308,6 +308,13 @@ const char* toString(VertexAttribute attribute) {
         case VertexAttribute::BONE_INDICES: return "bone indices";
         case VertexAttribute::BONE_WEIGHTS: return "bone weights";
         case VertexAttribute::CUSTOM0: return "custom0";
+        case VertexAttribute::CUSTOM1: return "custom1";
+        case VertexAttribute::CUSTOM2: return "custom2";
+        case VertexAttribute::CUSTOM3: return "custom3";
+        case VertexAttribute::CUSTOM4: return "custom4";
+        case VertexAttribute::CUSTOM5: return "custom5";
+        case VertexAttribute::CUSTOM6: return "custom6";
+        case VertexAttribute::CUSTOM7: return "custom7";
     }
     return "--";
 }

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -307,6 +307,7 @@ const char* toString(VertexAttribute attribute) {
         case VertexAttribute::UV1: return "uv1";
         case VertexAttribute::BONE_INDICES: return "bone indices";
         case VertexAttribute::BONE_WEIGHTS: return "bone weights";
+        case VertexAttribute::CUSTOM0: return "custom0";
     }
     return "--";
 }

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -586,6 +586,7 @@ export enum VertexAttribute {
     UV1,
     BONE_INDICES,
     BONE_WEIGHTS,
+    CUSTOM0,
 }
 
 export enum VertexBuffer$AttributeType {

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -587,6 +587,13 @@ export enum VertexAttribute {
     BONE_INDICES,
     BONE_WEIGHTS,
     CUSTOM0,
+    CUSTOM1,
+    CUSTOM2,
+    CUSTOM3,
+    CUSTOM4,
+    CUSTOM5,
+    CUSTOM6,
+    CUSTOM7,
 }
 
 export enum VertexBuffer$AttributeType {

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -49,7 +49,8 @@ enum_<VertexAttribute>("VertexAttribute")
     .value("UV0", UV0)
     .value("UV1", UV1)
     .value("BONE_INDICES", BONE_INDICES)
-    .value("BONE_WEIGHTS", BONE_WEIGHTS);
+    .value("BONE_WEIGHTS", BONE_WEIGHTS)
+    .value("CUSTOM0", CUSTOM0);
 
 enum_<VertexBuffer::AttributeType>("VertexBuffer$AttributeType")
     .value("BYTE", VertexBuffer::AttributeType::BYTE)

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -50,7 +50,14 @@ enum_<VertexAttribute>("VertexAttribute")
     .value("UV1", UV1)
     .value("BONE_INDICES", BONE_INDICES)
     .value("BONE_WEIGHTS", BONE_WEIGHTS)
-    .value("CUSTOM0", CUSTOM0);
+    .value("CUSTOM0", CUSTOM0)
+    .value("CUSTOM1", CUSTOM1)
+    .value("CUSTOM2", CUSTOM2)
+    .value("CUSTOM3", CUSTOM3)
+    .value("CUSTOM4", CUSTOM4)
+    .value("CUSTOM5", CUSTOM5)
+    .value("CUSTOM6", CUSTOM6)
+    .value("CUSTOM7", CUSTOM7);
 
 enum_<VertexBuffer::AttributeType>("VertexBuffer$AttributeType")
     .value("BYTE", VertexBuffer::AttributeType::BYTE)


### PR DESCRIPTION
This is a prep step for the upcoming morph feature and does not require
a bump to our material version number.

Stay tuned for a new sample app that demonstrates this feature.