### PR TITLE
Vulkan: fix layout and miplevel for depth attachments.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -396,7 +396,7 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     auto colorTexture = color.handle ? handle_cast<VulkanTexture>(mHandleMap, color.handle) : nullptr;
     auto depthTexture = depth.handle ? handle_cast<VulkanTexture>(mHandleMap, depth.handle) : nullptr;
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
-            width, height, color.level, colorTexture, depthTexture);
+            width, height, color.level, colorTexture, depth.level, depthTexture);
     mDisposer.createDisposable(renderTarget, [this, rth] () {
         destruct_handle<VulkanRenderTarget>(mHandleMap, rth);
     });
@@ -689,23 +689,26 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     const auto depth = rt->getDepth();
     const bool hasColor = color.format != VK_FORMAT_UNDEFINED;
     const bool hasDepth = depth.format != VK_FORMAT_UNDEFINED;
-    const bool depthOnly = hasDepth && !hasColor;
 
     mDisposer.acquire(rt, mContext.currentCommands->resources);
     mDisposer.acquire(color.offscreen, mContext.currentCommands->resources);
     mDisposer.acquire(depth.offscreen, mContext.currentCommands->resources);
 
-    VkImageLayout finalLayout;
-    if (!rt->isOffscreen()) {
-        finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    } else if (depthOnly) {
-        finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+    // TODO: do not make assumptions about the future use of this attachment, instead get a flag
+    // via RenderPassParams and use that to determine which layout to transition to at the end.
+    VkImageLayout finalColorLayout;
+    VkImageLayout finalDepthLayout;
+    if (rt->isOffscreen()) {
+        finalColorLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        finalDepthLayout = VK_IMAGE_LAYOUT_GENERAL;
     } else {
-        finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        finalColorLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        finalDepthLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     }
 
     VkRenderPass renderPass = mFramebufferCache.getRenderPass({
-        .finalLayout = finalLayout,
+        .finalColorLayout = finalColorLayout,
+        .finalDepthLayout = finalDepthLayout,
         .colorFormat = color.format,
         .depthFormat = depth.format,
         .flags.clear         = params.flags.clear,
@@ -718,10 +721,10 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     VulkanFboCache::FboKey fbo { .renderPass = renderPass };
     int numAttachments = 0;
     if (hasColor) {
-      fbo.attachments[numAttachments++] = color.view;
+        fbo.attachments[numAttachments++] = color.view;
     }
     if (hasDepth) {
-      fbo.attachments[numAttachments++] = depth.view;
+        fbo.attachments[numAttachments++] = depth.view;
     }
 
     VkRenderPassBeginInfo renderPassInfo {
@@ -948,6 +951,9 @@ void VulkanDriver::blit(TargetBufferFlags buffers,
             "Destination format is not blittable")) {
         return;
     }
+    if (any(buffers & TargetBufferFlags::DEPTH)) {
+        utils::slog.w << "Depth blits are not yet supported." << utils::io::endl;
+    }
 #endif
 
     const int32_t srcRight = srcRect.left + srcRect.width;
@@ -1088,9 +1094,15 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
             const auto* texture = handle_const_cast<VulkanTexture>(mHandleMap, boundSampler->t);
             mDisposer.acquire(texture, commands->resources);
 
+            // Check that we do not sample from the current color attachment. It's fine to sample
+            // from the current depth attachment when depth writes are disabled, which is useful in
+            // some SSAO implementations.
+            ASSERT_POSTCONDITION_NON_FATAL(
+                    mCurrentRenderTarget->getColor().image != texture->textureImage,
+                    "Attempting to sample color from the current render target");
+
             VkImageLayout layout = any(texture->usage & TextureUsage::DEPTH_ATTACHMENT) ?
-                        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL :
-                        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+                        VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             mBinder.bindSampler(bindingPoint, {
                 .sampler = vksampler,

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -38,7 +38,8 @@ public:
     // a VkRenderPass. It is hashed and used as a lookup key. Portions of this are extracted
     // from backend::RenderPassParams.
     struct alignas(8) RenderPassKey {
-        VkImageLayout finalLayout;  // 4 bytes
+        VkImageLayout finalColorLayout;  // 4 bytes
+        VkImageLayout finalDepthLayout;  // 4 bytes
         VkFormat colorFormat; // 4 bytes
         VkFormat depthFormat; // 4 bytes
         union {
@@ -50,13 +51,14 @@ public:
             };
             uint32_t value; // 4 bytes
         } flags;
+        uint32_t padding; // 4 bytes
     };
     struct RenderPassVal {
         VkRenderPass handle;
         uint32_t timestamp;
     };
     static_assert(sizeof(VkFormat) == 4, "VkFormat has unexpected size.");
-    static_assert(sizeof(RenderPassKey) == 16, "RenderPassKey has unexpected size.");
+    static_assert(sizeof(RenderPassKey) == 24, "RenderPassKey has unexpected size.");
     using RenderPassHash = utils::hash::MurmurHashFn<RenderPassKey>;
     struct RenderPassEq {
         bool operator()(const RenderPassKey& k1, const RenderPassKey& k2) const;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -94,9 +94,10 @@ static VulkanAttachment createOffscreenAttachment(VulkanTexture* tex) {
     return { tex->vkformat, tex->textureImage, tex->imageView, tex->textureImageMemory, tex };
 }
 
-VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h,
-        uint32_t miplevel, VulkanTexture* color, VulkanTexture* depth) : HwRenderTarget(w, h),
-        mContext(context), mOffscreen(true), mColorLevel(miplevel) {
+VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, uint32_t height,
+        uint32_t colorLevel, VulkanTexture* color, uint32_t depthLevel, VulkanTexture* depth) :
+        HwRenderTarget(width, height), mContext(context), mOffscreen(true), mColorLevel(colorLevel),
+        mDepthLevel(depthLevel) {
     mColor = createOffscreenAttachment(color);
     mDepth = createOffscreenAttachment(depth);
 
@@ -107,7 +108,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t w, uint3
             .image = mColor.image,
             .format = mColor.format,
             .subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-            .subresourceRange.baseMipLevel = miplevel,
+            .subresourceRange.baseMipLevel = colorLevel,
             .subresourceRange.levelCount = 1
         };
         if (color->target == SamplerType::SAMPLER_CUBEMAP) {
@@ -125,7 +126,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t w, uint3
             .image = mDepth.image,
             .format = mDepth.format,
             .subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
-            .subresourceRange.baseMipLevel = miplevel,
+            .subresourceRange.baseMipLevel = depthLevel,
             .subresourceRange.levelCount = 1
         };
         if (depth->target == SamplerType::SAMPLER_CUBEMAP) {
@@ -331,6 +332,7 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     if (error) {
         utils::slog.d << "vkCreateImage: "
             << "result = " << error << ", "
+            << "handle = " << utils::io::hex << textureImage << utils::io::dec << ", "
             << "extent = " << w << "x" << h << "x"<< depth << ", "
             << "mipLevels = " << int(levels) << ", "
             << "format = " << vkformat << utils::io::endl;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -45,12 +45,12 @@ struct VulkanTexture;
 struct VulkanRenderTarget : private HwRenderTarget {
 
     // Creates an offscreen render target.
-    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, uint32_t miplevel,
-            VulkanTexture* color, VulkanTexture* depth);
+    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, uint32_t colorLevel,
+            VulkanTexture* color, uint32_t depthLevel, VulkanTexture* depth);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
     explicit VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0), mContext(context),
-            mOffscreen(false), mColorLevel(0) {}
+            mOffscreen(false), mColorLevel(0), mDepthLevel(0) {}
 
     ~VulkanRenderTarget();
 
@@ -61,12 +61,14 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getColor() const;
     VulkanAttachment getDepth() const;
     uint32_t getColorLevel() const { return mColorLevel; }
+    uint32_t getDepthLevel() const { return mDepthLevel; }
 private:
     VulkanAttachment mColor = {};
     VulkanAttachment mDepth = {};
     VulkanContext& mContext;
     bool mOffscreen;
     uint32_t mColorLevel;
+    uint32_t mDepthLevel;
 };
 
 struct VulkanSwapChain : public HwSwapChain {


### PR DESCRIPTION
We now use GENERAL layout for depth-sampled images in order to support
the SSAO use case of simultaneous binding + sampling.

We may be able to optimize this in the future by enhancing DriverAPI
so that it feeds more information into the render pass.

Fixes #1627, #1649.