### PR TITLE
Improve backend documentation

### DIFF
--- a/filament/backend/include/backend/BufferDescriptor.h
+++ b/filament/backend/include/backend/BufferDescriptor.h
@@ -27,6 +27,14 @@
 namespace filament {
 namespace backend {
 
+/**
+ * A CPU memory-buffer descriptor, typically used to transfer data from the CPU to the GPU.
+ *
+ * A BufferDescriptor owns the memory buffer it references, therefore BufferDescriptor cannot
+ * be copied, but can be moved.
+ *
+ * BufferDescriptor releases ownership of the memory-buffer when it's destroyed.
+ */
 class UTILS_PUBLIC BufferDescriptor {
 public:
     /**
@@ -35,8 +43,10 @@ public:
      */
     using Callback = void(*)(void* buffer, size_t size, void* user);
 
+    //! creates an empty descriptor
     BufferDescriptor() noexcept = default;
 
+    //! calls the callback to advertise BufferDescriptor no-longer owns the buffer
     ~BufferDescriptor() noexcept {
         if (callback) {
             callback(buffer, size, user);
@@ -64,35 +74,46 @@ public:
         return *this;
     }
 
+    /**
+     * Creates a BufferDescriptor that references a CPU memory-buffer
+     * @param buffer    Memory address of the CPU buffer to reference
+     * @param size      Size of the CPU buffer in bytes
+     * @param callback  A callback used to release the CPU buffer from this BufferDescriptor
+     * @param user      An opaque user pointer passed to the callback function when it's called
+     */
     BufferDescriptor(void const* buffer, size_t size,
             Callback callback = nullptr, void* user = nullptr) noexcept
                 : buffer(const_cast<void*>(buffer)), size(size), callback(callback), user(user) {
     }
 
+    /**
+     * Set or replace the release callback function
+     * @param callback  The new callback function
+     * @param user      An opaque user pointer passed to the callbeck function when it's called
+     */
     void setCallback(Callback callback, void* user = nullptr) noexcept {
         this->callback = callback;
         this->user = user;
     }
 
+    //! Returns whether a release callback is set
     bool hasCallback() const noexcept { return callback != nullptr; }
 
-
+    //! Returns the currently set release callback function
     Callback getCallback() const noexcept {
         return callback;
     }
 
+    //! Returns the user opaque pointer associated to this BufferDescriptor
     void* getUser() const noexcept {
         return user;
     }
 
-    // buffer virtual address
+    //! CPU mempry-buffer virtual address
     void* buffer = nullptr;
 
-    // buffer size in bytes
+    //! CPU memory-buffer size in bytes
     size_t size = 0;
-
-    // -------------------------------------------------------------------------------------------
-    // no user serviceable parts below ...
 
 private:
     // callback when the buffer is consumed.

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -63,14 +63,14 @@ enum class Backend : uint8_t {
  * Bitmask for selecting render buffers
  */
 enum class TargetBufferFlags : uint8_t {
-    NONE = 0x0u,                 //!< No buffer selected.
-    COLOR = 0x1u,                //!< Color buffer selected.
-    DEPTH = 0x2u,                //!< Depth buffer selected.
-    STENCIL = 0x4u,              //!< Stencil buffer selected.
-    COLOR_AND_DEPTH = COLOR | DEPTH,
-    COLOR_AND_STENCIL = COLOR | STENCIL,
-    DEPTH_AND_STENCIL = DEPTH | STENCIL,
-    ALL = COLOR | DEPTH | STENCIL
+    NONE = 0x0u,                            //!< No buffer selected.
+    COLOR = 0x1u,                           //!< Color buffer selected.
+    DEPTH = 0x2u,                           //!< Depth buffer selected.
+    STENCIL = 0x4u,                         //!< Stencil buffer selected.
+    COLOR_AND_DEPTH = COLOR | DEPTH,        //!< Color and depth buffer selected.
+    COLOR_AND_STENCIL = COLOR | STENCIL,    //!< Color and stencil buffer selected.
+    DEPTH_AND_STENCIL = DEPTH | STENCIL,    //!< depth and stencil buffer selected.
+    ALL = COLOR | DEPTH | STENCIL           //!< Color, depth and stencil buffer selected.
 };
 
 /**
@@ -84,38 +84,18 @@ enum class BufferUsage : uint8_t {
 };
 
 /**
- * Selects which buffers to clear at the beginning of the render pass, as well as which buffers
- * can be discarded and the beginning and end of the render pass.
+ * Defines a viewport, which is the origin and extent of the clip-space.
+ * All drawing is clipped to the viewport.
  */
-
 struct Viewport {
-    int32_t left;
-    int32_t bottom;
-    uint32_t width;
-    uint32_t height;
+    int32_t left;       //!< left coordinate in window space.
+    int32_t bottom;     //!< bottom coordinate in window space.
+    uint32_t width;     //!< width in pixels
+    uint32_t height;    //!< height in pixels
+    //! get the right coordinate in window space of the viewport
     int32_t right() const noexcept { return left + width; }
+    //! get the top coordinate in window space of the viewport
     int32_t top() const noexcept { return bottom + height; }
-};
-
-struct RenderPassFlags {
-    TargetBufferFlags clear;
-    TargetBufferFlags discardStart;
-    TargetBufferFlags discardEnd;
-    bool ignoreScissor;
-};
-
-struct RenderPassParams {
-    // RenderPass flags (4 bytes)
-    RenderPassFlags flags{};
-
-    // Viewport (16 bytes)
-    Viewport viewport{};
-
-    // Clear values (32 bytes)
-    filament::math::float4 clearColor = {};
-    double clearDepth = 1.0;
-    uint32_t clearStencil = 0;
-    uint32_t reserved1 = 0;
 };
 
 /**
@@ -130,24 +110,34 @@ enum class FenceStatus : int8_t {
 
 static constexpr uint64_t FENCE_WAIT_FOR_EVER = uint64_t(-1);
 
-static constexpr size_t SHADER_MODEL_COUNT = 3;
+/**
+ * Shader model.
+ *
+ * These enumerants are used across all backends and refer to a level of functionality, rather
+ * than to an OpenGL specific shader model.
+ */
 enum class ShaderModel : uint8_t {
-    // For testing
+    //! For testing
     UNKNOWN    = 0,
-    // Mobile
-    GL_ES_30   = 1,
-    // Desktop
-    GL_CORE_41 = 2,
+    GL_ES_30   = 1,    //!< Mobile level functionality
+    GL_CORE_41 = 2,    //!< Desktop level functionality
 };
+static constexpr size_t SHADER_MODEL_COUNT = 3;
 
+/**
+ * Primitive types
+ */
 enum class PrimitiveType : uint8_t {
     // don't change the enums values (made to match GL)
-    POINTS      = 0,
-    LINES       = 1,
-    TRIANGLES   = 4,
+    POINTS      = 0,    //!< points
+    LINES       = 1,    //!< lines
+    TRIANGLES   = 4,    //!< triangles
     NONE        = 0xFF
 };
 
+/**
+ * Supported uniform types
+ */
 enum class UniformType : uint8_t {
     BOOL,
     BOOL2,
@@ -165,8 +155,8 @@ enum class UniformType : uint8_t {
     UINT2,
     UINT3,
     UINT4,
-    MAT3,
-    MAT4
+    MAT3,   //!< a 3x3 float matrix
+    MAT4    //!< a 4x4 float matrix
 };
 
 enum class Precision : uint8_t {
@@ -183,13 +173,17 @@ enum class SamplerType : uint8_t {
     SAMPLER_EXTERNAL,   //!< External texture
 };
 
+//! Texture sampler format
 enum class SamplerFormat : uint8_t {
-    INT = 0,
-    UINT = 1,
-    FLOAT = 2,
-    SHADOW = 3
+    INT = 0,        //!< signed integer sampler
+    UINT = 1,       //!< unsigned integer sampler
+    FLOAT = 2,      //!< float sampler
+    SHADOW = 3      //!< shadow sampler (PCF)
 };
 
+/**
+ * Supported element types
+ */
 enum class ElementType : uint8_t {
     BYTE,
     BYTE2,
@@ -219,42 +213,45 @@ enum class ElementType : uint8_t {
     HALF4,
 };
 
+//! Face culling Mode
 enum class CullingMode : uint8_t {
-    NONE,
-    FRONT,
-    BACK,
-    FRONT_AND_BACK
+    NONE,               //!< No culling, front and back faces are visible
+    FRONT,              //!< Front face culling, only back faces are visible
+    BACK,               //!< Back face culling, only front faces are visible
+    FRONT_AND_BACK      //!< Front and Back, geometry is not visible
 };
 
-//! PixelDataFormat
+//! Pixel Data Format
 enum class PixelDataFormat : uint8_t {
-    R,
-    R_INTEGER,
-    RG,
-    RG_INTEGER,
-    RGB,
-    RGB_INTEGER,
-    RGBA,
-    RGBA_INTEGER,
-    UNUSED,                 // used to be rgbm
-    DEPTH_COMPONENT,
-    DEPTH_STENCIL,
-    ALPHA
+    R,                  //!< One Red channel, float
+    R_INTEGER,          //!< One Red channel, integer
+    RG,                 //!< Two Red and Green channels, float
+    RG_INTEGER,         //!< Two Red and Green channels, integer
+    RGB,                //!< Three Red, Green and Blue channels, float
+    RGB_INTEGER,        //!< Three Red, Green and Blue channels, integer
+    RGBA,               //!< Four Red, Green, Blue and Alpha channels, float
+    RGBA_INTEGER,       //!< Four Red, Green, Blue and Alpha channels, integer
+    UNUSED,             // used to be rgbm
+    DEPTH_COMPONENT,    //!< Depth, 16-bit or 24-bits usually
+    DEPTH_STENCIL,      //!< Two Depth (24-bits) + Stencil (8-bits) channels
+    ALPHA               //! One Alpha channel, float
 };
 
+//! Pixel Data Type
 enum class PixelDataType : uint8_t {
-    UBYTE,
-    BYTE,
-    USHORT,
-    SHORT,
-    UINT,
-    INT,
-    HALF,
-    FLOAT,
-    COMPRESSED,
-    UINT_10F_11F_11F_REV,
+    UBYTE,          //!< unsigned byte
+    BYTE,           //!< signed byte
+    USHORT,         //!< unsigned short (16-bits)
+    SHORT,          //!< signed short (16-bits)
+    UINT,           //!< unsigned int (32-bits)
+    INT,            //!< signed int (32-bits)
+    HALF,           //!< half-float (16-bits float)
+    FLOAT,          //!< float (32-bits float)
+    COMPRESSED,     //!< compressed pixels, @see CompressedPixelDataType
+    UINT_10F_11F_11F_REV    //!< three low precision floating-point numbers
 };
 
+//! Compressed pixel data types
 enum class CompressedPixelDataType : uint16_t {
     // Mandatory in GLES 3.0 and GL 4.3
     EAC_R11, EAC_R11_SIGNED, EAC_RG11, EAC_RG11_SIGNED,
@@ -449,13 +446,14 @@ enum class TextureFormat : uint16_t {
     SRGB8_ALPHA8_ASTC_12x12,
 };
 
+//! Bitmask describing the intended Texture Usage
 enum class TextureUsage : uint8_t {
-    COLOR_ATTACHMENT    = 0x1,
-    DEPTH_ATTACHMENT    = 0x2,
-    STENCIL_ATTACHMENT  = 0x4,
-    UPLOADABLE          = 0x8,
-    SAMPLEABLE          = 0x10,
-    DEFAULT = UPLOADABLE | SAMPLEABLE
+    COLOR_ATTACHMENT    = 0x1,  //!< Texture can be used as a color attachment
+    DEPTH_ATTACHMENT    = 0x2,  //!< Texture can be used as a depth attachment
+    STENCIL_ATTACHMENT  = 0x4,  //!< Texture can be used as a stencil attachment
+    UPLOADABLE          = 0x8,  //!< Data can be uploaded into this texture (default)
+    SAMPLEABLE          = 0x10, //!< Texture can be sampled (default)
+    DEFAULT = UPLOADABLE | SAMPLEABLE   //!< Default texture usage
 };
 
 //! returns whether this format a compressed format
@@ -468,11 +466,12 @@ static constexpr bool isETC2Compression(TextureFormat format) noexcept {
     return format >= TextureFormat::EAC_R11 && format <= TextureFormat::ETC2_EAC_SRGBA8;
 }
 
+//! returns whether this format is an ETC3 compressed format
 static constexpr bool isS3TCCompression(TextureFormat format) noexcept {
     return format >= TextureFormat::DXT1_RGB && format <= TextureFormat::DXT5_RGBA;
 }
 
-//! TextureCubemapFace
+//! Texture Cubemap Face
 enum class TextureCubemapFace : uint8_t {
     // don't change the enums values
     POSITIVE_X = 0, //!< +x face
@@ -483,23 +482,24 @@ enum class TextureCubemapFace : uint8_t {
     NEGATIVE_Z = 5, //!< -z face
 };
 
+//! Face offsets for all faces of a cubemap
 struct FaceOffsets {
     using size_type = size_t;
     union {
         struct {
-            size_type px;
-            size_type nx;
-            size_type py;
-            size_type ny;
-            size_type pz;
-            size_type nz;
+            size_type px;   //!< +x face offset in bytes
+            size_type nx;   //!< -x face offset in bytes
+            size_type py;   //!< +y face offset in bytes
+            size_type ny;   //!< -y face offset in bytes
+            size_type pz;   //!< +z face offset in bytes
+            size_type nz;   //!< -z face offset in bytes
         };
         size_type offsets[6];
     };
     size_type  operator[](size_t n) const noexcept { return offsets[n]; }
     size_type& operator[](size_t n) { return offsets[n]; }
     FaceOffsets() noexcept = default;
-    FaceOffsets(size_type faceSize) noexcept {
+    explicit FaceOffsets(size_type faceSize) noexcept {
         px = faceSize * 0;
         nx = faceSize * 1;
         py = faceSize * 2;
@@ -526,56 +526,69 @@ struct FaceOffsets {
     }
 };
 
+//! Sampler Wrap mode
 enum class SamplerWrapMode : uint8_t {
-    CLAMP_TO_EDGE,
-    REPEAT,
-    MIRRORED_REPEAT,
+    CLAMP_TO_EDGE,      //!< clamp-to-edge. The edge of the texture extends to infinity.
+    REPEAT,             //!< repeat. The texture infinitely repeats in the wrap direction.
+    MIRRORED_REPEAT,    //!< mirrored-repeat. The texture infinitely repeats and mirrors in the wrap direction.
 };
 
+//! Sampler minification filter
 enum class SamplerMinFilter : uint8_t {
     // don't change the enums values
-    NEAREST = 0,
-    LINEAR = 1,
-    NEAREST_MIPMAP_NEAREST = 2,
-    LINEAR_MIPMAP_NEAREST = 3,
-    NEAREST_MIPMAP_LINEAR = 4,
-    LINEAR_MIPMAP_LINEAR = 5
+    NEAREST = 0,                //!< No filtering. Nearest neighbor is used.
+    LINEAR = 1,                 //!< Box filtering. Weighted average of 4 neighbors is used.
+    NEAREST_MIPMAP_NEAREST = 2, //!< Mip-mapping is activated. But no filtering occurs.
+    LINEAR_MIPMAP_NEAREST = 3,  //!< Box filtering within a mip-map level.
+    NEAREST_MIPMAP_LINEAR = 4,  //!< Mip-map levels are interpolated, but no other filtering occurs.
+    LINEAR_MIPMAP_LINEAR = 5    //!< Both interpolated Mip-mapping and linear filtering are used.
 };
 
+//! Sampler magnification filter
 enum class SamplerMagFilter : uint8_t {
     // don't change the enums values
-    NEAREST = 0,
-    LINEAR = 1,
+    NEAREST = 0,                //!< No filtering. Nearest neighbor is used.
+    LINEAR = 1,                 //!< Box filtering. Weighted average of 4 neighbors is used.
 };
 
+//! Sampler compare mode
 enum class SamplerCompareMode : uint8_t {
     // don't change the enums values
     NONE = 0,
     COMPARE_TO_TEXTURE = 1
 };
 
+//! comparison function for the depth sampler
 enum class SamplerCompareFunc : uint8_t {
     // don't change the enums values
-    LE = 0, GE, L, G, E, NE, A, N
+    LE = 0,     //!< Less or equal
+    GE,         //!< Greater or equal
+    L,          //!< Strictly less than
+    G,          //!< Strictly greater than
+    E,          //!< Equal
+    NE,         //!< Not equal
+    A,          //!< Always. Depth testing is deactivated.
+    N           //!< Never. The depth test always fails.
 };
 
+//! Sampler paramters
 struct SamplerParams { // NOLINT
     union {
         struct {
-            SamplerMagFilter filterMag      : 1;    // NEAREST
-            SamplerMinFilter filterMin      : 3;    // NEAREST
-            SamplerWrapMode wrapS           : 2;    // CLAMP_TO_EDGE
-            SamplerWrapMode wrapT           : 2;    // CLAMP_TO_EDGE
+            SamplerMagFilter filterMag      : 1;    //!< magnification filter (NEAREST)
+            SamplerMinFilter filterMin      : 3;    //!< minification filter  (NEAREST)
+            SamplerWrapMode wrapS           : 2;    //!< s-coordinate wrap mode (CLAMP_TO_EDGE)
+            SamplerWrapMode wrapT           : 2;    //!< t-coordinate wrap mode (CLAMP_TO_EDGE)
 
-            SamplerWrapMode wrapR           : 2;    // CLAMP_TO_EDGE
-            uint8_t anisotropyLog2          : 3;    // 0
-            SamplerCompareMode compareMode  : 1;    // NONE
-            uint8_t padding0                : 2;    // 0
+            SamplerWrapMode wrapR           : 2;    //!< r-coordinate wrap mode (CLAMP_TO_EDGE)
+            uint8_t anisotropyLog2          : 3;    //!< anisotropy level (0)
+            SamplerCompareMode compareMode  : 1;    //!< sampler compare mode (NONE)
+            uint8_t padding0                : 2;    //!< reserved. must be 0.
 
-            SamplerCompareFunc compareFunc  : 3;    // LE
-            uint8_t padding1                : 5;    // 0
+            SamplerCompareFunc compareFunc  : 3;    //!< sampler comparison function (LE)
+            uint8_t padding1                : 5;    //!< reserved. must be 0.
 
-            uint8_t padding2                : 8;    // 0
+            uint8_t padding2                : 8;    //!< reserved. must be 0.
         };
         uint32_t u{};
     };
@@ -587,43 +600,46 @@ private:
 
 static_assert(sizeof(SamplerParams) == sizeof(uint32_t), "SamplerParams must be 32 bits");
 
+//! blending equation function
 enum class BlendEquation : uint8_t {
-    ADD, SUBTRACT, REVERSE_SUBTRACT, MIN, MAX
+    ADD,                    //!< the fragment is added to the color buffer
+    SUBTRACT,               //!< the fragment is subtracted from the color buffer
+    REVERSE_SUBTRACT,       //!< the color buffer is subtracted from the fragment
+    MIN,                    //!< the min between the fragment and color buffer
+    MAX                     //!< the max between the fragment and color buffer
 };
 
+//! blending function
 enum class BlendFunction : uint8_t {
-    ZERO, ONE,
-    SRC_COLOR, ONE_MINUS_SRC_COLOR,
-    DST_COLOR, ONE_MINUS_DST_COLOR,
-    SRC_ALPHA, ONE_MINUS_SRC_ALPHA,
-    DST_ALPHA, ONE_MINUS_DST_ALPHA,
-    SRC_ALPHA_SATURATE
+    ZERO,                   //!< f(src, dst) = 0
+    ONE,                    //!< f(src, dst) = 1
+    SRC_COLOR,              //!< f(src, dst) = src
+    ONE_MINUS_SRC_COLOR,    //!< f(src, dst) = 1-src
+    DST_COLOR,              //!< f(src, dst) = dst
+    ONE_MINUS_DST_COLOR,    //!< f(src, dst) = 1-dst
+    SRC_ALPHA,              //!< f(src, dst) = src.a
+    ONE_MINUS_SRC_ALPHA,    //!< f(src, dst) = 1-src.a
+    DST_ALPHA,              //!< f(src, dst) = dst.a
+    ONE_MINUS_DST_ALPHA,    //!< f(src, dst) = 1-dst.a
+    SRC_ALPHA_SATURATE      //!< f(src, dst) = (1,1,1) * min(src.a, 1 - dst.a), 1
 };
 
-static constexpr size_t PIPELINE_STAGE_COUNT = 2;
-enum ShaderType : uint8_t {
-    VERTEX = 0,
-    FRAGMENT = 1
-};
-
-
+//! Vertex attribute descriptor
 struct Attribute {
+    //! attribute is normalized (remapped between 0 and 1)
     static constexpr uint8_t FLAG_NORMALIZED     = 0x1;
+    //! attribute is an integer
     static constexpr uint8_t FLAG_INTEGER_TARGET = 0x2;
-    uint32_t offset = 0;
-    uint8_t stride = 0;
-    uint8_t buffer = 0xFF;
-    ElementType type = ElementType::BYTE;
-    uint8_t flags = 0x0;
+    uint32_t offset = 0;                    //!< attribute offset in bytes
+    uint8_t stride = 0;                     //!< attribute stride in bytes
+    uint8_t buffer = 0xFF;                  //!< attribute buffer index
+    ElementType type = ElementType::BYTE;   //!< attribute element type
+    uint8_t flags = 0x0;                    //!< attribute flags
 };
 
 using AttributeArray = std::array<Attribute, MAX_VERTEX_ATTRIBUTE_COUNT>;
 
-struct PolygonOffset {
-    float slope = 0;        // factor in GL-speak
-    float constant = 0;     // units in GL-speak
-};
-
+//! Raster state descriptor
 struct RasterState {
 
     using CullingMode = filament::backend::CullingMode;
@@ -669,23 +685,109 @@ struct RasterState {
 
     union {
         struct {
+            //! culling mode
             CullingMode culling                 : 2;        //  2
+
+            //! blend equation for the red, green and blue components
             BlendEquation blendEquationRGB      : 3;        //  5
+            //! blend equation for the alpha component
             BlendEquation blendEquationAlpha    : 3;        //  8
+
+            //! blending function for the source color
             BlendFunction blendFunctionSrcRGB   : 4;        // 12
+            //! blending function for the source alpha
             BlendFunction blendFunctionSrcAlpha : 4;        // 16
+            //! blending function for the destination color
             BlendFunction blendFunctionDstRGB   : 4;        // 20
+            //! blending function for the destination alpha
             BlendFunction blendFunctionDstAlpha : 4;        // 24
+
+            //! Whether depth-buffer writes are enabled
             bool depthWrite                     : 1;        // 25
+            //! Depth test function
             DepthFunc depthFunc                 : 3;        // 28
+
+            //! Whether color-buffer writes are enabled
             bool colorWrite                     : 1;        // 29
+
+            //! use alpha-channel as coverage mask for anti-aliasing
             bool alphaToCoverage                : 1;        // 30
+
+            //! whether front face winding direction must be inverted
             bool inverseFrontFaces              : 1;        // 31
+
+            //! padding, must be 0
             uint8_t padding                     : 1;        // 32
         };
         uint32_t u = 0;
     };
 };
+
+/**
+ **********************************************************************************************
+ * \privatesection
+ */
+
+enum ShaderType : uint8_t {
+    VERTEX = 0,
+    FRAGMENT = 1
+};
+static constexpr size_t PIPELINE_STAGE_COUNT = 2;
+
+/**
+ * Selects which buffers to clear at the beginning of the render pass, as well as which buffers
+ * can be discarded at the beginning and end of the render pass.
+ *
+ */
+struct RenderPassFlags {
+    /**
+     * bitmask indicating which buffers to clear at the beginning of a render pass.
+     * This implies discard.
+     */
+    TargetBufferFlags clear;
+
+    /**
+     * bitmask indicating which buffers to discard at the beginning of a render pass.
+     * Discarded buffers have uninitialized content, they must be entirely drawn over or cleared.
+     */
+    TargetBufferFlags discardStart;
+
+    /**
+     * bitmask indicating which buffers to discard at the end of a render pass.
+     * Discarded buffers' content becomes invalid, they must not be read from again.
+     */
+    TargetBufferFlags discardEnd;
+
+    //! whether to ignore the scissor test during the clear operation
+    bool ignoreScissor;
+};
+
+/**
+ * Parameters of a render pass.
+ */
+struct RenderPassParams {
+    RenderPassFlags flags{};    //!< operations performed on the buffers for this pass
+
+    Viewport viewport{};        //!< viewport for this pass
+
+    //! Color to use to clear the COLOR buffer. RenderPassFlags::clear must be set.
+    filament::math::float4 clearColor = {};
+
+    //! Depth value to clear the depth buffer with
+    double clearDepth = 1.0;
+
+    //! Stencil value to clear the stencil buffer with
+    uint32_t clearStencil = 0;
+
+    //! reserved, must be zero
+    uint32_t reserved1 = 0;
+};
+
+struct PolygonOffset {
+    float slope = 0;        // factor in GL-speak
+    float constant = 0;     // units in GL-speak
+};
+
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -41,6 +41,8 @@ struct HwStream;
  * A type handle to a h/w resource
  */
 
+//! \privatesection
+
 class HandleBase {
 public:
     using HandleId = uint32_t;

--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -27,6 +27,8 @@
 namespace filament {
 namespace backend {
 
+//! \privatesection
+
 struct PipelineState {
     Handle<HwProgram> program;
     RasterState rasterState;

--- a/filament/backend/include/backend/PixelBufferDescriptor.h
+++ b/filament/backend/include/backend/PixelBufferDescriptor.h
@@ -31,6 +31,15 @@
 namespace filament {
 namespace backend {
 
+/**
+ * A descriptor to an image in main memory, typically used to transfer image data from the CPU
+ * to the GPU.
+ *
+ * A PixelBufferDescriptor owns the memory buffer it references, therefore PixelBufferDescriptor
+ * cannot be copied, but can be moved.
+ *
+ * PixelBufferDescriptor releases ownership of the memory-buffer when it's destroyed.
+ */
 class UTILS_PUBLIC PixelBufferDescriptor : public BufferDescriptor {
 public:
     using PixelDataFormat = backend::PixelDataFormat;
@@ -38,6 +47,20 @@ public:
 
     PixelBufferDescriptor() = default;
 
+    /**
+     * Creates a new PixelBufferDescriptor referencing an image in main memory
+     *
+     * @param buffer    Virtual address of the buffer containing the image
+     * @param size      Size in bytes of the buffer containing the image
+     * @param format    Format of the image pixels
+     * @param type      Type of the image pixels
+     * @param alignment Alignment in bytes of pixel rows
+     * @param left      Left coordinate in pixels
+     * @param top       Top coordinate in pixels
+     * @param stride    Stride of a row in pixels
+     * @param callback  A callback used to release the CPU buffer
+     * @param user      An opaque user pointer passed to the callback function when it's called
+     */
     PixelBufferDescriptor(void const* buffer, size_t size,
             PixelDataFormat format, PixelDataType type, uint8_t alignment = 1,
             uint32_t left = 0, uint32_t top = 0, uint32_t stride = 0,
@@ -47,6 +70,16 @@ public:
               format(format), type(type), alignment(alignment) {
     }
 
+    /**
+     * Creates a new PixelBufferDescriptor referencing an image in main memory
+     *
+     * @param buffer    Virtual address of the buffer containing the image
+     * @param size      Size in bytes of the buffer containing the image
+     * @param format    Format of the image pixels
+     * @param type      Type of the image pixels
+     * @param callback  A callback used to release the CPU buffer
+     * @param user      An opaque user pointer passed to the callback function when it's called
+     */
     PixelBufferDescriptor(void const* buffer, size_t size,
             PixelDataFormat format, PixelDataType type,
             Callback callback, void* user = nullptr) noexcept
@@ -54,6 +87,16 @@ public:
               stride(0), format(format), type(type), alignment(1) {
     }
 
+    /**
+     * Creates a new PixelBufferDescriptor referencing a compressed image in main memory
+     *
+     * @param buffer    Virtual address of the buffer containing the image
+     * @param size      Size in bytes of the buffer containing the image
+     * @param format    Compressed format of the image
+     * @param imageSize Compressed size of the image
+     * @param callback  A callback used to release the CPU buffer
+     * @param user      An opaque user pointer passed to the callback function when it's called
+     */
     PixelBufferDescriptor(void const* buffer, size_t size,
             backend::CompressedPixelDataType format, uint32_t imageSize,
             Callback callback, void* user = nullptr) noexcept
@@ -62,6 +105,16 @@ public:
               alignment(1) {
     }
 
+    /**
+     * Computes the size in bytes needed to fit an image of given dimensions and format
+     *
+     * @param format    Format of the image pixels
+     * @param type      Type of the image pixels
+     * @param stride    Stride of a row in pixels
+     * @param height    Height of the image in rows
+     * @param alignment Alignment in bytes of pixel rows
+     * @return The buffer size needed to fit this image in bytes
+     */
     static constexpr size_t computeDataSize(PixelDataFormat format, PixelDataType type,
             size_t stride, size_t height, size_t alignment) noexcept {
         assert(alignment);
@@ -123,19 +176,27 @@ public:
         return bprAligned * height;
     }
 
+    //! left coordinate in pixels
     uint32_t left   = 0;
+    //! top coordinate in pixels
     uint32_t top    = 0;
     union {
         struct {
+            //! stride in pixels
             uint32_t stride;
+            //! Pixel data format
             PixelDataFormat format;
         };
         struct {
+            //! compressed image size
             uint32_t imageSize;
+            //! compressed image format
             backend::CompressedPixelDataType compressedFormat;
         };
     };
+    //! pixel data type
     PixelDataType type : 4;
+    //! row alignment in bytes
     uint8_t alignment  : 4;
 };
 

--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -25,6 +25,8 @@
 namespace filament {
 namespace backend {
 
+//! \privatesection
+
 class TargetBufferInfo {
 public:
     // ctor for 2D textures

--- a/filament/docs/doxygen/filament.doxygen
+++ b/filament/docs/doxygen/filament.doxygen
@@ -112,7 +112,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = include backend/include ../libs/filabridge/include/filament
+INPUT                  = include backend/include/backend ../libs/filabridge/include/filament
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.inl \
                          *.h \

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -683,6 +683,7 @@ public:
     /**
      * Whether this Light casts shadows (disabled by default)
      *
+     * @param i     Instance of the component obtained from getInstance().
      * @param shadowCaster Enables or disables casting shadows from this Light.
      *
      * @warning

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -48,13 +48,17 @@ class UTILS_PUBLIC RenderTarget : public FilamentAPI {
 public:
     using CubemapFace = backend::TextureCubemapFace;
 
+    /**
+     * Attachment identifiers
+     */
     enum AttachmentPoint {
-        COLOR = 0,
-        DEPTH = 1,
+        COLOR = 0,      //!< identifies the color attachment
+        DEPTH = 1,      //!< identifies the depth attachment
     };
 
     static constexpr size_t ATTACHMENT_COUNT = 2;
 
+    //! Use Builder to construct a RenderTarget object instance
     class Builder : public BuilderBase<BuilderDetails> {
         friend struct BuilderDetails;
     public:
@@ -115,9 +119,33 @@ public:
         friend class details::FRenderTarget;
     };
 
+    /**
+     * Gets the texture set on the given attachment point
+     * @param attachment Attachment point
+     * @return A Texture object or nullptr if no texture is set for this attachment point
+     */
     Texture* getTexture(AttachmentPoint attachment) const noexcept;
+
+    /**
+     * Returns the mipmap level set on the given attachment point
+     * @param attachment Attachment point
+     * @return the mipmap level set on the given attachment point
+     */
     uint8_t getMipLevel(AttachmentPoint attachment) const noexcept;
+
+    /**
+     * Returns the face of a cubemap set on the given attachment point
+     * @param attachment Attachment point
+     * @return A cubemap face identifier. This is only relevant if the attachment's texture is
+     * a cubemap.
+     */
     CubemapFace getFace(AttachmentPoint attachment) const noexcept;
+
+    /**
+     * Returns the texture-layer set on the given attachment point
+     * @param attachment Attachment point
+     * @return A texture layer. This is only relevant if the attachment's texture is a 3D texture.
+     */
     uint32_t getLayer(AttachmentPoint attachment) const noexcept;
 };
 

--- a/filament/include/filament/TextureSampler.h
+++ b/filament/include/filament/TextureSampler.h
@@ -52,6 +52,9 @@ public:
      */
     TextureSampler() noexcept = default;
 
+    TextureSampler(const TextureSampler& rhs) noexcept = default;
+    TextureSampler& operator=(const TextureSampler& rhs) noexcept = default;
+
     /**
      * Creates a TextureSampler with the default parameters but setting the filtering and wrap modes.
      * @param minMag filtering for both minification and magnification
@@ -104,9 +107,6 @@ public:
         mSamplerParams.compareMode = mode;
         mSamplerParams.compareFunc = func;
     }
-
-    TextureSampler(const TextureSampler& rhs) noexcept = default;
-    TextureSampler& operator=(const TextureSampler& rhs) noexcept = default;
 
     /**
      * Sets the minification filter
@@ -168,17 +168,33 @@ public:
         mSamplerParams.compareFunc = func;
     }
 
-    backend::SamplerParams getSamplerParams() const noexcept  { return mSamplerParams; }
-
+    //! returns the minification filter value
     MinFilter getMinFilter() const noexcept { return mSamplerParams.filterMin; }
+
+    //! returns the magnification filter value
     MagFilter getMagFilter() const noexcept { return mSamplerParams.filterMag; }
+
+    //! returns the s-coordinate wrap mode (horizontal)
     WrapMode getWrapModeS() const noexcept  { return mSamplerParams.wrapS; }
+
+    //! returns the t-coordinate wrap mode (vertical)
     WrapMode getWrapModeT() const noexcept  { return mSamplerParams.wrapT; }
+
+    //! returns the r-coordinate wrap mode (depth)
     WrapMode getWrapModeR() const noexcept  { return mSamplerParams.wrapR; }
-    float getAnisotropy() const noexcept { return float(1 << mSamplerParams.anisotropyLog2); }
+
+    //! returns the anisotropy value
+    float getAnisotropy() const noexcept { return float(1u << mSamplerParams.anisotropyLog2); }
+
+    //! returns the compare mode
     CompareMode getCompareMode() const noexcept { return mSamplerParams.compareMode; }
+
+    //! returns the compare function
     CompareFunc getCompareFunc() const noexcept { return mSamplerParams.compareFunc; }
 
+
+    // no user-serviceable parts below...
+    backend::SamplerParams getSamplerParams() const noexcept  { return mSamplerParams; }
 
 private:
     backend::SamplerParams mSamplerParams;

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -32,30 +32,30 @@ struct RenderTarget::BuilderDetails {
     FRenderTarget::Attachment mAttachments[RenderTarget::ATTACHMENT_COUNT];
 };
 
-using BuilderType = RenderTarget::Builder;
-BuilderType::Builder() noexcept = default;
-BuilderType::~Builder() noexcept = default;
-BuilderType::Builder(Builder const& rhs) noexcept = default;
-BuilderType::Builder(Builder&& rhs) noexcept = default;
-BuilderType& BuilderType::operator=(BuilderType const& rhs) noexcept = default;
-BuilderType& BuilderType::operator=(BuilderType&& rhs) noexcept = default;
+using BuilderType = RenderTarget;
+BuilderType::Builder::Builder() noexcept = default;
+BuilderType::Builder::~Builder() noexcept = default;
+BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
 
-BuilderType& BuilderType::texture(AttachmentPoint pt, Texture* texture) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::texture(AttachmentPoint pt, Texture* texture) noexcept {
     mImpl->mAttachments[pt].texture = upcast(texture);
     return *this;
 }
 
-BuilderType& BuilderType::mipLevel(AttachmentPoint pt, uint8_t level) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::mipLevel(AttachmentPoint pt, uint8_t level) noexcept {
     mImpl->mAttachments[pt].mipLevel = level;
     return *this;
 }
 
-BuilderType& BuilderType::face(AttachmentPoint pt, CubemapFace face) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::face(AttachmentPoint pt, CubemapFace face) noexcept {
     mImpl->mAttachments[pt].face = face;
     return *this;
 }
 
-BuilderType& BuilderType::layer(AttachmentPoint pt, uint32_t layer) noexcept {
+RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t layer) noexcept {
     mImpl->mAttachments[pt].layer = layer;
     return *this;
 }


### PR DESCRIPTION
We need to document the backend headers that are public. 
Added documentation for:
- DriverEnums.h
- BufferDescriptor.h
- PixelBufferDescriptor.h

Disabled doxygen for public headers of backend that don't need to
be public for filament's API.

Also improved documentation for:
- LightManager.h
- RenderTarget.h
- TextureSampler.h