### PR TITLE
Round non-texture FBO attachments to 32 pixels

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -881,6 +881,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     /*
      * The GLES 3.0 spec states:
      *
+     *                             --------------
+     *
      * GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE is returned
      * - if the value of GL_RENDERBUFFER_SAMPLES is not the same for all attached renderbuffers or,
      * - if the attached images are a mix of renderbuffers and textures,
@@ -900,6 +902,15 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
      *
      * 'features.multisample_texture' below is a proxy for "GLES3.1 or GL4.x".
      *
+     *                             --------------
+     *
+     * About the size of the attachments:
+     *
+     *  If the attachment sizes are not all identical, the results of rendering are defined only
+     *  within the largest area that can fit in all of the attachments. This area is defined as
+     *  the intersection of rectangles having a lower left of (0, 0) and an upper right of
+     *  (width, height) for each attachment. Contents of attachments outside this area are
+     *  undefined after execution of a rendering command.
      */
 
     rt->gl.samples = samples;
@@ -916,8 +927,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         assert(color.handle);
         rt->gl.color.texture = handle_cast<GLTexture*>(color.handle);
         rt->gl.color.level = color.level;
-        assert(width == valueForLevel(color.level, rt->gl.color.texture->width) &&
-               height == valueForLevel(color.level, rt->gl.color.texture->height));
+        assert(width <= valueForLevel(color.level, rt->gl.color.texture->width) &&
+               height <= valueForLevel(color.level, rt->gl.color.texture->height));
 
         if (any(rt->gl.color.texture->usage & TextureUsage::SAMPLEABLE)) {
             framebufferTexture(color, rt, GL_COLOR_ATTACHMENT0);
@@ -940,8 +951,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         assert(!stencil.handle || stencil.handle == depth.handle);
         rt->gl.depth.texture = handle_cast<GLTexture*>(depth.handle);
         rt->gl.depth.level = depth.level;
-        assert(width == valueForLevel(depth.level, rt->gl.depth.texture->width) &&
-               height == valueForLevel(depth.level, rt->gl.depth.texture->height));
+        assert(width <= valueForLevel(depth.level, rt->gl.depth.texture->width) &&
+               height <= valueForLevel(depth.level, rt->gl.depth.texture->height));
         if (any(rt->gl.depth.texture->usage & TextureUsage::SAMPLEABLE)) {
             // special case: depth & stencil requested, and both provided as the same texture
             specialCased = true;
@@ -958,8 +969,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             assert(depth.handle);
             rt->gl.depth.texture = handle_cast<GLTexture*>(depth.handle);
             rt->gl.depth.level = depth.level;
-            assert(width == valueForLevel(depth.level, rt->gl.depth.texture->width) &&
-                   height == valueForLevel(depth.level, rt->gl.depth.texture->height));
+            assert(width <= valueForLevel(depth.level, rt->gl.depth.texture->width) &&
+                   height <= valueForLevel(depth.level, rt->gl.depth.texture->height));
             if (any(rt->gl.depth.texture->usage & TextureUsage::SAMPLEABLE)) {
                 framebufferTexture(depth, rt, GL_DEPTH_ATTACHMENT);
             } else {
@@ -970,8 +981,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             assert(stencil.handle);
             rt->gl.stencil.texture = handle_cast<GLTexture*>(stencil.handle);
             rt->gl.stencil.level = stencil.level;
-            assert(width == valueForLevel(stencil.level, rt->gl.stencil.texture->width) &&
-                   height == valueForLevel(stencil.level, rt->gl.stencil.texture->height));
+            assert(width <= valueForLevel(stencil.level, rt->gl.stencil.texture->width) &&
+                   height <= valueForLevel(stencil.level, rt->gl.stencil.texture->height));
             if (any(rt->gl.stencil.texture->usage & TextureUsage::SAMPLEABLE)) {
                 framebufferTexture(stencil, rt, GL_STENCIL_ATTACHMENT);
             } else {

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -113,6 +113,15 @@ backend::TextureHandle ResourceAllocator::createTexture(const char* name,
         backend::SamplerType target, uint8_t levels,
         backend::TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
         uint32_t depth, backend::TextureUsage usage) noexcept {
+
+    if (!(usage & TextureUsage::SAMPLEABLE)) {
+        // If this texture is not going to be sampled, we can round its size up
+        // this helps prevent many reallocations for small size changes.
+        // We round to 16 pixels, which works for 720p btw.
+        width  = (width  + 15u) & ~15u;
+        height = (height + 15u) & ~15u;
+    }
+
     // do we have a suitable texture in the cache?
     TextureHandle handle;
     if (mEnabled) {


### PR DESCRIPTION
this helps reducing churn in the resourceallocator cache.