### PR TITLE
fix screen-space refraction roughness calculation

### DIFF
--- a/filament/src/materials/separableGaussianBlur.mat
+++ b/filament/src/materials/separableGaussianBlur.mat
@@ -46,20 +46,9 @@ vertex {
 }
 
 fragment {
-    vec3 Tonemap_ReinhardWeighted(const vec3 x, float weight) {
-        // Weighted Reinhard tone-mapping operator designed for post-processing
-        // This tone-mapping operator is invertible
-        return x * (weight / (max3(x) + 1.0));
-    }
-
-    vec3 Tonemap_ReinhardWeighted_Invert(const vec3 x) {
-        // Inverse Reinhard tone-mapping operator, designed to be used in conjunction
-        // with the weighted Reinhard tone-mapping operator
-        return x / (1.0 - max3(x));
-    }
     void tap(inout vec3 sum, float weight, highp vec2 position) {
         vec3 s = textureLod(materialParams_source, position, materialParams.level).rgb;
-        sum += Tonemap_ReinhardWeighted(s, weight);
+        sum += s * weight;
     }
 
     void postProcess(inout PostProcessInputs postProcess) {
@@ -77,6 +66,6 @@ fragment {
             tap(sum, k, uv - o);
         }
 
-        postProcess.color.rgb = Tonemap_ReinhardWeighted_Invert(sum);
+        postProcess.color.rgb = sum;
     }
 }


### PR DESCRIPTION
It turns out that textureLod() only reads the base layer if the sampler
is not set to xxx_MIPMAP_xxx. This prevented the gaussian-blur code
to work properly.
Specifically, the horizontal pass would always use the base layer. Not
only this made the blur unstable, but also hurt performance significantly.

With this change, the untonamap/tonemap is no longer needed and the 
results are much more convincing with objects with highlights.