### PR TITLE
[GL backend] ensure that Handle<> are synchronously constructed

### DIFF
--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -91,6 +91,11 @@ template <typename T>
 struct Handle : public HandleBase {
     using HandleBase::HandleBase;
 
+    template<typename B, typename = std::enable_if_t<std::is_base_of<T, B>::value> >
+    Handle(Handle<B> const& base) noexcept
+            : HandleBase(base) {
+    }
+
 private:
 #if !defined(NDEBUG)
     template <typename U>

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -51,12 +51,13 @@ struct HwBase {
 };
 
 struct HwVertexBuffer : public HwBase {
-    AttributeArray attributes;            // 8 * MAX_VERTEX_ATTRIBUTE_COUNT
-    uint32_t vertexCount;                 //   4
-    uint8_t bufferCount;                  //   1
-    uint8_t attributeCount;               //   1
+    AttributeArray attributes{};          // 8 * MAX_VERTEX_ATTRIBUTE_COUNT
+    uint32_t vertexCount{};               //   4
+    uint8_t bufferCount{};                //   1
+    uint8_t attributeCount{};             //   1
     uint8_t padding[2]{};                 //   2 -> total struct is 136 bytes
 
+    HwVertexBuffer() noexcept = default;
     HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
             AttributeArray const& attributes) noexcept
             : attributes(attributes),
@@ -67,61 +68,67 @@ struct HwVertexBuffer : public HwBase {
 };
 
 struct HwIndexBuffer : public HwBase {
+    uint32_t count{};
+    uint8_t elementSize{};
+
+    HwIndexBuffer() noexcept = default;
     HwIndexBuffer(uint8_t elementSize, uint32_t indexCount) noexcept :
             count(indexCount), elementSize(elementSize) {
     }
-    uint32_t count;
-    uint8_t elementSize;
 };
 
 struct HwRenderPrimitive : public HwBase {
-    HwRenderPrimitive() noexcept = default;
-    uint32_t offset = 0;
-    uint32_t minIndex = 0;
-    uint32_t maxIndex = 0;
-    uint32_t count = 0;
-    uint32_t maxVertexCount = 0;
+    uint32_t offset{};
+    uint32_t minIndex{};
+    uint32_t maxIndex{};
+    uint32_t count{};
+    uint32_t maxVertexCount{};
     PrimitiveType type = PrimitiveType::TRIANGLES;
 };
 
 struct HwProgram : public HwBase {
 #ifndef NDEBUG
-    explicit HwProgram(utils::CString name) noexcept : name(std::move(name)) { }
     utils::CString name;
+    explicit HwProgram(utils::CString name) noexcept : name(std::move(name)) { }
 #else
     explicit HwProgram(const utils::CString&) noexcept { }
 #endif
+    HwProgram() noexcept = default;
 };
 
 struct HwSamplerGroup : public HwBase {
-    explicit HwSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
     // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
     std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
+    HwSamplerGroup() noexcept = default;
+    explicit HwSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
 };
 
 struct HwUniformBuffer : public HwBase {
 };
 
 struct HwTexture : public HwBase {
+    uint32_t width{};
+    uint32_t height{};
+    uint32_t depth{};
+    SamplerType target{};
+    uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
+    uint8_t samples : 4; // In practice this is always 1.
+    TextureFormat format{};
+    TextureUsage usage{};
+    HwStream* hwStream = nullptr;
+
+    HwTexture() noexcept : levels{}, samples{} {}
     HwTexture(backend::SamplerType target, uint8_t levels, uint8_t samples,
               uint32_t width, uint32_t height, uint32_t depth, TextureFormat fmt, TextureUsage usage) noexcept
             : width(width), height(height), depth(depth),
               target(target), levels(levels), samples(samples), format(fmt), usage(usage) { }
-    uint32_t width;
-    uint32_t height;
-    uint32_t depth;
-    SamplerType target;
-    uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
-    uint8_t samples : 4; // In practice this is always 1.
-    TextureFormat format;
-    TextureUsage usage;
-    HwStream* hwStream = nullptr;
 };
 
 struct HwRenderTarget : public HwBase {
+    uint32_t width{};
+    uint32_t height{};
+    HwRenderTarget() noexcept = default;
     HwRenderTarget(uint32_t w, uint32_t h) : width(w), height(h) { }
-    uint32_t width;
-    uint32_t height;
 };
 
 struct HwFence : public HwBase {
@@ -133,12 +140,15 @@ struct HwSwapChain : public HwBase {
 };
 
 struct HwStream : public HwBase {
-    HwStream() = default;
-    explicit HwStream(Platform::Stream* stream) : stream(stream), streamType(StreamType::NATIVE) { }
     Platform::Stream* stream = nullptr;
     StreamType streamType = StreamType::ACQUIRED;
-    uint32_t width = 0;
-    uint32_t height = 0;
+    uint32_t width{};
+    uint32_t height{};
+
+    HwStream() noexcept = default;
+    explicit HwStream(Platform::Stream* stream) noexcept
+            : stream(stream), streamType(StreamType::NATIVE) {
+    }
 };
 
 struct HwTimerQuery : public HwBase {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -64,18 +64,20 @@ public:
     struct GLVertexBuffer : public backend::HwVertexBuffer {
         using HwVertexBuffer::HwVertexBuffer;
         struct {
-            std::array<GLuint, backend::MAX_VERTEX_ATTRIBUTE_COUNT> buffers;  // 4 * MAX_VERTEX_ATTRIBUTE_COUNT bytes
+            // 4 * MAX_VERTEX_ATTRIBUTE_COUNT bytes
+            std::array<GLuint, backend::MAX_VERTEX_ATTRIBUTE_COUNT> buffers{};
         } gl;
     };
 
     struct GLIndexBuffer : public backend::HwIndexBuffer {
         using HwIndexBuffer::HwIndexBuffer;
         struct {
-            GLuint buffer;
+            GLuint buffer{};
         } gl;
     };
 
     struct GLUniformBuffer : public backend::HwUniformBuffer {
+        using HwUniformBuffer::HwUniformBuffer;
         GLUniformBuffer(uint32_t capacity, backend::BufferUsage usage) noexcept {
             gl.ubo.capacity = capacity;
             gl.ubo.usage = usage;
@@ -87,8 +89,6 @@ public:
 
     struct GLSamplerGroup : public backend::HwSamplerGroup {
         using HwSamplerGroup::HwSamplerGroup;
-        struct {
-        } gl;
     };
 
     struct GLRenderPrimitive : public backend::HwRenderPrimitive {
@@ -99,10 +99,10 @@ public:
     struct GLTexture : public backend::HwTexture {
         using HwTexture::HwTexture;
         struct {
-            GLuint id;              // texture or renderbuffer id
+            GLuint id = 0;          // texture or renderbuffer id
             mutable GLuint rb = 0;  // multi-sample sidecar renderbuffer
-            GLenum target;
-            GLenum internalFormat;
+            GLenum target = 0;
+            GLenum internalFormat = 0;
             mutable GLsync fence = nullptr;
 
             // texture parameters go here too
@@ -126,7 +126,7 @@ public:
     struct GLTimerQuery : public backend::HwTimerQuery {
         struct State {
             uint64_t elapsed = 0;
-            std::atomic_bool available;
+            std::atomic_bool available{};
         };
         struct {
             GLuint query = 0;
@@ -251,6 +251,9 @@ private:
     HandleArena mHandleArena;
 
     backend::HandleBase::HandleId allocateHandle(size_t size) noexcept;
+
+    template<typename D, typename ... ARGS>
+    backend::Handle<D> initHandle(ARGS&& ... args) noexcept;
 
     template<typename D, typename B, typename ... ARGS>
     typename std::enable_if<std::is_base_of<B, D>::value, D>::type*

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -37,6 +37,7 @@ namespace filament {
 class OpenGLProgram : public backend::HwProgram {
 public:
 
+    OpenGLProgram() noexcept = default;
     OpenGLProgram(OpenGLDriver* gl, const backend::Program& builder) noexcept;
     ~OpenGLProgram() noexcept;
 

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -110,11 +110,8 @@ FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
     }
 
     if (fs->mType == Type::HARD) {
-        // mFenceHandle could be invalid if the driver doesn't support h/w fences
-        status = FenceStatus::ERROR;
-        if (mFenceHandle) {
-            status = engine.getDriverApi().wait(mFenceHandle, timeout);
-        }
+        // note: even if the driver doesn't support h/w fences, mFenceHandle will be valid
+        status = engine.getDriverApi().wait(mFenceHandle, timeout);
     }
     return status;
 }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -326,7 +326,7 @@ public:
     void setCameraUser(FCamera* camera) noexcept { setCullingCamera(camera); }
 
     backend::Handle<backend::HwRenderTarget> getRenderTargetHandle() const noexcept {
-        constexpr backend::Handle<backend::HwRenderTarget> kEmptyHandle;
+        backend::Handle<backend::HwRenderTarget> kEmptyHandle;
         return mRenderTarget == nullptr ? kEmptyHandle : mRenderTarget->getHwHandle();
     }
 


### PR DESCRIPTION
Until now, only the memory of Hw handes was allocated synchronously,
handles were constructed later asynchronously. This was error prone
with the few (but growing) synchronous calls we have.

Now we have an init<> call that allocates and constructs handles synchronously,
the asynchronous construction if needed, is still performed with construct<>,
which is now implemented as "destroy+construct", this is okay because
most of our handles have trivial dtors.

This fixes a race with TimerQuery and Fence. Fences are still not fully 
working though, but at least won't access uninitialized memory.
Currently backend fences MUST be used trough FFence.