### PR TITLE
Update Windows READMEs for building with VS2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,13 +360,17 @@ See [ios/samples/README.md](./ios/samples/README.md) for more information.
 
 ### Windows
 
-#### Building on Windows with the Visual Studio 2019 compiler
+#### Building on Windows with Visual Studio 2019
 
 Install the following components:
 
 - [Visual Studio 2019](https://www.visualstudio.com/downloads)
+- [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
 - [Python 3.7](https://www.python.org/ftp/python/3.7.0/python-3.7.0.exe)
 - [CMake 3.14 or later](https://github.com/Kitware/CMake/releases/download/v3.14.7/cmake-3.14.7-win64-x64.msi)
+
+The latest Windows SDK can also by installed by opening Visual Studio and selecting _Get Tools and
+Features..._ under the _Tools_ menu.
 
 Open the `x64 Native Tools Command Prompt for VS 2019`.
 
@@ -378,120 +382,15 @@ Create a working directory, and run cmake in it:
 > cmake ..
 ```
 
-Then, you should be able to load the generated solution file `TNT.sln` in Visual Studio and build the `material_sandbox` project.
+Open the generated solution file `TNT.sln` in Visual Studio.
 
-Run it from the `out` directory with:
+To build all targets, run _Build Solution_ from the _Build_ menu. Alternatively, right click on a
+target in the _Solution Explorer_ and choose _Build_ to build a specific target.
+
+For example, build the `material_sandbox` sample and run it from the `out` directory with:
+
 ```
 > samples\Debug\material_sandbox.exe ..\assets\models\monkey\monkey.obj
-```
-
-#### Building on Windows with the Clang compiler
-
-The following instructions have been tested on a machine running Windows 10. They should take you
-from a machine with only the operating system to a machine able to build and run Filament.
-
-Google employees require additional steps which can be found here [go/filawin](http://go/filawin).
-
-Install the following components:
-
-- [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)
-- [Visual Studio 2015 or 2017](https://www.visualstudio.com/downloads)
-- [Clang 7](http://releases.llvm.org/download.html)
-- [Python 3.7](https://www.python.org/ftp/python/3.7.0/python-3.7.0.exe)
-- [Cmake 3.13 or later](https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-win64-x64.msi)
-
-If you're using Visual Studio 2017, you'll also need to install the [LLVM Compiler
-Toolchain](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain)
-extension.
-
-Open an appropriate Native Tools terminal for the version of Visual Studio you are using:
-- VS 2015: VS2015 x64 Native Tools Command Prompt
-- VS 2017: x64 Native Tools Command Prompt for VS 2017
-
-You can find these by clicking the start button and typing "x64 native tools".
-
-Create a working directory:
-```
-> mkdir out/cmake-release
-> cd out/cmake-release
-```
-
-Create the msBuild project:
-```
-# Visual Studio 2015:
-> cmake -T"LLVM-vs2014" -G "Visual Studio 14 2015 Win64" ../..
-
-# Visual Studio 2017
-> cmake ..\.. -T"LLVM" -G "Visual Studio 15 2017 Win64" ^
--DCMAKE_CXX_COMPILER:PATH="C:\Program Files\LLVM\bin\clang-cl.exe" ^
--DCMAKE_C_COMPILER:PATH="C:\Program Files\LLVM\bin\clang-cl.exe" ^
--DCMAKE_LINKER:PATH="C:\Program Files\LLVM\bin\lld-link.exe"
-```
-
-Check out the output and make sure Clang for Windows frontend was found. You should see a line
-showing the following output. Note that for Visual Studio 2017 this line may list Microsoft's
-compiler, but the build will still in fact use Clang and you can proceed.
-
-```
-Clang:C:/Program Files/LLVM/msbuild-bin/cl.exe
-```
-
-You are now ready to build:
-```
-> msbuild  TNT.sln /t:material_sandbox /m /p:configuration=Release
-```
-
-Run it:
-```
-> samples\Release\material_sandbox.exe ..\..\assets\models\monkey\monkey.obj
-```
-
-#### Tips
-
-- To troubleshoot an issue, use verbose mode via `/v:d` flag.
-- To build a specific project, use `/t:NAME` flag (e.g: `/t:material_sandbox`).
-- To build using more than one core, use parallel build flag: `/m`.
-- To build a specific profile, use `/p:configuration=` (e.g: `/p:configuration=Debug`,
-  `/p:configuration=Release`, and `/p:configuration=RelWithDebInfo`).
-- The msBuild project is what is used by Visual Studio behind the scene to build. Building from VS
-  or from the command-line is the same thing.
-
-#### Building with Ninja on Windows
-
-Alternatively, you can use [Ninja](https://ninja-build.org/) to build for Windows. An MSVC
-installation is still necessary.
-
-First, install the dependencies listed under [Windows](#Windows) as well as Ninja. Then open up a
-Native Tools terminal as before. Create a build directory inside Filament and run the
-following CMake command:
-
-```
-> cmake .. -G Ninja ^
--DCMAKE_CXX_COMPILER:PATH="C:\Program Files\LLVM\bin\clang-cl.exe" ^
--DCMAKE_C_COMPILER:PATH="C:\Program Files\LLVM\bin\clang-cl.exe" ^
--DCMAKE_LINKER:PATH="C:\Program Files\LLVM\bin\lld-link.exe" ^
--DCMAKE_BUILD_TYPE=Release
-```
-
-You should then be able to build by invoking Ninja:
-
-```
-> ninja
-```
-
-#### Development tips
-
-- Before shipping a binary, make sure you used Release profile and make sure you have no libc/libc++
-  dependencies with [Dependency Walker](http://www.dependencywalker.com).
-- Application Verifier and gflags.exe can be of great help to trackdown heap corruption. Application
-  Verifier is easy to setup with a GUI. For gflags, use: `gflags /p /enable pheap-buggy.exe`.
-
-#### Running a simple test
-
-To confirm Filament was properly built, run the following command from the build directory:
-
-```
-> samples\material_sandbox.exe --ibl=..\..\samples\envs\pillars ..\..\assets\models\sphere\sphere.obj
 ```
 
 ### Android

--- a/filament/README.md
+++ b/filament/README.md
@@ -134,22 +134,21 @@ When building Filament from source, the `USE_STATIC_CRT` CMake option can be
 used to change the run-time library version.
 
 ```
-FILAMENT_LIBS=lib/x86_64/mt/filament.lib lib/x86_64/mt/backend.lib lib/x86_64/mt/bluegl.lib \
-              lib/x86_64/mt/filabridge.lib lib/x86_64/mt/filaflat.lib lib/x86_64/mt/utils.lib \
-              lib/x86_64/mt/geometry.lib lib/x86_64/mt/smol-v.lib lib/x86_64/mt/ibl.lib
-CC=clang-cl.exe
+FILAMENT_LIBS=filament.lib backend.lib bluegl.lib filabridge.lib filaflat.lib utils.lib \
+              geometry.lib smol-v.lib ibl.lib
+CC=cl.exe
 
 main.exe: main.obj
-	$(CC) main.obj $(FILAMENT_LIBS) gdi32.lib user32.lib opengl32.lib
+	$(CC) main.obj /link /libpath:"lib\\x86_64\\mt\\" $(FILAMENT_LIBS) \
+	gdi32.lib user32.lib opengl32.lib
 
 main.obj: main.cpp
-	$(CC) /MT /Iinclude/ /std:c++14 /c main.cpp
+	$(CC) /MT /Iinclude\\ /std:c++14 /c main.cpp
 
 clean:
 	del main.exe main.obj
 
 .PHONY: clean
-
 ```
 
 ### Compiling


### PR DESCRIPTION
We no longer officially support building for Windows with Clang, which simplifies a lot of our README :)