### PR TITLE
fix a some problems with timer queries in the OpenGL backend

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -405,10 +405,10 @@ private:
     void executeGpuCommandsCompleteOps() noexcept;
     std::vector<std::pair<GLsync, std::function<void()>>> mGpuCommandCompleteOps;
 
-    // tasks regularly executed on the main thread at frame begin time until they return true
-    void whenFrameBegins(std::function<bool()> fn) noexcept;
-    void executeFrameBeginsOps() noexcept;
-    std::vector<std::function<bool()>> mFrameBeginsOps;
+    // tasks regularly executed on the main thread at until they return true
+    void runEveryNowAndThen(std::function<bool()> fn) noexcept;
+    void executeEveryNowAndThenOps() noexcept;
+    std::vector<std::function<bool()>> mEveryNowAndThenOps;
 
     // timer query implementation
     TimerQueryInterface* mTimerQueryImpl = nullptr;

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -25,7 +25,7 @@ using namespace utils;
 using namespace backend;
 
 FrameSkipper::FrameSkipper(FEngine& engine, size_t latency) noexcept
-        : mEngine(engine), mLast((uint32_t)std::max(latency, size_t(1)) - 1) {
+        : mEngine(engine), mLast(latency) {
     assert(latency <= MAX_FRAME_LATENCY);
 }
 
@@ -57,9 +57,7 @@ bool FrameSkipper::beginFrame() noexcept {
 }
 
 void FrameSkipper::endFrame() noexcept {
-    auto& driver = mEngine.getDriverApi();
-    auto sync = driver.createSync();
-    mDelayedSyncs[mLast] = sync;
+    mDelayedSyncs[mLast] = mEngine.getDriverApi().createSync();
 }
 
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -55,7 +55,7 @@ namespace details {
 
 FRenderer::FRenderer(FEngine& engine) :
         mEngine(engine),
-        mFrameSkipper(engine, 2),
+        mFrameSkipper(engine, 1u),
         mFrameInfoManager(engine),
         mIsRGB8Supported(false),
         mPerRenderPassArena(engine.getPerRenderPassAllocator())


### PR DESCRIPTION
in OpenGL we need to check the status of queries on the gl thread,
so we did this in when beginFrame was called -- however, this is
too late, because beginFrame is asynchronous, so we were always
behind by 1 frame.

we fix this by running the callbacks more often.