### PR TITLE
Add Java bindings for SurfaceOrientation.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: generate normals for flat-shaded models that do not have normals.
 - Material instances now allow dynamic depth testing and other rasterization state.
 - Support for Bloom as a post-process effect.
+- Added Java bindings for geometry::SurfaceOrientation.
 
 ## v1.4.5
 

--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(filament-jni SHARED
     src/main/cpp/Scene.cpp
     src/main/cpp/SkyBox.cpp
     src/main/cpp/Stream.cpp
+    src/main/cpp/SurfaceOrientation.cpp
     src/main/cpp/Texture.cpp
     src/main/cpp/TextureSampler.cpp
     src/main/cpp/TransformManager.cpp

--- a/android/filament-android/src/main/cpp/SurfaceOrientation.cpp
+++ b/android/filament-android/src/main/cpp/SurfaceOrientation.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include <geometry/SurfaceOrientation.h>
+
+#include "common/NioUtils.h"
+
+using namespace filament;
+using namespace filament::geometry;
+using namespace filament::math;
+
+namespace {
+    struct JniWrapper {
+        SurfaceOrientation::Builder* builder;
+        AutoBuffer* normals;
+        AutoBuffer* tangents;
+        AutoBuffer* uvs;
+        AutoBuffer* positions;
+        AutoBuffer* triangles16;
+        AutoBuffer* triangles32;
+    };
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nCreateBuilder(JNIEnv* env, jclass) {
+    JniWrapper* wrapper = new JniWrapper();
+    wrapper->builder = new SurfaceOrientation::Builder();
+    return (jlong) wrapper;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nDestroyBuilder(JNIEnv* env, jclass,
+        jlong nativeBuilder) {
+    auto wrapper = (JniWrapper*) nativeBuilder;
+    delete wrapper->builder;
+    delete wrapper->normals;
+    delete wrapper->tangents;
+    delete wrapper->uvs;
+    delete wrapper->positions;
+    delete wrapper->triangles16;
+    delete wrapper->triangles32;
+    delete wrapper;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nBuilderVertexCount(JNIEnv* env, jclass,
+        jlong nativeBuilder, int vertexCount) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    wrapper->builder->vertexCount(vertexCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderTriangleCount(JNIEnv* env, jclass,
+        jlong nativeBuilder, int triangleCount) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    wrapper->builder->triangleCount(triangleCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderNormals(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, jint remaining, int stride) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->normals = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->normals((const float3 *) buffer->getData(), stride);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderTangents(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, jint remaining, int stride) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->tangents = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->tangents((const float4 *) buffer->getData(), stride);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderUVs(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, int remaining, int stride) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->uvs = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->uvs((const float2 *) buffer->getData(), stride);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderPositions(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, int remaining, int stride) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->positions = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->positions((const float3 *) buffer->getData(), stride);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderTriangles16(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, int remaining) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->triangles16 = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->triangles((const ushort3 *) buffer->getData());
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_mBuilderTriangles32(JNIEnv* env, jclass,
+        jlong nativeBuilder, jobject javaBuffer, int remaining) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    AutoBuffer* buffer = wrapper->triangles32 = new AutoBuffer(env, javaBuffer, remaining);
+    wrapper->builder->triangles((const uint3 *) buffer->getData());
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nBuilderBuild(JNIEnv* env, jclass,
+        jlong nativeBuilder) {
+    auto wrapper = (JniWrapper *) nativeBuilder;
+    return (jlong) wrapper->builder->build();
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nGetVertexCount(JNIEnv* env, jclass,
+        jlong nativeObject) {
+    SurfaceOrientation* helper = (SurfaceOrientation*) nativeObject;
+    return helper->getVertexCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nGetQuatsAsFloat(JNIEnv* env, jclass,
+        jlong nativeObject, jobject javaBuffer, int remaining) {
+    SurfaceOrientation* helper = (SurfaceOrientation*) nativeObject;
+    AutoBuffer buffer(env, javaBuffer, remaining);
+    size_t requestedCount = std::min(buffer.getSize() / sizeof(float4), helper->getVertexCount());
+    helper->getQuats((quatf*) buffer.getData(), requestedCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nGetQuatsAsHalf(JNIEnv* env, jclass,
+        jlong nativeObject, jobject javaBuffer, int remaining) {
+    SurfaceOrientation* helper = (SurfaceOrientation*) nativeObject;
+    AutoBuffer buffer(env, javaBuffer, remaining);
+    size_t requestedCount = std::min(buffer.getSize() / sizeof(quath), helper->getVertexCount());
+    helper->getQuats((quath*) buffer.getData(), requestedCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nGetQuatsAsShort(JNIEnv* env, jclass,
+        jlong nativeObject, jobject javaBuffer, int remaining) {
+    SurfaceOrientation* helper = (SurfaceOrientation*) nativeObject;
+    AutoBuffer buffer(env, javaBuffer, remaining);
+    size_t requestedCount = std::min(buffer.getSize() / sizeof(short4), helper->getVertexCount());
+    helper->getQuats((short4*) buffer.getData(), requestedCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_SurfaceOrientation_nDestroy(JNIEnv* env, jclass,
+        jlong nativeSurfaceOrientation) {
+    SurfaceOrientation* helper = (SurfaceOrientation*) nativeSurfaceOrientation;
+    delete helper;
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/SurfaceOrientation.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/SurfaceOrientation.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+
+import java.nio.Buffer;
+
+/**
+ * Helper used to populate <code>TANGENTS</code> buffers.
+ */
+public class SurfaceOrientation {
+    private long mNativeObject;
+
+    private SurfaceOrientation(long nativeSurfaceOrientation) {
+        mNativeObject = nativeSurfaceOrientation;
+    }
+
+    /**
+     * Constructs an immutable surface orientation helper.
+     *
+     * At a minimum, clients must supply a vertex count.
+     * They can supply data in any of the following combinations:
+     *
+     * <ol>
+     * <li>normals only (not recommended)</li>
+     * <li>normals + tangents (sign of W determines bitangent orientation)</li>
+     * <li>normals + uvs + positions + indices</li>
+     * <li>positions + indices</li>
+     * </ol>
+     *
+     * Additionally, the client-side data has the following type constraints:
+     *
+     * <ol>
+     * <li>Normals must be float3</li>
+     * <li>Tangents must be float4</li>
+     * <li>UVs must be float2</li>
+     * <li>Positions must be float3</li>
+     * <li>Triangles must be uint3 or ushort3</li>
+     * </ol>
+     */
+    public static class Builder {
+        private int mVertexCount;
+        private int mTriangleCount;
+
+        private Buffer mNormals;
+        private int mNormalsStride;
+
+        private Buffer mTangents;
+        private int mTangentsStride;
+
+        private Buffer mTexCoords;
+        private int mTexCoordsStride;
+
+        private Buffer mPositions;
+        private int mPositionsStride;
+
+        private Buffer mTrianglesUint16;
+        private Buffer mTrianglesUint32;
+
+        @NonNull
+        public Builder vertexCount(@IntRange(from = 1) int vertexCount) {
+            mVertexCount = vertexCount;
+            return this;
+        }
+
+        @NonNull
+        public Builder normals(@NonNull Buffer buffer) {
+            mNormals = buffer;
+            mNormalsStride = 0;
+            return this;
+        }
+
+        @NonNull
+        public Builder tangents(@NonNull Buffer buffer) {
+            mTangents = buffer;
+            mTangentsStride = 0;
+            return this;
+        }
+
+        @NonNull
+        public Builder uvs(@NonNull Buffer buffer) {
+            mTexCoords = buffer;
+            mTexCoordsStride = 0;
+            return this;
+        }
+
+        @NonNull
+        public Builder positions(@NonNull Buffer buffer) {
+            mPositions = buffer;
+            mPositionsStride = 0;
+            return this;
+        }
+
+        @NonNull
+        public Builder triangleCount(int triangleCount) {
+            mTriangleCount = triangleCount;
+            return this;
+        }
+
+        @NonNull
+        public Builder triangles_uint16(@NonNull Buffer buffer) {
+            mTrianglesUint16 = buffer;
+            return this;
+        }
+
+        @NonNull
+        public Builder triangles_uint32(@NonNull Buffer buffer) {
+            mTrianglesUint32 = buffer;
+            return this;
+        }
+
+        /**
+         * Consumes the input data, produces quaternions, and destroys the native builder.
+         */
+        @NonNull
+        public SurfaceOrientation build() {
+
+            // The C++ Builder API specifies that the pointers are consumed during build(), not
+            // during the individual daisy-chain methods. Therefore we need to retain the Java
+            // buffers until this point in the code.
+
+            long builder = nCreateBuilder();
+            nBuilderVertexCount(builder, mVertexCount);
+            nBuilderTriangleCount(builder, mTriangleCount);
+
+            if (mNormals != null) {
+                nBuilderNormals(builder, mNormals, mNormals.remaining(), mNormalsStride);
+            }
+
+            if (mTangents != null) {
+                nBuilderTangents(builder, mTangents, mTangents.remaining(), mTangentsStride);
+            }
+
+            if (mTexCoords != null) {
+                nBuilderUVs(builder, mTexCoords, mTexCoords.remaining(), mTexCoordsStride);
+            }
+
+            if (mPositions != null) {
+                nBuilderPositions(builder, mPositions, mPositions.remaining(), mPositionsStride);
+            }
+
+            if (mTrianglesUint16 != null) {
+                nBuilderTriangles16(builder, mTrianglesUint16, mTrianglesUint16.remaining());
+            }
+
+            if (mTrianglesUint32 != null) {
+                nBuilderTriangles32(builder, mTrianglesUint32, mTrianglesUint32.remaining());
+            }
+
+            long nativeSurfaceOrientation = nBuilderBuild(builder);
+            nDestroyBuilder(builder);
+            if (nativeSurfaceOrientation == 0) {
+                throw new IllegalStateException("Could not create SurfaceOrientation");
+            }
+            return new SurfaceOrientation(nativeSurfaceOrientation);
+        }
+    }
+
+    public long getNativeObject() {
+        if (mNativeObject == 0) {
+            throw new IllegalStateException("Calling method on destroyed SurfaceOrientation");
+        }
+        return mNativeObject;
+    }
+
+    @IntRange(from = 0)
+    public int getVertexCount() {
+        return nGetVertexCount(mNativeObject);
+    }
+
+    @NonNull
+    public void getQuatsAsFloat(@NonNull Buffer buffer) {
+        nGetQuatsAsFloat(mNativeObject, buffer, buffer.remaining());
+    }
+
+    @NonNull
+    public void getQuatsAsHalf(@NonNull Buffer buffer) {
+        nGetQuatsAsHalf(mNativeObject, buffer, buffer.remaining());
+    }
+
+    @NonNull
+    public void getQuatsAsShort(@NonNull Buffer buffer) {
+        nGetQuatsAsShort(mNativeObject, buffer, buffer.remaining());
+    }
+
+    public void destroy() {
+        nDestroy(mNativeObject);
+        mNativeObject = 0;
+    }
+
+    private static native long nCreateBuilder();
+    private static native void nDestroyBuilder(long nativeBuilder);
+
+    private static native void nBuilderVertexCount(long nativeBuilder, int vertexCount);
+    private static native void nBuilderNormals(long nativeBuilder, Buffer buffer, int remaining, int stride);
+    private static native void nBuilderTangents(long nativeBuilder, Buffer buffer, int remaining, int stride);
+    private static native void nBuilderUVs(long nativeBuilder, Buffer buffer, int remaining, int stride);
+    private static native void nBuilderPositions(long nativeBuilder, Buffer buffer, int remaining, int stride);
+    private static native void nBuilderTriangleCount(long nativeBuilder, int triangleCount);
+    private static native void nBuilderTriangles16(long nativeBuilder, Buffer buffer, int remaining);
+    private static native void nBuilderTriangles32(long nativeBuilder, Buffer buffer, int remaining);
+    private static native long nBuilderBuild(long nativeBuilder);
+
+    private static native int nGetVertexCount(long nativeSurfaceOrientation);
+    private static native void nGetQuatsAsFloat(long nativeSurfaceOrientation, Buffer buffer, int remaining);
+    private static native void nGetQuatsAsHalf(long nativeSurfaceOrientation, Buffer buffer, int remaining);
+    private static native void nGetQuatsAsShort(long nativeSurfaceOrientation, Buffer buffer, int remaining);
+    private static native void nDestroy(long nativeSurfaceOrientation);
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/VertexBuffer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/VertexBuffer.java
@@ -416,6 +416,9 @@ public class VertexBuffer {
      * basis.
      * </p>
      *
+     * @deprecated Instead please use SurfaceOrientation since it has additional capabilities and a
+     * builder-style API.
+     *
      * @param context an initialized QuatTangentContext object
      */
     public static void populateTangentQuaternions(@NonNull QuatTangentContext context) {

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -221,7 +221,7 @@ void VertexBuffer::setBufferAt(Engine& engine, uint8_t bufferIndex,
 }
 
 void VertexBuffer::populateTangentQuaternions(const QuatTangentContext& ctx) {
-    auto quats = geometry::SurfaceOrientation::Builder()
+    auto* quats = geometry::SurfaceOrientation::Builder()
         .vertexCount(ctx.quatCount)
         .normals(ctx.normals, ctx.normalsStride)
         .tangents(ctx.tangents, ctx.tangentsStride)
@@ -229,15 +229,17 @@ void VertexBuffer::populateTangentQuaternions(const QuatTangentContext& ctx) {
 
     switch (ctx.quatType) {
         case HALF4:
-            quats.getQuats((quath*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
+            quats->getQuats((quath*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
             break;
         case SHORT4:
-            quats.getQuats((short4*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
+            quats->getQuats((short4*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
             break;
         case FLOAT4:
-            quats.getQuats((quatf*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
+            quats->getQuats((quatf*) ctx.outBuffer, ctx.quatCount, ctx.outStride);
             break;
     }
+
+    delete quats;
 }
 
 } // namespace filament

--- a/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
+++ b/ios/samples/hello-ar/hello-ar/FilamentArView/FilamentApp.cpp
@@ -106,11 +106,12 @@ void FilamentApp::updatePlaneGeometry(const FilamentArPlaneGeometry& geometry) {
     // upwards-facing normal, we only need to generate a single quaternion, which can be copied.
     quatf* quats = new quatf[vertexCount];
     static float3 normals[1] = { float3(0, 1, 0) };
-    geometry::SurfaceOrientation::Builder()
+    auto helper = geometry::SurfaceOrientation::Builder()
         .vertexCount(1)
         .normals(normals)
-        .build()
-        .getQuats(quats, 1);
+        .build();
+    helper->getQuats(quats, 1);
+    delete helper;
     for (int i = 1; i < vertexCount; i++) {
         quats[i] = quats[0];
     }

--- a/libs/geometry/include/geometry/SurfaceOrientation.h
+++ b/libs/geometry/include/geometry/SurfaceOrientation.h
@@ -83,9 +83,9 @@ public:
         Builder& triangles(const filament::math::ushort3*) noexcept;
 
         /**
-         * Generates quats or panics if the submitted data is an incomplete combination.
+         * Generates quats or returns null if the submitted data is an incomplete combination.
          */
-        SurfaceOrientation build();
+        SurfaceOrientation* build();
 
     private:
         OrientationBuilderImpl* mImpl;
@@ -111,7 +111,9 @@ public:
     void getQuats(filament::math::quatf* out, size_t quatCount, size_t stride = 0) const noexcept;
     void getQuats(filament::math::short4* out, size_t quatCount, size_t stride = 0) const noexcept;
     void getQuats(filament::math::quath* out, size_t quatCount, size_t stride = 0) const noexcept;
-    /** @} */
+    /**
+     * @}
+     */
 
 private:
     SurfaceOrientation(OrientationImpl*) noexcept;

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -766,8 +766,9 @@ void ResourceLoader::computeTangents(FFilamentAsset* asset) const {
         }
 
         // Compute surface orientation quaternions.
-        auto helper = sob.build();
-        helper.getQuats(quats, vertexCount);
+        geometry::SurfaceOrientation* helper = sob.build();
+        helper->getQuats(quats, vertexCount);
+        delete helper;
 
         // Upload quaternions to the GPU.
         VertexBuffer::BufferDescriptor bd(quats, vertexCount * sizeof(short4), FREE_CALLBACK);

--- a/samples/lucy_utils.cpp
+++ b/samples/lucy_utils.cpp
@@ -262,7 +262,9 @@ Entity createDisk(Engine* engine, Texture* reflection) {
 
     static quath quats[nverts];
     static float3 normals[1] = { float3(0, 0, 1) };
-    SurfaceOrientation::Builder().vertexCount(1).normals(normals).build().getQuats(quats, 1);
+    auto* helper = SurfaceOrientation::Builder().vertexCount(1).normals(normals).build();
+    helper->getQuats(quats, 1);
+    delete helper;
     for (int i = 1; i < nverts; i++) {
         quats[i] = quats[0];
     }

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1338,7 +1338,7 @@ class_<SurfaceBuilder>("SurfaceOrientation$Builder")
     })
 
     .function("_build", EMBIND_LAMBDA(SurfaceOrientation*, (SurfaceBuilder* builder), {
-        return new SurfaceOrientation(builder->build());
+        return builder->build();
     }), allow_raw_pointers());
 
 class_<SurfaceOrientation>("SurfaceOrientation")


### PR DESCRIPTION
Note that libgeometry is already included in `filament-android`, this
simply exposes more of its existing functionality.

The Java version of SurfaceOrientation is similar to the JavaScript
version because we are bundling it into the main Filament package, even
though it is a separate library in C++. This is much simpler than
creating a brand new Java package.

New Android sample that tests this is forthcoming.

Fixes #1729.