### PR TITLE
Better workaround a resource culling issue.

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -344,13 +344,11 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 data.color = builder.createTexture("Color Buffer",
                         { .width = svp.width, .height = svp.height, .format = hdrFormat });
 
-                if (colorPassNeedsDepthBuffer) {
-                    data.depth = builder.createTexture("Depth Buffer", {
-                            .width = svp.width, .height = svp.height,
-                            .format = TextureFormat::DEPTH24
-                    });
-                    data.depth = builder.write(builder.read(data.depth));
-                }
+                data.depth = builder.createTexture("Depth Buffer", {
+                        .width = svp.width, .height = svp.height,
+                        .format = TextureFormat::DEPTH24
+                });
+                data.depth = builder.write(builder.read(data.depth));
 
                 data.color = builder.write(builder.read(data.color));
                 data.rt = builder.createRenderTarget("Color Pass Target", {

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -26,6 +26,16 @@ using namespace backend;
 
 void FrameGraphTexture::create(FrameGraph& fg, const char* name,
         FrameGraphTexture::Descriptor const& desc) noexcept {
+
+    // FIXME (workaround): a texture could end up with no usage if it was used as an attachment
+    //  of a RenderTarget that itself was replaced by a moveResource(). In this case, the texture
+    //  is simply unused.  A better fix would be to let the framegraph culling eliminate the
+    //  this resource, but this is currently not working or set-up this way.
+    //  Instead, we simply do nothing here.
+    if (none(desc.usage)) {
+        return;
+    }
+
     assert(any(desc.usage));
     // (it means it's only used as an attachment for a rendertarget)
     uint8_t samples = desc.samples;


### PR DESCRIPTION
A texture resource can end-up with not usage bit set if it is used as
an attachment of a render target that gets replaced by a moveResource()
call. The framegraph should take care of culling our this resource,
in that case, but currently doesn't.

We worked around this issue by not declaring the resources, but it's
better to do this in the frame graph code, as to not affect the 
user facing API.