### PR TITLE
Expose libutils APIs that should have been public

### DIFF
--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -19,6 +19,8 @@
 
 // NOTE: this header should not include STL headers
 
+#include <utils/compiler.h>
+
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -68,7 +70,7 @@ template <size_t N>
 using StringLiteral = const char[N];
 
 //! \publicsection
-class StaticString {
+class UTILS_PUBLIC StaticString {
 public:
     using value_type      = char;
     using size_type       = uint32_t;
@@ -186,7 +188,7 @@ private:
 
 // ------------------------------------------------------------------------------------------------
 
-class CString {
+class UTILS_PUBLIC CString {
 public:
     using value_type      = char;
     using size_type       = uint32_t;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -37,7 +37,7 @@
 
 namespace utils {
 
-class UTILS_PUBLIC JobSystem {
+class JobSystem {
     static constexpr size_t MAX_JOB_COUNT = 4096;
     static_assert(MAX_JOB_COUNT <= 0x7FFE, "MAX_JOB_COUNT must be <= 0x7FFE");
     using WorkQueue = WorkStealingDequeue<uint16_t, MAX_JOB_COUNT>;

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -26,6 +26,7 @@
 
 #include <utils/Allocator.h>
 #include <utils/architecture.h>
+#include <utils/compiler.h>
 #include <utils/Condition.h>
 #include <utils/Log.h>
 #include <utils/memalign.h>
@@ -36,7 +37,7 @@
 
 namespace utils {
 
-class JobSystem {
+class UTILS_PUBLIC JobSystem {
     static constexpr size_t MAX_JOB_COUNT = 4096;
     static_assert(MAX_JOB_COUNT <= 0x7FFE, "MAX_JOB_COUNT must be <= 0x7FFE");
     using WorkQueue = WorkStealingDequeue<uint16_t, MAX_JOB_COUNT>;

--- a/libs/utils/include/utils/Log.h
+++ b/libs/utils/include/utils/Log.h
@@ -28,7 +28,7 @@
 namespace utils {
 namespace io {
 
-class LogStream : public ostream {
+class UTILS_PUBLIC LogStream : public ostream {
 public:
 
     enum Priority {
@@ -45,7 +45,7 @@ private:
 
 } // namespace io
 
-struct Loggers {
+struct UTILS_PUBLIC Loggers {
     // DEBUG level logging stream
     io::LogStream& d;
 
@@ -59,7 +59,7 @@ struct Loggers {
     io::LogStream& i;
 };
 
-extern Loggers slog;
+extern UTILS_PUBLIC Loggers slog;
 
 } // namespace utils
 

--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -67,7 +67,7 @@ private:
  * printf("%s\n", names->getName(names->getInstance(myEntity));
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-class NameComponentManager : public SingleInstanceComponentManager<details::SafeString> {
+class UTILS_PUBLIC NameComponentManager : public SingleInstanceComponentManager<details::SafeString> {
 public:
     using Instance = EntityInstance<NameComponentManager>;
 

--- a/libs/utils/include/utils/Panic.h
+++ b/libs/utils/include/utils/Panic.h
@@ -248,7 +248,7 @@ namespace utils {
  * The Panic class provides the std::exception protocol, it is the base exception object
  * used for all thrown exceptions.
  */
-class Panic {
+class UTILS_PUBLIC Panic {
 public:
     virtual ~Panic() noexcept;
 
@@ -299,7 +299,7 @@ public:
  * interface common to all exceptions thrown by the framework.
  */
 template <typename T>
-class TPanic : public Panic {
+class UTILS_PUBLIC TPanic : public Panic {
 public:
     // std::exception protocol
     const char* what() const noexcept override;
@@ -386,7 +386,7 @@ void logAndPanic(
  * ASSERT_PRECONDITION uses this Panic to report a precondition failure.
  * @see ASSERT_PRECONDITION
  */
-class PreconditionPanic : public TPanic<PreconditionPanic> {
+class UTILS_PUBLIC PreconditionPanic : public TPanic<PreconditionPanic> {
     // Programming error, can be avoided
     // e.g.: invalid arguments
     using TPanic<PreconditionPanic>::TPanic;
@@ -399,7 +399,7 @@ class PreconditionPanic : public TPanic<PreconditionPanic> {
  * ASSERT_POSTCONDITION uses this Panic to report a postcondition failure.
  * @see ASSERT_POSTCONDITION
  */
-class PostconditionPanic : public TPanic<PostconditionPanic> {
+class UTILS_PUBLIC PostconditionPanic : public TPanic<PostconditionPanic> {
     // Usually only detectable at runtime
     // e.g.: dead-lock would occur, arithmetic errors
     using TPanic<PostconditionPanic>::TPanic;
@@ -412,7 +412,7 @@ class PostconditionPanic : public TPanic<PostconditionPanic> {
  * ASSERT_ARITHMETIC uses this Panic to report an arithmetic (postcondition) failure.
  * @see ASSERT_ARITHMETIC
  */
-class ArithmeticPanic : public TPanic<ArithmeticPanic> {
+class UTILS_PUBLIC ArithmeticPanic : public TPanic<ArithmeticPanic> {
     // A common case of post-condition error
     // e.g.: underflow, overflow, internal computations errors
     using TPanic<ArithmeticPanic>::TPanic;

--- a/libs/utils/include/utils/Path.h
+++ b/libs/utils/include/utils/Path.h
@@ -17,6 +17,8 @@
 #ifndef UTILS_PATH_H_
 #define UTILS_PATH_H_
 
+#include <utils/compiler.h>
+
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -26,7 +28,7 @@ namespace utils {
 /**
  * An abstract representation of file and directory paths.
  */
-class Path {
+class UTILS_PUBLIC Path {
 public:
     /**
      * Creates a new empty path.

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -44,7 +44,7 @@ class EntityManager;
  *
  */
 template <typename ... Elements>
-class SingleInstanceComponentManager {
+class UTILS_PUBLIC SingleInstanceComponentManager {
 private:
 
     // this is just to avoid using std::default_random_engine, since we're in a public header.

--- a/libs/utils/include/utils/bitset.h
+++ b/libs/utils/include/utils/bitset.h
@@ -18,6 +18,7 @@
 #define TNT_UTILS_BITSET_H
 
 #include <utils/algorithm.h>
+#include <utils/compiler.h>
 
 #include <assert.h>
 #include <stddef.h>
@@ -44,7 +45,7 @@ namespace utils {
 template<typename T, size_t N = 1,
         typename = typename std::enable_if<std::is_integral<T>::value &&
                                            std::is_unsigned<T>::value>::type>
-class bitset {
+class UTILS_PUBLIC bitset {
     T storage[N];
 
 public:

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -25,7 +25,7 @@
 namespace utils {
 namespace io {
 
-class ostream {
+class UTILS_PUBLIC  ostream {
 public:
 
     virtual ~ostream();


### PR DESCRIPTION
Expose APIs used by other libraries' public headers and by sample apps.

This PR fixes #2265.