### PR TITLE
Reduce size of gltfio for Android.

### DIFF
--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -39,8 +39,6 @@ set_target_properties(smol-v PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libsmol-v.a)
 
 
-include_directories(.. ${FILAMENT_DIR}/include)
-
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-stack-protector")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math -ffp-contract=fast")
@@ -48,10 +46,11 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility-inlines-hid
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility=hidden")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer -ffunction-sections -fdata-sections")
 
-set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
-set(CMAKE_SHARED_LINKER_FLAGS" ${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
 
-set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libfilament-jni.map")
+set(VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/libfilament-jni.map")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${VERSION_SCRIPT}")
 
 add_library(filament-jni SHARED
     src/main/cpp/Camera.cpp
@@ -86,20 +85,30 @@ add_library(filament-jni SHARED
     ../common/NioUtils.cpp
 )
 
+# Ordering is significant in the following list. The PRIVATE qualifier prevents transitive deps.
 target_link_libraries(filament-jni
-    filament
-    backend
-    filaflat
-    filabridge
-    geometry
-    ibl
-    utils
-    log
-    GLESv3
-    EGL
-    android
-    jnigraphics
+    PRIVATE filament
+    PRIVATE backend
+    PRIVATE filaflat
+    PRIVATE filabridge
+    PRIVATE geometry
+    PRIVATE ibl
+    PRIVATE log
+    PRIVATE GLESv3
+    PRIVATE EGL
+    PRIVATE android
+    PRIVATE jnigraphics
+    PRIVATE utils
 )
+
+target_include_directories(filament-jni PRIVATE
+        ..
+        ${FILAMENT_DIR}/include
+        ../../third_party/robin-map
+        ../../libs/utils/include)
+
+# Force a relink when the version script is changed:
+set_target_properties(filament-jni PROPERTIES LINK_DEPENDS ${VERSION_SCRIPT})
 
 option(FILAMENT_SUPPORTS_VULKAN "Enables Vulkan on Android" OFF)
 

--- a/android/filament-android/libfilament-jni.map
+++ b/android/filament-android/libfilament-jni.map
@@ -1,4 +1,4 @@
 LIBFILAMENT {
-  global: Java_com_google_android_filament_*; JNI*;
+  global: *filament*; JNI*;
   local: *;
 };

--- a/android/filament-utils-android/src/main/cpp/Utils.cpp
+++ b/android/filament-utils-android/src/main/cpp/Utils.cpp
@@ -31,11 +31,17 @@ using namespace image;
 extern void registerCallbackUtils(JNIEnv*);
 extern void registerNioUtils(JNIEnv*);
 
+namespace gltfio {
+    void JNI_OnLoad(JNIEnv* env);
+}
+
 jint JNI_OnLoad(JavaVM* vm, void*) {
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;
     }
+
+    gltfio::JNI_OnLoad(env);
 
     registerCallbackUtils(env);
     registerNioUtils(env);

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -4,6 +4,10 @@ set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../filament-android ${CMAKE_CURRENT_BINARY_DIR}/filament-android)
 
+add_library(utils STATIC IMPORTED)
+set_target_properties(utils PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libutils.a)
+
 add_library(gltfio STATIC IMPORTED)
 set_target_properties(gltfio PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libgltfio_core.a)
@@ -46,5 +50,7 @@ set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
 target_link_libraries(gltfio-jni
         filament-jni
         gltfio
+        utils
         gltfio_resources
+        log
 )

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -73,6 +73,10 @@ target_include_directories(gltfio-jni PRIVATE
 set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/libgltfio-jni.symbols)
 
+# Force a relink when the version script is changed.
+set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/libgltfio-jni.map)
+
 # The ordering in the following list is important because CMake does not have dependency information.
 target_link_libraries(gltfio-jni
         filament-jni

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.6)
 
 set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
+set(GLTFIO_DIR ../../libs/gltfio)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../filament-android ${CMAKE_CURRENT_BINARY_DIR}/filament-android)
 
@@ -8,18 +9,9 @@ add_library(utils STATIC IMPORTED)
 set_target_properties(utils PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libutils.a)
 
-add_library(gltfio STATIC IMPORTED)
-set_target_properties(gltfio PROPERTIES IMPORTED_LOCATION
-        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libgltfio_core.a)
-
 add_library(gltfio_resources STATIC IMPORTED)
 set_target_properties(gltfio_resources PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libgltfio_resources.a)
-
-include_directories(${FILAMENT_DIR}/include
-        ..
-        ../../third_party/robin-map
-        ../../libs/utils/include)
 
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-stack-protector")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
@@ -34,13 +26,48 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-funct
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libgltfio-jni.map")
 
 add_library(gltfio-jni SHARED
+        ${GLTFIO_DIR}/include/gltfio/Animator.h
+        ${GLTFIO_DIR}/include/gltfio/AssetLoader.h
+        ${GLTFIO_DIR}/include/gltfio/MaterialProvider.h
+        ${GLTFIO_DIR}/include/gltfio/AssetPipeline.h
+        ${GLTFIO_DIR}/include/gltfio/ResourceLoader.h
+        ${GLTFIO_DIR}/include/gltfio/SimpleViewer.h
+        ${GLTFIO_DIR}/include/gltfio/FilamentAsset.h
+
+        ${GLTFIO_DIR}/src/Animator.cpp
+        ${GLTFIO_DIR}/src/AssetLoader.cpp
+        ${GLTFIO_DIR}/src/DependencyGraph.cpp
+        ${GLTFIO_DIR}/src/DependencyGraph.h
+        ${GLTFIO_DIR}/src/FFilamentAsset.h
+        ${GLTFIO_DIR}/src/FilamentAsset.cpp
+        ${GLTFIO_DIR}/src/GltfEnums.h
+        ${GLTFIO_DIR}/src/MaterialProvider.cpp
+        ${GLTFIO_DIR}/src/ResourceLoader.cpp
+        ${GLTFIO_DIR}/src/UbershaderLoader.cpp
+        ${GLTFIO_DIR}/src/Wireframe.cpp
+        ${GLTFIO_DIR}/src/Wireframe.h
+        ${GLTFIO_DIR}/src/math.h
+        ${GLTFIO_DIR}/src/upcast.h
+        ${GLTFIO_DIR}/src/Image.cpp
+
         src/main/cpp/Animator.cpp
         src/main/cpp/AssetLoader.cpp
         src/main/cpp/FilamentAsset.cpp
         src/main/cpp/MaterialProvider.cpp
         src/main/cpp/ResourceLoader.cpp
         src/main/cpp/Gltfio.cpp
+
         ../common/NioUtils.cpp
+)
+
+target_include_directories(gltfio-jni PRIVATE
+        ..
+        ${FILAMENT_DIR}/include
+        ${FILAMENT_DIR}/include/gltfio/resources
+        ../../third_party/cgltf
+        ../../third_party/robin-map
+        ../../third_party/stb
+        ../../libs/utils/include
 )
 
 set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
@@ -49,7 +76,6 @@ set_target_properties(gltfio-jni PROPERTIES LINK_DEPENDS
 # The ordering in the following list is important because CMake does not have dependency information.
 target_link_libraries(gltfio-jni
         filament-jni
-        gltfio
         utils
         gltfio_resources
         log

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -17,6 +17,16 @@ include_directories(${FILAMENT_DIR}/include
         ../../third_party/robin-map
         ../../libs/utils/include)
 
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-stack-protector")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffast-math -ffp-contract=fast")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility-inlines-hidden")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer -ffunction-sections -fdata-sections")
+
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
+
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libgltfio-jni.map")
 
 add_library(gltfio-jni SHARED

--- a/android/gltfio-android/libgltfio-jni.map
+++ b/android/gltfio-android/libgltfio-jni.map
@@ -1,4 +1,4 @@
 LIBGLTFIO {
-  global: Java_com_google_android_filament_*; JNI*;
+  global: Java_com_google_android_filament_*; *gltfio*; JNI*;
   local: *;
 };

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -30,9 +30,6 @@ using namespace filament;
 using namespace gltfio;
 using namespace utils;
 
-extern void registerCallbackUtils(JNIEnv*);
-extern void registerNioUtils(JNIEnv*);
-
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetLoader(JNIEnv*, jclass,
         jlong nativeEngine, jlong nativeProvider, jlong nativeEntities) {

--- a/android/gltfio-android/src/main/cpp/Gltfio.cpp
+++ b/android/gltfio-android/src/main/cpp/Gltfio.cpp
@@ -16,11 +16,27 @@
 
 #include <jni.h>
 
+#include <utils/compiler.h>
+
+extern void registerNioUtils(JNIEnv*);
+
 jint JNI_OnLoad(JavaVM* vm, void*) {
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;
     }
 
+    registerNioUtils(env);
+
     return JNI_VERSION_1_6;
+}
+
+// This alternative init function is necessary when gltfio is loaded using an ELF dependency.
+namespace gltfio {
+
+    UTILS_PUBLIC
+    void JNI_OnLoad(JNIEnv* env) {
+        registerNioUtils(env);
+    }
+
 }

--- a/filament/include/filament/Box.h
+++ b/filament/include/filament/Box.h
@@ -125,7 +125,7 @@ public:
 /**
  * An axis aligned box represented by its min and max coordinates
  */
-struct Aabb {
+struct UTILS_PUBLIC Aabb {
 
     /** min coordinates */
     math::float3 min = std::numeric_limits<float>::max();

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -143,6 +143,7 @@ else()
 
     install(TARGETS gltfio_core gltfio_resources ARCHIVE DESTINATION lib/${DIST_DIR})
     install(DIRECTORY ${PUBLIC_HDR_DIR}/gltfio DESTINATION include)
+    install(FILES ${RESOURCE_DIR}/gltfresources.h DESTINATION include/gltfio/resources)
 
 endif()
 


### PR DESCRIPTION
The net effect of these 3 changes on arm64 reduces the uncompressed libgltfio so from 1.5 MB to 850 KB.  Over 55% of the newly optimized binary is its rodata section (i.e. materials).

As a bonus, this ultimately reduces libfilament so by 8 KB because it fixes a typo in our CMake file wrt `--gc-sections`.

Later today, we would like to create a "gltfio-lite" which would only support lit opaque materials.  This would have a size of ~470 KB .