### PR TITLE
Add missing TypeScript declarations.

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -135,8 +135,7 @@ Filament.loadClassExtensions = function() {
         return result;
     };
 
-    /// createAssetLoader ::static method::
-    /// engine ::argument:: an instance of [Engine]
+    /// createAssetLoader ::method::
     /// ::retval:: an instance of [AssetLoader]
     /// Clients should create only one asset loader for the lifetime of their app, this prevents
     /// memory leaks and duplication of Material objects.

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -52,8 +52,14 @@ export interface Aabb {
     max: float3;
 }
 
+// TODO: Remove the entity type and just use integers for better parity with Java.
 export class Entity {
     public getId(): number;
+}
+
+export class EntityVector {
+    public get(index: number): Entity;
+    public size(): number;
 }
 
 export class LightManager$Instance {
@@ -109,7 +115,7 @@ export class VertexBuffer$Builder {
 
 export class IndexBuffer$Builder {
     public indexCount(count: number): IndexBuffer$Builder;
-    public bufferType(IndexBuffer$IndexType): IndexBuffer$Builder;
+    public bufferType(type: IndexBuffer$IndexType): IndexBuffer$Builder;
     public build(engine: Engine): IndexBuffer;
 }
 
@@ -189,7 +195,7 @@ export class RenderableManager {
     public hasComponent(entity: Entity): boolean;
     public getInstance(entity: Entity): RenderableManager$Instance;
     public static Builder(ngeos: number): RenderableManager$Builder;
-    public destroy(entity: Entity);
+    public destroy(entity: Entity): void;
     public setAxisAlignedBoundingBox(instance: RenderableManager$Instance, aabb: Box): void;
     public setLayerMask(instance: RenderableManager$Instance, select: number, values: number): void;
     public setPriority(instance: RenderableManager$Instance, priority: number): void;
@@ -202,7 +208,7 @@ export class RenderableManager {
     public setBonesFromMatrices(instance: RenderableManager$Instance, transforms: mat4[],
             offset: number): void
     public setMorphWeights(instance: RenderableManager$Instance, a: number, b: number, c: number,
-            d: number);
+            d: number): void;
     public getAxisAlignedBoundingBox(instance: RenderableManager$Instance): Box;
     public getPrimitiveCount(instance: RenderableManager$Instance): number;
     public setMaterialInstanceAt(instance: RenderableManager$Instance,
@@ -249,7 +255,7 @@ export class Frustum {
 }
 
 export class Camera {
-    public setProjection(Camera$Projection, left: number, right: number, bottom: number,
+    public setProjection(proj: Camera$Projection, left: number, right: number, bottom: number,
         top: number, near: number, far: number): void;
     public setProjectionFov(fovInDegrees: number, aspect: number,
         near: number, far: number, fov: Camera$Fov): void;
@@ -277,9 +283,9 @@ export class Camera {
 }
 
 export class IndirectLight {
-    public setIntensity(intensity: number);
+    public setIntensity(intensity: number): void;
     public getIntensity(): number;
-    public setRotation(value: mat3);
+    public setRotation(value: mat3): void;
     public getRotation(): mat3;
     public static getDirectionEstimate(f32array: any): float3;
     public static getColorEstimate(f32array: any, direction: float3): float4;
@@ -303,12 +309,13 @@ export class IcoSphere {
 }
 
 export class Scene {
-    public addEntity(entity: Entity);
+    public addEntity(entity: Entity): void;
+    public addEntities(entities: EntityVector): void;
     public getLightCount(): number;
     public getRenderableCount(): number;
-    public remove(entity: Entity);
-    public setIndirectLight(ibl: IndirectLight);
-    public setSkybox(sky: Skybox);
+    public remove(entity: Entity): void;
+    public setIndirectLight(ibl: IndirectLight|null): void;
+    public setSkybox(sky: Skybox|null): void;
 }
 
 export class RenderTarget {
@@ -318,11 +325,11 @@ export class RenderTarget {
 }
 
 export class View {
-    public setCamera(camera: Camera);
-    public setClearColor(color: float4);
-    public setScene(scene: Scene);
-    public setViewport(viewport: float4);
-    public setRenderTarget(renderTarget: RenderTarget);
+    public setCamera(camera: Camera): void;
+    public setClearColor(color: float4): void;
+    public setScene(scene: Scene): void;
+    public setViewport(viewport: float4): void;
+    public setRenderTarget(renderTarget: RenderTarget): void;
 }
 
 export class TransformManager {
@@ -357,6 +364,8 @@ export class Engine {
     public createTextureFromPng(url: string): Texture;
     public createView(): View;
 
+    public createAssetLoader(): gltfio$AssetLoader;
+
     public destroySwapChain(swapChain: SwapChain): void;
     public destroyRenderer(renderer: Renderer): void;
     public destroyView(view: View): void;
@@ -378,6 +387,36 @@ export class Engine {
     public getTransformManager(): TransformManager;
     public init(assets: string[], onready: () => void): void;
     public loadFilamesh(url: string, definstance: MaterialInstance, matinstances: object): Filamesh;
+}
+
+export class gltfio$AssetLoader {
+    public createAssetFromJson(buffer: any): gltfio$FilamentAsset;
+    public createAssetFromBinary(buffer: any): gltfio$FilamentAsset;
+    public delete(): void;
+}
+
+export class gltfio$FilamentAsset {
+    public loadResources(onDone: (finalize: () => void) => void, onFetched: (s: string) => void,
+            basePath: string|null, asyncInterval: number|null): void;
+    public getEntities(): EntityVector;
+    public getRoot(): Entity;
+    public popRenderable(): Entity;
+    public getMaterialInstances(): MaterialInstance[];
+    public getResourceUris(): string[];
+    public getBoundingBox(): Aabb;
+    public getName(entity: Entity): string;
+    public getAnimator(): gltfio$Animator;
+    public getWireframe(): Entity;
+    public getEngine(): Engine;
+    public releaseSourceData(): void;
+}
+
+export class gltfio$Animator {
+    public applyAnimation(index: number): void;
+    public updateBoneMatrices(): void;
+    public getAnimationCount(): number;
+    public getAnimationDuration(index: number): number;
+    public getAnimationName(index: number): string;
 }
 
 export enum Frustum$Plane {
@@ -717,7 +756,7 @@ export enum WrapMode {
 }
 
 export function _malloc(size: number): number;
-export function _free(size: number);
+export function _free(size: number): void;
 
 interface HeapInterface {
     set(buffer: any, pointer: number): any;


### PR DESCRIPTION
This patches up all the holes discovered when I tried porting the fidelity tests in `model-viewer` to our TypeScript declarations.

FYI @elalish