### PR TITLE
Correct out-of-order transform instances

### DIFF
--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -65,6 +65,17 @@ void FTransformManager::setParent(Instance i, Instance parent) noexcept {
             removeNode(i);
             insertNode(i, parent);
             updateNodeTransform(i);
+            // Ensure that instances are still in order
+            Instance it = std::min(i, parent);
+            Instance end = manager.end();
+            while (it != end) {
+              Instance itParent = Instance(manager[it].parent);
+              if (UTILS_UNLIKELY(itParent > it)) {
+                swapNode(it, itParent);
+              } else {
+                ++it;
+              }
+            }
         }
     }
 }
@@ -176,7 +187,7 @@ void FTransformManager::commitLocalTransformTransaction() noexcept {
         mat4f const* const UTILS_RESTRICT world = manager.raw_array<WORLD>();
         for (Instance i = manager.begin(), e = manager.end(); i != e; ++i) {
             // Ensure that children are always sorted after their parent.
-            if (UTILS_UNLIKELY(Instance(manager[i].parent) > i)) {
+            while (UTILS_UNLIKELY(Instance(manager[i].parent) > i)) {
                 swapNode(i, manager[i].parent);
             }
             Instance parent = manager[i].parent;
@@ -203,6 +214,17 @@ void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
         if (next) {
             // and we are the previous sibling of our next sibling
             manager[next].prev = i;
+        }
+        // ensure instances are still in order
+        Instance it = std::min(i, parent);
+        Instance end = manager.end();
+        while (it != end) {
+          Instance itParent = Instance(manager[it].parent);
+          if (UTILS_UNLIKELY(itParent > it)) {
+            swapNode(it, itParent);
+          } else {
+            ++it;
+          }
         }
     }
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -215,17 +215,6 @@ void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
             // and we are the previous sibling of our next sibling
             manager[next].prev = i;
         }
-        // ensure instances are still in order
-        Instance it = std::min(i, parent);
-        Instance end = manager.end();
-        while (it != end) {
-          Instance itParent = Instance(manager[it].parent);
-          if (UTILS_UNLIKELY(itParent > it)) {
-            swapNode(it, itParent);
-          } else {
-            ++it;
-          }
-        }
     }
 
     validateNode(i);

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -66,15 +66,16 @@ void FTransformManager::setParent(Instance i, Instance parent) noexcept {
             insertNode(i, parent);
             updateNodeTransform(i);
             // Ensure that instances are still in order
-            Instance it = std::min(i, parent);
-            Instance end = manager.end();
-            while (it != end) {
-              Instance itParent = Instance(manager[it].parent);
-              if (UTILS_UNLIKELY(itParent > it)) {
-                swapNode(it, itParent);
-              } else {
-                ++it;
-              }
+            if (i < parent) {
+                Instance end = manager.end();
+                while (i != end) {
+                    Instance iParent = Instance(manager[i].parent);
+                    if (UTILS_UNLIKELY(iParent > i)) {
+                        swapNode(i, iParent);
+                    } else {
+                        ++i;
+                    }
+                }
             }
         }
     }
@@ -186,10 +187,6 @@ void FTransformManager::commitLocalTransformTransaction() noexcept {
 
         mat4f const* const UTILS_RESTRICT world = manager.raw_array<WORLD>();
         for (Instance i = manager.begin(), e = manager.end(); i != e; ++i) {
-            // Ensure that children are always sorted after their parent.
-            while (UTILS_UNLIKELY(Instance(manager[i].parent) > i)) {
-                swapNode(i, manager[i].parent);
-            }
             Instance parent = manager[i].parent;
             assert(parent < i);
             manager[i].world = world[parent] * static_cast<mat4f const&>(manager[i].local);


### PR DESCRIPTION
Ensure that parents are always before children in transform manager, even after reparenting happens.

The current code only updates the order in the transaction commit if there's a single out-of-order node in the scene graph, but if multiple are out of order (or one swap doesn't fully fix the ordering), then we end up with out of order scenes, and incorrect world transforms.

Additionally, when nodes are reparented outside of a transaction, the order is not updated.