### PR TITLE
Fix an assert when the last uniform is an array.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- Fixed an assertion when a parameter array occurs last in a material definition.
 - Fixed morph shapes not rendering in WebGL.
 - Added support for the latest version of emscripten.
 - gltfio: fixed blackness seen with default material.

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -456,8 +456,48 @@ TEST(FilamentTest, UniformBuffer) {
 
     move = std::move(copy);
     CHECK(&move);
+}
 
-    //buffer.log(std::cout, ib);
+TEST(FilamentTest, UniformBufferSize1) {
+    UniformInterfaceBlock::Builder b;
+    b.name("UniformBufferSize1");
+    b.add("f4a", 1, UniformInterfaceBlock::Type::FLOAT4); // offset = 0
+    b.add("f4b", 1, UniformInterfaceBlock::Type::FLOAT4); // offset = 16
+    b.add("f1a", 1, UniformInterfaceBlock::Type::FLOAT);  // offset = 32
+    b.add("f1b", 1, UniformInterfaceBlock::Type::FLOAT);  // offset = 36
+    UniformInterfaceBlock uib(b.build());
+    UniformBuffer buffer(uib.getSize());
+
+    float4 f4(1.0f);
+    ssize_t f4_offset = uib.getUniformOffset("f4a", 0);
+    buffer.setUniformArray(f4_offset, &f4, 1);
+
+    float f1(1.0f);
+    ssize_t f1_offset = uib.getUniformOffset("f1b", 0);
+    buffer.setUniformArray(f1_offset, &f1, 1);
+
+    buffer.invalidate();
+}
+
+TEST(FilamentTest, UniformBufferSize2) {
+    UniformInterfaceBlock::Builder b;
+    b.name("UniformBufferSize2");
+    b.add("f4a", 1, UniformInterfaceBlock::Type::FLOAT4); // offset = 0
+    b.add("f4b", 1, UniformInterfaceBlock::Type::FLOAT4); // offset = 16
+    b.add("f1a", 1, UniformInterfaceBlock::Type::FLOAT);  // offset = 32
+    b.add("f2a", 1, UniformInterfaceBlock::Type::FLOAT2); // offset = 36
+    UniformInterfaceBlock uib(b.build());
+    UniformBuffer buffer(uib.getSize());
+
+    float4 f4(1.0f);
+    ssize_t f4_offset = uib.getUniformOffset("f4a", 0);
+    buffer.setUniformArray(f4_offset, &f4, 1);
+
+    float2 f2(1.0f);
+    ssize_t f2_offset = uib.getUniformOffset("f2a", 0);
+    buffer.setUniformArray(f2_offset, &f2, 1);
+
+    buffer.invalidate();
 }
 
 TEST(FilamentTest, BoxCulling) {

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -639,6 +639,16 @@ TEST_F(MaterialCompiler, Uv0AndUv1) {
     EXPECT_TRUE(result.isValid());
 }
 
+TEST_F(MaterialCompiler, Arrays) {
+    filamat::MaterialBuilder builder;
+
+    builder.parameter(UniformType::FLOAT4, 1, "f4");
+    builder.parameter(UniformType::FLOAT, 1, "f1");
+
+    filamat::Package result = builder.build();
+    EXPECT_TRUE(result.isValid());
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Clients who do not yet have this fix can usually work around this issue
by calling the non-array overload of `MaterialInstance::setParameter`
when the array size is 1.