### PR TITLE
Handle missing vertex attributes in Metal backend

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -880,6 +880,12 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                                             offsets:primitive->offsets.data()
                                           withRange:bufferRange];
 
+    // Bind the zero buffer, used for missing vertex attributes.
+    static const char bytes[4] = { 0 };
+    [mContext->currentCommandEncoder setVertexBytes:bytes
+                                             length:4
+                                            atIndex:(VERTEX_BUFFER_START + ZERO_VERTEX_BUFFER)];
+
     MetalIndexBuffer* indexBuffer = primitive->indexBuffer;
 
     [mContext->currentCommandEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -190,6 +190,17 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
     uint32_t bufferIndex = 0;
     for (uint32_t attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++) {
         if (!(enabledAttributes & (1U << attributeIndex))) {
+            // If the attribute is not enabled, bind it to the zero buffer. It's a Metal error for a
+            // shader to read from missing vertex attributes.
+            vertexDescription.attributes[attributeIndex] = {
+                    .format = MTLVertexFormatChar4,
+                    .buffer = ZERO_VERTEX_BUFFER,
+                    .offset = 0
+            };
+            vertexDescription.layouts[ZERO_VERTEX_BUFFER] = {
+                    .step = MTLVertexStepFunctionConstant,
+                    .stride = 4
+            };
             continue;
         }
         const auto& attribute = vertexBuffer->attributes[attributeIndex];
@@ -204,6 +215,7 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
                 .offset = 0
         };
         vertexDescription.layouts[bufferIndex] = {
+                .step = MTLVertexStepFunctionPerVertex,
                 .stride = attribute.stride
         };
 

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -44,11 +44,14 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
         }
     }
 
-    for (uint32_t i = 0; i < MAX_VERTEX_ATTRIBUTE_COUNT; i++) {
+    for (uint32_t i = 0; i < VERTEX_BUFFER_COUNT; i++) {
         if (vertexDescription.layouts[i].stride > 0) {
             const auto& layout = vertexDescription.layouts[i];
             vertex.layouts[VERTEX_BUFFER_START + i].stride = layout.stride;
-            vertex.layouts[VERTEX_BUFFER_START + i].stepFunction = MTLVertexStepFunctionPerVertex;
+            vertex.layouts[VERTEX_BUFFER_START + i].stepFunction = layout.step;
+            if (layout.step == MTLVertexStepFunctionConstant) {
+                vertex.layouts[VERTEX_BUFFER_START + i].stepRate = 0;
+            }
         }
     }
 


### PR DESCRIPTION
This addresses part of the issue raised in #1279 for the Metal backend.

Missing vertex attributes previously resulted in a crash, but now the shader will read 0s from any attributes that aren't set.