### PR TITLE
Vulkan: fix mipmapped render targets.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -393,16 +393,10 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
         TargetBufferInfo color, TargetBufferInfo depth,
         TargetBufferInfo stencil) {
+    auto colorTexture = color.handle ? handle_cast<VulkanTexture>(mHandleMap, color.handle) : nullptr;
+    auto depthTexture = depth.handle ? handle_cast<VulkanTexture>(mHandleMap, depth.handle) : nullptr;
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
-            width, height, color.level);
-    if (color.handle) {
-        auto colorTexture = handle_cast<VulkanTexture>(mHandleMap, color.handle);
-        renderTarget->setColorImage(colorTexture);
-    }
-    if (depth.handle) {
-        auto depthTexture = handle_cast<VulkanTexture>(mHandleMap, depth.handle);
-        renderTarget->setDepthImage(depthTexture);
-    }
+            width, height, color.level, colorTexture, depthTexture);
     mDisposer.createDisposable(renderTarget, [this, rth] () {
         destruct_handle<VulkanRenderTarget>(mHandleMap, rth);
     });

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -45,12 +45,14 @@ struct VulkanTexture;
 struct VulkanRenderTarget : private HwRenderTarget {
 
     // Creates an offscreen render target.
-    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, uint32_t miplevel) :
-            HwRenderTarget(w, h), mContext(context), mOffscreen(true), mColorLevel(miplevel) {}
+    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, uint32_t miplevel,
+            VulkanTexture* color, VulkanTexture* depth);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
     explicit VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0), mContext(context),
             mOffscreen(false), mColorLevel(0) {}
+
+    ~VulkanRenderTarget();
 
     bool isOffscreen() const { return mOffscreen; }
     void transformClientRectToPlatform(VkRect2D* bounds) const;
@@ -59,8 +61,6 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getColor() const;
     VulkanAttachment getDepth() const;
     uint32_t getColorLevel() const { return mColorLevel; }
-    void setColorImage(VulkanTexture* color);
-    void setDepthImage(VulkanTexture* depth);
 private:
     VulkanAttachment mColor = {};
     VulkanAttachment mDepth = {};


### PR DESCRIPTION
VkFramebuffer requires its attachments to have only one miplevel each, but our VulkanRenderTarget wrapper was sharing the VkImageView that is owned by the underlying texture object.

This fixes up VulkanRenderTarget so that it owns a unique VkImageView that is pinned to a specific miplevel.