### PR TITLE
Fix, incorrect vertex format for bone indices in Metal backend

### DIFF
--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -155,8 +155,12 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
             attributeArray[i].stride = attributes[i].stride;
             attributeArray[i].buffer = attributes[i].buffer;
             attributeArray[i].type   = attributes[i].type;
-            attributeArray[i].flags  = attributes[i].flags;
         }
+
+        // Even if the attribute is disabled, we need to copy the flags (in particular, the
+        // FLAG_INTEGER_TARGET we might have set above) to the attribute array passed to the
+        // backend.
+        attributeArray[i].flags  = attributes[i].flags;
     }
 
     FEngine::DriverApi& driver = engine.getDriverApi();


### PR DESCRIPTION
For vertex buffers that don't contain bone indices, the Metal backend still needs to know that the attribute should be read with an integer format, otherwise we get a pipeline creation crash.