### PR TITLE
gltfio + Android: improve memory management.

### DIFF
--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -96,3 +96,10 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetResourceUris(JNIEnv* e
         env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(resourceUris[i]));
     }
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nReleaseSourceData(JNIEnv* env, jclass,
+        jlong nativeAsset) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    asset->releaseSourceData();
+}

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -25,8 +25,8 @@ import com.google.android.filament.EntityManager;
 import java.nio.Buffer;
 
 /**
- * Consumes a blob of glTF 2.0 content (either JSON or GLB) and produces {@link FilamentAsset}
- * objects, which are bundles of Filament entities, material instances, textures, vertex buffers,
+ * Consumes a blob of glTF 2.0 content (either JSON or GLB) and produces a {@link FilamentAsset}
+ * object, which is a bundle of Filament entities, material instances, textures, vertex buffers,
  * and index buffers.
  *
  * <p>AssetLoader does not fetch external buffer data or create textures on its own. Clients can use
@@ -37,7 +37,7 @@ import java.nio.Buffer;
  *
  * companion object {
  *     init {
- *        Gltfio.init()
+ *        Gltfio.init() // or, use Utils.init() if depending on filament-utils
  *    }
  * }
  *
@@ -47,10 +47,10 @@ import java.nio.Buffer;
  *
  *     assetLoader = AssetLoader(engine, MaterialProvider(engine), EntityManager.get())
  *
- *     filamentAsset = assets.open("models/lucy.glb").use { input ->
+ *     filamentAsset = assets.open("models/lucy.gltf").use { input ->
  *         val bytes = ByteArray(input.available())
  *         input.read(bytes)
- *         assetLoader.createAssetFromBinary(ByteBuffer.wrap(bytes))!!
+ *         assetLoader.createAssetFromJson(ByteBuffer.wrap(bytes))!!
  *     }
  *
  *     val resourceLoader = ResourceLoader(engine)
@@ -61,6 +61,7 @@ import java.nio.Buffer;
  *     resourceLoader.loadResources(filamentAsset)
  *     resourceLoader.destroy()
  *     animator = asset.getAnimator()
+ *     filamentAsset.releaseSourceData();
  *
  *     scene.addEntities(filamentAsset.entities)
  * }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -112,6 +112,16 @@ public class FilamentAsset {
         return uris;
     }
 
+    /**
+     * Reclaims CPU-side memory for URI strings, binding lists, and raw animation data.
+     *
+     * This should only be called after ResourceLoader#loadResources().
+     * If using Animator, this should be called after getAnimator().
+     */
+    public void releaseSourceData() {
+        nReleaseSourceData(mNativeObject);
+    }
+
     void clearNativeObject() {
         mNativeObject = 0;
     }
@@ -124,4 +134,5 @@ public class FilamentAsset {
     private static native long nGetAnimator(long nativeAsset);
     private static native int nGetResourceUriCount(long nativeAsset);
     private static native void nGetResourceUris(long nativeAsset, String[] result);
+    private static native void nReleaseSourceData(long nativeAsset);
 }

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -48,6 +48,7 @@ class MainActivity : Activity() {
     private lateinit var assetLoader: AssetLoader
     private lateinit var filamentAsset: FilamentAsset
     private lateinit var gestureDetector: GestureDetector
+    private lateinit var filamentAnimator: Animator
 
     // core filament objects
     private lateinit var engine: Engine
@@ -118,6 +119,9 @@ class MainActivity : Activity() {
             resourceLoader.addResourceData(uri, buffer)
         }
         resourceLoader.loadResources(filamentAsset)
+        resourceLoader.destroy()
+        filamentAnimator = filamentAsset.animator
+        filamentAsset.releaseSourceData()
 
         scene.addEntities(filamentAsset.entities)
 

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -185,7 +185,11 @@ bool ResourceLoader::loadResources(FilamentAsset* asset) {
                 slog.e << "Unable to load external resource: " << uri << io::endl;
                 missingResources = true;
             }
-            gltf->buffers[i].data = iter->second.buffer;
+            // Make a copy to allow cgltf_free() to work as expected and prevent a double-free.
+            // TODO: Future versions of CGLTF will make this easier, see the following ticket.
+            // https://github.com/jkuhlmann/cgltf/issues/94
+            gltf->buffers[i].data = malloc(iter->second.size);
+            memcpy(gltf->buffers[i].data, iter->second.buffer, iter->second.size);
         } else {
             slog.e << "Unable to load " << uri << io::endl;
             return false;


### PR DESCRIPTION
According to Android Studio, this makes `gltf-viewer` Java usage go from 18 MB to 6 MB.