### PR TITLE
make TextureUsage and TargetBufferFlags enum class

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -19,6 +19,7 @@
 #ifndef TNT_FILAMENT_DRIVER_DRIVERENUMS_H
 #define TNT_FILAMENT_DRIVER_DRIVERENUMS_H
 
+#include <utils/BitmaskEnum.h>
 #include <utils/unwindows.h> // Because we define ERROR in the FenceStatus enum.
 
 #include <math/vec4.h>
@@ -29,7 +30,6 @@
 #include <stdint.h>
 
 namespace filament {
-
 /**
  * Types and enums used by filament's driver.
  *
@@ -62,7 +62,7 @@ enum class Backend : uint8_t {
 /**
  * Bitmask for selecting render buffers
  */
-enum TargetBufferFlags : uint8_t {
+enum class TargetBufferFlags : uint8_t {
     NONE = 0x0u,                 //!< No buffer selected.
     COLOR = 0x1u,                //!< Color buffer selected.
     DEPTH = 0x2u,                //!< Depth buffer selected.
@@ -72,29 +72,6 @@ enum TargetBufferFlags : uint8_t {
     DEPTH_AND_STENCIL = DEPTH | STENCIL,
     ALL = COLOR | DEPTH | STENCIL
 };
-
-// implement requirement of BitmaskType
-inline constexpr TargetBufferFlags operator~(TargetBufferFlags rhs) noexcept {
-    return TargetBufferFlags(~uint8_t(rhs) & uint8_t(TargetBufferFlags::ALL));
-}
-inline constexpr TargetBufferFlags operator|=(TargetBufferFlags& lhs, TargetBufferFlags rhs) noexcept {
-    return lhs = TargetBufferFlags(uint8_t(lhs) | uint8_t(rhs));
-}
-inline constexpr TargetBufferFlags operator&=(TargetBufferFlags& lhs, TargetBufferFlags rhs) noexcept {
-    return lhs = TargetBufferFlags(uint8_t(lhs) & uint8_t(rhs));
-}
-inline constexpr TargetBufferFlags operator^=(TargetBufferFlags& lhs, TargetBufferFlags rhs) noexcept {
-    return lhs = TargetBufferFlags(uint8_t(lhs) ^ uint8_t(rhs));
-}
-inline constexpr TargetBufferFlags operator|(TargetBufferFlags lhs, TargetBufferFlags rhs) noexcept {
-    return TargetBufferFlags(uint8_t(lhs) | uint8_t(rhs));
-}
-inline constexpr TargetBufferFlags operator&(TargetBufferFlags lhs, TargetBufferFlags rhs) noexcept {
-    return TargetBufferFlags(uint8_t(lhs) & uint8_t(rhs));
-}
-inline constexpr TargetBufferFlags operator^(TargetBufferFlags lhs, TargetBufferFlags rhs) noexcept {
-    return TargetBufferFlags(uint8_t(lhs) ^ uint8_t(rhs));
-}
 
 /**
  * Frequency at which a buffer is expected to be modified and used. This is used as an hint
@@ -478,7 +455,7 @@ enum class TextureFormat : uint16_t {
     SRGB8_ALPHA8_ASTC_12x12,
 };
 
-enum TextureUsage : uint8_t {
+enum class TextureUsage : uint8_t {
     COLOR_ATTACHMENT    = 0x1,
     DEPTH_ATTACHMENT    = 0x2,
     STENCIL_ATTACHMENT  = 0x4,
@@ -486,29 +463,6 @@ enum TextureUsage : uint8_t {
     SAMPLEABLE          = 0x10,
     DEFAULT = UPLOADABLE | SAMPLEABLE
 };
-
-// implement requirement of BitmaskType
-inline constexpr TextureUsage operator~(TextureUsage rhs) noexcept {
-    return TextureUsage(~uint8_t(rhs) & 0x1Fu);
-}
-inline constexpr TextureUsage operator|=(TextureUsage& lhs, TextureUsage rhs) noexcept {
-    return lhs = TextureUsage(uint8_t(lhs) | uint8_t(rhs));
-}
-inline constexpr TextureUsage operator&=(TextureUsage& lhs, TextureUsage rhs) noexcept {
-    return lhs = TextureUsage(uint8_t(lhs) & uint8_t(rhs));
-}
-inline constexpr TextureUsage operator^=(TextureUsage& lhs, TextureUsage rhs) noexcept {
-    return lhs = TextureUsage(uint8_t(lhs) ^ uint8_t(rhs));
-}
-inline constexpr TextureUsage operator|(TextureUsage lhs, TextureUsage rhs) noexcept {
-    return TextureUsage(uint8_t(lhs) | uint8_t(rhs));
-}
-inline constexpr TextureUsage operator&(TextureUsage lhs, TextureUsage rhs) noexcept {
-    return TextureUsage(uint8_t(lhs) & uint8_t(rhs));
-}
-inline constexpr TextureUsage operator^(TextureUsage lhs, TextureUsage rhs) noexcept {
-    return TextureUsage(uint8_t(lhs) ^ uint8_t(rhs));
-}
 
 //! returns whether this format a compressed format
 static constexpr bool isCompressedFormat(TextureFormat format) noexcept {
@@ -690,7 +644,7 @@ struct RasterState {
     using BlendEquation = filament::backend::BlendEquation;
     using BlendFunction = filament::backend::BlendFunction;
 
-    RasterState() noexcept { // NOLINT(cppcoreguidelines-pro-type-member-init)
+    RasterState() noexcept { // NOLINT
         static_assert(sizeof(RasterState) == sizeof(uint32_t),
                 "RasterState size not what was intended");
         culling = CullingMode::BACK;
@@ -748,5 +702,10 @@ struct RasterState {
 
 } // namespace backend
 } // namespace filament
+
+template<> struct utils::EnableBitMaskOperators<filament::backend::TargetBufferFlags>
+        : public std::true_type {};
+template<> struct utils::EnableBitMaskOperators<filament::backend::TextureUsage>
+        : public std::true_type {};
 
 #endif // TNT_FILAMENT_DRIVER_DRIVERENUMS_H

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -173,7 +173,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         if (color.handle) {
             auto colorTexture = handle_cast<MetalTexture>(mHandleMap, color.handle);
             return colorTexture->texture;
-        } else if (targetBufferFlags & TargetBufferFlags::COLOR) {
+        } else if (any(targetBufferFlags & TargetBufferFlags::COLOR)) {
             ASSERT_POSTCONDITION(false, "The COLOR flag was specified, but no color texture provided.");
         }
         return nil;
@@ -183,7 +183,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         if (depth.handle) {
             auto depthTexture = handle_cast<MetalTexture>(mHandleMap, depth.handle);
             return depthTexture->texture;
-        } else if (targetBufferFlags & TargetBufferFlags::DEPTH) {
+        } else if (any(targetBufferFlags & TargetBufferFlags::DEPTH)) {
             ASSERT_POSTCONDITION(false, "The DEPTH flag was specified, but no depth texture provided.");
         }
         return nil;
@@ -193,7 +193,8 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             getColorTexture(), getDepthTexture(), color.level, depth.level);
 
     ASSERT_POSTCONDITION(
-            !stencil.handle && !(targetBufferFlags & TargetBufferFlags::STENCIL),
+            !stencil.handle &&
+            !(targetBufferFlags & TargetBufferFlags::STENCIL),
             "Stencil buffer not supported.");
 }
 
@@ -564,8 +565,8 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     MTLRenderPassDescriptor* descriptor = [MTLRenderPassDescriptor renderPassDescriptor];
 
     const auto discardFlags = params.flags.discardEnd;
-    const auto discardColor = (discardFlags & TargetBufferFlags::COLOR);
-    const auto discardDepth = (discardFlags & TargetBufferFlags::DEPTH);
+    const bool discardColor = any(discardFlags & TargetBufferFlags::COLOR);
+    const bool discardDepth = any(discardFlags & TargetBufferFlags::DEPTH);
 
     // Color
 
@@ -776,12 +777,12 @@ void MetalDriver::blit(TargetBufferFlags buffers,
     args.destination.level = dstLevel;
     args.destination.region = dstRegion;
 
-    if (buffers & TargetBufferFlags::COLOR) {
+    if (any(buffers & TargetBufferFlags::COLOR)) {
         args.source.color = srcTexture;
         args.destination.color = dstTexture;
     }
 
-    if (buffers & TargetBufferFlags::DEPTH) {
+    if (any(buffers & TargetBufferFlags::DEPTH)) {
         args.source.depth = srcTarget->getBlitDepthSource();
         args.destination.depth = dstTarget->getDepth();
     }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -29,13 +29,13 @@ namespace metal {
 
 static inline MTLTextureUsage getMetalTextureUsage(TextureUsage usage) {
     NSUInteger u = 0;
-    if (usage & TextureUsage::COLOR_ATTACHMENT) {
+    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
         u |= MTLTextureUsageRenderTarget;
     }
-    if (usage & TextureUsage::DEPTH_ATTACHMENT) {
+    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
         u |= MTLTextureUsageRenderTarget;
     }
-    if (usage & TextureUsage::STENCIL_ATTACHMENT) {
+    if (any(usage & TextureUsage::STENCIL_ATTACHMENT)) {
         u |= MTLTextureUsageRenderTarget;
     }
 
@@ -46,7 +46,7 @@ static inline MTLTextureUsage getMetalTextureUsage(TextureUsage usage) {
 }
 
 static inline MTLStorageMode getMetalStorageMode(TextureUsage usage) {
-    if (usage & TextureUsage::UPLOADABLE) {
+    if (any(usage & TextureUsage::UPLOADABLE)) {
 #if defined(IOS)
         return MTLStorageModeShared;
 #else
@@ -481,9 +481,9 @@ MTLLoadAction MetalRenderTarget::getLoadAction(const RenderPassParams& params,
         TargetBufferFlags buffer) {
     const auto clearFlags = (TargetBufferFlags) params.flags.clear;
     const auto discardStartFlags = params.flags.discardStart;
-    if (clearFlags & buffer) {
+    if (any(clearFlags & buffer)) {
         return MTLLoadActionClear;
-    } else if (discardStartFlags & buffer) {
+    } else if (any(discardStartFlags & buffer)) {
         return MTLLoadActionDontCare;
     }
     return MTLLoadActionLoad;
@@ -492,14 +492,14 @@ MTLLoadAction MetalRenderTarget::getLoadAction(const RenderPassParams& params,
 MTLStoreAction MetalRenderTarget::getStoreAction(const RenderPassParams& params,
         TargetBufferFlags buffer) {
     const auto discardEndFlags = params.flags.discardEnd;
-    if (discardEndFlags & buffer) {
+    if (any(discardEndFlags & buffer)) {
         return MTLStoreActionDontCare;
     }
-    if (buffer & TargetBufferFlags::COLOR) {
+    if (any(buffer & TargetBufferFlags::COLOR)) {
         const bool shouldResolveColor = (multisampledColor && color);
         return shouldResolveColor ? MTLStoreActionMultisampleResolve : MTLStoreActionStore;
     }
-    if (buffer & TargetBufferFlags::DEPTH) {
+    if (any(buffer & TargetBufferFlags::DEPTH)) {
         const bool shouldResolveDepth = (multisampledDepth && depth);
         return shouldResolveDepth ? MTLStoreActionMultisampleResolve : MTLStoreActionStore;
     }

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -83,14 +83,14 @@ constexpr inline GLuint getComponentCount(backend::ElementType type) noexcept {
 
 constexpr inline GLbitfield getAttachmentBitfield(backend::TargetBufferFlags flags) noexcept {
     GLbitfield mask = 0;
-    if (flags & backend::TargetBufferFlags::COLOR) {
-        mask |= GL_COLOR_BUFFER_BIT;
+    if (any(flags & backend::TargetBufferFlags::COLOR)) {
+        mask |= (GLbitfield)GL_COLOR_BUFFER_BIT;
     }
-    if (flags  & backend::TargetBufferFlags::DEPTH) {
-        mask |= GL_DEPTH_BUFFER_BIT;
+    if (any(flags & backend::TargetBufferFlags::DEPTH)) {
+        mask |= (GLbitfield)GL_DEPTH_BUFFER_BIT;
     }
-    if (flags  & backend::TargetBufferFlags::STENCIL) {
-        mask |= GL_STENCIL_BUFFER_BIT;
+    if (any(flags & backend::TargetBufferFlags::STENCIL)) {
+        mask |= (GLbitfield)GL_STENCIL_BUFFER_BIT;
     }
     return mask;
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -385,7 +385,7 @@ private:
     }
 
     GLsizei getAttachments(std::array<GLenum, 3>& attachments,
-            GLRenderTarget const* rt, uint8_t buffers) const noexcept;
+            GLRenderTarget const* rt, backend::TargetBufferFlags buffers) const noexcept;
 
     static constexpr const size_t MAX_TEXTURE_UNIT_COUNT = 16;   // All mobile GPUs as of 2016
     static constexpr const size_t MAX_BUFFER_BINDINGS = 32;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -709,8 +709,8 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         .colorFormat = color.format,
         .depthFormat = depth.format,
         .flags.clear         = params.flags.clear,
-        .flags.discardStart  = params.flags.discardStart,
-        .flags.discardEnd    = params.flags.discardEnd,
+        .flags.discardStart  = (uint8_t)params.flags.discardStart,
+        .flags.discardEnd    = (uint8_t)params.flags.discardEnd,
         .flags.dependencies  = params.flags.dependencies
     });
     mBinder.bindRenderPass(renderPass);

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -108,7 +108,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     VkAttachmentDescription colorAttachment {
         .format = config.colorFormat,
         .samples = VK_SAMPLE_COUNT_1_BIT,
-        .loadOp = (config.flags.clear & TargetBufferFlags::COLOR) ?
+        .loadOp = (config.flags.clear & (uint8_t)TargetBufferFlags::COLOR) ?
                 VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
         .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
@@ -118,7 +118,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     VkAttachmentDescription depthAttachment {
         .format = config.depthFormat,
         .samples = VK_SAMPLE_COUNT_1_BIT,
-        .loadOp = (config.flags.clear & TargetBufferFlags::DEPTH) ?
+        .loadOp = (config.flags.clear & (uint8_t)TargetBufferFlags::DEPTH) ?
                 VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
         .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -309,21 +309,21 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
         imageInfo.arrayLayers = 6;
         imageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     }
-    if (usage & TextureUsage::SAMPLEABLE) {
+    if (any(usage & TextureUsage::SAMPLEABLE)) {
         imageInfo.usage |= VK_IMAGE_USAGE_SAMPLED_BIT;
     }
-    if (usage & TextureUsage::COLOR_ATTACHMENT) {
+    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
         imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     }
-    if (usage & TextureUsage::STENCIL_ATTACHMENT) {
+    if (any(usage & TextureUsage::STENCIL_ATTACHMENT)) {
         imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     }
-    if (usage & TextureUsage::UPLOADABLE) {
+    if (any(usage & TextureUsage::UPLOADABLE)) {
         // Uploadable textures can be used as a blit source (e.g. for mipmap generation)
         // therefore we must set both the TRANSFER_DST and TRANSFER_SRC flags.
         imageInfo.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
-    if (usage & TextureUsage::DEPTH_ATTACHMENT) {
+    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
         imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     }
 
@@ -367,7 +367,7 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
         viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
         viewInfo.subresourceRange.layerCount = 1;
     }
-    if (usage & TextureUsage::DEPTH_ATTACHMENT) {
+    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
         viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
     }
     error = vkCreateImageView(context.device, &viewInfo, VKALLOC, &imageView);

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -25,6 +25,7 @@
 
 namespace filament {
 
+using namespace backend;
 using namespace details;
 
 struct RenderTarget::BuilderDetails {
@@ -97,18 +98,18 @@ FRenderTarget::HwHandle FRenderTarget::createHandle(FEngine& engine, const Build
     FEngine::DriverApi& driver = engine.getDriverApi();
     const Attachment& color = builder.mImpl->mAttachments[COLOR];
     const Attachment& depth = builder.mImpl->mAttachments[DEPTH];
-    const backend::TargetBufferFlags flags =
-            depth.texture ? backend::COLOR_AND_DEPTH : backend::COLOR;
+    const TargetBufferFlags flags =
+            depth.texture ? TargetBufferFlags::COLOR_AND_DEPTH : TargetBufferFlags::COLOR;
 
     // For now we do not support multisampled render targets in the public-facing API, but please
     // note that post-processing includes FXAA by default.
     const uint8_t samples = 1;
 
-    const backend::TargetBufferInfo cinfo(upcast(color.texture)->getHwHandle(),
+    const TargetBufferInfo cinfo(upcast(color.texture)->getHwHandle(),
             color.mipLevel, color.face);
 
-    const backend::TargetBufferInfo dinfo(
-            depth.texture ? upcast(depth.texture)->getHwHandle() : backend::TextureHandle(),
+    const TargetBufferInfo dinfo(
+            depth.texture ? upcast(depth.texture)->getHwHandle() : TextureHandle(),
             color.mipLevel, color.face);
 
     const uint32_t width = FTexture::valueForLevel(color.mipLevel, color.texture->getWidth());

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -159,7 +159,7 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
 
     // FIXME: in the future this will come from the framegraph
     RenderPassParams params = {};
-    params.flags.clear = TargetBufferFlags::DEPTH;
+    params.flags.clear = (uint8_t)TargetBufferFlags::DEPTH;
     params.flags.discardStart = TargetBufferFlags::DEPTH;
     params.flags.discardEnd = TargetBufferFlags::COLOR_AND_STENCIL;
     params.clearDepth = 1.0;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -261,12 +261,12 @@ public:
         return mVisibleShadowCasters;
     }
 
-    TargetBufferFlags getClearFlags() const noexcept {
+    uint8_t getClearFlags() const noexcept {
         uint8_t clearFlags = 0;
-        if (getClearTargetColor())     clearFlags |= TargetBufferFlags::COLOR;
-        if (getClearTargetDepth())     clearFlags |= TargetBufferFlags::DEPTH;
-        if (getClearTargetStencil())   clearFlags |= TargetBufferFlags::STENCIL;
-        return TargetBufferFlags(clearFlags);
+        if (getClearTargetColor())     clearFlags |= (uint8_t)TargetBufferFlags::COLOR;
+        if (getClearTargetDepth())     clearFlags |= (uint8_t)TargetBufferFlags::DEPTH;
+        if (getClearTargetStencil())   clearFlags |= (uint8_t)TargetBufferFlags::STENCIL;
+        return clearFlags;
     }
 
     FCamera& getCameraUser() noexcept { return *mCullingCamera; }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -66,10 +66,10 @@ const char* FrameGraph::Builder::getName(FrameGraphHandle const& r) const noexce
 
 bool FrameGraph::Builder::isAttachment(FrameGraphId<FrameGraphTexture> r) const noexcept {
     fg::ResourceEntry<FrameGraphTexture>& entry = mFrameGraph.getResourceEntryUnchecked(r);
-    return entry.descriptor.usage & (
+    return any(entry.descriptor.usage & (
             TextureUsage::COLOR_ATTACHMENT |
             TextureUsage::DEPTH_ATTACHMENT |
-            TextureUsage::STENCIL_ATTACHMENT);
+            TextureUsage::STENCIL_ATTACHMENT));
 }
 
 FrameGraphRenderTarget::Descriptor&
@@ -367,7 +367,7 @@ TargetBufferFlags FrameGraph::computeDiscardFlags(DiscardPhase phase,
     auto const& desc = renderTarget.cache->desc;
 
     // for each pass...
-    while (discardFlags && curr != first) {
+    while (any(discardFlags) && curr != first) {
         PassNode const& pass = *curr++;
         // TODO: maybe find a more efficient way of figuring this out
         // for each resource written or read...

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -29,7 +29,7 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
     assert(desc.usage);
     // (it means it's only used as an attachment for a rendertarget)
     uint8_t samples = desc.samples;
-    if (desc.usage & TextureUsage::SAMPLEABLE) {
+    if (any(desc.usage & TextureUsage::SAMPLEABLE)) {
         samples = 1; // sampleable textures can't be multi-sampled
     }
     texture = fg.getResourceAllocator().createTexture(name, desc.type, desc.levels,

--- a/filament/src/fg/fg/RenderTarget.cpp
+++ b/filament/src/fg/fg/RenderTarget.cpp
@@ -35,9 +35,9 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
 
     if (pos != renderTargetCache.end()) {
         cache = pos->get();
-        cache->targetInfo.params.flags.clear |= userClearFlags;
+        cache->targetInfo.params.flags.clear |= (uint8_t)userClearFlags;
     } else {
-        uint8_t attachments = 0;
+        TargetBufferFlags attachments{};
         uint32_t width = 0;
         uint32_t height = 0;
         backend::TextureFormat colorFormat = {};
@@ -83,7 +83,7 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
             }
         }
 
-        if (attachments) {
+        if (any(attachments)) {
             if (minWidth == maxWidth && minHeight == maxHeight) {
                 // All attachments' size match, we're good to go.
                 width = minWidth;
@@ -100,7 +100,7 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
                             backend::TargetBufferFlags(attachments), width, height, colorFormat);
             renderTargetCache.emplace_back(pRenderTargetResource, fg);
             cache = pRenderTargetResource;
-            cache->targetInfo.params.flags.clear |= userClearFlags;
+            cache->targetInfo.params.flags.clear |= (uint8_t)userClearFlags;
         }
     }
 }

--- a/filament/src/fg/fg/RenderTargetResource.h
+++ b/filament/src/fg/fg/RenderTargetResource.h
@@ -70,7 +70,7 @@ struct RenderTargetResource final : public VirtualResource {  // 104
 
     void create(FrameGraph& fg) noexcept override {
         if (!imported) {
-            if (attachments) {
+            if (any(attachments)) {
                 // devirtualize our texture handles. By this point these handles have been
                 // remapped to their alias if any.
                 backend::TargetBufferInfo infos[FrameGraphRenderTarget::Attachments::COUNT];

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB_RECURSE PUBLIC_HDRS ${PUBLIC_HDR_DIR}/${TARGET}/*.h)
 set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/algorithm.h
         ${PUBLIC_HDR_DIR}/${TARGET}/bitset.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/BitmaskEnum.h
         ${PUBLIC_HDR_DIR}/${TARGET}/compiler.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Entity.h
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityInstance.h

--- a/libs/utils/include/utils/BitmaskEnum.h
+++ b/libs/utils/include/utils/BitmaskEnum.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_BITMASKENUM_H
+#define TNT_UTILS_BITMASKENUM_H
+
+#include <utils/compiler.h>
+
+#include <type_traits> // for std::false_type
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+namespace utils {
+template<typename Enum>
+struct EnableBitMaskOperators : public std::false_type { };
+} // namespace utils
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr bool operator!(Enum rhs) noexcept {
+    using underlying = std::underlying_type_t<Enum>;
+    return underlying(rhs) == 0;
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator~(Enum rhs) noexcept {
+    using underlying = std::underlying_type_t<Enum>;
+    return Enum(~underlying(rhs));
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator|(Enum lhs, Enum rhs) noexcept {
+    using underlying = std::underlying_type_t<Enum>;
+    return Enum(underlying(lhs) | underlying(rhs));
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator&(Enum lhs, Enum rhs) noexcept {
+    using underlying = std::underlying_type_t<Enum>;
+    return Enum(underlying(lhs) & underlying(rhs));
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator^(Enum lhs, Enum rhs) noexcept {
+    using underlying = std::underlying_type_t<Enum>;
+    return Enum(underlying(lhs) ^ underlying(rhs));
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator|=(Enum& lhs, Enum rhs) noexcept {
+    return lhs = lhs | rhs;
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator&=(Enum& lhs, Enum rhs) noexcept {
+    return lhs = lhs & rhs;
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr Enum operator^=(Enum& lhs, Enum rhs) noexcept {
+    return lhs = lhs ^ rhs;
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr bool none(Enum lhs) noexcept {
+    return !lhs;
+}
+
+template<typename Enum, typename std::enable_if_t<
+        std::is_enum<Enum>::value && utils::EnableBitMaskOperators<Enum>::value, int> = 0>
+inline constexpr bool any(Enum lhs) noexcept {
+    return !none(lhs);
+}
+
+
+#endif // TNT_UTILS_BITMASKENUM_H


### PR DESCRIPTION
This prevents values like NONE or COLOR which are very generic
names to collide with other classic enums. It also forces us to be
specific about what we're doing when converting to bitfields.

Also added a utility to easily enable any enum or enum class to
support binary operation (i.e. Bitmask contract), e.g.:

template<> struct utils::EnableBitMaskOperators<Foo> : public std::true_type{};

gives all binary operators to 'Foo'. Foo must be an enum.

Also added any() and none() convenience to convert an enum to a boolean.