### PR TITLE
fix spotlight documentation and clamping

### DIFF
--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -402,13 +402,14 @@ public:
         /**
          * Defines a spot light'st angular falloff attenuation.
          *
-         * A spot light is defined by a position, a direction and two cone angles,
-         * \p inner and \p outer. These two angles are used to define the angular falloff
-         * attenuation of the spot light.
+         * A spot light is defined by a position, a direction and two cones, \p inner and \p outer.
+         * These two cones are used to define the angular falloff attenuation of the spot light
+         * and are defined by the angle from the center axis to where the falloff begins (i.e.
+         * cones are defined by their half-angle).
          *
-         * @param inner inner cone angle in *radians* between 0 and @f$ \pi @f$
+         * @param inner inner cone angle in *radians* between 0 and @f$ \pi/2 @f$
 
-         * @param outer outer cone angle in *radians* between 0 and @f$ \pi @f$
+         * @param outer outer cone angle in *radians* between \p inner and @f$ \pi/2 @f$
 
          * @return This Builder, for chaining calls.
          *

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -253,13 +253,11 @@ void FLightManager::setIntensity(Instance i, float intensity) noexcept {
                 break;
 
             case Type::FOCUSED_SPOT: {
-                // li = lp / (2*pi*(1-cos(outer/2)))
+                // li = lp / (2 * pi * (1 - cos(cone_outer / 2)))
                 SpotParams& spotParams = manager[i].spotParams;
-                float2 scaleOffset = spotParams.scaleOffset;
-                float cosOuter = -scaleOffset.y / scaleOffset.x;
-                float cosHalfOuter = std::sqrt((1.0f + cosOuter) * 0.5f); // half-angle identities
-                luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosHalfOuter));
                 spotParams.luminousPower = luminousPower;
+                float cosOuter = std::sqrt(spotParams.cosOuterSquared);
+                luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosOuter));
                 break;
             }
             case Type::SPOT:
@@ -285,11 +283,11 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
     auto& manager = mManager;
     if (i && isSpotLight(i)) {
         // clamp the inner/outer angles to pi
-        float outerClamped = std::min(std::abs(outer), float(F_PI));
-        float innerClamped = std::min(std::abs(inner), float(F_PI));
+        float innerClamped = std::min(std::abs(inner), float(F_PI_2));
+        float outerClamped = std::min(std::abs(outer), float(F_PI_2));
 
-        // inner must always be smaller than outer
-        innerClamped = std::min(innerClamped, outerClamped);
+        // outer must always be bigger than inner
+        outerClamped = std::max(innerClamped, outerClamped);
 
         float cosOuter = fast::cos(outerClamped);
         float cosInner = fast::cos(innerClamped);
@@ -306,9 +304,9 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
         // we need to recompute the luminous intensity
         Type type = getLightType(i).type;
         if (type == Type::FOCUSED_SPOT) {
+            // li = lp / (2 * pi * (1 - cos(cone_outer / 2)))
             float luminousPower = spotParams.luminousPower;
-            float cosHalfOuter = std::sqrt((1.0f + cosOuter) * 0.5f); // half-angle identities
-            float luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosHalfOuter));
+            float luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosOuter));
             manager[i].intensity = luminousIntensity;
         }
     }

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -101,7 +101,7 @@ float getDistanceAttenuation(const highp vec3 posToLight, float falloff) {
 
 float getAngleAttenuation(const vec3 lightDir, const vec3 l, const vec2 scaleOffset) {
     float cd = dot(lightDir, l);
-    float attenuation  = saturate(cd * scaleOffset.x + scaleOffset.y);
+    float attenuation = saturate(cd * scaleOffset.x + scaleOffset.y);
     return attenuation * attenuation;
 }
 


### PR DESCRIPTION
filament spotlights use half-angles, which is the same as gltf.