### PR TITLE
Add custom vertex shaders for post-process materials

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -453,15 +453,21 @@ io::sstream& CodeGenerator::generateCommonMaterial(io::sstream& out, ShaderType 
     return out;
 }
 
-io::sstream& CodeGenerator::generateCommonPostProcess(io::sstream& out, ShaderType type) const {
-    if (type == ShaderType::FRAGMENT) {
-        out << SHADERS_COMMON_POST_PROCESS_FS_DATA;
+io::sstream& CodeGenerator::generatePostProcessInputs(io::sstream& out, ShaderType type) const {
+    if (type == ShaderType::VERTEX) {
+        out << SHADERS_POST_PROCESS_INPUTS_VS_DATA;
+    } else if (type == ShaderType::FRAGMENT) {
+        out << SHADERS_POST_PROCESS_INPUTS_FS_DATA;
     }
     return out;
 }
 
-utils::io::sstream& CodeGenerator::generateCommonGetters(utils::io::sstream& out) const {
+utils::io::sstream& CodeGenerator::generatePostProcessGetters(utils::io::sstream& out,
+        ShaderType type) const {
     out << SHADERS_COMMON_GETTERS_FS_DATA;
+    if (type == ShaderType::VERTEX) {
+        out << SHADERS_POST_PROCESS_GETTERS_VS_DATA;
+    }
     return out;
 }
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -64,7 +64,6 @@ public:
     // generate common functions for the given shader
     utils::io::sstream& generateCommon(utils::io::sstream& out, ShaderType type) const;
     utils::io::sstream& generateCommonMaterial(utils::io::sstream& out, ShaderType type) const;
-    utils::io::sstream& generateCommonPostProcess(utils::io::sstream& out, ShaderType type) const;
 
     // generate the shader's main()
     utils::io::sstream& generateShaderMain(utils::io::sstream& out, ShaderType type) const;
@@ -87,6 +86,7 @@ public:
     // generate declarations for non-custom "in" variables
     utils::io::sstream& generateShaderInputs(utils::io::sstream& out, ShaderType type,
         const filament::AttributeBitset& attributes, filament::Interpolation interpolation) const;
+    utils::io::sstream& generatePostProcessInputs(utils::io::sstream& out, ShaderType type) const;
 
     // generate no-op shader for depth prepass
     utils::io::sstream& generateDepthShaderMain(utils::io::sstream& out, ShaderType type) const;
@@ -113,7 +113,7 @@ public:
     utils::io::sstream& generateIndexedDefine(utils::io::sstream& out, const char* name,
             uint32_t index, uint32_t value) const;
 
-    utils::io::sstream& generateCommonGetters(utils::io::sstream& out) const;
+    utils::io::sstream& generatePostProcessGetters(utils::io::sstream& out, ShaderType type) const;
     utils::io::sstream& generateGetters(utils::io::sstream& out, ShaderType type) const;
     utils::io::sstream& generateParameters(utils::io::sstream& out, ShaderType type) const;
 

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -66,6 +66,17 @@ public:
             MaterialInfo const& material) const noexcept;
 
 private:
+
+    const std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
+            MaterialInfo const& material, uint8_t variant,
+            const filament::SamplerBindingMap& samplerBindingMap) const noexcept;
+
+    const std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
+            MaterialInfo const& material, uint8_t variant,
+            const filament::SamplerBindingMap& samplerBindingMap) const noexcept;
+
     MaterialBuilder::PropertyList mProperties;
     MaterialBuilder::VariableList mVariables;
     MaterialBuilder::MaterialDomain mMaterialDomain;
@@ -84,17 +95,6 @@ struct ShaderPostProcessGenerator {
             filament::PostProcessStage variant, uint8_t firstSampler) noexcept;
     static void generatePostProcessStageDefines(utils::io::sstream& vs, CodeGenerator const& cg,
             filament::PostProcessStage variant) noexcept;
-
-    static const std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-            MaterialInfo const& material, uint8_t variant,
-            const filament::SamplerBindingMap& samplerBindingMap,
-            utils::CString const& postProcessCode) noexcept;
-    static const std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
-            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-            MaterialInfo const& material, uint8_t variant,
-            const filament::SamplerBindingMap& samplerBindingMap,
-            utils::CString const& postProcessCode) noexcept;
 };
 
 } // namespace filament

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -18,7 +18,6 @@ set(SHADERS
         src/common_lighting.fs
         src/common_material.fs
         src/common_math.fs
-        src/common_post_process.fs
         src/common_shading.fs
         src/common_types.fs
         src/conversion_functions.fs
@@ -39,6 +38,9 @@ set(SHADERS
         src/material_inputs.vs
         src/post_process.fs
         src/post_process.vs
+        src/post_process_getters.vs
+        src/post_process_inputs.fs
+        src/post_process_inputs.vs
         src/post_process_old.fs
         src/post_process_old.vs
         src/shading_lit.fs

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -1,11 +1,30 @@
-LAYOUT_LOCATION(LOCATION_POSITION) in vec4 position;
-
-LAYOUT_LOCATION(0) out vec2 vertex_uv;
-
 void main() {
-    vertex_uv = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
+    // Initialize the vertex shader inputs to sensible default values.
+    PostProcessVertexInputs inputs;
+    initPostProcessMaterialVertex(inputs);
+
+    inputs.uv = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
 
     gl_Position = position;
+
+    // Invoke user code
+    postProcessVertex(inputs);
+
+    vertex_uv = inputs.uv;
+
+    // Handle user-defined interpolated attributes
+#if defined(VARIABLE_CUSTOM0)
+    VARIABLE_CUSTOM_AT0 = inputs.VARIABLE_CUSTOM0;
+#endif
+#if defined(VARIABLE_CUSTOM1)
+    VARIABLE_CUSTOM_AT1 = inputs.VARIABLE_CUSTOM1;
+#endif
+#if defined(VARIABLE_CUSTOM2)
+    VARIABLE_CUSTOM_AT2 = inputs.VARIABLE_CUSTOM2;
+#endif
+#if defined(VARIABLE_CUSTOM3)
+    VARIABLE_CUSTOM_AT3 = inputs.VARIABLE_CUSTOM3;
+#endif
 
 #if defined(TARGET_METAL_ENVIRONMENT)
     // Metal texture space is vertically flipped that of OpenGL's, so flip the Y coords so we sample

--- a/shaders/src/post_process_getters.vs
+++ b/shaders/src/post_process_getters.vs
@@ -1,0 +1,4 @@
+/** @public-api */
+vec4 getPosition() {
+    return position;
+}

--- a/shaders/src/post_process_inputs.fs
+++ b/shaders/src/post_process_inputs.fs
@@ -1,4 +1,4 @@
-LAYOUT_LOCATION(0) in highp vec2 vertex_uv;
+LAYOUT_LOCATION(LOCATION_UVS) in highp vec2 vertex_uv;
 
 LAYOUT_LOCATION(0) out vec4 fragColor;
 

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -1,0 +1,34 @@
+LAYOUT_LOCATION(LOCATION_POSITION) in vec4 position;
+
+LAYOUT_LOCATION(LOCATION_UVS) out vec2 vertex_uv;
+
+struct PostProcessVertexInputs {
+    vec2 uv;
+#ifdef VARIABLE_CUSTOM0
+    vec4 VARIABLE_CUSTOM0;
+#endif
+#ifdef VARIABLE_CUSTOM1
+    vec4 VARIABLE_CUSTOM1;
+#endif
+#ifdef VARIABLE_CUSTOM2
+    vec4 VARIABLE_CUSTOM2;
+#endif
+#ifdef VARIABLE_CUSTOM3
+    vec4 VARIABLE_CUSTOM3;
+#endif
+};
+
+void initPostProcessMaterialVertex(out PostProcessVertexInputs inputs) {
+#ifdef VARIABLE_CUSTOM0
+    inputs.VARIABLE_CUSTOM0 = vec4(0.0);
+#endif
+#ifdef VARIABLE_CUSTOM1
+    inputs.VARIABLE_CUSTOM1 = vec4(0.0);
+#endif
+#ifdef VARIABLE_CUSTOM2
+    inputs.VARIABLE_CUSTOM2 = vec4(0.0);
+#endif
+#ifdef VARIABLE_CUSTOM3
+    inputs.VARIABLE_CUSTOM3 = vec4(0.0);
+#endif
+}


### PR DESCRIPTION
Support custom vertex shaders in post-process materials:

```
vertex {
    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
        vec4 position = getPosition(); // clip-space
        postProcess.customVariable.xy = (position.xy * 0.5 + 0.5);
    }
}
```