### PR TITLE
filament: getTextureInternal

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -291,6 +291,13 @@ DECL_DRIVER_API_1(destroySwapChain,       backend::SwapChainHandle, sch)
 DECL_DRIVER_API_1(destroyStream,          backend::StreamHandle, sh)
 
 /*
+ * Get Internal Impl
+ * -------------------------
+ */
+
+DECL_DRIVER_API_SYNCHRONOUS_1(long, getTextureInternal, backend::TextureHandle, th)
+
+/*
  * Synchronous APIs
  * ----------------
  */

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -330,6 +330,14 @@ void MetalDriver::destroyTexture(Handle<HwTexture> th) {
     destruct_handle<MetalTexture>(mHandleMap, th);
 }
 
+long MetalDriver::getTextureInternal(Handle<HwTexture> th) {
+    if (th) {
+        //TODO
+    }
+
+    return 0;
+}
+
 void MetalDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     if (rth) {
         destruct_handle<MetalRenderTarget>(mHandleMap, rth);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1540,6 +1540,15 @@ void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
     }
 }
 
+long OpenGLDriver::getTextureInternal(Handle<HwTexture> th) {
+    if (th) {
+        GLTexture* t = handle_cast<GLTexture *>(th);
+        if (t)
+            return (long)(&t->gl.id);
+    }
+    return 0;
+}
+
 void OpenGLDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     DEBUG_MARKER()
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -369,6 +369,14 @@ void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
     }
 }
 
+long VulkanDriver::getTextureInternal(Handle<HwTexture> th) {
+    if (th) {
+        //TODO
+    }
+
+    return 0;
+}
+
 void VulkanDriver::createProgramR(Handle<HwProgram> ph, Program&& program) {
     auto vkprogram = construct_handle<VulkanProgram>(mHandleMap, ph, mContext, program);
     mDisposer.createDisposable(vkprogram, [this, ph] () {

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -240,6 +240,12 @@ public:
     InternalFormat getFormat() const noexcept;
 
     /**
+     * Return this texture Internal Implementation ( in OpenGL case, it returne address of gl texture id ).
+     * @return this texture Internal Implementation ( in OpenGL case, it returne address of gl texture id ).
+     */
+    long getTextureInternal(Engine& engine) const noexcept;
+
+    /**
      * Specify the image of a 2D texture for a level.
      *
      * @param engine    Engine this texture is associated to.

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -136,6 +136,11 @@ size_t FTexture::getDepth(size_t level) const noexcept {
     return valueForLevel(level, mDepth);
 }
 
+long FTexture::getTextureInternal(FEngine& engine) const noexcept {
+    FEngine::DriverApi& driver = engine.getDriverApi();
+    return driver.getTextureInternal(mHandle);
+}
+
 void FTexture::setImage(FEngine& engine,
         size_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         Texture::PixelBufferDescriptor&& buffer) const noexcept {
@@ -477,6 +482,10 @@ Texture::Sampler Texture::getTarget() const noexcept {
 
 Texture::InternalFormat Texture::getFormat() const noexcept {
     return upcast(this)->getFormat();
+}
+
+long Texture::getTextureInternal(Engine& engine) const noexcept {
+    return upcast(this)->getTextureInternal(upcast(engine));
 }
 
 void Texture::setImage(Engine& engine, size_t level,

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -52,6 +52,7 @@ public:
     Sampler getTarget() const noexcept { return mTarget; }
     InternalFormat getFormat() const noexcept { return mFormat; }
     Usage getUsage() const noexcept { return mUsage; }
+    long getTextureInternal(FEngine& engine) const noexcept;
 
     void setImage(FEngine& engine, size_t level,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,


### PR DESCRIPTION
Hi, @bejado @prideout 
I tried to get texture internal id, for request from https://github.com/google/filament/issues/1551.
I failed to declare to use void* in return value of getTextureInternal.
DECL_DRIVER_API_SYNCHRONOUS_1(long, getTextureInternal, backend::TextureHandle, th)
but, I could success with long type in return value.