### PR TITLE
Add visibility mask to RenderPass

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -82,6 +82,7 @@ RenderPass::Command* RenderPass::appendCommands(CommandTypeFlags const commandTy
     JobSystem& js = engine.getJobSystem();
     GrowingSlice<Command>& commands = mCommands;
     const RenderFlags renderFlags = mFlags;
+    const FScene::VisibleMaskType visibilityMask = mVisibilityMask;
     CameraInfo const& camera = mCamera;
     utils::Range<uint32_t> vr = mVisibleRenderables;
     if (UTILS_UNLIKELY(vr.empty())) {
@@ -107,10 +108,11 @@ RenderPass::Command* RenderPass::appendCommands(CommandTypeFlags const commandTy
     // we extract camera position/forward outside of the loop, because these are not cheap.
     const float3 cameraPosition(camera.getPosition());
     const float3 cameraForwardVector(camera.getForwardVector());
-    auto work = [commandTypeFlags, curr, &soa, renderFlags, cameraPosition, cameraForwardVector]
+    auto work = [commandTypeFlags, curr, &soa, renderFlags, visibilityMask, cameraPosition,
+                 cameraForwardVector]
             (uint32_t startIndex, uint32_t indexCount) {
         RenderPass::generateCommands(commandTypeFlags, curr,
-                soa, { startIndex, startIndex + indexCount }, renderFlags,
+                soa, { startIndex, startIndex + indexCount }, renderFlags, visibilityMask,
                 cameraPosition, cameraForwardVector);
     };
 
@@ -303,7 +305,7 @@ void RenderPass::setupColorCommand(Command& cmdDraw, bool hasDepthPass,
 UTILS_NOINLINE
 void RenderPass::generateCommands(uint32_t commandTypeFlags, Command* const commands,
         FScene::RenderableSoa const& soa, Range<uint32_t> range, RenderFlags renderFlags,
-        float3 cameraPosition, float3 cameraForward) noexcept {
+        FScene::VisibleMaskType visibilityMask, float3 cameraPosition, float3 cameraForward) noexcept {
 
     // generateCommands() writes both the draw and depth commands simultaneously such that
     // we go throw the list of renderables just once.
@@ -330,11 +332,11 @@ void RenderPass::generateCommands(uint32_t commandTypeFlags, Command* const comm
     switch (commandTypeFlags & (CommandTypeFlags::COLOR | CommandTypeFlags::DEPTH)) {
         case CommandTypeFlags::COLOR:
             generateCommandsImpl<CommandTypeFlags::COLOR>(commandTypeFlags, curr,
-                    soa, range, renderFlags, cameraPosition, cameraForward);
+                    soa, range, renderFlags, visibilityMask, cameraPosition, cameraForward);
             break;
         case CommandTypeFlags::DEPTH:
             generateCommandsImpl<CommandTypeFlags::DEPTH>(commandTypeFlags, curr,
-                    soa, range, renderFlags, cameraPosition, cameraForward);
+                    soa, range, renderFlags, visibilityMask, cameraPosition, cameraForward);
             break;
         default:
             // we should never end-up here
@@ -348,7 +350,7 @@ UTILS_NOINLINE
 void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         Command* UTILS_RESTRICT curr,
         FScene::RenderableSoa const& UTILS_RESTRICT soa, Range<uint32_t> range,
-        RenderFlags renderFlags,
+        RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
         float3 cameraPosition, float3 cameraForward) noexcept {
 
     // generateCommands() writes both the draw and depth commands simultaneously such that
@@ -367,6 +369,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     auto const* const UTILS_RESTRICT soaVisibility      = soa.data<FScene::VISIBILITY_STATE>();
     auto const* const UTILS_RESTRICT soaPrimitives      = soa.data<FScene::PRIMITIVES>();
     auto const* const UTILS_RESTRICT soaBonesUbh        = soa.data<FScene::BONES_UBH>();
+    auto const* const UTILS_RESTRICT soaVisibilityMask  = soa.data<FScene::VISIBLE_MASK>();
 
     const bool hasShadowing = renderFlags & HAS_SHADOWING;
     const bool viewInverseFrontFaces = renderFlags & HAS_INVERSE_FRONT_FACES;
@@ -387,6 +390,16 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     cmdDepth.primitive.rasterState.alphaToCoverage = false;
 
     for (uint32_t i = range.first; i < range.last; ++i) {
+        // Check if this renderable passes the visibilityMask. If it doesn't, encode a SENTINEL
+        // command (no-op).
+        if (!(soaVisibilityMask[i] & visibilityMask)) {
+            Command command;
+            command.key = uint64_t(Pass::SENTINEL);
+            *curr = command;
+            curr++;
+            continue;
+        }
+
         // Signed distance from camera to object's center. Positive distances are in front of
         // the camera. Some objects with a center behind the camera can still be visible
         // so their distance will be negative (this happens a lot for the shadow map).

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -392,11 +392,9 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     for (uint32_t i = range.first; i < range.last; ++i) {
         // Check if this renderable passes the visibilityMask. If it doesn't, encode a SENTINEL
         // command (no-op).
-        if (!(soaVisibilityMask[i] & visibilityMask)) {
-            Command command;
-            command.key = uint64_t(Pass::SENTINEL);
-            *curr = command;
-            curr++;
+        if (UTILS_UNLIKELY(!(soaVisibilityMask[i] & visibilityMask))) {
+            curr->key = uint64_t(Pass::SENTINEL);
+            ++curr;
             continue;
         }
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -30,6 +30,8 @@
 #include <utils/compiler.h>
 #include <utils/Slice.h>
 
+#include <limits>
+
 namespace utils {
 class JobSystem;
 }
@@ -245,6 +247,16 @@ public:
     void setCamera(const CameraInfo& camera) noexcept;
     void setRenderFlags(RenderFlags flags) noexcept;
 
+    // Sets the visibility mask, which is AND-ed against each Renderable's VISIBLE_MASK to determine
+    // if the renderable is visible for this pass.
+    // Defaults to all 1's, which means all renderables in this render pass will be rendered.
+    void setVisibilityMask(FScene::VisibleMaskType mask) noexcept { mVisibilityMask = mask; }
+
+    // Resets the visibility mask to the default value of all 1's.
+    void clearVisibilityMask() noexcept {
+        mVisibilityMask = std::numeric_limits<FScene::VisibleMaskType>::max();
+    }
+
     Command* begin() noexcept { return mCommands.begin(); }
     Command* end() noexcept { return mCommands.end(); }
 
@@ -289,12 +301,12 @@ private:
 
     static inline void generateCommands(uint32_t commandTypeFlags, Command* commands,
             FScene::RenderableSoa const& soa, utils::Range<uint32_t> range, RenderFlags renderFlags,
-            math::float3 cameraPosition, math::float3 cameraForward) noexcept;
+            FScene::VisibleMaskType visibilityMask, math::float3 cameraPosition, math::float3 cameraForward) noexcept;
 
     template<uint32_t commandTypeFlags>
     static inline void generateCommandsImpl(uint32_t, Command* commands,
             FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
-            RenderFlags renderFlags,
+            RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward) noexcept;
 
     static void setupColorCommand(Command& cmdDraw, bool hasDepthPass,
@@ -326,6 +338,7 @@ private:
     CameraInfo mCamera;
     // info about the scene features (e.g.: has shadows, lighting, etc...)
     RenderFlags mFlags{};
+    FScene::VisibleMaskType mVisibilityMask = std::numeric_limits<FScene::VisibleMaskType>::max();
     // whether to override the polygon offset setting
     bool mPolygonOffsetOverride = false;
     // value of the override

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -94,6 +94,8 @@ public:
      * Storage for per-frame renderable data
      */
 
+    using VisibleMaskType = Culler::result_type;
+
     enum {
         RENDERABLE_INSTANCE,    //  4 | instance of the Renderable component
         WORLD_TRANSFORM,        // 16 | instance of the Transform component
@@ -120,7 +122,7 @@ public:
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             backend::Handle<backend::HwUniformBuffer>,  // BONES_UBH
             math::float3,                               // WORLD_AABB_CENTER
-            Culler::result_type,                        // VISIBLE_MASK
+            VisibleMaskType,                            // VISIBLE_MASK
             math::float4,                               // MORPH_WEIGHTS
             uint8_t,                                    // LAYERS
             math::float3,                               // WORLD_AABB_EXTENT


### PR DESCRIPTION
With spot light shadows, render passes will need the ability to "skip" over certain renderables. `setVisibilityMask` accomplishes this by allowing clients to set a mask that is tested againt each renderable's `VISIBLE_MASK` to determine whether or not it should be skipped.