### PR TITLE
Split OpenGLDriver in two files

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -60,6 +60,8 @@ if (NOT USE_EXTERNAL_GLES3)
             src/opengl/GLUtils.h
             src/opengl/OpenGLBlitter.cpp
             src/opengl/OpenGLBlitter.h
+            src/opengl/OpenGLContext.cpp
+            src/opengl/OpenGLContext.h
             src/opengl/OpenGLDriver.cpp
             src/opengl/OpenGLDriver.h
             src/opengl/OpenGLDriverFactory.h

--- a/filament/backend/src/opengl/OpenGLBlitter.cpp
+++ b/filament/backend/src/opengl/OpenGLBlitter.cpp
@@ -17,6 +17,7 @@
 #include "OpenGLBlitter.h"
 
 #include "GLUtils.h"
+#include "OpenGLContext.h"
 
 #include <utils/compiler.h>
 #include <utils/Log.h>
@@ -167,7 +168,7 @@ void OpenGLBlitter::State::save() noexcept {
     // we're using tmu 0 as the source texture
     glActiveTexture(GL_TEXTURE0 + tmu);
 
-    // save that depends on glActiveTexture
+    // save what depends on glActiveTexture
     glGetIntegerv(GL_SAMPLER_BINDING, &sampler);
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &texture);
 

--- a/filament/backend/src/opengl/OpenGLBlitter.h
+++ b/filament/backend/src/opengl/OpenGLBlitter.h
@@ -22,9 +22,11 @@
 
 namespace filament {
 
+class OpenGLContext;
+
 class OpenGLBlitter {
 public:
-    explicit OpenGLBlitter() noexcept {}
+    explicit OpenGLBlitter(OpenGLContext& context) noexcept : mContext(context) {}
 
     void init() noexcept;
     void terminate() noexcept;
@@ -52,6 +54,7 @@ public:
     };
 
 private:
+    UTILS_UNUSED OpenGLContext& mContext;
     GLuint mSampler{};
     GLuint mVertexShader{};
     GLuint mFragmentShader{};

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OpenGLContext.h"
+
+// change to true to display all GL extensions in the console on start-up
+#define DEBUG_PRINT_EXTENSIONS false
+
+
+using namespace utils;
+
+namespace filament {
+
+using namespace backend;
+
+OpenGLContext::OpenGLContext() noexcept {
+    state.vao.p = &mDefaultVAO;
+    state.enables.caps.set(getIndexForCap(GL_DITHER));
+
+    UTILS_UNUSED char const* const vendor   = (char const*) glGetString(GL_VENDOR);
+    UTILS_UNUSED char const* const renderer = (char const*) glGetString(GL_RENDERER);
+    UTILS_UNUSED char const* const version  = (char const*) glGetString(GL_VERSION);
+    UTILS_UNUSED char const* const shader   = (char const*) glGetString(GL_SHADING_LANGUAGE_VERSION);
+
+#ifndef NDEBUG
+    slog.i
+        << vendor << io::endl
+        << renderer << io::endl
+        << version << io::endl
+        << shader << io::endl;
+#endif
+
+    // OpenGL (ES) version
+    GLint major = 0, minor = 0;
+    glGetIntegerv(GL_MAJOR_VERSION, &major);
+    glGetIntegerv(GL_MINOR_VERSION, &minor);
+    glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &gets.max_renderbuffer_size);
+    glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &gets.max_uniform_block_size);
+    glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &gets.uniform_buffer_offset_alignment);
+
+#ifndef NDEBUG
+    slog.i
+        << "GL_MAX_RENDERBUFFER_SIZE = " << gets.max_renderbuffer_size << io::endl
+        << "GL_MAX_UNIFORM_BLOCK_SIZE = " << gets.max_uniform_block_size << io::endl
+        << "GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT = " << gets.uniform_buffer_offset_alignment << io::endl;
+#endif
+
+    if (strstr(renderer, "Adreno")) {
+        bugs.clears_hurt_performance = true;
+    } else if (strstr(renderer, "Mali")) {
+        bugs.vao_doesnt_store_element_array_buffer_binding = true;
+        if (strstr(renderer, "Mali-T")) {
+            bugs.disable_glFlush = true;
+            bugs.disable_shared_context_draws = true;
+            bugs.texture_external_needs_rebind = true;
+        }
+    } else if (strstr(renderer, "Intel")) {
+        bugs.vao_doesnt_store_element_array_buffer_binding = true;
+    } else if (strstr(renderer, "PowerVR") || strstr(renderer, "Apple")) {
+    } else if (strstr(renderer, "Tegra") || strstr(renderer, "GeForce") || strstr(renderer, "NV")) {
+    } else if (strstr(renderer, "Vivante")) {
+    } else if (strstr(renderer, "AMD") || strstr(renderer, "ATI")) {
+    } else if (strstr(renderer, "Mozilla")) {
+        bugs.disable_invalidate_framebuffer = true;
+    }
+
+    // Figure out if we have the extension we need
+    GLint n;
+    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
+    ExtentionSet exts;
+    for (GLint i = 0; i < n; i++) {
+        const char * const extension = (const char*)glGetStringi(GL_EXTENSIONS, (GLuint)i);
+        exts.insert(StaticString::make(extension, strlen(extension)));
+        if (DEBUG_PRINT_EXTENSIONS) {
+            slog.d << extension << io::endl;
+        }
+    }
+
+    ShaderModel shaderModel = ShaderModel::UNKNOWN;
+    if (GLES31_HEADERS) {
+        if (major == 3 && minor >= 0) {
+            shaderModel = ShaderModel::GL_ES_30;
+        }
+        if (major == 3 && minor >= 1) {
+            features.multisample_texture = true;
+        }
+        initExtensionsGLES(major, minor, exts);
+    } else if (GL41_HEADERS) {
+        if (major == 4 && minor >= 1) {
+            shaderModel = ShaderModel::GL_CORE_41;
+        }
+        initExtensionsGL(major, minor, exts);
+        features.multisample_texture = true;
+    };
+    mShaderModel = shaderModel;
+
+    /*
+     * Set our default state
+     */
+
+    disable(GL_DITHER);
+    enable(GL_DEPTH_TEST);
+
+    // With desktop GL, the application must enable point size to allow vertex shaders to set it,
+    // but with OpenGL ES, this is always on and there is no enable flag.
+#if GL41_HEADERS
+    enable(GL_PROGRAM_POINT_SIZE);
+#endif
+
+    // TODO: Don't enable scissor when it is not necessary. This optimization could be done here in
+    // the driver by simply deferring the enable until the scissor rect is smaller than the window.
+    enable(GL_SCISSOR_TEST);
+
+#ifdef GL_ARB_seamless_cube_map
+    enable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
+#endif
+
+#ifdef GL_EXT_texture_filter_anisotropic
+    if (ext.texture_filter_anisotropic) {
+        glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &gets.maxAnisotropy);
+    }
+#endif
+
+#ifdef GL_FRAGMENT_SHADER_DERIVATIVE_HINT
+    glHint(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, GL_NICEST);
+#endif
+
+}
+
+UTILS_NOINLINE
+bool OpenGLContext::hasExtension(ExtentionSet const& map, utils::StaticString ext) noexcept {
+    return map.find(ext) != map.end();
+}
+
+void OpenGLContext::initExtensionsGLES(GLint major, GLint minor, ExtentionSet const& exts) {
+    // figure out and initialize the extensions we need
+    ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
+    ext.texture_compression_etc2 = true;
+    ext.QCOM_tiled_rendering = hasExtension(exts, "GL_QCOM_tiled_rendering");
+    ext.OES_EGL_image_external_essl3 = hasExtension(exts, "GL_OES_EGL_image_external_essl3");
+    ext.EXT_debug_marker = hasExtension(exts, "GL_EXT_debug_marker");
+    ext.EXT_color_buffer_half_float = hasExtension(exts, "GL_EXT_color_buffer_half_float");
+    ext.EXT_color_buffer_float = hasExtension(exts, "GL_EXT_color_buffer_float");
+    ext.APPLE_color_buffer_packed_float = hasExtension(exts, "GL_APPLE_color_buffer_packed_float");
+    ext.texture_compression_s3tc = hasExtension(exts, "WEBGL_compressed_texture_s3tc");
+    ext.EXT_multisampled_render_to_texture = hasExtension(exts, "GL_EXT_multisampled_render_to_texture");
+    // ES 3.2 implies EXT_color_buffer_float
+    if (major >= 3 && minor >= 2) {
+        ext.EXT_color_buffer_float = true;
+    }
+}
+
+void OpenGLContext::initExtensionsGL(GLint major, GLint minor, ExtentionSet const& exts) {
+    ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
+    ext.texture_compression_etc2 = hasExtension(exts, "GL_ARB_ES3_compatibility");
+    ext.texture_compression_s3tc = hasExtension(exts, "GL_EXT_texture_compression_s3tc");
+    ext.OES_EGL_image_external_essl3 = hasExtension(exts, "GL_OES_EGL_image_external_essl3");
+    ext.EXT_debug_marker = hasExtension(exts, "GL_EXT_debug_marker");
+    ext.EXT_color_buffer_half_float = true;  // Assumes core profile.
+    ext.EXT_color_buffer_float = true;  // Assumes core profile.
+    ext.APPLE_color_buffer_packed_float = true;  // Assumes core profile.
+}
+
+void OpenGLContext::bindBuffer(GLenum target, GLuint buffer) noexcept {
+    size_t targetIndex = getIndexForBufferTarget(target);
+    if (target == GL_ELEMENT_ARRAY_BUFFER) {
+        // GL_ELEMENT_ARRAY_BUFFER is a special case, where the currently bound VAO remembers
+        // the index buffer, unless there are no VAO bound (see: bindVertexArray)
+        assert(state.vao.p);
+        if (state.buffers.genericBinding[targetIndex] != buffer
+            || ((state.vao.p != &mDefaultVAO) && (state.vao.p->elementArray != buffer))) {
+            state.buffers.genericBinding[targetIndex] = buffer;
+            if (state.vao.p != &mDefaultVAO) {
+                state.vao.p->elementArray = buffer;
+            }
+            glBindBuffer(target, buffer);
+        }
+    } else {
+        update_state(state.buffers.genericBinding[targetIndex], buffer, [&]() {
+            glBindBuffer(target, buffer);
+        });
+    }
+}
+
+void OpenGLContext::pixelStore(GLenum pname, GLint param) noexcept {
+    GLint* pcur = nullptr;
+    switch (pname) {
+        case GL_PACK_ROW_LENGTH:
+            pcur = &state.pack.row_length;
+            break;
+        case GL_PACK_SKIP_ROWS:
+            pcur = &state.pack.skip_row;
+            break;
+        case GL_PACK_SKIP_PIXELS:
+            pcur = &state.pack.skip_pixels;
+            break;
+        case GL_PACK_ALIGNMENT:
+            pcur = &state.pack.alignment;
+            break;
+
+        case GL_UNPACK_ROW_LENGTH:
+            pcur = &state.unpack.row_length;
+            break;
+        case GL_UNPACK_ALIGNMENT:
+            pcur = &state.unpack.alignment;
+            break;
+        case GL_UNPACK_SKIP_PIXELS:
+            pcur = &state.unpack.skip_pixels;
+            break;
+        case GL_UNPACK_SKIP_ROWS:
+            pcur = &state.unpack.skip_row;
+            break;
+        default:
+            goto default_case;
+    }
+
+    if (UTILS_UNLIKELY(*pcur != param)) {
+        *pcur = param;
+default_case:
+        glPixelStorei(pname, param);
+    }
+}
+
+void OpenGLContext::unbindTexture(GLenum target, GLuint texture_id) noexcept {
+    // unbind this texture from all the units it might be bound to
+    // no need unbind the texture from FBOs because we're not tracking that state (and there is
+    // no need to).
+    const size_t index = getIndexForTextureTarget(target);
+    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
+        if (state.textures.units[unit].targets[index].texture_id == texture_id) {
+            bindTexture(unit, target, (GLuint)0, index);
+        }
+    }
+}
+
+void OpenGLContext::unbindSampler(GLuint sampler) noexcept {
+    // unbind this sampler from all the units it might be bound to
+#pragma nounroll    // clang generates >800B of code!!!
+    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
+        if (state.textures.units[unit].sampler == sampler) {
+            bindSampler(unit, 0);
+        }
+    }
+}
+
+void OpenGLContext::deleteBuffers(GLsizei n, const GLuint* buffers, GLenum target) noexcept {
+    glDeleteBuffers(n, buffers);
+    // bindings of bound buffers are reset to 0
+    const size_t targetIndex = getIndexForBufferTarget(target);
+    auto& genericBuffer = state.buffers.genericBinding[targetIndex];
+    #pragma nounroll
+    for (GLsizei i = 0; i < n; ++i) {
+        if (genericBuffer == buffers[i]) {
+            genericBuffer = 0;
+        }
+    }
+    if (target == GL_UNIFORM_BUFFER || target == GL_TRANSFORM_FEEDBACK_BUFFER) {
+        auto& indexedBuffer = state.buffers.targets[targetIndex];
+        #pragma nounroll // clang generates >1 KiB of code!!
+        for (GLsizei i = 0; i < n; ++i) {
+            #pragma nounroll
+            for (auto& buffer : indexedBuffer.buffers) {
+                if (buffer.name == buffers[i]) {
+                    buffer.name = 0;
+                    buffer.offset = 0;
+                    buffer.size = 0;
+                }
+            }
+        }
+    }
+}
+
+void OpenGLContext::deleteVextexArrays(GLsizei n, const GLuint* arrays) noexcept {
+    glDeleteVertexArrays(1, arrays);
+    // binding of a bound VAO is reset to 0
+    for (GLsizei i = 0; i < n; ++i) {
+        if (state.vao.p->vao == arrays[i]) {
+            bindVertexArray(nullptr);
+        }
+    }
+}
+
+} // namesapce filament

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -1,0 +1,555 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_OPENGLCONTEXT_H
+#define TNT_FILAMENT_BACKEND_OPENGLCONTEXT_H
+
+#include <math/vec4.h>
+
+#include <utils/CString.h>
+
+#include "GLUtils.h"
+
+#include <set>
+
+namespace filament {
+
+class OpenGLContext {
+public:
+    static constexpr const size_t MAX_TEXTURE_UNIT_COUNT = 16;   // All mobile GPUs as of 2016
+    static constexpr const size_t MAX_BUFFER_BINDINGS = 32;
+    typedef math::details::TVec4<GLint> vec4gli;
+
+    struct RenderPrimitive {
+        GLuint vao = 0;
+        GLenum indicesType = GL_UNSIGNED_INT;
+        GLuint elementArray = 0;
+        utils::bitset32 vertexAttribArray;
+    } gl;
+
+    OpenGLContext() noexcept;
+
+    // this is chosen to minimize code size
+    using ExtentionSet = std::set<utils::StaticString>;
+    static bool hasExtension(ExtentionSet const& exts, utils::StaticString ext) noexcept;
+    void initExtensionsGLES(GLint major, GLint minor, ExtentionSet const& extensionsMap);
+    void initExtensionsGL(GLint major, GLint minor, ExtentionSet const& extensionsMap);
+
+    constexpr static inline size_t getIndexForTextureTarget(GLuint target) noexcept;
+    constexpr        inline size_t getIndexForCap(GLenum cap) noexcept;
+    constexpr static inline size_t getIndexForBufferTarget(GLenum target) noexcept;
+
+    backend::ShaderModel getShaderModel() const noexcept { return mShaderModel; }
+
+
+    inline void useProgram(GLuint program) noexcept;
+
+          void pixelStore(GLenum, GLint) noexcept;
+    inline void activeTexture(GLuint unit) noexcept;
+    inline void bindTexture(GLuint unit, GLuint target, GLuint texId, size_t targetIndex) noexcept;
+    inline void bindTexture(GLuint unit, GLuint target, GLuint texId) noexcept;
+
+           void unbindTexture(GLenum target, GLuint id) noexcept;
+    inline void bindVertexArray(RenderPrimitive const* p) noexcept;
+    inline void bindSampler(GLuint unit, GLuint sampler) noexcept;
+           void unbindSampler(GLuint sampler) noexcept;
+
+           void bindBuffer(GLenum target, GLuint buffer) noexcept;
+    inline void bindBufferRange(GLenum target, GLuint index, GLuint buffer,
+            GLintptr offset, GLsizeiptr size) noexcept;
+
+    inline void bindFramebuffer(GLenum target, GLuint buffer) noexcept;
+
+    inline void enableVertexAttribArray(GLuint index) noexcept;
+    inline void disableVertexAttribArray(GLuint index) noexcept;
+    inline void enable(GLenum cap) noexcept;
+    inline void disable(GLenum cap) noexcept;
+    inline void frontFace(GLenum mode) noexcept;
+    inline void cullFace(GLenum mode) noexcept;
+    inline void blendEquation(GLenum modeRGB, GLenum modeA) noexcept;
+    inline void blendFunction(GLenum srcRGB, GLenum srcA, GLenum dstRGB, GLenum dstA) noexcept;
+    inline void colorMask(GLboolean flag) noexcept;
+    inline void depthMask(GLboolean flag) noexcept;
+    inline void depthFunc(GLenum func) noexcept;
+    inline void polygonOffset(GLfloat factor, GLfloat units) noexcept;
+
+    inline void setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
+    inline void viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
+
+    inline void setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) noexcept;
+    inline void setClearDepth(GLfloat depth) noexcept;
+    inline void setClearStencil(GLint stencil) noexcept;
+
+    void deleteBuffers(GLsizei n, const GLuint* buffers, GLenum target) noexcept;
+    void deleteVextexArrays(GLsizei n, const GLuint* arrays) noexcept;
+
+    // glGet*() values
+    struct {
+        GLint max_renderbuffer_size = 0;
+        GLint max_uniform_block_size = 0;
+        GLint uniform_buffer_offset_alignment = 256;
+        GLfloat maxAnisotropy = 0.0f;
+    } gets;
+
+    // features supported by this version of GL or GLES
+    struct {
+        bool multisample_texture = false;
+    } features;
+
+    // supported extensions detected at runtime
+    struct {
+        bool texture_compression_s3tc = false;
+        bool texture_compression_etc2 = false;
+        bool texture_filter_anisotropic = false;
+        bool QCOM_tiled_rendering = false;
+        bool OES_EGL_image_external_essl3 = false;
+        bool EXT_debug_marker = false;
+        bool EXT_color_buffer_half_float = false;
+        bool EXT_color_buffer_float = false;
+        bool APPLE_color_buffer_packed_float = false;
+        bool EXT_multisampled_render_to_texture = false;
+    } ext;
+
+    struct {
+        // Some drivers have issues with UBOs in the fragment shader when
+        // glFlush() is called between draw calls.
+        bool disable_glFlush = false;
+
+        // Some drivers seem to not store the GL_ELEMENT_ARRAY_BUFFER binding
+        // in the VAO state.
+        bool vao_doesnt_store_element_array_buffer_binding = false;
+
+        // On some drivers, glClear() cancels glInvalidateFrameBuffer() which results
+        // in extra GPU memory loads.
+        bool clears_hurt_performance = false;
+
+        // Some drivers have gl state issues when drawing from shared contexts
+        bool disable_shared_context_draws = false;
+
+        // Some drivers require the GL_TEXTURE_EXTERNAL_OES target to be bound when
+        // the texture image changes, even if it's already bound to that texture
+        bool texture_external_needs_rebind = false;
+
+        // Some web browsers seem to immediately clear the default framebuffer when calling
+        // glInvalidateFramebuffer with WebGL 2.0
+        bool disable_invalidate_framebuffer = false;
+    } bugs;
+
+    // state getters -- as needed.
+    GLuint getDrawFbo() const noexcept { return state.draw_fbo; }
+    vec4gli const& getViewport() const { return state.window.viewport; }
+
+    // function to handle state changes we don't control
+    void updateTexImage(GLenum target, GLuint id) noexcept {
+        const size_t index = getIndexForTextureTarget(target);
+        state.textures.units[state.textures.active].targets[index].texture_id = id;
+    }
+    void resetProgram() noexcept { state.program.use = 0; }
+
+private:
+    backend::ShaderModel mShaderModel;
+
+    // Try to keep the State structure sorted by data-access patterns
+    struct State {
+        GLuint draw_fbo = 0;
+        GLuint read_fbo = 0;
+
+        struct {
+            GLuint use = 0;
+        } program;
+
+        struct {
+            RenderPrimitive* p = nullptr;
+        } vao;
+
+        struct {
+            GLenum frontFace            = GL_CCW;
+            GLenum cullFace             = GL_BACK;
+            GLenum blendEquationRGB     = GL_FUNC_ADD;
+            GLenum blendEquationA       = GL_FUNC_ADD;
+            GLenum blendFunctionSrcRGB  = GL_ONE;
+            GLenum blendFunctionSrcA    = GL_ONE;
+            GLenum blendFunctionDstRGB  = GL_ZERO;
+            GLenum blendFunctionDstA    = GL_ZERO;
+            GLboolean colorMask         = GL_TRUE;
+            GLboolean depthMask         = GL_TRUE;
+            GLenum depthFunc            = GL_LESS;
+        } raster;
+
+        struct PolygonOffset {
+            GLfloat factor = 0;
+            GLfloat units = 0;
+            bool operator != (PolygonOffset const& rhs) noexcept {
+                return factor != rhs.factor || units != rhs.units;
+            }
+        } polygonOffset;
+
+        struct {
+            utils::bitset32 caps;
+        } enables;
+
+        struct {
+            struct {
+                struct {
+                    GLuint name = 0;
+                    GLintptr offset = 0;
+                    GLsizeiptr size = 0;
+                } buffers[MAX_BUFFER_BINDINGS];
+            } targets[2];   // there are only 2 indexed buffer target (uniform and transform feedback)
+            GLuint genericBinding[8] = { 0 };
+        } buffers;
+
+        struct {
+            GLuint active = 0;      // zero-based
+            struct {
+                GLuint sampler = 0;
+                struct {
+                    GLuint texture_id = 0;
+                } targets[5];
+            } units[MAX_TEXTURE_UNIT_COUNT];
+        } textures;
+
+        struct {
+            GLint row_length = 0;
+            GLint alignment = 4;
+            GLint skip_pixels = 0;
+            GLint skip_row = 0;
+        } unpack;
+
+        struct {
+            GLint row_length = 0;
+            GLint alignment = 4;
+            GLint skip_pixels = 0;
+            GLint skip_row = 0;
+        } pack;
+
+        struct {
+            vec4gli scissor { 0 };
+            vec4gli viewport { 0 };
+        } window;
+
+        struct {
+            math::float4 color = {};
+            GLfloat depth = 1.0f;
+            GLint stencil = 0;
+        } clears;
+    } state;
+
+    RenderPrimitive mDefaultVAO;
+
+    template <typename T, typename F>
+    static inline void update_state(T& state, T const& expected, F functor, bool force = false) noexcept {
+        if (UTILS_UNLIKELY(force || state != expected)) {
+            state = expected;
+            functor();
+        }
+    }
+
+    static constexpr const size_t TEXTURE_TARGET_COUNT =
+            sizeof(state.textures.units[0].targets) / sizeof(state.textures.units[0].targets[0]);
+
+};
+
+// ------------------------------------------------------------------------------------------------
+
+constexpr size_t OpenGLContext::getIndexForTextureTarget(GLuint target) noexcept {
+    switch (target) {
+        case GL_TEXTURE_2D:             return 0;
+        case GL_TEXTURE_2D_ARRAY:       return 1;
+        case GL_TEXTURE_CUBE_MAP:       return 2;
+        case GL_TEXTURE_2D_MULTISAMPLE: return 3;
+        case GL_TEXTURE_EXTERNAL_OES:   return 4;
+        default:                        return 0;
+    }
+}
+
+constexpr size_t OpenGLContext::getIndexForCap(GLenum cap) noexcept { //NOLINT
+    size_t index = 0;
+    switch (cap) {
+        case GL_BLEND:                          index =  0; break;
+        case GL_CULL_FACE:                      index =  1; break;
+        case GL_SCISSOR_TEST:                   index =  2; break;
+        case GL_DEPTH_TEST:                     index =  3; break;
+        case GL_STENCIL_TEST:                   index =  4; break;
+        case GL_DITHER:                         index =  5; break;
+        case GL_SAMPLE_ALPHA_TO_COVERAGE:       index =  6; break;
+        case GL_SAMPLE_COVERAGE:                index =  7; break;
+        case GL_POLYGON_OFFSET_FILL:            index =  8; break;
+        case GL_PRIMITIVE_RESTART_FIXED_INDEX:  index =  9; break;
+        case GL_RASTERIZER_DISCARD:             index = 10; break;
+#ifdef GL_ARB_seamless_cube_map
+            case GL_TEXTURE_CUBE_MAP_SEAMLESS:      index = 11; break;
+#endif
+#if GL41_HEADERS
+            case GL_PROGRAM_POINT_SIZE:             index = 12; break;
+#endif
+        default: index = 13; break; // should never happen
+    }
+    assert(index < 13 && index < state.enables.caps.size());
+    return index;
+}
+
+constexpr size_t OpenGLContext::getIndexForBufferTarget(GLenum target) noexcept {
+    size_t index = 0;
+    switch (target) {
+        // The indexed buffers MUST be first in this list
+        case GL_UNIFORM_BUFFER:             index = 0; break;
+        case GL_TRANSFORM_FEEDBACK_BUFFER:  index = 1; break;
+
+        case GL_ARRAY_BUFFER:               index = 2; break;
+        case GL_COPY_READ_BUFFER:           index = 3; break;
+        case GL_COPY_WRITE_BUFFER:          index = 4; break;
+        case GL_ELEMENT_ARRAY_BUFFER:       index = 5; break;
+        case GL_PIXEL_PACK_BUFFER:          index = 6; break;
+        case GL_PIXEL_UNPACK_BUFFER:        index = 7; break;
+        default: index = 8; break; // should never happen
+    }
+    assert(index < sizeof(state.buffers.genericBinding)/sizeof(state.buffers.genericBinding[0])); // NOLINT(misc-redundant-expression)
+    return index;
+}
+
+// ------------------------------------------------------------------------------------------------
+
+void OpenGLContext::activeTexture(GLuint unit) noexcept {
+    assert(unit < MAX_TEXTURE_UNIT_COUNT);
+    update_state(state.textures.active, unit, [&]() {
+        glActiveTexture(GL_TEXTURE0 + unit);
+    });
+}
+
+void OpenGLContext::bindSampler(GLuint unit, GLuint sampler) noexcept {
+    assert(unit < MAX_TEXTURE_UNIT_COUNT);
+    update_state(state.textures.units[unit].sampler, sampler, [&]() {
+        glBindSampler(unit, sampler);
+    });
+}
+
+void OpenGLContext::setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept {
+    vec4gli scissor(left, bottom, width, height);
+    update_state(state.window.scissor, scissor, [&]() {
+        glScissor(left, bottom, width, height);
+    });
+}
+
+void OpenGLContext::viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept {
+    vec4gli viewport(left, bottom, width, height);
+    update_state(state.window.viewport, viewport, [&]() {
+        glViewport(left, bottom, width, height);
+    });
+}
+
+void OpenGLContext::setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) noexcept {
+    math::float4 color(r, g, b, a);
+    update_state(state.clears.color, color, [&]() {
+        glClearColor(r, g, b, a);
+    });
+}
+
+void OpenGLContext::setClearDepth(GLfloat depth) noexcept {
+    update_state(state.clears.depth, depth, [&]() {
+        glClearDepthf(depth);
+    });
+}
+
+void OpenGLContext::setClearStencil(GLint stencil) noexcept {
+    update_state(state.clears.stencil, stencil, [&]() {
+        glClearStencil(stencil);
+    });
+}
+
+void OpenGLContext::bindVertexArray(RenderPrimitive const* p) noexcept {
+    RenderPrimitive* vao = p ? const_cast<RenderPrimitive *>(p) : &mDefaultVAO;
+    update_state(state.vao.p, vao, [&]() {
+        glBindVertexArray(vao->vao);
+        // update GL_ELEMENT_ARRAY_BUFFER, which is updated by glBindVertexArray
+        size_t targetIndex = getIndexForBufferTarget(GL_ELEMENT_ARRAY_BUFFER);
+        state.buffers.genericBinding[targetIndex] = vao->elementArray;
+        if (UTILS_UNLIKELY(bugs.vao_doesnt_store_element_array_buffer_binding)) {
+            // This shouldn't be needed, but it looks like some drivers don't do the implicit
+            // glBindBuffer().
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vao->elementArray);
+        }
+    });
+}
+
+void OpenGLContext::bindBufferRange(GLenum target, GLuint index, GLuint buffer,
+        GLintptr offset, GLsizeiptr size) noexcept {
+    size_t targetIndex = getIndexForBufferTarget(target);
+    assert(targetIndex <= 1); // sanity check
+
+    // this ALSO sets the generic binding
+    if (   state.buffers.targets[targetIndex].buffers[index].name != buffer
+           || state.buffers.targets[targetIndex].buffers[index].offset != offset
+           || state.buffers.targets[targetIndex].buffers[index].size != size) {
+        state.buffers.targets[targetIndex].buffers[index].name = buffer;
+        state.buffers.targets[targetIndex].buffers[index].offset = offset;
+        state.buffers.targets[targetIndex].buffers[index].size = size;
+        state.buffers.genericBinding[targetIndex] = buffer;
+        glBindBufferRange(target, index, buffer, offset, size);
+    }
+}
+
+void OpenGLContext::bindFramebuffer(GLenum target, GLuint buffer) noexcept {
+    switch (target) {
+        case GL_FRAMEBUFFER:
+            if (state.draw_fbo != buffer || state.read_fbo != buffer) {
+                state.draw_fbo = state.read_fbo = buffer;
+                glBindFramebuffer(target, buffer);
+            }
+            break;
+        case GL_DRAW_FRAMEBUFFER:
+            if (state.draw_fbo != buffer) {
+                state.draw_fbo = buffer;
+                glBindFramebuffer(target, buffer);
+            }
+            break;
+        case GL_READ_FRAMEBUFFER:
+            if (state.read_fbo != buffer) {
+                state.read_fbo = buffer;
+                glBindFramebuffer(target, buffer);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+void OpenGLContext::bindTexture(GLuint unit, GLuint target, GLuint texId, size_t targetIndex) noexcept {
+    assert(targetIndex == getIndexForTextureTarget(target));
+    assert(targetIndex < TEXTURE_TARGET_COUNT);
+    update_state(state.textures.units[unit].targets[targetIndex].texture_id, texId, [&]() {
+        activeTexture(unit);
+        glBindTexture(target, texId);
+    }, (target == GL_TEXTURE_EXTERNAL_OES) && bugs.texture_external_needs_rebind);
+}
+
+void OpenGLContext::bindTexture(GLuint unit, GLuint target, GLuint texId) noexcept {
+    bindTexture(unit, target, texId, getIndexForTextureTarget(target));
+}
+
+void OpenGLContext::useProgram(GLuint program) noexcept {
+    update_state(state.program.use, program, [&]() {
+        glUseProgram(program);
+    });
+}
+
+void OpenGLContext::enableVertexAttribArray(GLuint index) noexcept {
+    assert(state.vao.p);
+    assert(index < state.vao.p->vertexAttribArray.size());
+    if (UTILS_UNLIKELY(!state.vao.p->vertexAttribArray[index])) {
+        state.vao.p->vertexAttribArray.set(index);
+        glEnableVertexAttribArray(index);
+    }
+}
+
+void OpenGLContext::disableVertexAttribArray(GLuint index) noexcept {
+    assert(state.vao.p);
+    assert(index < state.vao.p->vertexAttribArray.size());
+    if (UTILS_UNLIKELY(state.vao.p->vertexAttribArray[index])) {
+        state.vao.p->vertexAttribArray.unset(index);
+        glDisableVertexAttribArray(index);
+    }
+}
+
+void OpenGLContext::enable(GLenum cap) noexcept {
+    size_t index = getIndexForCap(cap);
+    if (UTILS_UNLIKELY(!state.enables.caps[index])) {
+        state.enables.caps.set(index);
+        glEnable(cap);
+    }
+}
+
+void OpenGLContext::disable(GLenum cap) noexcept {
+    size_t index = getIndexForCap(cap);
+    if (UTILS_UNLIKELY(state.enables.caps[index])) {
+        state.enables.caps.unset(index);
+        glDisable(cap);
+    }
+}
+
+void OpenGLContext::frontFace(GLenum mode) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.frontFace, mode, [&]() {
+        glFrontFace(mode);
+    });
+}
+
+void OpenGLContext::cullFace(GLenum mode) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.cullFace, mode, [&]() {
+        glCullFace(mode);
+    });
+}
+
+void OpenGLContext::blendEquation(GLenum modeRGB, GLenum modeA) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    if (UTILS_UNLIKELY(
+            state.raster.blendEquationRGB != modeRGB || state.raster.blendEquationA != modeA)) {
+        state.raster.blendEquationRGB = modeRGB;
+        state.raster.blendEquationA   = modeA;
+        glBlendEquationSeparate(modeRGB, modeA);
+    }
+}
+
+void OpenGLContext::blendFunction(GLenum srcRGB, GLenum srcA, GLenum dstRGB, GLenum dstA) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    if (UTILS_UNLIKELY(
+            state.raster.blendFunctionSrcRGB != srcRGB ||
+            state.raster.blendFunctionSrcA != srcA ||
+            state.raster.blendFunctionDstRGB != dstRGB ||
+            state.raster.blendFunctionDstA != dstA)) {
+        state.raster.blendFunctionSrcRGB = srcRGB;
+        state.raster.blendFunctionSrcA = srcA;
+        state.raster.blendFunctionDstRGB = dstRGB;
+        state.raster.blendFunctionDstA = dstA;
+        glBlendFuncSeparate(srcRGB, dstRGB, srcA, dstA);
+    }
+}
+
+void OpenGLContext::colorMask(GLboolean flag) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.colorMask, flag, [&]() {
+        glColorMask(flag, flag, flag, flag);
+    });
+}
+void OpenGLContext::depthMask(GLboolean flag) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.depthMask, flag, [&]() {
+        glDepthMask(flag);
+    });
+}
+
+void OpenGLContext::depthFunc(GLenum func) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.depthFunc, func, [&]() {
+        glDepthFunc(func);
+    });
+}
+
+void OpenGLContext::polygonOffset(GLfloat factor, GLfloat units) noexcept {
+    update_state(state.polygonOffset, { factor, units }, [&]() {
+        if (factor != 0 || units != 0) {
+            glPolygonOffset(factor, units);
+            enable(GL_POLYGON_OFFSET_FILL);
+        } else {
+            disable(GL_POLYGON_OFFSET_FILL);
+        }
+    });
+}
+
+} // namesapce filament
+
+#endif //TNT_FILAMENT_BACKEND_OPENGLCONTEXT_H

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -29,11 +29,6 @@
 #include <utils/Panic.h>
 #include <utils/Systrace.h>
 
-#include <set>
-
-// change to true to display all GL extensions in the console on start-up
-#define DEBUG_PRINT_EXTENSIONS false
-
 // To emulate EXT_multisampled_render_to_texture properly we need to be able to copy from
 // a non-ms texture to an ms attachment. This is only allowed with OpenGL (not GLES), which
 // would be fine for us. However, this is also not trivial to implement in Metal so for now
@@ -133,122 +128,14 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
           mHandleArena("Handles", 2U * 1024U * 1024U), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
-    state.enables.caps.set(getIndexForCap(GL_DITHER));
-    state.vao.p = &mDefaultVAO;
 
     std::fill(mSamplerBindings.begin(), mSamplerBindings.end(), nullptr);
 
     // set a reasonable default value for our stream array
     mExternalStreams.reserve(8);
 
-   UTILS_UNUSED char const* const vendor   = (char const*) glGetString(GL_VENDOR);
-   UTILS_UNUSED char const* const renderer = (char const*) glGetString(GL_RENDERER);
-   UTILS_UNUSED char const* const version  = (char const*) glGetString(GL_VERSION);
-   UTILS_UNUSED char const* const shader   = (char const*) glGetString(GL_SHADING_LANGUAGE_VERSION);
-
 #ifndef NDEBUG
-    slog.i
-        << vendor << io::endl
-        << renderer << io::endl
-        << version << io::endl
-        << shader << io::endl
-        << "OS version: " << mPlatform.getOSVersion() << io::endl;
-#endif
-
-    // OpenGL (ES) version
-    GLint major = 0, minor = 0;
-    glGetIntegerv(GL_MAJOR_VERSION, &major);
-    glGetIntegerv(GL_MINOR_VERSION, &minor);
-    glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &gets.max_renderbuffer_size);
-    glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &gets.max_uniform_block_size);
-    glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &gets.uniform_buffer_offset_alignment);
-
-#ifndef NDEBUG
-    slog.i
-        << "GL_MAX_RENDERBUFFER_SIZE = " << gets.max_renderbuffer_size << io::endl
-        << "GL_MAX_UNIFORM_BLOCK_SIZE = " << gets.max_uniform_block_size << io::endl
-        << "GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT = " << gets.uniform_buffer_offset_alignment << io::endl;
-#endif
-
-    if (strstr(renderer, "Adreno")) {
-        bugs.clears_hurt_performance = true;
-    } else if (strstr(renderer, "Mali")) {
-        bugs.vao_doesnt_store_element_array_buffer_binding = true;
-        if (strstr(renderer, "Mali-T")) {
-            bugs.disable_glFlush = true;
-            bugs.disable_shared_context_draws = true;
-            bugs.texture_external_needs_rebind = true;
-        }
-    } else if (strstr(renderer, "Intel")) {
-        bugs.vao_doesnt_store_element_array_buffer_binding = true;
-    } else if (strstr(renderer, "PowerVR") || strstr(renderer, "Apple")) {
-    } else if (strstr(renderer, "Tegra") || strstr(renderer, "GeForce") || strstr(renderer, "NV")) {
-    } else if (strstr(renderer, "Vivante")) {
-    } else if (strstr(renderer, "AMD") || strstr(renderer, "ATI")) {
-    } else if (strstr(renderer, "Mozilla")) {
-        bugs.disable_invalidate_framebuffer = true;
-    }
-
-
-    // Figure out if we have the extension we need
-    GLint n;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &n);
-    ExtentionSet exts;
-    for (GLint i = 0; i < n; i++) {
-        const char * const ext = (const char*)glGetStringi(GL_EXTENSIONS, (GLuint)i);
-        exts.insert(StaticString::make(ext, strlen(ext)));
-        if (DEBUG_PRINT_EXTENSIONS) {
-            slog.d << ext << io::endl;
-        }
-    }
-
-    ShaderModel shaderModel = ShaderModel::UNKNOWN;
-    if (GLES31_HEADERS) {
-        if (major == 3 && minor >= 0) {
-            shaderModel = ShaderModel::GL_ES_30;
-        }
-        if (major == 3 && minor >= 1) {
-            features.multisample_texture = true;
-        }
-        initExtensionsGLES(major, minor, exts);
-    } else if (GL41_HEADERS) {
-        if (major == 4 && minor >= 1) {
-            shaderModel = ShaderModel::GL_CORE_41;
-        }
-        initExtensionsGL(major, minor, exts);
-        features.multisample_texture = true;
-    };
-    mShaderModel = shaderModel;
-
-    /*
-     * Set our default state
-     */
-
-    disable(GL_DITHER);
-    enable(GL_DEPTH_TEST);
-
-    // With desktop GL, the application must enable point size to allow vertex shaders to set it,
-    // but with OpenGL ES, this is always on and there is no enable flag.
-#if GL41_HEADERS
-    enable(GL_PROGRAM_POINT_SIZE);
-#endif
-
-    // TODO: Don't enable scissor when it is not necessary. This optimization could be done here in
-    // the driver by simply deferring the enable until the scissor rect is smaller than the window.
-    enable(GL_SCISSOR_TEST);
-
-#ifdef GL_ARB_seamless_cube_map
-    enable(GL_TEXTURE_CUBE_MAP_SEAMLESS);
-#endif
-
-#ifdef GL_EXT_texture_filter_anisotropic
-    if (ext.texture_filter_anisotropic) {
-        glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &mMaxAnisotropy);
-    }
-#endif
-
-#ifdef GL_FRAGMENT_SHADER_DERIVATIVE_HINT
-    glHint(GL_FRAGMENT_SHADER_DERIVATIVE_HINT, GL_NICEST);
+    slog.i << "OS version: " << mPlatform.getOSVersion() << io::endl;
 #endif
 
     // On some implementation we need to clear the viewport with a triangle, for performance
@@ -256,10 +143,10 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
     initClearProgram();
 
     // Initialize the blitter only if we have OES_EGL_image_external_essl3
-    if (ext.OES_EGL_image_external_essl3) {
-        mOpenGLBlitter = new OpenGLBlitter();
+    if (mContext.ext.OES_EGL_image_external_essl3) {
+        mOpenGLBlitter = new OpenGLBlitter(mContext);
         mOpenGLBlitter->init();
-        state.program.use = 0;
+        mContext.resetProgram();
     }
 }
 
@@ -271,43 +158,9 @@ OpenGLDriver::~OpenGLDriver() noexcept {
 // Driver interface concrete implementation
 // ------------------------------------------------------------------------------------------------
 
-UTILS_NOINLINE
-bool OpenGLDriver::hasExtension(ExtentionSet const& map, utils::StaticString ext) noexcept {
-    return map.find(ext) != map.end();
-}
-
-void OpenGLDriver::initExtensionsGLES(GLint major, GLint minor, ExtentionSet const& exts) {
-    // figure out and initialize the extensions we need
-    ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
-    ext.texture_compression_etc2 = true;
-    ext.QCOM_tiled_rendering = hasExtension(exts, "GL_QCOM_tiled_rendering");
-    ext.OES_EGL_image_external_essl3 = hasExtension(exts, "GL_OES_EGL_image_external_essl3");
-    ext.EXT_debug_marker = hasExtension(exts, "GL_EXT_debug_marker");
-    ext.EXT_color_buffer_half_float = hasExtension(exts, "GL_EXT_color_buffer_half_float");
-    ext.EXT_color_buffer_float = hasExtension(exts, "GL_EXT_color_buffer_float");
-    ext.APPLE_color_buffer_packed_float = hasExtension(exts, "GL_APPLE_color_buffer_packed_float");
-    ext.texture_compression_s3tc = hasExtension(exts, "WEBGL_compressed_texture_s3tc");
-    ext.EXT_multisampled_render_to_texture = hasExtension(exts, "GL_EXT_multisampled_render_to_texture");
-    // ES 3.2 implies EXT_color_buffer_float
-    if (major >= 3 && minor >= 2) {
-        ext.EXT_color_buffer_float = true;
-    }
-}
-
-void OpenGLDriver::initExtensionsGL(GLint major, GLint minor, ExtentionSet const& exts) {
-    ext.texture_filter_anisotropic = hasExtension(exts, "GL_EXT_texture_filter_anisotropic");
-    ext.texture_compression_etc2 = hasExtension(exts, "GL_ARB_ES3_compatibility");
-    ext.texture_compression_s3tc = hasExtension(exts, "GL_EXT_texture_compression_s3tc");
-    ext.OES_EGL_image_external_essl3 = hasExtension(exts, "GL_OES_EGL_image_external_essl3");
-    ext.EXT_debug_marker = hasExtension(exts, "GL_EXT_debug_marker");
-    ext.EXT_color_buffer_half_float = true;  // Assumes core profile.
-    ext.EXT_color_buffer_float = true;  // Assumes core profile.
-    ext.APPLE_color_buffer_packed_float = true;  // Assumes core profile.
-}
-
 void OpenGLDriver::terminate() {
     for (auto& item : mSamplerMap) {
-        unbindSampler(item.second);
+        mContext.unbindSampler(item.second);
         glDeleteSamplers(1, &item.second);
     }
     mSamplerMap.clear();
@@ -319,7 +172,7 @@ void OpenGLDriver::terminate() {
 }
 
 ShaderModel OpenGLDriver::getShaderModel() const noexcept {
-    return mShaderModel;
+    return mContext.getShaderModel();
 }
 
 const float2 OpenGLDriver::mClearTriangle[3] = {{ -1.0f,  3.0f },
@@ -368,7 +221,7 @@ void OpenGLDriver::initClearProgram() noexcept {
         glGetProgramiv(mClearProgram, GL_LINK_STATUS, &status);
         assert(status == GL_TRUE);
 
-        useProgram(mClearProgram);
+        mContext.useProgram(mClearProgram);
         mClearColorLocation = glGetUniformLocation(mClearProgram, "color");
         mClearDepthLocation = glGetUniformLocation(mClearProgram, "depth");
 
@@ -390,304 +243,54 @@ void OpenGLDriver::terminateClearProgram() noexcept {
 // Change and track GL state
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept {
-    vec4gli scissor(left, bottom, width, height);
-    update_state(state.window.scissor, scissor, [&]() {
-        glScissor(left, bottom, width, height);
-    });
-}
-
-void OpenGLDriver::setViewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept {
-    vec4gli viewport(left, bottom, width, height);
-    update_state(state.window.viewport, viewport, [&]() {
-        glViewport(left, bottom, width, height);
-    });
-}
-
-void OpenGLDriver::setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) noexcept {
-    float4 color(r, g, b, a);
-    update_state(state.clears.color, color, [&]() {
-        glClearColor(r, g, b, a);
-    });
-}
-
-void OpenGLDriver::setClearDepth(GLfloat depth) noexcept {
-    update_state(state.clears.depth, depth, [&]() {
-        glClearDepthf(depth);
-    });
-}
-
-void OpenGLDriver::setClearStencil(GLint stencil) noexcept {
-    update_state(state.clears.stencil, stencil, [&]() {
-        glClearStencil(stencil);
-    });
-}
-
-void OpenGLDriver::unbindTexture(GLenum target, GLuint texture_id) noexcept {
-    // unbind this texture from all the units it might be bound to
-    // no need unbind the texture from FBOs because we're not tracking that state (and there is
-    // no need to).
-    const size_t index = getIndexForTextureTarget(target);
-    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
-        if (state.textures.units[unit].targets[index].texture_id == texture_id) {
-            bindTexture(unit, target, (GLuint)0, index);
-        }
-    }
-}
-
-void OpenGLDriver::unbindSampler(GLuint sampler) noexcept {
-    // unbind this sampler from all the units it might be bound to
-    #pragma nounroll    // clang generates >800B of code!!!
-    for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
-        if (state.textures.units[unit].sampler == sampler) {
-            bindSampler(unit, 0);
-        }
-    }
-}
-
-void OpenGLDriver::bindBuffer(GLenum target, GLuint buffer) noexcept {
-    size_t targetIndex = getIndexForBufferTarget(target);
-    if (target == GL_ELEMENT_ARRAY_BUFFER) {
-        // GL_ELEMENT_ARRAY_BUFFER is a special case, where the currently bound VAO remembers
-        // the index buffer, unless there are no VAO bound (see: bindVertexArray)
-        assert(state.vao.p);
-        if (state.buffers.genericBinding[targetIndex] != buffer
-                || ((state.vao.p != &mDefaultVAO) && (state.vao.p->gl.elementArray != buffer))) {
-            state.buffers.genericBinding[targetIndex] = buffer;
-            if (state.vao.p != &mDefaultVAO) {
-                state.vao.p->gl.elementArray = buffer;
-            }
-            glBindBuffer(target, buffer);
-        }
-    } else {
-        update_state(state.buffers.genericBinding[targetIndex], buffer, [&]() {
-            glBindBuffer(target, buffer);
-        });
-    }
-}
-
-void OpenGLDriver::bindBufferRange(GLenum target, GLuint index, GLuint buffer,
-        GLintptr offset, GLsizeiptr size) noexcept {
-    size_t targetIndex = getIndexForBufferTarget(target);
-    assert(targetIndex <= 1); // sanity check
-
-    // this ALSO sets the generic binding
-        if (   state.buffers.targets[targetIndex].buffers[index].name != buffer
-            || state.buffers.targets[targetIndex].buffers[index].offset != offset
-            || state.buffers.targets[targetIndex].buffers[index].size != size) {
-        state.buffers.targets[targetIndex].buffers[index].name = buffer;
-        state.buffers.targets[targetIndex].buffers[index].offset = offset;
-        state.buffers.targets[targetIndex].buffers[index].size = size;
-        state.buffers.genericBinding[targetIndex] = buffer;
-        glBindBufferRange(target, index, buffer, offset, size);
-    }
-}
-
-void OpenGLDriver::bindFramebuffer(GLenum target, GLuint buffer) noexcept {
-    switch (target) {
-        case GL_FRAMEBUFFER:
-            if (state.draw_fbo != buffer || state.read_fbo != buffer) {
-                state.draw_fbo = state.read_fbo = buffer;
-                glBindFramebuffer(target, buffer);
-            }
-            break;
-        case GL_DRAW_FRAMEBUFFER:
-            if (state.draw_fbo != buffer) {
-                state.draw_fbo = buffer;
-                glBindFramebuffer(target, buffer);
-            }
-            break;
-        case GL_READ_FRAMEBUFFER:
-            if (state.read_fbo != buffer) {
-                state.read_fbo = buffer;
-                glBindFramebuffer(target, buffer);
-            }
-            break;
-        default:
-            break;
-    }
-}
-
-void OpenGLDriver::bindVertexArray(GLRenderPrimitive const* p) noexcept {
-    GLRenderPrimitive* vao = p ? const_cast<GLRenderPrimitive *>(p) : &mDefaultVAO;
-    update_state(state.vao.p, vao, [&]() {
-        glBindVertexArray(vao->gl.vao);
-        // update GL_ELEMENT_ARRAY_BUFFER, which is updated by glBindVertexArray
-        size_t targetIndex = getIndexForBufferTarget(GL_ELEMENT_ARRAY_BUFFER);
-        state.buffers.genericBinding[targetIndex] = vao->gl.elementArray;
-        if (UTILS_UNLIKELY(bugs.vao_doesnt_store_element_array_buffer_binding)) {
-            // This shouldn't be needed, but it looks like some drivers don't do the implicit
-            // glBindBuffer().
-            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vao->gl.elementArray);
-        }
-    });
-}
-
 void OpenGLDriver::bindTexture(GLuint unit, GLTexture const* t) noexcept {
     assert(t != nullptr);
-    bindTexture(unit, t->gl.target, t->gl.id, t->gl.targetIndex);
-}
-
-void OpenGLDriver::bindTexture(GLuint unit, GLuint target, GLuint texId, size_t targetIndex) noexcept {
-    assert(targetIndex == getIndexForTextureTarget(target));
-    assert(targetIndex < TEXTURE_TARGET_COUNT);
-    update_state(state.textures.units[unit].targets[targetIndex].texture_id, texId, [&]() {
-        activeTexture(unit);
-        glBindTexture(target, texId);
-    }, (target == GL_TEXTURE_EXTERNAL_OES) && bugs.texture_external_needs_rebind);
-}
-
-void OpenGLDriver::useProgram(GLuint program) noexcept {
-    update_state(state.program.use, program, [&]() {
-        glUseProgram(program);
-    });
+    mContext.bindTexture(unit, t->gl.target, t->gl.id, t->gl.targetIndex);
 }
 
 void OpenGLDriver::useProgram(OpenGLProgram* p) noexcept {
-    useProgram(p->gl.program);
+    mContext.useProgram(p->gl.program);
     // set-up textures and samplers in the proper TMUs (as specified in setSamplers)
     p->use(this);
 }
 
-void OpenGLDriver::enableVertexAttribArray(GLuint index) noexcept {
-    assert(state.vao.p);
-    assert(index < state.vao.p->gl.vertexAttribArray.size());
-    if (UTILS_UNLIKELY(!state.vao.p->gl.vertexAttribArray[index])) {
-        state.vao.p->gl.vertexAttribArray.set(index);
-        glEnableVertexAttribArray(index);
-    }
-}
-
-void OpenGLDriver::disableVertexAttribArray(GLuint index) noexcept {
-    assert(state.vao.p);
-    assert(index < state.vao.p->gl.vertexAttribArray.size());
-    if (UTILS_UNLIKELY(state.vao.p->gl.vertexAttribArray[index])) {
-        state.vao.p->gl.vertexAttribArray.unset(index);
-        glDisableVertexAttribArray(index);
-    }
-}
-
-void OpenGLDriver::enable(GLenum cap) noexcept {
-    size_t index = getIndexForCap(cap);
-    if (UTILS_UNLIKELY(!state.enables.caps[index])) {
-        state.enables.caps.set(index);
-        glEnable(cap);
-    }
-}
-
-void OpenGLDriver::disable(GLenum cap) noexcept {
-    size_t index = getIndexForCap(cap);
-    if (UTILS_UNLIKELY(state.enables.caps[index])) {
-        state.enables.caps.unset(index);
-        glDisable(cap);
-    }
-}
-
-void OpenGLDriver::frontFace(GLenum mode) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.frontFace, mode, [&]() {
-        glFrontFace(mode);
-    });
-}
-
-void OpenGLDriver::cullFace(GLenum mode) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.cullFace, mode, [&]() {
-        glCullFace(mode);
-    });
-}
-
-void OpenGLDriver::blendEquation(GLenum modeRGB, GLenum modeA) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    if (UTILS_UNLIKELY(
-            state.raster.blendEquationRGB != modeRGB || state.raster.blendEquationA != modeA)) {
-        state.raster.blendEquationRGB = modeRGB;
-        state.raster.blendEquationA   = modeA;
-        glBlendEquationSeparate(modeRGB, modeA);
-    }
-}
-
-void OpenGLDriver::blendFunction(GLenum srcRGB, GLenum srcA, GLenum dstRGB, GLenum dstA) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    if (UTILS_UNLIKELY(
-            state.raster.blendFunctionSrcRGB != srcRGB ||
-            state.raster.blendFunctionSrcA != srcA ||
-            state.raster.blendFunctionDstRGB != dstRGB ||
-            state.raster.blendFunctionDstA != dstA)) {
-        state.raster.blendFunctionSrcRGB = srcRGB;
-        state.raster.blendFunctionSrcA = srcA;
-        state.raster.blendFunctionDstRGB = dstRGB;
-        state.raster.blendFunctionDstA = dstA;
-        glBlendFuncSeparate(srcRGB, dstRGB, srcA, dstA);
-    }
-}
-
-void OpenGLDriver::colorMask(GLboolean flag) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.colorMask, flag, [&]() {
-        glColorMask(flag, flag, flag, flag);
-    });
-}
-void OpenGLDriver::depthMask(GLboolean flag) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.depthMask, flag, [&]() {
-        glDepthMask(flag);
-    });
-}
-
-void OpenGLDriver::depthFunc(GLenum func) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.depthFunc, func, [&]() {
-        glDepthFunc(func);
-    });
-}
-
-void OpenGLDriver::polygonOffset(GLfloat factor, GLfloat units) noexcept {
-    update_state(state.polygonOffset, { factor, units }, [&]() {
-        if (factor != 0 || units != 0) {
-            glPolygonOffset(factor, units);
-            enable(GL_POLYGON_OFFSET_FILL);
-        } else {
-            disable(GL_POLYGON_OFFSET_FILL);
-        }
-    });
-}
 
 void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
     mRasterState = rs;
+    auto& gl = mContext;
 
     // culling state
     switch (rs.culling) {
         case CullingMode::NONE:
-            disable(GL_CULL_FACE);
+            gl.disable(GL_CULL_FACE);
             break;
         case CullingMode::FRONT:
-            cullFace(GL_FRONT);
+            gl.cullFace(GL_FRONT);
             break;
         case CullingMode::BACK:
-            cullFace(GL_BACK);
+            gl.cullFace(GL_BACK);
             break;
         case CullingMode::FRONT_AND_BACK:
-            cullFace(GL_FRONT_AND_BACK);
+            gl.cullFace(GL_FRONT_AND_BACK);
             break;
     }
 
-    frontFace(rs.inverseFrontFaces ? GL_CW : GL_CCW);
+    gl.frontFace(rs.inverseFrontFaces ? GL_CW : GL_CCW);
 
     if (rs.culling != CullingMode::NONE) {
-        enable(GL_CULL_FACE);
+        gl.enable(GL_CULL_FACE);
     }
 
     // blending state
     if (!rs.hasBlending()) {
-        disable(GL_BLEND);
+        gl.disable(GL_BLEND);
     } else {
-        enable(GL_BLEND);
-        blendEquation(
+        gl.enable(GL_BLEND);
+        gl.blendEquation(
                 getBlendEquationMode(rs.blendEquationRGB),
                 getBlendEquationMode(rs.blendEquationAlpha));
 
-        blendFunction(
+        gl.blendFunction(
                 getBlendFunctionMode(rs.blendFunctionSrcRGB),
                 getBlendFunctionMode(rs.blendFunctionSrcAlpha),
                 getBlendFunctionMode(rs.blendFunctionDstRGB),
@@ -696,60 +299,21 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
 
     // depth test
     if (rs.depthFunc == RasterState::DepthFunc::A && !rs.depthWrite) {
-        disable(GL_DEPTH_TEST);
+        gl.disable(GL_DEPTH_TEST);
     } else {
-        enable(GL_DEPTH_TEST);
-        depthFunc(getDepthFunc(rs.depthFunc));
-        depthMask(GLboolean(rs.depthWrite));
+        gl.enable(GL_DEPTH_TEST);
+        gl.depthFunc(getDepthFunc(rs.depthFunc));
+        gl.depthMask(GLboolean(rs.depthWrite));
     }
 
     // write masks
-    colorMask(GLboolean(rs.colorWrite));
+    gl.colorMask(GLboolean(rs.colorWrite));
 
     // AA
     if (rs.alphaToCoverage) {
-        enable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+        gl.enable(GL_SAMPLE_ALPHA_TO_COVERAGE);
     } else {
-        disable(GL_SAMPLE_ALPHA_TO_COVERAGE);
-    }
-}
-
-void OpenGLDriver::pixelStore(GLenum pname, GLint param) noexcept {
-    GLint* pcur = nullptr;
-    switch (pname) {
-        case GL_PACK_ROW_LENGTH:
-            pcur = &state.pack.row_length;
-            break;
-        case GL_PACK_SKIP_ROWS:
-            pcur = &state.pack.skip_row;
-            break;
-        case GL_PACK_SKIP_PIXELS:
-            pcur = &state.pack.skip_pixels;
-            break;
-        case GL_PACK_ALIGNMENT:
-            pcur = &state.pack.alignment;
-            break;
-
-        case GL_UNPACK_ROW_LENGTH:
-            pcur = &state.unpack.row_length;
-            break;
-        case GL_UNPACK_ALIGNMENT:
-            pcur = &state.unpack.alignment;
-            break;
-        case GL_UNPACK_SKIP_PIXELS:
-            pcur = &state.unpack.skip_pixels;
-            break;
-        case GL_UNPACK_SKIP_ROWS:
-            pcur = &state.unpack.skip_row;
-            break;
-        default:
-            goto default_case;
-    }
-
-    if (UTILS_UNLIKELY(*pcur != param)) {
-        *pcur = param;
-default_case:
-        glPixelStorei(pname, param);
+        gl.disable(GL_SAMPLE_ALPHA_TO_COVERAGE);
     }
 }
 
@@ -909,6 +473,7 @@ void OpenGLDriver::createVertexBufferR(
     BufferUsage usage) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLVertexBuffer* vb = construct<GLVertexBuffer>(vbh,
             bufferCount, attributeCount, elementCount, attributes);
 
@@ -926,7 +491,7 @@ void OpenGLDriver::createVertexBufferR(
                 size = std::max(size, end);
             }
         }
-        bindBuffer(GL_ARRAY_BUFFER, vb->gl.buffers[i]);
+        gl.bindBuffer(GL_ARRAY_BUFFER, vb->gl.buffers[i]);
         glBufferData(GL_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
     }
 
@@ -940,12 +505,13 @@ void OpenGLDriver::createIndexBufferR(
         BufferUsage usage) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     GLIndexBuffer* ib = construct<GLIndexBuffer>(ibh, elementSize, indexCount);
     glGenBuffers(1, &ib->gl.buffer);
     GLsizeiptr size = elementSize * indexCount;
-    bindVertexArray(nullptr);
-    bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
+    gl.bindVertexArray(nullptr);
+    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -977,9 +543,10 @@ void OpenGLDriver::createUniformBufferR(
         BufferUsage usage) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLUniformBuffer* ub = construct<GLUniformBuffer>(ubh, size, usage);
     glGenBuffers(1, &ub->gl.ubo.id);
-    bindBuffer(GL_UNIFORM_BUFFER, ub->gl.ubo.id);
+    gl.bindBuffer(GL_UNIFORM_BUFFER, ub->gl.ubo.id);
     glBufferData(GL_UNIFORM_BUFFER, size, nullptr, getBufferUsage(usage));
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -989,8 +556,10 @@ UTILS_NOINLINE
 void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
         uint32_t width, uint32_t height, uint32_t depth) noexcept {
 
-    bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-    activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+    auto& gl = mContext;
+
+    bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+    gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
 
     switch (t->gl.target) {
         case GL_TEXTURE_2D:
@@ -1034,6 +603,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
         TextureUsage usage) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
     if (UTILS_LIKELY(usage & TextureUsage::SAMPLEABLE)) {
 
@@ -1058,25 +628,25 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
                 case SamplerType::SAMPLER_2D:
                     if (depth <= 1) {
                         t->gl.targetIndex = (uint8_t)
-                                getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D);
+                                gl.getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D);
                     } else {
                         t->gl.targetIndex = (uint8_t)
-                                getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D_ARRAY);
+                                gl.getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D_ARRAY);
                     }
                     break;
                 case SamplerType::SAMPLER_CUBEMAP:
                     t->gl.targetIndex = (uint8_t)
-                            getIndexForTextureTarget(t->gl.target = GL_TEXTURE_CUBE_MAP);
+                            gl.getIndexForTextureTarget(t->gl.target = GL_TEXTURE_CUBE_MAP);
                     break;
             }
 
             if (t->samples > 1) {
                 // Note: we can't be here in practice because filament's user API doesn't
                 // allow the creation of multi-sampled textures.
-                if (features.multisample_texture) {
+                if (gl.features.multisample_texture) {
                     // multi-sample texture on GL 3.2 / GLES 3.1 and above
                     t->gl.targetIndex = (uint8_t)
-                            getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D_MULTISAMPLE);
+                            gl.getIndexForTextureTarget(t->gl.target = GL_TEXTURE_2D_MULTISAMPLE);
                 } else {
                     // Turn off multi-sampling for that texture. It's just not supported.
                 }
@@ -1103,6 +673,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
 void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         GLRenderTarget const* rt, GLenum attachment) noexcept {
     GLTexture* t = handle_cast<GLTexture*>(binfo.handle);
+    auto& gl = mContext;
 
     assert(t->target != SamplerType::SAMPLER_EXTERNAL);
 
@@ -1121,11 +692,11 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     }
 
     if (rt->gl.samples <= 1 ||
-        (rt->gl.samples > 1 && t->samples > 1 && features.multisample_texture)) {
+        (rt->gl.samples > 1 && t->samples > 1 && gl.features.multisample_texture)) {
         // on GL3.2 / GLES3.1 and above multisample is handled when creating the texture.
         // If multisampled textures are not supported and we end-up here, things should
         // still work, albeit without MSAA.
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
         switch (target) {
             case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
             case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
@@ -1150,15 +721,15 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         CHECK_GL_ERROR(utils::slog.e)
     } else
 #if GLES31_HEADERS
-    if (ext.EXT_multisampled_render_to_texture && t->depth <= 1) {
+    if (gl.ext.EXT_multisampled_render_to_texture && t->depth <= 1) {
         assert(rt->gl.samples > 1);
         // We have a multi-sample rendertarget and we have EXT_multisampled_render_to_texture,
         // so, we can directly use a 1-sample texture as attachment, multi-sample resolve,
         // will happen automagically and efficiently in the driver.
         // This extension only exists on OpenGL ES.
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
         glext::glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
-                        attachment, target, t->gl.id, binfo.level, rt->gl.samples);
+                attachment, target, t->gl.id, binfo.level, rt->gl.samples);
     } else
 #endif
     { // here we emulate ext.EXT_multisampled_render_to_texture
@@ -1166,7 +737,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
 
         // If the texture doesn't already have one, create a sidecar multi-sampled renderbuffer,
         // which is where drawing will actually take place, make that our attachment.
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
         if (t->gl.rb == 0) {
             glGenRenderbuffers(1, &t->gl.rb);
             renderBufferStorage(t->gl.rb,
@@ -1179,7 +750,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         if (!rt->gl.fbo_read) {
             glGenFramebuffers(1, &rt->gl.fbo_read);
         }
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo_read);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo_read);
         switch (target) {
             case GL_TEXTURE_CUBE_MAP_POSITIVE_X:
             case GL_TEXTURE_CUBE_MAP_NEGATIVE_X:
@@ -1234,7 +805,8 @@ void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32
     glBindRenderbuffer(GL_RENDERBUFFER, rbo);
     if (samples > 1) {
 #if GLES31_HEADERS
-        if (ext.EXT_multisampled_render_to_texture) {
+        auto& gl = mContext;
+        if (gl.ext.EXT_multisampled_render_to_texture) {
             // FIXME: if real multi-sample textures are/will be used as attachment,
             //        we shouldn't be here. But we don't have an easy way to know at this point.
             glext::glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, samples, internalformat, width, height);
@@ -1250,7 +822,8 @@ void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32
 
 void OpenGLDriver::framebufferRenderbuffer(GLTexture const* t,
         GLRenderTarget const* rt, GLenum attachment) noexcept {
-    bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+    auto& gl = mContext;
+    gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, t->gl.id);
     // unbind the renderbuffer, to avoid any later confusion
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
@@ -1333,9 +906,9 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         }
 #ifndef NDEBUG
         // clear the color buffer we just allocated to yellow
-        setClearColor(1, 1, 0, 1);
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-        disable(GL_SCISSOR_TEST);
+        mContext.setClearColor(1, 1, 0, 1);
+        mContext.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+        mContext.disable(GL_SCISSOR_TEST);
         glClear(GL_COLOR_BUFFER_BIT);
 #endif
     }
@@ -1429,19 +1002,11 @@ void OpenGLDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     DEBUG_MARKER()
 
     if (vbh) {
+        auto& gl = mContext;
         GLVertexBuffer const* eb = handle_cast<const GLVertexBuffer*>(vbh);
         GLsizei n = GLsizei(eb->bufferCount);
         auto& buffers = eb->gl.buffers;
-        glDeleteBuffers(n, buffers.data());
-        // bindings of bound buffers are reset to 0
-        const size_t targetIndex = getIndexForBufferTarget(GL_ARRAY_BUFFER);
-        auto& target = state.buffers.genericBinding[targetIndex];
-        #pragma nounroll
-        for (GLsizei i = 0; i < n; ++i) {
-            if (target == buffers[i]) {
-                target = 0;
-            }
-        }
+        gl.deleteBuffers(n, buffers.data(), GL_ARRAY_BUFFER);
         destruct(vbh, eb);
     }
 }
@@ -1450,14 +1015,9 @@ void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     DEBUG_MARKER()
 
     if (ibh) {
+        auto& gl = mContext;
         GLIndexBuffer const* ib = handle_cast<const GLIndexBuffer*>(ibh);
-        glDeleteBuffers(1, &ib->gl.buffer);
-        // bindings of bound buffers are reset to 0
-        const size_t targetIndex = getIndexForBufferTarget(GL_ELEMENT_ARRAY_BUFFER);
-        auto& target = state.buffers.genericBinding[targetIndex];
-        if (target == ib->gl.buffer) {
-            target = 0;
-        }
+        gl.deleteBuffers(1, &ib->gl.buffer, GL_ELEMENT_ARRAY_BUFFER);
         destruct(ibh, ib);
     }
 }
@@ -1466,19 +1026,15 @@ void OpenGLDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
     if (rph) {
+        auto& gl = mContext;
         GLRenderPrimitive const* rp = handle_cast<const GLRenderPrimitive*>(rph);
-        glDeleteVertexArrays(1, &rp->gl.vao);
-        // binding of a bound VAO is reset to 0
-        if (state.vao.p == rp) {
-            bindVertexArray(nullptr);
-        }
+        gl.deleteVextexArrays(1, &rp->gl.vao);
         destruct(rph, rp);
     }
 }
 
 void OpenGLDriver::destroyProgram(Handle<HwProgram> ph) {
     DEBUG_MARKER()
-
     if (ph) {
         OpenGLProgram* p = handle_cast<OpenGLProgram*>(ph);
         destruct(ph, p);
@@ -1487,7 +1043,6 @@ void OpenGLDriver::destroyProgram(Handle<HwProgram> ph) {
 
 void OpenGLDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
-
     if (sbh) {
         GLSamplerGroup* sb = handle_cast<GLSamplerGroup*>(sbh);
         destruct(sbh, sb);
@@ -1496,25 +1051,10 @@ void OpenGLDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
 
 void OpenGLDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
     DEBUG_MARKER()
-
     if (ubh) {
+        auto& gl = mContext;
         GLUniformBuffer* ub = handle_cast<GLUniformBuffer*>(ubh);
-        glDeleteBuffers(1, &ub->gl.ubo.id);
-        // bindings of bound buffers are reset to 0
-        const size_t targetIndex = getIndexForBufferTarget(GL_UNIFORM_BUFFER);
-        auto& target = state.buffers.targets[targetIndex];
-
-        #pragma nounroll // clang generates >1 KiB of code!!
-        for (auto& buffer : target.buffers) {
-            if (buffer.name == ub->gl.ubo.id) {
-                buffer.name = 0;
-                buffer.offset = 0;
-                buffer.size = 0;
-            }
-        }
-        if (state.buffers.genericBinding[targetIndex] == ub->gl.ubo.id) {
-            state.buffers.genericBinding[targetIndex] = 0;
-        }
+        gl.deleteBuffers(1, &ub->gl.ubo.id, GL_UNIFORM_BUFFER);
         destruct(ubh, ub);
     }
 }
@@ -1523,9 +1063,10 @@ void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
     DEBUG_MARKER()
 
     if (th) {
+        auto& gl = mContext;
         GLTexture* t = handle_cast<GLTexture*>(th);
         if (UTILS_LIKELY(t->usage & TextureUsage::SAMPLEABLE)) {
-            unbindTexture(t->gl.target, t->gl.id);
+            gl.unbindTexture(t->gl.target, t->gl.id);
             if (UTILS_UNLIKELY(t->hwStream)) {
                 detachStream(t);
             }
@@ -1553,15 +1094,16 @@ void OpenGLDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     DEBUG_MARKER()
 
     if (rth) {
+        auto& gl = mContext;
         GLRenderTarget* rt = handle_cast<GLRenderTarget*>(rth);
         if (rt->gl.fbo) {
             // first unbind this framebuffer if needed
-            bindFramebuffer(GL_FRAMEBUFFER, 0);
+            gl.bindFramebuffer(GL_FRAMEBUFFER, 0);
             glDeleteFramebuffers(1, &rt->gl.fbo);
         }
         if (rt->gl.fbo_read) {
             // first unbind this framebuffer if needed
-            bindFramebuffer(GL_FRAMEBUFFER, 0);
+            gl.bindFramebuffer(GL_FRAMEBUFFER, 0);
             glDeleteFramebuffers(1, &rt->gl.fbo_read);
         }
         destruct(rth, rt);
@@ -1673,11 +1215,12 @@ FenceStatus OpenGLDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
 }
 
 bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
+    auto& gl = mContext;
     if (isETC2Compression(format)) {
-        return ext.texture_compression_etc2;
+        return gl.ext.texture_compression_etc2;
     }
     if (isS3TCCompression(format)) {
-        return ext.texture_compression_s3tc;
+        return gl.ext.texture_compression_s3tc;
     }
     return getInternalFormat(format) != 0;
 }
@@ -1701,6 +1244,7 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
     // Supported formats per http://docs.gl/es3/glRenderbufferStorage, note that desktop OpenGL may
     // support more formats, but it requires querying GL_INTERNALFORMAT_SUPPORTED which is not
     // available in OpenGL ES.
+    auto& gl = mContext;
     switch (format) {
         // Core formats.
         case TextureFormat::R8:
@@ -1744,21 +1288,21 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
         case TextureFormat::R16F:
         case TextureFormat::RG16F:
         case TextureFormat::RGBA16F:
-            return ext.EXT_color_buffer_float || ext.EXT_color_buffer_half_float;
+            return gl.ext.EXT_color_buffer_float || gl.ext.EXT_color_buffer_half_float;
 
         // RGB16F is only supported with EXT_color_buffer_half_float
         case TextureFormat::RGB16F:
-            return ext.EXT_color_buffer_half_float;
+            return gl.ext.EXT_color_buffer_half_float;
 
         // Float formats from GL_EXT_color_buffer_float
         case TextureFormat::R32F:
         case TextureFormat::RG32F:
         case TextureFormat::RGBA32F:
-            return ext.EXT_color_buffer_float;
+            return gl.ext.EXT_color_buffer_float;
 
         // RGB_11_11_10 is only supported with some  specific extensions
         case TextureFormat::R11F_G11F_B10F:
-            return ext.EXT_color_buffer_float || ext.APPLE_color_buffer_packed_float;
+            return gl.ext.EXT_color_buffer_float || gl.ext.APPLE_color_buffer_packed_float;
 
         default:
             return false;
@@ -1802,9 +1346,10 @@ void OpenGLDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh,
         size_t index, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLVertexBuffer* eb = handle_cast<GLVertexBuffer *>(vbh);
 
-    bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[index]);
+    gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[index]);
     glBufferSubData(GL_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
@@ -1816,11 +1361,12 @@ void OpenGLDriver::updateIndexBuffer(
         Handle<HwIndexBuffer> ibh, BufferDescriptor&& p, uint32_t byteOffset) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
     assert(ib->elementSize == 2 || ib->elementSize == 4);
 
-    bindVertexArray(nullptr);
-    bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
+    gl.bindVertexArray(nullptr);
+    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
     glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
@@ -1834,9 +1380,10 @@ void OpenGLDriver::loadUniformBuffer(Handle<HwUniformBuffer> ubh, BufferDescript
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer *>(ubh);
     assert(ub);
 
+    auto& gl = mContext;
     if (p.size > 0) {
         updateBuffer(GL_UNIFORM_BUFFER, &ub->gl.ubo, p,
-                (uint32_t)gets.uniform_buffer_offset_alignment);
+                (uint32_t)gl.gets.uniform_buffer_offset_alignment);
     }
     scheduleDestroy(std::move(p));
 }
@@ -1846,7 +1393,8 @@ void OpenGLDriver::updateBuffer(GLenum target,
     assert(buffer->capacity >= p.size);
     assert(buffer->id);
 
-    bindBuffer(target, buffer->id);
+    auto& gl = mContext;
+    gl.bindBuffer(target, buffer->id);
     if (buffer->usage == BufferUsage::STREAM) {
 
         buffer->size = (uint32_t)p.size;
@@ -1943,12 +1491,13 @@ void OpenGLDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
 void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     DEBUG_MARKER()
 
+    auto& gl = mContext;
     GLTexture* t = handle_cast<GLTexture *>(th);
     assert(t->gl.target != GL_TEXTURE_2D_MULTISAMPLE);
     // Note: glGenerateMimap can also fail if the internal format is not both
     // color-renderable and filterable (i.e.: doesn't work for depth)
-    bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-    activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+    bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+    gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
 
     t->gl.baseLevel = 0;
     t->gl.maxLevel = static_cast<uint8_t>(t->levels - 1);
@@ -1971,6 +1520,7 @@ void OpenGLDriver::setTextureData(GLTexture* t,
                                   uint32_t width, uint32_t height, uint32_t depth,
                                   PixelBufferDescriptor&& p, FaceOffsets const* faceOffsets) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     assert(xoffset + width <= t->width >> level);
     assert(yoffset + height <= t->height >> level);
@@ -1985,10 +1535,10 @@ void OpenGLDriver::setTextureData(GLTexture* t,
     GLenum glFormat = getFormat(p.format);
     GLenum glType = getType(p.type);
 
-    pixelStore(GL_UNPACK_ROW_LENGTH, p.stride);
-    pixelStore(GL_UNPACK_ALIGNMENT, p.alignment);
-    pixelStore(GL_UNPACK_SKIP_PIXELS, p.left);
-    pixelStore(GL_UNPACK_SKIP_ROWS, p.top);
+    gl.pixelStore(GL_UNPACK_ROW_LENGTH, p.stride);
+    gl.pixelStore(GL_UNPACK_ALIGNMENT, p.alignment);
+    gl.pixelStore(GL_UNPACK_SKIP_PIXELS, p.left);
+    gl.pixelStore(GL_UNPACK_SKIP_ROWS, p.top);
 
     switch (t->target) {
         case SamplerType::SAMPLER_EXTERNAL:
@@ -1997,8 +1547,8 @@ void OpenGLDriver::setTextureData(GLTexture* t,
             // fallthrough...
         case SamplerType::SAMPLER_2D:
             // NOTE: GL_TEXTURE_2D_MULTISAMPLE is not allowed
-            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+            bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+            gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             switch (t->gl.target) {
                 case GL_TEXTURE_2D:
                     glTexSubImage2D(t->gl.target, GLint(level),
@@ -2017,8 +1567,8 @@ void OpenGLDriver::setTextureData(GLTexture* t,
             break;
         case SamplerType::SAMPLER_CUBEMAP: {
             assert(t->gl.target == GL_TEXTURE_CUBE_MAP);
-            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+            bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+            gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
 #pragma nounroll
             for (size_t face = 0; face < 6; face++) {
@@ -2054,6 +1604,7 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
                                             uint32_t width, uint32_t height, uint32_t depth,
                                             PixelBufferDescriptor&& p, FaceOffsets const* faceOffsets) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     assert(xoffset + width <= t->width >> level);
     assert(yoffset + height <= t->height >> level);
@@ -2078,8 +1629,8 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
             // fallthrough...
         case SamplerType::SAMPLER_2D:
             // NOTE: GL_TEXTURE_2D_MULTISAMPLE is not allowed
-            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+            bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+            gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             switch (t->gl.target) {
                 case GL_TEXTURE_2D:
                     glCompressedTexSubImage2D(t->gl.target, GLint(level),
@@ -2099,8 +1650,8 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,
         case SamplerType::SAMPLER_CUBEMAP: {
             assert(faceOffsets);
             assert(t->gl.target == GL_TEXTURE_CUBE_MAP);
-            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+            bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+            gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
 #pragma nounroll
             for (size_t face = 0; face < 6; face++) {
@@ -2140,18 +1691,19 @@ void OpenGLDriver::cancelExternalImage(void* image) {
 
 void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     GLTexture* t = handle_cast<GLTexture*>(th);
+    auto& gl = mContext;
 
     mPlatform.setExternalImage(image, t);
 
     // TODO: move this logic to PlatformEGL.
-    if (ext.OES_EGL_image_external_essl3) {
+    if (gl.ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()
 
         assert(t->target == SamplerType::SAMPLER_EXTERNAL);
         assert(t->gl.target == GL_TEXTURE_EXTERNAL_OES);
 
-        bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, t);
-        activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+        bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
+        gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
 
 #ifdef GL_OES_EGL_image
         glEGLImageTargetTexture2DOES(GL_TEXTURE_EXTERNAL_OES, static_cast<GLeglImageOES>(image));
@@ -2160,7 +1712,8 @@ void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 
 void OpenGLDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
-    if (ext.OES_EGL_image_external_essl3) {
+    auto& gl = mContext;
+    if (gl.ext.OES_EGL_image_external_essl3) {
         DEBUG_MARKER()
 
         GLTexture* t = handle_cast<GLTexture*>(th);
@@ -2184,6 +1737,7 @@ void OpenGLDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) 
 
 UTILS_NOINLINE
 void OpenGLDriver::attachStream(GLTexture* t, GLStream* hwStream) noexcept {
+    auto& gl = mContext;
     mExternalStreams.push_back(t);
 
     if (hwStream->isNativeStream()) {
@@ -2191,7 +1745,7 @@ void OpenGLDriver::attachStream(GLTexture* t, GLStream* hwStream) noexcept {
     } else {
         assert(t->target == SamplerType::SAMPLER_EXTERNAL);
         // The texture doesn't need a texture name anymore, get rid of it
-        unbindTexture(t->gl.target, t->gl.id);
+        gl.unbindTexture(t->gl.target, t->gl.id);
         glDeleteTextures(1, &t->gl.id);
         t->gl.id = hwStream->user_thread.read[hwStream->user_thread.cur];
     }
@@ -2236,21 +1790,22 @@ void OpenGLDriver::replaceStream(GLTexture* t, GLStream* hwStream) noexcept {
 void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         const RenderPassParams& params) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     mRenderPassTarget = rth;
     mRenderPassParams = params;
-    const TargetBufferFlags clearFlags = TargetBufferFlags(params.flags.clear & ~RenderPassFlags::IGNORE_SCISSOR);
+    const auto clearFlags = TargetBufferFlags(params.flags.clear & ~RenderPassFlags::IGNORE_SCISSOR);
     const uint8_t ignoreScissor = params.flags.clear & RenderPassFlags::IGNORE_SCISSOR;
     TargetBufferFlags discardFlags = params.flags.discardStart;
 
     GLRenderTarget* rt = handle_cast<GLRenderTarget*>(rth);
-    if (UTILS_UNLIKELY(state.draw_fbo != rt->gl.fbo)) {
-        bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+    if (UTILS_UNLIKELY(gl.getDrawFbo() != rt->gl.fbo)) {
+        gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
 
         // glInvalidateFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
         // ignore it on GL (rather than having to do a runtime check).
         if (GLES31_HEADERS) {
-            if (!bugs.disable_invalidate_framebuffer) {
+            if (!gl.bugs.disable_invalidate_framebuffer) {
                 std::array<GLenum, 3> attachments; // NOLINT
                 GLsizei attachmentCount = getAttachments(attachments, rt, discardFlags);
                 if (attachmentCount) {
@@ -2278,7 +1833,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         }
     }
 
-    setViewport(params.viewport.left, params.viewport.bottom,
+    gl.viewport(params.viewport.left, params.viewport.bottom,
             params.viewport.width, params.viewport.height);
 
     // Use scissor test if not told to ignore, and if the viewport doesn't cover the whole target.
@@ -2288,7 +1843,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
                                     params.viewport.width != rt->width ||
                                     params.viewport.height != rt->height);
     if (respectScissor) {
-        setScissor(params.viewport.left, params.viewport.bottom,
+        gl.setScissor(params.viewport.left, params.viewport.bottom,
                 params.viewport.width, params.viewport.height);
     }
 
@@ -2297,11 +1852,11 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         const bool clearDepth   = any(clearFlags & TargetBufferFlags::DEPTH);
         const bool clearStencil = any(clearFlags & TargetBufferFlags::STENCIL);
         if (respectScissor) {
-            enable(GL_SCISSOR_TEST);
+            gl.enable(GL_SCISSOR_TEST);
         } else {
-            disable(GL_SCISSOR_TEST);
+            gl.disable(GL_SCISSOR_TEST);
         }
-        if (respectScissor && GLES31_HEADERS && bugs.clears_hurt_performance) {
+        if (respectScissor && GLES31_HEADERS && gl.bugs.clears_hurt_performance) {
             // With OpenGL ES, we clear the viewport using geometry to improve performance on certain
             // OpenGL drivers. e.g. on Adreno this avoids needless loads from the GMEM.
             clearWithGeometryPipe(clearColor, params.clearColor,
@@ -2317,15 +1872,17 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
 
 #ifndef NDEBUG
     // clear the discarded (but not the cleared ones) buffers in debug builds
-    setClearColor(1, 0, 0, 1);
-    bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-    disable(GL_SCISSOR_TEST);
+    mContext.setClearColor(1, 0, 0, 1);
+    mContext.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+    mContext.disable(GL_SCISSOR_TEST);
     glClear(getAttachmentBitfield(discardFlags & ~clearFlags));
 #endif
 }
 
 void OpenGLDriver::endRenderPass(int) {
     DEBUG_MARKER()
+    auto& gl = mContext;
+
     assert(mRenderPassTarget);
 
     GLRenderTarget const* const rt = handle_cast<GLRenderTarget*>(mRenderPassTarget);
@@ -2336,10 +1893,10 @@ void OpenGLDriver::endRenderPass(int) {
     // glInvalidateFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
     // ignore it on GL (rather than having to do a runtime check).
     if (GLES31_HEADERS) {
-        if (!bugs.disable_invalidate_framebuffer) {
+        if (!gl.bugs.disable_invalidate_framebuffer) {
             // we wouldn't have to bind the framebuffer if we had glInvalidateNamedFramebuffer()
-            bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-            std::array<GLenum, 3> attachments; // NOLINT(cppcoreguidelines-pro-type-member-init)
+            gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+            std::array<GLenum, 3> attachments; // NOLINT
             GLsizei attachmentCount = getAttachments(attachments, rt, discardFlags);
             if (attachmentCount) {
                 glInvalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
@@ -2350,9 +1907,9 @@ void OpenGLDriver::endRenderPass(int) {
 
 #ifndef NDEBUG
     // clear the discarded buffers in debug builds
-    setClearColor(0, 1, 0, 1);
-    bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-    disable(GL_SCISSOR_TEST);
+    mContext.setClearColor(0, 1, 0, 1);
+    mContext.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+    mContext.disable(GL_SCISSOR_TEST);
     glClear(getAttachmentBitfield(discardFlags));
 #endif
 
@@ -2362,6 +1919,7 @@ void OpenGLDriver::endRenderPass(int) {
 
 void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         backend::TargetBufferFlags discardFlags) noexcept {
+    auto& gl = mContext;
     const TargetBufferFlags resolve = rt->gl.resolve & ~discardFlags;
     GLbitfield mask = getAttachmentBitfield(resolve);
     if (UTILS_UNLIKELY(mask)) {
@@ -2370,9 +1928,9 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         if (action == ResolveAction::STORE) {
             std::swap(read, draw);
         }
-        bindFramebuffer(GL_READ_FRAMEBUFFER, read);
-        bindFramebuffer(GL_DRAW_FRAMEBUFFER, draw);
-        disable(GL_SCISSOR_TEST);
+        gl.bindFramebuffer(GL_READ_FRAMEBUFFER, read);
+        gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, draw);
+        gl.disable(GL_SCISSOR_TEST);
         glBlitFramebuffer(0, 0, rt->width, rt->height, 0, 0, rt->width, rt->height, mask, GL_NEAREST);
         CHECK_GL_ERROR(utils::slog.e)
     }
@@ -2382,6 +1940,7 @@ void OpenGLDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
         TargetBufferFlags buffers,
         uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     // glInvalidateSubFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
     // ignore it on GL (rather than having to do a runtime check).
@@ -2394,9 +1953,9 @@ void OpenGLDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
         uint32_t top   = std::min(bottom + height, rt->height);
 
         if (left < right && bottom < top) {
-            bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+            gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
 
-            std::array<GLenum, 3> attachments; // NOLINT(cppcoreguidelines-pro-type-member-init)
+            std::array<GLenum, 3> attachments; // NOLINT
             GLsizei attachmentCount = getAttachments(attachments, rt, buffers);
             if (attachmentCount) {
                 glInvalidateSubFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data(),
@@ -2429,6 +1988,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     if (rph) {
         GLRenderPrimitive* const rp = handle_cast<GLRenderPrimitive*>(rph);
@@ -2437,7 +1997,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
 
         assert(ib->elementSize == 2 || ib->elementSize == 4);
 
-        bindVertexArray(rp);
+        gl.bindVertexArray(&rp->gl);
         CHECK_GL_ERROR(utils::slog.e)
 
         rp->gl.indicesType = ib->elementSize == 4 ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
@@ -2446,7 +2006,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
             if (enabledAttributes & (1U << i)) {
                 uint8_t bi = eb->attributes[i].buffer;
                 assert(bi != 0xFF);
-                bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[bi]);
+                gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[bi]);
                 if (UTILS_UNLIKELY(eb->attributes[i].flags & Attribute::FLAG_INTEGER_TARGET)) {
                     glVertexAttribIPointer(GLuint(i),
                             getComponentCount(eb->attributes[i].type),
@@ -2462,13 +2022,13 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
                             (void*) uintptr_t(eb->attributes[i].offset));
                 }
 
-                enableVertexAttribArray(GLuint(i));
+                gl.enableVertexAttribArray(GLuint(i));
             } else {
-                disableVertexAttribArray(GLuint(i));
+                gl.disableVertexAttribArray(GLuint(i));
             }
         }
         // this records the index buffer into the currently bound VAO
-        bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
+        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
 
         CHECK_GL_ERROR(utils::slog.e)
     }
@@ -2492,6 +2052,7 @@ void OpenGLDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
 // Sets up a scissor rectangle that automatically gets clipped against the viewport.
 void OpenGLDriver::setViewportScissor(Viewport const& viewportScissor) noexcept {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     // In OpenGL, all four scissor parameters are actually signed, so clamp to MAX_INT32.
     const int32_t maxval = std::numeric_limits<int32_t>::max();
@@ -2502,19 +2063,18 @@ void OpenGLDriver::setViewportScissor(Viewport const& viewportScissor) noexcept 
     // Compute the intersection of the requested scissor rectangle with the current viewport.
     // Note that the viewport rectangle isn't necessarily equal to the bounds of the current
     // Filament View (e.g., when post-processing is enabled).
-    vec4gli scissor;
-    scissor.x = std::max((int32_t) left, state.window.viewport[0]);
-    scissor.y = std::max((int32_t) bottom, state.window.viewport[1]);
-    int32_t right = std::min((int32_t) left + (int32_t) width,
-            state.window.viewport[0] + state.window.viewport[2]);
-    int32_t top = std::min((int32_t) bottom + (int32_t) height,
-            state.window.viewport[1] + state.window.viewport[3]);
+    OpenGLContext::vec4gli scissor;
+    OpenGLContext::vec4gli viewport = gl.getViewport();
+    scissor.x = std::max((int32_t)left, viewport[0]);
+    scissor.y = std::max((int32_t)bottom, viewport[1]);
+    int32_t right = std::min((int32_t)left + (int32_t)width, viewport[0] + viewport[2]);
+    int32_t top = std::min((int32_t)bottom + (int32_t)height, viewport[1] + viewport[3]);
     // Compute width / height of the intersected region. If there's no intersection, pass zeroes
     // rather than negative values to satisfy OpenGL requirements.
     scissor.z = std::max(0, right - scissor.x);
     scissor.w = std::max(0, top - scissor.y);
-    setScissor(scissor.x, scissor.y, scissor.z, scissor.w);
-    enable(GL_SCISSOR_TEST);
+    gl.setScissor(scissor.x, scissor.y, scissor.z, scissor.w);
+    gl.enable(GL_SCISSOR_TEST);
 }
 
 /*
@@ -2525,6 +2085,7 @@ void OpenGLDriver::setViewportScissor(Viewport const& viewportScissor) noexcept 
 
 void OpenGLDriver::updateStream(GLTexture* t, DriverApi* driver) noexcept {
     SYSTRACE_CALL();
+    auto& gl = mContext;
 
     GLStream* s = static_cast<GLStream*>(t->hwStream);
     assert(s);
@@ -2532,7 +2093,7 @@ void OpenGLDriver::updateStream(GLTexture* t, DriverApi* driver) noexcept {
 
     // round-robin to the next texture name
     if (UTILS_UNLIKELY(DEBUG_NO_EXTERNAL_STREAM_COPY ||
-                       bugs.disable_shared_context_draws || !mOpenGLBlitter)) {
+                       gl.bugs.disable_shared_context_draws || !mOpenGLBlitter)) {
         driver->queueCommand([this, t, s]() {
             // the stream may have been destroyed since we enqueued the command
             // also make sure that this texture is still associated with the same stream
@@ -2620,6 +2181,7 @@ void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     GLStream* s = handle_cast<GLStream*>(sh);
     if (UTILS_LIKELY(!s->isNativeStream())) {
@@ -2631,15 +2193,15 @@ void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
         GLenum glFormat = getFormat(p.format);
         GLenum glType = getType(p.type);
 
-        pixelStore(GL_PACK_ROW_LENGTH, p.stride);
-        pixelStore(GL_PACK_ALIGNMENT, p.alignment);
-        pixelStore(GL_PACK_SKIP_PIXELS, p.left);
-        pixelStore(GL_PACK_SKIP_ROWS, p.top);
+        gl.pixelStore(GL_PACK_ROW_LENGTH, p.stride);
+        gl.pixelStore(GL_PACK_ALIGNMENT, p.alignment);
+        gl.pixelStore(GL_PACK_SKIP_PIXELS, p.left);
+        gl.pixelStore(GL_PACK_SKIP_ROWS, p.top);
 
         if (s->gl.fbo == 0) {
             glGenFramebuffers(1, &s->gl.fbo);
         }
-        bindFramebuffer(GL_FRAMEBUFFER, s->gl.fbo);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, s->gl.fbo);
 
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, tid, 0);
         CHECK_GL_ERROR(utils::slog.e)
@@ -2681,7 +2243,7 @@ void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
         glReadPixels(GLint(x), GLint(y), GLint(width), GLint(height), glFormat, glType, p.buffer);
         CHECK_GL_ERROR(utils::slog.e)
 
-        bindFramebuffer(GL_FRAMEBUFFER, 0);
+        gl.bindFramebuffer(GL_FRAMEBUFFER, 0);
         scheduleDestroy(std::move(p));
     }
 }
@@ -2692,21 +2254,23 @@ void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
 
 void OpenGLDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
     DEBUG_MARKER()
+    auto& gl = mContext;
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer *>(ubh);
     assert(ub->gl.ubo.base == 0);
-    bindBufferRange(GL_UNIFORM_BUFFER, GLuint(index), ub->gl.ubo.id, 0, ub->gl.ubo.capacity);
+    gl.bindBufferRange(GL_UNIFORM_BUFFER, GLuint(index), ub->gl.ubo.id, 0, ub->gl.ubo.capacity);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
 void OpenGLDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
         size_t offset, size_t size) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer*>(ubh);
     // TODO: Is this assert really needed? Note that size is only populated for STREAM buffers.
     assert(size <= ub->gl.ubo.size);
     assert(ub->gl.ubo.base + offset + size <= ub->gl.ubo.capacity);
-    bindBufferRange(GL_UNIFORM_BUFFER, GLuint(index), ub->gl.ubo.id, ub->gl.ubo.base + offset, size);
+    gl.bindBufferRange(GL_UNIFORM_BUFFER, GLuint(index), ub->gl.ubo.id, ub->gl.ubo.base + offset, size);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
@@ -2722,6 +2286,7 @@ void OpenGLDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
 
 GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     assert(mSamplerMap.find(params.u) == mSamplerMap.end());
+    auto& gl = mContext;
 
     GLuint s;
     glGenSamplers(1, &s);
@@ -2734,9 +2299,9 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     glSamplerParameteri(s, GL_TEXTURE_COMPARE_FUNC, getTextureCompareFunc(params.compareFunc));
 // TODO: Why does this fail with WebGL 2.0? The run-time check should suffice.
 #if defined(GL_EXT_texture_filter_anisotropic) && !defined(__EMSCRIPTEN__)
-    if (ext.texture_filter_anisotropic) {
-        GLfloat anisotropy = float(1 << params.anisotropyLog2);
-        glSamplerParameterf(s, GL_TEXTURE_MAX_ANISOTROPY_EXT, std::min(mMaxAnisotropy, anisotropy));
+    if (gl.ext.texture_filter_anisotropic) {
+        GLfloat anisotropy = float(1u << params.anisotropyLog2);
+        glSamplerParameterf(s, GL_TEXTURE_MAX_ANISOTROPY_EXT, std::min(gl.gets.maxAnisotropy, anisotropy));
     }
 #endif
     CHECK_GL_ERROR(utils::slog.e)
@@ -2746,7 +2311,8 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
 
 void OpenGLDriver::insertEventMarker(char const* string, size_t len) {
 #ifdef GL_EXT_debug_marker
-    if (ext.EXT_debug_marker) {
+    auto& gl = mContext;
+    if (gl.ext.EXT_debug_marker) {
         glInsertEventMarkerEXT(GLsizei(len ? len : strlen(string)), string);
     }
 #endif
@@ -2754,7 +2320,8 @@ void OpenGLDriver::insertEventMarker(char const* string, size_t len) {
 
 void OpenGLDriver::pushGroupMarker(char const* string,  size_t len) {
 #ifdef GL_EXT_debug_marker
-    if (ext.EXT_debug_marker) {
+    auto& gl = mContext;
+    if (gl.ext.EXT_debug_marker) {
         glPushGroupMarkerEXT(GLsizei(len ? len : strlen(string)), string);
     }
 #endif
@@ -2770,7 +2337,8 @@ void OpenGLDriver::stopCapture(int) {
 
 void OpenGLDriver::popGroupMarker(int) {
 #ifdef GL_EXT_debug_marker
-    if (ext.EXT_debug_marker) {
+    auto& gl = mContext;
+    if (gl.ext.EXT_debug_marker) {
         glPopGroupMarkerEXT();
     }
 #endif
@@ -2784,14 +2352,15 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& p) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     GLenum glFormat = getFormat(p.format);
     GLenum glType = getType(p.type);
 
-    pixelStore(GL_PACK_ROW_LENGTH, p.stride);
-    pixelStore(GL_PACK_ALIGNMENT, p.alignment);
-    pixelStore(GL_PACK_SKIP_PIXELS, p.left);
-    pixelStore(GL_PACK_SKIP_ROWS, p.top);
+    gl.pixelStore(GL_PACK_ROW_LENGTH, p.stride);
+    gl.pixelStore(GL_PACK_ALIGNMENT, p.alignment);
+    gl.pixelStore(GL_PACK_SKIP_PIXELS, p.left);
+    gl.pixelStore(GL_PACK_SKIP_ROWS, p.top);
 
     /*
      * glReadPixel() operation...
@@ -2819,7 +2388,7 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
      */
 
     GLRenderTarget const* s = handle_cast<GLRenderTarget const*>(src);
-    bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
 
     // TODO: we could use a PBO to make this asynchronous
     glReadPixels(GLint(x), GLint(y), GLint(width), GLint(height), glFormat, glType, p.buffer);
@@ -2847,18 +2416,18 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
 // ------------------------------------------------------------------------------------------------
 
 void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
+    auto& gl = mContext;
     insertEventMarker("beginFrame");
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {
         OpenGLPlatform& platform = mPlatform;
-        const size_t index = getIndexForTextureTarget(GL_TEXTURE_EXTERNAL_OES);
         for (GLTexture const* t : mExternalStreams) {
             assert(t && t->hwStream);
             if (static_cast<GLStream*>(t->hwStream)->isNativeStream()) {
                 assert(t->hwStream->stream);
-                platform.updateTexImage(t->hwStream->stream, &static_cast<GLStream*>(t->hwStream)->user_thread.timestamp);
+                platform.updateTexImage(t->hwStream->stream,
+                        &static_cast<GLStream*>(t->hwStream)->user_thread.timestamp);
                 // NOTE: We assume that updateTexImage() binds the texture on our behalf
-                GLuint activeUnit = state.textures.active;
-                state.textures.units[activeUnit].targets[index].texture_id = t->gl.id;
+                gl.updateTexImage(GL_TEXTURE_EXTERNAL_OES, t->gl.id);
             }
         }
     }
@@ -2876,7 +2445,8 @@ void OpenGLDriver::endFrame(uint32_t frameId) {
 
 void OpenGLDriver::flush(int) {
     DEBUG_MARKER()
-    if (!bugs.disable_glFlush) {
+    auto& gl = mContext;
+    if (!gl.bugs.disable_glFlush) {
         glFlush();
     }
 }
@@ -2887,6 +2457,7 @@ void OpenGLDriver::clearWithRasterPipe(
         bool clearDepth, double depth,
         bool clearStencil, uint32_t stencil) noexcept {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     GLbitfield bitmask = 0;
 
@@ -2894,17 +2465,17 @@ void OpenGLDriver::clearWithRasterPipe(
 
     if (clearColor) {
         bitmask |= GL_COLOR_BUFFER_BIT;
-        setClearColor(linearColor.r, linearColor.g, linearColor.b, linearColor.a);
+        gl.setClearColor(linearColor.r, linearColor.g, linearColor.b, linearColor.a);
         rs.colorWrite = true;
     }
     if (clearDepth) {
         bitmask |= GL_DEPTH_BUFFER_BIT;
-        setClearDepth(GLfloat(depth));
+        gl.setClearDepth(GLfloat(depth));
         rs.depthWrite = true;
     }
     if (clearStencil) {
         bitmask |= GL_STENCIL_BUFFER_BIT;
-        setClearStencil(GLint(stencil));
+        gl.setClearStencil(GLint(stencil));
         // stencil state is not part of RasterState for now
     }
 
@@ -2920,13 +2491,14 @@ void OpenGLDriver::clearWithGeometryPipe(
         bool clearDepth, double depth,
         bool clearStencil, uint32_t stencil) noexcept {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     // GLES is required to use this method; see initClearProgram.
     assert(GLES31_HEADERS);
 
     // TODO: handle stencil clear with geometry as well
     if (clearStencil) {
-        setClearStencil(GLint(stencil));
+        gl.setClearStencil(GLint(stencil));
         glClear(GL_STENCIL_BUFFER_BIT);
         CHECK_GL_ERROR(utils::slog.e)
     }
@@ -2938,14 +2510,14 @@ void OpenGLDriver::clearWithGeometryPipe(
 
     if (clearColor) {
         rs.colorWrite = true;
-        useProgram(mClearProgram);
+        gl.useProgram(mClearProgram);
         glUniform4f(mClearColorLocation,
                 linearColor.r, linearColor.g, linearColor.b, linearColor.a);
         CHECK_GL_ERROR(utils::slog.e)
     }
     if (clearDepth) {
         rs.depthWrite = true;
-        useProgram(mClearProgram);
+        gl.useProgram(mClearProgram);
         glUniform1f(mClearDepthLocation, float(depth) * 2.0f - 1.0f);
         CHECK_GL_ERROR(utils::slog.e)
     }
@@ -2953,8 +2525,8 @@ void OpenGLDriver::clearWithGeometryPipe(
     if (clearColor || clearDepth) {
         // by the time we get here, useProgram() has been called
         setRasterState(rs);
-        bindVertexArray(nullptr);
-        bindBuffer(GL_ARRAY_BUFFER, 0);
+        gl.bindVertexArray(nullptr);
+        gl.bindBuffer(GL_ARRAY_BUFFER, 0);
         glEnableVertexAttribArray(0);
         glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, mClearTriangle);
         glDrawArrays(GL_TRIANGLES, 0, 3);
@@ -2967,6 +2539,7 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
         Handle<HwRenderTarget> src, Viewport srcRect,
         SamplerMagFilter filter) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     GLbitfield mask = getAttachmentBitfield(buffers);
     if (mask) {
@@ -3005,9 +2578,9 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
             assert(!memcmp(&dstRect, &srcRect, sizeof(srcRect)));
         }
 
-        bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
-        bindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl.fbo);
-        disable(GL_SCISSOR_TEST);
+        gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
+        gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl.fbo);
+        gl.disable(GL_SCISSOR_TEST);
         glBlitFramebuffer(
                 srcRect.left, srcRect.bottom, srcRect.right(), srcRect.top(),
                 dstRect.left, dstRect.bottom, dstRect.right(), dstRect.top(),
@@ -3017,10 +2590,11 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
 }
 
 void OpenGLDriver::updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept {
+    auto& gl = mContext;
     if (texture && any(texture->usage & TextureUsage::SAMPLEABLE)) {
         if (targetLevel < texture->gl.baseLevel || targetLevel > texture->gl.maxLevel) {
-            bindTexture(MAX_TEXTURE_UNIT_COUNT - 1, texture);
-            activeTexture(MAX_TEXTURE_UNIT_COUNT - 1);
+            bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, texture);
+            gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             if (targetLevel < texture->gl.baseLevel) {
                 texture->gl.baseLevel = targetLevel;
                 glTexParameteri(texture->gl.target, GL_TEXTURE_BASE_LEVEL, targetLevel);
@@ -3036,6 +2610,7 @@ void OpenGLDriver::updateTextureLodRange(GLTexture* texture, int8_t targetLevel)
 
 void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
+    auto& gl = mContext;
 
     OpenGLProgram* p = handle_cast<OpenGLProgram*>(state.program);
 
@@ -3049,11 +2624,11 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
     useProgram(p);
 
     const GLRenderPrimitive* rp = handle_cast<const GLRenderPrimitive *>(rph);
-    bindVertexArray(rp);
+    gl.bindVertexArray(&rp->gl);
 
     setRasterState(state.rasterState);
 
-    polygonOffset(state.polygonOffset.slope, state.polygonOffset.constant);
+    gl.polygonOffset(state.polygonOffset.slope, state.polygonOffset.constant);
 
     setViewportScissor(state.scissor);
 

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -111,7 +111,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
         if (programBuilder.hasSamplers()) {
             // if we have samplers, we need to do a bit of extra work
             // activate this program so we can set all its samplers once and for all (glUniform1i)
-            gl->useProgram(program);
+            gl->getContext().useProgram(program);
 
             auto const& samplerGroupInfo = programBuilder.getSamplerGroupInfo();
             auto& indicesRun = mIndicesRuns;
@@ -213,7 +213,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
 
             // FIXME: getSampler() is expensive because it's a hashmap lookup
             GLuint sampler = gl->getSampler(samplers[index].s);
-            gl->bindSampler(tmu, sampler);
+            gl->getContext().bindSampler(tmu, sampler);
         }
     }
     CHECK_GL_ERROR(utils::slog.e)

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -17,20 +17,20 @@
 #ifndef TNT_FILAMENT_DRIVER_OPENGLPROGRAM_H
 #define TNT_FILAMENT_DRIVER_OPENGLPROGRAM_H
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <vector>
-
-#include <utils/compiler.h>
-#include <utils/Log.h>
-
 #include "DriverBase.h"
-#include "gl_headers.h"
 #include "OpenGLDriver.h"
 
 #include "private/backend/Driver.h"
 #include "private/backend/Program.h"
+
+#include <utils/compiler.h>
+#include <utils/Log.h>
+
+#include <vector>
+
+#include <stddef.h>
+#include <stdint.h>
+
 
 namespace filament {
 
@@ -68,7 +68,7 @@ public:
     static void logCompilationError(utils::io::ostream& out, GLuint shaderId, char const* source) noexcept;
 
 private:
-    static constexpr uint8_t TEXTURE_UNIT_COUNT = OpenGLDriver::MAX_TEXTURE_UNIT_COUNT;
+    static constexpr uint8_t TEXTURE_UNIT_COUNT = OpenGLContext::MAX_TEXTURE_UNIT_COUNT;
     static constexpr uint8_t VERTEX_SHADER_BIT   = uint8_t(1) << size_t(backend::Program::Shader::VERTEX);
     static constexpr uint8_t FRAGMENT_SHADER_BIT = uint8_t(1) << size_t(backend::Program::Shader::FRAGMENT);
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -35,8 +35,8 @@
 #include "android/ExternalStreamManagerAndroid.h"
 #include "android/VirtualMachineEnv.h"
 
+#include "OpenGLContext.h"
 #include "OpenGLDriverFactory.h"
-#include "gl_headers.h"
 
 #include <android/api-level.h>
 #include <sys/system_properties.h>
@@ -499,7 +499,7 @@ void PlatformEGL::createExternalImageTexture(void* texture) noexcept {
     glGenTextures(1, &t->gl.id);
     if (ext.OES_EGL_image_external_essl3) {
         t->gl.targetIndex = (uint8_t)
-                OpenGLDriver::getIndexForTextureTarget(t->gl.target = GL_TEXTURE_EXTERNAL_OES);
+                OpenGLContext::getIndexForTextureTarget(t->gl.target = GL_TEXTURE_EXTERNAL_OES);
     }
 }
 


### PR DESCRIPTION
We now have OpenGLContext which only tracks the OpenGL state.
It exposes an API very similar to OpenGL and does all the state
tracking. Currently, it doesn't expose non state-changing APIs 
(e.g. draw methods) and only implements the state-changing API we
need (to track the state of).