### PR TITLE
fix a data race on Debug builds

### DIFF
--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -35,9 +35,11 @@ static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE     = 3 * CONFIG_MIN_COMMAND
 
 #ifndef NDEBUG
 
+// on Debug builds, HeapAllocatorArena needs LockingPolicy::Mutex because it uses a
+// TrackingPolicy, which needs to be synchronized.
 using HeapAllocatorArena = utils::Arena<
         utils::HeapAllocator,
-        utils::LockingPolicy::NoLock,
+        utils::LockingPolicy::Mutex,
         utils::TrackingPolicy::DebugAndHighWatermark>;
 
 using LinearAllocatorArena = utils::Arena<
@@ -47,6 +49,8 @@ using LinearAllocatorArena = utils::Arena<
 
 #else
 
+// on Release builds, HeapAllocatorArena doesn't need a LockingPolicy because HeapAllocator is
+// intrinsically synchronized as it relies on heap allocations (i.e.: malloc/free)
 using HeapAllocatorArena = utils::Arena<
         utils::HeapAllocator,
         utils::LockingPolicy::NoLock>;


### PR DESCRIPTION
On Debug builds, HeapAllocatorArena needs LockingPolicy::Mutex because
it uses a TrackingPolicy, which needs to be synchronized.
On Release builds, HeapAllocatorArena doesn't need a LockingPolicy 
because HeapAllocator is intrinsically synchronized as it relies on
heap allocations (i.e.: malloc/free)