### PR TITLE
Make EntityManager and Panic dynamic-linkable.

### DIFF
--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -21,10 +21,11 @@
 #include <stdint.h>
 
 #include <utils/Entity.h>
+#include <utils/compiler.h>
 
 namespace utils {
 
-class EntityManager {
+class UTILS_PUBLIC EntityManager {
 public:
     // Get the global EntityManager. Is is recommended to cache this value.
     // Thread Safe.

--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -166,8 +166,8 @@ void logAndPanic(char const* function, char const* file, int line, const char* f
 
 // -----------------------------------------------------------------------------------------------
 
-template class TPanic<PreconditionPanic>;
-template class TPanic<PostconditionPanic>;
-template class TPanic<ArithmeticPanic>;
+template class UTILS_PUBLIC TPanic<PreconditionPanic>;
+template class UTILS_PUBLIC TPanic<PostconditionPanic>;
+template class UTILS_PUBLIC TPanic<ArithmeticPanic>;
 
 } // namespace utils


### PR DESCRIPTION
This enables dynamic linking to Filament inside of Sceneform by exporting symbols that are used in Sceneform's native layer.