### PR TITLE
Add release GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,175 @@
+name: Release
+
+# This Workflow can be triggered two ways:
+# 1. A GitHub release is created (using the GitHub web UI). This triggers all of the platforms to build and upload assets.
+# 2. A repository_dispatch API event is sent. This triggers a build for only the platform specified in the dispatch event.
+
+env:
+  RELEASE_TAG: ${{ github.event.client_payload.release_tag }}
+
+on:
+  repository_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  build-desktop:
+    name: build-desktop
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'release' || github.event.client_payload.platform == 'desktop'
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo ::set-output name=ref::${REF}
+          echo ::set-output name=tag::${TAG}
+      - uses: actions/checkout@v1.0.0
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Run build script
+        run: |
+          WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
+          cd build/$WORKFLOW_OS && ./build.sh release
+      - name: Upload release assets
+        run: |
+          pip3 install setuptools
+          pip3 install PyGithub
+          DATE=`date +%Y%m%d`
+          if [ -f out/filament-release-darwin.tgz ]; then mv out/filament-release-darwin.tgz out/filament-${DATE}-mac.tgz; fi;
+          if [ -f out/filament-release-linux.tgz ]; then mv out/filament-release-linux.tgz out/filament-${DATE}-linux.tgz; fi;
+          python3 build/common/upload-assets.py ${TAG} out/*.tgz
+        env:
+          TAG: ${{ steps.git_ref.outputs.tag }}
+          GITHUB_API_KEY: ${{ secrets.GITHUB_API_KEY }}
+
+  build-web:
+    name: build-web
+    runs-on: macos-latest
+    if: github.event_name == 'release' || github.event.client_payload.platform == 'web'
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo ::set-output name=ref::${REF}
+          echo ::set-output name=tag::${TAG}
+      - uses: actions/checkout@v1.0.0
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Run build script
+        run: |
+          cd build/web && ./build.sh release
+      - name: Upload release assets
+        run: |
+          pip3 install setuptools
+          pip3 install PyGithub
+          DATE=`date +%Y%m%d`
+          mv out/filament-release-web.tgz out/filament-${DATE}-web.tgz
+          python3 build/common/upload-assets.py ${TAG} out/*.tgz
+        env:
+          TAG: ${{ steps.git_ref.outputs.tag }}
+          GITHUB_API_KEY: ${{ secrets.GITHUB_API_KEY }}
+
+  build-android:
+    name: build-android
+    runs-on: macos-latest
+    if: github.event_name == 'release' || github.event.client_payload.platform == 'android'
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo ::set-output name=ref::${REF}
+          echo ::set-output name=tag::${TAG}
+      - uses: actions/checkout@v1.0.0
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Run build script
+        run: |
+          cd build/android && ./build.sh release
+      - name: Upload release assets
+        run: |
+          pip3 install setuptools
+          pip3 install PyGithub
+          DATE=`date +%Y%m%d`
+          mv out/filament-android-release.aar out/filament-${DATE}-android.aar
+          mv out/filamat-android-full-release.aar out/filamat-${DATE}-full-android.aar
+          mv out/filamat-android-lite-release.aar out/filamat-${DATE}-lite-android.aar
+          mv out/gltfio-android-release.aar out/gltfio-${DATE}-android.aar
+          python3 build/common/upload-assets.py ${TAG} out/*.aar
+        env:
+          TAG: ${{ steps.git_ref.outputs.tag }}
+          GITHUB_API_KEY: ${{ secrets.GITHUB_API_KEY }}
+
+  build-ios:
+    name: build-ios
+    runs-on: macos-latest
+    if: github.event_name == 'release' || github.event.client_payload.platform == 'ios'
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo ::set-output name=ref::${REF}
+          echo ::set-output name=tag::${TAG}
+      - uses: actions/checkout@v1.0.0
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Run build script
+        run: |
+          cd build/ios && ./build.sh release
+      - name: Upload release assets
+        run: |
+          pip3 install setuptools
+          pip3 install PyGithub
+          DATE=`date +%Y%m%d`
+          mv out/filament-release-ios.tgz out/filament-${DATE}-ios.tgz
+          python3 build/common/upload-assets.py ${TAG} out/*.tgz
+        env:
+          TAG: ${{ steps.git_ref.outputs.tag }}
+          GITHUB_API_KEY: ${{ secrets.GITHUB_API_KEY }}
+
+  build-windows:
+    name: build-windows
+    runs-on: windows-latest
+    if: github.event_name == 'release' || github.event.client_payload.platform == 'windows'
+
+    steps:
+      - name: Decide Git ref
+        id: git_ref
+        run: |
+          REF=${RELEASE_TAG:-${GITHUB_REF}}
+          TAG=${REF##*/}
+          echo ::set-output name=ref::${REF}
+          echo ::set-output name=tag::${TAG}
+        shell: bash
+      - uses: actions/checkout@v1.0.0
+        with:
+          ref: ${{ steps.git_ref.outputs.ref }}
+      - name: Run build script
+        run: |
+          build\windows\build-github.bat release
+        shell: cmd
+      - name: Upload release assets
+        run: |
+          pip3 install PyGithub
+          DATE=`date +%Y%m%d`
+          mv out/filament-windows.tgz out/filament-${DATE}-windows.tgz
+          python build/common/upload-assets.py ${TAG} out/*.tgz
+        shell: bash
+        env:
+          TAG: ${{ steps.git_ref.outputs.tag }}
+          GITHUB_API_KEY: ${{ secrets.GITHUB_API_KEY }}

--- a/build/common/upload-assets.py
+++ b/build/common/upload-assets.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from github import Github
+import os, sys
+
+def print_usage():
+    print('Upload assets to a Filament GitHub release.')
+    print()
+    print('Usage:')
+    print('  upload-assets.py <tag> <asset>...')
+    print()
+    print('Notes:')
+    print('  The GitHub release must already be created prior to running this script. This is typically done')
+    print('  through the GitHub web UI.')
+    print()
+    print('  <tag> is the Git tag for the desired release to attach assets to, for example, "v1.4.2".')
+    print()
+    print('  <asset> is a path to the asset file to upload. The file name will be used as the name of the')
+    print('  asset.')
+    print()
+    print('  The GITHUB_API_KEY environment variable must be set to a valid authentication token for a')
+    print('  collaborator account of the Filament repository.')
+
+# The first argument is the path to this script.
+if len(sys.argv) < 3:
+    print_usage()
+    sys.exit(1)
+
+tag = sys.argv[1]
+assets = sys.argv[2:]
+
+authentication_token = os.environ.get('GITHUB_API_KEY')
+if not authentication_token:
+    sys.stderr.write('Error: the GITHUB_API_KEY is not set.\n')
+    sys.exit(1)
+
+g = Github(authentication_token)
+
+FILAMENT_REPO = "google/filament"
+filament = g.get_repo(FILAMENT_REPO)
+
+def find_release_from_tag(repo, tag):
+    """ Find a release in the repo for the given Git tag string. """
+    releases = repo.get_releases()
+    for r in releases:
+        if r.tag_name == tag:
+            return r
+    return None
+
+release = find_release_from_tag(filament, tag)
+if not release:
+    sys.stderr.write(f"Error: Could not find release with tag '{tag}'.\n")
+    sys.exit(1)
+
+print(f"Found release with tag '{tag}'.")
+
+for asset_path in assets:
+    sys.stdout.write(f'Uploding asset: {asset_path}... ')
+    asset_name = os.path.basename(asset_path)
+    asset = release.upload_asset(asset_path, name=asset_name)
+    if asset:
+        sys.stdout.write('Success!\n')

--- a/build/windows/build-github.bat
+++ b/build/windows/build-github.bat
@@ -45,48 +45,60 @@ if errorlevel 1 exit /b %errorlevel%
 msbuild /version
 cmake --version
 
-mkdir out\cmake
-cd out\cmake
-if errorlevel 1 exit /b %errorlevel%
-
-cmake ..\.. -G "Visual Studio 16 2019" -A x64 || exit /b
-
 if "%BUILD_RELEASE%" == "1" (
     :: /MT
-    cmake . -DUSE_STATIC_CRT=ON -DCMAKE_INSTALL_PREFIX=..\mt
-    cmake --build . %INSTALL% --config Release -- /m || exit /b
+    call :BuildVariant mt "-DUSE_STATIC_CRT=ON" Release || exit /b
 
     if "%BUILD_RELEASE_VARIANTS%" == "1" (
         :: /MD
-        cmake . -DUSE_STATIC_CRT=OFF -DCMAKE_INSTALL_PREFIX=..\md
-        cmake --build . %INSTALL% --config Release -- /m || exit /b
+        call :BuildVariant md "-DUSE_STATIC_CRT=OFF" Release || exit /b
     )
 )
 
 if "%BUILD_DEBUG%" == "1" (
     :: MTd
-    cmake . -DUSE_STATIC_CRT=ON -DCMAKE_INSTALL_PREFIX=..\mtd
-    cmake --build . %INSTALL% --config Debug -- /m || exit /b
+    call :BuildVariant mtd "-DUSE_STATIC_CRT=ON" Debug || exit /b
 
     if "%BUILD_RELEASE_VARIANTS%" == "1" (
         :: MDd
-        cmake . -DUSE_STATIC_CRT=OFF -DCMAKE_INSTALL_PREFIX=..\mdd
-        cmake --build . %INSTALL% --config Debug -- /m || exit /b
+        call :BuildVariant mdd "-DUSE_STATIC_CRT=OFF" Debug || exit /b
     )
 )
 
 if "%BUILD_RELEASE_VARIANTS%" == "1" (
     :: Use the /MT version as the "base" install.
-    move ..\mt ..\install
-    mkdir ..\install\lib\x86_64\mt\
-    move ..\install\lib\x86_64\*.lib ..\install\lib\x86_64\mt\
+    move out\mt out\install
+    mkdir out\install\lib\x86_64\mt\
+    move out\install\lib\x86_64\*.lib out\install\lib\x86_64\mt\
 
-    xcopy ..\md\lib\x86_64\*.lib ..\install\lib\x86_64\md\
-    xcopy ..\mtd\lib\x86_64\*.lib ..\install\lib\x86_64\mtd\
-    xcopy ..\mdd\lib\x86_64\*.lib ..\install\lib\x86_64\mdd\
+    xcopy out\md\lib\x86_64\*.lib out\install\lib\x86_64\md\
+    xcopy out\mtd\lib\x86_64\*.lib out\install\lib\x86_64\mtd\
+    xcopy out\mdd\lib\x86_64\*.lib out\install\lib\x86_64\mdd\
 )
 
 :: Create an archive.
 if "%BUILD_RELEASE_VARIANTS%" == "1" (
-    7z a -ttar -so ..\filament-release.tar ..\install\* | 7z a -si ..\filament-windows.tgz
+    cd out\install
+    7z a -ttar -so ..\..\filament-release.tar * | 7z a -si ..\filament-windows.tgz
 )
+
+exit /b 0
+
+:BuildVariant
+set variant=%~1
+set flag=%~2
+set config=%~3
+
+mkdir out\cmake-%variant%
+cd out\cmake-%variant%
+if errorlevel 1 exit /b %errorlevel%
+
+cmake ..\.. -G "Visual Studio 16 2019" -A x64 %flag% -DCMAKE_INSTALL_PREFIX=..\%variant% || exit /b
+cmake --build . %INSTALL% --config %config% -- /m || exit /b
+
+cd ..\..
+
+:: Delete the cmake build folder, otherwise we run out of disk space on CI when
+:: building multiple variants.
+rd /s /q out\cmake-%variant%
+exit /b 0


### PR DESCRIPTION
This adds a new GitHub workflow to the repository that triggers release builds when a new Filament release is created. The workflow will automatically upload and attach built assets to the release.

The release workflow can be triggered for individual platforms through a GitHub [repository dispatch](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#external-events-repository_dispatch) event. This allows us to trigger a single platform to rebuild if we need to.