### PR TITLE
Simplify CameraManipulator.

### DIFF
--- a/samples/app/CameraManipulator.h
+++ b/samples/app/CameraManipulator.h
@@ -22,22 +22,10 @@
 #include <math/vec4.h>
 #include <math/mat4.h>
 
-#include <filament/Camera.h>
-
 class CameraManipulator {
 public:
-    using Camera = filament::Camera;
-    using CameraChangedCallback = std::function<void(Camera const* c)>;
-
     CameraManipulator();
-    CameraManipulator(Camera* camera, size_t width, size_t height);
-
-    void setCameraChangedCallback(CameraChangedCallback cb);
-
-    void setCamera(Camera* camera);
-    Camera const* getCamera() const {
-        return mCamera;
-    }
+    CameraManipulator(size_t width, size_t height);
 
     void setViewport(size_t w, size_t h);
 
@@ -46,25 +34,16 @@ public:
     void dolly(double delta, double dollySpeed = 5.0);
     void rotate(const filament::math::double2& delta, double rotateSpeed = 7.0);
 
-    void updateCameraTransform();
+    filament::math::mat4f getCameraTransform() const;
 
 private:
-    void updateCameraProjection();
-
-    Camera* mCamera = nullptr;
-
     filament::math::double3 mRotation;
     filament::math::double3 mTranslation;
 
     double mCenterOfInterest = 10.0;
     double mFovx = 65.0;
-    double mClipNear = 0.1;
-    double mClipFar = 11.0;
     size_t mWidth;
     size_t mHeight;
-    double mAspect = 1.0f;
-
-    std::function<void(Camera const* c)> mCameraChanged;
 };
 
 #endif // TNT_FILAMENT_SAMPLE_CAMERA_MANIPULATOR_H

--- a/samples/app/FilamentApp.h
+++ b/samples/app/FilamentApp.h
@@ -121,8 +121,6 @@ private:
         filament::View const* getView() const { return view; }
         filament::View* getView() { return view; }
 
-        CameraManipulator* getCameraManipulator() const { return mCameraManipulator; }
-
     private:
         enum class Mode : uint8_t {
             NONE, ROTATE, TRACK
@@ -173,7 +171,6 @@ private:
         filament::Engine::Backend mBackend;
 
         CameraManipulator mMainCameraMan;
-        CameraManipulator mOrthoCameraMan;
         CameraManipulator mDebugCameraMan;
         filament::SwapChain* mSwapChain = nullptr;
 


### PR DESCRIPTION
This removes a lot of code and will make it easier to migrate into a new
library with Java bindings, etc.

- The clipping planes and projection matrix were unused, removed them.

- In split view mode, our demos were using only 2 of the 3 manipulators,
  removed one.

- Instead of callbacks and update methods, users can simply ask for the
  current matrix at every frame.

- The manipulator's job is to consume mouse events and maintain an
  "look at" basis, there is no need to store a reference to a Filament
  Camera.