### PR TITLE
Fix some macOS / iOS build warnings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -146,6 +146,13 @@ function build_desktop_target {
 
     cd out/cmake-${lc_target}
 
+    # On macOS, set the deployment target to 10.14.
+    local name=`echo $(uname)`
+    local lc_name=`echo $name | tr '[:upper:]' '[:lower:]'`
+    if [[ "$lc_name" == "darwin" ]]; then
+        local deployment_target="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14"
+    fi
+
     if [[ ! -d "CMakeFiles" ]] || [[ "$ISSUE_CMAKE_ALWAYS" == "true" ]]; then
         cmake \
             -G "$BUILD_GENERATOR" \
@@ -153,6 +160,7 @@ function build_desktop_target {
             -DCMAKE_BUILD_TYPE=$1 \
             -DCMAKE_INSTALL_PREFIX=../${lc_target}/filament \
             -DENABLE_JAVA=${ENABLE_JAVA} \
+            ${deployment_target} \
             ../..
     fi
     ${BUILD_COMMAND} ${build_targets}

--- a/filament/backend/src/opengl/CocoaTouchExternalImage.mm
+++ b/filament/backend/src/opengl/CocoaTouchExternalImage.mm
@@ -25,6 +25,7 @@
 
 #include <math/vec2.h>
 
+#include <utils/compiler.h>
 #include <utils/Panic.h>
 
 namespace filament {
@@ -143,7 +144,7 @@ bool CocoaTouchExternalImage::set(CVPixelBufferRef image) noexcept {
 
     // The pixel buffer must be locked whenever we do rendering with it. We'll unlock it before
     // releasing.
-    CVReturn lockStatus = CVPixelBufferLockBaseAddress(image, 0);
+    UTILS_UNUSED_IN_RELEASE CVReturn lockStatus = CVPixelBufferLockBaseAddress(image, 0);
     assert(lockStatus == kCVReturnSuccess);
 
     if (planeCount == 0) {
@@ -217,9 +218,10 @@ CVOpenGLESTextureRef CocoaTouchExternalImage::createTextureFromImage(CVPixelBuff
     const size_t height = CVPixelBufferGetHeightOfPlane(image, plane);
 
     CVOpenGLESTextureRef texture = nullptr;
-    CVReturn success = CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
-        mTextureCache, image, nullptr, GL_TEXTURE_2D, glFormat, width, height,
-        glFormat, GL_UNSIGNED_BYTE, plane, &texture);
+    UTILS_UNUSED_IN_RELEASE CVReturn success =
+            CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+            mTextureCache, image, nullptr, GL_TEXTURE_2D, glFormat, width, height,
+            glFormat, GL_UNSIGNED_BYTE, plane, &texture);
     assert(success == kCVReturnSuccess);
 
     return texture;


### PR DESCRIPTION
This fixes a deprecation warning in `MetalDriver.mm` and a few unused variable warnings. CMake must be re-run before the deprecation warning will be silenced.