### PR TITLE
fix a race-condition in JobSystem

### DIFF
--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -403,6 +403,7 @@ private:
     uint8_t mParallelSplitCount = 0;                    // # of split allowable in parallel_for
     Job* mMasterJob = nullptr;
 
+    utils::SpinLock mThreadMapLock; // this should have very little contention
     tsl::robin_map<std::thread::id, ThreadState *> mThreadMap;
 };
 


### PR DESCRIPTION
mThreadMap needs to be protected as it's accessed from multiple threads.