### PR TITLE
Corrected typo in point light falloff attenuation

### DIFF
--- a/docs/Filament.md.html
+++ b/docs/Filament.md.html
@@ -1466,7 +1466,7 @@ Listing [glslPunctualLight] demonstrates how to implement physically based punct
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 float getSquareFalloffAttenuation(vec3 posToLight, float lightInvRadius) {
     float distanceSquare = dot(posToLight, posToLight);
-    float factor = distanceSquare * lightInvRadius * lightInvRadius;
+    float factor = distanceSquare * lightInvRadius;
     float smoothFactor = max(1.0 - factor * factor, 0.0);
     return (smoothFactor * smoothFactor) / max(distanceSquare, 1e-4);
 }


### PR DESCRIPTION
The correct attenuation is d^4 / r^2. The previous formula stated d^4 / r^4.
The actual code in light_ponctual.fs is correct.