### PR TITLE
Kill specular AO at low roughness

### DIFF
--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -50,7 +50,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
             }
         }
 
-        visibility = visibility * (1.0 - ssContactShadowOcclusion);
+        visibility *= 1.0 - ssContactShadowOcclusion;
 
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
         visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);


### PR DESCRIPTION
On metals (made only of specular light), specular AO can
create large black spots. This change simply kills specular
AO to avoid this artifact. In practice we should take into
account multiple bounces but this is rasterization...