### PR TITLE
Tone mapping always sets alpha channel to 1 in opaque mode

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -44,9 +44,9 @@ public:
     void init() noexcept;
     void terminate(backend::DriverApi& driver) noexcept;
 
-    FrameGraphId<FrameGraphTexture> toneMapping(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input,
-            backend::TextureFormat outFormat, bool dithering, bool translucent) noexcept;
+    FrameGraphId <FrameGraphTexture> toneMapping(FrameGraph& fg,
+            FrameGraphId <FrameGraphTexture> input,
+            backend::TextureFormat outFormat, bool dithering, bool translucent, bool fxaa) noexcept;
 
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -399,7 +399,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     if (hasPostProcess) {
         if (toneMapping) {
-            input = ppm.toneMapping(fg, input, ldrFormat, dithering, translucent);
+            input = ppm.toneMapping(fg, input, ldrFormat, dithering, translucent, fxaa);
         }
         if (fxaa) {
             input = ppm.fxaa(fg, input, ldrFormat, !toneMapping || translucent);

--- a/filament/src/materials/tonemapping.mat
+++ b/filament/src/materials/tonemapping.mat
@@ -9,6 +9,10 @@ material {
         {
             type : int,
             name : dithering
+        },
+        {
+            type : int,
+            name : fxaa
         }
     ],
     depthWrite : false,
@@ -35,7 +39,9 @@ fragment {
         vec4 color = vec4(resolveFragment(ivec2(getUV())), 1.0);
         color.rgb  = tonemap(color.rgb);
         color.rgb  = OECF(color.rgb);
-        color.a    = luminance(color.rgb);
+        if (materialParams.fxaa > 0) {
+            color.a = luminance(color.rgb);
+        }
 #else
         vec4 color = resolveAlphaFragment(ivec2(getUV()));
         color.rgb /= color.a + FLT_EPS;


### PR DESCRIPTION
This fixes an issue where the alpha channel could be left to garbage in
opaque mode with FXAA disabled.