### PR TITLE
Always use SH3 for indirect lighting

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ A new header is inserted each time a *tag* is created.
 - Added ETC2 and BC compressed texture support to Metal backend.
 - Rendering a SAMPLER_EXTERNAL texture before setting an external image no longer results in GPU errors.
 - Fixed a normals issue when skinning without a normal map or anisotropy.
+- Always use higher quality 3-bands SH for indirect lighting, even on mobile.
 
 ## v1.4.2
 

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -3,11 +3,7 @@
 //------------------------------------------------------------------------------
 
 // Number of spherical harmonics bands (1, 2 or 3)
-#if defined(TARGET_MOBILE)
-#define SPHERICAL_HARMONICS_BANDS           2
-#else
 #define SPHERICAL_HARMONICS_BANDS           3
-#endif
 
 // IBL integration algorithm
 #define IBL_INTEGRATION_PREFILTERED_CUBEMAP         0


### PR DESCRIPTION
We used to use SH2 on mobile/webgl, but the quality degradation is too
prominent. This adds ~16 adds though.