### PR TITLE
First step in reworking how rendertargets work in the framegraph

### DIFF
--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -288,10 +288,8 @@ private:
 
     FrameGraphHandle createResourceNode(fg::ResourceEntryBase* resource) noexcept;
 
-    enum class DiscardPhase { START, END };
-    backend::TargetBufferFlags computeDiscardFlags(DiscardPhase phase,
-            fg::PassNode const* curr, fg::PassNode const* first,
-            fg::RenderTarget const& renderTarget);
+    bool computeDiscard(const Vector<FrameGraphHandle> fg::PassNode::* list,
+            fg::PassNode const* curr, fg::PassNode const* first, FrameGraphHandle resource);
 
     bool equals(FrameGraphRenderTarget::Descriptor const& cacheEntry,
             FrameGraphRenderTarget::Descriptor const& rt) const noexcept;

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -107,7 +107,7 @@ RenderTargetHandle ResourceAllocator::createRenderTarget(const char* name,
 }
 
 void ResourceAllocator::destroyRenderTarget(RenderTargetHandle h) noexcept {
-    return mBackend.destroyRenderTarget(h);
+    mBackend.destroyRenderTarget(h);
 }
 
 backend::TextureHandle ResourceAllocator::createTexture(const char* name,

--- a/filament/src/fg/fg/RenderTarget.h
+++ b/filament/src/fg/fg/RenderTarget.h
@@ -49,7 +49,7 @@ struct RenderTarget { // 32
     backend::TargetBufferFlags userClearFlags{};
 
     // set in compile
-    backend::RenderPassFlags targetFlags{};
+    backend::TargetBufferFlags clear = {}; // this is eventually set by the user
     RenderTargetResource* cache = nullptr;
 
     void resolve(FrameGraph& fg) noexcept;

--- a/filament/src/fg/fg/RenderTargetResource.cpp
+++ b/filament/src/fg/fg/RenderTargetResource.cpp
@@ -22,7 +22,7 @@ using namespace backend;
 
 namespace fg {
 
-void RenderTargetResource::create(FrameGraph& fg) noexcept {
+void RenderTargetResource::preExecuteDevirtualize(FrameGraph& fg) noexcept {
     if (!imported) {
         if (any(attachments)) {
             // devirtualize our texture handles. By this point these handles have been
@@ -61,7 +61,7 @@ void RenderTargetResource::create(FrameGraph& fg) noexcept {
     }
 }
 
-void RenderTargetResource::destroy(FrameGraph& fg) noexcept {
+void RenderTargetResource::postExecuteDestroy(FrameGraph& fg) noexcept {
     if (!imported) {
         if (targetInfo.target) {
             fg.getResourceAllocator().destroyRenderTarget(targetInfo.target);

--- a/filament/src/fg/fg/RenderTargetResource.h
+++ b/filament/src/fg/fg/RenderTargetResource.h
@@ -69,9 +69,10 @@ struct RenderTargetResource final : public VirtualResource {  // 104
     // updated during execute with the current pass' discard flags
     FrameGraphPassResources::RenderTargetInfo targetInfo;
 
-    void create(FrameGraph& fg) noexcept override;
-
-    void destroy(FrameGraph& fg) noexcept override;
+    void preExecuteDevirtualize(FrameGraph& fg) noexcept override;
+    void postExecuteDestroy(FrameGraph& fg) noexcept override;
+    void preExecuteDestroy(FrameGraph& fg) noexcept override {}
+    void postExecuteDevirtualize(FrameGraph& fg) noexcept override {}
 };
 
 } // namespace fg

--- a/filament/src/fg/fg/ResourceEntry.h
+++ b/filament/src/fg/fg/ResourceEntry.h
@@ -35,6 +35,14 @@ public:
     ResourceEntryBase(ResourceEntryBase const&) = default;
     ~ResourceEntryBase() override;
 
+    void preExecuteDestroy(FrameGraph& fg) noexcept override {
+        discardEnd = true;
+    }
+
+    void postExecuteDevirtualize(FrameGraph& fg) noexcept override {
+        discardStart = false;
+    }
+
     // constants
     const char* const name;
     const uint16_t id;                      // for debugging and graphing
@@ -45,6 +53,10 @@ public:
 
     // computed during compile()
     uint32_t refs = 0;                      // final reference count
+
+    // updated during execute()
+    bool discardStart = true;
+    bool discardEnd = false;
 };
 
 
@@ -68,13 +80,13 @@ public:
 
     T& getResource() noexcept { return resource; }
 
-    void create(FrameGraph& fg) noexcept override {
+    void preExecuteDevirtualize(FrameGraph& fg) noexcept override {
         if (!imported) {
             resource.create(fg, name, descriptor);
         }
     }
 
-    void destroy(FrameGraph& fg) noexcept override {
+    void postExecuteDestroy(FrameGraph& fg) noexcept override {
         if (!imported) {
             resource.destroy(fg);
         }

--- a/filament/src/fg/fg/VirtualResource.h
+++ b/filament/src/fg/fg/VirtualResource.h
@@ -28,8 +28,10 @@ struct PassNode;
 struct VirtualResource {
     VirtualResource() noexcept = default;
     VirtualResource(VirtualResource const&) = default;
-    virtual void create(FrameGraph& fg) noexcept = 0;
-    virtual void destroy(FrameGraph& fg) noexcept = 0;
+    virtual void preExecuteDevirtualize(FrameGraph& fg) noexcept = 0;
+    virtual void preExecuteDestroy(FrameGraph& fg) noexcept = 0;
+    virtual void postExecuteDestroy(FrameGraph& fg) noexcept = 0;
+    virtual void postExecuteDevirtualize(FrameGraph& fg) noexcept = 0;
     virtual ~VirtualResource();
 
     // computed during compile()

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -60,8 +60,8 @@ TEST(FrameGraphTest, SimpleRenderPass) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
 
             });
 
@@ -113,8 +113,8 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR_AND_DEPTH, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 
     fg.present(renderPass.getData().outColor);
@@ -158,8 +158,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 depthPrepassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::DEPTH, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 
     struct ColorPassData {
@@ -195,8 +195,8 @@ TEST(FrameGraphTest, ScenarioDepthPrePass) {
                 colorPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::COLOR_AND_STENCIL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::DEPTH, rt.params.flags.discardEnd);
             });
 
     fg.present(colorPass.getData().outColor);
@@ -235,8 +235,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
                 renderPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 
 
@@ -259,8 +259,8 @@ TEST(FrameGraphTest, SimplePassCulling) {
                 postProcessPassExecuted = true;
                 auto const& rt = resources.getRenderTarget(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 
 
@@ -362,8 +362,8 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 rt1 = rt.target;
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.clear);
-                EXPECT_EQ(TargetBufferFlags::ALL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::COLOR, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 
     auto& renderPass2 = fg.addPass<RenderPassData>("Render2",
@@ -381,8 +381,8 @@ TEST(FrameGraphTest, RenderTargetLifetime) {
                 EXPECT_TRUE(rt.target);
                 EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.clear);
                 EXPECT_EQ(rt1.getId(), rt.target.getId());
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardStart);
-                EXPECT_EQ(TargetBufferFlags::DEPTH_AND_STENCIL, rt.params.flags.discardEnd);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
 
             });
 


### PR DESCRIPTION
The ultimate goal is to get rid of the concept of render targets in
the framegraph, and this is the first step. Here RenderTarget doesn't
store the discard flags anymore. These flags are now calculated
per-resource, per-pass.

A side effect of this change is that the discard flags are now slightly
better, as they don't contain attachments that don't exist.
i.e. we won't see the STENCIL flag set for instance.