### PR TITLE
Add support for screen-space contact shadows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ A new header is inserted each time a *tag* is created.
 - WebGL: Improved TypeScript annotations.
 - WebGL: Simplified callback API for glTF. (⚠ API Change)
 - gltfio: Removed deprecated "Bindings" API. (⚠ API Change)
+- Add support for screen-space contact shadows
 
 ## v1.4.5
 

--- a/android/filament-android/src/main/cpp/LightManager.cpp
+++ b/android/filament-android/src/main/cpp/LightManager.cpp
@@ -66,7 +66,8 @@ Java_com_google_android_filament_LightManager_nBuilderCastShadows(JNIEnv*, jclas
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_LightManager_nBuilderShadowOptions(JNIEnv*, jclass,
         jlong nativeBuilder, jint mapSize, jfloat constantBias, jfloat normalBias, jfloat shadowFar,
-        jfloat shadowNearHint, jfloat shadowFarHint, jboolean stable) {
+        jfloat shadowNearHint, jfloat shadowFarHint, jboolean stable,
+        jboolean screenSpaceContactShadows, jint stepCount, jfloat maxShadowDistance) {
     LightManager::Builder *builder = (LightManager::Builder *) nativeBuilder;
     builder->shadowOptions(
             LightManager::ShadowOptions{.mapSize = (uint32_t)mapSize,
@@ -75,7 +76,10 @@ Java_com_google_android_filament_LightManager_nBuilderShadowOptions(JNIEnv*, jcl
                                         .shadowFar = shadowFar,
                                         .shadowNearHint = shadowNearHint,
                                         .shadowFarHint = shadowFarHint,
-                                        .stable = (bool)stable});
+                                        .stable = (bool)stable,
+                                        .screenSpaceContactShadows = (bool)screenSpaceContactShadows,
+                                        .stepCount = uint8_t(stepCount),
+                                        .maxShadowDistance = maxShadowDistance});
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -165,6 +165,13 @@ Java_com_google_android_filament_RenderableManager_nBuilderReceiveShadows(JNIEnv
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderScreenSpaceContactShadows(JNIEnv*, jclass,
+        jlong nativeBuilder, jboolean enabled) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->screenSpaceContactShadows(enabled);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_RenderableManager_nBuilderSkinning(JNIEnv*, jclass,
         jlong nativeBuilder, jint boneCount) {
     RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
@@ -273,6 +280,13 @@ Java_com_google_android_filament_RenderableManager_nSetReceiveShadows(JNIEnv*, j
         jlong nativeRenderableManager, jint i, jboolean enabled) {
     RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
     rm->setReceiveShadows((RenderableManager::Instance) i, enabled);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSetScreenSpaceContactShadows(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jboolean enabled) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    rm->setScreenSpaceContactShadows((RenderableManager::Instance) i, enabled);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -56,6 +56,9 @@ public class LightManager {
         public float shadowNearHint = 1.0f;
         public float shadowFarHint = 100.0f;
         public boolean stable = true;
+        public boolean screenSpaceContactShadows = false;
+        public int stepCount = 8;
+        public float maxShadowDistance = 0.3f;
     }
 
     public static final float EFFICIENCY_INCANDESCENT = 0.0220f;
@@ -83,7 +86,8 @@ public class LightManager {
         public Builder shadowOptions(@NonNull ShadowOptions options) {
             nBuilderShadowOptions(mNativeBuilder,
                     options.mapSize, options.constantBias, options.normalBias, options.shadowFar,
-                    options.shadowNearHint, options.shadowFarHint, options.stable);
+                    options.shadowNearHint, options.shadowFarHint, options.stable,
+                    options.screenSpaceContactShadows, options.stepCount, options.maxShadowDistance);
             return this;
         }
 
@@ -282,7 +286,7 @@ public class LightManager {
     private static native void nDestroyBuilder(long nativeBuilder);
     private static native boolean nBuilderBuild(long nativeBuilder, long nativeEngine, int entity);
     private static native void nBuilderCastShadows(long nativeBuilder, boolean enable);
-    private static native void nBuilderShadowOptions(long nativeBuilder, int mapSize, float constantBias, float normalBias, float shadowFar, float shadowNearHint, float shadowFarhint, boolean stable);
+    private static native void nBuilderShadowOptions(long nativeBuilder, int mapSize, float constantBias, float normalBias, float shadowFar, float shadowNearHint, float shadowFarhint, boolean stable, boolean screenSpaceContactShadows, int stepCount, float maxShadowDistance);
     private static native void nBuilderCastLight(long nativeBuilder, boolean enabled);
     private static native void nBuilderPosition(long nativeBuilder, float x, float y, float z);
     private static native void nBuilderDirection(long nativeBuilder, float x, float y, float z);

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -284,6 +284,17 @@ public class RenderableManager {
             return this;
         }
 
+        /**
+         * Controls if this renderable uses screen-space contact shadows. This is more
+         * expensive but can improve the quality of shadows, especially in large scenes.
+         * (off by default).
+         */
+        @NonNull
+        public Builder screenSpaceContactShadows(boolean enabled) {
+            nBuilderScreenSpaceContactShadows(mNativeBuilder, enabled);
+            return this;
+        }
+
         @NonNull
         public Builder skinning(@IntRange(from = 0, to = 255) int boneCount) {
             nBuilderSkinning(mNativeBuilder, boneCount);
@@ -461,6 +472,16 @@ public class RenderableManager {
     }
 
     /**
+     * Changes whether or not the renderable can use screen-space contact shadows.
+
+     *
+     * @see Builder#screenSpaceContactShadows
+     */
+    public void setScreenSpaceContactShadows(@EntityInstance int i, boolean enabled) {
+        nSetScreenSpaceContactShadows(mNativeObject, i, enabled);
+    }
+
+    /**
      * Checks if the renderable can cast shadows.
      *
      * @see Builder#castShadows
@@ -614,6 +635,7 @@ public class RenderableManager {
     private static native void nBuilderCulling(long nativeBuilder, boolean enabled);
     private static native void nBuilderCastShadows(long nativeBuilder, boolean enabled);
     private static native void nBuilderReceiveShadows(long nativeBuilder, boolean enabled);
+    private static native void nBuilderScreenSpaceContactShadows(long nativeBuilder, boolean enabled);
     private static native void nBuilderSkinning(long nativeBuilder, int boneCount);
     private static native int nBuilderSkinningBones(long nativeBuilder, int boneCount, Buffer bones, int remaining);
     private static native void nBuilderMorphing(long nativeBuilder, boolean enabled);
@@ -626,6 +648,7 @@ public class RenderableManager {
     private static native void nSetPriority(long nativeRenderableManager, int i, int priority);
     private static native void nSetCastShadows(long nativeRenderableManager, int i, boolean enabled);
     private static native void nSetReceiveShadows(long nativeRenderableManager, int i, boolean enabled);
+    private static native void nSetScreenSpaceContactShadows(long nativeRenderableManager, int i, boolean enabled);
     private static native boolean nIsShadowCaster(long nativeRenderableManager, int i);
     private static native boolean nIsShadowReceiver(long nativeRenderableManager, int i);
     private static native void nGetAxisAlignedBoundingBox(long nativeRenderableManager, int i, float[] center, float[] halfExtent);

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -233,6 +233,27 @@ public:
          * Setting this value correctly is essential for LISPSM shadow-maps.
          */
         float polygonOffsetSlope = 2.0f;
+
+        /**
+         * Whether screen-space contact shadows are used. This applies regardless of whether a
+         * Renderable is a shadow caster. This setting is currently only used for directional
+         * lights, ignored otherwise.
+         * Screen-space contact shadows are typically useful in large scenes.
+         * (off by default)
+         */
+        bool screenSpaceContactShadows = false;
+
+        /**
+         * Number of ray-marching steps for screen-space contact shadows.
+         * (8 by default)
+         */
+        uint8_t stepCount = 8;
+
+        /**
+         * Maximum shadow-occluder distance for screen-space contact shadows (world units).
+         * (30 cm by default)
+         */
+        float maxShadowDistance = 0.3;
     };
 
     //! Use Builder to construct a Light object instance

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -229,6 +229,13 @@ public:
         Builder& receiveShadows(bool enable) noexcept;
 
         /**
+         * Controls if this renderable uses screen-space contact shadows. This is more
+         * expensive but can improve the quality of shadows, especially in large scenes.
+         * (off by default).
+         */
+        Builder& screenSpaceContactShadows(bool enable) noexcept;
+
+        /**
          * Enables GPU vertex skinning for up to 255 bones, 0 by default.
          *
          * Each vertex can be affected by up to 4 bones simultaneously. The attached
@@ -342,6 +349,13 @@ public:
      * \see Builder::receiveShadows()
      */
     void setReceiveShadows(Instance instance, bool enable) noexcept;
+
+    /**
+     * Changes whether or not the renderable can use screen-space contact shadows.
+     *
+     * \see Builder::screenSpaceContactShadows()
+     */
+    void setScreenSpaceContactShadows(Instance instance, bool enable) noexcept;
 
     /**
      * Checks if the renderable can cast shadows.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -557,6 +557,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
         FrameGraphId<FrameGraphTexture> depth;
         FrameGraphId<FrameGraphTexture> ssao;
         FrameGraphId<FrameGraphTexture> ssr;
+        FrameGraphId<FrameGraphTexture> structure;
         FrameGraphRenderTargetHandle rt{};
     };
 
@@ -572,7 +573,11 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 data.ssr  = blackboard.get<FrameGraphTexture>("ssr");
                 data.ssao = blackboard.get<FrameGraphTexture>("ssao");
                 data.color = blackboard.get<FrameGraphTexture>("color");
-                data.depth = blackboard.get<FrameGraphTexture>("depth");
+                data.structure = blackboard.get<FrameGraphTexture>("structure");
+
+                if (data.structure.isValid()) {
+                    data.structure = builder.sample(data.structure);
+                }
 
                 if (data.ssr.isValid()) {
                     data.ssr = builder.sample(data.ssr);
@@ -619,6 +624,9 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 // set samplers and uniforms
                 PostProcessManager& ppm = getEngine().getPostProcessManager();
                 view.prepareSSAO(data.ssao.isValid() ? resources.getTexture(data.ssao) : ppm.getOneTexture());
+                if (data.structure.isValid()) {
+                    view.prepareStructure(resources.getTexture(data.structure));
+                }
                 if (data.ssr.isValid()) {
                     view.prepareSSR(resources.getTexture(data.ssr), config.refractionLodOffset);
                 }

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -184,8 +184,7 @@ void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Hand
         const size_t offset = i * sizeof(PerRenderableUib);
 
         UniformBuffer::setUniform(buffer,
-                offset + offsetof(PerRenderableUib, worldFromModelMatrix),
-                model);
+                offset + offsetof(PerRenderableUib, worldFromModelMatrix), model);
 
         // Using mat3f::getTransformForNormals handles non-uniform scaling, but DOESN'T guarantee that
         // the transformed normals will have unit-length, therefore they need to be normalized
@@ -212,6 +211,9 @@ void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Hand
 
         UniformBuffer::setUniform(buffer, offset + offsetof(PerRenderableUib, morphingEnabled),
                 uint32_t(sceneData.elementAt<VISIBILITY_STATE>(i).morphing));
+
+        UniformBuffer::setUniform(buffer, offset + offsetof(PerRenderableUib, screenSpaceContactShadows),
+                uint32_t(sceneData.elementAt<VISIBILITY_STATE>(i).screenSpaceContactShadows));
 
         UniformBuffer::setUniform(buffer,
                 offset + offsetof(PerRenderableUib, morphWeights), sceneData.elementAt<MORPH_WEIGHTS>(i));

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -709,10 +709,16 @@ void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refraction
     mPerViewUb.setUniform(offsetof(PerViewUib, refractionLodOffset), refractionLodOffset);
 }
 
+void FView::prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept {
+    // sampler must be NEAREST
+    mPerViewSb.setSampler(PerViewSib::STRUCTURE, structure, {});
+}
+
 void FView::cleanupRenderPasses() const noexcept {
     auto& samplerGroup = mPerViewSb;
     samplerGroup.setSampler(PerViewSib::SSAO, {}, {});
     samplerGroup.setSampler(PerViewSib::SSR, {}, {});
+    samplerGroup.setSampler(PerViewSib::STRUCTURE, {}, {});
 }
 
 void FView::froxelize(FEngine& engine) const noexcept {

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -45,6 +45,7 @@ struct RenderableManager::BuilderDetails {
     bool mCulling : 1;
     bool mCastShadows : 1;
     bool mReceiveShadows : 1;
+    bool mScreenSpaceContactShadows : 1;
     bool mMorphingEnabled : 1;
     size_t mSkinningBoneCount = 0;
     Bone const* mUserBones = nullptr;
@@ -52,7 +53,7 @@ struct RenderableManager::BuilderDetails {
 
     explicit BuilderDetails(size_t count)
             : mEntries(count), mCulling(true), mCastShadows(false), mReceiveShadows(true),
-              mMorphingEnabled(false) {
+              mScreenSpaceContactShadows(false), mMorphingEnabled(false) {
     }
     // this is only needed for the explicit instantiation below
     BuilderDetails() = default;
@@ -132,6 +133,11 @@ RenderableManager::Builder& RenderableManager::Builder::castShadows(bool enable)
 
 RenderableManager::Builder& RenderableManager::Builder::receiveShadows(bool enable) noexcept {
     mImpl->mReceiveShadows = enable;
+    return *this;
+}
+
+RenderableManager::Builder& RenderableManager::Builder::screenSpaceContactShadows(bool enable) noexcept {
+    mImpl->mScreenSpaceContactShadows = enable;
     return *this;
 }
 
@@ -280,6 +286,7 @@ void FRenderableManager::create(
         setPriority(ci, builder->mPriority);
         setCastShadows(ci, builder->mCastShadows);
         setReceiveShadows(ci, builder->mReceiveShadows);
+        setScreenSpaceContactShadows(ci, builder->mScreenSpaceContactShadows);
         setCulling(ci, builder->mCulling);
         setSkinning(ci, false);
         setMorphing(ci, builder->mMorphingEnabled);
@@ -570,6 +577,10 @@ void RenderableManager::setCastShadows(Instance instance, bool enable) noexcept 
 
 void RenderableManager::setReceiveShadows(Instance instance, bool enable) noexcept {
     upcast(this)->setReceiveShadows(instance, enable);
+}
+
+void RenderableManager::setScreenSpaceContactShadows(Instance instance, bool enable) noexcept {
+    upcast(this)->setScreenSpaceContactShadows(instance, enable);
 }
 
 bool RenderableManager::isShadowCaster(Instance instance) const noexcept {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -52,13 +52,16 @@ public:
 
     // TODO: consider renaming, this pertains to material variants, not strictly visibility.
     struct Visibility {
-        uint8_t priority    : 3;
-        bool castShadows    : 1;
-        bool receiveShadows : 1;
-        bool culling        : 1;
-        bool skinning       : 1;
-        bool morphing       : 1;
+        uint8_t priority                : 3;
+        bool castShadows                : 1;
+        bool receiveShadows             : 1;
+        bool culling                    : 1;
+        bool skinning                   : 1;
+        bool morphing                   : 1;
+        bool screenSpaceContactShadows  : 1;
     };
+
+    static_assert(sizeof(Visibility) == sizeof(uint16_t), "Visibility should be 16 bits");
 
     explicit FRenderableManager(FEngine& engine) noexcept;
     ~FRenderableManager();
@@ -103,6 +106,7 @@ public:
 
     inline void setLayerMask(Instance instance, uint8_t layerMask) noexcept;
     inline void setReceiveShadows(Instance instance, bool enable) noexcept;
+    inline void setScreenSpaceContactShadows(Instance instance, bool enable) noexcept;
     inline void setCulling(Instance instance, bool enable) noexcept;
     inline void setSkinning(Instance instance, bool enable) noexcept;
     inline void setMorphing(Instance instance, bool enable) noexcept;
@@ -249,6 +253,13 @@ void FRenderableManager::setReceiveShadows(Instance instance, bool enable) noexc
     if (instance) {
         Visibility& visibility = mManager[instance].visibility;
         visibility.receiveShadows = enable;
+    }
+}
+
+void FRenderableManager::setScreenSpaceContactShadows(Instance instance, bool enable) noexcept {
+    if (instance) {
+        Visibility& visibility = mManager[instance].visibility;
+        visibility.screenSpaceContactShadows = enable;
     }
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -163,8 +163,9 @@ public:
     void prepareLighting(FEngine& engine, FEngine::DriverApi& driver,
             ArenaScope& arena, Viewport const& viewport) noexcept;
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
-    void cleanupRenderPasses() const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept;
+    void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
+    void cleanupRenderPasses() const noexcept;
     void froxelize(FEngine& engine) const noexcept;
     void commitUniforms(backend::DriverApi& driver) const noexcept;
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -280,12 +280,14 @@ FrameGraph& FrameGraph::compile() noexcept {
 
         // compute resources reference counts (i.e. resources we're reading from)
         for (FrameGraphHandle resource : pass.reads) {
+            assert(resource.isValid());
             // add a reference for each pass that reads from this resource
             resourceNodes[resource.index]->readerCount++;
         }
 
 #ifndef NDEBUG
         for (FrameGraphHandle resource : pass.writes) {
+            assert(resource.isValid());
             assert(resourceNodes[resource.index]->writer == &pass);
         }
 #endif

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -42,8 +42,9 @@ struct PerViewSib {
     static constexpr size_t IBL_SPECULAR   = 4;
     static constexpr size_t SSAO           = 5;
     static constexpr size_t SSR            = 6;
+    static constexpr size_t STRUCTURE      = 7;
 
-    static constexpr size_t SAMPLER_COUNT = 7;
+    static constexpr size_t SAMPLER_COUNT  = 8;
 };
 
 }

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -84,10 +84,13 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     filament::math::float2 iblMaxMipLevel; // maxlevel, float(1<<maxlevel)
     float refractionLodOffset;
-    uint32_t directionalShadows; // whether the directional light (sun) casts shadows
+
+    // bit 0: directional (sun) shadow enabled
+    // bit 8-15: screen-space contact shadows ray casting steps
+    uint32_t directionalShadows;
 
     filament::math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
-    float padding1;
+    float ssContactShadowDistance;
 
     // bring PerViewUib to 1 KiB
     filament::math::float4 padding2[15];
@@ -99,9 +102,11 @@ struct alignas(256) PerRenderableUib {
     filament::math::mat4f worldFromModelMatrix;
     filament::math::mat3f worldFromModelNormalMatrix; // this gets expanded to 48 bytes during the copy to the UBO
     alignas(16) filament::math::float4 morphWeights;
+    // TODO: we can pack all the boolean bellow
     uint32_t skinningEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
     uint32_t morphingEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
-    filament::math::float2 padding0;
+    uint32_t screenSpaceContactShadows; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
+    float padding0;
 };
 
 struct LightsUib {

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -30,13 +30,14 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib() noexcept {
     // TODO: ideally we'd want this to be constexpr, this is a compile time structure
     static SamplerInterfaceBlock sib = SamplerInterfaceBlock::Builder()
             .name("Light")
-            .add("shadowMap",     Type::SAMPLER_2D_ARRAY,   Format::SHADOW, Precision::LOW)
+            .add("shadowMap",     Type::SAMPLER_2D_ARRAY,   Format::SHADOW, Precision::MEDIUM)
             .add("records",       Type::SAMPLER_2D,         Format::UINT,   Precision::MEDIUM)
             .add("froxels",       Type::SAMPLER_2D,         Format::UINT,   Precision::MEDIUM)
             .add("iblDFG",        Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
             .add("iblSpecular",   Type::SAMPLER_CUBEMAP,    Format::FLOAT,  Precision::MEDIUM)
             .add("ssao",          Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
             .add("ssr",           Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
+            .add("structure",     Type::SAMPLER_2D,         Format::FLOAT,  Precision::MEDIUM)
             .build();
 
     assert(sib.getSize() == PerViewSib::SAMPLER_COUNT);

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -76,11 +76,11 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ibl max mip level
             .add("iblMaxMipLevel",          1, UniformInterfaceBlock::Type::FLOAT2)
             .add("refractionLodOffset",     1, UniformInterfaceBlock::Type::FLOAT)
-            .add("directionalShadows",      1, UniformInterfaceBlock::Type::BOOL)
+            .add("directionalShadows",      1, UniformInterfaceBlock::Type::UINT)
             // view
             .add("worldOffset",             1, UniformInterfaceBlock::Type::FLOAT3)
+            .add("ssContactShadowDistance", 1, UniformInterfaceBlock::Type::FLOAT)
             // bring size to 1 KiB
-            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT)
             .add("padding2",                15, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
@@ -94,7 +94,8 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
             .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             .add("skinningEnabled", 1, UniformInterfaceBlock::Type::INT)
             .add("morphingEnabled", 1, UniformInterfaceBlock::Type::INT)
-            .add("padding0", 1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("screenSpaceContactShadows", 1, UniformInterfaceBlock::Type::INT)
+            .add("padding0", 1, UniformInterfaceBlock::Type::FLOAT)
             .build();
     return uib;
 }

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -392,6 +392,8 @@ const std::string ShaderGenerator::createFragmentProgram(filament::backend::Shad
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
+            BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib());
+    cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::LIGHTS, UibGenerator::getLightsUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_MATERIAL_INSTANCE, material.uib);

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -204,6 +204,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
         if (!instance) continue;
 
         rcm.setCastShadows(instance, g_params.castShadows);
+        rcm.setScreenSpaceContactShadows(instance, true);
 
         if (!g_singleMode || count == 0) {
             for (size_t i = 0; i < rcm.getPrimitiveCount(instance); i++) {
@@ -476,6 +477,12 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderAngle("ibl rotation", &params.iblRotation);
             ImGuiExt::DirectionWidget("direction", params.lightDirection.v);
             ImGui::Indent();
+            if (ImGui::CollapsingHeader("Contact Shadows")) {
+                DebugRegistry& debug = engine->getDebugRegistry();
+                ImGui::Checkbox("enabled###contactShadows", &params.screenSpaceContactShadows);
+                ImGui::SliderInt("steps", &params.stepCount, 0, 255);
+                ImGui::SliderFloat("distance", &params.maxShadowDistance, 0.0f, 10.0f);
+            }
             if (ImGui::CollapsingHeader("SSAO")) {
                 DebugRegistry& debug = engine->getDebugRegistry();
                 ImGui::Checkbox("enabled###ssao", &params.ssao);
@@ -578,6 +585,9 @@ static void gui(filament::Engine* engine, filament::View*) {
     options.constantBias = params.constantBias;
     options.polygonOffsetConstant = params.polygonOffsetConstant;
     options.polygonOffsetSlope = params.polygonOffsetSlope;
+    options.screenSpaceContactShadows = params.screenSpaceContactShadows;
+    options.stepCount = params.stepCount;
+    options.maxShadowDistance = params.maxShadowDistance;
     lcm.setShadowOptions(lightInstance, options);
 }
 

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -109,6 +109,9 @@ struct SandboxParameters {
     bool ssao = false;
     filament::View::AmbientOcclusionOptions ssaoOptions;
     filament::View::BloomOptions bloomOptions;
+    bool screenSpaceContactShadows = false;
+    int stepCount = 8;
+    float maxShadowDistance = 0.3;
 };
 
 inline void createInstances(SandboxParameters& params, filament::Engine& engine) {

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -39,12 +39,12 @@ void evaluateDirectionalLight(const MaterialInputs material,
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
         float ssContactShadowOcclusion = 0.0;
-        if ((frameUniforms.directionalShadows & 1u) != 0u) {
-            if (frameUniforms.ssContactShadowDistance != 0.0) {
-                if (objectUniforms.screenSpaceContactShadows != 0) {
-                    ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
-                }
+        if (frameUniforms.ssContactShadowDistance != 0.0) {
+            if (objectUniforms.screenSpaceContactShadows != 0) {
+                ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
             }
+        }
+        if ((frameUniforms.directionalShadows & 1u) != 0u) {
             visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
             #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
             visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -39,18 +39,22 @@ void evaluateDirectionalLight(const MaterialInputs material,
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
         float ssContactShadowOcclusion = 0.0;
-        if (frameUniforms.ssContactShadowDistance != 0.0) {
+
+        if ((frameUniforms.directionalShadows & 1u) != 0u) {
+            visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
+        }
+
+        if (visibility > 0.0 && frameUniforms.ssContactShadowDistance != 0.0) {
             if (objectUniforms.screenSpaceContactShadows != 0) {
                 ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
             }
         }
-        if ((frameUniforms.directionalShadows & 1u) != 0u) {
-            visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
-            #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
-            visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
-            #endif
-        }
+
         visibility = visibility * (1.0 - ssContactShadowOcclusion);
+
+        #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
+        visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
+        #endif
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -38,12 +38,18 @@ void evaluateDirectionalLight(const MaterialInputs material,
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
+
+        float ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
+
         if (frameUniforms.directionalShadows) {
             visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
             #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
             visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
             #endif
         }
+
+        visibility = visibility * (1.0 - ssContactShadowOcclusion);
+
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -38,18 +38,19 @@ void evaluateDirectionalLight(const MaterialInputs material,
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
-
-        float ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
-
-        if (frameUniforms.directionalShadows) {
+        float ssContactShadowOcclusion = 0.0;
+        if ((frameUniforms.directionalShadows & 1u) != 0u) {
+            if (frameUniforms.ssContactShadowDistance != 0.0) {
+                if (objectUniforms.screenSpaceContactShadows != 0) {
+                    ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
+                }
+            }
             visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
             #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
             visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
             #endif
         }
-
         visibility = visibility * (1.0 - ssContactShadowOcclusion);
-
     } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         return;

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -269,14 +269,14 @@ void initScreenSpaceRay(out ScreenSpaceRay ray, highp vec3 wsRayStart, vec3 wsRa
 float screenSpaceContactShadow(vec3 lightDirection) {
     // cast a ray in the direction of the light
     float occlusion = 0.0;
-    const uint STEP_COUNT = 8u;
-    const float MAX_DISTANCE = 0.30f;   // 30cm
+    uint kStepCount = (frameUniforms.directionalShadows >> 8u) & 0xFFu;
+    float kDistanceMax = frameUniforms.ssContactShadowDistance;
 
     ScreenSpaceRay rayData;
-    initScreenSpaceRay(rayData, shading_position, lightDirection, MAX_DISTANCE);
+    initScreenSpaceRay(rayData, shading_position, lightDirection, kDistanceMax);
 
     // step
-    highp float dt = 1.0 / float(STEP_COUNT);
+    highp float dt = 1.0 / float(kStepCount);
 
     // tolerance
     float tolerance = abs(rayData.ssViewRayEnd.z - rayData.ssRayStart.z) * dt * 0.5;
@@ -289,7 +289,7 @@ float screenSpaceContactShadow(vec3 lightDirection) {
     float t = dt * dither + dt;
 
     highp vec3 ray;
-    for (uint i = 0 ; i < STEP_COUNT ; i++, t += dt) {
+    for (uint i = 0 ; i < kStepCount ; i++, t += dt) {
         ray = rayData.uvRayStart + rayData.uvRay * t;
         float z = textureLod(light_structure, uvToRenderTargetUV(ray.xy), 0.0).r;
         float dz = ray.z - z;


### PR DESCRIPTION
Large scene using LiSPSM, without and with screen-space contact shadows:

<img width="672" alt="without cs" src="https://user-images.githubusercontent.com/1240896/76676343-ac0ce680-657f-11ea-8c09-48246126c3a9.png">
<img width="673" alt="with cs" src="https://user-images.githubusercontent.com/1240896/76676348-ae6f4080-657f-11ea-89fd-d31d456b16b5.png">
