### PR TITLE
matc, matinfo et al: improve diagnostic output

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -84,6 +84,7 @@ protected:
     TargetApi mTargetApi = (TargetApi) 0;
     Optimization mOptimization = Optimization::PERFORMANCE;
     bool mPrintShaders = false;
+    bool mGenerateDebugInfo = false;
     utils::bitset32 mShaderModels;
     struct CodeGenParams {
         int shaderModel;
@@ -306,6 +307,9 @@ public:
     // TODO: this is present here for matc's "--print" flag, but ideally does not belong inside
     // MaterialBuilder
     MaterialBuilder& printShaders(bool printShaders) noexcept;
+
+    // if true, will include debugging information in generated SPIRV
+    MaterialBuilder& generateDebugInfo(bool generateDebugInfo) noexcept;
 
     // specifies a list of variants that should be filtered out during code generation.
     MaterialBuilder& variantFilter(uint8_t variantFilter) noexcept;

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -34,7 +34,13 @@ using SpirvBlob = std::vector<uint32_t>;
 
 class GLSLPostProcessor {
 public:
-    GLSLPostProcessor(MaterialBuilder::Optimization optimization, bool printShaders);
+
+    enum Flags : uint32_t {
+        PRINT_SHADERS = 1 << 0,
+        GENERATE_DEBUG_INFO = 1 << 1,
+    };
+
+    GLSLPostProcessor(MaterialBuilder::Optimization optimization, uint32_t flags);
 
     ~GLSLPostProcessor();
 
@@ -54,6 +60,7 @@ private:
 
     const MaterialBuilder::Optimization mOptimization;
     const bool mPrintShaders;
+    const bool mGenerateDebugInfo;
     std::string* mGlslOutput = nullptr;
     SpirvBlob* mSpirvOutput = nullptr;
     std::string* mMslOutput = nullptr;

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -51,7 +51,10 @@ Package PostprocessMaterialBuilder::build() {
 
     // Create a postprocessor to optimize / compile to Spir-V if necessary.
 #ifndef FILAMAT_LITE
-    GLSLPostProcessor postProcessor(mOptimization, mPrintShaders);
+    uint32_t flags = 0;
+    flags |= mPrintShaders ? GLSLPostProcessor::PRINT_SHADERS : 0;
+    flags |= mGenerateDebugInfo ? GLSLPostProcessor::GENERATE_DEBUG_INFO : 0;
+    GLSLPostProcessor postProcessor(mOptimization, flags);
 #endif
 
     // Create chunk tree.
@@ -205,7 +208,8 @@ Package PostprocessMaterialBuilder::build() {
 #ifndef FILAMAT_LITE
     // Emit SPIRV chunks
     if (!spirvEntries.empty()) {
-        container.addChild<filamat::DictionarySpirvChunk>(std::move(spirvDictionary));
+        const bool stripInfo = !mGenerateDebugInfo;
+        container.addChild<filamat::DictionarySpirvChunk>(std::move(spirvDictionary), stripInfo);
         container.addChild<MaterialSpirvChunk>(std::move(spirvEntries));
     }
 

--- a/libs/filamat/src/eiff/DictionarySpirvChunk.h
+++ b/libs/filamat/src/eiff/DictionarySpirvChunk.h
@@ -28,13 +28,14 @@ namespace filamat {
 
 class DictionarySpirvChunk final : public Chunk {
 public:
-    explicit DictionarySpirvChunk(BlobDictionary&& dictionary);
+    explicit DictionarySpirvChunk(BlobDictionary&& dictionary, bool stripDebugInfo);
     ~DictionarySpirvChunk() = default;
 
 private:
     void flatten(Flattener& f) override;
 
     BlobDictionary mDictionary;
+    bool mStripDebugInfo;
 };
 
 } // namespace filamat

--- a/libs/gltfio/materials/ubershader.mat.in
+++ b/libs/gltfio/materials/ubershader.mat.in
@@ -1,5 +1,5 @@
 material {
-    name : ubershader,
+    name : ubershader_${SHADINGMODEL}_${BLENDING},
     requires : [ uv0, uv1, color ],
     shadingModel : ${SHADINGMODEL},
     blending : ${BLENDING},

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -272,6 +272,7 @@ bool MaterialCompiler::run(const Config& config) {
         .targetApi(config.getTargetApi())
         .optimization(config.getOptimizationLevel())
         .printShaders(config.printShaders())
+        .generateDebugInfo(config.isDebug())
         .variantFilter(config.getVariantFilter() | builder.getVariantFilter());
 
     // Write builder.build() to output.


### PR DESCRIPTION
This enhances the existing matc option `--debug` so that it enables debug information in the resulting SPIR-V.

Previously we tied this to the build configuration which was not flexible. Moreover this needs to be orthogonal to shader opts, because we often need to debug problems that arise from optimization.

This CL also gives meaningful names to the ubershader materials and fixes up the new matinfo analysis so that it prints the entire SPIRV chunk that corresponds to each potentially problematic GLSL codeline.

Motivated by #1516.