### PR TITLE
Refactor renderable partitioning scheme for spot light shadows

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -178,7 +178,7 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
     };
     pass.setCamera(cameraInfo);
 
-    FView::Range visibleRenderables = view.getVisibleShadowCasters();
+    FView::Range visibleRenderables = view.getVisibleDirectionalShadowCasters();
     pass.setGeometry(scene.getRenderableData(), visibleRenderables, scene.getRenderableUBO());
 
     view.updatePrimitivesLod(engine, cameraInfo, scene.getRenderableData(), visibleRenderables);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -545,8 +545,8 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
         uint32_t iEnd = uint32_t(beginSpotLightCastersOnly - beginRenderables);
         uint32_t iSpotLightCastersEnd = uint32_t(endSpotLightCastersOnly - beginRenderables);
         mVisibleRenderables = Range{ 0, uint32_t(beginCastersOnly - beginRenderables) };
-        mVisibleDirectionalShadowCasters = Range{uint32_t(beginCasters - beginRenderables), iEnd };
-        mSpotLightShadowCasters = Range{0, iSpotLightCastersEnd };
+        mVisibleDirectionalShadowCasters = Range{ uint32_t(beginCasters - beginRenderables), iEnd };
+        mSpotLightShadowCasters = Range{ 0, iSpotLightCastersEnd };
         merged = Range{ 0, iSpotLightCastersEnd };
 
         // update those UBOs

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -514,13 +514,18 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
          * Parition the SoA so that renderables are partitioned w.r.t their visibility into the
          * following groups:
          *
-         * - renderables
-         * - renderables and directional shadow casters
-         * - directional shadow casters only
-         * - punctual light shadow casters only
-         * - invisible renderables
+         * 1. renderables
+         * 2. renderables and directional shadow casters
+         * 3. directional shadow casters only
+         * 4. punctual light shadow casters only
+         * 5. invisible renderables
          *
-         * this operation is somewhat heavy as it sorts the whole SoA. We use std::partition instead
+         * Note that the first three groups are partitioned based only on the lowest two bits of the
+         * VISIBLE_MASK (VISIBLE_RENDERABLE and VISIBLE_DIR_SHADOW_CASTER), and thus can also
+         * contain punctual light shadow casters as well. The fourth group contains *only* punctual
+         * shadow casters.
+         *
+         * This operation is somewhat heavy as it sorts the whole SoA. We use std::partition instead
          * of sort(), which gives us O(4.N) instead of O(N.log(N)) application of swap().
          */
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -505,18 +505,23 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
 
         /*
          * Shadowing: compute the shadow camera and cull shadow casters
-         * (this will set the VISIBLE_DIR_SHADOW_CASTER bit)
+         * (this will set the VISIBLE_DIR_SHADOW_CASTER bit and VISIBLE_SPOT_SHADOW_CASTER bits)
          */
 
         prepareShadowing(engine, driver, renderableData, scene->getLightData());
 
         /*
-         * partition the array of renderable w.r.t their visibility:
+         * Parition the SoA so that renderables are partitioned w.r.t their visibility into the
+         * following groups:
          *
-         * Sort the SoA so that invisible objects are first, then renderables,
-         * then both renderable and casters, then casters only -- this operation is somewhat heavy
-         * as it sorts the whole SoA. We use std::partition instead of sort(), which gives us
-         * O(3.N) instead of O(N.log(N)) application of swap().
+         * - renderables
+         * - renderables and directional shadow casters
+         * - directional shadow casters only
+         * - punctual light shadow casters only
+         * - invisible renderables
+         *
+         * this operation is somewhat heavy as it sorts the whole SoA. We use std::partition instead
+         * of sort(), which gives us O(4.N) instead of O(N.log(N)) application of swap().
          */
 
         // calculate the sorting key for all elements, based on their visibility
@@ -527,15 +532,22 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
 
         auto const beginRenderables = renderableData.begin();
         auto beginCasters = partition(beginRenderables, renderableData.end(), VISIBLE_RENDERABLE);
-        auto beginCastersOnly = partition(beginCasters, renderableData.end(), VISIBLE_ALL);
-        auto endCastersOnly = partition(beginCastersOnly, renderableData.end(),
+        auto beginCastersOnly = partition(beginCasters, renderableData.end(),
+                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER);
+        auto beginSpotLightCastersOnly = partition(beginCastersOnly, renderableData.end(),
                 VISIBLE_DIR_SHADOW_CASTER);
+        auto endSpotLightCastersOnly = std::partition(beginSpotLightCastersOnly,
+                renderableData.end(), [](auto it) {
+                    return (it.template get<FScene::VISIBLE_MASK>() & VISIBLE_SPOT_SHADOW_CASTER);
+                });
 
         // convert to indices
-        uint32_t iEnd = uint32_t(endCastersOnly - beginRenderables);
+        uint32_t iEnd = uint32_t(beginSpotLightCastersOnly - beginRenderables);
+        uint32_t iSpotLightCastersEnd = uint32_t(endSpotLightCastersOnly - beginRenderables);
         mVisibleRenderables = Range{ 0, uint32_t(beginCastersOnly - beginRenderables) };
-        mVisibleShadowCasters = Range{ uint32_t(beginCasters - beginRenderables), iEnd };
-        merged = Range{ 0, iEnd };
+        mVisibleDirectionalShadowCasters = Range{uint32_t(beginCasters - beginRenderables), iEnd };
+        mSpotLightShadowCasters = Range{0, iSpotLightCastersEnd };
+        merged = Range{ 0, iSpotLightCastersEnd };
 
         // update those UBOs
         const size_t size = merged.size() * sizeof(PerRenderableUib);
@@ -622,7 +634,10 @@ UTILS_NOINLINE
         FScene::RenderableSoa::iterator end,
         uint8_t mask) noexcept {
     return std::partition(begin, end, [mask](auto it) {
-        return it.template get<FScene::VISIBLE_MASK>() == mask;
+        // Mask VISIBLE_MASK to ignore higher bits related to spot shadows. We only partition based
+        // on renderable and directional shadow visibility.
+        return (it.template get<FScene::VISIBLE_MASK>() &
+                (VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER)) == mask;
     });
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -81,8 +81,6 @@ static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER_N(size_t n) {
 static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER =
         (0xFF >> (sizeof(uint8_t) * 8u - CONFIG_MAX_SHADOW_CASTING_SPOTS)) << 2u;
 
-static constexpr uint8_t VISIBLE_ALL = VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER;
-
 // Because we're using a uint8_t for the visibility mask, we're limited to 6 spot light shadows.
 // (2 of the bits are used for visible renderables + directional light shadow casters).
 static_assert(CONFIG_MAX_SHADOW_CASTING_SPOTS <= 6,
@@ -293,8 +291,12 @@ public:
         return mVisibleRenderables;
     }
 
-    Range const& getVisibleShadowCasters() const noexcept {
-        return mVisibleShadowCasters;
+    Range const& getVisibleDirectionalShadowCasters() const noexcept {
+        return mVisibleDirectionalShadowCasters;
+    }
+
+    Range const& getVisibleSpotShadowCasters() const noexcept {
+        return mSpotLightShadowCasters;
     }
 
     TargetBufferFlags getClearFlags() const noexcept {
@@ -405,7 +407,8 @@ private:
 
     // the following values are set by prepare()
     Range mVisibleRenderables;
-    Range mVisibleShadowCasters;
+    Range mVisibleDirectionalShadowCasters;
+    Range mSpotLightShadowCasters;
     uint32_t mRenderableUBOSize = 0;
     mutable bool mHasDirectionalLight = false;
     mutable bool mHasDynamicLighting = false;


### PR DESCRIPTION
This add a new group to the partitioning schemed used inside View to partition renderables. The new scheme is:

0. renderables
1. renderables and directional shadow casters
2. directional shadow casters only
3. **punctual light shadow casters only**
4. invisible renderables

Spot light passes iterate through groups 0-3 (inclusive), skipping renderables that aren't part of that spot light pass.