### PR TITLE
Stream API now supports acquire / release semantics.

### DIFF
--- a/android/common/CallbackUtils.h
+++ b/android/common/CallbackUtils.h
@@ -23,21 +23,6 @@
 
 #include <filament/Engine.h>
 
-struct JniCallback {
-    static JniCallback* make(filament::Engine* engine,
-            JNIEnv* env, jobject handler, jobject callback);
-
-    static void invoke(void* buffer, size_t n, void* user);
-
-private:
-    JniCallback(JNIEnv* env, jobject handler, jobject callback);
-    ~JniCallback();
-
-    JNIEnv* mEnv;
-    jobject mHandler;
-    jobject mCallback;
-};
-
 struct JniBufferCallback {
     static JniBufferCallback* make(filament::Engine* engine,
             JNIEnv* env, jobject handler, jobject callback, AutoBuffer&& buffer);
@@ -52,4 +37,20 @@ private:
     jobject mHandler;
     jobject mCallback;
     AutoBuffer mBuffer;
+};
+
+struct JniImageCallback {
+    static JniImageCallback* make(filament::Engine* engine, JNIEnv* env, jobject handler,
+            jobject runnable, long image);
+
+    static void invoke(void* image, void* user);
+
+private:
+    JniImageCallback(JNIEnv* env, jobject handler, jobject runnable, long image);
+    ~JniImageCallback();
+
+    JNIEnv* mEnv;
+    jobject mHandler;
+    jobject mCallback;
+    long mImage;
 };

--- a/android/filament-android/src/main/cpp/Stream.cpp
+++ b/android/filament-android/src/main/cpp/Stream.cpp
@@ -108,10 +108,10 @@ Java_com_google_android_filament_Stream_nBuilderBuild(JNIEnv*, jclass,
     return (jlong) builder->builder()->build(*engine);
 }
 
-extern "C" JNIEXPORT jboolean JNICALL
-Java_com_google_android_filament_Stream_nIsNative(JNIEnv*, jclass, jlong nativeStream) {
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Stream_nGetStreamType(JNIEnv*, jclass, jlong nativeStream) {
     Stream* stream = (Stream*) nativeStream;
-    return (jboolean) stream->isNativeStream();
+    return (jint) stream->getStreamType();
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -159,4 +159,13 @@ extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_Stream_nGetTimestamp(JNIEnv*, jclass, jlong nativeStream) {
     Stream *stream = (Stream *) nativeStream;
     return stream->getTimestamp();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Stream_nSetAcquiredImage(JNIEnv* env, jclass, jlong nativeStream,
+        jlong nativeEngine, jlong eglImage, jobject handler, jobject runnable) {
+    Engine* engine = (Engine*) nativeEngine;
+    Stream* stream = (Stream*) nativeStream;
+    auto* callback = JniImageCallback::make(engine, env, handler, runnable, eglImage);
+    stream->setAcquiredImage((void*) eglImage, &JniImageCallback::invoke, callback);
 }

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -624,6 +624,23 @@ enum class BlendFunction : uint8_t {
     SRC_ALPHA_SATURATE      //!< f(src, dst) = (1,1,1) * min(src.a, 1 - dst.a), 1
 };
 
+//! Stream for external textures
+enum class StreamType {
+    NATIVE,
+    TEXID,
+    ACQUIRED,
+};
+
+//! Releases an ACQUIRED external texture, guaranteed to be called on the application thread.
+using StreamCallback = void(*)(void* image, void* user);
+
+//! Bundles the state of an ACQUIRED stream.
+struct AcquiredImage {
+    void* image = nullptr;
+    backend::StreamCallback callback = nullptr;
+    void* userData = nullptr;
+};
+
 //! Vertex attribute descriptor
 struct Attribute {
     //! attribute is normalized (remapped between 0 and 1)

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -216,6 +216,8 @@ DECL_DRIVER_API_N(destroyStream,          backend::StreamHandle, sh)
 
 DECL_DRIVER_API_SYNCHRONOUS_0(void, terminate)
 DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStream, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStreamAcquired)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, setAcquiredImage, backend::StreamHandle, stream, void*, image, backend::StreamCallback, cb, void*, userData)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setStreamDimensions, backend::StreamHandle, stream, uint32_t, width, uint32_t, height)
 DECL_DRIVER_API_SYNCHRONOUS_N(int64_t, getStreamTimestamp, backend::StreamHandle, stream)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, updateStreams, backend::DriverApi*, driver)

--- a/filament/backend/src/Driver.cpp
+++ b/filament/backend/src/Driver.cpp
@@ -43,14 +43,27 @@ DriverBase::~DriverBase() noexcept {
 
 void DriverBase::purge() noexcept {
     std::vector<BufferDescriptor> buffersToPurge;
+    std::vector<AcquiredImage> imagesToPurge;
     std::unique_lock<std::mutex> lock(mPurgeLock);
     std::swap(buffersToPurge, mBufferToPurge);
+    std::swap(imagesToPurge, mImagesToPurge);
     lock.unlock(); // don't remove this, it ensures mBufferToPurge is destroyed without lock held
+    for (auto& image : imagesToPurge) {
+        image.callback(image.image, image.userData);
+    }
+    // When the BufferDescriptors go out of scope, their destructors invoke their callbacks.
 }
 
 void DriverBase::scheduleDestroySlow(BufferDescriptor&& buffer) noexcept {
     std::lock_guard<std::mutex> lock(mPurgeLock);
     mBufferToPurge.push_back(std::move(buffer));
+}
+
+// This is called from an async driver method so it's in the GL thread, but purge is called
+// on the user thread. This is typically called 0 or 1 times per frame.
+void DriverBase::scheduleRelease(const AcquiredImage& image) noexcept {
+    std::lock_guard<std::mutex> lock(mPurgeLock);
+    mImagesToPurge.push_back(image);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -132,9 +132,10 @@ struct HwSwapChain : public HwBase {
 };
 
 struct HwStream : public HwBase {
-    HwStream() = default;
-    explicit HwStream(Platform::Stream* stream) : stream(stream) { }
+    explicit HwStream() : streamType(StreamType::ACQUIRED) { }
+    explicit HwStream(Platform::Stream* stream) : stream(stream), streamType(StreamType::NATIVE) { }
     Platform::Stream* stream = nullptr;
+    StreamType streamType;
     uint32_t width = 0;
     uint32_t height = 0;
 };
@@ -168,9 +169,12 @@ protected:
 
     void scheduleDestroySlow(BufferDescriptor&& buffer) noexcept;
 
+    void scheduleRelease(const AcquiredImage& image) noexcept;
+
 private:
     std::mutex mPurgeLock;
     std::vector<BufferDescriptor> mBufferToPurge;
+    std::vector<AcquiredImage> mImagesToPurge;
 };
 
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -396,6 +396,14 @@ Handle<HwStream> MetalDriver::createStream(void* stream) {
     return {};
 }
 
+Handle<HwStream> MetalDriver::createStreamAcquired() {
+    return {};
+}
+
+void MetalDriver::setAcquiredImage(Handle<HwStream> sh, void* image, backend::StreamCallback cb,
+        void* userData) {
+}
+
 void MetalDriver::setStreamDimensions(Handle<HwStream> stream, uint32_t width,
         uint32_t height) {
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -124,7 +124,6 @@ public:
     struct GLStream : public backend::HwStream {
         static constexpr size_t ROUND_ROBIN_TEXTURE_COUNT = 3;      // 3 maximum
         using HwStream::HwStream;
-        bool isNativeStream() const { return gl.externalTextureId == 0; }
         struct Info {
             // storage for the read/write textures below
             backend::Platform::ExternalTexture* ets = nullptr;
@@ -143,8 +142,9 @@ public:
             GLuint fbo = 0;
         } gl;   // 20 bytes
 
+
         /*
-         * The fields below are access from the main application thread
+         * The fields below are accessed from the main application thread
          * (not the GL thread)
          */
         struct {
@@ -155,6 +155,8 @@ public:
             Info infos[ROUND_ROBIN_TEXTURE_COUNT];      // 48 bytes
             int64_t timestamp = 0;
             uint8_t cur = 0;
+            backend::AcquiredImage acquired;
+            backend::AcquiredImage pending;
         } user_thread;
     };
 
@@ -373,9 +375,12 @@ private:
     backend::OpenGLPlatform& mPlatform;
 
     OpenGLBlitter* mOpenGLBlitter = nullptr;
-    void updateStream(GLTexture* t, backend::DriverApi* driver) noexcept;
+    void updateStreamTexId(GLTexture* t, backend::DriverApi* driver) noexcept;
+    void updateStreamAcquired(GLTexture* t, backend::DriverApi* driver) noexcept;
     void updateBuffer(GLenum target, GLBuffer* buffer, backend::BufferDescriptor const& p, uint32_t alignment = 16) noexcept;
     void updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept;
+
+    void setExternalTexture(GLTexture* t, void* image);
 
     void whenGpuCommandsComplete(std::function<void()> fn) noexcept;
     void executeGpuCommandsCompleteOps() noexcept;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -549,6 +549,14 @@ Handle<HwStream> VulkanDriver::createStream(void* nativeStream) {
     return {};
 }
 
+Handle<HwStream> VulkanDriver::createStreamAcquired() {
+    return {};
+}
+
+void VulkanDriver::setAcquiredImage(Handle<HwStream> sh, void* image, backend::StreamCallback cb,
+        void* userData) {
+}
+
 void VulkanDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint32_t height) {
 }
 

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -84,6 +84,10 @@ namespace details {
 
 FStream::FStream(FEngine& engine, const Builder& builder) noexcept
         : mEngine(engine),
+          mStreamType(
+            builder->mExternalTextureId ? StreamType::TEXID :
+            (builder->mStream ? StreamType::NATIVE : StreamType::ACQUIRED)
+          ),
           mNativeStream(builder->mStream),
           mExternalTextureId(builder->mExternalTextureId),
           mWidth(builder->mWidth),
@@ -95,11 +99,17 @@ FStream::FStream(FEngine& engine, const Builder& builder) noexcept
     } else if (mExternalTextureId) {
         mStreamHandle = engine.getDriverApi().createStreamFromTextureId(
                 mExternalTextureId, mWidth, mHeight);
+    } else {
+        mStreamHandle = engine.getDriverApi().createStreamAcquired();
     }
 }
 
 void FStream::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroyStream(mStreamHandle);
+}
+
+void FStream::setAcquiredImage(void* image, Callback callback, void* userdata) noexcept {
+    mEngine.getDriverApi().setAcquiredImage(mStreamHandle, image, callback, userdata);
 }
 
 void FStream::setDimensions(uint32_t width, uint32_t height) noexcept {
@@ -116,7 +126,7 @@ void FStream::setDimensions(uint32_t width, uint32_t height) noexcept {
 
 void FStream::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         backend::PixelBufferDescriptor&& buffer) noexcept {
-    if (isExternalTextureId()) {
+    if (getStreamType() == StreamType::TEXID) {
         // this works only on external texture id streams
 
         const size_t sizeNeeded = PixelBufferDescriptor::computeDataSize(
@@ -150,8 +160,12 @@ int64_t FStream::getTimestamp() const noexcept {
 
 using namespace details;
 
-bool Stream::isNativeStream() const noexcept {
-    return upcast(this)->isNativeStream();
+StreamType Stream::getStreamType() const noexcept {
+    return upcast(this)->getStreamType();
+}
+
+void Stream::setAcquiredImage(void* image, Callback callback, void* userdata) noexcept {
+    upcast(this)->setAcquiredImage(image, callback, userdata);
 }
 
 void Stream::setDimensions(uint32_t width, uint32_t height) noexcept {

--- a/filament/src/details/Stream.h
+++ b/filament/src/details/Stream.h
@@ -37,14 +37,14 @@ public:
 
     backend::Handle<backend::HwStream> getHandle() const noexcept { return mStreamHandle; }
 
+    void setAcquiredImage(void* image, Callback callback, void* userdata) noexcept;
+
     void setDimensions(uint32_t width, uint32_t height) noexcept;
 
     void readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             backend::PixelBufferDescriptor&& buffer) noexcept;
 
-    bool isNativeStream() const noexcept { return mNativeStream != nullptr; }
-
-    bool isExternalTextureId() const noexcept { return !isNativeStream(); }
+    StreamType getStreamType() const noexcept { return mStreamType; }
 
     uint32_t getWidth() const noexcept { return mWidth; }
 
@@ -54,6 +54,7 @@ public:
 
 private:
     FEngine& mEngine;
+    const StreamType mStreamType;
     backend::Handle<backend::HwStream> mStreamHandle;
     void* mNativeStream = nullptr;
     intptr_t mExternalTextureId;


### PR DESCRIPTION
Previously, Streams had two modes (native and texid), this adds a third
mode called "acquired", which allows for copy-free synchronized external
textures in OpenGL and paves the way for Vulkan.

The native mode is now deprecated but texid mode needs to stay around
until all clients can be upgraded.

In an early prototype, this functionality was added directly into
Texture but required quite a bit of additional state tracking, so the
Stream API seemed like a better fit.

This API is probably not necessary for Metal due to Metal's shared
ownership semantics.

This has been tested with a new Android sample that will be added in a
subsequent PR.