### PR TITLE
Add support for MRT to the backend

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -64,14 +64,23 @@ enum class Backend : uint8_t {
  */
 enum class TargetBufferFlags : uint8_t {
     NONE = 0x0u,                            //!< No buffer selected.
-    COLOR = 0x1u,                           //!< Color buffer selected.
-    DEPTH = 0x2u,                           //!< Depth buffer selected.
-    STENCIL = 0x4u,                         //!< Stencil buffer selected.
+    COLOR0 = 0x1u,                          //!< Color buffer selected.
+    COLOR1 = 0x2u,                          //!< Color buffer selected.
+    COLOR2 = 0x4u,                          //!< Color buffer selected.
+    COLOR3 = 0x8u,                          //!< Color buffer selected.
+    COLOR = COLOR0,                         //!< Color buffer selected.
+    DEPTH = 0x10u,                          //!< Depth buffer selected.
+    STENCIL = 0x20u,                        //!< Stencil buffer selected.
     COLOR_AND_DEPTH = COLOR | DEPTH,        //!< Color and depth buffer selected.
     COLOR_AND_STENCIL = COLOR | STENCIL,    //!< Color and stencil buffer selected.
     DEPTH_AND_STENCIL = DEPTH | STENCIL,    //!< depth and stencil buffer selected.
     ALL = COLOR | DEPTH | STENCIL           //!< Color, depth and stencil buffer selected.
 };
+
+inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept {
+    assert(index < 4);
+    return TargetBufferFlags(1u << index);
+}
 
 /**
  * Frequency at which a buffer is expected to be modified and used. This is used as an hint

--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -52,6 +52,40 @@ public:
     TargetBufferInfo() noexcept { }
 };
 
+class MRT {
+    TargetBufferInfo mInfos[4];
+
+public:
+    TargetBufferInfo operator[](size_t i) const noexcept {
+        return mInfos[i];
+    }
+
+    MRT() noexcept = default;
+
+    MRT(TargetBufferInfo const& color) noexcept // NOLINT(hicpp-explicit-conversions)
+            : mInfos{ color } {
+    }
+
+    MRT(TargetBufferInfo const& color0, TargetBufferInfo const& color1) noexcept
+            : mInfos{ color0, color1 } {
+    }
+
+    MRT(TargetBufferInfo const& color0, TargetBufferInfo const& color1,
+        TargetBufferInfo const& color2) noexcept
+            : mInfos{ color0, color1, color2 } {
+    }
+
+    MRT(TargetBufferInfo const& color0, TargetBufferInfo const& color1,
+        TargetBufferInfo const& color2, TargetBufferInfo const& color3) noexcept
+            : mInfos{ color0, color1, color2, color3 } {
+    }
+
+    // this is here for backward compatibility
+    MRT(Handle<HwTexture> h, uint8_t level, uint16_t layer) noexcept
+            : mInfos{{ h, level, layer }} {
+    }
+};
+
 } // namespace backend
 } // namespace filament
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -199,7 +199,7 @@ DECL_DRIVER_API_R_N(backend::RenderTargetHandle, createRenderTarget,
         uint32_t, width,
         uint32_t, height,
         uint8_t, samples,
-        backend::TargetBufferInfo, color,
+        backend::MRT, color,
         backend::TargetBufferInfo, depth,
         backend::TargetBufferInfo, stencil)
 

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -102,7 +102,7 @@ private:
     }
 
     template<typename Dp, typename B>
-    Dp* handle_cast(HandleMap& handleMap, Handle<B>& handle) noexcept {
+    Dp* handle_cast(HandleMap& handleMap, Handle<B> handle) noexcept {
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         assert(handle);
         auto iter = handleMap.find(handle.getId());

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -185,12 +185,12 @@ void MetalDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int dum
 
 void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, TargetBufferInfo color,
+        uint8_t samples, backend::MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
 
     auto getColorTexture = [&]() -> id<MTLTexture> {
-        if (color.handle) {
-            auto colorTexture = handle_cast<MetalTexture>(mHandleMap, color.handle);
+        if (color[0].handle) {
+            auto colorTexture = handle_cast<MetalTexture>(mHandleMap, color[0].handle);
             ASSERT_PRECONDITION(colorTexture->texture,
                     "Color texture passed to render target has no texture allocation");
             return colorTexture->texture;
@@ -213,8 +213,8 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     };
 
     MetalRenderTarget::TargetInfo colorInfo;
-    colorInfo.level = color.level;
-    colorInfo.layer = color.layer;
+    colorInfo.level = color[0].level;
+    colorInfo.layer = color[0].layer;
 
     MetalRenderTarget::TargetInfo depthInfo;
     depthInfo.level = depth.level;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -169,7 +169,7 @@ public:
                 uint8_t level = 0; // level when attached to a texture
             };
             // field ordering to optimize size on 64-bits
-            RenderBuffer color;
+            RenderBuffer color[4];
             RenderBuffer depth;
             RenderBuffer stencil;
             GLuint fbo = 0;
@@ -333,7 +333,7 @@ private:
         return mSamplerBindings;
     }
 
-    GLsizei getAttachments(std::array<GLenum, 3>& attachments,
+    GLsizei getAttachments(std::array<GLenum, 6>& attachments,
             GLRenderTarget const* rt, backend::TargetBufferFlags buffers) const noexcept;
 
     backend::RasterState mRasterState;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -403,12 +403,12 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
-        TargetBufferInfo color, TargetBufferInfo depth,
+        backend::MRT color, TargetBufferInfo depth,
         TargetBufferInfo stencil) {
-    auto colorTexture = color.handle ? handle_cast<VulkanTexture>(mHandleMap, color.handle) : nullptr;
+    auto colorTexture = color[0].handle ? handle_cast<VulkanTexture>(mHandleMap, color[0].handle) : nullptr;
     auto depthTexture = depth.handle ? handle_cast<VulkanTexture>(mHandleMap, depth.handle) : nullptr;
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
-            width, height, color.level, colorTexture, depth.level, depthTexture);
+            width, height, color[0].level, colorTexture, depth.level, depthTexture);
     mDisposer.createDisposable(renderTarget, [this, rth] () {
         destruct_handle<VulkanRenderTarget>(mHandleMap, rth);
     });

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -96,7 +96,7 @@ private:
     }
 
     template<typename Dp, typename B>
-    Dp* handle_cast(HandleMap& handleMap, Handle<B>& handle) noexcept {
+    Dp* handle_cast(HandleMap& handleMap, Handle<B> handle) noexcept {
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         assert(handle);
         auto iter = handleMap.find(handle.getId());


### PR DESCRIPTION
- this simply changes the createRenderTarget() API to take an
  'MRT' structure for the color attachment. The MRT structure is
  just a wrapper around an array of four TargetBufferInfo.

- in this PR only implemented for OpenGL