### PR TITLE
Repair Android extension pointers.

### DIFF
--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -22,6 +22,9 @@
 
 #include <backend/DriverEnums.h>
 
+#include <string>
+#include <unordered_set>
+
 #include "gl_headers.h"
 
 namespace filament {
@@ -451,6 +454,28 @@ constexpr /* inline */ GLenum getInternalFormat(backend::TextureFormat format) n
         case TextureFormat::UNUSED:
             return 0;
     }
+}
+
+class unordered_string_set : public std::unordered_set<std::string> {
+public:
+    bool has(const char* str) {
+        return find(std::string(str)) != end();
+    }
+};
+
+inline unordered_string_set split(const char* spacedList) {
+    unordered_string_set set;
+    const char* current = spacedList;
+    const char* head = current;
+    do {
+        head = strchr(current, ' ');
+        std::string s(current, head ? head - current : strlen(current));
+        if (s.length()) {
+            set.insert(std::move(s));
+        }
+        current = head + 1;
+    } while (head);
+    return set;
 }
 
 } // namespace GLUtils

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -26,9 +26,6 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
-#include <string>
-#include <unordered_set>
-
 #include <assert.h>
 
 
@@ -82,28 +79,6 @@ static void clearGlError() noexcept {
     }
 }
 
-class unordered_string_set : public std::unordered_set<std::string> {
-public:
-    bool has(const char* str) {
-        return find(std::string(str)) != end();
-    }
-};
-
-static unordered_string_set split(const char* spacedList) {
-    unordered_string_set set;
-    const char* current = spacedList;
-    const char* head = current;
-    do {
-        head = strchr(current, ' ');
-        std::string s(current, head ? head - current : strlen(current));
-        if (s.length()) {
-            set.insert(std::move(s));
-        }
-        current = head + 1;
-    } while (head);
-    return set;
-}
-
 // ---------------------------------------------------------------------------------------------
 
 PlatformEGL::PlatformEGL() noexcept = default;
@@ -121,7 +96,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
 
     importGLESExtensionsEntryPoints();
 
-    auto extensions = split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
+    auto extensions = GLUtils::split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
 
     eglCreateSyncKHR = (PFNEGLCREATESYNCKHRPROC) eglGetProcAddress("eglCreateSyncKHR");
     eglDestroySyncKHR = (PFNEGLDESTROYSYNCKHRPROC) eglGetProcAddress("eglDestroySyncKHR");
@@ -395,7 +370,7 @@ void PlatformEGL::destroyExternalImage(void* texture) noexcept {
 }
 
 void PlatformEGL::initializeGlExtensions() noexcept {
-    unordered_string_set glExtensions;
+    GLUtils::unordered_string_set glExtensions;
     GLint n;
     glGetIntegerv(GL_NUM_EXTENSIONS, &n);
     for (GLint i = 0; i < n; ++i) {

--- a/filament/backend/src/opengl/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/PlatformEGLAndroid.cpp
@@ -89,6 +89,33 @@ PlatformEGLAndroid::PlatformEGLAndroid() noexcept
     }
 }
 
+backend::Driver* PlatformEGLAndroid::createDriver(void* sharedContext) noexcept {
+    backend::Driver* driver = PlatformEGL::createDriver(sharedContext);
+    auto extensions = GLUtils::split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
+
+    eglGetNativeClientBufferANDROID = (PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC) eglGetProcAddress("eglGetNativeClientBufferANDROID");
+
+    if (extensions.has("EGL_ANDROID_presentation_time")) {
+        eglPresentationTimeANDROID = (PFNEGLPRESENTATIONTIMEANDROIDPROC)eglGetProcAddress(
+                "eglPresentationTimeANDROID");
+    }
+
+    if (extensions.has("EGL_ANDROID_get_frame_timestamps")) {
+        eglGetCompositorTimingSupportedANDROID = (PFNEGLGETCOMPOSITORTIMINGSUPPORTEDANDROIDPROC)eglGetProcAddress(
+                "eglGetCompositorTimingSupportedANDROID");
+        eglGetCompositorTimingANDROID = (PFNEGLGETCOMPOSITORTIMINGANDROIDPROC)eglGetProcAddress(
+                "eglGetCompositorTimingANDROID");
+        eglGetNextFrameIdANDROID = (PFNEGLGETNEXTFRAMEIDANDROIDPROC)eglGetProcAddress(
+                "eglGetNextFrameIdANDROID");
+        eglGetFrameTimestampSupportedANDROID = (PFNEGLGETFRAMETIMESTAMPSUPPORTEDANDROIDPROC)eglGetProcAddress(
+                "eglGetFrameTimestampSupportedANDROID");
+        eglGetFrameTimestampsANDROID = (PFNEGLGETFRAMETIMESTAMPSANDROIDPROC)eglGetProcAddress(
+                "eglGetFrameTimestampsANDROID");
+    }
+
+    return driver;
+}
+
 void PlatformEGLAndroid::setPresentationTime(int64_t presentationTimeInNanosecond) noexcept {
     if (mCurrentDrawSurface != EGL_NO_SURFACE) {
         if (eglPresentationTimeANDROID) {

--- a/filament/backend/src/opengl/PlatformEGLAndroid.h
+++ b/filament/backend/src/opengl/PlatformEGLAndroid.h
@@ -29,6 +29,8 @@ public:
 
     PlatformEGLAndroid() noexcept;
 
+    backend::Driver* createDriver(void* sharedContext) noexcept final;
+
     int getOSVersion() const noexcept final;
 
     void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept final;


### PR DESCRIPTION
Fixes #1989 by fetching extension function pointers that were refactored
in #1977. Moved string-splitting utility to a common location so that
the base class and concrete classes can both use it.