### PR TITLE
Fix assertion using bones with Metal backend

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -540,11 +540,11 @@ bool MetalDriver::canGenerateMipmaps() {
 
 void MetalDriver::loadUniformBuffer(Handle<HwUniformBuffer> ubh,
         BufferDescriptor&& data) {
-   if (data.size <= 0) {
+    if (data.size <= 0) {
        return;
-   }
+    }
 
-   auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);
+    auto buffer = handle_cast<MetalUniformBuffer>(mHandleMap, ubh);
 
     buffer->copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -67,7 +67,7 @@ public:
     MetalUniformBuffer(MetalContext& context, size_t size);
     ~MetalUniformBuffer();
 
-    size_t getSize() const { return size; }
+    size_t getSize() const { return uniformSize; }
 
     /**
      * Update the uniform with data inside src. Potentially allocates a new buffer allocation to
@@ -90,7 +90,7 @@ public:
     void* getCpuBuffer() const;
 
 private:
-    size_t size = 0;
+    size_t uniformSize = 0;
     const MetalBufferPoolEntry* bufferPoolEntry = nullptr;
     void* cpuBuffer = nullptr;
     MetalContext& context;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -104,7 +104,7 @@ MetalIndexBuffer::~MetalIndexBuffer() {
 }
 
 MetalUniformBuffer::MetalUniformBuffer(MetalContext& context, size_t size) : HwUniformBuffer(),
-        size(size), context(context) {
+        uniformSize(size), context(context) {
     ASSERT_PRECONDITION(size > 0, "Cannot create Metal uniform with size %d.", size);
     // If the buffer is less than 4K in size, we don't use an explicit buffer and instead use
     // immediate command encoder methods like setVertexBytes:length:atIndex:.
@@ -129,8 +129,8 @@ void MetalUniformBuffer::copyIntoBuffer(void* src, size_t size) {
     if (size <= 0) {
         return;
     }
-    ASSERT_PRECONDITION(size <= this->size, "Attempting to copy %d bytes into a uniform of size %d",
-            size, this->size);
+    ASSERT_PRECONDITION(size <= this->uniformSize, "Attempting to copy %d bytes into a uniform of size %d",
+            size, this->uniformSize);
 
     // Either copy into the Metal buffer or into our cpu buffer.
     if (cpuBuffer) {
@@ -145,7 +145,7 @@ void MetalUniformBuffer::copyIntoBuffer(void* src, size_t size) {
         context.bufferPool->releaseBuffer(bufferPoolEntry);
     }
 
-    bufferPoolEntry = context.bufferPool->acquireBuffer(size);
+    bufferPoolEntry = context.bufferPool->acquireBuffer(this->uniformSize);
     memcpy(static_cast<uint8_t*>(bufferPoolEntry->buffer.contents), src, size);
 }
 
@@ -159,7 +159,7 @@ id<MTLBuffer> MetalUniformBuffer::getGpuBufferForDraw() {
 
         // If there isn't a CPU buffer, it means no data has been loaded into this uniform yet. To
         // avoid an error, we'll allocate an empty buffer.
-        bufferPoolEntry = context.bufferPool->acquireBuffer(size);
+        bufferPoolEntry = context.bufferPool->acquireBuffer(this->uniformSize);
     }
 
     // This uniform is being used in a draw call, so we retain it so it's not released back into the


### PR DESCRIPTION
We were getting Xcode assertions like the following when rendering skinned meshes:
```
validateFunctionArguments:3478: failed assertion `Vertex Function(main0): argument bonesUniforms[0] from buffer(2) with offset(0) and length(64) has space for 64 bytes, but argument has a length(16384).
```

Filament materials have a bones UBO that can hold the _max_ number of bones, but when Filament loads data into the bones uniform, it often loads far less data for meshes that have less than the _max_ count of bones. The Metal backend was allocating a buffer smaller than the full UBO size, hence the Xcode assertion.