### PR TITLE
Improve framegraph API and simplify implementation

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRCS
         src/components/TransformManager.cpp
         src/fg/FrameGraph.cpp
         src/fg/FrameGraphHandle.cpp
+        src/fg/fg/RenderTarget.cpp
         src/fg/fg/ResourceEntry.cpp
         src/fg/ResourceAllocator.cpp
         src/Box.cpp

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -272,8 +272,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::resolve(
                 data.input = builder.read(input, true);
 
                 data.srt = builder.createRenderTarget(builder.getName(data.input),
-                        { .attachments.color = { data.input },
-                          .samples = builder.getSamples(data.input)
+                        { .attachments.color = { data.input }
                         });
 
                 data.output = builder.createTexture("resolve output", {
@@ -312,8 +311,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dynamicScaling(FrameGraph& f
                 data.input = builder.read(input, true);
 
                 data.srt = builder.createRenderTarget(builder.getName(data.input),
-                        { .attachments.color = { data.input },
-                          .samples = builder.getSamples(data.input)
+                        { .attachments.color = { data.input }
                         });
 
                 data.output = builder.createTexture("scale output", {

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -240,7 +240,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     const bool colorPassNeedsDepthBuffer = hasPostProcess;
 
     const backend::Handle<backend::HwRenderTarget> viewRenderTarget = getRenderTarget(view);
-    FrameGraphId<FrameGraphTexture> output = fg.importResource("viewRenderTarget",
+    FrameGraphRenderTargetHandle fgViewRenderTarget = fg.importRenderTarget("viewRenderTarget",
             { .viewport = vp }, viewRenderTarget, vp.width, vp.height,
             view.getDiscardedTargetBuffers());
 
@@ -386,7 +386,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     fg.present(input);
 
-    fg.moveResource(output, input);
+    fg.moveResource(fgViewRenderTarget, input);
 
     fg.compile();
     //fg.export_graphviz(slog.d);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -291,7 +291,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             (FrameGraph::Builder& builder, ColorPassData& data) {
 
                 if (useSSAO) {
-                    data.ssao = builder.read(ssao);
+                    data.ssao = builder.sample(ssao);
                 }
 
                 data.color = builder.createTexture("Color Buffer",
@@ -302,10 +302,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                             .width = svp.width, .height = svp.height,
                             .format = TextureFormat::DEPTH24
                     });
-                    data.depth = builder.write(builder.read(data.depth, true));
+                    data.depth = builder.write(builder.read(data.depth));
                 }
 
-                data.color = builder.write(builder.read(data.color, true));
+                data.color = builder.write(builder.read(data.color));
                 data.rt = builder.createRenderTarget("Color Pass Target", {
                         .samples = msaa,
                         .attachments.color = data.color,

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -283,6 +283,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         FrameGraphId<FrameGraphTexture> color;
         FrameGraphId<FrameGraphTexture> depth;
         FrameGraphId<FrameGraphTexture> ssao;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& colorPass = fg.addPass<ColorPassData>("Color Pass",
@@ -306,7 +307,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 }
 
                 data.color = builder.write(builder.read(data.color, true));
-                builder.createRenderTarget("Color Pass Target", {
+                data.rt = builder.createRenderTarget("Color Pass Target", {
                         .samples = msaa,
                         .attachments.color = data.color,
                         .attachments.depth = data.depth
@@ -315,7 +316,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             [&pass, &ppm, colorPassBegin, colorPassEnd, jobFroxelize, &js, &view]
                     (FrameGraphPassResources const& resources,
                             ColorPassData const& data, DriverApi& driver) {
-                auto out = resources.getRenderTarget(data.color);
+                auto out = resources.getRenderTarget(data.rt);
                 Handle<HwTexture> ssao;
                 if (data.ssao.isValid()) {
                     ssao = resources.getTexture(data.ssao);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -295,13 +295,12 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 }
 
                 data.color = builder.createTexture("Color Buffer",
-                        { .width = svp.width, .height = svp.height, .format = hdrFormat, .samples = msaa });
+                        { .width = svp.width, .height = svp.height, .format = hdrFormat });
 
                 if (colorPassNeedsDepthBuffer) {
                     data.depth = builder.createTexture("Depth Buffer", {
                             .width = svp.width, .height = svp.height,
-                            .format = TextureFormat::DEPTH24,
-                            .samples = msaa
+                            .format = TextureFormat::DEPTH24
                     });
                     data.depth = builder.write(builder.read(data.depth, true));
                 }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -352,8 +352,8 @@ FrameGraphId<FrameGraphTexture> FrameGraph::importResource(const char* name,
 
     // Populate the cache with a RenderTargetResource
     // create a cache entry
-    RenderTargetResource* pRenderTargetResource = mArena.make<RenderTargetResource>(descriptor, true,
-            TargetBufferFlags::COLOR, width, height, TextureFormat{});
+    RenderTargetResource* pRenderTargetResource = mArena.make<RenderTargetResource>(name,
+            descriptor, true,TargetBufferFlags::COLOR, width, height, TextureFormat{});
     pRenderTargetResource->targetInfo.target = target;
     pRenderTargetResource->discardStart = discardStart;
     pRenderTargetResource->discardEnd = discardEnd;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -72,8 +72,8 @@ bool FrameGraph::Builder::isAttachment(FrameGraphId<FrameGraphTexture> r) const 
             TextureUsage::STENCIL_ATTACHMENT);
 }
 
-FrameGraphRenderTarget::Descriptor const&
-FrameGraph::Builder::getRenderTargetDescriptor(FrameGraphRenderTargetHandle handle) const {
+FrameGraphRenderTarget::Descriptor&
+FrameGraph::Builder::getRenderTargetDescriptor(FrameGraphRenderTargetHandle handle) {
     FrameGraph& fg = mFrameGraph;
     assert(handle < fg.mRenderTargets.size());
     return fg.mRenderTargets[handle].desc;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -98,8 +98,12 @@ FrameGraphRenderTargetHandle FrameGraph::Builder::createRenderTarget(FrameGraphI
     }, clearFlags);
 }
 
-FrameGraphHandle FrameGraph::Builder::read(FrameGraphHandle input, bool doesntNeedTexture) {
-    return mPass.read(mFrameGraph, input, doesntNeedTexture);
+FrameGraphHandle FrameGraph::Builder::read(FrameGraphHandle input) {
+    return mPass.read(mFrameGraph, input);
+}
+
+FrameGraphId<FrameGraphTexture> FrameGraph::Builder::sample(FrameGraphId<FrameGraphTexture> input) {
+    return mPass.sample(mFrameGraph, input);
 }
 
 FrameGraphHandle FrameGraph::Builder::write(FrameGraphHandle output) {
@@ -215,7 +219,7 @@ FrameGraphHandle FrameGraph::moveResource(FrameGraphHandle from, FrameGraphHandl
 void FrameGraph::present(FrameGraphHandle input) {
     addPass<std::tuple<>>("Present",
             [&](Builder& builder, auto& data) {
-                builder.read(input, true);
+                builder.read(input);
                 builder.sideEffect();
             }, [](FrameGraphPassResources const& resources, auto const& data, DriverApi&) {});
 }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -81,32 +81,12 @@ FrameGraph::Builder::getRenderTargetDescriptor(FrameGraphRenderTargetHandle hand
 
 FrameGraphRenderTargetHandle FrameGraph::Builder::createRenderTarget(const char* name,
         FrameGraphRenderTarget::Descriptor const& desc, TargetBufferFlags clearFlags) noexcept {
-
     // TODO: add support for cubemaps and arrays
-
     // TODO: enforce that we can't have a resource used in 2 rendertarget in the same pass
-
     FrameGraph& fg = mFrameGraph;
-
     fg::RenderTarget& renderTarget = fg.createRenderTarget(name, desc);
     renderTarget.userClearFlags = clearFlags;
-
     mPass.declareRenderTarget(renderTarget);
-
-    // update the referenced textures usage flags
-    static constexpr TextureUsage usages[] = {
-            TextureUsage::COLOR_ATTACHMENT,
-            TextureUsage::DEPTH_ATTACHMENT,
-            TextureUsage::STENCIL_ATTACHMENT
-    };
-    for (size_t i = 0; i < desc.attachments.textures.size(); i++) {
-        FrameGraphRenderTarget::Attachments::AttachmentInfo attachmentInfo = desc.attachments.textures[i];
-        if (attachmentInfo.isValid()) {
-            // figure out the attachment flags
-            fg::ResourceEntry<FrameGraphTexture>& entry = fg.getResourceEntry(attachmentInfo.getHandle());
-            entry.descriptor.usage |= usages[i];
-        }
-    }
     return FrameGraphRenderTargetHandle(renderTarget.index);
 }
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -122,16 +122,12 @@ public:
             return mFrameGraph.getDescriptor<T>(r);
         }
 
-        // return a render target's attachment sample count. Returns 1 if the resource
-        // is not an attachement to some rendertarget
-        uint8_t getSamples(FrameGraphId<FrameGraphTexture> r) const noexcept;
-
         // returns whether this texture resource is an attachment to some rendertarget
         bool isAttachment(FrameGraphId<FrameGraphTexture> r) const noexcept;
 
         // returns the descriptor of the render target this attachment belongs to
         FrameGraphRenderTarget::Descriptor const& getRenderTargetDescriptor(
-                FrameGraphId<FrameGraphTexture> attachment) const;
+                FrameGraphRenderTargetHandle handle) const;
 
     private:
         friend class FrameGraph;
@@ -263,8 +259,8 @@ private:
             fg::PassNode const* curr, fg::PassNode const* first,
             fg::RenderTarget const& renderTarget);
 
-    bool equals(FrameGraphRenderTarget::Descriptor const& lhs,
-            FrameGraphRenderTarget::Descriptor const& rhs) const noexcept;
+    bool equals(FrameGraphRenderTarget::Descriptor const& cacheEntry,
+            FrameGraphRenderTarget::Descriptor const& rt) const noexcept;
 
     void executeInternal(fg::PassNode const& node, backend::DriverApi& driver) noexcept;
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -84,9 +84,12 @@ public:
 
         // Read from a resource (i.e. add a reference to that resource)
         template<typename T>
-        FrameGraphId<T> read(FrameGraphId<T> input, bool doesntNeedTexture = false) {
-            return FrameGraphId<T>(read(FrameGraphHandle(input), doesntNeedTexture));
+        FrameGraphId<T> read(FrameGraphId<T> input) {
+            return FrameGraphId<T>(read(FrameGraphHandle(input)));
         }
+
+        // Sample from a texture resource (implies read())
+        FrameGraphId<FrameGraphTexture> sample(FrameGraphId<FrameGraphTexture> input);
 
         // Write to a resource (i.e. add a reference to that pass)
         template<typename T>
@@ -133,7 +136,7 @@ public:
         friend class FrameGraph;
         Builder(FrameGraph& fg, fg::PassNode& pass) noexcept;
         ~Builder() noexcept;
-        FrameGraphHandle read(FrameGraphHandle input, bool doesntNeedTexture);
+        FrameGraphHandle read(FrameGraphHandle input);
         FrameGraphHandle write(FrameGraphHandle output);
         FrameGraph& mFrameGraph;
         fg::PassNode& mPass;

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -118,7 +118,7 @@ public:
 
         // helper to get a resource's descriptor
         template<typename T>
-        typename T::Descriptor const& getDescriptor(FrameGraphId<T> r) {
+        typename T::Descriptor& getDescriptor(FrameGraphId<T> r) {
             return mFrameGraph.getDescriptor<T>(r);
         }
 
@@ -126,8 +126,8 @@ public:
         bool isAttachment(FrameGraphId<FrameGraphTexture> r) const noexcept;
 
         // returns the descriptor of the render target this attachment belongs to
-        FrameGraphRenderTarget::Descriptor const& getRenderTargetDescriptor(
-                FrameGraphRenderTargetHandle handle) const;
+        FrameGraphRenderTarget::Descriptor& getRenderTargetDescriptor(
+                FrameGraphRenderTargetHandle handle);
 
     private:
         friend class FrameGraph;
@@ -178,7 +178,7 @@ public:
 
     // Return the Descriptor associated to this resource handle. The handle must be valid.
     template<typename T>
-    typename T::Descriptor const& getDescriptor(FrameGraphId<T> r) {
+    typename T::Descriptor& getDescriptor(FrameGraphId<T> r) {
         fg::ResourceEntry<T>& entry = getResourceEntryUnchecked(r);
         return entry.descriptor;
     }

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -183,8 +183,13 @@ public:
         return entry.descriptor;
     }
 
+    // Return the FrameGraphRenderTarget Descriptor associated to this resource handle.
+    // The handle must be valid.
+    FrameGraphRenderTarget::Descriptor const& getDescriptor(
+            FrameGraphRenderTargetHandle handle) const noexcept;
+
     // Import a write-only render target from outside the framegraph and returns a handle to it.
-    FrameGraphId<FrameGraphTexture> importResource(const char* name,
+    FrameGraphRenderTargetHandle importRenderTarget(const char* name,
             FrameGraphRenderTarget::Descriptor descriptor,
             backend::Handle<backend::HwRenderTarget> target, uint32_t width, uint32_t height,
             backend::TargetBufferFlags discardStart = backend::TargetBufferFlags::NONE,
@@ -207,6 +212,12 @@ public:
     template<typename T>
     FrameGraphId<T> moveResource(FrameGraphId<T> from, FrameGraphId<T> to) {
         return FrameGraphId<T>(moveResource(FrameGraphHandle(from), FrameGraphHandle(to)));
+    }
+
+    // Helper for aliasing a render target's color attachment
+    template<typename T>
+    FrameGraphId<T> moveResource(FrameGraphRenderTargetHandle from, FrameGraphId<T> to) {
+        return moveResource(getDescriptor(from).attachments.color.getHandle(), to);
     }
 
     // allocates concrete resources and culls unreferenced passes

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -96,12 +96,12 @@ public:
 
         // create a render target in this pass.
         // read/write must have been called as appropriate before this.
-        void createRenderTarget(const char* name,
+        FrameGraphRenderTargetHandle createRenderTarget(const char* name,
                 FrameGraphRenderTarget::Descriptor const& desc,
                 backend::TargetBufferFlags clearFlags = {}) noexcept;
 
         // helper for single color attachment with WRITE access
-        void createRenderTarget(FrameGraphId<FrameGraphTexture>& texture,
+        FrameGraphRenderTargetHandle createRenderTarget(FrameGraphId<FrameGraphTexture>& texture,
                 backend::TargetBufferFlags clearFlags = {}) noexcept;
 
         // Declare that this pass has side effects outside the framegraph (i.e. it can't be culled)

--- a/filament/src/fg/FrameGraphHandle.h
+++ b/filament/src/fg/FrameGraphHandle.h
@@ -150,7 +150,7 @@ struct Attachments {
 struct Descriptor {
     Attachments attachments;
     Viewport viewport;
-    uint8_t samples = 1;            // # of samples
+    uint8_t samples = 0; // # of samples (0 = unset, default)
 };
 
 } // namespace FrameGraphRenderTarget

--- a/filament/src/fg/FrameGraphHandle.h
+++ b/filament/src/fg/FrameGraphHandle.h
@@ -108,6 +108,8 @@ public:
     explicit FrameGraphId(FrameGraphHandle r) : FrameGraphHandle(r) { }
 };
 
+using FrameGraphRenderTargetHandle = uint16_t;
+
 namespace FrameGraphRenderTarget {
 
 struct Attachments {

--- a/filament/src/fg/FrameGraphHandle.h
+++ b/filament/src/fg/FrameGraphHandle.h
@@ -45,7 +45,7 @@ struct FrameGraphTexture {
         uint32_t height = 1;    // height of resource in pixel
         uint32_t depth = 1;     // # of images for 3D textures
         uint8_t levels = 1;     // # of levels for textures
-        uint8_t samples = 1;
+        uint8_t samples = 0;    // 0=auto, 1=request not multisample, >1 only for NOT SAMPLEABLE
         backend::SamplerType type = backend::SamplerType::SAMPLER_2D;     // texture target type
         backend::TextureFormat format = backend::TextureFormat::RGBA8;    // resource internal format
         backend::TextureUsage usage = (backend::TextureUsage)0; // don't need to set this one

--- a/filament/src/fg/FrameGraphPassResources.h
+++ b/filament/src/fg/FrameGraphPassResources.h
@@ -61,7 +61,7 @@ public:
         return get(handle).texture;
     }
 
-    RenderTargetInfo getRenderTarget(FrameGraphHandle r, uint8_t level = 0) const noexcept;
+    RenderTargetInfo getRenderTarget(FrameGraphRenderTargetHandle handle, uint8_t level = 0) const noexcept;
 
 private:
     friend class FrameGraph;

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -102,7 +102,7 @@ RenderTargetHandle ResourceAllocator::createRenderTarget(
         uint8_t samples, TargetBufferInfo color, TargetBufferInfo depth,
         TargetBufferInfo stencil) noexcept {
     return mBackend.createRenderTarget(targetBufferFlags,
-            width, height, samples, color, depth, stencil);
+            width, height, samples ? samples : 1u, color, depth, stencil);
 }
 
 void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -97,7 +97,7 @@ void ResourceAllocator::terminate() noexcept {
     }
 }
 
-RenderTargetHandle ResourceAllocator::createRenderTarget(
+RenderTargetHandle ResourceAllocator::createRenderTarget(const char* name,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, TargetBufferInfo color, TargetBufferInfo depth,
         TargetBufferInfo stencil) noexcept {

--- a/filament/src/fg/ResourceAllocator.h
+++ b/filament/src/fg/ResourceAllocator.h
@@ -39,7 +39,7 @@ public:
 
     void terminate() noexcept;
 
-    backend::RenderTargetHandle createRenderTarget(
+    backend::RenderTargetHandle createRenderTarget(const char* name,
             backend::TargetBufferFlags targetBufferFlags,
             uint32_t width,
             uint32_t height,

--- a/filament/src/fg/fg/RenderTarget.cpp
+++ b/filament/src/fg/fg/RenderTarget.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RenderTarget.h"
+
+#include <backend/DriverEnums.h>
+
+namespace filament {
+
+using namespace backend;
+
+namespace fg {
+
+void RenderTarget::resolve(FrameGraph& fg) noexcept {
+    auto& renderTargetCache = fg.mRenderTargetCache;
+
+    // find a matching rendertarget
+    auto pos = std::find_if(renderTargetCache.begin(), renderTargetCache.end(),
+            [this, &fg](auto const& rt) {
+                return fg.equals(rt->desc, desc);
+            });
+
+    if (pos != renderTargetCache.end()) {
+        cache = pos->get();
+        cache->targetInfo.params.flags.clear |= userClearFlags;
+    } else {
+        uint8_t attachments = 0;
+        uint32_t width = 0;
+        uint32_t height = 0;
+        backend::TextureFormat colorFormat = {};
+
+        static constexpr TargetBufferFlags flags[] = {
+                TargetBufferFlags::COLOR,
+                TargetBufferFlags::DEPTH,
+                TargetBufferFlags::STENCIL };
+
+        static constexpr TextureUsage usages[] = {
+                TextureUsage::COLOR_ATTACHMENT,
+                TextureUsage::DEPTH_ATTACHMENT,
+                TextureUsage::STENCIL_ATTACHMENT };
+
+        uint32_t minWidth = std::numeric_limits<uint32_t>::max();
+        uint32_t maxWidth = 0;
+        uint32_t minHeight = std::numeric_limits<uint32_t>::max();
+        uint32_t maxHeight = 0;
+
+        for (size_t i = 0; i < desc.attachments.textures.size(); i++) {
+            FrameGraphRenderTarget::Attachments::AttachmentInfo attachment = desc.attachments.textures[i];
+            if (attachment.isValid()) {
+                fg::ResourceEntry<FrameGraphTexture>& entry =
+                        fg.getResourceEntryUnchecked(attachment.getHandle());
+                // update usage flags for referenced attachments
+                entry.descriptor.usage |= usages[i];
+                // update attachment sample count if not specified
+                entry.descriptor.samples = entry.descriptor.samples ? entry.descriptor.samples : desc.samples;
+                attachments |= flags[i];
+
+                // figure out the min/max dimensions across all attachments
+                const size_t level = attachment.getLevel();
+                const uint32_t w = details::FTexture::valueForLevel(level, entry.descriptor.width);
+                const uint32_t h = details::FTexture::valueForLevel(level, entry.descriptor.height);
+                minWidth  = std::min(minWidth,  w);
+                maxWidth  = std::max(maxWidth,  w);
+                minHeight = std::min(minHeight, h);
+                maxHeight = std::max(maxHeight, h);
+
+                if (i == FrameGraphRenderTarget::Attachments::COLOR) {
+                    colorFormat = entry.descriptor.format;
+                }
+            }
+        }
+
+        if (attachments) {
+            if (minWidth == maxWidth && minHeight == maxHeight) {
+                // All attachments' size match, we're good to go.
+                width = minWidth;
+                height = minHeight;
+            } else {
+                // TODO: what should we do here? Is it a user-error?
+                width = maxWidth;
+                height = maxHeight;
+            }
+
+            // create the cache entry
+            RenderTargetResource* pRenderTargetResource =
+                    fg.mArena.make<RenderTargetResource>(name, desc, false,
+                            backend::TargetBufferFlags(attachments), width, height, colorFormat);
+            renderTargetCache.emplace_back(pRenderTargetResource, fg);
+            cache = pRenderTargetResource;
+            cache->targetInfo.params.flags.clear |= userClearFlags;
+        }
+    }
+}
+
+} // namespace fg
+} // namespace filament

--- a/filament/src/fg/fg/RenderTarget.h
+++ b/filament/src/fg/fg/RenderTarget.h
@@ -115,7 +115,7 @@ struct RenderTarget { // 32
 
                 // create the cache entry
                 RenderTargetResource* pRenderTargetResource =
-                        fg.mArena.make<RenderTargetResource>(desc, false,
+                        fg.mArena.make<RenderTargetResource>(name, desc, false,
                                 backend::TargetBufferFlags(attachments), width, height, colorFormat);
                 renderTargetCache.emplace_back(pRenderTargetResource, fg);
                 cache = pRenderTargetResource;

--- a/filament/src/fg/fg/RenderTarget.h
+++ b/filament/src/fg/fg/RenderTarget.h
@@ -52,77 +52,7 @@ struct RenderTarget { // 32
     backend::RenderPassFlags targetFlags{};
     RenderTargetResource* cache = nullptr;
 
-    void resolve(FrameGraph& fg) noexcept {
-        auto& renderTargetCache = fg.mRenderTargetCache;
-
-        // find a matching rendertarget
-        auto pos = std::find_if(renderTargetCache.begin(), renderTargetCache.end(),
-                [this, &fg](auto const& rt) {
-                    return fg.equals(rt->desc, desc);
-                });
-
-        if (pos != renderTargetCache.end()) {
-            cache = pos->get();
-            cache->targetInfo.params.flags.clear |= userClearFlags;
-        } else {
-            uint8_t attachments = 0;
-            uint32_t width = 0;
-            uint32_t height = 0;
-            backend::TextureFormat colorFormat = {};
-
-            static constexpr backend::TargetBufferFlags flags[] = {
-                    backend::TargetBufferFlags::COLOR,
-                    backend::TargetBufferFlags::DEPTH,
-                    backend::TargetBufferFlags::STENCIL };
-
-            uint32_t minWidth = std::numeric_limits<uint32_t>::max();
-            uint32_t maxWidth = 0;
-            uint32_t minHeight = std::numeric_limits<uint32_t>::max();
-            uint32_t maxHeight = 0;
-
-            for (size_t i = 0; i < desc.attachments.textures.size(); i++) {
-                FrameGraphRenderTarget::Attachments::AttachmentInfo attachment = desc.attachments.textures[i];
-                if (attachment.isValid()) {
-                    fg::ResourceEntry<FrameGraphTexture>& entry =
-                            fg.getResourceEntryUnchecked(attachment.getHandle());
-                    attachments |= flags[i];
-
-                    // figure out the min/max dimensions across all attachments
-                    const size_t level = attachment.getLevel();
-                    const uint32_t w = details::FTexture::valueForLevel(level, entry.descriptor.width);
-                    const uint32_t h = details::FTexture::valueForLevel(level, entry.descriptor.height);
-                    minWidth  = std::min(minWidth,  w);
-                    maxWidth  = std::max(maxWidth,  w);
-                    minHeight = std::min(minHeight, h);
-                    maxHeight = std::max(maxHeight, h);
-
-                    if (i == FrameGraphRenderTarget::Attachments::COLOR) {
-                        colorFormat = entry.descriptor.format;
-                    }
-                }
-            }
-
-            if (attachments) {
-                if (minWidth == maxWidth && minHeight == maxHeight) {
-                    // All attachments' size match, we're good to go.
-                    width = minWidth;
-                    height = minHeight;
-                } else {
-                    // TODO: what should we do here? Is it a user-error?
-                    width = maxWidth;
-                    height = maxHeight;
-                }
-
-                // create the cache entry
-                RenderTargetResource* pRenderTargetResource =
-                        fg.mArena.make<RenderTargetResource>(name, desc, false,
-                                backend::TargetBufferFlags(attachments), width, height, colorFormat);
-                renderTargetCache.emplace_back(pRenderTargetResource, fg);
-                cache = pRenderTargetResource;
-                cache->targetInfo.params.flags.clear |= userClearFlags;
-            }
-        }
-    }
+    void resolve(FrameGraph& fg) noexcept;
 };
 
 } // namespace fg

--- a/filament/src/fg/fg/RenderTargetResource.h
+++ b/filament/src/fg/fg/RenderTargetResource.h
@@ -34,10 +34,10 @@ namespace fg {
 
 struct RenderTargetResource final : public VirtualResource {  // 104
 
-    RenderTargetResource(
+    RenderTargetResource(const char* name,
             FrameGraphRenderTarget::Descriptor const& desc, bool imported,
             backend::TargetBufferFlags targets, uint32_t width, uint32_t height, backend::TextureFormat format)
-            : desc(desc), imported(imported),
+            : desc(desc), imported(imported), name(name),
               attachments(targets), format(format), width(width), height(height) {
         targetInfo.params.viewport = desc.viewport;
         // if Descriptor was initialized with default values, set the viewport to width/height
@@ -55,6 +55,7 @@ struct RenderTargetResource final : public VirtualResource {  // 104
     // cache key
     const FrameGraphRenderTarget::Descriptor desc;
     const bool imported;
+    const char * const name;
 
     // render target creation info
     backend::TargetBufferFlags attachments;
@@ -84,8 +85,8 @@ struct RenderTargetResource final : public VirtualResource {  // 104
                 }
 
                 // create the concrete rendertarget
-                targetInfo.target = fg.getResourceAllocator().createRenderTarget(attachments,
-                        width, height, desc.samples, infos[0], infos[1], {});
+                targetInfo.target = fg.getResourceAllocator().createRenderTarget(name,
+                        attachments, width, height, desc.samples, infos[0], infos[1], {});
             }
         }
     }

--- a/filament/src/fg/fg/ResourceNode.h
+++ b/filament/src/fg/fg/ResourceNode.h
@@ -39,10 +39,6 @@ struct ResourceNode { // 24
     PassNode* writer = nullptr;     // writer to this node
     uint32_t readerCount = 0;       // # of passes reading from this resource
 
-    // updated by builder
-    static constexpr uint16_t UNINITIALIZED = std::numeric_limits<uint16_t>::max();
-    uint16_t renderTargetIndex = UNINITIALIZED;      // used to retrieve the RT infos
-
     // constants
     const uint8_t version;          // version of the resource when the node was created
 };

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -96,8 +96,8 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
                 data.outDepth = builder.createTexture("depth buffer", inputDesc);
 
 
-                data.outColor = builder.write(builder.read(data.outColor, true));
-                data.outDepth = builder.write(builder.read(data.outDepth, true));
+                data.outColor = builder.write(builder.read(data.outColor));
+                data.outDepth = builder.write(builder.read(data.outDepth));
                 data.rt = builder.createRenderTarget("rt", {
                         .attachments.color = data.outColor,
                         .attachments.depth = data.outDepth
@@ -145,7 +145,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 FrameGraphTexture::Descriptor inputDesc{};
                 inputDesc.format = TextureFormat::DEPTH24;
                 data.outDepth = builder.createTexture("depth buffer", inputDesc);
-                data.outDepth = builder.write(builder.read(data.outDepth, true));
+                data.outDepth = builder.write(builder.read(data.outDepth));
                 data.rt = builder.createRenderTarget("rt depth", {
                         .attachments.depth = data.outDepth
                 });
@@ -177,8 +177,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 // declare a read here, so a reference is added to the previous pass
                 data.outDepth = depthPrepass.getData().outDepth;
 
-                data.outColor = builder.write(builder.read(data.outColor, true));
-                data.outDepth = builder.write(builder.read(data.outDepth, true));
+                data.outColor = builder.write(builder.read(data.outColor));
+                data.outDepth = builder.write(builder.read(data.outDepth));
                 data.rt = builder.createRenderTarget("rt color+depth", {
                         .attachments.color = data.outColor,
                         .attachments.depth = data.outDepth
@@ -248,7 +248,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
 
     auto& postProcessPass = fg.addPass<PostProcessPassData>("PostProcess",
             [&](FrameGraph::Builder& builder, PostProcessPassData& data) {
-                data.input = builder.read(renderPass.getData().output);
+                data.input = builder.sample(renderPass.getData().output);
                 data.output = builder.createTexture("postprocess-renderTarget");
                 data.rt = builder.createRenderTarget(data.output);
             },
@@ -272,7 +272,7 @@ TEST(FrameGraphTest, SimplePassCulling) {
 
     auto& culledPass = fg.addPass<CulledPassData>("CulledPass",
             [&](FrameGraph::Builder& builder, CulledPassData& data) {
-                data.input = builder.read(renderPass.getData().output);
+                data.input = builder.sample(renderPass.getData().output);
                 data.output = builder.createTexture("unused-rendertarget");
                 data.rt = builder.createRenderTarget(data.output);
             },
@@ -339,7 +339,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
 
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
-                data.output = builder.write(builder.read(renderPass1.getData().output, true));
+                data.output = builder.write(builder.read(renderPass1.getData().output));
                 data.rt = builder.createRenderTarget("color", {
                         .attachments.color = { data.output }
                 }, (TargetBufferFlags)0x40);

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -41,6 +41,7 @@ TEST(FrameGraphTest, SimpleRenderPass) {
 
     struct RenderPassData {
         FrameGraphId<FrameGraphTexture> output;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& renderPass = fg.addPass<RenderPassData>("Render",
@@ -49,7 +50,7 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                         .format = TextureFormat::RGBA16F
                 };
                 data.output = builder.createTexture("color buffer", desc);
-                builder.createRenderTarget(data.output);
+                data.rt = builder.createRenderTarget(data.output);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &renderPassExecuted](
@@ -57,7 +58,7 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                     RenderPassData const& data,
                     DriverApi& driver) {
                 renderPassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.output);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
@@ -83,6 +84,7 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
     struct RenderPassData {
         FrameGraphId<FrameGraphTexture> outColor;
         FrameGraphId<FrameGraphTexture> outDepth;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& renderPass = fg.addPass<RenderPassData>("Render",
@@ -96,7 +98,7 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
 
                 data.outColor = builder.write(builder.read(data.outColor, true));
                 data.outDepth = builder.write(builder.read(data.outDepth, true));
-                builder.createRenderTarget("rt", {
+                data.rt = builder.createRenderTarget("rt", {
                         .attachments.color = data.outColor,
                         .attachments.depth = data.outDepth
                 });
@@ -109,7 +111,7 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
                     RenderPassData const& data,
                     DriverApi& driver) {
                 renderPassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.outColor);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::STENCIL, rt.params.flags.discardEnd);
@@ -135,6 +137,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
 
     struct DepthPrepassData {
         FrameGraphId<FrameGraphTexture> outDepth;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& depthPrepass = fg.addPass<DepthPrepassData>("depth prepass",
@@ -143,7 +146,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 inputDesc.format = TextureFormat::DEPTH24;
                 data.outDepth = builder.createTexture("depth buffer", inputDesc);
                 data.outDepth = builder.write(builder.read(data.outDepth, true));
-                builder.createRenderTarget("rt depth", {
+                data.rt = builder.createRenderTarget("rt depth", {
                         .attachments.depth = data.outDepth
                 });
                 EXPECT_TRUE(fg.isValid(data.outDepth));
@@ -153,7 +156,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                     DepthPrepassData const& data,
                     DriverApi& driver) {
                 depthPrepassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.outDepth);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardEnd);
@@ -162,6 +165,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
     struct ColorPassData {
         FrameGraphId<FrameGraphTexture> outColor;
         FrameGraphId<FrameGraphTexture> outDepth;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& colorPass = fg.addPass<ColorPassData>("color pass",
@@ -175,7 +179,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
 
                 data.outColor = builder.write(builder.read(data.outColor, true));
                 data.outDepth = builder.write(builder.read(data.outDepth, true));
-                builder.createRenderTarget("rt color+depth", {
+                data.rt = builder.createRenderTarget("rt color+depth", {
                         .attachments.color = data.outColor,
                         .attachments.depth = data.outDepth
                 });
@@ -189,7 +193,7 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                     ColorPassData const& data,
                     DriverApi& driver) {
                 colorPassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.outColor);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
@@ -216,19 +220,20 @@ TEST(FrameGraphTest, SimplePassCulling) {
 
     struct RenderPassData {
         FrameGraphId<FrameGraphTexture> output;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& renderPass = fg.addPass<RenderPassData>("Render",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
                 data.output = builder.createTexture("renderTarget");
-                builder.createRenderTarget(data.output);
+                data.rt = builder.createRenderTarget(data.output);
             },
             [=, &renderPassExecuted](
                     FrameGraphPassResources const& resources,
                     RenderPassData const& data,
                     backend::DriverApi& driver) {
                 renderPassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.output);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
@@ -238,20 +243,21 @@ TEST(FrameGraphTest, SimplePassCulling) {
     struct PostProcessPassData {
         FrameGraphId<FrameGraphTexture> input;
         FrameGraphId<FrameGraphTexture> output;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& postProcessPass = fg.addPass<PostProcessPassData>("PostProcess",
             [&](FrameGraph::Builder& builder, PostProcessPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
                 data.output = builder.createTexture("postprocess-renderTarget");
-                builder.createRenderTarget(data.output);
+                data.rt = builder.createRenderTarget(data.output);
             },
             [=, &postProcessPassExecuted](
                     FrameGraphPassResources const& resources,
                     PostProcessPassData const& data,
                     backend::DriverApi& driver) {
                 postProcessPassExecuted = true;
-                auto const& rt = resources.getRenderTarget(data.output);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
@@ -261,13 +267,14 @@ TEST(FrameGraphTest, SimplePassCulling) {
     struct CulledPassData {
         FrameGraphId<FrameGraphTexture> input;
         FrameGraphId<FrameGraphTexture> output;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& culledPass = fg.addPass<CulledPassData>("CulledPass",
             [&](FrameGraph::Builder& builder, CulledPassData& data) {
                 data.input = builder.read(renderPass.getData().output);
                 data.output = builder.createTexture("unused-rendertarget");
-                builder.createRenderTarget(data.output);
+                data.rt = builder.createRenderTarget(data.output);
             },
             [=, &culledPassExecuted](
                     FrameGraphPassResources const& resources,
@@ -306,6 +313,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
 
     struct RenderPassData {
         FrameGraphId<FrameGraphTexture> output;
+        FrameGraphRenderTargetHandle rt;
     };
 
     auto& renderPass1 = fg.addPass<RenderPassData>("Render1",
@@ -314,7 +322,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                         .format = TextureFormat::RGBA16F
                 };
                 data.output = builder.createTexture("color buffer", desc);
-                builder.createRenderTarget(data.output, (TargetBufferFlags)0x80);
+                data.rt = builder.createRenderTarget(data.output, (TargetBufferFlags)0x80);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &rt1, &renderPassExecuted1](
@@ -322,7 +330,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                     RenderPassData const& data,
                     DriverApi& driver) {
                 renderPassExecuted1 = true;
-                auto const& rt = resources.getRenderTarget(data.output);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 rt1 = rt.target;
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
@@ -332,7 +340,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
                 data.output = builder.write(builder.read(renderPass1.getData().output, true));
-                builder.createRenderTarget("color", {
+                data.rt = builder.createRenderTarget("color", {
                         .attachments.color = { data.output }
                 }, (TargetBufferFlags)0x40);
                 EXPECT_TRUE(fg.isValid(data.output));
@@ -342,7 +350,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                     RenderPassData const& data,
                     DriverApi& driver) {
                 renderPassExecuted2 = true;
-                auto const& rt = resources.getRenderTarget(data.output);
+                auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(0x40u|0x80u, rt.params.flags.clear);
                 EXPECT_EQ(rt1.getId(), rt.target.getId()); // FIXME: this test is always true the NoopDriver


### PR DESCRIPTION
The major change here is that declaring render targets now returns a `FrameGraphRenderTargetHandle` later used to retrieve the concrete render target. Before this change, one of its attachment had to be used. This was confusing and complexified the implementation.

Other changes:
- the sample count when declaring render targets for the 2nd time doesn't need to be specified,
  the framegraph will just reuse the previous sample count.
- also, no need to specify the sample count for attachments, it'll be set automatically from the
  sample count of the render target.
- use .sample() instead of .read() when the intention is to sample from a texture (as opposed to using it as a renderbuffer for instance).
