### PR TITLE
fix shader overflows leading to black pixels

### DIFF
--- a/shaders/src/post_process.fs
+++ b/shaders/src/post_process.fs
@@ -5,5 +5,9 @@ void main() {
     // Invoke user code
     postProcess(inputs);
 
+#if defined(TARGET_MOBILE)
+    inputs.color = clamp(inputs.color, 0.0, MEDIUMP_FLT_MAX);
+#endif
+
     fragColor = inputs.color;
 }


### PR DESCRIPTION
we clamp the output of post_process materials to 0,FLT16_MAX