### PR TITLE
Use unnormalized vectors to compute bump mapping.

### DIFF
--- a/shaders/src/common_shading.fs
+++ b/shaders/src/common_shading.fs
@@ -3,7 +3,8 @@
 highp mat3  shading_tangentToWorld;   // TBN matrix
 highp vec3  shading_position;         // position of the fragment in world space
       vec3  shading_view;             // normalized vector from the fragment to the eye
-      vec3  shading_normal;           // normalized normal, in world space
+      vec3  shading_normal;           // normalized transformed normal, in world space
+      vec3  shading_geometricNormal;  // normalized geometric normal, in world space
       vec3  shading_reflected;        // reflection of view about normal
       float shading_NoV;              // dot(normal, view), always strictly >= MIN_N_DOT_V
 

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -48,7 +48,7 @@ vec3 getWorldNormalVector() {
 
 /** @public-api */
 vec3 getWorldGeometricNormalVector() {
-    return shading_tangentToWorld[2];
+    return shading_geometricNormal;
 }
 
 /** @public-api */

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -16,13 +16,12 @@ void computeShadingParams() {
     }
 #endif
 
+    shading_geometricNormal = normalize(n);
+
 #if defined(MATERIAL_HAS_ANISOTROPY) || defined(MATERIAL_HAS_NORMAL) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
-    // Re-normalize post-interpolation values
-    shading_tangentToWorld = mat3(
-            normalize(vertex_worldTangent), normalize(vertex_worldBitangent), normalize(n));
+    // We use unnormalized post-interpolation values, assuming mikktspace tangents
+    shading_tangentToWorld = mat3(vertex_worldTangent, vertex_worldBitangent, n);
 #endif
-    // Leave the tangent and bitangent uninitialized, we won't use them
-    shading_tangentToWorld[2] = normalize(n);
 #endif
 
     shading_position = vertex_worldPosition;


### PR DESCRIPTION
If we assume the tangents and bitangents were generated using mikktspace,
we should use the unnormalized vectors, as indicated at mikktspace.com
or in http://www.metalliandy.com/mikktspace/downloads/mikktspace/mikktspace.h
(see last comment at the end of the file).