### PR TITLE
Repair twoPassesTwoSides transparency.

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -207,7 +207,6 @@ void RenderPass::recordDriverCommands(FEngine::DriverApi& driver, const Command*
             mi = materialInstance;
             ma = mi->getMaterial();
             pipeline.scissor = mi->getScissor();
-            pipeline.rasterState.culling = mi->getCullingMode();
             *pPipelinePolygonOffset = mi->getPolygonOffset();
             mi->use(driver);
         };
@@ -541,7 +540,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
                 // unconditionally write the command
                 cmdDepth.primitive.primitiveHandle = primitive.getHwHandle();
                 cmdDepth.primitive.mi = mi;
-                cmdDepth.primitive.rasterState.culling = rs.culling;
+                cmdDepth.primitive.rasterState.culling = mi->getCullingMode();
                 *curr = cmdDepth;
 
                 // FIXME: should writeDepthForShadowCasters take precedence over rs.depthWrite?


### PR DESCRIPTION
This regressed when we added support for dynamic backface culling
(#1641). Also note another fix we made: #1877.