### PR TITLE
Another SSAO optimization saving another ~16% 

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -89,9 +89,9 @@ private:
     FrameGraphId<FrameGraphTexture> mipmapPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, size_t level) noexcept;
 
-    FrameGraphId<FrameGraphTexture> bilateralBlurPass(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input,
-            FrameGraphId<FrameGraphTexture> depth, math::int2 axis) noexcept;
+    FrameGraphId<FrameGraphTexture> bilateralBlurPass(
+            FrameGraph& fg, FrameGraphId<FrameGraphTexture> input, math::int2 axis, float zf,
+            backend::TextureFormat format) noexcept;
 
     FrameGraphId<FrameGraphTexture> bloomPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,

--- a/filament/src/materials/bilateralBlur.mat
+++ b/filament/src/materials/bilateralBlur.mat
@@ -7,18 +7,13 @@ material {
             precision: medium
         },
         {
-            type : sampler2d,
-            name : depth,
-            precision: high
-        },
-        {
             type : float2,
             name : axis,
             precision: high
         },
         {
             type : float,
-            name : oneOverEdgeDistance
+            name : farPlaneOverEdgeDistance
         }
     ],
     variables : [
@@ -26,7 +21,7 @@ material {
     ],
     domain : postprocess,
     depthWrite : false,
-    depthCulling : true
+    depthCulling : false
 }
 
 vertex {
@@ -41,43 +36,42 @@ fragment {
         0.199471, 0.176033, 0.120985, 0.064759      // stdev = 2.0
     );
 
-    highp float linearizeDepth(highp float depth) {
-        // Our far plane is at infinity, which causes a division by zero below, which in turn
-        // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
-        // value representable in  a 24 bit depth buffer.
-        const float preventDiv0 = -1.0 / 16777216.0;
-        highp mat4 projection = getClipFromViewMatrix();
-        highp float z = depth * 2.0 - 1.0; // depth in clip space
-        return -projection[3].z / min(preventDiv0, z + projection[2].z);
+    float unpack(vec2 depth) {
+        // this is equivalent to (x8 * 256 + y8) / 65535, which gives a value between 0 and 1
+        return (depth.x * (256.0 / 257.0) + depth.y * (1.0 / 257.0));
     }
 
-    float bilateralWeight(const vec2 p, in float depth) {
-        float sampleDepth = textureLod(materialParams_depth, p, 0.0).r;
-        float ddepth = linearizeDepth(sampleDepth) - depth;
-        float diff = materialParams.oneOverEdgeDistance * ddepth;
+    float bilateralWeight(in float depth, in float sampleDepth) {
+        float diff = (sampleDepth - depth) * materialParams.farPlaneOverEdgeDistance;
         return max(0.0, 1.0 - diff * diff);
     }
 
     void tap(inout float sum, inout float totalWeight, float weight, float depth, vec2 position) {
         // ambient occlusion sample
-        float ao = textureLod(materialParams_ssao, position, 0.0).r;
+        vec3 data = textureLod(materialParams_ssao, position, 0.0).rgb;
+
         // bilateral sample
-        float bilateral = bilateralWeight(position, depth);
+        float bilateral = bilateralWeight(depth, unpack(data.gb));
         bilateral *= weight;
-        sum += ao * bilateral;
+        sum += data.r * bilateral;
         totalWeight += bilateral;
     }
 
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy; // interpolated at pixel's center
 
-        float depth = textureLod(materialParams_depth, uv, 0.0).r;
-        depth = linearizeDepth(depth);
+        vec3 data = textureLod(materialParams_ssao, uv, 0.0).rgb;
+        if (data.g * data.b == 1.0) {
+            // This is the skybox, skip
+            postProcess.color.rgb = data;
+            return;
+        }
 
         // we handle the center pixel separately because it doesn't participate in
         // bilateral filtering
+        float depth = unpack(data.gb);
         float totalWeight = kGaussianSamples[0];
-        float sum = textureLod(materialParams_ssao, uv, 0.0).r * totalWeight;
+        float sum = data.r * totalWeight;
 
         vec2 offset = materialParams.axis;
         for (int i = 1; i < kGaussianCount; i++) {
@@ -88,5 +82,6 @@ fragment {
         }
 
         postProcess.color.r = sum * (1.0 / totalWeight);
+        postProcess.color.gb = data.gb;
     }
 }

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -43,6 +43,10 @@ material {
             name : spiralTurns
         },
         {
+            type : float,
+            name : invFarPlane
+        },
+        {
             type : int,
             name : maxLevel
         }
@@ -63,9 +67,19 @@ vertex {
 
 fragment {
     const float kLog2LodRate = 3.0;
+    const float kEdgeDistance = 0.1; // this shouldn't be hardcoded
 
     vec2 sq(const vec2 a) {
         return a * a;
+    }
+
+    vec2 pack(highp float depth) {
+        // we need 16-bits of precision
+        highp float z = clamp(depth * materialParams.invFarPlane, 0.0, 1.0);
+        highp float t = floor(256.0 * z);
+        mediump float hi = t * (1.0 / 256.0);   // we only need 8-bits of precision
+        mediump float lo = (256.0 * z) - t;     // we only need b-bits of precision
+        return vec2(hi, lo);
     }
 
     // random number between 0 and 1, using interleaved gradient noise
@@ -96,11 +110,15 @@ fragment {
         return vec3(p * -linearDepth, linearDepth);
     }
 
+    highp vec3 faceNormal(highp vec3 dpdx, highp vec3 dpdy) {
+        return normalize(cross(dpdx, dpdy));
+    }
+
     // compute normals using derivatives, which essentially results in half-resolution normals
     // this creates arifacts around geometry edges.
     // Moreover, this seems a lot slower (measured on Pixel4), which I find curious.
     highp vec3 computeViewSpaceNormal(const highp vec3 position) {
-        return normalize(cross(dFdx(position), dFdy(position)));
+        return faceNormal(dFdx(position), dFdy(position));
     }
 
     // compute normals directly from the depth texture, resulting in full resolution normals
@@ -111,7 +129,7 @@ fragment {
         highp vec3 py = computeViewSpacePositionFromDepth(uvdy, sampleDepthLinear(uvdy, 0.0));
         highp vec3 dpdx = px - position;
         highp vec3 dpdy = py - position;
-        return normalize(cross(dpdx, dpdy));
+        return faceNormal(dpdx, dpdy);
     }
 
     // Ambient Occlusion, largely inspired from:
@@ -175,10 +193,9 @@ fragment {
         // using a 2x2 box. Thanks to the bilateral filter, we keep some sharp edges.
         // mod2() below will return either 0.5 or 1.5
         // This assumes full derivatives are supported.
-        const float kEdgeDistance = 0.1; // this shouldn't be hardcoded
         ivec2 coords = ivec2(gl_FragCoord.xy);
         ao += (1.0 - step(kEdgeDistance, abs(dFdx(origin.z)))) * dFdx(ao) * (0.5 - float(coords.x & 1));
         ao += (1.0 - step(kEdgeDistance, abs(dFdy(origin.z)))) * dFdy(ao) * (0.5 - float(coords.y & 1));
-        postProcess.color.r = ao;
+        postProcess.color.rgb = vec3(ao, pack(origin.z));
     }
 }

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -68,20 +68,6 @@ fragment {
         return a * a;
     }
 
-    // remaps to -1 and 1, repeating
-    float reduce(highp float x) {
-        return fract(0.5 * x + 0.5) * 2.0 - 1.0;
-    }
-
-    // very crude and fast sin/cos approximation
-    vec2 fast_cossin(highp float x) {
-        x *= 1.0/PI;
-        vec2 a = vec2(reduce(x + 0.5), reduce(x));
-        vec2 xn = sq(a * 2.0 + 1.0) - 1.0;
-        vec2 xp = 1.0 - sq(a * 2.0 - 1.0);
-        return vec2(a.x < 0.0 ? xn.x : xp.x, a.y < 0.0 ? xn.y : xp.y);
-    }
-
     // random number between 0 and 1, using interleaved gradient noise
     float random(vec2 w) {
         const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
@@ -138,7 +124,7 @@ fragment {
         //       once per pixel.
         float radius = (i + 0.5) * materialParams.sampleCount.y;
         float angle = (radius * materialParams.spiralTurns + noise) * (2.0 * PI);
-        return vec3(fast_cossin(angle), radius);
+        return vec3(cos(angle), sin(angle), radius);
     }
 
     void computeAmbientOcclusionSAO(inout float occlusion,


### PR DESCRIPTION
During the SSAO pass, we pack the decoded depth to the GB channels of
the AO texture, which reduces our bandwidth requirements during the
blurring pass, as well as some ALU usage.
It puts SSAO at about 2ms on pixel4/1080p.