### PR TITLE
Finish MRT support (GL backend only)

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -782,9 +782,6 @@ struct RenderPassFlags {
      * Discarded buffers' content becomes invalid, they must not be read from again.
      */
     TargetBufferFlags discardEnd;
-
-    //! whether to ignore the scissor test during the clear operation
-    bool ignoreScissor;
 };
 
 /**

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -68,13 +68,12 @@ enum class TargetBufferFlags : uint8_t {
     COLOR1 = 0x2u,                          //!< Color buffer selected.
     COLOR2 = 0x4u,                          //!< Color buffer selected.
     COLOR3 = 0x8u,                          //!< Color buffer selected.
-    COLOR = COLOR0,                         //!< Color buffer selected.
+    COLOR = COLOR0,                         //!< \deprecated
+    COLOR_ALL = COLOR0 | COLOR1 | COLOR2 | COLOR3,
     DEPTH = 0x10u,                          //!< Depth buffer selected.
     STENCIL = 0x20u,                        //!< Stencil buffer selected.
-    COLOR_AND_DEPTH = COLOR | DEPTH,        //!< Color and depth buffer selected.
-    COLOR_AND_STENCIL = COLOR | STENCIL,    //!< Color and stencil buffer selected.
     DEPTH_AND_STENCIL = DEPTH | STENCIL,    //!< depth and stencil buffer selected.
-    ALL = COLOR | DEPTH | STENCIL           //!< Color, depth and stencil buffer selected.
+    ALL = COLOR_ALL | DEPTH | STENCIL       //!< Color, depth and stencil buffer selected.
 };
 
 inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept {

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -318,14 +318,6 @@ DECL_DRIVER_API_N(beginRenderPass,
 
 DECL_DRIVER_API_0(endRenderPass)
 
-DECL_DRIVER_API_N(discardSubRenderTargetBuffers,
-        backend::RenderTargetHandle, rth,
-        backend::TargetBufferFlags, targetBufferFlags,
-        uint32_t, left,
-        uint32_t, bottom,
-        uint32_t, width,
-        uint32_t, height)
-
 DECL_DRIVER_API_N(setRenderPrimitiveBuffer,
         backend::RenderPrimitiveHandle, rph,
         backend::VertexBufferHandle, vbh,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -680,12 +680,6 @@ void MetalDriver::endRenderPass(int dummy) {
     mContext->currentRenderPassEncoder = nil;
 }
 
-void MetalDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
-        TargetBufferFlags targetBufferFlags, uint32_t left, uint32_t bottom, uint32_t width,
-        uint32_t height) {
-
-}
-
 void MetalDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh, uint32_t enabledAttributes) {
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -194,11 +194,6 @@ void NoopDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassPar
 void NoopDriver::endRenderPass(int) {
 }
 
-void NoopDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
-        TargetBufferFlags buffers,
-        uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
-}
-
 void NoopDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -56,7 +56,6 @@ OpenGLContext::OpenGLContext() noexcept {
 #endif
 
     if (strstr(renderer, "Adreno")) {
-        bugs.clears_hurt_performance = true;
     } else if (strstr(renderer, "Mali")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
         if (strstr(renderer, "Mali-T")) {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -89,10 +89,6 @@ public:
     inline void setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
 
-    inline void setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) noexcept;
-    inline void setClearDepth(GLfloat depth) noexcept;
-    inline void setClearStencil(GLint stencil) noexcept;
-
     void deleteBuffers(GLsizei n, const GLuint* buffers, GLenum target) noexcept;
     void deleteVextexArrays(GLsizei n, const GLuint* arrays) noexcept;
 
@@ -247,12 +243,6 @@ private:
             vec4gli scissor { 0 };
             vec4gli viewport { 0 };
         } window;
-
-        struct {
-            math::float4 color = {};
-            GLfloat depth = 1.0f;
-            GLint stencil = 0;
-        } clears;
     } state;
 
     RenderPrimitive mDefaultVAO;
@@ -355,25 +345,6 @@ void OpenGLContext::viewport(GLint left, GLint bottom, GLsizei width, GLsizei he
     vec4gli viewport(left, bottom, width, height);
     update_state(state.window.viewport, viewport, [&]() {
         glViewport(left, bottom, width, height);
-    });
-}
-
-void OpenGLContext::setClearColor(GLfloat r, GLfloat g, GLfloat b, GLfloat a) noexcept {
-    math::float4 color(r, g, b, a);
-    update_state(state.clears.color, color, [&]() {
-        glClearColor(r, g, b, a);
-    });
-}
-
-void OpenGLContext::setClearDepth(GLfloat depth) noexcept {
-    update_state(state.clears.depth, depth, [&]() {
-        glClearDepthf(depth);
-    });
-}
-
-void OpenGLContext::setClearStencil(GLint stencil) noexcept {
-    update_state(state.clears.stencil, stencil, [&]() {
-        glClearStencil(stencil);
     });
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -131,10 +131,6 @@ public:
         // in the VAO state.
         bool vao_doesnt_store_element_array_buffer_binding = false;
 
-        // On some drivers, glClear() cancels glInvalidateFrameBuffer() which results
-        // in extra GPU memory loads.
-        bool clears_hurt_performance = false;
-
         // Some drivers have gl state issues when drawing from shared contexts
         bool disable_shared_context_draws = false;
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2071,37 +2071,6 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
     }
 }
 
-void OpenGLDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
-        TargetBufferFlags buffers,
-        uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
-    DEBUG_MARKER()
-    auto& gl = mContext;
-
-    // glInvalidateSubFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
-    // ignore it on GL (rather than having to do a runtime check).
-    if (GLES30_HEADERS) {
-        // we wouldn't have to bind the framebuffer if we had glInvalidateNamedFramebuffer()
-        GLRenderTarget const* rt = handle_cast<GLRenderTarget const*>(rth);
-
-        // clamping is necessary to avoid GL_INVALID_VALUE
-        uint32_t right = std::min(left + width, rt->width);
-        uint32_t top   = std::min(bottom + height, rt->height);
-
-        if (left < right && bottom < top) {
-            gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-
-            std::array<GLenum, 6> attachments; // NOLINT
-            GLsizei attachmentCount = getAttachments(attachments, rt, buffers);
-            if (attachmentCount) {
-                glInvalidateSubFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data(),
-                        left, bottom, right - left, top - bottom);
-            }
-
-            CHECK_GL_ERROR(utils::slog.e)
-        }
-    }
-}
-
 GLsizei OpenGLDriver::getAttachments(std::array<GLenum, 6>& attachments,
         GLRenderTarget const* rt, TargetBufferFlags buffers) const noexcept {
     GLsizei attachmentCount = 0;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -342,19 +342,8 @@ private:
     backend::Handle<backend::HwRenderTarget> mRenderPassTarget;
     backend::RenderPassParams mRenderPassParams;
 
-    // state needed for clearing the viewport "by hand", i.e. with a triangle
-    GLuint mClearVertexShader;
-    GLuint mClearFragmentShader;
-    GLuint mClearProgram;
-    GLint mClearColorLocation;
-    GLint mClearDepthLocation;
-    static const math::float2 mClearTriangle[3];
-    void initClearProgram() noexcept;
-    void terminateClearProgram() noexcept;
     void clearWithRasterPipe(backend::TargetBufferFlags clearFlags,
             math::float4 const& linearColor, GLfloat depth, GLint stencil) noexcept;
-    void clearWithGeometryPipe(backend::TargetBufferFlags clearFlags,
-            math::float4 const& linearColor, double depth, uint32_t stencil) noexcept;
 
     void setViewportScissor(backend::Viewport const& viewportScissor) noexcept;
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -351,12 +351,10 @@ private:
     static const math::float2 mClearTriangle[3];
     void initClearProgram() noexcept;
     void terminateClearProgram() noexcept;
-    void clearWithRasterPipe(bool clearColor, math::float4 const& linearColor,
-            bool clearDepth, double depth,
-            bool clearStencil, uint32_t stencil) noexcept;
-    void clearWithGeometryPipe(bool clearColor, math::float4 const& linearColor,
-            bool clearDepth, double depth,
-            bool clearStencil, uint32_t stencil) noexcept;
+    void clearWithRasterPipe(backend::TargetBufferFlags clearFlags,
+            math::float4 const& linearColor, GLfloat depth, GLint stencil) noexcept;
+    void clearWithGeometryPipe(backend::TargetBufferFlags clearFlags,
+            math::float4 const& linearColor, double depth, uint32_t stencil) noexcept;
 
     void setViewportScissor(backend::Viewport const& viewportScissor) noexcept;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -825,11 +825,6 @@ void VulkanDriver::endRenderPass(int) {
     mContext.currentRenderPass.renderPass = VK_NULL_HANDLE;
 }
 
-void VulkanDriver::discardSubRenderTargetBuffers(Handle<HwRenderTarget> rth,
-        TargetBufferFlags buffers,
-        uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) {
-}
-
 void VulkanDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -99,8 +99,8 @@ FRenderTarget::HwHandle FRenderTarget::createHandle(FEngine& engine, const Build
     FEngine::DriverApi& driver = engine.getDriverApi();
     const Attachment& color = builder.mImpl->mAttachments[COLOR];
     const Attachment& depth = builder.mImpl->mAttachments[DEPTH];
-    const TargetBufferFlags flags =
-            depth.texture ? TargetBufferFlags::COLOR_AND_DEPTH : TargetBufferFlags::COLOR;
+    const TargetBufferFlags flags = depth.texture ?
+            (TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH) : TargetBufferFlags::COLOR0;
 
     // For now we do not support multisampled render targets in the public-facing API, but please
     // note that post-processing includes FXAA by default.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -644,7 +644,6 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
     if (flags & CLEAR) {
         params.clearColor = {0.f, 0.f, 0.f, 1.f};
         params.flags.clear = TargetBufferFlags::COLOR;
-        params.flags.ignoreScissor = true;
         params.flags.discardStart = TargetBufferFlags::ALL;
         params.flags.discardEnd = TargetBufferFlags::NONE;
         params.viewport.left = 0;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -160,7 +160,7 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
     RenderPassParams params = {};
     params.flags.clear = TargetBufferFlags::DEPTH;
     params.flags.discardStart = TargetBufferFlags::DEPTH;
-    params.flags.discardEnd = TargetBufferFlags::COLOR_AND_STENCIL;
+    params.flags.discardEnd = TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL;
     params.clearDepth = 1.0;
     params.viewport = viewport;
     // disable scissor for clearing so the whole surface, but set the viewport to the

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -163,9 +163,6 @@ void ShadowMap::render(DriverApi& driver, RenderPass& pass, FView& view) noexcep
     params.flags.discardEnd = TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL;
     params.clearDepth = 1.0;
     params.viewport = viewport;
-    // disable scissor for clearing so the whole surface, but set the viewport to the
-    // the inset-by-1 rectangle.
-    params.flags.ignoreScissor = true;
 
     FCamera const& camera = getCamera();
     details::CameraInfo cameraInfo = {

--- a/filament/src/fg/FrameGraphHandle.h
+++ b/filament/src/fg/FrameGraphHandle.h
@@ -138,19 +138,29 @@ struct FrameGraphRenderTarget {
             uint8_t mLevel = 0;
         };
 
-        constexpr Attachments() noexcept : textures{} {}
-        Attachments(AttachmentInfo c) noexcept : color(c) {}
-        Attachments(AttachmentInfo c, AttachmentInfo d) noexcept : color(c), depth(d) {}
+        Attachments() noexcept
+                : textures{} {
+        }
 
-        enum { COLOR = 0, DEPTH = 1 };
-        static constexpr size_t COUNT = 2;
-        union {
-            std::array<AttachmentInfo, COUNT> textures = {};
-            struct {
-                AttachmentInfo color;
-                AttachmentInfo depth;
-            };
-        };
+        Attachments(AttachmentInfo c) noexcept  // NOLINT(google-explicit-constructor,hicpp-explicit-conversions)
+                : textures{ c } {
+        }
+
+        Attachments(AttachmentInfo c, AttachmentInfo d) noexcept
+                : textures{ c, {}, {}, {}, d } {
+        }
+
+        Attachments(AttachmentInfo c, AttachmentInfo d, AttachmentInfo s) noexcept
+                : textures{ c, {}, {}, {}, d, s } {
+        }
+
+        Attachments(std::array<AttachmentInfo, 4> mrt,
+                AttachmentInfo d, AttachmentInfo s) noexcept
+                : textures{ mrt[0], mrt[1], mrt[2], mrt[3], d, s } {
+        }
+
+        static constexpr size_t COUNT = 6;
+        std::array<AttachmentInfo, COUNT> textures = {};
     };
 
     struct Descriptor {

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -100,7 +100,7 @@ void ResourceAllocator::terminate() noexcept {
 
 RenderTargetHandle ResourceAllocator::createRenderTarget(const char* name,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
-        uint8_t samples, TargetBufferInfo color, TargetBufferInfo depth,
+        uint8_t samples, MRT color, TargetBufferInfo depth,
         TargetBufferInfo stencil) noexcept {
     return mBackend.createRenderTarget(targetBufferFlags,
             width, height, samples ? samples : 1u, color, depth, stencil);

--- a/filament/src/fg/ResourceAllocator.h
+++ b/filament/src/fg/ResourceAllocator.h
@@ -41,7 +41,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
-            backend::TargetBufferInfo color,
+            backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept = 0;
 
@@ -71,7 +71,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
-            backend::TargetBufferInfo color,
+            backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept override;
 

--- a/filament/src/fg/fg/RenderTargetResourceEntry.cpp
+++ b/filament/src/fg/fg/RenderTargetResourceEntry.cpp
@@ -44,14 +44,26 @@ void RenderTargetResourceEntry::resolve(FrameGraph& fg) noexcept {
     auto& resource = getResource();
 
     static constexpr TargetBufferFlags flags[] = {
-            TargetBufferFlags::COLOR,
+            TargetBufferFlags::COLOR0,
+            TargetBufferFlags::COLOR1,
+            TargetBufferFlags::COLOR2,
+            TargetBufferFlags::COLOR3,
             TargetBufferFlags::DEPTH,
             TargetBufferFlags::STENCIL };
 
+    static_assert(sizeof(flags)/sizeof(*flags) == FrameGraphRenderTarget::Attachments::COUNT,
+            "array sizes don't match");
+
     static constexpr TextureUsage usages[] = {
+            TextureUsage::COLOR_ATTACHMENT,
+            TextureUsage::COLOR_ATTACHMENT,
+            TextureUsage::COLOR_ATTACHMENT,
             TextureUsage::COLOR_ATTACHMENT,
             TextureUsage::DEPTH_ATTACHMENT,
             TextureUsage::STENCIL_ATTACHMENT };
+
+    static_assert(sizeof(flags)/sizeof(*flags) == sizeof(usages)/sizeof(*usages),
+            "array sizes don't match");
 
     uint32_t minWidth = std::numeric_limits<uint32_t>::max();
     uint32_t minHeight = std::numeric_limits<uint32_t>::max();
@@ -114,9 +126,15 @@ void RenderTargetResourceEntry::update(FrameGraph& fg, PassNode const& pass) noe
         resource.params.flags.discardEnd   = TargetBufferFlags::NONE;
 
         static constexpr TargetBufferFlags flags[] = {
-                TargetBufferFlags::COLOR,
+                TargetBufferFlags::COLOR0,
+                TargetBufferFlags::COLOR1,
+                TargetBufferFlags::COLOR2,
+                TargetBufferFlags::COLOR3,
                 TargetBufferFlags::DEPTH,
                 TargetBufferFlags::STENCIL };
+
+        static_assert(sizeof(flags)/sizeof(*flags) == FrameGraphRenderTarget::Attachments::COUNT,
+                "array sizes don't match");
 
         auto& resourceNodes = fg.mResourceNodes;
         for (size_t i = 0; i < descriptor.attachments.textures.size(); i++) {
@@ -158,9 +176,14 @@ void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept 
             auto const& attachmentInfo = descriptor.attachments.textures[i];
 #ifndef NDEBUG
             static constexpr TargetBufferFlags flags[] = {
-                    TargetBufferFlags::COLOR,
+                    TargetBufferFlags::COLOR0,
+                    TargetBufferFlags::COLOR1,
+                    TargetBufferFlags::COLOR2,
+                    TargetBufferFlags::COLOR3,
                     TargetBufferFlags::DEPTH,
                     TargetBufferFlags::STENCIL };
+            static_assert(sizeof(flags)/sizeof(*flags) == FrameGraphRenderTarget::Attachments::COUNT,
+                    "array sizes don't match");
             assert(bool(attachments & flags[i]) == attachmentInfo.isValid());
 #endif
             if (attachmentInfo.isValid()) {
@@ -179,7 +202,9 @@ void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept 
 
         auto& resource = getResource();
         resource.target = fg.getResourceAllocator().createRenderTarget(name,
-                attachments, width, height, descriptor.samples, infos[0], infos[1], {});
+                attachments, width, height, descriptor.samples,
+                { infos[0], infos[1], infos[2], infos[3] },
+                infos[4], infos[5]);
     }
 
 }

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -40,7 +40,7 @@ public:
             uint32_t width,
             uint32_t height,
             uint8_t samples,
-            backend::TargetBufferInfo color,
+            backend::MRT color,
             backend::TargetBufferInfo depth,
             backend::TargetBufferInfo stencil) noexcept override {
         return backend::RenderTargetHandle(++handle);

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -162,7 +162,7 @@ TEST(FrameGraphTest, SimpleRenderPass2) {
                 renderPassExecuted = true;
                 auto const& rt = resources.get(data.rt);
                 EXPECT_TRUE(rt.target);
-                EXPECT_EQ(TargetBufferFlags::COLOR_AND_DEPTH, rt.params.flags.discardStart);
+                EXPECT_EQ(TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH, rt.params.flags.discardStart);
                 EXPECT_EQ(TargetBufferFlags::NONE, rt.params.flags.discardEnd);
             });
 


### PR DESCRIPTION
This adds support for MRT in the FrameGraph, and also enables it in the GL backend.

This PR also removes the concept of 'ignoreScissor' in beginRenderPass() -- it's now always ignored, this is to match how discard flags work (and how Metal works).