### PR TITLE
Make SamplerParam a C struct

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -611,13 +611,7 @@ enum class SamplerCompareFunc : uint8_t {
     LE = 0, GE, L, G, E, NE, A, N
 };
 
-struct SamplerParams {
-    enum class no_init { };
-    static constexpr no_init NO_INIT = { };
-
-    constexpr SamplerParams() noexcept : u(0) { }
-    explicit SamplerParams(no_init) noexcept { }
-
+struct SamplerParams { // NOLINT
     union {
         struct {
             SamplerMagFilter filterMag      : 1;    // NEAREST
@@ -636,7 +630,7 @@ struct SamplerParams {
 
             uint8_t padding2                : 8;    // 0
         };
-        uint32_t u;
+        uint32_t u{};
     };
 private:
     friend inline bool operator < (SamplerParams lhs, SamplerParams rhs) {

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -36,15 +36,11 @@ public:
     using SamplerParams = backend::SamplerParams;
 
     struct Sampler {
-        // we use a no-init default ctor so that the mBuffer array doesn't initializes itself
-        // needlessly.
-        Sampler() noexcept : t(Handle<HwTexture>::NO_INIT), s(SamplerParams::NO_INIT) { }
-        constexpr Sampler(Handle<HwTexture> t, SamplerParams s) noexcept : t(t), s(s) { }
         Handle<HwTexture> t;
         SamplerParams s;
     };
 
-    SamplerGroup() noexcept { } // NOLINT(modernize-use-equals-default)
+    SamplerGroup() noexcept { } // NOLINT
 
     // create a sampler group
     explicit SamplerGroup(size_t count) noexcept;
@@ -70,7 +66,7 @@ public:
     Sampler const* getSamplers() const noexcept { return mBuffer.data(); }
 
     // sampler count
-    size_t getSize() const noexcept { return mSize; }
+    size_t getSize() const noexcept { return mBuffer.size(); }
 
     // return if any samplers has been changed
     bool isDirty() const noexcept { return mDirty.any(); }
@@ -90,9 +86,66 @@ private:
     friend utils::io::ostream& operator<<(utils::io::ostream& out, const SamplerGroup& rhs);
 #endif
 
-    std::array<Sampler, backend::MAX_SAMPLER_COUNT> mBuffer;    // 128 bytes
+    // This could probably be cleaned-up and moved to libutils
+    template<class T, size_t N>
+    class static_vector { //NOLINT
+        typename std::aligned_storage<sizeof(T), alignof(T)>::type mData[N];
+        uint32_t mSize = 0;
+    public:
+        static_vector() = default; //NOLINT
+
+        ~static_vector() noexcept {
+            for (auto& elem : *this) {
+                elem.~T();
+            }
+        }
+
+        explicit static_vector(size_t count) noexcept : mSize(count) {
+            assert(count < N);
+            std::uninitialized_fill_n(begin(), count, T{});
+        }
+
+        static_vector(static_vector const& rhs) noexcept : mSize(rhs.mSize) {
+            std::uninitialized_copy(rhs.begin(), rhs.end(), begin());
+        }
+
+        size_t size() const noexcept { return mSize; }
+
+        T* data() noexcept { return reinterpret_cast<T*>(&mData[0]); }
+
+        T const* data() const noexcept { return reinterpret_cast<T const*>(&mData[0]); }
+
+        static_vector& operator=(static_vector const& rhs) noexcept {
+            if (this != &rhs) {
+                const size_t n = std::min(mSize, rhs.mSize);
+                std::copy_n(rhs.begin(), n, begin());
+                for (size_t pos = n, c = mSize; pos < c; ++pos) {
+                    data()[pos].~T();
+                }
+                std::uninitialized_copy(rhs.begin() + n, rhs.end(), begin() + n);
+                mSize = rhs.mSize;
+            }
+            return *this;
+        }
+
+        const T& operator[](size_t pos) const noexcept {
+            assert(pos < mSize);
+            return data()[pos];
+        }
+
+        T& operator[](size_t pos) noexcept {
+            assert(pos < mSize);
+            return data()[pos];
+        }
+
+        T* begin() { return data(); }
+        T* end() { return data() + mSize; }
+        T const* begin() const { return data(); }
+        T const* end() const { return data() + mSize; }
+    };
+
+    static_vector<Sampler, backend::MAX_SAMPLER_COUNT> mBuffer;    // 128 bytes
     mutable utils::bitset32 mDirty;
-    uint8_t mSize = 0;
 };
 
 } // namespace backend

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -181,8 +181,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
 
                 FMaterialInstance* pInstance = mTonemapping.getMaterialInstance();
                 pInstance->setParameter("dithering", dithering);
-                SamplerParams params;
-                pInstance->setParameter("colorBuffer", color, params);
+                pInstance->setParameter("colorBuffer", color, {});
 
                 auto duration = engine->getEngineTime();
                 float fraction = (duration.count() % 1000000000) / 1000000000.0f;
@@ -409,9 +408,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssao(FrameGraph& fg, RenderP
                         0.5f * cameraInfo.projection[0].x * desc.width,
                         0.5f * cameraInfo.projection[1].y * desc.height);
 
-                SamplerParams params;
                 FMaterialInstance* const pInstance = mSSAO.getMaterialInstance();
-                pInstance->setParameter("depth", depth, params);
+                pInstance->setParameter("depth", depth, {});
                 pInstance->setParameter("resolution",
                         float4{ desc.width, desc.height, 1.0f / desc.width, 1.0f / desc.height });
                 pInstance->setParameter("radius", data.options.radius);
@@ -520,9 +518,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::mipmapPass(FrameGraph& fg,
                 auto in = resources.getTexture(data.in);
                 auto out = resources.getRenderTarget(data.rt, level + 1u);
 
-                SamplerParams params;
                 FMaterialInstance* const pInstance = mMipmapDepth.getMaterialInstance();
-                pInstance->setParameter("depth", in, params);
+                pInstance->setParameter("depth", in, {});
                 pInstance->setParameter("level", uint32_t(level));
                 pInstance->commit(driver);
 
@@ -581,10 +578,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blurPass(FrameGraph& fg,
                 auto blurred = resources.getRenderTarget(data.rt);
                 auto const& desc = resources.getDescriptor(data.blurred);
 
-                SamplerParams params;
                 FMaterialInstance* const pInstance = mBlur.getMaterialInstance();
-                pInstance->setParameter("ssao", ssao, params);
-                pInstance->setParameter("depth", depth, params);
+                pInstance->setParameter("ssao", ssao, {});
+                pInstance->setParameter("depth", depth, {});
                 pInstance->setParameter("axis", axis);
                 pInstance->setParameter("resolution",
                         float4{ desc.width, desc.height, 1.0f / desc.width, 1.0f / desc.height });

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -136,13 +136,14 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
             TargetBufferFlags::DEPTH, dim, dim, 1,
             {}, { mShadowMapHandle }, {});
 
-    SamplerParams s;
-    s.filterMag = SamplerMagFilter::LINEAR;
-    s.filterMin = SamplerMinFilter::LINEAR;
-    s.compareFunc = SamplerCompareFunc::LE;
-    s.compareMode = SamplerCompareMode::COMPARE_TO_TEXTURE;
-    s.depthStencil = true;
-    sb.setSampler(PerViewSib::SHADOW_MAP, { mShadowMapHandle, s });
+    sb.setSampler(PerViewSib::SHADOW_MAP, {
+        mShadowMapHandle, {
+                    .filterMag = SamplerMagFilter::LINEAR,
+                    .filterMin = SamplerMinFilter::LINEAR,
+                    .compareFunc = SamplerCompareFunc::LE,
+                    .compareMode = SamplerCompareMode::COMPARE_TO_TEXTURE,
+                    .depthStencil = true
+            }});
 }
 
 void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcept {

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -345,11 +345,11 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
         u.setUniform(offsetof(PerViewUib, iblLuminance), ibl->getIntensity() * exposure);
         u.setUniformArray(offsetof(PerViewUib, iblSH), ibl->getSH(), 9);
         if (ibl->getReflectionMap()) {
-            SamplerParams reflectionSamplerParams;
-            reflectionSamplerParams.filterMag = SamplerMagFilter::LINEAR;
-            reflectionSamplerParams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR;
-            mPerViewSb.setSampler(PerViewSib::IBL_SPECULAR,
-                    { ibl->getReflectionMap(), reflectionSamplerParams });
+            mPerViewSb.setSampler(PerViewSib::IBL_SPECULAR, {
+                    ibl->getReflectionMap(), {
+                            .filterMag = SamplerMagFilter::LINEAR,
+                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
+                    }});
         }
     } else {
         FSkybox const* const skybox = scene->getSkybox();
@@ -635,9 +635,9 @@ void FView::prepareCamera(const CameraInfo& camera, const filament::Viewport& vi
 }
 
 void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
-    SamplerParams params;
-    params.filterMag = SamplerMagFilter::LINEAR;
-    mPerViewSb.setSampler(PerViewSib::SSAO, ssao, params);
+    mPerViewSb.setSampler(PerViewSib::SSAO, ssao, {
+            .filterMag = SamplerMagFilter::LINEAR
+    });
 }
 
 void FView::cleanupSSAO() const noexcept {


### PR DESCRIPTION
This simplifies its usage at call sites at lot.

The C++ ctor was needed before to create uninitialized objects, which
was needed in SamplerGroup. Instead we use a custom 'static_vector' 
(instead of std::array), this actually makes SamplerGroup's
implementation clearer.

static_vector<> is just a fixed-capacity, fixed-storage dynamic
vector. we currently don't expose it and implement only what we
need.