### PR TITLE
better GPU timings on Android

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2741,11 +2741,13 @@ void OpenGLDriver::flush(int) {
     if (!gl.bugs.disable_glFlush) {
         glFlush();
     }
+    mTimerQueryImpl->flush();
 }
 
 void OpenGLDriver::finish(int) {
     DEBUG_MARKER()
     glFinish();
+    mTimerQueryImpl->flush();
     executeGpuCommandsCompleteOps();
     executeFrameBeginsOps();
     // since we executed a glFinish(), all pending tasks should be done

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -125,7 +125,7 @@ public:
 
     struct GLTimerQuery : public backend::HwTimerQuery {
         struct State {
-            uint64_t elapsed = 0;
+            std::atomic<uint64_t> elapsed{};
             std::atomic_bool available{};
         };
         struct {

--- a/filament/backend/src/opengl/TimerQuery.h
+++ b/filament/backend/src/opengl/TimerQuery.h
@@ -41,6 +41,7 @@ protected:
 
 public:
     virtual ~TimerQueryInterface();
+    virtual void flush() = 0;
     virtual void beginTimeElapsedQuery(GLTimerQuery* query) = 0;
     virtual void endTimeElapsedQuery(GLTimerQuery* query) = 0;
     virtual bool queryResultAvailable(GLTimerQuery* query) = 0;
@@ -52,6 +53,7 @@ public:
     explicit TimerQueryNative(OpenGLContext& context);
     ~TimerQueryNative() override;
 private:
+    void flush() override;
     void beginTimeElapsedQuery(GLTimerQuery* query) override;
     void endTimeElapsedQuery(GLTimerQuery* query) override;
     bool queryResultAvailable(GLTimerQuery* query) override;
@@ -65,6 +67,7 @@ public:
     ~TimerQueryFence() override;
 private:
     using Job = std::function<void()>;
+    void flush() override;
     void beginTimeElapsedQuery(GLTimerQuery* query) override;
     void endTimeElapsedQuery(GLTimerQuery* query) override;
     bool queryResultAvailable(GLTimerQuery* query) override;
@@ -82,6 +85,7 @@ private:
     mutable utils::Condition mCondition;
     std::vector<Job> mQueue;
     bool mExitRequested = false;
+    GLTimerQuery* mActiveQuery = nullptr;
 };
 
 class TimerQueryFallback : public TimerQueryInterface {
@@ -89,6 +93,7 @@ public:
     explicit TimerQueryFallback();
     ~TimerQueryFallback() override;
 private:
+    void flush() override;
     void beginTimeElapsedQuery(GLTimerQuery* query) override;
     void endTimeElapsedQuery(GLTimerQuery* query) override;
     bool queryResultAvailable(GLTimerQuery* query) override;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -247,7 +247,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         // TODO: use the framegraph for the shadow passes
         RenderPass shadowMapPass = pass;
         view.renderShadowMaps(engine, driver, shadowMapPass);
-        driver.flush(); // Kick the GPU since we're done with this render target
         engine.flush(); // Wake-up the driver thread
     }
 


### PR DESCRIPTION
On drivers that don't implement timer queries properly, we use
fences instead, however we can't use a fence to determine the start
time of the GPU work (only the end time). To workaround this we
use the last call to glFlush() as a proxy.
At least on Pixel it works very well.

We also remove all mid-frame calls to flush(), we did this to kick
cpu work early, but it's not as efficient as overlapping the work
with the previous frame, it increases latency a bit though.