### PR TITLE
scissor is now part of PipelineState

### DIFF
--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -20,6 +20,8 @@
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
 
+#include <limits>
+
 #include <stdint.h>
 
 namespace filament {
@@ -29,6 +31,10 @@ struct PipelineState {
     Handle<HwProgram> program;
     RasterState rasterState;
     PolygonOffset polygonOffset;
+    Viewport scissor{ 0, 0,
+                      (uint32_t)std::numeric_limits<int32_t>::max(),
+                      (uint32_t)std::numeric_limits<int32_t>::max()
+    };
 };
 
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -290,13 +290,6 @@ DECL_DRIVER_API_N(setRenderPrimitiveRange,
         uint32_t, maxIndex,
         uint32_t, count)
 
-// Sets up a scissor rectangle that automatically gets clipped against the viewport.
-DECL_DRIVER_API_N(setViewportScissor,
-        int32_t, left,
-        int32_t, bottom,
-        uint32_t, width,
-        uint32_t, height)
-
 /*
  * Swap chain
  */

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -656,11 +656,6 @@ void MetalDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
     primitive->maxIndex = maxIndex > minIndex ? maxIndex : primitive->maxVertexCount - 1;
 }
 
-void MetalDriver::setViewportScissor(int32_t left, int32_t bottom, uint32_t width,
-        uint32_t height) {
-
-}
-
 void MetalDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> schRead) {
     ASSERT_PRECONDITION_NON_FATAL(schDraw == schRead,
                                   "Metal driver does not support distinct draw/read swap chains.");
@@ -848,6 +843,9 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                                          slopeScale:ps.polygonOffset.slope
                                               clamp:0.0];
     }
+
+    // FIXME: implement take ps.scissor into account
+    //  must be intersected with viewport (see OpenGLDriver.cpp for implementation details)
 
     // Bind uniform buffers.
     id<MTLBuffer> uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2490,16 +2490,15 @@ void OpenGLDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
 }
 
 // Sets up a scissor rectangle that automatically gets clipped against the viewport.
-void OpenGLDriver::setViewportScissor(
-        int32_t left, int32_t bottom, uint32_t width, uint32_t height) {
+void OpenGLDriver::setViewportScissor(Viewport const& viewportScissor) noexcept {
     DEBUG_MARKER()
 
     // In OpenGL, all four scissor parameters are actually signed, so clamp to MAX_INT32.
     const int32_t maxval = std::numeric_limits<int32_t>::max();
-    left = std::min(left, maxval);
-    bottom = std::min(bottom, maxval);
-    width = std::min(width, uint32_t(maxval));
-    height = std::min(height, uint32_t(maxval));
+    int32_t left = std::min(viewportScissor.left, maxval);
+    int32_t bottom = std::min(viewportScissor.bottom, maxval);
+    uint32_t width = std::min(viewportScissor.width, uint32_t(maxval));
+    uint32_t height = std::min(viewportScissor.height, uint32_t(maxval));
     // Compute the intersection of the requested scissor rectangle with the current viewport.
     // Note that the viewport rectangle isn't necessarily equal to the bounds of the current
     // Filament View (e.g., when post-processing is enabled).
@@ -2515,6 +2514,7 @@ void OpenGLDriver::setViewportScissor(
     scissor.z = std::max(0, right - scissor.x);
     scissor.w = std::max(0, top - scissor.y);
     setScissor(scissor.x, scissor.y, scissor.z, scissor.w);
+    enable(GL_SCISSOR_TEST);
 }
 
 /*
@@ -3055,7 +3055,7 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
 
     polygonOffset(state.polygonOffset.slope, state.polygonOffset.constant);
 
-    enable(GL_SCISSOR_TEST);
+    setViewportScissor(state.scissor);
 
     glDrawRangeElements(GLenum(rp->type), rp->minIndex, rp->maxIndex, rp->count,
             rp->gl.indicesType, reinterpret_cast<const void*>(rp->offset));

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -515,6 +515,8 @@ private:
             bool clearDepth, double depth,
             bool clearStencil, uint32_t stencil) noexcept;
 
+    void setViewportScissor(backend::Viewport const& viewportScissor) noexcept;
+
     // sampler buffer binding points (nullptr if not used)
     std::array<backend::HwSamplerGroup*, backend::Program::SAMPLER_BINDING_COUNT> mSamplerBindings;   // 8 pointers
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -147,12 +147,15 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::toneMapping(FrameGraph& fg, 
 
                 pInstance->commit(driver);
 
-                PipelineState pipeline;
-                pipeline.rasterState = mTonemapping.getMaterial()->getRasterState();
                 const uint8_t variant = static_cast<uint8_t> (
-                            translucent ?
-                            PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE );
-                pipeline.program = mTonemapping.getMaterial()->getProgram(variant);
+                        translucent ?
+                        PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE );
+
+                PipelineState pipeline{
+                        .program = mTonemapping.getMaterial()->getProgram(variant),
+                        .rasterState = mTonemapping.getMaterial()->getRasterState(),
+                        .scissor = pInstance->getScissor()
+                };
 
                 auto const& target = resources.getRenderTarget(data.rt);
                 driver.beginRenderPass(target.target, target.params);
@@ -200,12 +203,15 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::fxaa(FrameGraph& fg,
 
                 pInstance->commit(driver);
 
-                PipelineState pipeline;
-                pipeline.rasterState = mFxaa.getMaterial()->getRasterState();
                 const uint8_t variant = static_cast<uint8_t> (
-                            translucent ?
-                            PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE );
-                pipeline.program = mFxaa.getMaterial()->getProgram(variant);
+                        translucent ?
+                        PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE );
+
+                PipelineState pipeline{
+                        .program = mFxaa.getMaterial()->getProgram(variant),
+                        .rasterState = mFxaa.getMaterial()->getRasterState(),
+                        .scissor = pInstance->getScissor()
+                };
 
                 auto const& target = resources.getRenderTarget(data.rt);
                 driver.beginRenderPass(target.target, target.params);
@@ -381,6 +387,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssao(FrameGraph& fg, RenderP
                 pipeline.program = mSSAO.getProgram();
                 pipeline.rasterState = mSSAO.getMaterial()->getRasterState();
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::G;
+                pipeline.scissor = pInstance->getScissor();
 
                 driver.beginRenderPass(ssao.target, ssao.params);
                 pInstance->use(driver);
@@ -480,9 +487,11 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::mipmapPass(FrameGraph& fg,
                 pInstance->setParameter("level", uint32_t(level));
                 pInstance->commit(driver);
 
-                PipelineState pipeline;
-                pipeline.program = mMipmapDepth.getProgram();
-                pipeline.rasterState = mMipmapDepth.getMaterial()->getRasterState();
+                PipelineState pipeline{
+                    .program = mMipmapDepth.getProgram(),
+                    .rasterState = mMipmapDepth.getMaterial()->getRasterState(),
+                    .scissor = pInstance->getScissor()
+                };
 
                 driver.beginRenderPass(out.target, out.params);
                 pInstance->use(driver);
@@ -547,6 +556,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blurPass(FrameGraph& fg,
                 pipeline.program = mBlur.getProgram();
                 pipeline.rasterState = mBlur.getMaterial()->getRasterState();
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::G;
+                pipeline.scissor = pInstance->getScissor();
 
                 driver.beginRenderPass(blurred.target, blurred.params);
                 pInstance->use(driver);

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -179,6 +179,7 @@ void RenderPass::recordDriverCommands(FEngine::DriverApi& driver, FScene& scene,
             if (UTILS_UNLIKELY(mi != info.mi)) {
                 // this is always taken the first time
                 mi = info.mi;
+                pipeline.scissor = mi->getScissor();
                 *pPipelinePolygonOffset = mi->getPolygonOffset();
                 ma = mi->getMaterial();
                 mi->use(driver);

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -59,8 +59,6 @@ public:
         if (mSbHandle) {
             driver.bindSamplers(BindingPoints::PER_MATERIAL_INSTANCE, mSbHandle);
         }
-        driver.setViewportScissor(mScissorRect.left, mScissorRect.bottom,
-                mScissorRect.width, mScissorRect.height);
     }
 
     template <typename T>
@@ -95,6 +93,8 @@ public:
                 (uint32_t)std::numeric_limits<int32_t>::max()
         };
     }
+
+    backend::Viewport const& getScissor() const noexcept { return mScissorRect; }
 
     void setPolygonOffset(float scale, float constant) noexcept {
         mPolygonOffset = { scale, constant };


### PR DESCRIPTION
setViewportScissor is gone, which will avoid a runtime error if
called outside of begin/endRenderPass, making the driver API more
robust.