### PR TITLE
Fix VulkanDriver query for the DEPTH24 format.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -575,6 +575,10 @@ FenceStatus VulkanDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
 bool VulkanDriver::isTextureFormatSupported(TextureFormat format) {
     assert(mContext.physicalDevice);
     VkFormat vkformat = getVkFormat(format);
+    // We automatically use an alternative format when the client requests DEPTH24.
+    if (format == TextureFormat::DEPTH24) {
+        vkformat = mContext.depthFormat;
+    }
     if (vkformat == VK_FORMAT_UNDEFINED) {
         return false;
     }
@@ -586,6 +590,10 @@ bool VulkanDriver::isTextureFormatSupported(TextureFormat format) {
 bool VulkanDriver::isRenderTargetFormatSupported(TextureFormat format) {
     assert(mContext.physicalDevice);
     VkFormat vkformat = getVkFormat(format);
+    // We automatically use an alternative format when the client requests DEPTH24.
+    if (format == TextureFormat::DEPTH24) {
+        vkformat = mContext.depthFormat;
+    }
     if (vkformat == VK_FORMAT_UNDEFINED) {
         return false;
     }


### PR DESCRIPTION
This fixes one of the bugs seen with `gltf-bloom` on Android.

We already dynamically map Filament's DEPTH24 format to either VK_FORMAT_D32_SFLOAT or VK_FORMAT_X8_D24_UNORM_PACK32, depending on the platform. Therefore we should return `true` when asked if the backend supports DEPTH24. Otherwise the client will not be able to create a depth texture.