### PR TITLE
PostProcessManager: repair Vulkan by re-ordering commands.

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -189,7 +189,6 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
                 mPostProcessUb.setUniform(offsetof(PostProcessingUib, time), fraction);
 
                 pInstance->commit(driver);
-                pInstance->use(driver);
 
                 PipelineState pipeline;
                 pipeline.rasterState = mTonemapping.getMaterial()->getRasterState();
@@ -200,6 +199,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
 
                 auto const& target = resources.getRenderTarget(data.rt);
                 driver.beginRenderPass(target.target, target.params);
+                pInstance->use(driver);
                 driver.draw(pipeline, fullScreenRenderPrimitive);
                 driver.endRenderPass();
             });


### PR DESCRIPTION
The suzanne Vulkan demo was asserting because `setViewportScissor` can
only be called within a render pass, which means that
`MaterialInstance::use` can only be called within a render pass.

We probably need a better way to enforce these rules...