### PR TITLE
Fix out-of-bounds when glTF has many UV sets.

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -499,8 +499,12 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             utils::slog.e << "Unrecognized vertex semantic in " << name << utils::io::endl;
             return false;
         }
-        UvSet uvset = uvmap[inputAttribute.index];
         if (inputAttribute.type == cgltf_attribute_type_texcoord) {
+            if (inputAttribute.index >= sizeof(uvmap) / sizeof(uvmap[0])) {
+                utils::slog.e << "Too many texture coordinate sets in " << name << utils::io::endl;
+                continue;
+            }
+            UvSet uvset = uvmap[inputAttribute.index];
             switch (uvset) {
                 case UV0:
                     semantic = VertexAttribute::UV0;
@@ -649,6 +653,11 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                 uvmap[inputAttribute.index] == UNUSED)) {
             continue;
         }
+        if (inputAttribute.type == cgltf_attribute_type_texcoord &&
+                inputAttribute.index >= sizeof(uvmap) / sizeof(uvmap[0])) {
+            continue;
+        }
+
         if (inputAttribute.type == cgltf_attribute_type_normal) {
             mResult->mBufferBindings.push_back({
                 .uri = bv->buffer->uri,


### PR DESCRIPTION
glTF specifies that client implementations must support at least two UV
texture coordinate sets but does not seem to have an upper limit.

We use a mapping table in order to honor high-numbered UV set indices,
but our mapping table only accomodates 8 entries.

Fixes #2042