### PR TITLE
Adds missing include in NoopDriver that prevented the correct shader …

### DIFF
--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -16,6 +16,7 @@
 
 #include "noop/NoopDriver.h"
 #include "CommandStreamDispatcher.h"
+#include "opengl/gl_headers.h"
 
 namespace filament {
 


### PR DESCRIPTION
…model from being picked when using the Noop backend.