### PR TITLE
Add ground shadow option to gltf_viewer

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -181,6 +181,7 @@ add_library(gltf-resources ${DUMMY_SRC})
 
 set(GLTF_VIEWER_RESOURCE_FILES
     ${ROOT_DIR}/third_party/models/DamagedHelmet/DamagedHelmet.glb
+    ${MATERIAL_DIR}/groundShadow.filamat
 )
 
 get_resgen_vars(${RESOURCE_DIR} gltf_viewer)

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -33,7 +33,6 @@
 
 #include <getopt/getopt.h>
 
-#include <utils/Log.h>
 #include <utils/NameComponentManager.h>
 
 #include <math/vec3.h>

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -370,7 +370,8 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         short4 tbn = filament::math::packSnorm16(
                 mat3f::packTangentFrame(
                         filament::math::mat3f{
-                                float3{ 1.0f, 0.0f, 0.0f }, float3{ 0.0f, 0.0f, 1.0f },
+                                float3{ 1.0f, 0.0f, 0.0f },
+                                float3{ 0.0f, 0.0f, 1.0f },
                                 float3{ 0.0f, 1.0f, 0.0f }
                         }
                 ).xyzw);

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -241,7 +241,8 @@ static void setup(Engine* engine, View*, Scene* scene) {
         short4 tbn = filament::math::packSnorm16(
                 mat3f::packTangentFrame(
                         filament::math::mat3f{
-                                float3{ 1.0f, 0.0f, 0.0f }, float3{ 0.0f, 0.0f, 1.0f },
+                                float3{ 1.0f, 0.0f, 0.0f },
+                                float3{ 0.0f, 0.0f, 1.0f },
                                 float3{ 0.0f, 1.0f, 0.0f }
                         }
                 ).xyzw);

--- a/samples/materials/groundShadow.mat
+++ b/samples/materials/groundShadow.mat
@@ -8,6 +8,6 @@ material {
 fragment {
     void material(inout MaterialInputs material) {
         prepareMaterial(material);
-        material.baseColor = vec4(0.0, 0.0, 0.0, 0.7);
+        material.baseColor = vec4(0.0, 0.0, 0.0, 0.75);
     }
 }


### PR DESCRIPTION
The shadow is always positioned at the bottom of the loaded object's bounding box to ground it perfectly.

<img width="1904" alt="Screen Shot 2020-02-26 at 5 06 24 PM" src="https://user-images.githubusercontent.com/869684/75402796-aa260080-58ba-11ea-9783-09da837f6f82.png">