### PR TITLE
Add additional shadow info to lights uniform

### DIFF
--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -688,8 +688,8 @@ TEST(FilamentTest, FroxelData) {
     LightManager::Instance instance = engine->getLightManager().getInstance(e);
 
     FScene::LightSoa lights;
-    lights.push_back({}, {}, {}, {}, {});   // first one is always skipped
-    lights.push_back(float4{ 0, 0, -5, 1 }, {}, instance, 1, {});
+    lights.push_back({}, {}, {}, {}, {}, {});   // first one is always skipped
+    lights.push_back(float4{ 0, 0, -5, 1 }, {}, instance, 1, {}, {});
 
     {
         froxelData.froxelizeLights(*engine, {}, lights);

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -112,7 +112,8 @@ struct LightsUib {
     filament::math::float4 positionFalloff;   // { float3(pos), 1/falloff^2 }
     filament::math::float4 colorIntensity;    // { float3(col), intensity }
     filament::math::float4 directionIES;      // { float3(dir), IES index }
-    filament::math::float4 spotScaleOffset;   // { scale, offset, unused, unused }
+    filament::math::float2 spotScaleOffset;   // { scale, offset }
+    filament::math::uint2 shadow;             // { shadow bits (see ShadowInfo), unused }
 };
 
 // UBO for punctual (spot light) shadows.

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -3,6 +3,9 @@ struct Light {
     vec3 l;
     float attenuation;
     float NoL;
+    bool castsShadows;
+    uint shadowIndex;
+    uint shadowLayer;
 };
 
 struct PixelParams {

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -132,17 +132,23 @@ Light getSpotLight(uint index) {
     ivec2 texCoord = getRecordTexCoord(index);
     uint lightIndex = texelFetch(light_records, texCoord, 0).r;
 
-    highp vec4 positionFalloff = lightsUniforms.lights[lightIndex][0];
-    highp vec4 colorIntensity  = lightsUniforms.lights[lightIndex][1];
-          vec4 directionIES    = lightsUniforms.lights[lightIndex][2];
-          vec2 scaleOffset     = lightsUniforms.lights[lightIndex][3].xy;
+    highp vec4 positionFalloff       = lightsUniforms.lights[lightIndex][0];
+    highp vec4 colorIntensity        = lightsUniforms.lights[lightIndex][1];
+          vec4 directionIES          = lightsUniforms.lights[lightIndex][2];
+    highp vec4 scaleOffsetShadow     = lightsUniforms.lights[lightIndex][3];
 
     light.colorIntensity.rgb = colorIntensity.rgb;
     light.colorIntensity.w = computePreExposedIntensity(colorIntensity.w, frameUniforms.exposure);
 
     setupPunctualLight(light, positionFalloff);
 
-    light.attenuation *= getAngleAttenuation(-directionIES.xyz, light.l, scaleOffset);
+    light.attenuation *= getAngleAttenuation(-directionIES.xyz, light.l, scaleOffsetShadow.xy);
+
+    uint shadowBits = floatBitsToUint(scaleOffsetShadow.z);
+
+    light.castsShadows = bool(shadowBits & 0x1u);
+    light.shadowIndex = ((shadowBits & 0x01Eu) >> 1u);
+    light.shadowLayer = ((shadowBits & 0x1E0u) >> 5u);
 
     return light;
 }


### PR DESCRIPTION
This adds shadow information into the Lights UBO. This data gets packed into 32 bits and sent down to the shader, where they're unpacked and (in the near future) will be used to implement spot light shadows.