### PR TITLE
replace multimap by a vector for the framegraph texture cache

### DIFF
--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -31,6 +31,39 @@ using namespace details;
 
 namespace fg {
 
+// ------------------------------------------------------------------------------------------------
+
+template<typename K, typename V, typename H>
+UTILS_NOINLINE
+typename ResourceAllocator::AssociativeContainer<K, V, H>::iterator
+ResourceAllocator::AssociativeContainer<K, V, H>::erase(iterator it) {
+    return mContainer.erase(it);
+}
+
+template<typename K, typename V, typename H>
+typename ResourceAllocator::AssociativeContainer<K, V, H>::const_iterator
+ResourceAllocator::AssociativeContainer<K, V, H>::find(key_type const& key) const {
+    return const_cast<AssociativeContainer*>(this)->find(key);
+}
+
+template<typename K, typename V, typename H>
+UTILS_NOINLINE
+typename ResourceAllocator::AssociativeContainer<K, V, H>::iterator
+ResourceAllocator::AssociativeContainer<K, V, H>::find(key_type const& key) {
+    return std::find_if(mContainer.begin(), mContainer.end(), [&key](auto const& v) {
+        return v.first == key;
+    });
+}
+
+template<typename K, typename V, typename H>
+template<typename... ARGS>
+UTILS_NOINLINE
+void ResourceAllocator::AssociativeContainer<K, V, H>::emplace(ARGS&& ... args) {
+    mContainer.emplace_back(std::forward<ARGS>(args)...);
+}
+
+// ------------------------------------------------------------------------------------------------
+
 size_t ResourceAllocator::TextureKey::getSize() const noexcept {
     size_t pixelCount = width * height * depth;
     size_t size = pixelCount * FTexture::getFormatSize(format);
@@ -148,10 +181,12 @@ void ResourceAllocator::gc() noexcept {
         }
     }
 
+    //if (mAge % 60 == 0) dump();
     // TODO: maybe purge LRU entries if we have more than a certain number
     // TODO: maybe purge LRU entries if the size of the cache is too large
 }
 
+UTILS_NOINLINE
 void ResourceAllocator::dump() const noexcept {
     slog.d << "# entries=" << mTextureCache.size() << ", sz=" << mCacheSize / float(1u << 20u)
            << " MiB" << io::endl;

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -69,6 +69,8 @@ TEST(FrameGraphTest, SimpleRenderPass) {
     fg.execute(driverApi);
 
     EXPECT_TRUE(renderPassExecuted);
+
+    resourceAllocator.terminate();
 }
 
 TEST(FrameGraphTest, SimpleRenderPass2) {
@@ -118,6 +120,8 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
     fg.execute(driverApi);
 
     EXPECT_TRUE(renderPassExecuted);
+
+    resourceAllocator.terminate();
 }
 
 TEST(FrameGraphTest, ScenarioDepthPrePass) {
@@ -197,6 +201,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
 
     EXPECT_TRUE(depthPrepassExecuted);
     EXPECT_TRUE(colorPassExecuted);
+
+    resourceAllocator.terminate();
 }
 
 TEST(FrameGraphTest, SimplePassCulling) {
@@ -285,6 +291,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
     EXPECT_TRUE(renderPassExecuted);
     EXPECT_TRUE(postProcessPassExecuted);
     EXPECT_FALSE(culledPassExecuted);
+
+    resourceAllocator.terminate();
 }
 
 TEST(FrameGraphTest, RenderTargetLifetime) {
@@ -349,4 +357,6 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
 
     EXPECT_TRUE(renderPassExecuted1);
     EXPECT_TRUE(renderPassExecuted2);
+
+    resourceAllocator.terminate();
 }


### PR DESCRIPTION
because we don't expect many items in the cache, using a linear
search is not a problem -- multimap generates tons of code 
by comparison.