### PR TITLE
Desktop samples now use default backend.

### DIFF
--- a/samples/animation.cpp
+++ b/samples/animation.cpp
@@ -64,7 +64,6 @@ static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 int main(int argc, char** argv) {
     Config config;
     config.title = "animation";
-    config.backend = Engine::Backend::VULKAN;
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {

--- a/samples/depthtesting.cpp
+++ b/samples/depthtesting.cpp
@@ -65,7 +65,6 @@ static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 int main(int argc, char** argv) {
     Config config;
     config.title = "depthtesting";
-    config.backend = Engine::Backend::VULKAN;
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -50,7 +50,6 @@ static const char* IBL_FOLDER = "envs/pillars";
 int main(int argc, char** argv) {
     Config config;
     config.title = "hellopbr";
-    config.backend = Backend::VULKAN;
     config.iblDirectory = FilamentApp::getRootAssetsPath() + IBL_FOLDER;
 
     App app;

--- a/samples/hellotriangle.cpp
+++ b/samples/hellotriangle.cpp
@@ -64,7 +64,6 @@ static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 int main(int argc, char** argv) {
     Config config;
     config.title = "hellotriangle";
-    config.backend = Engine::Backend::VULKAN;
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {

--- a/samples/strobecolor.cpp
+++ b/samples/strobecolor.cpp
@@ -29,7 +29,6 @@ using namespace filament;
 int main(int argc, char** argv) {
     Config config;
     config.title = "strobecolor";
-    config.backend = Engine::Backend::VULKAN;
     Skybox* skybox;
 
     auto setup = [&skybox](Engine* engine, View* view, Scene* scene) {

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -78,11 +78,6 @@ static Texture* loadNormalMap(Engine* engine, const uint8_t* normals, size_t nby
 int main(int argc, char** argv) {
     Config config;
     config.title = "suzanne";
-#ifdef _MSC_VER
-    config.backend = Engine::Backend::OPENGL;
-#else
-    config.backend = Engine::Backend::VULKAN;
-#endif
     config.iblDirectory = FilamentApp::getRootAssetsPath() + IBL_FOLDER;
 
     App app;

--- a/samples/texturedquad.cpp
+++ b/samples/texturedquad.cpp
@@ -78,7 +78,6 @@ static constexpr uint16_t QUAD_INDICES[6] = {
 int main(int argc, char** argv) {
     Config config;
     config.title = "texturedquad";
-    config.backend = Engine::Backend::VULKAN;
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {

--- a/samples/vbotest.cpp
+++ b/samples/vbotest.cpp
@@ -44,7 +44,6 @@ static constexpr uint16_t TRIANGLE_INDICES[] { 0, 1, 2 };
 int main(int argc, char** argv) {
     Config config;
     config.title = "vbotest";
-    config.backend = Engine::Backend::VULKAN;
 
     // Aggregate positions and colors into a single buffer without interleaving.
     std::vector<uint8_t> vbo(sizeof(POSITIONS) + sizeof(COLORS));

--- a/samples/viewtest.cpp
+++ b/samples/viewtest.cpp
@@ -41,7 +41,6 @@ static constexpr uint16_t TRIANGLE_INDICES[3] = { 0, 1, 2 };
 int main(int argc, char** argv) {
     Config config;
     config.title = "viewtest";
-    config.backend = Engine::Backend::VULKAN;
 
     App app;
     auto setup = [&app](Engine* engine, View* view, Scene* scene) {


### PR DESCRIPTION
There is nothing specific to Vulkan in these tests, I meant to remove
the backend override when I removed the `vk_` prefix last week.