### PR TITLE
Handle GL_PROGRAM_POINT_SIZE correctly

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -609,9 +609,10 @@ constexpr size_t OpenGLDriver::getIndexForCap(GLenum cap) noexcept {
 #ifdef GL_ARB_seamless_cube_map
         case GL_TEXTURE_CUBE_MAP_SEAMLESS:      index = 11; break;
 #endif
-        default: index = 12; break; // should never happen
+        case GL_PROGRAM_POINT_SIZE:             index = 12; break;
+        default: index = 13; break; // should never happen
     }
-    assert(index < 12 && index < state.enables.caps.size());
+    assert(index < 13 && index < state.enables.caps.size());
     return index;
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -609,7 +609,9 @@ constexpr size_t OpenGLDriver::getIndexForCap(GLenum cap) noexcept {
 #ifdef GL_ARB_seamless_cube_map
         case GL_TEXTURE_CUBE_MAP_SEAMLESS:      index = 11; break;
 #endif
+#if GL41_HEADERS
         case GL_PROGRAM_POINT_SIZE:             index = 12; break;
+#endif
         default: index = 13; break; // should never happen
     }
     assert(index < 13 && index < state.enables.caps.size());


### PR DESCRIPTION
Necessary to call `enable(GL_PROGRAM_POINT_SIZE)`