### PR TITLE
better handle float rendertargets

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1745,9 +1745,8 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
         case TextureFormat::RGBA16F:
             return ext.EXT_color_buffer_float || ext.EXT_color_buffer_half_float;
 
-        // RGB32F and RGB16F are only supported with EXT_color_buffer_half_float
+        // RGB16F is only supported with EXT_color_buffer_half_float
         case TextureFormat::RGB16F:
-        case TextureFormat::RGB32F:
             return ext.EXT_color_buffer_half_float;
 
         // Float formats from GL_EXT_color_buffer_float

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -542,6 +542,8 @@ private:
         bool OES_EGL_image_external_essl3 = false;
         bool EXT_debug_marker = false;
         bool EXT_color_buffer_half_float = false;
+        bool EXT_color_buffer_float = false;
+        bool APPLE_color_buffer_packed_float = false;
         bool EXT_multisampled_render_to_texture = false;
     } ext;
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -121,7 +121,9 @@ private:
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;
     FrameInfoManager mFrameInfoManager;
-    bool mIsRGB16FSupported : 1;
+    backend::TextureFormat mHdrTranslucent{};
+    backend::TextureFormat mHdrQualityMedium{};
+    backend::TextureFormat mHdrQualityHigh{};
     bool mIsRGB8Supported : 1;
     Epoch mUserEpoch;
     math::float4 mShaderUserTime{};


### PR DESCRIPTION
some driver don't support all float buffers as rendertarget, so we
improve the backends (opengl in this PR) to return what it actually
supports and we update the client (filament) to take that into
account when making decisions.

fixes #1533