### PR TITLE
noexcept-ize libmath a bit more

### DIFF
--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -107,7 +107,7 @@ private:
 
 public:
     // array access
-    inline constexpr col_type const& operator[](size_t column) const {
+    inline constexpr col_type const& operator[](size_t column) const noexcept {
 #if __cplusplus >= 201402L
         // only possible in C++0x14 with constexpr
         assert(column < NUM_COLS);
@@ -115,7 +115,7 @@ public:
         return m_value[column];
     }
 
-    inline constexpr col_type& operator[](size_t column) {
+    inline constexpr col_type& operator[](size_t column) noexcept {
         assert(column < NUM_COLS);
         return m_value[column];
     }
@@ -127,7 +127,7 @@ public:
     /**
      * leaves object uninitialized. use with caution.
      */
-    constexpr explicit TMat22(no_init) {}
+    constexpr explicit TMat22(no_init) noexcept {}
 
 
     /**
@@ -142,7 +142,7 @@ public:
      *      \right)
      *      \f$
      */
-    constexpr TMat22();
+    constexpr TMat22() noexcept ;
 
     /**
      * initialize to Identity*scalar.
@@ -157,7 +157,7 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat22(U v);
+    constexpr explicit TMat22(U v) noexcept;
 
     /**
      * sets the diagonal to a vector.
@@ -172,13 +172,13 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat22(const TVec2<U>& v);
+    constexpr explicit TMat22(const TVec2<U>& v) noexcept;
 
     /**
      * construct from another matrix of the same size
      */
     template<typename U>
-    constexpr explicit TMat22(const TMat22<U>& rhs);
+    constexpr explicit TMat22(const TMat22<U>& rhs) noexcept;
 
     /**
      * construct from 2 column vectors.
@@ -192,7 +192,7 @@ public:
      *      \f$
      */
     template<typename A, typename B>
-    constexpr TMat22(const TVec2<A>& v0, const TVec2<B>& v1);
+    constexpr TMat22(const TVec2<A>& v0, const TVec2<B>& v1) noexcept;
 
     /** construct from 4 elements in column-major form.
      *
@@ -208,30 +208,26 @@ public:
     template<
             typename A, typename B,
             typename C, typename D>
-    constexpr explicit TMat22(A m00, B m01,
-            C m10, D m11);
+    constexpr explicit TMat22(A m00, B m01, C m10, D m11) noexcept ;
 
 
     struct row_major_init {
-        template<
-                typename A, typename B,
+        template<typename A, typename B,
                 typename C, typename D>
-        constexpr explicit row_major_init(A m00, B m01,
-                C m10, D m11) noexcept
-                : m(m00, m10,
-                m01, m11) {}
+        constexpr explicit row_major_init(A m00, B m01, C m10, D m11) noexcept
+                : m(m00, m10, m01, m11) {}
 
     private:
         friend TMat22;
         TMat22 m;
     };
 
-    constexpr explicit TMat22(row_major_init c) : TMat22(std::move(c.m)) {}
+    constexpr explicit TMat22(row_major_init c) noexcept : TMat22(std::move(c.m)) {}
 
     /**
      * Rotate by radians in the 2D plane
      */
-    static TMat22<T> rotate(T radian) {
+    static TMat22<T> rotate(T radian) noexcept {
         TMat22<T> r(TMat22<T>::NO_INIT);
         T c = std::cos(radian);
         T s = std::sin(radian);
@@ -258,19 +254,19 @@ public:
     }
 
     template<typename A>
-    static constexpr TMat22 translation(const TVec2<A>& t) {
+    static constexpr TMat22 translation(const TVec2<A>& t) noexcept {
         TMat22 r;
         r[2] = t;
         return r;
     }
 
     template<typename A>
-    static constexpr TMat22 scaling(const TVec2<A>& s) {
+    static constexpr TMat22 scaling(const TVec2<A>& s) noexcept {
         return TMat22{ s };
     }
 
     template<typename A>
-    static constexpr TMat22 scaling(A s) {
+    static constexpr TMat22 scaling(A s) noexcept {
         return TMat22{ TVec2<T>{ s, s }};
     }
 };
@@ -283,19 +279,19 @@ public:
 // operations.
 
 template<typename T>
-constexpr TMat22<T>::TMat22()
+constexpr TMat22<T>::TMat22() noexcept
         : m_value{ col_type(1, 0), col_type(0, 1) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat22<T>::TMat22(U v)
+constexpr TMat22<T>::TMat22(U v) noexcept
         : m_value{ col_type(v, 0), col_type(0, v) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat22<T>::TMat22(const TVec2<U>& v)
+constexpr TMat22<T>::TMat22(const TVec2<U>& v) noexcept
         : m_value{ col_type(v[0], 0), col_type(0, v[1]) } {
 }
 
@@ -303,16 +299,15 @@ constexpr TMat22<T>::TMat22(const TVec2<U>& v)
 // of values in the constructor is the transpose of the matrix
 // notation.
 template<typename T>
-template<
-        typename A, typename B,
+template<typename A, typename B,
         typename C, typename D>
-constexpr TMat22<T>::TMat22(A m00, B m01, C m10, D m11)
+constexpr TMat22<T>::TMat22(A m00, B m01, C m10, D m11) noexcept
         : m_value{ col_type(m00, m01), col_type(m10, m11) } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat22<T>::TMat22(const TMat22<U>& rhs) {
+constexpr TMat22<T>::TMat22(const TMat22<U>& rhs) noexcept {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
     }
@@ -321,7 +316,7 @@ constexpr TMat22<T>::TMat22(const TMat22<U>& rhs) {
 // Construct from 2 column vectors.
 template<typename T>
 template<typename A, typename B>
-constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1)
+constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1) noexcept
         : m_value{ v0, v1 } {
 }
 
@@ -331,7 +326,7 @@ constexpr TMat22<T>::TMat22(const TVec2<A>& v0, const TVec2<B>& v1)
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat22<T>::col_type MATH_PURE diag(const TMat22<T>& m) {
+constexpr typename TMat22<T>::col_type MATH_PURE diag(const TMat22<T>& m) noexcept {
     return matrix::diag(m);
 }
 

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -113,13 +113,13 @@ private:
 
 public:
     // array access
-    inline constexpr col_type const& operator[](size_t column) const {
+    inline constexpr col_type const& operator[](size_t column) const noexcept {
         // only possible in C++0x14 with constexpr
         assert(column < NUM_COLS);
         return m_value[column];
     }
 
-    inline constexpr col_type& operator[](size_t column) {
+    inline constexpr col_type& operator[](size_t column) noexcept {
         assert(column < NUM_COLS);
         return m_value[column];
     }
@@ -131,7 +131,7 @@ public:
     /**
      * leaves object uninitialized. use with caution.
      */
-    constexpr explicit TMat33(no_init) {}
+    constexpr explicit TMat33(no_init) noexcept {}
 
 
     /**
@@ -147,7 +147,7 @@ public:
      *      \right)
      *      \f$
      */
-    constexpr TMat33();
+    constexpr TMat33() noexcept;
 
     /**
      * initialize to Identity*scalar.
@@ -163,7 +163,7 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat33(U v);
+    constexpr explicit TMat33(U v) noexcept;
 
     /**
      * sets the diagonal to a vector.
@@ -179,13 +179,13 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat33(const TVec3<U>& v);
+    constexpr explicit TMat33(const TVec3<U>& v) noexcept;
 
     /**
      * construct from another matrix of the same size
      */
     template<typename U>
-    constexpr explicit TMat33(const TMat33<U>& rhs);
+    constexpr explicit TMat33(const TMat33<U>& rhs) noexcept;
 
     /**
      * construct from 3 column vectors.
@@ -199,7 +199,7 @@ public:
      *      \f$
      */
     template<typename A, typename B, typename C>
-    constexpr TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2);
+    constexpr TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2) noexcept;
 
     /** construct from 9 elements in column-major form.
      *
@@ -219,7 +219,7 @@ public:
             typename G, typename H, typename I>
     constexpr explicit TMat33(A m00, B m01, C m02,
             D m10, E m11, F m12,
-            G m20, H m21, I m22);
+            G m20, H m21, I m22) noexcept;
 
 
     struct row_major_init {
@@ -239,19 +239,19 @@ public:
         TMat33 m;
     };
 
-    constexpr explicit TMat33(row_major_init c) : TMat33(std::move(c.m)) {}
+    constexpr explicit TMat33(row_major_init c) noexcept : TMat33(std::move(c.m)) {}
 
     /**
      * construct from a quaternion
      */
     template<typename U>
-    constexpr explicit TMat33(const TQuaternion<U>& q);
+    constexpr explicit TMat33(const TQuaternion<U>& q) noexcept;
 
     /**
      * orthogonalize only works on matrices of size 3x3
      */
     friend inline
-    constexpr TMat33 orthogonalize(const TMat33& m) {
+    constexpr TMat33 orthogonalize(const TMat33& m) noexcept {
         TMat33 ret(TMat33::NO_INIT);
         ret[0] = normalize(m[0]);
         ret[2] = normalize(cross(ret[0], m[1]));
@@ -281,22 +281,22 @@ public:
      * vector.
      */
     static constexpr TQuaternion<T> packTangentFrame(
-            const TMat33& m, size_t storageSize = sizeof(int16_t));
+            const TMat33& m, size_t storageSize = sizeof(int16_t)) noexcept;
 
     template<typename A>
-    static constexpr TMat33 translation(const TVec3<A>& t) {
+    static constexpr TMat33 translation(const TVec3<A>& t) noexcept {
         TMat33 r;
         r[2] = t;
         return r;
     }
 
     template<typename A>
-    static constexpr TMat33 scaling(const TVec3<A>& s) {
+    static constexpr TMat33 scaling(const TVec3<A>& s) noexcept {
         return TMat33{ s };
     }
 
     template<typename A>
-    static constexpr TMat33 scaling(A s) {
+    static constexpr TMat33 scaling(A s) noexcept {
         return TMat33{ TVec3<T>{ s }};
     }
 };
@@ -309,7 +309,7 @@ public:
 // operations.
 
 template<typename T>
-constexpr TMat33<T>::TMat33()
+constexpr TMat33<T>::TMat33() noexcept
         : m_value{
         col_type(1, 0, 0),
         col_type(0, 1, 0),
@@ -318,7 +318,7 @@ constexpr TMat33<T>::TMat33()
 
 template<typename T>
 template<typename U>
-constexpr TMat33<T>::TMat33(U v)
+constexpr TMat33<T>::TMat33(U v) noexcept
         : m_value{
         col_type(v, 0, 0),
         col_type(0, v, 0),
@@ -327,7 +327,7 @@ constexpr TMat33<T>::TMat33(U v)
 
 template<typename T>
 template<typename U>
-constexpr TMat33<T>::TMat33(const TVec3<U>& v)
+constexpr TMat33<T>::TMat33(const TVec3<U>& v) noexcept
         : m_value{
         col_type(v[0], 0, 0),
         col_type(0, v[1], 0),
@@ -344,7 +344,7 @@ template<
         typename G, typename H, typename I>
 constexpr TMat33<T>::TMat33(A m00, B m01, C m02,
         D m10, E m11, F m12,
-        G m20, H m21, I m22)
+        G m20, H m21, I m22) noexcept
         : m_value{
         col_type(m00, m01, m02),
         col_type(m10, m11, m12),
@@ -353,7 +353,7 @@ constexpr TMat33<T>::TMat33(A m00, B m01, C m02,
 
 template<typename T>
 template<typename U>
-constexpr TMat33<T>::TMat33(const TMat33<U>& rhs) {
+constexpr TMat33<T>::TMat33(const TMat33<U>& rhs) noexcept {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
     }
@@ -362,13 +362,13 @@ constexpr TMat33<T>::TMat33(const TMat33<U>& rhs) {
 // Construct from 3 column vectors.
 template<typename T>
 template<typename A, typename B, typename C>
-constexpr TMat33<T>::TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2)
+constexpr TMat33<T>::TMat33(const TVec3<A>& v0, const TVec3<B>& v1, const TVec3<C>& v2) noexcept
         : m_value{ v0, v1, v2 } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) : m_value{} {
+constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) noexcept : m_value{} {
     const U n = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
     const U s = n > 0 ? 2 / n : 0;
     const U x = s * q.x;
@@ -390,7 +390,7 @@ constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) : m_value{} {
 
 //------------------------------------------------------------------------------
 template<typename T>
-constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t storageSize) {
+constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t storageSize) noexcept {
     TQuaternion<T> q = TMat33<T>{ m[0], cross(m[2], m[0]), m[2] }.toQuaternion();
     q = positive(normalize(q));
 
@@ -418,7 +418,7 @@ constexpr TQuaternion<T> TMat33<T>::packTangentFrame(const TMat33<T>& m, size_t 
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat33<T>::col_type MATH_PURE diag(const TMat33<T>& m) {
+constexpr typename TMat33<T>::col_type MATH_PURE diag(const TMat33<T>& m) noexcept {
     return matrix::diag(m);
 }
 

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -17,12 +17,13 @@
 #ifndef MATH_MAT4_H_
 #define MATH_MAT4_H_
 
+#include <math/compiler.h>
 #include <math/mat3.h>
 #include <math/quat.h>
+#include <math/scalar.h>
 #include <math/TMatHelpers.h>
 #include <math/vec3.h>
 #include <math/vec4.h>
-#include <math/compiler.h>
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -32,9 +33,6 @@ namespace filament {
 namespace math {
 // -------------------------------------------------------------------------------------
 namespace details {
-
-// Define PI here for compatibility with MSVC.
-static constexpr double PI = 3.14159265358979323846;
 
 template<typename T>
 class TQuaternion;
@@ -123,13 +121,13 @@ private:
 
 public:
     // array access
-    inline constexpr col_type const& operator[](size_t column) const {
+    inline constexpr col_type const& operator[](size_t column) const noexcept {
         // only possible in C++0x14 with constexpr
         assert(column < NUM_COLS);
         return m_value[column];
     }
 
-    inline constexpr col_type& operator[](size_t column) {
+    inline constexpr col_type& operator[](size_t column) noexcept {
         assert(column < NUM_COLS);
         return m_value[column];
     }
@@ -139,7 +137,7 @@ public:
      */
 
     // leaves object uninitialized. use with caution.
-    constexpr explicit TMat44(no_init) {}
+    constexpr explicit TMat44(no_init) noexcept {}
 
     /** initialize to identity.
      *
@@ -154,7 +152,7 @@ public:
      *      \right)
      *      \f$
      */
-    constexpr TMat44();
+    constexpr TMat44() noexcept;
 
     /** initialize to Identity*scalar.
      *
@@ -170,7 +168,7 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat44(U v);
+    constexpr explicit TMat44(U v) noexcept;
 
     /** sets the diagonal to a vector.
      *
@@ -186,11 +184,11 @@ public:
      *      \f$
      */
     template<typename U>
-    constexpr explicit TMat44(const TVec4<U>& v);
+    constexpr explicit TMat44(const TVec4<U>& v) noexcept;
 
     // construct from another matrix of the same size
     template<typename U>
-    constexpr explicit TMat44(const TMat44<U>& rhs);
+    constexpr explicit TMat44(const TMat44<U>& rhs) noexcept;
 
     /** construct from 4 column vectors.
      *
@@ -204,7 +202,7 @@ public:
      */
     template<typename A, typename B, typename C, typename D>
     constexpr TMat44(const TVec4<A>& v0, const TVec4<B>& v1, const TVec4<C>& v2,
-            const TVec4<D>& v3);
+            const TVec4<D>& v3) noexcept;
 
     /** construct from 16 elements in column-major form.
      *
@@ -227,7 +225,7 @@ public:
     constexpr explicit TMat44(A m00, B m01, C m02, D m03,
             E m10, F m11, G m12, H m13,
             I m20, J m21, K m22, L m23,
-            M m30, N m31, O m32, P m33);
+            M m30, N m31, O m32, P m33) noexcept;
 
 
     struct row_major_init {
@@ -250,31 +248,31 @@ public:
         TMat44 m;
     };
 
-    constexpr explicit TMat44(row_major_init c) : TMat44(std::move(c.m)) {}
+    constexpr explicit TMat44(row_major_init c) noexcept : TMat44(std::move(c.m)) {}
 
     /**
      * construct from a quaternion
      */
     template<typename U>
-    constexpr explicit TMat44(const TQuaternion<U>& q);
+    constexpr explicit TMat44(const TQuaternion<U>& q) noexcept;
 
     /**
      * construct from a 3x3 matrix
      */
     template<typename U>
-    constexpr explicit TMat44(const TMat33<U>& matrix);
+    constexpr explicit TMat44(const TMat33<U>& matrix) noexcept;
 
     /**
      * construct from a 3x3 matrix and 3d translation
      */
     template<typename U, typename V>
-    constexpr TMat44(const TMat33<U>& matrix, const TVec3<V>& translation);
+    constexpr TMat44(const TMat33<U>& matrix, const TVec3<V>& translation) noexcept;
 
     /**
      * construct from a 3x3 matrix and 4d last column.
      */
     template<typename U, typename V>
-    constexpr TMat44(const TMat33<U>& matrix, const TVec4<V>& column3);
+    constexpr TMat44(const TMat33<U>& matrix, const TVec4<V>& column3) noexcept;
 
     /*
      *  helpers
@@ -294,27 +292,27 @@ public:
         return result != 0;
     }
 
-    static constexpr TMat44 ortho(T left, T right, T bottom, T top, T near, T far);
+    static constexpr TMat44 ortho(T left, T right, T bottom, T top, T near, T far) noexcept;
 
-    static constexpr TMat44 frustum(T left, T right, T bottom, T top, T near, T far);
+    static constexpr TMat44 frustum(T left, T right, T bottom, T top, T near, T far) noexcept;
 
     enum class Fov {
         HORIZONTAL,
         VERTICAL
     };
-    static TMat44 perspective(T fov, T aspect, T near, T far, Fov direction = Fov::VERTICAL);
+    static TMat44 perspective(T fov, T aspect, T near, T far, Fov direction = Fov::VERTICAL) noexcept;
 
     template<typename A, typename B, typename C>
-    static TMat44 lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up);
+    static TMat44 lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up) noexcept;
 
     template<typename A>
-    static constexpr TVec3<A> project(const TMat44& projectionMatrix, TVec3<A> vertice) {
+    static constexpr TVec3<A> project(const TMat44& projectionMatrix, TVec3<A> vertice) noexcept{
         TVec4<A> r = projectionMatrix * TVec4<A>{ vertice, 1 };
         return TVec3<A>{ r[0], r[1], r[2] } * (1 / r[3]);
     }
 
     template<typename A>
-    static constexpr TVec4<A> project(const TMat44& projectionMatrix, TVec4<A> vertice) {
+    static constexpr TVec4<A> project(const TMat44& projectionMatrix, TVec4<A> vertice) noexcept{
         vertice = projectionMatrix * vertice;
         return { TVec3<A>{ vertice[0], vertice[1], vertice[2] } * (1 / vertice[3]), 1 };
     }
@@ -322,7 +320,7 @@ public:
     /**
      * Constructs a 3x3 matrix from the upper-left corner of this 4x4 matrix
      */
-    inline constexpr TMat33<T> upperLeft() const {
+    inline constexpr TMat33<T> upperLeft() const noexcept {
         const TVec3<T> v0 = { m_value[0][0], m_value[0][1], m_value[0][2] };
         const TVec3<T> v1 = { m_value[1][0], m_value[1][1], m_value[1][2] };
         const TVec3<T> v2 = { m_value[2][0], m_value[2][1], m_value[2][2] };
@@ -330,19 +328,19 @@ public:
     }
 
     template<typename A>
-    static constexpr TMat44 translation(const TVec3<A>& t) {
+    static constexpr TMat44 translation(const TVec3<A>& t) noexcept {
         TMat44 r;
         r[3] = TVec4<T>{ t, 1 };
         return r;
     }
 
     template<typename A>
-    static constexpr TMat44 scaling(const TVec3<A>& s) {
+    static constexpr TMat44 scaling(const TVec3<A>& s) noexcept {
         return TMat44{ TVec4<T>{ s, 1 }};
     }
 
     template<typename A>
-    static constexpr TMat44 scaling(A s) {
+    static constexpr TMat44 scaling(A s) noexcept {
         return TMat44{ TVec4<T>{ s, s, s, 1 }};
     }
 };
@@ -355,7 +353,7 @@ public:
 // operations.
 
 template<typename T>
-constexpr TMat44<T>::TMat44()
+constexpr TMat44<T>::TMat44() noexcept
         : m_value{
         col_type(1, 0, 0, 0),
         col_type(0, 1, 0, 0),
@@ -365,7 +363,7 @@ constexpr TMat44<T>::TMat44()
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(U v)
+constexpr TMat44<T>::TMat44(U v) noexcept
         : m_value{
         col_type(v, 0, 0, 0),
         col_type(0, v, 0, 0),
@@ -375,7 +373,7 @@ constexpr TMat44<T>::TMat44(U v)
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(const TVec4<U>& v)
+constexpr TMat44<T>::TMat44(const TVec4<U>& v) noexcept
         : m_value{
         col_type(v[0], 0, 0, 0),
         col_type(0, v[1], 0, 0),
@@ -394,7 +392,7 @@ template<
 constexpr TMat44<T>::TMat44(A m00, B m01, C m02, D m03,
         E m10, F m11, G m12, H m13,
         I m20, J m21, K m22, L m23,
-        M m30, N m31, O m32, P m33)
+        M m30, N m31, O m32, P m33) noexcept
         : m_value{
         col_type(m00, m01, m02, m03),
         col_type(m10, m11, m12, m13),
@@ -404,7 +402,7 @@ constexpr TMat44<T>::TMat44(A m00, B m01, C m02, D m03,
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(const TMat44<U>& rhs) {
+constexpr TMat44<T>::TMat44(const TMat44<U>& rhs) noexcept {
     for (size_t col = 0; col < NUM_COLS; ++col) {
         m_value[col] = col_type(rhs[col]);
     }
@@ -414,13 +412,13 @@ constexpr TMat44<T>::TMat44(const TMat44<U>& rhs) {
 template<typename T>
 template<typename A, typename B, typename C, typename D>
 constexpr TMat44<T>::TMat44(const TVec4<A>& v0, const TVec4<B>& v1,
-        const TVec4<C>& v2, const TVec4<D>& v3)
+        const TVec4<C>& v2, const TVec4<D>& v3) noexcept
         : m_value{ v0, v1, v2, v3 } {
 }
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(const TQuaternion<U>& q) : m_value{} {
+constexpr TMat44<T>::TMat44(const TQuaternion<U>& q) noexcept : m_value{} {
     const U n = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
     const U s = n > 0 ? 2 / n : 0;
     const U x = s * q.x;
@@ -443,7 +441,7 @@ constexpr TMat44<T>::TMat44(const TQuaternion<U>& q) : m_value{} {
 
 template<typename T>
 template<typename U>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m)
+constexpr TMat44<T>::TMat44(const TMat33<U>& m) noexcept
         : m_value{
         col_type(m[0][0], m[0][1], m[0][2], 0),
         col_type(m[1][0], m[1][1], m[1][2], 0),
@@ -454,7 +452,7 @@ constexpr TMat44<T>::TMat44(const TMat33<U>& m)
 
 template<typename T>
 template<typename U, typename V>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec3<V>& v)
+constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec3<V>& v) noexcept
         : m_value{
         col_type(m[0][0], m[0][1], m[0][2], 0),
         col_type(m[1][0], m[1][1], m[1][2], 0),
@@ -465,7 +463,7 @@ constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec3<V>& v)
 
 template<typename T>
 template<typename U, typename V>
-constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec4<V>& v)
+constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec4<V>& v) noexcept
         : m_value{
         col_type(m[0][0], m[0][1], m[0][2], 0),
         col_type(m[1][0], m[1][1], m[1][2], 0),
@@ -480,7 +478,7 @@ constexpr TMat44<T>::TMat44(const TMat33<U>& m, const TVec4<V>& v)
 // ----------------------------------------------------------------------------------------
 
 template<typename T>
-constexpr TMat44<T> TMat44<T>::ortho(T left, T right, T bottom, T top, T near, T far) {
+constexpr TMat44<T> TMat44<T>::ortho(T left, T right, T bottom, T top, T near, T far) noexcept {
     TMat44<T> m;
     m[0][0] = 2 / (right - left);
     m[1][1] = 2 / (top - bottom);
@@ -492,7 +490,7 @@ constexpr TMat44<T> TMat44<T>::ortho(T left, T right, T bottom, T top, T near, T
 }
 
 template<typename T>
-constexpr TMat44<T> TMat44<T>::frustum(T left, T right, T bottom, T top, T near, T far) {
+constexpr TMat44<T> TMat44<T>::frustum(T left, T right, T bottom, T top, T near, T far) noexcept {
     TMat44<T> m;
     m[0][0] = (2 * near) / (right - left);
     m[1][1] = (2 * near) / (top - bottom);
@@ -506,14 +504,14 @@ constexpr TMat44<T> TMat44<T>::frustum(T left, T right, T bottom, T top, T near,
 }
 
 template<typename T>
-TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov direction) {
+TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov direction) noexcept {
     T h, w;
 
     if (direction == TMat44::Fov::VERTICAL) {
-        h = std::tan(fov * PI / 360.0f) * near;
+        h = std::tan(fov * F_PI / 360.0f) * near;
         w = h * aspect;
     } else {
-        w = std::tan(fov * PI / 360.0f) * near;
+        w = std::tan(fov * F_PI / 360.0f) * near;
         h = w / aspect;
     }
     return frustum(-w, w, -h, h, near, far);
@@ -527,7 +525,7 @@ TMat44<T> TMat44<T>::perspective(T fov, T aspect, T near, T far, TMat44::Fov dir
 template<typename T>
 template<typename A, typename B, typename C>
 TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center,
-        const TVec3<C>& up) {
+        const TVec3<C>& up) noexcept {
     TVec3<T> z_axis(normalize(center - eye));
     TVec3<T> norm_up(normalize(up));
     if (std::abs(dot(z_axis, norm_up)) > T(0.999)) {
@@ -547,11 +545,10 @@ TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center,
 // Arithmetic operators outside of class
 // ----------------------------------------------------------------------------------------
 
-
 // mat44 * vec3, result is vec3( mat44 * {vec3, 1} )
 template<typename T, typename U>
 constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
-        const TVec3<U>& rhs) {
+        const TVec3<U>& rhs) noexcept {
     return lhs * TVec4<U>{ rhs, 1 };
 }
 
@@ -561,7 +558,7 @@ constexpr typename TMat44<T>::col_type MATH_PURE operator*(const TMat44<T>& lhs,
  * BASE<T>::col_type is not accessible from there (???)
  */
 template<typename T>
-constexpr typename TMat44<T>::col_type MATH_PURE diag(const TMat44<T>& m) {
+constexpr typename TMat44<T>::col_type MATH_PURE diag(const TMat44<T>& m) noexcept {
     return matrix::diag(m);
 }
 

--- a/libs/math/include/math/vec2.h
+++ b/libs/math/include/math/vec2.h
@@ -56,13 +56,13 @@ public:
     inline constexpr size_type size() const { return SIZE; }
 
     // array access
-    inline constexpr T const& operator[](size_t i) const {
+    inline constexpr T const& operator[](size_t i) const noexcept {
         // only possible in C++0x14 with constexpr
         assert(i < SIZE);
         return v[i];
     }
 
-    inline constexpr T& operator[](size_t i) {
+    inline constexpr T& operator[](size_t i) noexcept {
         assert(i < SIZE);
         return v[i];
     }
@@ -74,18 +74,18 @@ public:
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec2(A v) : v{ T(v), T(v) } {}
+    constexpr TVec2(A v) noexcept : v{ T(v), T(v) } {}
 
     template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
-    constexpr TVec2(A x, B y) : v{ T(x), T(y) } {}
+    constexpr TVec2(A x, B y) noexcept : v{ T(x), T(y) } {}
 
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec2(const TVec2<A>& v) : v{ T(v[0]), T(v[1]) } {}
+    constexpr TVec2(const TVec2<A>& v) noexcept : v{ T(v[0]), T(v[1]) } {}
 
     // cross product works only on vectors of size 2 or 3
     template<typename U>
     friend inline constexpr
-    arithmetic_result_t<T, U> cross(const TVec2& u, const TVec2<U>& v) {
+    arithmetic_result_t<T, U> cross(const TVec2& u, const TVec2<U>& v) noexcept {
         return u[0] * v[1] - u[1] * v[0];
     }
 };

--- a/libs/math/include/math/vec3.h
+++ b/libs/math/include/math/vec3.h
@@ -69,13 +69,13 @@ public:
     inline constexpr size_type size() const { return SIZE; }
 
     // array access
-    inline constexpr T const& operator[](size_t i) const {
+    inline constexpr T const& operator[](size_t i) const noexcept {
         // only possible in C++0x14 with constexpr
         assert(i < SIZE);
         return v[i];
     }
 
-    inline constexpr T& operator[](size_t i) {
+    inline constexpr T& operator[](size_t i) noexcept {
         assert(i < SIZE);
         return v[i];
     }
@@ -83,26 +83,26 @@ public:
     // constructors
 
     // default constructor
-    MATH_DEFAULT_CTOR_CONSTEXPR TVec3() MATH_DEFAULT_CTOR
+    MATH_DEFAULT_CTOR_CONSTEXPR TVec3() noexcept MATH_DEFAULT_CTOR
 
     // handles implicit conversion to a tvec3. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec3(A v) : v{ T(v), T(v), T(v) } {}
+    constexpr TVec3(A v) noexcept : v{ T(v), T(v), T(v) } {}
 
     template<typename A, typename B, typename C,
             typename = enable_if_arithmetic_t<A, B, C>>
-    constexpr TVec3(A x, B y, C z) : v{ T(x), T(y), T(z) } {}
+    constexpr TVec3(A x, B y, C z) noexcept : v{ T(x), T(y), T(z) } {}
 
     template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
-    constexpr TVec3(const TVec2<A>& v, B z) : v{ T(v[0]), T(v[1]), T(z) } {}
+    constexpr TVec3(const TVec2<A>& v, B z) noexcept : v{ T(v[0]), T(v[1]), T(z) } {}
 
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec3(const TVec3<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]) } {}
+    constexpr TVec3(const TVec3<A>& v) noexcept : v{ T(v[0]), T(v[1]), T(v[2]) } {}
 
     // cross product works only on vectors of size 3
     template<typename U>
     friend inline constexpr
-    TVec3<arithmetic_result_t<T, U>> cross(const TVec3& u, const TVec3<U>& v) {
+    TVec3<arithmetic_result_t<T, U>> cross(const TVec3& u, const TVec3<U>& v) noexcept {
         return {
                 u[1] * v[2] - u[2] * v[1],
                 u[2] * v[0] - u[0] * v[2],

--- a/libs/math/include/math/vec4.h
+++ b/libs/math/include/math/vec4.h
@@ -69,13 +69,13 @@ public:
     inline constexpr size_type size() const { return SIZE; }
 
     // array access
-    inline constexpr T const& operator[](size_t i) const {
+    inline constexpr T const& operator[](size_t i) const noexcept {
         // only possible in C++0x14 with constexpr
         assert(i < SIZE);
         return v[i];
     }
 
-    inline constexpr T& operator[](size_t i) {
+    inline constexpr T& operator[](size_t i) noexcept {
         assert(i < SIZE);
         return v[i];
     }
@@ -83,29 +83,29 @@ public:
     // constructors
 
     // default constructor
-    MATH_DEFAULT_CTOR_CONSTEXPR TVec4() MATH_DEFAULT_CTOR
+    MATH_DEFAULT_CTOR_CONSTEXPR TVec4() noexcept MATH_DEFAULT_CTOR
 
     // handles implicit conversion to a tvec4. must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec4(A v) : v{ T(v), T(v), T(v), T(v) } {}
+    constexpr TVec4(A v) noexcept : v{ T(v), T(v), T(v), T(v) } {}
 
     template<typename A, typename B, typename C, typename D,
             typename = enable_if_arithmetic_t<A, B, C, D>>
-    constexpr TVec4(A x, B y, C z, D w) : v{ T(x), T(y), T(z), T(w) } {}
+    constexpr TVec4(A x, B y, C z, D w) noexcept : v{ T(x), T(y), T(z), T(w) } {}
 
     template<typename A, typename B, typename C,
             typename = enable_if_arithmetic_t<A, B, C>>
-    constexpr TVec4(const TVec2<A>& v, B z, C w) : v{ T(v[0]), T(v[1]), T(z), T(w) } {}
+    constexpr TVec4(const TVec2<A>& v, B z, C w) noexcept : v{ T(v[0]), T(v[1]), T(z), T(w) } {}
 
     template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
-    constexpr TVec4(const TVec2<A>& v, const TVec2<B>& w) : v{
+    constexpr TVec4(const TVec2<A>& v, const TVec2<B>& w) noexcept : v{
             T(v[0]), T(v[1]), T(w[0]), T(w[1]) } {}
 
     template<typename A, typename B, typename = enable_if_arithmetic_t<A, B>>
-    constexpr TVec4(const TVec3<A>& v, B w) : v{ T(v[0]), T(v[1]), T(v[2]), T(w) } {}
+    constexpr TVec4(const TVec3<A>& v, B w) noexcept : v{ T(v[0]), T(v[1]), T(v[2]), T(w) } {}
 
     template<typename A, typename = enable_if_arithmetic_t<A>>
-    constexpr TVec4(const TVec4<A>& v) : v{ T(v[0]), T(v[1]), T(v[2]), T(v[3]) } {}
+    constexpr TVec4(const TVec4<A>& v) noexcept : v{ T(v[0]), T(v[1]), T(v[2]), T(v[3]) } {}
 };
 
 }  // namespace details


### PR DESCRIPTION
this gets rid of a few ide-warnings about static initialization of
arrays with math types.