### PR TITLE
Make sure sun in the skybox blooms enough

### DIFF
--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -28,6 +28,7 @@ fragment {
         if (materialParams.showSun && frameUniforms.sun.w >= 0.0f) {
             vec3 direction = normalize(variable_eyeDirection.xyz);
             vec3 sun = frameUniforms.lightColorIntensity.rgb * frameUniforms.lightColorIntensity.a;
+            sun *= 4.0 * PI; // emprirical factor to make the sun look better with bloom
             float cosAngle = dot(direction, frameUniforms.lightDirection);
             float x = (cosAngle - frameUniforms.sun.x) * frameUniforms.sun.z;
             float gradient = pow(1.0 - saturate(x), frameUniforms.sun.w);

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -27,8 +27,8 @@ fragment {
         sky *= frameUniforms.iblLuminance;
         if (materialParams.showSun && frameUniforms.sun.w >= 0.0f) {
             vec3 direction = normalize(variable_eyeDirection.xyz);
-            vec3 sun = frameUniforms.lightColorIntensity.rgb * frameUniforms.lightColorIntensity.a;
-            sun *= 4.0 * PI; // emprirical factor to make the sun look better with bloom
+            // 4*PI is an emprirical factor to make the sun look better with bloom
+            vec3 sun = frameUniforms.lightColorIntensity.rgb * (frameUniforms.lightColorIntensity.a * (4.0 * PI));
             float cosAngle = dot(direction, frameUniforms.lightDirection);
             float x = (cosAngle - frameUniforms.sun.x) * frameUniforms.sun.z;
             float gradient = pow(1.0 - saturate(x), frameUniforms.sun.w);


### PR DESCRIPTION
This is a temporary (hopefully) hack to make the skybox sun look 
better when bloom is enabled (this doesn't affect how the "sun" lights
objects, only how it looks in the skybox).
This scale factor was adjusted empirically.