### PR TITLE
fog improvements

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -273,7 +273,7 @@ public class View {
         /**
          * distance in world units from the camera where the fog starts ( >= 0.0 )
          */
-        public float distance = 1.0f;
+        public float distance = 0.0f;
 
         /**
          * fog's maximum opacity between 0 and 1

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -169,7 +169,7 @@ public:
      * Options to control fog in the scene
      */
     struct FogOptions {
-        float distance = 1.0f;              //!< distance in world units from the camera where the fog starts ( >= 0.0 )
+        float distance = 0.0f;              //!< distance in world units from the camera where the fog starts ( >= 0.0 )
         float maximumOpacity = 1.0f;        //!< fog's maximum opacity between 0 and 1
         float height = 0.0f;                //!< fog's floor in world units
         float heightFalloff = 1.0f;         //!< how fast fog dissipates with altitude

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -463,7 +463,7 @@ void SimpleViewer::updateUserInterface() {
         ImGui::SliderFloat("Height", &mFogOptions.height, 0.0f, 100.0f);
         ImGui::SliderFloat("Height Falloff", &mFogOptions.heightFalloff, 0.0f, 10.0f);
         ImGui::SliderFloat("Scattering Start", &mFogOptions.inScatteringStart, 0.0f, 100.0f);
-        ImGui::SliderFloat("Scattering Size", &mFogOptions.inScatteringSize, 0.0f, 10.0f);
+        ImGui::SliderFloat("Scattering Size", &mFogOptions.inScatteringSize, 0.0f, 100.0f);
         ImGui::Checkbox("Color from IBL", &mFogOptions.fogColorFromIbl);
         ImGui::ColorPicker3("Color", mFogOptions.color.v);
     }

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -501,7 +501,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderFloat("Height", &params.fogOptions.height, 0.0f, 100.0f);
             ImGui::SliderFloat("Height Falloff", &params.fogOptions.heightFalloff, 0.0f, 10.0f);
             ImGui::SliderFloat("Scattering Start", &params.fogOptions.inScatteringStart, 0.0f, 100.0f);
-            ImGui::SliderFloat("Scattering Size", &params.fogOptions.inScatteringSize, 0.0f, 1.0f);
+            ImGui::SliderFloat("Scattering Size", &params.fogOptions.inScatteringSize, 0.0f, 100.0f);
             ImGui::Checkbox("Color from IBL", &params.fogOptions.fogColorFromIbl);
             ImGui::ColorPicker3("Color", params.fogOptions.color.v);
         }

--- a/shaders/src/fog.fs
+++ b/shaders/src/fog.fs
@@ -8,9 +8,11 @@ vec4 fog(vec4 color, vec3 view) {
         float B = frameUniforms.fogHeightFalloff;
 
         float d = length(view);
-        float h = abs(view.y) < FLT_EPS ? FLT_EPS : view.y;   // avoid divide-by-zero
 
-        float fogIntegralFunctionOfDistance = A * (1.0 - exp2(-B * h)) / h;
+        float h = view.y;
+        // The function below is continuous at h=0, so to avoid a divide-by-zero, we use the
+        // constant approximation 'B'. A better approximation would be B * (1 - 0.5 * B * h)
+        float fogIntegralFunctionOfDistance = A * ((abs(h) < 0.001) ? B : ((1.0 - exp(-B * h)) / h));
         float fogIntegral = fogIntegralFunctionOfDistance * max(d - frameUniforms.fogStart, 0.0);
 
         // remap fogIntegral to an opacity between 0 and 1. saturate(fogIntegral) is too harsh.


### PR DESCRIPTION
- handle heightFalloff=0 (i.e. fog doesn't depend on height) correctly,
  previously, a divide-by-zero on the cpu side would get in the way.
  The fix is to clamp heightFalloff to a small-enough value, and to
  make sure that this is handled correctly in the shader.

- default fog distance is 0 instead of 1m

- inScatteringSize parameter should be allowed to be large in samples