### PR TITLE
simple allocation debugger

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -228,7 +228,7 @@ private:
 #ifndef NDEBUG
     using HandleArena = utils::Arena<HandleAllocator,
             utils::LockingPolicy::SpinLock,
-            utils::TrackingPolicy::HighWatermark>;
+            utils::TrackingPolicy::Debug>;
 #else
     using HandleArena = utils::Arena<HandleAllocator,
             utils::LockingPolicy::SpinLock>;

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -196,7 +196,7 @@ bool Froxelizer::prepare(
     assert(mFroxelShardedData.begin());
 
     // initialize buffers that need to be
-    memset(mLightRecords.data(),0, mLightRecords.sizeInBytes());
+    memset(mLightRecords.data(), 0, mLightRecords.sizeInBytes());
 
     return uniformsNeedUpdating;
 }

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -195,11 +195,8 @@ bool Froxelizer::prepare(
     assert(mLightRecords.begin());
     assert(mFroxelShardedData.begin());
 
-#ifndef NDEBUG
-    memset(mFroxelBufferUser.data(),    0x55, mFroxelBufferUser.sizeInBytes());
-    memset(mRecordBufferUser.data(),    0xEB, mRecordBufferUser.sizeInBytes());
-    memset(mFroxelShardedData.data(),   0xFD, mFroxelShardedData.sizeInBytes());
-#endif
+    // initialize buffers that need to be
+    memset(mLightRecords.data(),0, mLightRecords.sizeInBytes());
 
     return uniformsNeedUpdating;
 }

--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -37,7 +37,8 @@ static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE     = 3 * CONFIG_MIN_COMMAND
 
 using HeapAllocatorArena = utils::Arena<
         utils::HeapAllocator,
-        utils::LockingPolicy::NoLock>;
+        utils::LockingPolicy::NoLock,
+        utils::TrackingPolicy::Debug>;
 
 using LinearAllocatorArena = utils::Arena<
         utils::LinearAllocator,

--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -42,7 +42,7 @@ using HeapAllocatorArena = utils::Arena<
 using LinearAllocatorArena = utils::Arena<
         utils::LinearAllocator,
         utils::LockingPolicy::NoLock,
-        utils::TrackingPolicy::HighWatermark>;
+        utils::TrackingPolicy::Debug>;
 
 #else
 

--- a/libs/utils/src/Allocator.cpp
+++ b/libs/utils/src/Allocator.cpp
@@ -125,6 +125,15 @@ AtomicFreeList::AtomicFreeList(void* begin, void* end,
     mHead.store({ int32_t(head - mStorage), 0 });
 }
 
+// ------------------------------------------------------------------------------------------------
+
+void TrackingPolicy::HighWatermark::onAlloc(
+        void* p, size_t size, size_t alignment, size_t extra) noexcept {
+    if (!mBase) { mBase = p; }
+    mCurrent += uint32_t(size);
+    mHighWaterMark = mCurrent > mHighWaterMark ? mCurrent : mHighWaterMark;
+}
+
 TrackingPolicy::HighWatermark::~HighWatermark() noexcept {
     size_t wm = mHighWaterMark;
     size_t wmpct = wm / (mSize / 100);
@@ -133,5 +142,30 @@ TrackingPolicy::HighWatermark::~HighWatermark() noexcept {
             << wm / 1024 << " KiB (" << wmpct << "%)" << io::endl;
     }
 }
+
+void TrackingPolicy::Debug::onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept {
+    memset(p, 0xeb, size);
+    HighWatermark::onAlloc(p, size, alignment, extra);
+}
+
+void TrackingPolicy::Debug::onFree(void* p, size_t size) noexcept {
+    memset(p, 0xef, size);
+    HighWatermark::onFree(p, size);
+}
+
+void TrackingPolicy::Debug::onReset() noexcept {
+    if (mBase) {
+        memset(mBase, 0xec, mSize);
+    }
+    HighWatermark::onReset();
+}
+
+void TrackingPolicy::Debug::onRewind(void* addr) noexcept {
+    if (mBase) {
+        memset(addr, 0x55, uintptr_t(mBase) + mSize - uintptr_t(addr));
+    }
+    HighWatermark::onRewind(addr);
+}
+
 
 } // namespace utils

--- a/libs/utils/src/Allocator.cpp
+++ b/libs/utils/src/Allocator.cpp
@@ -135,11 +135,13 @@ void TrackingPolicy::HighWatermark::onAlloc(
 }
 
 TrackingPolicy::HighWatermark::~HighWatermark() noexcept {
-    size_t wm = mHighWaterMark;
-    size_t wmpct = wm / (mSize / 100);
-    if (wmpct > 80) {
-        slog.d << mName << " arena: High watermark "
-            << wm / 1024 << " KiB (" << wmpct << "%)" << io::endl;
+    if (mSize > 0) {
+        size_t wm = mHighWaterMark;
+        size_t wmpct = wm / (mSize / 100);
+        if (wmpct > 80) {
+            slog.d << mName << " arena: High watermark "
+                   << wm / 1024 << " KiB (" << wmpct << "%)" << io::endl;
+        }
     }
 }
 


### PR DESCRIPTION
This can be enabled by using the Tracking::Debug policy,
currently this just fills allocation on alloc() and free(),
which is useful to help detect access to uninitialized memory
and use after free.

Now enabled by default in libfilament allocators on debug builds.

This caught uninitialized access in the froxelizer.