### PR TITLE
refactor Renderer to make it more flexible

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -473,7 +473,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssao(FrameGraph& fg, RenderP
     return ssao;
 }
 
-FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, RenderPass& pass,
+FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, RenderPass const& pass,
         uint32_t width, uint32_t height,
         View::AmbientOcclusionOptions const& options) noexcept {
 
@@ -482,9 +482,6 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, Re
         FrameGraphId<FrameGraphTexture> depth;
         FrameGraphRenderTargetHandle rt;
     };
-
-    RenderPass::Command const* first = pass.getCommands().begin();
-    RenderPass::Command const* last = pass.getCommands().end();
 
     // sanitize a bit the user provided scaling factor
     const float scale = std::min(std::abs(options.resolution), 1.0f);
@@ -510,10 +507,10 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::depthPass(FrameGraph& fg, Re
                 data.rt = builder.createRenderTarget("SSAO Depth Target", d,
                                                      TargetBufferFlags::DEPTH);
             },
-            [=, &pass](FrameGraphPassResources const& resources,
+            [pass](FrameGraphPassResources const& resources,
                     DepthPassData const& data, DriverApi& driver) {
                 auto out = resources.getRenderTarget(data.rt);
-                pass.execute(resources.getPassName(), out.target, out.params, first, last);
+                pass.execute(resources.getPassName(), out.target, out.params);
             });
 
     return ssaoDepthPass.getData().depth;

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -69,7 +69,7 @@ public:
 private:
     details::FEngine& mEngine;
 
-    FrameGraphId<FrameGraphTexture> depthPass(FrameGraph& fg, details::RenderPass& pass,
+    FrameGraphId<FrameGraphTexture> depthPass(FrameGraph& fg, details::RenderPass const& pass,
             uint32_t width, uint32_t height, View::AmbientOcclusionOptions const& options) noexcept;
 
     FrameGraphId<FrameGraphTexture> mipmapPass(FrameGraph& fg,

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -256,6 +256,8 @@ public:
     void setCamera(const CameraInfo& camera) noexcept;
     void setRenderFlags(RenderFlags flags) noexcept;
 
+    Command* newCommandBuffer() noexcept;
+
     // returns mCommands.end()
     Command* appendCommands(CommandTypeFlags commandTypeFlags) noexcept;
 
@@ -263,14 +265,13 @@ public:
     Command* appendCustomCommand(Pass pass, CustomCommand custom, uint32_t order,
             std::function<void()> command);
 
-    // sorts commands from curr to mCommands.end(), then trims sentinels and returns
+    // sorts commands, then trims sentinels and returns
     // the new mCommands.end()
-    Command* sortCommands(Command* curr) noexcept;
+    Command* sortCommands() noexcept;
 
     void execute(const char* name,
             backend::Handle<backend::HwRenderTarget> renderTarget,
-            backend::RenderPassParams params,
-            Command const* first, Command const* last) const noexcept;
+            backend::RenderPassParams params) const noexcept;
 
     utils::GrowingSlice<Command>& getCommands() { return mCommands; }
     utils::Slice<Command> const& getCommands() const { return mCommands; }
@@ -317,8 +318,7 @@ private:
     // a reference to the Engine, mostly to get to things like JobSystem
     FEngine& mEngine;
 
-    // a reference to the command vector (so we can for e.g. append to it)
-    utils::GrowingSlice<Command>& mCommands;
+    utils::GrowingSlice<Command> mCommands;
 
     // the SOA containing the renderables we're interested in
     FScene::RenderableSoa const* mRenderableSoa = nullptr;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -186,14 +186,9 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
     view.commitUniforms(driver);
 
     pass.overridePolygonOffset(&mPolygonOffset);
-
-    auto curr = pass.getCommands().end();
     pass.appendCommands(RenderPass::SHADOW);
-    pass.sortCommands(curr);
-
-    pass.execute("Shadow map Pass", getRenderTarget(), params,
-            pass.getCommands().begin(), pass.getCommands().end());
-    pass.overridePolygonOffset(nullptr);
+    pass.sortCommands();
+    pass.execute("Shadow map Pass", getRenderTarget(), params);
 }
 
 void ShadowMap::terminate(DriverApi& driverApi) noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -104,13 +104,15 @@ private:
 
     struct PrepareColorPassesData {
         FrameGraphId<FrameGraphTexture> ssao;
+        FrameGraphId<FrameGraphTexture> color;
+        FrameGraphId<FrameGraphTexture> depth;
         Viewport svp;
         backend::TextureFormat hdrFormat;
         uint8_t msaa;
     };
 
     static FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg,
-            PrepareColorPassesData const& blackboard, RenderPass const& pass,
+            PrepareColorPassesData& blackboard, RenderPass const& pass,
             backend::TargetBufferFlags clearFlags, math::float4 clearColor = {}) noexcept;
 
     void recordHighWatermark(size_t watermark) noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -100,7 +100,18 @@ private:
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
             backend::PixelBufferDescriptor&& buffer);
 
-    RenderPass::CommandTypeFlags getCommandType(View::DepthPrepass prepass) const noexcept;
+    static RenderPass::CommandTypeFlags getCommandType(View::DepthPrepass prepass) noexcept;
+
+    struct PrepareColorPassesData {
+        FrameGraphId<FrameGraphTexture> ssao;
+        Viewport svp;
+        backend::TextureFormat hdrFormat;
+        uint8_t msaa;
+    };
+
+    static FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg,
+            PrepareColorPassesData const& blackboard, RenderPass const& pass,
+            backend::TargetBufferFlags clearFlags, math::float4 clearColor = {}) noexcept;
 
     void recordHighWatermark(size_t watermark) noexcept {
         mCommandsHighWatermark = std::max(mCommandsHighWatermark, watermark);

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -216,7 +216,7 @@ FrameGraphHandle FrameGraph::moveResource(FrameGraphHandle from, FrameGraphHandl
 }
 
 void FrameGraph::present(FrameGraphHandle input) {
-    addPass<std::tuple<>>("Present",
+    addPass<Empty>("Present",
             [&](Builder& builder, auto& data) {
                 builder.read(input);
                 builder.sideEffect();

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -154,6 +154,7 @@ FrameGraphPassResources::getRenderTarget(FrameGraphRenderTargetHandle handle, ui
     // overwrite discard flags with the per-rendertarget (per-pass) computed value
     info.params.flags.discardStart = renderTarget.targetFlags.discardStart;
     info.params.flags.discardEnd   = renderTarget.targetFlags.discardEnd;
+    info.params.flags.clear        = renderTarget.userClearFlags;
 
     // check that this FrameGraphRenderTarget is indeed declared by this pass
     ASSERT_POSTCONDITION_NON_FATAL(info.target,

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -147,6 +147,8 @@ public:
     FrameGraph& operator = (FrameGraph const&) = delete;
     ~FrameGraph();
 
+    struct Empty{};
+
     /*
      * Add a pass to the framegraph.
      * The Setup lambda is called synchronously and used to declare which and how resources are
@@ -174,6 +176,16 @@ public:
 
     // Adds a reference to 'input', preventing it from being culled.
     void present(FrameGraphHandle input);
+
+    // Adds a simple execute-only pass with side effect (so it's not culled)
+    template<typename Execute>
+    void simpleSideEffectPass(const char* name, Execute&& execute) {
+        addPass<Empty>(name, [](FrameGraph::Builder& builder, auto& data) { builder.sideEffect(); },
+                [execute](FrameGraphPassResources const& resources, auto const& data,
+                        backend::DriverApi& driver) {
+                    execute();
+                });
+    }
 
     // Returns whether the resource handle is valid. A resource handle becomes invalid after
     // it's used to declare a resource write (see Builder::write()).

--- a/filament/src/fg/fg/RenderTarget.cpp
+++ b/filament/src/fg/fg/RenderTarget.cpp
@@ -35,7 +35,6 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
 
     if (pos != renderTargetCache.end()) {
         cache = pos->get();
-        cache->targetInfo.params.flags.clear |= userClearFlags;
     } else {
         TargetBufferFlags attachments{};
         uint32_t width = 0;
@@ -100,7 +99,6 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
                             backend::TargetBufferFlags(attachments), width, height, colorFormat);
             renderTargetCache.emplace_back(pRenderTargetResource, fg);
             cache = pRenderTargetResource;
-            cache->targetInfo.params.flags.clear |= userClearFlags;
         }
     }
 }

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -350,7 +350,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                         .format = TextureFormat::RGBA16F
                 };
                 data.output = builder.createTexture("color buffer", desc);
-                data.rt = builder.createRenderTarget(data.output, (TargetBufferFlags)0x80);
+                data.rt = builder.createRenderTarget(data.output, TargetBufferFlags::COLOR);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &rt1, &renderPassExecuted1](
@@ -361,6 +361,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 auto const& rt = resources.getRenderTarget(data.rt);
                 rt1 = rt.target;
                 EXPECT_TRUE(rt.target);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.clear);
                 EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
             });
@@ -368,9 +369,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
             [&](FrameGraph::Builder& builder, RenderPassData& data) {
                 data.output = builder.write(builder.read(renderPass1.getData().output));
-                data.rt = builder.createRenderTarget("color", {
-                        .attachments.color = { data.output }
-                }, (TargetBufferFlags)0x40);
+                data.rt = builder.createRenderTarget(data.output, TargetBufferFlags::NONE);
                 EXPECT_TRUE(fg.isValid(data.output));
             },
             [=, &rt1, &renderPassExecuted2](
@@ -380,7 +379,7 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 renderPassExecuted2 = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags(0x40u|0x80u), rt.params.flags.clear);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.clear);
                 EXPECT_EQ(rt1.getId(), rt.target.getId());
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);

--- a/libs/utils/include/utils/Slice.h
+++ b/libs/utils/include/utils/Slice.h
@@ -163,6 +163,8 @@ public:
     using size_type         = typename Slice<T, SIZE_TYPE>::size_type;
 
     GrowingSlice() noexcept = default;
+    GrowingSlice(GrowingSlice const& rhs) noexcept = default;
+    GrowingSlice(GrowingSlice&& rhs) noexcept = default;
 
     template<typename Iter>
     GrowingSlice(Iter begin, size_type count) noexcept
@@ -180,7 +182,7 @@ public:
     template<typename Iter>
     void set(Iter begin, size_type count) UTILS_RESTRICT noexcept {
         this->Slice<T, SIZE_TYPE>::set(begin, count);
-       mCapOffset = count;
+        mCapOffset = count;
     }
 
     template<typename Iter>


### PR DESCRIPTION
This is in preparation to supporting screen-space effects.
There are two major changes:

- RenderPass is now copiable and intended to be passed by copy to
  the execute stage of frame graph passes

- The color pass is in its own function now


This actually simplify RenderPass api.