### PR TITLE
Web: remove more &free callbacks.

### DIFF
--- a/libs/gltfio/src/Wireframe.cpp
+++ b/libs/gltfio/src/Wireframe.cpp
@@ -35,6 +35,8 @@ using namespace filament::math;
 using namespace std;
 using namespace utils;
 
+static const auto FREE_CALLBACK = [](void* mem, size_t, void*) { free(mem); };
+
 namespace gltfio {
 namespace details {
 
@@ -139,12 +141,11 @@ Wireframe::Wireframe(FFilamentAsset* asset) : mAsset(asset) {
         .bufferType(IndexBuffer::IndexType::UINT)
         .build(*engine);
 
-    auto destroy = (VertexBuffer::BufferDescriptor::Callback) free;
     mVertexBuffer->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(
-                    verts, mVertexBuffer->getVertexCount() * sizeof(float3), destroy));
+                    verts, mVertexBuffer->getVertexCount() * sizeof(float3), FREE_CALLBACK));
 
     mIndexBuffer->setBuffer(*engine, IndexBuffer::BufferDescriptor(
-                    inds, mIndexBuffer->getIndexCount() * sizeof(uint32_t), destroy));
+                    inds, mIndexBuffer->getIndexCount() * sizeof(uint32_t), FREE_CALLBACK));
 
     mEntity = EntityManager::get().create();
 


### PR DESCRIPTION
It is not safe to take the address of a stdlib function with emscripten, this causes an intermittent crash in the WebGL backend.