### PR TITLE
Fix iOS build samples CI

### DIFF
--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -21,4 +21,4 @@ jobs:
           path: out/filament-release-ios.tgz
       - name: Build iOS samples
         run: |
-          cd build/ios && ./build-samples.sh
+          cd build/ios && ./build-samples.sh continuous

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -50,7 +50,7 @@ jobs:
           cd build/ios && ./build.sh presubmit
       - name: Build iOS samples
         run: |
-          cd build/ios && ./build-samples.sh
+          cd build/ios && ./build-samples.sh presubmit
 
   build-web:
     name: build-web


### PR DESCRIPTION
The iOS CI script should have caught the recent ASAN linker errors.