### PR TITLE
gltfio: Introduce the asynchronous API and use it.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - The Android support libraries (gltfio and filament-utils) now use dynamic linking.
 - Screen-space refraction is now supported.
 - Removed depth-prepass related APIs.
+- gltfio: add asynchronous API to ResourceLoader.
 
 ## v1.4.5
 

--- a/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
@@ -76,3 +76,25 @@ Java_com_google_android_filament_gltfio_ResourceLoader_nLoadResources(JNIEnv*, j
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
     loader->loadResources(asset);
 }
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_gltfio_ResourceLoader_nAsyncBeginLoad(JNIEnv*, jclass,
+        jlong nativeLoader, jlong nativeAsset) {
+    ResourceLoader* loader = (ResourceLoader*) nativeLoader;
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    return loader->asyncBeginLoad(asset);
+}
+
+extern "C" JNIEXPORT jfloat JNICALL
+Java_com_google_android_filament_gltfio_ResourceLoader_nAsyncGetLoadProgress(JNIEnv*, jclass,
+        jlong nativeLoader) {
+    ResourceLoader* loader = (ResourceLoader*) nativeLoader;
+    return loader->asyncGetLoadProgress();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_ResourceLoader_nAsyncUpdateLoad(JNIEnv*, jclass,
+        jlong nativeLoader) {
+    ResourceLoader* loader = (ResourceLoader*) nativeLoader;
+    loader->asyncUpdateLoad();
+}

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
@@ -26,9 +26,10 @@ import java.lang.reflect.Method;
 import java.nio.Buffer;
 
 /**
- * Uploads vertex buffers and textures to the GPU and computes tangents.
+ * Prepares and uploads vertex buffers and textures to the GPU.
  *
- * <p>For a usage example, see the documentation for {@link AssetLoader}.</p>
+ * <p>For a usage example, see the documentation for {@link AssetLoader}.
+ * All methods should be called from the main thread.</p>
  *
  * @see AssetLoader
  * @see FilamentAsset
@@ -58,12 +59,15 @@ public class ResourceLoader {
     /**
      * Feeds the binary content of an external resource into the loader's URI cache.
      *
-     * <p><code>ResourceLoader</code> does not know how to download external resources on its own
-     * (for example, external resources might come from a filesystem, a database, or the internet)
-     * so this method allows clients to download external resources and push them to the loader.</p>
+     * On some platforms, `ResourceLoader` does not know how to download external resources on its
+     * own (external resources might come from a filesystem, a database, or the internet) so this
+     * method allows clients to download external resources and push them to the loader.
      *
-     * <p>When loading GLB files (as opposed to JSON-based glTF files), clients typically do not
-     * need to call this method.</p>
+     * Every resource should be passed in before calling [loadResources] or [asyncBeginLoad]. See
+     * also [FilamentAsset#getResourceUris].
+     *
+     * When loading GLB files (as opposed to JSON-based glTF files), clients typically do not
+     * need to call this method.
      *
      * @param uri the string path that matches an image URI or buffer URI in the glTF
      * @param buffer the binary blob corresponding to the given URI
@@ -76,7 +80,7 @@ public class ResourceLoader {
     }
 
     /**
-     * Checks if the given resource has already been loaded.
+     * Checks if the given resource has already been added to the URI cache.
      */
     public boolean hasResourceData(@NonNull String uri) {
         return nHasResourceData(mNativeObject, uri);
@@ -86,8 +90,7 @@ public class ResourceLoader {
      * Iterates through all external buffers and images and creates corresponding Filament objects
      * (vertex buffers, textures, etc), which become owned by the asset.
      *
-     * <p>This is the main entry point for <code>ResourceLoader</code>, and only needs to be called
-     * once.</p>
+     * NOTE: this is a synchronous API, please see [asyncBeginLoad] as an alternative.
      *
      * @param asset the Filament asset that contains URI-based resources
      * @return self (for daisy chaining)
@@ -98,10 +101,43 @@ public class ResourceLoader {
         return this;
     }
 
+    /**
+     * Starts an asynchronous resource load.
+     *
+     * Returns false if the loading process was unable to start.
+     *
+     * This is an alternative to #loadResources and requires periodic calls to #asyncUpdateLoad.
+     * On multi-threaded systems this creates threads for texture decoding.
+     */
+    public boolean asyncBeginLoad(@NonNull FilamentAsset asset) {
+        return nAsyncBeginLoad(mNativeObject, asset.getNativeObject());
+    }
+
+    /**
+     * Gets the status of an asynchronous resource load as a percentage in [0,1].
+     */
+    public float asyncGetLoadProgress() {
+        return nAsyncGetLoadProgress(mNativeObject);
+    }
+
+    /**
+     * Updates an asynchronous load by performing any pending work that must take place
+     * on the main thread.
+     *
+     * Clients must periodically call this until #asyncGetLoadProgress returns 100%.
+     * After progress reaches 100%, calling this is harmless; it just does nothing.
+     */
+    public void asyncUpdateLoad() {
+        nAsyncUpdateLoad(mNativeObject);
+    }
+
     private static native long nCreateResourceLoader(long nativeEngine);
     private static native void nDestroyResourceLoader(long nativeLoader);
     private static native void nAddResourceData(long nativeLoader, String url, Buffer buffer,
             int remaining);
     private static native boolean nHasResourceData(long nativeLoader, String url);
     private static native void nLoadResources(long nativeLoader, long nativeAsset);
+    private static native boolean nAsyncBeginLoad(long nativeLoader, long nativeAsset);
+    private static native float nAsyncGetLoadProgress(long nativeLoader);
+    private static native void nAsyncUpdateLoad(long nativeLoader);
 }

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -254,12 +254,17 @@ Filament.loadClassExtensions = function() {
     // URL, but clients can do the following to resolve a relative URL:
     //    const basePath = '' + new URL(myRelativeUrl, document.location);
     // If the given base path is null, document.location is used as the base.
-    Filament.gltfio$FilamentAsset.prototype.loadResources = function(onDone, onFetched, basePath) {
+    //
+    // The optional asyncInterval argument allows clients to control how finalization is amortized
+    // over time. It represents the number of milliseconds between each texture decoding task.
+    Filament.gltfio$FilamentAsset.prototype.loadResources = function(onDone, onFetched, basePath,
+            asyncInterval) {
         const asset = this;
         const engine = this.getEngine();
         const names = this.getResourceUris();
         const urlset = new Set();
         const urlToName = {};
+        const interval = asyncInterval || 30;
 
         basePath = basePath || document.location;
 
@@ -275,15 +280,21 @@ Filament.loadClassExtensions = function() {
 
         const onComplete = function() {
             const finalize = function() {
-                resourceLoader.loadResources(asset);
+                resourceLoader.asyncBeginLoad(asset);
 
-                // The buffer data won't get sent to the GPU until the next call to
-                // "renderer.render()", so wait two frames before freeing the CPU-side data.
-                window.requestAnimationFrame(function() {
-                    window.requestAnimationFrame(function() {
+                // Decode a PNG or JPEG every 100 milliseconds. This is slow but it's useful to
+                // decode in the native layer instead of using Canvas2D. This allows us to have more
+                // control (handling of alpha, srgb, etc) and better parity with Filament on native
+                // platforms. In the future we may wish to offload this to web workers.
+                const timer = setInterval(() => {
+                    resourceLoader.asyncUpdateLoad();
+                    const progress = resourceLoader.asyncGetLoadProgress();
+                    if (progress >= 1) {
+                        clearInterval(timer);
                         resourceLoader.delete();
-                    });
-                });
+                    }
+                }, interval);
+
             };
             if (onDone) {
                 onDone(finalize);

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1455,6 +1455,13 @@ class_<ResourceLoader>("gltfio$ResourceLoader")
 
     .function("loadResources", EMBIND_LAMBDA(bool, (ResourceLoader* self, FilamentAsset* asset), {
         return self->loadResources(asset);
-    }), allow_raw_pointers());
+    }), allow_raw_pointers())
+
+    .function("asyncBeginLoad", EMBIND_LAMBDA(bool, (ResourceLoader* self, FilamentAsset* asset), {
+        return self->asyncBeginLoad(asset);
+    }), allow_raw_pointers())
+
+    .function("asyncGetLoadProgress", &ResourceLoader::asyncGetLoadProgress)
+    .function("asyncUpdateLoad", &ResourceLoader::asyncUpdateLoad);
 
 } // EMSCRIPTEN_BINDINGS


### PR DESCRIPTION
We were already using jobs for decoding PNG and JPEG files, but we were doing a join. This add three methods to ResourceLoader that allow clients to amortize the decoding process across multiple frames, even on single-threaded platforms like WebGL.

This PR adds async loading to the following demos:
- samples/gltf_viewer (now shows a progress bar in the UI)
- android/sample-gltf-viewer
- web/samples/helmet.html

Fixes #1876.