### PR TITLE
Fix culling in MaterialInstance

### DIFF
--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -69,6 +69,11 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material)
 // This version is used to initialize the default material instance
 void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* material) {
     mMaterial = material;
+
+    // We inherit the resolved culling mode rather than the builder-set culling mode.
+    // This preserves the property whereby double-sidedness automatically disables culling.
+    mCulling = mMaterial->getRasterState().culling;
+
     mMaterialSortingKey = RenderPass::makeMaterialSortingKey(
             material->getId(), material->generateMaterialInstanceId());
 


### PR DESCRIPTION
`mCulling` wasn't being set if the `initDefaultInstance` code path is taken.