### PR TITLE
Add support for mapping individual planes of iOS external images

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ A new header is inserted each time a *tag* is created.
 - Fixed a normals issue when skinning without a normal map or anisotropy.
 - Fixed an issue where translucent views couldn't be used with post-processing.
 - Always use higher quality 3-bands SH for indirect lighting, even on mobile.
+- The Metal backend can now handle binding individual planes of YUV external images.
 
 ## v1.4.2
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1620,6 +1620,7 @@ The following APIs are only available from the fragment block:
 **inverseTonemap(float3)**          | float3   |  Applies the inverse tone mapping operator to the specified linear sRGB color and returns a linear sRGB color. This operation may be an approximation
 **inverseTonemapSRGB(float3)**      | float3   |  Applies the inverse tone mapping operator to the specified non-linear sRGB color and returns a linear sRGB color. This operation may be an approximation
 **luminance(float3)**               | float    |  Computes the luminance of the specified linear sRGB color
+**ycbcrToRgb(float, float2)**       | float3   |  Converts a luminance and CbCr pair to a sRGB color
 **uvToRenderTargetUV(float2)**      | float2   |  Transforms a UV coordinate to allow sampling from a `RenderTarget` attachment
 
 !!! TIP: world space

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -277,6 +277,11 @@ DECL_DRIVER_API_N(setExternalImage,
         backend::TextureHandle, th,
         void*, image)
 
+DECL_DRIVER_API_N(setExternalImagePlane,
+        backend::TextureHandle, th,
+        void*, image,
+        size_t, plane)
+
 DECL_DRIVER_API_N(setExternalStream,
         backend::TextureHandle, th,
         backend::StreamHandle, sh)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -552,6 +552,11 @@ void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     texture->externalImage.set((CVPixelBufferRef) image);
 }
 
+void MetalDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+    auto texture = handle_cast<MetalTexture>(mHandleMap, th);
+    texture->externalImage.set((CVPixelBufferRef) image, plane);
+}
+
 void MetalDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 
 }

--- a/filament/backend/src/metal/MetalExternalImage.h
+++ b/filament/backend/src/metal/MetalExternalImage.h
@@ -55,6 +55,14 @@ public:
     void set(CVPixelBufferRef image) noexcept;
 
     /**
+     * Set this external image to a specific plane of the passed-in CVPixelBuffer. Future calls to
+     * getMetalTextureForDraw will return a texture backed by a single plane of this CVPixelBuffer.
+     * Previous CVPixelBuffers and related resources will be released when all GPU work using them
+     * has finished.
+     */
+    void set(CVPixelBufferRef image, size_t plane) noexcept;
+
+    /**
      * Get a Metal texture used to draw this image and denote that it is used for the current frame.
      * For future frames that use this external image, getMetalTextureForDraw must be called again.
      */
@@ -67,6 +75,8 @@ public:
     static void shutdown() noexcept;
 
 private:
+
+    void unset();
 
     CVMetalTextureRef createTextureFromImage(CVPixelBufferRef image, MTLPixelFormat format,
             size_t plane);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1749,6 +1749,10 @@ void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     setExternalTexture(handle_cast<GLTexture*>(th), image);
 }
 
+void OpenGLDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+
+}
+
 void OpenGLDriver::setExternalTexture(GLTexture* t, void* image) {
     auto& gl = mContext;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -673,6 +673,9 @@ void VulkanDriver::cancelExternalImage(void* image) {
 void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 
+void VulkanDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+}
+
 void VulkanDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 }
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -337,6 +337,35 @@ public:
      */
     void setExternalImage(Engine& engine, void* image) noexcept;
 
+    /**
+     * Specify the external image and plane to associate with this Texture. Typically the external
+     * image is OS specific, and can be a video or camera frame. When using this method, the
+     * external image must be a planar type (such as a YUV camera frame). The plane parameter
+     * selects which image plane is bound to this texture.
+     *
+     * A single external image can be bound to different Filament textures, with each texture
+     * associated with a separate plane:
+     *
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * textureA->setExternalImage(engine, image, 0);
+     * textureB->setExternalImage(engine, image, 1);
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     *
+     * There are many restrictions when using an external image as a texture, such as:
+     *   - only the level of detail (lod) 0 can be specified
+     *   - only nearest or linear filtering is supported
+     *   - the size and format of the texture is defined by the external image
+     *
+     * @param engine        Engine this texture is associated to.
+     * @param image         An opaque handle to a platform specific image. Supported types are
+     *                      eglImageOES on Android and CVPixelBufferRef on iOS.
+     * @param plane         The plane index of the external image to associate with this texture.
+     *
+     *                      This method is only meaningful on iOS with
+     *                      kCVPixelFormatType_420YpCbCr8BiPlanarFullRange images. On platforms
+     *                      other than iOS, this method is a no-op.
+     */
+    void setExternalImage(Engine& engine, void* image, size_t plane) noexcept;
 
     /**
      * Specify the external stream to associate with this Texture. Typically the external

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -167,6 +167,15 @@ void FTexture::setExternalImage(FEngine& engine, void* image) noexcept {
     }
 }
 
+void FTexture::setExternalImage(FEngine& engine, void* image, size_t plane) noexcept {
+    if (mTarget == Sampler::SAMPLER_EXTERNAL) {
+        // The call to setupExternalImage is synchronous, and allows the driver to take ownership of
+        // the external image on this thread, if necessary.
+        engine.getDriverApi().setupExternalImage(image);
+        engine.getDriverApi().setExternalImagePlane(mHandle, image, plane);
+    }
+}
+
 void FTexture::setExternalStream(FEngine& engine, FStream* stream) noexcept {
     if (stream) {
         if (!ASSERT_POSTCONDITION_NON_FATAL(mTarget == Sampler::SAMPLER_EXTERNAL,
@@ -500,6 +509,10 @@ void Texture::setImage(Engine& engine, size_t level,
 
 void Texture::setExternalImage(Engine& engine, void* image) noexcept {
     upcast(this)->setExternalImage(upcast(engine), image);
+}
+
+void Texture::setExternalImage(Engine& engine, void* image, size_t plane) noexcept {
+    upcast(this)->setExternalImage(upcast(engine), image, plane);
 }
 
 void Texture::setExternalStream(Engine& engine, Stream* stream) noexcept {

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -65,6 +65,7 @@ public:
             PrefilterOptions const* options);
 
     void setExternalImage(FEngine& engine, void* image) noexcept;
+    void setExternalImage(FEngine& engine, void* image, size_t plane) noexcept;
     void setExternalStream(FEngine& engine, FStream* stream) noexcept;
 
     void generateMipmaps(FEngine& engine) const noexcept;

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -24,6 +24,22 @@ void unpremultiply(inout vec4 color) {
     color.rgb /= max(color.a, FLT_EPS);
 }
 
+/**
+ * Applies a full range YCbCr to sRGB conversion and returns an RGB color.
+ *
+ * @public-api
+ */
+vec3 ycbcrToRgb(float luminance, vec2 cbcr) {
+    // Taken from https://developer.apple.com/documentation/arkit/arframe/2867984-capturedimage
+    mat4 ycbcrToRgbTransform = mat4(
+        +1.0000f, +1.0000f, +1.0000f, +0.0000f,
+        +0.0000f, -0.3441f, +1.7720f, +0.0000f,
+        +1.4020f, -0.7141f, +0.0000f, +0.0000f,
+        -0.7010f, +0.5291f, -0.8860f, +1.0000f
+    );
+    return (ycbcrToRgbTransform * vec4(luminance, cbcr, 1.0)).rgb;
+}
+
 //------------------------------------------------------------------------------
 // Tone mapping operations
 //------------------------------------------------------------------------------

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -31,11 +31,11 @@ void unpremultiply(inout vec4 color) {
  */
 vec3 ycbcrToRgb(float luminance, vec2 cbcr) {
     // Taken from https://developer.apple.com/documentation/arkit/arframe/2867984-capturedimage
-    mat4 ycbcrToRgbTransform = mat4(
-        +1.0000f, +1.0000f, +1.0000f, +0.0000f,
-        +0.0000f, -0.3441f, +1.7720f, +0.0000f,
-        +1.4020f, -0.7141f, +0.0000f, +0.0000f,
-        -0.7010f, +0.5291f, -0.8860f, +1.0000f
+    const mat4 ycbcrToRgbTransform = mat4(
+        1.0000, 1.0000, 1.0000, 0.0000,
+        0.0000, -0.3441, 1.7720, 0.0000,
+        1.4020, -0.7141, 0.0000, 0.0000,
+        -0.7010, 0.5291, -0.8860, 1.0000
     );
     return (ycbcrToRgbTransform * vec4(luminance, cbcr, 1.0)).rgb;
 }


### PR DESCRIPTION
This change allows mapping individual planes of iOS external images to Filament textures. This
allows the YCbCr -> RGB conversion to be done in the fragment shader (as opposed to a compute
shader).