### PR TITLE
Android: introduce ModelViewer helper.

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
@@ -58,72 +58,68 @@ class GestureDetector(private val view: View, private val manipulator: Manipulat
     private val kZoomConfidenceDistance = 10
     private val kZoomSpeed = 1f / 10f
 
-    init {
-        view.setOnTouchListener func@{ _, event ->
-            val touch = TouchPair(event, view.height)
-            when (event.actionMasked) {
-                MotionEvent.ACTION_MOVE -> {
+    fun onTouchEvent(event: MotionEvent) {
+        val touch = TouchPair(event, view.height)
+        when (event.actionMasked) {
+            MotionEvent.ACTION_MOVE -> {
 
-                    // CANCEL GESTURE DUE TO UNEXPECTED POINTER COUNT
+                // CANCEL GESTURE DUE TO UNEXPECTED POINTER COUNT
 
-                    if ((event.pointerCount != 1 && currentGesture == Gesture.ORBIT) ||
-                            (event.pointerCount != 2 && currentGesture == Gesture.PAN) ||
-                            (event.pointerCount != 2 && currentGesture == Gesture.ZOOM)) {
-                        endGesture()
-                        return@func true
-                    }
-
-                    // UPDATE EXISTING GESTURE
-
-                    if (currentGesture == Gesture.ZOOM) {
-                        val d0 = previousTouch.separation
-                        val d1 = touch.separation
-                        manipulator.zoom(touch.x, touch.y, (d0 - d1) * kZoomSpeed)
-                        previousTouch = touch
-                        return@func true
-                    }
-
-                    if (currentGesture != Gesture.NONE) {
-                        manipulator.grabUpdate(touch.x, touch.y)
-                        return@func true
-                    }
-
-                    // DETECT NEW GESTURE
-
-                    if (event.pointerCount == 1) {
-                        tentativeOrbitEvents.add(touch)
-                    }
-
-                    if (event.pointerCount == 2) {
-                        tentativePanEvents.add(touch)
-                        tentativeZoomEvents.add(touch)
-                    }
-
-                    if (isOrbitGesture()) {
-                        manipulator.grabBegin(touch.x, touch.y, false)
-                        currentGesture = Gesture.ORBIT
-                        return@func true
-                    }
-
-                    if (isZoomGesture()) {
-                        currentGesture = Gesture.ZOOM
-                        previousTouch = touch
-                        return@func true
-                    }
-
-                    if (isPanGesture()) {
-                        manipulator.grabBegin(touch.x, touch.y, true)
-                        currentGesture = Gesture.PAN
-                        return@func true
-                    }
-                }
-                MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
+                if ((event.pointerCount != 1 && currentGesture == Gesture.ORBIT) ||
+                        (event.pointerCount != 2 && currentGesture == Gesture.PAN) ||
+                        (event.pointerCount != 2 && currentGesture == Gesture.ZOOM)) {
                     endGesture()
+                    return
+                }
+
+                // UPDATE EXISTING GESTURE
+
+                if (currentGesture == Gesture.ZOOM) {
+                    val d0 = previousTouch.separation
+                    val d1 = touch.separation
+                    manipulator.zoom(touch.x, touch.y, (d0 - d1) * kZoomSpeed)
+                    previousTouch = touch
+                    return
+                }
+
+                if (currentGesture != Gesture.NONE) {
+                    manipulator.grabUpdate(touch.x, touch.y)
+                    return
+                }
+
+                // DETECT NEW GESTURE
+
+                if (event.pointerCount == 1) {
+                    tentativeOrbitEvents.add(touch)
+                }
+
+                if (event.pointerCount == 2) {
+                    tentativePanEvents.add(touch)
+                    tentativeZoomEvents.add(touch)
+                }
+
+                if (isOrbitGesture()) {
+                    manipulator.grabBegin(touch.x, touch.y, false)
+                    currentGesture = Gesture.ORBIT
+                    return
+                }
+
+                if (isZoomGesture()) {
+                    currentGesture = Gesture.ZOOM
+                    previousTouch = touch
+                    return
+                }
+
+                if (isPanGesture()) {
+                    manipulator.grabBegin(touch.x, touch.y, true)
+                    currentGesture = Gesture.PAN
+                    return
                 }
             }
-            true
+            MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
+                endGesture()
+            }
         }
-
     }
 
     private fun endGesture() {

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
@@ -21,7 +21,7 @@ import android.view.View
 import java.util.*
 
 /**
- * Sets up a touch listener on an Android View and forwards events to a camera manipulator.
+ * Responds to Android touch events and manages a camera manipulator.
  * Supports one-touch orbit, two-touch pan, and pinch-to-zoom.
  */
 class GestureDetector(private val view: View, private val manipulator: Manipulator) {

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -19,18 +19,19 @@ package com.google.android.filament.utils
 import android.view.MotionEvent
 import android.view.Surface
 import android.view.SurfaceView
+import android.view.TextureView
 import com.google.android.filament.*
 import com.google.android.filament.android.UiHelper
 import com.google.android.filament.gltfio.*
 import java.nio.Buffer
 
 /**
- * Helper class for rendering glTF models with an orbit controller.
+ * Helps render glTF models into a [SurfaceView] or [TextureView] with an orbit controller.
  *
  * `ModelViewer` owns a Filament engine, renderer, swapchain, view, and scene. It allows clients
- * to access these objects via read-only properties. By design, the viewer can display only one
- * glTF scene at a time. The scene can be scaled and translated into the viewing frustum by
- * calling [transformToUnitCube]. All ECS entities can be accessed via the [asset] property.
+ * to access these objects via read-only properties. The viewer can display only one glTF scene
+ * at a time, which can be scaled and translated into the viewing frustum by calling
+ * [transformToUnitCube]. All ECS entities can be accessed via the [asset] property.
  *
  * For GLB files, clients can call [loadModelGlb] and pass in a [Buffer] with the contents of the
  * GLB file. For glTF files, clients can call [loadModelGltf] and pass in a [Buffer] with the JSON
@@ -46,7 +47,7 @@ import java.nio.Buffer
  *
  * See `sample-gltf-viewer` for a usage example.
  */
-class ModelViewer(val surfaceView: SurfaceView) {
+class ModelViewer {
 
     var asset: FilamentAsset? = null
         private set
@@ -78,23 +79,7 @@ class ModelViewer(val surfaceView: SurfaceView) {
     private val kShutterSpeed = 1f / 125f
     private val kSensitivity = 100f
 
-    /**
-     * Creates the Filament engine, scene, and helper objects.
-     *
-     * When the model viewer is no longer needed, clients should call [detach] to explicitly
-     * free all native objects.
-     */
     init {
-        uiHelper.renderCallback = SurfaceCallback()
-        uiHelper.attachTo(surfaceView)
-
-        cameraManipulator = Manipulator.Builder()
-                .targetPosition(0.0f, 0.0f, -4.0f)
-                .viewport(surfaceView.width, surfaceView.height)
-                .build(Manipulator.Mode.ORBIT)
-
-        gestureDetector = GestureDetector(surfaceView, cameraManipulator)
-
         engine = Engine.create()
         renderer = engine.createRenderer()
         scene = engine.createScene()
@@ -119,6 +104,29 @@ class ModelViewer(val surfaceView: SurfaceView) {
                 .build(engine, light)
 
         scene.addEntity(light)
+    }
+
+    constructor(surfaceView: SurfaceView) {
+        cameraManipulator = Manipulator.Builder()
+                .targetPosition(0.0f, 0.0f, -4.0f)
+                .viewport(surfaceView.width, surfaceView.height)
+                .build(Manipulator.Mode.ORBIT)
+
+        gestureDetector = GestureDetector(surfaceView, cameraManipulator)
+        uiHelper.renderCallback = SurfaceCallback()
+        uiHelper.attachTo(surfaceView)
+    }
+
+    @Suppress("unused")
+    constructor(textureView: TextureView) {
+        cameraManipulator = Manipulator.Builder()
+                .targetPosition(0.0f, 0.0f, -4.0f)
+                .viewport(textureView.width, textureView.height)
+                .build(Manipulator.Mode.ORBIT)
+
+        gestureDetector = GestureDetector(textureView, cameraManipulator)
+        uiHelper.renderCallback = SurfaceCallback()
+        uiHelper.attachTo(textureView)
     }
 
     /**

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament.utils
+
+import android.view.MotionEvent
+import android.view.Surface
+import android.view.SurfaceView
+import com.google.android.filament.*
+import com.google.android.filament.android.UiHelper
+import com.google.android.filament.gltfio.*
+import java.nio.Buffer
+
+/**
+ * Helper class for rendering glTF models with an orbit controller.
+ *
+ * `ModelViewer` owns a Filament engine, renderer, swapchain, view, and scene. It allows clients
+ * to access these objects via read-only properties. By design, the viewer can display only one
+ * glTF scene at a time. The scene can be scaled and translated into the viewing frustum by
+ * calling [transformToUnitCube]. All ECS entities can be accessed via the [asset] property.
+ *
+ * For GLB files, clients can call [loadModelGlb] and pass in a [Buffer] with the contents of the
+ * GLB file. For glTF files, clients can call [loadModelGltf] and pass in a [Buffer] with the JSON
+ * contents, as well as a callback for loading external resources.
+ *
+ * `ModelViewer` reduces much of the boilerplate required for simple Filament applications, but
+ * clients still have the responsibility of adding an [IndirectLight] and [Skybox] to the scene.
+ * Additionally, clients should:
+ *
+ * 1. Call [onTouchEvent] from a touch handler.
+ * 2. Call [render] and [Animator.applyAnimation] from a `Choreographer` frame callback.
+ * 3. Call [detach] when the model viewer is no longer needed.
+ *
+ * See `sample-gltf-viewer` for a usage example.
+ */
+class ModelViewer(val surfaceView: SurfaceView) {
+
+    var asset: FilamentAsset? = null
+        private set
+
+    var animator: Animator? = null
+        private set
+
+    val engine: Engine
+    val scene: Scene
+    val view: View
+    val camera: Camera
+    @Entity val light: Int
+
+    private val uiHelper: UiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK)
+    private val cameraManipulator: Manipulator
+    private val gestureDetector: GestureDetector
+    private val renderer: Renderer
+    private var swapChain: SwapChain? = null
+    private var assetLoader: AssetLoader
+
+    private val eyePos = DoubleArray(3)
+    private val target = DoubleArray(3)
+    private val upward = DoubleArray(3)
+
+    private val kNearPlane = 0.5
+    private val kFarPlane = 10000.0
+    private val kFovDegrees = 45.0
+    private val kAperture = 16f
+    private val kShutterSpeed = 1f / 125f
+    private val kSensitivity = 100f
+
+    /**
+     * Creates the Filament engine, scene, and helper objects.
+     *
+     * When the model viewer is no longer needed, clients should call [detach] to explicitly
+     * free all native objects.
+     */
+    init {
+        uiHelper.renderCallback = SurfaceCallback()
+        uiHelper.attachTo(surfaceView)
+
+        cameraManipulator = Manipulator.Builder()
+                .targetPosition(0.0f, 0.0f, -4.0f)
+                .viewport(surfaceView.width, surfaceView.height)
+                .build(Manipulator.Mode.ORBIT)
+
+        gestureDetector = GestureDetector(surfaceView, cameraManipulator)
+
+        engine = Engine.create()
+        renderer = engine.createRenderer()
+        scene = engine.createScene()
+        camera = engine.createCamera().apply { setExposure(kAperture, kShutterSpeed, kSensitivity) }
+        view = engine.createView()
+        view.scene = scene
+        view.camera = camera
+
+        assetLoader = AssetLoader(engine, MaterialProvider(engine), EntityManager.get())
+
+        // Always add a direct light source since it is required for shadowing.
+        // We highly recommend adding an indirect light as well.
+
+        light = EntityManager.get().create()
+
+        val (r, g, b) = Colors.cct(6_500.0f)
+        LightManager.Builder(LightManager.Type.DIRECTIONAL)
+                .color(r, g, b)
+                .intensity(300_000.0f)
+                .direction(0.0f, -1.0f, 0.0f)
+                .castShadows(true)
+                .build(engine, light)
+
+        scene.addEntity(light)
+    }
+
+    /**
+     * Loads a monolithic binary glTF and populates the Filament scene.
+     */
+    fun loadModelGlb(buffer: Buffer) {
+        destroyModel()
+        asset = assetLoader.createAssetFromJson(buffer)
+        asset?.let { asset ->
+            val resourceLoader = ResourceLoader(engine)
+            resourceLoader.loadResources(asset)
+            resourceLoader.destroy()
+            animator = asset.animator
+            asset.releaseSourceData()
+            scene.addEntities(asset.entities)
+        }
+    }
+
+    /**
+     * Loads a JSON-style glTF file and populates the Filament scene.
+     */
+    fun loadModelGltf(buffer: Buffer, callback: (String) -> Buffer) {
+        destroyModel()
+        asset = assetLoader.createAssetFromJson(buffer)
+        asset?.let { asset ->
+            val resourceLoader = ResourceLoader(engine)
+            for (uri in asset.resourceUris) {
+                resourceLoader.addResourceData(uri, callback(uri))
+            }
+            resourceLoader.loadResources(asset)
+            resourceLoader.destroy()
+            animator = asset.animator
+            asset.releaseSourceData()
+            scene.addEntities(asset.entities)
+        }
+    }
+
+    /**
+     * Sets up a root transform on the current model to make it fit into the viewing frustum.
+     */
+    fun transformToUnitCube() {
+        asset?.let { asset ->
+            val tm = engine.transformManager
+            val center = asset.boundingBox.center.let { v-> Float3(v[0], v[1], v[2]) }
+            val halfExtent = asset.boundingBox.halfExtent.let { v-> Float3(v[0], v[1], v[2]) }
+            val maxExtent = 2.0f * max(halfExtent)
+            val scaleFactor = 2.0f / maxExtent
+            center.z = center.z + 4.0f / scaleFactor
+            val transform = scale(Float3(scaleFactor)) * translation(Float3(-center))
+            tm.setTransform(tm.getInstance(asset.root), transpose(transform).toFloatArray())
+        }
+    }
+
+    /**
+     * Frees all entities associated with the most recently-loaded model.
+     *
+     * @see detach
+     */
+    fun destroyModel() {
+        asset?.let { asset ->
+            assetLoader.destroyAsset(asset)
+            this.asset = null
+            this.animator = null
+        }
+    }
+
+    /**
+     * Destroys the Filament engine and all related objects.
+     *
+     * The ModelViewer becomes invalid after this is called.
+     *
+     * @see destroyModel
+     */
+    fun detach() {
+        uiHelper.detach()
+
+        destroyModel()
+        assetLoader.destroy()
+
+        engine.destroyEntity(light)
+        engine.destroyRenderer(renderer)
+        engine.destroyView(view)
+        engine.destroyScene(scene)
+        engine.destroyCamera(camera)
+
+        EntityManager.get().destroy(light)
+
+        engine.destroy()
+    }
+
+    /**
+     * Renders the model and updates the Filament camera.
+     */
+    fun render() {
+        if (!uiHelper.isReadyToRender) {
+            return
+        }
+
+        cameraManipulator.getLookAt(eyePos, target, upward)
+        camera.lookAt(
+                eyePos[0], eyePos[1], eyePos[2],
+                target[0], target[1], target[2],
+                upward[0], upward[1], upward[2])
+
+        if (renderer.beginFrame(swapChain!!)) {
+            renderer.render(view)
+            renderer.endFrame()
+        }
+    }
+
+    /**
+     * Handles a [MotionEvent] to enable one-finger orbit, two-finger pan, and pinch-to-zoom.
+     */
+    fun onTouchEvent(event: MotionEvent) {
+        gestureDetector.onTouchEvent(event)
+    }
+
+    inner class SurfaceCallback : UiHelper.RendererCallback {
+        override fun onNativeWindowChanged(surface: Surface) {
+            swapChain?.let { engine.destroySwapChain(it) }
+            swapChain = engine.createSwapChain(surface)
+        }
+
+        override fun onDetachedFromSurface() {
+            swapChain?.let {
+                engine.destroySwapChain(it)
+                engine.flushAndWait()
+                swapChain = null
+            }
+        }
+
+        override fun onResized(width: Int, height: Int) {
+            view.viewport = Viewport(0, 0, width, height)
+            val aspect = width.toDouble() / height.toDouble()
+            camera.setProjection(kFovDegrees, aspect, kNearPlane, kFarPlane, Camera.Fov.VERTICAL)
+            cameraManipulator.setViewport(width, height)
+        }
+    }
+}

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Utils.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Utils.kt
@@ -16,12 +16,11 @@
 
 package com.google.android.filament.utils;
 
-public class Utils {
-
+object Utils {
     /**
      * Initializes the utils JNI layer. Must be called before using any utils functionality.
      */
-    public static void init() {
-        System.loadLibrary("filament-utils-jni");
+    fun init() {
+        System.loadLibrary("filament-utils-jni")
     }
 }

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -16,20 +16,20 @@
 
 package com.google.android.filament.gltf
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
-import android.view.Choreographer
-import android.view.Surface
-import android.view.SurfaceView
 import android.util.Log
-
-import com.google.android.filament.*
-import com.google.android.filament.android.UiHelper
-import com.google.android.filament.gltfio.*
-import com.google.android.filament.utils.*
-
+import android.view.Choreographer
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.SurfaceView
+import com.google.android.filament.utils.KtxLoader
+import com.google.android.filament.utils.ModelViewer
+import com.google.android.filament.utils.Utils
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
+
 
 class MainActivity : Activity() {
 
@@ -39,118 +39,67 @@ class MainActivity : Activity() {
     }
 
     private lateinit var surfaceView: SurfaceView
-    private lateinit var uiHelper: UiHelper
     private lateinit var choreographer: Choreographer
     private val frameScheduler = FrameCallback()
+    private lateinit var modelViewer: ModelViewer
+    private val doubleTapListener = DoubleTapListener()
+    private lateinit var doubleTapDetector: GestureDetector
 
-    // gltfio and utils objects
-    private lateinit var manipulator: Manipulator
-    private lateinit var assetLoader: AssetLoader
-    private lateinit var filamentAsset: FilamentAsset
-    private lateinit var gestureDetector: GestureDetector
-    private lateinit var filamentAnimator: Animator
-
-    // core filament objects
-    private lateinit var engine: Engine
-    private lateinit var renderer: Renderer
-    private lateinit var scene: Scene
-    private lateinit var view: View
-    private lateinit var camera: Camera
-    private var swapChain: SwapChain? = null
-    @Entity private var light = 0
-
+    @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         surfaceView = SurfaceView(this).apply { setContentView(this) }
-
         choreographer = Choreographer.getInstance()
 
-        uiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK)
-        uiHelper.renderCallback = SurfaceCallback()
-        uiHelper.attachTo(surfaceView)
+        doubleTapDetector = GestureDetector(applicationContext, doubleTapListener)
 
-        manipulator = Manipulator.Builder()
-                .targetPosition(0.0f, 0.0f, -4.0f)
-                .viewport(surfaceView.width, surfaceView.height)
-                .build(Manipulator.Mode.ORBIT)
+        modelViewer = ModelViewer(surfaceView)
 
-        gestureDetector = GestureDetector(surfaceView, manipulator)
+        surfaceView.setOnTouchListener { _, event ->
+            modelViewer.onTouchEvent(event)
+            doubleTapDetector.onTouchEvent(event)
+            true
+        }
 
-        // Engine, Renderer, Scene, Camera, View
-        // -------------------------------------
+        createRenderables()
+        createIndirectLight()
+    }
 
-        engine = Engine.create()
-        renderer = engine.createRenderer()
-        scene = engine.createScene()
-        camera = engine.createCamera().apply { setExposure(16.0f, 1.0f / 125.0f, 100.0f) }
-        view = engine.createView()
-        view.scene = scene
-        view.camera = camera
+    private fun createRenderables() {
+        val buffer = assets.open("models/scene.gltf").use { input ->
+            val bytes = ByteArray(input.available())
+            input.read(bytes)
+            ByteBuffer.wrap(bytes)
+        }
+        modelViewer.loadModelGltf(buffer) { uri ->
+            readUncompressedAsset("models/$uri")
+        }
+        modelViewer.transformToUnitCube()
+    }
 
-        // IndirectLight and SkyBox
-        // ------------------------
-
+    private fun createIndirectLight() {
+        val engine = modelViewer.engine
+        val scene = modelViewer.scene
         val ibl = "venetian_crossroads_2k"
-
         readUncompressedAsset("envs/$ibl/${ibl}_ibl.ktx").let {
             scene.indirectLight = KtxLoader.createIndirectLight(engine, it, KtxLoader.Options())
             scene.indirectLight!!.intensity = 50_000.0f
         }
-
         readUncompressedAsset("envs/$ibl/${ibl}_skybox.ktx").let {
             scene.skybox = KtxLoader.createSkybox(engine, it, KtxLoader.Options())
         }
+    }
 
-        // glTF Entities, Textures, and Materials
-        // --------------------------------------
-
-        assetLoader = AssetLoader(engine, MaterialProvider(engine), EntityManager.get())
-
-        filamentAsset = assets.open("models/scene.gltf").use { input ->
-            val bytes = ByteArray(input.available())
-            input.read(bytes)
-            assetLoader.createAssetFromJson(ByteBuffer.wrap(bytes))!!
+    private fun readUncompressedAsset(assetName: String): ByteBuffer {
+        Log.i("gltf-viewer", "Reading ${assetName}...")
+        assets.openFd(assetName).use { fd ->
+            val input = fd.createInputStream()
+            val dst = ByteBuffer.allocate(fd.length.toInt())
+            val src = Channels.newChannel(input)
+            src.read(dst)
+            src.close()
+            return dst.apply { rewind() }
         }
-
-        val resourceLoader = ResourceLoader(engine)
-        for (uri in filamentAsset.resourceUris) {
-            val buffer = readUncompressedAsset("models/$uri")
-            resourceLoader.addResourceData(uri, buffer)
-        }
-        resourceLoader.loadResources(filamentAsset)
-        resourceLoader.destroy()
-        filamentAnimator = filamentAsset.animator
-        filamentAsset.releaseSourceData()
-
-        scene.addEntities(filamentAsset.entities)
-
-        // Transform to unit cube
-        // ----------------------
-
-        val tm = engine.transformManager
-        val center = filamentAsset.boundingBox.center.let { Float3(it[0], it[1], it[2]) }
-        val halfExtent  = filamentAsset.boundingBox.halfExtent.let { Float3(it[0], it[1], it[2]) }
-        val maxExtent = 2.0f * max(halfExtent)
-        val scaleFactor = 2.0f / maxExtent
-        center.z = center.z + 4.0f / scaleFactor
-        val xform = scale(Float3(scaleFactor)) * translation(Float3(-center))
-        tm.setTransform(tm.getInstance(filamentAsset.root), transpose(xform).toFloatArray())
-
-        // Light Sources
-        // -------------
-
-        light = EntityManager.get().create()
-
-        val (r, g, b) = Colors.cct(6_500.0f)
-        LightManager.Builder(LightManager.Type.DIRECTIONAL)
-                .color(r, g, b)
-                .intensity(300_000.0f)
-                .direction(0.0f, -1.0f, 0.0f)
-                .castShadows(true)
-                .build(engine, light)
-
-        scene.addEntity(light)
     }
 
     override fun onResume() {
@@ -165,96 +114,33 @@ class MainActivity : Activity() {
 
     override fun onDestroy() {
         super.onDestroy()
-
-        // Stop the animation and any pending frame
         choreographer.removeFrameCallback(frameScheduler)
-
-        // Always detach the surface before destroying the engine
-        uiHelper.detach()
-
-        assetLoader.destroyAsset(filamentAsset)
-        assetLoader.destroy()
-
-        engine.destroyEntity(light)
-        engine.destroyRenderer(renderer)
-        engine.destroyView(view)
-        engine.destroyScene(scene)
-        engine.destroyCamera(camera)
-
-        // Engine.destroyEntity() destroys Filament components only, not the entity itself.
-        val entityManager = EntityManager.get()
-        entityManager.destroy(light)
-
-        // Destroying the engine will free up any resource you may have forgotten
-        // to destroy, but it's recommended to do the cleanup properly
-        engine.destroy()
+        modelViewer.scene.skybox?.let { modelViewer.engine.destroySkybox(it) }
+        modelViewer.scene.indirectLight?.let { modelViewer.engine.destroyIndirectLight(it) }
+        modelViewer.detach()
     }
 
     inner class FrameCallback : Choreographer.FrameCallback {
-        private val eyepos = DoubleArray(3)
-        private val target = DoubleArray(3)
-        private val upward = DoubleArray(3)
         private val startTime = System.nanoTime()
         override fun doFrame(frameTimeNanos: Long) {
             choreographer.postFrameCallback(this)
 
-            if (!uiHelper.isReadyToRender) {
-                return
+            modelViewer.animator?.apply {
+                val elapsedTimeSeconds = (frameTimeNanos - startTime).toDouble() / 1_000_000_000
+                this.applyAnimation(0, elapsedTimeSeconds.toFloat())
+                this.updateBoneMatrices()
             }
 
-            manipulator.getLookAt(eyepos, target, upward)
-            camera.lookAt(
-                    eyepos[0], eyepos[1], eyepos[2],
-                    target[0], target[1], target[2],
-                    upward[0], upward[1], upward[2])
-
-            val elapsedTimeSeconds = (frameTimeNanos - startTime).toDouble() / 1_000_000_000
-            filamentAsset.animator.applyAnimation(0, elapsedTimeSeconds.toFloat())
-            filamentAsset.animator.updateBoneMatrices()
-
-            if (renderer.beginFrame(swapChain!!)) {
-                renderer.render(view)
-                renderer.endFrame()
-            }
+            modelViewer.render()
         }
     }
 
-    inner class SurfaceCallback : UiHelper.RendererCallback {
-        override fun onNativeWindowChanged(surface: Surface) {
-            swapChain?.let { engine.destroySwapChain(it) }
-            swapChain = engine.createSwapChain(surface)
-        }
-
-        override fun onDetachedFromSurface() {
-            swapChain?.let {
-                engine.destroySwapChain(it)
-                // Required to ensure we don't return before Filament is done executing the
-                // destroySwapChain command, otherwise Android might destroy the Surface
-                // too early
-                engine.flushAndWait()
-                swapChain = null
-            }
-        }
-
-        override fun onResized(width: Int, height: Int) {
-            view.viewport = Viewport(0, 0, width, height)
-            val aspect = width.toDouble() / height.toDouble()
-            camera.setProjection(45.0, aspect, 0.5, 10000.0, Camera.Fov.VERTICAL)
-            manipulator.setViewport(width, height)
-        }
-    }
-
-    private fun readUncompressedAsset(assetName: String): ByteBuffer {
-        Log.i("gltf-viewer", "Reading ${assetName}...")
-        assets.openFd(assetName).use { fd ->
-            val input = fd.createInputStream()
-            val dst = ByteBuffer.allocate(fd.length.toInt())
-
-            val src = Channels.newChannel(input)
-            src.read(dst)
-            src.close()
-
-            return dst.apply { rewind() }
+    // Just for testing purposes, this releases the model and reloads it.
+    inner class DoubleTapListener : GestureDetector.SimpleOnGestureListener() {
+        override fun onDoubleTap(e: MotionEvent?): Boolean {
+            modelViewer.destroyModel()
+            createRenderables()
+            return super.onDoubleTap(e)
         }
     }
 }

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -19,7 +19,6 @@ package com.google.android.filament.gltf
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
-import android.util.Log
 import android.view.Choreographer
 import android.view.GestureDetector
 import android.view.MotionEvent
@@ -91,7 +90,6 @@ class MainActivity : Activity() {
     }
 
     private fun readUncompressedAsset(assetName: String): ByteBuffer {
-        Log.i("gltf-viewer", "Reading ${assetName}...")
         assets.openFd(assetName).use { fd ->
             val input = fd.createInputStream()
             val dst = ByteBuffer.allocate(fd.length.toInt())

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -29,7 +29,6 @@ import com.google.android.filament.utils.Utils
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 
-
 class MainActivity : Activity() {
 
     companion object {
@@ -113,9 +112,6 @@ class MainActivity : Activity() {
     override fun onDestroy() {
         super.onDestroy()
         choreographer.removeFrameCallback(frameScheduler)
-        modelViewer.scene.skybox?.let { modelViewer.engine.destroySkybox(it) }
-        modelViewer.scene.indirectLight?.let { modelViewer.engine.destroyIndirectLight(it) }
-        modelViewer.detach()
     }
 
     inner class FrameCallback : Choreographer.FrameCallback {


### PR DESCRIPTION
This reduces the LOC of our gltf-viewer app from 260 to 146. This could
have been more, but I feel this provides good balance between
flexibility and convenience.

The raw gltfio API involves multiple objects (FilamentAsset,
AssetLoader, ResourceLoader) whereas the ModelViewer has a simple facade
consisting of two methods, one for GLB and one for GLTF. The underlying
gltfio objects are available via non-settable properties.