### PR TITLE
make libmath much more constexpr friendly

### DIFF
--- a/libs/math/include/math/TMatHelpers.h
+++ b/libs/math/include/math/TMatHelpers.h
@@ -63,18 +63,18 @@ inline constexpr double  trace(double v) { return v; }
  * Matrix inversion
  */
 template<typename MATRIX>
-MATRIX MATH_PURE gaussJordanInverse(const MATRIX& src) {
+constexpr MATRIX MATH_PURE gaussJordanInverse(const MATRIX& src) {
     typedef typename MATRIX::value_type T;
-    static constexpr unsigned int N = MATRIX::NUM_ROWS;
+    constexpr unsigned int N = MATRIX::NUM_ROWS;
     MATRIX tmp(src);
     MATRIX inverted(1);
 
     for (size_t i = 0; i < N; ++i) {
         // look for largest element in i'th column
         size_t swap = i;
-        T t = std::abs(tmp[i][i]);
+        T t = tmp[i][i] < 0 ? -tmp[i][i] : tmp[i][i];
         for (size_t j = i + 1; j < N; ++j) {
-            const T t2 = std::abs(tmp[j][i]);
+            const T t2 = tmp[j][i] < 0 ? -tmp[j][i] : tmp[j][i];
             if (t2 > t) {
                 swap = j;
                 t = t2;
@@ -112,7 +112,7 @@ MATRIX MATH_PURE gaussJordanInverse(const MATRIX& src) {
 //------------------------------------------------------------------------------
 // 2x2 matrix inverse is easy.
 template <typename MATRIX>
-MATRIX MATH_PURE fastInverse2(const MATRIX& x) {
+constexpr MATRIX MATH_PURE fastInverse2(const MATRIX& x) {
     typedef typename MATRIX::value_type T;
 
     // Assuming the input matrix is:
@@ -125,7 +125,7 @@ MATRIX MATH_PURE fastInverse2(const MATRIX& x) {
     //
     // Importantly, our matrices are column-major!
 
-    MATRIX inverted(MATRIX::NO_INIT);
+    MATRIX inverted{};
 
     const T a = x[0][0];
     const T c = x[0][1];
@@ -146,7 +146,7 @@ MATRIX MATH_PURE fastInverse2(const MATRIX& x) {
 // matrix inversion:
 // http://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3.C3.973_matrices
 template <typename MATRIX>
-MATRIX MATH_PURE fastInverse3(const MATRIX& x) {
+constexpr MATRIX MATH_PURE fastInverse3(const MATRIX& x) {
     typedef typename MATRIX::value_type T;
 
     // Assuming the input matrix is:
@@ -173,7 +173,7 @@ MATRIX MATH_PURE fastInverse3(const MATRIX& x) {
     //
     // Importantly, our matrices are column-major!
 
-    MATRIX inverted(MATRIX::NO_INIT);
+    MATRIX inverted{};
 
     const T a = x[0][0];
     const T b = x[1][0];
@@ -225,7 +225,7 @@ inline constexpr MATRIX MATH_PURE inverse(const MATRIX& matrix) {
 }
 
 template<typename MATRIX_R, typename MATRIX_A, typename MATRIX_B>
-MATRIX_R MATH_PURE multiply(const MATRIX_A& lhs, const MATRIX_B& rhs) {
+constexpr MATRIX_R MATH_PURE multiply(const MATRIX_A& lhs, const MATRIX_B& rhs) {
     // pre-requisite:
     //  lhs : D columns, R rows
     //  rhs : C columns, D rows
@@ -238,7 +238,7 @@ MATRIX_R MATH_PURE multiply(const MATRIX_A& lhs, const MATRIX_B& rhs) {
     static_assert(MATRIX_R::NUM_ROWS == MATRIX_A::NUM_ROWS,
             "invalid dimension of matrix multiply result.");
 
-    MATRIX_R res(MATRIX_R::NO_INIT);
+    MATRIX_R res{};
     for (size_t col = 0; col < MATRIX_R::NUM_COLS; ++col) {
         res[col] = lhs * rhs[col];
     }
@@ -247,10 +247,10 @@ MATRIX_R MATH_PURE multiply(const MATRIX_A& lhs, const MATRIX_B& rhs) {
 
 // transpose. this handles matrices of matrices
 template <typename MATRIX>
-MATRIX MATH_PURE transpose(const MATRIX& m) {
+constexpr MATRIX MATH_PURE transpose(const MATRIX& m) {
     // for now we only handle square matrix transpose
     static_assert(MATRIX::NUM_COLS == MATRIX::NUM_ROWS, "transpose only supports square matrices");
-    MATRIX result(MATRIX::NO_INIT);
+    MATRIX result{};
     for (size_t col = 0; col < MATRIX::NUM_COLS; ++col) {
         for (size_t row = 0; row < MATRIX::NUM_ROWS; ++row) {
             result[col][row] = transpose(m[row][col]);
@@ -261,7 +261,7 @@ MATRIX MATH_PURE transpose(const MATRIX& m) {
 
 // trace. this handles matrices of matrices
 template <typename MATRIX>
-typename MATRIX::value_type MATH_PURE trace(const MATRIX& m) {
+constexpr typename MATRIX::value_type MATH_PURE trace(const MATRIX& m) {
     static_assert(MATRIX::NUM_COLS == MATRIX::NUM_ROWS, "trace only defined for square matrices");
     typename MATRIX::value_type result(0);
     for (size_t col = 0; col < MATRIX::NUM_COLS; ++col) {
@@ -272,9 +272,9 @@ typename MATRIX::value_type MATH_PURE trace(const MATRIX& m) {
 
 // diag. this handles matrices of matrices
 template <typename MATRIX>
-typename MATRIX::col_type MATH_PURE diag(const MATRIX& m) {
+constexpr typename MATRIX::col_type MATH_PURE diag(const MATRIX& m) {
     static_assert(MATRIX::NUM_COLS == MATRIX::NUM_ROWS, "diag only defined for square matrices");
-    typename MATRIX::col_type result;
+    typename MATRIX::col_type result{};
     for (size_t col = 0; col < MATRIX::NUM_COLS; ++col) {
         result[col] = m[col][col];
     }
@@ -342,7 +342,7 @@ template <template<typename T> class BASE, typename T>
 class TMatProductOperators {
 public:
     // multiply by a scalar
-    BASE<T>& operator *= (T v) {
+    constexpr BASE<T>& operator *= (T v) {
         BASE<T>& lhs(static_cast< BASE<T>& >(*this));
         for (size_t col = 0; col < BASE<T>::NUM_COLS; ++col) {
             lhs[col] *= v;
@@ -352,14 +352,14 @@ public:
 
     //  matrix *= matrix
     template<typename U>
-    const BASE<T>& operator *= (const BASE<U>& rhs) {
+    constexpr BASE<T>& operator *= (const BASE<U>& rhs) {
         BASE<T>& lhs(static_cast< BASE<T>& >(*this));
         lhs = matrix::multiply<BASE<T> >(lhs, rhs);
         return lhs;
     }
 
     // divide by a scalar
-    BASE<T>& operator /= (T v) {
+    constexpr BASE<T>& operator /= (T v) {
         BASE<T>& lhs(static_cast< BASE<T>& >(*this));
         for (size_t col = 0; col < BASE<T>::NUM_COLS; ++col) {
             lhs[col] /= v;
@@ -369,7 +369,7 @@ public:
 
     // matrix * matrix, result is a matrix of the same type than the lhs matrix
     template<typename U>
-    friend BASE<T> MATH_PURE operator *(const BASE<T>& lhs, const BASE<U>& rhs) {
+    friend inline constexpr BASE<T> MATH_PURE operator *(const BASE<T>& lhs, const BASE<U>& rhs) {
         return matrix::multiply<BASE<T> >(lhs, rhs);
     }
 };
@@ -399,7 +399,7 @@ public:
      * is instantiated, at which point they're only templated on the 2nd parameter
      * (the first one, BASE<T> being known).
      */
-    friend inline BASE<T> MATH_PURE inverse(const BASE<T>& matrix) {
+    friend inline constexpr BASE<T> MATH_PURE inverse(const BASE<T>& matrix) {
         return matrix::inverse(matrix);
     }
     friend inline constexpr BASE<T> MATH_PURE transpose(const BASE<T>& m) {
@@ -455,20 +455,20 @@ public:
         BASE<T> r;
         T c = std::cos(radian);
         T s = std::sin(radian);
-        if (about.x == 1 && about.y == 0 && about.z == 0) {
+        if (about[0] == 1 && about[1] == 0 && about[2] == 0) {
             r[1][1] = c;   r[2][2] = c;
             r[1][2] = s;   r[2][1] = -s;
-        } else if (about.x == 0 && about.y == 1 && about.z == 0) {
+        } else if (about[0] == 0 && about[1] == 1 && about[2] == 0) {
             r[0][0] = c;   r[2][2] = c;
             r[2][0] = s;   r[0][2] = -s;
-        } else if (about.x == 0 && about.y == 0 && about.z == 1) {
+        } else if (about[0] == 0 && about[1] == 0 && about[2] == 1) {
             r[0][0] = c;   r[1][1] = c;
             r[0][1] = s;   r[1][0] = -s;
         } else {
             VEC nabout = normalize(about);
-            typename VEC::value_type x = nabout.x;
-            typename VEC::value_type y = nabout.y;
-            typename VEC::value_type z = nabout.z;
+            typename VEC::value_type x = nabout[0];
+            typename VEC::value_type y = nabout[1];
+            typename VEC::value_type z = nabout[2];
             T nc = 1 - c;
             T xy = x * y;
             T yz = y * z;

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -34,6 +34,15 @@ namespace math {
 namespace details {
 // -------------------------------------------------------------------------------------
 
+template<typename U>
+inline constexpr U min(U a, U b) noexcept {
+    return a < b ? a : b;
+}
+template<typename U>
+inline constexpr U max(U a, U b) noexcept {
+    return a > b ? a : b;
+}
+
 /*
  * No user serviceable parts here.
  *
@@ -56,15 +65,16 @@ public:
      * element type.
      */
     template<typename OTHER>
-    constexpr VECTOR<T>& operator +=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator+=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] += v[i];
         }
         return lhs;
     }
+
     template<typename OTHER>
-    constexpr VECTOR<T>& operator -=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator-=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] -= v[i];
@@ -77,14 +87,15 @@ public:
      * like "vector *= scalar" by letting the compiler implicitly convert a scalar
      * to a vector (assuming the BASE<T> allows it).
      */
-    constexpr VECTOR<T>& operator +=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator+=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] += v[i];
         }
         return lhs;
     }
-    constexpr VECTOR<T>& operator -=(const VECTOR<T>& v) {
+
+    constexpr VECTOR<T>& operator-=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] -= v[i];
@@ -137,15 +148,16 @@ public:
      * element type.
      */
     template<typename OTHER>
-    constexpr VECTOR<T>& operator *=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator*=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] *= v[i];
         }
         return lhs;
     }
+
     template<typename OTHER>
-    constexpr VECTOR<T>& operator /=(const VECTOR<OTHER>& v) {
+    constexpr VECTOR<T>& operator/=(const VECTOR<OTHER>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] /= v[i];
@@ -158,14 +170,15 @@ public:
      * like "vector *= scalar" by letting the compiler implicitly convert a scalar
      * to a vector (assuming the BASE<T> allows it).
      */
-    constexpr VECTOR<T>& operator *=(const VECTOR<T>& v) {
+    constexpr VECTOR<T>& operator*=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] *= v[i];
         }
         return lhs;
     }
-    constexpr VECTOR<T>& operator /=(const VECTOR<T>& v) {
+
+    constexpr VECTOR<T>& operator/=(const VECTOR<T>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] /= v[i];
@@ -185,12 +198,13 @@ public:
      * but of a different element type.
      */
     template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator *(VECTOR<T> lv, const VECTOR<RT>& rv) {
+    friend inline constexpr VECTOR<T> MATH_PURE operator*(VECTOR<T> lv, const VECTOR<RT>& rv) {
         // don't pass lv by reference because we need a copy anyways
         return lv *= rv;
     }
+
     template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator /(VECTOR<T> lv, const VECTOR<RT>& rv) {
+    friend inline constexpr VECTOR<T> MATH_PURE operator/(VECTOR<T> lv, const VECTOR<RT>& rv) {
         // don't pass lv by reference because we need a copy anyways
         return lv /= rv;
     }
@@ -201,11 +215,12 @@ public:
      * letting the compiler implicitly convert a scalar to a vector (assuming
      * the BASE<T> allows it).
      */
-    friend inline constexpr VECTOR<T> MATH_PURE operator *(VECTOR<T> lv, const VECTOR<T>& rv) {
+    friend inline constexpr VECTOR<T> MATH_PURE operator*(VECTOR<T> lv, const VECTOR<T>& rv) {
         // don't pass lv by reference because we need a copy anyways
         return lv *= rv;
     }
-    friend inline constexpr VECTOR<T> MATH_PURE operator /(VECTOR<T> lv, const VECTOR<T>& rv) {
+
+    friend inline constexpr VECTOR<T> MATH_PURE operator/(VECTOR<T> lv, const VECTOR<T>& rv) {
         // don't pass lv by reference because we need a copy anyways
         return lv /= rv;
     }
@@ -223,8 +238,8 @@ public:
 template<template<typename T> class VECTOR, typename T>
 class TVecUnaryOperators {
 public:
-    VECTOR<T> operator -() const {
-        VECTOR<T> r;
+    constexpr VECTOR<T> operator -() const {
+        VECTOR<T> r{};
         VECTOR<T> const& rv(static_cast<VECTOR<T> const&>(*this));
         for (size_t i = 0; i < r.size(); i++) {
             r[i] = -rv[i];
@@ -252,26 +267,28 @@ public:
      * (the first one, BASE<T> being known).
      */
     template<typename RT>
-    friend inline
-    bool MATH_PURE operator ==(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    friend inline constexpr
+    bool MATH_PURE operator==(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         // w/ inlining we end-up with many branches that will pollute the BPU cache
         MATH_NOUNROLL
-        for (size_t i = 0; i < lv.size(); i++)
-            if (lv[i] != rv[i])
+        for (size_t i = 0; i < lv.size(); i++) {
+            if (lv[i] != rv[i]) {
                 return false;
+            }
+        }
         return true;
     }
 
     template<typename RT>
-    friend inline
-    bool MATH_PURE operator !=(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        return !operator ==(lv, rv);
+    friend inline constexpr
+    bool MATH_PURE operator!=(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+        return !operator==(lv, rv);
     }
 
     template<typename RT>
-    friend inline
+    friend inline constexpr
     VECTOR<bool> MATH_PURE equal(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        VECTOR<bool> r;
+        VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] == rv[i];
         }
@@ -279,9 +296,9 @@ public:
     }
 
     template<typename RT>
-    friend inline
+    friend inline constexpr
     VECTOR<bool> MATH_PURE notEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        VECTOR<bool> r;
+        VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] != rv[i];
         }
@@ -289,9 +306,9 @@ public:
     }
 
     template<typename RT>
-    friend inline
+    friend inline constexpr
     VECTOR<bool> MATH_PURE lessThan(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        VECTOR<bool> r;
+        VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] < rv[i];
         }
@@ -299,9 +316,9 @@ public:
     }
 
     template<typename RT>
-    friend inline
+    friend inline constexpr
     VECTOR<bool> MATH_PURE lessThanEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        VECTOR<bool> r;
+        VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] <= rv[i];
         }
@@ -309,7 +326,7 @@ public:
     }
 
     template<typename RT>
-    friend inline
+    friend inline constexpr
     VECTOR<bool> MATH_PURE greaterThan(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
         VECTOR<bool> r;
         for (size_t i = 0; i < lv.size(); i++) {
@@ -321,7 +338,7 @@ public:
     template<typename RT>
     friend inline
     VECTOR<bool> MATH_PURE greaterThanEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        VECTOR<bool> r;
+        VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] >= rv[i];
         }
@@ -381,7 +398,7 @@ public:
         return length2(rv - lv);
     }
 
-    friend inline constexpr VECTOR<T> MATH_PURE normalize(const VECTOR<T>& lv) {
+    friend inline VECTOR<T> MATH_PURE normalize(const VECTOR<T>& lv) {
         return lv * (T(1) / length(lv));
     }
 
@@ -389,107 +406,106 @@ public:
         return T(1) / v;
     }
 
-    friend inline VECTOR<T> MATH_PURE abs(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
-            v[i] = std::abs(v[i]);
+    friend inline constexpr VECTOR<T> MATH_PURE abs(VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = v[i] < 0 ? -v[i] : v[i];
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE floor(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::floor(v[i]);
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE ceil(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::ceil(v[i]);
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE round(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::round(v[i]);
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE inversesqrt(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = T(1) / std::sqrt(v[i]);
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE sqrt(VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::sqrt(v[i]);
         }
         return v;
     }
 
     friend inline VECTOR<T> MATH_PURE pow(VECTOR<T> v, T p) {
-        for (size_t i=0 ; i<v.size() ; i++) {
+        for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::pow(v[i], p);
         }
         return v;
     }
 
-    friend inline VECTOR<T> MATH_PURE saturate(const VECTOR<T>& lv) {
+    friend inline constexpr VECTOR<T> MATH_PURE saturate(const VECTOR<T>& lv) {
         return clamp(lv, T(0), T(1));
     }
 
-    friend inline VECTOR<T> MATH_PURE clamp(VECTOR<T> v, T min, T max) {
-        for (size_t i=0 ; i< v.size() ; i++) {
-            v[i] = std::min(max, std::max(min, v[i]));
+    friend inline constexpr VECTOR<T> MATH_PURE clamp(VECTOR<T> v, T min, T max) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = details::min(max, details::max(min, v[i]));
         }
         return v;
     }
 
-    friend inline VECTOR<T> MATH_PURE clamp(VECTOR<T> v, VECTOR<T> min, VECTOR<T> max) {
+    friend inline constexpr VECTOR<T> MATH_PURE clamp(VECTOR<T> v, VECTOR<T> min, VECTOR<T> max) {
         for (size_t i=0 ; i< v.size() ; i++) {
-            v[i] = std::min(max[i], std::max(min[i], v[i]));
+            v[i] = details::min(max[i], details::max(min[i], v[i]));
         }
         return v;
     }
 
-    friend inline VECTOR<T> MATH_PURE fma(const VECTOR<T>& lv, const VECTOR<T>& rv, VECTOR<T> a) {
-        for (size_t i=0 ; i<lv.size() ; i++) {
-            //a[i] = std::fma(lv[i], rv[i], a[i]);
+    friend inline constexpr VECTOR<T> MATH_PURE fma(const VECTOR<T>& lv, const VECTOR<T>& rv, VECTOR<T> a) {
+        for (size_t i = 0; i < lv.size(); i++) {
             a[i] += (lv[i] * rv[i]);
         }
         return a;
     }
 
-    friend inline VECTOR<T> MATH_PURE min(const VECTOR<T>& u, VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
-            v[i] = std::min(u[i], v[i]);
+    friend inline constexpr VECTOR<T> MATH_PURE min(const VECTOR<T>& u, VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = details::min(u[i], v[i]);
         }
         return v;
     }
 
-    friend inline VECTOR<T> MATH_PURE max(const VECTOR<T>& u, VECTOR<T> v) {
-        for (size_t i=0 ; i<v.size() ; i++) {
-            v[i] = std::max(u[i], v[i]);
+    friend inline constexpr VECTOR<T> MATH_PURE max(const VECTOR<T>& u, VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = details::max(u[i], v[i]);
         }
         return v;
     }
 
-    friend inline T MATH_PURE max(const VECTOR<T>& v) {
+    friend inline constexpr T MATH_PURE max(const VECTOR<T>& v) {
         T r(std::numeric_limits<T>::lowest());
-        for (size_t i=0 ; i<v.size() ; i++) {
-            r = std::max(r, v[i]);
+        for (size_t i = 0; i < v.size(); i++) {
+            r = max(r, v[i]);
         }
         return r;
     }
 
-    friend inline T MATH_PURE min(const VECTOR<T>& v) {
+    friend inline constexpr T MATH_PURE min(const VECTOR<T>& v) {
         T r(std::numeric_limits<T>::max());
         for (size_t i=0 ; i<v.size() ; i++) {
-            r = std::min(r, v[i]);
+            r = min(r, v[i]);
         }
         return r;
     }
@@ -501,14 +517,14 @@ public:
         return v;
     }
 
-    friend inline bool MATH_PURE any(const VECTOR<T>& v) {
+    friend inline constexpr bool MATH_PURE any(const VECTOR<T>& v) {
         for (size_t i = 0; i < v.size(); i++) {
             if (v[i] != T(0)) return true;
         }
         return false;
     }
 
-    friend inline bool MATH_PURE all(const VECTOR<T>& v) {
+    friend inline constexpr bool MATH_PURE all(const VECTOR<T>& v) {
         bool result = true;
         for (size_t i = 0; i < v.size(); i++) {
             result &= (v[i] != T(0));

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -63,17 +63,19 @@ namespace details {
  * m[n] is the \f$ n^{th} \f$ column of the matrix and is a vec2.
  *
  */
-template <typename T>
+template<typename T>
 class MATH_EMPTY_BASES TMat22 :
-                public TVecUnaryOperators<TMat22, T>,
-                public TVecComparisonOperators<TMat22, T>,
-                public TVecAddOperators<TMat22, T>,
-                public TMatProductOperators<TMat22, T>,
-                public TMatSquareFunctions<TMat22, T>,
-                public TMatHelpers<TMat22, T>,
-                public TMatDebug<TMat22, T> {
+        public TVecUnaryOperators<TMat22, T>,
+        public TVecComparisonOperators<TMat22, T>,
+        public TVecAddOperators<TMat22, T>,
+        public TMatProductOperators<TMat22, T>,
+        public TMatSquareFunctions<TMat22, T>,
+        public TMatHelpers<TMat22, T>,
+        public TMatDebug<TMat22, T> {
 public:
-    enum no_init { NO_INIT };
+    enum no_init {
+        NO_INIT
+    };
     typedef T value_type;
     typedef T& reference;
     typedef T const& const_reference;
@@ -113,7 +115,7 @@ public:
         return m_value[column];
     }
 
-    inline col_type& operator[](size_t column) {
+    inline constexpr col_type& operator[](size_t column) {
         assert(column < NUM_COLS);
         return m_value[column];
     }
@@ -169,13 +171,13 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat22(const TVec2<U>& v);
 
     /**
      * construct from another matrix of the same size
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat22(const TMat22<U>& rhs);
 
     /**
@@ -189,7 +191,7 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename A, typename B>
+    template<typename A, typename B>
     constexpr TMat22(const TVec2<A>& v0, const TVec2<B>& v1);
 
     /** construct from 4 elements in column-major form.
@@ -203,11 +205,11 @@ public:
      *      \right)
      *      \f$
      */
-    template <
-        typename A, typename B,
-        typename C, typename D>
+    template<
+            typename A, typename B,
+            typename C, typename D>
     constexpr explicit TMat22(A m00, B m01,
-                              C m10, D m11);
+            C m10, D m11);
 
 
     struct row_major_init {
@@ -215,15 +217,16 @@ public:
                 typename A, typename B,
                 typename C, typename D>
         constexpr explicit row_major_init(A m00, B m01,
-                                          C m10, D m11) noexcept
+                C m10, D m11) noexcept
                 : m(m00, m10,
-                    m01, m11) {}
+                m01, m11) {}
+
     private:
         friend TMat22;
         TMat22 m;
     };
 
-    constexpr explicit TMat22(row_major_init c) : TMat22(std::move(c.m)) { }
+    constexpr explicit TMat22(row_major_init c) : TMat22(std::move(c.m)) {}
 
     /**
      * Rotate by radians in the 2D plane
@@ -232,8 +235,10 @@ public:
         TMat22<T> r(TMat22<T>::NO_INIT);
         T c = std::cos(radian);
         T s = std::sin(radian);
-        r[0][0] = c;   r[1][1] = c;
-        r[0][1] = s;   r[1][0] = -s;
+        r[0][0] = c;
+        r[1][1] = c;
+        r[0][1] = s;
+        r[1][0] = -s;
         return r;
     }
 
@@ -245,28 +250,28 @@ public:
         uint64_t result = 0;
         // For some reason clang is not able to vectoize this loop when the number of iteration
         // is known and constant (!?!?!). Still this is better than operator==.
-        #pragma clang loop vectorize_width(2)
+#pragma clang loop vectorize_width(2)
         for (size_t i = 0; i < sizeof(TMat22) / sizeof(uint64_t); i++) {
             result |= li[i] ^ ri[i];
         }
         return result != 0;
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat22 translation(const TVec2<A>& t) {
         TMat22 r;
         r[2] = t;
         return r;
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat22 scaling(const TVec2<A>& s) {
         return TMat22{ s };
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat22 scaling(A s) {
-        return TMat22{ TVec2<T>{ s, s } };
+        return TMat22{ TVec2<T>{ s, s }};
     }
 };
 
@@ -277,41 +282,36 @@ public:
 // Since the matrix code could become pretty big quickly, we don't inline most
 // operations.
 
-template <typename T>
-constexpr TMat22<T>::TMat22() {
-    m_value[0] = col_type(1, 0);
-    m_value[1] = col_type(0, 1);
-}
-
-template <typename T>
-template <typename U>
-constexpr TMat22<T>::TMat22(U v) {
-    m_value[0] = col_type(v, 0);
-    m_value[1] = col_type(0, v);
+template<typename T>
+constexpr TMat22<T>::TMat22()
+        : m_value{ col_type(1, 0), col_type(0, 1) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat22<T>::TMat22(const TVec2<U>& v) {
-    m_value[0] = col_type(v.x, 0);
-    m_value[1] = col_type(0, v.y);
+constexpr TMat22<T>::TMat22(U v)
+        : m_value{ col_type(v, 0), col_type(0, v) } {
+}
+
+template<typename T>
+template<typename U>
+constexpr TMat22<T>::TMat22(const TVec2<U>& v)
+        : m_value{ col_type(v[0], 0), col_type(0, v[1]) } {
 }
 
 // construct from 4 scalars. Note that the arrangement
 // of values in the constructor is the transpose of the matrix
 // notation.
 template<typename T>
-template <
-    typename A, typename B,
-    typename C, typename D>
-constexpr TMat22<T>::TMat22(A m00, B m01,
-                            C m10, D m11) {
-    m_value[0] = col_type(m00, m01);
-    m_value[1] = col_type(m10, m11);
+template<
+        typename A, typename B,
+        typename C, typename D>
+constexpr TMat22<T>::TMat22(A m00, B m01, C m10, D m11)
+        : m_value{ col_type(m00, m01), col_type(m10, m11) } {
 }
 
-template <typename T>
-template <typename U>
+template<typename T>
+template<typename U>
 constexpr TMat22<T>::TMat22(const TMat22<U>& rhs) {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
@@ -319,11 +319,10 @@ constexpr TMat22<T>::TMat22(const TMat22<U>& rhs) {
 }
 
 // Construct from 2 column vectors.
-template <typename T>
-template <typename A, typename B>
-constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1) {
-    m_value[0] = v0;
-    m_value[1] = v1;
+template<typename T>
+template<typename A, typename B>
+constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1)
+        : m_value{ v0, v1 } {
 }
 
 // ----------------------------------------------------------------------------------------
@@ -339,10 +338,11 @@ constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1) {
  */
 
 // matrix * column-vector, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat22<U>::col_type MATH_PURE operator *(const TMat22<T>& lhs, const TVec2<U>& rhs) {
+template<typename T, typename U>
+constexpr typename TMat22<U>::col_type MATH_PURE
+operator*(const TMat22<T>& lhs, const TVec2<U>& rhs) {
     // Result is initialized to zero.
-    typename TMat22<U>::col_type result = {};
+    typename TMat22<U>::col_type result{};
     for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
         result += lhs[col] * rhs[col];
     }
@@ -350,9 +350,10 @@ constexpr typename TMat22<U>::col_type MATH_PURE operator *(const TMat22<T>& lhs
 }
 
 // row-vector * matrix, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat22<U>::row_type MATH_PURE operator *(const TVec2<U>& lhs, const TMat22<T>& rhs) {
-    typename TMat22<U>::row_type result;
+template<typename T, typename U>
+constexpr typename TMat22<U>::row_type MATH_PURE
+operator*(const TVec2<U>& lhs, const TMat22<T>& rhs) {
+    typename TMat22<U>::row_type result{};
     for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
     }
@@ -395,8 +396,9 @@ typedef details::TMat22<float> mat2f;
 }  // namespace filament
 
 namespace std {
-template <typename T>
-constexpr void swap( filament::math::details::TMat22<T>& lhs,  filament::math::details::TMat22<T>& rhs) noexcept {
+template<typename T>
+constexpr void swap(filament::math::details::TMat22<T>& lhs,
+        filament::math::details::TMat22<T>& rhs) noexcept {
     // This generates much better code than the default implementation
     // It's unclear why, I believe this is due to an optimization bug in the clang.
     //

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -68,24 +68,26 @@ namespace details {
  * m[n] is the \f$ n^{th} \f$ column of the matrix and is a vec3.
  *
  */
-template <typename T>
+template<typename T>
 class MATH_EMPTY_BASES TMat33 :
-                public TVecUnaryOperators<TMat33, T>,
-                public TVecComparisonOperators<TMat33, T>,
-                public TVecAddOperators<TMat33, T>,
-                public TMatProductOperators<TMat33, T>,
-                public TMatSquareFunctions<TMat33, T>,
-                public TMatTransform<TMat33, T>,
-                public TMatHelpers<TMat33, T>,
-                public TMatDebug<TMat33, T> {
+        public TVecUnaryOperators<TMat33, T>,
+        public TVecComparisonOperators<TMat33, T>,
+        public TVecAddOperators<TMat33, T>,
+        public TMatProductOperators<TMat33, T>,
+        public TMatSquareFunctions<TMat33, T>,
+        public TMatTransform<TMat33, T>,
+        public TMatHelpers<TMat33, T>,
+        public TMatDebug<TMat33, T> {
 public:
-    enum no_init { NO_INIT };
+    enum no_init {
+        NO_INIT
+    };
     typedef T value_type;
     typedef T& reference;
     typedef T const& const_reference;
     typedef size_t size_type;
-    typedef TVec3<T> col_type;
-    typedef TVec3<T> row_type;
+    typedef TVec3 <T> col_type;
+    typedef TVec3 <T> row_type;
 
     static constexpr size_t COL_SIZE = col_type::SIZE;  // size of a column (i.e.: number of rows)
     static constexpr size_t ROW_SIZE = row_type::SIZE;  // size of a row (i.e.: number of columns)
@@ -129,7 +131,7 @@ public:
     /**
      * leaves object uninitialized. use with caution.
      */
-    constexpr explicit TMat33(no_init)  {}
+    constexpr explicit TMat33(no_init) {}
 
 
     /**
@@ -176,13 +178,13 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename U>
-    constexpr explicit TMat33(const TVec3<U>& v);
+    template<typename U>
+    constexpr explicit TMat33(const TVec3 <U>& v);
 
     /**
      * construct from another matrix of the same size
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat33(const TMat33<U>& rhs);
 
     /**
@@ -196,8 +198,8 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename A, typename B, typename C>
-    constexpr TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2);
+    template<typename A, typename B, typename C>
+    constexpr TMat33(const TVec3 <A>& v0, const TVec3 <B>& v1, const TVec3 <C>& v2);
 
     /** construct from 9 elements in column-major form.
      *
@@ -211,13 +213,13 @@ public:
      *      \right)
      *      \f$
      */
-    template <
-        typename A, typename B, typename C,
-        typename D, typename E, typename F,
-        typename G, typename H, typename I>
+    template<
+            typename A, typename B, typename C,
+            typename D, typename E, typename F,
+            typename G, typename H, typename I>
     constexpr explicit TMat33(A m00, B m01, C m02,
-                              D m10, E m11, F m12,
-                              G m20, H m21, I m22);
+            D m10, E m11, F m12,
+            G m20, H m21, I m22);
 
 
     struct row_major_init {
@@ -226,23 +228,24 @@ public:
                 typename D, typename E, typename F,
                 typename G, typename H, typename I>
         constexpr explicit row_major_init(A m00, B m01, C m02,
-                                          D m10, E m11, F m12,
-                                          G m20, H m21, I m22) noexcept
+                D m10, E m11, F m12,
+                G m20, H m21, I m22) noexcept
                 : m(m00, m10, m20,
-                    m01, m11, m21,
-                    m02, m12, m22) {}
+                m01, m11, m21,
+                m02, m12, m22) {}
+
     private:
         friend TMat33;
         TMat33 m;
     };
 
-    constexpr explicit TMat33(row_major_init c) : TMat33(std::move(c.m)) { }
+    constexpr explicit TMat33(row_major_init c) : TMat33(std::move(c.m)) {}
 
     /**
      * construct from a quaternion
      */
-    template <typename U>
-    constexpr explicit TMat33(const TQuaternion<U>& q);
+    template<typename U>
+    constexpr explicit TMat33(const TQuaternion <U>& q);
 
     /**
      * orthogonalize only works on matrices of size 3x3
@@ -265,24 +268,24 @@ public:
      * to 2 bytes, making the resulting quaternion suitable for storage into an SNORM16
      * vector.
      */
-    static constexpr TQuaternion<T> packTangentFrame(const TMat33& m,
+    static constexpr TQuaternion <T> packTangentFrame(const TMat33& m,
             size_t storageSize = sizeof(int16_t));
 
-    template <typename A>
-    static constexpr TMat33 translation(const TVec3<A>& t) {
+    template<typename A>
+    static constexpr TMat33 translation(const TVec3 <A>& t) {
         TMat33 r;
         r[2] = t;
         return r;
     }
 
-    template <typename A>
-    static constexpr TMat33 scaling(const TVec3<A>& s) {
+    template<typename A>
+    static constexpr TMat33 scaling(const TVec3 <A>& s) {
         return TMat33{ s };
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat33 scaling(A s) {
-        return TMat33{ TVec3<T>{ s } };
+        return TMat33{ TVec3 < T > { s }};
     }
 };
 
@@ -293,47 +296,51 @@ public:
 // Since the matrix code could become pretty big quickly, we don't inline most
 // operations.
 
-template <typename T>
-constexpr TMat33<T>::TMat33() {
-    m_value[0] = col_type(1, 0, 0);
-    m_value[1] = col_type(0, 1, 0);
-    m_value[2] = col_type(0, 0, 1);
-}
-
-template <typename T>
-template <typename U>
-constexpr TMat33<T>::TMat33(U v) {
-    m_value[0] = col_type(v, 0, 0);
-    m_value[1] = col_type(0, v, 0);
-    m_value[2] = col_type(0, 0, v);
+template<typename T>
+constexpr TMat33<T>::TMat33()
+        : m_value{
+        col_type(1, 0, 0),
+        col_type(0, 1, 0),
+        col_type(0, 0, 1) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat33<T>::TMat33(const TVec3<U>& v) {
-    m_value[0] = col_type(v.x, 0, 0);
-    m_value[1] = col_type(0, v.y, 0);
-    m_value[2] = col_type(0, 0, v.z);
+constexpr TMat33<T>::TMat33(U v)
+        : m_value{
+        col_type(v, 0, 0),
+        col_type(0, v, 0),
+        col_type(0, 0, v) } {
+}
+
+template<typename T>
+template<typename U>
+constexpr TMat33<T>::TMat33(const TVec3 <U>& v)
+        : m_value{
+        col_type(v[0], 0, 0),
+        col_type(0, v[1], 0),
+        col_type(0, 0, v[2]) } {
 }
 
 // construct from 16 scalars. Note that the arrangement
 // of values in the constructor is the transpose of the matrix
 // notation.
 template<typename T>
-template <
-    typename A, typename B, typename C,
-    typename D, typename E, typename F,
-    typename G, typename H, typename I>
+template<
+        typename A, typename B, typename C,
+        typename D, typename E, typename F,
+        typename G, typename H, typename I>
 constexpr TMat33<T>::TMat33(A m00, B m01, C m02,
-                            D m10, E m11, F m12,
-                            G m20, H m21, I m22) {
-    m_value[0] = col_type(m00, m01, m02);
-    m_value[1] = col_type(m10, m11, m12);
-    m_value[2] = col_type(m20, m21, m22);
+        D m10, E m11, F m12,
+        G m20, H m21, I m22)
+        : m_value{
+        col_type(m00, m01, m02),
+        col_type(m10, m11, m12),
+        col_type(m20, m21, m22) } {
 }
 
-template <typename T>
-template <typename U>
+template<typename T>
+template<typename U>
 constexpr TMat33<T>::TMat33(const TMat33<U>& rhs) {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
@@ -341,34 +348,32 @@ constexpr TMat33<T>::TMat33(const TMat33<U>& rhs) {
 }
 
 // Construct from 3 column vectors.
-template <typename T>
-template <typename A, typename B, typename C>
-constexpr TMat33<T>::TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2) {
-    m_value[0] = v0;
-    m_value[1] = v1;
-    m_value[2] = v2;
+template<typename T>
+template<typename A, typename B, typename C>
+constexpr TMat33<T>::TMat33(const TVec3 <A>& v0, const TVec3 <B>& v1, const TVec3 <C>& v2)
+        : m_value{ v0, v1, v2 } {
 }
 
-template <typename T>
-template <typename U>
-constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) {
-    const U n = q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w;
-    const U s = n > 0 ? 2/n : 0;
-    const U x = s*q.x;
-    const U y = s*q.y;
-    const U z = s*q.z;
-    const U xx = x*q.x;
-    const U xy = x*q.y;
-    const U xz = x*q.z;
-    const U xw = x*q.w;
-    const U yy = y*q.y;
-    const U yz = y*q.z;
-    const U yw = y*q.w;
-    const U zz = z*q.z;
-    const U zw = z*q.w;
-    m_value[0] = col_type(1-yy-zz,    xy+zw,    xz-yw);  // NOLINT
-    m_value[1] = col_type(  xy-zw,  1-xx-zz,    yz+xw);  // NOLINT
-    m_value[2] = col_type(  xz+yw,    yz-xw,  1-xx-yy);  // NOLINT
+template<typename T>
+template<typename U>
+constexpr TMat33<T>::TMat33(const TQuaternion <U>& q) : m_value{} {
+    const U n = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+    const U s = n > 0 ? 2 / n : 0;
+    const U x = s * q.x;
+    const U y = s * q.y;
+    const U z = s * q.z;
+    const U xx = x * q.x;
+    const U xy = x * q.y;
+    const U xz = x * q.z;
+    const U xw = x * q.w;
+    const U yy = y * q.y;
+    const U yz = y * q.z;
+    const U yw = y * q.w;
+    const U zz = z * q.z;
+    const U zw = z * q.w;
+    m_value[0] = col_type(1 - yy - zz, xy + zw, xz - yw);  // NOLINT
+    m_value[1] = col_type(xy - zw, 1 - xx - zz, yz + xw);  // NOLINT
+    m_value[2] = col_type(xz + yw, yz - xw, 1 - xx - yy);  // NOLINT
 }
 
 // ----------------------------------------------------------------------------------------
@@ -384,10 +389,11 @@ constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) {
  */
 
 // matrix * column-vector, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat33<U>::col_type MATH_PURE operator *(const TMat33<T>& lhs, const TVec3<U>& rhs) {
+template<typename T, typename U>
+constexpr typename TMat33<U>::col_type MATH_PURE operator*(const TMat33<T>& lhs,
+        const TVec3 <U>& rhs) {
     // Result is initialized to zero.
-    typename TMat33<U>::col_type result = {};
+    typename TMat33<U>::col_type result{};
     for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
         result += lhs[col] * rhs[col];
     }
@@ -395,9 +401,10 @@ constexpr typename TMat33<U>::col_type MATH_PURE operator *(const TMat33<T>& lhs
 }
 
 // row-vector * matrix, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat33<U>::row_type MATH_PURE operator *(const TVec3<U>& lhs, const TMat33<T>& rhs) {
-    typename TMat33<U>::row_type result;
+template<typename T, typename U>
+constexpr typename TMat33<U>::row_type MATH_PURE operator*(const TVec3 <U>& lhs,
+        const TMat33<T>& rhs) {
+    typename TMat33<U>::row_type result{};
     for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
     }
@@ -420,8 +427,8 @@ operator*(U lhs, const TMat33<T>& rhs) {
 
 //------------------------------------------------------------------------------
 template<typename T>
-constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t storageSize) {
-    TQuaternion<T> q = TMat33<T>{m[0], cross(m[2], m[0]), m[2]}.toQuaternion();
+constexpr TQuaternion <T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t storageSize) {
+    TQuaternion <T> q = TMat33<T>{ m[0], cross(m[2], m[0]), m[2] }.toQuaternion();
     q = positive(normalize(q));
 
     // Ensure w is never 0.0
@@ -430,7 +437,7 @@ constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t 
     if (q.w < bias) {
         q.w = bias;
 
-        const T factor = (T) (std::sqrt(1.0 - (double) bias * (double) bias));
+        const T factor = (T)(std::sqrt(1.0 - (double)bias * (double)bias));
         q.xyz *= factor;
     }
 
@@ -464,8 +471,9 @@ typedef details::TMat33<float> mat3f;
 }  // namespace filament
 
 namespace std {
-template <typename T>
-constexpr void swap( filament::math::details::TMat33<T>& lhs,  filament::math::details::TMat33<T>& rhs) noexcept {
+template<typename T>
+constexpr void swap(filament::math::details::TMat33<T>& lhs,
+        filament::math::details::TMat33<T>& rhs) noexcept {
     // This generates much better code than the default implementation
     // It's unclear why, I believe this is due to an optimization bug in the clang.
     //

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -78,18 +78,20 @@ class TQuaternion;
  * m[n] is the \f$ n^{th} \f$ column of the matrix and is a double4.
  *
  */
-template <typename T>
+template<typename T>
 class MATH_EMPTY_BASES TMat44 :
-                public TVecUnaryOperators<TMat44, T>,
-                public TVecComparisonOperators<TMat44, T>,
-                public TVecAddOperators<TMat44, T>,
-                public TMatProductOperators<TMat44, T>,
-                public TMatSquareFunctions<TMat44, T>,
-                public TMatTransform<TMat44, T>,
-                public TMatHelpers<TMat44, T>,
-                public TMatDebug<TMat44, T> {
+        public TVecUnaryOperators<TMat44, T>,
+        public TVecComparisonOperators<TMat44, T>,
+        public TVecAddOperators<TMat44, T>,
+        public TMatProductOperators<TMat44, T>,
+        public TMatSquareFunctions<TMat44, T>,
+        public TMatTransform<TMat44, T>,
+        public TMatHelpers<TMat44, T>,
+        public TMatDebug<TMat44, T> {
 public:
-    enum no_init { NO_INIT };
+    enum no_init {
+        NO_INIT
+    };
     typedef T value_type;
     typedef T& reference;
     typedef T const& const_reference;
@@ -183,11 +185,11 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat44(const TVec4<U>& v);
 
     // construct from another matrix of the same size
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat44(const TMat44<U>& rhs);
 
     /** construct from 4 column vectors.
@@ -200,8 +202,9 @@ public:
      *      \right)
      *      \f$
      */
-    template <typename A, typename B, typename C, typename D>
-    constexpr TMat44(const TVec4<A>& v0, const TVec4<B>& v1, const TVec4<C>& v2, const TVec4<D>& v3);
+    template<typename A, typename B, typename C, typename D>
+    constexpr TMat44(const TVec4<A>& v0, const TVec4<B>& v1, const TVec4<C>& v2,
+            const TVec4<D>& v3);
 
     /** construct from 16 elements in column-major form.
      *
@@ -216,15 +219,15 @@ public:
      *      \right)
      *      \f$
      */
-    template <
-        typename A, typename B, typename C, typename D,
-        typename E, typename F, typename G, typename H,
-        typename I, typename J, typename K, typename L,
-        typename M, typename N, typename O, typename P>
+    template<
+            typename A, typename B, typename C, typename D,
+            typename E, typename F, typename G, typename H,
+            typename I, typename J, typename K, typename L,
+            typename M, typename N, typename O, typename P>
     constexpr explicit TMat44(A m00, B m01, C m02, D m03,
-                              E m10, F m11, G m12, H m13,
-                              I m20, J m21, K m22, L m23,
-                              M m30, N m31, O m32, P m33);
+            E m10, F m11, G m12, H m13,
+            I m20, J m21, K m22, L m23,
+            M m30, N m31, O m32, P m33);
 
 
     struct row_major_init {
@@ -234,42 +237,43 @@ public:
                 typename I, typename J, typename K, typename L,
                 typename M, typename N, typename O, typename P>
         constexpr explicit row_major_init(A m00, B m01, C m02, D m03,
-                            E m10, F m11, G m12, H m13,
-                            I m20, J m21, K m22, L m23,
-                            M m30, N m31, O m32, P m33) noexcept
+                E m10, F m11, G m12, H m13,
+                I m20, J m21, K m22, L m23,
+                M m30, N m31, O m32, P m33) noexcept
                 : m(m00, m10, m20, m30,
-                    m01, m11, m21, m31,
-                    m02, m12, m22, m32,
-                    m03, m13, m23, m33) {}
+                m01, m11, m21, m31,
+                m02, m12, m22, m32,
+                m03, m13, m23, m33) {}
+
     private:
         friend TMat44;
         TMat44 m;
     };
 
-    constexpr explicit TMat44(row_major_init c) : TMat44(std::move(c.m)) { }
+    constexpr explicit TMat44(row_major_init c) : TMat44(std::move(c.m)) {}
 
     /**
      * construct from a quaternion
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat44(const TQuaternion<U>& q);
 
     /**
      * construct from a 3x3 matrix
      */
-    template <typename U>
+    template<typename U>
     constexpr explicit TMat44(const TMat33<U>& matrix);
 
     /**
      * construct from a 3x3 matrix and 3d translation
      */
-    template <typename U, typename V>
+    template<typename U, typename V>
     constexpr TMat44(const TMat33<U>& matrix, const TVec3<V>& translation);
 
     /**
      * construct from a 3x3 matrix and 4d last column.
      */
-    template <typename U, typename V>
+    template<typename U, typename V>
     constexpr TMat44(const TMat33<U>& matrix, const TVec4<V>& column3);
 
     /*
@@ -298,45 +302,48 @@ public:
         HORIZONTAL,
         VERTICAL
     };
-    static constexpr TMat44 perspective(T fov, T aspect, T near, T far, Fov direction = Fov::VERTICAL);
+    static TMat44 perspective(T fov, T aspect, T near, T far, Fov direction = Fov::VERTICAL);
 
-    template <typename A, typename B, typename C>
-    static constexpr TMat44 lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up);
+    template<typename A, typename B, typename C>
+    static TMat44 lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up);
 
-    template <typename A>
+    template<typename A>
     static constexpr TVec3<A> project(const TMat44& projectionMatrix, TVec3<A> vertice) {
         TVec4<A> r = projectionMatrix * TVec4<A>{ vertice, 1 };
-        return r.xyz * (1 / r.w);
+        return TVec3<A>{ r[0], r[1], r[2] } * (1 / r[3]);
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TVec4<A> project(const TMat44& projectionMatrix, TVec4<A> vertice) {
         vertice = projectionMatrix * vertice;
-        return { vertice.xyz * (1 / vertice.w), 1 };
+        return { TVec3<A>{ vertice[0], vertice[1], vertice[2] } * (1 / vertice[3]), 1 };
     }
 
     /**
      * Constructs a 3x3 matrix from the upper-left corner of this 4x4 matrix
      */
     inline constexpr TMat33<T> upperLeft() const {
-        return TMat33<T>(m_value[0].xyz, m_value[1].xyz, m_value[2].xyz);
+        const TVec3<T> v0 = { m_value[0][0], m_value[0][1], m_value[0][2] };
+        const TVec3<T> v1 = { m_value[1][0], m_value[1][1], m_value[1][2] };
+        const TVec3<T> v2 = { m_value[2][0], m_value[2][1], m_value[2][2] };
+        return TMat33<T>(v0, v1, v2);
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat44 translation(const TVec3<A>& t) {
         TMat44 r;
         r[3] = TVec4<T>{ t, 1 };
         return r;
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat44 scaling(const TVec3<A>& s) {
-        return TMat44{ TVec4<T>{ s, 1 } };
+        return TMat44{ TVec4<T>{ s, 1 }};
     }
 
-    template <typename A>
+    template<typename A>
     static constexpr TMat44 scaling(A s) {
-        return TMat44{ TVec4<T>{ s, s, s, 1 } };
+        return TMat44{ TVec4<T>{ s, s, s, 1 }};
     }
 };
 
@@ -347,51 +354,56 @@ public:
 // Since the matrix code could become pretty big quickly, we don't inline most
 // operations.
 
-template <typename T>
-constexpr TMat44<T>::TMat44() {
-    m_value[0] = col_type(1.0f, 0.0f, 0.0f, 0.0f);
-    m_value[1] = col_type(0.0f, 1.0f, 0.0f, 0.0f);
-    m_value[2] = col_type(0.0f, 0.0f, 1.0f, 0.0f);
-    m_value[3] = col_type(0.0f, 0.0f, 0.0f, 1.0f);
-}
-
-template <typename T>
-template <typename U>
-constexpr TMat44<T>::TMat44(U v) {
-    m_value[0] = col_type(v, 0, 0, 0);
-    m_value[1] = col_type(0, v, 0, 0);
-    m_value[2] = col_type(0, 0, v, 0);
-    m_value[3] = col_type(0, 0, 0, v);
+template<typename T>
+constexpr TMat44<T>::TMat44()
+        : m_value{
+        col_type(1, 0, 0, 0),
+        col_type(0, 1, 0, 0),
+        col_type(0, 0, 1, 0),
+        col_type(0, 0, 0, 1) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(const TVec4<U>& v) {
-    m_value[0] = col_type(v.x, 0, 0, 0);
-    m_value[1] = col_type(0, v.y, 0, 0);
-    m_value[2] = col_type(0, 0, v.z, 0);
-    m_value[3] = col_type(0, 0, 0, v.w);
+constexpr TMat44<T>::TMat44(U v)
+        : m_value{
+        col_type(v, 0, 0, 0),
+        col_type(0, v, 0, 0),
+        col_type(0, 0, v, 0),
+        col_type(0, 0, 0, v) } {
 }
+
+template<typename T>
+template<typename U>
+constexpr TMat44<T>::TMat44(const TVec4<U>& v)
+        : m_value{
+        col_type(v[0], 0, 0, 0),
+        col_type(0, v[1], 0, 0),
+        col_type(0, 0, v[2], 0),
+        col_type(0, 0, 0, v[3]) } {
+}
+
 
 // construct from 16 scalars
 template<typename T>
-template <
-    typename A, typename B, typename C, typename D,
-    typename E, typename F, typename G, typename H,
-    typename I, typename J, typename K, typename L,
-    typename M, typename N, typename O, typename P>
+template<
+        typename A, typename B, typename C, typename D,
+        typename E, typename F, typename G, typename H,
+        typename I, typename J, typename K, typename L,
+        typename M, typename N, typename O, typename P>
 constexpr TMat44<T>::TMat44(A m00, B m01, C m02, D m03,
-                            E m10, F m11, G m12, H m13,
-                            I m20, J m21, K m22, L m23,
-                            M m30, N m31, O m32, P m33) {
-    m_value[0] = col_type(m00, m01, m02, m03);
-    m_value[1] = col_type(m10, m11, m12, m13);
-    m_value[2] = col_type(m20, m21, m22, m23);
-    m_value[3] = col_type(m30, m31, m32, m33);
+        E m10, F m11, G m12, H m13,
+        I m20, J m21, K m22, L m23,
+        M m30, N m31, O m32, P m33)
+        : m_value{
+        col_type(m00, m01, m02, m03),
+        col_type(m10, m11, m12, m13),
+        col_type(m20, m21, m22, m23),
+        col_type(m30, m31, m32, m33) } {
 }
 
-template <typename T>
-template <typename U>
+template<typename T>
+template<typename U>
 constexpr TMat44<T>::TMat44(const TMat44<U>& rhs) {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
@@ -399,100 +411,103 @@ constexpr TMat44<T>::TMat44(const TMat44<U>& rhs) {
 }
 
 // Construct from 4 column vectors.
-template <typename T>
-template <typename A, typename B, typename C, typename D>
+template<typename T>
+template<typename A, typename B, typename C, typename D>
 constexpr TMat44<T>::TMat44(const TVec4<A>& v0, const TVec4<B>& v1,
-                            const TVec4<C>& v2, const TVec4<D>& v3) {
-    m_value[0] = col_type(v0);
-    m_value[1] = col_type(v1);
-    m_value[2] = col_type(v2);
-    m_value[3] = col_type(v3);
+        const TVec4<C>& v2, const TVec4<D>& v3)
+        : m_value{ v0, v1, v2, v3 } {
 }
 
-template <typename T>
-template <typename U>
-constexpr TMat44<T>::TMat44(const TQuaternion<U>& q) {
-    const U n = q.x*q.x + q.y*q.y + q.z*q.z + q.w*q.w;
-    const U s = n > 0 ? 2/n : 0;
-    const U x = s*q.x;
-    const U y = s*q.y;
-    const U z = s*q.z;
-    const U xx = x*q.x;
-    const U xy = x*q.y;
-    const U xz = x*q.z;
-    const U xw = x*q.w;
-    const U yy = y*q.y;
-    const U yz = y*q.z;
-    const U yw = y*q.w;
-    const U zz = z*q.z;
-    const U zw = z*q.w;
-    m_value[0] = col_type(1-yy-zz,    xy+zw,    xz-yw,   0);
-    m_value[1] = col_type(  xy-zw,  1-xx-zz,    yz+xw,   0);  // NOLINT
-    m_value[2] = col_type(  xz+yw,    yz-xw,  1-xx-yy,   0);  // NOLINT
-    m_value[3] = col_type(      0,        0,        0,   1);  // NOLINT
+template<typename T>
+template<typename U>
+constexpr TMat44<T>::TMat44(const TQuaternion<U>& q) : m_value{} {
+    const U n = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+    const U s = n > 0 ? 2 / n : 0;
+    const U x = s * q.x;
+    const U y = s * q.y;
+    const U z = s * q.z;
+    const U xx = x * q.x;
+    const U xy = x * q.y;
+    const U xz = x * q.z;
+    const U xw = x * q.w;
+    const U yy = y * q.y;
+    const U yz = y * q.z;
+    const U yw = y * q.w;
+    const U zz = z * q.z;
+    const U zw = z * q.w;
+    m_value[0] = col_type(1 - yy - zz, xy + zw, xz - yw, 0);
+    m_value[1] = col_type(xy - zw, 1 - xx - zz, yz + xw, 0);  // NOLINT
+    m_value[2] = col_type(xz + yw, yz - xw, 1 - xx - yy, 0);  // NOLINT
+    m_value[3] = col_type(0, 0, 0, 1);  // NOLINT
 }
 
-template <typename T>
-template <typename U>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m) {
-    m_value[0] = col_type(m[0][0], m[0][1], m[0][2], 0);
-    m_value[1] = col_type(m[1][0], m[1][1], m[1][2], 0);
-    m_value[2] = col_type(m[2][0], m[2][1], m[2][2], 0);
-    m_value[3] = col_type(      0,       0,       0, 1);  // NOLINT
+template<typename T>
+template<typename U>
+constexpr TMat44<T>::TMat44(const TMat33<U>& m)
+        : m_value{
+        col_type(m[0][0], m[0][1], m[0][2], 0),
+        col_type(m[1][0], m[1][1], m[1][2], 0),
+        col_type(m[2][0], m[2][1], m[2][2], 0),
+        col_type(0, 0, 0, 1) }  // NOLINT
+{
 }
 
-template <typename T>
-template <typename U, typename V>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec3<V>& v) {
-    m_value[0] = col_type(m[0][0], m[0][1], m[0][2], 0);
-    m_value[1] = col_type(m[1][0], m[1][1], m[1][2], 0);
-    m_value[2] = col_type(m[2][0], m[2][1], m[2][2], 0);
-    m_value[3] = col_type(   v[0],    v[1],    v[2], 1);  // NOLINT
+template<typename T>
+template<typename U, typename V>
+constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec3<V>& v)
+        : m_value{
+        col_type(m[0][0], m[0][1], m[0][2], 0),
+        col_type(m[1][0], m[1][1], m[1][2], 0),
+        col_type(m[2][0], m[2][1], m[2][2], 0),
+        col_type(v[0], v[1], v[2], 1) }  // NOLINT
+{
 }
 
-template <typename T>
-template <typename U, typename V>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec4<V>& v) {
-    m_value[0] = col_type(m[0][0], m[0][1], m[0][2],    0);  // NOLINT
-    m_value[1] = col_type(m[1][0], m[1][1], m[1][2],    0);  // NOLINT
-    m_value[2] = col_type(m[2][0], m[2][1], m[2][2],    0);  // NOLINT
-    m_value[3] = col_type(   v[0],    v[1],    v[2], v[3]);  // NOLINT
+template<typename T>
+template<typename U, typename V>
+constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec4<V>& v)
+        : m_value{
+        col_type(m[0][0], m[0][1], m[0][2], 0),
+        col_type(m[1][0], m[1][1], m[1][2], 0),
+        col_type(m[2][0], m[2][1], m[2][2], 0),
+        col_type(v[0], v[1], v[2], v[3]) }  // NOLINT
+{
 }
+
 
 // ----------------------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 constexpr TMat44<T> TMat44<T>::ortho(T left, T right, T bottom, T top, T near, T far) {
     TMat44<T> m;
-    m[0][0] =  2 / (right - left);
-    m[1][1] =  2 / (top   - bottom);
-    m[2][2] = -2 / (far   - near);
-    m[3][0] = -(right + left)   / (right - left);
-    m[3][1] = -(top   + bottom) / (top   - bottom);
-    m[3][2] = -(far   + near)   / (far   - near);
+    m[0][0] = 2 / (right - left);
+    m[1][1] = 2 / (top - bottom);
+    m[2][2] = -2 / (far - near);
+    m[3][0] = -(right + left) / (right - left);
+    m[3][1] = -(top + bottom) / (top - bottom);
+    m[3][2] = -(far + near) / (far - near);
     return m;
 }
 
-template <typename T>
+template<typename T>
 constexpr TMat44<T> TMat44<T>::frustum(T left, T right, T bottom, T top, T near, T far) {
     TMat44<T> m;
-    m[0][0] =  (2 * near) / (right - left);
-    m[1][1] =  (2 * near) / (top   - bottom);
-    m[2][0] =  (right + left)   / (right - left);
-    m[2][1] =  (top   + bottom) / (top   - bottom);
-    m[2][2] = -(far   + near)   / (far   - near);
+    m[0][0] = (2 * near) / (right - left);
+    m[1][1] = (2 * near) / (top - bottom);
+    m[2][0] = (right + left) / (right - left);
+    m[2][1] = (top + bottom) / (top - bottom);
+    m[2][2] = -(far + near) / (far - near);
     m[2][3] = -1;
-    m[3][2] = -(2 * far * near) / (far   - near);
-    m[3][3] =  0;
+    m[3][2] = -(2 * far * near) / (far - near);
+    m[3][3] = 0;
     return m;
 }
 
-template <typename T>
-constexpr TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov direction) {
-    T h;
-    T w;
+template<typename T>
+TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov direction) {
+    T h, w;
 
     if (direction == TMat44::Fov::VERTICAL) {
         h = std::tan(fov * PI / 360.0f) * near;
@@ -509,9 +524,10 @@ constexpr TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat4
  * local Y-up coordinate system. "eye" is where the camera is located, "center" is the point it's
  * looking at and "up" defines where the Y axis of the camera's local coordinate system is.
  */
-template <typename T>
-template <typename A, typename B, typename C>
-constexpr TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up) {
+template<typename T>
+template<typename A, typename B, typename C>
+TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center,
+        const TVec3<C>& up) {
     TVec3<T> z_axis(normalize(center - eye));
     TVec3<T> norm_up(normalize(up));
     if (std::abs(dot(z_axis, norm_up)) > T(0.999)) {
@@ -540,10 +556,11 @@ constexpr TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& cente
  */
 
 // matrix * column-vector, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat44<T>::col_type MATH_PURE operator *(const TMat44<T>& lhs, const TVec4<U>& rhs) {
+template<typename T, typename U>
+constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
+        const TVec4<U>& rhs) {
     // Result is initialized to zero.
-    typename TMat44<T>::col_type result = {};
+    typename TMat44<T>::col_type result{};
     for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
         result += lhs[col] * T(rhs[col]);
     }
@@ -551,16 +568,18 @@ constexpr typename TMat44<T>::col_type MATH_PURE operator *(const TMat44<T>& lhs
 }
 
 // mat44 * vec3, result is vec3( mat44 * {vec3, 1} )
-template <typename T, typename U>
-constexpr typename TMat44<T>::col_type MATH_PURE operator *(const TMat44<T>& lhs, const TVec3<U>& rhs) {
+template<typename T, typename U>
+constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
+        const TVec3<U>& rhs) {
     return lhs * TVec4<U>{ rhs, 1 };
 }
 
 
 // row-vector * matrix, result is a vector of the same type than the input vector
-template <typename T, typename U>
-constexpr typename TMat44<U>::row_type MATH_PURE operator *(const TVec4<U>& lhs, const TMat44<T>& rhs) {
-    typename TMat44<U>::row_type result;
+template<typename T, typename U>
+constexpr typename TMat44<U>::row_type MATH_PURE operator*(const TVec4<U>& lhs,
+        const TMat44<T>& rhs) {
+    typename TMat44<U>::row_type result{};
     for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
         result[col] = dot(lhs, rhs[col]);
     }
@@ -568,16 +587,16 @@ constexpr typename TMat44<U>::row_type MATH_PURE operator *(const TVec4<U>& lhs,
 }
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
-template <typename T, typename U>
+template<typename T, typename U>
 constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
-operator *(TMat44<T> lhs, U rhs) {
+operator*(TMat44<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
-template <typename T, typename U>
+template<typename T, typename U>
 constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
-operator *(U lhs, const TMat44<T>& rhs) {
+operator*(U lhs, const TMat44<T>& rhs) {
     return rhs * lhs;
 }
 
@@ -603,8 +622,9 @@ typedef details::TMat44<float> mat4f;
 }  // namespace filament
 
 namespace std {
-template <typename T>
-constexpr void swap( filament::math::details::TMat44<T>& lhs,  filament::math::details::TMat44<T>& rhs) noexcept {
+template<typename T>
+constexpr void swap(filament::math::details::TMat44<T>& lhs,
+        filament::math::details::TMat44<T>& rhs) noexcept {
     // This generates much better code than the default implementation
     // It's unclear why, I believe this is due to an optimization bug in the clang.
     //

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -74,19 +74,19 @@ public:
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A>
-    constexpr TVec2(A v) : x(v), y(v) { }
+    constexpr TVec2(A v) : v{ T(v), T(v) } {}
 
     template<typename A, typename B>
-    constexpr TVec2(A x, B y) : x(x), y(y) { }
+    constexpr TVec2(A x, B y) : v{ T(x), T(y) } {}
 
     template<typename A>
-    constexpr TVec2(const TVec2<A>& v) : x(v.x), y(v.y) { }
+    constexpr TVec2(const TVec2<A>& v) : v{ T(v[0]), T(v[1]) } {}
 
     // cross product works only on vectors of size 2 or 3
-    template <typename RT>
+    template<typename RT>
     friend inline
     constexpr value_type cross(const TVec2& u, const TVec2<RT>& v) {
-        return value_type(u.x*v.y - u.y*v.x);
+        return value_type(u[0] * v[1] - u[1] * v[0]);
     }
 };
 

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -87,25 +87,24 @@ public:
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A>
-    constexpr TVec3(A v) : x(v), y(v), z(v) { }
+    constexpr TVec3(A v) : v{ T(v), T(v), T(v) } {}
 
     template<typename A, typename B, typename C>
-    constexpr TVec3(A x, B y, C z) : x(x), y(y), z(z) { }
+    constexpr TVec3(A x, B y, C z) : v{ T(x), T(y), T(z) } {}
 
     template<typename A, typename B>
-    constexpr TVec3(const TVec2<A>& v, B z) : x(v.x), y(v.y), z(z) { }
+    constexpr TVec3(const TVec2<A>& v, B z) : v{ T(v[0]), T(v[1]), T(z) } {}
 
     template<typename A>
-    constexpr TVec3(const TVec3<A>& v) : x(v.x), y(v.y), z(v.z) { }
+    constexpr TVec3(const TVec3<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]) } {}
 
     // cross product works only on vectors of size 3
     template <typename RT>
-    friend inline
-    constexpr TVec3 cross(const TVec3& u, const TVec3<RT>& v) {
+    friend inline constexpr TVec3 cross(const TVec3& u, const TVec3<RT>& v) {
         return TVec3(
-                u.y*v.z - u.z*v.y,
-                u.z*v.x - u.x*v.z,
-                u.x*v.y - u.y*v.x);
+                u[1] * v[2] - u[2] * v[1],
+                u[2] * v[0] - u[0] * v[2],
+                u[0] * v[1] - u[1] * v[0]);
     }
 };
 

--- a/libs/math/include/math/vec4.h
+++ b/libs/math/include/math/vec4.h
@@ -86,19 +86,22 @@ public:
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A>
-    constexpr TVec4(A v) : x(v), y(v), z(v), w(v) { }
+    constexpr TVec4(A v) : v{ T(v), T(v), T(v), T(v) } {}
 
     template<typename A, typename B, typename C, typename D>
-    constexpr TVec4(A x, B y, C z, D w) : x(x), y(y), z(z), w(w) { }
+    constexpr TVec4(A x, B y, C z, D w) : v{ T(x), T(y), T(z), T(w) } {}
 
     template<typename A, typename B, typename C>
-    constexpr TVec4(const TVec2<A>& v, B z, C w) : x(v.x), y(v.y), z(z), w(w) { }
+    constexpr TVec4(const TVec2<A>& v, B z, C w) : v{ T(v[0]), T(v[1]), T(z), T(w) } {}
 
     template<typename A, typename B>
-    constexpr TVec4(const TVec3<A>& v, B w) : x(v.x), y(v.y), z(v.z), w(w) { }
+    constexpr TVec4(const TVec2<A>& v, const TVec2<B>& w) : v{ T(v[0]), T(v[1]), T(w[0]), T(w[1]) } {}
+
+    template<typename A, typename B>
+    constexpr TVec4(const TVec3<A>& v, B w) : v{ T(v[0]), T(v[1]), T(v[2]), T(w) } {}
 
     template<typename A>
-    constexpr TVec4(const TVec4<A>& v) : x(v.x), y(v.y), z(v.z), w(v.w) { }
+    constexpr TVec4(const TVec4<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]), T(v[3]) } {}
 };
 
 }  // namespace details

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -31,6 +31,78 @@ class MatTest : public testing::Test {
 protected:
 };
 
+TEST_F(MatTest, ConstexprMat2) {
+    constexpr float a = M_PI;
+    constexpr mat2f M;
+    constexpr mat2f M0(a);
+    constexpr mat2f M1(float2{a, a});
+    constexpr mat2f M2(1,2,3,4);
+    constexpr mat2f M3(M2);
+    constexpr mat2f M4(float2{1,2}, float2{3,4});
+    constexpr float2 f0 = M0 * float2{1,2};
+    constexpr float2 f1 = float2{1,2} * M1;
+    constexpr mat2f M5 = M2 * 2;
+    constexpr mat2f M7 = 2 * M2;
+    constexpr float2 f3 = diag(M0);
+    constexpr mat2f M8 = transpose(M0);
+    constexpr mat2f M9 = inverse(M0);
+    constexpr mat2f M10 = M8 * M9;
+    constexpr float s0 = trace(M0);
+}
+
+TEST_F(MatTest, ConstexprMat3) {
+    constexpr float a = M_PI;
+    constexpr mat3f M;
+    constexpr mat3f M0(a);
+    constexpr mat3f M1(float3{a, a, a});
+    constexpr mat3f M2(1,2,3,4,5,6,7,8,9);
+    constexpr mat3f M3(M2);
+    constexpr mat3f M4(float3{1,2,3}, float3{4,5,6}, float3{7,8,9});
+    constexpr float3 f0 = M0 * float3{1,2,3};
+    constexpr float3 f1 = float3{1,2,3} * M1;
+    constexpr mat3f M5 = M2 * 2;
+    constexpr mat3f M7 = 2 * M2;
+    constexpr float3 f3 = diag(M0);
+    constexpr mat3f M8 = transpose(M0);
+    constexpr mat3f M9 = inverse(M0);
+    constexpr mat3f M10 = M8 * M9;
+    constexpr float s0 = trace(M0);
+    constexpr quatf q;
+    constexpr mat3f M11{q};
+}
+
+TEST_F(MatTest, ConstexprMat4) {
+    constexpr float a = M_PI;
+    constexpr mat4f M;
+    constexpr mat4f M0(a);
+    constexpr mat4f M1(float4{a, a, a, a});
+    constexpr mat4f M2(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
+    constexpr mat4f M3(M2);
+    constexpr mat4f M4(float4{1,2,3,4}, float4{5,6,7,8}, float4{9,10,11,12}, float4{13,14,15,16});
+    constexpr float4 f0 = M0 * float4{1,2,3,4};
+    constexpr float4 f1 = float4{1,2,3,4} * M1;
+    constexpr mat4f M5 = M2 * 2;
+    constexpr mat4f M7 = 2 * M2;
+    constexpr float4 f3 = diag(M0);
+    constexpr mat4f M8 = transpose(M0);
+    constexpr mat4f M9 = inverse(M0);
+    constexpr mat4f M10 = M8 * M9;
+    constexpr float s0 = trace(M0);
+    constexpr quatf q;
+    constexpr mat4f M11{q};
+    constexpr mat4f M13{mat3f{}};
+    constexpr mat4f M14{mat3f{}, float3{}};
+    constexpr mat4f M15{mat3f{}, float4{}};
+    constexpr mat4f O = mat4f::ortho(0, 1, 0, 1, -1, 1);
+    constexpr mat4f F = mat4f::frustum(0, 1, 0, 1, -1, 1);
+    constexpr float4 f4 = mat4f::project(F, float4{1,2,3,1});
+    constexpr float3 f5 = mat4f::project(F, float3{1,2,3});
+    constexpr mat3f U = M11.upperLeft();
+    constexpr mat4f T = mat4f::translation(f5);
+    constexpr mat4f S = mat4f::scaling(f5);
+    constexpr mat4f V = mat4f::scaling(s0);
+}
+
 TEST_F(MatTest, Basics) {
     EXPECT_EQ(sizeof(mat4), sizeof(double)*16);
 }

--- a/libs/math/tests/test_vec.cpp
+++ b/libs/math/tests/test_vec.cpp
@@ -26,6 +26,59 @@ class VecTest : public testing::Test {
 protected:
 };
 
+TEST_F(VecTest, Constexpr) {
+    constexpr float a = M_PI;
+    constexpr float2 A2 = a;
+    constexpr float2 B2 = { a, a };
+    constexpr float2 C2 = A2;
+    constexpr float3 D2 = cross(A2, C2);
+
+    constexpr float3 A3 = a;
+    constexpr float3 B3 = { a, a, a };
+    constexpr float3 C3 = A3;
+    constexpr float3 D3 = { A2, a };
+    constexpr float3 E3 = cross(A3, D3);
+
+    constexpr float4 A4 = a;
+    constexpr float4 B4 = { a, a, a, a };
+    constexpr float4 C4 = A4;
+    constexpr float4 D4 = { A2, a, a };
+    constexpr float4 E4 = { A2, B2 };
+
+    constexpr float4 AN4 = abs(A4);
+    constexpr float4 BN4 = abs(B4);
+    constexpr float4 CN4 = abs(C4);
+    constexpr float4 DN4 = abs(D4);
+    constexpr float4 EN4 = abs(E4);
+
+    constexpr float4 AS4 = saturate(A4);
+    constexpr float4 BS4 = saturate(B4);
+    constexpr float4 CS4 = saturate(C4);
+    constexpr float4 DS4 = saturate(D4);
+    constexpr float4 ES4 = saturate(E4);
+
+    constexpr float d0 = dot(A4, A4);
+    constexpr float d1 = dot(B4, A4);
+    constexpr float d2 = dot(C4, A4);
+    constexpr float d4 = dot(D4, A4);
+
+    constexpr float4 S0 = A4 + B4;
+    constexpr float4 S1 = C4 - D4;
+    constexpr float4 S2 = A4 * a;
+    constexpr float4 S3 = A4 * A4;
+    constexpr float4 S4 = A4 / a;
+    constexpr float4 S5 = A4 / A4;
+
+    constexpr float4 S6 = -E4;
+
+    constexpr bool b0 = A4 == B4;
+    constexpr bool b1 = A4 != B4;
+
+    constexpr bool4 b2 = equal(A4, B4);
+    constexpr bool b3 = any(A4);
+    constexpr bool b4 = all(A4);
+}
+
 TEST_F(VecTest, Basics) {
     double4 v4;
     double3& v3(v4.xyz);


### PR DESCRIPTION
It turns out that most of libmath couldn't be used in constexpr
expression due to our use of union{}. The C++ standard requires that
all accesses to a union{} in a constexpr expression be the same
element.

Also because libm and cmath are not constexpr some functions such
as length() or normalize() can't be constexpr. The same is true for
anything needing things like sqrt, cos, sin, ceil, floor.

This change mainly does the following:
- replace all accesses to vector elements by operator[]
  (this ensure all of libmath uses the same union element)

- avoid use of std::min / std::max / std::abs

- avoid uninitialized variables, which can't be constexpr

- remove 'constexpr' keyword on functions that can never be

It is now possible to write things like:

    constexpr mat4f I = inverse(
            transpose(mat4f::translation(float3{ 1, 2, 3 }) 
                 * mat4f::scaling(4)));