### PR TITLE
Ensure GitHub actions target presubmit

### DIFF
--- a/.github/workflows/presubmit-ios.yml
+++ b/.github/workflows/presubmit-ios.yml
@@ -14,4 +14,4 @@ jobs:
         run: |
           cd build/ios && ./build.sh ${TARGET}
         env:
-          target: presubmit
+          TARGET: presubmit

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,4 +19,4 @@ jobs:
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
           cd build/$WORKFLOW_OS && ./build.sh ${TARGET}
         env:
-          target: presubmit
+          TARGET: presubmit


### PR DESCRIPTION
For some reason, the iOS GitHub action is failing when it tries to make an archive. We can deal with that problem later; for now, we can ensure PRs trigger a "presubmit" job (with no archive generation), which they weren't because env vars are case sensitive.