### PR TITLE
Swap chains are now always created with a depth buffer

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -78,7 +78,8 @@ struct MetalContext {
 
     // Surface-related properties.
     MetalSwapChain* currentSurface = nullptr;
-    id<CAMetalDrawable> currentDrawable = nullptr;
+    id<CAMetalDrawable> currentDrawable = nil;
+    id<MTLTexture> currentDepthTexture = nil;
     id<MTLTexture> headlessDrawable = nil;
     MTLPixelFormat currentSurfacePixelFormat = MTLPixelFormatInvalid;
     MTLPixelFormat currentDepthPixelFormat = MTLPixelFormatInvalid;
@@ -103,6 +104,8 @@ struct MetalContext {
 // drawable's texture.
 // For headless swapchains a new texture is created.
 id<MTLTexture> acquireDrawable(MetalContext* context);
+
+id<MTLTexture> acquireDepthTexture(MetalContext* context);
 
 id<MTLCommandBuffer> acquireCommandBuffer(MetalContext* context);
 

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -77,6 +77,33 @@ id<MTLTexture> acquireDrawable(MetalContext* context) {
     return context->currentDrawable.texture;
 }
 
+id<MTLTexture> acquireDepthTexture(MetalContext* context) {
+    if (context->currentDepthTexture) {
+        return context->currentDepthTexture;
+    }
+
+    const MTLPixelFormat depthFormat =
+#if defined(IOS)
+            MTLPixelFormatDepth32Float;
+#else
+            MTLPixelFormatDepth24Unorm_Stencil8;
+#endif
+
+    const NSUInteger width = context->currentSurface->surfaceWidth;
+    const NSUInteger height = context->currentSurface->surfaceHeight;
+    MTLTextureDescriptor* descriptor =
+            [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:depthFormat
+                                                               width:width
+                                                              height:height
+                                                            mipmapped:NO];
+    descriptor.usage = MTLTextureUsageRenderTarget;
+    descriptor.resourceOptions = MTLResourceStorageModePrivate;
+
+    context->currentDepthTexture = [context->device newTextureWithDescriptor:descriptor];
+
+    return context->currentDepthTexture;
+}
+
 id<MTLCommandBuffer> acquireCommandBuffer(MetalContext* context) {
     id<MTLCommandBuffer> commandBuffer = [context->commandQueue commandBuffer];
     ASSERT_POSTCONDITION(commandBuffer != nil, "Could not obtain command buffer.");

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -79,7 +79,13 @@ id<MTLTexture> acquireDrawable(MetalContext* context) {
 
 id<MTLTexture> acquireDepthTexture(MetalContext* context) {
     if (context->currentDepthTexture) {
-        return context->currentDepthTexture;
+        // If the surface size has changed, we'll need to allocate a new depth texture.
+        if (context->currentDepthTexture.width != context->currentSurface->surfaceWidth ||
+            context->currentDepthTexture.height != context->currentSurface->surfaceHeight) {
+            context->currentDepthTexture = nil;
+        } else {
+            return context->currentDepthTexture;
+        }
     }
 
     const MTLPixelFormat depthFormat =
@@ -95,7 +101,7 @@ id<MTLTexture> acquireDepthTexture(MetalContext* context) {
             [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:depthFormat
                                                                width:width
                                                               height:height
-                                                            mipmapped:NO];
+                                                           mipmapped:NO];
     descriptor.usage = MTLTextureUsageRenderTarget;
     descriptor.resourceOptions = MTLResourceStorageModePrivate;
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -452,6 +452,9 @@ id<MTLTexture> MetalRenderTarget::getColor() {
 }
 
 id<MTLTexture> MetalRenderTarget::getDepth() {
+    if (defaultRenderTarget) {
+        return acquireDepthTexture(context);
+    }
     if (multisampledDepth) {
         return multisampledDepth;
     }
@@ -530,7 +533,6 @@ id<MTLTexture> MetalRenderTarget::createMultisampledTexture(id<MTLDevice> device
 
     return [device newTextureWithDescriptor:descriptor];
 }
-
 
 MetalFence::MetalFence(MetalContext& context) {
 #if METAL_FENCES_SUPPORTED

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -51,6 +51,7 @@ Driver* PlatformCocoaGL::createDriver(void* sharedContext) noexcept {
     // NSOpenGLPFAColorSize: when unspecified, a format that matches the screen is preferred
     NSOpenGLPixelFormatAttribute pixelFormatAttributes[] = {
             NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
+            NSOpenGLPFADepthSize,    (NSOpenGLPixelFormatAttribute) 24,
             NSOpenGLPFADoubleBuffer, (NSOpenGLPixelFormatAttribute) true,
             NSOpenGLPFAAccelerated,  (NSOpenGLPixelFormatAttribute) true,
             NSOpenGLPFANoRecovery,   (NSOpenGLPixelFormatAttribute) true,

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -194,6 +194,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
             EGL_GREEN_SIZE,  8,
             EGL_BLUE_SIZE,   8,
             EGL_ALPHA_SIZE,  0, // reserved to set ALPHA_SIZE below
+            EGL_DEPTH_SIZE, 24,
             EGL_RECORDABLE_ANDROID, 1,
             EGL_NONE
     };

--- a/filament/backend/src/opengl/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/PlatformGLX.cpp
@@ -33,12 +33,12 @@
 #define LIBRARY_X11 "libX11.so.6"
 
 // Function pointer types for X11 functions
-typedef Display* (*X11_OPEN_DISPLAY)(const char*);
-typedef Display* (*X11_CLOSE_DISPLAY)(Display*);
+typedef Display* (* X11_OPEN_DISPLAY)(const char*);
+typedef Display* (* X11_CLOSE_DISPLAY)(Display*);
 
 // Function pointer types for GLX functions
-typedef void (*GLX_DESTROY_CONTEXT)(Display*, GLXContext);
-typedef void (*GLX_SWAP_BUFFERS)(Display *dpy, GLXDrawable drawable);
+typedef void (* GLX_DESTROY_CONTEXT)(Display*, GLXContext);
+typedef void (* GLX_SWAP_BUFFERS)(Display* dpy, GLXDrawable drawable);
 // Stores GLX function pointers and a handle to the system's GLX library
 struct GLXFunctions {
     PFNGLXCHOOSEFBCONFIGPROC chooseFbConfig;
@@ -93,29 +93,29 @@ static bool loadLibraries() {
     }
 
     getProcAddress =
-            (PFNGLXGETPROCADDRESSPROC) dlsym(g_glx.library, "glXGetProcAddressARB");
+            (PFNGLXGETPROCADDRESSPROC)dlsym(g_glx.library, "glXGetProcAddressARB");
 
     g_glx.chooseFbConfig = (PFNGLXCHOOSEFBCONFIGPROC)
-            getProcAddress((const GLubyte*) "glXChooseFBConfig");
+            getProcAddress((const GLubyte*)"glXChooseFBConfig");
     g_glx.createContext = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
-            getProcAddress((const GLubyte*) "glXCreateContextAttribsARB");
+            getProcAddress((const GLubyte*)"glXCreateContextAttribsARB");
     g_glx.createPbuffer = (PFNGLXCREATEPBUFFERPROC)
-            getProcAddress((const GLubyte*) "glXCreatePbuffer");
+            getProcAddress((const GLubyte*)"glXCreatePbuffer");
     g_glx.destroyPbuffer = (PFNGLXDESTROYPBUFFERPROC)
-            getProcAddress((const GLubyte*) "glXDestroyPbuffer");
+            getProcAddress((const GLubyte*)"glXDestroyPbuffer");
     g_glx.setCurrentContext = (PFNGLXMAKECONTEXTCURRENTPROC)
-            getProcAddress((const GLubyte*) "glXMakeContextCurrent");
+            getProcAddress((const GLubyte*)"glXMakeContextCurrent");
     g_glx.destroyContext = (GLX_DESTROY_CONTEXT)
-            getProcAddress((const GLubyte*) "glXDestroyContext");
+            getProcAddress((const GLubyte*)"glXDestroyContext");
     g_glx.swapBuffers = (GLX_SWAP_BUFFERS)
-            getProcAddress((const GLubyte*) "glXSwapBuffers");
+            getProcAddress((const GLubyte*)"glXSwapBuffers");
 
     g_glx.queryContext = (PFNGLXQUERYCONTEXTPROC)
-            getProcAddress((const GLubyte*) "glXQueryContext");
+            getProcAddress((const GLubyte*)"glXQueryContext");
     g_glx.getFbConfigs = (PFNGLXGETFBCONFIGSPROC)
-            getProcAddress((const GLubyte*) "glXGetFBConfigs");
+            getProcAddress((const GLubyte*)"glXGetFBConfigs");
     g_glx.getFbConfigAttrib = (PFNGLXGETFBCONFIGATTRIBPROC)
-            getProcAddress((const GLubyte*) "glXGetFBConfigAttrib");    
+            getProcAddress((const GLubyte*)"glXGetFBConfigAttrib");
 
     g_x11.library = dlopen(LIBRARY_X11, RTLD_LOCAL | RTLD_NOW);
     if (!g_x11.library) {
@@ -123,8 +123,8 @@ static bool loadLibraries() {
         return false;
     }
 
-    g_x11.openDisplay  = (X11_OPEN_DISPLAY)  dlsym(g_x11.library, "XOpenDisplay");
-    g_x11.closeDisplay = (X11_CLOSE_DISPLAY) dlsym(g_x11.library, "XCloseDisplay");
+    g_x11.openDisplay = (X11_OPEN_DISPLAY)dlsym(g_x11.library, "XOpenDisplay");
+    g_x11.closeDisplay = (X11_CLOSE_DISPLAY)dlsym(g_x11.library, "XCloseDisplay");
     return true;
 }
 
@@ -142,20 +142,20 @@ Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
     }
 
     if (sharedGLContext != nullptr) {
-      
         int r = -1;
         int usedFbId = -1;
         GLXContext sharedCtx = (GLXContext)((void*)sharedGLContext);
-      
+
         r = g_glx.queryContext(mGLXDisplay, sharedCtx, GLX_FBCONFIG_ID, &usedFbId);
         if (r != 0) {
-            utils::slog.e << "Failed to get GLX_FBCONFIG_ID from shared GL context." << utils::io::endl;
+            utils::slog.e << "Failed to get GLX_FBCONFIG_ID from shared GL context."
+                          << utils::io::endl;
             return nullptr;
         }
-    
+
         int numConfigs = 0;
         GLXFBConfig* fbConfigs = g_glx.getFbConfigs(mGLXDisplay, 0, &numConfigs);
-        
+
         if (fbConfigs == nullptr) {
             utils::slog.e << "Failed to get the available GLXFBConfigs." << utils::io::endl;
             return nullptr;
@@ -163,15 +163,15 @@ Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
 
         int fbId = 0;
         int fbIndex = -1;
-    
+
         for (int i = 0; i < numConfigs; ++i) {
-        
             r = g_glx.getFbConfigAttrib(mGLXDisplay, fbConfigs[i], GLX_FBCONFIG_ID, &fbId);
             if (r != 0) {
-                utils::slog.e << "Failed to get GLX_FBCONFIG_ID for entry " << i << "." << utils::io::endl;
+                utils::slog.e << "Failed to get GLX_FBCONFIG_ID for entry " << i << "."
+                              << utils::io::endl;
                 continue;
             }
-        
+
             if (fbId == usedFbId) {
                 fbIndex = i;
                 break;
@@ -179,30 +179,34 @@ Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
         }
 
         if (fbIndex < 0) {
-            utils::slog.e << "Failed to find an `GLXFBConfig` with the requested ID." << utils::io::endl;
+            utils::slog.e << "Failed to find an `GLXFBConfig` with the requested ID."
+                          << utils::io::endl;
             return nullptr;
         }
-      
-        mGLXConfig = fbConfigs + fbIndex;
-    }
-    else {
 
+        mGLXConfig = fbConfigs + fbIndex;
+    } else {
         // Create a context
-        static int attribs[] = { GLX_DOUBLEBUFFER, True, None };
+        static int attribs[] = {
+                GLX_DOUBLEBUFFER, True,
+                GLX_DEPTH_SIZE, 24,
+                None
+        };
 
         int configCount = 0;
         mGLXConfig = g_glx.chooseFbConfig(mGLXDisplay, DefaultScreen(mGLXDisplay),
-                                          attribs, &configCount);
+                attribs, &configCount);
         if (mGLXConfig == nullptr || configCount == 0) {
             return nullptr;
         }
     }
 
     PFNGLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribs = (PFNGLXCREATECONTEXTATTRIBSARBPROC)
-            getProcAddress((GLubyte*) "glXCreateContextAttribsARB");
+            getProcAddress((GLubyte*)"glXCreateContextAttribsARB");
 
     if (glXCreateContextAttribs == nullptr) {
-        utils::slog.i << "Unable to retrieve function pointer for `glXCreateContextAttribs()`." << utils::io::endl;
+        utils::slog.i << "Unable to retrieve function pointer for `glXCreateContextAttribs()`."
+                      << utils::io::endl;
         return nullptr;
     }
 
@@ -211,12 +215,12 @@ Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
             GLX_CONTEXT_MINOR_VERSION_ARB, 1,
             GL_NONE
     };
-    
+
     mGLXContext = g_glx.createContext(mGLXDisplay, mGLXConfig[0],
-            (GLXContext) sharedGLContext, True, contextAttribs);
+            (GLXContext)sharedGLContext, True, contextAttribs);
 
     int pbufferAttribs[] = {
-            GLX_PBUFFER_WIDTH,  1,
+            GLX_PBUFFER_WIDTH, 1,
             GLX_PBUFFER_HEIGHT, 1,
             GL_NONE
     };
@@ -241,7 +245,7 @@ void PlatformGLX::terminate() noexcept {
 Platform::SwapChain* PlatformGLX::createSwapChain(void* nativeWindow, uint64_t& flags) noexcept {
     // Transparent swap chain is not supported
     flags &= ~backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
-    return (SwapChain*) nativeWindow;
+    return (SwapChain*)nativeWindow;
 }
 
 Platform::SwapChain* PlatformGLX::createSwapChain(
@@ -249,7 +253,7 @@ Platform::SwapChain* PlatformGLX::createSwapChain(
     // Transparent swap chain is not supported
     flags &= ~backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
     int pbufferAttribs[] = {
-            GLX_PBUFFER_WIDTH,  int(width),
+            GLX_PBUFFER_WIDTH, int(width),
             GLX_PBUFFER_HEIGHT, int(height),
             GL_NONE
     };
@@ -257,7 +261,7 @@ Platform::SwapChain* PlatformGLX::createSwapChain(
     if (sur) {
         mPBuffers.push_back(sur);
     }
-    return (SwapChain*) sur;
+    return (SwapChain*)sur;
 }
 
 void PlatformGLX::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
@@ -271,7 +275,7 @@ void PlatformGLX::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
 void PlatformGLX::makeCurrent(
         Platform::SwapChain* drawSwapChain, Platform::SwapChain* readSwapChain) noexcept {
     g_glx.setCurrentContext(mGLXDisplay,
-            (GLXDrawable) drawSwapChain, (GLXDrawable) readSwapChain, mGLXContext);
+            (GLXDrawable)drawSwapChain, (GLXDrawable)readSwapChain, mGLXContext);
 }
 
 void PlatformGLX::commit(Platform::SwapChain* swapChain) noexcept {

--- a/filament/backend/src/opengl/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/PlatformWebGL.cpp
@@ -30,7 +30,7 @@ void PlatformWebGL::terminate() noexcept {
 
 Platform::SwapChain* PlatformWebGL::createSwapChain(
         void* nativeWindow, uint64_t& flags) noexcept {
-    return (SwapChain*) nativeWindow;
+    return (SwapChain*)nativeWindow;
 }
 
 Platform::SwapChain* PlatformWebGL::createSwapChain(
@@ -43,7 +43,7 @@ void PlatformWebGL::destroySwapChain(Platform::SwapChain* swapChain) noexcept {
 }
 
 void PlatformWebGL::makeCurrent(Platform::SwapChain* drawSwapChain,
-                                Platform::SwapChain* readSwapChain) noexcept {
+        Platform::SwapChain* readSwapChain) noexcept {
 }
 
 void PlatformWebGL::commit(Platform::SwapChain* swapChain) noexcept {

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -386,6 +386,8 @@ void createSwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceContex
     for (uint32_t i = 0; i < allocateInfo.commandBufferCount; ++i) {
         surfaceContext.swapContexts[i].commands.cmdbuffer = cmdbufs[i];
     }
+
+    createDepthBuffer(context, surfaceContext, context.depthFormat);
 }
 
 uint32_t selectMemoryType(VulkanContext& context, uint32_t flags, VkFlags reqs) {
@@ -552,6 +554,80 @@ void flushWorkCommandBuffer(VulkanContext& context) {
     vkEndCommandBuffer(work.cmdbuffer);
     vkQueueSubmit(context.graphicsQueue, 1, &submitInfo, work.fence->fence);
     work.fence->submitted = true;
+}
+
+void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfaceContext,
+        VkFormat depthFormat) {
+    // Create an appropriately-sized device-only VkImage.
+    const auto size = surfaceContext.surfaceCapabilities.currentExtent;
+    VkImage depthImage;
+    VkImageCreateInfo imageInfo {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .extent = { size.width, size.height, 1 },
+        .format = depthFormat,
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+    };
+    VkResult error = vkCreateImage(context.device, &imageInfo, VKALLOC, &depthImage);
+    assert(!error && "Unable to create depth image.");
+
+    // Allocate memory for the VkImage and bind it.
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(context.device, depthImage, &memReqs);
+    VkMemoryAllocateInfo allocInfo {
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = memReqs.size,
+        .memoryTypeIndex = selectMemoryType(context, memReqs.memoryTypeBits,
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
+    };
+    error = vkAllocateMemory(context.device, &allocInfo, nullptr,
+            &surfaceContext.depth.memory);
+    assert(!error && "Unable to allocate depth memory.");
+    error = vkBindImageMemory(context.device, depthImage, surfaceContext.depth.memory, 0);
+    assert(!error && "Unable to bind depth memory.");
+
+    // Create a VkImageView so that we can attach depth to the framebuffer.
+    VkImageView depthView;
+    VkImageViewCreateInfo viewInfo {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .image = depthImage,
+        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .format = depthFormat,
+        .subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
+        .subresourceRange.levelCount = 1,
+        .subresourceRange.layerCount = 1,
+    };
+    error = vkCreateImageView(context.device, &viewInfo, VKALLOC, &depthView);
+    assert(!error && "Unable to create depth view.");
+
+    // Unlike the color attachments (which are double-buffered or triple-buffered), we only need one
+    // depth attachment in the entire chain.
+    surfaceContext.depth.view = depthView;
+    surfaceContext.depth.image = depthImage;
+    surfaceContext.depth.format = depthFormat;
+
+    // Begin a new command buffer solely for the purpose of transitioning the image layout.
+    VkCommandBuffer cmdbuffer = acquireWorkCommandBuffer(context);
+
+    // Transition the depth image into an optimal layout.
+    VkImageMemoryBarrier barrier {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image = depthImage,
+        .subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
+        .subresourceRange.levelCount = 1,
+        .subresourceRange.layerCount = 1,
+        .dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+    };
+    vkCmdPipelineBarrier(cmdbuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+            VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    flushWorkCommandBuffer(context);
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -120,6 +120,7 @@ struct VulkanSurfaceContext {
     uint32_t currentSwapIndex;
     VkSemaphore imageAvailable;
     VkSemaphore renderingFinished;
+    VulkanAttachment depth;
 };
 
 void selectPhysicalDevice(VulkanContext& context);
@@ -137,6 +138,7 @@ VkFormat findSupportedFormat(VulkanContext& context, const std::vector<VkFormat>
         VkImageTiling tiling, VkFormatFeatureFlags features);
 VkCommandBuffer acquireWorkCommandBuffer(VulkanContext& context);
 void flushWorkCommandBuffer(VulkanContext& context);
+void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& sc, VkFormat depthFormat);
 
 } // namespace filament
 } // namespace backend

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -535,6 +535,9 @@ void VulkanDriver::destroySwapChain(Handle<HwSwapChain> sch) {
         vkDestroySemaphore(mContext.device, surfaceContext.imageAvailable, VKALLOC);
         vkDestroySemaphore(mContext.device, surfaceContext.renderingFinished, VKALLOC);
         vkDestroySurfaceKHR(mContext.instance, surfaceContext.surface, VKALLOC);
+        vkDestroyImageView(mContext.device, surfaceContext.depth.view, VKALLOC);
+        vkDestroyImage(mContext.device, surfaceContext.depth.image, VKALLOC);
+        vkFreeMemory(mContext.device, surfaceContext.depth.memory, VKALLOC);
         if (mContext.currentSurface == &surfaceContext) {
             mContext.currentSurface = nullptr;
         }

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -344,13 +344,11 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 data.color = builder.createTexture("Color Buffer",
                         { .width = svp.width, .height = svp.height, .format = hdrFormat });
 
-                if (colorPassNeedsDepthBuffer) {
-                    data.depth = builder.createTexture("Depth Buffer", {
-                            .width = svp.width, .height = svp.height,
-                            .format = TextureFormat::DEPTH24
-                    });
-                    data.depth = builder.write(builder.read(data.depth));
-                }
+                data.depth = builder.createTexture("Depth Buffer", {
+                        .width = svp.width, .height = svp.height,
+                        .format = TextureFormat::DEPTH24
+                });
+                data.depth = builder.write(builder.read(data.depth));
 
                 data.color = builder.write(builder.read(data.color));
                 data.rt = builder.createRenderTarget("Color Pass Target", {

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -269,14 +269,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // FIXME: this doesn't work when the target is a user provided rendertarget
     const bool translucent = mSwapChain->isTransparent() || blending;
 
-
     const TextureFormat hdrFormat = getHdrFormat(view, translucent);
-
-    // FIXME: we use "hasPostProcess" as a proxy for deciding if we need a depth-buffer or not
-    //        historically this has been true, but it's definitely wrong.
-    //        This hack is needed because viewRenderTarget(output) doesn't have a depth-buffer,
-    //        so when skipping post-process (which draws directly into it), we can't rely on it.
-    const bool colorPassNeedsDepthBuffer = hasPostProcess;
 
     const Handle<HwRenderTarget> viewRenderTarget = getRenderTarget(view);
     FrameGraphRenderTargetHandle fgViewRenderTarget = fg.importRenderTarget("viewRenderTarget",
@@ -334,7 +327,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     };
 
     auto& colorPass = fg.addPass<ColorPassData>("Color Pass",
-            [&svp, hdrFormat, colorPassNeedsDepthBuffer, msaa, clearFlags, useSSAO, ssao]
+            [&svp, hdrFormat, msaa, clearFlags, useSSAO, ssao]
             (FrameGraph::Builder& builder, ColorPassData& data) {
 
                 if (useSSAO) {
@@ -419,12 +412,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (viewRenderTarget == mRenderTarget) {
             // The default render target is not multi-sampled, so we need an intermediate
             // buffer.
-            // The default render target also doesn't have a depth buffer, so if one is needed, we
-            // use an intermediate buffer also.
             // The intermediate buffer  is accomplished with a "fake" dynamicScaling (i.e. blit)
             // operation.
 
-            if (msaa > 1 || colorPassNeedsDepthBuffer) {
+            if (msaa > 1) {
                 input = ppm.dynamicScaling(fg, msaa, scaled, blending, input, ldrFormat);
             }
         }

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -26,6 +26,16 @@ using namespace backend;
 
 void FrameGraphTexture::create(FrameGraph& fg, const char* name,
         FrameGraphTexture::Descriptor const& desc) noexcept {
+
+    // FIXME (workaround): a texture could end up with no usage if it was used as an attachment
+    //  of a RenderTarget that itself was replaced by a moveResource(). In this case, the texture
+    //  is simply unused.  A better fix would be to let the framegraph culling eliminate the
+    //  this resource, but this is currently not working or set-up this way.
+    //  Instead, we simply do nothing here.
+    if (none(desc.usage)) {
+        return;
+    }
+
     assert(any(desc.usage));
     // (it means it's only used as an attachment for a rendertarget)
     uint8_t samples = desc.samples;


### PR DESCRIPTION
This is to allow direct rendering of 3D objects into the swapchain 
under certain circumstances (no msaa or postprocessing).