### PR TITLE
Fix normal mapping with skinning / morphing in Metal

### DIFF
--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -220,6 +220,10 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
             return nullptr;
     }
 
+#ifndef NDEBUG
+    builder.optimization(MaterialBuilder::Optimization::NONE);
+#endif
+
     static_assert(std::tuple_size<UvMap>::value == 8, "Badly sized uvset.");
     int numUvSets = getNumUvSets(uvmap);
     if (numUvSets > 0) {

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -49,7 +49,9 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal);
         material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
         #if defined(HAS_SKINNING_OR_MORPHING)
-            skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
+            if (objectUniforms.skinningEnabled == 1) {
+                skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
+            }
         #endif
     #endif // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL
 #endif // HAS_ATTRIBUTE_TANGENTS


### PR DESCRIPTION
I'm perplexed why OpenGL wasn't affected by this, but I believe adding this check to mirror line 39 is this is the right fix..