### PR TITLE
Fix, allow missing bone indices vertex attribute in Metal driver

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -935,9 +935,9 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                                           withRange:bufferRange];
 
     // Bind the zero buffer, used for missing vertex attributes.
-    static const char bytes[4] = { 0 };
+    static const char bytes[16] = { 0 };
     [mContext->currentCommandEncoder setVertexBytes:bytes
-                                             length:4
+                                             length:16
                                             atIndex:(VERTEX_BUFFER_START + ZERO_VERTEX_BUFFER)];
 
     MetalIndexBuffer* indexBuffer = primitive->indexBuffer;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -198,16 +198,24 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
     uint32_t bufferIndex = 0;
     for (uint32_t attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++) {
         if (!(enabledAttributes & (1U << attributeIndex))) {
+            // TODO: all vertex attributes are vec4 (vector of floats), except for
+            // mesh_bone_indices, which is a uvec4 (vector of unsigned integers).
+            // We must use the correct format, but ideally the Metal driver should not need to know
+            // this.
+            const auto boneIndicesLocation = 5; // VertexAttribute::BONE_INDICES
+            const MTLVertexFormat format = attributeIndex == boneIndicesLocation ?
+                    MTLVertexFormatUInt4 : MTLVertexFormatFloat4;
+
             // If the attribute is not enabled, bind it to the zero buffer. It's a Metal error for a
             // shader to read from missing vertex attributes.
             vertexDescription.attributes[attributeIndex] = {
-                    .format = MTLVertexFormatChar4,
+                    .format = format,
                     .buffer = ZERO_VERTEX_BUFFER,
                     .offset = 0
             };
             vertexDescription.layouts[ZERO_VERTEX_BUFFER] = {
                     .step = MTLVertexStepFunctionConstant,
-                    .stride = 4
+                    .stride = 16
             };
             continue;
         }


### PR DESCRIPTION
Fixes #1525

`mesh_bone_indices` is a special vertex attribute (it's uvec4, as opposed to vec4). If a renderable
doesn't provide the attribute, we read from a faux vertex buffer called the "zero buffer". The
vertex format still needs to be specified as `MTLVertexFormatUInt4`, otherwise Metal errors.

This is a hack for now—we've discussed the idea of programatic vertex pulling as a potential future
workaround.