### PR TITLE
Fix a multisample related bug in the FrameGraph

### DIFF
--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -29,7 +29,7 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
 
     // FIXME (workaround): a texture could end up with no usage if it was used as an attachment
     //  of a RenderTarget that itself was replaced by a moveResource(). In this case, the texture
-    //  is simply unused.  A better fix would be to let the framegraph culling eliminate the
+    //  is simply unused.  A better fix would be to let the framegraph culling eliminate
     //  this resource, but this is currently not working or set-up this way.
     //  Instead, we simply do nothing here.
     if (none(desc.usage)) {
@@ -37,11 +37,16 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
     }
 
     assert(any(desc.usage));
-    // (it means it's only used as an attachment for a rendertarget)
+
     uint8_t samples = desc.samples;
+    assert(samples <= 1 || none(desc.usage & TextureUsage::SAMPLEABLE));
     if (any(desc.usage & TextureUsage::SAMPLEABLE)) {
-        samples = 1; // sampleable textures can't be multi-sampled
+        // Sampleable textures can't be multi-sampled
+        // This should never happen (and will be caught by the assert above), but just to be safe,
+        // we reset the sample count to 1 in that case.
+        samples = 1;
     }
+
     texture = fg.getResourceAllocator().createTexture(name, desc.type, desc.levels,
             desc.format, samples, desc.width, desc.height, desc.depth, desc.usage);
 }
@@ -49,7 +54,6 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
 void FrameGraphTexture::destroy(FrameGraph& fg) noexcept {
     if (texture) {
         fg.getResourceAllocator().destroyTexture(texture);
-        //texture.clear(); // needed because of noop driver
     }
 }
 

--- a/filament/src/fg/fg/RenderTarget.cpp
+++ b/filament/src/fg/fg/RenderTarget.cpp
@@ -63,8 +63,13 @@ void RenderTarget::resolve(FrameGraph& fg) noexcept {
                         fg.getResourceEntryUnchecked(attachment.getHandle());
                 // update usage flags for referenced attachments
                 entry.descriptor.usage |= usages[i];
-                // update attachment sample count if not specified
-                entry.descriptor.samples = entry.descriptor.samples ? entry.descriptor.samples : desc.samples;
+
+                // update attachment sample count if not specified and usage permits it
+                if (!entry.descriptor.samples &&
+                    none(entry.descriptor.usage & backend::TextureUsage::SAMPLEABLE)) {
+                    entry.descriptor.samples = desc.samples;
+                }
+
                 attachments |= flags[i];
 
                 // figure out the min/max dimensions across all attachments


### PR DESCRIPTION
The FrameGraph would erroneously specify a sample count on textures
that are sampleable and used as an attachment to a multisampled 
target -- however, that's not allowed.

We didn't run into issues, because had a workaround for this when
creating the texture. This is augmented by an assertion.