### PR TITLE
Add a quality option to dynamic-scaling

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -162,17 +162,18 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetDynamicResolutionOptions(JNIEnv*,
         jclass, jlong nativeView, jboolean enabled, jboolean homogeneousScaling,
         jfloat targetFrameTimeMilli, jfloat headRoomRatio, jfloat scaleRate,
-        jfloat minScale, jfloat maxScale, jint history) {
-    View* view = (View*) nativeView;
+        jfloat minScale, jfloat maxScale, jint history, jint quality) {
+    View* view = (View*)nativeView;
     View::DynamicResolutionOptions options;
     options.enabled = enabled;
     options.homogeneousScaling = homogeneousScaling;
     options.targetFrameTimeMilli = targetFrameTimeMilli;
     options.headRoomRatio = headRoomRatio;
     options.scaleRate = scaleRate;
-    options.minScale = filament::math::float2{minScale};
-    options.maxScale = filament::math::float2{maxScale};
-    options.history = (uint8_t) history;
+    options.minScale = filament::math::float2{ minScale };
+    options.maxScale = filament::math::float2{ maxScale };
+    options.history = (uint8_t)history;
+    options.quality = (View::QualityLevel)quality;
     view->setDynamicResolutionOptions(options);
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -133,6 +133,14 @@ public class View {
          * History size. higher values, tend to filter more (clamped to 30).
          */
         public int history = 9;
+
+        /**
+         * Upscaling quality. LOW: 1 bilinear taps, MEDIUM: 4 bilinear taps, HIGH: 9 bilinear taps.
+         * If minScale needs to be very low, it might help to use MEDIUM or HIGH here.
+         * The default upsacling quality is set to LOW.
+         */
+        @NonNull
+        public QualityLevel quality = QualityLevel.LOW;
     }
 
     /**
@@ -652,7 +660,8 @@ public class View {
                 options.scaleRate,
                 options.minScale,
                 options.maxScale,
-                options.history);
+                options.history,
+                options.quality.ordinal());
     }
 
     /**
@@ -878,7 +887,7 @@ public class View {
     private static native void nSetDynamicResolutionOptions(long nativeView,
             boolean enabled, boolean homogeneousScaling,
             float targetFrameTimeMilli, float headRoomRatio, float scaleRate,
-            float minScale, float maxScale, int history);
+            float minScale, float maxScale, int history, int quality);
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -141,7 +141,9 @@ set(PRIVATE_HDRS
 
 set(MATERIAL_SRCS
         src/materials/defaultMaterial.mat
-        src/materials/blit.mat
+        src/materials/blitLow.mat
+        src/materials/blitMedium.mat
+        src/materials/blitHigh.mat
         src/materials/bloomDownsample.mat
         src/materials/bloomUpsample.mat
         src/materials/bilateralBlur.mat

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -94,6 +94,8 @@ public:
      * history:   History size. higher values, tend to filter more (clamped to 30)
      * minScale:  the minimum scale in X and Y this View should use
      * maxScale:  the maximum scale in X and Y this View should use
+     * quality:   upscaling quality.
+     *            LOW: 1 bilinear tap, Medium: 4 bilinear taps, High: 9 bilinear taps (tent)
      *
      * \note
      * Dynamic resolution is only supported on platforms where the time to render
@@ -120,6 +122,7 @@ public:
         uint8_t history = 9;                            //!< history size
         bool enabled = false;                           //!< enable or disable dynamic resolution
         bool homogeneousScaling = false;                //!< set to true to force homogeneous scaling
+        QualityLevel quality = QualityLevel::LOW;       //!< Upscaling quality
     };
 
     /**

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -56,9 +56,9 @@ public:
     FrameGraphId<FrameGraphTexture> opaqueBlit(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, FrameGraphTexture::Descriptor outDesc) noexcept;
 
-    FrameGraphId <FrameGraphTexture> blendBlit(FrameGraph& fg,
-            FrameGraphId <FrameGraphTexture> input,
-            FrameGraphTexture::Descriptor outDesc) noexcept;
+    FrameGraphId<FrameGraphTexture> blendBlit(
+            FrameGraph& fg, bool translucent, View::QualityLevel quality,
+            FrameGraphId<FrameGraphTexture> input, FrameGraphTexture::Descriptor outDesc) noexcept;
 
     FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
@@ -132,7 +132,7 @@ private:
     PostProcessMaterial mSeparableGaussianBlur;
     PostProcessMaterial mBloomDownsample;
     PostProcessMaterial mBloomUpsample;
-    PostProcessMaterial mBlit;
+    PostProcessMaterial mBlit[3];
     PostProcessMaterial mTonemapping;
     PostProcessMaterial mFxaa;
 

--- a/filament/src/materials/blitHigh.mat
+++ b/filament/src/materials/blitHigh.mat
@@ -1,0 +1,47 @@
+material {
+    name : blit,
+    parameters : [
+        {
+            type : sampler2d,
+            name : color,
+            precision: medium
+        },
+        {
+            type : float4,
+            name : resolution,
+            precision: high
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = postProcess.normalizedUV;
+    }
+}
+
+fragment {
+    void postProcess(inout PostProcessInputs postProcess) {
+        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
+        highp float du = materialParams.resolution.z;
+        highp float dv = materialParams.resolution.w;
+        vec4 c0, c1;
+        c0  = textureLod(materialParams_color, uv + vec2(-du, -dv), 0.0);
+        c0 += textureLod(materialParams_color, uv + vec2( du, -dv), 0.0);
+        c0 += textureLod(materialParams_color, uv + vec2( du,  dv), 0.0);
+        c0 += textureLod(materialParams_color, uv + vec2(-du,  dv), 0.0);
+        c0 += 4.0 * textureLod(materialParams_color, uv, 0.0);
+        c1  = textureLod(materialParams_color, uv + vec2(-du,  0.0), 0.0);
+        c1 += textureLod(materialParams_color, uv + vec2( 0.0, -dv), 0.0);
+        c1 += textureLod(materialParams_color, uv + vec2( du,  0.0), 0.0);
+        c1 += textureLod(materialParams_color, uv + vec2( 0.0,  dv), 0.0);
+        postProcess.color = (c0 + 2.0 * c1) * (1.0 / 16.0);
+    }
+}
+

--- a/filament/src/materials/blitLow.mat
+++ b/filament/src/materials/blitLow.mat
@@ -5,6 +5,11 @@ material {
             type : sampler2d,
             name : color,
             precision: medium
+        },
+        {
+            type : float4,
+            name : resolution,
+            precision: high
         }
     ],
     variables : [
@@ -23,8 +28,7 @@ vertex {
 
 fragment {
     void postProcess(inout PostProcessInputs postProcess) {
-        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
-        postProcess.color = textureLod(materialParams_color, uv, 0.0);
+        postProcess.color = textureLod(materialParams_color, variable_vertex.xy, 0.0);
     }
 }
 

--- a/filament/src/materials/blitMedium.mat
+++ b/filament/src/materials/blitMedium.mat
@@ -1,0 +1,42 @@
+material {
+    name : blit,
+    parameters : [
+        {
+            type : sampler2d,
+            name : color,
+            precision: medium
+        },
+        {
+            type : float4,
+            name : resolution,
+            precision: high
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = postProcess.normalizedUV;
+    }
+}
+
+fragment {
+    void postProcess(inout PostProcessInputs postProcess) {
+        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
+        highp float du = 0.5 * materialParams.resolution.z;
+        highp float dv = 0.5 * materialParams.resolution.w;
+        vec4 c;
+        c  = textureLod(materialParams_color, uv + vec2(-du, -dv), 0.0);
+        c += textureLod(materialParams_color, uv + vec2( du, -dv), 0.0);
+        c += textureLod(materialParams_color, uv + vec2( du,  dv), 0.0);
+        c += textureLod(materialParams_color, uv + vec2(-du,  dv), 0.0);
+        postProcess.color = c * 0.25;
+    }
+}
+


### PR DESCRIPTION
It controls the quality of the upsampling filter. This can help a lot
if heavy scaling is needed to maintain performance, it also helps if
MSAA is not enabled.

There are 3 quality levels, low, medium and high. 1, 4 and 9 bilinear
taps are used for each level respectively. The high quality setting
employs a tent filter.