### PR TITLE
Allocators shouldn't crash when allocation fails

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -395,6 +395,7 @@ void OpenGLDriver::HandleAllocator::free(void* p, size_t size) noexcept {
 UTILS_NOINLINE
 HandleBase::HandleId OpenGLDriver::allocateHandle(size_t size) noexcept {
     void* addr = mHandleArena.alloc(size);
+    assert(addr);
     char* const base = (char *)mHandleArena.getArea().begin();
     size_t offset = (char*)addr - base;
     return HandleBase::HandleId(offset >> HandleAllocator::MIN_ALIGNMENT_SHIFT);

--- a/libs/utils/src/Allocator.cpp
+++ b/libs/utils/src/Allocator.cpp
@@ -166,11 +166,15 @@ void TrackingPolicy::HighWatermark::onRewind(void const* addr) noexcept {
 // ------------------------------------------------------------------------------------------------
 
 void TrackingPolicy::Debug::onAlloc(void* p, size_t size, size_t alignment, size_t extra) noexcept {
-    memset(p, 0xeb, size);
+    if (p) {
+        memset(p, 0xeb, size);
+    }
 }
 
 void TrackingPolicy::Debug::onFree(void* p, size_t size) noexcept {
-    memset(p, 0xef, size);
+    if (p) {
+        memset(p, 0xef, size);
+    }
 }
 
 void TrackingPolicy::Debug::onReset() noexcept {


### PR DESCRIPTION
The allocator debug code didn't check that allocations where
successful before filling buffers.