### PR TITLE
matinfo can print dictionaries, shrink Metal dictionary

### DIFF
--- a/libs/filaflat/include/filaflat/BlobDictionary.h
+++ b/libs/filaflat/include/filaflat/BlobDictionary.h
@@ -57,6 +57,10 @@ public:
         return (const char*) mBlobs[index].data();
     }
 
+    inline size_t size() const noexcept {
+        return mBlobs.size();
+    }
+
 private:
     std::vector<Blob> mBlobs;
 };

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -162,6 +162,7 @@ void SpvToMsl(const SpirvBlob* spirv, std::string* outMsl) {
     }
 
     *outMsl = mslCompiler.compile();
+    *outMsl = shrinkString(*outMsl);
 }
 
 bool GLSLPostProcessor::process(const std::string& inputShader,

--- a/libs/matdbg/include/matdbg/ShaderExtractor.h
+++ b/libs/matdbg/include/matdbg/ShaderExtractor.h
@@ -25,6 +25,10 @@
 
 #include <utils/CString.h>
 
+namespace filaflat {
+class BlobDictionary;
+}
+
 namespace filament {
 namespace matdbg {
 
@@ -36,6 +40,7 @@ public:
     bool parse() noexcept;
     bool getShader(backend::ShaderModel shaderModel,
             uint8_t variant, backend::ShaderType stage, filaflat::ShaderBuilder& shader) noexcept;
+    bool getDictionary(filaflat::BlobDictionary& dictionary) noexcept;
 
     static utils::CString spirvToGLSL(const uint32_t* data, size_t wordCount);
     static utils::CString spirvToText(const uint32_t* data, size_t wordCount);

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -68,6 +68,10 @@ bool ShaderExtractor::parse() noexcept {
     return false;
 }
 
+bool ShaderExtractor::getDictionary(BlobDictionary& dictionary) noexcept {
+    return DictionaryReader::unflatten(mChunkContainer, mDictionaryTag, dictionary);
+}
+
 bool ShaderExtractor::getShader(ShaderModel shaderModel,
         uint8_t variant, ShaderType stage, ShaderBuilder& shader) noexcept {
 


### PR DESCRIPTION
This change adds new commands to matinfo to print dictionaries.
This feature is useful to debug dictionaries, and I just used
it to identify that using a shared dictionary would save ~12 KiB
in the Android build. The macOS build (GLSL + Metal) would go
down to 71 KiB from 136 KiB.

The SPIRV to Metal conversion leaves leading spaces and some
comments. This change also runs the shrinker on optimized Metal
shaders to further reduce the size of shaders.