### PR TITLE
remove unneeded includes in public headers

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -18,6 +18,9 @@
 
 #include <filament/Engine.h>
 
+#include <utils/Entity.h>
+#include <utils/EntityManager.h>
+
 using namespace filament;
 using namespace utils;
 

--- a/android/filament-android/src/main/cpp/IndexBuffer.cpp
+++ b/android/filament-android/src/main/cpp/IndexBuffer.cpp
@@ -22,6 +22,8 @@
 
 #include <filament/IndexBuffer.h>
 
+#include <backend/BufferDescriptor.h>
+
 #include "common/CallbackUtils.h"
 #include "common/NioUtils.h"
 

--- a/android/filament-android/src/main/cpp/LightManager.cpp
+++ b/android/filament-android/src/main/cpp/LightManager.cpp
@@ -18,6 +18,8 @@
 
 #include <filament/LightManager.h>
 
+#include <utils/Entity.h>
+
 using namespace filament;
 using namespace utils;
 

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -18,6 +18,10 @@
 #include <jni.h>
 
 #include <filament/RenderableManager.h>
+#include <filament/MaterialInstance.h>
+
+#include <utils/Entity.h>
+
 #include "common/NioUtils.h"
 
 using namespace filament;

--- a/android/filament-android/src/main/cpp/Scene.cpp
+++ b/android/filament-android/src/main/cpp/Scene.cpp
@@ -18,6 +18,8 @@
 
 #include <filament/Scene.h>
 
+#include <utils/Entity.h>
+
 using namespace filament;
 using namespace utils;
 

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -17,6 +17,7 @@
 #include <jni.h>
 
 #include <filament/View.h>
+#include <filament/Viewport.h>
 
 using namespace filament;
 

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -19,13 +19,15 @@
 #ifndef TNT_FILAMENT_CAMERA_H
 #define TNT_FILAMENT_CAMERA_H
 
-#include <filament/Frustum.h>
 #include <filament/FilamentAPI.h>
 
-#include <utils/Entity.h>
 #include <utils/compiler.h>
 
 #include <math/mat4.h>
+
+namespace utils {
+class Entity;
+} // namespace utils
 
 namespace filament {
 
@@ -289,7 +291,7 @@ public:
     math::float3 getForwardVector() const noexcept;
 
     //! Returns a Frustum object in world space
-    Frustum getFrustum() const noexcept;
+    class Frustum getFrustum() const noexcept;
 
     //! Returns the entity representing this camera
     utils::Entity getEntity() const noexcept;

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -17,14 +17,13 @@
 #ifndef TNT_FILAMENT_ENGINE_H
 #define TNT_FILAMENT_ENGINE_H
 
-#include <filament/Camera.h>
-#include <filament/Fence.h>
-#include <filament/SwapChain.h>
-
 #include <backend/Platform.h>
 
 #include <utils/compiler.h>
-#include <utils/EntityManager.h>
+
+namespace utils {
+class Entity;
+} // namespace utils
 
 namespace filament {
 
@@ -40,6 +39,7 @@ class RenderTarget;
 class Scene;
 class Skybox;
 class Stream;
+class SwapChain;
 class Texture;
 class VertexBuffer;
 class View;
@@ -398,9 +398,7 @@ public:
      *
      * @return A camera component
      */
-    inline Camera* createCamera() noexcept {
-        return createCamera(utils::EntityManager::get().create());
-    }
+    Camera* createCamera() noexcept;
 
     /**
      * helper for destroying the Camera component and its Entity in one call
@@ -409,9 +407,7 @@ public:
      *               components managed by filament are destroyed.
      * @deprecated use destroyCameraComponent(Entity) instead
      */
-    inline void destroy(const Camera* camera) {
-        destroy(camera->getEntity());
-    }
+    void destroy(const Camera* camera);
 
    /**
      * Invokes one iteration of the render loop, used only on single-threaded platforms.

--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -19,8 +19,6 @@
 #ifndef TNT_FILAMENT_FRUSTUM_H
 #define TNT_FILAMENT_FRUSTUM_H
 
-#include <filament/Box.h>
-
 #include <utils/compiler.h>
 
 #include <math/mat4.h>
@@ -28,6 +26,8 @@
 #include <utils/unwindows.h> // Because we define NEAR and FAR in the Plane enum.
 
 namespace filament {
+
+class Box;
 
 namespace details {
 class Culler;

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -21,12 +21,15 @@
 #include <filament/Color.h>
 
 #include <utils/compiler.h>
-#include <utils/Entity.h>
 #include <utils/EntityInstance.h>
 
 #include <math/vec3.h>
 
 #include <math.h>
+
+namespace utils {
+    class Entity;
+} // namespace utils
 
 namespace filament {
 

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -21,22 +21,27 @@
 #include <filament/FilamentAPI.h>
 #include <filament/MaterialEnums.h>
 #include <filament/MaterialInstance.h>
-#include <filament/Texture.h>
-#include <filament/TextureSampler.h>
 
 #include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
-#include <utils/CString.h>
 
 #include <math/vec4.h>
 
 #include <stdint.h>
 
+namespace utils {
+    class CString;
+} // namespace utils
+
 namespace filament {
+
+class Texture;
+class TextureSampler;
+
 namespace details {
-class  FEngine;
-class  FMaterial;
+class FEngine;
+class FMaterial;
 } // namespace details
 
 class Engine;

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -19,7 +19,6 @@
 
 #include <filament/FilamentAPI.h>
 #include <filament/Color.h>
-#include <filament/TextureSampler.h>
 
 #include <backend/DriverEnums.h>
 
@@ -29,6 +28,7 @@ namespace filament {
 
 class Material;
 class Texture;
+class TextureSampler;
 class UniformBuffer;
 class UniformInterfaceBlock;
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -18,15 +18,12 @@
 #define TNT_FILAMENT_RENDERABLECOMPONENTMANAGER_H
 
 #include <filament/Box.h>
-#include <filament/VertexBuffer.h>
-#include <filament/IndexBuffer.h>
-#include <filament/Material.h>
-#include <filament/MaterialInstance.h>
-#include <filament/Renderer.h>
 #include <filament/FilamentAPI.h>
+#include <filament/MaterialEnums.h>
+
+#include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
-#include <utils/Entity.h>
 #include <utils/EntityInstance.h>
 
 #include <math/mat4.h>
@@ -35,7 +32,18 @@
 
 #include <type_traits>
 
+namespace utils {
+    class Entity;
+} // namespace utils
+
 namespace filament {
+
+class Engine;
+class IndexBuffer;
+class Material;
+class MaterialInstance;
+class Renderer;
+class VertexBuffer;
 
 namespace details {
 class FEngine;

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -20,7 +20,6 @@
 #define TNT_FILAMENT_RENDERER_H
 
 #include <filament/FilamentAPI.h>
-#include <filament/Viewport.h>
 
 #include <utils/compiler.h>
 
@@ -34,6 +33,7 @@ class Engine;
 class RenderTarget;
 class SwapChain;
 class View;
+class Viewport;
 
 namespace backend {
 class PixelBufferDescriptor;

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -22,7 +22,10 @@
 #include <filament/FilamentAPI.h>
 
 #include <utils/compiler.h>
-#include <utils/Entity.h>
+
+namespace utils {
+    class Entity;
+} // namespace utils
 
 namespace filament {
 

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -20,12 +20,16 @@
 #include <filament/FilamentAPI.h>
 
 #include <utils/compiler.h>
-#include <utils/Entity.h>
 #include <utils/EntityInstance.h>
 
 #include <math/mat4.h>
 
 #include <iterator>
+
+
+namespace utils {
+class Entity;
+} // namespace utils
 
 namespace filament {
 

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -23,7 +23,6 @@
 #include <filament/MaterialEnums.h>
 
 #include <backend/BufferDescriptor.h>
-
 #include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -19,9 +19,7 @@
 #ifndef TNT_FILAMENT_VIEW_H
 #define TNT_FILAMENT_VIEW_H
 
-#include <filament/Camera.h>
 #include <filament/Color.h>
-#include <filament/Viewport.h>
 #include <filament/FilamentAPI.h>
 
 #include <backend/DriverEnums.h>
@@ -37,6 +35,7 @@ class Camera;
 class MaterialInstance;
 class RenderTarget;
 class Scene;
+class Viewport;
 
 /**
  * A View encompasses all the state needed for rendering a Scene.

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -16,6 +16,8 @@
 
 #include "details/Culler.h"
 
+#include <filament/Box.h>
+
 #include <math/fast.h>
 
 using namespace filament::math;

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -970,5 +970,12 @@ DebugRegistry& Engine::getDebugRegistry() noexcept {
     return upcast(this)->getDebugRegistry();
 }
 
+Camera* Engine::createCamera() noexcept {
+    return createCamera(utils::EntityManager::get().create());
+}
+
+void Engine::destroy(const Camera* camera) {
+    destroy(camera->getEntity());
+}
 
 } // namespace filament

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -34,6 +34,7 @@
 
 #include <MaterialParser.h>
 
+#include <utils/CString.h>
 #include <utils/Panic.h>
 
 #include <sstream>

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -16,11 +16,11 @@
 
 #include <filament/MaterialInstance.h>
 
+#include <filament/TextureSampler.h>
+
 #include "details/MaterialInstance.h"
 
 #include "RenderPass.h"
-
-#include <private/filament/UniformInterfaceBlock.h>
 
 #include "details/Engine.h"
 #include "details/Material.h"

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -19,6 +19,7 @@
 #include "details/Engine.h"
 
 #include "fg/FrameGraph.h"
+#include "fg/FrameGraphPassResources.h"
 
 #include "RenderPass.h"
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -31,6 +31,7 @@
 
 #include "fg/FrameGraph.h"
 #include "fg/FrameGraphHandle.h"
+#include "fg/FrameGraphPassResources.h"
 #include "fg/ResourceAllocator.h"
 
 

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -26,6 +26,8 @@
 
 #include "FilamentAPI-impl.h"
 
+#include <filament/TextureSampler.h>
+
 #include <backend/DriverEnums.h>
 
 #include <utils/Panic.h>

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -28,6 +28,7 @@
 #include "details/Skybox.h"
 
 #include <filament/Exposure.h>
+#include <filament/TextureSampler.h>
 
 #include <private/filament/SibGenerator.h>
 #include <private/filament/UibGenerator.h>

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -43,6 +43,8 @@ namespace details {
 
 class FMaterialInstance;
 class FRenderPrimitive;
+class FIndexBuffer;
+class FVertexBuffer;
 
 class FRenderableManager : public RenderableManager {
 public:

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -29,6 +29,7 @@
 #include "details/Camera.h"
 #include "details/DebugRegistry.h"
 #include "details/Fence.h"
+#include "details/IndexBuffer.h"
 #include "details/RenderTarget.h"
 #include "details/ResourceList.h"
 #include "details/Skybox.h"

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -21,7 +21,6 @@
 #include "Blackboard.h"
 #include "FrameGraphPass.h"
 #include "FrameGraphHandle.h"
-#include "FrameGraphPassResources.h"
 
 #include <fg/fg/ResourceEntry.h>
 

--- a/filament/src/fg/fg/PassNode.h
+++ b/filament/src/fg/fg/PassNode.h
@@ -19,15 +19,15 @@
 
 #include "fg/FrameGraph.h"
 
-#include "ResourceNode.h"
-#include "VirtualResource.h"
-
 #include <vector>
 
 #include <stdint.h>
 
 namespace filament {
 namespace fg {
+
+struct ResourceNode;
+struct VirtualResource;
 
 struct PassNode { // 200
     template <typename T>

--- a/filament/src/fg/fg/RenderTarget.cpp
+++ b/filament/src/fg/fg/RenderTarget.cpp
@@ -16,6 +16,12 @@
 
 #include "RenderTarget.h"
 
+#include "fg/FrameGraph.h"
+
+#include "RenderTargetResource.h"
+
+#include "details/Texture.h"
+
 #include <backend/DriverEnums.h>
 
 namespace filament {

--- a/filament/src/fg/fg/RenderTarget.h
+++ b/filament/src/fg/fg/RenderTarget.h
@@ -19,17 +19,17 @@
 
 #include <backend/DriverEnums.h>
 
-#include "details/Texture.h"
-
-#include "fg/FrameGraph.h"
 #include "fg/FrameGraphHandle.h"
-
-#include "RenderTargetResource.h"
 
 #include <stdint.h>
 
 namespace filament {
+
+class FrameGraph;
+
 namespace fg {
+
+struct RenderTargetResource;
 
 struct RenderTarget { // 32
     RenderTarget(const char* name,

--- a/filament/src/fg/fg/RenderTargetResource.h
+++ b/filament/src/fg/fg/RenderTargetResource.h
@@ -21,8 +21,9 @@
 #include <backend/TargetBufferInfo.h>
 
 #include "fg/FrameGraph.h"
-
+#include "fg/FrameGraphPassResources.h"
 #include "fg/ResourceAllocator.h"
+
 #include "ResourceNode.h"
 #include "VirtualResource.h"
 

--- a/filament/test/filament_rendering_test.cpp
+++ b/filament/test/filament_rendering_test.cpp
@@ -19,6 +19,8 @@
 #include <filament/Engine.h>
 #include <filament/Renderer.h>
 #include <filament/View.h>
+#include <filament/Viewport.h>
+
 #include <backend/PixelBufferDescriptor.h>
 
 using namespace filament;

--- a/libs/filagui/include/filagui/ImGuiHelper.h
+++ b/libs/filagui/include/filagui/ImGuiHelper.h
@@ -28,6 +28,7 @@
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
+#include <utils/Entity.h>
 #include <utils/Path.h>
 
 struct ImDrawData;

--- a/libs/filagui/src/ImGuiHelper.cpp
+++ b/libs/filagui/src/ImGuiHelper.cpp
@@ -22,14 +22,16 @@
 #include <imgui.h>
 
 #include <filamat/MaterialBuilder.h>
-#include <filament/VertexBuffer.h>
+#include <filament/Fence.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
 #include <utils/EntityManager.h>
 
 using namespace filament::math;

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -20,9 +20,11 @@
 #include <filament/Box.h>
 #include <filament/Engine.h>
 #include <filament/Fence.h>
+#include <filament/IndexBuffer.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
+#include <filament/VertexBuffer.h>
 
 #include <meshoptimizer.h>
 

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -24,6 +24,7 @@
 #include <gltfio/MaterialProvider.h>
 
 namespace utils {
+    class EntityManager;
     class NameComponentManager;
 }
 

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -214,6 +214,8 @@ filament::math::mat4f fitIntoUnitCube(const filament::Aabb& bounds);
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 
+#include <utils/EntityManager.h>
+
 #include <math/mat4.h>
 #include <math/vec3.h>
 

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -17,6 +17,8 @@
 #include <gltfio/MaterialProvider.h>
 
 #include <filament/MaterialInstance.h>
+#include <filament/Texture.h>
+#include <filament/TextureSampler.h>
 
 #include <math/mat4.h>
 

--- a/samples/app/Cube.h
+++ b/samples/app/Cube.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <filament/Engine.h>
+#include <filament/Box.h>
 #include <filament/Camera.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>

--- a/samples/app/Sphere.cpp
+++ b/samples/app/Sphere.cpp
@@ -19,6 +19,7 @@
 
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
+#include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>

--- a/samples/frame_generator.cpp
+++ b/samples/frame_generator.cpp
@@ -36,6 +36,7 @@
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
+#include <filament/Renderer.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -22,9 +22,12 @@
 
 #include <filagui/ImGuiMath.h>
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
 #include <filament/Scene.h>
 #include <filament/View.h>
+#include <filament/VertexBuffer.h>
 
 #include <gltfio/AssetLoader.h>
 #include <gltfio/AssetPipeline.h>

--- a/samples/heightfield.cpp
+++ b/samples/heightfield.cpp
@@ -22,10 +22,12 @@
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
+#include <utils/EntityManager.h>
 #include <utils/JobSystem.h>
 #include <utils/Path.h>
 

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -25,11 +25,13 @@
 #include <utils/Path.h>
 
 #include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
 #include <filament/Material.h>
 #include <filament/Scene.h>
 #include <filament/LightManager.h>
 #include <filament/RenderableManager.h>
 #include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
 
 #include <math/norm.h>
 #include <utils/Log.h>

--- a/samples/lucy_bloom.cpp
+++ b/samples/lucy_bloom.cpp
@@ -18,6 +18,7 @@
 #include "app/FilamentApp.h"
 #include "app/IBL.h"
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/IndirectLight.h>
@@ -30,6 +31,8 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include <gltfio/AssetLoader.h>
 #include <gltfio/FilamentAsset.h>

--- a/samples/lucy_utils.cpp
+++ b/samples/lucy_utils.cpp
@@ -21,13 +21,18 @@
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/IndirectLight.h>
+#include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/TransformManager.h>
+#include <filament/TextureSampler.h>
 #include <filament/VertexBuffer.h>
 
 #include <geometry/SurfaceOrientation.h>
+
+#include <utils/Entity.h>
+#include <utils/EntityManager.h>
 
 #include <stb_image.h>
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -29,6 +29,7 @@
 #include <filament/Engine.h>
 #include <filament/DebugRegistry.h>
 #include <filament/IndirectLight.h>
+#include <filament/IndexBuffer.h>
 #include <filament/LightManager.h>
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
@@ -36,6 +37,7 @@
 #include <filament/Scene.h>
 #include <filament/TransformManager.h>
 #include <filament/View.h>
+#include <filament/VertexBuffer.h>
 
 #include <math/mat3.h>
 #include <math/mat4.h>

--- a/samples/point_sprites.cpp
+++ b/samples/point_sprites.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
@@ -21,8 +22,11 @@
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/TransformManager.h>
+#include <filament/TextureSampler.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include <image/ImageSampler.h>
 #include <image/LinearImage.h>

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -28,9 +28,10 @@
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
-#include <filament/TransformManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
+#include <filament/TransformManager.h>
 
 #include <math/mat3.h>
 #include <math/mat4.h>

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -28,6 +28,7 @@
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/RenderableManager.h>
+#include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -17,10 +17,14 @@
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
 #include <filament/LightManager.h>
+#include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
+#include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include <filameshio/MeshReader.h>
 

--- a/samples/vk_animation.cpp
+++ b/samples/vk_animation.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
@@ -23,6 +24,8 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include "../samples/app/Config.h"
 #include "../samples/app/FilamentApp.h"

--- a/samples/vk_depthtesting.cpp
+++ b/samples/vk_depthtesting.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
@@ -23,6 +24,8 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include "../samples/app/Config.h"
 #include "../samples/app/FilamentApp.h"

--- a/samples/vk_hellopbr.cpp
+++ b/samples/vk_hellopbr.cpp
@@ -16,10 +16,13 @@
 
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
+#include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/TransformManager.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include <filameshio/MeshReader.h>
 

--- a/samples/vk_hellotriangle.cpp
+++ b/samples/vk_hellotriangle.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
@@ -23,6 +24,8 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include "../samples/app/Config.h"
 #include "../samples/app/FilamentApp.h"

--- a/samples/vk_shadowtest.cpp
+++ b/samples/vk_shadowtest.cpp
@@ -15,11 +15,15 @@
  */
 
 #include <filament/Engine.h>
+#include <filament/IndexBuffer.h>
 #include <filament/LightManager.h>
+#include <filament/Material.h>
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
+#include <filament/TextureSampler.h>
 #include <filament/TransformManager.h>
+#include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
 #include <math/norm.h>

--- a/samples/vk_texturedquad.cpp
+++ b/samples/vk_texturedquad.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/Camera.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Material.h>
@@ -21,8 +22,11 @@
 #include <filament/RenderableManager.h>
 #include <filament/Scene.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+
+#include <utils/EntityManager.h>
 
 #include <utils/Path.h>
 

--- a/samples/vk_vbotest.cpp
+++ b/samples/vk_vbotest.cpp
@@ -23,6 +23,8 @@
 
 #include "../samples/app/FilamentApp.h"
 
+#include <utils/EntityManager.h>
+
 #include "generated/resources/resources.h"
 
 using namespace filament;

--- a/samples/vk_viewtest.cpp
+++ b/samples/vk_viewtest.cpp
@@ -22,6 +22,8 @@
 
 #include "../samples/app/FilamentApp.h"
 
+#include <utils/EntityManager.h>
+
 using namespace filament;
 
 struct App {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -36,6 +36,7 @@
 
 #include <filament/Camera.h>
 #include <filament/Engine.h>
+#include <filament/Frustum.h>
 #include <filament/IndexBuffer.h>
 #include <filament/IndirectLight.h>
 #include <filament/LightManager.h>
@@ -51,6 +52,7 @@
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
+#include <filament/Viewport.h>
 
 #include <geometry/SurfaceOrientation.h>
 

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -16,6 +16,7 @@
 
 #include <filament/Camera.h>
 #include <filament/Color.h>
+#include <filament/Frustum.h>
 #include <filament/IndexBuffer.h>
 #include <filament/LightManager.h>
 #include <filament/RenderableManager.h>


### PR DESCRIPTION
Replace with forward declarations if needed and includes in .cpp that
now need them.
The idea here is to have our headers have the least amount of impact as
possible on our clients (e.g. compilation time).