### PR TITLE
Fix full-screen triangle winding.

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -119,6 +119,8 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
 
 
 // these must be static because only a pointer is copied to the render stream
+// Note that these coordinates are specified in OpenGL clip space. Other backends can transform
+// these in the vertex shader as needed.
 static const half4 sFullScreenTriangleVertices[3] = {
         { -1.0_h, -1.0_h, 1.0_h, 1.0_h },
         {  3.0_h, -1.0_h, 1.0_h, 1.0_h },

--- a/filament/src/materials/blur.mat
+++ b/filament/src/materials/blur.mat
@@ -25,16 +25,12 @@ material {
     ],
     domain : postprocess,
     depthWrite : false,
-    depthCulling : true,
-    culling: none
+    depthCulling : true
 }
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        // far-plane in view space
-        vec4 position = getPosition(); // clip-space
-        postProcess.vertex.xy = (position.xy * 0.5 + 0.5);
-        postProcess.vertex.zw = position.xy;
+        postProcess.vertex.xy = postProcess.uv;
     }
 }
 

--- a/filament/src/materials/blur.mat
+++ b/filament/src/materials/blur.mat
@@ -30,7 +30,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.uv;
+        postProcess.vertex.xy = postProcess.normalizedUV;
     }
 }
 

--- a/filament/src/materials/fxaa.mat
+++ b/filament/src/materials/fxaa.mat
@@ -9,7 +9,6 @@ material {
     ],
     depthWrite : false,
     depthCulling : false,
-    culling : none,
     domain : postprocess,
     variables : [
         vertex
@@ -19,9 +18,7 @@ material {
 vertex {
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        float4 position = getPosition();
-        postProcess.vertex.xy = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
-        postProcess.vertex.xy *= frameUniforms.resolution.zw;
+        postProcess.vertex.xy = postProcess.uv;
     }
 
 }

--- a/filament/src/materials/fxaa.mat
+++ b/filament/src/materials/fxaa.mat
@@ -18,7 +18,7 @@ material {
 vertex {
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.uv;
+        postProcess.vertex.xy = postProcess.normalizedUV;
     }
 
 }

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -45,7 +45,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.uv;
+        postProcess.vertex.xy = postProcess.normalizedUV;
     }
 }
 

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -40,16 +40,12 @@ material {
     ],
     domain : postprocess,
     depthWrite : false,
-    depthCulling : true,
-    culling: none
+    depthCulling : true
 }
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        // far-plane in view space
-        vec4 position = getPosition(); // clip-space
-        postProcess.vertex.xy = (position.xy * 0.5 + 0.5);
-        postProcess.vertex.zw = position.xy;
+        postProcess.vertex.xy = postProcess.uv;
     }
 }
 

--- a/filament/src/materials/ssao.mat
+++ b/filament/src/materials/ssao.mat
@@ -42,8 +42,7 @@ material {
     depthWrite : false,
     depthCulling : true,
     shadingModel : unlit,
-    variantFilter : [ skinning, shadowReceiver ],
-    culling: none
+    variantFilter : [ skinning, shadowReceiver ]
 }
 
 vertex {

--- a/filament/src/materials/tonemapping.mat
+++ b/filament/src/materials/tonemapping.mat
@@ -13,7 +13,6 @@ material {
     ],
     depthWrite : false,
     depthCulling : false,
-    culling: none,
     domain: postprocess
 }
 

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -3,14 +3,21 @@ void main() {
     PostProcessVertexInputs inputs;
     initPostProcessMaterialVertex(inputs);
 
-    inputs.uv = (position.xy * 0.5 + 0.5) * frameUniforms.resolution.xy;
+    inputs.uv = position.xy * 0.5 + 0.5;
+    inputs.texelCoords = inputs.uv * frameUniforms.resolution.xy;
 
-    gl_Position = position;
+// In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
+#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+    inputs.texelCoords.y = frameUniforms.resolution.y - 1.0 - inputs.texelCoords.y;
+    inputs.uv.y = 1.0 - inputs.uv.y;
+#endif
+
+    gl_Position = getPosition();
 
     // Invoke user code
     postProcessVertex(inputs);
 
-    vertex_uv = inputs.uv;
+    vertex_uv = inputs.texelCoords;
 
     // Handle user-defined interpolated attributes
 #if defined(VARIABLE_CUSTOM0)
@@ -24,12 +31,5 @@ void main() {
 #endif
 #if defined(VARIABLE_CUSTOM3)
     VARIABLE_CUSTOM_AT3 = inputs.VARIABLE_CUSTOM3;
-#endif
-
-#if defined(TARGET_METAL_ENVIRONMENT)
-    // Metal texture space is vertically flipped that of OpenGL's, so flip the Y coords so we sample
-    // the frame correctly. Vulkan doesn't need this fix because its clip space is mirrored
-    // (the Y axis points down the screen).
-    gl_Position.y = -gl_Position.y;
 #endif
 }

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -3,13 +3,13 @@ void main() {
     PostProcessVertexInputs inputs;
     initPostProcessMaterialVertex(inputs);
 
-    inputs.uv = position.xy * 0.5 + 0.5;
-    inputs.texelCoords = inputs.uv * frameUniforms.resolution.xy;
+    inputs.normalizedUV = position.xy * 0.5 + 0.5;
+    inputs.texelCoords = inputs.normalizedUV * frameUniforms.resolution.xy;
 
 // In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
 #if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
     inputs.texelCoords.y = frameUniforms.resolution.y - 1.0 - inputs.texelCoords.y;
-    inputs.uv.y = 1.0 - inputs.uv.y;
+    inputs.normalizedUV.y = 1.0 - inputs.normalizedUV.y;
 #endif
 
     gl_Position = getPosition();

--- a/shaders/src/post_process_getters.vs
+++ b/shaders/src/post_process_getters.vs
@@ -1,4 +1,11 @@
 /** @public-api */
 vec4 getPosition() {
-    return position;
+    vec4 pos = position;
+
+// In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    pos.y = -pos.y;
+#endif
+
+    return pos;
 }

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -3,7 +3,13 @@ LAYOUT_LOCATION(LOCATION_POSITION) in vec4 position;
 LAYOUT_LOCATION(LOCATION_UVS) out vec2 vertex_uv;
 
 struct PostProcessVertexInputs {
+
+    // We provide normalized (uv) and non-normalized (texelCoords) texture coordinates to
+    // custom vertex shaders. By default the non-normalized coordinates are passed through
+    // to the fragment shader.
     vec2 uv;
+    vec2 texelCoords;
+
 #ifdef VARIABLE_CUSTOM0
     vec4 VARIABLE_CUSTOM0;
 #endif

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -4,10 +4,9 @@ LAYOUT_LOCATION(LOCATION_UVS) out vec2 vertex_uv;
 
 struct PostProcessVertexInputs {
 
-    // We provide normalized (uv) and non-normalized (texelCoords) texture coordinates to
-    // custom vertex shaders. By default the non-normalized coordinates are passed through
-    // to the fragment shader.
-    vec2 uv;
+    // We provide normalized and non-normalized texture coordinates to custom vertex shaders.
+    // By default the non-normalized coordinates are passed through to the fragment shader.
+    vec2 normalizedUV;
     vec2 texelCoords;
 
 #ifdef VARIABLE_CUSTOM0


### PR DESCRIPTION
If you tried removing `culling: none` from any post-process materials, everything would be fine in GL but Vulkan would be black because our full-screen triangle was back-facing.

Usually this did not manifest as a discernible issue because tex coords were also flipped.