### PR TITLE
Add options to skip samples

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -79,20 +79,22 @@ compilation step simply pass the `-j` flag to `build.sh`:
 $ ./build.sh -j release
 ```
 
-If you use CMake directly instead of the build script, pass `-DENABLE_JAVA=OFF` to CMake instead.
+If you use CMake directly instead of the build script, pass `-DFILAMENT_ENABLE_JAVA=OFF`
+to CMake instead.
 
 ### Filament-specific CMake Options
 
 The following CMake options are boolean options specific to Filament:
 
-- `ENABLE_JAVA`:                Compile Java projects: requires a JDK and the JAVA_HOME env var
-- `ENABLE_LTO`:                 Enable link-time optimizations if supported by the compiler
-- `FILAMENT_BUILD_FILAMAT`:     Build filamat and JNI buildings
-- `FILAMENT_SUPPORTS_METAL`:    Include the Metal backend
-- `FILAMENT_SUPPORTS_VULKAN`:   Include the Vulkan backend
-- `GENERATE_JS_DOCS`:           Build WebGL documentation and tutorials
-- `INSTALL_BACKEND_TEST`:       Install the backend test library so it can be consumed on iOS
-- `USE_EXTERNAL_GLES3`:         Experimental: Compile Filament against OpenGL ES 3
+- `FILAMENT_ENABLE_JAVA`:          Compile Java projects: requires a JDK and the JAVA_HOME env var
+- `FILAMENT_ENABLE_LTO`:           Enable link-time optimizations if supported by the compiler
+- `FILAMENT_BUILD_FILAMAT`:        Build filamat and JNI buildings
+- `FILAMENT_SUPPORTS_METAL`:       Include the Metal backend
+- `FILAMENT_SUPPORTS_VULKAN`:      Include the Vulkan backend
+- `FILAMENT_GENERATE_JS_DOCS`:     Build WebGL documentation and tutorials
+- `FILAMENT_INSTALL_BACKEND_TEST`: Install the backend test library so it can be consumed on iOS
+- `FILAMENT_USE_EXTERNAL_GLES3`:   Experimental: Compile Filament against OpenGL ES 3
+- `FILAMENT_SKIP_SAMPLES`:         Don't build sample apps
 
 To turn an option on or off:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,15 @@ project(TNT)
 # ==================================================================================================
 # Options
 # ==================================================================================================
-option(ENABLE_JAVA "Compile Java projects, requires a JDK and the JAVA_HOME env var" ON)
+option(FILAMENT_ENABLE_JAVA "Compile Java projects, requires a JDK and the JAVA_HOME env var" ON)
 
-option(USE_EXTERNAL_GLES3 "Experimental: Compile Filament against OpenGL ES 3" OFF)
+option(FILAMENT_USE_EXTERNAL_GLES3 "Experimental: Compile Filament against OpenGL ES 3" OFF)
 
-option(GENERATE_JS_DOCS "Build WebGL documentation and tutorials" OFF)
+option(FILAMENT_GENERATE_JS_DOCS "Build WebGL documentation and tutorials" OFF)
 
-option(ENABLE_LTO "Enable link-time optimizations if supported by the compiler" OFF)
+option(FILAMENT_ENABLE_LTO "Enable link-time optimizations if supported by the compiler" OFF)
+
+option(FILAMENT_SKIP_SAMPLES "Don't build samples" OFF)
 
 # ==================================================================================================
 # Support for ccache
@@ -162,7 +164,7 @@ endif()
 # ==================================================================================================
 # Link time optimizations (LTO)
 # ==================================================================================================
-if (ENABLE_LTO)
+if (FILAMENT_ENABLE_LTO)
     include(CheckIPOSupported)
 
     check_ipo_supported(RESULT IPO_SUPPORT)
@@ -188,7 +190,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function")
 endif()
 
-if (USE_EXTERNAL_GLES3)
+if (FILAMENT_USE_EXTERNAL_GLES3)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_EXTERNAL_GLES3")
 endif()
 
@@ -520,13 +522,13 @@ if (APPLE)
     add_subdirectory(${EXTERNAL}/moltenvk/tnt)
 endif()
 
-set (FILAMENT_SAMPLES_BINARY_DIR ${PROJECT_BINARY_DIR}/samples)
+set(FILAMENT_SAMPLES_BINARY_DIR ${PROJECT_BINARY_DIR}/samples)
 
 if (WEBGL)
     add_subdirectory(web/filament-js)
     add_subdirectory(web/samples)
 
-    if (GENERATE_JS_DOCS)
+    if (FILAMENT_GENERATE_JS_DOCS)
         add_subdirectory(web/docs)
     endif()
 
@@ -541,6 +543,7 @@ if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
 
     add_subdirectory(${FILAMENT}/java/filamat)
     add_subdirectory(${FILAMENT}/java/filament)
+
     add_subdirectory(${FILAMENT}/samples)
 
     add_subdirectory(${EXTERNAL}/astcenc/tnt)

--- a/android/Windows.md
+++ b/android/Windows.md
@@ -25,7 +25,7 @@ cmake ^
     -DCMAKE_C_COMPILER:PATH="C:\Program Files\LLVM\bin\clang-cl.exe" ^
     -DCMAKE_LINKER:PATH="C:\Program Files\LLVM\bin\lld-link.exe" ^
     -DCMAKE_INSTALL_PREFIX=..\release\filament ^
-    -DENABLE_JAVA=NO ^
+    -DFILAMENT_ENABLE_JAVA=NO ^
     -DCMAKE_BUILD_TYPE=Release ^
     ..\..
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,6 +4,9 @@
 //     Path to the Filament distribution/install directory for Android
 //     (produced by make/ninja install). This directory must contain lib/arm64-v8a/ etc.
 //
+// filament_skip_samples
+//     Exclude samples from the project. Useful to speed up compilation.
+//
 // Example:
 //     ./gradlew -Pfilament_dist_dir=../dist-android-release assembleRelease
 
@@ -54,5 +57,13 @@ subprojects { project ->
         mavenCentral()
         google()
         jcenter()
+    }
+}
+
+gradle.taskGraph.whenReady {
+    gradle.taskGraph.allTasks.each {
+        it.onlyIf {
+            !it.project.ext.has('isSample') || !project.hasProperty('filament_skip_samples')
+         }
     }
 }

--- a/android/samples/sample-gltf-bloom/build.gradle
+++ b/android/samples/sample-gltf-bloom/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-gltf-viewer/build.gradle
+++ b/android/samples/sample-gltf-viewer/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     cmgenArgs = "-q --format=ktx --size=256 --extract-blur=0.1 --deploy=src/main/assets/envs/venetian_crossroads_2k"
     iblInputFile = file("../../../third_party/environments/venetian_crossroads_2k.hdr")

--- a/android/samples/sample-hello-camera/build.gradle
+++ b/android/samples/sample-hello-camera/build.gradle
@@ -1,23 +1,9 @@
-/*
- * Copyright (C) 2019 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
+
+project.ext.isSample = true
 
 filamentTools {
     materialInputDir = file("src/main/materials")

--- a/android/samples/sample-hello-triangle/build.gradle
+++ b/android/samples/sample-hello-triangle/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-image-based-lighting/build.gradle
+++ b/android/samples/sample-image-based-lighting/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-lit-cube/build.gradle
+++ b/android/samples/sample-lit-cube/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-material-builder/build.gradle
+++ b/android/samples/sample-material-builder/build.gradle
@@ -1,8 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-
 apply plugin: FilamentToolsPlugin
+
+project.ext.isSample = true
 
 filamentTools {
     meshInputFile = file("../../../third_party/models/shader_ball/shader_ball.obj")

--- a/android/samples/sample-stream-test/build.gradle
+++ b/android/samples/sample-stream-test/build.gradle
@@ -1,23 +1,9 @@
-/*
- * Copyright (C) 2019 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
+
+project.ext.isSample = true
 
 filamentTools {
     materialInputDir = file("src/main/materials")

--- a/android/samples/sample-texture-view/build.gradle
+++ b/android/samples/sample-texture-view/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-textured-object/build.gradle
+++ b/android/samples/sample-textured-object/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/android/samples/sample-transparent-view/build.gradle
+++ b/android/samples/sample-transparent-view/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: FilamentToolsPlugin
 
+project.ext.isSample = true
+
 filamentTools {
     materialInputDir = file("src/main/materials")
     materialOutputDir = file("src/main/assets/materials")

--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ RUN_TESTS=false
 
 JS_DOCS_OPTION="-DGENERATE_JS_DOCS=OFF"
 
-ENABLE_JAVA=ON
+FILAMENT_ENABLE_JAVA=ON
 
 INSTALL_COMMAND=
 
@@ -159,7 +159,7 @@ function build_desktop_target {
             -DIMPORT_EXECUTABLES_DIR=out \
             -DCMAKE_BUILD_TYPE=$1 \
             -DCMAKE_INSTALL_PREFIX=../${lc_target}/filament \
-            -DENABLE_JAVA=${ENABLE_JAVA} \
+            -DFILAMENT_ENABLE_JAVA=${FILAMENT_ENABLE_JAVA} \
             ${deployment_target} \
             ../..
     fi
@@ -603,7 +603,7 @@ function validate_build_command {
     local javac_binary=`which javac`
     if [[ "$JAVA_HOME" == "" ]] || [[ ! "$javac_binary" ]]; then
         echo "Warning: JAVA_HOME is not set, skipping Java projects"
-        ENABLE_JAVA=OFF
+        FILAMENT_ENABLE_JAVA=OFF
     fi
     # If building a WebAssembly module, ensure we know where Emscripten lives.
     if [[ "$EMSDK" == "" ]] && [[ "$ISSUE_WEBGL_BUILD" == "true" ]]; then
@@ -671,7 +671,7 @@ while getopts ":hacfijmp:tuvslw" opt; do
             INSTALL_COMMAND=install
             ;;
         j)
-            ENABLE_JAVA=OFF
+            FILAMENT_ENABLE_JAVA=OFF
             ;;
         m)
             BUILD_GENERATOR="Unix Makefiles"

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -54,7 +54,7 @@ set(PRIVATE_HDRS
 # OpenGL / OpenGL ES Sources
 # ==================================================================================================
 
-if (NOT USE_EXTERNAL_GLES3)
+if (NOT FILAMENT_USE_EXTERNAL_GLES3)
     list(APPEND SRCS
             src/opengl/gl_headers.cpp
             src/opengl/gl_headers.h

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -17,35 +17,35 @@
 #include <backend/Platform.h>
 
 #if defined(ANDROID)
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformEGLAndroid.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkAndroid.h"
     #endif
 #elif defined(IOS)
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformCocoaTouchGL.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkCocoaTouch.h"
     #endif
 #elif defined(__APPLE__)
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformCocoaGL.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkCocoa.h"
     #endif
 #elif defined(__linux__)
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformGLX.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkLinux.h"
     #endif
 #elif defined(WIN32)
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformWGL.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
@@ -54,7 +54,7 @@
 #elif defined(__EMSCRIPTEN__)
     #include "opengl/PlatformWebGL.h"
 #else
-    #ifndef USE_EXTERNAL_GLES3
+    #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformDummyGL.h"
     #endif
 #endif
@@ -108,7 +108,7 @@ DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
         return nullptr;
 #endif
     }
-    #if defined(USE_EXTERNAL_GLES3)
+    #if defined(FILAMENT_USE_EXTERNAL_GLES3)
         return nullptr;
     #elif defined(EGL) && !defined(ANDROID)
         return new PlatformEGL();

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(ANDROID) || defined(USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
+#if defined(ANDROID) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
 
 #include <EGL/egl.h>
 #include <GLES3/gl31.h>

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DRIVER_GL_HEADERS_H
 #define TNT_FILAMENT_DRIVER_GL_HEADERS_H
 
-#if defined(ANDROID) || defined(USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
+#if defined(ANDROID) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
 
     #include <GLES3/gl31.h>
     #include <GLES2/gl2ext.h>

--- a/java/filamat/CMakeLists.txt
+++ b/java/filamat/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(filament-java)
 
-if (NOT ENABLE_JAVA)
+if (NOT FILAMENT_ENABLE_JAVA)
     return()
 endif()
 

--- a/java/filament/CMakeLists.txt
+++ b/java/filament/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(filament-java)
 
-if (NOT ENABLE_JAVA)
+if (NOT FILAMENT_ENABLE_JAVA)
     return()
 endif()
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(filament-samples C ASM)
 
+if (FILAMENT_SKIP_SAMPLES)
+    return()
+endif()
+
 set(ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 set(RESOURCE_DIR  "${GENERATION_ROOT}/generated/resources")

--- a/web/samples/CMakeLists.txt
+++ b/web/samples/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(websamples)
 
+if (FILAMENT_SKIP_SAMPLES)
+    return()
+endif()
+
 set(SERVER_DIR ${PROJECT_BINARY_DIR})
 set(ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 


### PR DESCRIPTION
`-DFILAMENT_SKIP_SAMPLES=ON` with CMake
`-Pfilament_skip_samples` with Gradle

This change also renames CMake options specific to Filament
to avoid clashes with subprojects.

This change fixes #1431.