### PR TITLE
Make ResourceAllocator mockable and update test

### DIFF
--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -170,7 +170,7 @@ FrameGraphPassResources::getRenderTarget(FrameGraphRenderTargetHandle handle, ui
 
 // ------------------------------------------------------------------------------------------------
 
-FrameGraph::FrameGraph(fg::ResourceAllocator& resourceAllocator)
+FrameGraph::FrameGraph(fg::ResourceAllocatorInterface& resourceAllocator)
         : mResourceAllocator(resourceAllocator),
           mArena("FrameGraph Arena", 32768), // TODO: the Area will eventually come from outside
           mPassNodes(mArena),

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -55,7 +55,7 @@ struct RenderTarget;
 struct RenderTargetResource;
 struct PassNode;
 struct Alias;
-class ResourceAllocator;
+class ResourceAllocatorInterface;
 } // namespace fg
 
 class FrameGraphPassResources;
@@ -142,7 +142,7 @@ public:
         fg::PassNode& mPass;
     };
 
-    explicit FrameGraph(fg::ResourceAllocator& resourceAllocator);
+    explicit FrameGraph(fg::ResourceAllocatorInterface& resourceAllocator);
     FrameGraph(FrameGraph const&) = delete;
     FrameGraph& operator = (FrameGraph const&) = delete;
     ~FrameGraph();
@@ -278,7 +278,7 @@ private:
 
     void executeInternal(fg::PassNode const& node, backend::DriverApi& driver) noexcept;
 
-    fg::ResourceAllocator& getResourceAllocator() noexcept { return mResourceAllocator; }
+    fg::ResourceAllocatorInterface& getResourceAllocator() noexcept { return mResourceAllocator; }
 
     void reset() noexcept;
 
@@ -310,7 +310,7 @@ private:
 
     FrameGraphHandle moveResource(FrameGraphHandle from, FrameGraphHandle to);
 
-    fg::ResourceAllocator& mResourceAllocator;
+    fg::ResourceAllocatorInterface& mResourceAllocator;
     details::LinearAllocatorArena mArena;
     Vector<fg::PassNode> mPassNodes;                    // list of frame graph passes
     Vector<fg::ResourceNode> mResourceNodes;            // list of resource nodes

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -63,6 +63,7 @@ void ResourceAllocator::AssociativeContainer<K, V, H>::emplace(ARGS&& ... args) 
 }
 
 // ------------------------------------------------------------------------------------------------
+ResourceAllocatorInterface::~ResourceAllocatorInterface() = default;
 
 size_t ResourceAllocator::TextureKey::getSize() const noexcept {
     size_t pixelCount = width * height * depth;

--- a/filament/src/fg/ResourceAllocator.h
+++ b/filament/src/fg/ResourceAllocator.h
@@ -32,10 +32,37 @@
 namespace filament {
 namespace fg {
 
-class ResourceAllocator {
+// The only reason we use an interface here is for unit-tests, so we can mock this allocator.
+// This is not too time-critical, so that's okay.
+class ResourceAllocatorInterface {
+public:
+    virtual backend::RenderTargetHandle createRenderTarget(const char* name,
+            backend::TargetBufferFlags targetBufferFlags,
+            uint32_t width,
+            uint32_t height,
+            uint8_t samples,
+            backend::TargetBufferInfo color,
+            backend::TargetBufferInfo depth,
+            backend::TargetBufferInfo stencil) noexcept = 0;
+
+    virtual void destroyRenderTarget(backend::RenderTargetHandle h) noexcept = 0;
+
+    virtual backend::TextureHandle createTexture(const char* name, backend::SamplerType target,
+            uint8_t levels,
+            backend::TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+            uint32_t depth, backend::TextureUsage usage) noexcept = 0;
+
+    virtual void destroyTexture(backend::TextureHandle h) noexcept = 0;
+
+protected:
+    virtual ~ResourceAllocatorInterface();
+};
+
+
+class ResourceAllocator final : public ResourceAllocatorInterface {
 public:
     explicit ResourceAllocator(backend::DriverApi& driverApi) noexcept;
-    ~ResourceAllocator() noexcept;
+    ~ResourceAllocator() noexcept override;
 
     void terminate() noexcept;
 
@@ -46,16 +73,16 @@ public:
             uint8_t samples,
             backend::TargetBufferInfo color,
             backend::TargetBufferInfo depth,
-            backend::TargetBufferInfo stencil) noexcept;
+            backend::TargetBufferInfo stencil) noexcept override;
 
-    void destroyRenderTarget(backend::RenderTargetHandle h) noexcept;
+    void destroyRenderTarget(backend::RenderTargetHandle h) noexcept override;
 
     backend::TextureHandle createTexture(const char* name, backend::SamplerType target,
             uint8_t levels,
             backend::TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
-            uint32_t depth, backend::TextureUsage usage) noexcept;
+            uint32_t depth, backend::TextureUsage usage) noexcept override;
 
-    void destroyTexture(backend::TextureHandle h) noexcept;
+    void destroyTexture(backend::TextureHandle h) noexcept override;
 
     void gc() noexcept;
 


### PR DESCRIPTION
We have one very important unit test that is supposed to make sure
the framegraph reuses the same rendertarget between 2 passes, this
unit test would always succeed when using the NoopDriver.
Now that we can mock the ResourceAllocator, we can ensure this unit
test is doing its job.