### PR TITLE
Filament now supports GPU vertex morphing.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 This file contains one line summaries of commits that are worthy of mentioning in release notes.
 A new header is inserted each time a *tag* is created.
 
+- Added support for vertex morphing.
 - Introduced custom attributes, accessible from the vertex shader.
 - Added Java / Kotlin bindings for KtxLoader.
 - Added JavaScript / Typescript bindings for the new `RenderTarget` class.

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -182,6 +182,12 @@ Java_com_google_android_filament_RenderableManager_nBuilderSkinningBones(JNIEnv*
     return 0;
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderMorphing(JNIEnv*, jclass,
+        jlong nativeBuilder, jboolean enabled) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->morphing(enabled);
+}
 
 
 extern "C" JNIEXPORT jint JNICALL
@@ -216,6 +222,16 @@ Java_com_google_android_filament_RenderableManager_nSetBonesAsQuaternions(JNIEnv
     rm->setBones((RenderableManager::Instance)i,
             static_cast<RenderableManager::Bone const *>(data), (size_t)boneCount, (size_t)offset);
     return 0;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSetMorphWeights(JNIEnv* env, jclass,
+        jlong nativeRenderableManager, jint instance, jfloatArray weights) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    jfloat* vec = env->GetFloatArrayElements(weights, NULL);
+    math::float4 floatvec(vec[0], vec[1], vec[2], vec[3]);
+    env->ReleaseFloatArrayElements(weights, vec, JNI_ABORT);
+    rm->setMorphWeights((RenderableManager::Instance)instance, floatvec);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -169,6 +169,12 @@ public class RenderableManager {
             return this;
         }
 
+        @NonNull
+        public Builder morphing(boolean enabled) {
+            nBuilderMorphing(mNativeBuilder, enabled);
+            return this;
+        }
+
         public void build(@NonNull Engine engine, @Entity int entity) {
             if (!nBuilderBuild(mNativeBuilder, engine.getNativeObject(), entity)) {
                 throw new IllegalStateException(
@@ -223,6 +229,10 @@ public class RenderableManager {
         if (result < 0) {
             throw new BufferOverflowException();
         }
+    }
+
+    public void setMorphWeights(@EntityInstance int i, float[] weights) {
+        nSetMorphWeights(mNativeObject, i, weights);
     }
 
     public void setAxisAlignedBoundingBox(@EntityInstance int i, @NonNull Box aabb) {
@@ -351,9 +361,11 @@ public class RenderableManager {
     private static native void nBuilderReceiveShadows(long nativeBuilder, boolean enabled);
     private static native void nBuilderSkinning(long nativeBuilder, int boneCount);
     private static native int nBuilderSkinningBones(long nativeBuilder, int boneCount, Buffer bones, int remaining);
+    private static native void nBuilderMorphing(long nativeBuilder, boolean enabled);
 
     private static native int nSetBonesAsMatrices(long nativeObject, int i, Buffer matrices, int remaining, int boneCount, int offset);
     private static native int nSetBonesAsQuaternions(long nativeObject, int i, Buffer quaternions, int remaining, int boneCount, int offset);
+    private static native void nSetMorphWeights(long nativeObject, int instance, float[] weights);
     private static native void nSetAxisAlignedBoundingBox(long nativeRenderableManager, int i, float cx, float cy, float cz, float ex, float ey, float ez);
     private static native void nSetLayerMask(long nativeRenderableManager, int i, int select, int value);
     private static native void nSetPriority(long nativeRenderableManager, int i, int priority);

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1717,7 +1717,7 @@ variants:
 - `directionalLighting`, used when a directional light is present in the scene
 - `dynamicLighting`, used when a non-directional light (point, spot, etc.) is present in the scene
 - `shadowReceiver`, used when an object can receive shadows
-- `skinning`, used when an object is animated using GPU skinning
+- `skinning`, used when an object is animated using GPU skinning or vertex morphing
 
 Example:
 ```

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -31,6 +31,7 @@
 
 #include <math/mat4.h>
 #include <math/vec3.h>
+#include <math/vec4.h>
 
 #include <type_traits>
 
@@ -86,6 +87,7 @@ public:
         Builder& skinning(size_t boneCount) noexcept; // 0 by default, 255 max
         Builder& skinning(size_t boneCount, Bone const* bones) noexcept;
         Builder& skinning(size_t boneCount, math::mat4f const* transforms) noexcept;
+        Builder& morphing(bool enable) noexcept; // false by default
 
         // Sets an ordering index for blended primitives that all live at the same Z value.
         Builder& blendOrder(size_t index, uint16_t order) noexcept; // 0 by default
@@ -146,6 +148,7 @@ public:
     void setBones(Instance instance, Bone const* transforms, size_t boneCount = 1, size_t offset = 0) noexcept;
     void setBones(Instance instance, math::mat4f const* transforms, size_t boneCount = 1, size_t offset = 0) noexcept;
 
+    void setMorphWeights(Instance instance, math::float4 const& weights) noexcept;
 
     // getters...
     const Box& getAxisAlignedBoundingBox(Instance instance) const noexcept;

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -335,7 +335,7 @@ backend::Handle<backend::HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t var
         .setUniformBlock(BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib().getName())
         .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
 
-    if (Variant(variantKey).hasSkinning()) {
+    if (Variant(variantKey).hasSkinningOrMorphing()) {
         pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES,
                 UibGenerator::getPerRenderableBonesUib().getName());
     }

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -366,7 +366,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         cmdColor.primitive.index = (uint16_t)i;
         cmdColor.primitive.perRenderableBones = soaBonesUbh[i];
         materialVariant.setShadowReceiver(soaVisibility[i].receiveShadows & hasShadowing);
-        materialVariant.setSkinning(soaVisibility[i].skinning);
+        materialVariant.setSkinning(soaVisibility[i].skinning || soaVisibility[i].morphing);
 
         // we're assuming we're always doing the depth (either way, it's correct)
         // this will generate front to back rendering
@@ -375,7 +375,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         cmdDepth.key |= makeField(distanceBits, DISTANCE_BITS_MASK, DISTANCE_BITS_SHIFT);
         cmdDepth.primitive.index = (uint16_t)i;
         cmdDepth.primitive.perRenderableBones = soaBonesUbh[i];
-        cmdDepth.primitive.materialVariant.setSkinning(soaVisibility[i].skinning);
+        cmdDepth.primitive.materialVariant.setSkinning(soaVisibility[i].skinning || soaVisibility[i].morphing);
 
         const bool shadowCaster = soaVisibility[i].castShadows & hasShadowing;
         const bool writeDepthForShadowCasters = depthContainsShadowCasters & shadowCaster;

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -124,6 +124,7 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
                     rcm.getBonesUbh(ri),
                     worldAABB.center,
                     0,
+                    rcm.getMorphWeights(ri),
                     rcm.getLayerMask(ri),
                     worldAABB.halfExtent,
                     {}, {});
@@ -196,6 +197,15 @@ void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Hand
 
         UniformBuffer::setUniform(buffer,
                 offset + offsetof(PerRenderableUib, worldFromModelNormalMatrix), m);
+
+        UniformBuffer::setUniform(buffer, offset + offsetof(PerRenderableUib, skinningEnabled),
+                sceneData.elementAt<VISIBILITY_STATE>(i).skinning);
+
+        UniformBuffer::setUniform(buffer, offset + offsetof(PerRenderableUib, morphingEnabled),
+                sceneData.elementAt<VISIBILITY_STATE>(i).morphing);
+
+        UniformBuffer::setUniform(buffer,
+                offset + offsetof(PerRenderableUib, morphWeights), sceneData.elementAt<MORPH_WEIGHTS>(i));
     }
 
     // TODO: handle static objects separately

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -101,6 +101,7 @@ public:
         BONES_UBH,              //  4 bones uniform buffer handle
         WORLD_AABB_CENTER,      // 12 world-space bounding box center of the renderable
         VISIBLE_MASK,           //  1 each bit represents a visibility in a pass
+        MORPH_WEIGHTS,          //  4 floats for morphing
 
         // These are not needed anymore after culling
         LAYERS,                 //  1 layers
@@ -112,16 +113,17 @@ public:
     };
 
     using RenderableSoa = utils::StructureOfArrays<
-            utils::EntityInstance<RenderableManager>,
-            math::mat4f,
-            FRenderableManager::Visibility,
-            backend::Handle<backend::HwUniformBuffer>,
-            math::float3,
-            Culler::result_type,
-            uint8_t,
-            math::float3,
-            utils::Slice<FRenderPrimitive>,
-            uint32_t
+            utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
+            math::mat4f,                                // WORLD_TRANSFORM
+            FRenderableManager::Visibility,             // VISIBILITY_STATE
+            backend::Handle<backend::HwUniformBuffer>,  // BONES_UBH
+            math::float3,                               // WORLD_AABB_CENTER
+            Culler::result_type,                        // VISIBLE_MASK
+            math::float4,                               // MORPH_WEIGHTS
+            uint8_t,                                    // LAYERS
+            math::float3,                               // WORLD_AABB_EXTENT
+            utils::Slice<FRenderPrimitive>,             // PRIMITIVES
+            uint32_t                                    // SUMMED_PRIMITIVE_COUNT
     >;
 
     RenderableSoa const& getRenderableData() const noexcept { return mRenderableData; }

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -124,6 +124,17 @@ enum VertexAttribute : uint8_t {
     CUSTOM5         = 13,
     CUSTOM6         = 14,
     CUSTOM7         = 15,
+
+    // Aliases for vertex morphing.
+    MORPH_POSITION_0 = CUSTOM0,
+    MORPH_POSITION_1 = CUSTOM1,
+    MORPH_POSITION_2 = CUSTOM2,
+    MORPH_POSITION_3 = CUSTOM3,
+    MORPH_TANGENTS_0 = CUSTOM4,
+    MORPH_TANGENTS_1 = CUSTOM5,
+    MORPH_TANGENTS_2 = CUSTOM6,
+    MORPH_TANGENTS_3 = CUSTOM7,
+
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -92,7 +92,11 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 // PerRenderableUib must have an alignment of 256 to be compatible with all versions of GLES.
 struct alignas(256) PerRenderableUib {
     filament::math::mat4f worldFromModelMatrix;
-    filament::math::mat3f worldFromModelNormalMatrix;
+    filament::math::mat3f worldFromModelNormalMatrix; // this gets expanded to 48 bytes during the copy to the UBO
+    alignas(16) filament::math::float4 morphWeights;
+    uint32_t skinningEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
+    uint32_t morphingEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
+    filament::math::float2 padding0;
 };
 
 struct LightsUib {

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -52,11 +52,11 @@ namespace filament {
         static constexpr uint8_t DIRECTIONAL_LIGHTING   = 0x01; // directional light present, per frame/world position
         static constexpr uint8_t DYNAMIC_LIGHTING       = 0x02; // point, spot or area present, per frame/world position
         static constexpr uint8_t SHADOW_RECEIVER        = 0x04; // receives shadows, per renderable
-        static constexpr uint8_t SKINNING               = 0x08; // GPU skinning
+        static constexpr uint8_t SKINNING_OR_MORPHING   = 0x08; // GPU skinning and/or morphing
 
         static constexpr uint8_t VERTEX_MASK = DIRECTIONAL_LIGHTING |
                                                SHADOW_RECEIVER |
-                                               SKINNING;
+                                               SKINNING_OR_MORPHING;
 
         static constexpr uint8_t FRAGMENT_MASK = DIRECTIONAL_LIGHTING |
                                                  DYNAMIC_LIGHTING |
@@ -71,17 +71,17 @@ namespace filament {
         static constexpr uint8_t DEPTH_VARIANT = SHADOW_RECEIVER;
 
         // this mask filters out the lighting variants
-        static constexpr uint8_t UNLIT_MASK    = SKINNING;
+        static constexpr uint8_t UNLIT_MASK    = SKINNING_OR_MORPHING;
 
         static_assert((VERTEX_MASK | FRAGMENT_MASK) == VARIANT_COUNT - 1,
                 "inconsistency between vertex/fragment masks and variant count");
 
-        inline bool hasSkinning() const noexcept { return key & SKINNING; }
+        inline bool hasSkinningOrMorphing() const noexcept { return key & SKINNING_OR_MORPHING; }
         inline bool hasDirectionalLighting() const noexcept { return key & DIRECTIONAL_LIGHTING; }
         inline bool hasDynamicLighting() const noexcept { return key & DYNAMIC_LIGHTING; }
         inline bool hasShadowReceiver() const noexcept { return key & SHADOW_RECEIVER; }
 
-        inline void setSkinning(bool v) noexcept { set(v, SKINNING); }
+        inline void setSkinning(bool v) noexcept { set(v, SKINNING_OR_MORPHING); }
         inline void setDirectionalLighting(bool v) noexcept { set(v, DIRECTIONAL_LIGHTING); }
         inline void setDynamicLighting(bool v) noexcept { set(v, DYNAMIC_LIGHTING); }
         inline void setShadowReceiver(bool v) noexcept { set(v, SHADOW_RECEIVER); }

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -75,7 +75,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("userTime",                1, UniformInterfaceBlock::Type::FLOAT4)
             // ibl max mip level
             .add("iblMaxMipLevel",          1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("padding10",               1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT2)
             // bring size to 1 KiB
             .add("padding1",                16, UniformInterfaceBlock::Type::FLOAT4)
             .build();
@@ -87,6 +87,10 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
             .name("ObjectUniforms")
             .add("worldFromModelMatrix",       1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromModelNormalMatrix", 1, UniformInterfaceBlock::Type::MAT3, Precision::HIGH)
+            .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
+            .add("skinningEnabled", 1, UniformInterfaceBlock::Type::INT)
+            .add("morphingEnabled", 1, UniformInterfaceBlock::Type::INT)
+            .add("padding0", 1, UniformInterfaceBlock::Type::FLOAT2)
             .build();
     return uib;
 }

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -167,14 +167,22 @@ const std::string ShaderGenerator::createVertexProgram(filament::backend::Shader
     cg.generateDefine(vs, "HAS_DIRECTIONAL_LIGHTING", litVariants && variant.hasDirectionalLighting());
     cg.generateDefine(vs, "HAS_SHADOWING", litVariants && variant.hasShadowReceiver());
     cg.generateDefine(vs, "HAS_SHADOW_MULTIPLIER", material.hasShadowMultiplier);
-    cg.generateDefine(vs, "HAS_SKINNING", variant.hasSkinning());
+    cg.generateDefine(vs, "HAS_SKINNING_OR_MORPHING", variant.hasSkinningOrMorphing());
     cg.generateDefine(vs, getShadingDefine(material.shading), true);
     generateMaterialDefines(vs, cg, mProperties);
 
     AttributeBitset attributes = material.requiredAttributes;
-    if (variant.hasSkinning()) {
+    if (variant.hasSkinningOrMorphing()) {
         attributes.set(VertexAttribute::BONE_INDICES);
         attributes.set(VertexAttribute::BONE_WEIGHTS);
+        attributes.set(VertexAttribute::MORPH_POSITION_0);
+        attributes.set(VertexAttribute::MORPH_POSITION_1);
+        attributes.set(VertexAttribute::MORPH_POSITION_2);
+        attributes.set(VertexAttribute::MORPH_POSITION_3);
+        attributes.set(VertexAttribute::MORPH_TANGENTS_0);
+        attributes.set(VertexAttribute::MORPH_TANGENTS_1);
+        attributes.set(VertexAttribute::MORPH_TANGENTS_2);
+        attributes.set(VertexAttribute::MORPH_TANGENTS_3);
     }
     cg.generateShaderInputs(vs, ShaderType::VERTEX, attributes, interpolation);
 
@@ -192,7 +200,7 @@ const std::string ShaderGenerator::createVertexProgram(filament::backend::Shader
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib());
-    if (variant.hasSkinning()) {
+    if (variant.hasSkinningOrMorphing()) {
         cg.generateUniforms(vs, ShaderType::VERTEX,
                 BindingPoints::PER_RENDERABLE_BONES,
                 UibGenerator::getPerRenderableBonesUib());

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -4,7 +4,7 @@ void materialVertex(inout MaterialVertexInputs m) { }
 
 void main() {
 #if defined(VERTEX_DOMAIN_DEVICE)
-    gl_Position = getSkinnedPosition();
+    gl_Position = getPosition();
 #else
     MaterialVertexInputs material;
     initMaterialVertex(material);

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -102,7 +102,7 @@ static uint8_t parseVariantFilter(const std::string& arg) {
         } else if (item == "shadowReceiver") {
             variantFilter |= filament::Variant::SHADOW_RECEIVER;
         } else if (item == "skinning") {
-            variantFilter |= filament::Variant::SKINNING;
+            variantFilter |= filament::Variant::SKINNING_OR_MORPHING;
         }
     }
     return variantFilter;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -472,7 +472,7 @@ static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& v
         strToEnum["directionalLighting"] = filament::Variant::DIRECTIONAL_LIGHTING;
         strToEnum["dynamicLighting"] = filament::Variant::DYNAMIC_LIGHTING;
         strToEnum["shadowReceiver"] = filament::Variant::SHADOW_RECEIVER;
-        strToEnum["skinning"] = filament::Variant::SKINNING;
+        strToEnum["skinning"] = filament::Variant::SKINNING_OR_MORPHING;
         return strToEnum;
     }();
     uint8_t variantFilter = 0;

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -120,6 +120,7 @@ export class RenderableManager$Builder {
     public skinning(boneCount: number): RenderableManager$Builder;
     public skinningBones(transforms: RenderableManager$Bone[]): RenderableManager$Builder;
     public skinningMatrices(transforms: mat4[]): RenderableManager$Builder;
+    public morphing(enable: boolean): RenderableManager$Builder;
     public blendOrder(index: number, order: number): RenderableManager$Builder;
     public build(engine: Engine, entity: Entity): void;
 }
@@ -166,6 +167,8 @@ export class RenderableManager {
             offset: number): void
     public setBonesFromMatrices(instance: RenderableManager$Instance, transforms: mat4[],
             offset: number): void
+    public setMorphWeights(instance: RenderableManager$Instance, a: number, b: number, c: number,
+            d: number);
     public getAxisAlignedBoundingBox(instance: RenderableManager$Instance): Box;
     public getPrimitiveCount(instance: RenderableManager$Instance): number;
     public setMaterialInstanceAt(instance: RenderableManager$Instance,
@@ -579,21 +582,29 @@ export enum RenderTarget$AttachmentPoint {
 }
 
 export enum VertexAttribute {
-    POSITION,
-    TANGENTS,
-    COLOR,
-    UV0,
-    UV1,
-    BONE_INDICES,
-    BONE_WEIGHTS,
-    CUSTOM0,
-    CUSTOM1,
-    CUSTOM2,
-    CUSTOM3,
-    CUSTOM4,
-    CUSTOM5,
-    CUSTOM6,
-    CUSTOM7,
+    POSITION = 0,
+    TANGENTS = 1,
+    COLOR = 2,
+    UV0 = 3,
+    UV1 = 4,
+    BONE_INDICES = 5,
+    BONE_WEIGHTS = 6,
+    CUSTOM0 = 7,
+    CUSTOM1 = 8,
+    CUSTOM2 = 9,
+    CUSTOM3 = 10,
+    CUSTOM4 = 11,
+    CUSTOM5 = 12,
+    CUSTOM6 = 13,
+    CUSTOM7 = 14,
+    MORPH_POSITION_0 = CUSTOM0,
+    MORPH_POSITION_1 = CUSTOM1,
+    MORPH_POSITION_2 = CUSTOM2,
+    MORPH_POSITION_3 = CUSTOM3,
+    MORPH_TANGENTS_0 = CUSTOM4,
+    MORPH_TANGENTS_1 = CUSTOM5,
+    MORPH_TANGENTS_2 = CUSTOM6,
+    MORPH_TANGENTS_3 = CUSTOM7,
 }
 
 export enum VertexBuffer$AttributeType {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -649,6 +649,9 @@ class_<RenderableBuilder>("RenderableManager$Builder")
         return &builder->skinning(matrices.size(), matrices.data());
     })
 
+    .BUILDER_FUNCTION("morphing", RenderableBuilder, (RenderableBuilder* builder, bool enable), {
+        return &builder->morphing(enable); })
+
     .BUILDER_FUNCTION("blendOrder", RenderableBuilder,
             (RenderableBuilder* builder, size_t index, uint16_t order), {
         return &builder->blendOrder(index, order); })
@@ -691,13 +694,19 @@ class_<RenderableManager>("RenderableManager")
     }), allow_raw_pointers())
 
     .function("setBonesFromMatrices", EMBIND_LAMBDA(void, (RenderableManager* self,
-        RenderableManager::Instance instance, emscripten::val transforms, size_t offset), {
+            RenderableManager::Instance instance, emscripten::val transforms, size_t offset), {
         auto nbones = transforms["length"].as<size_t>();
         std::vector<filament::math::mat4f> bones(nbones);
         for (size_t i = 0; i < nbones; i++) {
             bones[i] = transforms[i].as<flatmat4>().m;
         }
         self->setBones(instance, bones.data(), bones.size(), offset);
+    }), allow_raw_pointers())
+
+    // NOTE: this cannot take a float4 due to a binding issue.
+    .function("setMorphWeights", EMBIND_LAMBDA(void, (RenderableManager* self,
+            RenderableManager::Instance instance, float x, float y, float z, float w), {
+        self->setMorphWeights(instance, {x, y, z, w});
     }), allow_raw_pointers())
 
     .function("getAxisAlignedBoundingBox", &RenderableManager::getAxisAlignedBoundingBox)

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -57,7 +57,15 @@ enum_<VertexAttribute>("VertexAttribute")
     .value("CUSTOM4", CUSTOM4)
     .value("CUSTOM5", CUSTOM5)
     .value("CUSTOM6", CUSTOM6)
-    .value("CUSTOM7", CUSTOM7);
+    .value("CUSTOM7", CUSTOM7)
+    .value("MORPH_POSITION_0", MORPH_POSITION_0)
+    .value("MORPH_POSITION_1", MORPH_POSITION_1)
+    .value("MORPH_POSITION_2", MORPH_POSITION_2)
+    .value("MORPH_POSITION_3", MORPH_POSITION_3)
+    .value("MORPH_TANGENTS_0", MORPH_TANGENTS_0)
+    .value("MORPH_TANGENTS_1", MORPH_TANGENTS_1)
+    .value("MORPH_TANGENTS_2", MORPH_TANGENTS_2)
+    .value("MORPH_TANGENTS_3", MORPH_TANGENTS_3);
 
 enum_<VertexBuffer::AttributeType>("VertexBuffer$AttributeType")
     .value("BYTE", VertexBuffer::AttributeType::BYTE)


### PR DESCRIPTION
This works by aliasing CUSTOM0 - CUSTOM7 to morphing attributes, and by
extending our existing skinning variant.

This PR was tested against some upcoming changes to gltfio.

Issue #1149, #1417