### PR TITLE
laying the foundations for a rendertarget cache

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRCS
         src/components/RenderableManager.cpp
         src/components/TransformManager.cpp
         src/fg/FrameGraph.cpp
+        src/fg/ResourceAllocator.cpp
         src/Box.cpp
         src/Camera.cpp
         src/Color.cpp
@@ -90,6 +91,7 @@ set(PRIVATE_HDRS
         src/fg/FrameGraphPass.h
         src/fg/FrameGraphPassResources.h
         src/fg/FrameGraphResource.h
+        src/fg/ResourceAllocator.h
         src/details/Allocators.h
         src/details/Camera.h
         src/details/Culler.h

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -16,6 +16,8 @@
 
 #include "details/Engine.h"
 
+#include "MaterialParser.h"
+
 #include "details/DFG.h"
 #include "details/VertexBuffer.h"
 #include "details/Fence.h"
@@ -32,14 +34,14 @@
 #include "details/Texture.h"
 #include "details/View.h"
 
+#include "fg/ResourceAllocator.h"
+
 #include "private/backend/Program.h"
 
 #include <private/filament/SibGenerator.h>
 
 #include <filament/Exposure.h>
 #include <filament/MaterialEnums.h>
-
-#include <MaterialParser.h>
 
 #include <filaflat/ShaderBuilder.h>
 
@@ -158,6 +160,8 @@ void FEngine::init() {
     mCommandStream = CommandStream(*mDriver, mCommandBufferQueue.getCircularBuffer());
     DriverApi& driverApi = getDriverApi();
 
+    mResourceAllocator = new fg::ResourceAllocator(driverApi);
+
     // Parse all post process shaders now, but create them lazily
     mPostProcessParser = std::make_unique<MaterialParser>(mBackend,
             MATERIALS_POSTPROCESS_DATA, MATERIALS_POSTPROCESS_SIZE);
@@ -228,6 +232,7 @@ void FEngine::init() {
 
 FEngine::~FEngine() noexcept {
     ASSERT_DESTRUCTOR(mTerminated, "Engine destroyed but not terminated!");
+    delete mResourceAllocator;
     delete mDriver;
     if (mOwnPlatform) {
         DefaultPlatform::destroy((DefaultPlatform**)&mPlatform);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -31,6 +31,7 @@
 
 #include "fg/FrameGraph.h"
 #include "fg/FrameGraphResource.h"
+#include "fg/ResourceAllocator.h"
 
 
 #include <utils/Panic.h>
@@ -228,7 +229,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
      * Frame graph
      */
 
-    FrameGraph fg;
+    FrameGraph fg(engine.getResourceAllocator());
 
     const TextureFormat hdrFormat = getHdrFormat(view);
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -37,6 +37,7 @@
 #include "private/backend/DriverApi.h"
 
 #include <private/filament/EngineEnums.h>
+#include <private/filament/UniformInterfaceBlock.h>
 
 #include <filament/Engine.h>
 #include <filament/VertexBuffer.h>
@@ -45,9 +46,8 @@
 #include <filament/MaterialEnums.h>
 #include <filament/Texture.h>
 #include <filament/Skybox.h>
-#include <filament/Stream.h>
 
-#include <private/filament/UniformInterfaceBlock.h>
+#include <filament/Stream.h>
 
 #include <filaflat/ShaderBuilder.h>
 
@@ -65,13 +65,14 @@ namespace filament {
 class Renderer;
 class MaterialParser;
 
-
 namespace backend {
-
 class Driver;
 class Program;
+} // namespace driver
 
-} // namespac driver
+namespace fg {
+class ResourceAllocator;
+} // namespace fg
 
 
 namespace details {
@@ -195,6 +196,11 @@ public:
         return mBackend;
     }
 
+    fg::ResourceAllocator& getResourceAllocator() noexcept {
+        assert(mResourceAllocator);
+        return *mResourceAllocator;
+    }
+
     void* streamAlloc(size_t size, size_t alignment) noexcept;
 
     utils::JobSystem& getJobSystem() noexcept { return mJobSystem; }
@@ -305,6 +311,7 @@ private:
     FTransformManager mTransformManager;
     FLightManager mLightManager;
     FCameraManager mCameraManager;
+    fg::ResourceAllocator* mResourceAllocator = nullptr;
 
     ResourceList<FRenderer> mRenderers{ "Renderer" };
     ResourceList<FView> mViews{ "View" };

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -54,6 +54,7 @@ struct RenderTarget;
 struct RenderTargetResource;
 struct PassNode;
 struct Alias;
+class ResourceAllocator;
 } // namespace fg
 
 class FrameGraphPassResources;
@@ -128,7 +129,7 @@ public:
         fg::PassNode& mPass;
     };
 
-    FrameGraph();
+    explicit FrameGraph(fg::ResourceAllocator& resourceAllocator);
     FrameGraph(FrameGraph const&) = delete;
     FrameGraph& operator = (FrameGraph const&) = delete;
     ~FrameGraph();
@@ -213,6 +214,7 @@ private:
     friend struct fg::PassNode;
     friend struct fg::RenderTarget;
     friend struct fg::RenderTargetResource;
+    friend struct fg::Resource;
 
     template <typename T>
     struct Deleter {
@@ -249,7 +251,11 @@ private:
 
     void executeInternal(fg::PassNode const& node, backend::DriverApi& driver) noexcept;
 
+    fg::ResourceAllocator& getResourceAllocator() noexcept { return mResourceAllocator; }
+
     void reset() noexcept;
+
+    fg::ResourceAllocator& mResourceAllocator;
 
     details::LinearAllocatorArena mArena;
     Vector<fg::PassNode> mPassNodes;                    // list of frame graph passes

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ResourceAllocator.h"
+
+#include "private/backend/DriverApi.h"
+
+namespace filament {
+
+using namespace backend;
+
+namespace fg {
+
+ResourceAllocator::ResourceAllocator(DriverApi& driverApi) noexcept
+        : mBackend(driverApi) {
+}
+
+RenderTargetHandle ResourceAllocator::createRenderTarget(
+        TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
+        uint8_t samples, TargetBufferInfo color, TargetBufferInfo depth,
+        TargetBufferInfo stencil) noexcept {
+    return mBackend.createRenderTarget(targetBufferFlags,
+            width, height, samples, color, depth, stencil);
+}
+
+void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {
+    return mBackend.destroyRenderTarget(h);
+}
+
+TextureHandle ResourceAllocator::createTexture(SamplerType target, uint8_t levels,
+        TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+        uint32_t depth, TextureUsage usage) noexcept {
+    return mBackend.createTexture(target, levels, format, samples, width, height, depth, usage);
+}
+
+void ResourceAllocator::destroyTexture(TextureHandle h) noexcept {
+    return mBackend.destroyTexture(h);
+}
+
+} // namespace fg
+} // namespace filament

--- a/filament/src/fg/ResourceAllocator.h
+++ b/filament/src/fg/ResourceAllocator.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_FG_RESOURCEALLOCATOR_H
+#define TNT_FILAMENT_FG_RESOURCEALLOCATOR_H
+
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+#include <backend/TargetBufferInfo.h>
+
+#include "private/backend/DriverApiForward.h"
+
+#include <stdint.h>
+
+namespace filament {
+namespace fg {
+
+class ResourceAllocator {
+public:
+    explicit ResourceAllocator(backend::DriverApi& driverApi) noexcept;
+
+    backend::RenderTargetHandle createRenderTarget(
+            backend::TargetBufferFlags targetBufferFlags,
+            uint32_t width,
+            uint32_t height,
+            uint8_t samples,
+            backend::TargetBufferInfo color,
+            backend::TargetBufferInfo depth,
+            backend::TargetBufferInfo stencil) noexcept;
+
+    void destroyRenderTarget(backend::RenderTargetHandle h) noexcept;
+
+    backend::TextureHandle createTexture(
+            backend::SamplerType target,
+            uint8_t levels,
+            backend::TextureFormat format,
+            uint8_t samples,
+            uint32_t width,
+            uint32_t height,
+            uint32_t depth,
+            backend::TextureUsage usage) noexcept;
+
+    void destroyTexture(backend::TextureHandle h) noexcept;
+
+private:
+    backend::DriverApi& mBackend;
+};
+
+}// namespace fg
+} // namespace filament
+
+#endif //TNT_FILAMENT_FG_RESOURCEALLOCATOR_H

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -18,6 +18,7 @@
 
 #include "fg/FrameGraph.h"
 #include "fg/FrameGraphPassResources.h"
+#include "fg/ResourceAllocator.h"
 
 #include <backend/Platform.h>
 
@@ -33,7 +34,8 @@ static CommandStream driverApi(*platform->createDriver(nullptr), buffer);
 
 TEST(FrameGraphTest, SimpleRenderPass) {
 
-    FrameGraph fg;
+    fg::ResourceAllocator resourceAllocator(driverApi);
+    FrameGraph fg(resourceAllocator);
 
     bool renderPassExecuted = false;
 
@@ -71,7 +73,8 @@ TEST(FrameGraphTest, SimpleRenderPass) {
 
 TEST(FrameGraphTest, SimpleRenderPass2) {
 
-    FrameGraph fg;
+    fg::ResourceAllocator resourceAllocator(driverApi);
+    FrameGraph fg(resourceAllocator);
 
     bool renderPassExecuted = false;
 
@@ -119,7 +122,8 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
 
 TEST(FrameGraphTest, ScenarioDepthPrePass) {
 
-    FrameGraph fg;
+    fg::ResourceAllocator resourceAllocator(driverApi);
+    FrameGraph fg(resourceAllocator);
 
     bool depthPrepassExecuted = false;
     bool colorPassExecuted = false;
@@ -197,7 +201,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
 
 TEST(FrameGraphTest, SimplePassCulling) {
 
-    FrameGraph fg;
+    fg::ResourceAllocator resourceAllocator(driverApi);
+    FrameGraph fg(resourceAllocator);
 
     bool renderPassExecuted = false;
     bool postProcessPassExecuted = false;
@@ -284,7 +289,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
 
 TEST(FrameGraphTest, RenderTargetLifetime) {
 
-    FrameGraph fg;
+    fg::ResourceAllocator resourceAllocator(driverApi);
+    FrameGraph fg(resourceAllocator);
 
     bool renderPassExecuted1 = false;
     bool renderPassExecuted2 = false;
@@ -330,7 +336,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 renderPassExecuted2 = true;
                 auto const& rt = resources.getRenderTarget(data.output);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(0x40|0x80, rt.params.flags.clear);
+                EXPECT_EQ(0x40u|0x80u, rt.params.flags.clear);
                 EXPECT_EQ(rt1.getId(), rt.target.getId()); // FIXME: this test is always true the NoopDriver
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);


### PR DESCRIPTION
Some drivers have performance issues when repeatedly (once per frame)
allocating and destroying render targets, so we will
re-introduce a cache for that.

this just adds the hooks for the cache.