### PR TITLE
workaround an MSVC bug with brace initialization

### DIFF
--- a/libs/math/include/math/compiler.h
+++ b/libs/math/include/math/compiler.h
@@ -65,6 +65,7 @@
 
 #ifdef _MSC_VER
 #   define MATH_EMPTY_BASES __declspec(empty_bases)
+
 // MSVC does not support loop unrolling hints
 #   define MATH_NOUNROLL
 
@@ -72,6 +73,17 @@
 #   ifndef MAKE_CONSTEXPR
 #       define MAKE_CONSTEXPR(e) (e)
 #   endif
+
+// About value initialization, the C++ standard says:
+//   if T is a class type with a default constructor that is neither user-provided nor deleted
+//   (that is, it may be a class with an implicitly-defined or defaulted default constructor),
+//   the object is zero-initialized and then it is default-initialized
+//   if it has a non-trivial default constructor;
+// Unfortunately, MSVC always calls the default constructor, even if it is trivial, which
+// breaks constexpr-ness. To workaround this, we're always zero-initializing TVecN<>
+#   define MATH_CONSTEXPR_INIT {}
+#   define MATH_DEFAULT_CTOR {}
+#   define MATH_DEFAULT_CTOR_CONSTEXPR constexpr
 
 #else // _MSC_VER
 
@@ -82,5 +94,9 @@
 #   ifndef MAKE_CONSTEXPR
 #       define MAKE_CONSTEXPR(e) __builtin_constant_p(e) ? (e) : (e)
 #   endif
+
+#   define MATH_CONSTEXPR_INIT
+#   define MATH_DEFAULT_CTOR = default;
+#   define MATH_DEFAULT_CTOR_CONSTEXPR
 
 #endif // _MSC_VER

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -97,24 +97,24 @@ public:
     constexpr TQuaternion() : x(0), y(0), z(0), w(0) {}
 
     // handles implicit conversion to a tvec4. must not be explicit.
-    template<typename A, typename = enable_if_arithmetic_t<T>>
-    constexpr TQuaternion(A w) : x(0), y(0), z(0), w(w) {
-    }
+    template<typename A, typename = enable_if_arithmetic_t<A>>
+    constexpr TQuaternion(A w) : x(0), y(0), z(0), w(w) {}
 
     // initialize from 4 values to w + xi + yj + zk
-    template<typename A, typename B, typename C, typename D>
+    template<typename A, typename B, typename C, typename D,
+            typename = enable_if_arithmetic_t<A, B, C, D>>
     constexpr TQuaternion(A w, B x, C y, D z) : x(x), y(y), z(z), w(w) {}
 
     // initialize from a vec3 + a value to : v.xi + v.yj + v.zk + w
-    template<typename A, typename B>
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
     constexpr TQuaternion(const TVec3<A>& v, B w) : x(v.x), y(v.y), z(v.z), w(w) {}
 
-    // initialize from a double4
-    template<typename A>
+    // initialize from a vec4
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr explicit TQuaternion(const TVec4<A>& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
     // initialize from a quaternion of a different type
-    template<typename A>
+    template<typename A, typename = enable_if_arithmetic_t<A>>
     constexpr explicit TQuaternion(const TQuaternion<A>& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
     // conjugate operator
@@ -123,7 +123,7 @@ public:
     }
 
     // constructs a quaternion from an axis and angle
-    template<typename A, typename B>
+    template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
     constexpr static TQuaternion MATH_PURE fromAxisAngle(const TVec3<A>& axis, B angle) {
         return TQuaternion(std::sin(angle * 0.5) * normalize(axis), std::cos(angle * 0.5));
     }

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -47,7 +47,7 @@ public:
     static constexpr size_t SIZE = 2;
 
     union {
-        T v[SIZE];
+        T v[SIZE] MATH_CONSTEXPR_INIT;
         struct { T x, y; };
         struct { T s, t; };
         struct { T r, g; };
@@ -70,7 +70,7 @@ public:
     // constructors
 
     // default constructor
-    constexpr TVec2() = default;
+    MATH_DEFAULT_CTOR_CONSTEXPR TVec2() MATH_DEFAULT_CTOR
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -45,7 +45,7 @@ public:
     static constexpr size_t SIZE = 3;
 
     union {
-        T v[SIZE];
+        T v[SIZE] MATH_CONSTEXPR_INIT;
         TVec2<T> xy;
         TVec2<T> st;
         TVec2<T> rg;
@@ -83,7 +83,7 @@ public:
     // constructors
 
     // default constructor
-    constexpr TVec3() = default;
+    MATH_DEFAULT_CTOR_CONSTEXPR TVec3() MATH_DEFAULT_CTOR
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>

--- a/libs/math/include/math/vec4.h
+++ b/libs/math/include/math/vec4.h
@@ -45,7 +45,7 @@ public:
     static constexpr size_t SIZE = 4;
 
     union {
-        T v[SIZE];
+        T v[SIZE] MATH_CONSTEXPR_INIT;
         TVec2<T> xy, st, rg;
         TVec3<T> xyz, stp, rgb;
         struct {
@@ -83,7 +83,7 @@ public:
     // constructors
 
     // default constructor
-    constexpr TVec4() = default;
+    MATH_DEFAULT_CTOR_CONSTEXPR TVec4() MATH_DEFAULT_CTOR
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>

--- a/libs/math/tests/test_vec.cpp
+++ b/libs/math/tests/test_vec.cpp
@@ -28,6 +28,7 @@ protected:
 
 TEST_F(VecTest, Constexpr) {
     constexpr float a = M_PI;
+    constexpr float2 Z2{};
     constexpr float2 A2 = a;
     constexpr float2 B2 = { a, a };
     constexpr float2 C2 = A2;
@@ -35,12 +36,14 @@ TEST_F(VecTest, Constexpr) {
     constexpr float2 F2 = A2 + 0.5 - 1.0 + (1 + A2);
     constexpr float3 D2 = cross(A2, C2);
 
+    constexpr float3 Z3{};
     constexpr float3 A3 = a;
     constexpr float3 B3 = { a, a, a };
     constexpr float3 C3 = A3;
     constexpr float3 D3 = { A2, a };
     constexpr float3 E3 = cross(A3, D3);
 
+    constexpr float4 Z4{};
     constexpr float4 A4 = a;
     constexpr float4 B4 = { a, a, a, a };
     constexpr float4 C4 = A4;

--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -258,9 +258,7 @@ RandomAccessIterator partition_point(
 template <class To, class From>
 typename std::enable_if_t<
     (sizeof(To) == sizeof(From)) &&
-    std::is_trivially_copyable<From>::value &&
-    std::is_trivial<To>::value,
-    // this implementation requires that To is trivially default constructible
+    std::is_trivially_copyable<From>::value,
     To>
 // constexpr support needs compiler magic
 bit_cast(const From &src) noexcept {


### PR DESCRIPTION
the C++ standard says:

   if T is a class type with a default constructor that is neither 
   user-provided nor deleted (that is, it may be a class with an
   implicitly-defined or defaulted default constructor), the object 
   is zero-initialized and then it is default-initialized if it has a 
   non-trivial default constructor

Unfortunately, MSVC always calls the default constructor, even if it 
is trivial, which breaks constexpr-ness. 
To workaround this, we're always zero-initializing TVecN<>


Also removed constexpr from default constructors, since they never can
be constexpr as they're not initializing the vector.