### PR TITLE
improve SSrefr highlights at low roughness

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -69,13 +69,13 @@ public:
             View::AmbientOcclusionOptions const& options) noexcept;
 
     FrameGraphId<FrameGraphTexture> generateGaussianMipmap(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, size_t roughnessLodCount,
+            FrameGraphId<FrameGraphTexture> input, size_t roughnessLodCount, bool reinhard,
             size_t kernelWidth, float sigmaRatio = 6.0f) noexcept;
 
     FrameGraphId<FrameGraphTexture> gaussianBlurPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, uint8_t srcLevel,
             FrameGraphId<FrameGraphTexture> output, uint8_t dstLevel,
-            size_t kernelWidth, float sigma = 6.0f) noexcept;
+            bool reinhard, size_t kernelWidth, float sigma = 6.0f) noexcept;
 
     backend::Handle<backend::HwTexture> getNoSSAOTexture() const {
         return mNoSSAOTexture;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -513,7 +513,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
                 .format = TextureFormat::R11F_G11F_B10F,
         });
 
-        input = ppm.generateGaussianMipmap(fg, input, roughnessLodCount, kernelSize);
+        input = ppm.generateGaussianMipmap(fg, input, roughnessLodCount, true, kernelSize);
 
         struct PrepareSSRData {
             FrameGraphId<FrameGraphTexture> ssr;

--- a/filament/src/materials/separableGaussianBlur.mat
+++ b/filament/src/materials/separableGaussianBlur.mat
@@ -24,6 +24,10 @@ material {
             name : count
         },
         {
+            type : int,
+            name : reinhard
+        },
+        {
             type : float2[32],
             name : kernel
         }
@@ -51,19 +55,39 @@ fragment {
         sum += s * weight;
     }
 
+    void tapReinhard(inout vec3 sum, inout float totalWeight, float weight, highp vec2 position) {
+        vec3 s = textureLod(materialParams_source, position, materialParams.level).rgb;
+        float w = weight / (1.0 + max3(s));
+        totalWeight += w;
+        sum += s * w;
+    }
+
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy;
 
         // we handle the center pixel separately
         vec3 sum = vec3(0);
-        tap(sum, materialParams.kernel[0].x, uv);
 
-        vec2 offset = materialParams.axis;
-        for (int i = 1; i < materialParams.count; i++, offset += materialParams.axis * 2.0) {
-            float k = materialParams.kernel[i].x;
-            vec2 o = offset + materialParams.axis * materialParams.kernel[i].y;
-            tap(sum, k, uv + o);
-            tap(sum, k, uv - o);
+        if (materialParams.reinhard != 0) {
+            float totalWeight = 0.0;
+            tapReinhard(sum, totalWeight, materialParams.kernel[0].x, uv);
+            vec2 offset = materialParams.axis;
+            for (int i = 1; i < materialParams.count; i++, offset += materialParams.axis * 2.0) {
+                float k = materialParams.kernel[i].x;
+                vec2 o = offset + materialParams.axis * materialParams.kernel[i].y;
+                tapReinhard(sum, totalWeight, k, uv + o);
+                tapReinhard(sum, totalWeight, k, uv - o);
+            }
+            sum *= 1.0 / totalWeight;
+        } else {
+            tap(sum, materialParams.kernel[0].x, uv);
+            vec2 offset = materialParams.axis;
+            for (int i = 1; i < materialParams.count; i++, offset += materialParams.axis * 2.0) {
+                float k = materialParams.kernel[i].x;
+                vec2 o = offset + materialParams.axis * materialParams.kernel[i].y;
+                tap(sum, k, uv + o);
+                tap(sum, k, uv - o);
+            }
         }
 
         postProcess.color.rgb = sum;


### PR DESCRIPTION
We untonemap/tonemap the first level of blur to reduce the very high
frequencies due to HDR highlights in the image, this produce a softer
image at higher roughness. This can programmatically be turned off,
but that setting is not exposed.