### PR TITLE
Fix upper limit on vertex attributes. (affects GL)

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -42,9 +42,8 @@ namespace backend {
 static constexpr uint64_t SWAP_CHAIN_CONFIG_TRANSPARENT = 0x1;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_READABLE = 0x2;
 
-static constexpr size_t MAX_ATTRIBUTE_BUFFER_COUNT = 8; // FIXME: what should this be?
-static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 7; // FIXME: what should this be?
-static constexpr size_t MAX_SAMPLER_COUNT = 16;         // Matches the Adreno Vulkan driver.
+static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 16; // This is guaranteed by OpenGL ES.
+static constexpr size_t MAX_SAMPLER_COUNT = 16;          // Matches the Adreno Vulkan driver.
 
 static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
 static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;
@@ -677,7 +676,7 @@ struct Attribute {
     uint8_t flags = 0x0;
 };
 
-using AttributeArray = std::array<Attribute, MAX_ATTRIBUTE_BUFFER_COUNT>;
+using AttributeArray = std::array<Attribute, MAX_VERTEX_ATTRIBUTE_COUNT>;
 
 struct PolygonOffset {
     float slope = 0;        // factor in GL-speak

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -50,11 +50,11 @@ struct HwBase {
 };
 
 struct HwVertexBuffer : public HwBase {
-    AttributeArray attributes;            // 8*8
+    AttributeArray attributes;            // 8 * MAX_VERTEX_ATTRIBUTE_COUNT
     uint32_t vertexCount;                 //   4
     uint8_t bufferCount;                  //   1
     uint8_t attributeCount;               //   1
-    uint8_t padding[2]{};                 //   2 -> 56 bytes
+    uint8_t padding[2]{};                 //   2 -> total struct is 136 bytes
 
     HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
             AttributeArray const& attributes) noexcept

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -761,10 +761,10 @@ default_case:
 //    GLRenderTarget            : 56        few
 // -- less than 64 bytes
 
-//    GLVertexBuffer            : 80        moderate
+//    GLVertexBuffer            : 208       moderate
 //    GLStream                  : 120       few
 //    GLUniformBuffer           : 128       many
-// -- less than 128 bytes
+// -- less than or equal to 208 bytes
 
 
 OpenGLDriver::HandleAllocator::HandleAllocator(const utils::HeapArea& area)
@@ -818,7 +818,7 @@ template<typename D, typename B, typename ... ARGS>
 typename std::enable_if<std::is_base_of<B, D>::value, D>::type*
 OpenGLDriver::construct(Handle<B> const& handle, ARGS&& ... args) noexcept {
     assert(handle);
-    static_assert(sizeof(D) <= 128, "Handle<> too large");
+    static_assert(sizeof(D) <= 208, "Handle<> too large");
     D* addr = handle_cast<D *>(const_cast<Handle<B>&>(handle));
     new(addr) D(std::forward<ARGS>(args)...);
 #if !defined(NDEBUG) && UTILS_HAS_RTTI

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -63,7 +63,7 @@ public:
     struct GLVertexBuffer : public backend::HwVertexBuffer {
         using HwVertexBuffer::HwVertexBuffer;
         struct {
-            std::array<GLuint, backend::MAX_ATTRIBUTE_BUFFER_COUNT> buffers;  // 4*6 bytes
+            std::array<GLuint, backend::MAX_VERTEX_ATTRIBUTE_COUNT> buffers;  // 4 * MAX_VERTEX_ATTRIBUTE_COUNT bytes
         } gl;
     };
 
@@ -212,7 +212,7 @@ private:
     class HandleAllocator {
         utils::PoolAllocator< 16, 16>   mPool0;
         utils::PoolAllocator< 64, 32>   mPool1;
-        utils::PoolAllocator<128, 32>   mPool2;
+        utils::PoolAllocator<208, 32>   mPool2;
     public:
         static constexpr size_t MIN_ALIGNMENT_SHIFT = 4;
         explicit HandleAllocator(const utils::HeapArea& area);

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -37,7 +37,7 @@ using namespace backend;
 using namespace filament::math;
 
 struct VertexBuffer::BuilderDetails {
-    FVertexBuffer::AttributeData mAttributes[MAX_ATTRIBUTE_BUFFER_COUNT];
+    FVertexBuffer::AttributeData mAttributes[MAX_VERTEX_ATTRIBUTE_COUNT];
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
@@ -76,8 +76,8 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         byteStride = (uint8_t)attributeSize;
     }
 
-    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFER_COUNT &&
-        size_t(bufferIndex) < MAX_ATTRIBUTE_BUFFER_COUNT) {
+    if (size_t(attribute) < MAX_VERTEX_ATTRIBUTE_COUNT &&
+        size_t(bufferIndex) < MAX_VERTEX_ATTRIBUTE_COUNT) {
 
 #ifndef NDEBUG
         if (byteOffset & 0x3) {
@@ -105,7 +105,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
 
 VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribute,
         bool normalized) noexcept {
-    if (size_t(attribute) < MAX_ATTRIBUTE_BUFFER_COUNT) {
+    if (size_t(attribute) < MAX_VERTEX_ATTRIBUTE_COUNT) {
         FVertexBuffer::AttributeData& entry = mImpl->mAttributes[attribute];
         if (normalized) {
             entry.flags |= Attribute::FLAG_NORMALIZED;
@@ -124,8 +124,8 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount > 0, "bufferCount cannot be 0")) {
         return nullptr;
     }
-    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount <= MAX_ATTRIBUTE_BUFFER_COUNT,
-            "bufferCount cannot be more than %d", MAX_ATTRIBUTE_BUFFER_COUNT)) {
+    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount <= MAX_VERTEX_ATTRIBUTE_COUNT,
+            "bufferCount cannot be more than %d", MAX_VERTEX_ATTRIBUTE_COUNT)) {
         return nullptr;
     }
 
@@ -145,7 +145,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     AttributeArray attributeArray;
 
-    static_assert(attributeArray.size() == MAX_ATTRIBUTE_BUFFER_COUNT,
+    static_assert(attributeArray.size() == MAX_VERTEX_ATTRIBUTE_COUNT,
             "Attribute and Builder::Attribute arrays must match");
 
     static_assert(sizeof(Attribute) == sizeof(AttributeData),

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -62,7 +62,7 @@ private:
     };
 
     backend::Handle<backend::HwVertexBuffer> mHandle;
-    std::array<AttributeData, backend::MAX_ATTRIBUTE_BUFFER_COUNT> mAttributes;
+    std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -115,14 +115,15 @@ enum VertexAttribute : uint8_t {
     UV1             = 4, //!< texture coordinates (float2)
     BONE_INDICES    = 5, //!< indices of 4 bones, as unsigned integers (uvec4)
     BONE_WEIGHTS    = 6, //!< weights of the 4 bones (normalized float4)
-    CUSTOM0         = 7,
-    CUSTOM1         = 8,
-    CUSTOM2         = 9,
-    CUSTOM3         = 10,
-    CUSTOM4         = 11,
-    CUSTOM5         = 12,
-    CUSTOM6         = 13,
-    CUSTOM7         = 14,
+    // -- we have 1 unused slot here --
+    CUSTOM0         = 8,
+    CUSTOM1         = 9,
+    CUSTOM2         = 10,
+    CUSTOM3         = 11,
+    CUSTOM4         = 12,
+    CUSTOM5         = 13,
+    CUSTOM6         = 14,
+    CUSTOM7         = 15,
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 


### PR DESCRIPTION
This combines two constants into one, and changes it into a value that
is actually correct.  :)

Technically the movement of the CUSTOM attributes will change the layout
qualifier and therefore merits a materials version bump, however custom
attributes were only recently introduced so this seems unnecessary.

Did some quick testing with 3 samples: gltf_viewer, lucy_bloom, and
point_sprites.