### PR TITLE
Fix incorrect twoPassesOneSide rendering with Metal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@ A new header is inserted each time a *tag* is created.
 - Material instances now allow dynamic depth testing and other rasterization state.
 - Support for Bloom as a post-process effect.
 - Added Java bindings for geometry::SurfaceOrientation.
+- Fixed bug rendering transparent objects with Metal backend.
 
 ## v1.4.5
 

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -1690,7 +1690,7 @@ non-shader data.
    honoring the <code>culling</code> mode, etc.
 </li>
 <li class="minus"><code>twoPassesOneSide</code>: the transparent object is first rendered in the depth buffer, then again in
-  the color buffer, honoring the <code>cullling</code> mode. This effectively renders only half of the
+  the color buffer, honoring the <code>culling</code> mode. This effectively renders only half of the
   transparent object as shown in <a href="#figure_transparencytwopassesoneside">figure&#xA0;31</a>.
 </li>
 <li class="minus"><code>twoPassesTwoSides</code>: the transparent object is rendered twice in the color buffer: first with its

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1251,7 +1251,7 @@ The three possible transparency modes are:
 - `default`: the transparent object is rendered normally (as seen in figure [transparencyDefault]),
    honoring the `culling` mode, etc.
 - `twoPassesOneSide`: the transparent object is first rendered in the depth buffer, then again in
-  the color buffer, honoring the `cullling` mode. This effectively renders only half of the
+  the color buffer, honoring the `culling` mode. This effectively renders only half of the
   transparent object as shown in figure [transparencyTwoPassesOneSide].
 - `twoPassesTwoSides`: the transparent object is rendered twice in the color buffer: first with its
   back faces, then with its front faces. This mode lets you render both set of faces while reducing

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -231,7 +231,8 @@ struct PipelineState {
                 this->colorAttachmentPixelFormat == rhs.colorAttachmentPixelFormat &&
                 this->depthAttachmentPixelFormat == rhs.depthAttachmentPixelFormat &&
                 this->sampleCount == rhs.sampleCount &&
-                this->blendState == rhs.blendState
+                this->blendState == rhs.blendState &&
+                this->colorWrite == rhs.colorWrite
         );
     }
 


### PR DESCRIPTION
A state tracking bug led to disappearing objects rendered with the `twoPassesOneSide` setting.