### PR TITLE
Update Material class to handle both surface and post-process materials

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -115,6 +115,25 @@ Material* Material::Builder::build(Engine& engine) {
 
 namespace details {
 
+static void addSamplerGroup(Program& pb, uint8_t bindingPoint, SamplerInterfaceBlock const& sib,
+        SamplerBindingMap const& map) {
+    const size_t samplerCount = sib.getSize();
+    if (samplerCount) {
+        std::vector<Program::Sampler> samplers(samplerCount);
+        auto const& list = sib.getSamplerInfoList();
+        for (size_t i = 0, c = samplerCount; i < c; ++i) {
+            CString uniformName(
+                    SamplerInterfaceBlock::getUniformName(sib.getName().c_str(),
+                            list[i].name.c_str()));
+            uint8_t binding;
+            bool ok = map.getSamplerBinding(bindingPoint, (uint8_t)i, &binding);
+            assert(ok);
+            samplers[i] = { std::move(uniformName), binding };
+        }
+        pb.setSamplerGroup(bindingPoint, samplers.data(), samplers.size());
+    }
+}
+
 FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
         : mEngine(engine),
           mMaterialId(engine.getMaterialId())
@@ -289,12 +308,62 @@ bool FMaterial::hasParameter(const char* name) const noexcept {
 }
 
 backend::Handle<backend::HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
-    const ShaderModel sm = mEngine.getDriver().getShaderModel();
+    switch (getMaterialDomain()) {
+        case MaterialDomain::SURFACE:
+            return getSurfaceProgramSlow(variantKey);
+
+        case MaterialDomain::POST_PROCESS:
+            return getPostProcessProgramSlow(variantKey);
+    }
+}
+
+backend::Handle<backend::HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
+    const noexcept {
+    // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
+    // if we're unlit, we don't have any bits that correspond to lit materials
+    assert( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );
 
     assert(!Variant::isReserved(variantKey));
 
     uint8_t vertexVariantKey = Variant::filterVariantVertex(variantKey);
     uint8_t fragmentVariantKey = Variant::filterVariantFragment(variantKey);
+
+    Program pb = getProgramBuilderWithVariants(variantKey, vertexVariantKey, fragmentVariantKey);
+    pb
+        .setUniformBlock(BindingPoints::PER_VIEW, UibGenerator::getPerViewUib().getName())
+        .setUniformBlock(BindingPoints::LIGHTS, UibGenerator::getLightsUib().getName())
+        .setUniformBlock(BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib().getName())
+        .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
+
+    if (Variant(variantKey).hasSkinning()) {
+        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES,
+                UibGenerator::getPerRenderableBonesUib().getName());
+    }
+
+    addSamplerGroup(pb, BindingPoints::PER_VIEW, SibGenerator::getPerViewSib(), mSamplerBindings);
+    addSamplerGroup(pb, BindingPoints::PER_MATERIAL_INSTANCE, mSamplerInterfaceBlock, mSamplerBindings);
+
+    return createAndCacheProgram(std::move(pb), variantKey);
+}
+
+backend::Handle<backend::HwProgram> FMaterial::getPostProcessProgramSlow(uint8_t variantKey)
+    const noexcept {
+
+    Program pb = getProgramBuilderWithVariants(variantKey, variantKey, variantKey);
+    pb
+            .setUniformBlock(BindingPoints::PER_VIEW, UibGenerator::getPerViewUib().getName())
+            .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
+
+    addSamplerGroup(pb, BindingPoints::PER_MATERIAL_INSTANCE, mSamplerInterfaceBlock, mSamplerBindings);
+
+    return createAndCacheProgram(std::move(pb), variantKey);
+}
+
+Program FMaterial::getProgramBuilderWithVariants(
+        uint8_t variantKey,
+        uint8_t vertexVariantKey,
+        uint8_t fragmentVariantKey) const noexcept {
+    const ShaderModel sm = mEngine.getDriver().getShaderModel();
 
     /*
      * Vertex shader
@@ -327,39 +396,13 @@ backend::Handle<backend::HwProgram> FMaterial::getProgramSlow(uint8_t variantKey
     Program pb;
     pb      .diagnostics(mName, variantKey)
             .withVertexShader(vsBuilder.data(), vsBuilder.size())
-            .withFragmentShader(fsBuilder.data(), fsBuilder.size())
-            .setUniformBlock(BindingPoints::PER_VIEW, UibGenerator::getPerViewUib().getName())
-            .setUniformBlock(BindingPoints::LIGHTS, UibGenerator::getLightsUib().getName())
-            .setUniformBlock(BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib().getName())
-            .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
+            .withFragmentShader(fsBuilder.data(), fsBuilder.size());
+    return pb;
+}
 
-    if (Variant(variantKey).hasSkinning()) {
-        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES,
-                UibGenerator::getPerRenderableBonesUib().getName());
-    }
-
-    auto addSamplerGroup = [&pb]
-            (uint8_t bindingPoint, SamplerInterfaceBlock const& sib, SamplerBindingMap const& map) {
-        const size_t samplerCount = sib.getSize();
-        if (samplerCount) {
-            std::vector<Program::Sampler> samplers(samplerCount);
-            auto const& list = sib.getSamplerInfoList();
-            for (size_t i = 0, c = samplerCount; i < c; ++i) {
-                CString uniformName(
-                        SamplerInterfaceBlock::getUniformName(sib.getName().c_str(),
-                                list[i].name.c_str()));
-                uint8_t binding;
-                map.getSamplerBinding(bindingPoint, (uint8_t)i, &binding);
-                samplers[i] = { std::move(uniformName), binding };
-            }
-            pb.setSamplerGroup(bindingPoint, samplers.data(), samplers.size());
-        }
-    };
-
-    addSamplerGroup(BindingPoints::PER_VIEW, SibGenerator::getPerViewSib(), mSamplerBindings);
-    addSamplerGroup(BindingPoints::PER_MATERIAL_INSTANCE, mSamplerInterfaceBlock, mSamplerBindings);
-
-    auto program = mEngine.getDriverApi().createProgram(std::move(pb));
+backend::Handle<backend::HwProgram> FMaterial::createAndCacheProgram(Program&& p,
+        uint8_t variantKey) const noexcept {
+    auto program = mEngine.getDriverApi().createProgram(std::move(p));
     assert(program);
 
     mCachedPrograms[variantKey] = program;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -74,14 +74,16 @@ public:
     FEngine& getEngine() const noexcept  { return mEngine; }
 
     backend::Handle<backend::HwProgram> getProgramSlow(uint8_t variantKey) const noexcept;
+    backend::Handle<backend::HwProgram> getSurfaceProgramSlow(uint8_t variantKey) const noexcept;
+    backend::Handle<backend::HwProgram> getPostProcessProgramSlow(uint8_t variantKey) const noexcept;
     backend::Handle<backend::HwProgram> getProgram(uint8_t variantKey) const noexcept {
-
-        // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
-        assert( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );
-
         backend::Handle<backend::HwProgram> const entry = mCachedPrograms[variantKey];
         return UTILS_LIKELY(entry) ? entry : getProgramSlow(variantKey);
     }
+    backend::Program getProgramBuilderWithVariants(uint8_t variantKey, uint8_t vertexVariantKey,
+            uint8_t fragmentVariantKey) const noexcept;
+    backend::Handle<backend::HwProgram> createAndCacheProgram(backend::Program&& p,
+            uint8_t variantKey) const noexcept;
 
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 


### PR DESCRIPTION
This PR splits `getProgramSlow` into two new methods:
- `getSurfaceProgramSlow`
- `getPostProcessProgramSlow`