### PR TITLE
WebGL: fix JPEG decoding.

### DIFF
--- a/web/filament-js/wasmloader.js
+++ b/web/filament-js/wasmloader.js
@@ -83,21 +83,6 @@ Filament.fetch = function(assets, onDone, onFetched) {
     var remainingAssets = assets.length;
     assets.forEach(function(name) {
         const lower = name.toLowerCase();
-        if (lower.endsWith('.jpeg') || lower.endsWith('.jpg')) {
-            var img = new Image();
-            img.src = name;
-            img.decoding = 'async';
-            img.onload = function() {
-                Filament.assets[name] = img;
-                if (onFetched) {
-                    onFetched(name);
-                }
-                if (--remainingAssets === 0 && onDone) {
-                    onDone();
-                }
-            };
-            return;
-        }
         fetch(name).then(function(response) {
             if (!response.ok) {
                 throw new Error(name);


### PR DESCRIPTION
The WebGL build has already been using STB-based decoding for a while now and we already include the JPEG decoder in our wasm bundle. This removes some vestigial code that was getting in the way.

Fixes #1565.

![Screen Shot 2019-08-28 at 12 58 39 PM](https://user-images.githubusercontent.com/1288904/63888522-f8058e80-c993-11e9-9e78-043db33f990a.png)
