### PR TITLE
Build tweaks for Android.

### DIFF
--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -80,6 +80,7 @@ set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
 
 # The ordering in the following list is important because CMake does not have dependency information.
 target_link_libraries(gltfio-jni
+        android
         gltfio
         gltfio_resources
         filament

--- a/build.sh
+++ b/build.sh
@@ -119,8 +119,9 @@ LC_UNAME=`echo ${UNAME} | tr '[:upper:]' '[:lower:]'`
 function build_clean {
     echo "Cleaning build directories..."
     rm -Rf out
-    rm -Rf android/filament-android/build
-    rm -Rf android/filament-android/.externalNativeBuild
+    rm -Rf android/filament-android/build android/filament-android/.externalNativeBuild
+    rm -Rf android/filamat-android/build android/filamat-android/.externalNativeBuild
+    rm -Rf android/gltfio-android/build android/gltfio-android/.externalNativeBuild
 }
 
 function build_desktop_target {


### PR DESCRIPTION
(1) Sometimes (but not always!) gltfio-android was failing to build due to two missing ANativeWindow functions. Linking in `android` seems to fix this, and is consistent with libfilament-jni.

(2) Improve our `build.sh -c` utility by clobbering some additional Android build directories. This is especially useful after adding `-Pextra_cmake_args=-DFILAMENT_SUPPORTS_VULKAN=ON`, otherwise Gradle will try to use a cached CMake configuration.