### PR TITLE
Improve Metal textures

### DIFF
--- a/filament/backend/src/BackendUtils.cpp
+++ b/filament/backend/src/BackendUtils.cpp
@@ -116,6 +116,7 @@ size_t getFormatSize(TextureFormat format) noexcept {
             return 8;
 
         case TextureFormat::DXT1_RGB:
+        case TextureFormat::DXT1_RGBA:
             return 8;
 
         case TextureFormat::DXT3_RGBA:
@@ -173,6 +174,7 @@ size_t getBlockWidth(TextureFormat format) noexcept {
             return 4;
 
         case TextureFormat::DXT1_RGB:
+        case TextureFormat::DXT1_RGBA:
         case TextureFormat::DXT3_RGBA:
         case TextureFormat::DXT5_RGBA:
             return 4;

--- a/filament/backend/src/TextureReshaper.h
+++ b/filament/backend/src/TextureReshaper.h
@@ -18,6 +18,7 @@
 #define TNT_TEXTURERESHAPER_H
 
 #include <backend/DriverEnums.h>
+#include <backend/PixelBufferDescriptor.h>
 
 namespace filament {
 namespace backend {
@@ -42,27 +43,17 @@ public:
     /**
      * reshapes the pixel buffer by adding components.
      *
-     * @param data The pixel buffer to reshape.
-     * @param size The size in bytes of the pixel buffer.
-     * @return The reshaped pixel buffer.
+     * @param p The pixel buffer to reshape.
+     * @return A new PixelBufferDescriptor containing the reshaped pixels.
      */
-    void* reshape(void* data, size_t size) const;
-
-    /**
-     * The reshape method allocates a temporary buffer for reshaped pixels. Call freeBuffer to free
-     * the reshaped pixel buffer. If the pixels did not need reshaping, this method is an no-op.
-     *
-     * @param buffer The buffer returned from a prior call to reshape.
-     */
-    void freeBuffer(void* buffer) const;
+    PixelBufferDescriptor reshape(PixelBufferDescriptor&& p) const;
 
     static bool canReshapeTextureFormat(TextureFormat format) noexcept;
 
 private:
 
-    std::function<void*(void*, size_t)> reshapeFunction =
-            [](void* buffer, size_t){ return buffer; };
-    std::function<void(void*)> deleter = [](void* buffer){};
+    std::function<PixelBufferDescriptor(PixelBufferDescriptor&& p)> reshapeFunction =
+            [](PixelBufferDescriptor&& p){ return std::move(p); };
     TextureFormat reshapedFormat;
 
 };

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -527,7 +527,7 @@ void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t x
 void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
         PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->loadCubeImage(std::move(data), faceOffsets, level);
+    tex->loadCubeImage(faceOffsets, level, std::move(data));
 }
 
 void MetalDriver::setupExternalImage(void* image) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -521,15 +521,13 @@ void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&
 void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t xoffset,
         uint32_t yoffset, uint32_t width, uint32_t height, PixelBufferDescriptor&& data) {
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->load2DImage(level, xoffset, yoffset, width, height, data);
-    scheduleDestroy(std::move(data));
+    tex->load2DImage(level, xoffset, yoffset, width, height, std::move(data));
 }
 
 void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
         PixelBufferDescriptor&& data, FaceOffsets faceOffsets) {
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->loadCubeImage(data, faceOffsets, level);
-    scheduleDestroy(std::move(data));
+    tex->loadCubeImage(std::move(data), faceOffsets, level);
 }
 
 void MetalDriver::setupExternalImage(void* image) {
@@ -825,9 +823,9 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
         const uint8_t* bufferStart = (const uint8_t*) p->buffer + (p->left * bpp) +
                                                                   (p->top * bpr);
         [readPixelsTexture getBytes:(void*) bufferStart
-                       bytesPerRow:bpr
-                        fromRegion:srcRegion
-                       mipmapLevel:0];
+                        bytesPerRow:bpr
+                         fromRegion:srcRegion
+                        mipmapLevel:0];
         scheduleDestroy(std::move(*p));
     }];
 }

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -230,7 +230,7 @@ constexpr inline MTLPixelFormat getMetalFormat(TextureFormat format) noexcept {
 #endif
 
 #if !defined(IOS)
-        // DXT (BC) formats are only available on macOS desktkop.
+        // DXT (BC) formats are only available on macOS desktop.
         // See https://en.wikipedia.org/wiki/S3_Texture_Compression#S3TC_format_comparison
         case TextureFormat::DXT1_RGBA: return MTLPixelFormatBC1_RGBA;
         case TextureFormat::DXT3_RGBA: return MTLPixelFormatBC2_RGBA;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -105,11 +105,13 @@ struct MetalTexture : public HwTexture {
     ~MetalTexture();
 
     void load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-            uint32_t height, PixelBufferDescriptor& data) noexcept;
-    void loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
+            uint32_t height, PixelBufferDescriptor&& p) noexcept;
+    void loadCubeImage(PixelBufferDescriptor&& p, const FaceOffsets& faceOffsets,
             int miplevel);
-
-    NSUInteger getBytesPerRow(PixelDataType type, NSUInteger width) const noexcept;
+    void loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
+            uint32_t height, uint32_t byteOffset, uint32_t slice,
+            PixelBufferDescriptor& data, id<MTLBlitCommandEncoder> blitCommandEncoder,
+            id<MTLCommandBuffer> blitCommandBuffer) noexcept;
 
     MetalContext& context;
     MetalExternalImage externalImage;
@@ -117,6 +119,7 @@ struct MetalTexture : public HwTexture {
     uint8_t bytesPerElement; // The number of bytes per pixel, or block (for compressed texture formats).
     uint8_t blockWidth; // The number of horizontal pixels per block (only for compressed texture formats).
     TextureReshaper reshaper;
+    MTLPixelFormat metalPixelFormat;
 };
 
 struct MetalSamplerGroup : public HwSamplerGroup {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -106,8 +106,7 @@ struct MetalTexture : public HwTexture {
 
     void load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
             uint32_t height, PixelBufferDescriptor&& p) noexcept;
-    void loadCubeImage(PixelBufferDescriptor&& p, const FaceOffsets& faceOffsets,
-            int miplevel);
+    void loadCubeImage(const FaceOffsets& faceOffsets, int miplevel, PixelBufferDescriptor&& p);
     void loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
             uint32_t height, uint32_t byteOffset, uint32_t slice,
             PixelBufferDescriptor& data, id<MTLBlitCommandEncoder> blitCommandEncoder,

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -47,17 +47,6 @@ static inline MTLTextureUsage getMetalTextureUsage(TextureUsage usage) {
     return MTLTextureUsage(u);
 }
 
-static inline MTLStorageMode getMetalStorageMode(TextureUsage usage) {
-    if (any(usage & TextureUsage::UPLOADABLE)) {
-#if defined(IOS)
-        return MTLStorageModeShared;
-#else
-        return MTLStorageModeManaged;
-#endif
-    }
-    return MTLStorageModePrivate;
-}
-
 MetalSwapChain::MetalSwapChain(id<MTLDevice> device, CAMetalLayer* nativeWindow)
         : layer(nativeWindow) {
     layer.device = device;
@@ -220,20 +209,20 @@ MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, u
     // Metal does not natively support 3 component textures. We'll emulate support by reshaping the
     // image data and using a 4 component texture.
     const TextureFormat reshapedFormat = reshaper.getReshapedFormat();
-    const MTLPixelFormat pixelFormat = decidePixelFormat(context.device, reshapedFormat);
+    metalPixelFormat = decidePixelFormat(context.device, reshapedFormat);
 
     bytesPerElement = static_cast<uint8_t>(getFormatSize(reshapedFormat));
     assert(bytesPerElement > 0);
     blockWidth = static_cast<uint8_t>(getBlockWidth(reshapedFormat));
 
-    ASSERT_POSTCONDITION(pixelFormat != MTLPixelFormatInvalid, "Pixel format not supported.");
+    ASSERT_POSTCONDITION(metalPixelFormat != MTLPixelFormatInvalid, "Pixel format not supported.");
 
     const BOOL mipmapped = levels > 1;
     const BOOL multisampled = samples > 1;
 
     MTLTextureDescriptor* descriptor;
     if (target == backend::SamplerType::SAMPLER_2D) {
-        descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat
+        descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:metalPixelFormat
                                                                         width:width
                                                                        height:height
                                                                     mipmapped:mipmapped];
@@ -241,18 +230,18 @@ MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, u
         descriptor.textureType = multisampled ? MTLTextureType2DMultisample : MTLTextureType2D;
         descriptor.sampleCount = multisampled ? samples : 1;
         descriptor.usage = getMetalTextureUsage(usage);
-        descriptor.storageMode = getMetalStorageMode(usage);
+        descriptor.storageMode = MTLStorageModePrivate;
         texture = [context.device newTextureWithDescriptor:descriptor];
         ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
     } else if (target == backend::SamplerType::SAMPLER_CUBEMAP) {
         ASSERT_POSTCONDITION(!multisampled, "Multisampled cubemap faces not supported.");
         ASSERT_POSTCONDITION(width == height, "Cubemap faces must be square.");
-        descriptor = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:pixelFormat
+        descriptor = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:metalPixelFormat
                                                                            size:width
                                                                       mipmapped:mipmapped];
         descriptor.mipmapLevelCount = levels;
         descriptor.usage = getMetalTextureUsage(usage);
-        descriptor.storageMode = getMetalStorageMode(usage);
+        descriptor.storageMode = MTLStorageModePrivate;
         texture = [context.device newTextureWithDescriptor:descriptor];
         ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
     } else if (target == backend::SamplerType::SAMPLER_EXTERNAL) {
@@ -269,60 +258,113 @@ MetalTexture::~MetalTexture() {
 }
 
 void MetalTexture::load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-        uint32_t height, PixelBufferDescriptor& data) noexcept {
-    void* buffer = reshaper.reshape(data.buffer, data.size);
+            uint32_t height, PixelBufferDescriptor&& p) noexcept {
+    PixelBufferDescriptor data = reshaper.reshape(std::move(p));
 
-    MTLRegion region {
-        .origin = {
-            .x = xoffset,
-            .y = yoffset,
-            .z =  0
-        },
-        .size = {
-            .height = height,
-            .width = width,
-            .depth = 1
-        }
-    };
-    const NSUInteger bytesPerRow = getBytesPerRow(data.type, width);
-    [texture replaceRegion:region
-               mipmapLevel:level
-                     slice:0
-                 withBytes:buffer
-               bytesPerRow:bytesPerRow
-             bytesPerImage:0];          // only needed for MTLTextureType3D
+    id<MTLCommandBuffer> blitCommandBuffer = [context.commandQueue commandBuffer];
+    id<MTLBlitCommandEncoder> blitCommandEncoder = [blitCommandBuffer blitCommandEncoder];
 
-    reshaper.freeBuffer(buffer);
+    loadSlice(level, xoffset, yoffset, width, height, 0, 0, data, blitCommandEncoder,
+            blitCommandBuffer);
+
+    [blitCommandEncoder endEncoding];
+    [blitCommandBuffer commit];
 }
 
-void MetalTexture::loadCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
+void MetalTexture::loadCubeImage(PixelBufferDescriptor&& p, const FaceOffsets& faceOffsets,
         int miplevel) {
-    const NSUInteger faceWidth = width >> miplevel;
-    const NSUInteger bytesPerRow = getBytesPerRow(data.type, faceWidth);
+    PixelBufferDescriptor data = reshaper.reshape(std::move(p));
 
-    MTLRegion region = MTLRegionMake2D(0, 0, faceWidth, faceWidth);
+    id<MTLCommandBuffer> blitCommandBuffer = [context.commandQueue commandBuffer];
+    id<MTLBlitCommandEncoder> blitCommandEncoder = [blitCommandBuffer blitCommandEncoder];
+
+    const NSUInteger faceWidth = width >> miplevel;
+
     for (NSUInteger slice = 0; slice < 6; slice++) {
         FaceOffsets::size_type faceOffset = faceOffsets.offsets[slice];
-        [texture replaceRegion:region
-                   mipmapLevel:static_cast<NSUInteger>(miplevel)
-                         slice:slice
-                     withBytes:static_cast<uint8_t*>(data.buffer) + faceOffset
-                   bytesPerRow:bytesPerRow
-                 bytesPerImage:0];
+        loadSlice(miplevel, 0, 0, faceWidth, faceWidth, faceOffset, slice, data, blitCommandEncoder,
+                blitCommandBuffer);
     }
+
+    [blitCommandEncoder endEncoding];
+    [blitCommandBuffer commit];
 }
 
-NSUInteger MetalTexture::getBytesPerRow(PixelDataType type, NSUInteger width) const noexcept {
-    // From https://developer.apple.com/documentation/metal/mtltexture/1515464-replaceregion:
-    // For an ordinary or packed pixel format, the stride, in bytes, between rows of source data.
-    // For a compressed pixel format, the stride is the number of bytes from the beginning of one
-    // row of blocks to the beginning of the next.
-    if (type == PixelDataType::COMPRESSED) {
+void MetalTexture::loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
+        uint32_t height, uint32_t byteOffset, uint32_t slice,
+        PixelBufferDescriptor& data, id<MTLBlitCommandEncoder> blitCommandEncoder,
+        id<MTLCommandBuffer> blitCommandBuffer) noexcept {
+    const size_t stride = data.stride ? data.stride : width;
+    size_t bytesPerRow = PixelBufferDescriptor::computeDataSize(data.format, data.type, stride, 1,
+            data.alignment);
+    size_t bytesPerPixel = PixelBufferDescriptor::computeDataSize(data.format, data.type, 1, 1, 1);
+    size_t bytesPerSlice = bytesPerRow * height;    // a slice is a 2D image, or face of a cubemap
+
+    const size_t sourceOffset = (data.left * bytesPerPixel) + (data.top * bytesPerRow) + byteOffset;
+
+    if (data.type == PixelDataType::COMPRESSED) {
         assert(blockWidth > 0);
+        // From https://developer.apple.com/documentation/metal/mtltexture/1515464-replaceregion:
+        // For an ordinary or packed pixel format, the stride, in bytes, between rows of source
+        // data. For a compressed pixel format, the stride is the number of bytes from the
+        // beginning of one row of blocks to the beginning of the next.
         const NSUInteger blocksPerRow = std::ceil(width / (float) blockWidth);
-        return bytesPerElement * blocksPerRow;
+        const NSUInteger blocksPerCol = std::ceil(height / (float) blockWidth);
+        bytesPerRow = bytesPerElement * blocksPerRow;
+        bytesPerSlice = bytesPerRow * blocksPerCol;
+    }
+
+    ASSERT_PRECONDITION(data.size >= bytesPerSlice, "Expected buffer size of at least %d but "
+            "received PixelBufferDescriptor with size %d.", bytesPerSlice, data.size);
+
+    // Depending on the size of the required buffer, we either allocate a staging buffer or a
+    // staging texture. Then the texture data is blited to the "real" texture.
+    const size_t stagingBufferSize = bytesPerSlice;
+    if (UTILS_LIKELY(stagingBufferSize <= context.device.maxBufferLength)) {
+        auto entry = context.bufferPool->acquireBuffer(stagingBufferSize);
+        memcpy(entry->buffer.contents,
+                static_cast<uint8_t*>(data.buffer) + sourceOffset,
+                stagingBufferSize);
+        [blitCommandEncoder copyFromBuffer:entry->buffer
+                              sourceOffset:0
+                         sourceBytesPerRow:bytesPerRow
+                       sourceBytesPerImage:0
+                                sourceSize:MTLSizeMake(width, height, 1)
+                                 toTexture:texture
+                          destinationSlice:slice
+                          destinationLevel:level
+                         destinationOrigin:MTLOriginMake(xoffset, yoffset, 0)];
+        [blitCommandBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
+            context.bufferPool->releaseBuffer(entry);
+        }];
     } else {
-        return bytesPerElement * width;
+       // The texture is too large to fit into a single buffer, create a staging texture instead.
+       MTLTextureDescriptor* descriptor =
+               [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:metalPixelFormat
+                                                                  width:width
+                                                                 height:height
+                                                              mipmapped:NO];
+#if defined(IOS)
+       descriptor.storageMode = MTLStorageModeShared;
+#else
+       descriptor.storageMode = MTLStorageModeManaged;
+#endif
+       id<MTLTexture> stagingTexture = [context.device newTextureWithDescriptor:descriptor];
+       [stagingTexture replaceRegion:MTLRegionMake2D(0, 0, width, height)
+                         mipmapLevel:0
+                               slice:0
+                           withBytes:static_cast<uint8_t*>(data.buffer) + sourceOffset
+                         bytesPerRow:bytesPerRow
+                       bytesPerImage:0];
+       [blitCommandEncoder copyFromTexture:stagingTexture
+                               sourceSlice:0
+                               sourceLevel:0
+                              sourceOrigin:MTLOriginMake(0, 0, 0)
+                                sourceSize:MTLSizeMake(width, height, 1)
+                                 toTexture:texture
+                          destinationSlice:slice
+                          destinationLevel:level
+                         destinationOrigin:MTLOriginMake(xoffset, yoffset, 0)];
     }
 }
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -258,7 +258,7 @@ MetalTexture::~MetalTexture() {
 }
 
 void MetalTexture::load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-            uint32_t height, PixelBufferDescriptor&& p) noexcept {
+        uint32_t height, PixelBufferDescriptor&& p) noexcept {
     PixelBufferDescriptor data = reshaper.reshape(std::move(p));
 
     id<MTLCommandBuffer> blitCommandBuffer = [context.commandQueue commandBuffer];
@@ -271,8 +271,8 @@ void MetalTexture::load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffse
     [blitCommandBuffer commit];
 }
 
-void MetalTexture::loadCubeImage(PixelBufferDescriptor&& p, const FaceOffsets& faceOffsets,
-        int miplevel) {
+void MetalTexture::loadCubeImage(const FaceOffsets& faceOffsets, int miplevel,
+        PixelBufferDescriptor&& p) {
     PixelBufferDescriptor data = reshaper.reshape(std::move(p));
 
     id<MTLCommandBuffer> blitCommandBuffer = [context.commandQueue commandBuffer];


### PR DESCRIPTION
- Textures are now PRIVATE, which should improve mobile GPU performance
- Textures can be updated each frame without conflicting with GPU
- Fixed support for BC textures
- Respect PixelBufferDescriptor's left, top, and alignment parameters when uploading textures