### PR TITLE
Fix MSVC 2019 16.4 build

### DIFF
--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -29,6 +29,20 @@
 
 namespace filament {
 namespace math {
+
+// MSVC 2019 16.4 doesn't seem to like it when we specialize std::is_arithmetic for
+// filament::math::half, so we're forced to create own is_arithmetic here and specialize it inside
+// of half.h.
+template<typename T>
+struct is_arithmetic : std::integral_constant<bool,
+        std::is_integral<T>::value || std::is_floating_point<T>::value> {
+};
+
+}
+}
+
+namespace filament {
+namespace math {
 namespace details {
 // -------------------------------------------------------------------------------------
 
@@ -52,10 +66,10 @@ using arithmetic_result_t = typename arithmetic_result<T, U>::type;
 
 template<typename A, typename B = int, typename C = int, typename D = int>
 using enable_if_arithmetic_t = std::enable_if_t<
-        std::is_arithmetic<A>::value &&
-        std::is_arithmetic<B>::value &&
-        std::is_arithmetic<C>::value &&
-        std::is_arithmetic<D>::value>;
+        is_arithmetic<A>::value &&
+        is_arithmetic<B>::value &&
+        is_arithmetic<C>::value &&
+        is_arithmetic<D>::value>;
 
 /*
  * No user serviceable parts here.

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -29,20 +29,6 @@
 
 namespace filament {
 namespace math {
-
-// MSVC 2019 16.4 doesn't seem to like it when we specialize std::is_arithmetic for
-// filament::math::half, so we're forced to create own is_arithmetic here and specialize it inside
-// of half.h.
-template<typename T>
-struct is_arithmetic : std::integral_constant<bool,
-        std::is_integral<T>::value || std::is_floating_point<T>::value> {
-};
-
-}
-}
-
-namespace filament {
-namespace math {
 namespace details {
 // -------------------------------------------------------------------------------------
 

--- a/libs/math/include/math/compiler.h
+++ b/libs/math/include/math/compiler.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #if defined (WIN32)
 
 #ifdef max
@@ -108,3 +110,17 @@
 #   define CONSTEXPR_IF_NOT_MSVC constexpr
 
 #endif // _MSC_VER
+
+namespace filament {
+namespace math {
+
+// MSVC 2019 16.4 doesn't seem to like it when we specialize std::is_arithmetic for
+// filament::math::half, so we're forced to create our own is_arithmetic here and specialize it
+// inside of half.h.
+template<typename T>
+struct is_arithmetic : std::integral_constant<bool,
+        std::is_integral<T>::value || std::is_floating_point<T>::value> {
+};
+
+}
+}

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -22,7 +22,6 @@
 #include <type_traits>
 
 #include <math/compiler.h>
-#include <math/TVecHelpers.h>
 
 namespace filament {
 namespace math {

--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include <math/compiler.h>
+#include <math/TVecHelpers.h>
 
 namespace filament {
 namespace math {
@@ -162,6 +163,8 @@ inline constexpr half operator "" _h(long double v) {
     return half( static_cast<float>(v) );
 }
 
+template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
+
 } // namespace math
 } // namespace filament
 
@@ -170,6 +173,8 @@ namespace std {
 template<> struct is_floating_point<filament::math::half> : public std::true_type {};
 
 // note: this shouldn't be needed (is_floating_point<> is enough) but some version of msvc need it
+// This stopped working with MSVC 2019 16.4, so we specialize our own version of is_arithmetic in
+// the math::filament namespace (see above).
 template<> struct is_arithmetic<filament::math::half> : public std::true_type {};
 
 template<>


### PR DESCRIPTION
The latest version of MSVC appears to not allow `std::is_arithmetic` specializations for custom types. This is the best workaround I can think of at the moment.

Fixes #1939