### PR TITLE
Fix SSAO when blending is used

### DIFF
--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -114,7 +114,9 @@ public:
         // objects that use alpha-testing or blending in the depth prepass.
         COLOR_WITH_DEPTH_PREPASS = DEPTH | COLOR | DEPTH_FILTER_TRANSLUCENT_OBJECTS | DEPTH_FILTER_ALPHA_MASKED_OBJECTS,
         // generate commands for shadow map
-        SHADOW = DEPTH | DEPTH_CONTAINS_SHADOW_CASTERS
+        SHADOW = DEPTH | DEPTH_CONTAINS_SHADOW_CASTERS,
+        // generate commands for SSAO
+        SSAO = DEPTH | DEPTH_FILTER_TRANSLUCENT_OBJECTS | DEPTH_FILTER_ALPHA_MASKED_OBJECTS,
     };
 
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -297,7 +297,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // SSAO pass -- automatically culled if not used
     if (useSSAO) {
         auto curr = pass.getCommands().end();
-        pass.appendCommands(RenderPass::CommandTypeFlags::DEPTH);
+        pass.appendCommands(RenderPass::CommandTypeFlags::SSAO);
         pass.sortCommands(curr);
     }
 


### PR DESCRIPTION
When doing the depth path for ssao, we need to remove the blended
objects, i.e. produce a depth path similar to the regular depth prepass.