### PR TITLE
libmath: prevent NaN's in slerp due to acos.

### DIFF
--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -25,6 +25,7 @@
 #include <iostream>
 
 #include <math/compiler.h>
+#include <math/scalar.h>
 #include <math/vec3.h>
 
 namespace filament {
@@ -255,7 +256,7 @@ public:
             return normalize(lerp(p, q, t));
         }
         const T npq = std::sqrt(dot(p, p) * dot(q, q));  // ||p|| * ||q||
-        const T a = std::acos(absd / npq);
+        const T a = std::acos(clamp(absd / npq, T(-1), T(1)));
         const T a0 = a * (1 - t);
         const T a1 = a * t;
         const T sina = sin(a);

--- a/libs/math/tests/test_quat.cpp
+++ b/libs/math/tests/test_quat.cpp
@@ -299,3 +299,14 @@ TEST_F(QuatTest, MultiplicationExhaustive) {
         ASSERT_FLOAT_EQ(ab.w, ab_other.w);
     }
 }
+
+TEST_F(QuatTest, NaN) {
+    quatf qa = {.5, .5, .5, .5};
+    quatf qb = {0.49995, 0.49998, 0.49998, 0.49995};
+    quatf qs = slerp(qa, qb, 0.034934);
+
+    EXPECT_NEAR(qs[0], 0.5, 0.1);
+    EXPECT_NEAR(qs[1], 0.5, 0.1);
+    EXPECT_NEAR(qs[2], 0.5, 0.1);
+    EXPECT_NEAR(qs[3], 0.5, 0.1);
+}


### PR DESCRIPTION
Fixes #1749.