### PR TITLE
More comments and small bug fixes regarding MSAA

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -52,9 +52,8 @@ public:
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
             bool translucent) noexcept;
 
-    FrameGraphId<FrameGraphTexture> dynamicScaling(FrameGraph& fg,
-            uint8_t msaa, bool scaled, bool blend,
-            FrameGraphId<FrameGraphTexture> input,
+    FrameGraphId<FrameGraphTexture> dynamicScaling(
+            FrameGraph& fg, bool scaled, bool blend, FrameGraphId<FrameGraphTexture> input,
             backend::TextureFormat outFormat) noexcept;
 
     FrameGraphId<FrameGraphTexture> quadBlit(FrameGraph& fg,

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -383,7 +383,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             input = ppm.fxaa(fg, input, ldrFormat, !toneMapping || translucent);
         }
         if (scaled) {
-            input = ppm.dynamicScaling(fg, msaa, scaled, blending, input, ldrFormat);
+            input = ppm.dynamicScaling(fg, scaled, blending, input, ldrFormat);
         }
     }
 
@@ -399,7 +399,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     const bool outputIsInput = fg.equal(input, colorPassOutput);
     if ((outputIsInput && viewRenderTarget == mRenderTarget && msaa > 1) ||
         (!outputIsInput && blending)) {
-        input = ppm.dynamicScaling(fg, msaa, scaled, blending, input, ldrFormat);
+        input = ppm.dynamicScaling(fg, scaled, blending, input, ldrFormat);
     }
 
     fg.present(input);

--- a/filament/src/fg/fg/RenderTargetResource.cpp
+++ b/filament/src/fg/fg/RenderTargetResource.cpp
@@ -46,7 +46,12 @@ void RenderTargetResource::create(FrameGraph& fg) noexcept {
                             fg.getResourceEntryUnchecked(attachmentInfo.getHandle());
                     infos[i].handle = entry.getResource().texture;
                     infos[i].level = attachmentInfo.getLevel();
+                    // the attachment buffer (texture or renderbuffer) must be valid
                     assert(infos[i].handle);
+                    // the attachment level must be within range
+                    assert(infos[i].level < entry.descriptor.levels);
+                    // if the attachment is multisampled, then the rendertarget must be too
+                    assert(entry.descriptor.samples <= 1 || entry.descriptor.samples == desc.samples);
                 }
             }
             targetInfo.target = fg.getResourceAllocator().createRenderTarget(name,


### PR DESCRIPTION
- always take the "blit" path (rather than quad path) when MSAA
  and is on. we now rely on the render target to have been resolved
  into its texture (implicitly or explicitly). This means in some cases
  there will be 2 bliss in a row -- but that's still better than a
  blit and a quad. These are unavoidable without using a custom resolve.

- removed creating renderbuffer with the EXT_multisampled_render_to_texture
  extension because we didn't support it fully and didn't support
  the fallback mode (for desktop or if the extension is not there).
  Also this case never happens currently.

- added more assert()

- added a bunch of comments explaining the restrictions of using MSAA
  regarding blitting.