### PR TITLE
Make filament's readPixels() asynchronous wrt the GPU

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -322,13 +322,26 @@ public class Texture {
         public CompressedFormat compressedFormat;
 
         @Nullable public Object handler;
-        @Nullable public Runnable callback;
 
         /**
-         * Valid handler types:
-         * - Android: Handler, Executor
-         * - Other: Executor
+         * Callback used to destroy the buffer data.
+         * <p>
+         * Guarantees:
+         * <ul>
+         *     <li>Called on the main filament thread.</li>
+         * </ul>
+         * </p>
+         *
+         * <p>
+         * Limitations:
+         * <ul>
+         *     <li>Must be lightweight.</li>
+         *     <li>Must not call filament APIs.</li>
+         * </ul>
+         * </p>
          */
+        @Nullable public Runnable callback;
+
 
         /**
          * Creates a <code>PixelBufferDescriptor</code>

--- a/filament/backend/include/backend/BufferDescriptor.h
+++ b/filament/backend/include/backend/BufferDescriptor.h
@@ -39,7 +39,12 @@ class UTILS_PUBLIC BufferDescriptor {
 public:
     /**
      * Callback used to destroy the buffer data.
-     * It is guaranteed to be called on the main filament thread.
+     * Guarantees:
+     *      Called on the main filament thread.
+     *
+     * Limitations:
+     *      Must be lightweight.
+     *      Must not call filament APIs.
      */
     using Callback = void(*)(void* buffer, size_t size, void* user);
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -366,7 +366,6 @@ private:
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
     mutable std::vector<GLTexture*> mExternalStreams;
 
-
     void attachStream(GLTexture* t, GLStream* stream) noexcept;
     void detachStream(GLTexture* t) noexcept;
     void replaceStream(GLTexture* t, GLStream* stream) noexcept;
@@ -377,6 +376,10 @@ private:
     void updateStream(GLTexture* t, backend::DriverApi* driver) noexcept;
     void updateBuffer(GLenum target, GLBuffer* buffer, backend::BufferDescriptor const& p, uint32_t alignment = 16) noexcept;
     void updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept;
+
+    void whenGpuCommandsComplete(std::function<void()> fn) noexcept;
+    void executeGpuCommandsCompleteOps() noexcept;
+    std::vector< std::pair<GLsync, std::function<void(void)>> > mGpuCommandCompleteOps;
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -379,7 +379,7 @@ private:
 
     void whenGpuCommandsComplete(std::function<void()> fn) noexcept;
     void executeGpuCommandsCompleteOps() noexcept;
-    std::vector< std::pair<GLsync, std::function<void(void)>> > mGpuCommandCompleteOps;
+    std::vector<std::pair<GLsync, std::function<void(void)>>> mGpuCommandCompleteOps;
 };
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This doesn't change the user facing API because it already used a
callback.

With this change we implement readPixels() with a PBO, which won't
stall the GPU. Then we periodically check a fence to see when the
command is completed, at which point we map the PBO and copy the data
to the user buffer.