### PR TITLE
macOS: support high DPI displays, do not rely on SDL.

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/SwapChain.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/SwapChain.java
@@ -85,6 +85,12 @@ public class SwapChain {
      */
     public static final long CONFIG_READABLE = 0x2;
 
+    /**
+     * This flag is required on some platforms in order to create a window with a high DPI surface.
+     * Currently this is only used for macOS.
+     */
+    public static final long CONFIG_HIGH_DPI = 0x4;
+
     SwapChain(long nativeSwapChain, Object surface) {
         mNativeObject = nativeSwapChain;
         mSurface = surface;

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -41,6 +41,7 @@ namespace backend {
 
 static constexpr uint64_t SWAP_CHAIN_CONFIG_TRANSPARENT = 0x1;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_READABLE = 0x2;
+static constexpr uint64_t SWAP_CHAIN_CONFIG_HIGH_DPI = 0x4;
 
 static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 16; // This is guaranteed by OpenGL ES.
 static constexpr size_t MAX_SAMPLER_COUNT = 16;          // Matches the Adreno Vulkan driver.

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -79,8 +79,15 @@ void PlatformCocoaGL::terminate() noexcept {
 }
 
 Platform::SwapChain* PlatformCocoaGL::createSwapChain(void* nativewindow, uint64_t& flags) noexcept {
+
+    if (flags & SWAP_CHAIN_CONFIG_HIGH_DPI) {
+        NSView* nsView = (__bridge NSView*)nativewindow;
+        [nsView setWantsBestResolutionOpenGLSurface:YES];
+    }
+
     // Transparent SwapChain is not supported
     flags &= ~backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
+
     return (SwapChain*) nativewindow;
 }
 

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -153,6 +153,12 @@ public:
      */
     static const uint64_t CONFIG_READABLE = backend::SWAP_CHAIN_CONFIG_READABLE;
 
+    /**
+     * This flag is required on some platforms in order to create a high DPI swap chain.
+     * Currently this is only used for macOS.
+     */
+    static const uint64_t CONFIG_HIGH_DPI = backend::SWAP_CHAIN_CONFIG_HIGH_DPI;
+
     void* getNativeWindow() const noexcept;
 };
 


### PR DESCRIPTION
Currently SDL calls `setWantsBestResolutionOpenGLSurface` on our behalf, but we shouldn't require our clients to use SDL. I tried writing a Filament app using GLFW and it was impossible for me to create a high DPI view, even after setting the GLFW hint flag.