### PR TITLE
Fix froxel coordinate calculation on Metal and Vulkan

### DIFF
--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -24,11 +24,17 @@ struct FroxelParams {
 uvec3 getFroxelCoords(const vec3 fragCoords) {
     uvec3 froxelCoord;
 
-    froxelCoord.xy = uvec2((fragCoords.xy - frameUniforms.origin.xy) *
+    vec3 adjustedFragCoords = fragCoords;
+// In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
+#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+    adjustedFragCoords.y = frameUniforms.resolution.y - adjustedFragCoords.y;
+#endif
+
+    froxelCoord.xy = uvec2((adjustedFragCoords.xy - frameUniforms.origin.xy) *
             vec2(frameUniforms.oneOverFroxelDimension, frameUniforms.oneOverFroxelDimensionY));
 
     froxelCoord.z = uint(max(0.0,
-            log2(frameUniforms.zParams.x * fragCoords.z + frameUniforms.zParams.y) *
+            log2(frameUniforms.zParams.x * adjustedFragCoords.z + frameUniforms.zParams.y) *
                     frameUniforms.zParams.z + frameUniforms.zParams.w));
 
     return froxelCoord;


### PR DESCRIPTION
This fixes punctual lights with Metal and Vulkan. Metal and Vulkan have a vertically flipped texture space, so we need to adjust the fragment coords when calculating froxel coords, otherwise we incorrectly sample the froxel texture.

To test, I ran `lightbulb` and passed the `-d` flag.