### PR TITLE
gltfio: honor node labels if they exist.

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -323,11 +323,15 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity) {
     Primitive* outputPrim = mMeshCache[mesh].data();
     const cgltf_primitive* inputPrim = &mesh->primitives[0];
 
-    if (mNameManager && mesh->name) {
+    // Create a name component using the node label if it exists, otherwise use the mesh label.
+    const char* name = node->name ? node->name : mesh->name;
+    if (mNameManager && name) {
         mNameManager->addComponent(entity);
-        mNameManager->setName(mNameManager->getInstance(entity), mesh->name);
+        mNameManager->setName(mNameManager->getInstance(entity), name);
     }
-    const char* name = mesh->name ? mesh->name : (node->name ? node->name : "mesh");
+
+    // If neither a node or mesh name is provided in the glTF, use "node" for error messages.
+    name = name ? name : "node";
 
     Aabb aabb;
 


### PR DESCRIPTION
In glTF, multiple nodes can refer to the same mesh, and each node can be
assigned a unqiue string label. Previously we used NameComponentManager
to annotate entities with mesh labels rather than node labels. This was
wrong because Filament entities are 1:1 with nodes, not meshes.

We still fall back to mesh labels when node labels are not provided.