### PR TITLE
cleanup command stream parameter passing

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -61,6 +61,20 @@
 
 #define EXPAND(x) x
 
+#define APPLY0(M,...)
+#define APPLY1(M, A, ...) EXPAND(M(A))
+#define APPLY2(M, A, ...) EXPAND(M(A)), EXPAND(APPLY1(M, __VA_ARGS__))
+#define APPLY3(M, A, ...) EXPAND(M(A)), EXPAND(APPLY2(M, __VA_ARGS__))
+#define APPLY4(M, A, ...) EXPAND(M(A)), EXPAND(APPLY3(M, __VA_ARGS__))
+#define APPLY5(M, A, ...) EXPAND(M(A)), EXPAND(APPLY4(M, __VA_ARGS__))
+#define APPLY6(M, A, ...) EXPAND(M(A)), EXPAND(APPLY5(M, __VA_ARGS__))
+#define APPLY7(M, A, ...) EXPAND(M(A)), EXPAND(APPLY6(M, __VA_ARGS__))
+#define APPLY8(M, A, ...) EXPAND(M(A)), EXPAND(APPLY7(M, __VA_ARGS__))
+#define APPLY9(M, A, ...) EXPAND(M(A)), EXPAND(APPLY8(M, __VA_ARGS__))
+#define APPLY_N__(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, X, ...) APPLY##X
+#define APPLY(M, ...) EXPAND(EXPAND(APPLY_N__(M, __VA_ARGS__, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))(M, __VA_ARGS__))
+
+
 #define PAIR_ARGS_0(M, ...)
 #define PAIR_ARGS_1(M, X, Y, ...) M(X, Y)
 #define PAIR_ARGS_2(M, X, Y, ...) M(X, Y), EXPAND(PAIR_ARGS_1(M, __VA_ARGS__))


### PR DESCRIPTION
- the tuple<> where we store the parameters should only remove the
  reference, but not decay, so that arrays could theoretically
  be stored (more on this below).

- use std::forward<> instead of std::move<> in Command's ctor, this is
  more appropriate, we just want to forward the arguments unchanged.

- add std::move() to all parameters on the command stream stub, it is
  appropriate here, because we receive parameters by value or r-value 
  references.

All this was an attempt to support C-style arrays as parameters, but
it doesn't work because they are decay'ed to pointers when they
appear as parameters.