### PR TITLE
OpenGL: shader errors should not cause termination.

### DIFF
--- a/filament/backend/src/opengl/GLUtils.cpp
+++ b/filament/backend/src/opengl/GLUtils.cpp
@@ -16,7 +16,7 @@
 
 #include "GLUtils.h"
 
-#include <ostream>
+#include <utils/trap.h>
 
 #include "private/backend/Driver.h"
 
@@ -53,7 +53,7 @@ void checkGLError(io::ostream& out, const char* function, size_t line) noexcept 
     }
     out << "OpenGL error " << io::hex << err << " (" << error << ") in \""
         << function << "\" at line " << io::dec << line << io::endl;
-    std::terminate();
+    debug_trap();
 }
 
 void checkFramebufferStatus(io::ostream& out, const char* function, size_t line) noexcept {
@@ -84,7 +84,7 @@ void checkFramebufferStatus(io::ostream& out, const char* function, size_t line)
     }
     out << "OpenGL framebuffer error " << io::hex << status << " (" << error << ") in \""
         << function << "\" at line " << io::dec << line << io::endl;
-    std::terminate();
+    debug_trap();
 }
 
 } // namespace GLUtils

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3023,6 +3023,14 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
     OpenGLProgram* p = handle_cast<OpenGLProgram*>(state.program);
+
+    // If the material debugger is enabled, avoid fatal (or cascading) errors and that can occur
+    // during the draw call when the program is invalid. The shader compile error has already been
+    // dumped to the console at this point, so it's fine to simply return early.
+    if (FILAMENT_ENABLE_MATDBG && UTILS_UNLIKELY(!p->isValid())) {
+        return;
+    }
+
     useProgram(p);
 
     const GLRenderPrimitive* rp = handle_cast<const GLRenderPrimitive *>(rph);

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -150,11 +150,11 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
         mIsValid = true;
     }
 
-    // failing to compile a program can't be fatal, because this will happen a lot in
+    // Failing to compile a program can't be fatal, because this will happen a lot in
     // the material tools. We need to have a better way to handle these errors and
-    // return to the editor.
+    // return to the editor. Also note the early "return" statements in this function.
     if (UTILS_UNLIKELY(!isValid())) {
-        PANIC_LOG("failed to compile glsl program");
+        PANIC_LOG("Failed to compile GLSL program.");
     }
 }
 


### PR DESCRIPTION
We now check for FILAMENT_ENABLE_MATDBG and simply skip the draw call
when the program is invalid. The initial error message is still dumped
to the console, but we will not terminate or dump an infinite cascade of
error messages.