### PR TITLE
Fix point/spot lights when viewport is not in 0,0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,9 +23,10 @@ A new header is inserted each time a *tag* is created.
 - Improved dynamic resolution implementation to be more accurate and target more platforms.
 - `beginFrame()` now accepts a v-sync timestamp for accurate frame time measurement (used for
   frame skipping and dynamic resolution). You can pass `0` to get the old behavior (️⚠ API change).
-- Fix several issues related to multi-view support. (⚠️ **API breakage**) removed
+- Fixed several issues related to multi-view support. (⚠️ **API breakage**) removed
   `View::setClearColor()`, a similar functionality is now handled by `Renderer::setClearOptions()`
   and `Skybox`, the later now can be set to a constant color.
+- Fixed spot/point lights rendering bug depending on Viewport position.
 
 ## v1.5.2
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -314,7 +314,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     pass.setGeometry(scene.getRenderableData(), view.getVisibleRenderables(), scene.getRenderableUBO());
 
     view.updatePrimitivesLod(engine, cameraInfo,scene.getRenderableData(), view.getVisibleRenderables());
-    view.prepareCamera(cameraInfo, svp);
+    view.prepareCamera(cameraInfo);
+    view.prepareViewport(svp);
     view.commitUniforms(driver);
 
 
@@ -618,6 +619,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
             },
             [=, &view](FrameGraphPassResources const& resources,
                             ColorPassData const& data, DriverApi& driver) {
+                auto out = resources.get(data.rt);
 
                 // set samplers and uniforms
                 PostProcessManager& ppm = getEngine().getPostProcessManager();
@@ -628,9 +630,9 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 if (data.ssr.isValid()) {
                     view.prepareSSR(resources.getTexture(data.ssr), config.refractionLodOffset);
                 }
+                view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport));
                 view.commitUniforms(driver);
 
-                auto out = resources.get(data.rt);
                 out.params.clearColor = data.clearColor;
 
                 pass.execute(resources.getPassName(), out.target, out.params);

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -93,7 +93,8 @@ void ShadowMap::render(DriverApi& driver, Handle<HwRenderTarget> rt,
     pass.setGeometry(scene.getRenderableData(), range, scene.getRenderableUBO());
 
     view.updatePrimitivesLod(engine, cameraInfo, scene.getRenderableData(), range);
-    view.prepareCamera(cameraInfo, viewport);
+    view.prepareCamera(cameraInfo);
+    view.prepareViewport(viewport);
     view.commitUniforms(driver);
 
     pass.overridePolygonOffset(&mPolygonOffset);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -620,7 +620,7 @@ UTILS_NOINLINE
     });
 }
 
-void FView::prepareCamera(const CameraInfo& camera, const filament::Viewport& viewport) const noexcept {
+void FView::prepareCamera(const CameraInfo& camera) const noexcept {
     SYSTRACE_CALL();
 
     const mat4f viewFromWorld(camera.view);
@@ -639,15 +639,18 @@ void FView::prepareCamera(const CameraInfo& camera, const filament::Viewport& vi
     u.setUniform(offsetof(PerViewUib, viewFromClipMatrix), viewFromClip);      // 1/projection
     u.setUniform(offsetof(PerViewUib, clipFromWorldMatrix), clipFromWorld);    // projection * view
     u.setUniform(offsetof(PerViewUib, worldFromClipMatrix), worldFromClip);    // 1/(projection * view)
+    u.setUniform(offsetof(PerViewUib, cameraPosition), float3{camera.getPosition()});
+    u.setUniform(offsetof(PerViewUib, worldOffset), camera.worldOffset);
+    u.setUniform(offsetof(PerViewUib, cameraFar), camera.zf);
+}
 
+void FView::prepareViewport(const filament::Viewport &viewport) const noexcept {
+    SYSTRACE_CALL();
+    UniformBuffer& u = mPerViewUb;
     const float w = viewport.width;
     const float h = viewport.height;
     u.setUniform(offsetof(PerViewUib, resolution), float4{ w, h, 1.0f / w, 1.0f / h });
     u.setUniform(offsetof(PerViewUib, origin), float2{ viewport.left, viewport.bottom });
-
-    u.setUniform(offsetof(PerViewUib, cameraPosition), float3{camera.getPosition()});
-    u.setUniform(offsetof(PerViewUib, worldOffset), camera.worldOffset);
-    u.setUniform(offsetof(PerViewUib, cameraFar), camera.zf);
 }
 
 void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -146,7 +146,8 @@ public:
         return mName.c_str();
     }
 
-    void prepareCamera(const CameraInfo& camera, const Viewport& viewport) const noexcept;
+    void prepareCamera(const CameraInfo& camera) const noexcept;
+    void prepareViewport(const Viewport& viewport) const noexcept;
     void prepareShadowing(FEngine& engine, backend::DriverApi& driver,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
     void prepareLighting(FEngine& engine, FEngine::DriverApi& driver,


### PR DESCRIPTION
the problem was that the actual viewport's origin can be different
from the viewport set by the user, for instance when the view is
rendered in an intermediate buffer.