### PR TITLE
fix a strange static initialization problem on macOS

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -109,10 +109,10 @@ FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLCont
 // these must be static because only a pointer is copied to the render stream
 // Note that these coordinates are specified in OpenGL clip space. Other backends can transform
 // these in the vertex shader as needed.
-static const half4 sFullScreenTriangleVertices[3] = {
-        { -1.0_h, -1.0_h, 1.0_h, 1.0_h },
-        {  3.0_h, -1.0_h, 1.0_h, 1.0_h },
-        { -1.0_h,  3.0_h, 1.0_h, 1.0_h }
+static constexpr float4 sFullScreenTriangleVertices[3] = {
+        { -1.0f, -1.0f, 1.0f, 1.0f },
+        {  3.0f, -1.0f, 1.0f, 1.0f },
+        { -1.0f,  3.0f, 1.0f, 1.0f }
 };
 
 // these must be static because only a pointer is copied to the render stream
@@ -155,7 +155,7 @@ void FEngine::init() {
     mFullScreenTriangleVb = upcast(VertexBuffer::Builder()
             .vertexCount(3)
             .bufferCount(1)
-            .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::HALF4, 0)
+            .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT4, 0)
             .build(*this));
 
     mFullScreenTriangleVb->setBufferAt(*this, 0,


### PR DESCRIPTION
It looks like using `half` during static initialization causes issues,
where sometimes these values are not initialized correctly.
The problem goes away when some other random static initializer 
executes, which suggests a race, except there is only a single thread
at that point.

I think for some reason `half4` are not put in the data section where
float4 are.

note: we don't understand the exact issue yet