### PR TITLE
Refactor Metal buffers, allow in-frame vertex and index updates.

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -100,6 +100,7 @@ endif()
 if (FILAMENT_SUPPORTS_METAL)
     list(APPEND SRCS
             src/metal/MetalBlitter.mm
+            src/metal/MetalBuffer.mm
             src/metal/MetalBufferPool.mm
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm
@@ -292,7 +293,8 @@ if (APPLE)
         test/TrianglePrimitive.cpp
         test/Arguments.cpp
         test/test_MissingRequiredAttributes.cpp
-        test/test_ReadPixels.cpp)
+        test/test_ReadPixels.cpp
+        test/test_BufferUpdates.cpp)
 
     target_link_libraries(backend_test PRIVATE
         backend

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_METALBUFFER_H
+#define TNT_FILAMENT_DRIVER_METALBUFFER_H
+
+#include "MetalContext.h"
+#include "MetalBufferPool.h"
+
+#include <Metal/Metal.h>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+class MetalBuffer {
+public:
+
+    MetalBuffer(MetalContext& context, size_t size, bool forceGpuBuffer = false);
+    ~MetalBuffer();
+
+    MetalBuffer(const MetalBuffer& rhs) = delete;
+    MetalBuffer& operator=(const MetalBuffer& rhs) = delete;
+
+    size_t getSize() const noexcept { return mBufferSize; }
+
+    /**
+     * Update the buffer with data inside src. Potentially allocates a new buffer allocation to hold
+     * the bytes which will be released when the current frame is finished.
+     */
+    void copyIntoBuffer(void* src, size_t size);
+
+    /**
+     * Denotes that this buffer is used for a draw call ensuring that its allocation remains valid
+     * until the end of the current frame.
+     *
+     * @return The MTLBuffer representing the current state of the buffer to bind, or nil if there
+     * is no device allocation.
+     */
+    id<MTLBuffer> getGpuBufferForDraw() noexcept;
+
+    void* getCpuBuffer() const noexcept { return mCpuBuffer; }
+
+    enum Stage {
+        VERTEX = 1,
+        FRAGMENT = 2
+    };
+
+    /**
+     * Bind multiple buffers to pipeline stages.
+     *
+     * bindBuffers binds an array of buffers to the given stage(s) of a MTLRenderCommandEncoder's
+     * pipeline.
+     */
+    static void bindBuffers(id<MTLRenderCommandEncoder> encoder, size_t bufferStart,
+            uint8_t stages, MetalBuffer* const* buffers, size_t const* offsets, size_t count);
+
+private:
+
+    size_t mBufferSize = 0;
+    const MetalBufferPoolEntry* mBufferPoolEntry = nullptr;
+    void* mCpuBuffer = nullptr;
+    MetalContext& mContext;
+
+};
+
+} // namespace metal
+} // namespace backend
+} // namespace filament
+
+#endif

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalBuffer.h"
+
+#include <utils/Panic.h>
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+MetalBuffer::MetalBuffer(MetalContext& context, size_t size, bool forceGpuBuffer)
+        : mBufferSize(size), mContext(context) {
+    assert(size > 0);
+    // If the buffer is less than 4K in size, we don't use an explicit buffer and instead use
+    // immediate command encoder methods like setVertexBytes:length:atIndex:.
+    // TODO: we shouldn't do this if the data persists for multiple uses.
+    if (size <= 4 * 1024 && !forceGpuBuffer) {   // 4K
+        mBufferPoolEntry = nullptr;
+        mCpuBuffer = malloc(size);
+    }
+}
+
+MetalBuffer::~MetalBuffer() {
+    if (mCpuBuffer) {
+        free(mCpuBuffer);
+    }
+    // This buffer is being destroyed. If we have a buffer pool entry, release it as it is no longer
+    // needed.
+    if (mBufferPoolEntry) {
+        mContext.bufferPool->releaseBuffer(mBufferPoolEntry);
+    }
+}
+
+void MetalBuffer::copyIntoBuffer(void* src, size_t size) {
+    if (size <= 0) {
+        return;
+    }
+    ASSERT_PRECONDITION(size <= mBufferSize, "Attempting to copy %d bytes into a buffer of size %d",
+            size, mBufferSize);
+
+    // Either copy into the Metal buffer or into our cpu buffer.
+    if (mCpuBuffer) {
+        memcpy(mCpuBuffer, src, size);
+        return;
+    }
+
+    // We're about to acquire a new buffer to hold the new contents. If we previously had obtained a
+    // buffer we release it, decrementing its reference count, as we no longer needs it.
+    if (mBufferPoolEntry) {
+        mContext.bufferPool->releaseBuffer(mBufferPoolEntry);
+    }
+
+    mBufferPoolEntry = mContext.bufferPool->acquireBuffer(mBufferSize);
+    memcpy(static_cast<uint8_t*>(mBufferPoolEntry->buffer.contents), src, size);
+}
+
+id<MTLBuffer> MetalBuffer::getGpuBufferForDraw() noexcept {
+    if (!mBufferPoolEntry) {
+        // If there's a CPU buffer, then we return nil here, as the CPU-side buffer will be bound
+        // separately.
+        if (mCpuBuffer) {
+            return nil;
+        }
+
+        // If there isn't a CPU buffer, it means no data has been loaded into this buffer yet. To
+        // avoid an error, we'll allocate an empty buffer.
+        mBufferPoolEntry = mContext.bufferPool->acquireBuffer(mBufferSize);
+    }
+
+    // This buffer is being used in a draw call, so we retain it so it's not released back into the
+    // buffer pool until the frame has finished.
+    auto uniformDeleter = [bufferPool = mContext.bufferPool] (const void* resource) {
+        bufferPool->releaseBuffer((const MetalBufferPoolEntry*) resource);
+    };
+    id<MTLCommandBuffer> commandBuffer = mContext.currentCommandBuffer;
+    if (mContext.resourceTracker.trackResource((__bridge void*) commandBuffer, mBufferPoolEntry,
+            uniformDeleter)) {
+        // We only want to retain the buffer once per command buffer- trackResource will return
+        // true if this is the first time tracking this uniform for this command buffer.
+        mContext.bufferPool->retainBuffer(mBufferPoolEntry);
+    }
+
+    return mBufferPoolEntry->buffer;
+}
+
+void MetalBuffer::bindBuffers(id<MTLRenderCommandEncoder> encoder, size_t bufferStart,
+        uint8_t stages, MetalBuffer* const* buffers, size_t const* offsets, size_t count) {
+    const NSRange bufferRange = NSMakeRange(bufferStart, count);
+
+    std::vector<id<MTLBuffer>> metalBuffers(count, nil);
+    std::vector<size_t> metalOffsets(count, 0);
+
+    for (size_t b = 0; b < count; b++) {
+        MetalBuffer* const buffer = buffers[b];
+        if (!buffer) {
+            continue;
+        }
+        // getGpuBufferForDraw() might return nil, which means there isn't a device allocation for
+        // this buffer. In this case, we'll bind the buffer below with the CPU-side memory.
+        id<MTLBuffer> gpuBuffer = buffer->getGpuBufferForDraw();
+        if (!gpuBuffer) {
+            continue;
+        }
+        metalBuffers[b] = gpuBuffer;
+        metalOffsets[b] = offsets[b];
+    }
+
+    if (stages & Stage::VERTEX) {
+        [encoder setVertexBuffers:metalBuffers.data()
+                          offsets:metalOffsets.data()
+                        withRange:bufferRange];
+    }
+    if (stages & Stage::FRAGMENT) {
+        [encoder setFragmentBuffers:metalBuffers.data()
+                            offsets:metalOffsets.data()
+                          withRange:bufferRange];
+    }
+
+    for (size_t b = 0; b < count; b++) {
+        MetalBuffer* const buffer = buffers[b];
+        if (!buffer) {
+            continue;
+        }
+
+        const void* cpuBuffer = buffer->getCpuBuffer();
+        if (!cpuBuffer) {
+            continue;
+        }
+
+        const size_t bufferIndex = bufferStart + b;
+        const size_t offset = offsets[b];
+        auto* bytes = static_cast<const uint8_t*>(cpuBuffer);
+
+        if (stages & Stage::VERTEX) {
+            [encoder setVertexBytes:(bytes + offset)
+                             length:(buffer->getSize() - offset)
+                            atIndex:bufferIndex];
+        }
+        if (stages & Stage::FRAGMENT) {
+            [encoder setFragmentBytes:(bytes + offset)
+                               length:(buffer->getSize() - offset)
+                              atIndex:bufferIndex];
+        }
+    }
+}
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -32,7 +32,7 @@ namespace backend {
 namespace metal {
 
 class MetalRenderTarget;
-class MetalUniformBuffer;
+struct MetalUniformBuffer;
 struct MetalIndexBuffer;
 struct MetalSamplerGroup;
 struct MetalSwapChain;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -34,7 +34,7 @@ class MetalPlatform;
 
 namespace metal {
 
-class MetalUniformBuffer;
+struct MetalUniformBuffer;
 struct MetalContext;
 struct MetalProgram;
 struct UniformBufferState;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -23,6 +23,7 @@
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h> // for CAMetalLayer
 
+#include "MetalBuffer.h"
 #include "MetalContext.h"
 #include "MetalDefines.h"
 #include "MetalEnums.h"
@@ -54,50 +55,23 @@ struct MetalSwapChain : public HwSwapChain {
 };
 
 struct MetalVertexBuffer : public HwVertexBuffer {
-    MetalVertexBuffer(id<MTLDevice> device, uint8_t bufferCount, uint8_t attributeCount,
+    MetalVertexBuffer(MetalContext& context, uint8_t bufferCount, uint8_t attributeCount,
             uint32_t vertexCount, AttributeArray const& attributes);
+    ~MetalVertexBuffer();
 
-    std::vector<id<MTLBuffer>> buffers;
+    std::vector<MetalBuffer*> buffers;
 };
 
 struct MetalIndexBuffer : public HwIndexBuffer {
-    MetalIndexBuffer(id<MTLDevice> device, uint8_t elementSize, uint32_t indexCount);
+    MetalIndexBuffer(MetalContext& context, uint8_t elementSize, uint32_t indexCount);
 
-    id<MTLBuffer> buffer;
+    MetalBuffer buffer;
 };
 
-class MetalUniformBuffer : public HwUniformBuffer {
-public:
+struct MetalUniformBuffer : public HwUniformBuffer {
     MetalUniformBuffer(MetalContext& context, size_t size);
-    ~MetalUniformBuffer();
 
-    size_t getSize() const { return uniformSize; }
-
-    /**
-     * Update the uniform with data inside src. Potentially allocates a new buffer allocation to
-     * hold the bytes which will be released when the current frame is finished.
-     */
-    void copyIntoBuffer(void* src, size_t size);
-
-    /**
-     * Denotes that this uniform is used for a draw call ensuring that its allocation remains valid
-     * until the end of the current frame.
-     *
-     * @return The MTLBuffer representing the current state of the uniform to bind, or nil if there
-     * is no device allocation.
-     */
-    id<MTLBuffer> getGpuBufferForDraw();
-
-    /**
-     * @return A pointer to the CPU buffer holding the uniform data or nullptr if there isn't one.
-     */
-    void* getCpuBuffer() const;
-
-private:
-    size_t uniformSize = 0;
-    const MetalBufferPoolEntry* bufferPoolEntry = nullptr;
-    void* cpuBuffer = nullptr;
-    MetalContext& context;
+    MetalBuffer buffer;
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {
@@ -112,7 +86,7 @@ struct MetalRenderPrimitive : public HwRenderPrimitive {
     // This struct is used to create the pipeline description to describe vertex assembly.
     VertexDescription vertexDescription = {};
 
-    std::vector<id<MTLBuffer>> buffers;
+    std::vector<MetalBuffer*> buffers;
     std::vector<NSUInteger> offsets;
 };
 

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -28,13 +28,7 @@
 
 #include <filament/MaterialEnums.h>
 
-#include <math/vec4.h>
-
 namespace test {
-
-struct UniformBuffer {
-    filament::math::float4 color;
-};
 
 class BackendTest : public ::testing::Test {
 public:

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -31,8 +31,10 @@ static constexpr filament::math::float2 gVertices[3] = {
 
 static constexpr short gIndices[3] = { 0, 1, 2 };
 
-TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi)
-        : mDriverApi(driverApi) {
+TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
+        bool allocateLargeBuffers) : mDriverApi(driverApi) {
+    mVertexCount = allocateLargeBuffers ? 2048 : 3;
+    mIndexCount = allocateLargeBuffers ? 4096 : 3;
     AttributeArray attributes = {
             Attribute {
                     .offset = 0,
@@ -45,18 +47,45 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi)
     AttributeBitset enabledAttributes;
     enabledAttributes.set(VertexAttribute::POSITION);
 
-    mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, 3, attributes, BufferUsage::STATIC);
-    BufferDescriptor vBuffer(gVertices, sizeof(filament::math::float2) * 3, nullptr);
-    mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vBuffer), 0);
+    mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes,
+            BufferUsage::STATIC);
+    BufferDescriptor vertexBufferDesc(gVertices, sizeof(filament::math::float2) * 3, nullptr);
+    mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vertexBufferDesc), 0);
 
-    mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, 3, BufferUsage::STATIC);
-    BufferDescriptor iBuffer(gIndices, sizeof(short) * 3, nullptr);
-    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(iBuffer), 0);
+    mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
+            BufferUsage::STATIC);
+    BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3, nullptr);
+    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 
     mRenderPrimitive = mDriverApi.createRenderPrimitive(0);
 
-    mDriverApi.setRenderPrimitiveBuffer(mRenderPrimitive, mVertexBuffer, mIndexBuffer, enabledAttributes.getValue());
+    mDriverApi.setRenderPrimitiveBuffer(mRenderPrimitive, mVertexBuffer, mIndexBuffer,
+            enabledAttributes.getValue());
     mDriverApi.setRenderPrimitiveRange(mRenderPrimitive, PrimitiveType::TRIANGLES, 0, 0, 2, 3);
+}
+
+void TrianglePrimitive::updateVertices(const filament::math::float2 vertices[3]) noexcept {
+    void* buffer = malloc(sizeof(filament::math::float2) * mVertexCount);
+    filament::math::float2* vertBuffer = (filament::math::float2*) buffer;
+    std::copy(vertices, vertices + 3, vertBuffer);
+
+    BufferDescriptor vBuffer(vertBuffer, sizeof(filament::math::float2) * mVertexCount,
+            [] (void* buffer, size_t size, void* user) {
+        free(buffer);
+    });
+    mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vBuffer), 0);
+}
+
+void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
+    void* buffer = malloc(sizeof(short) * mIndexCount);
+    short* indexBuffer = (short*) buffer;
+    std::copy(indices, indices + 3, indexBuffer);
+
+    BufferDescriptor bufferDesc(indexBuffer, sizeof(short) * mIndexCount,
+            [] (void* buffer, size_t size, void* user) {
+        free(buffer);
+    });
+    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), 0);
 }
 
 TrianglePrimitive::~TrianglePrimitive() {

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -19,6 +19,8 @@
 
 #include "private/backend/DriverApi.h"
 
+#include <math/vec2.h>
+
 namespace test {
 
 /**
@@ -32,12 +34,18 @@ public:
     using VertexHandle = filament::backend::Handle<filament::backend::HwVertexBuffer>;
     using IndexHandle = filament::backend::Handle<filament::backend::HwIndexBuffer>;
 
-    TrianglePrimitive(filament::backend::DriverApi& driverApi);
+    TrianglePrimitive(filament::backend::DriverApi& driverApi, bool allocateLargeBuffers = false);
     ~TrianglePrimitive();
 
     PrimitiveHandle getRenderPrimitive() const noexcept;
 
+    void updateVertices(const filament::math::float2 vertices[3]) noexcept;
+    void updateIndices(const short indices[3]) noexcept;
+
 private:
+
+    size_t mVertexCount = 3;
+    size_t mIndexCount = 3;
 
     filament::backend::DriverApi& mDriverApi;
 

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTest.h"
+
+#include "ShaderGenerator.h"
+#include "TrianglePrimitive.h"
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Shaders
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::string vertex (R"(#version 450 core
+
+layout(location = 0) in vec4 mesh_position;
+
+layout(location = 0) out uvec4 indices;
+
+void main() {
+    gl_Position = vec4(mesh_position.xy, 0.0, 1.0);
+}
+)");
+
+std::string fragment (R"(#version 450 core
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0);
+}
+
+)");
+
+}
+
+namespace test {
+
+using namespace filament;
+using namespace filament::backend;
+
+TEST_F(BackendTest, VertexBufferUpdate) {
+    const bool largeBuffers = false;
+
+    // If updateIndices is true, then even-numbered triangles will have their indices set to
+    // {0, 0, 0}, effectively "hiding" every other triangle.
+    const bool updateIndices = true;
+
+    // The test is executed within this block scope to force destructors to run before
+    // executeCommands().
+    {
+        // Create a platform-specific SwapChain and make it current.
+        auto swapChain = createSwapChain();
+        getDriverApi().makeCurrent(swapChain, swapChain);
+
+        // Create a program.
+        ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
+        Program p = shaderGen.getProgram();
+        auto program = getDriverApi().createProgram(std::move(p));
+
+        auto defaultRenderTarget = getDriverApi().createDefaultRenderTarget(0);
+
+        // To test large buffers (which exercise a different code path) create an extra large
+        // buffer. Only the first 3 vertices will be used.
+        TrianglePrimitive triangle(getDriverApi(), largeBuffers);
+
+        RenderPassParams params = {};
+        fullViewport(params);
+        params.flags.clear = TargetBufferFlags::COLOR;
+        params.clearColor = {0.f, 1.f, 0.f, 1.f};
+        params.flags.discardStart = TargetBufferFlags::ALL;
+        params.flags.discardEnd = TargetBufferFlags::NONE;
+
+        PipelineState state;
+        state.program = program;
+        state.rasterState.colorWrite = true;
+        state.rasterState.depthWrite = false;
+        state.rasterState.depthFunc = RasterState::DepthFunc::A;
+        state.rasterState.culling = CullingMode::NONE;
+
+        getDriverApi().startCapture(0);
+
+        getDriverApi().makeCurrent(swapChain, swapChain);
+        getDriverApi().beginFrame(0, 0, nullptr, nullptr);
+
+        // Draw 10 triangles, updating the vertex buffer / index buffer each time.
+        getDriverApi().beginRenderPass(defaultRenderTarget, params);
+        size_t triangleIndex = 0;
+        for (float i = -1.0f; i < 1.0f; i += 0.2f) {
+            const float low = i, high = i + 0.2;
+            const filament::math::float2 v[3] {{low, low}, {high, low}, {low, high}};
+            triangle.updateVertices(v);
+
+            if (updateIndices) {
+                if (triangleIndex % 2 == 0) {
+                    const short i[3] {0, 1, 2};
+                    triangle.updateIndices(i);
+                } else {
+                    // This effectively hides this triangle.
+                    const short i[3] {0, 0, 0};
+                    triangle.updateIndices(i);
+                }
+            }
+            getDriverApi().draw(state, triangle.getRenderPrimitive());
+
+            triangleIndex++;
+        }
+        getDriverApi().endRenderPass();
+
+        getDriverApi().flush();
+        getDriverApi().commit(swapChain);
+        getDriverApi().endFrame(0);
+
+        getDriverApi().stopCapture(0);
+
+        getDriverApi().destroyProgram(program);
+        getDriverApi().destroySwapChain(swapChain);
+        getDriverApi().destroyRenderTarget(defaultRenderTarget);
+    }
+
+    executeCommands();
+}
+
+} // namespace test


### PR DESCRIPTION
This moves the logic behind allocating Metal buffers out of `MetalUniformBuffer` and into a new class, `MetalBuffer`. This allows vertex and index buffers to be updated within a frame