### PR TITLE
gltfio: expose all resource URI strings.

### DIFF
--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -77,9 +77,9 @@ public:
     size_t getTextureBindingCount() const noexcept;
     const TextureBinding* getTextureBindings() const noexcept;
 
-    /** Gets resource URLs for all externally-referenced buffers. */
-    size_t getResourceUrlCount() const noexcept;
-    const char* const* getResourceUrls() const noexcept;
+    /** Gets resource URIs for all externally-referenced buffers. */
+    size_t getResourceUriCount() const noexcept;
+    const char* const* getResourceUris() const noexcept;
 
     /** Gets the bounding box computed from the supplied min / max values in glTF accessors. */
     filament::Aabb getBoundingBox() const noexcept;

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -77,6 +77,10 @@ public:
     size_t getTextureBindingCount() const noexcept;
     const TextureBinding* getTextureBindings() const noexcept;
 
+    /** Gets resource URLs for all externally-referenced buffers. */
+    size_t getResourceUrlCount() const noexcept;
+    const char* const* getResourceUrls() const noexcept;
+
     /** Gets the bounding box computed from the supplied min / max values in glTF accessors. */
     filament::Aabb getBoundingBox() const noexcept;
 

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -247,8 +247,8 @@ void FAssetLoader::createAsset(const cgltf_data* srcAsset) {
         }
     }
 
-    // Find every unique resource URL and store a pointer to any of the cgltf-owned cstrings
-    // that match the URL. These strings get freed during releaseSourceData().
+    // Find every unique resource URI and store a pointer to any of the cgltf-owned cstrings
+    // that match the URI. These strings get freed during releaseSourceData().
     tsl::robin_map<std::string, const char*> resourceUris;
     auto addResourceUri = [&resourceUris](const char* uri) {
         if (uri) {

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -247,6 +247,25 @@ void FAssetLoader::createAsset(const cgltf_data* srcAsset) {
         }
     }
 
+    // Find every unique resource URL and store a pointer to any of the cgltf-owned cstrings
+    // that match the URL. These strings get freed during releaseSourceData().
+    tsl::robin_map<std::string, const char*> resourceUris;
+    auto addResourceUri = [&resourceUris](const char* uri) {
+        if (uri) {
+            resourceUris[uri] = uri;
+        }
+    };
+    for (cgltf_size i = 0, len = srcAsset->buffers_count; i < len; ++i) {
+        addResourceUri(srcAsset->buffers[i].uri);
+    }
+    for (cgltf_size i = 0, len = srcAsset->images_count; i < len; ++i) {
+        addResourceUri(srcAsset->images[i].uri);
+    }
+    mResult->mResourceUrls.reserve(resourceUris.size());
+    for (auto pair : resourceUris) {
+        mResult->mResourceUrls.push_back(pair.second);
+    }
+
     // We're done with the import, so free up transient bookkeeping resources.
     mMatInstanceCache.clear();
     mMeshCache.clear();

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -121,11 +121,11 @@ struct FFilamentAsset : public FilamentAsset {
         return mTextureBindings.data();
     }
 
-    size_t getResourceUrlCount() const noexcept {
+    size_t getResourceUriCount() const noexcept {
         return mResourceUrls.size();
     }
 
-    const char* const* getResourceUrls() const noexcept {
+    const char* const* getResourceUris() const noexcept {
         return mResourceUrls.data();
     }
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -121,6 +121,14 @@ struct FFilamentAsset : public FilamentAsset {
         return mTextureBindings.data();
     }
 
+    size_t getResourceUrlCount() const noexcept {
+        return mResourceUrls.size();
+    }
+
+    const char* const* getResourceUrls() const noexcept {
+        return mResourceUrls.data();
+    }
+
     filament::Aabb getBoundingBox() const noexcept {
         return mBoundingBox;
     }
@@ -156,6 +164,8 @@ struct FFilamentAsset : public FilamentAsset {
         mBufferBindings.shrink_to_fit();
         mTextureBindings.clear();
         mTextureBindings.shrink_to_fit();
+        mResourceUrls.clear();
+        mResourceUrls.shrink_to_fit();
         mNodeMap.clear();
         mPrimMap.clear();
         releaseSourceAsset();
@@ -200,6 +210,7 @@ struct FFilamentAsset : public FilamentAsset {
      * Transient source data that can freed via releaseSourceData(). */
     std::vector<BufferBinding> mBufferBindings;
     std::vector<TextureBinding> mTextureBindings;
+    std::vector<const char*> mResourceUrls;
     const cgltf_data* mSourceAsset = nullptr;
     tsl::robin_map<const cgltf_node*, utils::Entity> mNodeMap;
     tsl::robin_map<const cgltf_primitive*, filament::VertexBuffer*> mPrimMap;

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -63,12 +63,12 @@ const TextureBinding* FilamentAsset::getTextureBindings() const noexcept {
     return upcast(this)->getTextureBindings();
 }
 
-size_t FilamentAsset::getResourceUrlCount() const noexcept {
-    return upcast(this)->getResourceUrlCount();
+size_t FilamentAsset::getResourceUriCount() const noexcept {
+    return upcast(this)->getResourceUriCount();
 }
 
-const char* const* FilamentAsset::getResourceUrls() const noexcept {
-    return upcast(this)->getResourceUrls();
+const char* const* FilamentAsset::getResourceUris() const noexcept {
+    return upcast(this)->getResourceUris();
 }
 
 filament::Aabb FilamentAsset::getBoundingBox() const noexcept {

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -63,6 +63,14 @@ const TextureBinding* FilamentAsset::getTextureBindings() const noexcept {
     return upcast(this)->getTextureBindings();
 }
 
+size_t FilamentAsset::getResourceUrlCount() const noexcept {
+    return upcast(this)->getResourceUrlCount();
+}
+
+const char* const* FilamentAsset::getResourceUrls() const noexcept {
+    return upcast(this)->getResourceUrls();
+}
+
 filament::Aabb FilamentAsset::getBoundingBox() const noexcept {
     return upcast(this)->getBoundingBox();
 }

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -258,7 +258,7 @@ Filament.loadClassExtensions = function() {
     Filament.gltfio$FilamentAsset.prototype.loadResources = function(onDone, onFetched, basePath) {
         const asset = this;
         const engine = this.getEngine();
-        const names = this.getResourceUrls();
+        const names = this.getResourceUris();
         const urlset = new Set();
         const urlToName = {};
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1315,11 +1315,11 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         return std::vector<const MaterialInstance*>(ptr, ptr + self->getMaterialInstanceCount());
     }), allow_raw_pointers())
 
-    .function("getResourceUrls", EMBIND_LAMBDA(std::vector<std::string>, (FilamentAsset* self), {
+    .function("getResourceUris", EMBIND_LAMBDA(std::vector<std::string>, (FilamentAsset* self), {
         std::vector<std::string> retval;
-        auto urls = self->getResourceUrls();
-        for (size_t i = 0, len = self->getResourceUrlCount(); i < len; ++i) {
-            retval.push_back(urls[i]);
+        auto uris = self->getResourceUris();
+        for (size_t i = 0, len = self->getResourceUriCount(); i < len; ++i) {
+            retval.push_back(uris[i]);
         }
         return retval;
     }), allow_raw_pointers())

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1317,13 +1317,9 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
 
     .function("getResourceUrls", EMBIND_LAMBDA(std::vector<std::string>, (FilamentAsset* self), {
         std::vector<std::string> retval;
-        const BufferBinding* bbinding = self->getBufferBindings();
-        for (size_t i = 0, len = self->getBufferBindingCount(); i < len; ++i, ++bbinding) {
-            retval.push_back(bbinding->uri);
-        }
-        const TextureBinding* tbinding = self->getTextureBindings();
-        for (size_t i = 0, len = self->getTextureBindingCount(); i < len; ++i, ++tbinding) {
-            retval.push_back(tbinding->uri);
+        auto urls = self->getResourceUrls();
+        for (size_t i = 0, len = self->getResourceUrlCount(); i < len; ++i) {
+            retval.push_back(urls[i]);
         }
         return retval;
     }), allow_raw_pointers())

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -70,7 +70,7 @@ class App {
 
         const messages = document.getElementById('messages');
 
-        // Crudely indicate progress by printing the URL of each resource as it is loaded.
+        // Crudely indicate progress by printing the URI of each resource as it is loaded.
         // Note that we wait 1 ms after the last asset has downloaded, but before finalization.
         // This gives the browser time to display the latest status.
         const onFetched = (uri) => messages.innerText += `Downloaded ${uri}\n`;


### PR DESCRIPTION
Some buffers (like animation data) do not contain any vertex data but web-based clients still need to know about them.

This interface is much simpler than the bindings lists, and in fact we might remove the binding lists in the future to simplify the API.

Fixes #1593.