### PR TITLE
validate Engine in all Builder::build() methods

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -94,7 +94,6 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
             instance->mOwnPlatform = true;
         }
         instance->mDriver = platform->createDriver(sharedGLContext);
-        instance->execute();
     } else {
         // start the driver thread
         instance->mDriverThread = std::thread(&FEngine::loop, instance);

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -48,6 +48,7 @@ IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noex
 }
 
 IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     return upcast(engine).createIndexBuffer(*this);
 }
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -148,6 +148,7 @@ IndirectLight::Builder& IndirectLight::Builder::rotation(mat3f const& rotation) 
 }
 
 IndirectLight* IndirectLight::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     if (mImpl->mReflectionsMap) {
         if (!ASSERT_POSTCONDITION_NON_FATAL(
                 mImpl->mReflectionsMap->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP,

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -73,6 +73,7 @@ Material::Builder& Material::Builder::package(const void* payload, size_t size) 
 }
 
 Material* Material::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     MaterialParser* materialParser = FMaterial::createParser(
             upcast(engine).getBackend(), mImpl->mPayload, mImpl->mSize);
 

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -61,6 +61,7 @@ RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t
 }
 
 RenderTarget* RenderTarget::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     using backend::TextureUsage;
     const FRenderTarget::Attachment& color = mImpl->mAttachments[COLOR];
     const FRenderTarget::Attachment& depth = mImpl->mAttachments[DEPTH];

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -69,6 +69,7 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
 }
 
 Skybox* Skybox::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
 
     if (!ASSERT_PRECONDITION_NON_FATAL(cubemap, "environment texture not set")) {

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -69,7 +69,7 @@ Stream::Builder& Stream::Builder::height(uint32_t height) noexcept {
 }
 
 Stream* Stream::Builder::build(Engine& engine) {
-
+    FEngine::assertValid(engine);
     if (!ASSERT_PRECONDITION_NON_FATAL(!mImpl->mStream || !mImpl->mExternalTextureId,
             "One and only one of the stream or external texture can be specified")) {
         return nullptr;

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -92,6 +92,7 @@ Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
 }
 
 Texture* Texture::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     if (!ASSERT_POSTCONDITION_NON_FATAL(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
             "Texture format %u not supported on this platform", mImpl->mFormat)) {
         return nullptr;

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -110,10 +110,10 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
 }
 
 VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
+    FEngine::assertValid(engine);
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mVertexCount > 0, "vertexCount cannot be 0")) {
         return nullptr;
     }
-
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount > 0, "bufferCount cannot be 0")) {
         return nullptr;
     }

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -130,6 +130,7 @@ LightManager::Builder& LightManager::Builder::sunHaloFalloff(float haloFalloff) 
 }
 
 LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entity entity) {
+    FEngine::assertValid(engine);
     upcast(engine).createLight(*this, entity);
     return Success;
 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -167,6 +167,7 @@ RenderableManager::Builder& RenderableManager::Builder::blendOrder(size_t index,
 }
 
 RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity entity) {
+    FEngine::assertValid(engine);
     bool isEmpty = true;
 
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -132,6 +132,8 @@ public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
             Platform* platform = nullptr, void* sharedGLContext = nullptr);
 
+    static void assertValid(Engine const& engine);
+
     ~FEngine() noexcept;
 
     backend::Driver& getDriver() const noexcept { return *mDriver; }


### PR DESCRIPTION
We now assert if the Engine given is invalid,
which would happen if it was used after being
destroyed.

Builder::build() is a reasonable place for this since it's generally
not in the critical path.