### PR TITLE
gltfio: hide entities with not-yet-ready textures.

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -149,7 +149,6 @@ class ModelViewer {
             resourceLoader.asyncBeginLoad(asset)
             animator = asset.animator
             asset.releaseSourceData()
-            scene.addEntities(asset.entities)
         }
     }
 
@@ -166,7 +165,6 @@ class ModelViewer {
             resourceLoader.asyncBeginLoad(asset)
             animator = asset.animator
             asset.releaseSourceData()
-            scene.addEntities(asset.entities)
         }
     }
 
@@ -207,6 +205,15 @@ class ModelViewer {
 
         // Allow the resource loader to finalize textures that have become ready.
         resourceLoader.asyncUpdateLoad()
+
+        // Add renderable entities to the scene as they become ready.
+        asset?.let {
+            var entity = 0
+            val popRenderable = {entity = it.popRenderable(); entity != 0}
+            while (popRenderable()) {
+                scene.addEntity(entity)
+            }
+        }
 
         // Extract the camera basis from the helper and push it to the Filament camera.
         cameraManipulator.getLookAt(eyePos, target, upward)

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -37,6 +37,17 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nPopRenderable(JNIEnv*, jc
 }
 
 extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nPopRenderables(JNIEnv* env, jclass,
+        jlong nativeAsset, jintArray result) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    jsize available = env->GetArrayLength(result);
+    Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
+    size_t retval = asset->popRenderables(entities, available);
+    env->ReleaseIntArrayElements(result, (jint*) entities, 0);
+    return retval;
+}
+
+extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetEntityCount(JNIEnv*, jclass,
         jlong nativeAsset) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
@@ -47,8 +58,10 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetEntities(JNIEnv* env, jclass,
         jlong nativeAsset, jintArray result) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    jsize available = env->GetArrayLength(result);
     Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
-    std::copy_n(asset->getEntities(), asset->getEntityCount(), entities);
+    std::copy_n(asset->getEntities(),
+            std::min(available, (jsize) asset->getEntityCount()), entities);
     env->ReleaseIntArrayElements(result, (jint*) entities, 0);
 }
 

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -30,6 +30,13 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetRoot(JNIEnv*, jclass, 
 }
 
 extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nPopRenderable(JNIEnv*, jclass,
+        jlong nativeAsset) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    return asset->popRenderable().getId();
+}
+
+extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetEntityCount(JNIEnv*, jclass,
         jlong nativeAsset) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -64,8 +64,13 @@ public class FilamentAsset {
     /**
      * Pops a ready renderable off the queue, or returns 0 if no renderables have become ready.
      *
+     * NOTE: To determine the progress percentage or completion status, please use
+     * ResourceLoader#asyncGetLoadProgress.
+     *
      * This helper method allows clients to progressively add renderables to the scene as textures
      * gradually become ready through asynchronous loading.
+     *
+     * See also ResourceLoader#asyncBeginLoad.
      */
     public @Entity int popRenderable() {
         return nPopRenderable(mNativeObject);

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -62,6 +62,16 @@ public class FilamentAsset {
     }
 
     /**
+     * Pops a ready renderable off the queue, or returns 0 if no renderables have become ready.
+     *
+     * This helper method allows clients to progressively add renderables to the scene as textures
+     * gradually become ready through asynchronous loading.
+     */
+    public @Entity int popRenderable() {
+        return nPopRenderable(mNativeObject);
+    }
+
+    /**
      * Gets the list of entities, one for each glTF node.
      *
      * <p>All of these have a transform component. Some of the returned entities may also have a
@@ -127,6 +137,7 @@ public class FilamentAsset {
     }
 
     private static native int nGetRoot(long nativeAsset);
+    private static native int nPopRenderable(long nativeAsset);
     private static native int nGetEntityCount(long nativeAsset);
     private static native void nGetEntities(long nativeAsset, int[] result);
     private static native void nGetBoundingBox(long nativeAsset, float[] box);

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -17,6 +17,7 @@
 package com.google.android.filament.gltfio;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.android.filament.Box;
 import com.google.android.filament.Entity;
@@ -74,6 +75,16 @@ public class FilamentAsset {
      */
     public @Entity int popRenderable() {
         return nPopRenderable(mNativeObject);
+    }
+
+    /**
+     * Pops one or more renderables off the queue, or returns the available number.
+     *
+     * Returns the number of entities written into the given array. If the given array
+     * is null, returns the number of available renderables.
+     */
+    public int popRenderables(@Nullable @Entity int[] entities) {
+        return nPopRenderables(mNativeObject, entities);
     }
 
     /**
@@ -143,6 +154,7 @@ public class FilamentAsset {
 
     private static native int nGetRoot(long nativeAsset);
     private static native int nPopRenderable(long nativeAsset);
+    private static native int nPopRenderables(long nativeAsset, int[] result);
     private static native int nGetEntityCount(long nativeAsset);
     private static native void nGetEntities(long nativeAsset, int[] result);
     private static native void nGetBoundingBox(long nativeAsset, float[] box);

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -20,6 +20,8 @@ set(PUBLIC_HDRS
 set(SRCS
         src/Animator.cpp
         src/AssetLoader.cpp
+        src/DependencyGraph.cpp
+        src/DependencyGraph.h
         src/FFilamentAsset.h
         src/FilamentAsset.cpp
         src/GltfEnums.h

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -72,6 +72,19 @@ public:
     /** Gets the transform root for the asset, which has no matching glTF node. */
     utils::Entity getRoot() const noexcept;
 
+    /**
+     * Pops a ready renderable off the queue, or returns 0 if no renderables have become ready.
+     *
+     * This helper method allows clients to progressively add renderables to the scene as textures
+     * gradually become ready through asynchronous loading. For example, on every frame progressive
+     * applications can do something like this:
+     *
+     *    while (utils::Entity e = popRenderable()) { scene.addEntity(e); }
+     *
+     * See ResourceLoader#asyncBeginLoad.
+     */
+    utils::Entity popRenderable() noexcept;
+
     /** Gets all material instances. These are already bound to renderables. */
     const filament::MaterialInstance* const* getMaterialInstances() const noexcept;
 
@@ -80,18 +93,6 @@ public:
 
     /** Gets the number of materials returned by getMaterialInstances(). */
     size_t getMaterialInstanceCount() const noexcept;
-
-    /** Gets loading instructions for vertex buffers and index buffers. */
-    const BufferBinding* getBufferBindings() const noexcept;
-
-    /** Gets the number of bindings returned by getBufferBindings(). */
-    size_t getBufferBindingCount() const noexcept;
-
-    /** Gets loading instructions for textures. */
-    const TextureBinding* getTextureBindings() const noexcept;
-
-    /** Gets the number of bindings returned by getTextureBindings(). */
-    size_t getTextureBindingCount() const noexcept;
 
     /** Gets resource URIs for all externally-referenced buffers. */
     const char* const* getResourceUris() const noexcept;
@@ -135,6 +136,11 @@ public:
      * calling releaseSourceData();
      */
     const void* getSourceAsset() noexcept;
+
+    const BufferBinding* getBufferBindings() const noexcept;   //!< \deprecated please use ResourceLoader
+    size_t getBufferBindingCount() const noexcept;             //!< \deprecated please use ResourceLoader
+    const TextureBinding* getTextureBindings() const noexcept; //!< \deprecated please use ResourceLoader
+    size_t getTextureBindingCount() const noexcept;            //!< \deprecated please use ResourceLoader
 
     /*! \cond PRIVATE */
 protected:

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -76,7 +76,8 @@ public:
      * Pops a ready renderable off the queue, or returns 0 if no renderables have become ready.
      *
      * NOTE: To determine the progress percentage or completion status, please use
-     * ResourceLoader#asyncGetLoadProgress.
+     * ResourceLoader#asyncGetLoadProgress. To get the number of ready renderables,
+     * please use popRenderables().
      *
      * This method allows clients to progressively add the asset's renderables to the scene as
      * textures gradually become ready through asynchronous loading. For example, on every frame
@@ -84,9 +85,21 @@ public:
      *
      *    while (utils::Entity e = popRenderable()) { scene.addEntity(e); }
      *
-     * See ResourceLoader#asyncBeginLoad.
+     * \see ResourceLoader#asyncBeginLoad
+     * \see popRenderables()
      */
     utils::Entity popRenderable() noexcept;
+
+    /**
+     * Pops up to "count" ready renderables off the queue, or returns the available number.
+     *
+     * The given pointer should either be null or point to memory that can hold up to count
+     * entities. If the pointer is null, returns the number of available renderables. Otherwise
+     * returns the number of entities that have been written.
+     *
+     * \see ResourceLoader#asyncBeginLoad
+     */
+    size_t popRenderables(utils::Entity* entities, size_t count) noexcept;
 
     /** Gets all material instances. These are already bound to renderables. */
     const filament::MaterialInstance* const* getMaterialInstances() const noexcept;

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -75,9 +75,12 @@ public:
     /**
      * Pops a ready renderable off the queue, or returns 0 if no renderables have become ready.
      *
-     * This helper method allows clients to progressively add renderables to the scene as textures
-     * gradually become ready through asynchronous loading. For example, on every frame progressive
-     * applications can do something like this:
+     * NOTE: To determine the progress percentage or completion status, please use
+     * ResourceLoader#asyncGetLoadProgress.
+     *
+     * This method allows clients to progressively add the asset's renderables to the scene as
+     * textures gradually become ready through asynchronous loading. For example, on every frame
+     * progressive applications can do something like this:
      *
      *    while (utils::Entity e = popRenderable()) { scene.addEntity(e); }
      *

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -259,6 +259,9 @@ SimpleViewer::~SimpleViewer() {
 
 void SimpleViewer::setAsset(FilamentAsset* asset, bool scale) {
     if (mAsset == asset) {
+        while (utils::Entity e = mAsset->popRenderable()) {
+            mScene->addEntity(e);
+        }
         return;
     }
     removeAsset();
@@ -274,7 +277,9 @@ void SimpleViewer::setAsset(FilamentAsset* asset, bool scale) {
         filament::math::mat4f transform = fitIntoUnitCube(mAsset->getBoundingBox());
         tcm.setTransform(root, transform);
     }
-    mScene->addEntities(mAsset->getEntities(), mAsset->getEntityCount());
+    while (utils::Entity e = mAsset->popRenderable()) {
+        mScene->addEntity(e);
+    }
 }
 
 void SimpleViewer::removeAsset() {

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -69,17 +69,16 @@ public:
     ~SimpleViewer();
 
     /**
-     * Sets or changes the asset that is being viewed.
+     * Adds the asset's ready-to-render entities into the scene and optionally transforms the root
+     * node to make it fit into a unit cube at the origin.
      *
-     * This adds all the asset's entities into the scene and optionally transforms the asset to make
-     * it fit into a unit cube at the origin. The viewer does not claim ownership over the asset or
-     * its entities. Clients should use AssetLoader and ResourceLoader to load an asset before
-     * passing it in.
+     * The viewer does not claim ownership over the asset or its entities. Clients should use
+     * AssetLoader and ResourceLoader to load an asset before passing it in.
      *
      * @param asset The asset to view.
      * @param scale Adds a transform to the root to fit the asset into a unit cube at the origin.
      */
-    void setAsset(FilamentAsset* asset, bool scale);
+    void populateScene(FilamentAsset* asset, bool scale);
 
     /**
      * Removes the current asset from the viewer.
@@ -257,7 +256,7 @@ SimpleViewer::~SimpleViewer() {
     mEngine->destroy(mSunlight);
 }
 
-void SimpleViewer::setAsset(FilamentAsset* asset, bool scale) {
+void SimpleViewer::populateScene(FilamentAsset* asset, bool scale) {
     if (mAsset == asset) {
         while (utils::Entity e = mAsset->popRenderable()) {
             mScene->addEntity(e);

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -358,6 +358,7 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity) {
         UvMap uvmap {};
         bool hasVertexColor = primitiveHasVertexColor(inputPrim);
         MaterialInstance* mi = createMaterialInstance(inputPrim->material, &uvmap, hasVertexColor);
+        mResult->mDependencyGraph.addEdge(entity, mi);
         builder.material(index, mi);
 
         // Create a Filament VertexBuffer and IndexBuffer for this prim if we haven't already.
@@ -963,6 +964,7 @@ void FAssetLoader::addTextureBinding(MaterialInstance* materialInstance, const c
         .sampler = dstSampler,
         .srgb = srgb
     });
+    mResult->mDependencyGraph.addEdge(materialInstance, parameterName);
 }
 
 void FAssetLoader::importSkinningData(Skin& dstSkin, const cgltf_skin& srcSkin) {

--- a/libs/gltfio/src/DependencyGraph.cpp
+++ b/libs/gltfio/src/DependencyGraph.cpp
@@ -59,7 +59,7 @@ void DependencyGraph::addEdge(Texture* texture, MaterialInstance* material, cons
 
 void DependencyGraph::markAsReady(Texture* texture) {
     assert(texture && mFinalized);
-    mTextures.at(texture)->ready = true;
+    mTextureNodes.at(texture)->ready = true;
 
     // Iterate over the materials associated with this texture to check if any have become ready.
     // This is O(n2) but the inner loop is always small.
@@ -94,10 +94,10 @@ void DependencyGraph::markAsReady(MaterialInstance* material) {
     }
 }
 
-DependencyGraph::TextureStatus* DependencyGraph::getStatus(Texture* texture) {
-    auto iter = mTextures.find(texture);
-    if (iter == mTextures.end()) {
-        TextureStatus* status = (mTextures[texture] = std::make_unique<TextureStatus>()).get();
+DependencyGraph::TextureNode* DependencyGraph::getStatus(Texture* texture) {
+    auto iter = mTextureNodes.find(texture);
+    if (iter == mTextureNodes.end()) {
+        TextureNode* status = (mTextureNodes[texture] = std::make_unique<TextureNode>()).get();
         *status = {texture, false};
         return status;
     }

--- a/libs/gltfio/src/DependencyGraph.cpp
+++ b/libs/gltfio/src/DependencyGraph.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "DependencyGraph.h"
+
+using namespace filament;
+using namespace utils;
+
+namespace gltfio {
+
+Entity DependencyGraph::popReadyRenderable() noexcept {
+    if (mReadyRenderables.empty()) {
+        return Entity();
+    }
+    auto oldest = mReadyRenderables.front();
+    mReadyRenderables.pop();
+    return oldest;
+}
+
+void DependencyGraph::addEdge(Entity entity, MaterialInstance* mi) {
+    assert(!mFinalized);
+    mMaterialToEntity[mi].insert(entity);
+    mEntityToMaterial[entity].materials.insert(mi);
+}
+
+void DependencyGraph::addEdge(MaterialInstance* mi, const char* parameter) {
+    assert(!mFinalized);
+    mMaterialToTexture[mi].params[parameter] = nullptr;
+}
+
+void DependencyGraph::finalize() {
+    assert(!mFinalized);
+    for (auto pair : mEntityToMaterial) {
+        if (pair.second.materials.empty()) {
+            mReadyRenderables.push(pair.first);
+        }
+    }
+    mFinalized = true;
+}
+
+void DependencyGraph::addEdge(Texture* texture, MaterialInstance* material, const char* parameter) {
+    assert(mFinalized);
+    mTextureToMaterial[texture].insert(material);
+    mMaterialToTexture.at(material).params.at(parameter) = getStatus(texture);
+}
+
+void DependencyGraph::markAsReady(Texture* texture) {
+    assert(texture && mFinalized);
+    mTextures.at(texture)->ready = true;
+
+    // Iterate over the materials associated with this texture to check if any have become ready.
+    // This is O(n2) but the inner loop is always small.
+    auto& materials = mTextureToMaterial.at(texture);
+    for (auto material : materials) {
+        auto& status = mMaterialToTexture.at(material);
+
+        // Check this material's texture parameters, there are 5 in the worst case.
+        bool materialIsReady = true;
+        for (auto pair : status.params) {
+            if (!pair.second->ready) {
+                materialIsReady = false;
+                break;
+            }
+        }
+
+        // If all of its textures are ready, then the material has become ready.
+        if (materialIsReady) {
+            markAsReady(material);
+        }
+    }
+}
+
+void DependencyGraph::markAsReady(MaterialInstance* material) {
+    auto& entities = mMaterialToEntity.at(material);
+    for (auto entity : entities) {
+        auto& status = mEntityToMaterial.at(entity);
+        assert(status.numReadyMaterials < status.materials.size());
+        if (++status.numReadyMaterials == status.materials.size()) {
+            mReadyRenderables.push(entity);
+        }
+    }
+}
+
+DependencyGraph::TextureStatus* DependencyGraph::getStatus(Texture* texture) {
+    auto iter = mTextures.find(texture);
+    if (iter == mTextures.end()) {
+        TextureStatus* status = (mTextures[texture] = std::make_unique<TextureStatus>()).get();
+        *status = {texture, false};
+        return status;
+    }
+    return iter->second.get();
+}
+
+} // namespace gltfio

--- a/libs/gltfio/src/DependencyGraph.cpp
+++ b/libs/gltfio/src/DependencyGraph.cpp
@@ -21,13 +21,16 @@ using namespace utils;
 
 namespace gltfio {
 
-Entity DependencyGraph::popReadyRenderable() noexcept {
-    if (mReadyRenderables.empty()) {
-        return Entity();
+size_t DependencyGraph::popRenderables(Entity* result, size_t count) noexcept {
+    if (result == nullptr) {
+        return mReadyRenderables.size();
     }
-    auto oldest = mReadyRenderables.front();
-    mReadyRenderables.pop();
-    return oldest;
+    size_t numWritten = 0;
+    while (numWritten < count && !mReadyRenderables.empty()) {
+        result[numWritten++] = mReadyRenderables.front();
+        mReadyRenderables.pop();
+    }
+    return numWritten;
 }
 
 void DependencyGraph::addEdge(Entity entity, MaterialInstance* mi) {

--- a/libs/gltfio/src/DependencyGraph.h
+++ b/libs/gltfio/src/DependencyGraph.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_DEPENDENCY_GRAPH_H
+#define GLTFIO_DEPENDENCY_GRAPH_H
+
+#include <utils/Entity.h>
+
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
+
+#include <queue>
+#include <string>
+
+namespace filament {
+    class MaterialInstance;
+    class Texture;
+}
+
+namespace gltfio {
+
+/**
+ * Internal graph that enables FilamentAsset to discover "ready-to-render" entities by tracking
+ * the Texture objects that each entity depends on.
+ *
+ * Renderables connect to a set of material instances, which in turn connect to a set of parameter
+ * names, which in turn connect to a set of texture objects. These relationships are not easily
+ * inspectable using the Filament API or ECS.
+ *
+ * One graph corresponds to a single glTF asset. The graph only contains weak references, it does
+ * not have ownership over any Filament objects. Here's an example:
+ *
+ *    Entity          Entity   Entity   Entity
+ *      |            /      \     |     /
+ *      |           /        \    |    /
+ *   Material   Material       Material
+ *             /   |    \          |
+ *            /    |     \         |
+ *        Param  Param   Param   Param
+ *           \     /        \     /
+ *            \   /          \   /
+ *          Texture         Texture
+ *
+ * Note that the left-most entity in the above graph has no textures, so it becomes ready as soon as
+ * finalize is called.
+ */
+class DependencyGraph {
+public:
+    using Material = filament::MaterialInstance;
+    using Entity = utils::Entity;
+
+    // Returns a ready-to-render entity, or 0 if no new entities have become renderable.
+    Entity popReadyRenderable() noexcept;
+
+    // These are called during the initial asset loader phase.
+    void addEdge(Entity entity, Material* material);
+    void addEdge(Material* material, const char* parameter);
+
+    // This is called at the end of the initial asset loading phase.
+    void finalize();
+
+    // These are called after textures have created and decoded.
+    void addEdge(filament::Texture* texture, Material* material, const char* parameter);
+    void markAsReady(filament::Texture* texture);
+
+private:
+    struct TextureStatus {
+        filament::Texture* texture;
+        bool ready;
+    };
+
+    struct MaterialStatus {
+        tsl::robin_map<std::string, TextureStatus*> params;
+    };
+
+    struct EntityStatus {
+        tsl::robin_set<Material*> materials;
+        size_t numReadyMaterials = 0;
+    };
+
+    void markAsReady(Material* material);
+    TextureStatus* getStatus(filament::Texture* texture);
+
+    tsl::robin_map<Entity, EntityStatus> mEntityToMaterial;
+    tsl::robin_map<Material*, tsl::robin_set<Entity>> mMaterialToEntity;
+    tsl::robin_map<Material*, MaterialStatus> mMaterialToTexture;
+    tsl::robin_map<filament::Texture*, tsl::robin_set<Material*>> mTextureToMaterial;
+    tsl::robin_map<filament::Texture*, std::unique_ptr<TextureStatus>> mTextures;
+    std::queue<Entity> mReadyRenderables;
+    bool mFinalized = false;
+};
+
+} // namespace gltfio
+
+#endif // GLTFIO_DEPENDENCY_GRAPH_H

--- a/libs/gltfio/src/DependencyGraph.h
+++ b/libs/gltfio/src/DependencyGraph.h
@@ -62,8 +62,10 @@ public:
     using Material = filament::MaterialInstance;
     using Entity = utils::Entity;
 
-    // Returns a ready-to-render entity, or 0 if no new entities have become renderable.
-    Entity popReadyRenderable() noexcept;
+    // Pops up to "count" ready-to-render entities off the queue.
+    // If "result" is non-null, returns the number of written items.
+    // If "result" is null, returns the number of available entities.
+    size_t popRenderables(Entity* result, size_t count) noexcept;
 
     // These are called during the initial asset loader phase.
     void addEdge(Entity entity, Material* material);

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -94,8 +94,8 @@ struct FFilamentAsset : public FilamentAsset {
         return mRoot;
     }
 
-    utils::Entity popRenderable() noexcept {
-        return mDependencyGraph.popReadyRenderable();
+    size_t popRenderables(utils::Entity* entities, size_t count) noexcept {
+        return mDependencyGraph.popRenderables(entities, count);
     }
 
     size_t getMaterialInstanceCount() const noexcept {

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -36,7 +36,13 @@ Entity FilamentAsset::getRoot() const noexcept {
 }
 
 Entity FilamentAsset::popRenderable() noexcept {
-    return upcast(this)->popRenderable();
+    Entity result[1];
+    const bool empty = !popRenderables(result, 1);
+    return empty ? Entity() : result[0];
+}
+
+size_t FilamentAsset::popRenderables(Entity* result, size_t count) noexcept {
+    return upcast(this)->popRenderables(result, count);
 }
 
 size_t FilamentAsset::getMaterialInstanceCount() const noexcept {

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -35,6 +35,10 @@ Entity FilamentAsset::getRoot() const noexcept {
     return upcast(this)->getRoot();
 }
 
+Entity FilamentAsset::popRenderable() noexcept {
+    return upcast(this)->popRenderable();
+}
+
 size_t FilamentAsset::getMaterialInstanceCount() const noexcept {
     return upcast(this)->getMaterialInstanceCount();
 }

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -332,7 +332,7 @@ static void updateViewerMesh(BakerApp& app) {
         app.viewerAsset->getAnimator();
 
         // Remove old renderables and add new renderables to the scene.
-        app.viewer->setAsset(app.viewerAsset, !app.viewerActualSize);
+        app.viewer->populateScene(app.viewerAsset, !app.viewerActualSize);
 
         // Destory old Filament entities.
         app.loader->destroyAsset(previousViewerAsset);

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -261,7 +261,7 @@ int main(int argc, char** argv) {
         app.resourceLoader->asyncUpdateLoad();
 
         // Add renderables to the scene as they become ready.
-        app.viewer->setAsset(app.asset, !app.actualSize);
+        app.viewer->populateScene(app.asset, !app.actualSize);
 
         app.viewer->applyAnimation(now);
     };

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -260,10 +260,8 @@ int main(int argc, char** argv) {
     auto animate = [&app](Engine* engine, View* view, double now) {
         app.resourceLoader->asyncUpdateLoad();
 
-        // Add the renderables to the scene after the textures have finished loading.
-        if (app.resourceLoader->asyncGetLoadProgress() == 1.0f) {
-            app.viewer->setAsset(app.asset, !app.actualSize);
-        }
+        // Add renderables to the scene as they become ready.
+        app.viewer->setAsset(app.asset, !app.actualSize);
 
         app.viewer->applyAnimation(now);
     };

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -38,7 +38,6 @@ export type mat3 = glm.mat3|number[];
 export type mat4 = glm.mat4|number[];
 export type quat = glm.quat|number[];
 
-export class Entity {}
 export class Skybox {}
 export class Texture {}
 export class SwapChain {}
@@ -51,6 +50,10 @@ export interface Box {
 export interface Aabb {
     min: float3;
     max: float3;
+}
+
+export class Entity {
+    public getId(): number;
 }
 
 export class LightManager$Instance {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1067,7 +1067,8 @@ class_<SkyBuilder>("Skybox$Builder")
 
 /// Entity ::core class:: Handle to an object consisting of a set of components.
 /// To create an entity with no components, use [EntityManager].
-class_<utils::Entity>("Entity");
+class_<utils::Entity>("Entity")
+    .function("getId", &utils::Entity::getId);
 
 /// EntityManager ::core class:: Singleton used for constructing entities in Filament's ECS.
 class_<utils::EntityManager>("EntityManager")
@@ -1374,6 +1375,8 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
     }), allow_raw_pointers())
 
     .function("getRoot", &FilamentAsset::getRoot)
+
+    .function("popRenderable", &FilamentAsset::popRenderable)
 
     .function("getMaterialInstances", EMBIND_LAMBDA(std::vector<const MaterialInstance*>,
             (FilamentAsset* self), {

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -92,9 +92,6 @@ class App {
                     instance.delete();
                 }
 
-                // Add renderables to the scene.
-                scene.addEntities(entities);
-
                 // Hide the HUD.
                 messages.remove();
             }, 1);
@@ -116,10 +113,23 @@ class App {
     }
 
     render() {
+        // Spin the model according to the trackball controller.
         const tcm = this.engine.getTransformManager();
         const inst = tcm.getInstance(this.asset.getRoot());
         tcm.setTransform(inst, this.trackball.getMatrix());
         inst.delete();
+
+        // Add renderable entities to the scene as they become ready.
+        let entity;
+        const popRenderable = () => {
+            entity = this.asset.popRenderable();
+            return entity.getId() != 0;
+        }
+        while (popRenderable()) {
+            this.scene.addEntity(entity);
+        }
+
+        // Render the scene and request the next animation frame.
         this.renderer.render(this.swapChain, this.view);
         window.requestAnimationFrame(this.render);
     }


### PR DESCRIPTION
This feature adds one new method to `FilamentAsset` and uses it in our
Kotlin, JavaScript, and C++ helpers:

    utils::Entity popRenderable() noexcept;

This pops a ready renderable off an internal queue, or returns 0 if no
renderables have become ready. It provides a simple way for clients to
gradually add renderables to the scene as they become ready. Previously
clients could only get the entire list of entities, regardless of
whether they had Renderable components or complete textures.

To facilitate this feature, this PR adds a new internal-only class to
gltfio called `DependencyGraph`, which is a temporary object used for
bookkeeping during the asynchronous load.

`DependencyGraph` discovers ready-to-render entities by tracking the
textures that each entity depends on. This is a graph because
renderables connect to a set of material instances, which in turn
connect to a set of parameter names, which in turn connect to a set of
texture objects. These relationships are not easily inspectable using
the Filament API or ECS.

![async](https://user-images.githubusercontent.com/1288904/73573345-00bd2d80-4428-11ea-81b1-7e69992d0f32.gif)
