### PR TITLE
Fix support for 565 textures

### DIFF
--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -430,6 +430,7 @@ public:
 
     PixelDataType getType(int format) const noexcept {
         switch (format) {
+            case BITMAP_CONFIG_RGB_565:  return PixelDataType::USHORT_565;
             case BITMAP_CONFIG_RGBA_F16: return PixelDataType::HALF;
             default:                     return PixelDataType::UBYTE;
         }

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -273,26 +273,28 @@ public class Texture {
      * Pixel data type
      */
     public enum Type {
-        /** unsigned byte, 8-bits */
+        /** unsigned byte, 8-bit */
         UBYTE,
-        /** signed byte, 8-bits */
+        /** signed byte, 8-bit */
         BYTE,
-        /** unsigned short, 16-bits */
+        /** unsigned short, 16-bits*/
         USHORT,
-        /** signed short, 16-bits */
+        /** signed short, 16-bit */
         SHORT,
-        /** unsigned int, 32-bits */
+        /** unsigned int, 32-bit */
         UINT,
-        /** signed int, 32-bits */
+        /** signed int, 32-bit */
         INT,
-        /** half-float, 16-bits float with 10 bits mantissa */
+        /** half-float, 16-bit float with 10 bits mantissa */
         HALF,
-        /** float, 32-bits float, with 24 bits mantissa */
+        /** float, 32-bit float, with 24 bits mantissa */
         FLOAT,
-        /** a compessed type */
+        /** a compressed type */
         COMPRESSED,
-        /** unsigned 5.6 (5.5 for blue) float packed in 32-bits */
-        UINT_10F_11F_11F_REV
+        /** unsigned 5.6 (5.5 for blue) float packed in a 32-bit integer. */
+        UINT_10F_11F_11F_REV,
+        /** unsigned 5/6 bit integers packed in a 16-bit short. */
+        USHORT_565,
     }
 
     /**
@@ -342,7 +344,6 @@ public class Texture {
          * </p>
          */
         @Nullable public Runnable callback;
-
 
         /**
          * Creates a <code>PixelBufferDescriptor</code>

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
@@ -90,8 +90,8 @@ private fun format(bitmap: Bitmap) = when (bitmap.config.name) {
 
 // Not required when SKIP_BITMAP_COPY is true
 private fun type(bitmap: Bitmap) = when (bitmap.config.name) {
-    "ALPHA_8"   -> Texture.Type.UBYTE
-    "RGB_565"   -> Texture.Type.UBYTE
+    "ALPHA_8"   -> Texture.Type.USHORT
+    "RGB_565"   -> Texture.Type.USHORT_565
     "ARGB_8888" -> Texture.Type.UBYTE
     "RGBA_F16"  -> Texture.Type.HALF
     else -> throw IllegalArgumentException("Unsupported bitmap configuration")

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -248,16 +248,17 @@ enum class PixelDataFormat : uint8_t {
 
 //! Pixel Data Type
 enum class PixelDataType : uint8_t {
-    UBYTE,          //!< unsigned byte
-    BYTE,           //!< signed byte
-    USHORT,         //!< unsigned short (16-bits)
-    SHORT,          //!< signed short (16-bits)
-    UINT,           //!< unsigned int (32-bits)
-    INT,            //!< signed int (32-bits)
-    HALF,           //!< half-float (16-bits float)
-    FLOAT,          //!< float (32-bits float)
-    COMPRESSED,     //!< compressed pixels, @see CompressedPixelDataType
-    UINT_10F_11F_11F_REV    //!< three low precision floating-point numbers
+    UBYTE,                //!< unsigned byte
+    BYTE,                 //!< signed byte
+    USHORT,               //!< unsigned short (16-bit)
+    SHORT,                //!< signed short (16-bit)
+    UINT,                 //!< unsigned int (16-bit)
+    INT,                  //!< signed int (32-bit)
+    HALF,                 //!< half-float (16-bit float)
+    FLOAT,                //!< float (32-bits float)
+    COMPRESSED,           //!< compressed pixels, @see CompressedPixelDataType
+    UINT_10F_11F_11F_REV, //!< three low precision floating-point numbers
+    USHORT_565            //!< unsigned int (16-bit), encodes 3 RGB channels
 };
 
 //! Compressed pixel data types

--- a/filament/backend/include/backend/PixelBufferDescriptor.h
+++ b/filament/backend/include/backend/PixelBufferDescriptor.h
@@ -154,6 +154,7 @@ public:
             case PixelDataType::BYTE:
                 // nothing to do
                 break;
+            case PixelDataType::USHORT_565:
             case PixelDataType::USHORT:
             case PixelDataType::SHORT:
             case PixelDataType::HALF:

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -260,16 +260,17 @@ constexpr inline GLenum getFormat(backend::PixelDataFormat format) noexcept {
 constexpr inline GLenum getType(backend::PixelDataType type) noexcept {
     using PixelDataType = backend::PixelDataType;
     switch (type) {
-        case PixelDataType::UBYTE:              return GL_UNSIGNED_BYTE;
-        case PixelDataType::BYTE:               return GL_BYTE;
-        case PixelDataType::USHORT:             return GL_UNSIGNED_SHORT;
-        case PixelDataType::SHORT:              return GL_SHORT;
-        case PixelDataType::UINT:               return GL_UNSIGNED_INT;
-        case PixelDataType::INT:                return GL_INT;
-        case PixelDataType::HALF:               return GL_HALF_FLOAT;
-        case PixelDataType::FLOAT:              return GL_FLOAT;
-        case PixelDataType::UINT_10F_11F_11F_REV:  return GL_UNSIGNED_INT_10F_11F_11F_REV;
-        case PixelDataType::COMPRESSED:         return 0; // should never happen
+        case PixelDataType::UBYTE:                return GL_UNSIGNED_BYTE;
+        case PixelDataType::BYTE:                 return GL_BYTE;
+        case PixelDataType::USHORT:               return GL_UNSIGNED_SHORT;
+        case PixelDataType::SHORT:                return GL_SHORT;
+        case PixelDataType::UINT:                 return GL_UNSIGNED_INT;
+        case PixelDataType::INT:                  return GL_INT;
+        case PixelDataType::HALF:                 return GL_HALF_FLOAT;
+        case PixelDataType::FLOAT:                return GL_FLOAT;
+        case PixelDataType::UINT_10F_11F_11F_REV: return GL_UNSIGNED_INT_10F_11F_11F_REV;
+        case PixelDataType::USHORT_565:           return GL_UNSIGNED_SHORT_5_6_5;
+        case PixelDataType::COMPRESSED:           return 0; // should never happen
     }
 }
 

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -562,6 +562,8 @@ export enum PixelDataType {
     INT,
     HALF,
     FLOAT,
+    UINT_10F_11F_11F_REV,
+    USHORT_565,
 }
 
 export enum RenderableManager$PrimitiveType {

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -292,7 +292,9 @@ enum_<backend::PixelDataType>("PixelDataType")
     .value("UINT", backend::PixelDataType::UINT)
     .value("INT", backend::PixelDataType::INT)
     .value("HALF", backend::PixelDataType::HALF)
-    .value("FLOAT", backend::PixelDataType::FLOAT);
+    .value("FLOAT", backend::PixelDataType::FLOAT)
+    .value("UINT_10F_11F_11F_REV", backend::PixelDataType::UINT_10F_11F_11F_REV)
+    .value("USHORT_565", backend::PixelDataType::USHORT_565);
 
 enum_<backend::CompressedPixelDataType>("CompressedPixelDataType")
     .value("EAC_R11", backend::CompressedPixelDataType::EAC_R11)


### PR DESCRIPTION
This requires exposing a new `USHORT_565` pixel data type. Fixes #2336.