### PR TITLE
New API to import textures into filament

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -70,11 +70,12 @@
 #define PAIR_ARGS_6(M, X, Y, ...) M(X, Y), EXPAND(PAIR_ARGS_5(M, __VA_ARGS__))
 #define PAIR_ARGS_7(M, X, Y, ...) M(X, Y), EXPAND(PAIR_ARGS_6(M, __VA_ARGS__))
 #define PAIR_ARGS_8(M, X, Y, ...) M(X, Y), EXPAND(PAIR_ARGS_7(M, __VA_ARGS__))
+#define PAIR_ARGS_9(M, X, Y, ...) M(X, Y), EXPAND(PAIR_ARGS_8(M, __VA_ARGS__))
 
-#define PAIR_ARGS_N__(_0, E1, _1, E2, _2, E3, _3, E4, _4, E5, _5, E6, _6, E7, _7, E8, _8, X, ...) PAIR_ARGS_##X
+#define PAIR_ARGS_N__(_0, E1, _1, E2, _2, E3, _3, E4, _4, E5, _5, E6, _6, E7, _7, E8, _8, E9, _9, X, ...) PAIR_ARGS_##X
 
 #define PAIR_ARGS_N(M, ...) \
-    EXPAND(EXPAND(PAIR_ARGS_N__(0, ##__VA_ARGS__, 8, E, 7, E, 6, E, 5, E, 4, E, 3, E, 2, E, 1, E, 0))(M, __VA_ARGS__))
+    EXPAND(EXPAND(PAIR_ARGS_N__(0, ##__VA_ARGS__, 9, E, 8, E, 7, E, 6, E, 5, E, 4, E, 3, E, 2, E, 1, E, 0))(M, __VA_ARGS__))
 
 #define ARG(T, P) T P
 
@@ -145,6 +146,17 @@ DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
+        backend::SamplerType, target,
+        uint8_t, levels,
+        backend::TextureFormat, format,
+        uint8_t, samples,
+        uint32_t, width,
+        uint32_t, height,
+        uint32_t, depth,
+        backend::TextureUsage, usage)
+
+DECL_DRIVER_API_R_N(backend::TextureHandle, importTexture,
+        intptr_t, id,
         backend::SamplerType, target,
         uint8_t, levels,
         backend::TextureFormat, format,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -156,6 +156,12 @@ void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8
             width, height, depth, usage);
 }
 
+void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
+        SamplerType target, uint8_t levels,
+        TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
+        uint32_t depth, TextureUsage usage) {
+}
+
 void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
     construct_handle<MetalSamplerGroup>(mHandleMap, sbh, size);
 }
@@ -243,6 +249,10 @@ Handle<HwIndexBuffer> MetalDriver::createIndexBufferS() noexcept {
 }
 
 Handle<HwTexture> MetalDriver::createTextureS() noexcept {
+    return alloc_handle<MetalTexture, HwTexture>();
+}
+
+Handle<HwTexture> MetalDriver::importTextureS() noexcept {
     return alloc_handle<MetalTexture, HwTexture>();
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -109,6 +109,7 @@ public:
             int8_t baseLevel = 127;
             int8_t maxLevel = -1;
             uint8_t targetIndex = 0;    // optimization: index corresponding to target
+            bool imported = false;
         } gl;
 
         void* platformPImpl = nullptr;

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -358,9 +358,15 @@ backend::FenceStatus PlatformEGL::waitFence(
 void PlatformEGL::createExternalImageTexture(void* texture) noexcept {
     auto* t = (OpenGLDriver::GLTexture*) texture;
     glGenTextures(1, &t->gl.id);
-    if (ext.OES_EGL_image_external_essl3) {
+    if (UTILS_LIKELY(ext.OES_EGL_image_external_essl3)) {
+        t->gl.target = GL_TEXTURE_EXTERNAL_OES;
         t->gl.targetIndex = (uint8_t)
-                OpenGLContext::getIndexForTextureTarget(t->gl.target = GL_TEXTURE_EXTERNAL_OES);
+                OpenGLContext::getIndexForTextureTarget(GL_TEXTURE_EXTERNAL_OES);
+    } else {
+        // if texture external is not supported, revert to texture 2d
+        t->gl.target = GL_TEXTURE_2D;
+        t->gl.targetIndex = (uint8_t)
+                OpenGLContext::getIndexForTextureTarget(GL_TEXTURE_2D);
     }
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -366,6 +366,13 @@ void VulkanDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
     });
 }
 
+void VulkanDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
+        SamplerType target, uint8_t levels,
+        TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
+        TextureUsage usage) {
+    // not support in this backend
+}
+
 void VulkanDriver::destroyTexture(Handle<HwTexture> th) {
     if (th) {
         auto texture = handle_cast<VulkanTexture>(mHandleMap, th);
@@ -459,6 +466,10 @@ Handle<HwIndexBuffer> VulkanDriver::createIndexBufferS() noexcept {
 }
 
 Handle<HwTexture> VulkanDriver::createTextureS() noexcept {
+    return alloc_handle<VulkanTexture, HwTexture>();
+}
+
+Handle<HwTexture> VulkanDriver::importTextureS() noexcept {
     return alloc_handle<VulkanTexture, HwTexture>();
 }
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -188,6 +188,10 @@ public:
          */
         Texture* build(Engine& engine);
 
+        /* no user serviceable parts below */
+
+        Builder& import(intptr_t id) noexcept;
+
     private:
         friend class details::FTexture;
     };

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -29,6 +29,8 @@
 #include <ibl/Image.h>
 
 #include <utils/Panic.h>
+#include <filament/Texture.h>
+
 
 using namespace utils;
 
@@ -38,6 +40,7 @@ using namespace details;
 using namespace backend;
 
 struct Texture::BuilderDetails {
+    intptr_t mImportedId = 0;
     uint32_t mWidth = 1;
     uint32_t mHeight = 1;
     uint32_t mDepth = 1;
@@ -91,6 +94,12 @@ Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
     return *this;
 }
 
+Texture::Builder& Texture::Builder::import(intptr_t id) noexcept {
+    assert(id); // imported id can't be zero
+    mImpl->mImportedId = id;
+    return *this;
+}
+
 Texture* Texture::Builder::build(Engine& engine) {
     FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_POSTCONDITION_NON_FATAL(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
@@ -115,8 +124,14 @@ FTexture::FTexture(FEngine& engine, const Builder& builder) {
             static_cast<uint8_t>(std::ilogbf(std::max(mWidth, mHeight)) + 1));
 
     FEngine::DriverApi& driver = engine.getDriverApi();
-    mHandle = driver.createTexture(
-            mTarget, mLevelCount, mFormat, mSampleCount, mWidth, mHeight, mDepth, mUsage);
+    if (UTILS_LIKELY(builder->mImportedId == 0)) {
+        mHandle = driver.createTexture(
+                mTarget, mLevelCount, mFormat, mSampleCount, mWidth, mHeight, mDepth, mUsage);
+    } else {
+        assert(mUsage & TextureUsage::SAMPLEABLE);
+        mHandle = driver.importTexture(builder->mImportedId,
+                mTarget, mLevelCount, mFormat, mSampleCount, mWidth, mHeight, mDepth, mUsage);
+    }
 }
 
 // frees driver resources, object becomes invalid

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -87,6 +87,7 @@ public:
 
 private:
     friend class Texture;
+    FStream* mStream = nullptr;
     backend::Handle<backend::HwTexture> mHandle;
     uint32_t mWidth = 1;
     uint32_t mHeight = 1;
@@ -95,7 +96,6 @@ private:
     Sampler mTarget = Sampler::SAMPLER_2D;
     uint8_t mLevelCount = 1;
     uint8_t mSampleCount = 1;
-    FStream* mStream = nullptr;
     Usage mUsage = Usage::DEFAULT;
 };
 


### PR DESCRIPTION
If you need this, you know who you are.
The new Texture::Builder::import() allows to specify a OpenGLES texture
id from a shared GL context, effectively importing the texture into
filament.
The texture is NOT destroyed when calling Engine::destroy(Texture*), only
its filament handle.