### PR TITLE
don't use our own sync primitives when TSAN is used

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -431,7 +431,12 @@ struct NoLock {
     void unlock() noexcept { }
 };
 
+// Unfortunately TSAN doesn't support homegrown synchronization primitives
+#if defined(__SANITIZE_THREAD__)
+using SpinLock = utils::Mutex;
+#else
 using SpinLock = utils::SpinLock;
+#endif
 
 using Mutex = utils::Mutex;
 

--- a/libs/utils/include/utils/Condition.h
+++ b/libs/utils/include/utils/Condition.h
@@ -17,7 +17,7 @@
 #ifndef UTILS_CONDITION_H
 #define UTILS_CONDITION_H
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__SANITIZE_THREAD__)
 #include <utils/linux/Condition.h>
 #else
 #include <utils/generic/Condition.h>

--- a/libs/utils/include/utils/Mutex.h
+++ b/libs/utils/include/utils/Mutex.h
@@ -17,7 +17,7 @@
 #ifndef UTILS_MUTEX_H
 #define UTILS_MUTEX_H
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__SANITIZE_THREAD__)
 #include <utils/linux/Mutex.h>
 #else
 #include <utils/generic/Mutex.h>


### PR DESCRIPTION
TSAN seems to have problems with homegrown sync primitives, such as
spinlocks, so we just don't use them when TSAN is enabled.