### PR TITLE
RenderPass cleanup/refactoring

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -427,7 +427,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, Re
     // We limit the level size to 32 pixels (which is where the -5 comes from)
     const size_t levelCount = std::max(1, std::ilogbf(std::max(width, height)) + 1 - 5);
 
-    // SSAO generates its own depth path at 1/4 resolution
+    // SSAO generates its own depth pass at the requested resolution
     auto& ssaoDepthPass = fg.addPass<DepthPassData>("SSAO Depth Pass",
             [&](FrameGraph::Builder& builder, DepthPassData& data) {
                 data.depth = builder.createTexture("Depth Buffer", {
@@ -440,8 +440,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, Re
                 // nested designated initializers not in C++ standard: https://tinyurl.com/y6krwocx
                 FrameGraphRenderTarget::Descriptor d;
                 d.attachments.depth = data.depth;
-                data.rt = builder.createRenderTarget("SSAO Depth Target",
-                                                     d,
+                data.rt = builder.createRenderTarget("SSAO Depth Target", d,
                                                      TargetBufferFlags::DEPTH);
             },
             [=, &pass](FrameGraphPassResources const& resources,
@@ -468,9 +467,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::mipmapPass(FrameGraph& fg,
     auto& depthMipmapPass = fg.addPass<DepthMipData>("Depth Mipmap Pass",
             [&](FrameGraph::Builder& builder, DepthMipData& data) {
                 const char* name = builder.getName(input);
-
                 data.in = builder.sample(input);
-
                 data.out = builder.write(data.in);
                 FrameGraphRenderTarget::Descriptor d;
                 d.attachments.depth = { data.out, uint8_t(level + 1) };

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -278,7 +278,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     CameraInfo const& cameraInfo = view.getCameraInfo();
     pass.setCamera(cameraInfo);
-    pass.setGeometry(scene, view.getVisibleRenderables());
+    pass.setGeometry(scene.getRenderableData(), view.getVisibleRenderables(), scene.getRenderableUBO());
 
     view.updatePrimitivesLod(engine, cameraInfo,
             scene.getRenderableData(), view.getVisibleRenderables());

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -179,7 +179,7 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
     pass.setCamera(cameraInfo);
 
     FView::Range visibleRenderables = view.getVisibleShadowCasters();
-    pass.setGeometry(scene, visibleRenderables);
+    pass.setGeometry(scene.getRenderableData(), visibleRenderables, scene.getRenderableUBO());
 
     view.updatePrimitivesLod(engine, cameraInfo, scene.getRenderableData(), visibleRenderables);
     view.prepareCamera(cameraInfo, viewport);


### PR DESCRIPTION
RenderPass's API now doesn't need to know about FScene, instead we
pass the geometry info as parameters.

This is one step towards keeping the "scene" concept more away from
rendering.