### PR TITLE
WebGL: Improve the callback API for glTF.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,13 +7,15 @@ A new header is inserted each time a *tag* is created.
 
 - The Android support libraries (gltfio and filament-utils) now use dynamic linking.
 - Screen-space refraction is now supported.
-- Removed depth-prepass related APIs.
+- Removed depth-prepass related APIs. (⚠ API Change)
 - gltfio: add asynchronous API to ResourceLoader.
 - gltfio: generate normals for flat-shaded models that do not have normals.
 - Material instances now allow dynamic depth testing and other rasterization state.
 - Support for Bloom as a post-process effect.
 - Added Java bindings for geometry::SurfaceOrientation.
 - Fixed bug rendering transparent objects with Metal backend.
+- WebGL: Improved TypeScript annotations.
+- WebGL: Simplified callback API for glTF. (⚠ API Change)
 
 ## v1.4.5
 

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -396,7 +396,7 @@ export class gltfio$AssetLoader {
 }
 
 export class gltfio$FilamentAsset {
-    public loadResources(onDone: (finalize: () => void) => void, onFetched: (s: string) => void,
+    public loadResources(onDone: () => void|null, onFetched: (s: string) => void|null,
             basePath: string|null, asyncInterval: number|null): void;
     public getEntities(): EntityVector;
     public getRoot(): Entity;

--- a/web/samples/animation.html
+++ b/web/samples/animation.html
@@ -38,8 +38,7 @@ class App {
         Filament.LightManager.Builder(LightType.SUN).direction([0, 0, -1]).build(engine, sunlight);
         this.scene.addEntity(sunlight);
 
-        const onDone = finalize => {
-            finalize();
+        const onDone = () => {
             loader.delete();
 
             // Dynamically enable two-sided lighting for testing purposes.

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -72,29 +72,22 @@ class App {
         const messages = document.getElementById('messages');
 
         // Crudely indicate progress by printing the URI of each resource as it is loaded.
-        // Note that we wait 1 ms after the last asset has downloaded, but before finalization.
-        // This gives the browser time to display the latest status.
         const onFetched = (uri) => messages.innerText += `Downloaded ${uri}\n`;
-        const onDone = (finalize) => {
-            messages.innerText += 'Finalizing...\n'
-            setTimeout(() => {
+        const onDone = () => {
+            // Destroy the asset loader.
+            loader.delete();
 
-                // Decode the textures using stb.
-                finalize();
-                loader.delete();
+            // Enable shadows on every renderable.
+            const entities = asset.getEntities();
+            const rm = engine.getRenderableManager();
+            for (let i = 0; i < entities.size(); i++) {
+                const instance = rm.getInstance(entities.get(i));
+                rm.setCastShadows(instance, true);
+                instance.delete();
+            }
 
-                // Enable shadows on every renderable.
-                const entities = asset.getEntities();
-                const rm = engine.getRenderableManager();
-                for (let i = 0; i < entities.size(); i++) {
-                    const instance = rm.getInstance(entities.get(i));
-                    rm.setCastShadows(instance, true);
-                    instance.delete();
-                }
-
-                // Hide the HUD.
-                messages.remove();
-            }, 1);
+            // Hide the HUD.
+            messages.remove();
         };
         asset.loadResources(onDone, onFetched);
 

--- a/web/samples/morphing.html
+++ b/web/samples/morphing.html
@@ -35,8 +35,7 @@ class App {
         const loader = engine.createAssetLoader();
         const asset = this.asset = loader.createAssetFromBinary(mesh_url);
 
-        const onDone = finalize => {
-            finalize();
+        const onDone = () => {
             loader.delete();
             scene.addEntities(asset.getEntities());
             this.animator = asset.getAnimator();


### PR DESCRIPTION
After the native async functionality landed, there was no way for web clients to be notified that the decoding has finished. This PR changes the existing `onDone` callback so that it gets called after all textures have been decoded. (Previously it was called after downloading rather than decoding.)

This has the side effect of simplifying the API because clients no longer need to call a finalize function.

I realized that this needed to be done while locally upgrading the `model-viewer` fidelity tests to a Filament release candidate.  FYI @elalish