### PR TITLE
Preallocate uniform buffers in Metal

### DIFF
--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -93,6 +93,7 @@ private:
     size_t size = 0;
     const MetalBufferPoolEntry* bufferPoolEntry = nullptr;
     void* cpuBuffer = nullptr;
+    bool bufferPoolEntryIsPreallocated = false;
     MetalContext& context;
 };
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -93,7 +93,6 @@ private:
     size_t size = 0;
     const MetalBufferPoolEntry* bufferPoolEntry = nullptr;
     void* cpuBuffer = nullptr;
-    bool bufferPoolEntryIsPreallocated = false;
     MetalContext& context;
 };
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -111,7 +111,6 @@ MetalUniformBuffer::MetalUniformBuffer(MetalContext& context, size_t size) : HwU
     if (size <= 4 * 1024) {   // 4K
         bufferPoolEntry = nullptr;
         cpuBuffer = malloc(size);
-        return;
     }
 }
 


### PR DESCRIPTION
It is valid for Filament to create a uniform buffer but not load any data into it, as long as the
shader does not read from the uniform. Previously, Metal uniform buffers were allocated at the first
data load, but this change "preallocates" a uniform buffer allocation at creation time to handle
this case. It's a Metal validation error to draw with a program that references an unbound uniform
buffer.