### PR TITLE
gltfio: do not abort for sparse data, warn instead.

### DIFF
--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -178,6 +178,7 @@ struct BufferBinding {
     bool generateTrivialIndices; // the resource loader must generate indices like: 0, 1, 2, ...
     bool generateDummyData;      // the resource loader should generate a sequence of 1.0 values
     bool generateTangents;       // the resource loader should generate tangents
+    bool sparseAccessor;         // the resource loader should apply a sparse data set
 
     bool isMorphTarget;
     uint8_t morphTargetIndex;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -535,11 +535,6 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             return false;
         }
 
-        if (inputAccessor->is_sparse) {
-            slog.e << "Sparse accessors not yet supported in " << name << io::endl;
-            return false;
-        }
-
         // The cgltf library provides a stride value for all accessors, even though they do not
         // exist in the glTF file. It is computed from the type and the stride of the buffer view.
         // As a convenience, cgltf also replaces zero (default) stride with the actual stride.
@@ -582,11 +577,6 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             VertexBuffer::AttributeType atype;
             if (!getElementType(inputAccessor->type, inputAccessor->component_type, &atype)) {
                 slog.e << "Unsupported accessor type in " << name << io::endl;
-                return false;
-            }
-
-            if (inputAccessor->is_sparse) {
-                slog.e << "Sparse accessors not yet supported in " << name << io::endl;
                 return false;
             }
 
@@ -665,6 +655,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                 .generateTrivialIndices = false,
                 .generateDummyData = false,
                 .generateTangents = true,
+                .sparseAccessor = (bool) inputAccessor->is_sparse,
             });
             continue;
         }
@@ -680,7 +671,8 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             .convertBytesToShorts = false,
             .generateTrivialIndices = false,
             .generateDummyData = false,
-            .generateTangents = false
+            .generateTangents = false,
+            .sparseAccessor = (bool) inputAccessor->is_sparse,
         });
     }
 
@@ -701,6 +693,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                     .generateTrivialIndices = false,
                     .generateDummyData = false,
                     .generateTangents = true,
+                    .sparseAccessor = (bool) inputAccessor->is_sparse,
                     .isMorphTarget = true,
                     .morphTargetIndex = (uint8_t) targetIndex,
                 });
@@ -724,6 +717,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                 .generateTrivialIndices = false,
                 .generateDummyData = false,
                 .generateTangents = false,
+                .sparseAccessor = (bool) inputAccessor->is_sparse,
             });
         }
     }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -222,6 +222,7 @@ bool ResourceLoader::loadResources(FilamentAsset* asset) {
     // Upload data to the GPU.
     const BufferBinding* bindings = asset->getBufferBindings();
     bool needsTangents = false;
+    bool needsSparseData = false;
     for (size_t i = 0, n = asset->getBufferBindingCount(); i < n; ++i) {
         auto bb = bindings[i];
         if (bb.vertexBuffer && bb.generateTangents) {
@@ -254,6 +255,15 @@ bool ResourceLoader::loadResources(FilamentAsset* asset) {
             IndexBuffer::BufferDescriptor bd(data8, bb.size, AssetPool::onLoadedResource, mPool);
             bb.indexBuffer->setBuffer(*mConfig.engine, std::move(bd));
         }
+        if (bb.sparseAccessor) {
+            needsSparseData = true;
+        }
+    }
+
+    // Since sparse accessors are easy to punt gracefully, we can emit a warning instead of
+    // aborting. We fall back to simply using the base data without applying the sparse updates.
+    if (needsSparseData) {
+        slog.w << "Sparse accessors are not yet supported." << io::endl;
     }
 
     // Copy over the inverse bind matrices to allow users to destroy the source asset.


### PR DESCRIPTION
Sparse accessors are easy to punt gracefully, we can emit a warning
and instead use the dense "base" data.

Also, after cgltf support for this lands, we will need to apply sparse
data in ResourceLoader, so this adds a bit of plumbing to prep for that.

Relates to #1727.