### PR TITLE
Use GL_EXTENSION for GL_OES_EGL_image_external_essl3

### DIFF
--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -288,7 +288,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
         goto error;
     }
 
-    initailizeGlExtensions();
+    initializeGlExtensions();
 
     // success!!
     return OpenGLDriverFactory::create(this, sharedContext);
@@ -508,7 +508,7 @@ void PlatformEGL::destroyExternalImage(void* texture) noexcept {
     glDeleteTextures(1, &t->gl.id);
 }
 
-void PlatformEGL::initailizeGlExtensions() noexcept {
+void PlatformEGL::initializeGlExtensions() noexcept {
     unordered_string_set glExtensions;
     GLint n;
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -150,8 +150,6 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
 
     auto extensions = split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
 
-    ext.OES_EGL_image_external_essl3 = extensions.has("GL_OES_EGL_image_external_essl3");
-
     eglCreateSyncKHR = (PFNEGLCREATESYNCKHRPROC) eglGetProcAddress("eglCreateSyncKHR");
     eglDestroySyncKHR = (PFNEGLDESTROYSYNCKHRPROC) eglGetProcAddress("eglDestroySyncKHR");
     eglClientWaitSyncKHR = (PFNEGLCLIENTWAITSYNCKHRPROC) eglGetProcAddress("eglClientWaitSyncKHR");
@@ -289,6 +287,8 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
         logEglError("eglMakeCurrent");
         goto error;
     }
+
+    initailizeGlExtensions();
 
     // success!!
     return OpenGLDriverFactory::create(this, sharedContext);
@@ -506,6 +506,17 @@ void PlatformEGL::createExternalImageTexture(void* texture) noexcept {
 void PlatformEGL::destroyExternalImage(void* texture) noexcept {
     auto* t = (OpenGLDriver::GLTexture*) texture;
     glDeleteTextures(1, &t->gl.id);
+}
+
+void PlatformEGL::initailizeGlExtensions() noexcept {
+    unordered_string_set glExtensions;
+    GLint n;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
+    for (GLint i = 0; i < n; ++i) {
+        const char * const extension = (const char*)glGetStringi(GL_EXTENSIONS, (GLuint)i);
+        glExtensions.insert(extension);
+    }
+    ext.OES_EGL_image_external_essl3 = glExtensions.has("GL_OES_EGL_image_external_essl3");
 }
 
 // This must called when the library is loaded. We need this to get a reference to the global VM

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -72,6 +72,7 @@ public:
 
 private:
     EGLBoolean makeCurrent(EGLSurface drawSurface, EGLSurface readSurface) noexcept;
+    void initailizeGlExtensions() noexcept;
 
     EGLDisplay mEGLDisplay = EGL_NO_DISPLAY;
     EGLContext mEGLContext = EGL_NO_CONTEXT;

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -72,7 +72,7 @@ public:
 
 private:
     EGLBoolean makeCurrent(EGLSurface drawSurface, EGLSurface readSurface) noexcept;
-    void initailizeGlExtensions() noexcept;
+    void initializeGlExtensions() noexcept;
 
     EGLDisplay mEGLDisplay = EGL_NO_DISPLAY;
     EGLContext mEGLContext = EGL_NO_CONTEXT;


### PR DESCRIPTION
A prior change that reworked some code incorrectly attempted to
use the existing EGL extensions to set a GL extension boolean.

Added additional GL extension code.