### PR TITLE
Support lights in gltfio / gltf_viewer

### DIFF
--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -58,7 +58,7 @@ public:
 
     /**
      * Gets the list of entities, one for each glTF node. All of these have a Transform component.
-     * Some of the returned entities may also have a Renderable component.
+     * Some of the returned entities may also have a Renderable component and/or a Light component.
      */
     const utils::Entity* getEntities() const noexcept;
 
@@ -66,6 +66,16 @@ public:
      * Gets the number of entities returned by getEntities().
      */
     size_t getEntityCount() const noexcept;
+
+    /**
+     * Gets the list of entities in the scene representing lights. All of these have a Light component.
+     */
+    const utils::Entity* getLightEntities() const noexcept;
+
+    /**
+     * Gets the number of entities returned by getLightEntities().
+     */
+    size_t getLightEntityCount() const noexcept;
 
     /** Gets the transform root for the asset, which has no matching glTF node. */
     utils::Entity getRoot() const noexcept;

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -108,6 +108,14 @@ struct FFilamentAsset : public FilamentAsset {
         return mEntities.empty() ? nullptr : mEntities.data();
     }
 
+    const utils::Entity* getLightEntities() const noexcept {
+        return mLightEntities.empty() ? nullptr : mLightEntities.data();
+    }
+
+    size_t getLightEntityCount() const noexcept {
+        return mLightEntities.size();
+    }
+
     utils::Entity getRoot() const noexcept {
         return mRoot;
     }
@@ -210,6 +218,7 @@ struct FFilamentAsset : public FilamentAsset {
     utils::NameComponentManager* mNameManager;
     std::vector<uint8_t> mGlbData;
     std::vector<utils::Entity> mEntities;
+    std::vector<utils::Entity> mLightEntities;
     std::vector<filament::MaterialInstance*> mMaterialInstances;
     std::vector<filament::VertexBuffer*> mVertexBuffers;
     std::vector<filament::IndexBuffer*> mIndexBuffers;

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -31,6 +31,14 @@ const Entity* FilamentAsset::getEntities() const noexcept {
     return upcast(this)->getEntities();
 }
 
+const Entity* FilamentAsset::getLightEntities() const noexcept {
+    return upcast(this)->getLightEntities();
+}
+
+size_t FilamentAsset::getLightEntityCount() const noexcept {
+    return upcast(this)->getLightEntityCount();
+}
+
 Entity FilamentAsset::getRoot() const noexcept {
     return upcast(this)->getRoot();
 }


### PR DESCRIPTION
This should make it easier to test lighting setups. Note: Blender can export glTF files with lights, but it does not write out the correct intensity values.