### PR TITLE
Turn off contact shadows by default in gltf viewer

### DIFF
--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -195,7 +195,7 @@ private:
     bool mEnableWireframe = false;
     bool mEnableSunlight = true;
     bool mEnableShadows = true;
-    bool mEnableContactShadows = true;
+    bool mEnableContactShadows = false;
     bool mEnableDithering = true;
     bool mEnableFxaa = true;
     bool mEnableMsaa = true;


### PR DESCRIPTION
They don't look very good since most glTF files are single, small-ish objects.