### PR TITLE
clampNoV function ignores argument

### DIFF
--- a/shaders/src/common_material.fs
+++ b/shaders/src/common_material.fs
@@ -11,7 +11,7 @@
 
 float clampNoV(float NoV) {
     // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
-    return max(dot(shading_normal, shading_view), MIN_N_DOT_V);
+    return max(NoV, MIN_N_DOT_V);
 }
 
 vec3 computeDiffuseColor(const vec4 baseColor, float metallic) {


### PR DESCRIPTION
The "clampNoV" shader function is ignoring the passed dot product argument and recomputing the dot product itself. This will result in the wrong NoV value being used for clear coat IBL computations.