### PR TITLE
Fix typo in Noop on mobile.

### DIFF
--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -32,7 +32,7 @@ NoopDriver::~NoopDriver() noexcept = default;
 
 backend::ShaderModel NoopDriver::getShaderModel() const noexcept {
 #if defined(GLES31_HEADERS)
-    return backend::ShaderModel::GL_CORE_30;
+    return backend::ShaderModel::GL_ES_30;
 #else
     return backend::ShaderModel::GL_CORE_41;
 #endif


### PR DESCRIPTION
Mobile shader model is GL_ES_30 instead of GL_CORE_30 - renaming in Noop backend.