### PR TITLE
fix a few issues with MSAA blits

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -259,8 +259,16 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::resolve(
     return ppResolve.getData().output;
 }
 
-FrameGraphId<FrameGraphTexture> PostProcessManager::dynamicScaling(FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat) noexcept {
+FrameGraphId <FrameGraphTexture> PostProcessManager::dynamicScaling(FrameGraph& fg,
+        uint8_t msaa, bool scaled,
+        FrameGraphId <FrameGraphTexture> input, backend::TextureFormat outFormat) noexcept {
+
+    FrameGraphTexture::Descriptor const& inputDesc = fg.getDescriptor(input);
+    if (msaa > 1 && (scaled || inputDesc.format != outFormat)) {
+        // scaling and format conversion are not allowed with a MSAA blit, so we resolve first
+        // TODO: we could avoid this by using a quad instead of a blit
+        input = resolve(fg, input);
+    }
 
     struct PostProcessScaling {
         FrameGraphId<FrameGraphTexture> input;
@@ -278,7 +286,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dynamicScaling(FrameGraph& f
                 d.attachments.color = { data.input };
                 data.srt = builder.createRenderTarget(builder.getName(data.input), d);
 
-                data.output = builder.createTexture("scale output", {
+                data.output = builder.createTexture("scaled output", {
                         .width = inputDesc.width,
                         .height = inputDesc.height,
                         .format = outFormat

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -52,8 +52,9 @@ public:
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
             bool translucent) noexcept;
 
-    FrameGraphId<FrameGraphTexture> dynamicScaling(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat) noexcept;
+    FrameGraphId <FrameGraphTexture> dynamicScaling(
+            FrameGraph& fg, uint8_t msaa, bool scaled, FrameGraphId <FrameGraphTexture> input,
+            backend::TextureFormat outFormat) noexcept;
 
     FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input) noexcept;


### PR DESCRIPTION
1) When scaling is enabled, we're using a blit at the end of the frame,
   however, if MSAA is also enabled, this blit is not allowed, so we
   need an explicit MSAA resolve.

2) When rendering directly into the default render target with MSAA
   enabled, we need an explicit resolve ONLY IF there is a format
   conversion, because those are also not allowed. 
   Before, we were doing this resolve regardless.

3) The test for "rendering directly into the default target" had
   become wrong because, the Render target can now be a user texture
   (which is assumed to have the proper MSAA-ness and a depth buffer),
   so no intermediate buffer should be needed for those. We now
   check that render target is actually the default render target