### PR TITLE
Remove iOS OpenGL ES 3.1 hack

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -589,8 +589,6 @@ void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
                 // TODO: use glTexStorage2DMultisample() on GL 4.3 and above
                 glTexImage2DMultisample(t->gl.target, t->samples, t->gl.internalFormat,
                         GLsizei(width), GLsizei(height), GL_TRUE);
-#else
-#   error "GL/GLES header version not supported"
 #endif
             } else {
                 PANIC_LOG("GL_TEXTURE_2D_MULTISAMPLE is not supported");

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -86,29 +86,3 @@ void importGLESExtensionsEntryPoints() {
 } // namespace glext
 
 #endif
-
-#if defined(IOS)
-
-#include <OpenGLES/ES3/gl.h>
-#include <OpenGLES/ES3/glext.h>
-
-#include <utils/Panic.h>
-
-void glTexStorage2DMultisample (GLenum target, GLsizei samples, GLenum internalformat,
-            GLsizei width, GLsizei height, GLboolean fixedsamplelocations) {
-    PANIC_PRECONDITION("glTexStorage2DMultisample should not be called on iOS.");
-}
-
-namespace glext {
-    void glFramebufferTexture2DMultisampleEXT (GLenum target, GLenum attachment,
-            GLenum textarget, GLuint texture, GLint level, GLsizei samples) {
-        PANIC_PRECONDITION("glFramebufferTexture2DMultisampleEXT should not be called on iOS.");
-    }
-
-    void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
-            GLenum internalformat, GLsizei width, GLsizei height) {
-        PANIC_PRECONDITION("glRenderbufferStorageMultisampleEXT should not be called on iOS.");
-    }
-}
-
-#endif

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -56,22 +56,9 @@
     #include <OpenGLES/ES3/glext.h>
 
     /* The iOS SDK only provides OpenGL ES headers up to 3.0. Filament works with OpenGL 3.0, but
-     * requires 3.1 headers in order to compile. We fake it by adding the necessary 3.1 declarations
-     * below. */
+     * requires the following 3.1 define in order to compile. */
 
-    #define GL_ES_VERSION_3_1 1
     #define GL_TEXTURE_2D_MULTISAMPLE         0x9100
-
-    void glTexStorage2DMultisample (GLenum target, GLsizei samples, GLenum internalformat,
-            GLsizei width, GLsizei height, GLboolean fixedsamplelocations);
-
-    namespace glext {
-        void glFramebufferTexture2DMultisampleEXT (GLenum target, GLenum attachment,
-                GLenum textarget, GLuint texture, GLint level, GLsizei samples);
-
-        void glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples,
-                GLenum internalformat, GLsizei width, GLsizei height);
-    }
 
 #else
     #include <bluegl/BlueGL.h>
@@ -84,8 +71,8 @@
 
 #include "NullGLES.h"
 
-#if (!defined(GL_ES_VERSION_3_1) && !defined(GL_VERSION_4_1))
-#error "Minimum header version must be OpenGL ES 3.1 or OpenGL 4.1"
+#if (!defined(GL_ES_VERSION_3_0) && !defined(GL_VERSION_4_1))
+#error "Minimum header version must be OpenGL ES 3.0 or OpenGL 4.1"
 #endif
 
 #if defined(GL_ES_VERSION_3_1)


### PR DESCRIPTION
There's no longer a need to fake ES 3.1 support, the OpenGL driver supports iOS's ES 3.0 now (with one tiny define necessary).