### PR TITLE
Add getSpotLightOuterCone method to LightManager

### DIFF
--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -617,6 +617,8 @@ public:
      */
     void setSpotLightCone(Instance i, float inner, float outer) noexcept;
 
+    float getSpotLightOuterCone(Instance i) const noexcept;
+
     /**
      * Dynamically updates the angular radius of a Type.SUN light
      *

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -299,6 +299,7 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
         float offset = -cosOuter * scale;
 
         SpotParams& spotParams = manager[i].spotParams;
+        spotParams.outerClamped = outerClamped;
         spotParams.cosOuterSquared = cosOuterSquared;
         spotParams.sinInverse = 1 / std::sqrt(1 - cosOuterSquared);
         spotParams.scaleOffset = { scale, offset };
@@ -404,6 +405,10 @@ float LightManager::getFalloff(Instance i) const noexcept {
 
 void LightManager::setSpotLightCone(Instance i, float inner, float outer) noexcept {
     upcast(this)->setSpotLightCone(i, inner, outer);
+}
+
+float LightManager::getSpotLightOuterCone(Instance i) const noexcept {
+    return upcast(this)->getSpotParams(i).outerClamped;
 }
 
 void LightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept {

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -71,6 +71,7 @@ public:
 
     struct SpotParams {
         float radius = 0;
+        float outerClamped = 0;
         float cosOuterSquared = 1;
         float sinInverse = std::numeric_limits<float>::infinity();
         float luminousPower = 0;


### PR DESCRIPTION
Spot lights will need this data in order to calculate the shadow frustum.