### PR TITLE
matdbg: allow live editing for GLSL shaders.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: Fixed a transforms issue with non-uniform scale.
 - webgl: Fixed an issue with JPEG textures.
 - Windows: fix link error in debug builds.
+- The web-based material inspector now allows editing GLSL code.
 
 ## v1.3.2
 

--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PUBLIC_HDR_DIR include)
 set(PUBLIC_HDRS
     include/matdbg/DebugServer.h
     include/matdbg/JsonWriter.h
+    include/matdbg/ShaderReplacer.h
     include/matdbg/ShaderExtractor.h
     include/matdbg/ShaderInfo.h
     include/matdbg/TextWriter.h
@@ -20,6 +21,7 @@ set(SRCS
     src/CommonWriter.h
     src/DebugServer.cpp
     src/JsonWriter.cpp
+    src/ShaderReplacer.cpp
     src/ShaderExtractor.cpp
     src/ShaderInfo.cpp
     src/TextWriter.cpp

--- a/libs/matdbg/include/matdbg/DebugServer.h
+++ b/libs/matdbg/include/matdbg/DebugServer.h
@@ -17,7 +17,10 @@
 #ifndef MATDBG_DEBUGSERVER_H
 #define MATDBG_DEBUGSERVER_H
 
+#include <utils/compiler.h>
 #include <utils/CString.h>
+
+#include <backend/DriverEnums.h>
 
 #include <tsl/robin_map.h>
 
@@ -61,7 +64,7 @@ private:
 
     struct MaterialRecord {
         void* userdata;
-        uint8_t* package;
+        const uint8_t* package;
         size_t packageSize;
         utils::CString name;
         MaterialKey key;
@@ -69,7 +72,15 @@ private:
 
     const MaterialRecord* getRecord(const MaterialKey& key) const;
 
-    const ServerMode mServerMode;
+    /**
+     *  Replaces the entire content of a particular shader variant. The given shader index uses the
+     *  same ordering that the variants have within the package.
+     */
+    bool handleEditCommand(const MaterialKey& mat, backend::Backend api, int shaderIndex,
+            const char* newShaderContent, size_t newShaderLength);
+
+    UTILS_UNUSED const ServerMode mServerMode;
+
     CivetServer* mServer;
     tsl::robin_map<MaterialKey, MaterialRecord> mMaterialRecords;
     utils::CString mHtml;

--- a/libs/matdbg/include/matdbg/ShaderExtractor.h
+++ b/libs/matdbg/include/matdbg/ShaderExtractor.h
@@ -28,6 +28,8 @@
 namespace filament {
 namespace matdbg {
 
+// ShaderExtractor is a utility class for extracting shader source from a material package. It works
+// in a manner similar to ShaderReplacer.
 class ShaderExtractor {
 public:
     ShaderExtractor(backend::Backend backend, const void* data, size_t size);

--- a/libs/matdbg/include/matdbg/ShaderReplacer.h
+++ b/libs/matdbg/include/matdbg/ShaderReplacer.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MATDBG_SHADERREPLACER_H
+#define MATDBG_SHADERREPLACER_H
+
+#include <filaflat/ChunkContainer.h>
+
+#include <backend/DriverEnums.h>
+
+namespace filament {
+namespace matdbg {
+
+// ShaderReplacer is a utility class for replacing shader source within a material package. It works
+// in a manner similar to ShaderExtractor.
+class ShaderReplacer {
+public:
+    ShaderReplacer(backend::Backend backend, const void* data, size_t size);
+    ~ShaderReplacer();
+    bool replaceShaderSource(backend::ShaderModel shaderModel, uint8_t variant,
+            backend::ShaderType stage, const char* sourceString, size_t stringLength);
+    const uint8_t* getEditedPackage() const;
+    size_t getEditedSize() const;
+private:
+    const backend::Backend mBackend;
+    filaflat::ChunkContainer mOriginalPackage;
+    filaflat::ChunkContainer* mEditedPackage = nullptr;
+    filamat::ChunkType mMaterialTag = filamat::ChunkType::Unknown;
+    filamat::ChunkType mDictionaryTag = filamat::ChunkType::Unknown;
+};
+
+} // namespace matdbg
+} // namespace filament
+
+#endif  // MATDBG_SHADERREPLACER_H

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -24,6 +24,7 @@
 #include <spirv_glsl.hpp>
 #include <spirv-tools/libspirv.h>
 
+#include <matdbg/ShaderReplacer.h>
 #include <matdbg/ShaderExtractor.h>
 #include <matdbg/ShaderInfo.h>
 #include <matdbg/JsonWriter.h>
@@ -32,6 +33,7 @@
 
 #include <backend/DriverEnums.h>
 
+#include <sstream>
 #include <string>
 
 // If set to 0, this serves HTML from a resgen resource. Use 1 only during local development, which
@@ -202,13 +204,6 @@ public:
         }
 
         if (glindex[0]) {
-            ShaderExtractor extractor(Backend::OPENGL, result->package, result->packageSize);
-            if (!extractor.parse() ||
-                    (!extractor.isShadingMaterial() && !extractor.isPostProcessMaterial())) {
-                return error(__LINE__);
-            }
-
-            filaflat::ShaderBuilder builder;
             std::vector<ShaderInfo> info(getShaderCount(package, ChunkType::MaterialGlsl));
             if (!getGlShaderInfo(package, info.data())) {
                 return error(__LINE__);
@@ -219,7 +214,14 @@ public:
                 return error(__LINE__);
             }
 
+            ShaderExtractor extractor(Backend::OPENGL, result->package, result->packageSize);
+            if (!extractor.parse() ||
+                    (!extractor.isShadingMaterial() && !extractor.isPostProcessMaterial())) {
+                return error(__LINE__);
+            }
+
             const auto& item = info[shaderIndex];
+            filaflat::ShaderBuilder builder;
             extractor.getShader(item.shaderModel, item.variant, item.pipelineStage, builder);
 
             mg_printf(conn, kSuccessHeader.c_str(), "application/txt");
@@ -316,7 +318,41 @@ public:
 
     bool handleData(CivetServer *server, struct mg_connection *conn, int bits, char *data,
             size_t size) override {
-        // TODO: trigger the "shader has been edited" callback via mServer->mEditHandler(...)
+        // TODO: Is there a better way to ignore the handshake message that occurs after startup?
+        if  (size < 8) {
+            return true;
+        }
+
+        // Every WebSocket message is prefixed with a 4-character command followed by a space.
+        //
+        // For now we simply use istringstream for parsing, so command arguments are delimited
+        // with space characters.
+        //
+        // The "API index" matches the values of filament::backend::Backend (zero is invalid).
+        //
+        // The "shader index" is a zero-based index into the list of variants using the order that
+        // they appear in the package, where each API (GL / VK / Metal) has its own list.
+        //
+        // Commands:
+        //
+        //     EDIT [material id] [api index] [shader index] [entire shader source....]
+        //
+
+        const static StaticString kEditCmd = "EDIT ";
+        const static size_t kEditCmdLength = kEditCmd.size();
+
+        if (strncmp(data, kEditCmd.c_str(), kEditCmdLength)) {
+            slog.e << "Bad WebSocket message." << io::endl;
+            return false;
+        }
+        std::istringstream str(data + kEditCmdLength);
+        uint32_t matid;
+        int api;
+        int shaderIndex;
+        str >> std::hex >> matid >> std::dec >> api >> shaderIndex;
+        const char* source = data + kEditCmdLength + str.tellg();
+        const size_t remaining = size - kEditCmdLength - str.tellg();
+        mServer->handleEditCommand(matid, backend::Backend(api), shaderIndex, source, remaining);
         return true;
     }
 
@@ -408,6 +444,76 @@ void DebugServer::addMaterial(const CString& name, const void* data, size_t size
 const DebugServer::MaterialRecord* DebugServer::getRecord(const MaterialKey& key) const {
     const auto& iter = mMaterialRecords.find(key);
     return iter == mMaterialRecords.end() ? nullptr : &iter->second;
+}
+
+bool DebugServer::handleEditCommand(const MaterialKey& key, backend::Backend api, int shaderIndex,
+            const char* source, size_t size) {
+    const auto error = [](int line) {
+        slog.e << "DebugServer: Unable to apply shader edit at line " << line << io::endl;
+        return false;
+    };
+
+    if (mMaterialRecords.find(key) == mMaterialRecords.end()) {
+        return error(__LINE__);
+    }
+    MaterialRecord& material = mMaterialRecords[key];
+    filaflat::ChunkContainer package(material.package, material.packageSize);
+    if (!package.parse()) {
+        return error(__LINE__);
+    }
+
+    const backend::Backend apiType = (backend::Backend) api;
+    std::vector<ShaderInfo> infos;
+    size_t shaderCount;
+    switch (apiType) {
+        case backend::Backend::OPENGL: {
+            shaderCount = getShaderCount(package, ChunkType::MaterialGlsl);
+            infos.resize(shaderCount);
+            if (!getGlShaderInfo(package, infos.data())) {
+                return error(__LINE__);
+            }
+            break;
+        }
+        case backend::Backend::VULKAN: {
+            shaderCount = getShaderCount(package, ChunkType::MaterialSpirv);
+            infos.resize(shaderCount);
+            if (!getVkShaderInfo(package, infos.data())) {
+                return error(__LINE__);
+            }
+            break;
+        }
+        case backend::Backend::METAL: {
+            shaderCount = getShaderCount(package, ChunkType::MaterialMetal);
+            infos.resize(shaderCount);
+            if (!getMetalShaderInfo(package, infos.data())) {
+                return error(__LINE__);
+            }
+            break;
+        }
+        default:
+            error(__LINE__);
+    }
+
+    if (shaderIndex < 0 || shaderIndex >= shaderCount) {
+        return error(__LINE__);
+    }
+
+    const ShaderInfo info = infos[shaderIndex];
+    ShaderReplacer editor(apiType, package.getData(), package.getSize());
+    if (!editor.replaceShaderSource(info.shaderModel, info.variant, info.pipelineStage, source, size)) {
+        return error(__LINE__);
+    }
+
+    delete [] material.package;
+
+    material.package = editor.getEditedPackage();
+    material.packageSize = editor.getEditedSize();
+
+    if (mEditCallback) {
+        mEditCallback(material.userdata, material.name, material.package, material.packageSize);
+    }
+
+    return true;
 }
 
 } // namespace matdbg

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -94,8 +94,7 @@ bool ShaderExtractor::getShader(ShaderModel shaderModel,
         return false;
     }
 
-    return mMaterialChunk.getShader(shader,
-            blobDictionary, (uint8_t)shaderModel, variant, stage);
+    return mMaterialChunk.getShader(shader, blobDictionary, (uint8_t)shaderModel, variant, stage);
 }
 
 CString ShaderExtractor::spirvToGLSL(const uint32_t* data, size_t wordCount) {

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <matdbg/ShaderReplacer.h>
+
+#include <backend/DriverEnums.h>
+
+#include <utils/Log.h>
+
+#include <tsl/robin_map.h>
+
+#include <sstream>
+
+namespace filament {
+namespace matdbg {
+
+using namespace backend;
+using namespace filaflat;
+using namespace std;
+using namespace tsl;
+using namespace utils;
+
+using filamat::ChunkType;
+
+// Utility class for managing a pair of lists: a list of shader records, and a list of string lines
+// that can be encoded into an index list. Also knows how to read & write the relevant IFF chunks.
+class ShaderIndex {
+public:
+    // Consumes a chunk and builds the string list.
+    void addStringLines(const uint8_t* chunkContent, size_t size);
+
+    // Consumes a chunk and builds the shader records.
+    void addShaderRecords(const uint8_t* chunkContent, size_t size);
+
+    // Produces a chunk holding the string list.
+    void writeLinesChunk(ChunkType tag, ostream& stream) const;
+
+    // Produces a chunk holding the shader records.
+    void writeShadersChunk(ChunkType tag, ostream& stream) const;
+
+    // Replaces the specified shader text with new content.
+    void replaceShader(backend::ShaderModel shaderModel, uint8_t variant,
+            backend::ShaderType stage, const char* source, size_t sourceLength);
+
+    bool isEmpty() const { return mStringLines.size() == 0 && mShaderRecords.size() == 0; }
+
+private:
+    struct ShaderRecord {
+        uint8_t model;
+        uint8_t variant;
+        uint8_t stage;
+        uint32_t offset;
+        vector<uint16_t> lineIndices;
+        string decodedShaderText;
+        uint32_t stringLength;
+    };
+
+    void decodeShadersFromIndices();
+    void encodeShadersToIndices();
+
+    vector<ShaderRecord> mShaderRecords;
+    vector<string> mStringLines;
+};
+
+ShaderReplacer::ShaderReplacer(Backend backend, const void* data, size_t size) :
+        mBackend(backend), mOriginalPackage(data, size) {
+    switch (backend) {
+        case Backend::OPENGL:
+            mMaterialTag = ChunkType::MaterialGlsl;
+            mDictionaryTag = ChunkType::DictionaryGlsl;
+            break;
+        case Backend::METAL:
+            mMaterialTag = ChunkType::MaterialMetal;
+            mDictionaryTag = ChunkType::DictionaryMetal;
+            break;
+        case Backend::VULKAN:
+            mMaterialTag = ChunkType::MaterialSpirv;
+            mDictionaryTag = ChunkType::DictionarySpirv;
+            break;
+        default:
+            break;
+    }
+}
+
+ShaderReplacer::~ShaderReplacer() {
+    delete mEditedPackage;
+}
+
+bool ShaderReplacer::replaceShaderSource(backend::ShaderModel shaderModel, uint8_t variant,
+            backend::ShaderType stage, const char* source, size_t sourceLength) {
+    if (!mOriginalPackage.parse()) {
+        return false;
+    }
+
+    ChunkContainer const& cc = mOriginalPackage;
+    if (!cc.hasChunk(mMaterialTag) || !cc.hasChunk(mDictionaryTag)) {
+        return false;
+    }
+
+    if (mDictionaryTag == ChunkType::DictionarySpirv) {
+        slog.e << "SPIR-V editing is not yet supported." << io::endl;
+        return false;
+    }
+
+    // Clone all chunks except Dictionary* and Material*.
+    stringstream sstream(string((const char*) cc.getData(), cc.getSize()));
+    stringstream tstream;
+    ShaderIndex shaderIndex;
+    {
+        uint64_t type;
+        uint32_t size;
+        vector<uint8_t> content;
+        while (sstream) {
+            sstream.read((char*) &type, sizeof(type));
+            sstream.read((char*) &size, sizeof(size));
+            content.resize(size);
+            sstream.read((char*) content.data(), size);
+            if (ChunkType(type) == mDictionaryTag) {
+                shaderIndex.addStringLines(content.data(), size);
+                continue;
+            }
+            if (ChunkType(type) == mMaterialTag) {
+                shaderIndex.addShaderRecords(content.data(), size);
+                continue;
+            }
+            tstream.write((char*) &type, sizeof(type));
+            tstream.write((char*) &size, sizeof(size));
+            tstream.write((char*) content.data(), size);
+        }
+    }
+
+    // Append the new chunks for Dictionary* and Material*.
+    if (!shaderIndex.isEmpty()) {
+        shaderIndex.replaceShader(shaderModel, variant, stage, source, sourceLength);
+        shaderIndex.writeLinesChunk(mDictionaryTag, tstream);
+        shaderIndex.writeShadersChunk(mMaterialTag, tstream);
+    }
+
+    // Copy the new package from the stringstream into a ChunkContainer.
+    const size_t size = tstream.str().size();
+    uint8_t* data = new uint8_t[size];
+    memcpy(data, tstream.str().data(), size);
+    mEditedPackage = new filaflat::ChunkContainer(data, size);
+    return true;
+}
+
+const uint8_t* ShaderReplacer::getEditedPackage() const {
+    return  (const uint8_t*) mEditedPackage->getData();
+}
+
+size_t ShaderReplacer::getEditedSize() const {
+    return  mEditedPackage->getSize();
+}
+
+void ShaderIndex::addStringLines(const uint8_t* chunkContent, size_t size) {
+    uint32_t count = *((const uint32_t*) chunkContent);
+    mStringLines.resize(count);
+    const uint8_t* ptr = chunkContent + 4;
+    for (uint32_t i = 0; i < count; i++) {
+        mStringLines[i] = string((const char*) ptr);
+        ptr += mStringLines[i].length() + 1;
+    }
+}
+
+void ShaderIndex::addShaderRecords(const uint8_t* chunkContent, size_t size) {
+    stringstream stream(string((const char*) chunkContent, size));
+    uint64_t recordCount;
+    stream.read((char*) &recordCount, sizeof(recordCount));
+    mShaderRecords.resize(recordCount);
+    for (auto& record : mShaderRecords) {
+        stream.read((char*) &record.model, sizeof(ShaderRecord::model));
+        stream.read((char*) &record.variant, sizeof(ShaderRecord::variant));
+        stream.read((char*) &record.stage, sizeof(ShaderRecord::stage));
+        stream.read((char*) &record.offset, sizeof(ShaderRecord::offset));
+
+        const uint8_t* linePtr = chunkContent + record.offset;
+        record.stringLength = *((uint32_t*) linePtr);
+        linePtr += sizeof(uint32_t);
+
+        const uint32_t lineCount = *((uint32_t*) linePtr);
+        record.lineIndices.resize(lineCount);
+        linePtr += sizeof(uint32_t);
+
+        memcpy(record.lineIndices.data(), linePtr, lineCount * sizeof(uint16_t));
+    }
+}
+
+void ShaderIndex::writeLinesChunk(ChunkType tag, ostream& stream) const {
+    // First perform a prepass to compute chunk size.
+    uint32_t size = sizeof(uint32_t);
+    for (const auto& stringLine : mStringLines) {
+        size += stringLine.length() + 1;
+    }
+
+    // Serialize the chunk.
+    uint64_t type = tag;
+    stream.write((char*) &type, sizeof(type));
+    stream.write((char*) &size, sizeof(size));
+    uint32_t count = mStringLines.size();
+    stream.write((char*) &count, sizeof(count));
+    for (const auto& stringLine : mStringLines) {
+        stream.write(stringLine.c_str(), stringLine.length() + 1);
+    }
+}
+
+void ShaderIndex::writeShadersChunk(ChunkType tag, ostream& stream) const {
+    // First perform a prepass to compute chunk size.
+    uint32_t size = sizeof(uint64_t);
+    for (const auto& record : mShaderRecords) {
+        size += sizeof(ShaderRecord::model);
+        size += sizeof(ShaderRecord::variant);
+        size += sizeof(ShaderRecord::stage);
+        size += sizeof(ShaderRecord::offset);
+    }
+    for (const auto& record : mShaderRecords) {
+        size += sizeof(ShaderRecord::stringLength);
+        size += sizeof(uint32_t);
+        size += record.lineIndices.size() * sizeof(uint16_t);
+    }
+
+    // Serialize the chunk.
+    uint64_t type = tag;
+    stream.write((char*) &type, sizeof(type));
+    stream.write((char*) &size, sizeof(size));
+    uint64_t recordCount = mShaderRecords.size();
+    stream.write((char*) &recordCount, sizeof(recordCount));
+    for (const auto& record : mShaderRecords) {
+        stream.write((char*) &record.model, sizeof(ShaderRecord::model));
+        stream.write((char*) &record.variant, sizeof(ShaderRecord::variant));
+        stream.write((char*) &record.stage, sizeof(ShaderRecord::stage));
+        stream.write((char*) &record.offset, sizeof(ShaderRecord::offset));
+    }
+    for (const auto& record : mShaderRecords) {
+        uint32_t lineCount = record.lineIndices.size();
+        stream.write((char*) &record.stringLength, sizeof(ShaderRecord::stringLength));
+        stream.write((char*) &lineCount, sizeof(lineCount));
+        stream.write((char*) record.lineIndices.data(), lineCount * sizeof(uint16_t));
+    }
+}
+
+void ShaderIndex::replaceShader(backend::ShaderModel shaderModel, uint8_t variant,
+            backend::ShaderType stage, const char* source, size_t sourceLength) {
+    decodeShadersFromIndices();
+    const uint8_t model = (uint8_t) shaderModel;
+    for (auto& record : mShaderRecords) {
+        if (record.model == model && record.variant == variant && record.stage == stage) {
+            record.decodedShaderText = std::string(source, sourceLength);
+            break;
+        }
+    }
+    encodeShadersToIndices();
+}
+
+void ShaderIndex::decodeShadersFromIndices() {
+    for (auto& record : mShaderRecords) {
+        record.decodedShaderText.clear();
+        for (uint16_t index : record.lineIndices) {
+            if (index >= mStringLines.size()) {
+                slog.e << "Internal chunk decoding error." << io::endl;
+                return;
+            }
+            record.decodedShaderText += mStringLines[index] + "\n";
+        }
+    }
+}
+
+void ShaderIndex::encodeShadersToIndices() {
+    robin_map<string, uint16_t> table;
+    for (size_t i = 0; i < mStringLines.size(); i++) {
+        table[mStringLines[i]] = uint16_t(i);
+    }
+
+    uint32_t offset = sizeof(uint64_t);
+    for (const auto& record : mShaderRecords) {
+        offset += sizeof(ShaderRecord::model);
+        offset += sizeof(ShaderRecord::variant);
+        offset += sizeof(ShaderRecord::stage);
+        offset += sizeof(ShaderRecord::offset);
+    }
+
+    for (auto& record : mShaderRecords) {
+        record.stringLength = record.decodedShaderText.length() + 1;
+        record.lineIndices.clear();
+        record.offset = offset;
+
+        offset += sizeof(ShaderRecord::stringLength);
+        offset += sizeof(uint32_t);
+
+        const char* s = record.decodedShaderText.c_str();
+        size_t length = record.decodedShaderText.length();
+        for (size_t cur = 0; s[cur] != '\0'; cur++) {
+            size_t pos = cur;
+            size_t len = 0;
+            while (s[cur] != '\n') {
+                cur++;
+                len++;
+            }
+            if (pos + len > length) {
+                slog.e << "Internal chunk encoding error." << io::endl;
+                return;
+            }
+            string newLine(s, pos, len);
+            auto iter = table.find(newLine);
+            if (iter == table.end()) {
+                size_t index = mStringLines.size();
+                if (index > UINT16_MAX) {
+                    slog.e << "Chunk encoding error: too many unique codelines." << io::endl;
+                    return;
+                }
+                record.lineIndices.push_back(index);
+                table[newLine] = index;
+                mStringLines.push_back(newLine);
+                continue;
+            }
+            record.lineIndices.push_back(iter->second);
+        }
+        offset += sizeof(uint16_t) * record.lineIndices.size();
+    }
+}
+
+
+} // namespace matdbg
+} // namespace filament

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -42,8 +42,6 @@ using filaflat::ChunkContainer;
 using filament::backend::Backend;
 using utils::Path;
 
-static const int alignment = 24;
-
 struct Config {
     bool printGLSL = false;
     bool printSPIRV = false;


### PR DESCRIPTION
This performs surgical modification of the IFF chunks rather than
invoking filamat from within matdbg. Low-level direct manipulation
(bypassing optimization passes etc) allows us to diagnose issues with
the shading pipeline.

This CL also adds keystroke bindings to the Monaco editor. You can
press Cmd+S to rebuild the current materials, or use Ctrl+Arrow to
navigate between shader variants and materials.

In a subsequent CL I will add a README that describes how this works in
detail, it will include a list of limitations and a feature wishlist.