### PR TITLE
The FrameGraph is now emitting debug markers

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -182,11 +182,9 @@ void RenderPass::execute(const char* name,
     DriverApi& driver = engine.getDriverApi();
 
     // Now, execute all commands
-    driver.pushGroupMarker(name);
     driver.beginRenderPass(renderTarget, params);
     RenderPass::recordDriverCommands(driver, first, last);
     driver.endRenderPass();
-    driver.popGroupMarker();
 }
 
 UTILS_NOINLINE // no need to be inlined

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -426,8 +426,10 @@ void FrameGraph::reset() noexcept {
 
 void FrameGraph::execute(FEngine& engine, DriverApi& driver) noexcept {
     auto const& passNodes = mPassNodes;
+    driver.pushGroupMarker("FrameGraph");
     for (PassNode const& node : passNodes) {
         if (node.refCount) {
+            driver.pushGroupMarker(node.name);
             executeInternal(node, driver);
             if (&node != &passNodes.back()) {
                 // wake-up the driver thread and consume data in the command queue, this helps with
@@ -437,10 +439,12 @@ void FrameGraph::execute(FEngine& engine, DriverApi& driver) noexcept {
                 // 2) an engine.flush() is always performed by Renderer at the end of a renderJob.
                 engine.flush();
             }
+            driver.popGroupMarker();
         }
     }
     // this is a good place to kick the GPU, since we've just done a bunch of work
     driver.flush();
+    driver.popGroupMarker();
     reset();
 }
 


### PR DESCRIPTION
A debug marker is emitted for each pass.
This greatly improves debugging with RenderDoc for instance.