### PR TITLE
Fir a deadlock when exiting on MacOS (GL backend)

### DIFF
--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -147,13 +147,7 @@ bool PlatformCocoaGL::pumpEvents() noexcept {
     if (![NSThread isMainThread]) {
         return false;
     }
-    while (true) {
-        NSEvent *event = [NSApp nextEventMatchingMask:NSEventMaskAny untilDate:[NSDate distantPast] inMode:NSDefaultRunLoopMode dequeue:YES];
-        if (event == nil) {
-            break;
-        }
-        [NSApp sendEvent:event];
-    }
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate distantPast]];
     return true;
 }
 

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -99,7 +99,7 @@ FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
             }
             engine.pumpPlatformEvents();
             const auto elapsed = std::chrono::system_clock::now() - startTime;
-            if (elapsed >= ns(timeout)) {
+            if (timeout != Fence::FENCE_WAIT_FOR_EVER && elapsed >= ns(timeout)) {
                 break;
             }
         }


### PR DESCRIPTION
Closes #2159

There was two issues:
1) Fence::wait would return prematurely when the the timeout was
   set to WAIT_FOREVER.

2) (At least) when running from the command line, events were not
   read from the main queue. Instead we have to use NSRunLoop instead
   of NSApplication APIs.