### PR TITLE
Minor improvements to Engine validation.

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -60,9 +60,42 @@ using namespace filaflat;
 
 namespace details {
 
-// The global list of engines
-static std::unordered_map<Engine const*, std::unique_ptr<FEngine>> sEngines;
-static std::mutex sEnginesLock;
+// Global list of engines used for diagnostic purposes only.
+// This console output in the constructor helps catch situations where the Filament library is
+// loaded twice, or not at all. Note that we avoid using slog due to static initialization.
+class EngineList {
+public:
+    EngineList() {
+        io::LogStream cinfo(io::LogStream::Priority::INFO);
+        cinfo << "Filament library loaded." << io::endl;
+    }
+    void add(FEngine* instance) {
+        std::unique_ptr<FEngine> engine(instance);
+        std::lock_guard<std::mutex> guard(mLock);
+        Engine* handle = engine.get();
+        mEngines[handle] = std::move(engine);
+    }
+    std::unique_ptr<FEngine> remove(FEngine* instance) {
+        std::unique_ptr<FEngine> filamentEngine;
+        std::lock_guard<std::mutex> guard(mLock);
+        auto const& pos = mEngines.find(instance);
+        if (pos != mEngines.end()) {
+            std::swap(filamentEngine, pos->second);
+            mEngines.erase(pos);
+        }
+        return filamentEngine;
+    }
+    bool isValid(Engine const& engine, const char* function)  {
+        std::lock_guard<std::mutex> guard(mLock);
+        auto const& pos = mEngines.find(&engine);
+        return pos != mEngines.end();
+    }
+private:
+    std::unordered_map<Engine const*, std::unique_ptr<FEngine>> mEngines;
+    std::mutex mLock;
+};
+
+static EngineList sEngines;
 
 FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLContext) {
     FEngine* instance = new FEngine(backend, platform, sharedGLContext);
@@ -98,13 +131,7 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
         }
     }
 
-    // Add this Engine to the list of active Engines
-    { // scope for the lock
-        std::unique_ptr<FEngine> engine(instance);
-        std::lock_guard<std::mutex> guard(sEnginesLock);
-        Engine* handle = engine.get();
-        sEngines[handle] = std::move(engine);
-    }
+    sEngines.add(instance);
 
     // now we can initialize the largest part of the engine
     instance->init();
@@ -116,16 +143,10 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
     return instance;
 }
 
-void FEngine::assertValid(Engine const& engine) {
-    bool valid;
-    { // scope for the lock
-        std::lock_guard<std::mutex> guard(sEnginesLock);
-        auto const& engines = sEngines;
-        auto const& pos = engines.find(&engine);
-        valid = pos != engines.end();
-    }
+void FEngine::assertValid(Engine const& engine, const char* function) {
+    bool valid = sEngines.isValid(engine, function);
     ASSERT_POSTCONDITION(valid,
-            "Using an Engine instance (@ %p) after it's been destroyed", &engine);
+            "Using an invalid Engine instance (@ %p) from %s.", &engine, function);
 }
 
 // these must be static because only a pointer is copied to the render stream
@@ -751,17 +772,7 @@ bool FEngine::execute() {
 
 void FEngine::destroy(FEngine* engine) {
     if (engine) {
-        std::unique_ptr<FEngine> filamentEngine;
-
-        std::unique_lock<std::mutex> guard(sEnginesLock);
-        auto const& pos = sEngines.find(engine);
-        if (pos != sEngines.end()) {
-            std::swap(filamentEngine, pos->second);
-            sEngines.erase(pos);
-        }
-        guard.unlock();
-
-        // Make sure to call into shutdown() without the lock held
+        std::unique_ptr<FEngine> filamentEngine = sEngines.remove(engine);
         if (filamentEngine) {
             filamentEngine->shutdown();
         }

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -48,7 +48,7 @@ IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noex
 }
 
 IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     return upcast(engine).createIndexBuffer(*this);
 }
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -148,7 +148,7 @@ IndirectLight::Builder& IndirectLight::Builder::rotation(mat3f const& rotation) 
 }
 
 IndirectLight* IndirectLight::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (mImpl->mReflectionsMap) {
         if (!ASSERT_POSTCONDITION_NON_FATAL(
                 mImpl->mReflectionsMap->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP,

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -73,7 +73,7 @@ Material::Builder& Material::Builder::package(const void* payload, size_t size) 
 }
 
 Material* Material::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     MaterialParser* materialParser = FMaterial::createParser(
             upcast(engine).getBackend(), mImpl->mPayload, mImpl->mSize);
 

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -61,7 +61,7 @@ RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t
 }
 
 RenderTarget* RenderTarget::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     using backend::TextureUsage;
     const FRenderTarget::Attachment& color = mImpl->mAttachments[COLOR];
     const FRenderTarget::Attachment& depth = mImpl->mAttachments[DEPTH];

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -68,7 +68,7 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
 }
 
 Skybox* Skybox::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
 
     if (!ASSERT_PRECONDITION_NON_FATAL(cubemap, "environment texture not set")) {

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -69,7 +69,7 @@ Stream::Builder& Stream::Builder::height(uint32_t height) noexcept {
 }
 
 Stream* Stream::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_PRECONDITION_NON_FATAL(!mImpl->mStream || !mImpl->mExternalTextureId,
             "One and only one of the stream or external texture can be specified")) {
         return nullptr;

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -92,7 +92,7 @@ Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
 }
 
 Texture* Texture::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_POSTCONDITION_NON_FATAL(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
             "Texture format %u not supported on this platform", mImpl->mFormat)) {
         return nullptr;

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -108,7 +108,7 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
 }
 
 VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mVertexCount > 0, "vertexCount cannot be 0")) {
         return nullptr;
     }

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -128,7 +128,7 @@ LightManager::Builder& LightManager::Builder::sunHaloFalloff(float haloFalloff) 
 }
 
 LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entity entity) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     upcast(engine).createLight(*this, entity);
     return Success;
 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -167,7 +167,7 @@ RenderableManager::Builder& RenderableManager::Builder::blendOrder(size_t index,
 }
 
 RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity entity) {
-    FEngine::assertValid(engine);
+    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     bool isEmpty = true;
 
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -134,7 +134,7 @@ public:
 
     static void destroy(FEngine* engine);
 
-    static void assertValid(Engine const& engine);
+    static void assertValid(Engine const& engine, const char* function);
 
     ~FEngine() noexcept;
 


### PR DESCRIPTION
This enhances the assert added in 2548da9 in the following ways:

- Adds console output at startup to help detect "double load" bugs.
- Adds PRETTY_FUNCTION to show where the invalid usage is coming from.
- Tweaks the wording since use-after-destroy is not always the cause.
- Consolidates usage of static globals into a helper class.

Motivated by #1811.