### PR TITLE
Missing backend now throws Java exception, not segfault.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -409,6 +409,7 @@ function build_android {
     if [[ "$ISSUE_RELEASE_BUILD" == "true" ]]; then
         ./gradlew \
             -Pfilament_dist_dir=../out/android-release/filament \
+            -Pextra_cmake_args=${VULKAN_ANDROID_OPTION} \
             :filament-android:assembleRelease \
             :gltfio-android:assembleRelease \
             :filament-utils-android:assembleRelease
@@ -709,8 +710,8 @@ while getopts ":hacfijmp:tuvslw" opt; do
             VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
             echo "Enabling support for Vulkan in the core Filament library."
             echo ""
-            echo "To switch your application to Vulkan, in Android Studio go to "
-            echo "File > Settings > Build > Compiler. In the command-line options field, "
+            echo "To switch your application to Vulkan, in Android Studio go to Preferences > "
+            echo "Build, Executation Deployment > Compiler. In the command-line options field, "
             echo "add -Pextra_cmake_args=-DFILAMENT_SUPPORTS_VULKAN=ON."
             echo "Also be sure to pass Engine.Backend.VULKAN to Engine.create."
             echo ""

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -114,6 +114,10 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
             instance->mPlatform = platform;
             instance->mOwnPlatform = true;
         }
+        if (platform == nullptr) {
+            slog.e << "Selected backend not supported in this build." << io::endl;
+            return nullptr;
+        }
         instance->mDriver = platform->createDriver(sharedGLContext);
     } else {
         // start the driver thread
@@ -430,6 +434,11 @@ int FEngine::loop() {
                 break;
         }
         slog.d << io::endl;
+        if (mPlatform == nullptr) {
+            slog.e << "Selected backend not supported in this build." << io::endl;
+            mDriverBarrier.latch();
+            return 0;
+        }
     }
 
 #if FILAMENT_ENABLE_MATDBG


### PR DESCRIPTION
If a client application selects a backend that is not supported by the
build, Engine::create() now returns null, which allows the Java wrapper
to throw IllegalStateException. Prevously, we would crash in the native
layer by hitting a null pointer in Engine::loop().