### PR TITLE
fix a possible memory corruption in debug builds

### DIFF
--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -38,12 +38,12 @@ static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE     = 3 * CONFIG_MIN_COMMAND
 using HeapAllocatorArena = utils::Arena<
         utils::HeapAllocator,
         utils::LockingPolicy::NoLock,
-        utils::TrackingPolicy::Debug>;
+        utils::TrackingPolicy::DebugAndHighWatermark>;
 
 using LinearAllocatorArena = utils::Arena<
         utils::LinearAllocator,
         utils::LockingPolicy::NoLock,
-        utils::TrackingPolicy::Debug>;
+        utils::TrackingPolicy::DebugAndHighWatermark>;
 
 #else
 

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -443,7 +443,7 @@ namespace TrackingPolicy {
 // default no-op tracker
 struct Untracked {
     Untracked() noexcept = default;
-    Untracked(const char* name, size_t size) noexcept { }
+    Untracked(const char* name, void* base, size_t size) noexcept { }
     void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept { }
     void onFree(void* p, size_t = 0) noexcept { }
     void onReset() noexcept { }
@@ -453,12 +453,13 @@ struct Untracked {
 // This just track the max memory usage and logs it in the destructor
 struct HighWatermark {
     HighWatermark() noexcept = default;
-    HighWatermark(const char* name, size_t size) noexcept : mName(name), mSize(uint32_t(size)) { }
+    HighWatermark(const char* name, void* base, size_t size) noexcept
+        : mName(name), mBase(base), mSize(uint32_t(size)) { }
     ~HighWatermark() noexcept;
     void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept;
-    void onFree(void* p, size_t size) noexcept { mCurrent -= uint32_t(size); }
-    void onReset() noexcept {  mCurrent = 0; }
-    void onRewind(void const* addr) noexcept { mCurrent = uint32_t(uintptr_t(addr) - uintptr_t(mBase)); }
+    void onFree(void* p, size_t size) noexcept;
+    void onReset() noexcept;
+    void onRewind(void const* addr) noexcept;
 protected:
     const char* mName = nullptr;
     void* mBase = nullptr;
@@ -468,16 +469,41 @@ protected:
 };
 
 // This just fills buffers with known values to help catch uninitialized access and use after free.
-// It also tracks the high water mark
-struct Debug : protected HighWatermark {
+struct Debug {
     Debug() noexcept = default;
-    Debug(const char* name, size_t size) noexcept : HighWatermark(name, size) { }
+    Debug(const char* name, void* base, size_t size) noexcept
+            : mName(name), mBase(base), mSize(uint32_t(size)) { }
     void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept;
-    void onFree(void* p, size_t = 0) noexcept;
+    void onFree(void* p, size_t size) noexcept;
     void onReset() noexcept;
     void onRewind(void* addr) noexcept;
+protected:
+    const char* mName = nullptr;
+    void* mBase = nullptr;
+    uint32_t mSize = 0;
 };
 
+struct DebugAndHighWatermark : protected HighWatermark, protected Debug {
+    DebugAndHighWatermark() noexcept = default;
+    DebugAndHighWatermark(const char* name, void* base, size_t size) noexcept
+            : HighWatermark(name, base, size), Debug(name, base, size) { }
+    void onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept {
+        HighWatermark::onAlloc(p, size, alignment, extra);
+        Debug::onAlloc(p, size, alignment, extra);
+    }
+    void onFree(void* p, size_t size) noexcept {
+        HighWatermark::onFree(p, size);
+        Debug::onFree(p, size);
+    }
+    void onReset() noexcept {
+        HighWatermark::onReset();
+        Debug::onReset();
+    }
+    void onRewind(void* addr) noexcept {
+        HighWatermark::onRewind(addr);
+        Debug::onRewind(addr);
+    }
+};
 
 } // namespace TrackingPolicy
 
@@ -497,7 +523,7 @@ public:
     Arena(const char* name, size_t size, ARGS&& ... args)
             : mArea(size),
               mAllocator(mArea, std::forward<ARGS>(args) ... ),
-              mListener(name, size),
+              mListener(name, mArea.data(), size),
               mArenaName(name) {
     }
 

--- a/libs/utils/test/test_Allocators.cpp
+++ b/libs/utils/test/test_Allocators.cpp
@@ -157,7 +157,7 @@ TEST(AllocatorTest, PoolAllocator) {
 TEST(AllocatorTest, CppAllocator) {
     struct Tracking {
         Tracking() noexcept { }
-        Tracking(const char* name, size_t size) noexcept { }
+        Tracking(const char* name, void const* base, size_t size) noexcept { }
         void onAlloc(void* p, size_t size, size_t alignment, size_t extra) {
             allocations.push_back(p);
         }
@@ -287,7 +287,7 @@ TEST(AllocatorTest, ScopedStackArena) {
 TEST(AllocatorTest, STLAllocator) {
     struct Tracking {
         Tracking() noexcept { }
-        Tracking(const char* name, size_t size) noexcept { }
+        Tracking(const char* name, void const* base, size_t size) noexcept { }
         void onAlloc(void* p, size_t size, size_t alignment, size_t extra) {
             allocations.push_back(p);
         }


### PR DESCRIPTION
TrackingPolicy::Debug didn't store the base pointer of the Area, and
instead relied on the first allocation to discover it, however, because
of alignment, the first allocation may not match the base pointer.
Because of that there could be an overflow in onRewind(), i.e. we
could rewind to a pointer before the (wrongly computed) base. This
overflow caused the debug memset to go awry and stomped on memory.

This is fixed by passing the base pointer to the constructor of the
TrackingPolicy. This base pointer could be nullptr with certain
allocators, but in that case, onReset/onRewind should never be called;
and this is enforced at compile time.

Also fixed a (luckily) harmless buffer overflow when preparing the
dynamic lights, if the number of lights wasn't a multiple of 4. This
was harmless because we use a linear allocator, so overflows are not 
really overflows.