### PR TITLE
OpenGL Driver: add support for KHR_debug.

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -142,17 +142,29 @@ OpenGLContext::OpenGLContext() noexcept {
     if (ext.KHR_debug) {
         auto cb = [](GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
                 const GLchar* message, const void *userParam) {
-            slog.e << "KHR_debug: " << message << io::endl;
+            io::LogStream* stream;
+            switch (severity) {
+                case GL_DEBUG_SEVERITY_HIGH: stream = &slog.e; break;
+                case GL_DEBUG_SEVERITY_MEDIUM: stream = &slog.w; break;
+                case GL_DEBUG_SEVERITY_LOW: stream = &slog.d; break;
+                case GL_DEBUG_SEVERITY_NOTIFICATION: stream = &slog.i; break;
+            }
+            io::LogStream& out = *stream;
+            out << "KHR_debug ";
+            switch (type) {
+                case GL_DEBUG_TYPE_ERROR: out << "ERROR"; break;
+                case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR: out << "DEPRECATED_BEHAVIOR"; break;
+                case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR: out << "UNDEFINED_BEHAVIOR"; break;
+                case GL_DEBUG_TYPE_PORTABILITY: out << "PORTABILITY"; break;
+                case GL_DEBUG_TYPE_PERFORMANCE: out << "PERFORMANCE"; break;
+                case GL_DEBUG_TYPE_OTHER: out << "OTHER"; break;
+                case GL_DEBUG_TYPE_MARKER: out << "MARKER"; break;
+            }
+            out << ": " << message << io::endl;
         };
-#if defined(ANDROID) || defined(USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
-        glEnable(GL_DEBUG_OUTPUT_KHR);
-        glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);
-        glext::glDebugMessageCallbackKHR(cb, nullptr);
-#elif defined(GL_VERSION_4_3)
         glEnable(GL_DEBUG_OUTPUT);
         glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
         glDebugMessageCallback(cb, nullptr);
-#endif
     }
 #endif
 }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -121,6 +121,7 @@ public:
         bool EXT_color_buffer_float = false;
         bool APPLE_color_buffer_packed_float = false;
         bool EXT_multisampled_render_to_texture = false;
+        bool KHR_debug = false;
     } ext;
 
     struct {

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -38,6 +38,10 @@ PFNGLPOPGROUPMARKEREXTPROC glPopGroupMarkerEXT;
 PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
 PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
 #endif
+#ifdef GL_KHR_debug
+PFNGLDEBUGMESSAGECALLBACKKHRPROC glDebugMessageCallbackKHR;
+PFNGLGETDEBUGMESSAGELOGKHRPROC glGetDebugMessageLogKHR;
+#endif
 
 static std::once_flag sGlExtInitialized;
 
@@ -79,6 +83,14 @@ void importGLESExtensionsEntryPoints() {
         glRenderbufferStorageMultisampleEXT =
                 (PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)eglGetProcAddress(
                         "glRenderbufferStorageMultisampleEXT");
+#endif
+#ifdef GL_KHR_debug
+        glDebugMessageCallbackKHR =
+                (PFNGLDEBUGMESSAGECALLBACKKHRPROC)eglGetProcAddress(
+                        "glDebugMessageCallbackKHR");
+        glGetDebugMessageLogKHR =
+                (PFNGLGETDEBUGMESSAGELOGKHRPROC)eglGetProcAddress(
+                        "glGetDebugMessageLogKHR");
 #endif
     });
 }

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -50,6 +50,25 @@
 #endif
     }
 
+    // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:
+    #define GL_DEBUG_OUTPUT                   0x92E0
+    #define GL_DEBUG_OUTPUT_SYNCHRONOUS       0x8242
+
+    #define GL_DEBUG_SEVERITY_HIGH            0x9146
+    #define GL_DEBUG_SEVERITY_MEDIUM          0x9147
+    #define GL_DEBUG_SEVERITY_LOW             0x9148
+    #define GL_DEBUG_SEVERITY_NOTIFICATION    0x826B
+
+    #define GL_DEBUG_TYPE_MARKER              0x8268
+    #define GL_DEBUG_TYPE_ERROR               0x824C
+    #define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
+    #define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR  0x824E
+    #define GL_DEBUG_TYPE_PORTABILITY         0x824F
+    #define GL_DEBUG_TYPE_PERFORMANCE         0x8250
+    #define GL_DEBUG_TYPE_OTHER               0x8251
+
+    #define glDebugMessageCallback            glext::glDebugMessageCallbackKHR
+
     using namespace glext;
 
 #elif defined(IOS)

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -44,6 +44,10 @@
         extern PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
         extern PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
 #endif
+#ifdef GL_KHR_debug
+        extern PFNGLDEBUGMESSAGECALLBACKKHRPROC glDebugMessageCallbackKHR;
+        extern PFNGLGETDEBUGMESSAGELOGKHRPROC glGetDebugMessageLogKHR;
+#endif
     }
 
     using namespace glext;


### PR DESCRIPTION
This extension dumps out some interesting vendor-specific information
to the log, which could be useful for debugging. Interestingly, some
of Android demos produce this output on Pixel 3:

```
  KHR_debug: EsxBufferObject::Map - Ignoring EsxBufferMapUnsyncedBit
```

Enabled for debug builds only.