### PR TITLE
disable spinlocks on ARMv7

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -431,8 +431,11 @@ struct NoLock {
     void unlock() noexcept { }
 };
 
-// Unfortunately TSAN doesn't support homegrown synchronization primitives
 #if defined(__SANITIZE_THREAD__)
+// Unfortunately TSAN doesn't support homegrown synchronization primitives
+using SpinLock = utils::Mutex;
+#elif defined(__ARM_ARCH_7A__)
+// We've had problems with  "wfe" on some ARM-V7 devices, causing spurious SIGILL
 using SpinLock = utils::Mutex;
 #else
 using SpinLock = utils::SpinLock;


### PR DESCRIPTION
we've had issues with some devices running in arm mode, where they
would throw spurious SIGILL on the WFE instruction used in spin locks.
Since on Android Mutexes are very efficient, we just use that instead.

This might fix #2197