### PR TITLE
gltfio: add nominal support for flat shading.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ A new header is inserted each time a *tag* is created.
 - Screen-space refraction is now supported.
 - Removed depth-prepass related APIs.
 - gltfio: add asynchronous API to ResourceLoader.
+- gltfio: generate normals for flat-shaded models that do not have normals.
 
 ## v1.4.5
 

--- a/libs/geometry/include/geometry/SurfaceOrientation.h
+++ b/libs/geometry/include/geometry/SurfaceOrientation.h
@@ -41,12 +41,25 @@ public:
      * The Builder is used to construct an immutable surface orientation helper.
      *
      * Clients provide pointers into their own data, which is synchronously consumed during build().
-     * At a minimum, clients must supply a vertex count and normals buffer. They can supply data in
-     * any of the following three combinations:
+     * At a minimum, clients must supply a vertex count. They can supply data in any of the
+     * following combinations:
      *
-     *   1. vec3 normals only (not recommended)
-     *   2. vec3 normals + vec4 tangents (sign of W determines bitangent orientation)
-     *   3. vec3 normals + vec2 uvs + vec3 positions + uint3 indices
+     *   1. normals only ........................... not recommended, selects arbitrary orientation
+     *   2. normals + tangents ..................... sign of W determines bitangent orientation
+     *   3. normals + uvs + positions + indices .... selects Lengyel’s Method
+     *   4. positions + indices .................... generates normals for flat shading only
+     *
+     * Additionally, the client-side data has the following type constraints:
+     *
+     *  - Normals must be float3
+     *  - Tangents must be float4
+     *  - UVs must be float2
+     *  - Positions must be float3
+     *  - Triangles must be uint3 or ushort3
+     *
+     * Currently, mikktspace is not supported because it requires re-indexing the mesh. Instead
+     * we use the method described by Eric Lengyel in "Foundations of Game Engine Development"
+     * (Volume 2, Chapter 7).
      */
     class Builder {
     public:
@@ -56,14 +69,11 @@ public:
         Builder& operator=(Builder&& that) noexcept;
 
         /**
-         * These two attributes are required. They are not passed into the constructor to force
-         * calling code to be self-documenting.
-         * @{
+         * This attribute is required.
          */
         Builder& vertexCount(size_t vertexCount) noexcept;
-        Builder& normals(const filament::math::float3*, size_t stride = 0) noexcept;
-        /** @} */
 
+        Builder& normals(const filament::math::float3*, size_t stride = 0) noexcept;
         Builder& tangents(const filament::math::float4*, size_t stride = 0) noexcept;
         Builder& uvs(const filament::math::float2*, size_t stride = 0) noexcept;
         Builder& positions(const filament::math::float3*, size_t stride = 0) noexcept;

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -690,7 +690,7 @@ void ResourceLoader::computeTangents(FFilamentAsset* asset) const {
 
         // At a minimum we need normals to generate tangents.
         auto normalsInfo = accessors[cgltf_attribute_type_normal];
-        if (normalsInfo == nullptr || vertexCount == 0) {
+        if (vertexCount == 0) {
             return;
         }
 
@@ -700,11 +700,13 @@ void ResourceLoader::computeTangents(FFilamentAsset* asset) const {
         sob.vertexCount(vertexCount);
 
         // Convert normals into packed floats.
-        assert(normalsInfo->count == vertexCount);
-        assert(normalsInfo->type == cgltf_type_vec3);
-        fp32Normals.resize(vertexCount);
-        cgltf_accessor_unpack_floats(normalsInfo, &fp32Normals[0].x, vertexCount * 3);
-        sob.normals(fp32Normals.data());
+        if (normalsInfo) {
+            assert(normalsInfo->count == vertexCount);
+            assert(normalsInfo->type == cgltf_type_vec3);
+            fp32Normals.resize(vertexCount);
+            cgltf_accessor_unpack_floats(normalsInfo, &fp32Normals[0].x, vertexCount * 3);
+            sob.normals(fp32Normals.data());
+        }
 
         // Convert tangents into packed floats.
         auto tangentsInfo = accessors[cgltf_attribute_type_tangent];


### PR DESCRIPTION
<img width="1136" alt="fox" src="https://user-images.githubusercontent.com/1288904/74192731-f3175d00-4c0a-11ea-9472-82e545eb844b.png">

This "fixes" the new animated Fox model in the glTF conformance suite. As per the glTF spec, we now generate per-face normals for the case where normals are not specified in the model.

Note that true flat shading (i.e. flat interpolation) is not a requirement in the glTF spec, since some Khronos members advocate for WebGL 1.0 compatibility.

Fixes #2088.