### PR TITLE
Rework array texture support

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -83,6 +83,8 @@ public class Texture {
     public enum Sampler {
         /** 2D sampler */
         SAMPLER_2D,
+        /** 2D array sampler  */
+        SAMPLER_2D_ARRAY,
         /** Cubemap sampler */
         SAMPLER_CUBEMAP,
         /** External texture sampler */
@@ -581,8 +583,12 @@ public class Texture {
         }
 
         /**
-         * Specifies the texture's number of layers. This creates a 3D texture.
-         * @param depth texture number of layer, must be at least 1. Default is 1.
+         * Specifies the texture's number of layers. Values greater than 1 create a 3D texture.
+         *
+         * <p>This <code>Texture</code> instance must use
+         * {@link Sampler#SAMPLER_2D_ARRAY SAMPLER_2D_ARRAY} or it has no effect.</p>
+         *
+         * @param depth texture number of layers. Default is 1.
          * @return This Builder, for chaining calls.
          */
         @NonNull

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -168,7 +168,8 @@ enum class Precision : uint8_t {
 
 //! Texture sampler type
 enum class SamplerType : uint8_t {
-    SAMPLER_2D,         //!< 2D or 2D array texture
+    SAMPLER_2D,         //!< 2D texture
+    SAMPLER_2D_ARRAY,   //!< 2D array texture
     SAMPLER_CUBEMAP,    //!< Cube map texture
     SAMPLER_EXTERNAL,   //!< External texture
 };

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -98,9 +98,9 @@ struct MetalProgram : public HwProgram {
 };
 
 struct MetalTexture : public HwTexture {
-    MetalTexture(MetalContext& context, backend::SamplerType target, uint8_t levels,
-            TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
-            TextureUsage usage) noexcept;
+    MetalTexture(MetalContext& context, SamplerType target, uint8_t levels, TextureFormat format,
+            uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage)
+            noexcept;
     ~MetalTexture();
 
     void load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
@@ -127,8 +127,14 @@ struct MetalSamplerGroup : public HwSamplerGroup {
 
 class MetalRenderTarget : public HwRenderTarget {
 public:
+
+    struct TargetInfo {
+        uint8_t level;
+        uint16_t layer;
+    };
+
     MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height, uint8_t samples,
-            id<MTLTexture> color, id<MTLTexture> depth, uint8_t colorLevel, uint8_t depthLevel);
+            id<MTLTexture> color, TargetInfo colorInfo, id<MTLTexture> depth, TargetInfo depthInfo);
     explicit MetalRenderTarget(MetalContext* context)
             : HwRenderTarget(0, 0), context(context), defaultRenderTarget(true) {}
 
@@ -143,8 +149,9 @@ public:
     id<MTLTexture> getDepthResolve();
     id<MTLTexture> getBlitColorSource();
     id<MTLTexture> getBlitDepthSource();
-    uint8_t getColorLevel() { return colorLevel; }
-    uint8_t getDepthLevel() { return depthLevel; }
+
+    const TargetInfo& getColorInfo() const { return colorInfo; }
+    const TargetInfo& getDepthInfo() const { return depthInfo; }
 
 private:
     static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, MTLPixelFormat format,
@@ -153,11 +160,9 @@ private:
     MetalContext* context;
     bool defaultRenderTarget = false;
     uint8_t samples = 1;
-    uint8_t colorLevel = 0;
-    uint8_t depthLevel = 0;
 
-    id<MTLTexture> color = nil;
-    id<MTLTexture> depth = nil;
+    id<MTLTexture> color = nil, depth = nil;
+    TargetInfo colorInfo = {}, depthInfo = {};
     id<MTLTexture> multisampledColor = nil;
     id<MTLTexture> multisampledDepth = nil;
 };

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -200,7 +200,7 @@ static MTLPixelFormat decidePixelFormat(id<MTLDevice> device, TextureFormat form
     return metalFormat;
 }
 
-MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, uint8_t levels,
+MetalTexture::MetalTexture(MetalContext& context, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height, uint32_t depth,
         TextureUsage usage) noexcept
     : HwTexture(target, levels, samples, width, height, depth, format, usage), context(context),
@@ -220,37 +220,63 @@ MetalTexture::MetalTexture(MetalContext& context, backend::SamplerType target, u
 
     const BOOL mipmapped = levels > 1;
     const BOOL multisampled = samples > 1;
+    const BOOL textureArray = target == SamplerType::SAMPLER_2D_ARRAY;
+
+    const auto getTextureType = [](bool isArray, bool isMultisampled) {
+        uint8_t value = 0;
+        if (isMultisampled) {
+            value |= 0b10u;
+        }
+        if (isArray) {
+            value |= 0b01u;
+        }
+        switch (value) {
+            default:
+            case 0b00:
+                return MTLTextureType2D;
+            case 0b01:
+                return MTLTextureType2DArray;
+            case 0b10:
+                return MTLTextureType2DMultisample;
+            case 0b11:
+                return MTLTextureType2DMultisampleArray;
+        }
+    };
 
     MTLTextureDescriptor* descriptor;
-    if (target == backend::SamplerType::SAMPLER_2D) {
-        descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:metalPixelFormat
-                                                                        width:width
-                                                                       height:height
-                                                                    mipmapped:mipmapped];
-        descriptor.mipmapLevelCount = levels;
-        descriptor.textureType = multisampled ? MTLTextureType2DMultisample : MTLTextureType2D;
-        descriptor.sampleCount = multisampled ? samples : 1;
-        descriptor.usage = getMetalTextureUsage(usage);
-        descriptor.storageMode = MTLStorageModePrivate;
-        texture = [context.device newTextureWithDescriptor:descriptor];
-        ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
-    } else if (target == backend::SamplerType::SAMPLER_CUBEMAP) {
-        ASSERT_POSTCONDITION(!multisampled, "Multisampled cubemap faces not supported.");
-        ASSERT_POSTCONDITION(width == height, "Cubemap faces must be square.");
-        descriptor = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:metalPixelFormat
-                                                                           size:width
-                                                                      mipmapped:mipmapped];
-        descriptor.mipmapLevelCount = levels;
-        descriptor.usage = getMetalTextureUsage(usage);
-        descriptor.storageMode = MTLStorageModePrivate;
-        texture = [context.device newTextureWithDescriptor:descriptor];
-        ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
-    } else if (target == backend::SamplerType::SAMPLER_EXTERNAL) {
-        // If we're using external textures (CVPixelBufferRefs), we don't need to make any texture
-        // allocations.
-        texture = nil;
-    } else {
-        ASSERT_POSTCONDITION(false, "Sampler type not supported.");
+    switch (target) {
+        case SamplerType::SAMPLER_2D:
+        case SamplerType::SAMPLER_2D_ARRAY:
+            descriptor = [MTLTextureDescriptor new];
+            descriptor.pixelFormat = metalPixelFormat;
+            descriptor.textureType = getTextureType(textureArray, multisampled);
+            descriptor.width = width;
+            descriptor.height = height;
+            descriptor.arrayLength = depth;
+            descriptor.mipmapLevelCount = levels;
+            descriptor.sampleCount = multisampled ? samples : 1;
+            descriptor.usage = getMetalTextureUsage(usage);
+            descriptor.storageMode = MTLStorageModePrivate;
+            texture = [context.device newTextureWithDescriptor:descriptor];
+            ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
+            break;
+        case SamplerType::SAMPLER_CUBEMAP:
+            ASSERT_POSTCONDITION(!multisampled, "Multisampled cubemap faces not supported.");
+            ASSERT_POSTCONDITION(width == height, "Cubemap faces must be square.");
+            descriptor = [MTLTextureDescriptor textureCubeDescriptorWithPixelFormat:metalPixelFormat
+                                                                               size:width
+                                                                          mipmapped:mipmapped];
+            descriptor.mipmapLevelCount = levels;
+            descriptor.usage = getMetalTextureUsage(usage);
+            descriptor.storageMode = MTLStorageModePrivate;
+            texture = [context.device newTextureWithDescriptor:descriptor];
+            ASSERT_POSTCONDITION(texture != nil, "Could not create Metal texture. Out of memory?");
+            break;
+        case SamplerType::SAMPLER_EXTERNAL:
+            // If we're using external textures (CVPixelBufferRefs), we don't need to make any
+            // texture allocations.
+            texture = nil;
+            break;
     }
 }
 
@@ -369,9 +395,9 @@ void MetalTexture::loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset,
 }
 
 MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height,
-        uint8_t samples, id<MTLTexture> color, id<MTLTexture> depth, uint8_t colorLevel,
-        uint8_t depthLevel) : HwRenderTarget(width, height), context(context), samples(samples),
-        colorLevel(colorLevel), depthLevel(depthLevel) {
+        uint8_t samples, id<MTLTexture> color, TargetInfo colorInfo, id<MTLTexture> depth,
+        TargetInfo depthInfo) : HwRenderTarget(width, height), context(context), samples(samples),
+        colorInfo(colorInfo), depthInfo(depthInfo) {
     ASSERT_PRECONDITION(color || depth, "Must provide either a color or depth texture.");
 
     if (color) {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -222,6 +222,11 @@ MetalTexture::MetalTexture(MetalContext& context, SamplerType target, uint8_t le
     const BOOL multisampled = samples > 1;
     const BOOL textureArray = target == SamplerType::SAMPLER_2D_ARRAY;
 
+#if defined(IOS)
+    ASSERT_PRECONDITION(!textureArray || !multisampled,
+            "iOS does not support multisampled texture arrays.");
+#endif
+
     const auto getTextureType = [](bool isArray, bool isMultisampled) {
         uint8_t value = 0;
         if (isMultisampled) {
@@ -239,7 +244,12 @@ MetalTexture::MetalTexture(MetalContext& context, SamplerType target, uint8_t le
             case 0b10:
                 return MTLTextureType2DMultisample;
             case 0b11:
+#if !defined(IOS)
                 return MTLTextureType2DMultisampleArray;
+#else
+                // should not get here
+                return MTLTextureType2DArray;
+#endif
         }
     };
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -126,9 +126,11 @@ public:
 
         /**
          * Specifies the depth in texels of the texture. Doesn't need to be a power-of-two.
-         * This creates a 3D textures.
+         * The depth controls the number of layers in a 2D array texture. Values greater than 1
+         * effectively create a 3D texture.
          * @param depth Depth of the texture in texels (default: 1).
          * @return This Builder, for chaining calls.
+         * @attention This Texture instance must use Sampler::SAMPLER_2D_ARRAY or it has no effect.
          */
         Builder& depth(uint32_t depth) noexcept;
 
@@ -142,9 +144,8 @@ public:
         Builder& levels(uint8_t levels) noexcept;
 
         /**
-         * Specifies whether this texture is a cubemap
-         * @param target either Sampler::SAMPLER_2D or
-         *                      Sampler::SAMPLER_CUBEMAP
+         * Specifies the type of sampler to use.
+         * @param target Sampler type
          * @return This Builder, for chaining calls.
          * @see Sampler
          */

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -573,26 +573,23 @@ char const* CodeGenerator::getUniformTypeName(UniformInterfaceBlock::Type type) 
 
 char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat format,
         bool multisample) const noexcept {
+    assert(!multisample);   // multisample samplers not yet supported.
     switch (type) {
         case SamplerType::SAMPLER_2D:
-            if (!multisample) {
-                switch (format) {
-                    case SamplerFormat::INT:    return "isampler2D";
-                    case SamplerFormat::UINT:   return "usampler2D";
-                    case SamplerFormat::FLOAT:  return "sampler2D";
-                    case SamplerFormat::SHADOW: return "sampler2DShadow";
-                }
-            } else {
-                assert(format != SamplerFormat::SHADOW);
-                switch (format) {
-                    case SamplerFormat::INT:    return "ms_isampler2D";
-                    case SamplerFormat::UINT:   return "ms_usampler2D";
-                    case SamplerFormat::FLOAT:  return "ms_sampler2D";
-                    case SamplerFormat::SHADOW: return "sampler2DShadow";   // should not happen
-                }
+            switch (format) {
+                case SamplerFormat::INT:    return "isampler2D";
+                case SamplerFormat::UINT:   return "usampler2D";
+                case SamplerFormat::FLOAT:  return "sampler2D";
+                case SamplerFormat::SHADOW: return "sampler2DShadow";
+            }
+        case SamplerType::SAMPLER_2D_ARRAY:
+            switch (format) {
+                case SamplerFormat::INT:    return "isampler2DArray";
+                case SamplerFormat::UINT:   return "usampler2DArray";
+                case SamplerFormat::FLOAT:  return "sampler2DArray";
+                case SamplerFormat::SHADOW: return "sampler2DArrayShadow";
             }
         case SamplerType::SAMPLER_CUBEMAP:
-            assert(!multisample);
             switch (format) {
                 case SamplerFormat::INT:    return "isamplerCube";
                 case SamplerFormat::UINT:   return "usamplerCube";
@@ -600,7 +597,6 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
                 case SamplerFormat::SHADOW: return "samplerCubeShadow";
             }
         case SamplerType::SAMPLER_EXTERNAL:
-            assert(!multisample);
             assert(format != SamplerFormat::SHADOW);
             // Vulkan doesn't have external textures in the sense as GL. Vulkan external textures
             // are created via VK_ANDROID_external_memory_android_hardware_buffer, but they are

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -182,6 +182,7 @@ template<>
 const char* toString(backend::SamplerType type) {
     switch (type) {
         case backend::SamplerType::SAMPLER_2D: return "sampler2D";
+        case backend::SamplerType::SAMPLER_2D_ARRAY: return "sampler2DArray";
         case backend::SamplerType::SAMPLER_CUBEMAP: return "samplerCubemap";
         case backend::SamplerType::SAMPLER_EXTERNAL: return "samplerExternal";
     }


### PR DESCRIPTION
This reworks Filament's array texture support, adding a new `SAMPLER_2D_ARRAY` sampler type and support for array textures in Metal. This is in preparation for spot light shadows, which will change the current shadow map into an array texture, each layer for a separate light.