### PR TITLE
gltfio: remove locale.cpp dependency

### DIFF
--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -26,8 +26,6 @@ add_library(gltfio-jni SHARED
         src/main/cpp/MaterialProvider.cpp
         src/main/cpp/ResourceLoader.cpp
         src/main/cpp/Gltfio.cpp
-
-        ../common/CallbackUtils.cpp
         ../common/NioUtils.cpp
 )
 

--- a/android/gltfio-android/src/main/cpp/Gltfio.cpp
+++ b/android/gltfio-android/src/main/cpp/Gltfio.cpp
@@ -16,19 +16,11 @@
 
 #include <jni.h>
 
-#include "common/NioUtils.h"
-
-extern void registerCallbackUtils(JNIEnv*);
-extern void registerNioUtils(JNIEnv*);
-
 jint JNI_OnLoad(JavaVM* vm, void*) {
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;
     }
-
-    registerCallbackUtils(env);
-    registerNioUtils(env);
 
     return JNI_VERSION_1_6;
 }

--- a/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
@@ -37,7 +37,7 @@ extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_ResourceLoader_nCreateResourceLoader(JNIEnv*, jclass,
         jlong nativeEngine) {
     Engine* engine = (Engine*) nativeEngine;
-    return (jlong) new ResourceLoader({ engine, utils::Path(), true, true });
+    return (jlong) new ResourceLoader({ engine, {}, true, true });
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -21,8 +21,6 @@
 
 #include <backend/BufferDescriptor.h>
 
-#include <string>
-
 namespace filament {
     class Engine;
 }
@@ -44,8 +42,8 @@ struct ResourceConfiguration {
     class filament::Engine* engine;
 
     //! Optional path or URI that points to the base glTF file. This is used solely
-    //! to resolve relative paths.
-    std::string gltfPath;
+    //! to resolve relative paths. The string pointer is not retained.
+    const char* gltfPath;
 
     //! If true, adjusts skinning weights to sum to 1. Well formed glTF files do not need this,
     //! but it is useful for robustness.

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -21,7 +21,7 @@
 
 #include <backend/BufferDescriptor.h>
 
-#include <utils/Path.h>
+#include <string>
 
 namespace filament {
     class Engine;
@@ -45,7 +45,7 @@ struct ResourceConfiguration {
 
     //! Optional path or URI that points to the base glTF file. This is used solely
     //! to resolve relative paths.
-    utils::Path gltfPath;
+    std::string gltfPath;
 
     //! If true, adjusts skinning weights to sum to 1. Well formed glTF files do not need this,
     //! but it is useful for robustness.

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -42,7 +42,6 @@
 
 #include <tsl/robin_map.h>
 
-#include <set>
 #include <string>
 #include <vector>
 

--- a/libs/utils/src/Path.cpp
+++ b/libs/utils/src/Path.cpp
@@ -19,7 +19,6 @@
 #include <sstream>
 #include <ostream>
 #include <iterator>
-#include <regex>
 
 #if defined(WIN32)
 #   include <utils/compiler.h>
@@ -185,12 +184,12 @@ std::vector<std::string> Path::split() const {
     size_t current;
     ssize_t next = -1;
 
-    // Matches a leading disk designator (C:\), forward slash (/), or back slash (\)
-    const static std::regex driveDesignationRegex(R"_regex(^([a-zA-Z]:\\|\\|\/))_regex");
-    std::smatch match;
-    if (std::regex_search(m_path, match, driveDesignationRegex)) {
-        segments.push_back(match[0]);
-        next = match[0].length() - 1;
+    // If there is a leading disk designator such as C:, this naturally becomes the first segment.
+    // However if there there is leading slash or back slash, we need to explicitly preserve it.
+    // Note that we are guaranteed to have at least one char in the path at this point.
+    if (m_path[0] == '/' || m_path[0] == '\\') {
+        segments.push_back(m_path.substr(0, 1));
+        next = 0;
     }
 
     do {

--- a/libs/utils/test/test_Path.cpp
+++ b/libs/utils/test/test_Path.cpp
@@ -249,6 +249,10 @@ TEST(PathTest, GetParent) {
     r = p.getParent();
     EXPECT_EQ("/out/", r);
 
+    p = "F:\\out\\bin\\";
+    r = p.getParent();
+    EXPECT_EQ("F:/out/", r);
+
     p = "out/bin";
     r = p.getParent();
     EXPECT_EQ("out/", r);
@@ -304,6 +308,10 @@ TEST(PathTest, Split) {
     EXPECT_EQ(1, segments.size());
     EXPECT_EQ("/", segments[0]);
 
+    segments = Path("d:\\").split();
+    EXPECT_EQ(1, segments.size());
+    EXPECT_EQ("d:", segments[0]);
+
     segments = Path("out/blue/bin").split();
     EXPECT_EQ(3, segments.size());
     EXPECT_EQ("out", segments[0]);
@@ -316,6 +324,18 @@ TEST(PathTest, Split) {
     EXPECT_EQ("out", segments[1]);
     EXPECT_EQ("blue", segments[2]);
     EXPECT_EQ("bin", segments[3]);
+
+    segments = Path("d:\\out\\blue").split();
+    EXPECT_EQ(3, segments.size());
+    EXPECT_EQ("d:", segments[0]);
+    EXPECT_EQ("out", segments[1]);
+    EXPECT_EQ("blue", segments[2]);
+
+    segments = Path("\\out\\blue").split();
+    EXPECT_EQ(3, segments.size());
+    EXPECT_EQ("/", segments[0]);
+    EXPECT_EQ("out", segments[1]);
+    EXPECT_EQ("blue", segments[2]);
 
     segments = Path("/out/blue/bin/").split();
     EXPECT_EQ(4, segments.size());

--- a/samples/gltf_baker.cpp
+++ b/samples/gltf_baker.cpp
@@ -323,7 +323,7 @@ static void updateViewerMesh(BakerApp& app) {
         // Load external textures and buffers.
         gltfio::ResourceLoader({
             .engine = app.engine,
-            .gltfPath = app.filename.getAbsolutePath(),
+            .gltfPath = app.filename.getAbsolutePath().c_str(),
             .normalizeSkinningWeights = true,
             .recomputeBoundingBoxes = false
         }).loadResources(app.viewerAsset);

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv) {
         // Load external textures and buffers.
         ResourceConfiguration configuration;
         configuration.engine = app.engine;
-        configuration.gltfPath = filename.getAbsolutePath();
+        configuration.gltfPath = filename.getAbsolutePath().c_str();
         configuration.normalizeSkinningWeights = true;
         configuration.recomputeBoundingBoxes = false;
         if (!app.resourceLoader) {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1444,7 +1444,7 @@ class_<ResourceLoader>("gltfio$ResourceLoader")
     .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine), {
         return new ResourceLoader({
             .engine = engine,
-            .gltfPath = utils::Path(),
+            .gltfPath = nullptr,
             .normalizeSkinningWeights = true,
             .recomputeBoundingBoxes = true
         });


### PR DESCRIPTION
For Android and wasm we do not use the filesystem and therefore do not
need `utils::Path`.

```
libgltfio-jni.so BEFORE 1.9 MB (693 KB gzipped)
libgltfio-jni.so AFTER  1.4 MB (542 KB gzipped)
```