### PR TITLE
use enable_if<> instead of static_assert()

### DIFF
--- a/libs/math/include/math/fast.h
+++ b/libs/math/include/math/fast.h
@@ -33,7 +33,7 @@ namespace fast {
 // fast cos(x), ~8 cycles (vs. 66 cycles on ARM)
 // can be vectorized
 // x between -pi and pi
-template<typename T, typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
+template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
 constexpr T MATH_PURE cos(T x) noexcept {
     x *= T(M_1_PI / 2);
     x -= T(0.25) + std::floor(x + T(0.25));
@@ -45,7 +45,7 @@ constexpr T MATH_PURE cos(T x) noexcept {
 // fast sin(x), ~8 cycles (vs. 66 cycles on ARM)
 // can be vectorized
 // x between -pi and pi
-template<typename T, typename = typename std::enable_if<std::is_floating_point<T>::value>::type>
+template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
 constexpr T MATH_PURE sin(T x) noexcept {
     return filament::math::fast::cos<T>(x - T(M_PI_2));
 }
@@ -156,19 +156,19 @@ inline uint16_t MATH_PURE qsub(uint16_t a, uint16_t b) noexcept { return vqsubh_
 inline uint32_t MATH_PURE qsub(uint32_t a, uint32_t b) noexcept { return vqsubs_s32(a, b); }
 #else
 
-template<typename T, typename = typename std::enable_if<
+template<typename T, typename = std::enable_if_t<
         std::is_same<uint8_t, T>::value ||
         std::is_same<uint16_t, T>::value ||
-        std::is_same<uint32_t, T>::value>::type>
+        std::is_same<uint32_t, T>::value>>
 inline T MATH_PURE qadd(T a, T b) noexcept {
     T r = a + b;
     return r | -T(r < a);
 }
 
-template<typename T, typename = typename std::enable_if<
+template<typename T, typename = std::enable_if_t<
         std::is_same<uint8_t, T>::value ||
         std::is_same<uint16_t, T>::value ||
-        std::is_same<uint32_t, T>::value>::type>
+        std::is_same<uint32_t, T>::value>>
 inline T MATH_PURE qsub(T a, T b) noexcept {
     T r = a - b;
     return r & -T(r <= a);

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -362,14 +362,14 @@ operator*(const TVec2<U>& lhs, const TMat22<T>& rhs) {
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat22<T>> MATH_PURE
 operator*(TMat22<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat22<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat22<T>> MATH_PURE
 operator*(U lhs, const TMat22<T>& rhs) {
     return rhs * lhs;
 }

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -425,14 +425,14 @@ constexpr typename TMat33<U>::row_type MATH_PURE operator*(const TVec3<U>& lhs,
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat33<T>> MATH_PURE
 operator*(TMat33<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat33<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat33<T>> MATH_PURE
 operator*(U lhs, const TMat33<T>& rhs) {
     return rhs * lhs;
 }

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -588,14 +588,14 @@ constexpr typename TMat44<U>::row_type MATH_PURE operator*(const TVec4<U>& lhs,
 
 // matrix * scalar, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat44<T>> MATH_PURE
 operator*(TMat44<T> lhs, U rhs) {
     return lhs *= rhs;
 }
 
 // scalar * matrix, result is a matrix of the same type than the input matrix
 template<typename T, typename U>
-constexpr typename std::enable_if<std::is_arithmetic<U>::value, TMat44<T>>::type MATH_PURE
+constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat44<T>> MATH_PURE
 operator*(U lhs, const TMat44<T>& rhs) {
     return rhs * lhs;
 }

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -97,9 +97,9 @@ public:
     constexpr TQuaternion() : x(0), y(0), z(0), w(0) {}
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A>
+    template<typename A,
+            typename = std::enable_if_t<std::is_arithmetic<A>::value, int>>
     constexpr TQuaternion(A w) : x(0), y(0), z(0), w(w) {
-        static_assert(std::is_arithmetic<A>::value, "requires arithmetic type");
     }
 
     // initialize from 4 values to w + xi + yj + zk

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -94,7 +94,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 using vec2 = details::TVec2<T>;
 
 using double2 = vec2<double>;

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -112,7 +112,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 using vec3 = details::TVec3<T>;
 
 using double3 = vec3<double>;

--- a/libs/math/include/math/vec4.h
+++ b/libs/math/include/math/vec4.h
@@ -110,7 +110,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value>::type>
+template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 using vec4 = details::TVec4<T>;
 
 using double4 = vec4<double>;


### PR DESCRIPTION
This is nicer because this way the methods that don't match don't
even exist. Also make it better when editing code with a C++ aware
ide.

Also use the less verbose `std::enable_if_t<>`