### PR TITLE
New mathfwd.h header

### DIFF
--- a/android/filament-android/src/main/cpp/Camera.cpp
+++ b/android/filament-android/src/main/cpp/Camera.cpp
@@ -18,6 +18,8 @@
 
 #include <filament/Camera.h>
 
+#include <math/mat4.h>
+
 using namespace filament;
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/cpp/IndirectLight.cpp
+++ b/android/filament-android/src/main/cpp/IndirectLight.cpp
@@ -20,6 +20,7 @@
 #include <filament/Texture.h>
 #include <common/NioUtils.h>
 #include <common/CallbackUtils.h>
+#include <math/mat4.h>
 
 using namespace filament;
 

--- a/android/filament-android/src/main/cpp/SurfaceOrientation.cpp
+++ b/android/filament-android/src/main/cpp/SurfaceOrientation.cpp
@@ -20,6 +20,8 @@
 
 #include "common/NioUtils.h"
 
+#include <algorithm>
+
 using namespace filament;
 using namespace filament::geometry;
 using namespace filament::math;

--- a/android/filament-android/src/main/cpp/TransformManager.cpp
+++ b/android/filament-android/src/main/cpp/TransformManager.cpp
@@ -17,8 +17,11 @@
 
 #include <jni.h>
 
-#include <utils/Entity.h>
 #include <filament/TransformManager.h>
+
+#include <utils/Entity.h>
+
+#include <math/mat4.h>
 
 using namespace utils;
 using namespace filament;

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -23,7 +23,7 @@
 
 #include <utils/compiler.h>
 
-#include <math/mat4.h>
+#include <math/mathfwd.h>
 
 namespace utils {
 class Entity;
@@ -258,7 +258,15 @@ public:
      */
     void lookAt(const math::float3& eye,
                 const math::float3& center,
-                const math::float3& up = { 0, 1, 0 }) noexcept;
+                const math::float3& up) noexcept;
+
+    /** Sets the camera's view matrix, assuming up is along the y axis
+     *
+     * @param eye       The position of the camera in world space.
+     * @param center    The point in world space the camera is looking at.
+     */
+    void lookAt(const math::float3& eye,
+                const math::float3& center) noexcept;
 
     /** Returns the camera's model matrix
      *

--- a/filament/include/filament/DebugRegistry.h
+++ b/filament/include/filament/DebugRegistry.h
@@ -23,12 +23,10 @@
 
 #include <utils/compiler.h>
 
-#include <math/vec2.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
+#include <math/mathfwd.h>
 
 // FIXME: could we get rid of <utility>
-#include <utility>
+#include <utility> // for std::pair
 
 #include <stdint.h>
 

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -23,7 +23,7 @@
 
 #include <utils/compiler.h>
 
-#include <math/mat4.h>
+#include <math/mathfwd.h>
 
 namespace filament {
 

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -23,9 +23,7 @@
 #include <utils/compiler.h>
 #include <utils/EntityInstance.h>
 
-#include <math/vec3.h>
-
-#include <math.h>
+#include <math/mathfwd.h>
 
 namespace utils {
     class Entity;

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -26,7 +26,7 @@
 
 #include <utils/compiler.h>
 
-#include <math/vec4.h>
+#include <math/mathfwd.h>
 
 #include <stdint.h>
 

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -24,11 +24,7 @@
 
 #include <utils/compiler.h>
 
-#include <math/mat3.h>
-#include <math/mat4.h>
-#include <math/vec2.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
+#include <math/mathfwd.h>
 
 namespace filament {
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -26,9 +26,7 @@
 #include <utils/compiler.h>
 #include <utils/EntityInstance.h>
 
-#include <math/mat4.h>
-#include <math/vec3.h>
-#include <math/vec4.h>
+#include <math/mathfwd.h>
 
 #include <type_traits>
 

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -22,7 +22,7 @@
 #include <utils/compiler.h>
 #include <utils/EntityInstance.h>
 
-#include <math/mat4.h>
+#include <math/mathfwd.h>
 
 #include <iterator>
 
@@ -126,7 +126,8 @@ public:
      *
      * @see destroy()
      */
-    void create(utils::Entity entity, Instance parent = {}, const math::mat4f& localTransform = {});
+    void create(utils::Entity entity, Instance parent, const math::mat4f& localTransform);
+    void create(utils::Entity entity, Instance parent = {});
 
     /**
      * Destroys this component from the given entity, children are orphaned.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -26,8 +26,7 @@
 
 #include <utils/compiler.h>
 
-#include <math/vec2.h>
-#include <math/vec3.h>
+#include <math/mathfwd.h>
 
 namespace filament {
 

--- a/filament/include/filament/Viewport.h
+++ b/filament/include/filament/Viewport.h
@@ -24,7 +24,7 @@
 #include <utils/compiler.h>
 
 #include <math/scalar.h>
-#include <math/vec2.h>
+#include <math/mathfwd.h>
 
 #include <stddef.h>
 #include <stdint.h>

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -292,6 +292,10 @@ void Camera::lookAt(const float3& eye, const float3& center, float3 const& up) n
     upcast(this)->lookAt(eye, center, up);
 }
 
+void Camera::lookAt(const float3& eye, const float3& center) noexcept {
+    upcast(this)->lookAt(eye, center, {0, 1, 0});
+}
+
 mat4f Camera::getModelMatrix() const noexcept {
     return upcast(this)->getModelMatrix();
 }

--- a/filament/src/DebugRegistry.cpp
+++ b/filament/src/DebugRegistry.cpp
@@ -16,6 +16,10 @@
 
 #include "details/DebugRegistry.h"
 
+#include <math/vec2.h>
+#include <math/vec3.h>
+#include <math/vec4.h>
+
 #ifndef NDEBUG
 #   define DEBUG_PROPERTIES_WRITABLE true
 #else

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -27,6 +27,7 @@
 #include <utils/Panic.h>
 
 #include <math/scalar.h>
+#include <math/mat4.h>
 
 #define IBL_INTEGRATION_PREFILTERED_CUBEMAP         0
 #define IBL_INTEGRATION_IMPORTANCE_SAMPLING         1

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -16,6 +16,8 @@
 
 #include "components/TransformManager.h"
 
+#include <math/mat4.h>
+
 using namespace utils;
 using namespace filament::math;
 
@@ -393,6 +395,10 @@ TransformManager::children_iterator& TransformManager::children_iterator::operat
 
 void TransformManager::create(Entity entity, Instance parent, const mat4f& worldTransform) {
     upcast(this)->create(entity, parent, worldTransform);
+}
+
+void TransformManager::create(Entity entity, Instance parent) {
+    upcast(this)->create(entity, parent, {});
 }
 
 void TransformManager::destroy(Entity e) noexcept {

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -26,6 +26,8 @@
 
 #include <utils/compiler.h>
 
+#include <math/mat3.h>
+
 #include <array>
 
 namespace filament {

--- a/libs/filagui/src/ImGuiExtensions.cpp
+++ b/libs/filagui/src/ImGuiExtensions.cpp
@@ -22,6 +22,7 @@
 #include <math/vec3.h>
 #include <math/quat.h>
 
+#include <algorithm>
 #include <limits>
 
 using namespace filament::math;
@@ -30,7 +31,7 @@ using namespace filament::math;
 // Maughan's port to ImGui. Thanks Chris!
 class ArrowWidget {
 public:
-    ArrowWidget(float3 direction);
+    explicit ArrowWidget(float3 direction);
     bool draw();
     float3 getDirection() const;
 private:

--- a/libs/image/include/image/ColorTransform.h
+++ b/libs/image/include/image/ColorTransform.h
@@ -26,6 +26,7 @@
 #include <math/vec4.h>
 #include <math/half.h>
 
+#include <algorithm>
 #include <memory>
 
 namespace image {

--- a/libs/math/CMakeLists.txt
+++ b/libs/math/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PUBLIC_HDRS
         include/math/compiler.h
         include/math/fast.h
         include/math/half.h
+        include/math/mathfwd.h
         include/math/mat2.h
         include/math/mat3.h
         include/math/mat4.h
@@ -64,7 +65,7 @@ target_link_libraries(test_${TARGET} PRIVATE math gtest)
 # ==================================================================================================
 
 set(BENCHMARK_SRCS
-        benchmarks/benchmark_fast.cpp)
+        benchmarks/benchmark_fast.cpp include/math/mathfwd.h)
 
 add_executable(benchmark_${TARGET} ${BENCHMARK_SRCS})
 

--- a/libs/math/include/math/mathfwd.h
+++ b/libs/math/include/math/mathfwd.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MATH_MATHFWD_H_
+#define MATH_MATHFWD_H_
+
+#include <stdint.h>
+
+namespace filament {
+namespace math {
+namespace details {
+
+template<typename T> class TVec2;
+template<typename T> class TVec3;
+template<typename T> class TVec4;
+
+template<typename T> class TMat22;
+template<typename T> class TMat33;
+template<typename T> class TMat44;
+
+}  // namespace details
+
+using double2   = details::TVec2<double>;
+using float2    = details::TVec2<float>;
+using int2      = details::TVec2<int32_t>;
+using uint2     = details::TVec2<uint32_t>;
+using short2    = details::TVec2<int16_t>;
+using ushort2   = details::TVec2<uint16_t>;
+using byte2     = details::TVec2<int8_t>;
+using ubyte2    = details::TVec2<uint8_t>;
+using bool2     = details::TVec2<bool>;
+
+using double3   = details::TVec3<double>;
+using float3    = details::TVec3<float>;
+using int3      = details::TVec3<int32_t>;
+using uint3     = details::TVec3<uint32_t>;
+using short3    = details::TVec3<int16_t>;
+using ushort3   = details::TVec3<uint16_t>;
+using byte3     = details::TVec3<int8_t>;
+using ubyte3    = details::TVec3<uint8_t>;
+using bool3     = details::TVec3<bool>;
+
+using double4   = details::TVec4<double>;
+using float4    = details::TVec4<float>;
+using int4      = details::TVec4<int32_t>;
+using uint4     = details::TVec4<uint32_t>;
+using short4    = details::TVec4<int16_t>;
+using ushort4   = details::TVec4<uint16_t>;
+using byte4     = details::TVec4<int8_t>;
+using ubyte4    = details::TVec4<uint8_t>;
+using bool4     = details::TVec4<bool>;
+
+using mat2      = details::TMat22<double>;
+using mat2f     = details::TMat22<float>;
+
+using mat3      = details::TMat33<double>;
+using mat3f     = details::TMat33<float>;
+
+using mat4      = details::TMat44<double>;
+using mat4f     = details::TMat44<float>;
+
+}  // namespace math
+}  // namespace filament
+
+#endif  // MATH_MATHFWD_H_

--- a/libs/math/include/math/scalar.h
+++ b/libs/math/include/math/scalar.h
@@ -17,8 +17,6 @@
 #ifndef TNT_MATH_SCALAR_H
 #define TNT_MATH_SCALAR_H
 
-#include <algorithm>
-#include <cmath>
 #include <math/compiler.h>
 
 namespace filament {
@@ -39,13 +37,23 @@ constexpr const double F_SQRT2    = 1.41421356237309504880168872420969808;
 constexpr const double F_SQRT1_2  = 0.707106781186547524400844362104849039;
 
 template<typename T>
-inline constexpr T MATH_PURE saturate(T v) noexcept {
-    return T(std::min(T(1), std::max(T(0), v)));
+inline constexpr T MATH_PURE min(T a, T b) noexcept {
+    return a < b ? a : b;
+}
+
+template<typename T>
+inline constexpr T MATH_PURE max(T a, T b) noexcept {
+    return a > b ? a : b;
 }
 
 template<typename T>
 inline constexpr T MATH_PURE clamp(T v, T min, T max) noexcept {
-    return T(std::min(max, std::max(min, v)));
+    return T(math::min(max, math::max(min, v)));
+}
+
+template<typename T>
+inline constexpr T MATH_PURE saturate(T v) noexcept {
+    return clamp(T(1), T(0), v);
 }
 
 template<typename T>

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -544,7 +544,12 @@ class_<Camera>("Camera")
         self->setModelMatrix(m.m);
     }), allow_raw_pointers())
 
-    .function("lookAt", &Camera::lookAt)
+    .function("lookAt", EMBIND_LAMBDA(void, (Camera* self,
+            const math::float3& eye,
+            const math::float3& center,
+            const math::float3& up), {
+        self->lookAt(eye, center, up);
+    }), allow_raw_pointers())
 
     .function("getModelMatrix", EMBIND_LAMBDA(flatmat4, (Camera* self), {
         return flatmat4 { self->getModelMatrix() };


### PR DESCRIPTION
math/mathwfd.h forward declares all {mat|vec}{2|3|4}<> classes,
which allows us to remove their respective #include in a lot of
our public headers.
Our math headers are full of templates, so this should help build times
a bit.

Also we want to keep the public headers as minimalist as possible.