### PR TITLE
Add support for KHR_materials_clearcoat to gltfio

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -467,7 +467,7 @@ public:
     // Returns true if any of the parameter samplers is of type samplerExternal
     bool hasExternalSampler() const noexcept;
 
-    static constexpr size_t MAX_PARAMETERS_COUNT = 32;
+    static constexpr size_t MAX_PARAMETERS_COUNT = 48;
     using ParameterList = Parameter[MAX_PARAMETERS_COUNT];
 
     // returns the number of parameters declared in this material

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -60,13 +60,22 @@ struct alignas(4) MaterialKey {
     };
     uint8_t baseColorUV;
     // -- 32 bit boundary --
+    bool hasClearCoatTexture : 1;
+    uint8_t clearCoatUV : 7;
+    bool hasClearCoatRoughnessTexture : 1;
+    uint8_t clearCoatRoughnessUV : 7;
+    bool hasClearCoatNormalTexture : 1;
+    uint8_t clearCoatNormalUV : 7;
+    bool hasClearCoat : 1;
+    bool hasTextureTransforms : 7;
+    // -- 32 bit boundary --
     uint8_t emissiveUV;
     uint8_t aoUV;
     uint8_t normalUV;
-    bool hasTextureTransforms : 8;
+    uint8_t UNUSED;
 };
 
-static_assert(sizeof(MaterialKey) == 8, "MaterialKey has unexpected padding.");
+static_assert(sizeof(MaterialKey) == 12, "MaterialKey has unexpected padding.");
 
 bool operator==(const MaterialKey& k1, const MaterialKey& k2);
 

--- a/libs/gltfio/materials/ubershader.mat.in
+++ b/libs/gltfio/materials/ubershader.mat.in
@@ -41,7 +41,21 @@ material {
         { type : int, name : emissiveIndex },
         { type : float3, name : emissiveFactor },
         { type : sampler2d, name : emissiveMap },
-        { type : mat3, name : emissiveUvMatrix }
+        { type : mat3, name : emissiveUvMatrix },
+
+        // Cleat coat
+        { type : float, name : clearCoatFactor },
+        { type : float, name : clearCoatRoughnessFactor },
+        { type : int, name : clearCoatIndex },
+        { type : sampler2d, name : clearCoatMap },
+        { type : mat3, name : clearCoatUvMatrix },
+        { type : int, name : clearCoatRoughnessIndex },
+        { type : sampler2d, name : clearCoatRoughnessMap },
+        { type : mat3, name : clearCoatRoughnessUvMatrix },
+        { type : int, name : clearCoatNormalIndex },
+        { type : sampler2d, name : clearCoatNormalMap },
+        { type : mat3, name : clearCoatNormalUvMatrix },
+        { type : float, name : clearCoatNormalScale }
     ],
 }
 
@@ -58,6 +72,14 @@ fragment {
                 material.normal = texture(materialParams_normalMap, uv).xyz * 2.0 - 1.0;
                 material.normal.xy *= materialParams.normalScale;
             }
+            #if defined(SHADING_MODEL_LIT)
+            if (materialParams.clearCoatNormalIndex > -1) {
+                float2 uv = uvs[materialParams.clearCoatNormalIndex];
+                uv = (vec3(uv, 1.0) * materialParams.clearCoatNormalUvMatrix).xy;
+                material.clearCoatNormal = texture(materialParams_clearCoatNormalMap, uv).xyz * 2.0 - 1.0;
+                material.clearCoatNormal.xy *= materialParams.clearCoatNormalScale;
+            }
+            #endif
         #endif
 
         prepareMaterial(material);
@@ -80,6 +102,22 @@ fragment {
             #if defined(SHADING_MODEL_LIT)
                 material.roughness = materialParams.roughnessFactor;
                 material.metallic = materialParams.metallicFactor;
+
+                // KHR_materials_clearcoat forbids clear coat from
+                // being applied in the specular/glossiness model
+                material.clearCoat = materialParams.clearCoatFactor;
+                material.clearCoatRoughness = materialParams.clearCoatRoughnessFactor;
+
+                if (materialParams.clearCoatIndex > -1) {
+                    float2 uv = uvs[materialParams.clearCoatIndex];
+                    uv = (vec3(uv, 1.0) * materialParams.clearCoatUvMatrix).xy;
+                    material.clearCoat *= texture(materialParams_clearCoatMap, uv).r;
+                }
+                if (materialParams.clearCoatRoughnessIndex > -1) {
+                    float2 uv = uvs[materialParams.clearCoatRoughnessIndex];
+                    uv = (vec3(uv, 1.0) * materialParams.clearCoatRoughnessUvMatrix).xy;
+                    material.clearCoatRoughness *= texture(materialParams_clearCoatRoughnessMap, uv).g;
+                }
             #endif
 
             material.emissive.rgb = materialParams.emissiveFactor.rgb;

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -90,6 +90,18 @@ std::string shaderFromKey(const MaterialKey& config) {
         )SHADER";
     }
 
+    if (config.hasClearCoat && config.hasClearCoatNormalTexture && !config.unlit) {
+        shader += "float2 clearCoatNormalUV = ${clearCoatNormal};\n";
+        if (config.hasTextureTransforms) {
+            shader += "clearCoatNormalUV = (vec3(clearCoatNormalUV, 1.0) * "
+                    "materialParams.clearCoatNormalUvMatrix).xy;\n";
+        }
+        shader += R"SHADER(
+            material.clearCoatNormal = texture(materialParams_clearCoatNormalMap, clearCoatNormalUV).xyz * 2.0 - 1.0;
+            material.clearCoatNormal.xy *= materialParams.clearCoatNormalScale;
+        )SHADER";
+    }
+
     if (config.enableDiagnostics && !config.unlit) {
         shader += R"SHADER(
             if (materialParams.enableDiagnostics) {
@@ -189,6 +201,34 @@ std::string shaderFromKey(const MaterialKey& config) {
                 material.emissive.a = 3.0;
             )SHADER";
         }
+        if (config.hasClearCoat) {
+            shader += R"SHADER(
+                material.clearCoat = materialParams.clearCoatFactor;
+                material.clearCoatRoughness = materialParams.clearCoatRoughnessFactor;
+            )SHADER";
+
+            if (config.hasClearCoatTexture) {
+                shader += "float2 clearCoatUV = ${clearCoat};\n";
+                if (config.hasTextureTransforms) {
+                    shader += "clearCoatUV = (vec3(clearCoatUV, 1.0) * "
+                            "materialParams.clearCoatUvMatrix).xy;\n";
+                }
+                shader += R"SHADER(
+                    material.clearCoat *= texture(materialParams_clearCoatMap, clearCoatUV).r;
+                )SHADER";
+            }
+
+            if (config.hasClearCoatRoughnessTexture) {
+                shader += "float2 clearCoatRoughnessUV = ${clearCoatRoughness};\n";
+                if (config.hasTextureTransforms) {
+                    shader += "clearCoatRoughnessUV = (vec3(clearCoatRoughnessUV, 1.0) * "
+                              "materialParams.clearCoatRoughnessUvMatrix).xy;\n";
+                }
+                shader += R"SHADER(
+                    material.clearCoatRoughness *= texture(materialParams_clearCoatRoughnessMap, clearCoatRoughnessUV).g;
+                )SHADER";
+            }
+        }
     }
 
     shader += "}\n";
@@ -278,6 +318,31 @@ Material* createMaterial(Engine* engine, const MaterialKey& config, const UvMap&
         builder.parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "emissiveMap");
         if (config.hasTextureTransforms) {
             builder.parameter(MaterialBuilder::UniformType::MAT3, "emissiveUvMatrix");
+        }
+    }
+
+    // CLEAR COAT
+    if (config.hasClearCoat) {
+        builder.parameter(MaterialBuilder::UniformType::FLOAT, "clearCoatFactor");
+        builder.parameter(MaterialBuilder::UniformType::FLOAT, "clearCoatRoughnessFactor");
+        if (config.hasClearCoatTexture) {
+            builder.parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "clearCoatMap");
+            if (config.hasTextureTransforms) {
+                builder.parameter(MaterialBuilder::UniformType::MAT3, "clearCoatUvMatrix");
+            }
+        }
+        if (config.hasClearCoatRoughnessTexture) {
+            builder.parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "clearCoatRoughnessMap");
+            if (config.hasTextureTransforms) {
+                builder.parameter(MaterialBuilder::UniformType::MAT3, "clearCoatRoughnessUvMatrix");
+            }
+        }
+        if (config.hasClearCoatNormalTexture) {
+            builder.parameter(MaterialBuilder::UniformType::FLOAT, "clearCoatNormalScale");
+            builder.parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "clearCoatNormalMap");
+            if (config.hasTextureTransforms) {
+                builder.parameter(MaterialBuilder::UniformType::MAT3, "clearCoatNormalUvMatrix");
+            }
         }
     }
 

--- a/libs/gltfio/src/MaterialProvider.cpp
+++ b/libs/gltfio/src/MaterialProvider.cpp
@@ -35,7 +35,14 @@ bool gltfio::operator==(const MaterialKey& k1, const MaterialKey& k2) {
         (k1.metallicRoughnessUV == k2.metallicRoughnessUV) &&
         (k1.emissiveUV == k2.emissiveUV) &&
         (k1.aoUV == k2.aoUV) &&
-        (k1.normalUV == k2.normalUV);
+        (k1.normalUV == k2.normalUV) &&
+        (k1.hasClearCoat == k2.hasClearCoat) &&
+        (k1.hasClearCoatTexture == k2.hasClearCoatTexture) &&
+        (k1.hasClearCoatRoughnessTexture == k2.hasClearCoatRoughnessTexture) &&
+        (k1.hasClearCoatNormalTexture == k2.hasClearCoatNormalTexture) &&
+        (k1.clearCoatUV == k2.clearCoatUV) &&
+        (k1.clearCoatRoughnessUV == k2.clearCoatRoughnessUV) &&
+        (k1.clearCoatNormalUV == k2.clearCoatNormalUV);
 }
 
 // Filament supports up to 2 UV sets. glTF has arbitrary texcoord set indices, but it allows
@@ -73,6 +80,28 @@ void details::constrainMaterial(MaterialKey* key, UvMap* uvmap) {
             retval[key->emissiveUV] = (UvSet) index++;
         }
     }
+    if (key->hasClearCoatTexture && retval[key->clearCoatUV] == UNUSED) {
+        if (index > MAX_INDEX) {
+            key->hasClearCoatTexture = false;
+        } else {
+            retval[key->clearCoatUV] = (UvSet) index++;
+        }
+    }
+    if (key->hasClearCoatRoughnessTexture && retval[key->clearCoatRoughnessUV] == UNUSED) {
+        if (index > MAX_INDEX) {
+            key->hasClearCoatRoughnessTexture = false;
+        } else {
+            retval[key->clearCoatRoughnessUV] = (UvSet) index++;
+        }
+    }
+    if (key->hasClearCoatNormalTexture && retval[key->clearCoatNormalUV] == UNUSED) {
+        if (index > MAX_INDEX) {
+            key->hasClearCoatNormalTexture = false;
+        } else {
+            retval[key->clearCoatNormalUV] = (UvSet) index++;
+        }
+    }
+    // NOTE: KHR_materials_clearcoat does not provide separate UVs, we'll assume UV0
     *uvmap = retval;
 }
 
@@ -90,9 +119,15 @@ void details::processShaderString(std::string* shader, const UvMap& uvmap,
     const auto& metallicRoughnessUV = uvstrings[uvmap[config.metallicRoughnessUV]];
     const auto& emissiveUV = uvstrings[uvmap[config.emissiveUV]];
     const auto& aoUV = uvstrings[uvmap[config.aoUV]];
+    const auto& clearCoatUV = uvstrings[uvmap[config.clearCoatUV]];
+    const auto& clearCoatRoughnessUV = uvstrings[uvmap[config.clearCoatRoughnessUV]];
+    const auto& clearCoatNormalUV = uvstrings[uvmap[config.clearCoatNormalUV]];
     replaceAll("${normal}", normalUV);
     replaceAll("${color}", baseColorUV);
     replaceAll("${metallic}", metallicRoughnessUV);
     replaceAll("${ao}", aoUV);
     replaceAll("${emissive}", emissiveUV);
+    replaceAll("${clearCoat}", clearCoatUV);
+    replaceAll("${clearCoatRoughness}", clearCoatRoughnessUV);
+    replaceAll("${clearCoatNormal}", clearCoatNormalUV);
 }

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -159,6 +159,9 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
             getUvIndex(config->metallicRoughnessUV, config->hasMetallicRoughnessTexture));
     mi->setParameter("aoIndex", getUvIndex(config->aoUV, config->hasOcclusionTexture));
     mi->setParameter("emissiveIndex", getUvIndex(config->emissiveUV, config->hasEmissiveTexture));
+    mi->setParameter("clearCoatIndex", getUvIndex(config->clearCoatUV, config->hasClearCoatTexture));
+    mi->setParameter("clearCoatRoughnessIndex", getUvIndex(config->clearCoatRoughnessUV, config->hasClearCoatRoughnessTexture));
+    mi->setParameter("clearCoatNormalIndex", getUvIndex(config->clearCoatNormalUV, config->hasClearCoatNormalTexture));
 
     mi->setDoubleSided(config->doubleSided);
     mi->setCullingMode(config->doubleSided ? CullingMode::NONE : CullingMode::BACK);
@@ -169,6 +172,9 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
     mi->setParameter("normalUvMatrix", identity);
     mi->setParameter("occlusionUvMatrix", identity);
     mi->setParameter("emissiveUvMatrix", identity);
+    mi->setParameter("clearCoatUvMatrix", identity);
+    mi->setParameter("clearCoatRoughnessUvMatrix", identity);
+    mi->setParameter("clearCoatNormalUvMatrix", identity);
 
     // Some WebGL implementations emit a warning at draw call time if the shader declares a sampler
     // that has not been bound to a texture, even if the texture lookup is conditional. Therefore we

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -12,25 +12,23 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal, vertex_worldTangent);
 
         #if defined(HAS_SKINNING_OR_MORPHING)
+        if (objectUniforms.morphingEnabled == 1) {
+            vec3 normal0, normal1, normal2, normal3;
+            toTangentFrame(mesh_custom4, normal0);
+            toTangentFrame(mesh_custom5, normal1);
+            toTangentFrame(mesh_custom6, normal2);
+            toTangentFrame(mesh_custom7, normal3);
+            material.worldNormal += objectUniforms.morphWeights.x * normal0;
+            material.worldNormal += objectUniforms.morphWeights.y * normal1;
+            material.worldNormal += objectUniforms.morphWeights.z * normal2;
+            material.worldNormal += objectUniforms.morphWeights.w * normal3;
+            material.worldNormal = normalize(material.worldNormal);
+        }
 
-            if (objectUniforms.morphingEnabled == 1) {
-                vec3 normal0, normal1, normal2, normal3;
-                toTangentFrame(mesh_custom4, normal0);
-                toTangentFrame(mesh_custom5, normal1);
-                toTangentFrame(mesh_custom6, normal2);
-                toTangentFrame(mesh_custom7, normal3);
-                material.worldNormal += objectUniforms.morphWeights.x * normal0;
-                material.worldNormal += objectUniforms.morphWeights.y * normal1;
-                material.worldNormal += objectUniforms.morphWeights.z * normal2;
-                material.worldNormal += objectUniforms.morphWeights.w * normal3;
-                material.worldNormal = normalize(material.worldNormal);
-            }
-
-            if (objectUniforms.skinningEnabled == 1) {
-                skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
-                skinNormal(vertex_worldTangent, mesh_bone_indices, mesh_bone_weights);
-            }
-
+        if (objectUniforms.skinningEnabled == 1) {
+            skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
+            skinNormal(vertex_worldTangent, mesh_bone_indices, mesh_bone_weights);
+        }
         #endif
 
         // We don't need to normalize here, even if there's a scale in the matrix
@@ -44,7 +42,7 @@ void main() {
         // normalization here since we'll do it after interpolation in the fragment stage
         vertex_worldBitangent =
                 cross(material.worldNormal, vertex_worldTangent) * sign(mesh_tangents.w);
-    #else // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL
+    #else // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL || MATERIAL_HAS_CLEAR_COAT_NORMAL
         // Without anisotropy or normal mapping we only need the normal vector
         toTangentFrame(mesh_tangents, material.worldNormal);
 
@@ -56,7 +54,7 @@ void main() {
 
         material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
 
-    #endif // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL
+    #endif // MATERIAL_HAS_ANISOTROPY || MATERIAL_HAS_NORMAL || MATERIAL_HAS_CLEAR_COAT_NORMAL
 #endif // HAS_ATTRIBUTE_TANGENTS
 
     // Invoke user code


### PR DESCRIPTION
Here is an example of `gltf_viewer` after loading the [official Khronos clear coat sample asset](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/ClearCoatTest):
<img width="1136" alt="Screen Shot 2020-02-25 at 8 57 46 PM" src="https://user-images.githubusercontent.com/869684/75313530-f2d5af00-5811-11ea-8d92-01837184c7e1.png">
