### PR TITLE
Disable RenderingTest from CI test suite

### DIFF
--- a/build/common/test_list.txt
+++ b/build/common/test_list.txt
@@ -1,4 +1,4 @@
-filament/test/test_filament --gtest_filter=-FilamentTest.FroxelData:FilamentExposureWithEngineTest.SetExposure:FilamentExposureWithEngineTest.ComputeEV100
+filament/test/test_filament --gtest_filter=-FilamentTest.FroxelData:FilamentExposureWithEngineTest.SetExposure:FilamentExposureWithEngineTest.ComputeEV100:RenderingTest.*
 libs/math/test_math
 libs/image/test_image compare libs/image/tests/reference/
 libs/utils/test_utils


### PR DESCRIPTION
This is currently causing continuous tests to fail when running in CI. Let's temporarily disable until we can investigate.