### PR TITLE
Fix out-of-bounds in an [unused] utility.

### DIFF
--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -241,7 +241,8 @@ RandomAccessIterator partition_point(
         // handle non power-of-two sized arrays. If it's POT, the next line is a no-op
         // and gets optimized out if the size is known at compile time.
         len = 1u << (31 - clz(uint32_t(len)));     // next power of two length / 2
-        first += pred(first[len]) ? ((last - first) - len) : 0;
+        size_t difference = (last - first) - len;
+        first += !difference || pred(first[len]) ? difference : 0;
     }
 
     while (len) {

--- a/libs/utils/test/test_algorithm.cpp
+++ b/libs/utils/test/test_algorithm.cpp
@@ -234,4 +234,12 @@ TEST(AlgorithmTest, Partition) {
 
     r = utils::partition_point(std::begin(array), std::end(array), [](int i) { return i < 2; });
     EXPECT_EQ(std::begin(array), r);
+
+    int array7[7] = { 2, 5, 4, 8, 9, 9, 9 };
+    r = utils::partition_point(std::begin(array7), std::end(array7), [](int i) { return i < 9; });
+    EXPECT_EQ(4, r - std::begin(array7));
+
+    int array9[9] = { 2, 5, 4, 8, 9, 9, 9, 9, 9 };
+    r = utils::partition_point(std::begin(array9), std::end(array9), [](int i) { return i < 9; });
+    EXPECT_EQ(4, r - std::begin(array9));
 }


### PR DESCRIPTION
This was caught by ASAN.

Our algorithm header has many one-liners that compute the "next power of
two length / 2" but they all have the caveat that if the input is
already POT, then the "/ 2" part does not occur.

Usually we deal with this by testing the difference against zero.
However in `partition_point` we were skipping the test, thus causing a
potential out-of-bounds access.

I fixed `partition_point` and added a few more tests for non-POT cases.