### PR TITLE
Use a simplified fast acos() for specular AO

### DIFF
--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -26,8 +26,8 @@ float SpecularAO_Lagarde(float NoV, float visibility, float roughness) {
 float sphericalCapsIntersection(float cosCap1, float cosCap2, float cosDistance) {
     // Oat and Sander 2007, "Ambient Aperture Lighting"
     // Approximation mentioned by Jimenez et al. 2016
-    float r1 = acosFast(cosCap1);
-    float r2 = acosFast(cosCap2);
+    float r1 = acosFastPositive(cosCap1);
+    float r2 = acosFastPositive(cosCap2);
     float d  = acosFast(cosDistance);
 
     // We work with cosine angles, replace the original paper's use of
@@ -42,7 +42,7 @@ float sphericalCapsIntersection(float cosCap1, float cosCap2, float cosDistance)
     }
 
     float delta = abs(r1 - r2);
-    float x = 1.0 - saturate((d - delta) / max(r1 + r2 - delta, 0.0001));
+    float x = 1.0 - saturate((d - delta) / max(r1 + r2 - delta, 1e-4));
     // simplified smoothstep()
     float area = sq(x) * (-2.0 * x + 3.0);
     return area * (1.0 - max(cosCap1, cosCap2));

--- a/shaders/src/common_math.fs
+++ b/shaders/src/common_math.fs
@@ -56,6 +56,10 @@ float max3(const vec3 v) {
 // Trigonometry
 //------------------------------------------------------------------------------
 
+/**
+ * Approximates acos(x) with a max absolute error of 9.0x10^-3.
+ * Valid in the range -1..1.
+ */
 float acosFast(float x) {
     // Lagarde 2014, "Inverse trigonometric functions GPU optimization for AMD GCN architecture"
     // This is the approximation of degree 1, with a max absolute error of 9.0x10^-3
@@ -63,6 +67,15 @@ float acosFast(float x) {
     float p = -0.1565827 * y + 1.570796;
     p *= sqrt(1.0 - y);
     return x >= 0.0 ? p : PI - p;
+}
+
+/**
+ * Approximates acos(x) with a max absolute error of 9.0x10^-3.
+ * Valid only in the range 0..1.
+ */
+float acosFastPositive(float x) {
+    float p = -0.1565827 * x + 1.570796;
+    return p * sqrt(1.0 - x);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The two spherical caps used in the intersection computations
have angles in the range 0..pi/2.