### PR TITLE
Fix quat slerp so it takes shortest path.

### DIFF
--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -247,14 +247,15 @@ public:
     friend inline
     QUATERNION<T> MATH_PURE slerp(const QUATERNION<T>& p, const QUATERNION<T>& q, T t) {
         // could also be computed as: pow(q * inverse(p), t) * p;
-        const T d = std::abs(dot(p, q));
+        const T d = dot(p, q);
+        const T absd = std::abs(d);
         static constexpr T value_eps = T(10) * std::numeric_limits<T>::epsilon();
         // Prevent blowing up when slerping between two quaternions that are very near each other.
-        if ((T(1) - d) < value_eps) {
+        if ((T(1) - absd) < value_eps) {
             return normalize(lerp(p, q, t));
         }
         const T npq = std::sqrt(dot(p, p) * dot(q, q));  // ||p|| * ||q||
-        const T a = std::acos(d / npq);
+        const T a = std::acos(absd / npq);
         const T a0 = a * (1 - t);
         const T a1 = a * t;
         const T sina = sin(a);

--- a/libs/math/tests/test_quat.cpp
+++ b/libs/math/tests/test_quat.cpp
@@ -265,6 +265,13 @@ TEST_F(QuatTest, ArithmeticFunc) {
     EXPECT_DOUBLE_EQ(qr.y, qs.y);
     EXPECT_DOUBLE_EQ(qr.z, qs.z);
     EXPECT_DOUBLE_EQ(qr.w, qs.w);
+
+    // Ensure that we're taking the shortest path.
+    qa = {-0.707, 0, 0, 0.707};
+    qb = {1, 0, 0, 0};
+    qs = slerp(qa, qb, 0.5);
+    EXPECT_NEAR(qs[3], -0.92, 0.1);
+    EXPECT_NEAR(qs[2], +0.38, 0.1);
 }
 
 TEST_F(QuatTest, MultiplicationExhaustive) {


### PR DESCRIPTION
The last codeline in our `slerp` implementation was checking if `d < 0`, but it was always false.

Verified with a unit test and with the gltf file that's in the bug description.

Fixes #1716.

This regressed in c65e561c59c70fdf2f960823ea15ecef5b5b1bfe.