### PR TITLE
camutils: add support for Builder pattern.

### DIFF
--- a/libs/camutils/src/Manipulator.cpp
+++ b/libs/camutils/src/Manipulator.cpp
@@ -26,12 +26,93 @@ using namespace filament::math;
 namespace filament {
 namespace camutils {
 
-template <typename FLOAT> Manipulator<FLOAT>*
-Manipulator<FLOAT>::create(Mode mode, const Manipulator<FLOAT>::Config& props) {
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::viewport(int width, int height) {
+    details.viewport[0] = width;
+    details.viewport[1] = height;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::targetPosition(FLOAT x, FLOAT y, FLOAT z) {
+    details.targetPosition = {x, y, z};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::upVector(FLOAT x, FLOAT y, FLOAT z) {
+    details.upVector = {x, y, z};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::zoomSpeed(FLOAT val) {
+    details.zoomSpeed = val;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::orbitHomePosition(FLOAT x, FLOAT y, FLOAT z) {
+    details.orbitHomePosition = {x, y, z};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::orbitSpeed(FLOAT x, FLOAT y) {
+    details.orbitSpeed = {x, y};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::fovDirection(Fov fov) {
+    details.fovDirection = fov;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::fovDegrees(FLOAT degrees) {
+    details.fovDegrees = degrees;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::farPlane(FLOAT distance) {
+    details.farPlane = distance;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::mapExtent(FLOAT worldWidth, FLOAT worldHeight) {
+    details.mapExtent = {worldWidth, worldHeight};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::mapMinDistance(FLOAT mindist) {
+    details.mapMinDistance = mindist;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d) {
+    details.groundPlane = {a, b, c, d};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::raycastCallback(RayCallback cb, void* userdata) {
+    details.raycastCallback = cb;
+    details.raycastUserdata = userdata;
+    return *this;
+}
+
+
+template <typename FLOAT>
+Manipulator<FLOAT>* Manipulator<FLOAT>::Builder::build(Mode mode) {
     if (mode == Mode::MAP) {
-        return new MapManipulator<FLOAT>(mode, props);
+        return new MapManipulator<FLOAT>(mode, details);
     }
-    return new OrbitManipulator<FLOAT>(mode, props);
+    return new OrbitManipulator<FLOAT>(mode, details);
 }
 
 template <typename FLOAT>

--- a/libs/camutils/tests/test_camutils.cpp
+++ b/libs/camutils/tests/test_camutils.cpp
@@ -39,14 +39,14 @@ TEST_F(CamUtilsTest, Orbit) {
 
     float3 eye, targetPosition, up;
 
-    CamManipulator* orbit = CamManipulator::create(camutils::Mode::ORBIT, {
-        .viewport = {256, 256},
-        .targetPosition = {0, 0, 0},
-        .upVector = {0, 1, 0},
-        .zoomSpeed = 0.01,
-        .orbitHomePosition = {0, 0, 4},
-        .orbitSpeed = {1, 1},
-    });
+    CamManipulator* orbit = CamManipulator::Builder()
+        .viewport(256, 256)
+        .targetPosition(0, 0, 0)
+        .upVector(0, 1, 0)
+        .zoomSpeed(0.01)
+        .orbitHomePosition(0, 0, 4)
+        .orbitSpeed(1, 1)
+        .build(camutils::Mode::ORBIT);
 
     orbit->getLookAt(&eye, &targetPosition, &up);
     EXPECT_VEC_EQ(eye, 0, 0, 4);
@@ -69,12 +69,12 @@ TEST_F(CamUtilsTest, Map) {
 
     float3 eye, targetPosition, up;
 
-    CamManipulator* map = CamManipulator::create(camutils::Mode::MAP, {
-        .viewport = {256, 256},
-        .targetPosition = {0, 0, 0},
-        .zoomSpeed = 0.01,
-        .orbitHomePosition = {0, 0, 4},
-    });
+    CamManipulator* map = CamManipulator::Builder()
+        .viewport(256, 256)
+        .targetPosition(0, 0, 0)
+        .zoomSpeed(0.01)
+        .orbitHomePosition(0, 0, 4)
+        .build(camutils::Mode::MAP);
 
     delete map;
 }

--- a/samples/app/FilamentApp.cpp
+++ b/samples/app/FilamentApp.cpp
@@ -522,8 +522,8 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
 
     // set-up the camera manipulators
     camutils::Mode mode = camutils::Mode::ORBIT;
-    mMainCameraMan = CameraManipulator::create(mode, { .targetPosition = {0, 0, -4} });
-    mDebugCameraMan = CameraManipulator::create(mode, { .targetPosition = {0, 0, -4} });
+    mMainCameraMan = CameraManipulator::Builder().targetPosition(0, 0, -4).build(mode);
+    mDebugCameraMan = CameraManipulator::Builder().targetPosition(0, 0, -4).build(mode);
 
     mMainView->setCamera(mMainCamera);
     mMainView->setCameraManipulator(mMainCameraMan);


### PR DESCRIPTION
This makes the upcoming Java bindings simpler and improves parity with
existing API conventions.

Note that camutils does not depend on filament and therefore cannot use
BuilderBase.

Note that the Manipulator Builder state is public which breaks with
convention but makes implementation simple and allows C++ clients to
continue using modern initializer syntax if they wish.