### PR TITLE
Fix normals with skinning when there is no normal map.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: fixed blackness seen with default material.
 - Added ETC2 and BC compressed texture support to Metal backend.
 - Rendering a SAMPLER_EXTERNAL texture before setting an external image no longer results in GPU errors.
+- Fixed a normals issue when skinning without a normal map or anisotropy.
 
 ## v1.4.2
 

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -47,12 +47,15 @@ void main() {
     #else // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL
         // Without anisotropy or normal mapping we only need the normal vector
         toTangentFrame(mesh_tangents, material.worldNormal);
-        material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
+
         #if defined(HAS_SKINNING_OR_MORPHING)
             if (objectUniforms.skinningEnabled == 1) {
                 skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
             }
         #endif
+
+        material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
+
     #endif // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL
 #endif // HAS_ATTRIBUTE_TANGENTS
 


### PR DESCRIPTION
I tested this with the CesiumMan model, the lighting seems improved
around his hands.

Fixes #1848.