### PR TITLE
Break driver dependency on Texture.h

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PUBLIC_HDRS
 )
 
 set(SRCS
+        src/BackendUtils.cpp
         src/CircularBuffer.cpp
         src/CommandBufferQueue.cpp
         src/CommandStream.cpp

--- a/filament/backend/include/private/backend/BackendUtils.h
+++ b/filament/backend/include/private/backend/BackendUtils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <backend/DriverEnums.h>
+
+#include <stddef.h>
+
+namespace filament {
+namespace backend {
+
+/**
+ * Returns the number of bytes per pixel for the given format.
+ */
+size_t getFormatSize(TextureFormat format) noexcept;
+
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/BackendUtils.cpp
+++ b/filament/backend/src/BackendUtils.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "private/backend/BackendUtils.h"
+
+namespace filament {
+namespace backend {
+
+size_t getFormatSize(TextureFormat format) noexcept {
+    switch (format) {
+        // 8-bits per element
+        case TextureFormat::R8:
+        case TextureFormat::R8_SNORM:
+        case TextureFormat::R8UI:
+        case TextureFormat::R8I:
+        case TextureFormat::STENCIL8:
+            return 1;
+
+        // 16-bits per element
+        case TextureFormat::R16F:
+        case TextureFormat::R16UI:
+        case TextureFormat::R16I:
+        case TextureFormat::RG8:
+        case TextureFormat::RG8_SNORM:
+        case TextureFormat::RG8UI:
+        case TextureFormat::RG8I:
+        case TextureFormat::RGB565:
+        case TextureFormat::RGB5_A1:
+        case TextureFormat::RGBA4:
+        case TextureFormat::DEPTH16:
+            return 2;
+
+        // 24-bits per element
+        case TextureFormat::RGB8:
+        case TextureFormat::SRGB8:
+        case TextureFormat::RGB8_SNORM:
+        case TextureFormat::RGB8UI:
+        case TextureFormat::RGB8I:
+        case TextureFormat::DEPTH24:
+            return 3;
+
+        // 32-bits per element
+        case TextureFormat::R32F:
+        case TextureFormat::R32UI:
+        case TextureFormat::R32I:
+        case TextureFormat::RG16F:
+        case TextureFormat::RG16UI:
+        case TextureFormat::RG16I:
+        case TextureFormat::R11F_G11F_B10F:
+        case TextureFormat::RGB9_E5:
+        case TextureFormat::RGBA8:
+        case TextureFormat::SRGB8_A8:
+        case TextureFormat::RGBA8_SNORM:
+        case TextureFormat::RGB10_A2:
+        case TextureFormat::RGBA8UI:
+        case TextureFormat::RGBA8I:
+        case TextureFormat::DEPTH32F:
+        case TextureFormat::DEPTH24_STENCIL8:
+        case TextureFormat::DEPTH32F_STENCIL8:
+            return 4;
+
+        // 48-bits per element
+        case TextureFormat::RGB16F:
+        case TextureFormat::RGB16UI:
+        case TextureFormat::RGB16I:
+            return 6;
+
+        // 64-bits per element
+        case TextureFormat::RG32F:
+        case TextureFormat::RG32UI:
+        case TextureFormat::RG32I:
+        case TextureFormat::RGBA16F:
+        case TextureFormat::RGBA16UI:
+        case TextureFormat::RGBA16I:
+            return 8;
+
+        // 96-bits per element
+        case TextureFormat::RGB32F:
+        case TextureFormat::RGB32UI:
+        case TextureFormat::RGB32I:
+            return 12;
+
+        // 128-bits per element
+        case TextureFormat::RGBA32F:
+        case TextureFormat::RGBA32UI:
+        case TextureFormat::RGBA32I:
+            return 16;
+
+        default:
+            return 0;
+    }
+}
+
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -20,6 +20,8 @@
 
 #include <details/Texture.h> // for FTexture::getFormatSize
 
+#include "private/backend/BackendUtils.h"
+
 #include <utils/Panic.h>
 #include <utils/trap.h>
 
@@ -303,7 +305,7 @@ MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, u
     const TextureFormat reshapedFormat = reshaper.getReshapedFormat();
     const MTLPixelFormat pixelFormat = decidePixelFormat(context.device, reshapedFormat);
 
-    bytesPerPixel = static_cast<uint8_t>(details::FTexture::getFormatSize(reshapedFormat));
+    bytesPerPixel = static_cast<uint8_t>(getFormatSize(reshapedFormat));
 
     ASSERT_POSTCONDITION(pixelFormat != MTLPixelFormatInvalid, "Pixel format not supported.");
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -18,8 +18,6 @@
 
 #include "MetalEnums.h"
 
-#include <details/Texture.h> // for FTexture::getFormatSize
-
 #include "private/backend/BackendUtils.h"
 
 #include <utils/Panic.h>

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -18,7 +18,7 @@
 
 #include <utils/Panic.h>
 
-#include <details/Texture.h> // for FTexture::getFormatSize
+#include "private/backend/BackendUtils.h"
 
 namespace filament {
 namespace backend {
@@ -228,7 +228,7 @@ VkFormat getVkFormat(TextureFormat format) {
 // See also FTexture::computeTextureDataSize, which takes a public-facing Texture format rather
 // than a driver-level Texture format, and can account for a specified byte alignment.
 uint32_t getBytesPerPixel(TextureFormat format) {
-    return (uint32_t) details::FTexture::getFormatSize(format);
+    return (uint32_t) getFormatSize(format);
 }
 
 VkCompareOp getCompareOp(SamplerCompareFunc func) {

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -19,6 +19,8 @@
 #include "details/Engine.h"
 #include "details/Stream.h"
 
+#include "private/backend/BackendUtils.h"
+
 #include "FilamentAPI-impl.h"
 
 #include <ibl/Cubemap.h>
@@ -241,89 +243,7 @@ size_t FTexture::computeTextureDataSize(Texture::Format format, Texture::Type ty
 }
 
 size_t FTexture::getFormatSize(InternalFormat format) noexcept {
-    using TextureFormat = InternalFormat;
-    switch (format) {
-        // 8-bits per element
-        case TextureFormat::R8:
-        case TextureFormat::R8_SNORM:
-        case TextureFormat::R8UI:
-        case TextureFormat::R8I:
-        case TextureFormat::STENCIL8:
-            return 1;
-
-        // 16-bits per element
-        case TextureFormat::R16F:
-        case TextureFormat::R16UI:
-        case TextureFormat::R16I:
-        case TextureFormat::RG8:
-        case TextureFormat::RG8_SNORM:
-        case TextureFormat::RG8UI:
-        case TextureFormat::RG8I:
-        case TextureFormat::RGB565:
-        case TextureFormat::RGB5_A1:
-        case TextureFormat::RGBA4:
-        case TextureFormat::DEPTH16:
-            return 2;
-
-        // 24-bits per element
-        case TextureFormat::RGB8:
-        case TextureFormat::SRGB8:
-        case TextureFormat::RGB8_SNORM:
-        case TextureFormat::RGB8UI:
-        case TextureFormat::RGB8I:
-        case TextureFormat::DEPTH24:
-            return 3;
-
-        // 32-bits per element
-        case TextureFormat::R32F:
-        case TextureFormat::R32UI:
-        case TextureFormat::R32I:
-        case TextureFormat::RG16F:
-        case TextureFormat::RG16UI:
-        case TextureFormat::RG16I:
-        case TextureFormat::R11F_G11F_B10F:
-        case TextureFormat::RGB9_E5:
-        case TextureFormat::RGBA8:
-        case TextureFormat::SRGB8_A8:
-        case TextureFormat::RGBA8_SNORM:
-        case TextureFormat::RGB10_A2:
-        case TextureFormat::RGBA8UI:
-        case TextureFormat::RGBA8I:
-        case TextureFormat::DEPTH32F:
-        case TextureFormat::DEPTH24_STENCIL8:
-        case TextureFormat::DEPTH32F_STENCIL8:
-            return 4;
-
-        // 48-bits per element
-        case TextureFormat::RGB16F:
-        case TextureFormat::RGB16UI:
-        case TextureFormat::RGB16I:
-            return 6;
-
-        // 64-bits per element
-        case TextureFormat::RG32F:
-        case TextureFormat::RG32UI:
-        case TextureFormat::RG32I:
-        case TextureFormat::RGBA16F:
-        case TextureFormat::RGBA16UI:
-        case TextureFormat::RGBA16I:
-            return 8;
-
-        // 96-bits per element
-        case TextureFormat::RGB32F:
-        case TextureFormat::RGB32UI:
-        case TextureFormat::RGB32I:
-            return 12;
-
-        // 128-bits per element
-        case TextureFormat::RGBA32F:
-        case TextureFormat::RGBA32UI:
-        case TextureFormat::RGBA32I:
-            return 16;
-
-        default:
-            return 0;
-    }
+    return backend::getFormatSize(format);
 }
 
 


### PR DESCRIPTION
Drivers shouldn't be depending on details/Texture.h, especially not when it's only for a single, straightforward function. This moves the `getFormatSize` implementation to a new `BackendUtils.h` file.