### PR TITLE
Make including jawt_md.h more resilient

### DIFF
--- a/android/filament-android/src/main/cpp/nativewindow/Darwin.mm
+++ b/android/filament-android/src/main/cpp/nativewindow/Darwin.mm
@@ -17,7 +17,16 @@
 #include <stdio.h>
 
 #include <jawt.h>
+
+#if defined(__has_include)
+#if __has_include(<darwin/jawt_md.h>)
 #include <darwin/jawt_md.h>
+#else
+#include <jawt_md.h>
+#endif
+#else
+#include <darwin/jawt_md.h>
+#endif
 
 #include <filament/Engine.h>
 #include "JAWTUtils.h"


### PR DESCRIPTION
Sometimes CMake decides to use the JNI bits included with XCode instead
of those from the installed JDK. The header files are located in different
directories. This does the proper include.