### PR TITLE
Avoid undefined behavior when doing pointer calculation.

### DIFF
--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -99,7 +99,7 @@ public:
         // of return value -- it allows the compiler to perform the tail call optimization.
         intptr_t next;
         mExecute(driver, this, &next);
-        return reinterpret_cast<CommandBase*>(reinterpret_cast<char*>(this) + next);
+        return reinterpret_cast<CommandBase*>(reinterpret_cast<intptr_t>(this) + next);
     }
 
     inline ~CommandBase() noexcept = default;


### PR DESCRIPTION
Performing `base + offset` pointer arithmetic is only allowed when `base` itself is not nullptr. In other words, the compiler is assumed to allow that `base + offset` is always non-null, which an upcoming compiler release will do in this case. The result is that CommandStream.cpp, which calls this in a loop until the result is nullptr, will never terminate (until it runs junk data and crashes).

Avoid this by using intptr_t instead of actual pointers (i.e. char*), which seems to avoid this failure.