### PR TITLE
fix a clearing bug with imported rendertargets

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -292,11 +292,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     const Handle<HwRenderTarget> viewRenderTarget = getRenderTarget(view);
     FrameGraphRenderTargetHandle fgViewRenderTarget = fg.import<FrameGraphRenderTarget>(
-            "viewRenderTarget",{ .viewport = vp },{
+            "viewRenderTarget",{ .viewport = vp, .clearFlags = clearFlags },{
                     .target = viewRenderTarget,
                     .params = {
                             .flags = { .discardStart = discardedFlags },
-                            .viewport = vp
                     }});
 
     /*

--- a/filament/src/fg/fg/RenderTargetResourceEntry.cpp
+++ b/filament/src/fg/fg/RenderTargetResourceEntry.cpp
@@ -113,6 +113,10 @@ void RenderTargetResourceEntry::resolve(FrameGraph& fg) noexcept {
             resource.params.viewport.height = height;
         }
         resource.params.flags.clear = descriptor.clearFlags;
+    } else {
+        // this can happen with imported targets
+        resource.params.viewport = descriptor.viewport;
+        resource.params.flags.clear = descriptor.clearFlags;
     }
 }
 
@@ -149,14 +153,14 @@ void RenderTargetResourceEntry::update(FrameGraph& fg, PassNode const& pass) noe
             }
         }
 
-        // clear implies discarding the content of the buffer
-        resource.params.flags.discardStart |= resource.params.flags.clear;
-
         // check that this FrameGraphRenderTarget is indeed declared by this pass
         ASSERT_POSTCONDITION_NON_FATAL(resource.target,
                 "Pass \"%s\" doesn't declare rendertarget \"%s\" -- expect graphic corruptions",
                 pass.name, name);
     }
+
+    // clear implies discarding the content of the buffer
+    resource.params.flags.discardStart |= resource.params.flags.clear;
 }
 
 void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept {

--- a/samples/app/FilamentApp.cpp
+++ b/samples/app/FilamentApp.cpp
@@ -123,6 +123,7 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
         mScene->addEntity(lightmapCube->getWireFrameRenderable());
         mScene->addEntity(lightmapCube->getSolidRenderable());
 
+        window->mDepthView->getView()->setVisibleLayers(0x4, 0x4);
         window->mGodView->getView()->setVisibleLayers(0x6, 0x6);
         window->mOrthoView->getView()->setVisibleLayers(0x6, 0x6);
 


### PR DESCRIPTION
the view clear flags would not be honored when rendering directly
into an imported render target.

note: now that this works this could cause an issue when using
multiple views side-by-side and one of them doesn't have a skybox,
that view will trigger a clear of the whole buffer (because clears
clear everything, not just the viewport).
A solution will come in a later PR.

Fixes #2312