### PR TITLE
Improve ibl diffuse with absolute hdr environments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: Added Java / Kotlin bindings for Animator.
 - gltfio: Fixed panic with the Android gltf-bloom demo.
 - gltfio: Java clients should no longer call Filament#init.
+- Improved IBL diffuse by allowing to use the specular cubemap at `roughness` = 1 instead of Spherical Harmonics
 
 ## v1.4.1
 

--- a/android/filament-android/src/main/cpp/IndirectLight.cpp
+++ b/android/filament-android/src/main/cpp/IndirectLight.cpp
@@ -135,10 +135,31 @@ Java_com_google_android_filament_IndirectLight_nGetDirectionEstimate(JNIEnv* env
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_IndirectLight_nGetColorEstimate(JNIEnv* env, jclass,
-        jlong nativeIndirectLight, jfloatArray outColor_, float x, float y, float z) {
+        jlong nativeIndirectLight, jfloatArray outColor_, jfloat x, jfloat y, jfloat z) {
     IndirectLight *indirectLight = (IndirectLight *) nativeIndirectLight;
     jfloat *outColor = env->GetFloatArrayElements(outColor_, NULL);
     *reinterpret_cast<filament::math::float4*>(outColor) =
             indirectLight->getColorEstimate(math::float3{x, y, z});
     env->ReleaseFloatArrayElements(outColor_, outColor, 0);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_IndirectLight_nGetDirectionEstimateStatic(JNIEnv *env, jclass,
+        jfloatArray sh_, jfloatArray outDirection_) {
+    jfloat* sh = env->GetFloatArrayElements(sh_, NULL);
+    jfloat *outDirection = env->GetFloatArrayElements(outDirection_, NULL);
+    *reinterpret_cast<filament::math::float3*>(outDirection) = IndirectLight::getDirectionEstimate((filament::math::float3*)sh);
+    env->ReleaseFloatArrayElements(outDirection_, outDirection, 0);
+    env->ReleaseFloatArrayElements(sh_, sh, JNI_ABORT);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_IndirectLight_nGetColorEstimateStatic(JNIEnv *env, jclass,
+        jfloatArray outColor_, jfloatArray sh_, jfloat x, jfloat y, jfloat z) {
+    jfloat* sh = env->GetFloatArrayElements(sh_, NULL);
+    jfloat *outColor = env->GetFloatArrayElements(outColor_, NULL);
+    *reinterpret_cast<filament::math::float4*>(outColor) =
+            IndirectLight::getColorEstimate((filament::math::float3*)sh, math::float3{x, y, z});
+    env->ReleaseFloatArrayElements(outColor_, outColor, 0);
+    env->ReleaseFloatArrayElements(sh_, sh, JNI_ABORT);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
@@ -63,7 +63,10 @@ import com.google.android.filament.proguard.UsedByReflection;
  * <h1>Irradiance</h1>
  *
  * <p>The irradiance represents the light that comes from the environment and shines an
- * object's surface. It is represented as
+ * object's surface.
+ * The irradiance is calculated automatically from the Reflections (see below), and generally
+ * doesn't need to be provided explicitly.  However, it can be provided separately from the
+ * Reflections as
  * <a href="https://en.wikipedia.org/wiki/Spherical_harmonics">Spherical Harmonics</a> (SH) of 1, 2 or
  * 3 bands, respectively 1, 4 or 9 coefficients.</p>
  *
@@ -402,6 +405,7 @@ public class IndirectLight {
      * <p>The dominant light direction can be used to set a directional light's direction,
      * for instance to produce shadows that match the environment.</p>
      *
+     * @param sh        pre-scaled 3-bands spherical harmonics
      * @param direction an array of 3 floats to receive a unit vector representing the direction of
      *                 the dominant light or <code>null</code>
      * @return the <code>direction</code> paramter if it was provided, or a newly allocated float
@@ -410,12 +414,26 @@ public class IndirectLight {
      * @see LightManager.Builder#direction
      * @see #getColorEstimate
      */
+
+    @NonNull @Size(min = 3)
+    public static float[] getDirectionEstimate(@NonNull float[] sh, @Nullable @Size(min = 3) float[] direction) {
+        if (sh.length < 9 * 3) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "3 bands SH required, array must be at least 9 x float3");
+        }
+        direction = Asserts.assertFloat3(direction);
+        nGetDirectionEstimateStatic(sh, direction);
+        return direction;
+    }
+
+    /** @deprecated */
     @NonNull @Size(min = 3)
     public float[] getDirectionEstimate(@Nullable @Size(min = 3) float[] direction) {
         direction = Asserts.assertFloat3(direction);
         nGetDirectionEstimate(getNativeObject(), direction);
         return direction;
     }
+
 
     /**
      * Helper to estimate the color and relative intensity of the environment in a given direction.
@@ -424,6 +442,7 @@ public class IndirectLight {
      * make sure to multiply this relative intensity by the the intensity of this indirect light.</p>
      *
      * @param colorIntensity an array of 4 floats to receive the result or <code>null</code>
+     * @param sh        pre-scaled 3-bands spherical harmonics
      * @param x the x coordinate of a unit vector representing the direction of the light
      * @param y the x coordinate of a unit vector representing the direction of the light
      * @param z the x coordinate of a unit vector representing the direction of the light
@@ -437,6 +456,19 @@ public class IndirectLight {
      * @see #getIntensity
      * @see #setIntensity
      */
+    @NonNull @Size(min = 4)
+    public static float[] getColorEstimate(@Nullable @Size(min = 4) float[] colorIntensity, @NonNull float[] sh, float x, float y, float z) {
+        if (sh.length < 9 * 3) {
+            throw new ArrayIndexOutOfBoundsException(
+                    "3 bands SH required, array must be at least 9 x float3");
+        }
+        colorIntensity = Asserts.assertFloat4(colorIntensity);
+        nGetColorEstimateStatic(colorIntensity, sh, x, y, z);
+        return colorIntensity;
+    }
+
+
+    /** @deprecated */
     @NonNull @Size(min = 4)
     public float[] getColorEstimate(@Nullable @Size(min = 4) float[] colorIntensity, float x, float y, float z) {
         colorIntensity = Asserts.assertFloat4(colorIntensity);
@@ -472,4 +504,7 @@ public class IndirectLight {
     private static native void nGetRotation(long nativeIndirectLight, float[] outRotation);
     private static native void nGetDirectionEstimate(long nativeIndirectLight, float[] outDirection);
     private static native void nGetColorEstimate(long nativeIndirectLight, float[] outColor, float x, float y, float z);
+
+    private static native void nGetDirectionEstimateStatic(float[] sh, float[] direction);
+    private static native void nGetColorEstimateStatic(float[] colorIntensity, float[] sh, float x, float y, float z);
 }

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -61,7 +61,6 @@ class FIndirectLight;
  *
  *  filament::IndirectLight* environment = filament::IndirectLight::Builder()
  *              .reflections(cubemap)
- *              .irradiance(numBands, sphericalHarmonicsCoefficients)
  *              .build(*engine);
  *
  *  engine->destroy(environment);
@@ -72,7 +71,11 @@ class FIndirectLight;
  * ==========
  *
  * The irradiance represents the light that comes from the environment and shines an
- * object's surface. It is represented as
+ * object's surface.
+ *
+ * The irradiance is calculated automatically from the Reflections (see below), and generally
+ * doesn't need to be provided explicitly.  However, it can be provided separately from the
+ * Reflections as
  * [spherical harmonics](https://en.wikipedia.org/wiki/Spherical_harmonics) (SH) of 1, 2 or
  * 3 bands, respectively 1, 4 or 9 coefficients.
  *
@@ -281,7 +284,8 @@ public:
     const math::mat3f& getRotation() const noexcept;
 
     /**
-     * Helper to estimate the direction of the dominant light in the environment.
+     * Helper to estimate the direction of the dominant light in the environment represented by
+     * spherical harmonics.
      *
      * This assumes that there is only a single dominant light (such as the sun in outdoors
      * environments), if it's not the case the direction returned will be an average of the
@@ -293,19 +297,23 @@ public:
      * The dominant light direction can be used to set a directional light's direction,
      * for instance to produce shadows that match the environment.
      *
+     * @param sh        3-band spherical harmonics
+     *
      * @return A unit vector representing the direction of the dominant light
      *
      * @see LightManager::Builder::direction()
      * @see getColorEstimate()
      */
-    math::float3 getDirectionEstimate() const noexcept;
+    static math::float3 getDirectionEstimate(const math::float3 sh[9]) noexcept;
 
     /**
-     * Helper to estimate the color and relative intensity of the environment in a given direction.
+     * Helper to estimate the color and relative intensity of the environment represented by
+     * spherical harmonics in a given direction.
      *
      * This can be used to set the color and intensity of a directional light. In this case
      * make sure to multiply this relative intensity by the the intensity of this indirect light.
      *
+     * @param sh        3-band spherical harmonics
      * @param direction a unit vector representing the direction of the light to estimate the
      *                  color of. Typically this the value returned by getDirectionEstimate().
      *
@@ -316,6 +324,13 @@ public:
      * @see LightManager::Builder::intensity()
      * @see getDirectionEstimate, getIntensity, setIntensity
      */
+    static math::float4 getColorEstimate(const math::float3 sh[9], math::float3 direction) noexcept;
+
+
+    /** @deprecated use static versions instead */
+    math::float3 getDirectionEstimate() const noexcept;
+
+    /** @deprecated use static versions instead */
     math::float4 getColorEstimate(math::float3 direction) const noexcept;
 };
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -43,7 +43,7 @@ using namespace details;
 struct IndirectLight::BuilderDetails {
     Texture const* mReflectionsMap = nullptr;
     Texture const* mIrradianceMap = nullptr;
-    float3 mIrradianceCoefs[9] = {};
+    float3 mIrradianceCoefs[9] = { 65504.0 }; // magic value (max fp16) to indicate sh are not set
     mat3f mRotation = {};
     float mIntensity = FIndirectLight::DEFAULT_INTENSITY;
 };
@@ -205,8 +205,8 @@ void FIndirectLight::terminate(FEngine& engine) {
     }
 }
 
-math::float3 FIndirectLight::getDirectionEstimate() const noexcept {
-    auto const& f = mIrradianceCoefs;
+
+math::float3 FIndirectLight::getDirectionEstimate(math::float3 const* f) noexcept {
     // The linear direction is found as normalize(-sh[3], -sh[1], sh[2]), but the coefficients
     // we store are already pre-normalized, so the negative sign disappears.
     // Note: we normalize the directions only after blending, this matches code used elsewhere --
@@ -218,16 +218,15 @@ math::float3 FIndirectLight::getDirectionEstimate() const noexcept {
     return -normalize(r * 0.2126f + g * 0.7152f + b * 0.0722f);
 }
 
-float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
+math::float4 FIndirectLight::getColorEstimate(math::float3 const* Le, math::float3 direction) noexcept {
     // See: https://www.gamasutra.com/view/news/129689/Indepth_Extracting_dominant_light_from_Spherical_Harmonics.php
+
+    // note Le is our pre-convolved, pre-scaled SH coefficients for the environment
 
     // first get the direction
     const float3 s = -direction;
 
     // The light intensity on one channel is given by: dot(Ld, Le) / dot(Ld, Ld)
-
-    // our pre-convolved, pre-scaled SH coefficients for the environment
-    auto const& Le = mIrradianceCoefs;
 
     // SH coefficients of the directional light pre-scaled by 1/A[i]
     // (we pre-scale by 1/A[i] to undo Le's pre-scaling by A[i]
@@ -259,6 +258,14 @@ float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
     return { LdDotLe / intensity, intensity };
 }
 
+math::float3 FIndirectLight::getDirectionEstimate() const noexcept {
+    return getDirectionEstimate(mIrradianceCoefs.data());
+}
+
+float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
+   return getColorEstimate(mIrradianceCoefs.data(), direction);
+}
+
 } // namespace details
 
 // ------------------------------------------------------------------------------------------------
@@ -287,6 +294,14 @@ math::float3 IndirectLight::getDirectionEstimate() const noexcept {
 
 math::float4 IndirectLight::getColorEstimate(math::float3 direction) const noexcept {
     return upcast(this)->getColorEstimate(direction);
+}
+
+math::float3 IndirectLight::getDirectionEstimate(const math::float3* sh) noexcept {
+    return FIndirectLight::getDirectionEstimate(sh);
+}
+
+math::float4 IndirectLight::getColorEstimate(const math::float3* sh, math::float3 direction) noexcept {
+    return FIndirectLight::getColorEstimate(sh, direction);
 }
 
 } // namespace filament

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -51,6 +51,8 @@ public:
     size_t getMaxMipLevel() const noexcept { return mMaxMipLevel; }
     math::float3 getDirectionEstimate() const noexcept;
     math::float4 getColorEstimate(math::float3 direction) const noexcept;
+    static math::float3 getDirectionEstimate(const math::float3 sh[9]) noexcept;
+    static math::float4 getColorEstimate(const math::float3 sh[9], math::float3 direction) noexcept;
 
 private:
     backend::Handle<backend::HwTexture> mReflectionsMapHandle;

--- a/libs/ibl/src/CubemapSH.cpp
+++ b/libs/ibl/src/CubemapSH.cpp
@@ -596,6 +596,7 @@ void CubemapSH::renderSH(JobSystem& js, Cubemap& cm,
                     for (size_t i = 0; i < numCoefs; i++) {
                         c += sh[i] * (K[i] * SHb[i]);
                     }
+                    c *= F_1_PI;
                     state.min = min(c, state.min);
                     Cubemap::writeAt(data, Cubemap::Texel(c));
                 }

--- a/samples/app/IBL.cpp
+++ b/samples/app/IBL.cpp
@@ -79,7 +79,6 @@ bool IBL::loadFromKtx(const std::string& prefix) {
 
     mIndirectLight = IndirectLight::Builder()
             .reflections(mTexture)
-            .irradiance(3, mBands)
             .intensity(IBL_INTENSITY)
             .build(mEngine);
 

--- a/samples/app/IBL.h
+++ b/samples/app/IBL.h
@@ -54,6 +54,8 @@ public:
         return mSkybox;
     }
 
+    filament::math::float3 const* getSphericalHarmonics() const { return mBands; }
+
 private:
     bool loadCubemapLevel(filament::Texture** texture, const utils::Path& path,
             size_t level = 0, std::string const& levelPrefix = "") const;

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -266,8 +266,8 @@ static void setup(Engine* engine, View*, Scene* scene) {
     if (ibl) {
         auto& params = g_params;
         IndirectLight* const pIndirectLight = ibl->getIndirectLight();
-        params.lightDirection = pIndirectLight->getDirectionEstimate();
-        float4 c = pIndirectLight->getColorEstimate(params.lightDirection);
+        params.lightDirection = IndirectLight::getDirectionEstimate(ibl->getSphericalHarmonics());
+        float4 c = pIndirectLight->getColorEstimate(ibl->getSphericalHarmonics(), params.lightDirection);
         params.lightIntensity = c.w * pIndirectLight->getIntensity();
         params.lightColor = c.rgb;
     }

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -61,12 +61,21 @@ vec3 Irradiance_SphericalHarmonics(const vec3 n) {
         , 0.0);
 }
 
+vec3 Irradiance_RoughnessOne(const vec3 n) {
+    // note: lod used is always integer, hopefully the hardware skips tri-linear filtering
+    return decodeDataForIBL(textureLod(light_iblSpecular, n, frameUniforms.iblMaxMipLevel.x));
+}
+
 //------------------------------------------------------------------------------
 // IBL irradiance dispatch
 //------------------------------------------------------------------------------
 
 vec3 diffuseIrradiance(const vec3 n) {
-    return Irradiance_SphericalHarmonics(n);
+    if (frameUniforms.iblSH[0].x == 65504.0) {
+        return Irradiance_RoughnessOne(n);
+    } else {
+        return Irradiance_SphericalHarmonics(n);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1008,9 +1008,9 @@ class_<IndirectLight>("IndirectLight")
     }), allow_raw_pointers())
     .function("getRotation", EMBIND_LAMBDA(flatmat3, (IndirectLight* self), {
         return flatmat3 { self->getRotation() };
-    }), allow_raw_pointers())
-    .function("getDirectionEstimate", &IndirectLight::getDirectionEstimate)
-    .function("getColorEstimate", &IndirectLight::getColorEstimate);
+    }), allow_raw_pointers());
+//    .function("getDirectionEstimate", &IndirectLight::getDirectionEstimate)
+//    .function("getColorEstimate", &IndirectLight::getColorEstimate);
 
 class_<IblBuilder>("IndirectLight$Builder")
     .function("_build", EMBIND_LAMBDA(IndirectLight*, (IblBuilder* builder, Engine* engine), {


### PR DESCRIPTION
Before: Spherical Harmonics fail to encode the diffuse.
<img width="1136" alt="Screen Shot 2019-12-10 at 01 29 12" src="https://user-images.githubusercontent.com/1240896/70517076-e2544900-1aec-11ea-88e3-28c898bf583c.png">

After: Diffuse is better encoded, but shows some undersampling.
<img width="1136" alt="Screen Shot 2019-12-10 at 01 26 20" src="https://user-images.githubusercontent.com/1240896/70517072-e08a8580-1aec-11ea-8ba5-a40b4f11bffc.png">
