### PR TITLE
Add "sync" objects to the driver

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -116,6 +116,15 @@ enum class FenceStatus : int8_t {
     TIMEOUT_EXPIRED = 1,        //!< wait()'s timeout expired. The Fence condition is not satisfied.
 };
 
+/**
+ * Status codes for sync objects
+ */
+enum class SyncStatus : int8_t {
+    ERROR = -1,          //!< An error occured. The Sync is not signaled.
+    SIGNALED = 0,        //!< The Sync is signaled.
+    NOT_SIGNALED = 1,    //!< The Sync is not signaled yet
+};
+
 static constexpr uint64_t FENCE_WAIT_FOR_EVER = uint64_t(-1);
 
 /**

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -25,18 +25,19 @@
 namespace filament {
 namespace backend {
 
-struct HwVertexBuffer;
 struct HwFence;
 struct HwIndexBuffer;
 struct HwProgram;
 struct HwRenderPrimitive;
 struct HwRenderTarget;
 struct HwSamplerGroup;
-struct HwTexture;
-struct HwUniformBuffer;
-struct HwSwapChain;
 struct HwStream;
+struct HwSwapChain;
+struct HwSync;
+struct HwTexture;
 struct HwTimerQuery;
+struct HwUniformBuffer;
+struct HwVertexBuffer;
 
 /*
  * A type handle to a h/w resource
@@ -113,10 +114,11 @@ using RenderTargetHandle    = Handle<HwRenderTarget>;
 using SamplerGroupHandle    = Handle<HwSamplerGroup>;
 using StreamHandle          = Handle<HwStream>;
 using SwapChainHandle       = Handle<HwSwapChain>;
+using SyncHandle            = Handle<HwSync>;
 using TextureHandle         = Handle<HwTexture>;
+using TimerQueryHandle      = Handle<HwTimerQuery>;
 using UniformBufferHandle   = Handle<HwUniformBuffer>;
 using VertexBufferHandle    = Handle<HwVertexBuffer>;
-using TimerQueryHandle      = Handle<HwTimerQuery>;
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -205,6 +205,8 @@ DECL_DRIVER_API_R_N(backend::RenderTargetHandle, createRenderTarget,
 
 DECL_DRIVER_API_R_0(backend::FenceHandle, createFence)
 
+DECL_DRIVER_API_R_0(backend::SyncHandle, createSync)
+
 DECL_DRIVER_API_R_N(backend::SwapChainHandle, createSwapChain,
         void*, nativeWindow,
         uint64_t, flags)
@@ -238,6 +240,7 @@ DECL_DRIVER_API_N(destroyRenderTarget,    backend::RenderTargetHandle, rth)
 DECL_DRIVER_API_N(destroySwapChain,       backend::SwapChainHandle, sch)
 DECL_DRIVER_API_N(destroyStream,          backend::StreamHandle, sh)
 DECL_DRIVER_API_N(destroyTimerQuery,      backend::TimerQueryHandle, sh)
+DECL_DRIVER_API_N(destroySync,            backend::SyncHandle, sh)
 
 /*
  * Synchronous APIs
@@ -261,6 +264,7 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, cancelExternalImage, void*, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, getTimerQueryValue, backend::TimerQueryHandle, query, uint64_t*, elapsedTime)
+DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncHandle, sh)
 
 /*
  * Updating driver objects

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -135,6 +135,9 @@ struct HwFence : public HwBase {
     Platform::Fence* fence = nullptr;
 };
 
+struct HwSync : public HwBase {
+};
+
 struct HwSwapChain : public HwBase {
     Platform::SwapChain* swapChain = nullptr;
 };

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -242,6 +242,10 @@ void MetalDriver::createFenceR(Handle<HwFence> fh, int dummy) {
     construct_handle<MetalFence>(mHandleMap, fh, *mContext);
 }
 
+void MetalDriver::createSyncR(Handle<HwSync> sh, int) {
+    // TODO: implement Sync objects
+}
+
 void MetalDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags) {
     auto* metalLayer = (__bridge CAMetalLayer*) nativeWindow;
     construct_handle<MetalSwapChain>(mHandleMap, sch, mContext->device, metalLayer);
@@ -302,6 +306,11 @@ Handle<HwRenderTarget> MetalDriver::createRenderTargetS() noexcept {
 
 Handle<HwFence> MetalDriver::createFenceS() noexcept {
     return alloc_handle<MetalFence, HwFence>();
+}
+
+Handle<HwSync> MetalDriver::createSyncS() noexcept {
+    // TODO: implement Sync objects
+    return {};
 }
 
 Handle<HwSwapChain> MetalDriver::createSwapChainS() noexcept {
@@ -411,6 +420,11 @@ void MetalDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
         destruct_handle<MetalTimerQuery>(mHandleMap, tqh);
     }
 }
+
+void MetalDriver::destroySync(Handle<HwSync> sh) {
+    // TODO: implement Sync objects
+}
+
 
 void MetalDriver::terminate() {
     // Wait for all frames to finish by submitting and waiting on a dummy command buffer.
@@ -595,6 +609,11 @@ void MetalDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 bool MetalDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint64_t* elapsedTime) {
     auto* tq = handle_cast<MetalTimerQuery>(mHandleMap, tqh);
     return mContext->timerQueryImpl->getQueryResult(tq, elapsedTime);
+}
+
+SyncStatus MetalDriver::getSyncStatus(Handle<HwSync> sh) {
+    // TODO: implement Sync objects
+    return SyncStatus::SIGNALED;
 }
 
 void MetalDriver::generateMipmaps(Handle<HwTexture> th) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -94,6 +94,9 @@ void NoopDriver::destroyStream(Handle<HwStream> sh) {
 void NoopDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 
+void NoopDriver::destroySync(Handle<HwSync> fh) {
+}
+
 Handle<HwStream> NoopDriver::createStreamNative(void* nativeStream) {
     return {};
 }
@@ -170,6 +173,10 @@ void NoopDriver::cancelExternalImage(void* image) {
 
 bool NoopDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint64_t* elapsedTime) {
     return false;
+}
+
+SyncStatus NoopDriver::getSyncStatus(Handle<HwSync> sh) {
+    return SyncStatus::SIGNALED;
 }
 
 void NoopDriver::setExternalImage(Handle<HwTexture> th, void* image) {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -194,6 +194,17 @@ public:
         backend::TargetBufferFlags targets = {};
     };
 
+struct GLSync : public backend::HwSync {
+    using HwSync::HwSync;
+    struct State {
+        std::atomic<GLenum> status{ GL_TIMEOUT_EXPIRED };
+    };
+    struct {
+        GLsync sync;
+    } gl;
+    std::shared_ptr<State> result{ std::make_shared<GLSync::State>() };
+};
+
     OpenGLDriver(OpenGLDriver const&) = delete;
     OpenGLDriver& operator=(OpenGLDriver const&) = delete;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -433,6 +433,10 @@ void VulkanDriver::createFenceR(Handle<HwFence> fh, int) {
      construct_handle<VulkanFence>(mHandleMap, fh, *mContext.currentCommands);
 }
 
+void VulkanDriver::createSyncR(Handle<HwSync> sh, int) {
+    // TODO: implement sync objects
+}
+
 void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
         uint64_t flags) {
     auto* swapChain = construct_handle<VulkanSwapChain>(mHandleMap, sch);
@@ -504,6 +508,11 @@ Handle<HwFence> VulkanDriver::createFenceS() noexcept {
     return alloc_handle<VulkanFence, HwFence>();
 }
 
+Handle<HwSync> VulkanDriver::createSyncS() noexcept {
+    // TODO: implement Sync ojbects
+    return {};
+}
+
 Handle<HwSwapChain> VulkanDriver::createSwapChainS() noexcept {
     return alloc_handle<VulkanSwapChain, HwSwapChain>();
 }
@@ -568,6 +577,11 @@ void VulkanDriver::destroyStream(Handle<HwStream> sh) {
 
 void VulkanDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
 }
+
+void VulkanDriver::destroySync(Handle<HwSync> sh) {
+    // TODO: implement Sync objects
+}
+
 
 Handle<HwStream> VulkanDriver::createStreamNative(void* nativeStream) {
     return {};
@@ -696,6 +710,11 @@ void VulkanDriver::cancelExternalImage(void* image) {
 
 bool VulkanDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint64_t* elapsedTime) {
     return false;
+}
+
+SyncStatus VulkanDriver::getSyncStatus(Handle<HwSync> sh) {
+    // TODO: implement Sync objects
+    return SyncStatus::SIGNALED;
 }
 
 void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {

--- a/filament/src/details/FrameSkipper.h
+++ b/filament/src/details/FrameSkipper.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DETAILS_FRAMESKIPPER_H
 #define TNT_FILAMENT_DETAILS_FRAMESKIPPER_H
 
-#include "details/Fence.h"
+#include "backend/Handle.h"
 
 #include <array>
 
@@ -41,8 +41,8 @@ public:
 
 private:
     FEngine& mEngine;
-    using Container = std::array<FFence*, MAX_FRAME_LATENCY>;
-    mutable Container mDelayedFences{};
+    using Container = std::array<backend::Handle<backend::HwSync>, MAX_FRAME_LATENCY>;
+    mutable Container mDelayedSyncs{};
     size_t mLast;
 };
 


### PR DESCRIPTION
A sync object for us is like a fence that cannot be waited on. It can
only be queried.
This is useful for filament to know if (not when) some previous
commands have finished executing.

In OpenGL this is different from "fences" which only exist in EGL and
can be waited on from any thread.
"sync" objects correspond to GLsync object in OpenGL and are widely
supported, as opposed to EGL fences.

So we use the term "fence" to refer to synchronization object that are
external to OpenGL and the term "sync" for the native gl synchronization
objects. This distinction may or may not exist in other APIs.


rewrite the FrameSkipper to use this, which enables it on MacOS.