### PR TITLE
workaround OpenGLES driver bug

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -64,6 +64,9 @@ OpenGLContext::OpenGLContext() noexcept {
             bugs.disable_shared_context_draws = true;
             bugs.texture_external_needs_rebind = true;
         }
+        if (strstr(renderer, "Mali-G")) {
+            bugs.disable_texture_filter_anisotropic = true;
+        }
     } else if (strstr(renderer, "Intel")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
     } else if (strstr(renderer, "PowerVR") || strstr(renderer, "Apple")) {
@@ -127,7 +130,7 @@ OpenGLContext::OpenGLContext() noexcept {
 #endif
 
 #ifdef GL_EXT_texture_filter_anisotropic
-    if (ext.texture_filter_anisotropic) {
+    if (ext.texture_filter_anisotropic && !bugs.disable_texture_filter_anisotropic) {
         glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &gets.maxAnisotropy);
     }
 #endif

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -147,6 +147,10 @@ public:
         // Some web browsers seem to immediately clear the default framebuffer when calling
         // glInvalidateFramebuffer with WebGL 2.0
         bool disable_invalidate_framebuffer = false;
+
+        // Some drivers declare GL_EXT_texture_filter_anisotropic but don't support
+        // calling glSamplerParameter() with GL_TEXTURE_MAX_ANISOTROPY_EXT
+        bool disable_texture_filter_anisotropic = false;
     } bugs;
 
     // state getters -- as needed.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2436,7 +2436,7 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
 // TODO: Why does this fail with WebGL 2.0? The run-time check should suffice.
 #if defined(GL_EXT_texture_filter_anisotropic) && !defined(__EMSCRIPTEN__)
     auto& gl = mContext;
-    if (gl.ext.texture_filter_anisotropic) {
+    if (gl.ext.texture_filter_anisotropic && !gl.bugs.disable_texture_filter_anisotropic) {
         GLfloat anisotropy = float(1u << params.anisotropyLog2);
         glSamplerParameterf(s, GL_TEXTURE_MAX_ANISOTROPY_EXT, std::min(gl.gets.maxAnisotropy, anisotropy));
     }


### PR DESCRIPTION
some drivers declare supporting anisotropic filtering, but don't
support calling glSamplerParameter() to set the max anisotropy, presumably because they only support glTexParameter().
We simply turn off anisotropic filtering on these drivers.