### PR TITLE
most StructureOfArray<> methods cannot be constexpr

### DIFF
--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -92,109 +92,109 @@ public:
     UTILS_NOINLINE void setSunHaloSize(Instance i, float haloSize) noexcept;
     UTILS_NOINLINE void setSunHaloFalloff(Instance i, float haloFalloff) noexcept;
 
-    constexpr LightType const& getLightType(Instance i) const noexcept {
+    LightType const& getLightType(Instance i) const noexcept {
         return mManager[i].lightType;
     }
 
-    constexpr Type getType(Instance i) const noexcept {
+    Type getType(Instance i) const noexcept {
         return getLightType(i).type;
     }
 
-    constexpr bool isShadowCaster(Instance i) const noexcept {
+    bool isShadowCaster(Instance i) const noexcept {
         return getLightType(i).shadowCaster;
     }
 
-    constexpr bool isLightCaster(Instance i) const noexcept {
+    bool isLightCaster(Instance i) const noexcept {
         return getLightType(i).lightCaster;
     }
 
-    constexpr bool isPointLight(Instance i) const noexcept { 
+    bool isPointLight(Instance i) const noexcept {
         return getType(i) == Type::POINT; 
     }
 
-    constexpr bool isSpotLight(Instance i) const noexcept {
+    bool isSpotLight(Instance i) const noexcept {
         Type type = getType(i);
         return type == Type::FOCUSED_SPOT || type == Type::SPOT;
     }
 
-    constexpr bool isDirectionalLight(Instance i) const noexcept {
+    bool isDirectionalLight(Instance i) const noexcept {
         Type type = getType(i);
         return type == Type::DIRECTIONAL || type == Type::SUN;
     }
 
-    constexpr bool isIESLight(Instance i) const noexcept {
+    bool isIESLight(Instance i) const noexcept {
         return false;   // TODO: change this when we support IES lights
     }
 
-    constexpr bool isSunLight(Instance i) const noexcept {
+    bool isSunLight(Instance i) const noexcept {
         return getType(i) == Type::SUN; 
     }
 
-    constexpr uint32_t getShadowMapSize(Instance i) const noexcept {
+    uint32_t getShadowMapSize(Instance i) const noexcept {
         return getShadowParams(i).options.mapSize;
     }
 
-    constexpr ShadowParams const& getShadowParams(Instance i) const noexcept {
+    ShadowParams const& getShadowParams(Instance i) const noexcept {
         return mManager[i].shadowParams;
     }
 
-    constexpr float getShadowConstantBias(Instance i) const noexcept {
+    float getShadowConstantBias(Instance i) const noexcept {
         return getShadowParams(i).options.constantBias;
     }
 
-    constexpr float getShadowNormalBias(Instance i) const noexcept {
+    float getShadowNormalBias(Instance i) const noexcept {
         return getShadowParams(i).options.normalBias;
     }
 
-    constexpr float getShadowFar(Instance i) const noexcept {
+    float getShadowFar(Instance i) const noexcept {
         return getShadowParams(i).options.shadowFar;
     }
 
-    constexpr const math::float3& getColor(Instance i) const noexcept {
+    const math::float3& getColor(Instance i) const noexcept {
         return mManager[i].color;
     }
 
-    constexpr float getIntensity(Instance i) const noexcept {
+    float getIntensity(Instance i) const noexcept {
         return mManager[i].intensity;
     }
 
-    constexpr float getSunAngularRadius(Instance i) const noexcept {
+    float getSunAngularRadius(Instance i) const noexcept {
         return mManager[i].sunAngularRadius;
     }
 
-    constexpr float getSunHaloSize(Instance i) const noexcept {
+    float getSunHaloSize(Instance i) const noexcept {
         return mManager[i].sunHaloSize;
     }
 
-    constexpr float getSunHaloFalloff(Instance i) const noexcept {
+    float getSunHaloFalloff(Instance i) const noexcept {
         return mManager[i].sunHaloFalloff;
     }
 
-    constexpr float getSquaredFalloffInv(Instance i) const noexcept {
+    float getSquaredFalloffInv(Instance i) const noexcept {
         return mManager[i].squaredFallOffInv;
     }
 
-    constexpr SpotParams const& getSpotParams(Instance i) const noexcept {
+    SpotParams const& getSpotParams(Instance i) const noexcept {
         return mManager[i].spotParams;
     }
 
-    constexpr float getCosOuterSquared(Instance i) const noexcept {
+    float getCosOuterSquared(Instance i) const noexcept {
         return getSpotParams(i).cosOuterSquared;
     }
 
-    constexpr float getSinInverse(Instance i) const noexcept {
+    float getSinInverse(Instance i) const noexcept {
         return getSpotParams(i).sinInverse;
     }
 
-    constexpr float getRadius(Instance i) const noexcept {
+    float getRadius(Instance i) const noexcept {
         return getSpotParams(i).radius;
     }
 
-    constexpr const math::float3& getLocalPosition(Instance i) const noexcept {
+    const math::float3& getLocalPosition(Instance i) const noexcept {
         return mManager[i].position;
     }
 
-    constexpr const math::float3& getLocalDirection(Instance i) const noexcept {
+    const math::float3& getLocalDirection(Instance i) const noexcept {
         return mManager[i].direction;
     }
 
@@ -244,7 +244,7 @@ private:
         struct Proxy {
             // all of this gets inlined
             UTILS_ALWAYS_INLINE
-            constexpr Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
+            Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
                     : lightType{ sim, i } { }
 
             union {
@@ -263,10 +263,10 @@ private:
             };
         };
 
-        UTILS_ALWAYS_INLINE constexpr Proxy operator[](Instance i) noexcept {
+        UTILS_ALWAYS_INLINE Proxy operator[](Instance i) noexcept {
             return { *this, i };
         }
-        UTILS_ALWAYS_INLINE constexpr const Proxy operator[](Instance i) const noexcept {
+        UTILS_ALWAYS_INLINE const Proxy operator[](Instance i) const noexcept {
             return { const_cast<Sim&>(*this), i };
         }
     };

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -181,7 +181,7 @@ private:
         struct Proxy {
             // all of this gets inlined
             UTILS_ALWAYS_INLINE
-            constexpr Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
+            Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
                     : aabb{ sim, i } { }
 
             union {
@@ -195,10 +195,10 @@ private:
             };
         };
 
-        UTILS_ALWAYS_INLINE constexpr Proxy operator[](Instance i) noexcept {
+        UTILS_ALWAYS_INLINE Proxy operator[](Instance i) noexcept {
             return { *this, i };
         }
-        UTILS_ALWAYS_INLINE constexpr const Proxy operator[](Instance i) const noexcept {
+        UTILS_ALWAYS_INLINE const Proxy operator[](Instance i) const noexcept {
             return { const_cast<Sim&>(*this), i };
         }
     };

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -132,7 +132,7 @@ private:
         struct Proxy {
             // all of this gets inlined
             UTILS_ALWAYS_INLINE
-            constexpr Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
+            Proxy(Base& sim, utils::EntityInstanceBase::Type i) noexcept
                     : local{ sim, i } { }
 
             union {
@@ -146,10 +146,10 @@ private:
             };
         };
 
-        UTILS_ALWAYS_INLINE constexpr Proxy operator[](Instance i) noexcept {
+        UTILS_ALWAYS_INLINE Proxy operator[](Instance i) noexcept {
             return { *this, i };
         }
-        UTILS_ALWAYS_INLINE constexpr const Proxy operator[](Instance i) const noexcept {
+        UTILS_ALWAYS_INLINE const Proxy operator[](Instance i) const noexcept {
             return { const_cast<Sim&>(*this), i };
         }
     };

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -140,46 +140,46 @@ public:
 
     // return a pointer to the first element of the ElementIndex'th array
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex>* begin() noexcept {
+    typename SoA::template TypeAt<ElementIndex>* begin() noexcept {
         return mData.template data<ElementIndex>() + 1;
     }
 
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex> const* begin() const noexcept {
+    typename SoA::template TypeAt<ElementIndex> const* begin() const noexcept {
         return mData.template data<ElementIndex>() + 1;
     }
 
     // return a pointer to the past-the-end element of the ElementIndex'th array
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex>* end() noexcept {
+    typename SoA::template TypeAt<ElementIndex>* end() noexcept {
         return begin<ElementIndex>() + getComponentCount();
     }
 
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex> const* end() const noexcept {
+    typename SoA::template TypeAt<ElementIndex> const* end() const noexcept {
         return begin<ElementIndex>() + getComponentCount();
     }
 
     // return a Slice<>
     template<size_t ElementIndex>
-    constexpr Slice<typename SoA::template TypeAt<ElementIndex>> slice() noexcept {
+    Slice<typename SoA::template TypeAt<ElementIndex>> slice() noexcept {
         return { begin<ElementIndex>(), end<ElementIndex>() };
     }
 
     template<size_t ElementIndex>
-    constexpr Slice<const typename SoA::template TypeAt<ElementIndex>> slice() const noexcept {
+    Slice<const typename SoA::template TypeAt<ElementIndex>> slice() const noexcept {
         return { begin<ElementIndex>(), end<ElementIndex>() };
     }
 
     // return a reference to the index'th element of the ElementIndex'th array
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex>& elementAt(Instance index) noexcept {
+    typename SoA::template TypeAt<ElementIndex>& elementAt(Instance index) noexcept {
         assert(index);
         return data<ElementIndex>()[index];
     }
 
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex> const& elementAt(Instance index) const noexcept {
+    typename SoA::template TypeAt<ElementIndex> const& elementAt(Instance index) const noexcept {
         assert(index);
         return data<ElementIndex>()[index];
     }
@@ -187,14 +187,14 @@ public:
     // returns a pointer to the RAW ARRAY of components including the first dummy component
     // Use with caution.
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex> const* raw_array() const noexcept {
+    typename SoA::template TypeAt<ElementIndex> const* raw_array() const noexcept {
         return data<ElementIndex>();
     }
 
     // We need our own version of Field because mData is private
     template<size_t E>
     struct Field : public SoA::template Field<E> {
-        constexpr Field(SingleInstanceComponentManager& soa, EntityInstanceBase::Type i) noexcept
+        Field(SingleInstanceComponentManager& soa, EntityInstanceBase::Type i) noexcept
                 : SoA::template Field<E>{ soa.mData, i } {
         }
         using SoA::template Field<E>::operator =;
@@ -202,12 +202,12 @@ public:
 
 protected:
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex>* data() noexcept {
+    typename SoA::template TypeAt<ElementIndex>* data() noexcept {
         return mData.template data<ElementIndex>();
     }
 
     template<size_t ElementIndex>
-    constexpr typename SoA::template TypeAt<ElementIndex> const* data() const noexcept {
+    typename SoA::template TypeAt<ElementIndex> const* data() const noexcept {
         return mData.template data<ElementIndex>();
     }
 

--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -366,64 +366,64 @@ public:
 
     // return a pointer to the first element of the ElementIndex]th array
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex>* data() noexcept {
+    TypeAt<ElementIndex>* data() noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex);
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex> const* data() const noexcept {
+    TypeAt<ElementIndex> const* data() const noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex);
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex>* begin() noexcept {
+    TypeAt<ElementIndex>* begin() noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex);
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex> const* begin() const noexcept {
+    TypeAt<ElementIndex> const* begin() const noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex);
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex>* end() noexcept {
+    TypeAt<ElementIndex>* end() noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex) + size();
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex> const* end() const noexcept {
+    TypeAt<ElementIndex> const* end() const noexcept {
         return getArray<TypeAt<ElementIndex>>(ElementIndex) + size();
     }
 
     template<size_t ElementIndex>
-    constexpr Slice<TypeAt<ElementIndex>> slice() noexcept {
+    Slice<TypeAt<ElementIndex>> slice() noexcept {
         return { begin<ElementIndex>(), end<ElementIndex>() };
     }
 
     template<size_t ElementIndex>
-    constexpr Slice<const TypeAt<ElementIndex>> slice() const noexcept {
+    Slice<const TypeAt<ElementIndex>> slice() const noexcept {
         return { begin<ElementIndex>(), end<ElementIndex>() };
     }
 
     // return a reference to the index'th element of the ElementIndex'th array
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex>& elementAt(size_t index) noexcept {
+    TypeAt<ElementIndex>& elementAt(size_t index) noexcept {
         return data<ElementIndex>()[index];
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex> const& elementAt(size_t index) const noexcept {
+    TypeAt<ElementIndex> const& elementAt(size_t index) const noexcept {
         return data<ElementIndex>()[index];
     }
 
     // return a reference to the last element of the ElementIndex'th array
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex>& back() noexcept {
+    TypeAt<ElementIndex>& back() noexcept {
         return data<ElementIndex>()[size() - 1];
     }
 
     template<size_t ElementIndex>
-    constexpr TypeAt<ElementIndex> const& back() const noexcept {
+    TypeAt<ElementIndex> const& back() const noexcept {
         return data<ElementIndex>()[size() - 1];
     }
 
@@ -439,59 +439,59 @@ public:
         }
 
         // auto-conversion to the field's type
-        UTILS_ALWAYS_INLINE constexpr operator Type&() noexcept {
+        UTILS_ALWAYS_INLINE operator Type&() noexcept {
             return soa.elementAt<E>(i);
         }
-        UTILS_ALWAYS_INLINE constexpr operator Type const&() const noexcept {
+        UTILS_ALWAYS_INLINE operator Type const&() const noexcept {
             return soa.elementAt<E>(i);
         }
         // dereferencing the selected field
-        UTILS_ALWAYS_INLINE constexpr Type& operator ->() noexcept {
+        UTILS_ALWAYS_INLINE Type& operator ->() noexcept {
             return soa.elementAt<E>(i);
         }
-        UTILS_ALWAYS_INLINE constexpr Type const& operator ->() const noexcept {
+        UTILS_ALWAYS_INLINE Type const& operator ->() const noexcept {
             return soa.elementAt<E>(i);
         }
         // address-of the selected field
-        UTILS_ALWAYS_INLINE constexpr Type* operator &() noexcept {
+        UTILS_ALWAYS_INLINE Type* operator &() noexcept {
             return &soa.elementAt<E>(i);
         }
-        UTILS_ALWAYS_INLINE constexpr Type const* operator &() const noexcept {
+        UTILS_ALWAYS_INLINE Type const* operator &() const noexcept {
             return &soa.elementAt<E>(i);
         }
         // assignment to the field
-        UTILS_ALWAYS_INLINE constexpr Type const& operator = (Type const& other) noexcept {
+        UTILS_ALWAYS_INLINE Type const& operator = (Type const& other) noexcept {
             return (soa.elementAt<E>(i) = other);
         }
-        UTILS_ALWAYS_INLINE constexpr Type const& operator = (Type&& other) noexcept {
+        UTILS_ALWAYS_INLINE Type const& operator = (Type&& other) noexcept {
             return (soa.elementAt<E>(i) = other);
         }
         // comparisons
-        UTILS_ALWAYS_INLINE constexpr bool operator==(Type const& other) const {
+        UTILS_ALWAYS_INLINE bool operator==(Type const& other) const {
             return (soa.elementAt<E>(i) == other);
         }
-        UTILS_ALWAYS_INLINE constexpr bool operator!=(Type const& other) const {
+        UTILS_ALWAYS_INLINE bool operator!=(Type const& other) const {
             return (soa.elementAt<E>(i) != other);
         }
         // calling the field
         template <typename ... ARGS>
-        UTILS_ALWAYS_INLINE constexpr decltype(auto) operator()(ARGS&& ... args) noexcept {
+        UTILS_ALWAYS_INLINE decltype(auto) operator()(ARGS&& ... args) noexcept {
             return soa.elementAt<E>(i)(std::forward<ARGS>(args)...);
         }
         template <typename ... ARGS>
-        UTILS_ALWAYS_INLINE constexpr decltype(auto) operator()(ARGS&& ... args) const noexcept {
+        UTILS_ALWAYS_INLINE decltype(auto) operator()(ARGS&& ... args) const noexcept {
             return soa.elementAt<E>(i)(std::forward<ARGS>(args)...);
         }
     };
 
 private:
     template<typename T>
-    constexpr T const* getArray(size_t arrayIndex) const {
+    T const* getArray(size_t arrayIndex) const {
         return static_cast<T const*>(mArrayOffset[arrayIndex]);
     }
 
     template<typename T>
-    constexpr T* getArray(size_t arrayIndex) {
+    T* getArray(size_t arrayIndex) {
         return static_cast<T*>(mArrayOffset[arrayIndex]);
     }
 
@@ -509,12 +509,12 @@ private:
     }
 
     // this calculate the offset adjusted for all data alignment of a given array
-    static inline constexpr size_t getOffset(size_t index, size_t capacity) noexcept {
+    static inline size_t getOffset(size_t index, size_t capacity) noexcept {
         auto offsets = getOffsets(capacity);
         return offsets[index];
     }
 
-    static inline constexpr std::array<size_t, kArrayCount> getOffsets(size_t capacity) noexcept {
+    static inline std::array<size_t, kArrayCount> getOffsets(size_t capacity) noexcept {
         // compute the required size of each array
         const size_t sizes[] = { (sizeof(Elements) * capacity)... };
 


### PR DESCRIPTION
This is because we can't create a constexpr SoA in the first place,
and it wouldn't be very useful if we could.

This change ripples into users of SoA.