### PR TITLE
Add support for spot light shadows

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SRCS
         src/RenderTarget.cpp
         src/Scene.cpp
         src/ShadowMap.cpp
+        src/ShadowMapManager.cpp
         src/Skybox.cpp
         src/SwapChain.cpp
         src/Stream.cpp
@@ -123,6 +124,7 @@ set(PRIVATE_HDRS
         src/details/ResourceList.h
         src/details/Scene.h
         src/details/ShadowMap.h
+        src/details/ShadowMapManager.h
         src/details/Skybox.h
         src/details/Stream.h
         src/details/SwapChain.h

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -246,7 +246,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     if (view.hasShadowing()) {
         // TODO: use the framegraph for the shadow passes
         RenderPass shadowMapPass = pass;
-        view.getShadowMap().render(driver, shadowMapPass, view);
+        view.renderShadowMaps(engine, driver, shadowMapPass);
         driver.flush(); // Kick the GPU since we're done with this render target
         engine.flush(); // Wake-up the driver thread
     }

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -140,11 +140,11 @@ bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perVi
         assert(l == 0);
 
         const size_t textureDimension = mDirectionalShadowMap.getLayout().size;
-        const ShadowMap::ShadowMapLayout layout {
-            .textureDimension = textureDimension,
-            .atlasDimension = textureSize,
-            .shadowDimension = textureDimension - 2,
-            .zResolution = mTextureZResolution
+        const ShadowMap::ShadowMapLayout layout{
+                .zResolution = mTextureZResolution,
+                .atlasDimension = textureSize,
+                .textureDimension = textureDimension,
+                .shadowDimension = textureDimension - 2
         };
         shadowMap.update(lightData, 0, scene, viewingCameraInfo, visibleLayers, layout);
         if (shadowMap.hasVisibleShadows()) {
@@ -182,11 +182,11 @@ bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perVi
         size_t l = mSpotShadowMaps[i].getLightIndex();
 
         const size_t textureDimension = mSpotShadowMaps[i].getLayout().size;
-        const ShadowMap::ShadowMapLayout layout {
-                .textureDimension = textureDimension,
+        const ShadowMap::ShadowMapLayout layout{
+                .zResolution = mTextureZResolution,
                 .atlasDimension = textureSize,
-                .shadowDimension = textureDimension - 2,
-                .zResolution = mTextureZResolution
+                .textureDimension = textureDimension,
+                .shadowDimension = textureDimension - 2
         };
         shadowMap.update(lightData, l, scene, viewingCameraInfo, visibleLayers, layout);
         if (shadowMap.hasVisibleShadows()) {

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -17,7 +17,6 @@
 #ifndef TNT_FILABRIDGE_UIBGENERATOR_H
 #define TNT_FILABRIDGE_UIBGENERATOR_H
 
-
 #include <math/mat4.h>
 #include <math/vec4.h>
 

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -44,7 +44,7 @@ namespace filament {
         //       Vertex depth            1     X     0     0     0
         //     Fragment depth            1     0     0     0     0
         //           Reserved            1     X     X     X     X
-        //           Reserved            0     X     1     X     0
+        //           Reserved            0     X     1     0     0
         //
         // Standard variants:
         //      Vertex shader            0     X     X     0     X
@@ -99,13 +99,14 @@ namespace filament {
         static constexpr bool isReserved(uint8_t variantKey) noexcept {
             // reserved variants that should just be skipped
             return (variantKey & DEPTH_MASK) > DEPTH ||
-                    (!(variantKey & DIRECTIONAL_LIGHTING) && (variantKey & SHADOW_RECEIVER));
+                    variantKey == 0b00100 ||
+                    variantKey == 0b01100;
         }
 
         static constexpr uint8_t filterVariantVertex(uint8_t variantKey) noexcept {
             // filter out vertex variants that are not needed. For e.g. dynamic lighting
             // doesn't affect the vertex shader.
-            return variantKey & VERTEX_MASK;
+            return variantKey;
         }
 
         static constexpr uint8_t filterVariantFragment(uint8_t variantKey) noexcept {

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -87,6 +87,13 @@ highp vec3 getLightSpacePosition() {
 }
 #endif
 
+#if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
+highp vec3 getSpotLightSpacePosition(uint index) {
+    vec4 position = vertex_spotLightSpacePosition[index];
+    return position.xyz * (1.0 / position.w);
+}
+#endif
+
 #if defined(MATERIAL_HAS_DOUBLE_SIDED_CAPABILITY)
 bool isDoubleSided() {
     return materialParams._doubleSided;

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -6,6 +6,12 @@ mat4 getLightFromWorldMatrix() {
     return frameUniforms.lightFromWorldMatrix;
 }
 
+#if defined(HAS_SHADOWING)
+mat4 getSpotLightFromWorldMatrix(uint index) {
+    return shadowUniforms.spotLightFromWorldMatrix[index];
+}
+#endif
+
 /** @public-api */
 mat4 getWorldFromModelMatrix() {
     return objectUniforms.worldFromModelMatrix;

--- a/shaders/src/inputs.fs
+++ b/shaders/src/inputs.fs
@@ -28,4 +28,8 @@ LAYOUT_LOCATION(10) in highp vec4 vertex_uv01;
 LAYOUT_LOCATION(11) in highp vec4 vertex_lightSpacePosition;
 #endif
 
+#if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
+LAYOUT_LOCATION(12) in highp vec4 vertex_spotLightSpacePosition[MAX_SHADOW_CASTING_SPOTS];
+#endif
+
 layout(location = 0) out vec4 fragColor;

--- a/shaders/src/inputs.vs
+++ b/shaders/src/inputs.vs
@@ -78,3 +78,7 @@ LAYOUT_LOCATION(10) out highp vec4 vertex_uv01;
 #if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
 LAYOUT_LOCATION(11) out highp vec4 vertex_lightSpacePosition;
 #endif
+
+#if defined(HAS_SHADOWING)
+LAYOUT_LOCATION(12) out highp vec4 vertex_spotLightSpacePosition[MAX_SHADOW_CASTING_SPOTS];
+#endif

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -38,10 +38,12 @@ void evaluateDirectionalLight(const MaterialInputs material,
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
-        visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
-        #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
-        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
-        #endif
+        if (frameUniforms.directionalShadows) {
+            visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
+            #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
+            visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
+            #endif
+        }
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -213,12 +213,19 @@ void evaluatePunctualLights(const PixelParams pixel, inout vec3 color) {
     // Iterate spotlights
     for ( ; index < end; index++) {
         Light light = getSpotLight(index);
+        float visibility = 1.0;
+#if defined(HAS_SHADOWING)
+        if (light.castsShadows && light.NoL > 0.0) {
+            visibility = shadow(light_shadowMap, light.shadowLayer,
+                    getSpotLightSpacePosition(light.shadowIndex));
+        }
+#endif
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         if (light.NoL > 0.0) {
-            color.rgb += surfaceShading(pixel, light, 1.0);
+            color.rgb += surfaceShading(pixel, light, visibility);
         }
 #else
-        color.rgb += surfaceShading(pixel, light, 1.0);
+        color.rgb += surfaceShading(pixel, light, visibility);
 #endif
     }
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -92,7 +92,17 @@ void main() {
 #endif
 
 #if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
-    vertex_lightSpacePosition = getLightSpacePosition(vertex_worldPosition, vertex_worldNormal);
+    vertex_lightSpacePosition = getLightSpacePosition(vertex_worldPosition, vertex_worldNormal,
+            frameUniforms.lightDirection, frameUniforms.shadowBias.y, getLightFromWorldMatrix());
+#endif
+
+#if defined(HAS_SHADOWING)
+    for (uint l = 0u; l < uint(MAX_SHADOW_CASTING_SPOTS); l++) {
+        vec3 dir = shadowUniforms.directionShadowBias[l].xyz;
+        float bias = shadowUniforms.directionShadowBias[l].w;
+        vertex_spotLightSpacePosition[l] = getLightSpacePosition(vertex_worldPosition,
+                vertex_worldNormal, dir, bias, getSpotLightFromWorldMatrix(l));
+    }
 #endif
 
 #if defined(VERTEX_DOMAIN_DEVICE)

--- a/shaders/src/shadowing.vs
+++ b/shaders/src/shadowing.vs
@@ -2,19 +2,19 @@
 // Shadowing
 //------------------------------------------------------------------------------
 
-#if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
+#if defined(HAS_SHADOWING)
 /**
  * Computes the light space position of the specified world space point.
  * The returned point may contain a bias to attempt to eliminate common
  * shadowing artifacts such as "acne". To achieve this, the world space
  * normal at the point must also be passed to this function.
  */
-vec4 getLightSpacePosition(const vec3 p, const vec3 n) {
-    vec3 l = frameUniforms.lightDirection;
+vec4 getLightSpacePosition(const vec3 p, const vec3 n, const vec3 l, const float b,
+        const mat4 lightFromWorldMatrix) {
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
-    vec3 offsetPosition = p + n * (sinTheta * frameUniforms.shadowBias.y);
-    vec4 lightSpacePosition = (getLightFromWorldMatrix() * vec4(offsetPosition, 1.0));
+    vec3 offsetPosition = p + n * (sinTheta * b);
+    vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(offsetPosition, 1.0));
     return lightSpacePosition;
 }
 #endif


### PR DESCRIPTION
Add spot light shadow support to Filament. This removes a lot of the logic inside of `ShadowMap`, which was added to `ShadowMapManager`. This also adds the view logic for calling into `ShadowMapManager` and the shader code to sample the shadow map array.

![spot-light-shadows](https://user-images.githubusercontent.com/5298046/76034230-3788d680-5ef3-11ea-9d33-88995beabae7.gif)
