### PR TITLE
Vulkan: use GENERAL layout for render target textures.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -139,6 +139,7 @@ VkFormat findSupportedFormat(VulkanContext& context, const std::vector<VkFormat>
 VkCommandBuffer acquireWorkCommandBuffer(VulkanContext& context);
 void flushWorkCommandBuffer(VulkanContext& context);
 void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& sc, VkFormat depthFormat);
+VkImageLayout getTextureLayout(TextureUsage usage);
 
 } // namespace filament
 } // namespace backend

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -723,8 +723,8 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     const VkExtent2D extent = rt->getExtent();
     assert(extent.width > 0 && extent.height > 0);
 
-    const auto color = rt->getColor();
-    const auto depth = rt->getDepth();
+    const VulkanAttachment color = rt->getColor();
+    const VulkanAttachment depth = rt->getDepth();
     const bool hasColor = color.format != VK_FORMAT_UNDEFINED;
     const bool hasDepth = depth.format != VK_FORMAT_UNDEFINED;
 
@@ -736,15 +736,8 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     VkImageLayout finalDepthLayout;
 
     if (rt->isOffscreen()) {
-
-        // If we're discarding the contents of the color buffer after the render pass, it's safe to
-        // assume that we will not be sampling from it.
-        finalColorLayout = any(params.flags.discardEnd & TargetBufferFlags::COLOR) ?
-                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL :
-                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
+        finalColorLayout = VK_IMAGE_LAYOUT_GENERAL;
         finalDepthLayout = VK_IMAGE_LAYOUT_GENERAL;
-
     } else {
         finalColorLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
         finalDepthLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
@@ -1032,7 +1025,7 @@ void VulkanDriver::blit(TargetBufferFlags buffers,
                 filter == SamplerMagFilter::NEAREST ? VK_FILTER_NEAREST : VK_FILTER_LINEAR);
 
         VulkanTexture::transitionImageLayout(cmdbuffer, dstImage, VK_IMAGE_LAYOUT_UNDEFINED,
-                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, dstLevel, 1);
+                VK_IMAGE_LAYOUT_GENERAL, dstLevel, 1);
     };
 
     if (!mContext.currentCommands) {
@@ -1139,20 +1132,10 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
             const auto* texture = handle_const_cast<VulkanTexture>(mHandleMap, boundSampler->t);
             mDisposer.acquire(texture, commands->resources);
 
-            // Check that we do not sample from the current color attachment. It's fine to sample
-            // from the current depth attachment when depth writes are disabled, which is useful in
-            // some SSAO implementations.
-            ASSERT_POSTCONDITION_NON_FATAL(
-                    mCurrentRenderTarget->getColor().image != texture->textureImage,
-                    "Attempting to sample color from the current render target");
-
-            VkImageLayout layout = any(texture->usage & TextureUsage::DEPTH_ATTACHMENT) ?
-                        VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
             mBinder.bindSampler(bindingPoint, {
                 .sampler = vksampler,
                 .imageView = texture->imageView,
-                .imageLayout = layout
+                .imageLayout = getTextureLayout(texture->usage)
             });
         }
     }


### PR DESCRIPTION
This fixes the validation error that occurs when rendering to one miplevel while sampling from another. It might even be faster since fewer layout transitions are required.