### PR TITLE
Stream API now supports acquire / release semantics.

### DIFF
--- a/android/common/CallbackUtils.h
+++ b/android/common/CallbackUtils.h
@@ -23,21 +23,6 @@
 
 #include <filament/Engine.h>
 
-struct JniCallback {
-    static JniCallback* make(filament::Engine* engine,
-            JNIEnv* env, jobject handler, jobject callback);
-
-    static void invoke(void* buffer, size_t n, void* user);
-
-private:
-    JniCallback(JNIEnv* env, jobject handler, jobject callback);
-    ~JniCallback();
-
-    JNIEnv* mEnv;
-    jobject mHandler;
-    jobject mCallback;
-};
-
 struct JniBufferCallback {
     static JniBufferCallback* make(filament::Engine* engine,
             JNIEnv* env, jobject handler, jobject callback, AutoBuffer&& buffer);
@@ -52,4 +37,20 @@ private:
     jobject mHandler;
     jobject mCallback;
     AutoBuffer mBuffer;
+};
+
+struct JniImageCallback {
+    static JniImageCallback* make(filament::Engine* engine, JNIEnv* env, jobject handler,
+            jobject runnable, long image);
+
+    static void invoke(void* image, void* user);
+
+private:
+    JniImageCallback(JNIEnv* env, jobject handler, jobject runnable, long image);
+    ~JniImageCallback();
+
+    JNIEnv* mEnv;
+    jobject mHandler;
+    jobject mCallback;
+    long mImage;
 };

--- a/android/filament-android/src/main/java/com/google/android/filament/Stream.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Stream.java
@@ -40,10 +40,10 @@ public class Stream {
         /** Not synchronized but copy-free. Good for video. */
         NATIVE,
 
-        /** Synchronized, but GL-only and incurs copies. Good for AR on older devices. */
+        /** Synchronized, but GL-only and incurs copies. Good for AR on devices before API 26. */
         TEXTURE_ID,
 
-        /** Synchronized, copy-free, and take a release callback. Good for AR on newer devices. */
+        /** Synchronized, copy-free, and take a release callback. Good for AR but requires API 26+. */
         ACQUIRED,
     };
 

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRCS
 )
 
 set(PRIVATE_HDRS
+        include/private/backend/AcquiredImage.h
         include/private/backend/CircularBuffer.h
         include/private/backend/CommandBufferQueue.h
         include/private/backend/CommandStream.h

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -624,6 +624,23 @@ enum class BlendFunction : uint8_t {
     SRC_ALPHA_SATURATE      //!< f(src, dst) = (1,1,1) * min(src.a, 1 - dst.a), 1
 };
 
+//! Stream for external textures
+enum class StreamType {
+    NATIVE,
+    TEXTURE_ID,
+    ACQUIRED,
+};
+
+//! Releases an ACQUIRED external texture, guaranteed to be called on the application thread.
+using StreamCallback = void(*)(void* image, void* user);
+
+//! Bundles the state of an ACQUIRED stream.
+struct AcquiredImage {
+    void* image = nullptr;
+    backend::StreamCallback callback = nullptr;
+    void* userData = nullptr;
+};
+
 //! Vertex attribute descriptor
 struct Attribute {
     //! attribute is normalized (remapped between 0 and 1)

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -626,9 +626,9 @@ enum class BlendFunction : uint8_t {
 
 //! Stream for external textures
 enum class StreamType {
-    NATIVE,
-    TEXTURE_ID,
-    ACQUIRED,
+    NATIVE,     //!< Not synchronized but copy-free. Good for video.
+    TEXTURE_ID, //!< Synchronized, but GL-only and incurs copies. Good for AR on devices before API 26.
+    ACQUIRED,   //!< Synchronized, copy-free, and take a release callback. Good for AR but requires API 26+.
 };
 
 //! Releases an ACQUIRED external texture, guaranteed to be called on the application thread.

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -634,13 +634,6 @@ enum class StreamType {
 //! Releases an ACQUIRED external texture, guaranteed to be called on the application thread.
 using StreamCallback = void(*)(void* image, void* user);
 
-//! Bundles the state of an ACQUIRED stream.
-struct AcquiredImage {
-    void* image = nullptr;
-    backend::StreamCallback callback = nullptr;
-    void* userData = nullptr;
-};
-
 //! Vertex attribute descriptor
 struct Attribute {
     //! attribute is normalized (remapped between 0 and 1)

--- a/filament/backend/include/private/backend/AcquiredImage.h
+++ b/filament/backend/include/private/backend/AcquiredImage.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_ACQUIRED_IMAGE_H
+#define TNT_FILAMENT_BACKEND_ACQUIRED_IMAGE_H
+
+#include <backend/DriverEnums.h>
+
+namespace filament {
+namespace backend {
+
+// This lightweight POD allows us to bundle the state required to process an ACQUIRED stream.
+// Since these types of external images need to be moved around and queued up, an encapsulation is
+// very useful.
+
+struct AcquiredImage {
+    void* image = nullptr;
+    backend::StreamCallback callback = nullptr;
+    void* userData = nullptr;
+};
+
+} // namespace backend
+} // namespace filament
+
+#endif // TNT_FILAMENT_BACKEND_ACQUIRED_IMAGE_H

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -215,7 +215,9 @@ DECL_DRIVER_API_N(destroyStream,          backend::StreamHandle, sh)
  */
 
 DECL_DRIVER_API_SYNCHRONOUS_0(void, terminate)
-DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStream, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStreamNative, void*, stream)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::StreamHandle, createStreamAcquired)
+DECL_DRIVER_API_SYNCHRONOUS_N(void, setAcquiredImage, backend::StreamHandle, stream, void*, image, backend::StreamCallback, cb, void*, userData)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setStreamDimensions, backend::StreamHandle, stream, uint32_t, width, uint32_t, height)
 DECL_DRIVER_API_SYNCHRONOUS_N(int64_t, getStreamTimestamp, backend::StreamHandle, stream)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, updateStreams, backend::DriverApi*, driver)

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -107,6 +107,11 @@ public:
     // called once before a SAMPLER_EXTERNAL texture is destroyed.
     virtual void destroyExternalImage(void* texture) noexcept {}
 
+    // allows platforms to convert the given image object into a new type (e.g. HardwareBuffer => EGLImage)
+    // by default, performs no conversion.
+    virtual AcquiredImage createAcquiredImage(void* hwbuffer, backend::StreamCallback cb, void* userData) noexcept {
+        return {hwbuffer, cb, userData};
+    }
 };
 
 } // namespace backend

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -19,6 +19,8 @@
 
 #include <backend/Platform.h>
 
+#include "private/backend/AcquiredImage.h"
+
 namespace filament {
 namespace backend {
 

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -91,6 +91,10 @@ public:
 
     virtual void destroyExternalTextureStorage(ExternalTexture* ets) noexcept = 0;
 
+    // The method allows platforms to convert a user-supplied external image object into a new type
+    // (e.g. HardwareBuffer => EGLImage). It makes sense for the default implementation to do nothing.
+    virtual AcquiredImage transformAcquiredImage(AcquiredImage source) noexcept { return source; }
+
     // called to bind the platform-specific externalImage to a texture
     // texture points to a OpenGLDriver::GLTexture
     virtual bool setExternalImage(void* externalImage, void* texture) noexcept {
@@ -108,12 +112,6 @@ public:
 
     // called once before a SAMPLER_EXTERNAL texture is destroyed.
     virtual void destroyExternalImage(void* texture) noexcept {}
-
-    // allows platforms to convert the given image object into a new type (e.g. HardwareBuffer => EGLImage)
-    // by default, performs no conversion.
-    virtual AcquiredImage createAcquiredImage(void* hwbuffer, backend::StreamCallback cb, void* userData) noexcept {
-        return {hwbuffer, cb, userData};
-    }
 };
 
 } // namespace backend

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -133,8 +133,9 @@ struct HwSwapChain : public HwBase {
 
 struct HwStream : public HwBase {
     HwStream() = default;
-    explicit HwStream(Platform::Stream* stream) : stream(stream) { }
+    explicit HwStream(Platform::Stream* stream) : stream(stream), streamType(StreamType::NATIVE) { }
     Platform::Stream* stream = nullptr;
+    StreamType streamType = StreamType::ACQUIRED;
     uint32_t width = 0;
     uint32_t height = 0;
 };
@@ -168,9 +169,12 @@ protected:
 
     void scheduleDestroySlow(BufferDescriptor&& buffer) noexcept;
 
+    void scheduleRelease(AcquiredImage&& image) noexcept;
+
 private:
     std::mutex mPurgeLock;
     std::vector<BufferDescriptor> mBufferToPurge;
+    std::vector<AcquiredImage> mImagesToPurge;
 };
 
 

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -24,6 +24,7 @@
 
 #include <backend/DriverEnums.h>
 
+#include "private/backend/AcquiredImage.h"
 #include "private/backend/Driver.h"
 #include "private/backend/SamplerGroup.h"
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -392,8 +392,16 @@ ShaderModel MetalDriver::getShaderModel() const noexcept {
 #endif
 }
 
-Handle<HwStream> MetalDriver::createStream(void* stream) {
+Handle<HwStream> MetalDriver::createStreamNative(void* stream) {
     return {};
+}
+
+Handle<HwStream> MetalDriver::createStreamAcquired() {
+    return {};
+}
+
+void MetalDriver::setAcquiredImage(Handle<HwStream> sh, void* image, backend::StreamCallback cb,
+        void* userData) {
 }
 
 void MetalDriver::setStreamDimensions(Handle<HwStream> stream, uint32_t width,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1209,7 +1209,7 @@ void OpenGLDriver::setAcquiredImage(Handle<HwStream> sh, void* hwbuffer,
         scheduleRelease(std::move(glstream->user_thread.pending));
         slog.w << "Acquired image is set more than once per frame." << io::endl;
     }
-    glstream->user_thread.pending = mPlatform.createAcquiredImage(hwbuffer, cb, userData);
+    glstream->user_thread.pending = mPlatform.transformAcquiredImage({hwbuffer, cb, userData});
 }
 
 void OpenGLDriver::updateStreams(DriverApi* driver) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2205,9 +2205,7 @@ void OpenGLDriver::updateStreamAcquired(GLTexture* gltexture, DriverApi* driver)
     driver->queueCommand([this, gltexture, image, previousImage]() {
         setExternalTexture(gltexture, image);
         if (previousImage.image) {
-            whenGpuCommandsComplete([this, previousImage]()  {
-                scheduleRelease(AcquiredImage(previousImage));
-            });
+            scheduleRelease(AcquiredImage(previousImage));
         }
     });
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -124,7 +124,6 @@ public:
     struct GLStream : public backend::HwStream {
         static constexpr size_t ROUND_ROBIN_TEXTURE_COUNT = 3;      // 3 maximum
         using HwStream::HwStream;
-        bool isNativeStream() const { return gl.externalTextureId == 0; }
         struct Info {
             // storage for the read/write textures below
             backend::Platform::ExternalTexture* ets = nullptr;
@@ -143,8 +142,9 @@ public:
             GLuint fbo = 0;
         } gl;   // 20 bytes
 
+
         /*
-         * The fields below are access from the main application thread
+         * The fields below are accessed from the main application thread
          * (not the GL thread)
          */
         struct {
@@ -155,6 +155,8 @@ public:
             Info infos[ROUND_ROBIN_TEXTURE_COUNT];      // 48 bytes
             int64_t timestamp = 0;
             uint8_t cur = 0;
+            backend::AcquiredImage acquired;
+            backend::AcquiredImage pending;
         } user_thread;
     };
 
@@ -373,9 +375,12 @@ private:
     backend::OpenGLPlatform& mPlatform;
 
     OpenGLBlitter* mOpenGLBlitter = nullptr;
-    void updateStream(GLTexture* t, backend::DriverApi* driver) noexcept;
+    void updateStreamTexId(GLTexture* t, backend::DriverApi* driver) noexcept;
+    void updateStreamAcquired(GLTexture* t, backend::DriverApi* driver) noexcept;
     void updateBuffer(GLenum target, GLBuffer* buffer, backend::BufferDescriptor const& p, uint32_t alignment = 16) noexcept;
     void updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept;
+
+    void setExternalTexture(GLTexture* t, void* image);
 
     void whenGpuCommandsComplete(std::function<void()> fn) noexcept;
     void executeGpuCommandsCompleteOps() noexcept;

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -552,22 +552,29 @@ backend::AcquiredImage PlatformEGL::createAcquiredImage(void* hwbuffer, backend:
     }
     // Note that this cannot be used to stream protected video (for now) because we do not set EGL_PROTECTED_CONTENT_EXT.
     EGLint attrs[] = { EGL_NONE, EGL_NONE };
-    EGLImageKHR eglImage = eglCreateImageKHR(eglGetCurrentDisplay(), EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attrs);
+    EGLImageKHR eglImage = eglCreateImageKHR(mEGLDisplay, EGL_NO_CONTEXT, EGL_NATIVE_BUFFER_ANDROID, clientBuffer, attrs);
     if (eglImage == EGL_NO_IMAGE_KHR) {
         slog.e << "eglCreateImageKHR returned no image." << io::endl;
         return {};
     }
 
     // Destroy the EGLImage before invoking the user's callback.
-    AcquiredImage* closure = new AcquiredImage();
+    struct Closure {
+        void* image;
+        backend::StreamCallback callback;
+        void* userData;
+        EGLDisplay display;
+    };
+    Closure* closure = new Closure();
     closure->callback = userCallback;
     closure->image = hwbuffer;
     closure->userData = userData;
+    closure->display = mEGLDisplay;
     auto patchedCallback = [](void* image, void* userdata) {
-        if (eglDestroyImageKHR(eglGetCurrentDisplay(), (EGLImageKHR) image) == EGL_FALSE) {
+        Closure* closure = (Closure*) userdata;
+        if (eglDestroyImageKHR(closure->display, (EGLImageKHR) image) == EGL_FALSE) {
             slog.e << "eglDestroyImageKHR failed." << io::endl;
         }
-        backend::AcquiredImage* closure = (backend::AcquiredImage*) userdata;
         closure->callback(closure->image, closure->userData);
         delete closure;
     };

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -542,7 +542,10 @@ void PlatformEGL::destroyExternalImage(void* texture) noexcept {
     glDeleteTextures(1, &t->gl.id);
 }
 
-backend::AcquiredImage PlatformEGL::createAcquiredImage(void* hwbuffer, backend::StreamCallback userCallback, void* userData) noexcept {
+backend::AcquiredImage PlatformEGL::transformAcquiredImage(backend::AcquiredImage source) noexcept {
+    void* const hwbuffer = source.image;
+    const backend::StreamCallback userCallback = source.callback;
+    void* const userData = source.userData;
 
     // Convert the AHardwareBuffer to EGLImage.
     EGLClientBuffer clientBuffer = eglGetNativeClientBufferANDROID((const AHardwareBuffer*) hwbuffer);

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -69,6 +69,8 @@ public:
     void createExternalImageTexture(void* texture) noexcept final;
     void destroyExternalImage(void* texture) noexcept final;
 
+    backend::AcquiredImage createAcquiredImage(void* hwbuffer, backend::StreamCallback cb, void* userData) noexcept final;
+
     int getOSVersion() const noexcept final;
 
 private:

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -69,7 +69,7 @@ public:
     void createExternalImageTexture(void* texture) noexcept final;
     void destroyExternalImage(void* texture) noexcept final;
 
-    backend::AcquiredImage createAcquiredImage(void* hwbuffer, backend::StreamCallback cb, void* userData) noexcept final;
+    backend::AcquiredImage transformAcquiredImage(backend::AcquiredImage source) noexcept final;
 
     int getOSVersion() const noexcept final;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -545,8 +545,16 @@ void VulkanDriver::destroySwapChain(Handle<HwSwapChain> sch) {
 void VulkanDriver::destroyStream(Handle<HwStream> sh) {
 }
 
-Handle<HwStream> VulkanDriver::createStream(void* nativeStream) {
+Handle<HwStream> VulkanDriver::createStreamNative(void* nativeStream) {
     return {};
+}
+
+Handle<HwStream> VulkanDriver::createStreamAcquired() {
+    return {};
+}
+
+void VulkanDriver::setAcquiredImage(Handle<HwStream> sh, void* image, backend::StreamCallback cb,
+        void* userData) {
 }
 
 void VulkanDriver::setStreamDimensions(Handle<HwStream> sh, uint32_t width, uint32_t height) {

--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -37,7 +37,18 @@ class UTILS_PUBLIC Stream : public FilamentAPI {
     struct BuilderDetails;
 
 public:
-    //! Use Builder to construct an Stream object instance
+    using Callback = backend::StreamCallback;
+    using StreamType = backend::StreamType;
+
+    /**
+     * Constructs a Stream object instance.
+     *
+     * By default, Stream objects are ACQUIRED and must have external images pushed to them via
+     * <pre>Stream::setAcquiredImage</pre>.
+     *
+     * To create a NATIVE or TEXTURE_ID stream, call one of the <pre>stream</pre> methods
+     * on the builder.
+     */
     class Builder : public BuilderBase<BuilderDetails> {
         friend struct BuilderDetails;
     public:
@@ -49,7 +60,7 @@ public:
         Builder& operator=(Builder&& rhs) noexcept;
 
         /**
-         * Creates a native stream. Native streams can sample data directly from an
+         * Creates a NATIVE stream. Native streams can sample data directly from an
          * opaque platform object such as a SurfaceTexture on Android.
          *
          * @param stream An opaque native stream handle. e.g.: on Android this is an
@@ -60,7 +71,7 @@ public:
         Builder& stream(void* stream) noexcept;
 
         /**
-         * Creates a copy stream. A copy stream will sample data from the supplied
+         * Creates a TEXTURE_ID stream. This will sample data from the supplied
          * external texture and copy it into an internal private texture.
          *
          * @param externalTextureId An opaque texture id (typically a GLuint created with glGenTextures)
@@ -107,9 +118,17 @@ public:
     };
 
     /**
-     * Indicates whether this stream is a native stream or a copy stream.
+     * Indicates whether this stream is a NATIVE stream, TEXTURE_ID stream, or ACQUIRED stream.
      */
-    bool isNativeStream() const noexcept;
+    StreamType getStreamType() const noexcept;
+
+    /**
+     * Updates an ACQUIRED stream with an image that is guaranteed to be used in the next frame.
+     *
+     * This method should be called on the same thread that calls Renderer::beginFrame, which is
+     * also where the callback is invoked.
+     */
+    void setAcquiredImage(void* image, Callback callback, void* userdata) noexcept;
 
     /**
      * Updates the size of the incoming stream. Whether this value is used is

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -84,6 +84,10 @@ namespace details {
 
 FStream::FStream(FEngine& engine, const Builder& builder) noexcept
         : mEngine(engine),
+          mStreamType(
+            builder->mExternalTextureId ? StreamType::TEXTURE_ID :
+            (builder->mStream ? StreamType::NATIVE : StreamType::ACQUIRED)
+          ),
           mNativeStream(builder->mStream),
           mExternalTextureId(builder->mExternalTextureId),
           mWidth(builder->mWidth),
@@ -91,15 +95,21 @@ FStream::FStream(FEngine& engine, const Builder& builder) noexcept
 
     if (mNativeStream) {
         // Note: this is a synchronous call. On Android, this calls back into Java.
-        mStreamHandle = engine.getDriverApi().createStream(mNativeStream);
+        mStreamHandle = engine.getDriverApi().createStreamNative(mNativeStream);
     } else if (mExternalTextureId) {
         mStreamHandle = engine.getDriverApi().createStreamFromTextureId(
                 mExternalTextureId, mWidth, mHeight);
+    } else {
+        mStreamHandle = engine.getDriverApi().createStreamAcquired();
     }
 }
 
 void FStream::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroyStream(mStreamHandle);
+}
+
+void FStream::setAcquiredImage(void* image, Callback callback, void* userdata) noexcept {
+    mEngine.getDriverApi().setAcquiredImage(mStreamHandle, image, callback, userdata);
 }
 
 void FStream::setDimensions(uint32_t width, uint32_t height) noexcept {
@@ -116,7 +126,7 @@ void FStream::setDimensions(uint32_t width, uint32_t height) noexcept {
 
 void FStream::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         backend::PixelBufferDescriptor&& buffer) noexcept {
-    if (isExternalTextureId()) {
+    if (getStreamType() == StreamType::TEXTURE_ID) {
         // this works only on external texture id streams
 
         const size_t sizeNeeded = PixelBufferDescriptor::computeDataSize(
@@ -150,8 +160,12 @@ int64_t FStream::getTimestamp() const noexcept {
 
 using namespace details;
 
-bool Stream::isNativeStream() const noexcept {
-    return upcast(this)->isNativeStream();
+StreamType Stream::getStreamType() const noexcept {
+    return upcast(this)->getStreamType();
+}
+
+void Stream::setAcquiredImage(void* image, Callback callback, void* userdata) noexcept {
+    upcast(this)->setAcquiredImage(image, callback, userdata);
 }
 
 void Stream::setDimensions(uint32_t width, uint32_t height) noexcept {

--- a/filament/src/details/Stream.h
+++ b/filament/src/details/Stream.h
@@ -37,14 +37,14 @@ public:
 
     backend::Handle<backend::HwStream> getHandle() const noexcept { return mStreamHandle; }
 
+    void setAcquiredImage(void* image, Callback callback, void* userdata) noexcept;
+
     void setDimensions(uint32_t width, uint32_t height) noexcept;
 
     void readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             backend::PixelBufferDescriptor&& buffer) noexcept;
 
-    bool isNativeStream() const noexcept { return mNativeStream != nullptr; }
-
-    bool isExternalTextureId() const noexcept { return !isNativeStream(); }
+    StreamType getStreamType() const noexcept { return mStreamType; }
 
     uint32_t getWidth() const noexcept { return mWidth; }
 
@@ -54,6 +54,7 @@ public:
 
 private:
     FEngine& mEngine;
+    const StreamType mStreamType;
     backend::Handle<backend::HwStream> mStreamHandle;
     void* mNativeStream = nullptr;
     intptr_t mExternalTextureId;


### PR DESCRIPTION
Previously, Streams had two modes (native and texid), this adds a third
mode called "acquired", which allows for copy-free synchronized external
textures in OpenGL and paves the way for Vulkan.

The native mode is now deprecated but texid mode needs to stay around
until all clients can be upgraded.

In an early prototype, this functionality was added directly into
Texture but required quite a bit of additional state tracking, so the
Stream API seemed like a better fit.

This API is probably not necessary for Metal due to Metal's shared
ownership semantics.

This has been tested with a new Android sample that will be added in a
subsequent PR.