### PR TITLE
Use lowercase for Exposure namespace.

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -50,6 +50,7 @@ private:
 - all *source* files must reside under the `src` folder
 - tests reside under the `test` folder
 - public headers of a `foo` library must live in a folder named `foo`
+- namespaces should be lowercase, and all new namespaces should be nested under in `filament`
 
 ```
 libfoo.so

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -316,7 +316,7 @@ public:
      * With the default parameters, the scene must contain at least one Light of intensity
      * similar to the sun (e.g.: a 100,000 lux directional light).
      *
-     * @see Light, Exposure
+     * @see Light, exposure
      */
     void setExposure(float aperture, float shutterSpeed, float sensitivity) noexcept;
 

--- a/filament/include/filament/Exposure.h
+++ b/filament/include/filament/Exposure.h
@@ -29,7 +29,7 @@ class Camera;
  * A series of utilities to compute exposure, exposure value at ISO 100 (EV100),
  * luminance and illuminance using a physically-based camera model.
  */
-namespace Exposure {
+namespace exposure {
 
 /**
  * Returns the exposure value (EV at ISO 100) of the specified camera.

--- a/filament/src/Exposure.cpp
+++ b/filament/src/Exposure.cpp
@@ -24,7 +24,7 @@ namespace filament {
 
 using namespace details;
 
-namespace Exposure {
+namespace exposure {
 
 float ev100(const Camera& c) noexcept {
     const FCamera& camera = upcast(c);
@@ -201,5 +201,5 @@ float illuminance(float ev100) noexcept {
     return 2.5f * std::pow(2.0f, ev100);
 }
 
-} // namespace Exposure
+} // namespace exposure
 } // namespace filament

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -333,7 +333,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 
     // Exposure
     const float ev100 = camera.ev100;
-    const float exposure = Exposure::exposure(ev100);
+    const float exposure = exposure::exposure(ev100);
     u.setUniform(offsetof(PerViewUib, exposure), exposure);
     u.setUniform(offsetof(PerViewUib, ev100), ev100);
 
@@ -459,7 +459,7 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
             // far plane
             .zf                 = camera->getCullingFar(),
             // exposure
-            .ev100              = Exposure::ev100(*camera),
+            .ev100              = exposure::ev100(*camera),
             // world offset to allow users to determine the API-level camera position
             .worldOffset        = camera->getPosition(),
             // world origin transform, use only for debugging

--- a/filament/test/filament_test_exposure.cpp
+++ b/filament/test/filament_test_exposure.cpp
@@ -71,31 +71,31 @@ TEST_F(FilamentExposureWithEngineTest, ComputeEV100) {
     Camera* camera = engine->createCamera();
 
     camera->setExposure(16.0f, 1 / 125.0f, 100.0f);
-    int32_t ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    int32_t ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(15, ev100);
 
     camera->setExposure(16.0f, 1 / 125.0f, 400.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(13, ev100);
 
     camera->setExposure(8.0f, 1 / 125.0f, 100.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(13, ev100);
 
     camera->setExposure(16.0f, 1 / 30.0f, 100.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(13, ev100);
 
     camera->setExposure(22.0f, 1 / 125.0f, 100.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(16, ev100);
 
     camera->setExposure(16.0f, 1 / 250.0f, 100.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(16, ev100);
 
     camera->setExposure(16.0f, 1 / 125.0f, 50.0f);
-    ev100 = static_cast<int32_t>(roundf(Exposure::ev100(*camera)));
+    ev100 = static_cast<int32_t>(roundf(exposure::ev100(*camera)));
     EXPECT_EQ(16, ev100);
 
     engine->destroy(camera);
@@ -105,10 +105,10 @@ TEST_F(FilamentExposureTest, ComputeEV100FromLuminance) {
     using namespace filament;
 
     // 4,096 cd/m^2 is equivalent to a "sunny 16" setting: f/16, 1/125s, ISO 100
-    int32_t ev100 = static_cast<int32_t>(roundf(Exposure::ev100FromLuminance(4096)));
+    int32_t ev100 = static_cast<int32_t>(roundf(exposure::ev100FromLuminance(4096)));
     EXPECT_EQ(15, ev100);
 
-    int32_t sunny16 = static_cast<int32_t>(roundf(Exposure::ev100(16.0f, 1 / 125.0f, 100.0f)));
+    int32_t sunny16 = static_cast<int32_t>(roundf(exposure::ev100(16.0f, 1 / 125.0f, 100.0f)));
     EXPECT_EQ(ev100, sunny16);
 }
 
@@ -116,10 +116,10 @@ TEST_F(FilamentExposureTest, ComputeLuminanceFromEV100) {
     using namespace filament;
 
     // 4,096 cd/m^2 is equivalent to a "sunny 16" setting: f/16, 1/125s, ISO 100
-    int32_t luminance = static_cast<int32_t>(roundf(Exposure::luminance(15.0f)));
+    int32_t luminance = static_cast<int32_t>(roundf(exposure::luminance(15.0f)));
     EXPECT_EQ(4096, luminance);
 
-    int32_t sunny16 = static_cast<int32_t>(roundf(Exposure::luminance(16.0f, 1 / 125.0f, 100.0f)));
+    int32_t sunny16 = static_cast<int32_t>(roundf(exposure::luminance(16.0f, 1 / 125.0f, 100.0f)));
     EXPECT_EQ(4000, sunny16);
 }
 
@@ -127,10 +127,10 @@ TEST_F(FilamentExposureTest, ComputeEV100FromIlluminance) {
     using namespace filament;
 
     // 81,920 lux is equivalent to a "sunny 16" setting: f/16, 1/125s, ISO 100
-    int32_t ev100 = static_cast<int32_t>(roundf(Exposure::ev100FromIlluminance(81920)));
+    int32_t ev100 = static_cast<int32_t>(roundf(exposure::ev100FromIlluminance(81920)));
     EXPECT_EQ(15, ev100);
 
-    int32_t sunny16 = static_cast<int32_t>(roundf(Exposure::ev100(16.0f, 1 / 125.0f, 100.0f)));
+    int32_t sunny16 = static_cast<int32_t>(roundf(exposure::ev100(16.0f, 1 / 125.0f, 100.0f)));
     EXPECT_EQ(ev100, sunny16);
 }
 
@@ -139,9 +139,9 @@ TEST_F(FilamentExposureTest, ComputeIlluminanceFromEV100) {
     using namespace filament;
 
     // 81,920 lux is equivalent to a "sunny 16" setting: f/16, 1/125s, ISO 100
-    int32_t illuminance = static_cast<int32_t>(roundf(Exposure::illuminance(15.0f)));
+    int32_t illuminance = static_cast<int32_t>(roundf(exposure::illuminance(15.0f)));
     EXPECT_EQ(81920, illuminance);
 
-    int32_t sunny16 = static_cast<int32_t>(roundf(Exposure::illuminance(16.0f, 1 / 125.0f, 100.0f)));
+    int32_t sunny16 = static_cast<int32_t>(roundf(exposure::illuminance(16.0f, 1 / 125.0f, 100.0f)));
     EXPECT_EQ(80000, sunny16);
 }


### PR DESCRIPTION
I noticed this while browsing doxygen output.  It's more consistent with ibl, image, imageio, gltfio, backend, details, filamat, etc.