### PR TITLE
revert part of a recent TransformManager change

### DIFF
--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -65,18 +65,10 @@ void FTransformManager::setParent(Instance i, Instance parent) noexcept {
             removeNode(i);
             insertNode(i, parent);
             updateNodeTransform(i);
-            // Ensure that instances are still in order
-            if (!mLocalTransformTransactionOpen && i < parent) {
-                Instance end = manager.end();
-                while (i != end) {
-                    Instance iParent = Instance(manager[i].parent);
-                    if (UTILS_UNLIKELY(iParent > i)) {
-                        swapNode(i, iParent);
-                    } else {
-                        ++i;
-                    }
-                }
-            }
+            // Note: setParent() doesn't reorder the child after the parent in the array,
+            // but that's not a problem because TransformManager doesn't rely on that.
+            // Also note that commitLocalTransformTransaction() does reorder all children after
+            // their parent, as an optimization to calculate the world transform.
         }
     }
 }

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -235,13 +235,13 @@ TEST(FilamentTest, TransformManager) {
     tcm.create(entities[2]);
     EXPECT_TRUE(tcm.hasComponent(entities[2]));
     TransformManager::Instance newParent = tcm.getInstance(entities[2]);
-    EXPECT_TRUE(bool(newParent));
+    ASSERT_LT(child, newParent);
 
     // test reparenting
     tcm.setParent(child, newParent);
 
-    // make sure child/parent are out of order
-    ASSERT_LT(child, newParent);
+    // make sure child/parent are out of order (i.e.: setParent() doesn't invalidate instances)
+    EXPECT_LT(tcm.getInstance(entities[1]), tcm.getInstance(entities[2]));
 
     // local transaction reorders parent/child
     tcm.openLocalTransformTransaction();


### PR DESCRIPTION
setParent() is not supposed to reorder child/parents in the array
because it doesn't rely on them being orderer. This also has the
advantage of not invalidating Instances.

However, commitLocalTransformTransaction() does rely on child/parent
ordering and the previous change did fix that.