### PR TITLE
Fix regression with getDefaultInstance().

### DIFF
--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -76,9 +76,15 @@ FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material)
 void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* material) {
     mMaterial = material;
 
+    const RasterState& rasterState = mMaterial->getRasterState();
+
     // We inherit the resolved culling mode rather than the builder-set culling mode.
     // This preserves the property whereby double-sidedness automatically disables culling.
-    mCulling = mMaterial->getRasterState().culling;
+    mCulling = rasterState.culling;
+
+    mColorWrite = rasterState.colorWrite;
+    mDepthWrite = rasterState.depthWrite;
+    mDepthFunc = rasterState.depthFunc;
 
     mMaterialSortingKey = RenderPass::makeMaterialSortingKey(
             material->getId(), material->generateMaterialInstanceId());

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -138,7 +138,7 @@ private:
 
     FMaterialInstance() noexcept;
     void initDefaultInstance(FEngine& engine, FMaterial const* material);
-    void initParameters(FMaterial const* material);
+    void initialize(FMaterial const* material);
 
     void commitSlow(FEngine::DriverApi& driver) const;
 


### PR DESCRIPTION
This caused color writes to be disabled in our "hello triangle" samples.

Fixes #2164.