### PR TITLE
gltfio: simplify API, privatize bindings.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ A new header is inserted each time a *tag* is created.
 - Fixed bug in Camera::setLensProjection() and added the aspect ratio parameter. (⚠ API Change)
 - WebGL: Improved TypeScript annotations.
 - WebGL: Simplified callback API for glTF. (⚠ API Change)
+- gltfio: Removed deprecated "Bindings" API. (⚠ API Change)
 
 ## v1.4.5
 

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PUBLIC_HDRS
 set(SRCS
         src/Animator.cpp
         src/AssetLoader.cpp
+        src/Bindings.h
         src/DependencyGraph.cpp
         src/DependencyGraph.h
         src/FFilamentAsset.h

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -31,8 +31,6 @@ namespace filament {
 
 namespace gltfio {
 
-struct BufferBinding;
-struct TextureBinding;
 class Animator;
 
 /**
@@ -53,7 +51,7 @@ class Animator;
  * and upload data into vertex buffers and index buffers.
  *
  * \todo Only the default glTF scene is loaded, other glTF scenes are ignored.
- * \todo Cameras, extras, and extensions are ignored.
+ * \todo Cameras are ignored.
  */
 class FilamentAsset {
 public:
@@ -153,11 +151,6 @@ public:
      */
     const void* getSourceAsset() noexcept;
 
-    const BufferBinding* getBufferBindings() const noexcept;   //!< \deprecated please use ResourceLoader
-    size_t getBufferBindingCount() const noexcept;             //!< \deprecated please use ResourceLoader
-    const TextureBinding* getTextureBindings() const noexcept; //!< \deprecated please use ResourceLoader
-    size_t getTextureBindingCount() const noexcept;            //!< \deprecated please use ResourceLoader
-
     /*! \cond PRIVATE */
 protected:
     FilamentAsset() noexcept = default;
@@ -169,61 +162,6 @@ public:
     FilamentAsset& operator=(FilamentAsset const&) = delete;
     FilamentAsset& operator=(FilamentAsset&&) = delete;
     /*! \endcond */
-};
-
-/**
- * \struct BufferBinding FilamentAsset.h gltfio/FilamentAsset.h
- * \brief Read-only structure that tells the resource loader how to load a source blob into a
- * filament::VertexBuffer, filament::IndexBuffer, etc.
- *
- * \warning Clients usually do not need to interact with BufferBinding directly, they can use
- * ResourceLoader instead.
- *
- * Each binding instance corresponds to one of the following:
- *
- * - One call to VertexBuffer::setBufferAt().
- * - One call to IndexBuffer::setBuffer().
- */
-struct BufferBinding {
-    const char* uri;      // unique identifier for the source blob
-    uint32_t totalSize;   // size in bytes of the source blob at the given URI
-    uint8_t bufferIndex;  // only used when the destination is a VertexBuffer
-    uint32_t offset;      // byte count used only for vertex and index buffers
-    uint32_t size;        // byte count used only for vertex and index buffers
-    void** data;          // pointer to the resource data in the source asset (if loaded)
-
-    // Only one of the following two destinations can be non-null.
-    filament::VertexBuffer* vertexBuffer;
-    filament::IndexBuffer* indexBuffer;
-
-    bool convertBytesToShorts;   // the resource loader must convert the buffer from u8 to u16
-    bool generateTrivialIndices; // the resource loader must generate indices like: 0, 1, 2, ...
-    bool generateDummyData;      // the resource loader should generate a sequence of 1.0 values
-    bool generateTangents;       // the resource loader should generate tangents
-    bool sparseAccessor;         // the resource loader should apply a sparse data set
-
-    bool isMorphTarget;
-    uint8_t morphTargetIndex;
-};
-
-/**
- * \struct TextureBinding FilamentAsset.h gltfio/FilamentAsset.h
- * \brief Read-only structure that describes a binding between filament::Texture and
- * filament::MaterialInstance.
- *
- * \warning Clients usually do not need to interact with TextureBinding directly, they can use
- * ResourceLoader instead.
- */
-struct TextureBinding {
-    const char* uri;
-    uint32_t totalSize;
-    const char* mimeType;
-    void** data;
-    size_t offset;
-    filament::MaterialInstance* materialInstance;
-    const char* materialParameter;
-    filament::TextureSampler sampler;
-    bool srgb;
 };
 
 } // namespace gltfio

--- a/libs/gltfio/src/Bindings.h
+++ b/libs/gltfio/src/Bindings.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_BINDINGS_H
+#define GLTFIO_BINDINGS_H
+
+namespace filament {
+    class VertexBuffer;
+    class IndexBuffer;
+    class MaterialInstance;
+    class TextureSampler;
+}
+
+namespace gltfio {
+
+/**
+ * Read-only structure that tells ResourceLoader how to load a source blob into a
+ * filament::VertexBuffer, filament::IndexBuffer, etc.
+ *
+ * Each binding instance corresponds to one of the following:
+ *
+ * - One call to VertexBuffer::setBufferAt().
+ * - One call to IndexBuffer::setBuffer().
+ */
+struct BufferBinding {
+    const char* uri;      // unique identifier for the source blob
+    uint32_t totalSize;   // size in bytes of the source blob at the given URI
+    uint8_t bufferIndex;  // only used when the destination is a VertexBuffer
+    uint32_t offset;      // byte count used only for vertex and index buffers
+    uint32_t size;        // byte count used only for vertex and index buffers
+    void** data;          // pointer to the resource data in the source asset (if loaded)
+
+    // Only one of the following two destinations can be non-null.
+    filament::VertexBuffer* vertexBuffer;
+    filament::IndexBuffer* indexBuffer;
+
+    bool convertBytesToShorts;   // the resource loader must convert the buffer from u8 to u16
+    bool generateTrivialIndices; // the resource loader must generate indices like: 0, 1, 2, ...
+    bool generateDummyData;      // the resource loader should generate a sequence of 1.0 values
+    bool generateTangents;       // the resource loader should generate tangents
+    bool sparseAccessor;         // the resource loader should apply a sparse data set
+
+    bool isMorphTarget;
+    uint8_t morphTargetIndex;
+};
+
+/**
+ * Read-only structure that describes a binding between filament::Texture and
+ * filament::MaterialInstance.
+ */
+struct TextureBinding {
+    const char* uri;
+    uint32_t totalSize;
+    const char* mimeType;
+    void** data;
+    size_t offset;
+    filament::MaterialInstance* materialInstance;
+    const char* materialParameter;
+    filament::TextureSampler sampler;
+    bool srgb;
+};
+
+} // namsepace gltfio
+
+#endif // GLTFIO_BINDINGS_H

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -37,6 +37,7 @@
 #include <cgltf.h>
 
 #include "upcast.h"
+#include "Bindings.h"
 #include "Wireframe.h"
 #include "DependencyGraph.h"
 

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -57,22 +57,6 @@ MaterialInstance* const* FilamentAsset::getMaterialInstances() noexcept {
     return upcast(this)->getMaterialInstances();
 }
 
-size_t FilamentAsset::getBufferBindingCount() const noexcept {
-    return upcast(this)->getBufferBindingCount();
-}
-
-const BufferBinding* FilamentAsset::getBufferBindings() const noexcept {
-    return upcast(this)->getBufferBindings();
-}
-
-size_t FilamentAsset::getTextureBindingCount() const noexcept {
-    return upcast(this)->getTextureBindingCount();
-}
-
-const TextureBinding* FilamentAsset::getTextureBindings() const noexcept {
-    return upcast(this)->getTextureBindings();
-}
-
 size_t FilamentAsset::getResourceUriCount() const noexcept {
     return upcast(this)->getResourceUriCount();
 }


### PR DESCRIPTION
The binding list can be internalized, clients should instead use `getResourceUris()` and `ResourceLoader` to load external resources.