### PR TITLE
Add a way to override the material of a RenderPass

### DIFF
--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -248,6 +248,7 @@ public:
 
     RenderPass(FEngine& engine, utils::GrowingSlice<Command>& commands) noexcept;
     void overridePolygonOffset(backend::PolygonOffset* polygonOffset) noexcept;
+    void overrideMaterial(FMaterial const* material, FMaterialInstance const* mi) noexcept;
     void setGeometry(FScene::RenderableSoa const& soa, utils::Range<uint32_t> vr,
             backend::Handle<backend::HwUniformBuffer> uboHandle) noexcept;
     void setCamera(const CameraInfo& camera) noexcept;
@@ -332,6 +333,7 @@ private:
     bool mPolygonOffsetOverride = false;
     // value of the override
     backend::PolygonOffset mPolygonOffset{};
+    FMaterialInstance const* mMaterialInstanceOverride = nullptr;
 
     // a vector for our custom commands
     mutable CustomCommandVector mCustomCommands;


### PR DESCRIPTION
We used to have this functionality, but it we removed it because we
didn't have a use for it and it was costly.

This new implementation is only internal, and would (will?) be useful
if we wanted to generate a special buffer for SSAO for instance (instead
of just depth). This implementation, overrides the material at the time
the commands are executed, which is much cheaper than the previous
implementation.