### PR TITLE
improve latency a bit

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -632,6 +632,11 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 auto out = resources.get(data.rt);
                 out.params.clearColor = clearColor;
                 pass.execute(resources.getPassName(), out.target, out.params);
+
+                // color pass is typically heavy and we don't have much CPU work left after
+                // this point, so flushing now allows us to start the GPU earlier and reduce
+                // latency, without creating bubbles.
+                driver.flush();
             });
 
     return colorPass.getData().color;


### PR DESCRIPTION
we now flush the backend (e.g. GL) after the color pass, this a 
good time because a lot of GPU work has been queued by that point, this
allows the GPU to start while we queue the post-processing commands.
This reduces latency by about 2.5ms on pixel4.