### PR TITLE
Use post-process material domain for FXAA

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -135,6 +135,9 @@ set(PRIVATE_HDRS
         src/UniformBuffer.h
         src/upcast.h)
 
+# tonemapping.mat and fxaa.mat #include files inside the shaders/src directory. Since the
+# included files are part of libshaders, which matc depends on, they don't need to be
+# explicitly listed as dependencies.
 set(MATERIAL_SRCS
         src/materials/defaultMaterial.mat
         src/materials/blur.mat
@@ -143,6 +146,7 @@ set(MATERIAL_SRCS
         src/materials/sao.mat
         src/materials/ssao.mat
         src/materials/tonemapping.mat
+        src/materials/fxaa.mat
 )
 
 # Embed the binary resource blob for materials.

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -148,7 +148,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
                 });
                 data.rt = builder.createRenderTarget(data.output);
             },
-            [=, engine = &engine](FrameGraphPassResources const& resources,
+            [=, &engine](FrameGraphPassResources const& resources,
                     PostProcessToneMapping const& data, DriverApi& driver) {
                 auto const& color = resources.getTexture(data.input);
 
@@ -157,7 +157,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
                 SamplerParams params;
                 pInstance->setParameter("colorBuffer", color, params);
 
-                auto duration = engine->getEngineTime();
+                auto duration = engine.getEngineTime();
                 float fraction = (duration.count() % 1000000000) / 1000000000.0f;
                 mPostProcessUb.setUniform(offsetof(PostProcessingUib, time), fraction);
 
@@ -204,7 +204,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::fxaa(FrameGraph& fg,
                 });
                 data.rt = builder.createRenderTarget(data.output);
             },
-            [=, engine = &engine](FrameGraphPassResources const& resources,
+            [=, &engine](FrameGraphPassResources const& resources,
                     PostProcessFXAA const& data, DriverApi& driver) {
                 auto const& texture = resources.getTexture(data.input);
 
@@ -214,7 +214,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::fxaa(FrameGraph& fg,
                 params.filterMin = SamplerMinFilter::LINEAR;
                 pInstance->setParameter("colorBuffer", texture, params);
 
-                auto duration = engine->getEngineTime();
+                auto duration = engine.getEngineTime();
                 float fraction = (duration.count() % 1000000000) / 1000000000.0f;
                 mPostProcessUb.setUniform(offsetof(PostProcessingUib, time), fraction);
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -43,10 +43,6 @@ public:
 
     void init() noexcept;
     void terminate(backend::DriverApi& driver) noexcept;
-    void setSource(uint32_t viewportWidth, uint32_t viewportHeight,
-            backend::Handle<backend::HwTexture> color,
-            backend::Handle<backend::HwTexture> depth,
-            uint32_t textureWidth, uint32_t textureHeight) const noexcept;
 
     FrameGraphId<FrameGraphTexture> toneMapping(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input,
@@ -119,6 +115,7 @@ private:
     PostProcessMaterial mMipmapDepth;
     PostProcessMaterial mBlur;
     PostProcessMaterial mTonemapping;
+    PostProcessMaterial mFxaa;
 
     backend::Handle<backend::HwTexture> mNoSSAOTexture;
 };

--- a/filament/src/materials/fxaa.mat
+++ b/filament/src/materials/fxaa.mat
@@ -1,0 +1,75 @@
+material {
+    name : fxaa,
+    parameters : [
+        {
+            type : sampler2d,
+            name : colorBuffer,
+            precision : high
+        }
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    culling : none,
+    domain : postprocess,
+    variables : [
+        vertex
+    ]
+}
+
+vertex {
+
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        float4 position = getPosition();
+        postProcess.vertex.xy = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
+        postProcess.vertex.xy *= frameUniforms.resolution.zw;
+    }
+
+}
+
+fragment {
+
+#include "../../../shaders/src/fxaa.fs"
+
+    void postProcess(inout PostProcessInputs postProcess) {
+        // First, compute an exact upper bound for the area we need to sample from.
+        // The render target may be larger than the viewport that was used for scene
+        // rendering, so we cannot rely on the wrap mode alone.
+        highp vec2 fboSize = vec2(textureSize(materialParams_colorBuffer, 0));
+        highp vec2 invSize = 1.0 / fboSize;
+        highp vec2 halfTexel = 0.5 * invSize;
+        highp vec2 viewportSize = frameUniforms.resolution.xy;
+
+        // The clamp needs to be over-aggressive by a half-texel due to bilinear sampling.
+        highp vec2 excessSize = 0.5 + fboSize - viewportSize;
+        highp vec2 upperBound = 1.0 - excessSize * invSize;
+
+        // Next, compute the coordinates of the texel center and its bounding box.
+        // There is no need to clamp the min corner since the wrap mode will do
+        // it automatically.
+
+        // variable_vertex is already interpolated to pixel center by the GPU
+        highp vec2 texelCenter = min(variable_vertex.xy, upperBound);
+        highp vec2 texelMaxCorner = min(variable_vertex.xy + halfTexel, upperBound);
+        highp vec2 texelMinCorner = variable_vertex.xy - halfTexel;
+
+        vec4 color = fxaa(
+                texelCenter,
+                vec4(texelMinCorner, texelMaxCorner),
+                materialParams_colorBuffer,
+                invSize,             // FxaaFloat4 fxaaConsoleRcpFrameOpt,
+                2.0 * invSize,       // FxaaFloat4 fxaaConsoleRcpFrameOpt2,
+                8.0,                 // FxaaFloat fxaaConsoleEdgeSharpness,
+#if defined(G3D_FXAA_PATCHES) && G3D_FXAA_PATCHES == 1
+                0.08,                // FxaaFloat fxaaConsoleEdgeThreshold,
+#else
+                0.125,               // FxaaFloat fxaaConsoleEdgeThreshold,
+#endif
+                0.04                 // FxaaFloat fxaaConsoleEdgeThresholdMin
+        );
+#if POST_PROCESS_OPAQUE
+        color.a = 1.0;
+#endif
+        postProcess.color = color;
+    }
+
+}

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -116,7 +116,6 @@ struct PostProcessingUib {
     static const UniformInterfaceBlock& getUib() noexcept {
         return UibGenerator::getPostProcessingUib();
     }
-    filament::math::float2 uvScale;
     float time;             // time in seconds, with a 1 second period, used for dithering
     int dithering;          // type of dithering 0=none, 1=enabled
 };


### PR DESCRIPTION
Convert the FXAA to a post-process material. This also removes:
- `setSource` method, which isn't needed anymore
- The `uvScale` uniform, which was always 1.0