### PR TITLE
simplify DriverAPI.inc macros

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -59,143 +59,40 @@
  * Convenience macros. These are PRIVATE, don't use.
  */
 
-// turns all arguments of this macro into a single argument
-#define SINGLE_ARG(...) __VA_ARGS__
+#define PAIR_ARGS_1(M, X, Y, ...) M(X, Y)
+#define PAIR_ARGS_2(M, X, Y, ...) M(X, Y), PAIR_ARGS_1(M, __VA_ARGS__)
+#define PAIR_ARGS_3(M, X, Y, ...) M(X, Y), PAIR_ARGS_2(M, __VA_ARGS__)
+#define PAIR_ARGS_4(M, X, Y, ...) M(X, Y), PAIR_ARGS_3(M, __VA_ARGS__)
+#define PAIR_ARGS_5(M, X, Y, ...) M(X, Y), PAIR_ARGS_4(M, __VA_ARGS__)
+#define PAIR_ARGS_6(M, X, Y, ...) M(X, Y), PAIR_ARGS_5(M, __VA_ARGS__)
+#define PAIR_ARGS_7(M, X, Y, ...) M(X, Y), PAIR_ARGS_6(M, __VA_ARGS__)
+#define PAIR_ARGS_8(M, X, Y, ...) M(X, Y), PAIR_ARGS_7(M, __VA_ARGS__)
 
-// adds Parameter to the parameter List
-#define PARAM_LIST_ADD(Parameter, List) \
-        SINGLE_ARG(Parameter, List)
+#define PAIR_ARGS_N__(_0, E1, _1, E2, _2, E3, _3, E4, _4, E5, _5, E6, _6, E7, _7, E8, _8, X, ...) PAIR_ARGS_##X
 
-// adds argument Type Parameter to the argument List
-#define ARG_LIST_ADD(Type, Parameter, List) \
-        SINGLE_ARG(Type Parameter, List)
+#define PAIR_ARGS_N(M, ...) \
+    PAIR_ARGS_N__(0, ##__VA_ARGS__, 8, E, 7, E, 6, E, 5, E, 4, E, 3, E, 2, E, 1, E, 0)(M, __VA_ARGS__)
 
-// parameter lists
-#define PARAM_1( P0)                                          P0
-#define PARAM_2( P1,  P0)                                     PARAM_LIST_ADD(P1,  PARAM_1( P0))
-#define PARAM_3( P2,  P1, P0)                                 PARAM_LIST_ADD(P2,  PARAM_2( P1, P0))
-#define PARAM_4( P3,  P2, P1, P0)                             PARAM_LIST_ADD(P3,  PARAM_3( P2, P1, P0))
-#define PARAM_5( P4,  P3, P2, P1, P0)                         PARAM_LIST_ADD(P4,  PARAM_4( P3, P2, P1, P0))
-#define PARAM_6( P5,  P4, P3, P2, P1, P0)                     PARAM_LIST_ADD(P5,  PARAM_5( P4, P3, P2, P1, P0))
-#define PARAM_7( P6,  P5, P4, P3, P2, P1, P0)                 PARAM_LIST_ADD(P6,  PARAM_6( P5, P4, P3, P2, P1, P0))
-#define PARAM_8( P7,  P6, P5, P4, P3, P2, P1, P0)             PARAM_LIST_ADD(P7,  PARAM_7( P6, P5, P4, P3, P2, P1, P0))
-#define PARAM_9( P8,  P7, P6, P5, P4, P3, P2, P1, P0)         PARAM_LIST_ADD(P8,  PARAM_8( P7, P6, P5, P4, P3, P2, P1, P0))
-#define PARAM_10(P9,  P8, P7, P6, P5, P4, P3, P2, P1, P0)     PARAM_LIST_ADD(P9,  PARAM_9( P8, P7, P6, P5, P4, P3, P2, P1, P0))
-#define PARAM_11(P10, P9, P8, P7, P6, P5, P4, P3, P2, P1, P0) PARAM_LIST_ADD(P10, PARAM_10(P9, P8, P7, P6, P5, P4, P3, P2, P1, P0))
+#define ARG(T, P) T P
 
-// argument lists
-#define ARG_1( T0,  P0)                                                                                  T0 P0
-#define ARG_2( T1,  P1,  T0, P0)                                                                         ARG_LIST_ADD(T1,  P1,  ARG_1( T0, P0))
-#define ARG_3( T2,  P2,  T1, P1, T0, P0)                                                                 ARG_LIST_ADD(T2,  P2,  ARG_2( T1, P1, T0, P0))
-#define ARG_4( T3,  P3,  T2, P2, T1, P1, T0, P0)                                                         ARG_LIST_ADD(T3,  P3,  ARG_3( T2, P2, T1, P1, T0, P0))
-#define ARG_5( T4,  P4,  T3, P3, T2, P2, T1, P1, T0, P0)                                                 ARG_LIST_ADD(T4,  P4,  ARG_4( T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_6( T5,  P5,  T4, P4, T3, P3, T2, P2, T1, P1, T0, P0)                                         ARG_LIST_ADD(T5,  P5,  ARG_5( T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_7( T6,  P6,  T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0)                                 ARG_LIST_ADD(T6,  P6,  ARG_6( T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_8( T7,  P7,  T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0)                         ARG_LIST_ADD(T7,  P7,  ARG_7( T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_9( T8,  P8,  T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0)                 ARG_LIST_ADD(T8,  P8,  ARG_8( T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_10(T9,  P9,  T8, P8, T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0)         ARG_LIST_ADD(T9,  P9,  ARG_9( T8, P8, T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
-#define ARG_11(T10, P10, T9, P9, T8, P8, T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0) ARG_LIST_ADD(T10, P10, ARG_10(T9, P9, T8, P8, T7, P7, T6, P6, T5, P5, T4, P4, T3, P3, T2, P2, T1, P1, T0, P0))
+#define PARAM(T, P) P
 
+#define DECL_DRIVER_API_N(N, ...) \
+    DECL_DRIVER_API(N, PAIR_ARGS_N(ARG, __VA_ARGS__), PAIR_ARGS_N(PARAM, __VA_ARGS__))
 
-#define DECL_DRIVER_API_0(N)                                                            \
-    DECL_DRIVER_API(N, ARG_1(int, dummy=0),                                             \
-                       PARAM_1(dummy))
+#define DECL_DRIVER_API_R_N(R, N, ...) \
+    DECL_DRIVER_API_RETURN(R, N, PAIR_ARGS_N(ARG, __VA_ARGS__), PAIR_ARGS_N(PARAM, __VA_ARGS__))
 
-#define DECL_DRIVER_API_1(N, T0, P0)                                                    \
-    DECL_DRIVER_API(N, ARG_1(T0, P0),                                                   \
-                       PARAM_1(P0))
+#define DECL_DRIVER_API_SYNCHRONOUS_N(R, N, ...) \
+    DECL_DRIVER_API_SYNCHRONOUS(R, N, PAIR_ARGS_N(ARG, __VA_ARGS__), PAIR_ARGS_N(PARAM, __VA_ARGS__))
 
-#define DECL_DRIVER_API_2(N, T0, P0, T1, P1)                                            \
-    DECL_DRIVER_API(N, ARG_2(T0, P0, T1, P1),                                           \
-                       PARAM_2(P0, P1))
-
-#define DECL_DRIVER_API_3(N, T0, P0, T1, P1, T2, P2)                                    \
-    DECL_DRIVER_API(N, ARG_3(T0, P0, T1, P1, T2, P2),                                   \
-                       PARAM_3(P0, P1, P2))
-
-#define DECL_DRIVER_API_4(N, T0, P0, T1, P1, T2, P2, T3, P3)                            \
-    DECL_DRIVER_API(N, ARG_4(T0, P0, T1, P1, T2, P2, T3, P3),                           \
-                       PARAM_4(P0, P1, P2, P3))
-
-#define DECL_DRIVER_API_5(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4)                    \
-    DECL_DRIVER_API(N, ARG_5(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4),                   \
-                       PARAM_5(P0, P1, P2, P3, P4))
-
-#define DECL_DRIVER_API_6(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5)            \
-    DECL_DRIVER_API(N, ARG_6(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5),           \
-                       PARAM_6(P0, P1, P2, P3, P4, P5))
-
-#define DECL_DRIVER_API_7(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6)    \
-    DECL_DRIVER_API(N, ARG_7(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6),   \
-                       PARAM_7(P0, P1, P2, P3, P4, P5, P6))
-
-#define DECL_DRIVER_API_8(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7)  \
-    DECL_DRIVER_API(N, ARG_8(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7), \
-                       PARAM_8(P0, P1, P2, P3, P4, P5, P6, P7))
-
-#define DECL_DRIVER_API_9(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8)  \
-    DECL_DRIVER_API(N, ARG_9(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8), \
-                       PARAM_9(P0, P1, P2, P3, P4, P5, P6, P7, P8))
-
-#define DECL_DRIVER_API_10(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8, T9, P9)  \
-    DECL_DRIVER_API(N, ARG_10(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8, T9, P9), \
-                       PARAM_10(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9))
-
-#define DECL_DRIVER_API_11(N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8, T9, P9, T10, P10)  \
-    DECL_DRIVER_API(N, ARG_11(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7, T8, P8, T9, P9, T10, P10), \
-                       PARAM_11(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10))
-
-
-#define DECL_DRIVER_API_R_0(R, N)                                                         \
-    DECL_DRIVER_API_RETURN(R, N, ARG_1(int, dummy=0),                                     \
-                       PARAM_1(dummy))
-
-#define DECL_DRIVER_API_R_1(R, N, T0, P0)                                                 \
-    DECL_DRIVER_API_RETURN(R, N, ARG_1(T0, P0),                                           \
-                       PARAM_1(P0))
-
-#define DECL_DRIVER_API_R_2(R, N, T0, P0, T1, P1)                                         \
-    DECL_DRIVER_API_RETURN(R, N, ARG_2(T0, P0, T1, P1),                                   \
-                       PARAM_2(P0, P1))
-
-#define DECL_DRIVER_API_R_3(R, N, T0, P0, T1, P1, T2, P2)                                 \
-    DECL_DRIVER_API_RETURN(R, N, ARG_3(T0, P0, T1, P1, T2, P2),                           \
-                       PARAM_3(P0, P1, P2))
-
-#define DECL_DRIVER_API_R_4(R, N, T0, P0, T1, P1, T2, P2, T3, P3)                         \
-    DECL_DRIVER_API_RETURN(R, N, ARG_4(T0, P0, T1, P1, T2, P2, T3, P3),                   \
-                       PARAM_4(P0, P1, P2, P3))
-
-#define DECL_DRIVER_API_R_5(R, N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4)                 \
-    DECL_DRIVER_API_RETURN(R, N, ARG_5(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4),           \
-                       PARAM_5(P0, P1, P2, P3, P4))
-
-#define DECL_DRIVER_API_R_6(R, N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5)         \
-    DECL_DRIVER_API_RETURN(R, N, ARG_6(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5),   \
-                       PARAM_6(P0, P1, P2, P3, P4, P5))
-
-#define DECL_DRIVER_API_R_7(R, N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6)       \
-    DECL_DRIVER_API_RETURN(R, N, ARG_7(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6), \
-                       PARAM_7(P0, P1, P2, P3, P4, P5, P6))
-
-#define DECL_DRIVER_API_R_8(R, N, T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7)       \
-    DECL_DRIVER_API_RETURN(R, N, ARG_8(T0, P0, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6, T7, P7), \
-                       PARAM_8(P0, P1, P2, P3, P4, P5, P6, P7))
-
-#define DECL_DRIVER_API_SYNCHRONOUS_0(R, N)                                                    \
-    DECL_DRIVER_API_SYNCHRONOUS(R, N,,)
-
-#define DECL_DRIVER_API_SYNCHRONOUS_1(R, N, T0, P0)                                            \
-    DECL_DRIVER_API_SYNCHRONOUS(R, N, ARG_1(T0, P0),                                           \
-                       PARAM_1(P0))
-
-#define DECL_DRIVER_API_SYNCHRONOUS_2(R, N, T0, P0, T1, P1)                                    \
-    DECL_DRIVER_API_SYNCHRONOUS(R, N, ARG_2(T0, P0, T1, P1),                                   \
-                       PARAM_2(P0, P1))
-
-#define DECL_DRIVER_API_SYNCHRONOUS_3(R, N, T0, P0, T1, P1, T2, P2)                            \
-    DECL_DRIVER_API_SYNCHRONOUS(R, N, ARG_3(T0, P0, T1, P1, T2, P2),                           \
-                       PARAM_3(P0, P1, P2))
+/* we can't handle empty lists because we don't have __VA_OPT__() in C++14 and the ## hack
+ * only works for omitted arguments, not empty lists */
+#define PARAM_1( P, ...) P
+#define ARG_1( T, P, ...) T P
+#define DECL_DRIVER_API_0(N)                DECL_DRIVER_API(N, ARG_1(int, dummy=0), PARAM_1(dummy))
+#define DECL_DRIVER_API_R_0(R, N)           DECL_DRIVER_API_RETURN(R, N, ARG_1(int, dummy=0), PARAM_1(dummy))
+#define DECL_DRIVER_API_SYNCHRONOUS_0(R, N) DECL_DRIVER_API_SYNCHRONOUS(R, N,,)
 
 /*
  * Driver API below...
@@ -204,14 +101,14 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
-DECL_DRIVER_API_2(beginFrame,
+DECL_DRIVER_API_N(beginFrame,
         int64_t, monotonic_clock_ns,
         uint32_t, frameId)
 
-DECL_DRIVER_API_1(setPresentationTime,
+DECL_DRIVER_API_N(setPresentationTime,
         int64_t, monotonic_clock_ns)
 
-DECL_DRIVER_API_1(endFrame,
+DECL_DRIVER_API_N(endFrame,
         uint32_t, frameId)
 
 // hint to the driver that we're done with all render targets up to this point. i.e. the driver
@@ -223,19 +120,19 @@ DECL_DRIVER_API_0(flush)
  * -----------------------
  */
 
-DECL_DRIVER_API_R_5(backend::VertexBufferHandle, createVertexBuffer,
+DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
         uint8_t, bufferCount,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
         backend::AttributeArray, attributes,
         backend::BufferUsage, usage)
 
-DECL_DRIVER_API_R_3(backend::IndexBufferHandle, createIndexBuffer,
+DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
         uint32_t, indexCount,
         backend::BufferUsage, usage)
 
-DECL_DRIVER_API_R_8(backend::TextureHandle, createTexture,
+DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
         uint8_t, levels,
         backend::TextureFormat, format,
@@ -245,21 +142,21 @@ DECL_DRIVER_API_R_8(backend::TextureHandle, createTexture,
         uint32_t, depth,
         backend::TextureUsage, usage)
 
-DECL_DRIVER_API_R_1(backend::SamplerGroupHandle, createSamplerGroup,
+DECL_DRIVER_API_R_N(backend::SamplerGroupHandle, createSamplerGroup,
         size_t, size)
 
-DECL_DRIVER_API_R_2(backend::UniformBufferHandle, createUniformBuffer,
+DECL_DRIVER_API_R_N(backend::UniformBufferHandle, createUniformBuffer,
         size_t, size,
         backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_0(backend::RenderPrimitiveHandle, createRenderPrimitive)
 
-DECL_DRIVER_API_R_1(backend::ProgramHandle, createProgram,
+DECL_DRIVER_API_R_N(backend::ProgramHandle, createProgram,
         backend::Program&&, program)
 
 DECL_DRIVER_API_R_0(backend::RenderTargetHandle, createDefaultRenderTarget)
 
-DECL_DRIVER_API_R_7(backend::RenderTargetHandle, createRenderTarget,
+DECL_DRIVER_API_R_N(backend::RenderTargetHandle, createRenderTarget,
         backend::TargetBufferFlags, targetBufferFlags,
         uint32_t, width,
         uint32_t, height,
@@ -270,25 +167,30 @@ DECL_DRIVER_API_R_7(backend::RenderTargetHandle, createRenderTarget,
 
 DECL_DRIVER_API_R_0(backend::FenceHandle, createFence)
 
-DECL_DRIVER_API_R_2(backend::SwapChainHandle, createSwapChain, void*, nativeWindow, uint64_t, flags)
+DECL_DRIVER_API_R_N(backend::SwapChainHandle, createSwapChain,
+        void*, nativeWindow,
+        uint64_t, flags)
 
-DECL_DRIVER_API_R_3(backend::StreamHandle, createStreamFromTextureId, intptr_t, externalTextureId, uint32_t, width, uint32_t, height)
+DECL_DRIVER_API_R_N(backend::StreamHandle, createStreamFromTextureId,
+        intptr_t, externalTextureId,
+        uint32_t, width,
+        uint32_t, height)
 
 /*
  * Destroying driver objects
  * -------------------------
  */
 
-DECL_DRIVER_API_1(destroyVertexBuffer,    backend::VertexBufferHandle, vbh)
-DECL_DRIVER_API_1(destroyIndexBuffer,     backend::IndexBufferHandle, ibh)
-DECL_DRIVER_API_1(destroyRenderPrimitive, backend::RenderPrimitiveHandle, rph)
-DECL_DRIVER_API_1(destroyProgram,         backend::ProgramHandle, ph)
-DECL_DRIVER_API_1(destroySamplerGroup,    backend::SamplerGroupHandle, sbh)
-DECL_DRIVER_API_1(destroyUniformBuffer,   backend::UniformBufferHandle, ubh)
-DECL_DRIVER_API_1(destroyTexture,         backend::TextureHandle, th)
-DECL_DRIVER_API_1(destroyRenderTarget,    backend::RenderTargetHandle, rth)
-DECL_DRIVER_API_1(destroySwapChain,       backend::SwapChainHandle, sch)
-DECL_DRIVER_API_1(destroyStream,          backend::StreamHandle, sh)
+DECL_DRIVER_API_N(destroyVertexBuffer,    backend::VertexBufferHandle, vbh)
+DECL_DRIVER_API_N(destroyIndexBuffer,     backend::IndexBufferHandle, ibh)
+DECL_DRIVER_API_N(destroyRenderPrimitive, backend::RenderPrimitiveHandle, rph)
+DECL_DRIVER_API_N(destroyProgram,         backend::ProgramHandle, ph)
+DECL_DRIVER_API_N(destroySamplerGroup,    backend::SamplerGroupHandle, sbh)
+DECL_DRIVER_API_N(destroyUniformBuffer,   backend::UniformBufferHandle, ubh)
+DECL_DRIVER_API_N(destroyTexture,         backend::TextureHandle, th)
+DECL_DRIVER_API_N(destroyRenderTarget,    backend::RenderTargetHandle, rth)
+DECL_DRIVER_API_N(destroySwapChain,       backend::SwapChainHandle, sch)
+DECL_DRIVER_API_N(destroyStream,          backend::StreamHandle, sh)
 
 /*
  * Synchronous APIs
@@ -296,58 +198,45 @@ DECL_DRIVER_API_1(destroyStream,          backend::StreamHandle, sh)
  */
 
 DECL_DRIVER_API_SYNCHRONOUS_0(void, terminate)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(backend::StreamHandle, createStream, void*, stream)
-
-DECL_DRIVER_API_SYNCHRONOUS_3(void, setStreamDimensions, backend::StreamHandle, stream, uint32_t, width, uint32_t, height)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(int64_t, getStreamTimestamp, backend::StreamHandle, stream)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(void, updateStreams, backend::DriverApi*, driver)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(void, destroyFence, backend::FenceHandle, fh)
-
-DECL_DRIVER_API_SYNCHRONOUS_2(backend::FenceStatus, wait, backend::FenceHandle, fh, uint64_t, timeout)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(bool, isTextureFormatSupported, backend::TextureFormat, format)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(bool, isTextureFormatMipmappable, backend::TextureFormat, format)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
-
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStream, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, setStreamDimensions, backend::StreamHandle, stream, uint32_t, width, uint32_t, height)
+DECL_DRIVER_API_SYNCHRONOUS_N(int64_t, getStreamTimestamp, backend::StreamHandle, stream)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, updateStreams, backend::DriverApi*, driver)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, destroyFence, backend::FenceHandle, fh)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::FenceStatus, wait, backend::FenceHandle, fh, uint64_t, timeout)
+DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatSupported, backend::TextureFormat, format)
+DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::TextureFormat, format)
+DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
-
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(void, setupExternalImage, void*, image)
-
-DECL_DRIVER_API_SYNCHRONOUS_1(void, cancelExternalImage, void*, image)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, cancelExternalImage, void*, image)
 
 /*
  * Updating driver objects
  * -----------------------
  */
 
-DECL_DRIVER_API_4(updateVertexBuffer,
+DECL_DRIVER_API_N(updateVertexBuffer,
         backend::VertexBufferHandle, vbh,
         size_t, index,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
-DECL_DRIVER_API_3(updateIndexBuffer,
+DECL_DRIVER_API_N(updateIndexBuffer,
         backend::IndexBufferHandle, ibh,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
-DECL_DRIVER_API_2(loadUniformBuffer,
+DECL_DRIVER_API_N(loadUniformBuffer,
         backend::UniformBufferHandle, ubh,
         backend::BufferDescriptor&&, buffer)
 
-DECL_DRIVER_API_2(updateSamplerGroup,
+DECL_DRIVER_API_N(updateSamplerGroup,
         backend::SamplerGroupHandle, ubh,
         backend::SamplerGroup&&, samplerGroup)
 
-DECL_DRIVER_API_7(update2DImage,
+DECL_DRIVER_API_N(update2DImage,
         backend::TextureHandle, th,
         uint32_t, level,
         uint32_t, xoffset,
@@ -356,30 +245,30 @@ DECL_DRIVER_API_7(update2DImage,
         uint32_t, height,
         backend::PixelBufferDescriptor&&, data)
 
-DECL_DRIVER_API_4(updateCubeImage,
+DECL_DRIVER_API_N(updateCubeImage,
         backend::TextureHandle, th,
         uint32_t, level,
         backend::PixelBufferDescriptor&&, data,
         backend::FaceOffsets, faceOffsets)
 
-DECL_DRIVER_API_1(generateMipmaps,
+DECL_DRIVER_API_N(generateMipmaps,
         backend::TextureHandle, th)
 
-DECL_DRIVER_API_2(setExternalImage,
+DECL_DRIVER_API_N(setExternalImage,
         backend::TextureHandle, th,
         void*, image)
 
-DECL_DRIVER_API_2(setExternalStream,
+DECL_DRIVER_API_N(setExternalStream,
         backend::TextureHandle, th,
         backend::StreamHandle, sh)
 
-DECL_DRIVER_API_2(beginRenderPass,
+DECL_DRIVER_API_N(beginRenderPass,
         backend::RenderTargetHandle, rth,
         const backend::RenderPassParams&, params)
 
 DECL_DRIVER_API_0(endRenderPass)
 
-DECL_DRIVER_API_6(discardSubRenderTargetBuffers,
+DECL_DRIVER_API_N(discardSubRenderTargetBuffers,
         backend::RenderTargetHandle, rth,
         backend::TargetBufferFlags, targetBufferFlags,
         uint32_t, left,
@@ -387,13 +276,13 @@ DECL_DRIVER_API_6(discardSubRenderTargetBuffers,
         uint32_t, width,
         uint32_t, height)
 
-DECL_DRIVER_API_4(setRenderPrimitiveBuffer,
+DECL_DRIVER_API_N(setRenderPrimitiveBuffer,
         backend::RenderPrimitiveHandle, rph,
         backend::VertexBufferHandle, vbh,
         backend::IndexBufferHandle, ibh,
         uint32_t, enabledAttributes)
 
-DECL_DRIVER_API_6(setRenderPrimitiveRange,
+DECL_DRIVER_API_N(setRenderPrimitiveRange,
         backend::RenderPrimitiveHandle, rph,
         backend::PrimitiveType, pt,
         uint32_t, offset,
@@ -402,7 +291,7 @@ DECL_DRIVER_API_6(setRenderPrimitiveRange,
         uint32_t, count)
 
 // Sets up a scissor rectangle that automatically gets clipped against the viewport.
-DECL_DRIVER_API_4(setViewportScissor,
+DECL_DRIVER_API_N(setViewportScissor,
         int32_t, left,
         int32_t, bottom,
         uint32_t, width,
@@ -412,12 +301,12 @@ DECL_DRIVER_API_4(setViewportScissor,
  * Swap chain
  */
 
-DECL_DRIVER_API_2(makeCurrent,
+DECL_DRIVER_API_N(makeCurrent,
         backend::SwapChainHandle, schDraw,
         backend::SwapChainHandle, schRead)
 
 
-DECL_DRIVER_API_1(commit,
+DECL_DRIVER_API_N(commit,
         backend::SwapChainHandle, sch)
 
 /*
@@ -425,25 +314,25 @@ DECL_DRIVER_API_1(commit,
  * -----------------------
  */
 
-DECL_DRIVER_API_2(bindUniformBuffer,
+DECL_DRIVER_API_N(bindUniformBuffer,
         size_t, index,
         backend::UniformBufferHandle, ubh)
 
-DECL_DRIVER_API_4(bindUniformBufferRange,
+DECL_DRIVER_API_N(bindUniformBufferRange,
         size_t, index,
         backend::UniformBufferHandle, ubh,
         size_t, offset,
         size_t, size)
 
-DECL_DRIVER_API_2(bindSamplers,
+DECL_DRIVER_API_N(bindSamplers,
         size_t, index,
         backend::SamplerGroupHandle, sbh)
 
-DECL_DRIVER_API_2(insertEventMarker,
+DECL_DRIVER_API_N(insertEventMarker,
         const char*, string,
         size_t, len = 0)
 
-DECL_DRIVER_API_2(pushGroupMarker,
+DECL_DRIVER_API_N(pushGroupMarker,
         const char*, string,
         size_t, len = 0)
 
@@ -459,7 +348,7 @@ DECL_DRIVER_API_0(stopCapture)
  * --------------------
  */
 
-DECL_DRIVER_API_6(readPixels,
+DECL_DRIVER_API_N(readPixels,
         backend::RenderTargetHandle, src,
         uint32_t, x,
         uint32_t, y,
@@ -467,7 +356,7 @@ DECL_DRIVER_API_6(readPixels,
         uint32_t, height,
         backend::PixelBufferDescriptor&&, data)
 
-DECL_DRIVER_API_6(readStreamPixels,
+DECL_DRIVER_API_N(readStreamPixels,
         backend::StreamHandle, sh,
         uint32_t, x,
         uint32_t, y,
@@ -480,7 +369,7 @@ DECL_DRIVER_API_6(readStreamPixels,
  * --------------------
  */
 
-DECL_DRIVER_API_6(blit,
+DECL_DRIVER_API_N(blit,
         backend::TargetBufferFlags, buffers,
         backend::RenderTargetHandle, dst,
         backend::Viewport, dstRect,
@@ -488,70 +377,37 @@ DECL_DRIVER_API_6(blit,
         backend::Viewport, srcRect,
         backend::SamplerMagFilter, filter)
 
-DECL_DRIVER_API_2(draw,
+DECL_DRIVER_API_N(draw,
         backend::PipelineState, state,
         backend::RenderPrimitiveHandle, rph)
 
 #pragma clang diagnostic pop
 
-#undef SINGLE_ARG
-#undef PARAM_LIST_ADD
-#undef ARG_LIST_ADD
-
 #undef PARAM_1
-#undef PARAM_2
-#undef PARAM_3
-#undef PARAM_4
-#undef PARAM_5
-#undef PARAM_6
-#undef PARAM_7
-#undef PARAM_8
-#undef PARAM_9
-#undef PARAM_10
-#undef PARAM_11
-
 #undef ARG_1
-#undef ARG_2
-#undef ARG_3
-#undef ARG_4
-#undef ARG_5
-#undef ARG_6
-#undef ARG_7
-#undef ARG_8
-#undef ARG_9
-#undef ARG_10
-#undef ARG_11
-
 #undef DECL_DRIVER_API_0
-#undef DECL_DRIVER_API_1
-#undef DECL_DRIVER_API_2
-#undef DECL_DRIVER_API_3
-#undef DECL_DRIVER_API_4
-#undef DECL_DRIVER_API_5
-#undef DECL_DRIVER_API_6
-#undef DECL_DRIVER_API_7
-#undef DECL_DRIVER_API_8
-#undef DECL_DRIVER_API_9
-#undef DECL_DRIVER_API_10
-#undef DECL_DRIVER_API_11
-
 #undef DECL_DRIVER_API_R_0
-#undef DECL_DRIVER_API_R_1
-#undef DECL_DRIVER_API_R_2
-#undef DECL_DRIVER_API_R_3
-#undef DECL_DRIVER_API_R_4
-#undef DECL_DRIVER_API_R_5
-#undef DECL_DRIVER_API_R_6
-#undef DECL_DRIVER_API_R_7
-#undef DECL_DRIVER_API_R_8
-
 #undef DECL_DRIVER_API_SYNCHRONOUS_0
-#undef DECL_DRIVER_API_SYNCHRONOUS_1
-#undef DECL_DRIVER_API_SYNCHRONOUS_2
-#undef DECL_DRIVER_API_SYNCHRONOUS_3
+
+#undef PARAM
+#undef ARG
+#undef DECL_DRIVER_API_N
+#undef DECL_DRIVER_API_R_N
+#undef DECL_DRIVER_API_SYNCHRONOUS_N
 
 #undef DECL_DRIVER_API
 #undef DECL_DRIVER_API_SYNCHRONOUS
 #undef DECL_DRIVER_API_RETURN
+
+#undef PAIR_ARGS_1
+#undef PAIR_ARGS_2
+#undef PAIR_ARGS_3
+#undef PAIR_ARGS_4
+#undef PAIR_ARGS_5
+#undef PAIR_ARGS_6
+#undef PAIR_ARGS_7
+#undef PAIR_ARGS_8
+#undef PAIR_ARGS_N__
+#undef PAIR_ARGS_N
 
 // No include guard!!!


### PR DESCRIPTION
by using variadic macros we can greatly simplify the macros
definitions for declaring the backend API.

in particular we don't need a macro per number-of-argument, this is
now done automatically.

Unfortunately, we still can't handle zero-argument declarations, so
we keep the _0 variants.