### PR TITLE
SamplerParams is not default-initialized anymore

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -590,7 +590,7 @@ struct SamplerParams { // NOLINT
 
             uint8_t padding2                : 8;    //!< reserved. must be 0.
         };
-        uint32_t u{};
+        uint32_t u;
     };
 private:
     friend inline bool operator < (SamplerParams lhs, SamplerParams rhs) {

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -37,7 +37,7 @@ public:
 
     struct Sampler {
         Handle<HwTexture> t;
-        SamplerParams s;
+        SamplerParams s{};
     };
 
     SamplerGroup() noexcept { } // NOLINT

--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -180,9 +180,10 @@ void MetalBlitter::blit(const BlitArgs& args) {
         [encoder setFragmentTexture:args.source.depth atIndex:1];
     }
 
-    SamplerParams samplerState;
-    samplerState.filterMin = static_cast<SamplerMinFilter>(args.filter);
-    samplerState.filterMag = args.filter;
+    SamplerParams samplerState{
+            .filterMag = args.filter,
+            .filterMin = static_cast<SamplerMinFilter>(args.filter)
+    };
     id<MTLSamplerState> sampler = mContext.samplerStateCache.getOrCreateState(samplerState);
     [encoder setFragmentSamplerState:sampler atIndex:0];
 

--- a/filament/include/filament/TextureSampler.h
+++ b/filament/include/filament/TextureSampler.h
@@ -197,7 +197,7 @@ public:
     backend::SamplerParams getSamplerParams() const noexcept  { return mSamplerParams; }
 
 private:
-    backend::SamplerParams mSamplerParams;
+    backend::SamplerParams mSamplerParams{};
 };
 
 } // namespace filament

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -196,10 +196,10 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::fxaa(FrameGraph& fg,
                 auto const& texture = resources.getTexture(data.input);
 
                 FMaterialInstance* pInstance = mFxaa.getMaterialInstance();
-                SamplerParams params;
-                params.filterMag = SamplerMagFilter::LINEAR;
-                params.filterMin = SamplerMinFilter::LINEAR;
-                pInstance->setParameter("colorBuffer", texture, params);
+                pInstance->setParameter("colorBuffer", texture, {
+                        .filterMag = SamplerMagFilter::LINEAR,
+                        .filterMin = SamplerMinFilter::LINEAR
+                });
 
                 pInstance->commit(driver);
 


### PR DESCRIPTION
This is to allow designated aggregate initialization in C++20.
We do this because we have been relying on C99 designated
initialization, which is only supported by clang, other compilers need
c++20 to get a similar functionality. Therefore, we now try to limit
Ourselves to C++20 rules.

This could break existing code, since now SamplerParams needs to be
zero-initialized:

SamplerParams p{};

This is generally not an issue because the intended use is:

doSomethingWithSamplerParams({
      .filterMag = LINEAR,
   });