### PR TITLE
get rid of the static list of Engines

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -60,43 +60,6 @@ using namespace filaflat;
 
 namespace details {
 
-// Global list of engines used for diagnostic purposes only.
-// This console output in the constructor helps catch situations where the Filament library is
-// loaded twice, or not at all. Note that we avoid using slog due to static initialization.
-class EngineList {
-public:
-    EngineList() {
-        io::LogStream cinfo(io::LogStream::Priority::INFO);
-        cinfo << "Filament library loaded." << io::endl;
-    }
-    void add(FEngine* instance) {
-        std::unique_ptr<FEngine> engine(instance);
-        std::lock_guard<std::mutex> guard(mLock);
-        Engine* handle = engine.get();
-        mEngines[handle] = std::move(engine);
-    }
-    std::unique_ptr<FEngine> remove(FEngine* instance) {
-        std::unique_ptr<FEngine> filamentEngine;
-        std::lock_guard<std::mutex> guard(mLock);
-        auto const& pos = mEngines.find(instance);
-        if (pos != mEngines.end()) {
-            std::swap(filamentEngine, pos->second);
-            mEngines.erase(pos);
-        }
-        return filamentEngine;
-    }
-    bool isValid(Engine const& engine, const char* function)  {
-        std::lock_guard<std::mutex> guard(mLock);
-        auto const& pos = mEngines.find(&engine);
-        return pos != mEngines.end();
-    }
-private:
-    std::unordered_map<Engine const*, std::unique_ptr<FEngine>> mEngines;
-    std::mutex mLock;
-};
-
-static EngineList sEngines;
-
 FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLContext) {
     FEngine* instance = new FEngine(backend, platform, sharedGLContext);
 
@@ -133,8 +96,6 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
         }
     }
 
-    sEngines.add(instance);
-
     // now we can initialize the largest part of the engine
     instance->init();
 
@@ -143,12 +104,6 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
     }
 
     return instance;
-}
-
-void FEngine::assertValid(Engine const& engine, const char* function) {
-    bool valid = sEngines.isValid(engine, function);
-    ASSERT_POSTCONDITION(valid,
-            "Using an invalid Engine instance (@ %p) from %s.", &engine, function);
 }
 
 // these must be static because only a pointer is copied to the render stream
@@ -801,10 +756,8 @@ bool FEngine::execute() {
 
 void FEngine::destroy(FEngine* engine) {
     if (engine) {
-        std::unique_ptr<FEngine> filamentEngine = sEngines.remove(engine);
-        if (filamentEngine) {
-            filamentEngine->shutdown();
-        }
+        engine->shutdown();
+        delete engine;
     }
 }
 

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -48,7 +48,6 @@ IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noex
 }
 
 IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     return upcast(engine).createIndexBuffer(*this);
 }
 

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -149,7 +149,6 @@ IndirectLight::Builder& IndirectLight::Builder::rotation(mat3f const& rotation) 
 }
 
 IndirectLight* IndirectLight::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (mImpl->mReflectionsMap) {
         if (!ASSERT_POSTCONDITION_NON_FATAL(
                 mImpl->mReflectionsMap->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP,

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -74,7 +74,6 @@ Material::Builder& Material::Builder::package(const void* payload, size_t size) 
 }
 
 Material* Material::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     MaterialParser* materialParser = FMaterial::createParser(
             upcast(engine).getBackend(), mImpl->mPayload, mImpl->mSize);
 

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -61,7 +61,6 @@ RenderTarget::Builder& RenderTarget::Builder::layer(AttachmentPoint pt, uint32_t
 }
 
 RenderTarget* RenderTarget::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     using backend::TextureUsage;
     const FRenderTarget::Attachment& color = mImpl->mAttachments[COLOR];
     const FRenderTarget::Attachment& depth = mImpl->mAttachments[DEPTH];

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -78,7 +78,6 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
 }
 
 Skybox* Skybox::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
 
     if (!ASSERT_PRECONDITION_NON_FATAL(!cubemap || cubemap->isCubemap(),

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -69,7 +69,6 @@ Stream::Builder& Stream::Builder::height(uint32_t height) noexcept {
 }
 
 Stream* Stream::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_PRECONDITION_NON_FATAL(!mImpl->mStream || !mImpl->mExternalTextureId,
             "One and only one of the stream or external texture can be specified")) {
         return nullptr;

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -100,7 +100,6 @@ Texture::Builder& Texture::Builder::import(intptr_t id) noexcept {
 }
 
 Texture* Texture::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_POSTCONDITION_NON_FATAL(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
             "Texture format %u not supported on this platform", mImpl->mFormat)) {
         return nullptr;

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -111,7 +111,6 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
 }
 
 VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mVertexCount > 0, "vertexCount cannot be 0")) {
         return nullptr;
     }

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -128,7 +128,6 @@ LightManager::Builder& LightManager::Builder::sunHaloFalloff(float haloFalloff) 
 }
 
 LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entity entity) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     upcast(engine).createLight(*this, entity);
     return Success;
 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -173,7 +173,6 @@ RenderableManager::Builder& RenderableManager::Builder::blendOrder(size_t index,
 }
 
 RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity entity) {
-    FEngine::assertValid(engine, __PRETTY_FUNCTION__);
     bool isEmpty = true;
 
     if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT,

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -135,8 +135,6 @@ public:
 
     static void destroy(FEngine* engine);
 
-    static void assertValid(Engine const& engine, const char* function);
-
     ~FEngine() noexcept;
 
     backend::Driver& getDriver() const noexcept { return *mDriver; }


### PR DESCRIPTION
Originally it was used for validating the Engine* used, but this
makes no sense (no reason to validate this pointer more than any
other one).

The list also made sure that Engine instances were automatically 
destroyed when the filament library was unloaded, but again, there
is no reason to do this -- it's C++ after all!