### PR TITLE
gltfio now creates and adopts its own JobSystem

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- gltfio: fixed null pointer exception seen with some Android clients.
+- Engine now exposes its JobSystem to C++ clients.
+
 ## v1.5.1
 
 - Fixed "no texture bound" warning in WebGL.

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -146,7 +146,7 @@ class ModelViewer : android.view.View.OnTouchListener {
      */
     fun loadModelGlb(buffer: Buffer) {
         destroyModel()
-        asset = assetLoader.createAssetFromJson(buffer)
+        asset = assetLoader.createAssetFromBinary(buffer)
         asset?.let { asset ->
             resourceLoader.asyncBeginLoad(asset)
             animator = asset.animator

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -118,8 +118,8 @@ class MainActivity : Activity() {
                 if (animationCount > 0) {
                     val elapsedTimeSeconds = (frameTimeNanos - startTime).toDouble() / 1_000_000_000
                     applyAnimation(0, elapsedTimeSeconds.toFloat())
-                    updateBoneMatrices()
                 }
+                updateBoneMatrices()
             }
 
             modelViewer.render()

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -23,6 +23,7 @@
 
 namespace utils {
 class Entity;
+class JobSystem;
 } // namespace utils
 
 namespace filament {
@@ -411,10 +412,15 @@ public:
 
    /**
      * Invokes one iteration of the render loop, used only on single-threaded platforms.
-     * 
+     *
      * This should be called every time the windowing system needs to paint (e.g. at 60 Hz).
      */
     void execute();
+
+   /**
+     * Retrieves the job system that the Engine has ownership over.
+     */
+    utils::JobSystem& getJobSystem() noexcept;
 
     DebugRegistry& getDebugRegistry() noexcept;
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -175,6 +175,7 @@ FEngine::FEngine(Backend backend, Platform* platform, void* sharedGLContext) :
         mCameraManager(*this),
         mCommandBufferQueue(CONFIG_MIN_COMMAND_BUFFERS_SIZE, CONFIG_COMMAND_BUFFERS_SIZE),
         mPerRenderPassAllocator("per-renderpass allocator", CONFIG_PER_RENDER_PASS_ARENA_SIZE),
+        mJobSystem(0, 2),
         mEngineEpoch(std::chrono::steady_clock::now()),
         mDriverBarrier(1)
 {
@@ -966,6 +967,10 @@ void Engine::execute() {
     ASSERT_PRECONDITION(!UTILS_HAS_THREADING, "Execute is meant for single-threaded platforms.");
     upcast(this)->flush();
     upcast(this)->execute();
+}
+
+utils::JobSystem& Engine::getJobSystem() noexcept {
+    return upcast(this)->getJobSystem();
 }
 
 DebugRegistry& Engine::getDebugRegistry() noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -210,9 +210,6 @@ public:
 
     void* streamAlloc(size_t size, size_t alignment) noexcept;
 
-    utils::JobSystem& getJobSystem() noexcept { return mJobSystem; }
-
-
     Epoch getEngineEpoch() const { return mEngineEpoch; }
     duration getEngineTime() const noexcept {
         return clock::now() - getEngineEpoch();
@@ -292,6 +289,10 @@ public:
     }
 
     bool execute();
+
+    utils::JobSystem& getJobSystem() noexcept {
+        return mJobSystem;
+    }
 
 private:
     FEngine(Backend backend, Platform* platform, void* sharedGLContext);


### PR DESCRIPTION
In 1.4.5, gltfio was not actually loaded using dynamic linking. It was safe to assume that a global JobSystem was available, since ResourceLoader takes an Engine in its constructor.

In 1.5.0+, gltfio can be loaded dynamically so it is unsafe to assume that a global JobSystem is available. Strangely, this was intermittently working (e.g. with debug builds) which might somehow be due to loading order.

This change also includes a small fix to ModelViewer (for GLB models) and sample-gltf-viewer (for models that have skinning without animation).

Tested this PR against our upcoming tutorial by manually copying aar files; also tested it against our existing gltf_viewer sample.

Fixes #2319.