### PR TITLE
gltfio: fix transforms for nodes with non-uniform scale.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,9 @@ A new header is inserted each time a *tag* is created.
 
 - Dielectrics now behave properly under a white furnace (energy preserving and conserving)
 - Clear coat roughness now remains in the 0..1 (previously remapped to the 0..0.6 range)
-- Fixed several issues with gltfio ubershader mode.
+- gltfio: Fixed several limitations with ubershader mode.
+- gltfio: Fixed a transforms issue with non-uniform scale.
+- webgl: Fixed an issue with JPEG textures.
 
 ## v1.3.2
 

--- a/libs/gltfio/src/math.h
+++ b/libs/gltfio/src/math.h
@@ -95,15 +95,15 @@ inline filament::math::mat4f composeMatrix(const filament::math::float3& transla
     float sz = scale[2];
     return filament::math::mat4f(
         (1 - 2 * qy*qy - 2 * qz*qz) * sx,
-        (2 * qx*qy + 2 * qz*qw) * sy,
-        (2 * qx*qz - 2 * qy*qw) * sz,
+        (2 * qx*qy + 2 * qz*qw) * sx,
+        (2 * qx*qz - 2 * qy*qw) * sx,
         0.f,
-        (2 * qx*qy - 2 * qz*qw) * sx,
+        (2 * qx*qy - 2 * qz*qw) * sy,
         (1 - 2 * qx*qx - 2 * qz*qz) * sy,
-        (2 * qy*qz + 2 * qx*qw) * sz,
+        (2 * qy*qz + 2 * qx*qw) * sy,
         0.f,
-        (2 * qx*qz + 2 * qy*qw) * sx,
-        (2 * qy*qz - 2 * qx*qw) * sy,
+        (2 * qx*qz + 2 * qy*qw) * sz,
+        (2 * qy*qz - 2 * qx*qw) * sz,
         (1 - 2 * qx*qx - 2 * qy*qy) * sz,
         0.f, tx, ty, tz, 1.f);
 }

--- a/third_party/cgltf/cgltf.h
+++ b/third_party/cgltf/cgltf.h
@@ -1441,17 +1441,17 @@ void cgltf_node_transform_local(const cgltf_node* node, cgltf_float* out_matrix)
 		float sz = node->scale[2];
 
 		lm[0] = (1 - 2 * qy*qy - 2 * qz*qz) * sx;
-		lm[1] = (2 * qx*qy + 2 * qz*qw) * sy;
-		lm[2] = (2 * qx*qz - 2 * qy*qw) * sz;
+		lm[1] = (2 * qx*qy + 2 * qz*qw) * sx;
+		lm[2] = (2 * qx*qz - 2 * qy*qw) * sx;
 		lm[3] = 0.f;
 
-		lm[4] = (2 * qx*qy - 2 * qz*qw) * sx;
+		lm[4] = (2 * qx*qy - 2 * qz*qw) * sy;
 		lm[5] = (1 - 2 * qx*qx - 2 * qz*qz) * sy;
-		lm[6] = (2 * qy*qz + 2 * qx*qw) * sz;
+		lm[6] = (2 * qy*qz + 2 * qx*qw) * sy;
 		lm[7] = 0.f;
 
-		lm[8] = (2 * qx*qz + 2 * qy*qw) * sx;
-		lm[9] = (2 * qy*qz - 2 * qx*qw) * sy;
+		lm[8] = (2 * qx*qz + 2 * qy*qw) * sz;
+		lm[9] = (2 * qy*qz - 2 * qx*qw) * sz;
 		lm[10] = (1 - 2 * qx*qx - 2 * qy*qy) * sz;
 		lm[11] = 0.f;
 


### PR DESCRIPTION
I tested this with the problem model and a couple other models.

This bug is inherited from cgltf_node_transform_local, so I will upstream the fix. There are two ways to see that the new math is correct:

1) Look at decomposeMatrix and note that scales belong to rows, not columns.
2) Look at the Brandon Jones implementation [here](http://glmatrix.net/docs/mat4.js.html#line1079).

Fixes #1519.