### PR TITLE
CMake: add a convenient "run" target for quick testing.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,9 @@ function print_help {
     echo "    Desktop matc target, release build:"
     echo "        \$ ./$self_name release matc"
     echo ""
+    echo "    Build gltf_viewer then immediately run it with no arguments:"
+    echo "        \$ ./$self_name release run_gltf_viewer"
+    echo ""
  }
 
 # Requirements

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -393,3 +393,9 @@ add_dependencies(filament assets)
 
 add_custom_target(envs DEPENDS ${target_envmaps})
 add_dependencies(filament envs)
+
+add_custom_target(run_gltf_viewer DEPENDS gltf_viewer
+        COMMAND gltf_viewer)
+
+add_custom_target(run_material_sandbox DEPENDS material_sandbox
+        COMMAND material_sandbox --ibl=venetian_crossroads_2k assets/models/material_sphere/material_sphere.obj)


### PR DESCRIPTION
This adds a shortcut for building `gltf_viewer` then immediately running it with the default model, which is something we do a lot.  Lets you avoid typing the path to executable.