### PR TITLE
Desktop samples should not link Embree.

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -111,15 +111,8 @@ if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
     # ==================================================================================================
     # Link the core library with additional dependencies to create the "full" library
     # ==================================================================================================
-    add_library(${TARGET} STATIC ${PUBLIC_HDRS}
-        src/MaterialGenerator.cpp
-        src/AssetPipeline.cpp)
-    target_link_libraries(${TARGET} PUBLIC
-        filamat
-        xatlas
-        meshoptimizer
-        gltfio_core
-        rays)
+    add_library(${TARGET} STATIC ${PUBLIC_HDRS} src/MaterialGenerator.cpp)
+    target_link_libraries(${TARGET} PUBLIC filamat gltfio_core)
     target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
     # ==================================================================================================
@@ -146,3 +139,11 @@ else()
     install(DIRECTORY ${PUBLIC_HDR_DIR}/gltfio DESTINATION include)
 
 endif()
+
+# ==================================================================================================
+# Create the glTF pipeline library (used by gltf_baker)
+# ==================================================================================================
+
+add_library(gltfio_pipeline STATIC ${PUBLIC_HDRS} src/AssetPipeline.cpp)
+target_link_libraries(gltfio_pipeline PUBLIC xatlas meshoptimizer gltfio rays)
+target_include_directories(gltfio_pipeline PUBLIC ${PUBLIC_HDR_DIR})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -260,7 +260,7 @@ if (NOT ANDROID)
     target_link_libraries(frame_generator PRIVATE imageio)
     target_link_libraries(suzanne PRIVATE suzanne-resources)
     target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio)
-    target_link_libraries(gltf_baker PRIVATE gltf-resources gltfio imageio)
+    target_link_libraries(gltf_baker PRIVATE gltf-resources gltfio_pipeline imageio)
 
     add_executable(lucy_bloom lucy_bloom.cpp lucy_utils.h lucy_utils.cpp)
     target_compile_options(lucy_bloom PRIVATE ${COMPILER_FLAGS})


### PR DESCRIPTION
We now build three gltfio libraries:

 - gltfio_core ....... lightweight library with ubershaders
 - gltfio ............ uses filamat to generate materials at runtime
 - gltfio_pipeline ... depends on path tracer functionality