### PR TITLE
Cleanup render loop to prepare for more features

### DIFF
--- a/filament/backend/src/SamplerGroup.cpp
+++ b/filament/backend/src/SamplerGroup.cpp
@@ -64,8 +64,11 @@ SamplerGroup& SamplerGroup::setSamplers(SamplerGroup const& rhs) noexcept {
 
 void SamplerGroup::setSampler(size_t index, Sampler const& sampler) noexcept {
     if (index < mBuffer.size()) {
-        mBuffer[index] = sampler;
-        mDirty.set(index);
+        auto& cur = mBuffer[index];
+        if (cur.t != sampler.t || cur.s.u != sampler.s.u) {
+            cur = sampler;
+            mDirty.set(index);
+        }
     }
 }
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -63,8 +63,11 @@ public:
     FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
 
-    FrameGraphId<FrameGraphTexture> ssao(FrameGraph& fg, details::RenderPass& pass,
-            filament::Viewport const& svp,
+    FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg, details::RenderPass const& pass,
+            uint32_t width, uint32_t height, float scale) noexcept;
+
+    FrameGraphId<FrameGraphTexture> screenSpaceAmbientOclusion(FrameGraph& fg,
+            details::RenderPass& pass, filament::Viewport const& svp,
             details::CameraInfo const& cameraInfo,
             View::AmbientOcclusionOptions const& options) noexcept;
 
@@ -82,9 +85,6 @@ public:
 
 private:
     details::FEngine& mEngine;
-
-    FrameGraphId<FrameGraphTexture> depthPass(FrameGraph& fg, details::RenderPass const& pass,
-            uint32_t width, uint32_t height, View::AmbientOcclusionOptions const& options) noexcept;
 
     FrameGraphId<FrameGraphTexture> mipmapPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, size_t level) noexcept;

--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -160,9 +160,7 @@ public:
 
     // get uniform of known types from the proper offset (e.g.: use offsetof())
     template<typename T, typename = typename is_supported_type<T>::type>
-    T const& getUniform(size_t offset) const noexcept {
-        // we don't support mat3f because a specialization would force us to return by value.
-        static_assert(!std::is_same<math::mat3f, T>::value, "mat3f not supported");
+    T getUniform(size_t offset) const noexcept {
         return *reinterpret_cast<T const*>(static_cast<char const*>(mBuffer) + offset);
     }
 
@@ -225,6 +223,13 @@ inline void UniformBuffer::setUniform(void* addr, size_t offset, const math::mat
     temp.v[2][1] = v[2][1];
     temp.v[2][2] = v[2][2];
     temp.v[2][3] = 0; // not needed, but doesn't cost anything
+}
+
+template<>
+inline math::mat3f UniformBuffer::getUniform(size_t offset) const noexcept {
+    math::float4 const* p = reinterpret_cast<math::float4 const*>(
+            static_cast<char const*>(mBuffer) + offset);
+    return { p[0].xyz, p[1].xyz, p[2].xyz };
 }
 
 template<>

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -709,12 +709,10 @@ void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refraction
     mPerViewUb.setUniform(offsetof(PerViewUib, refractionLodOffset), refractionLodOffset);
 }
 
-void FView::cleanupSSAO() const noexcept {
-    mPerViewSb.setSampler(PerViewSib::SSAO, {}, {});
-}
-
-void FView::cleanupSSR() const noexcept {
-    mPerViewSb.setSampler(PerViewSib::SSR, {}, {});
+void FView::cleanupRenderPasses() const noexcept {
+    auto& samplerGroup = mPerViewSb;
+    samplerGroup.setSampler(PerViewSib::SSAO, {}, {});
+    samplerGroup.setSampler(PerViewSib::SSR, {}, {});
 }
 
 void FView::froxelize(FEngine& engine) const noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -106,16 +106,17 @@ private:
         math::float2 scale;
         backend::TextureFormat hdrFormat;
         uint8_t msaa;
+        backend::TargetBufferFlags clearFlags;
+        math::float4 clearColor = {};
+        float refractionLodOffset;
     };
 
-    static FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg, const char* name,
-            FrameGraphTexture::Descriptor const& colorBufferDesc, ColorPassConfig const& config,
-            RenderPass const& pass, backend::TargetBufferFlags clearFlags,
-            math::float4 clearColor = {}) noexcept;
+    FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg, const char* name,
+            FrameGraphTexture::Descriptor const& colorBufferDesc,
+            ColorPassConfig const& config, RenderPass const& pass, FView const& view) const noexcept;
 
     FrameGraphId<FrameGraphTexture> refractionPass(FrameGraph& fg,
-            ColorPassConfig const& config, RenderPass const& pass,
-            FView const& view, backend::TargetBufferFlags clearFlags) const noexcept;
+            ColorPassConfig config, RenderPass const& pass, FView const& view) const noexcept;
 
     void recordHighWatermark(size_t watermark) noexcept {
         mCommandsHighWatermark = std::max(mCommandsHighWatermark, watermark);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -163,9 +163,8 @@ public:
     void prepareLighting(FEngine& engine, FEngine::DriverApi& driver,
             ArenaScope& arena, Viewport const& viewport) noexcept;
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
-    void cleanupSSAO() const noexcept;
+    void cleanupRenderPasses() const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept;
-    void cleanupSSR() const noexcept;
     void froxelize(FEngine& engine) const noexcept;
     void commitUniforms(backend::DriverApi& driver) const noexcept;
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;
@@ -322,6 +321,10 @@ public:
     static void cullRenderables(utils::JobSystem& js, FScene::RenderableSoa& renderableData,
             Frustum const& frustum, size_t bit) noexcept;
 
+    UniformBuffer& getViewUniforms() const { return mPerViewUb; }
+    backend::SamplerGroup& getViewSamplers() const { return mPerViewSb; }
+    UniformBuffer& getShadowUniforms() const { return mShadowUb; }
+
 private:
     static constexpr size_t MAX_FRAMETIME_HISTORY = 32u;
 
@@ -355,10 +358,6 @@ private:
     backend::Handle<backend::HwUniformBuffer> mLightUbh;
     backend::Handle<backend::HwUniformBuffer> mShadowUbh;
     backend::Handle<backend::HwUniformBuffer> mRenderableUbh;
-
-    backend::Handle<backend::HwSamplerGroup> getUsh() const noexcept { return mPerViewSbh; }
-    backend::Handle<backend::HwUniformBuffer> getUbh() const noexcept { return mPerViewUbh; }
-    backend::Handle<backend::HwUniformBuffer> getLightUbh() const noexcept { return mLightUbh; }
 
     FScene* mScene = nullptr;
     FCamera* mCullingCamera = nullptr;

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -189,7 +189,7 @@ public:
         addPass<Empty>(name, [](FrameGraph::Builder& builder, auto&) { builder.sideEffect(); },
                 [execute](FrameGraphPassResources const&, auto const&,
                         backend::DriverApi& driver) {
-                    execute();
+                    execute(driver);
                 });
     }
 


### PR DESCRIPTION
- decouple the depth and ssao passes, so that the depth
  pass could be used by another client, down the framegraph

- set uniforms/samplers from the execute closure of the color pass,
  instead of using a separate pass. This is more correct and it 
  potentially reduces calls to commitUniforms.

- make setSampler check that the value set is different,
  the idea here is that it's much more costly to have to commit the
  samplers rather than having to compare them. Also realistically we
  don't have a lot of samplers in a frame, so that's not a lot of
  compares.

- one downside of this change is that commands for the SSAO pass are
  always generated, we will fix that in an upcoming change.