### PR TITLE
Implement Headless SwapChain mode.

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -60,6 +60,13 @@ Java_com_google_android_filament_Engine_nCreateSwapChain(JNIEnv* env,
 }
 
 extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_Engine_nCreateSwapChainHeadless(JNIEnv* env,
+        jclass klass, jlong nativeEngine, jint width, jint height, jlong flags) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jlong) engine->createSwapChain(width, height, (uint64_t) flags);
+}
+
+extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_Engine_nCreateSwapChainFromRawPointer(JNIEnv*,
         jclass, jlong nativeEngine, jlong pointer, jlong flags) {
      Engine* engine = (Engine*) nativeEngine;

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -291,6 +291,32 @@ public class Engine {
     }
 
     /**
+     * Creates a headless {@link SwapChain}
+     *
+     * @param width  width of the rendering buffer
+     * @param height height of the rendering buffer
+     * @param flags  configuration flags, see {@link SwapChain}
+     *
+     * @return a newly created {@link SwapChain} object
+     *
+     * @exception IllegalStateException can be thrown if the SwapChain couldn't be created
+     *
+     * @see SwapChain#CONFIG_DEFAULT
+     * @see SwapChain#CONFIG_TRANSPARENT
+     * @see SwapChain#CONFIG_READABLE
+     *
+     */
+    @NonNull
+    public SwapChain createSwapChain(int width, int height, long flags) {
+        if (width >= 0 && height >= 0) {
+            long nativeSwapChain = nCreateSwapChainHeadless(getNativeObject(), width, height, flags);
+            if (nativeSwapChain == 0) throw new IllegalStateException("Couldn't create SwapChain");
+            return new SwapChain(nativeSwapChain, null);
+        }
+        throw new IllegalArgumentException("Invalid parameters");
+    }
+
+    /**
      * Creates a {@link SwapChain} from a {@link NativeSurface}.
      *
      * @param surface a properly initialized {@link NativeSurface}
@@ -608,6 +634,7 @@ public class Engine {
     private static native void nDestroyEngine(long nativeEngine);
     private static native long nGetBackend(long nativeEngine);
     private static native long nCreateSwapChain(long nativeEngine, Object nativeWindow, long flags);
+    private static native long nCreateSwapChainHeadless(long nativeEngine, int width, int height, long flags);
     private static native long nCreateSwapChainFromRawPointer(long nativeEngine, long pointer, long flags);
     private static native void nDestroySwapChain(long nativeEngine, long nativeSwapChain);
     private static native long nCreateView(long nativeEngine);

--- a/android/filament-android/src/main/java/com/google/android/filament/SwapChain.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/SwapChain.java
@@ -85,15 +85,15 @@ public class SwapChain {
      */
     public static final long CONFIG_READABLE = 0x2;
 
-    SwapChain(long nativeSwapChain, @NonNull Object surface) {
+    SwapChain(long nativeSwapChain, Object surface) {
         mNativeObject = nativeSwapChain;
         mSurface = surface;
     }
 
     /**
-     * @return the native <code>Object</code> this <code>SwapChain</code> was created from.
+     * @return the native <code>Object</code> this <code>SwapChain</code> was created from or null
+     *         for a headless SwapChain.
      */
-    @NonNull
     public Object getNativeWindow() {
         return mSurface;
     }

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -124,6 +124,9 @@ DECL_DRIVER_API_N(endFrame,
 // can start rendering. e.g. correspond to glFlush() for a GLES driver.
 DECL_DRIVER_API_0(flush)
 
+// flush and wait for the effects to be done
+DECL_DRIVER_API_0(finish)
+
 /*
  * Creating driver objects
  * -----------------------
@@ -178,6 +181,11 @@ DECL_DRIVER_API_R_0(backend::FenceHandle, createFence)
 
 DECL_DRIVER_API_R_N(backend::SwapChainHandle, createSwapChain,
         void*, nativeWindow,
+        uint64_t, flags)
+
+DECL_DRIVER_API_R_N(backend::SwapChainHandle, createSwapChainHeadless,
+        uint32_t, width,
+        uint32_t, height,
         uint64_t, flags)
 
 DECL_DRIVER_API_R_N(backend::StreamHandle, createStreamFromTextureId,

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -41,6 +41,10 @@ public:
     virtual void terminate() noexcept = 0;
 
     virtual SwapChain* createSwapChain(void* nativeWindow, uint64_t& flags) noexcept = 0;
+
+    // headless swapchain
+    virtual SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept = 0;
+
     virtual void destroySwapChain(SwapChain* swapChain) noexcept = 0;
 
     virtual void createDefaultRenderTarget(uint32_t& framebuffer, uint32_t& colorbuffer,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -127,8 +127,12 @@ void MetalDriver::endFrame(uint32_t frameId) {
     CVMetalTextureCacheFlush(mContext->textureCache, 0);
 }
 
-void MetalDriver::flush(int dummy) {
+void MetalDriver::flush(int) {
+    // TODO: implement flush, equivalent of glFlush() (needed for performance)
+}
 
+void MetalDriver::finish(int) {
+    // TODO: implement finish, equivalent of glFinish() (needed for unit tests)
 }
 
 void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
@@ -217,6 +221,11 @@ void MetalDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, 
     construct_handle<MetalSwapChain>(mHandleMap, sch, mContext->device, metalLayer);
 }
 
+void MetalDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
+        uint32_t width, uint32_t height, uint64_t flags) {
+    // TODO: implement headless swapchain
+}
+
 void MetalDriver::createStreamFromTextureIdR(Handle<HwStream>, intptr_t externalTextureId,
         uint32_t width, uint32_t height) {
 
@@ -263,6 +272,10 @@ Handle<HwFence> MetalDriver::createFenceS() noexcept {
 }
 
 Handle<HwSwapChain> MetalDriver::createSwapChainS() noexcept {
+    return alloc_handle<MetalSwapChain, HwSwapChain>();
+}
+
+Handle<HwSwapChain> MetalDriver::createSwapChainHeadlessS() noexcept {
     return alloc_handle<MetalSwapChain, HwSwapChain>();
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -36,11 +36,7 @@ OpenGLContext::OpenGLContext() noexcept {
     UTILS_UNUSED char const* const shader   = (char const*) glGetString(GL_SHADING_LANGUAGE_VERSION);
 
 #ifndef NDEBUG
-    slog.i
-        << vendor << io::endl
-        << renderer << io::endl
-        << version << io::endl
-        << shader << io::endl;
+    slog.i << vendor << ", " << renderer << ", " << version << ", " << shader << io::endl;
 #endif
 
     // OpenGL (ES) version
@@ -51,7 +47,8 @@ OpenGLContext::OpenGLContext() noexcept {
     glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &gets.max_uniform_block_size);
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &gets.uniform_buffer_offset_alignment);
 
-#ifndef NDEBUG
+#if 0
+    // this is useful for development, but too verbose even for debug builds
     slog.i
         << "GL_MAX_RENDERBUFFER_SIZE = " << gets.max_renderbuffer_size << io::endl
         << "GL_MAX_UNIFORM_BLOCK_SIZE = " << gets.max_uniform_block_size << io::endl

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -36,6 +36,7 @@ public:
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
     void commit(SwapChain* swapChain) noexcept final;

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -36,6 +36,7 @@ public:
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
     void commit(SwapChain* swapChain) noexcept final;

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -106,6 +106,11 @@ Platform::SwapChain* PlatformCocoaTouchGL::createSwapChain(void* nativewindow, u
     return (SwapChain*) nativewindow;
 }
 
+Platform::SwapChain* PlatformCocoaTouchGL::createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept {
+    // TODO: implement headless SwapChain
+    return nullptr;
+}
+
 void PlatformCocoaTouchGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
 }
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -343,8 +343,10 @@ void PlatformEGL::terminate() noexcept {
 Platform::SwapChain* PlatformEGL::createSwapChain(
         void* nativeWindow, uint64_t& flags) noexcept {
     EGLSurface sur = eglCreateWindowSurface(mEGLDisplay,
-            (flags & backend::SWAP_CHAIN_CONFIG_TRANSPARENT) ? mEGLTransparentConfig : mEGLConfig,
+            (flags & backend::SWAP_CHAIN_CONFIG_TRANSPARENT) ?
+            mEGLTransparentConfig : mEGLConfig,
             (EGLNativeWindowType)nativeWindow, nullptr);
+
     if (UTILS_UNLIKELY(sur == EGL_NO_SURFACE)) {
         logEglError("eglCreateWindowSurface");
         return nullptr;
@@ -358,6 +360,26 @@ Platform::SwapChain* PlatformEGL::createSwapChain(
     //    logEglError("eglSurfaceAttrib(..., EGL_TIMESTAMPS_ANDROID, EGL_TRUE)");
     //    // this is not fatal
     //}
+    return (SwapChain*)sur;
+}
+
+Platform::SwapChain* PlatformEGL::createSwapChain(
+        uint32_t width, uint32_t height, uint64_t& flags) noexcept {
+
+    EGLint attribs[] = {
+            EGL_WIDTH, EGLint(width),
+            EGL_HEIGHT, EGLint(height),
+            EGL_NONE
+    };
+
+    EGLSurface sur = eglCreatePbufferSurface(mEGLDisplay,
+                (flags & backend::SWAP_CHAIN_CONFIG_TRANSPARENT) ?
+                mEGLTransparentConfig : mEGLConfig, attribs);
+
+    if (UTILS_UNLIKELY(sur == EGL_NO_SURFACE)) {
+        logEglError("eglCreatePbufferSurface");
+        return nullptr;
+    }
     return (SwapChain*)sur;
 }
 

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -43,6 +43,7 @@ public:
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
     void commit(SwapChain* swapChain) noexcept final;

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -26,6 +26,8 @@
 
 #include "private/backend/OpenGLPlatform.h"
 
+#include <vector>
+
 namespace filament {
 
 class PlatformGLX final : public backend::OpenGLPlatform {
@@ -36,6 +38,7 @@ public:
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
     void commit(SwapChain* swapChain) noexcept override;
@@ -64,6 +67,7 @@ private:
     GLXContext mGLXContext;
     GLXFBConfig* mGLXConfig;
     GLXPbuffer mDummySurface;
+    std::vector<GLXPbuffer> mPBuffers;
 };
 
 } // namespace filament

--- a/filament/backend/src/opengl/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/PlatformWGL.cpp
@@ -182,6 +182,11 @@ Platform::SwapChain* PlatformWGL::createSwapChain(void* nativeWindow, uint64_t& 
     return swapChain;
 }
 
+Platform::SwapChain* PlatformWGL::createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept {
+    // TODO: implement headless SwapChain
+    return nullptr;
+}
+
 void PlatformWGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
     HDC dc = (HDC) swapChain;
     HWND window = WindowFromDC(dc);

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -34,6 +34,7 @@ public:
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
     void commit(SwapChain* swapChain) noexcept override;

--- a/filament/backend/src/opengl/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/PlatformWebGL.cpp
@@ -33,6 +33,12 @@ Platform::SwapChain* PlatformWebGL::createSwapChain(
     return (SwapChain*) nativeWindow;
 }
 
+Platform::SwapChain* PlatformWebGL::createSwapChain(
+        uint32_t width, uint32_t height, uint64_t& flags) noexcept {
+    // TODO: implement headless SwapChain
+    return nullptr;
+}
+
 void PlatformWebGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
 }
 

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -35,6 +35,7 @@ public:
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override;
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final override;
     void destroySwapChain(SwapChain* swapChain) noexcept final override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final override;
     void commit(SwapChain* swapChain) noexcept final override;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -283,6 +283,10 @@ void VulkanDriver::flush(int) {
     // Todo: equivalent of glFlush()
 }
 
+void VulkanDriver::finish(int) {
+    // Todo: equivalent of glFinish()
+}
+
 void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t count) {
     construct_handle<VulkanSamplerGroup>(mHandleMap, sbh, mContext, count);
 }
@@ -436,6 +440,12 @@ void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
     mContext.currentSurface = &sc;
 }
 
+void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
+        uint32_t width, uint32_t height, uint64_t flags) {
+    //auto* swapChain = construct_handle<VulkanSwapChain>(mHandleMap, sch);
+    // TODO: implement headless swapchain
+}
+
 void VulkanDriver::createStreamFromTextureIdR(Handle<HwStream> sh, intptr_t externalTextureId,
         uint32_t width, uint32_t height) {
 }
@@ -481,6 +491,10 @@ Handle<HwFence> VulkanDriver::createFenceS() noexcept {
 }
 
 Handle<HwSwapChain> VulkanDriver::createSwapChainS() noexcept {
+    return alloc_handle<VulkanSwapChain, HwSwapChain>();
+}
+
+Handle<HwSwapChain> VulkanDriver::createSwapChainHeadlessS() noexcept {
     return alloc_handle<VulkanSwapChain, HwSwapChain>();
 }
 

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -259,6 +259,20 @@ public:
      */
     SwapChain* createSwapChain(void* nativeWindow, uint64_t flags = 0) noexcept;
 
+
+    /**
+     * Creates a headless SwapChain.
+     *
+      * @param width    Width of the drawing buffer in pixels.
+      * @param height   Height of the drawing buffer in pixels.
+     * @param flags     One or more configuration flags as defined in `SwapChain`.
+     *
+     * @return A pointer to the newly created SwapChain or nullptr if it couldn't be created.
+     *
+     * @see Renderer.beginFrame()
+     */
+    SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t flags = 0) noexcept;
+
     /**
      * Creates a renderer associated to this engine.
      *

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -22,9 +22,13 @@ namespace filament {
 namespace details {
 
 FSwapChain::FSwapChain(FEngine& engine, void* nativeWindow, uint64_t flags)
-        : mNativeWindow(nativeWindow) {
-    mConfigFlags = flags;
-    mSwapChain = engine.getDriverApi().createSwapChain(nativeWindow, mConfigFlags);
+        : mNativeWindow(nativeWindow), mConfigFlags(flags) {
+    mSwapChain = engine.getDriverApi().createSwapChain(nativeWindow, flags);
+}
+
+FSwapChain::FSwapChain(FEngine& engine, uint32_t width, uint32_t height, uint64_t flags)
+        : mConfigFlags(flags) {
+    mSwapChain = engine.getDriverApi().createSwapChainHeadless(width, height, flags);
 }
 
 void FSwapChain::terminate(FEngine& engine) noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -239,6 +239,7 @@ public:
     FView* createView() noexcept;
     FFence* createFence(FFence::Type type) noexcept;
     FSwapChain* createSwapChain(void* nativeWindow, uint64_t flags) noexcept;
+    FSwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t flags) noexcept;
 
     FCamera* createCamera(utils::Entity entity) noexcept;
     FCamera* getCameraComponent(utils::Entity entity) noexcept;

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -33,6 +33,7 @@ class FEngine;
 class FSwapChain : public SwapChain {
 public:
     FSwapChain(FEngine& engine, void* nativeWindow, uint64_t flags);
+    FSwapChain(FEngine& engine, uint32_t width, uint32_t height, uint64_t flags);
     void terminate(FEngine& engine) noexcept;
 
     void makeCurrent(backend::DriverApi& driverApi) noexcept {

--- a/filament/test/CMakeLists.txt
+++ b/filament/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT IOS AND NOT WEBGL)
     # The following tests rely on private APIs that are stripped
     # away in Release builds
     if (TNT_DEV)
-        add_executable(test_${TARGET} filament_test_exposure.cpp filament_framegraph_test.cpp filament_test.cpp)
+        add_executable(test_${TARGET} filament_test_exposure.cpp filament_rendering_test.cpp filament_framegraph_test.cpp filament_test.cpp)
         target_link_libraries(test_${TARGET} PRIVATE filament gtest)
         target_compile_options(test_${TARGET} PRIVATE ${COMPILER_FLAGS})
 

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filament/Engine.h>
+#include <filament/Renderer.h>
+#include <filament/View.h>
+#include <backend/PixelBufferDescriptor.h>
+
+using namespace filament;
+using namespace backend;
+
+class RenderingTest : public testing::Test {
+protected:
+    Engine* mEngine = nullptr;
+    SwapChain* mSurface = nullptr;
+    Renderer* mRenderer = nullptr;
+    View* mView = nullptr;
+    Scene* mScene = nullptr;
+    Camera* mCamera = nullptr;
+
+    using closure_t = std::function<void(uint8_t const* rgba, uint32_t width, uint32_t height)>;
+
+    void SetUp() override {
+        mEngine = Engine::create();
+        mSurface = mEngine->createSwapChain(16, 16);
+        mRenderer = mEngine->createRenderer();
+
+        mScene = mEngine->createScene();
+        mCamera = mEngine->createCamera();
+
+        mView = mEngine->createView();
+        mView->setViewport({0, 0, 16, 16});
+        mView->setScene(mScene);
+        mView->setCamera(mCamera);
+    }
+
+    void TearDown() override {
+        mEngine->destroy(mCamera);
+        mEngine->destroy(mScene);
+        mEngine->destroy(mView);
+        mEngine->destroy(mRenderer);
+        mEngine->destroy(mSurface);
+        Engine::destroy(&mEngine);
+    }
+
+    void runTest(closure_t closure) {
+        auto* user = new closure_t(std::move(closure));
+
+        size_t size = 16 * 16 * 4;
+        void* buffer = malloc(size);
+        memset(buffer, 0, size);
+        PixelBufferDescriptor pd(buffer, size,
+                PixelDataFormat::RGBA, PixelDataType::UBYTE,
+                callback, user);
+
+        Renderer* pRenderer = mRenderer;
+        pRenderer->beginFrame(mSurface);
+        pRenderer->render(mView);
+        pRenderer->readPixels(0, 0, 16, 16, std::move(pd));
+        pRenderer->endFrame();
+
+        // Note: this is where the runTest() callback will be called.
+        mEngine->flushAndWait();
+    }
+
+private:
+    static void callback(void* buffer, size_t size, void* user) {
+        closure_t* closure = (closure_t *)user;
+        uint8_t const* rgba = (uint8_t const*)buffer;
+        (*closure)(rgba, 16, 16);
+        delete closure;
+        ::free(buffer);
+    }
+};
+
+TEST_F(RenderingTest, ClearRed) {
+    mView->setClearColor(LinearColorA{1, 0, 0, 1});
+    mView->setToneMapping(View::ToneMapping::LINEAR);
+    mView->setDithering(View::Dithering::NONE);
+    runTest([this](uint8_t const* rgba, uint32_t width, uint32_t height) {
+        EXPECT_EQ(rgba[0], 0xff);
+        EXPECT_EQ(rgba[1], 0);
+        EXPECT_EQ(rgba[2], 0);
+        EXPECT_EQ(rgba[3], 0xff);
+    });
+}
+
+TEST_F(RenderingTest, ClearGreen) {
+    mView->setClearColor(LinearColorA{0, 1, 0, 1});
+    mView->setToneMapping(View::ToneMapping::LINEAR);
+    mView->setDithering(View::Dithering::NONE);
+    runTest([this](uint8_t const* rgba, uint32_t width, uint32_t height) {
+        EXPECT_EQ(rgba[0], 0);
+        EXPECT_EQ(rgba[1], 0xff);
+        EXPECT_EQ(rgba[2], 0);
+        EXPECT_EQ(rgba[3], 0xff);
+    });
+}


### PR DESCRIPTION
This is useful for unit tests. The content of the swapchain can be
read to main memory with Renderer::readPixels().


This PR doesn't implement this new feature in the following backends and
platforms (TODO):

VulkanDriver.cpp
MetalDriver.mm

PlatformWGL.cpp
PlatformWebGL.cpp
PlatformCocoaGL.mm
PlatformCocoaTouchGL.mm