### PR TITLE
Fix a SSRefr when dynamic-scaling is enabled

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -52,20 +52,16 @@ public:
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
             bool translucent) noexcept;
 
-    FrameGraphId<FrameGraphTexture> dynamicScaling(
-            FrameGraph& fg, bool scaled, bool blend, FrameGraphId<FrameGraphTexture> input,
-            backend::TextureFormat outFormat) noexcept;
+    FrameGraphId<FrameGraphTexture> dynamicScaling(FrameGraph& fg, bool blend,
+            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphTexture::Descriptor outDesc) noexcept;
 
     FrameGraphId<FrameGraphTexture> quadBlit(FrameGraph& fg,
             bool blend, FrameGraphId<FrameGraphTexture> input,
             backend::TextureFormat outFormat) noexcept;
 
-    FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg, const char* outputBufferName,
-            FrameGraphId<FrameGraphTexture> input) noexcept;
-
-    FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg, const char* outputBufferName,
-            uint8_t levels, backend::TextureFormat preferredOutputFormat,
-            FrameGraphId<FrameGraphTexture> input) noexcept;
+    FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
+            const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
 
     FrameGraphId<FrameGraphTexture> ssao(FrameGraph& fg, details::RenderPass& pass,
             filament::Viewport const& svp,

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -101,7 +101,9 @@ private:
             backend::PixelBufferDescriptor&& buffer);
 
     struct ColorPassConfig {
+        Viewport vp;
         Viewport svp;
+        math::float2 scale;
         backend::TextureFormat hdrFormat;
         uint8_t msaa;
     };


### PR DESCRIPTION
because the intermediate buffer could have non-square pixels, blurring
the buffer would result in an anamorphic blur.

We fix this by properly scaling the buffer before blurring.