### PR TITLE
fix IndirectLight::radiance()

### DIFF
--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -73,15 +73,15 @@ IndirectLight::Builder& IndirectLight::Builder::radiance(uint8_t bands, float3 c
     if (bands >= 1) {
         irradiance[0] = sh[0] * 0.282095f;
         if (bands >= 2) {
-            irradiance[1] = sh[1] * 0.325735f;
-            irradiance[2] = sh[2] * 0.325735f;
-            irradiance[3] = sh[3] * 0.325735f;
+            irradiance[1] = sh[1] * -0.325735f;
+            irradiance[2] = sh[2] *  0.325735f;
+            irradiance[3] = sh[3] * -0.325735f;
             if (bands >= 3) {
-                irradiance[4] = sh[4] * 0.045523f;
-                irradiance[5] = sh[5] * 0.091046f;
-                irradiance[6] = sh[6] * 0.157696f;
-                irradiance[7] = sh[7] * 0.091046f;
-                irradiance[8] = sh[8] * 0.045523f;
+                irradiance[4] = sh[4] *  0.273137f;
+                irradiance[5] = sh[5] * -0.273137f;
+                irradiance[6] = sh[6] *  0.078848f;
+                irradiance[7] = sh[7] * -0.273137f;
+                irradiance[8] = sh[8] *  0.136569f;
             }
         }
     }

--- a/tools/cmgen/src/cmgen.cpp
+++ b/tools/cmgen/src/cmgen.cpp
@@ -662,7 +662,7 @@ void generateMipmaps(utils::JobSystem& js, std::vector<Cubemap>& levels,
     size_t dim = base.getDimensions();
     size_t mipLevel = 0;
     while (dim > 1) {
-        dim >>= 1;
+        dim >>= 1u;
         Cubemap dst = CubemapUtils::create(temp, dim);
         const Cubemap& src(levels[mipLevel++]);
         CubemapUtils::downsampleCubemapLevelBoxFilter(js, dst, src);
@@ -675,7 +675,8 @@ void generateMipmaps(utils::JobSystem& js, std::vector<Cubemap>& levels,
 void sphericalHarmonics(utils::JobSystem& js, const utils::Path& iname, const Cubemap& inputCubemap) {
     std::unique_ptr<filament::math::float3[]> sh;
     if (g_sh_shader) {
-        sh = CubemapSH::computeIrradianceSH3Bands(js, inputCubemap);
+        sh = CubemapSH::computeSH(js, inputCubemap, 3, true);
+        CubemapSH::preprocessSHForShader(sh);
     } else {
         sh = CubemapSH::computeSH(js, inputCubemap, g_sh_compute, g_sh_irradiance);
     }


### PR DESCRIPTION
The conversion factors from radiance to irradiance where wrong.

The bug above was found while refactoring the code to be clearer. Now
the method that computes the coefficients for the shader calls the
regular SH code and applies all the appropriate factors on that.

With this change the options`--sh-shader` and `-sh=3 -i` won't
produce the same result because `--sh-shader` includes the lambertian
diffuse. `--sh` now always produces actual SH coefficients.