### PR TITLE
cmgen: do not create useless folder for KTX files

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - Fixed bad state after removing an IBL from the Scene.
 - Fixed incorrect punctual light binning (affected Metal and Vulkan backends).
 - Fixed crash when using a Metal headless SwapChain with an Intel integrated GPU.
+- cmgen now places KTX files directly in the specified deployment folder.
 
 ## v1.4.3
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -99,7 +99,7 @@ add_library(common-resources ${DUMMY_SRC} ${RESGEN_SOURCE})
 # Invoke cmgen to build KTX files for the default IBL and skybox
 # ==================================================================================================
 
-set(CMGEN_ARGS --quiet -x . --format=ktx --size=256 --extract-blur=0.1)
+set(CMGEN_ARGS --quiet --format=ktx --size=256 --extract-blur=0.1)
 
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${ROOT_DIR}/${SOURCE}")
@@ -111,7 +111,7 @@ function(add_envmap SOURCE TARGET)
     set(target_envmaps ${target_envmaps} ${target_envmap} PARENT_SCOPE)
 
     add_custom_command(OUTPUT ${target_skybox} ${target_envmap}
-        COMMAND cmgen ${CMGEN_ARGS} ${source_envmap}
+        COMMAND cmgen -x ${TARGET} ${CMGEN_ARGS} ${source_envmap}
         MAIN_DEPENDENCY ${source_envmap}
         DEPENDS cmgen)
 endfunction()
@@ -394,8 +394,8 @@ add_dependencies(filament assets)
 add_custom_target(envs DEPENDS ${target_envmaps})
 add_dependencies(filament envs)
 
-add_custom_target(run_gltf_viewer DEPENDS gltf_viewer
+add_custom_target(run_gltf_viewer DEPENDS gltf_viewer assets
         COMMAND gltf_viewer)
 
-add_custom_target(run_material_sandbox DEPENDS material_sandbox
+add_custom_target(run_material_sandbox DEPENDS material_sandbox assets
         COMMAND material_sandbox --ibl=venetian_crossroads_2k assets/models/material_sphere/material_sphere.obj)

--- a/web/docs/tutorial_redball.md
+++ b/web/docs/tutorial_redball.md
@@ -58,7 +58,7 @@ produce two cubemap files: a mipmapped IBL and a blurry skybox.
 Download [pillars_2k.hdr], then invoke the following command in your terminal.
 
 ```bash
-cmgen -x . --format=ktx --size=256 --extract-blur=0.1 pillars_2k.hdr
+cmgen -x pillars_2k --format=ktx --size=256 --extract-blur=0.1 pillars_2k.hdr
 ```
 
 You should now have a `pillars_2k` folder containing a couple KTX files for the IBL and skybox, as

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -124,8 +124,8 @@ add_mesh("assets/models/monkey/monkey.obj" "suzanne.filamesh")
 add_mesh("third_party/models/shader_ball/shader_ball.obj" "shader_ball.filamesh")
 
 # Generate IBL and skybox images using cmgen.
-set(CMGEN_ARGS --quiet -x . --format=ktx --size=256 --extract-blur=0.1)
-set(CMGEN_ARGS_TINY --quiet -x . --format=ktx --size=64 --extract-blur=0.1)
+set(CMGEN_ARGS --quiet --format=ktx --size=256 --extract-blur=0.1)
+set(CMGEN_ARGS_TINY --quiet --format=ktx --size=64 --extract-blur=0.1)
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${ROOT_DIR}/${SOURCE}")
 
@@ -143,11 +143,11 @@ function(add_envmap SOURCE TARGET)
     add_custom_command(OUTPUT ${target_skybox} ${target_skybox_tiny} ${target_envmap}
 
         # Create a low-resolution skybox, then rename it.
-        COMMAND cmgen ${CMGEN_ARGS_TINY} ${source_envmap}
+        COMMAND cmgen -x ${TARGET} ${CMGEN_ARGS_TINY} ${source_envmap}
         COMMAND mv ${target_skybox} ${target_skybox_tiny}
 
         # Finally, create KTX files for the uncompressed envmap.
-        COMMAND cmgen ${CMGEN_ARGS} ${source_envmap}
+        COMMAND cmgen -x ${TARGET} ${CMGEN_ARGS} ${source_envmap}
 
         MAIN_DEPENDENCY ${source_envmap}
         DEPENDS cmgen)


### PR DESCRIPTION
With KTX, we should simply create the specified output folder and put the KTX file(s) in there. There is no need to create a subfolder of the output folder.

This change also allows users to pick a custom name for their KTX file, because we only use the deployment name when generating filenames.