### PR TITLE
matc: do not crash when material passes bad out arg.

### DIFF
--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -277,9 +277,11 @@ void GLSLTools::scanSymbolForProperty(Symbol& symbol,
                 FunctionParameter& parameter = functionCallParameters.at(access.parameterIdx);
                 if (parameter.qualifier == FunctionParameter::OUT || parameter.qualifier ==
                         FunctionParameter::INOUT) {
-                    MaterialBuilder::Property p =
-                            Enums::toEnum<Property>(symbol.getDirectIndexStructName());
-                    properties[size_t(p)] = true;
+                    const std::string& propName = symbol.getDirectIndexStructName();
+                    if (Enums::isValid<Property>(propName)) {
+                        MaterialBuilder::Property p = Enums::toEnum<Property>(propName);
+                        properties[size_t(p)] = true;
+                    }
                 }
             } else {
                 findPropertyWritesOperations(access.string, access.parameterIdx, rootNode,


### PR DESCRIPTION
Our enum-to-string converter was throwing an exception rather than
printing a friendly error message in some cases.

To be specific, I hit this when writing:

    vec3 worldTangent;
    toTangentFrame(mesh_tangents, material.worldNormal, worldTangent);