### PR TITLE
gltfio: support external resources on Android.

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -54,11 +54,11 @@ import java.nio.Buffer;
  *     }
  *
  *     val resourceLoader = ResourceLoader(engine)
- *     resourceLoader.loadResources(filamentAsset)
  *     for (uri in filamentAsset.resourceUris) {
  *         val buffer = loadResource(uri)
  *         resourceLoader.addResourceData(uri, buffer)
  *     }
+ *     resourceLoader.loadResources(filamentAsset)
  *     resourceLoader.destroy()
  *     animator = asset.getAnimator()
  *
@@ -119,7 +119,7 @@ public class AssetLoader {
     @Nullable
     public FilamentAsset createAssetFromBinary(@NonNull Buffer buffer) {
         long nativeAsset = nCreateAssetFromBinary(mNativeObject, buffer, buffer.remaining());
-        return new FilamentAsset(nativeAsset);
+        return nativeAsset != 0 ? new FilamentAsset(nativeAsset) : null;
     }
 
     /**
@@ -128,7 +128,7 @@ public class AssetLoader {
     @Nullable
     public FilamentAsset createAssetFromJson(@NonNull Buffer buffer) {
         long nativeAsset = nCreateAssetFromJson(mNativeObject, buffer, buffer.remaining());
-        return new FilamentAsset(nativeAsset);
+        return nativeAsset != 0 ? new FilamentAsset(nativeAsset) : null;
     }
 
     /**

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -164,6 +164,7 @@ FFilamentAsset* FAssetLoader::createAssetFromJson(const uint8_t* bytes, uint32_t
     cgltf_data* sourceAsset;
     cgltf_result result = cgltf_parse(&options, bytes, nbytes, &sourceAsset);
     if (result != cgltf_result_success) {
+        slog.e << "Unable to parse JSON file." << io::endl;
         return nullptr;
     }
     createAsset(sourceAsset);
@@ -185,6 +186,7 @@ FilamentAsset* FAssetLoader::createAssetFromBinary(const uint8_t* bytes, uint32_
     cgltf_data* sourceAsset;
     cgltf_result result = cgltf_parse(&options, glbdata.data(), nbytes, &sourceAsset);
     if (result != cgltf_result_success) {
+        slog.e << "Unable to parse glb file." << io::endl;
         return nullptr;
     }
     createAsset(sourceAsset);


### PR DESCRIPTION
This was untested because our only glTF Android sample uses glb instead
of JSON. We will soon be adding a new Android demo that uses an actual
gltf file.

This fixes #1841.