### PR TITLE
matdbg: add the DebugServer.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 This file contains one line summaries of commits that are worthy of mentioning in release notes.
 A new header is inserted each time a *tag* is created.
 
+- Add a live material debugger with a web-based interface.
+
 ## v1.3.1
 
 - Unified Filament Sceneform and npm releases.

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -260,6 +260,14 @@ target_link_libraries(${TARGET} PUBLIC filabridge)
 target_link_libraries(${TARGET} PUBLIC image_headers)
 target_link_libraries(${TARGET} PUBLIC ibl)
 
+# Link in matdbg for Desktop + Debug only since it pulls in filamat and a web server.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT IOS AND NOT ANDROID AND NOT WEBGL)
+    target_link_libraries(${TARGET} PUBLIC matdbg)
+    add_definitions(-DFILAMENT_ENABLE_MATDBG=1)
+else()
+    add_definitions(-DFILAMENT_ENABLE_MATDBG=0)
+endif()
+
 # Android, iOS, and WebGL do not use bluegl.
 if(NOT IOS AND NOT ANDROID AND NOT WEBGL)
     target_link_libraries(${TARGET} PRIVATE bluegl)

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -160,6 +160,10 @@ void FEngine::init() {
     mCommandStream = CommandStream(*mDriver, mCommandBufferQueue.getCircularBuffer());
     DriverApi& driverApi = getDriverApi();
 
+#if FILAMENT_ENABLE_MATDBG
+    debug.server = new matdbg::DebugServer(matdbg::ENGINE);
+#endif
+
     mResourceAllocator = new fg::ResourceAllocator(driverApi);
 
     // Parse all post process shaders now, but create them lazily

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -110,7 +110,16 @@ Material* Material::Builder::build(Engine& engine) {
 
     mImpl->mMaterialParser = materialParser;
 
-    return upcast(engine).createMaterial(*this);
+    Material* result = upcast(engine).createMaterial(*this);
+
+#if FILAMENT_ENABLE_MATDBG
+    matdbg::DebugServer* server = upcast(engine).debug.server;
+    CString name;
+    materialParser->getName(&name);
+    server->addMaterial(name, mImpl->mPayload, mImpl->mSize, result);
+#endif
+
+    return result;
 }
 
 namespace details {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -49,6 +49,16 @@
 
 #include <filament/Stream.h>
 
+#if FILAMENT_ENABLE_MATDBG
+#include <matdbg/DebugServer.h>
+#else
+namespace filament {
+namespace matdbg {
+class DebugServer;
+} // namespace matdbg
+} // namespace filament
+#endif
+
 #include <filaflat/ShaderBuilder.h>
 
 #include <utils/compiler.h>
@@ -377,6 +387,7 @@ public:
         struct {
             bool camera_at_origin = true;
         } view;
+         matdbg::DebugServer* server;
     } debug;
 };
 

--- a/libs/filaflat/include/filaflat/ChunkContainer.h
+++ b/libs/filaflat/include/filaflat/ChunkContainer.h
@@ -73,6 +73,10 @@ public:
         return mChunks.find(type) != mChunks.end();
     }
 
+    void const* getData() const { return mData; }
+
+    size_t getSize() const { return mSize; }
+
 private:
     bool parseChunk(Unflattener& unflattener);
 

--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PUBLIC_HDR_DIR include)
 # ==================================================================================================
 
 set(PUBLIC_HDRS
+    include/matdbg/DebugServer.h
     include/matdbg/JsonWriter.h
     include/matdbg/ShaderExtractor.h
     include/matdbg/ShaderInfo.h
@@ -17,11 +18,41 @@ set(PUBLIC_HDRS
 
 set(SRCS
     src/CommonWriter.h
+    src/DebugServer.cpp
     src/JsonWriter.cpp
     src/ShaderExtractor.cpp
     src/ShaderInfo.cpp
     src/TextWriter.cpp
 )
+
+# ==================================================================================================
+# Resources
+# ==================================================================================================
+
+set(RESOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+set(RESOURCE_BINS
+        ${CMAKE_CURRENT_SOURCE_DIR}/web/style.css
+        ${CMAKE_CURRENT_SOURCE_DIR}/web/script.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/web/index.html
+)
+
+get_resgen_vars(${RESOURCE_DIR} matdbg_resources)
+
+add_custom_command(
+        OUTPUT ${RESGEN_OUTPUTS}
+        COMMAND resgen -t ${RESGEN_FLAGS} ${RESOURCE_BINS}
+        DEPENDS resgen ${RESOURCE_BINS}
+)
+
+if (DEFINED RESGEN_SOURCE_FLAGS)
+    set_source_files_properties(${RESGEN_SOURCE} PROPERTIES COMPILE_FLAGS ${RESGEN_SOURCE_FLAGS})
+endif()
+
+set(DUMMY_SRC "${RESOURCE_DIR}/dummy.c")
+add_custom_command(OUTPUT ${DUMMY_SRC} COMMAND echo "//" > ${DUMMY_SRC})
+
+add_library(matdbg_resources ${DUMMY_SRC} ${RESGEN_SOURCE})
 
 # ==================================================================================================
 # Include and target definitions
@@ -36,10 +67,12 @@ target_link_libraries(${TARGET} PUBLIC
         filaflat
         filabridge
         backend
+        civetweb
         utils
         SPIRV
         SPIRV-Tools
         spirv-cross-glsl
+        matdbg_resources
 )
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})

--- a/libs/matdbg/include/matdbg/DebugServer.h
+++ b/libs/matdbg/include/matdbg/DebugServer.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MATDBG_DEBUGSERVER_H
+#define MATDBG_DEBUGSERVER_H
+
+#include <utils/CString.h>
+
+#include <tsl/robin_map.h>
+
+class CivetServer;
+
+namespace filament {
+namespace matdbg {
+
+enum ServerMode { ENGINE, STANDALONE };
+
+/**
+ * Server-side material debugger.
+ *
+ * This class manages an HTTP server and a WebSockets server that listen on a secondary thread. It
+ * receives material packages from the Filament C++ engine or from a standalone tool such as
+ * matinfo.
+ */
+class DebugServer {
+public:
+    DebugServer(ServerMode mode, int port = 8080);
+    ~DebugServer();
+
+    /**
+     * Notifies the debugger that the given material package is being loaded into the engine.
+     */
+    void addMaterial(const utils::CString& name, const void* data, size_t size,
+            void* userdata = nullptr);
+
+    using EditCallback = void(*)(void* userdata, const utils::CString& name, const void*, size_t);
+
+    /**
+     * Sets up a callback that allows the Filament engine to listen for shader edits. The callback
+     * might be triggered from a secondary thread.
+     */
+    void setEditCallback(EditCallback callback) { mEditCallback = callback; }
+
+private:
+    using MaterialKey = uint32_t;
+
+    struct MaterialRecord {
+        void* userdata;
+        uint8_t* package;
+        size_t packageSize;
+        utils::CString name;
+        MaterialKey key;
+    };
+
+    const MaterialRecord* getRecord(const MaterialKey& key) const;
+
+    const ServerMode mServerMode;
+    CivetServer* mServer;
+    tsl::robin_map<MaterialKey, MaterialRecord> mMaterialRecords;
+    utils::CString mHtml;
+    utils::CString mJavascript;
+    utils::CString mCss;
+    EditCallback mEditCallback = nullptr;
+
+    class FileRequestHandler* mFileHandler;
+    class RestRequestHandler* mRestHandler;
+    class WebSocketHandler* mWebSocketHandler;
+
+    friend class FileRequestHandler;
+    friend class RestRequestHandler;
+    friend class WebSocketHandler;
+};
+
+} // namespace matdbg
+} // namespace filament
+
+#endif  // MATDBG_DEBUGSERVER_H

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <matdbg/DebugServer.h>
+
+#include <CivetServer.h>
+
+#include <utils/Hash.h>
+#include <utils/Log.h>
+
+#include <spirv_glsl.hpp>
+#include <spirv-tools/libspirv.h>
+
+#include <matdbg/ShaderExtractor.h>
+#include <matdbg/ShaderInfo.h>
+#include <matdbg/JsonWriter.h>
+
+#include <filaflat/ChunkContainer.h>
+
+#include <backend/DriverEnums.h>
+
+#include <string>
+
+// If set to 0, this serves HTML from a resgen resource. Use 1 only during local development, which
+// serves files directly from the source code tree.
+#define SERVE_FROM_SOURCE_TREE 0
+
+#if !SERVE_FROM_SOURCE_TREE
+#include "matdbg_resources.h"
+#endif
+
+namespace filament {
+namespace matdbg {
+
+using namespace utils;
+using namespace filament::backend;
+
+using filaflat::ChunkContainer;
+using filamat::ChunkType;
+
+static const StaticString kSuccessHeader =
+        "HTTP/1.1 200 OK\r\nContent-Type: %s\r\n"
+        "Connection: close\r\n\r\n";
+
+class FileRequestHandler : public CivetHandler {
+public:
+    FileRequestHandler(DebugServer* server) : mServer(server) {}
+    bool handleGet(CivetServer *server, struct mg_connection *conn) {
+        const struct mg_request_info* request = mg_get_request_info(conn);
+        std::string uri(request->request_uri);
+        if (uri == "/" || uri == "/index.html") {
+            #if SERVE_FROM_SOURCE_TREE
+            mg_send_file(conn, "libs/matdbg/web/index.html");
+            #else
+            mg_printf(conn, kSuccessHeader.c_str(), "text/html");
+            mg_write(conn, mServer->mHtml.c_str(), mServer->mHtml.size());
+            #endif
+            return true;
+        }
+        if (uri == "/style.css") {
+            #if SERVE_FROM_SOURCE_TREE
+            mg_send_file(conn, "libs/matdbg/web/style.css");
+            #else
+            mg_printf(conn, kSuccessHeader.c_str(), "text/css");
+            mg_write(conn, mServer->mCss.c_str(), mServer->mCss.size());
+            #endif
+            return true;
+        }
+        if (uri == "/script.js") {
+            #if SERVE_FROM_SOURCE_TREE
+            mg_send_file(conn, "libs/matdbg/web/script.js");
+            #else
+            mg_printf(conn, kSuccessHeader.c_str(), "text/javascript");
+            mg_write(conn, mServer->mJavascript.c_str(), mServer->mJavascript.size());
+            #endif
+            return true;
+        }
+        slog.e << "DebugServer: bad request at line " <<  __LINE__ << ": " << uri << io::endl;
+        return false;
+    }
+private:
+    DebugServer* mServer;
+};
+
+// Handles the following REST requests, where {id} is an 8-digit hex string.
+//
+//    GET /api/matids
+//    GET /api/materials
+//    GET /api/material?matid={id}
+//    GET /api/shader?matid={id}&type=[glsl|spirv]&[glindex|vkindex|metalindex]={index}
+//
+class RestRequestHandler : public CivetHandler {
+public:
+    RestRequestHandler(DebugServer* server) : mServer(server) {}
+
+    bool handleGet(CivetServer *server, struct mg_connection *conn) {
+        const struct mg_request_info* request = mg_get_request_info(conn);
+        std::string uri(request->local_uri);
+
+        const auto error = [request](int line) {
+            slog.e << "DebugServer: 404 at " <<  line << ": " << request->query_string << io::endl;
+            return false;
+        };
+
+        if (uri == "/api/matids") {
+            mg_printf(conn, kSuccessHeader.c_str(), "application/json");
+            mg_printf(conn, "[");
+            int index = 0;
+            for (const auto& record : mServer->mMaterialRecords) {
+                const bool last = (++index) == mServer->mMaterialRecords.size();
+                mg_printf(conn, "\"%8.8x\" %s", record.first, last ? "" : ",");
+            }
+            mg_printf(conn, "]");
+            return true;
+        }
+
+        if (uri == "/api/materials") {
+            mg_printf(conn, kSuccessHeader.c_str(), "application/json");
+            mg_printf(conn, "[");
+            int index = 0;
+            for (const auto& record : mServer->mMaterialRecords) {
+                const bool last = (++index) == mServer->mMaterialRecords.size();
+
+                ChunkContainer package(record.second.package, record.second.packageSize);
+                if (!package.parse()) {
+                    return error(__LINE__);
+                }
+
+                JsonWriter writer;
+                if (!writer.writeMaterialInfo(package)) {
+                    return error(__LINE__);
+                }
+
+                mg_printf(conn, "{ \"matid\": \"%8.8x\", %s } %s", record.first,
+                        writer.getJsonString(), last ? "" : ",");
+            }
+            mg_printf(conn, "]");
+            return true;
+        }
+
+        if (!request->query_string) {
+            return error(__LINE__);
+        }
+
+        const size_t qlength = strlen(request->query_string);
+        char matid[9] = {};
+        if (mg_get_var(request->query_string, qlength, "matid", matid, sizeof(matid)) < 0) {
+            return error(__LINE__);
+        }
+        const uint32_t id = strtol(matid, nullptr, 16);
+        const DebugServer::MaterialRecord* result = mServer->getRecord(id);
+        if (result == nullptr) {
+            return error(__LINE__);
+        }
+
+        ChunkContainer package(result->package, result->packageSize);
+        if (!package.parse()) {
+            return error(__LINE__);
+        }
+
+        if (uri == "/api/material") {
+            JsonWriter writer;
+            if (!writer.writeMaterialInfo(package)) {
+                return error(__LINE__);
+            }
+            mg_printf(conn, kSuccessHeader.c_str(), "application/json");
+            mg_printf(conn, "{ %s }", writer.getJsonString());
+            return true;
+        }
+
+        char type[6] = {};
+        if (mg_get_var(request->query_string, qlength, "type", type, sizeof(type)) < 0) {
+            return error(__LINE__);
+        }
+
+        char glindex[4] = {};
+        char vkindex[4] = {};
+        char metalindex[4] = {};
+        mg_get_var(request->query_string, qlength, "glindex", glindex, sizeof(glindex));
+        mg_get_var(request->query_string, qlength, "vkindex", vkindex, sizeof(vkindex));
+        mg_get_var(request->query_string, qlength, "metalindex", metalindex, sizeof(metalindex));
+
+        if (!glindex[0] && !vkindex[0] && !metalindex[0]) {
+            return error(__LINE__);
+        }
+
+        if (uri != "/api/shader") {
+            return error(__LINE__);
+        }
+
+        if (glindex[0]) {
+            ShaderExtractor extractor(Backend::OPENGL, result->package, result->packageSize);
+            if (!extractor.parse() ||
+                    (!extractor.isShadingMaterial() && !extractor.isPostProcessMaterial())) {
+                return error(__LINE__);
+            }
+
+            filaflat::ShaderBuilder builder;
+            std::vector<ShaderInfo> info(getShaderCount(package, ChunkType::MaterialGlsl));
+            if (!getGlShaderInfo(package, info.data())) {
+                return error(__LINE__);
+            }
+
+            const int shaderIndex = std::stoi(glindex);
+            if (shaderIndex >= info.size()) {
+                return error(__LINE__);
+            }
+
+            const auto& item = info[shaderIndex];
+            extractor.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
+
+            mg_printf(conn, kSuccessHeader.c_str(), "application/txt");
+            mg_write(conn, builder.data(), builder.size() - 1);
+            return true;
+        }
+
+        if (vkindex[0]) {
+            ShaderExtractor extractor(Backend::VULKAN, result->package, result->packageSize);
+            if (!extractor.parse() ||
+                    (!extractor.isShadingMaterial() && !extractor.isPostProcessMaterial())) {
+                return error(__LINE__);
+            }
+
+            filaflat::ShaderBuilder builder;
+            std::vector<ShaderInfo> info(getShaderCount(package, ChunkType::MaterialSpirv));
+            if (!getVkShaderInfo(package, info.data())) {
+                return error(__LINE__);
+            }
+
+            const int shaderIndex = std::stoi(vkindex);
+            if (shaderIndex >= info.size()) {
+                return error(__LINE__);
+            }
+
+            const auto& item = info[shaderIndex];
+            extractor.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
+
+            // TODO: Add a transpiler that depends on "type" and add an MSL type instead of
+            // piggybacking on type=GLSL.
+
+            mg_printf(conn, kSuccessHeader.c_str(), "application/text");
+
+            if (true) {
+                auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+                spv_text text = nullptr;
+                const uint32_t options = SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;
+                const uint32_t* data = (const uint32_t*) builder.data();
+                spvBinaryToText(context, data, builder.size() / 4, options, &text, nullptr);
+
+                mg_write(conn, text->str, text->length);
+                spvTextDestroy(text);
+                spvContextDestroy(context);
+            }
+
+            return true;
+        }
+
+        if (metalindex[0]) {
+            ShaderExtractor extractor(Backend::METAL, result->package, result->packageSize);
+            if (!extractor.parse() ||
+                    (!extractor.isShadingMaterial() && !extractor.isPostProcessMaterial())) {
+                return error(__LINE__);
+            }
+
+            filaflat::ShaderBuilder builder;
+            std::vector<ShaderInfo> info(getShaderCount(package, ChunkType::MaterialMetal));
+            if (!getMetalShaderInfo(package, info.data())) {
+                return error(__LINE__);
+            }
+
+            const int shaderIndex = std::stoi(metalindex);
+            if (shaderIndex >= info.size()) {
+                return error(__LINE__);
+            }
+
+            const auto& item = info[shaderIndex];
+            extractor.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
+
+            mg_printf(conn, kSuccessHeader.c_str(), "application/txt");
+            mg_write(conn, builder.data(), builder.size() - 1);
+            return true;
+        }
+
+        return error(__LINE__);
+    }
+
+private:
+    DebugServer* mServer;
+};
+
+class WebSocketHandler : public CivetWebSocketHandler {
+public:
+    WebSocketHandler(DebugServer* server) : mServer(server) {}
+
+    bool handleConnection(CivetServer *server, const struct mg_connection *conn) override {
+        return true;
+    }
+
+    void handleReadyState(CivetServer *server, struct mg_connection *conn) override {
+        mConnection = conn;
+    }
+
+    bool handleData(CivetServer *server, struct mg_connection *conn, int bits, char *data,
+            size_t size) override {
+        // TODO: trigger the "shader has been edited" callback via mServer->mEditHandler(...)
+        return true;
+    }
+
+    void handleClose(CivetServer *server, const struct mg_connection *conn) override {
+        mConnection = nullptr;
+    }
+
+    // Notify the JavaScript client that a new material package has been loaded.
+    void notify(const DebugServer::MaterialRecord& material) {
+        if (mConnection) {
+            char matid[9] = {};
+            sprintf(matid, "%8.8x", material.key);
+            mg_websocket_write(mConnection, MG_WEBSOCKET_OPCODE_TEXT, matid, 8);
+        }
+    }
+
+private:
+    DebugServer* mServer;
+    struct mg_connection* mConnection = nullptr;
+};
+
+DebugServer::DebugServer(ServerMode mode, int port) : mServerMode(mode) {
+    #if !SERVE_FROM_SOURCE_TREE
+    mHtml = CString((const char*) MATDBG_RESOURCES_INDEX_DATA, MATDBG_RESOURCES_INDEX_SIZE - 1);
+    mJavascript = CString((const char*) MATDBG_RESOURCES_SCRIPT_DATA, MATDBG_RESOURCES_SCRIPT_SIZE - 1);
+    mCss = CString((const char*) MATDBG_RESOURCES_STYLE_DATA, MATDBG_RESOURCES_STYLE_SIZE - 1);
+    #endif
+
+    const char* kServerOptions[] = { "listening_ports", "8080", nullptr };
+    std::string portString = std::to_string(port);
+    kServerOptions[1] = portString.c_str();
+
+    mServer = new CivetServer(kServerOptions);
+    mFileHandler = new FileRequestHandler(this);
+    mRestHandler = new RestRequestHandler(this);
+    mWebSocketHandler = new WebSocketHandler(this);
+
+    mServer->addHandler("/api", mRestHandler);
+    mServer->addHandler("", mFileHandler);
+    mServer->addWebSocketHandler("", mWebSocketHandler);
+
+    slog.i << "DebugServer listening at http://localhost:" << port << io::endl;
+}
+
+DebugServer::~DebugServer() {
+    for (auto& pair : mMaterialRecords) {
+        delete [] pair.second.package;
+    }
+    delete mFileHandler;
+    delete mRestHandler;
+    delete mServer;
+}
+
+void DebugServer::addMaterial(const CString& name, const void* data, size_t size, void* userdata) {
+    filaflat::ChunkContainer* container = new filaflat::ChunkContainer(data, size);
+    if (!container->parse()) {
+        slog.e << "DebugServer: unable to parse material package: " << name.c_str() << io::endl;
+        return;
+    }
+
+    const uint32_t seed = 42;
+    auto words = (const uint32_t*) data;
+    MaterialKey key = utils::hash::murmur3(words, size / 4, seed);
+
+    // Retain a copy of the package to permit queries after the client application has
+    // freed up the original material package.
+    uint8_t* package = new uint8_t[size];
+    memcpy(package, data, size);
+
+    MaterialRecord info = {userdata, package, size, name, key};
+    mMaterialRecords.insert({key, info});
+    mWebSocketHandler->notify(info);
+}
+
+const DebugServer::MaterialRecord* DebugServer::getRecord(const MaterialKey& key) const {
+    const auto& iter = mMaterialRecords.find(key);
+    return iter == mMaterialRecords.end() ? nullptr : &iter->second;
+}
+
+} // namespace matdbg
+} // namespace filament

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -25,6 +25,8 @@
 
 #include "CommonWriter.h"
 
+#include <private/filament/Variant.h>
+
 #include <iomanip>
 #include <sstream>
 
@@ -87,15 +89,14 @@ static void printShaderInfo(ostream& json, const std::vector<ShaderInfo>& info) 
         const auto& item = info[i];
         string variantString = "";
 
-        // NOTE: the variant enum is private to Filament so unfortunately we need to decode the bits
-        // using magic constants. The 3-character nomenclature used here is consistent with the
-        // ASCII art seen in the Variant header file and allows the information to fit in a
-        // reasonable amount of space on the page. The HTML file has a legend.
+        // NOTE: The 3-character nomenclature used here is consistent with the ASCII art seen in the
+        // Variant header file and allows the information to fit in a reasonable amount of space on
+        // the page. The HTML file has a legend.
         if (item.variant) {
-            if (item.variant & 0x01)  variantString += "DIR|";
-            if (item.variant & 0x02)  variantString += "DYN|";
-            if (item.variant & 0x04)  variantString += "SRE|";
-            if (item.variant & 0x08)  variantString += "SKN|";
+            if (item.variant & filament::Variant::DIRECTIONAL_LIGHTING)  variantString += "DIR|";
+            if (item.variant & filament::Variant::DYNAMIC_LIGHTING)      variantString += "DYN|";
+            if (item.variant & filament::Variant::SHADOW_RECEIVER)       variantString += "SRE|";
+            if (item.variant & filament::Variant::SKINNING_OR_MORPHING)  variantString += "SKN|";
             variantString = variantString.substr(0, variantString.length() - 1);
         }
 

--- a/libs/matdbg/web/index.html
+++ b/libs/matdbg/web/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Filament Debugger</title>
+    <meta charset="utf-8">
+    <link rel="icon" type="image/png" href="https://google.github.io/filament/favicon.png" />
+    <link href="https://fonts.googleapis.com/css?family=Lexend Deca" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="vbox viewport">
+
+        <header>matdbg</header>
+        <section class="main hbox space-between">
+          <nav>
+            <div id="material-list">
+            </div>
+            <div id="material-detail">
+            </div>
+          </nav>
+          <article id="shader-source">
+          </article>
+        </section>
+        <footer>&nbsp;</footer>
+
+    <template id="material-list-template">
+    <pre>
+{{#material}}<a href="#material" class="{{classes}}" data-matid="{{matid}}">{{matid}} {{name}}</a>
+{{/material}}
+    </pre>
+    </template>
+
+    <template id="material-detail-template">
+    <pre>
+name = {{ name }}
+version = {{ version }}
+
+DIR = DIRECTIONAL_LIGHTING
+DYN = DYNAMIC_LIGHTING
+SRE = SHADOW_RECEIVER
+SKN = SKINNING_OR_MORPHING
+
+<b>OpenGL shaders</b>
+{{#opengl}}
+<a href="#shader" class="{{classes}}" data-glindex="{{index}}">{{index}} {{shaderModel}} {{pipelineStage}} {{variantString}}</a>
+{{/opengl}}
+
+<b>Vulkan shaders</b>
+{{#vulkan}}
+<a href="#shader" class="{{classes}}" data-vkindex="{{index}}">{{index}} {{shaderModel}} {{pipelineStage}} {{variantString}}</a>
+{{/vulkan}}
+
+<b>Metal shaders</b>
+{{#metal}}
+<a href="#shader" class="{{classes}}" data-metalindex="{{index}}">{{index}} {{shaderModel}} {{pipelineStage}} {{variantString}}</a>
+{{/metal}}
+    </pre>
+    </template>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.1/mustache.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.17.1/min/vs/loader.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/libs/matdbg/web/script.js
+++ b/libs/matdbg/web/script.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const kMonacoBaseUrl = 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.17.1/min/';
+
+const materialList = document.getElementById("material-list");
+const materialDetail = document.getElementById("material-detail");
+const footer = document.getElementsByTagName("footer")[0];
+const shaderSource = document.getElementById("shader-source");
+const matDetailTemplate = document.getElementById("material-detail-template");
+const matListTemplate = document.getElementById("material-list-template");
+
+const gMaterialDatabase = {};
+
+let gSocket = null;
+let gEditor = null;
+let gCurrentMaterial = "00000000";
+let gCurrentShader = { glindex: -1, vkindex: -1, metalindex: -1 };
+let gCurrentSocketId = 0;
+
+require.config({ paths: { "vs": `${kMonacoBaseUrl}vs` }});
+
+window.MonacoEnvironment = {
+    getWorkerUrl: function(workerId, label) {
+      return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+        self.MonacoEnvironment = {
+          baseUrl: '${kMonacoBaseUrl}'
+        };
+        importScripts('${kMonacoBaseUrl}vs/base/worker/workerMain.js');`
+      )}`;
+    }
+};
+
+document.querySelector("body").addEventListener("click", function(e) {
+    const anchor = e.target.closest("a");
+    if (!anchor) {
+        return;
+    }
+    e.preventDefault();
+    const cmd = anchor.hash.slice(1);
+
+    // Handle selection of a material.
+    if (cmd == "material") {
+        selectMaterial(anchor.dataset.matid);
+        return;
+    }
+
+    // Handle selection of a shader.
+    if (cmd == "shader") {
+        selectShader(anchor.dataset);
+        return;
+    }
+
+}, false);
+
+function fetchMaterial(matid) {
+    fetch(`api/material?matid=${matid}`).then(function(response) {
+        return response.json();
+    }).then(function(matInfo) {
+        if (matid in gMaterialDatabase) {
+            return;
+        }
+        matInfo.matid = matid;
+        gMaterialDatabase[matid] = matInfo;
+        for (const shader of matInfo.opengl) fetchShader({glindex: shader.index}, matInfo);
+        for (const shader of matInfo.vulkan) fetchShader({vkindex: shader.index}, matInfo);
+        for (const shader of matInfo.metal)  fetchShader({metalindex: shader.index}, matInfo);
+        renderMaterialList();
+    });
+}
+
+function startSocket() {
+    const url = new URL(document.URL)
+    const ws = new WebSocket(`ws://${url.host}`);
+
+    const reconnect = () => {
+        gSocket = null;
+        setTimeout(() => startSocket(), 3000);
+    };
+
+    // When a new server has come online, ask it what materials it has.
+    ws.addEventListener("open", () => {
+        footer.innerText = `connection ${gCurrentSocketId}`;
+        gCurrentSocketId++;
+
+        fetch("api/matids").then(function(response) {
+            return response.json();
+        }).then(function(matInfo) {
+            for (matid of matInfo) {
+                if (!(matid in gMaterialDatabase)) {
+                    fetchMaterial(matid);
+                }
+            }
+        });
+    });
+
+    ws.addEventListener("close", (e) => {
+        footer.innerText = "no connection";
+        reconnect();
+    });
+
+    ws.addEventListener("message", event => {
+        const matid = event.data;
+        fetchMaterial(matid);
+    });
+
+    gSocket = ws;
+}
+
+function fetchMaterials() {
+    fetch("api/materials").then(function(response) {
+        return response.json();
+    }).then(function(matJson) {
+        for (const matInfo of matJson) {
+            if (matInfo.matid in gMaterialDatabase) {
+                continue;
+            }
+            gMaterialDatabase[matInfo.matid] = matInfo;
+            for (const shader of matInfo.opengl) fetchShader({glindex: shader.index}, matInfo);
+            for (const shader of matInfo.vulkan) fetchShader({vkindex: shader.index}, matInfo);
+            for (const shader of matInfo.metal)  fetchShader({metalindex: shader.index}, matInfo);
+        }
+        selectMaterial(matJson[0].matid);
+    });
+}
+
+function fetchShader(selection, matinfo) {
+    let query, target;
+    if (selection.glindex >= 0) {
+        query = `type=glsl&glindex=${selection.glindex}`;
+        target = matinfo.opengl[parseInt(selection.glindex)];
+    }
+    if (selection.vkindex >= 0) {
+        query = `type=spirv&vkindex=${selection.vkindex}`;
+        target = matinfo.vulkan[parseInt(selection.vkindex)];
+    }
+    if (selection.metalindex >= 0) {
+        query = `type=glsl&metalindex=${selection.metalindex}`;
+        target = matinfo.metal[parseInt(selection.metalindex)];
+    }
+    fetch(`api/shader?matid=${matinfo.matid}&${query}`).then(function(response) {
+        return response.text();
+    }).then(function(shaderText) {
+        target.text = shaderText;
+    });
+}
+
+function renderMaterialList() {
+    const materials = [];
+    for (const matid in gMaterialDatabase) {
+        const item = gMaterialDatabase[matid];
+        item.classes = matid === gCurrentMaterial ? "active" : "";
+        materials.push(item);
+    }
+    materialList.innerHTML = Mustache.render(matListTemplate.innerHTML, { "material": materials } );
+}
+
+function updateClassList(array, indexProperty, selectedIndex) {
+    for (let item of array) {
+        const active = parseInt(item[indexProperty]) === selectedIndex;
+        item.classes = active ? "active" : "";
+    }
+}
+
+function renderMaterialDetail() {
+    const mat = gMaterialDatabase[gCurrentMaterial];
+    updateClassList(mat.opengl, "index", parseInt(gCurrentShader.glindex));
+    updateClassList(mat.vulkan, "index", parseInt(gCurrentShader.vkindex));
+    updateClassList(mat.metal, "index", parseInt(gCurrentShader.metalindex));
+    materialDetail.innerHTML = Mustache.render(matDetailTemplate.innerHTML, mat);
+}
+
+function selectShader(selection) {
+    const mat = gMaterialDatabase[gCurrentMaterial];
+    let text;
+    if (selection.glindex >= 0) text = mat.opengl[parseInt(selection.glindex)].text;
+    if (selection.vkindex >= 0) text = mat.vulkan[parseInt(selection.vkindex)].text;
+    if (selection.metalindex >= 0) text = mat.metal[parseInt(selection.metalindex)].text;
+    if (!text) {
+        console.error("Shader source not yet available.");
+        return;
+    }
+    gCurrentShader = selection;
+    renderMaterialDetail();
+    gEditor.setValue(text);
+    shaderSource.style.visibility = "visible";
+}
+
+function selectMaterial(matid) {
+    gCurrentMaterial = matid;
+    renderMaterialList();
+    renderMaterialDetail();
+}
+
+function init() {
+    require(["vs/editor/editor.main"], function () {
+        gEditor = monaco.editor.create(shaderSource, {
+            value: "",
+            language: "cpp",
+            scrollBeyondLastLine: false,
+            readOnly: false,
+            minimap: { enabled: false }
+        });
+        fetchMaterials();
+    });
+
+    Mustache.parse(matDetailTemplate.innerHTML);
+    Mustache.parse(matListTemplate.innerHTML);
+
+    startSocket();
+}
+
+init();

--- a/libs/matdbg/web/style.css
+++ b/libs/matdbg/web/style.css
@@ -1,0 +1,70 @@
+html, body, .viewport {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    font-family: 'Lexend Deca', sans-serif;
+    overflow: hidden;
+}
+
+a, a:visited {
+    text-decoration: none;
+    color: #567;
+}
+
+a:hover, a.active {
+    font-weight: bold;
+    color: #07f;
+}
+
+pre {
+    font-family: Menlo, Monaco, "Courier New", monospace;
+}
+
+.vbox {
+    display: flex;
+    flex-direction: column;
+}
+
+.hbox {
+    display: flex;
+    flex-direction: row;
+}
+
+.space-between {
+    justify-content: space-between;
+}
+
+header, footer {
+    height: 26px;
+    background: cornflowerblue;
+    padding: 5px 0 0 5px;
+}
+
+.main {
+    flex: 1;
+}
+
+article {
+    flex: 5;
+    border-top: solid 2px;
+    border-bottom: solid 2px;
+    visibility: hidden;
+}
+
+nav {
+    border: solid 2px;
+    font-size: 12px;
+    flex: 1;
+}
+
+nav > *:first-child {
+    border-bottom: solid 2px;
+}
+
+nav > * {
+    padding-left: 5px;
+    padding-right: 5px;
+}


### PR DESCRIPTION
This also links matdbg into the Filament Engine in debug config (allowing live inspection of raw shader code) and the matinfo tool (to support the `--web-server` option).

In both cases, the library spins up a small web server that listens to http://localhost:8080. You can run any Filament app and attach to it.

The web client caches all material information. This allows the user to close an atttached Filament app, and the web app will continue to function properly (useful for crash diagnosis). Moreover the user can launch a second Filament app and the web client will add its materials to the existing list (useful when comparing two Filament apps).

For now this only supports inspection, not editing. Some of the material info such as required attributes is not yet displayed but this will be easy to flesh out in a subsequent PR.

<img width="1086" alt="Screen Shot 2019-08-22 at 3 08 11 PM" src="https://user-images.githubusercontent.com/1288904/63553241-b043ba80-c4ee-11e9-816c-c6acb1d6cdf7.png">
