### PR TITLE
Only install iOS builds if requested

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -508,7 +508,12 @@ function build_ios_target {
             ../..
     fi
 
-    ${BUILD_COMMAND} install
+    ${BUILD_COMMAND}
+
+    if [[ "$INSTALL_COMMAND" ]]; then
+        echo "Installing ${lc_target} in out/${lc_target}/filament..."
+        ${BUILD_COMMAND} ${INSTALL_COMMAND}
+    fi
 
     if [[ -d "../ios-${lc_target}/filament" ]]; then
         if [[ "$ISSUE_ARCHIVES" == "true" ]]; then

--- a/ios/samples/README.md
+++ b/ios/samples/README.md
@@ -41,7 +41,7 @@ command. For example, the following command will build for both devices (ARM64) 
 (x86_64) in Debug mode:
 
 ```
-$ ./build.sh -s -p ios debug
+$ ./build.sh -s -p ios -i debug
 ```
 
 When building for the simulator, the sample will then link against the libraries present in


### PR DESCRIPTION
This hopefully fixes the iOS GitHub Action. The install was always being done, which fails (maybe due to lack of space on the CI machine?). If this is the case, then we'll need to revisit for release builds (which require an install / archive).