### PR TITLE
Fixes resizing window not resizing the OpenGL backing store on macOS

### DIFF
--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -124,15 +124,21 @@ void PlatformCocoaGL::makeCurrent(Platform::SwapChain* drawSwapChain,
         // arrival of macOS 10.15 (Catalina). If we were to call these methods from the GL thread,
         // we would see EXC_BAD_INSTRUCTION.
 
+        // NOTE: "setView" requires "clearDrawable" called first when setting
+        // to the same view. Not calling "clearDrawable" results in resizing
+        // problems, most evident when using GLFW.
+
         // Create a copy of the current GL context pointer for the closure.
         NSOpenGLContext* glContext = pImpl->mGLContext;
 
         #if UTILS_HAS_THREADING
         dispatch_sync(dispatch_get_main_queue(), ^(void) {
+            [glContext clearDrawable];
             [glContext setView:nsView];
             [glContext update];
         });
         #else
+            [glContext clearDrawable];
             [glContext setView:nsView];
             [glContext update];
         #endif


### PR DESCRIPTION
When using Filament with GLFW on macOS (10.14.6, Radeon Pro Vega 20 4 GB), resizing a window does not resize the backing store. At least, it does not change the number of pixels that are displayed. I created a program that sets the clear color to white and then changes it to a random color on each resize (attached). Using just GLFW and glClear, the window resized correctly. With GLFW + Filament and calling view->setClearColor(), the initial draw is correct, but resizing leaves red areas. If the window is made larger, the original area is a random color but the right and bottom are red. If the window is made smaller, it looks like the original area is translated down. I preferred debugging by opening the window on a low-res monitor and then moving it to my retina laptop monitor; exactly 1/4 of the window, in the upper left, was a random color with the rest red. I verified that the viewport and scissors rect are correct in OpenGLDriver::clearWithRasterPipe(), and that framebuffer 0 is being used.

I have noticed problems resizing the Vulkan examples, where they can be resized once or they crash/hang (suzanne, most notably). I have not investigated, but perhaps something similar is happening there.

[resize-test.zip](https://github.com/google/filament/files/4382977/resize-test.zip)



