### PR TITLE
WebGL: enable depth buffer in swap chain.

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -39,7 +39,7 @@ Filament.loadClassExtensions = function() {
             majorVersion: 2,
             minorVersion: 0,
             antialias: false,
-            depth: false,
+            depth: true,
             alpha: false
         };
         options = Object.assign(defaults, options);


### PR DESCRIPTION
In PR #1906 we enabled depth for all backends, but we forgot web.

Note that this required 0 new codelines whereas Vulkan required 116
additional codelines. :)