### PR TITLE
Engine: add support for material edits.

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -170,6 +170,8 @@ void FEngine::init() {
         if (!debug.server->isReady()) {
             delete debug.server;
             debug.server = nullptr;
+        } else {
+            debug.server->setEditCallback(FMaterial::onEditCallback);
         }
     }
 #endif

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -73,20 +73,8 @@ Material::Builder& Material::Builder::package(const void* payload, size_t size) 
 }
 
 Material* Material::Builder::build(Engine& engine) {
-    MaterialParser* materialParser = new MaterialParser(
+    MaterialParser* materialParser = FMaterial::createParser(
             upcast(engine).getBackend(), mImpl->mPayload, mImpl->mSize);
-    bool materialOK = materialParser->parse() && materialParser->isShadingMaterial();
-    if (!ASSERT_POSTCONDITION_NON_FATAL(materialOK, "could not parse the material package")) {
-        return nullptr;
-    }
-
-    uint32_t version;
-    materialParser->getMaterialVersion(&version);
-    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
-            "received %d.", MATERIAL_VERSION, version);
-
-    assert(upcast(engine).getBackend() != Backend::DEFAULT &&
-            "Default backend has not been resolved.");
 
     uint32_t v;
     materialParser->getShaderModels(&v);
@@ -290,20 +278,7 @@ FMaterial::~FMaterial() noexcept {
 }
 
 void FMaterial::terminate(FEngine& engine) {
-    DriverApi& driverApi = engine.getDriverApi();
-    auto& cachedPrograms = mCachedPrograms;
-    for (size_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
-        if (!mIsDefaultMaterial) {
-            // The depth variants may be shared with the default material, in which case
-            // we should not free it now.
-            bool isSharedVariant = Variant(i).isDepthPass() && !mHasCustomDepthShader;
-            if (isSharedVariant) {
-                // we don't own this variant, skip.
-                continue;
-            }
-        }
-        driverApi.destroyProgram(cachedPrograms[i]);
-    }
+    destroyPrograms(engine);
     mDefaultInstance.terminate(engine);
 }
 
@@ -448,6 +423,70 @@ size_t FMaterial::getParameters(ParameterInfo* parameters, size_t count) const n
     }
 
     return count;
+}
+
+// Swaps in an edited version of the original package that was used to create the material. The
+// edited package was stashed in response to a debugger event. This is invoked only when the
+// Material Debugger is attached. The only editable features of a material package are the shader
+// source strings, so here we trigger a rebuild of the HwProgram objects.
+void FMaterial::applyPendingEdits() noexcept {
+    slog.d << "Applying edits to " << mName.c_str() << io::endl;
+    destroyPrograms(mEngine);
+    for (auto& program : mCachedPrograms) {
+        program.clear();
+    }
+    delete mMaterialParser;
+    mMaterialParser = mPendingEdits;
+    mPendingEdits = nullptr;
+}
+
+// Callback handler for the debug server, potentially called from any thread. This method is never
+// called during normal operation and exists for debugging purposes only.
+void FMaterial::onEditCallback(void* userdata, const utils::CString& name, const void* packageData,
+        size_t packageSize) {
+    FMaterial* material = upcast((Material*) userdata);
+    FEngine& engine = material->mEngine;
+
+    // This is called on a web server thread so we defer clearing the program cache
+    // and swapping out the MaterialParser until the next getProgram call.
+    material->mPendingEdits = FMaterial::createParser(engine.getBackend(), packageData,
+            packageSize);
+}
+
+MaterialParser* FMaterial::createParser(backend::Backend backend, const void* data,
+        size_t size) {
+    MaterialParser* materialParser = new MaterialParser(backend, data, size);
+
+    bool materialOK = materialParser->parse() && materialParser->isShadingMaterial();
+    if (!ASSERT_POSTCONDITION_NON_FATAL(materialOK, "could not parse the material package")) {
+        return nullptr;
+    }
+
+    uint32_t version;
+    materialParser->getMaterialVersion(&version);
+    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
+            "received %d.", MATERIAL_VERSION, version);
+
+    assert(backend != Backend::DEFAULT && "Default backend has not been resolved.");
+
+    return materialParser;
+}
+
+void FMaterial::destroyPrograms(FEngine& engine) {
+    DriverApi& driverApi = engine.getDriverApi();
+    auto& cachedPrograms = mCachedPrograms;
+    for (size_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
+        if (!mIsDefaultMaterial) {
+            // The depth variants may be shared with the default material, in which case
+            // we should not free it now.
+            bool isSharedVariant = Variant(i).isDepthPass() && !mHasCustomDepthShader;
+            if (isSharedVariant) {
+                // we don't own this variant, skip.
+                continue;
+            }
+        }
+        driverApi.destroyProgram(cachedPrograms[i]);
+    }
 }
 
 } // namespace details

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -31,6 +31,7 @@
 
 #include <utils/compiler.h>
 
+#include <atomic>
 
 namespace filament {
 
@@ -77,6 +78,11 @@ public:
     backend::Handle<backend::HwProgram> getSurfaceProgramSlow(uint8_t variantKey) const noexcept;
     backend::Handle<backend::HwProgram> getPostProcessProgramSlow(uint8_t variantKey) const noexcept;
     backend::Handle<backend::HwProgram> getProgram(uint8_t variantKey) const noexcept {
+#if FILAMENT_ENABLE_MATDBG
+        if (UTILS_UNLIKELY(mPendingEdits)) {
+            const_cast<FMaterial*>(this)->applyPendingEdits();
+        }
+#endif
         backend::Handle<backend::HwProgram> const entry = mCachedPrograms[variantKey];
         return UTILS_LIKELY(entry) ? entry : getProgramSlow(variantKey);
     }
@@ -122,6 +128,18 @@ public:
 
     uint32_t generateMaterialInstanceId() const noexcept { return mMaterialInstanceId++; }
 
+    void applyPendingEdits() noexcept;
+
+    void destroyPrograms(FEngine& engine);
+
+    // Callback handler for the debug server, potentially called from any thread. The userdata
+    // argument has the same value that was passed to DebugServer::addMaterial(), which should
+    // be an instance of the public-facing Material.
+    static void onEditCallback(void* userdata, const utils::CString& name, const void* packageData,
+            size_t packageSize);
+
+    static MaterialParser* createParser(backend::Backend backend, const void* data, size_t size);
+
 private:
     // try to order by frequency of use
     mutable std::array<backend::Handle<backend::HwProgram>, VARIANT_COUNT> mCachedPrograms;
@@ -160,6 +178,7 @@ private:
     const uint32_t mMaterialId;
     mutable uint32_t mMaterialInstanceId = 0;
     MaterialParser* mMaterialParser = nullptr;
+    std::atomic<MaterialParser*> mPendingEdits = {};
 };
 
 


### PR DESCRIPTION
This only adds Engine-side support for edits. The debugger client will
be enhanced in another PR. This works by simply clearing the program
cache and swapping out the MaterialParser. Neat!

However, there are some gotchas:

- The DebugServer callback is triggered on another thread so to be safe
  we defer the swap until the subsequent call to getProgram().

- The getProgram() method is const but in reality it can insert entries
  into a mutable cache. This CL makes the constness of it even more
  misleading by applying edits.
