### PR TITLE
Fix wasm by avoiding the "&free" trick.

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -72,7 +72,8 @@ void ShadowMap::fillWithDebugPattern(backend::DriverApi& driverApi) const noexce
     size_t size = dim * dim;
     uint8_t* ptr = (uint8_t*)malloc(size);
     driverApi.update2DImage(mShadowMapHandle, 0, 0, 0, dim, dim, {
-        ptr, size, PixelDataFormat::DEPTH_COMPONENT, PixelDataType::UBYTE, (BufferDescriptor::Callback)&free
+        ptr, size, PixelDataFormat::DEPTH_COMPONENT, PixelDataType::UBYTE,
+        [] (void* buffer, size_t, void*) { free(buffer); }
     });
     for (size_t y = 0; y < dim; ++y) {
         for (size_t x = 0; x < dim; ++x) {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -287,7 +287,7 @@ bool ResourceLoader::createTextures(details::FFilamentAsset* asset) const {
                 size_t(w * h * 4),
                 Texture::Format::RGBA,
                 Texture::Type::UBYTE,
-                (Texture::PixelBufferDescriptor::Callback) &free);
+                [] (void* buffer, size_t, void*) { free(buffer); });
 
         tex->setImage(*mConfig.engine, 0, std::move(pbd));
         tex->generateMipmaps(*mConfig.engine);


### PR DESCRIPTION
We should not use the address of a stdlib function for BufferDescriptor
callbacks. With emcc this compiles without warnings or errors, but
produces incorrect code that causes intermittent out-of-memory errors at
run time.