### PR TITLE
Remove unnecessary quotes from shader

### DIFF
--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -407,7 +407,7 @@ void applyRefraction(const PixelParams pixel,
 #elif REFRACTION_TYPE == REFRACTION_TYPE_THIN
     refractionThinSphere(pixel, n0, -shading_view, ray);
 #else
-#error "invalid REFRACTION_TYPE"
+#error invalid REFRACTION_TYPE
 #endif
 
     /* compute transmission T */


### PR DESCRIPTION
Some drivers were tripping up at the quotes. Fixes #2184.