### PR TITLE
Fix minor time calculation imprecision

### DIFF
--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -563,8 +563,8 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
      * Update driver state
      */
 
-    const uint64_t oneSecondReminder = engine.getEngineTime().count() % 1000000000;
-    const float fraction = float(double(oneSecondReminder) / 1000000000.0);
+    const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
+    const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
     mPerViewUb.setUniform(offsetof(PerViewUib, time), fraction);
     mPerViewUb.setUniform(offsetof(PerViewUib, userTime), userTime);
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -563,7 +563,8 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
      * Update driver state
      */
 
-    float fraction = (engine.getEngineTime().count() % 1000000000) / 1000000000.0f;
+    const uint64_t oneSecondReminder = engine.getEngineTime().count() % 1000000000;
+    const float fraction = float(double(oneSecondReminder) / 1000000000.0);
     mPerViewUb.setUniform(offsetof(PerViewUib, time), fraction);
     mPerViewUb.setUniform(offsetof(PerViewUib, userTime), userTime);
 
@@ -583,7 +584,7 @@ void FView::computeVisibilityMasks(
     // __restrict__ seems to only be taken into account as function parameters. This is very
     // important here, otherwise, this loop doesn't get vectorized.
     // This is vectorized 16x.
-    count = (count + 0xF) & ~0xF; // capacity guaranteed to be multiple of 16
+    count = (count + 0xFu) & ~0xFu; // capacity guaranteed to be multiple of 16
     for (size_t i = 0; i < count; ++i) {
         Culler::result_type mask = visibleMask[i];
         FRenderableManager::Visibility v = visibility[i];
@@ -591,7 +592,7 @@ void FView::computeVisibilityMasks(
         bool visRenderables   = (!v.culling || (mask & VISIBLE_RENDERABLE))    && inVisibleLayer;
         bool visShadowCasters = (!v.culling || (mask & VISIBLE_SHADOW_CASTER)) && inVisibleLayer && v.castShadows;
         visibleMask[i] = Culler::result_type(visRenderables) |
-                         Culler::result_type(visShadowCasters << 1);
+                         Culler::result_type(visShadowCasters << 1u);
     }
 }
 

--- a/libs/utils/include/utils/Entity.h
+++ b/libs/utils/include/utils/Entity.h
@@ -53,6 +53,8 @@ public:
 
     explicit operator bool() const noexcept { return !isNull(); }
 
+    void clear() noexcept  { mIdentity = 0; }
+
 private:
     friend class EntityManager;
     friend class EntityManagerImpl;


### PR DESCRIPTION
use double for the shader's 'second' time calculation, since 1 billion cannot be stored
in a float accurately.