### PR TITLE
Update compile & targetSdk from 28 to 29

### DIFF
--- a/android/filamat-android/build.gradle
+++ b/android/filamat-android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 
 group = "com.google.android.filament"
-version = "0.1"
+version = "1.3"
 
 apply plugin: 'com.android.library'
 
@@ -35,10 +35,10 @@ if (project.hasProperty("filament_dist_dir")) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/android/filament-android/build.gradle
+++ b/android/filament-android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 
 group = "com.google.android.filament"
-version = "0.1"
+version = "1.3"
 
 apply plugin: 'com.android.library'
 
@@ -35,13 +35,13 @@ if (project.hasProperty("filament_dist_dir")) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         // Our minSdkVersion is actually 21, we lie and say 14 here so apps don't have
         // to increase their minSdkVersion unnecessarily. It is however up to them to
         // ensure they do not initialize Filament on API levels < 21.
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/android/gltfio-android/build.gradle
+++ b/android/gltfio-android/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 }
 
 group = "com.google.android.filament"
-version = "0.1"
+version = "1.3"
 
 apply plugin: 'com.android.library'
 
@@ -35,10 +35,10 @@ if (project.hasProperty("filament_dist_dir")) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 

--- a/android/samples/gltf-bloom/app/build.gradle
+++ b/android/samples/gltf-bloom/app/build.gradle
@@ -35,11 +35,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.gltf"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/hello-triangle/app/build.gradle
+++ b/android/samples/hello-triangle/app/build.gradle
@@ -19,11 +19,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.hellotriangle"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/image-based-lighting/app/build.gradle
+++ b/android/samples/image-based-lighting/app/build.gradle
@@ -37,11 +37,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.ibl"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/lit-cube/app/build.gradle
+++ b/android/samples/lit-cube/app/build.gradle
@@ -19,11 +19,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.litcube"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/material-builder/app/build.gradle
+++ b/android/samples/material-builder/app/build.gradle
@@ -24,11 +24,11 @@ preBuild.dependsOn compileMesh
 preBuild.dependsOn generateIbl
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.material_builder"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/texture-view/app/build.gradle
+++ b/android/samples/texture-view/app/build.gradle
@@ -19,11 +19,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.textureview"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/textured-object/app/build.gradle
+++ b/android/samples/textured-object/app/build.gradle
@@ -37,11 +37,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.textured"
         minSdkVersion 26
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/android/samples/transparent-view/app/build.gradle
+++ b/android/samples/transparent-view/app/build.gradle
@@ -19,11 +19,11 @@ clean.doFirst {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.android.filament.hellotriangle"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Android Q (API 29) is now out and it's good practice to compile and target the latest API level to verify behavior.