### PR TITLE
Fix Metal crash on Catalina

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@ A new header is inserted each time a *tag* is created.
 - Support for Bloom as a post-process effect.
 - Added Java bindings for geometry::SurfaceOrientation.
 - Fixed bug rendering transparent objects with Metal backend.
+- Fixed crash on macOS Catalina when rendering with Metal backend
 
 ## v1.4.5
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ A new header is inserted each time a *tag* is created.
 - Support for Bloom as a post-process effect.
 - Added Java bindings for geometry::SurfaceOrientation.
 - Fixed bug rendering transparent objects with Metal backend.
-- Fixed crash on macOS Catalina when rendering with Metal backend
+- Fixed crash on macOS Catalina when rendering with Metal backend.
 
 ## v1.4.5
 

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -98,8 +98,8 @@ fragment {
         return -projection[3].z / min(preventDiv0, z + projection[2].z);
     }
 
-    highp float sampleDepthLinear(const vec2 uv, float level) {
-        return linearizeDepth(textureLod(materialParams_depth, uv, level).r);
+    highp float sampleDepthLinear(const vec2 uv, float lod) {
+        return linearizeDepth(textureLod(materialParams_depth, uv, lod).r);
     }
 
     highp vec3 computeViewSpacePositionFromDepth(vec2 p, highp float linearDepth) {


### PR DESCRIPTION
The syntax for the equivalent of `textureLod` in Metal shading language precludes us from using a variable named `level`.