### PR TITLE
Use resgen to make builds faster.

### DIFF
--- a/tools/resgen/src/main.cpp
+++ b/tools/resgen/src/main.cpp
@@ -300,8 +300,8 @@ int main(int argc, char* argv[]) {
         // Write the xxd-style ASCII array, followed by a blank line.
         if (g_generateC) {
             xxdDefinitions
-                    << "int " << prname << "_OFFSET = " << offset << "\n"
-                    << "int " << prname << "_SIZE = " << content.size() << "\n";
+                    << "int " << prname << "_OFFSET = " << offset << ";\n"
+                    << "int " << prname << "_SIZE = " << content.size() << ";\n";
 
             xxdStream << "// " << rname << "\n";
             xxdStream << setfill('0') << hex;


### PR DESCRIPTION
Previously, whenever we changed a resource (e.g. a shader), we would need to re-compile and re-link. This makes it so that it incurs only a re-link.

Before this, changing `sandboxLit.mat` incurred a 30-second release build (single job), this change reduces it to 8 sec.