### PR TITLE
Try to fix Windows build by reducing disk space footprint

### DIFF
--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/android && ./build.sh continuous

--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/ios && ./build.sh continuous

--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/linux && ./build.sh continuous

--- a/.github/workflows/mac-continuous.yml
+++ b/.github/workflows/mac-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/mac && ./build.sh continuous

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -12,7 +12,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           build\windows\build-github.bat presubmit
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/android && ./build.sh presubmit
@@ -44,7 +44,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/ios && ./build.sh presubmit
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/web && ./build.sh presubmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           TAG=${REF##*/}
           echo ::set-output name=ref::${REF}
           echo ::set-output name=tag::${TAG}
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
@@ -62,7 +62,7 @@ jobs:
           TAG=${REF##*/}
           echo ::set-output name=ref::${REF}
           echo ::set-output name=tag::${TAG}
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
@@ -92,7 +92,7 @@ jobs:
           TAG=${REF##*/}
           echo ::set-output name=ref::${REF}
           echo ::set-output name=tag::${TAG}
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
@@ -126,7 +126,7 @@ jobs:
           TAG=${REF##*/}
           echo ::set-output name=ref::${REF}
           echo ::set-output name=tag::${TAG}
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
@@ -157,7 +157,7 @@ jobs:
           echo ::set-output name=ref::${REF}
           echo ::set-output name=tag::${TAG}
         shell: bash
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
         with:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script

--- a/.github/workflows/web-continuous.yml
+++ b/.github/workflows/web-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           cd build/web && ./build.sh continuous

--- a/.github/workflows/windows-continuous.yml
+++ b/.github/workflows/windows-continuous.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
           build\windows\build-github.bat continuous

--- a/build/windows/build-github.bat
+++ b/build/windows/build-github.bat
@@ -38,7 +38,7 @@ if "%TARGET%" == "release" (
 
 set VISUAL_STUDIO_VERSION="Enterprise"
 if "%RUNNING_LOCALLY%" == "1" (
-    set VISUAL_STUDIO_VERSION="Professional"
+    set VISUAL_STUDIO_VERSION="Community"
     set "PATH=%PATH%;C:\Program Files\7-Zip"
 )
 
@@ -48,16 +48,8 @@ if errorlevel 1 exit /b %errorlevel%
 msbuild /version
 cmake --version
 
-if "%BUILD_RELEASE%" == "1" (
-    :: /MT
-    call :BuildVariant mt "-DUSE_STATIC_CRT=ON" Release || exit /b
-
-    if "%BUILD_RELEASE_VARIANTS%" == "1" (
-        :: /MD
-        call :BuildVariant md "-DUSE_STATIC_CRT=OFF" Release || exit /b
-    )
-)
-
+:: Important: build debug builds first, when disk space is plentiful. Debug builds require
+:: significantly more temporary space.
 if "%BUILD_DEBUG%" == "1" (
     :: MTd
     call :BuildVariant mtd "-DUSE_STATIC_CRT=ON" Debug || exit /b
@@ -65,6 +57,16 @@ if "%BUILD_DEBUG%" == "1" (
     if "%BUILD_RELEASE_VARIANTS%" == "1" (
         :: MDd
         call :BuildVariant mdd "-DUSE_STATIC_CRT=OFF" Debug || exit /b
+    )
+)
+
+if "%BUILD_RELEASE%" == "1" (
+    :: /MT
+    call :BuildVariant mt "-DUSE_STATIC_CRT=ON" Release || exit /b
+
+    if "%BUILD_RELEASE_VARIANTS%" == "1" (
+        :: /MD
+        call :BuildVariant md "-DUSE_STATIC_CRT=OFF" Release || exit /b
     )
 )
 


### PR DESCRIPTION
Previous Windows CI jobs were running out of server disk space. This isn't a permanent solution, but gives us an extra gig of wiggle-room by building Debug first (which requires more temp space) and switching to Checkout v2, which does a shallow checkout.