### PR TITLE
make sure "structure" pass is culled when not needed

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -315,7 +315,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // --------------------------------------------------------------------------------------------
     // structure pass -- automatically culled if not used
     // Currently it consists of a simple depth pass.
-    // This is normally used by SSAO
+    // This is normally used by SSAO and contact-shadows
 
     // TODO: this should be a FrameGraph pass to participate to automatic culling
     pass.newCommandBuffer();
@@ -348,7 +348,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             .hdrFormat = hdrFormat,
             .msaa = msaa,
             .clearFlags = clearFlags,
-            .clearColor = clearColor
+            .clearColor = clearColor,
+            .hasContactShadows = scene.hasContactShadows()
     };
 
     // We use a framegraph pass to wait for froxelization to finish (so it can be done
@@ -576,7 +577,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 data.color = blackboard.get<FrameGraphTexture>("color");
                 data.structure = blackboard.get<FrameGraphTexture>("structure");
 
-                if (data.structure.isValid()) {
+                if (config.hasContactShadows) {
+                    assert(data.structure.isValid());
                     data.structure = builder.sample(data.structure);
                 }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -109,6 +109,7 @@ private:
         backend::TargetBufferFlags clearFlags;
         math::float4 clearColor = {};
         float refractionLodOffset;
+        bool hasContactShadows;
     };
 
     FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg, const char* name,

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -194,6 +194,8 @@ public:
 
     void updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Handle<backend::HwUniformBuffer> renderableUbh) noexcept;
 
+    bool hasContactShadows() const noexcept;
+
 private:
     static inline void computeLightRanges(math::float2* zrange,
             CameraInfo const& camera, const math::float4* spheres, size_t count) noexcept;
@@ -215,13 +217,14 @@ private:
 
     /*
      * The data below is valid only during a view pass. i.e. if a scene is used in multiple
-     * views, the data below is update for each view.
+     * views, the data below is updated for each view.
      * In essence, this data should be owned by View, but it's so scene-specific, that for now
      * we store it here.
      */
     RenderableSoa mRenderableData;
     LightSoa mLightData;
     backend::Handle<backend::HwUniformBuffer> mRenderableViewUbh; // This is actually owned by the view.
+    bool mHasContactShadows = false;
 };
 
 FILAMENT_UPCAST(Scene)


### PR DESCRIPTION
the structure (depth path) wasn't culled even if both ssao and
contact-shadows were disabled.