### PR TITLE
fix issues with ignoring beginFrame() return value

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -268,9 +268,12 @@ public class Renderer {
      *                       time base. This typically comes from
      *                       {@link android.view.Choreographer.FrameCallback}.
      *
-     * @return <code>false</code> if the current frame must be skipped<br>
-     *         When skipping a frame, the whole frame is canceled, and {@link #endFrame} must not
-     *         be called.
+     * @return <code>true</code>: the current frame must be drawn, and {@link #endFrame} must be called<br>
+     *         <code>false</code>: the current frame should be skipped, when skipping a frame,
+     *         the whole frame is canceled, and {@link #endFrame} must not
+     *         be called. However, the user can choose to proceed as though <code>true</code> was
+     *         returned and produce a frame anyways, by making calls to {@link #render(View)},
+     *         in which case {@link #endFrame} must be called.
      *
      * @see #endFrame
      * @see #render

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -123,6 +123,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
+DECL_DRIVER_API_0(tick)
+
 DECL_DRIVER_API_N(beginFrame,
         int64_t, monotonic_clock_ns,
         uint32_t, frameId,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -97,6 +97,10 @@ void MetalDriver::debugCommand(const char *methodName) {
 }
 #endif
 
+
+void MetalDriver::tick(int) {
+}
+
 void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
         backend::FrameFinishedCallback callback, void* user) {
     // If a callback was specified, then the client is responsible for presenting the frame.
@@ -111,11 +115,10 @@ void MetalDriver::execute(std::function<void(void)> fn) noexcept {
 }
 
 void MetalDriver::setPresentationTime(int64_t monotonic_clock_ns) {
-
 }
 
 void MetalDriver::endFrame(uint32_t frameId) {
-    // If we haven't commited the command buffer (if the frame was canceled), do it now. There may
+    // If we haven't committed the command buffer (if the frame was canceled), do it now. There may
     // be commands in it (like fence signaling) that need to execute.
     submitPendingCommands(mContext);
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -45,6 +45,9 @@ template class backend::ConcreteDispatcher<NoopDriver>;
 void NoopDriver::terminate() {
 }
 
+void NoopDriver::tick(int) {
+}
+
 void NoopDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
         backend::FrameFinishedCallback, void*) {
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2704,12 +2704,15 @@ void OpenGLDriver::executeEveryNowAndThenOps() noexcept {
 // Rendering ops
 // ------------------------------------------------------------------------------------------------
 
+void OpenGLDriver::tick(int) {
+    executeGpuCommandsCompleteOps();
+    executeEveryNowAndThenOps();
+}
+
 void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
         backend::FrameFinishedCallback, void*) {
     auto& gl = mContext;
     insertEventMarker("beginFrame");
-    executeGpuCommandsCompleteOps();
-    executeEveryNowAndThenOps();
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {
         OpenGLPlatform& platform = mPlatform;
         for (GLTexture const* t : mExternalStreams) {
@@ -2732,8 +2735,6 @@ void OpenGLDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 void OpenGLDriver::endFrame(uint32_t frameId) {
     //SYSTRACE_NAME("glFinish");
     //glFinish();
-    //executeGpuCommandsCompleteOps();
-    executeEveryNowAndThenOps();
     insertEventMarker("endFrame");
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -235,6 +235,9 @@ void VulkanDriver::terminate() {
     mContext.instance = nullptr;
 }
 
+void VulkanDriver::tick(int) {
+}
+
 void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
         backend::FrameFinishedCallback, void*) {
     // We allow multiple beginFrame / endFrame pairs before commit(), so gracefully return early

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -410,6 +410,10 @@ public:
      * beginFrame() attempts to detect this situation and returns false in that case, indicating
      * to the caller to skip the current frame.
      *
+     * When beginFrame() returns true, it is mandatory to render the frame and call endFrame().
+     * However, when beginFrame() returns false, the caller has the choice to either skip the
+     * frame and not call endFrame(), or proceed as though true was returned.
+     *
      * Typically, Filament is responsible for scheduling the frame's presentation to the SwapChain.
      * If a backend::FrameFinishedCallback is provided, however, the application bares the
      * responsibility of scheduling a frame for presentation by calling the backend::PresentCallable
@@ -426,8 +430,8 @@ public:
      * @param user      User data to be passed to the callback function.
      *
      * @return
-     *      *false* the current frame must be skipped,
-     *      *true* the current frame can be drawn.
+     *      *false* the current frame should be skipped,
+     *      *true* the current frame must be drawn and endFrame() must be called.
      *
      * @remark
      * When skipping a frame, the whole frame is canceled, and endFrame() must not be called.
@@ -448,7 +452,9 @@ public:
      * endFrame() schedules the current frame to be displayed on the Renderer's window.
      *
      * @note
-     * All calls to render() must happen *before* endFrame().
+     * All calls to render() must happen *before* endFrame(). endFrame() must be called if
+     * beginFrame() returned true, otherwise, endFrame() must not be called unless the caller
+     * ignored beginFrame()'s return value.
      *
      * @see
      * beginFrame()

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -57,7 +57,15 @@ bool FrameSkipper::beginFrame() noexcept {
 }
 
 void FrameSkipper::endFrame() noexcept {
-    mDelayedSyncs[mLast] = mEngine.getDriverApi().createSync();
+    // if the user produced a new frame despite the fact that the previous one wasn't finished
+    // (i.e. FrameSkipper::beginFrame() returned false), we need to make sure to replace
+    // a fence that might be here already)
+    auto& driver = mEngine.getDriverApi();
+    auto& sync = mDelayedSyncs[mLast];
+    if (sync) {
+        driver.destroySync(sync);
+    }
+    sync = driver.createSync();
 }
 
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -187,6 +187,7 @@ private:
     ClearOptions mClearOptions;
     backend::TargetBufferFlags mDiscardedFlags;
     backend::TargetBufferFlags mClearFlags;
+    std::function<void()> mBeginFrameInternal;
 
     // per-frame arena for this Renderer
     LinearAllocatorArena& mPerRenderPassArena;


### PR DESCRIPTION
ignoring beginFrame() return value is allowed, but doing so would
leave filament in an invalid state.

we now make sure that we don't execute any code after determining whether
the frame should be skipped, and execute the remainder of beginFrame() 
upon the first call to render(View*).

We also make sure the FrameSkipper can deal with its endFrame() being 
called when the current fence hasn't signaled.