### PR TITLE
Use our own constants instead of M_PI, M_*, etc.

### DIFF
--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -46,7 +46,7 @@ FCamera::FCamera(FEngine& engine, Entity e)
 void UTILS_NOINLINE FCamera::setProjection(double fov, double aspect, double near, double far,
         Camera::Fov direction) noexcept {
     double w, h;
-    double s = std::tan(fov * (M_PI / 360.0)) * near;
+    double s = std::tan(fov * (F_PI / 360.0)) * near;
     if (direction == Fov::VERTICAL) {
         w = s * aspect;
         h = s;

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -21,11 +21,10 @@
 
 #include "FilamentAPI-impl.h"
 
-#include <utils/Panic.h>
-
 #include <backend/DriverEnums.h>
 #include <filament/IndirectLight.h>
-#include <utils/Log.h>
+
+#include <utils/Panic.h>
 
 #include <math/scalar.h>
 
@@ -90,21 +89,21 @@ IndirectLight::Builder& IndirectLight::Builder::radiance(uint8_t bands, float3 c
     // To save math in the shader, we pre-multiply our SH coefficient by the A[i] factors.
     // Additionally, we include the lambertian diffuse BRDF 1/pi and truncated cos.
 
-    constexpr float M_SQRT_PI = 1.7724538509f;
-    constexpr float M_SQRT_3  = 1.7320508076f;
-    constexpr float M_SQRT_5  = 2.2360679775f;
-    constexpr float M_SQRT_15 = 3.8729833462f;
-    constexpr float C[] = { M_PI, 2.0943951f, 0.785398f }; // <cos>
+    constexpr float F_SQRT_PI = 1.7724538509f;
+    constexpr float F_SQRT_3  = 1.7320508076f;
+    constexpr float F_SQRT_5  = 2.2360679775f;
+    constexpr float F_SQRT_15 = 3.8729833462f;
+    constexpr float C[] = { F_PI, 2.0943951f, 0.785398f }; // <cos>
     constexpr float A[] = {
-                  1.0f / (2.0f * M_SQRT_PI) * C[0] * M_1_PI,    // 0  0
-            -M_SQRT_3  / (2.0f * M_SQRT_PI) * C[1] * M_1_PI,    // 1 -1
-             M_SQRT_3  / (2.0f * M_SQRT_PI) * C[1] * M_1_PI,    // 1  0
-            -M_SQRT_3  / (2.0f * M_SQRT_PI) * C[1] * M_1_PI,    // 1  1
-             M_SQRT_15 / (2.0f * M_SQRT_PI) * C[2] * M_1_PI,    // 2 -2
-            -M_SQRT_15 / (2.0f * M_SQRT_PI) * C[2] * M_1_PI,    // 3 -1
-             M_SQRT_5  / (4.0f * M_SQRT_PI) * C[2] * M_1_PI,    // 3  0
-            -M_SQRT_15 / (2.0f * M_SQRT_PI) * C[2] * M_1_PI,    // 3  1
-             M_SQRT_15 / (4.0f * M_SQRT_PI) * C[2] * M_1_PI     // 3  2
+                  1.0f / (2.0f * F_SQRT_PI) * C[0] * F_1_PI,    // 0  0
+            -F_SQRT_3  / (2.0f * F_SQRT_PI) * C[1] * F_1_PI,    // 1 -1
+             F_SQRT_3  / (2.0f * F_SQRT_PI) * C[1] * F_1_PI,    // 1  0
+            -F_SQRT_3  / (2.0f * F_SQRT_PI) * C[1] * F_1_PI,    // 1  1
+             F_SQRT_15 / (2.0f * F_SQRT_PI) * C[2] * F_1_PI,    // 2 -2
+            -F_SQRT_15 / (2.0f * F_SQRT_PI) * C[2] * F_1_PI,    // 3 -1
+             F_SQRT_5  / (4.0f * F_SQRT_PI) * C[2] * F_1_PI,    // 3  0
+            -F_SQRT_15 / (2.0f * F_SQRT_PI) * C[2] * F_1_PI,    // 3  1
+             F_SQRT_15 / (4.0f * F_SQRT_PI) * C[2] * F_1_PI     // 3  2
     };
 
     // this is a way to "document" the actual value of these coefficients and at the same
@@ -251,12 +250,12 @@ float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
 
     // The scale factor below is explained in the gamasutra article above, however it seems
     // to cause the intensity of the light to be too low.
-    //      constexpr float c = (16.0f * M_PI / 17.0f);
-    //      constexpr float LdSquared = (9.0f / (4.0f * M_PI)) * c * c;
+    //      constexpr float c = (16.0f * F_PI / 17.0f);
+    //      constexpr float LdSquared = (9.0f / (4.0f * F_PI)) * c * c;
     //      LdDotLe *= c / LdSquared; // Note the final coefficient is 17/36
 
     // We multiply by PI because our SH coefficients contain the 1/PI lambertian BRDF.
-    LdDotLe *= M_PI;
+    LdDotLe *= F_PI;
 
     // Make sure we don't have negative intensities
     LdDotLe = max(LdDotLe, float3{0});

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -20,10 +20,12 @@
 
 #include "details/Engine.h"
 
-#include <math/fast.h>
-#include <math/scalar.h>
 #include <filament/LightManager.h>
 
+#include <math/fast.h>
+#include <math/scalar.h>
+
+#include <assert.h>
 
 using namespace filament::math;
 using namespace utils;
@@ -43,7 +45,7 @@ struct LightManager::BuilderDetails {
     LinearColor mColor = LinearColor{ 1.0f };
     float mIntensity = 100000.0f;
     float3 mDirection = { 0.0f, -1.0f, 0.0f };
-    float2 mSpotInnerOuter = { (float)M_PI, (float)M_PI };
+    float2 mSpotInnerOuter = { (float) F_PI, (float) F_PI };
     float mSunAngle = 0.00951f; // 0.545° in radians
     float mSunHaloSize = 10.0f;
     float mSunHaloFalloff = 80.0f;
@@ -249,7 +251,7 @@ void FLightManager::setIntensity(Instance i, float intensity) noexcept {
 
             case Type::POINT:
                 // li = lp / (4*pi)
-                luminousIntensity = luminousPower * float(M_1_PI) * 0.25f;
+                luminousIntensity = luminousPower * float(F_1_PI) * 0.25f;
                 break;
 
             case Type::FOCUSED_SPOT: {
@@ -258,13 +260,13 @@ void FLightManager::setIntensity(Instance i, float intensity) noexcept {
                 float2 scaleOffset = spotParams.scaleOffset;
                 float cosOuter = -scaleOffset.y / scaleOffset.x;
                 float cosHalfOuter = std::sqrt((1.0f + cosOuter) * 0.5f); // half-angle identities
-                luminousIntensity = luminousPower / (2.0f * float(M_PI) * (1.0f - cosHalfOuter));
+                luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosHalfOuter));
                 spotParams.luminousPower = luminousPower;
                 break;
             }
             case Type::SPOT:
                 // li = lp / pi
-                luminousIntensity = luminousPower * float(M_1_PI);
+                luminousIntensity = luminousPower * float(F_1_PI);
                 break;
         }
         manager[i].intensity = luminousIntensity;
@@ -285,8 +287,8 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
     auto& manager = mManager;
     if (i && isSpotLight(i)) {
         // clamp the inner/outer angles to pi
-        float outerClamped = std::min(std::abs(outer), float(M_PI));
-        float innerClamped = std::min(std::abs(inner), float(M_PI));
+        float outerClamped = std::min(std::abs(outer), float(F_PI));
+        float innerClamped = std::min(std::abs(inner), float(F_PI));
 
         // inner must always be smaller than outer
         innerClamped = std::min(innerClamped, outerClamped);
@@ -307,7 +309,7 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
         if (type == Type::FOCUSED_SPOT) {
             float luminousPower = spotParams.luminousPower;
             float cosHalfOuter = std::sqrt((1.0f + cosOuter) * 0.5f); // half-angle identities
-            float luminousIntensity = luminousPower / (2.0f * float(M_PI) * (1.0f - cosHalfOuter));
+            float luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosHalfOuter));
             manager[i].intensity = luminousIntensity;
         }
     }
@@ -316,7 +318,7 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
 void FLightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept {
     if (i && isSunLight(i)) {
         angularRadius = clamp(angularRadius, 0.25f, 20.0f);
-        mManager[i].sunAngularRadius = angularRadius * float(M_PI / 180.0);
+        mManager[i].sunAngularRadius = angularRadius * float(F_PI / 180.0);
     }
 }
 
@@ -411,7 +413,7 @@ void LightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept
 
 float LightManager::getSunAngularRadius(Instance i) const noexcept {
     float radius = upcast(this)->getSunAngularRadius(i);
-    return radius * float(180.0 / M_PI);
+    return radius * float(180.0 / F_PI);
 }
 
 void LightManager::setSunHaloSize(Instance i, float haloSize) noexcept {

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -489,9 +489,9 @@ TEST(FilamentTest, FroxelData) {
     Froxel f = froxelData.getFroxelAt(0,0,0);
 
     // 45-deg plane, with normal pointing outward to the left
-    EXPECT_FLOAT_EQ(-M_SQRT2/2, f.planes[Froxel::LEFT].x);
+    EXPECT_FLOAT_EQ(-F_SQRT2/2, f.planes[Froxel::LEFT].x);
     EXPECT_FLOAT_EQ(         0, f.planes[Froxel::LEFT].y);
-    EXPECT_FLOAT_EQ( M_SQRT2/2, f.planes[Froxel::LEFT].z);
+    EXPECT_FLOAT_EQ( F_SQRT2/2, f.planes[Froxel::LEFT].z);
 
     // the right side of froxel 1 is near 45-deg plane pointing outward to the right
     EXPECT_TRUE(f.planes[Froxel::RIGHT].x > 0);
@@ -500,9 +500,9 @@ TEST(FilamentTest, FroxelData) {
 
     // right side of last horizontal froxel is 45-deg plane pointing outward to the right
     Froxel g = froxelData.getFroxelAt(froxelData.getFroxelCountX()-1,0,0);
-    EXPECT_FLOAT_EQ(M_SQRT2/2, g.planes[Froxel::RIGHT].x);
+    EXPECT_FLOAT_EQ(F_SQRT2/2, g.planes[Froxel::RIGHT].x);
     EXPECT_FLOAT_EQ(        0, g.planes[Froxel::RIGHT].y);
-    EXPECT_FLOAT_EQ(M_SQRT2/2, g.planes[Froxel::RIGHT].z);
+    EXPECT_FLOAT_EQ(F_SQRT2/2, g.planes[Froxel::RIGHT].z);
 
     // first froxel near plane facing us
     EXPECT_FLOAT_EQ(        0, f.planes[Froxel::NEAR].x);
@@ -677,21 +677,21 @@ TEST(FilamentTest, Bones) {
     Test::check(mat4f::scaling(float3{ 4, -2, 3 }));
     Test::check(mat4f::scaling(float3{ 4, 2, -3 }));
 
-    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 0, 1 }));
-    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 1, 0 }));
-    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 0, 0 }));
-    Test::check(mat4f::rotation(M_PI_2, float3{ 0, 1, 1 }));
-    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 0, 1 }));
-    Test::check(mat4f::rotation(M_PI_2, float3{ 1, 1, 0 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 0, 1 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 1, 0 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 0, 0 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 0, 1, 1 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 0, 1 }));
-    Test::check(mat4f::rotation(-M_PI_2, float3{ 1, 1, 0 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 0, 0, 1 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 0, 1, 0 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 1, 0, 0 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 0, 1, 1 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 1, 0, 1 }));
+    Test::check(mat4f::rotation(F_PI_2, float3{ 1, 1, 0 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 0, 0, 1 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 0, 1, 0 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 1, 0, 0 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 0, 1, 1 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 1, 0, 1 }));
+    Test::check(mat4f::rotation(-F_PI_2, float3{ 1, 1, 0 }));
 
     mat4f m = mat4f::translation(float3{ 1, 2, 3 }) *
-                                                    mat4f::rotation(-M_PI_2, float3{ 1, 1, 0 }) *
+                                                    mat4f::rotation(-F_PI_2, float3{ 1, 1, 0 }) *
                                                     mat4f::scaling(float3{ -2, 3, 0.04 });
 
     Test::check(m);

--- a/filament/tools/ssaogen.cpp
+++ b/filament/tools/ssaogen.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <math/scalar.h>
 #include <math/vec3.h>
 
 #include <random>
@@ -21,13 +22,11 @@
 
 using namespace filament::math;
 
-
 static float lerp(float a, float b, float f) {
     return a + f * (b - a);
 }
 
 int main(int argc, char** argv) {
-
     std::uniform_real_distribution<float> random(0.0, 1.0);
     std::default_random_engine generator;
 
@@ -44,11 +43,11 @@ int main(int argc, char** argv) {
         };
         d = normalize(d);
         d = d * r * lerp(0.1f, 1.0f, s * s);
-        if (!(i & 1)) {
+        if (!(i & 1u)) {
             std::cout << "    ";
         }
         std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
-        if (i & 1) {
+        if (i & 1u) {
             std::cout << std::endl;
         }
     }
@@ -65,11 +64,11 @@ int main(int argc, char** argv) {
                 random(generator) * 2 - 1,
         };
         d = normalize(d);
-        if ((i & 0x1) == 0) {
+        if ((i & 0x1u) == 0) {
             std::cout << "    ";
         }
         std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
-        if ((i & 0x1) == 0x1) {
+        if ((i & 0x1u) == 0x1) {
             std::cout << std::endl;
         }
     }
@@ -105,9 +104,9 @@ int main(int argc, char** argv) {
      * Unfortunately, because angle depends on radius^2, it's not possible to separate phi and i,
      * as the final expression is:
      *
-     *   g(phi) = phi^2   * 2.0 * M_PI * kSpiralTurns * K
-     *          + phi     * 2.0 * M_PI * (1.0 + kSpiralTurns * K)
-     *          + i * phi * 4.0 * M_PI * kSpiralTurns * K;   // K is a constant
+     *   g(phi) = phi^2   * 2.0 * F_PI * kSpiralTurns * K
+     *          + phi     * 2.0 * F_PI * (1.0 + kSpiralTurns * K)
+     *          + i * phi * 4.0 * F_PI * kSpiralTurns * K;   // K is a constant
      *
      * g(phi) has a term in "i * phi" which links both expressions.
      *
@@ -122,12 +121,12 @@ int main(int argc, char** argv) {
     const float dalpha = 1.0f / (spiralSampleCount - 0.5f);
     for (size_t i = 0; i < spiralSampleCount; i++) {
         float radius = (i + 0.5f) * dalpha;
-        float angle = radius * radius * (2 * M_PI * kSpiralTurns);
-        if ((i & 0x1) == 0) {
+        float angle = float(radius * radius * (2 * F_PI * kSpiralTurns));
+        if ((i & 0x1u) == 0) {
             std::cout << "    ";
         }
         std::cout << " vec3(" << std::cos(angle) << ", " << std::sin(angle) << ", " << radius << "),";
-        if ((i & 0x1) == 0x1) {
+        if ((i & 0x1u) == 0x1) {
             std::cout << std::endl;
         }
     }
@@ -140,15 +139,15 @@ int main(int argc, char** argv) {
     for (size_t i = 0; i < trigNoiseSampleCount; i++) {
         float phi = random(generator);
         float dr = phi * dalpha;
-        float dphi =    2.0 * M_PI * kSpiralTurns * phi * phi * dalpha * dalpha
-                + phi * 2.0 * M_PI * (1.0 + kSpiralTurns * dalpha * dalpha)
-                + phi * 4.0 * M_PI * kSpiralTurns * dalpha * dalpha;
+        float dphi = float(2.0 * F_PI * kSpiralTurns * phi * phi * dalpha * dalpha
+                   + phi * 2.0 * F_PI * (1.0 + kSpiralTurns * dalpha * dalpha)
+                   + phi * 4.0 * F_PI * kSpiralTurns * dalpha * dalpha);
         float3 d = { std::cos(dphi), std::sin(dphi), dr };
-        if ((i & 0x1) == 0) {
+        if ((i & 0x1u) == 0) {
             std::cout << "    ";
         }
         std::cout << " vec3(" << d.x << ", " << d.y << ", " << d.z << "),";
-        if ((i & 0x1) == 0x1) {
+        if ((i & 0x1u) == 0x1) {
             std::cout << std::endl;
         }
     }
@@ -171,15 +170,15 @@ int main(int argc, char** argv) {
         // Cut-off frequency definition:
         //      fc = 1.1774 / (2pi * q)       (half power frequency or 0.707 amplitude)
 
-        float q = (gaussianWidth + 1) / 6.0;  // ~1.667 for 9 taps
-        float g = (1.0 / (std::sqrt(2.0 * M_PI) * q)) * std::exp(-(x * x) / (2.0 * q * q));
+        float q = (gaussianWidth + 1.0f) / 6.0f;  // ~1.667 for 9 taps
+        float g = (1.0 / (std::sqrt(2.0 * F_PI) * q)) * std::exp(-(x * x) / (2.0 * q * q));
         weightSum += g * (i == 0 ? 1.0f : 2.0f);
 
-        if ((i & 0x7) == 0) {
+        if ((i & 0x7u) == 0) {
             std::cout << "    ";
         }
         std::cout << g << ", ";
-        if ((i & 0x7) == 0x7) {
+        if ((i & 0x7u) == 0x7) {
             std::cout << std::endl;
         }
     }

--- a/libs/bluevk/CMakeLists.txt
+++ b/libs/bluevk/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
-target_link_libraries(${TARGET} utils)
+target_link_libraries(${TARGET} utils math)
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 

--- a/libs/bluevk/tests/test_bluevk_sdl.cpp
+++ b/libs/bluevk/tests/test_bluevk_sdl.cpp
@@ -27,7 +27,12 @@
 #include "SDL_vulkan.h"
 
 #include <bluevk/BlueVK.h>
+
 #include <utils/Log.h>
+
+#include <math/scalar.h>
+
+using namespace filament::math;
 
 struct VulkanDriver {
     VkInstance instance;
@@ -720,8 +725,8 @@ static SDL_bool render() {
     }
     currentTime = (double) SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
     clearColor.float32[0] = (float)(0.5 + 0.5 * SDL_sin(SPEED * currentTime));
-    clearColor.float32[1] = (float)(0.5 + 0.5 * SDL_sin(SPEED * currentTime + M_PI * 2 / 3));
-    clearColor.float32[2] = (float)(0.5 + 0.5 * SDL_sin(SPEED * currentTime + M_PI * 4 / 3));
+    clearColor.float32[1] = (float)(0.5 + 0.5 * SDL_sin(SPEED * currentTime + F_PI * 2 / 3));
+    clearColor.float32[2] = (float)(0.5 + 0.5 * SDL_sin(SPEED * currentTime + F_PI * 4 / 3));
     clearColor.float32[3] = 1;
     rerecordCommandBuffer(frameIndex, &clearColor);
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;

--- a/libs/filagui/src/ImGuiExtensions.cpp
+++ b/libs/filagui/src/ImGuiExtensions.cpp
@@ -252,8 +252,8 @@ void ArrowWidget::createArrow() {
 
     float x0, x1, y0, y1, z0, z1, a0, a1, nx, nn;
     for (int i = 0; i < SUBDIV; ++i) {
-        a0 = 2.0f*float(M_PI)*(float(i)) / SUBDIV;
-        a1 = 2.0f*float(M_PI)*(float(i + 1)) / SUBDIV;
+        a0 = 2.0f*float(F_PI)*(float(i)) / SUBDIV;
+        a1 = 2.0f*float(F_PI)*(float(i + 1)) / SUBDIV;
         x0 = ARROW_BGN;
         x1 = ARROW_END - CONE_LENGTH;
         y0 = cosf(a0);

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -47,7 +47,7 @@ static float pow6(float x) {
 }
 
 static float3 hemisphereImportanceSampleDggx(float2 u, float a) { // pdf = D(a) * cosTheta
-    const float phi = 2.0f * (float) M_PI * u.x;
+    const float phi = 2.0f * (float) F_PI * u.x;
     // NOTE: (aa-1) == (a-1)(a+1) produces better fp accuracy
     const float cosTheta2 = (1 - u.y) / (1 + (a + 1) * ((a - 1) * u.y));
     const float cosTheta = std::sqrt(cosTheta2);
@@ -55,16 +55,16 @@ static float3 hemisphereImportanceSampleDggx(float2 u, float a) { // pdf = D(a) 
     return { sinTheta * std::cos(phi), sinTheta * std::sin(phi), cosTheta };
 }
 
-static float3 UTILS_UNUSED hemisphereCosSample(float2 u) {  // pdf = cosTheta / M_PI;
-    const float phi = 2.0f * (float) M_PI * u.x;
+static float3 UTILS_UNUSED hemisphereCosSample(float2 u) {  // pdf = cosTheta / F_PI;
+    const float phi = 2.0f * (float) F_PI * u.x;
     const float cosTheta2 = 1 - u.y;
     const float cosTheta = std::sqrt(cosTheta2);
     const float sinTheta = std::sqrt(1 - cosTheta2);
     return { sinTheta * std::cos(phi), sinTheta * std::sin(phi), cosTheta };
 }
 
-static float3 UTILS_UNUSED hemisphereUniformSample(float2 u) { // pdf = 1.0 / (2.0 * M_PI);
-    const float phi = 2.0f * (float) M_PI * u.x;
+static float3 UTILS_UNUSED hemisphereUniformSample(float2 u) { // pdf = 1.0 / (2.0 * F_PI);
+    const float phi = 2.0f * (float) F_PI * u.x;
     const float cosTheta = 1 - u.y;
     const float sinTheta = std::sqrt(1 - cosTheta * cosTheta);
     return { sinTheta * std::cos(phi), sinTheta * std::sin(phi), cosTheta };
@@ -128,7 +128,7 @@ static float3 UTILS_UNUSED hemisphereUniformSample(float2 u) { // pdf = 1.0 / (2
  *  +--------------------------------------------+
  */
 static float3 UTILS_UNUSED hemisphereImportanceSampleDCharlie(float2 u, float a) { // pdf = DistributionCharlie() * cosTheta
-    const float phi = 2.0f * (float) M_PI * u.x;
+    const float phi = 2.0f * (float) F_PI * u.x;
 
     const float sinTheta = std::pow(u.y, a / (2 * a + 1));
     const float cosTheta = std::sqrt(1 - sinTheta * sinTheta);
@@ -140,7 +140,7 @@ static float DistributionGGX(float NoH, float linearRoughness) {
     // NOTE: (aa-1) == (a-1)(a+1) produces better fp accuracy
     float a = linearRoughness;
     float f = (a - 1) * ((a + 1) * (NoH * NoH)) + 1;
-    return (a * a) / ((float) M_PI * f * f);
+    return (a * a) / ((float) F_PI * f * f);
 }
 
 static float UTILS_UNUSED DistributionAshikhmin(float NoH, float linearRoughness) {
@@ -149,7 +149,7 @@ static float UTILS_UNUSED DistributionAshikhmin(float NoH, float linearRoughness
     float cos2h = NoH * NoH;
     float sin2h = 1 - cos2h;
     float sin4h = sin2h * sin2h;
-    return 1.0f / ((float) M_PI * (1 + 4 * a2)) * (sin4h + 4 * std::exp(-cos2h / (a2 * sin2h)));
+    return 1.0f / ((float) F_PI * (1 + 4 * a2)) * (sin4h + 4 * std::exp(-cos2h / (a2 * sin2h)));
 }
 
 static float UTILS_UNUSED DistributionCharlie(float NoH, float linearRoughness) {
@@ -158,7 +158,7 @@ static float UTILS_UNUSED DistributionCharlie(float NoH, float linearRoughness) 
     float invAlpha = 1 / a;
     float cos2h = NoH * NoH;
     float sin2h = 1 - cos2h;
-    return (2.0f + invAlpha) * std::pow(sin2h, invAlpha * 0.5f) / (2.0f * (float) M_PI);
+    return (2.0f + invAlpha) * std::pow(sin2h, invAlpha * 0.5f) / (2.0f * (float) F_PI);
 }
 
 static float Fresnel(float f0, float f90, float LoH) {
@@ -302,7 +302,7 @@ void CubemapIBL::roughnessFilter(
     const float maxLevelf = maxLevel;
     const Cubemap& base(levels[0]);
     const size_t dim0 = base.getDimensions();
-    const float omegaP = (4.0f * (float) M_PI) / float(6 * dim0 * dim0);
+    const float omegaP = (4.0f * (float) F_PI) / float(6 * dim0 * dim0);
     std::atomic_uint progress = {0};
 
     if (linearRoughness == 0) {
@@ -540,7 +540,7 @@ void CubemapIBL::diffuseIrradiance(JobSystem& js, Cubemap& dst, const std::vecto
     const float maxLevelf = maxLevel;
     const Cubemap& base(levels[0]);
     const size_t dim0 = base.getDimensions();
-    const float omegaP = (4.0f * (float) M_PI) / float(6 * dim0 * dim0);
+    const float omegaP = (4.0f * (float) F_PI) / float(6 * dim0 * dim0);
 
     std::atomic_uint progress = {0};
 
@@ -563,7 +563,7 @@ void CubemapIBL::diffuseIrradiance(JobSystem& js, Cubemap& dst, const std::vecto
         const float NoL = dot(N, L);
 
         if (NoL > 0) {
-            float pdf = NoL * (float) M_1_PI;
+            float pdf = NoL * (float) F_1_PI;
 
             constexpr float K = 4;
             const float omegaS = 1.0f / (numSamples * pdf);
@@ -628,7 +628,7 @@ static float2 UTILS_UNUSED DFV_NoIS(float NoV, float roughness, size_t numSample
         if (NoL > 0) {
             // Note: remember VoH == LoH  (H is half vector)
             const float J = 1.0f / (4.0f * VoH);
-            const float pdf = NoH / (float) M_PI;
+            const float pdf = NoH / (float) F_PI;
             const float d = DistributionGGX(NoH, linearRoughness) * NoL / (pdf * J);
             const float Fc = pow5(1 - VoH);
             const float v = Visibility(NoV, NoL, linearRoughness);
@@ -814,7 +814,7 @@ static float2 DFV_Multiscatter(float NoV, float linearRoughness, size_t numSampl
 
 static float UTILS_UNUSED DFV_LazanyiTerm(float NoV, float linearRoughness, size_t numSamples) {
     float r = 0;
-    const float cosThetaMax = (float) std::cos(81.7 * M_PI / 180.0);
+    const float cosThetaMax = (float) std::cos(81.7 * F_PI / 180.0);
     const float q = 1.0f / (cosThetaMax * pow6(1.0f - cosThetaMax));
     const float3 V(std::sqrt(1 - NoV * NoV), 0, NoV);
     for (size_t i = 0; i < numSamples; i++) {
@@ -850,7 +850,7 @@ static float DFV_Charlie_Uniform(float NoV, float linearRoughness, size_t numSam
         }
     }
     // uniform sampling, the PDF is 1/2pi, 4 comes from the Jacobian
-    return r * (4.0f * 2.0f * (float) M_PI / numSamples);
+    return r * (4.0f * 2.0f * (float) F_PI / numSamples);
 }
 
 /*

--- a/libs/ibl/src/CubemapSH.cpp
+++ b/libs/ibl/src/CubemapSH.cpp
@@ -70,7 +70,7 @@ static constexpr float factorial(size_t n, size_t d = 1) {
 float CubemapSH::Kml(ssize_t m, size_t l) {
     m = m < 0 ? -m : m;  // abs() is not constexpr
     const float K = (2 * l + 1) * factorial(size_t(l - m), size_t(l + m));
-    return std::sqrt(K) * (M_2_SQRTPI * 0.25);
+    return std::sqrt(K) * (F_2_SQRTPI * 0.25);
 }
 
 std::vector<float> CubemapSH::Ki(size_t numBands) {
@@ -80,7 +80,7 @@ std::vector<float> CubemapSH::Ki(size_t numBands) {
         K[SHindex(0, l)] = Kml(0, l);
         for (size_t m = 1; m <= l; m++) {
             K[SHindex(m, l)] =
-            K[SHindex(-m, l)] = M_SQRT2 * Kml(m, l);
+            K[SHindex(-m, l)] = F_SQRT2 * Kml(m, l);
         }
     }
     return K;
@@ -89,16 +89,16 @@ std::vector<float> CubemapSH::Ki(size_t numBands) {
 // < cos(theta) > SH coefficients pre-multiplied by 1 / K(0,l)
 constexpr float CubemapSH::computeTruncatedCosSh(size_t l) {
     if (l == 0) {
-        return M_PI;
+        return F_PI;
     } else if (l == 1) {
-        return 2 * M_PI / 3;
+        return 2 * F_PI / 3;
     } else if (l & 1u) {
         return 0;
     }
     const size_t l_2 = l / 2;
     float A0 = ((l_2 & 1u) ? 1.0f : -1.0f) / ((l + 2) * (l - 1));
     float A1 = factorial(l, l_2) / (factorial(l_2) * (1 << l));
-    return 2 * M_PI * A0 * A1;
+    return 2 * F_PI * A0 * A1;
 }
 
 /*
@@ -244,7 +244,7 @@ float3 CubemapSH::rotateShericalHarmonicBand1(float3 band1, mat3f const& M) {
 
 CubemapSH::float5 CubemapSH::rotateShericalHarmonicBand2(float5 const& band2, mat3f const& M) {
     constexpr float M_SQRT_3  = 1.7320508076f;
-    constexpr float n = M_SQRT1_2;
+    constexpr float n = F_SQRT1_2;
 
     //  Below we precompute (with help of Mathematica):
     //    constexpr float3 N0{ 1, 0, 0 };
@@ -319,7 +319,7 @@ float CubemapSH::sincWindow(size_t l, float w) {
 
     // we use a sinc window scaled to the desired window size in bands units
     // a sinc window only has zonal harmonics
-    float x = (float(M_PI) * l) / w;
+    float x = (float(F_PI) * l) / w;
     x = std::sin(x) / x;
 
     // The convolution of a SH function f and a ZH function h is just the product of both
@@ -437,7 +437,7 @@ void CubemapSH::windowSH(std::unique_ptr<float3[]>& sh, size_t numBands, float c
             };
 
             float dz;
-            float z = -M_SQRT1_2;   // we start guessing at the min of |m|=1 function
+            float z = -F_SQRT1_2;   // we start guessing at the min of |m|=1 function
             do {
                 minimum = func(z); // evaluate our function
                 dz = increment(z); // refine our guess by this amount
@@ -650,7 +650,7 @@ void CubemapSH::preprocessSHForShader(std::unique_ptr<filament::math::float3[]>&
     };
 
     for (size_t i = 0; i < numCoefs; i++) {
-        SH[i] *= A[i] * M_1_PI;
+        SH[i] *= A[i] * F_1_PI;
     }
 }
 
@@ -710,23 +710,23 @@ float UTILS_UNUSED CubemapSH::Legendre(ssize_t l, ssize_t m, float x) {
 // Only used for debugging
 float UTILS_UNUSED CubemapSH::TSH(int l, int m, const float3& d) {
     if (l==0 && m==0) {
-        return 1 / (2*sqrt(M_PI));
+        return 1 / (2*sqrt(F_PI));
     } else if (l==1 && m==-1) {
-        return -(sqrt(3)*d.y)/(2*sqrt(M_PI));
+        return -(sqrt(3)*d.y)/(2*sqrt(F_PI));
     } else if (l==1 && m==0) {
-        return  (sqrt(3)*d.z)/(2*sqrt(M_PI));
+        return  (sqrt(3)*d.z)/(2*sqrt(F_PI));
     } else if (l==1 && m==1) {
-        return -(sqrt(3)*d.x)/(2*sqrt(M_PI));
+        return -(sqrt(3)*d.x)/(2*sqrt(F_PI));
     } else if (l==2 && m==-2) {
-        return (sqrt(15)*d.y*d.x)/(2*sqrt(M_PI));
+        return (sqrt(15)*d.y*d.x)/(2*sqrt(F_PI));
     } else if (l==2 && m==-1) {
-        return -(sqrt(15)*d.y*d.z)/(2*sqrt(M_PI));
+        return -(sqrt(15)*d.y*d.z)/(2*sqrt(F_PI));
     } else if (l==2 && m==0) {
-        return (sqrt(5)*(3*d.z*d.z-1))/(4*sqrt(M_PI));
+        return (sqrt(5)*(3*d.z*d.z-1))/(4*sqrt(F_PI));
     } else if (l==2 && m==1) {
-        return -(sqrt(15)*d.z*d.x)/(2*sqrt(M_PI));
+        return -(sqrt(15)*d.z*d.x)/(2*sqrt(F_PI));
     } else if (l==2 && m==2) {
-        return (sqrt(15)*(d.x*d.x - d.y*d.y))/(4*sqrt(M_PI));
+        return (sqrt(15)*(d.x*d.x - d.y*d.y))/(4*sqrt(F_PI));
     }
     return 0;
 }
@@ -736,31 +736,31 @@ void UTILS_UNUSED CubemapSH::printShBase(std::ostream& out, int l, int m) {
         const char* d = nullptr;
         float c = 0;
         if (l==0 && m==0) {
-            c = M_2_SQRTPI * 0.25;
+            c = F_2_SQRTPI * 0.25;
             d = "               ";
         } else if (l==1 && m==-1) {
-            c = -M_2_SQRTPI * sqrt(3) * 0.25;
+            c = -F_2_SQRTPI * sqrt(3) * 0.25;
             d = " * y;          ";
         } else if (l==1 && m==0) {
-            c = M_2_SQRTPI * sqrt(3) * 0.25;
+            c = F_2_SQRTPI * sqrt(3) * 0.25;
             d = " * z;          ";
         } else if (l==1 && m==1) {
-            c = -M_2_SQRTPI * sqrt(3) * 0.25;
+            c = -F_2_SQRTPI * sqrt(3) * 0.25;
             d = " * x;          ";
         } else if (l==2 && m==-2) {
-            c = M_2_SQRTPI * sqrt(15) * 0.25;
+            c = F_2_SQRTPI * sqrt(15) * 0.25;
             d = " * y*x;        ";
         } else if (l==2 && m==-1) {
-            c = -M_2_SQRTPI * sqrt(15) * 0.25;
+            c = -F_2_SQRTPI * sqrt(15) * 0.25;
             d = " * y*z;        ";
         } else if (l==2 && m==0) {
-            c =  M_2_SQRTPI * sqrt(5) * 0.125;
+            c =  F_2_SQRTPI * sqrt(5) * 0.125;
             d = " * (3*z*z -1); ";
         } else if (l==2 && m==1) {
-            c = -M_2_SQRTPI * sqrt(15) * 0.25;
+            c = -F_2_SQRTPI * sqrt(15) * 0.25;
             d = " * z*x;        ";
         } else if (l==2 && m==2) {
-            c = M_2_SQRTPI * sqrt(15) * 0.125;
+            c = F_2_SQRTPI * sqrt(15) * 0.125;
             d = " * (x*x - y*y);";
         }
         out << "SHb[" << SHindex(m, size_t(l)) << "] = ";

--- a/libs/ibl/src/CubemapUtils.cpp
+++ b/libs/ibl/src/CubemapUtils.cpp
@@ -75,8 +75,8 @@ void CubemapUtils::equirectangularToCubemap(JobSystem& js, Cubemap& dst, const I
     const size_t height = src.getHeight();
 
     auto toRectilinear = [width, height](float3 s) -> float2 {
-        float xf = std::atan2(s.x, s.z) * M_1_PI;   // range [-1.0, 1.0]
-        float yf = std::asin(s.y) * (2 * M_1_PI);   // range [-1.0, 1.0]
+        float xf = std::atan2(s.x, s.z) * F_1_PI;   // range [-1.0, 1.0]
+        float yf = std::asin(s.y) * (2 * F_1_PI);   // range [-1.0, 1.0]
         xf = (xf + 1.0f) * 0.5f * (width  - 1);        // range [0, width [
         yf = (1.0f - yf) * 0.5f * (height - 1);        // range [0, height[
         return float2(xf, yf);
@@ -140,8 +140,8 @@ void CubemapUtils::cubemapToEquirectangular(JobSystem& js, Image& dst, const Cub
                     const float2 u = hammersley(uint32_t(sample), 1.0f / numSamples);
                     float x = 2.0f * (i + u.x) / w - 1.0f;
                     float y = 1.0f - 2.0f * (j + u.y) / h;
-                    float theta = x * M_PI;
-                    float phi = y * M_PI * 0.5;
+                    float theta = x * F_PI;
+                    float phi = y * F_PI * 0.5;
                     float3 s = {
                             std::cos(phi) * std::sin(theta),
                             std::sin(phi),

--- a/libs/image/src/ImageSampler.cpp
+++ b/libs/image/src/ImageSampler.cpp
@@ -17,8 +17,10 @@
 #include <image/ImageSampler.h>
 #include <image/ImageOps.h>
 
+#include <math/scalar.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
+
 #include <utils/Panic.h>
 #include <utils/CString.h>
 
@@ -36,7 +38,7 @@ struct FilterFunction {
     bool rejectExternalSamples = true;
 };
 
-constexpr float M_PIf = float(M_PI);
+constexpr float M_PIf = float(filament::math::F_PI);
 
 const FilterFunction Box {
     .fn = [](float t) { return t <= 0.5f ? 1.0f : 0.0f; },
@@ -340,8 +342,8 @@ void generateMipmaps(const LinearImage& source, Filter filter, LinearImage* resu
     uint32_t width = source.getWidth();
     uint32_t height = source.getHeight();
     for (uint32_t n = 0; n < mips; ++n) {
-       width = std::max(width >> 1, 1u);
-       height = std::max(height >> 1, 1u);
+       width = std::max(width >> 1u, 1u);
+       height = std::max(height >> 1u, 1u);
        result[n] = resampleImage(source, width, height, filter);
     }
 }
@@ -352,8 +354,8 @@ uint32_t getMipmapCount(const LinearImage& source) {
     uint32_t count = 0;
     while (width > 1 || height > 1) {
         ++count;
-        width = std::max(width >> 1, 1u);
-        height = std::max(height >> 1, 1u);
+        width = std::max(width >> 1u, 1u);
+        height = std::max(height >> 1u, 1u);
     }
     return count;
 }

--- a/libs/math/benchmarks/benchmark_fast.cpp
+++ b/libs/math/benchmarks/benchmark_fast.cpp
@@ -38,7 +38,7 @@ static void BM_trig(benchmark::State& state) noexcept {
     std::vector<float> data(1024);
     std::vector<typename T::result_type> res(1024);
     for (size_t i = 0; i < data.size(); i++) {
-        data[i] = float((float(i) / data.size()) * M_2_PI - M_PI);
+        data[i] = float((float(i) / data.size()) * F_2_PI - F_PI);
     }
 
     {

--- a/libs/math/include/math/fast.h
+++ b/libs/math/include/math/fast.h
@@ -18,9 +18,11 @@
 #define TNT_MATH_FAST_H
 
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 #include <type_traits>
+
 #include <math/compiler.h>
+#include <math/scalar.h>
 
 #ifdef __ARM_NEON
 #include <arm_neon.h>
@@ -35,7 +37,7 @@ namespace fast {
 // x between -pi and pi
 template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
 constexpr T MATH_PURE cos(T x) noexcept {
-    x *= T(M_1_PI / 2);
+    x *= T(F_1_PI / 2);
     x -= T(0.25) + std::floor(x + T(0.25));
     x *= T(16.0) * std::abs(x) - T(8.0);
     x += T(0.225) * x * (std::abs(x) - T(1.0));
@@ -47,7 +49,7 @@ constexpr T MATH_PURE cos(T x) noexcept {
 // x between -pi and pi
 template<typename T, typename = std::enable_if_t<std::is_floating_point<T>::value>>
 constexpr T MATH_PURE sin(T x) noexcept {
-    return filament::math::fast::cos<T>(x - T(M_PI_2));
+    return filament::math::fast::cos<T>(x - T(F_PI_2));
 }
 
 constexpr inline float MATH_PURE ilog2(float x) noexcept {

--- a/libs/math/include/math/scalar.h
+++ b/libs/math/include/math/scalar.h
@@ -24,6 +24,20 @@
 namespace filament {
 namespace math {
 
+constexpr const double F_E        = 2.71828182845904523536028747135266250;
+constexpr const double F_LOG2E    = 1.44269504088896340735992468100189214;
+constexpr const double F_LOG10E   = 0.434294481903251827651128918916605082;
+constexpr const double F_LN2      = 0.693147180559945309417232121458176568;
+constexpr const double F_LN10     = 2.30258509299404568401799145468436421;
+constexpr const double F_PI       = 3.14159265358979323846264338327950288;
+constexpr const double F_PI_2     = 1.57079632679489661923132169163975144;
+constexpr const double F_PI_4     = 0.785398163397448309615660845819875721;
+constexpr const double F_1_PI     = 0.318309886183790671537767526745028724;
+constexpr const double F_2_PI     = 0.636619772367581343075535053490057448;
+constexpr const double F_2_SQRTPI = 1.12837916709551257389615890312154517;
+constexpr const double F_SQRT2    = 1.41421356237309504880168872420969808;
+constexpr const double F_SQRT1_2  = 0.707106781186547524400844362104849039;
+
 template<typename T>
 inline constexpr T MATH_PURE saturate(T v) noexcept {
     return T(std::min(T(1), std::max(T(0), v)));

--- a/libs/math/tests/test_fast.cpp
+++ b/libs/math/tests/test_fast.cpp
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-#include <math.h>
-
 #include <gtest/gtest.h>
 
 #include <math/fast.h>
+#include <math/scalar.h>
 
 using namespace filament::math;
 
@@ -27,48 +26,47 @@ protected:
 };
 
 TEST_F(FastTest, Trig) {
-    constexpr float sqrt1_2f = (float)M_SQRT1_2;
-    constexpr double sqrt1_2d = M_SQRT1_2;
+    constexpr float sqrt1_2f = (float) F_SQRT1_2;
+    constexpr double sqrt1_2d = F_SQRT1_2;
     constexpr float abs_error = 0.002f; // 0.2%
 
-
-    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<float>(-M_PI));
-    EXPECT_NEAR    (-sqrt1_2f,  fast::sin<float>(-M_PI_2 - M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ(-1.0f,      fast::sin<float>(-M_PI_2));
-    EXPECT_NEAR    (-sqrt1_2f,  fast::sin<float>(-M_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<float>(-F_PI));
+    EXPECT_NEAR    (-sqrt1_2f,  fast::sin<float>(-F_PI_2 - F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::sin<float>(-F_PI_2));
+    EXPECT_NEAR    (-sqrt1_2f,  fast::sin<float>(-F_PI_4), abs_error);
     EXPECT_FLOAT_EQ( 0.0f,      fast::sin<float>(0.0));
-    EXPECT_NEAR    ( sqrt1_2f,  fast::sin<float>(M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 1.0f,      fast::sin<float>(M_PI_2));
-    EXPECT_NEAR    ( sqrt1_2f,  fast::sin<float>(M_PI_2 + M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<float>(M_PI));
+    EXPECT_NEAR    ( sqrt1_2f,  fast::sin<float>(F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 1.0f,      fast::sin<float>(F_PI_2));
+    EXPECT_NEAR    ( sqrt1_2f,  fast::sin<float>(F_PI_2 + F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<float>(F_PI));
 
-    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<float>(-M_PI));
-    EXPECT_NEAR    (-sqrt1_2f,  fast::cos<float>(-M_PI_2 - M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<float>(-M_PI_2));
-    EXPECT_NEAR    (sqrt1_2f,   fast::cos<float>(-M_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<float>(-F_PI));
+    EXPECT_NEAR    (-sqrt1_2f,  fast::cos<float>(-F_PI_2 - F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<float>(-F_PI_2));
+    EXPECT_NEAR    (sqrt1_2f,   fast::cos<float>(-F_PI_4), abs_error);
     EXPECT_FLOAT_EQ( 1.0f,      fast::cos<float>(0.0));
-    EXPECT_NEAR    (sqrt1_2f,   fast::cos<float>(M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<float>(M_PI_2));
-    EXPECT_NEAR    (-sqrt1_2f,  fast::cos<float>(M_PI_2 + M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<float>(M_PI));
+    EXPECT_NEAR    (sqrt1_2f,   fast::cos<float>(F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<float>(F_PI_2));
+    EXPECT_NEAR    (-sqrt1_2f,  fast::cos<float>(F_PI_2 + F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<float>(F_PI));
 
-    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<double>(-M_PI));
-    EXPECT_NEAR    (-sqrt1_2d,  fast::sin<double>(-M_PI_2 - M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ(-1.0f,      fast::sin<double>(-M_PI_2));
-    EXPECT_NEAR    (-sqrt1_2d,  fast::sin<double>(-M_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<double>(-F_PI));
+    EXPECT_NEAR    (-sqrt1_2d,  fast::sin<double>(-F_PI_2 - F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::sin<double>(-F_PI_2));
+    EXPECT_NEAR    (-sqrt1_2d,  fast::sin<double>(-F_PI_4), abs_error);
     EXPECT_FLOAT_EQ( 0.0f,      fast::sin<double>(0.0));
-    EXPECT_NEAR    ( sqrt1_2d,  fast::sin<double>(M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 1.0f,      fast::sin<double>(M_PI_2));
-    EXPECT_NEAR    ( sqrt1_2d,  fast::sin<double>(M_PI_2 + M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<double>(M_PI));
+    EXPECT_NEAR    ( sqrt1_2d,  fast::sin<double>(F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 1.0f,      fast::sin<double>(F_PI_2));
+    EXPECT_NEAR    ( sqrt1_2d,  fast::sin<double>(F_PI_2 + F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::sin<double>(F_PI));
 
-    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<double>(-M_PI));
-    EXPECT_NEAR    (-sqrt1_2d,  fast::cos<double>(-M_PI_2 - M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<double>(-M_PI_2));
-    EXPECT_NEAR    (sqrt1_2d,   fast::cos<double>(-M_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<double>(-F_PI));
+    EXPECT_NEAR    (-sqrt1_2d,  fast::cos<double>(-F_PI_2 - F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<double>(-F_PI_2));
+    EXPECT_NEAR    (sqrt1_2d,   fast::cos<double>(-F_PI_4), abs_error);
     EXPECT_FLOAT_EQ( 1.0f,      fast::cos<double>(0.0));
-    EXPECT_NEAR    (sqrt1_2d,   fast::cos<double>(M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<double>(M_PI_2));
-    EXPECT_NEAR    (-sqrt1_2d,  fast::cos<double>(M_PI_2 + M_PI_4), abs_error);
-    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<double>(M_PI));
+    EXPECT_NEAR    (sqrt1_2d,   fast::cos<double>(F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ( 0.0f,      fast::cos<double>(F_PI_2));
+    EXPECT_NEAR    (-sqrt1_2d,  fast::cos<double>(F_PI_2 + F_PI_4), abs_error);
+    EXPECT_FLOAT_EQ(-1.0f,      fast::cos<double>(F_PI));
 }

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -24,6 +24,7 @@
 #include <math/mat4.h>
 #include <math/mat3.h>
 #include <math/quat.h>
+#include <math/scalar.h>
 
 using namespace filament::math;
 
@@ -32,7 +33,7 @@ protected:
 };
 
 TEST_F(MatTest, ConstexprMat2) {
-    constexpr float a = M_PI;
+    constexpr float a = F_PI;
     constexpr mat2f M;
     constexpr mat2f M0(a);
     constexpr mat2f M1(float2{a, a});
@@ -55,7 +56,7 @@ TEST_F(MatTest, ConstexprMat2) {
 }
 
 TEST_F(MatTest, ConstexprMat3) {
-    constexpr float a = M_PI;
+    constexpr float a = F_PI;
     constexpr mat3f M;
     constexpr mat3f M0(a);
     constexpr mat3f M1(float3{a, a, a});
@@ -77,7 +78,7 @@ TEST_F(MatTest, ConstexprMat3) {
 }
 
 TEST_F(MatTest, ConstexprMat4) {
-    constexpr float a = M_PI;
+    constexpr float a = F_PI;
     constexpr mat4f M;
     constexpr mat4f M0(a);
     constexpr mat4f M1(float4{a, a, a, a});
@@ -662,7 +663,7 @@ TYPED_TEST(MatTestT, EulerZYX_44) {
     typedef filament::math::details::TMat44<TypeParam> M44T;
 
     std::default_random_engine generator(82828); // NOLINT
-    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*M_PI, 6.0 * 2.0*M_PI);
+    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*F_PI, 6.0 * 2.0*F_PI);
     auto rand_gen = std::bind(distribution, generator);
 
     for (size_t i = 0; i < 100; ++i) {
@@ -681,7 +682,7 @@ TYPED_TEST(MatTestT, EulerZYX_33) {
     typedef filament::math::details::TMat33<TypeParam> M33T;
 
     std::default_random_engine generator(112233); // NOLINT
-    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*M_PI, 6.0 * 2.0*M_PI);
+    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*F_PI, 6.0 * 2.0*F_PI);
     auto rand_gen = std::bind(distribution, generator);
 
     for (size_t i = 0; i < 100; ++i) {
@@ -702,7 +703,7 @@ TYPED_TEST(MatTestT, ToQuaternionPostTranslation) {
     typedef filament::math::details::TQuaternion<TypeParam> QuatT;
 
     std::default_random_engine generator(112233); // NOLINT
-    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*M_PI, 6.0 * 2.0*M_PI);
+    std::uniform_real_distribution<TypeParam> distribution(-6.0 * 2.0*F_PI, 6.0 * 2.0*F_PI);
     auto rand_gen = std::bind(distribution, generator);
 
     for (size_t i = 0; i < 100; ++i) {

--- a/libs/math/tests/test_quat.cpp
+++ b/libs/math/tests/test_quat.cpp
@@ -24,6 +24,7 @@
 #include <math/mat4.h>
 #include <math/vec4.h>
 #include <math/vec3.h>
+#include <math/scalar.h>
 
 using namespace filament::math;
 
@@ -235,7 +236,7 @@ TEST_F(QuatTest, ArithmeticFunc) {
     EXPECT_DOUBLE_EQ(1, length(qn));
     EXPECT_DOUBLE_EQ(1, dot(qn, qn));
 
-    quat qr = quat::fromAxisAngle(double3(0, 0, 1), M_PI / 2);
+    quat qr = quat::fromAxisAngle(double3(0, 0, 1), F_PI / 2);
     EXPECT_EQ(mat4(qr).toQuaternion(), qr);
     EXPECT_EQ(1_i, mat4(1_i).toQuaternion());
     EXPECT_EQ(1_j, mat4(1_j).toQuaternion());
@@ -252,9 +253,9 @@ TEST_F(QuatTest, ArithmeticFunc) {
     EXPECT_NEAR(qq.w, q2.w, 1e-15);
 
     quat qa = quat::fromAxisAngle(double3(0, 0, 1), 0);
-    quat qb = quat::fromAxisAngle(double3(0, 0, 1), M_PI / 2);
+    quat qb = quat::fromAxisAngle(double3(0, 0, 1), F_PI / 2);
     quat qs = slerp(qa, qb, 0.5);
-    qr = quat::fromAxisAngle(double3(0, 0, 1), M_PI / 4);
+    qr = quat::fromAxisAngle(double3(0, 0, 1), F_PI / 4);
     EXPECT_DOUBLE_EQ(qr.x, qs.x);
     EXPECT_DOUBLE_EQ(qr.y, qs.y);
     EXPECT_DOUBLE_EQ(qr.z, qs.z);

--- a/libs/math/tests/test_vec.cpp
+++ b/libs/math/tests/test_vec.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <math/vec4.h>
+#include <math/scalar.h>
 
 using namespace filament::math;
 
@@ -27,7 +28,7 @@ protected:
 };
 
 TEST_F(VecTest, Constexpr) {
-    constexpr float a = M_PI;
+    constexpr float a = F_PI;
     constexpr float2 Z2{};
     constexpr float2 A2 = a;
     constexpr float2 B2 = { a, a };

--- a/libs/rays/src/PathTracer.cpp
+++ b/libs/rays/src/PathTracer.cpp
@@ -20,6 +20,7 @@
 #include <image/LinearImage.h>
 
 #include <math/mat4.h>
+#include <math/scalar.h>
 #include <math/vec2.h>
 
 #include <utils/JobSystem.h>
@@ -52,7 +53,7 @@ struct PixelRectangle {
 // TODO: the following two functions should be shared with libs/ibl
 
 static double3 hemisphereCosSample(double2 u) {
-    const double phi = 2 * M_PI * u.x;
+    const double phi = 2 * F_PI * u.x;
     const double cosTheta2 = 1 - u.y;
     const double cosTheta = std::sqrt(cosTheta2);
     const double sinTheta = std::sqrt(1 - cosTheta2);
@@ -167,7 +168,7 @@ static void renderTile(EmbreeContext* context, PixelRectangle rect) {
     const float tfar = context->config.aoRayFar;
     const float iw = 1.0f / ao.getWidth();
     const float ih = 1.0f / ao.getHeight();
-    const float theta = camera.vfovDegrees * M_PI / 180;
+    const float theta = camera.vfovDegrees * F_PI / 180;
     const float f = tanf(theta / 2);
     const float a = camera.aspectRatio;
     const float3 org = camera.eyePosition;

--- a/tools/skygen/src/main.cpp
+++ b/tools/skygen/src/main.cpp
@@ -86,8 +86,8 @@ static float angleBetween(float thetav, float phiv, float theta, float phi) {
 
 static void generateSky(LinearImage image) {
     printf("Sky parameters\n");
-    printf("    Elevation: %.2f°\n", g_elevation * 180.0 * M_1_PI);
-    printf("    Azimuth:   %.2f°\n", g_azimuth * 180.0 * M_1_PI);
+    printf("    Elevation: %.2f°\n", g_elevation * 180.0 * F_1_PI);
+    printf("    Azimuth:   %.2f°\n", g_azimuth * 180.0 * F_1_PI);
     printf("    Turbidity: %.2f\n", g_turbidity);
     printf("\n");
 
@@ -95,8 +95,8 @@ static void generateSky(LinearImage image) {
         std::vector<float> maximas;
         std::mutex maximasMutex;
 
-        float solarElevation = clamp(g_elevation, 0.0f, float(M_PI_2));
-        float sunTheta = float(M_PI_2 - solarElevation);
+        float solarElevation = clamp(g_elevation, 0.0f, float(F_PI_2));
+        float sunTheta = float(F_PI_2 - solarElevation);
         float sunPhi = 0.0f;
 
         float3 integral = 0.0f;
@@ -128,14 +128,14 @@ static void generateSky(LinearImage image) {
                 float3* UTILS_RESTRICT data = image.get<float3>(0, (uint32_t) y);
 
                 float v = (y + 0.5f) / h;
-                float theta = float(M_PI * v);
-                if (theta > M_PI_2) return;
+                float theta = float(F_PI * v);
+                if (theta > F_PI_2) return;
 
                 float integralDelta = sin(theta) / (w * h / 2.0f);
 
                 for (size_t x = 0; x < w; x++, data++) {
                     float u = (x + 0.5f) / w;
-                    float phi = float(-2.0 * M_PI * u + M_PI + g_azimuth);
+                    float phi = float(-2.0 * F_PI * u + F_PI + g_azimuth);
 
                     float gamma = angleBetween(theta, phi, jobData.sunTheta, jobData.sunPhi);
 
@@ -146,7 +146,7 @@ static void generateSky(LinearImage image) {
                     };
 
                     if (g_normalize) {
-                        sample *= float(4.0 * M_PI / 683.0);
+                        sample *= float(4.0 * F_PI / 683.0);
                     }
 
                     maxSample = std::max(maxSample, sample.y);
@@ -196,7 +196,7 @@ static void generateSky(LinearImage image) {
             }
             break;
     }
-    if (g_normalize) maxValue /= float(4.0 * M_PI / 683.0);
+    if (g_normalize) maxValue /= float(4.0 * F_PI / 683.0);
 
     const size_t w = image.getWidth();
     const size_t h = image.getHeight();
@@ -223,7 +223,7 @@ static void generateSky(LinearImage image) {
     printf("Information\n");
     printf("    Max radiance:    %.2f W/(m^2.sr.nm)\n", maxValue);
     printf("    Max luminance:   %.2f nt\n", maxValue * 683.0f);
-    printf("    Max illuminance: %.2f lx\n", maxValue * 683.0f * 2.0 * M_PI);
+    printf("    Max illuminance: %.2f lx\n", maxValue * 683.0f * 2.0 * F_PI);
     printf("\n");
 
     printf("Rendering parameters\n");
@@ -366,10 +366,10 @@ static int handleArguments(int argc, char* argv[]) {
                 g_turbidity = clamp(strtof(arg.c_str(), nullptr), 1.0f, 11.0f);
                 break;
             case 'e':
-                g_elevation = (float) (strtof(arg.c_str(), nullptr) * M_PI / 180.0);
+                g_elevation = (float) (strtof(arg.c_str(), nullptr) * F_PI / 180.0);
                 break;
             case 'a':
-                g_azimuth = (float) (strtof(arg.c_str(), nullptr) * M_PI / 180.0);
+                g_azimuth = (float) (strtof(arg.c_str(), nullptr) * F_PI / 180.0);
                 break;
             case 'g':
                 g_groundAlbedo = clamp(strtof(arg.c_str(), nullptr), 0.0f, 1.0f);

--- a/tools/specular-color/src/main.cpp
+++ b/tools/specular-color/src/main.cpp
@@ -790,7 +790,7 @@ static Reflectance computeColor(const std::vector<Sample>& samples) {
 
     // We default to 81.7° but this can be specified by the user, so we use the
     // notation theta82/f81 in the code
-    float cosTheta82 = std::cos(g_incidenceAngle * M_PI / 180.0f);
+    float cosTheta82 = std::cos(g_incidenceAngle * F_PI / 180.0f);
 
     // We need to evaluate the Fresnel equation at each spectral sample of
     // complex IOR over the visible spectrum. For each spectral sample, we
@@ -805,7 +805,7 @@ static Reflectance computeColor(const std::vector<Sample>& samples) {
     // yields a linear sRGB color.
     for (size_t i = 0; i < CIE_XYZ_COUNT; i++) {
         // Current wavelength
-        float w = CIE_XYZ_START + i;
+        float w = float(CIE_XYZ_START + i);
 
         // Find most appropriate CIE XYZ sample for the wavelength
         auto sample = findSample(samples, w);


### PR DESCRIPTION
These constants are not part of the standard and not guaranteed to be part of `math.h`.
We instead use our own constexpr definitions in the filament::math namespace, as part of
the scalar.h include. To avoid conflicts, our definitions are named `F_*` instead of `M_*`.