### PR TITLE
OpenGL driver: fix error with uvec4 attribs, clean up Vulkan/Metal.

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -198,12 +198,8 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
     uint32_t bufferIndex = 0;
     for (uint32_t attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++) {
         if (!(enabledAttributes & (1U << attributeIndex))) {
-            // TODO: all vertex attributes are vec4 (vector of floats), except for
-            // mesh_bone_indices, which is a uvec4 (vector of unsigned integers).
-            // We must use the correct format, but ideally the Metal driver should not need to know
-            // this.
-            const auto boneIndicesLocation = 5; // VertexAttribute::BONE_INDICES
-            const MTLVertexFormat format = attributeIndex == boneIndicesLocation ?
+            const uint8_t flags = vertexBuffer->attributes[attributeIndex].flags;
+            const MTLVertexFormat format = (flags & Attribute::FLAG_INTEGER_TARGET) ?
                     MTLVertexFormatUInt4 : MTLVertexFormatFloat4;
 
             // If the attribute is not enabled, bind it to the zero buffer. It's a Metal error for a

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -470,11 +470,11 @@ Handle<HwStream> OpenGLDriver::createStreamFromTextureIdS() noexcept {
 
 void OpenGLDriver::createVertexBufferR(
         Handle<HwVertexBuffer> vbh,
-    uint8_t bufferCount,
-    uint8_t attributeCount,
-    uint32_t elementCount,
-    AttributeArray attributes,
-    BufferUsage usage) {
+        uint8_t bufferCount,
+        uint8_t attributeCount,
+        uint32_t elementCount,
+        AttributeArray attributes,
+        BufferUsage usage) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
@@ -2032,6 +2032,15 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
 
                 gl.enableVertexAttribArray(GLuint(i));
             } else {
+
+                // In some OpenGL implementations, we must supply a properly-typed placeholder for
+                // every integer input that is declared in the vertex shader.
+                if (UTILS_UNLIKELY(eb->attributes[i].flags & Attribute::FLAG_INTEGER_TARGET)) {
+                    glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
+                } else {
+                    glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);
+                }
+
                 gl.disableVertexAttribArray(GLuint(i));
             }
         }

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -597,12 +597,9 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
         // be consumed by the shader.
         if (!(enabledAttributes & (1U << attribIndex))) {
 
-            // TODO: all vertex attributes are floats, except for mesh_bone_indices, which are
-            // unsigned integers. Ideally the Vulkan backend would not need to know about this.
-            const uint32_t kBoneIndicesLocation = 5; // VertexAttribute::BONE_INDICES
-            vkformat = attribIndex == kBoneIndicesLocation ? VK_FORMAT_R8G8B8A8_UINT : vkformat;
+            const bool isInteger = attrib.flags & Attribute::FLAG_INTEGER_TARGET;
+            vkformat = isInteger ? VK_FORMAT_R8G8B8A8_UINT : vkformat;
 
-            // TODO: avoid using dummy buffers by adding the concept of frozen renderables.
             if (UTILS_LIKELY(enabledAttributes & 1)) {
                 attrib = vertexBuffer->attributes[0];
             } else {

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -43,10 +43,6 @@ struct VertexBuffer::BuilderDetails {
     uint8_t mBufferCount = 0;
 };
 
-static bool hasIntegerTarget(VertexAttribute attribute) {
-    return attribute == BONE_INDICES;
-}
-
 using BuilderType = VertexBuffer;
 BuilderType::Builder::Builder() noexcept = default;
 BuilderType::Builder::~Builder() noexcept = default;
@@ -95,9 +91,6 @@ VertexBuffer::Builder& VertexBuffer::Builder::attribute(VertexAttribute attribut
         entry.offset = byteOffset;
         entry.stride = byteStride;
         entry.type = attributeType;
-        if (hasIntegerTarget(attribute)) {
-            entry.flags |= Attribute::FLAG_INTEGER_TARGET;
-        }
         mImpl->mDeclaredAttributes.set(attribute);
     }
     return *this;
@@ -139,6 +132,10 @@ namespace details {
 FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& builder)
         : mVertexCount(builder->mVertexCount), mBufferCount(builder->mBufferCount) {
     std::copy(std::begin(builder->mAttributes), std::end(builder->mAttributes), mAttributes.begin());
+
+    // Backends do not (and should not) know the semantics of each vertex attribute, but they
+    // need to know whether the vertex shader consumes them as integers or as floats.
+    mAttributes[BONE_INDICES].flags |= Attribute::FLAG_INTEGER_TARGET;
 
     mDeclaredAttributes = builder->mDeclaredAttributes;
     uint8_t attributeCount = (uint8_t) mDeclaredAttributes.count();


### PR DESCRIPTION
The vertex shader in the material variant for skinning-and-morphing
declares a `uvec4` attribute that can be unused and disabled, but still
needs to be typed correctly.

The fix is motivated by WebGL, but the issue might occur with other
OpenGL implementations that have strict drivers.

Fixes #1726