### PR TITLE
improve mixed-precision vector operations

### DIFF
--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -22,10 +22,9 @@
 #include <stdint.h>
 #include <sys/types.h>
 
-#include <cmath>
-#include <functional>
-#include <limits>
-#include <iostream>
+#include <cmath>            // for std:: namespace
+#include <functional>       // for appl() and map()
+#include <iostream>         // for operator<<
 
 #include <math/compiler.h>
 
@@ -43,6 +42,15 @@ template<typename U>
 inline constexpr U max(U a, U b) noexcept {
     return a > b ? a : b;
 }
+
+template<typename T, typename U>
+struct arithmetic_result {
+    using type = decltype(std::declval<T>() + std::declval<U>());
+};
+
+template<typename T, typename U>
+using arithmetic_result_t = typename arithmetic_result<T, U>::type;
+
 
 /*
  * No user serviceable parts here.
@@ -115,16 +123,20 @@ public:
     /* The operators below handle operation between vectors of the same size
      * but of a different element type.
      */
-    template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator+(VECTOR<T> lv, const VECTOR<RT>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv += rv;
+    template<typename U>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator+(const VECTOR<T>& lv, const VECTOR<U>& rv) {
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
+        res += rv;
+        return res;
     }
 
-    template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator-(VECTOR<T> lv, const VECTOR<RT>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv -= rv;
+    template<typename U>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator-(const VECTOR<T>& lv, const VECTOR<U>& rv) {
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
+        res -= rv;
+        return res;
     }
 
     /* The operators below (which are not templates once this class is instanced,
@@ -200,16 +212,20 @@ public:
     /* The operators below handle operation between vectors of the same size
      * but of a different element type.
      */
-    template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator*(VECTOR<T> lv, const VECTOR<RT>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv *= rv;
+    template<typename U>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator*(const VECTOR<T>& lv, const VECTOR<U>& rv) {
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
+        res *= rv;
+        return res;
     }
 
-    template<typename RT>
-    friend inline constexpr VECTOR<T> MATH_PURE operator/(VECTOR<T> lv, const VECTOR<RT>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv /= rv;
+    template<typename U>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator/(const VECTOR<T>& lv, const VECTOR<U>& rv) {
+        arithmetic_result_t<T, U> res(lv);
+        res /= rv;
+        return res;
     }
 
     /* The operators below (which are not templates once this class is instanced,
@@ -269,9 +285,9 @@ public:
      * is instantiated, at which point they're only templated on the 2nd parameter
      * (the first one, BASE<T> being known).
      */
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    bool MATH_PURE operator==(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    bool MATH_PURE operator==(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         // w/ inlining we end-up with many branches that will pollute the BPU cache
         MATH_NOUNROLL
         for (size_t i = 0; i < lv.size(); i++) {
@@ -282,15 +298,15 @@ public:
         return true;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    bool MATH_PURE operator!=(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    bool MATH_PURE operator!=(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         return !operator==(lv, rv);
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    VECTOR<bool> MATH_PURE equal(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE equal(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] == rv[i];
@@ -298,9 +314,9 @@ public:
         return r;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    VECTOR<bool> MATH_PURE notEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE notEqual(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] != rv[i];
@@ -308,9 +324,9 @@ public:
         return r;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    VECTOR<bool> MATH_PURE lessThan(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE lessThan(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] < rv[i];
@@ -318,9 +334,9 @@ public:
         return r;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    VECTOR<bool> MATH_PURE lessThanEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE lessThanEqual(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] <= rv[i];
@@ -328,9 +344,9 @@ public:
         return r;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline constexpr
-    VECTOR<bool> MATH_PURE greaterThan(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE greaterThan(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r;
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] > rv[i];
@@ -338,9 +354,9 @@ public:
         return r;
     }
 
-    template<typename RT>
+    template<typename U>
     friend inline
-    VECTOR<bool> MATH_PURE greaterThanEqual(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    VECTOR<bool> MATH_PURE greaterThanEqual(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<bool> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r[i] = lv[i] >= rv[i];
@@ -366,9 +382,10 @@ public:
      * is instantiated, at which point they're only templated on the 2nd parameter
      * (the first one, BASE<T> being known).
      */
-    template<typename RT>
-    friend constexpr inline T MATH_PURE dot(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
-        T r(0);
+    template<typename U>
+    friend constexpr inline
+    arithmetic_result_t<T, U> MATH_PURE dot(const VECTOR<T>& lv, const VECTOR<U>& rv) {
+        arithmetic_result_t<T, U> r{};
         for (size_t i = 0; i < lv.size(); i++) {
             r += lv[i] * rv[i];
         }
@@ -391,13 +408,15 @@ public:
         return norm2(lv);
     }
 
-    template<typename RT>
-    friend inline constexpr T MATH_PURE distance(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    template<typename U>
+    friend inline constexpr
+    arithmetic_result_t<T, U> MATH_PURE distance(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         return length(rv - lv);
     }
 
-    template<typename RT>
-    friend inline constexpr T MATH_PURE distance2(const VECTOR<T>& lv, const VECTOR<RT>& rv) {
+    template<typename U>
+    friend inline constexpr
+    arithmetic_result_t<T, U> MATH_PURE distance2(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         return length2(rv - lv);
     }
 
@@ -499,16 +518,16 @@ public:
     }
 
     friend inline constexpr T MATH_PURE max(const VECTOR<T>& v) {
-        T r(std::numeric_limits<T>::lowest());
-        for (size_t i = 0; i < v.size(); i++) {
+        T r(v[0]);
+        for (size_t i = 1; i < v.size(); i++) {
             r = max(r, v[i]);
         }
         return r;
     }
 
     friend inline constexpr T MATH_PURE min(const VECTOR<T>& v) {
-        T r(std::numeric_limits<T>::max());
-        for (size_t i = 0; i < v.size(); i++) {
+        T r(v[0]);
+        for (size_t i = 1; i < v.size(); i++) {
             r = min(r, v[i]);
         }
         return r;

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -79,8 +79,8 @@ public:
     /* compound assignment from a another vector of the same size but different
      * element type.
      */
-    template<typename OTHER>
-    constexpr VECTOR<T>& operator+=(const VECTOR<OTHER>& v) {
+    template<typename U>
+    constexpr VECTOR<T>& operator+=(const VECTOR<U>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] += v[i];
@@ -88,8 +88,13 @@ public:
         return lhs;
     }
 
-    template<typename OTHER>
-    constexpr VECTOR<T>& operator-=(const VECTOR<OTHER>& v) {
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    constexpr VECTOR<T>& operator+=(U v) {
+        return operator+=(VECTOR<U>(v));
+    }
+
+    template<typename U>
+    constexpr VECTOR<T>& operator-=(const VECTOR<U>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] -= v[i];
@@ -97,25 +102,9 @@ public:
         return lhs;
     }
 
-    /* compound assignment from a another vector of the same type.
-     * These operators can be used for implicit conversion and  handle operations
-     * like "vector *= scalar" by letting the compiler implicitly convert a scalar
-     * to a vector (assuming the BASE<T> allows it).
-     */
-    constexpr VECTOR<T>& operator+=(const VECTOR<T>& v) {
-        VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
-        for (size_t i = 0; i < lhs.size(); i++) {
-            lhs[i] += v[i];
-        }
-        return lhs;
-    }
-
-    constexpr VECTOR<T>& operator-=(const VECTOR<T>& v) {
-        VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
-        for (size_t i = 0; i < lhs.size(); i++) {
-            lhs[i] -= v[i];
-        }
-        return lhs;
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    constexpr VECTOR<T>& operator-=(U v) {
+        return operator-=(VECTOR<U>(v));
     }
 
     /*
@@ -126,15 +115,18 @@ public:
      * (the first one, BASE<T> being known).
      */
 
-    /* The operators below handle operation between vectors of the same size
-     * but of a different element type.
-     */
     template<typename U>
     friend inline constexpr
     VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator+(const VECTOR<T>& lv, const VECTOR<U>& rv) {
         VECTOR<arithmetic_result_t<T, U>> res(lv);
         res += rv;
         return res;
+    }
+
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator+(const VECTOR<T>& lv, U rv) {
+        return lv + VECTOR<U>(rv);
     }
 
     template<typename U>
@@ -145,20 +137,10 @@ public:
         return res;
     }
 
-    /* The operators below (which are not templates once this class is instanced,
-     * i.e.: BASE<T> is known) can be used for implicit conversion on both sides.
-     * These handle operations like "vector + scalar" and "scalar + vector" by
-     * letting the compiler implicitly convert a scalar to a vector (assuming
-     * the BASE<T> allows it).
-     */
-    friend inline constexpr VECTOR<T> MATH_PURE operator+(VECTOR<T> lv, const VECTOR<T>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv += rv;
-    }
-
-    friend inline constexpr VECTOR<T> MATH_PURE operator-(VECTOR<T> lv, const VECTOR<T>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv -= rv;
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator-(const VECTOR<T>& lv, U rv) {
+        return lv - VECTOR<U>(rv);
     }
 };
 
@@ -168,8 +150,8 @@ public:
     /* compound assignment from a another vector of the same size but different
      * element type.
      */
-    template<typename OTHER>
-    constexpr VECTOR<T>& operator*=(const VECTOR<OTHER>& v) {
+    template<typename U>
+    constexpr VECTOR<T>& operator*=(const VECTOR<U>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] *= v[i];
@@ -177,8 +159,13 @@ public:
         return lhs;
     }
 
-    template<typename OTHER>
-    constexpr VECTOR<T>& operator/=(const VECTOR<OTHER>& v) {
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    constexpr VECTOR<T>& operator*=(U v) {
+        return operator*=(VECTOR<U>(v));
+    }
+
+    template<typename U>
+    constexpr VECTOR<T>& operator/=(const VECTOR<U>& v) {
         VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
         for (size_t i = 0; i < lhs.size(); i++) {
             lhs[i] /= v[i];
@@ -186,25 +173,9 @@ public:
         return lhs;
     }
 
-    /* compound assignment from a another vector of the same type.
-     * These operators can be used for implicit conversion and  handle operations
-     * like "vector *= scalar" by letting the compiler implicitly convert a scalar
-     * to a vector (assuming the BASE<T> allows it).
-     */
-    constexpr VECTOR<T>& operator*=(const VECTOR<T>& v) {
-        VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
-        for (size_t i = 0; i < lhs.size(); i++) {
-            lhs[i] *= v[i];
-        }
-        return lhs;
-    }
-
-    constexpr VECTOR<T>& operator/=(const VECTOR<T>& v) {
-        VECTOR<T>& lhs = static_cast<VECTOR<T>&>(*this);
-        for (size_t i = 0; i < lhs.size(); i++) {
-            lhs[i] /= v[i];
-        }
-        return lhs;
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    constexpr VECTOR<T>& operator/=(U v) {
+        return operator/=(VECTOR<U>(v));
     }
 
     /*
@@ -215,9 +186,6 @@ public:
      * (the first one, BASE<T> being known).
      */
 
-    /* The operators below handle operation between vectors of the same size
-     * but of a different element type.
-     */
     template<typename U>
     friend inline constexpr
     VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator*(const VECTOR<T>& lv, const VECTOR<U>& rv) {
@@ -226,28 +194,26 @@ public:
         return res;
     }
 
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator*(const VECTOR<T>& lv, U rv) {
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
+        return res * VECTOR<U>(rv);
+    }
+
     template<typename U>
     friend inline constexpr
     VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator/(const VECTOR<T>& lv, const VECTOR<U>& rv) {
-        arithmetic_result_t<T, U> res(lv);
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
         res /= rv;
         return res;
     }
 
-    /* The operators below (which are not templates once this class is instanced,
-     * i.e.: BASE<T> is known) can be used for implicit conversion on both sides.
-     * These handle operations like "vector * scalar" and "scalar * vector" by
-     * letting the compiler implicitly convert a scalar to a vector (assuming
-     * the BASE<T> allows it).
-     */
-    friend inline constexpr VECTOR<T> MATH_PURE operator*(VECTOR<T> lv, const VECTOR<T>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv *= rv;
-    }
-
-    friend inline constexpr VECTOR<T> MATH_PURE operator/(VECTOR<T> lv, const VECTOR<T>& rv) {
-        // don't pass lv by reference because we need a copy anyways
-        return lv /= rv;
+    template<typename U, typename = enable_if_arithmetic_t<U>>
+    friend inline constexpr
+    VECTOR<arithmetic_result_t<T, U>> MATH_PURE operator/(const VECTOR<T>& lv, U rv) {
+        VECTOR<arithmetic_result_t<T, U>> res(lv);
+        return res / VECTOR<U>(rv);
     }
 };
 

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-
 #ifndef MATH_TVECHELPERS_H_
 #define MATH_TVECHELPERS_H_
 
-#include <math.h>
-#include <stdint.h>
-#include <sys/types.h>
+#include <math/compiler.h>
 
 #include <cmath>            // for std:: namespace
 #include <functional>       // for appl() and map()
 #include <iostream>         // for operator<<
 
-#include <math/compiler.h>
+#include <math.h>
+#include <stdint.h>
+#include <sys/types.h>
 
 namespace filament {
 namespace math {
@@ -107,6 +106,7 @@ public:
         return operator-=(VECTOR<U>(v));
     }
 
+private:
     /*
      * NOTE: the functions below ARE NOT member methods. They are friend functions
      * with they definition inlined with their declaration. This makes these
@@ -178,6 +178,7 @@ public:
         return operator/=(VECTOR<U>(v));
     }
 
+private:
     /*
      * NOTE: the functions below ARE NOT member methods. They are friend functions
      * with they definition inlined with their declaration. This makes these
@@ -249,7 +250,7 @@ public:
  */
 template<template<typename T> class VECTOR, typename T>
 class TVecComparisonOperators {
-public:
+private:
     /*
      * NOTE: the functions below ARE NOT member methods. They are friend functions
      * with they definition inlined with their declaration. This makes these
@@ -346,7 +347,7 @@ public:
  */
 template<template<typename T> class VECTOR, typename T>
 class TVecFunctions {
-public:
+private:
     /*
      * NOTE: the functions below ARE NOT member methods. They are friend functions
      * with they definition inlined with their declaration. This makes these
@@ -546,7 +547,7 @@ public:
  */
 template<template<typename T> class VECTOR, typename T>
 class TVecDebug {
-public:
+private:
     /*
      * NOTE: the functions below ARE NOT member methods. They are friend functions
      * with they definition inlined with their declaration. This makes these

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -51,6 +51,12 @@ struct arithmetic_result {
 template<typename T, typename U>
 using arithmetic_result_t = typename arithmetic_result<T, U>::type;
 
+template<typename A, typename B = int, typename C = int, typename D = int>
+using enable_if_arithmetic_t = std::enable_if_t<
+        std::is_arithmetic<A>::value &&
+        std::is_arithmetic<B>::value &&
+        std::is_arithmetic<C>::value &&
+        std::is_arithmetic<D>::value>;
 
 /*
  * No user serviceable parts here.

--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -68,7 +68,7 @@ class MATH_EMPTY_BASES TMat22 :
         public TVecUnaryOperators<TMat22, T>,
         public TVecComparisonOperators<TMat22, T>,
         public TVecAddOperators<TMat22, T>,
-        public TMatProductOperators<TMat22, T>,
+        public TMatProductOperators<TMat22, T, TVec2>,
         public TMatSquareFunctions<TMat22, T>,
         public TMatHelpers<TMat22, T>,
         public TMatDebug<TMat22, T> {
@@ -323,55 +323,6 @@ template<typename T>
 template<typename A, typename B>
 constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1)
         : m_value{ v0, v1 } {
-}
-
-// ----------------------------------------------------------------------------------------
-// Arithmetic operators outside of class
-// ----------------------------------------------------------------------------------------
-
-/* We use non-friend functions here to prevent the compiler from using
- * implicit conversions, for instance of a scalar to a vector. The result would
- * not be what the caller expects.
- *
- * Also note that the order of the arguments in the inner loop is important since
- * it determines the output type (only relevant when T != U).
- */
-
-// matrix * column-vector, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat22<U>::col_type MATH_PURE
-operator*(const TMat22<T>& lhs, const TVec2<U>& rhs) {
-    // Result is initialized to zero.
-    typename TMat22<U>::col_type result{};
-    for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
-        result += lhs[col] * rhs[col];
-    }
-    return result;
-}
-
-// row-vector * matrix, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat22<U>::row_type MATH_PURE
-operator*(const TVec2<U>& lhs, const TMat22<T>& rhs) {
-    typename TMat22<U>::row_type result{};
-    for (size_t col = 0; col < TMat22<T>::NUM_COLS; ++col) {
-        result[col] = dot(lhs, rhs[col]);
-    }
-    return result;
-}
-
-// matrix * scalar, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat22<T>> MATH_PURE
-operator*(TMat22<T> lhs, U rhs) {
-    return lhs *= rhs;
-}
-
-// scalar * matrix, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat22<T>> MATH_PURE
-operator*(U lhs, const TMat22<T>& rhs) {
-    return rhs * lhs;
 }
 
 // ----------------------------------------------------------------------------------------

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -73,7 +73,7 @@ class MATH_EMPTY_BASES TMat33 :
         public TVecUnaryOperators<TMat33, T>,
         public TVecComparisonOperators<TMat33, T>,
         public TVecAddOperators<TMat33, T>,
-        public TMatProductOperators<TMat33, T>,
+        public TMatProductOperators<TMat33, T, TVec3>,
         public TMatSquareFunctions<TMat33, T>,
         public TMatTransform<TMat33, T>,
         public TMatHelpers<TMat33, T>,
@@ -386,55 +386,6 @@ constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) : m_value{} {
     m_value[0] = col_type(1 - yy - zz, xy + zw, xz - yw);  // NOLINT
     m_value[1] = col_type(xy - zw, 1 - xx - zz, yz + xw);  // NOLINT
     m_value[2] = col_type(xz + yw, yz - xw, 1 - xx - yy);  // NOLINT
-}
-
-// ----------------------------------------------------------------------------------------
-// Arithmetic operators outside of class
-// ----------------------------------------------------------------------------------------
-
-/* We use non-friend functions here to prevent the compiler from using
- * implicit conversions, for instance of a scalar to a vector. The result would
- * not be what the caller expects.
- *
- * Also note that the order of the arguments in the inner loop is important since
- * it determines the output type (only relevant when T != U).
- */
-
-// matrix * column-vector, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat33<U>::col_type MATH_PURE operator*(const TMat33<T>& lhs,
-        const TVec3<U>& rhs) {
-    // Result is initialized to zero.
-    typename TMat33<U>::col_type result{};
-    for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
-        result += lhs[col] * rhs[col];
-    }
-    return result;
-}
-
-// row-vector * matrix, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat33<U>::row_type MATH_PURE operator*(const TVec3<U>& lhs,
-        const TMat33<T>& rhs) {
-    typename TMat33<U>::row_type result{};
-    for (size_t col = 0; col < TMat33<T>::NUM_COLS; ++col) {
-        result[col] = dot(lhs, rhs[col]);
-    }
-    return result;
-}
-
-// matrix * scalar, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat33<T>> MATH_PURE
-operator*(TMat33<T> lhs, U rhs) {
-    return lhs *= rhs;
-}
-
-// scalar * matrix, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat33<T>> MATH_PURE
-operator*(U lhs, const TMat33<T>& rhs) {
-    return rhs * lhs;
 }
 
 //------------------------------------------------------------------------------

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -83,7 +83,7 @@ class MATH_EMPTY_BASES TMat44 :
         public TVecUnaryOperators<TMat44, T>,
         public TVecComparisonOperators<TMat44, T>,
         public TVecAddOperators<TMat44, T>,
-        public TMatProductOperators<TMat44, T>,
+        public TMatProductOperators<TMat44, T, TVec4>,
         public TMatSquareFunctions<TMat44, T>,
         public TMatTransform<TMat44, T>,
         public TMatHelpers<TMat44, T>,
@@ -547,57 +547,12 @@ TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center,
 // Arithmetic operators outside of class
 // ----------------------------------------------------------------------------------------
 
-/* We use non-friend functions here to prevent the compiler from using
- * implicit conversions, for instance of a scalar to a vector. The result would
- * not be what the caller expects.
- *
- * Also note that the order of the arguments in the inner loop is important since
- * it determines the output type (only relevant when T != U).
- */
-
-// matrix * column-vector, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
-        const TVec4<U>& rhs) {
-    // Result is initialized to zero.
-    typename TMat44<T>::col_type result{};
-    for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
-        result += lhs[col] * T(rhs[col]);
-    }
-    return result;
-}
 
 // mat44 * vec3, result is vec3( mat44 * {vec3, 1} )
 template<typename T, typename U>
 constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
         const TVec3<U>& rhs) {
     return lhs * TVec4<U>{ rhs, 1 };
-}
-
-
-// row-vector * matrix, result is a vector of the same type than the input vector
-template<typename T, typename U>
-constexpr typename TMat44<U>::row_type MATH_PURE operator*(const TVec4<U>& lhs,
-        const TMat44<T>& rhs) {
-    typename TMat44<U>::row_type result{};
-    for (size_t col = 0; col < TMat44<T>::NUM_COLS; ++col) {
-        result[col] = dot(lhs, rhs[col]);
-    }
-    return result;
-}
-
-// matrix * scalar, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat44<T>> MATH_PURE
-operator*(TMat44<T> lhs, U rhs) {
-    return lhs *= rhs;
-}
-
-// scalar * matrix, result is a matrix of the same type than the input matrix
-template<typename T, typename U>
-constexpr std::enable_if_t<std::is_arithmetic<U>::value, TMat44<T>> MATH_PURE
-operator*(U lhs, const TMat44<T>& rhs) {
-    return rhs * lhs;
 }
 
 // ----------------------------------------------------------------------------------------

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -97,8 +97,7 @@ public:
     constexpr TQuaternion() : x(0), y(0), z(0), w(0) {}
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A,
-            typename = std::enable_if_t<std::is_arithmetic<A>::value, int>>
+    template<typename A, typename = enable_if_arithmetic_t<T>>
     constexpr TQuaternion(A w) : x(0), y(0), z(0), w(w) {
     }
 

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -83,10 +83,10 @@ public:
     constexpr TVec2(const TVec2<A>& v) : v{ T(v[0]), T(v[1]) } {}
 
     // cross product works only on vectors of size 2 or 3
-    template<typename RT>
-    friend inline
-    constexpr value_type cross(const TVec2& u, const TVec2<RT>& v) {
-        return value_type(u[0] * v[1] - u[1] * v[0]);
+    template<typename U>
+    friend inline constexpr
+    arithmetic_result_t<T, U> cross(const TVec2& u, const TVec2<U>& v) {
+        return u[0] * v[1] - u[1] * v[0];
     }
 };
 

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -73,13 +73,13 @@ public:
     constexpr TVec2() = default;
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec2(A v) : v{ T(v), T(v) } {}
 
-    template<typename A, typename B>
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
     constexpr TVec2(A x, B y) : v{ T(x), T(y) } {}
 
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec2(const TVec2<A>& v) : v{ T(v[0]), T(v[1]) } {}
 
     // cross product works only on vectors of size 2 or 3
@@ -94,7 +94,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template<typename T, typename = details::enable_if_arithmetic_t<T>>
 using vec2 = details::TVec2<T>;
 
 using double2 = vec2<double>;

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -86,16 +86,17 @@ public:
     constexpr TVec3() = default;
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec3(A v) : v{ T(v), T(v), T(v) } {}
 
-    template<typename A, typename B, typename C>
+    template<typename A, typename B, typename C,
+            typename = enable_if_arithmetic_t<A, B, C>>
     constexpr TVec3(A x, B y, C z) : v{ T(x), T(y), T(z) } {}
 
-    template<typename A, typename B>
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
     constexpr TVec3(const TVec2<A>& v, B z) : v{ T(v[0]), T(v[1]), T(z) } {}
 
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec3(const TVec3<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]) } {}
 
     // cross product works only on vectors of size 3
@@ -113,7 +114,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template<typename T, typename = details::enable_if_arithmetic_t<T>>
 using vec3 = details::TVec3<T>;
 
 using double3 = vec3<double>;

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -99,12 +99,13 @@ public:
     constexpr TVec3(const TVec3<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]) } {}
 
     // cross product works only on vectors of size 3
-    template<typename RT>
-    friend inline constexpr TVec3 cross(const TVec3& u, const TVec3<RT>& v) {
-        return TVec3(
+    template<typename U>
+    friend inline constexpr
+    TVec3<arithmetic_result_t<T, U>> cross(const TVec3& u, const TVec3<U>& v) {
+        return {
                 u[1] * v[2] - u[2] * v[1],
                 u[2] * v[0] - u[0] * v[2],
-                u[0] * v[1] - u[1] * v[0]);
+                u[0] * v[1] - u[1] * v[0] };
     }
 };
 

--- a/libs/math/include/math/vec4.h
+++ b/libs/math/include/math/vec4.h
@@ -86,23 +86,25 @@ public:
     constexpr TVec4() = default;
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec4(A v) : v{ T(v), T(v), T(v), T(v) } {}
 
-    template<typename A, typename B, typename C, typename D>
+    template<typename A, typename B, typename C, typename D,
+            typename = enable_if_arithmetic_t<A, B, C, D>>
     constexpr TVec4(A x, B y, C z, D w) : v{ T(x), T(y), T(z), T(w) } {}
 
-    template<typename A, typename B, typename C>
-    constexpr TVec4(const TVec2 <A>& v, B z, C w) : v{ T(v[0]), T(v[1]), T(z), T(w) } {}
+    template<typename A, typename B, typename C,
+            typename = enable_if_arithmetic_t<A, B, C>>
+    constexpr TVec4(const TVec2<A>& v, B z, C w) : v{ T(v[0]), T(v[1]), T(z), T(w) } {}
 
-    template<typename A, typename B>
-    constexpr TVec4(const TVec2 <A>& v, const TVec2 <B>& w) : v{
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
+    constexpr TVec4(const TVec2<A>& v, const TVec2<B>& w) : v{
             T(v[0]), T(v[1]), T(w[0]), T(w[1]) } {}
 
-    template<typename A, typename B>
-    constexpr TVec4(const TVec3 <A>& v, B w) : v{ T(v[0]), T(v[1]), T(v[2]), T(w) } {}
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
+    constexpr TVec4(const TVec3<A>& v, B w) : v{ T(v[0]), T(v[1]), T(v[2]), T(w) } {}
 
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr TVec4(const TVec4<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]), T(v[3]) } {}
 };
 
@@ -110,7 +112,7 @@ public:
 
 // ----------------------------------------------------------------------------------------
 
-template<typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+template<typename T, typename = details::enable_if_arithmetic_t<T>>
 using vec4 = details::TVec4<T>;
 
 using double4 = vec4<double>;

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -46,9 +46,12 @@ TEST_F(MatTest, ConstexprMat2) {
     constexpr float2 f3 = diag(M0);
     constexpr mat2f M8 = transpose(M0);
     constexpr mat2f M9 = inverse(M0);
+    constexpr mat2f M12 = abs(M0);
     constexpr mat2f M11 = details::matrix::cof(M0);
     constexpr mat2f M10 = M8 * M9;
     constexpr float s0 = trace(M0);
+    constexpr float f4 = M[0][0];
+    constexpr float f5 = M(0, 0);
 }
 
 TEST_F(MatTest, ConstexprMat3) {

--- a/libs/math/tests/test_vec.cpp
+++ b/libs/math/tests/test_vec.cpp
@@ -31,6 +31,8 @@ TEST_F(VecTest, Constexpr) {
     constexpr float2 A2 = a;
     constexpr float2 B2 = { a, a };
     constexpr float2 C2 = A2;
+    constexpr float2 E2 = A2 + 0.5f;
+    constexpr float2 F2 = A2 + 0.5 - 1.0 + (1 + A2);
     constexpr float3 D2 = cross(A2, C2);
 
     constexpr float3 A3 = a;
@@ -64,7 +66,8 @@ TEST_F(VecTest, Constexpr) {
 
     constexpr float4 S0 = A4 + B4;
     constexpr float4 S1 = C4 - D4;
-    constexpr float4 S2 = A4 * a;
+    constexpr float4 S2 = (a * A4) + (A4 * a);
+    constexpr float4 S7 = (a / A4) + (A4 / a);
     constexpr float4 S3 = A4 * A4;
     constexpr float4 S4 = A4 / a;
     constexpr float4 S5 = A4 / A4;


### PR DESCRIPTION
We now follow the same rules than for basic types, when performing
mixed-precision operations, e.g.:

  float3 + double3 -> double3
  double3 + float3 -> double3
  dot(float3, double3) -> double

In particular, e.g. swapping the arguments to arithmetic operations
now always yields to the same result type (before, float3 + double3
would not return the same type than double3 + float3).