### PR TITLE
New experimental filtering options to cmgen

### DIFF
--- a/libs/ibl/include/ibl/CubemapSH.h
+++ b/libs/ibl/include/ibl/CubemapSH.h
@@ -52,6 +52,8 @@ public:
     static void renderSH(utils::JobSystem& js, Cubemap& cm,
             const std::unique_ptr<filament::math::float3[]>& sh, size_t numBands);
 
+    static void windowSH(std::unique_ptr<filament::math::float3[]>& sh, size_t numBands, float cutoff);
+
     /**
      * Compute spherical harmonics of the irradiance of the given cubemap.
      * The SH basis are pre-scaled for easier rendering by the shader. The resulting coefficients
@@ -76,8 +78,7 @@ private:
         return l * (l + 1) + m;
     }
 
-    static void computeShBasis(float* SHb, size_t numBands,
-            const filament::math::float3& s);
+    static void computeShBasis(float* SHb, size_t numBands, const filament::math::float3& s);
 
     static float Kml(ssize_t m, size_t l);
 
@@ -85,7 +86,9 @@ private:
 
     static constexpr float computeTruncatedCosSh(size_t l);
 
-    // debugging only...
+    static float sincWindow(size_t l, float w);
+
+        // debugging only...
     static float Legendre(ssize_t l, ssize_t m, float x);
     static float TSH(int l, int m, const filament::math::float3& d);
     static void printShBase(std::ostream& out, int l, int m);

--- a/libs/ibl/src/CubemapUtils.cpp
+++ b/libs/ibl/src/CubemapUtils.cpp
@@ -36,11 +36,15 @@ namespace ibl {
 
 void CubemapUtils::clamp(Image& src) {
     // We clamp all values to 256 which correspond to the maximum value (before
-    // gamma compression) that we can store.
+    // gamma compression) that we can store in RGBM.
     // This clamping is necessary because:
     // - our importance-sampling (when calculating the pre-filtered mipmaps)
     //   behaves badly with with very strong high-frequencies.
     // - SH can't encode such environments with a small number of bands.
+    //
+    // HOWEVER this causes high dynamic range images to loose a lot of energy.
+    // See https://github.com/google/filament/issues/1387
+    //
     const size_t width = src.getWidth();
     const size_t height = src.getHeight();
     for (size_t y=0 ; y<height ; ++y) {


### PR DESCRIPTION
--sh-window=band, -w band : this low-pass-filters the environment
such that bands above 'band' are zero. This can be used to reduce ringing
when the source environment has high frequencies

--noclamp : turns off clamping before processing the cube map


This is still work in progress.