### PR TITLE
Improve low roughness significantly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- Improve high roughness material rendering by default when regenerating environments maps
+
 ## v1.4.3
 
 - Fixed an assertion when a parameter array occurs last in a material definition.

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -156,12 +156,6 @@ IndirectLight* IndirectLight::Builder::build(Engine& engine) {
             return nullptr;
         }
 
-        if (!ASSERT_POSTCONDITION_NON_FATAL(mImpl->mReflectionsMap->getLevels() ==
-                upcast(mImpl->mReflectionsMap)->getMaxLevelCount(),
-                "reflection map must have %u mipmap levels",
-                upcast(mImpl->mReflectionsMap)->getMaxLevelCount())) {
-            return nullptr;
-        }
         if (IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING) {
             mImpl->mReflectionsMap->generateMipmaps(engine);
         }


### PR DESCRIPTION
Filament will now allow incomplete mipmap chains for the IBL and
map the roughness to the available chain.

This allows to create roughness cubemaps with a minim size for
roughness==1, instead of always mapping it to 1x1.

cmgen will now use 16x16 cubemaps for roughness==1, which
improves the quality of rough objects significantly.

The beauty of this is that there is no asset or API change. Old assets
will continue to work like before.

Before:
<img width="1136" alt="roughness-before" src="https://user-images.githubusercontent.com/1240896/70366623-8c15aa80-184d-11ea-930e-20d738713043.png">

After:
<img width="1136" alt="roughness-after" src="https://user-images.githubusercontent.com/1240896/70366628-9768d600-184d-11ea-97cd-d7c0a4cfe9ba.png">
