### PR TITLE
added an option to turn off pre-filtering in cmgen

### DIFF
--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -482,7 +482,7 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
 
         Image image;
         Cubemap dst = CubemapUtils::create(image, dim);
-        CubemapIBL::roughnessFilter(js, dst, levels, linearRoughness, numSamples, mirror);
+        CubemapIBL::roughnessFilter(js, dst, levels, linearRoughness, numSamples, mirror, true);
 
         Texture::PixelBufferDescriptor pbd(image.getData(), image.getSize(),
                 Texture::PixelBufferDescriptor::PixelDataFormat::RGB,

--- a/libs/ibl/include/ibl/CubemapIBL.h
+++ b/libs/ibl/include/ibl/CubemapIBL.h
@@ -51,9 +51,10 @@ public:
      * @param maxNumSamples     number of samples for importance sampling
      * @param updater           a callback for the caller to track progress
      */
-    static void roughnessFilter(utils::JobSystem& js, Cubemap& dst,
-            const std::vector<Cubemap>& levels, float linearRoughness,
-            size_t maxNumSamples, math::float3 mirror, Progress updater = {});
+    static void roughnessFilter(
+            utils::JobSystem& js, Cubemap& dst, const std::vector<Cubemap>& levels,
+            float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
+            Progress updater = {});
 
     //! Computes the "DFG" term of the "split-sum" approximation and stores it in a 2D image
     static void DFG(utils::JobSystem& js, Image& dst, bool multiscatter, bool cloth);

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -285,8 +285,10 @@ static float UTILS_UNUSED VisibilityAshikhmin(float NoV, float NoL, float /*a*/)
  *
  */
 
-void CubemapIBL::roughnessFilter(JobSystem& js, Cubemap& dst, const std::vector<Cubemap>& levels,
-        float linearRoughness, size_t maxNumSamples, float3 mirror, CubemapIBL::Progress updater)
+void CubemapIBL::roughnessFilter(
+        utils::JobSystem& js, Cubemap& dst, const std::vector<Cubemap>& levels,
+        float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
+        Progress updater)
 {
     const float numSamples = maxNumSamples;
     const float inumSamples = 1.0f / numSamples;
@@ -373,7 +375,7 @@ void CubemapIBL::roughnessFilter(JobSystem& js, Cubemap& dst, const std::vector<
             constexpr float K = 4;
             const float omegaS = 1 / (numSamples * pdf);
             const float l = float(log4(omegaS) - log4(omegaP) + log4(K));
-            const float mipLevel = clamp(float(l), 0.0f, maxLevelf);
+            const float mipLevel = prefilter ? clamp(float(l), 0.0f, maxLevelf) : 0.0f;
 
             const float brdf_NoL = float(NoL);
 


### PR DESCRIPTION
When processing very high dynamic range environments, the importance
sampling code falls appart, it becomes a user choice to decide if
prefilter importance sampling is better or worse than just regular
importance sampling -- both are usually bad.

--ibl-no-prefilter gives the user this choice.

Importance Sampling
![no-prefilter](https://user-images.githubusercontent.com/1240896/61511612-2020cb80-a9ac-11e9-86a0-1c15917b482e.png)

Prefiltered Importance Sampling
![prefilter](https://user-images.githubusercontent.com/1240896/61511642-40e92100-a9ac-11e9-86d3-2dfc1bb9b393.png)


