### PR TITLE
rework refraction filtering/blurring to improve performance

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -73,9 +73,9 @@ public:
             details::CameraInfo const& cameraInfo,
             View::AmbientOcclusionOptions const& options) noexcept;
 
-    FrameGraphId<FrameGraphTexture> gaussianBlurPass(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, uint8_t srcLevel,
-            uint8_t dstLevel, float alpha) noexcept;
+    FrameGraphId <FrameGraphTexture> gaussianBlurPass(FrameGraph& fg,
+            FrameGraphId <FrameGraphTexture> input, uint8_t srcLevel, uint8_t dstLevel,
+            size_t kernelWidth, float sigma) noexcept;
 
     backend::Handle<backend::HwTexture> getNoSSAOTexture() const {
         return mNoSSAOTexture;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -647,11 +647,12 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
     });
 }
 
-void FView::prepareSSR(Handle<HwTexture> ssr) const noexcept {
+void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept {
     mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
             .filterMag = SamplerMagFilter::LINEAR,
             .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
     });
+    mPerViewUb.setUniform(offsetof(PerViewUib, refractionLodOffset), refractionLodOffset);
 }
 
 void FView::cleanupSSAO() const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -128,7 +128,7 @@ public:
             ArenaScope& arena, Viewport const& viewport) noexcept;
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
     void cleanupSSAO() const noexcept;
-    void prepareSSR(backend::Handle<backend::HwTexture> ssr) const noexcept;
+    void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept;
     void cleanupSSR() const noexcept;
     void froxelize(FEngine& engine) const noexcept;
     void commitUniforms(backend::DriverApi& driver) const noexcept;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -173,7 +173,7 @@ FrameGraphPassResources::getRenderTarget(FrameGraphRenderTargetHandle handle, ui
 
 FrameGraph::FrameGraph(fg::ResourceAllocatorInterface& resourceAllocator)
         : mResourceAllocator(resourceAllocator),
-          mArena("FrameGraph Arena", 32768), // TODO: the Area will eventually come from outside
+          mArena("FrameGraph Arena", 65536), // TODO: the Area will eventually come from outside
           mPassNodes(mArena),
           mResourceNodes(mArena),
           mRenderTargets(mArena),

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -45,6 +45,7 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
     if (!(desc.usage & TextureUsage::SAMPLEABLE)) {
         levels = 1;
     }
+    assert(levels <= static_cast<uint8_t>(std::ilogbf(std::max(desc.width, desc.height)) + 1));
 
     uint8_t samples = desc.samples;
     assert(samples <= 1 || none(desc.usage & TextureUsage::SAMPLEABLE));

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -81,7 +81,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     filament::math::float4 userTime;  // time(s), (double)time - (float)time, 0, 0
 
     filament::math::float2 iblMaxMipLevel; // maxlevel, float(1<<maxlevel)
-    filament::math::float2 padding0;
+    float refractionLodOffset;
+    float padding0;
 
     filament::math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
     float padding1;

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -75,7 +75,8 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("userTime",                1, UniformInterfaceBlock::Type::FLOAT4)
             // ibl max mip level
             .add("iblMaxMipLevel",          1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("refractionLodOffset",     1, UniformInterfaceBlock::Type::FLOAT)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
             // view
             .add("worldOffset",             1, UniformInterfaceBlock::Type::FLOAT3)
             // bring size to 1 KiB

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -445,11 +445,11 @@ void applyRefraction(const PixelParams pixel,
     p.xy = uvToRenderTargetUV(p.xy * (0.5 / p.w) + 0.5);
 
     // perceptualRoughness to LOD
-    const float kNumRoughnessLods = 5.0;
     // Empirical factor to compensate for the gaussian approximation of Dggx, chosen so
     // cubemap and screen-space modes match at perceptualRoughness 0.125
     float tweakedPerceptualRoughness = perceptualRoughness * 1.74;
-    float lod = log2(tweakedPerceptualRoughness * 2.0) + (kNumRoughnessLods - 1.0);
+    float lod = max(0.0, 2.0 * log2(tweakedPerceptualRoughness) + frameUniforms.refractionLodOffset);
+
     vec3 Ft = textureLod(light_ssr, p.xy, lod).rgb;
 #endif
 


### PR DESCRIPTION
We now use a fixed-size kernel (right now 17), for each mip-level.
And we workout the mapping from roughness to such mip.

This improves performance by reducing significantly the number of taps
per mip, however, we don't control how much blur is actually applied
at each level. This gives a mip-chain that is proportional to
'roughness'.

It's now easier to tune quality vs. speed by tweaking the kernel's width
as well as how we map 'sigma' to a the kernel width.