### PR TITLE
workaround a framegraph bug with imported rendertargets

### DIFF
--- a/filament/src/fg/fg/RenderTargetResourceEntry.h
+++ b/filament/src/fg/fg/RenderTargetResourceEntry.h
@@ -39,7 +39,7 @@ private:
     void resolve(FrameGraph& fg) noexcept override;
     void preExecuteDevirtualize(FrameGraph& fg) noexcept override;
     void postExecuteDestroy(FrameGraph& fg) noexcept override;
-    void preExecuteDestroy(FrameGraph& fg) noexcept override { }
+    void preExecuteDestroy(FrameGraph& fg) noexcept override;
     void postExecuteDevirtualize(FrameGraph& fg) noexcept override;
     RenderTargetResourceEntry* asRenderTargetResourceEntry() noexcept override { return this; }
 


### PR DESCRIPTION
Imported render targets are only partially implemented, which
caused a discard flags bug. It would happen when an imported
 render target is used more than once like when using SSrefr
without tone mapping.  In that case, the 2nd pass would use the same
discard flags as the first pass.