### PR TITLE
Texture support for filagui/ImGui

### DIFF
--- a/libs/filagui/src/materials/uiBlit.mat
+++ b/libs/filagui/src/materials/uiBlit.mat
@@ -18,12 +18,11 @@ material {
 
 fragment {
     void material(inout MaterialInputs material) {
-        prepareMaterial(material);
+	prepareMaterial(material);
         vec2 uv = getUV0();
         uv.y = 1.0 - uv.y;
-        float alpha = texture(materialParams_albedo, uv).r;
-        material.baseColor = getColor();
-        material.baseColor.a *= alpha;
+        vec4 albedo = texture(materialParams_albedo, uv);
+        material.baseColor = getColor() * albedo;
         material.baseColor.rgb *= material.baseColor.a;
     }
 }


### PR DESCRIPTION
Stores font texture as RGBA instead of R. This is because the ui material will not be compatible for RGBA textures, as it is expecting an R texture. I was unable get a texture with ALPHA format to function as I wanted.

This also removes material instance caching by scissor rect. Instead it just assigns the scissor rect to each new primitive, as well as an optional texture.