### PR TITLE
Remove post-process uniform / sampler blocks

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -484,8 +484,7 @@ backend::Handle<backend::HwProgram> FEngine::createPostProcessProgram(MaterialPa
     pb      .diagnostics(CString("Post Process"))
             .withVertexShader(vShaderBuilder.data(), vShaderBuilder.size())
             .withFragmentShader(fShaderBuilder.data(), fShaderBuilder.size())
-            .setUniformBlock(BindingPoints::PER_VIEW, PerViewUib::getUib().getName())
-            .setUniformBlock(BindingPoints::POST_PROCESS, PostProcessingUib::getUib().getName());
+            .setUniformBlock(BindingPoints::PER_VIEW, PerViewUib::getUib().getName());
 
     auto addSamplerGroup = [&pb]
             (uint8_t bindingPoint, SamplerInterfaceBlock const& sib, SamplerBindingMap const& map) {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -92,11 +92,7 @@ void PostProcessManager::init() noexcept {
     mTonemapping = PostProcessMaterial(mEngine, MATERIALS_TONEMAPPING_DATA, MATERIALS_TONEMAPPING_SIZE);
     mFxaa = PostProcessMaterial(mEngine, MATERIALS_FXAA_DATA, MATERIALS_FXAA_SIZE);
 
-    // create sampler for post-process FBO
     DriverApi& driver = mEngine.getDriverApi();
-    mPostProcessSbh = driver.createSamplerGroup(PostProcessSib::SAMPLER_COUNT);
-    driver.bindSamplers(BindingPoints::POST_PROCESS, mPostProcessSbh);
-
     mNoSSAOTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::R8, 0, 1, 1, 1, TextureUsage::DEFAULT);
 
@@ -108,7 +104,6 @@ void PostProcessManager::init() noexcept {
 }
 
 void PostProcessManager::terminate(backend::DriverApi& driver) noexcept {
-    driver.destroySamplerGroup(mPostProcessSbh);
     driver.destroyTexture(mNoSSAOTexture);
     mSSAO.terminate(mEngine);
     mMipmapDepth.terminate(mEngine);

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -82,9 +82,7 @@ private:
             FrameGraphId<FrameGraphTexture> depth, math::int2 axis) noexcept;
 
     // we need only one of these
-    mutable UniformBuffer mPostProcessUb;
     backend::Handle<backend::HwSamplerGroup> mPostProcessSbh;
-    backend::Handle<backend::HwUniformBuffer> mPostProcessUbh;
 
     class PostProcessMaterial {
     public:

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -81,9 +81,6 @@ private:
             FrameGraphId<FrameGraphTexture> input,
             FrameGraphId<FrameGraphTexture> depth, math::int2 axis) noexcept;
 
-    // we need only one of these
-    backend::Handle<backend::HwSamplerGroup> mPostProcessSbh;
-
     class PostProcessMaterial {
     public:
         PostProcessMaterial() noexcept = default;

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -43,7 +43,7 @@ namespace BindingPoints {
     constexpr uint8_t PER_RENDERABLE          = 1;    // uniforms/samplers updated per renderable
     constexpr uint8_t PER_RENDERABLE_BONES    = 2;    // bones data, per renderable
     constexpr uint8_t LIGHTS                  = 3;    // lights data array
-    constexpr uint8_t POST_PROCESS            = 4;    // deprecated
+    constexpr uint8_t POST_PROCESS_DEPRECATED = 4;    // deprecated
     constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                   = 6;
     // These are limited by Program::UNIFORM_BINDING_COUNT (currently 6)

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -43,7 +43,7 @@ namespace BindingPoints {
     constexpr uint8_t PER_RENDERABLE          = 1;    // uniforms/samplers updated per renderable
     constexpr uint8_t PER_RENDERABLE_BONES    = 2;    // bones data, per renderable
     constexpr uint8_t LIGHTS                  = 3;    // lights data array
-    constexpr uint8_t POST_PROCESS            = 4;    // samplers for the post process pass
+    constexpr uint8_t POST_PROCESS            = 4;    // deprecated
     constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                   = 6;
     // These are limited by Program::UNIFORM_BINDING_COUNT (currently 6)

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -30,7 +30,6 @@ class SamplerInterfaceBlock;
 class SibGenerator {
 public:
     static SamplerInterfaceBlock const& getPerViewSib() noexcept;
-    static SamplerInterfaceBlock const& getPostProcessSib() noexcept;
     static SamplerInterfaceBlock const* getSib(uint8_t bindingPoint) noexcept;
 };
 
@@ -44,14 +43,6 @@ struct PerViewSib {
     static constexpr size_t SSAO           = 5;
 
     static constexpr size_t SAMPLER_COUNT = 6;
-};
-
-struct PostProcessSib {
-    // indices of each samplers in this SamplerInterfaceBlock (see: getPostProcessSib())
-    static constexpr size_t COLOR_BUFFER   = 0;
-    static constexpr size_t DEPTH_BUFFER   = 1;
-
-    static constexpr size_t SAMPLER_COUNT = 2;
 };
 
 }

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -30,7 +30,6 @@ public:
     static UniformInterfaceBlock const& getPerViewUib() noexcept;
     static UniformInterfaceBlock const& getPerRenderableUib() noexcept;
     static UniformInterfaceBlock const& getLightsUib() noexcept;
-    static UniformInterfaceBlock const& getPostProcessingUib() noexcept;
     static UniformInterfaceBlock const& getPerRenderableBonesUib() noexcept;
 };
 
@@ -110,14 +109,6 @@ struct LightsUib {
     filament::math::float4 colorIntensity;    // { float3(col), intensity }
     filament::math::float4 directionIES;      // { float3(dir), IES index }
     filament::math::float4 spotScaleOffset;   // { scale, offset, unused, unused }
-};
-
-struct PostProcessingUib {
-    static const UniformInterfaceBlock& getUib() noexcept {
-        return UibGenerator::getPostProcessingUib();
-    }
-    float time;             // time in seconds, with a 1 second period, used for dithering
-    int dithering;          // type of dithering 0=none, 1=enabled
 };
 
 // This is not the UBO proper, but just an element of a bone array.

--- a/libs/filabridge/src/SamplerBindingMap.cpp
+++ b/libs/filabridge/src/SamplerBindingMap.cpp
@@ -34,8 +34,6 @@ void SamplerBindingMap::populate(const SamplerInterfaceBlock* perMaterialSib,
         filament::SamplerInterfaceBlock const* sib;
         if (blockIndex == filament::BindingPoints::PER_MATERIAL_INSTANCE) {
             sib = perMaterialSib;
-        } else if (perMaterialSib && blockIndex == filament::BindingPoints::POST_PROCESS) {
-            sib = nullptr;
         } else {
             sib = filament::SibGenerator::getSib(blockIndex);
         }

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -43,23 +43,6 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib() noexcept {
     return sib;
 }
 
-SamplerInterfaceBlock const & SibGenerator::getPostProcessSib() noexcept {
-    using Type = SamplerInterfaceBlock::Type;
-    using Format = SamplerInterfaceBlock::Format;
-    using Precision = SamplerInterfaceBlock::Precision;
-
-    // TODO: ideally we'd want this to be constexpr, this is a compile time structure
-    static SamplerInterfaceBlock sib = SamplerInterfaceBlock::Builder()
-            .name("PostProcess")
-            .add("colorBuffer", Type::SAMPLER_2D, Format::FLOAT, Precision::MEDIUM, false)
-            .add("depthBuffer", Type::SAMPLER_2D, Format::FLOAT, Precision::MEDIUM, false)
-            .build();
-
-    assert(sib.getSize() == PostProcessSib::SAMPLER_COUNT);
-
-    return sib;
-}
-
 SamplerInterfaceBlock const* SibGenerator::getSib(uint8_t bindingPoint) noexcept {
     switch (bindingPoint) {
         case BindingPoints::PER_VIEW:
@@ -68,8 +51,6 @@ SamplerInterfaceBlock const* SibGenerator::getSib(uint8_t bindingPoint) noexcept
             return nullptr;
         case BindingPoints::LIGHTS:
             return nullptr;
-        case BindingPoints::POST_PROCESS:
-            return &getPostProcessSib();
         default:
             return nullptr;
     }

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -106,16 +106,6 @@ UniformInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
     return uib;
 }
 
-UniformInterfaceBlock const& UibGenerator::getPostProcessingUib() noexcept {
-    static UniformInterfaceBlock uib =  UniformInterfaceBlock::Builder()
-            .name("PostProcessUniforms")
-            .add("uvScale",   1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("time",      1, UniformInterfaceBlock::Type::FLOAT)
-            .add("dithering", 1, UniformInterfaceBlock::Type::INT)
-            .build();
-    return uib;
-}
-
 UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name("BonesUniforms")

--- a/libs/filamat/src/PostprocessMaterialBuilder.cpp
+++ b/libs/filamat/src/PostprocessMaterialBuilder.cpp
@@ -87,7 +87,7 @@ Package PostprocessMaterialBuilder::build() {
         filament::SamplerBindingMap samplerBindingMap;
         samplerBindingMap.populate();
         const uint8_t firstSampler =
-                samplerBindingMap.getBlockOffset(filament::BindingPoints::POST_PROCESS);
+                samplerBindingMap.getBlockOffset(filament::BindingPoints::POST_PROCESS_DEPRECATED);
 
         // Metal Shading Language is cross-compiled from Vulkan.
         const bool targetApiNeedsSpirv =

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -418,8 +418,6 @@ const std::string ShaderPostProcessGenerator::createPostProcessVertexProgramOld(
 
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
-    cg.generateUniforms(vs, ShaderType::VERTEX,
-            BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
     cg.generateSamplers(vs,
             firstSampler, SibGenerator::getPostProcessSib());
 
@@ -440,8 +438,6 @@ const std::string ShaderPostProcessGenerator::createPostProcessFragmentProgramOl
 
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
-    cg.generateUniforms(fs, ShaderType::FRAGMENT,
-            BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
     cg.generateSamplers(fs,
             firstSampler, SibGenerator::getPostProcessSib());
 
@@ -513,8 +509,6 @@ const std::string ShaderGenerator::createPostProcessVertexProgram(
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(vs, ShaderType::VERTEX,
-            BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
-    cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_MATERIAL_INSTANCE, material.uib);
 
     cg.generateSamplers(vs,
@@ -553,8 +547,6 @@ const std::string ShaderGenerator::createPostProcessFragmentProgram(
 
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
-    cg.generateUniforms(fs, ShaderType::FRAGMENT,
-            BindingPoints::POST_PROCESS, UibGenerator::getPostProcessingUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_MATERIAL_INSTANCE, material.uib);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -418,8 +418,6 @@ const std::string ShaderPostProcessGenerator::createPostProcessVertexProgramOld(
 
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
-    cg.generateSamplers(vs,
-            firstSampler, SibGenerator::getPostProcessSib());
 
     cg.generateCommon(vs, ShaderType::VERTEX);
     cg.generatePostProcessMainOld(vs, ShaderType::VERTEX, variant);
@@ -438,8 +436,6 @@ const std::string ShaderPostProcessGenerator::createPostProcessFragmentProgramOl
 
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
-    cg.generateSamplers(fs,
-            firstSampler, SibGenerator::getPostProcessSib());
 
     cg.generateCommon(fs, ShaderType::FRAGMENT);
     cg.generatePostProcessMainOld(fs, ShaderType::FRAGMENT, variant);

--- a/shaders/src/dithering.fs
+++ b/shaders/src/dithering.fs
@@ -21,7 +21,7 @@
 
 float triangleNoise(highp vec2 n) {
     // triangle noise, in [-1.0..1.0[ range
-    n += vec2(0.07 * fract(postProcessUniforms.time));
+    n += vec2(0.07 * fract(frameUniforms.time));
     n  = fract(n * vec2(5.3987, 5.4421));
     n += dot(n.yx, n.xy + vec2(21.5351, 14.3137));
 
@@ -42,7 +42,7 @@ vec4 Dither_InterleavedGradientNoise(vec4 rgba) {
     // Jimenez 2014, "Next Generation Post-Processing in Call of Duty"
 
     // The noise variable must be highp to workaround Adreno bug #1096.
-    highp float noise = interleavedGradientNoise(gl_FragCoord.xy + postProcessUniforms.time);
+    highp float noise = interleavedGradientNoise(gl_FragCoord.xy + frameUniforms.time);
 
     // remap from [0..1[ to [-1..1[
     noise = (noise * 2.0) - 1.0;
@@ -51,7 +51,7 @@ vec4 Dither_InterleavedGradientNoise(vec4 rgba) {
 
 vec4 Dither_Vlachos(vec4 rgba) {
     // Vlachos 2016, "Advanced VR Rendering"
-    highp vec3 noise = vec3(dot(vec2(171.0, 231.0), gl_FragCoord.xy + postProcessUniforms.time));
+    highp vec3 noise = vec3(dot(vec2(171.0, 231.0), gl_FragCoord.xy + frameUniforms.time));
     noise = fract(noise / vec3(103.0, 71.0, 97.0));
     // remap from [0..1[ to [-1..1[
     noise = (noise * 2.0) - 1.0;

--- a/shaders/src/post_process_old.fs
+++ b/shaders/src/post_process_old.fs
@@ -4,11 +4,11 @@ LAYOUT_LOCATION(0) out vec4 fragColor;
 
 #if POST_PROCESS_TONE_MAPPING
 vec3 resolveFragment(const ivec2 uv) {
-    return texelFetch(postProcess_colorBuffer, uv, 0).rgb;
+    return vec3(0.0);
 }
 
 vec4 resolveAlphaFragment(const ivec2 uv) {
-    return texelFetch(postProcess_colorBuffer, uv, 0);
+    return vec4(0.0);
 }
 
 vec4 resolve() {
@@ -41,7 +41,7 @@ vec4 PostProcess_AntiAliasing() {
     // First, compute an exact upper bound for the area we need to sample from.
     // The render target may be larger than the viewport that was used for scene
     // rendering, so we cannot rely on the wrap mode alone.
-    highp vec2 fboSize = vec2(textureSize(postProcess_colorBuffer, 0));
+    highp vec2 fboSize = vec2(0.0);
     highp vec2 invSize = 1.0 / fboSize;
     highp vec2 halfTexel = 0.5 * invSize;
     highp vec2 viewportSize = frameUniforms.resolution.xy;
@@ -59,20 +59,7 @@ vec4 PostProcess_AntiAliasing() {
     highp vec2 texelMaxCorner = min(vertex_uv + halfTexel, upperBound);
     highp vec2 texelMinCorner = vertex_uv - halfTexel;
 
-    vec4 color = fxaa(
-            texelCenter,
-            vec4(texelMinCorner, texelMaxCorner),
-            postProcess_colorBuffer,
-            invSize,             // FxaaFloat4 fxaaConsoleRcpFrameOpt,
-            2.0 * invSize,       // FxaaFloat4 fxaaConsoleRcpFrameOpt2,
-            8.0,                 // FxaaFloat fxaaConsoleEdgeSharpness,
-#if defined(G3D_FXAA_PATCHES) && G3D_FXAA_PATCHES == 1
-            0.08,                // FxaaFloat fxaaConsoleEdgeThreshold,
-#else
-            0.125,               // FxaaFloat fxaaConsoleEdgeThreshold,
-#endif
-            0.04                 // FxaaFloat fxaaConsoleEdgeThresholdMin
-    );
+    vec4 color = vec4(0.0);
 #if POST_PROCESS_OPAQUE
     color.a = 1.0;
 #endif

--- a/shaders/src/post_process_old.fs
+++ b/shaders/src/post_process_old.fs
@@ -29,9 +29,9 @@ vec4 resolve() {
 
 vec4 PostProcess_ToneMapping() {
     vec4 color = resolve();
-    if (postProcessUniforms.dithering > 0) {
-        color = dither(color);
-    }
+    // if (postProcessUniforms.dithering > 0) {
+        // color = dither(color);
+    // }
     return color;
 }
 #endif

--- a/shaders/src/post_process_old.vs
+++ b/shaders/src/post_process_old.vs
@@ -8,7 +8,7 @@ void main() {
 
 #if POST_PROCESS_ANTI_ALIASING
     // texel to uv, accounting for the texture actual size
-    vertex_uv *= frameUniforms.resolution.zw * postProcessUniforms.uvScale;
+    vertex_uv *= frameUniforms.resolution.zw;
 #endif
 
     gl_Position = position;


### PR DESCRIPTION
This removes "old" post-process uniforms and samplers. The new post-process materials don't need them, as they use `PER_MATERIAL_INSTANCE` ones. Dithering uses the `time` uniform, which it now gets from `frameUniforms`.