### PR TITLE
gltfio-lite optimization

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -103,11 +103,37 @@ add_library(gltfio_resources ${DUMMY_SRC} ${RESGEN_SOURCE})
 # Build "lite" resources library, which contains only a few materials
 # ==================================================================================================
 
-set(RESOURCE_BINS
-    "${RESOURCE_DIR}/lit_opaque.filamat"
-    "${RESOURCE_DIR}/lit_fade.filamat")
+set(LITE_DIR ${CMAKE_CURRENT_BINARY_DIR}/lite)
 
-get_resgen_vars(${RESOURCE_DIR} gltfresources_lite)
+function(generate_lite_mat BLENDING)
+    set(DOUBLESIDED false)
+    set(SHADINGMODEL lit)
+    set(GENERATED_MAT "${LITE_DIR}/${SHADINGMODEL}_${BLENDING}.mat")
+    configure_file(materials/gltflite.mat.in ${GENERATED_MAT})
+    set(MATERIAL_SRCS ${MATERIAL_SRCS} ${GENERATED_MAT} PARENT_SCOPE)
+endfunction()
+
+set(MATERIAL_SRCS)
+generate_lite_mat(fade)
+generate_lite_mat(opaque)
+
+foreach (input_path ${MATERIAL_SRCS})
+    get_filename_component(basename "${input_path}" NAME_WE)
+    set(output_path "${LITE_DIR}/${basename}.filamat")
+    add_custom_command(
+            OUTPUT ${output_path}
+            COMMAND matc ${MATC_BASE_FLAGS} -o ${output_path} ${input_path}
+            MAIN_DEPENDENCY ${input_path}
+            DEPENDS matc
+            COMMENT "Compiling material ${input_path} to ${output_path}"
+    )
+endforeach()
+
+set(RESOURCE_BINS
+    "${LITE_DIR}/lit_opaque.filamat"
+    "${LITE_DIR}/lit_fade.filamat")
+
+get_resgen_vars(${LITE_DIR} gltfresources_lite)
 
 add_custom_command(
         OUTPUT ${RESGEN_OUTPUTS}
@@ -119,7 +145,7 @@ if (DEFINED RESGEN_SOURCE_FLAGS)
     set_source_files_properties(${RESGEN_SOURCE} PROPERTIES COMPILE_FLAGS ${RESGEN_SOURCE_FLAGS})
 endif()
 
-set(DUMMY_SRC "${RESOURCE_DIR}/dummy.c")
+set(DUMMY_SRC "${LITE_DIR}/dummy.c")
 add_custom_command(OUTPUT ${DUMMY_SRC} COMMAND echo "//" > ${DUMMY_SRC})
 
 add_library(gltfio_resources_lite ${DUMMY_SRC} ${RESGEN_SOURCE})
@@ -170,6 +196,6 @@ else()
     install(TARGETS gltfio_core gltfio_resources gltfio_resources_lite ARCHIVE DESTINATION lib/${DIST_DIR})
     install(DIRECTORY ${PUBLIC_HDR_DIR}/gltfio DESTINATION include)
     install(FILES ${RESOURCE_DIR}/gltfresources.h DESTINATION include/gltfio/resources)
-    install(FILES ${RESOURCE_DIR}/gltfresources_lite.h DESTINATION include/gltfio/resources)
+    install(FILES ${LITE_DIR}/gltfresources_lite.h DESTINATION include/gltfio/resources)
 
 endif()

--- a/libs/gltfio/materials/gltflite.mat.in
+++ b/libs/gltfio/materials/gltflite.mat.in
@@ -1,0 +1,97 @@
+material {
+    name : gltflite_${SHADINGMODEL}_${BLENDING},
+    requires : [ uv0, uv1, color ],
+    shadingModel : ${SHADINGMODEL},
+    blending : ${BLENDING},
+    depthWrite : true,
+    doubleSided : ${DOUBLESIDED},
+    flipUV : false,
+    specularAmbientOcclusion: simple,
+    parameters : [
+
+        // Base Color
+        { type : int, name : baseColorIndex },
+        { type : float4, name : baseColorFactor },
+        { type : sampler2d, name : baseColorMap },
+
+        // Metallic-Roughness Map
+        { type : int, name : metallicRoughnessIndex },
+        { type : float, name : metallicFactor },
+        { type : float, name : roughnessFactor },
+        { type : sampler2d, name : metallicRoughnessMap },
+
+        // Normal Map
+        { type : int, name : normalIndex },
+        { type : float, name : normalScale },
+        { type : sampler2d, name : normalMap },
+
+        // Ambient Occlusion
+        { type : int, name : aoIndex },
+        { type : float, name : aoStrength },
+        { type : sampler2d, name : occlusionMap },
+
+        // Emissive Map
+        { type : int, name : emissiveIndex },
+        { type : float3, name : emissiveFactor },
+        { type : sampler2d, name : emissiveMap }
+    ],
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        float2 uvs[2];
+        uvs[0] = getUV0();
+        uvs[1] = getUV1();
+
+        #if !defined(SHADING_MODEL_UNLIT)
+            if (materialParams.normalIndex > -1) {
+                float2 uv = uvs[materialParams.normalIndex];
+                material.normal = texture(materialParams_normalMap, uv).xyz * 2.0 - 1.0;
+                material.normal.xy *= materialParams.normalScale;
+            }
+        #endif
+
+        prepareMaterial(material);
+        material.baseColor = materialParams.baseColorFactor;
+
+        if (materialParams.baseColorIndex > -1) {
+            float2 uv = uvs[materialParams.baseColorIndex];
+            material.baseColor *= texture(materialParams_baseColorMap, uv);
+        }
+
+        #if defined(BLEND_MODE_TRANSPARENT)
+            material.baseColor.rgb *= material.baseColor.a;
+        #endif
+
+        material.baseColor *= getColor();
+
+        #if !defined(SHADING_MODEL_UNLIT)
+
+            #if defined(SHADING_MODEL_LIT)
+                material.roughness = materialParams.roughnessFactor;
+                material.metallic = materialParams.metallicFactor;
+            #endif
+
+            material.emissive.rgb = materialParams.emissiveFactor.rgb;
+            material.emissive.a = 3.0;
+
+            if (materialParams.metallicRoughnessIndex > -1) {
+                float2 uv = uvs[materialParams.metallicRoughnessIndex];
+
+                vec4 mr = texture(materialParams_metallicRoughnessMap, uv);
+                material.roughness *= mr.g;
+                material.metallic *= mr.b;
+            }
+
+            if (materialParams.aoIndex > -1) {
+                float2 uv = uvs[materialParams.aoIndex];
+                material.ambientOcclusion = texture(materialParams_occlusionMap, uv).r *
+                        materialParams.aoStrength;
+            }
+            if (materialParams.emissiveIndex > -1) {
+                float2 uv = uvs[materialParams.emissiveIndex];
+                material.emissive.rgb *= texture(materialParams_emissiveMap, uv).rgb;
+            }
+        #endif
+    }
+}


### PR DESCRIPTION
gltfio-lite now has its own template rather than re-using the ubershader one, which allows us to remove support for various glTF extensions like texture matrices.