### PR TITLE
Fix cmakelist to install subdir properly

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(utils)
 
 set(TARGET utils)
+set(TARGET_LINUX ${TARGET}/linux)
+set(TARGET_GENERIC ${TARGET}/generic)
 set(PUBLIC_HDR_DIR include)
 
 # ==================================================================================================
@@ -27,8 +29,14 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/SpinLock.h
         ${PUBLIC_HDR_DIR}/${TARGET}/StructureOfArrays.h
         ${PUBLIC_HDR_DIR}/${TARGET}/unwindows.h
-        ${PUBLIC_HDR_DIR}/${TARGET}/generic/Mutex.h
-        ${PUBLIC_HDR_DIR}/${TARGET}/linux/Mutex.h
+)
+
+set(DIST_LINUX_HDRS
+        ${PUBLIC_HDR_DIR}/${TARGET_LINUX}/Mutex.h
+)
+
+set(DIST_GENERIC_HDRS
+        ${PUBLIC_HDR_DIR}/${TARGET_GENERIC}/Mutex.h
 )
 
 set(SRCS
@@ -104,6 +112,11 @@ target_compile_options(${TARGET} PRIVATE
 set(INSTALL_TYPE ARCHIVE)
 install(TARGETS ${TARGET} ${INSTALL_TYPE} DESTINATION lib/${DIST_DIR})
 install(FILES ${DIST_HDRS} DESTINATION include/${TARGET})
+if (LINUX)
+install(FILES ${DIST_LINUX_HDRS} DESTINATION include/${TARGET_LINUX})
+else()
+install(FILES ${DIST_GENERIC_HDRS} DESTINATION include/${TARGET_GENERIC})
+endif()
 
 # ==================================================================================================
 # Test executables


### PR DESCRIPTION
Fix "[Expose libutils APIs that should have been public](https://github.com/google/filament/commit/45df197bd62681e1dd5899f8b7e4bc083a801cb8)" commit which does not install the subfolder to dest dir properly

