### PR TITLE
Use array texture for shadow maps

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -128,7 +128,7 @@ void ShadowMap::prepare(DriverApi& driver, SamplerGroup& sb) noexcept {
     }
 
     mShadowMapHandle = driver.createTexture(
-            SamplerType::SAMPLER_2D, 1, format, 1, dim, dim, 1,
+            SamplerType::SAMPLER_2D_ARRAY, 1, format, 1, dim, dim, 1,
             TextureUsage::DEPTH_ATTACHMENT | TextureUsage::SAMPLEABLE);
 
     mShadowMapRenderTarget = driver.createRenderTarget(

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -30,13 +30,13 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib() noexcept {
     // TODO: ideally we'd want this to be constexpr, this is a compile time structure
     static SamplerInterfaceBlock sib = SamplerInterfaceBlock::Builder()
             .name("Light")
-            .add("shadowMap",     Type::SAMPLER_2D,      Format::SHADOW,Precision::LOW)
-            .add("records",       Type::SAMPLER_2D,      Format::UINT,  Precision::MEDIUM)
-            .add("froxels",       Type::SAMPLER_2D,      Format::UINT,  Precision::MEDIUM)
-            .add("iblDFG",        Type::SAMPLER_2D,      Format::FLOAT, Precision::MEDIUM)
-            .add("iblSpecular",   Type::SAMPLER_CUBEMAP, Format::FLOAT, Precision::MEDIUM)
-            .add("ssao",          Type::SAMPLER_2D,      Format::FLOAT, Precision::MEDIUM)
-            .add("ssr",           Type::SAMPLER_2D,      Format::FLOAT, Precision::MEDIUM)
+            .add("shadowMap",     Type::SAMPLER_2D_ARRAY,   Format::SHADOW, Precision::LOW)
+            .add("records",       Type::SAMPLER_2D,         Format::UINT,   Precision::MEDIUM)
+            .add("froxels",       Type::SAMPLER_2D,         Format::UINT,   Precision::MEDIUM)
+            .add("iblDFG",        Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
+            .add("iblSpecular",   Type::SAMPLER_CUBEMAP,    Format::FLOAT,  Precision::MEDIUM)
+            .add("ssao",          Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
+            .add("ssr",           Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
             .build();
 
     assert(sib.getSize() == PerViewSib::SAMPLER_COUNT);

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -38,7 +38,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
-        visibility = shadow(light_shadowMap, getLightSpacePosition());
+        visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
         visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
         #endif

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -36,7 +36,7 @@ vec4 evaluateMaterial(const MaterialInputs material) {
 
 #if defined(HAS_DIRECTIONAL_LIGHTING)
 #if defined(HAS_SHADOWING)
-    color *= 1.0 - shadow(light_shadowMap, getLightSpacePosition());
+    color *= 1.0 - shadow(light_shadowMap, 0u, getLightSpacePosition());
 #else
     color = vec4(0.0);
 #endif


### PR DESCRIPTION
This switches the shadow map from a 2D texture to a 2D array texture. We are still only rendering into the first layer.