### PR TITLE
handle basis inverting transforms (e.g. planar symmetries)

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -202,7 +202,7 @@ void RenderPass::recordDriverCommands(FEngine::DriverApi& driver, FScene& scene,
 UTILS_ALWAYS_INLINE // this function exists only to make the code more readable. we want it inlined.
 inline              // and we don't need it in the compilation unit
 void RenderPass::setupColorCommand(Command& cmdDraw, bool hasDepthPass,
-        FMaterialInstance const* const UTILS_RESTRICT mi) noexcept {
+        FMaterialInstance const* const UTILS_RESTRICT mi, bool inverseFrontFaces) noexcept {
 
     FMaterial const * const UTILS_RESTRICT ma = mi->getMaterial();
     uint8_t variant =
@@ -224,6 +224,7 @@ void RenderPass::setupColorCommand(Command& cmdDraw, bool hasDepthPass,
     bool hasBlending = ma->getRasterState().hasBlending();
     cmdDraw.key = hasBlending ? keyBlending : keyDraw;
     cmdDraw.primitive.rasterState = ma->getRasterState();
+    cmdDraw.primitive.rasterState.inverseFrontFaces = inverseFrontFaces;
     cmdDraw.primitive.mi = mi;
     cmdDraw.primitive.materialVariant.key = variant;
 
@@ -310,12 +311,13 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     const bool depthFilterAlphaMaskedObjects = bool(extraFlags & CommandTypeFlags::DEPTH_FILTER_ALPHA_MASKED_OBJECTS);
 
     auto const* const UTILS_RESTRICT soaWorldAABBCenter = soa.data<FScene::WORLD_AABB_CENTER>();
+    auto const* const UTILS_RESTRICT soaReversedWinding = soa.data<FScene::REVERSED_WINDING_ORDER>();
     auto const* const UTILS_RESTRICT soaVisibility      = soa.data<FScene::VISIBILITY_STATE>();
     auto const* const UTILS_RESTRICT soaPrimitives      = soa.data<FScene::PRIMITIVES>();
     auto const* const UTILS_RESTRICT soaBonesUbh        = soa.data<FScene::BONES_UBH>();
 
     const bool hasShadowing = renderFlags & HAS_SHADOWING;
-    const bool inverseFrontFaces = renderFlags & HAS_INVERSE_FRONT_FACES;
+    const bool viewInverseFrontFaces = renderFlags & HAS_INVERSE_FRONT_FACES;
 
     Variant materialVariant;
     materialVariant.setDirectionalLighting(renderFlags & HAS_DIRECTIONAL_LIGHT);
@@ -331,7 +333,6 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     cmdDepth.primitive.rasterState.depthWrite = true;
     cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::L;
     cmdDepth.primitive.rasterState.alphaToCoverage = false;
-    cmdDepth.primitive.rasterState.inverseFrontFaces = inverseFrontFaces;
 
     for (uint32_t i = range.first; i < range.last; ++i) {
         // Signed distance from camera to object's center. Positive distances are in front of
@@ -364,6 +365,9 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         distance = -distance;
         const uint32_t distanceBits = reinterpret_cast<uint32_t&>(distance);
 
+        // calculate the per-primitive face winding order inversion
+        const bool inverseFrontFaces = viewInverseFrontFaces ^ soaReversedWinding[i];
+
         cmdColor.key = makeField(soaVisibility[i].priority, PRIORITY_MASK, PRIORITY_SHIFT);
         cmdColor.primitive.index = (uint16_t)i;
         cmdColor.primitive.perRenderableBones = soaBonesUbh[i];
@@ -378,6 +382,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         cmdDepth.primitive.index = (uint16_t)i;
         cmdDepth.primitive.perRenderableBones = soaBonesUbh[i];
         cmdDepth.primitive.materialVariant.setSkinning(soaVisibility[i].skinning || soaVisibility[i].morphing);
+        cmdDepth.primitive.rasterState.inverseFrontFaces = inverseFrontFaces;
 
         const bool shadowCaster = soaVisibility[i].castShadows & hasShadowing;
         const bool writeDepthForShadowCasters = depthContainsShadowCasters & shadowCaster;
@@ -393,9 +398,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
             if (colorPass) {
                 cmdColor.primitive.primitiveHandle = primitive.getHwHandle();
                 cmdColor.primitive.materialVariant = materialVariant;
-                RenderPass::setupColorCommand(cmdColor, depthPass, mi);
-                // Inverting front faces applies to all renderables and primitives in the view
-                cmdColor.primitive.rasterState.inverseFrontFaces = inverseFrontFaces;
+                RenderPass::setupColorCommand(cmdColor, depthPass, mi, inverseFrontFaces);
 
                 const bool blendPass = Pass(cmdColor.key & PASS_MASK) == Pass::BLENDED;
                 if (blendPass) {
@@ -461,7 +464,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
                         // in each buckets. We use the top 10 bits of the distance, which
                         // bucketizes the depth by its log2 and in 4 linear chunks in each bucket.
                         cmdColor.key &= ~Z_BUCKET_MASK;
-                        cmdColor.key |= makeField(distanceBits >> 22, Z_BUCKET_MASK,
+                        cmdColor.key |= makeField(distanceBits >> 22u, Z_BUCKET_MASK,
                                 Z_BUCKET_SHIFT);
                     }
                     // ...with depth pre-pass, we just sort by materials

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -257,7 +257,7 @@ private:
             math::float3 cameraForward) noexcept;
 
     static void setupColorCommand(Command& cmdDraw, bool hasDepthPass,
-            FMaterialInstance const* mi) noexcept;
+            FMaterialInstance const* const mi, bool inverseFrontFaces) noexcept;
 
     void recordDriverCommands(FEngine::DriverApi& driver, FScene& scene,
             const Command* first, const Command* last) const noexcept;

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -96,19 +96,22 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
     float maxIntensity = 0.0f;
 
     for (Entity e : entities) {
-        if (!em.isAlive(e))
+        if (!em.isAlive(e)) {
             continue;
+        }
 
         // getInstance() always returns null if the entity is the Null entity
         // so we don't need to check for that, but we need to check it's alive
         auto ri = rcm.getInstance(e);
         auto li = lcm.getInstance(e);
-        if (!ri & !li)
+        if (!ri & !li) {
             continue;
+        }
 
         // get the world transform
         auto ti = tcm.getInstance(e);
         const mat4f worldTransform = worldOriginTransform * tcm.getWorldTransform(ti);
+        const bool reversedWindingOrder = det(worldTransform.upperLeft()) < 0;
 
         // don't even draw this object if it doesn't have a transform (which shouldn't happen
         // because one is always created when creating a Renderable component).
@@ -118,16 +121,19 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
 
             // we know there is enough space in the array
             sceneData.push_back_unsafe(
-                    ri,
-                    worldTransform,
-                    rcm.getVisibility(ri),
-                    rcm.getBonesUbh(ri),
-                    worldAABB.center,
-                    0,
-                    rcm.getMorphWeights(ri),
-                    rcm.getLayerMask(ri),
-                    worldAABB.halfExtent,
-                    {}, {});
+                    ri,                       // RENDERABLE_INSTANCE
+                    worldTransform,           // WORLD_TRANSFORM
+                    reversedWindingOrder,     // REVERSED_WINDING_ORDER
+                    rcm.getVisibility(ri),    // VISIBILITY_STATE
+                    rcm.getBonesUbh(ri),      // BONES_UBH
+                    worldAABB.center,         // WORLD_AABB_CENTER
+                    0,                        // VISIBLE_MASK
+                    rcm.getMorphWeights(ri),  // MORPH_WEIGHTS
+                    rcm.getLayerMask(ri),     // LAYERS
+                    worldAABB.halfExtent,     // WORLD_AABB_EXTENT
+                    {},                       // PRIMITIVES
+                    0                         // SUMMED_PRIMITIVE_COUNT
+            );
         }
 
         if (li) {
@@ -139,7 +145,8 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
                     float3 d = lcm.getLocalDirection(li);
                     // using mat3f::getTransformForNormals handles non-uniform scaling
                     d = normalize(mat3f::getTransformForNormals(worldTransform.upperLeft()) * d);
-                    lightData.elementAt<FScene::POSITION_RADIUS>(0) = float4{ 0, 0, 0, std::numeric_limits<float>::infinity() };
+                    lightData.elementAt<FScene::POSITION_RADIUS>(0) =
+                            float4{ 0, 0, 0, std::numeric_limits<float>::infinity() };
                     lightData.elementAt<FScene::DIRECTION>(0)       = d;
                     lightData.elementAt<FScene::LIGHT_INSTANCE>(0)  = li;
                 }

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -95,26 +95,28 @@ public:
      */
 
     enum {
-        RENDERABLE_INSTANCE,    //  4 instance of the Renderable component
-        WORLD_TRANSFORM,        // 16 instance of the Transform component
-        VISIBILITY_STATE,       //  1 visibility data of the component
-        BONES_UBH,              //  4 bones uniform buffer handle
-        WORLD_AABB_CENTER,      // 12 world-space bounding box center of the renderable
-        VISIBLE_MASK,           //  1 each bit represents a visibility in a pass
-        MORPH_WEIGHTS,          //  4 floats for morphing
+        RENDERABLE_INSTANCE,    //  4 | instance of the Renderable component
+        WORLD_TRANSFORM,        // 16 | instance of the Transform component
+        REVERSED_WINDING_ORDER, //  1 | det(WORLD_TRANSFORM)<0
+        VISIBILITY_STATE,       //  1 | visibility data of the component
+        BONES_UBH,              //  4 | bones uniform buffer handle
+        WORLD_AABB_CENTER,      // 12 | world-space bounding box center of the renderable
+        VISIBLE_MASK,           //  1 | each bit represents a visibility in a pass
+        MORPH_WEIGHTS,          //  4 | floats for morphing
 
         // These are not needed anymore after culling
-        LAYERS,                 //  1 layers
-        WORLD_AABB_EXTENT,      // 12 world-space bounding box half-extent of the renderable
+        LAYERS,                 //  1 | layers
+        WORLD_AABB_EXTENT,      // 12 | world-space bounding box half-extent of the renderable
 
         // These are temporaries and should be stored out of line
-        PRIMITIVES,             //  8 level-of-detail'ed primitives
-        SUMMED_PRIMITIVE_COUNT, //  4 summed visible primitive counts
+        PRIMITIVES,             //  8 | level-of-detail'ed primitives
+        SUMMED_PRIMITIVE_COUNT, //  4 | summed visible primitive counts
     };
 
     using RenderableSoa = utils::StructureOfArrays<
             utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
             math::mat4f,                                // WORLD_TRANSFORM
+            bool,                                       // REVERSED_WINDING_ORDER
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             backend::Handle<backend::HwUniformBuffer>,  // BONES_UBH
             math::float3,                               // WORLD_AABB_CENTER

--- a/libs/math/include/math/TMatHelpers.h
+++ b/libs/math/include/math/TMatHelpers.h
@@ -253,6 +253,19 @@ struct Determinant {
 };
 
 template<typename T>
+struct Determinant<T, 3> {
+    static constexpr T determinant(Matrix<T, 3> in) {
+        return
+            in[0][0] * in[1][1] * in[2][2] +
+            in[1][0] * in[2][1] * in[0][2] +
+            in[2][0] * in[0][1] * in[1][2] -
+            in[2][0] * in[1][1] * in[0][2] -
+            in[1][0] * in[0][1] * in[2][2] -
+            in[0][0] * in[2][1] * in[1][2];
+    }
+};
+
+template<typename T>
 struct Determinant<T, 2> {
     static constexpr T determinant(Matrix<T, 2> in) {
         return in[0][0] * in[1][1] - in[0][1] * in[1][0];


### PR DESCRIPTION
We now inverse the face winding order based on the determinant of
each render primitive world's transform. This prevents front/back faces
to be reversed when using a left-handed basis, after transform.

Fix #1520