### PR TITLE
Refactor computeVisibilityMasks logic, visibility bits

### DIFF
--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -56,6 +56,40 @@ class FMaterialInstance;
 class FRenderer;
 class FScene;
 
+// The value of the 'VISIBLE_MASK' after culling. Each bit represents visibility in a frustum
+// (either camera or light).
+//
+// bits                          7 6 5 4 3 2 1 0
+// +-------------------------------------------+
+// VISIBLE_RENDERABLE                          X
+// VISIBLE_DIR_SHADOW_CASTER                 X
+// VISIBLE_SPOT_SHADOW_CASTER_0            X
+// VISIBLE_SPOT_SHADOW_CASTER_1          X
+// ...
+
+static constexpr size_t VISIBLE_RENDERABLE_BIT = 0u;
+static constexpr size_t VISIBLE_DIR_SHADOW_CASTER_BIT = 1u;
+static constexpr size_t VISIBLE_SPOT_SHADOW_CASTER_N_BIT(size_t n) { return n + 2; }
+
+static constexpr uint8_t VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
+static constexpr uint8_t VISIBLE_DIR_SHADOW_CASTER = 1u << VISIBLE_DIR_SHADOW_CASTER_BIT;
+static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER_N(size_t n) {
+    return 1u << VISIBLE_SPOT_SHADOW_CASTER_N_BIT(n);
+}
+
+// ORing of all the VISIBLE_SPOT_SHADOW_CASTER bits
+static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER =
+        (0xFF >> (sizeof(uint8_t) * 8u - CONFIG_MAX_SHADOW_CASTING_SPOTS)) << 2u;
+
+static constexpr uint8_t VISIBLE_ALL = VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER;
+
+// Because we're using a uint8_t for the visibility mask, we're limited to 6 spot light shadows.
+// (2 of the bits are used for visible renderables + directional light shadow casters).
+static_assert(CONFIG_MAX_SHADOW_CASTING_SPOTS <= 6,
+        "CONFIG_MAX_SHADOW_CASTING_SPOTS cannot be higher than 6.");
+
+// ------------------------------------------------------------------------------------------------
+
 class FView : public View {
 public:
     using Range = utils::Range<uint32_t>;

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -53,7 +53,7 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // Light space coordinates are computed in the vertex shader and interpolated across fragments.
 // Thus, each additional shadow-casting spot light adds 4 additional varying components. Higher
 // values may cause the number of varyings to exceed the driver limit.
-constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 2;
+constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 0;
 
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -49,6 +49,12 @@ static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
 constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
 constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 
+// The maximum number of spot lights in a scene that can cast shadows.
+// Light space coordinates are computed in the vertex shader and interpolated across fragments.
+// Thus, each additional shadow-casting spot light adds 4 additional varying components. Higher
+// values may cause the number of varyings to exceed the driver limit.
+constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 2;
+
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.
 constexpr size_t CONFIG_MAX_BONE_COUNT = 256;


### PR DESCRIPTION
This PR contains more preparation for spot lights shadows.

- visibility mask bits renamed and new ones are added for spot lights
- `computeVisibilityMasks` is refactored to be easier to reason about. Its logic remains the same.