### PR TITLE
Protect against state mismatch in the Java View.

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -35,7 +35,7 @@ public class View {
     private AmbientOcclusionOptions mAmbientOcclusionOptions;
     private RenderTarget mRenderTarget;
 
-    public static class DynamicResolutionOptions {
+    public static final class DynamicResolutionOptions {
         public boolean enabled = false;
         public boolean homogeneousScaling = false;
         public float targetFrameTimeMilli = 1000.0f / 60.0f;
@@ -46,7 +46,7 @@ public class View {
         public int history = 9;
     }
 
-    public static class AmbientOcclusionOptions {
+    public static final class AmbientOcclusionOptions {
         public float radius = 0.3f;
         public float bias = 0.005f;
         public float power = 0.0f;
@@ -60,7 +60,7 @@ public class View {
         ULTRA
     }
 
-    public static class RenderQuality {
+    public static final class RenderQuality {
         public QualityLevel hdrColorBuffer = QualityLevel.HIGH;
     }
 
@@ -131,7 +131,7 @@ public class View {
     }
 
     public void setViewport(@NonNull Viewport viewport) {
-        mViewport = viewport;
+        mViewport.copyFrom(viewport);
         nSetViewport(getNativeObject(),
                 mViewport.left, mViewport.bottom, mViewport.width, mViewport.height);
     }

--- a/android/filament-android/src/main/java/com/google/android/filament/Viewport.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Viewport.java
@@ -26,6 +26,13 @@ public class Viewport {
         this.height = height;
     }
 
+    public copyFrom(Viewport vp) {
+        this.left = vp.left;
+        this.bottom = vp.bottom;
+        this.width = vp.width;
+        this.height = vp.height;
+    }
+
     // left coordinate in pixels
     public int left;
 


### PR DESCRIPTION
setViewport() was holding on to a reference of the client's Viewport
object, which could potentially be mutated after the call. This would
cause a mismatch between the values in getViewport() and the actual
values honored by the native layer.

Similar issues existed for our simple config structs like
DynamicResolutionOptions, but I fixed these by making them immutable
since clients are not likely to hold on to them.