### PR TITLE
Change how emissive works

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,19 +15,22 @@ A new header is inserted each time a *tag* is created.
 - Refraction can now be set on `MaterialBuilder` from Java.
 - Refraction mode and type can now be set by calling `MaterialBuilder::refractionMode()`.
   and `MaterialBuilder::refractionType()` instad of `materialRefraction()` and
-  `materialRefractionType()` (️⚠ API change).
+  `materialRefractionType()` (️⚠️ **API change**).
 - Fixed documentation confusion about focused spot vs spot lights.
 - Fixed a race condition in the job system.
 - Fixed support for 565 bitmaps on Android.
 - Added support for timer queries in the Metal backend.
 - Improved dynamic resolution implementation to be more accurate and target more platforms.
 - `beginFrame()` now accepts a v-sync timestamp for accurate frame time measurement (used for
-  frame skipping and dynamic resolution). You can pass `0` to get the old behavior (️⚠ API change).
-- Fixed several issues related to multi-view support. (⚠️ **API breakage**) removed
+  frame skipping and dynamic resolution). You can pass `0` to get the old behavior (⚠️ **API change**).
+- Fixed several issues related to multi-view support: removed
   `View::setClearColor()`, a similar functionality is now handled by `Renderer::setClearOptions()`
-  and `Skybox`, the later now can be set to a constant color.
+  and `Skybox`, the later now can be set to a constant color (⚠️ **API breakage**).
 - Fixed spot/point lights rendering bug depending on Viewport position.
 - Textures can now be swizzled.
+- The emissive property of materials is now expressed in nits and the alpha channel contains the
+  exposure weight (at 0.0 the exposure is not applied to the emissive component of a surface, at
+  1.0 the exposure is applied just like with any regular light) (⚠️ **API breakage**).
 
 ## v1.5.2
 

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -265,7 +265,7 @@ The type and range of each property is described in <a href="#table_standardprop
 <tr><td style="text-align:right"> <strong class="asterisk">normal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">bentNormal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Linear RGB, encodes a direction vector in tangent space </td></tr>
-<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=[-n..n] </td><td style="text-align:left"> Alpha is the exposure compensation </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..n], a=[0..1] </td><td style="text-align:left"> Linear RGB intensity in nits, alpha encodes the exposure weight </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">ior</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [1..n] </td><td style="text-align:left"> Optional, usually deduced from the reflectance </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">transmission</strong> </td><td style="text-align:center"> float </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> &#xA0; </td></tr>
@@ -734,22 +734,27 @@ map and a surface normal map</div></div></center>
 
 
 The <code>emissive</code> property can be used to simulate additional light emitted by the surface. It is
-defined as a <code>float4</code> value that contains an RGB color (in linear space) as well as an exposure
-compensation value (in the alpha channel).
+defined as a <code>float4</code> value that contains an RGB intensity in nits as well as an exposure
+weight (in the alpha channel).
 
 </p><p>
 
-Even though an exposure value actually indicates combinations of camera settings, it is often used
-by photographers to describe light intensity. This is why cameras let photographers apply an
-exposure compensation to over or under-expose an image. This setting can be used for artistic
-control but also to achieve proper exposure (snow for instance will be exposed for as
-18% middle-grey).
+The intensity in nits allows an emissive surface to function as a light and can be used to recreate
+real world surfaces. For instance a computer display has an intensity between 200 and 1,000 nits.
 
 </p><p>
 
-The exposure compensation value of the emissive property can be used to force the emissive color
-to be brighter (positive values) or darker (negative values) than the current exposure. If the bloom
-effect is enabled, using a positive exposure compensation can force the surface to bloom.
+If you prefer to work in EV (or f-stops), you can simplify multiply your emissive color by the
+output of the API <code>filament::Exposure::luminance(ev)</code>. This API returns the luminance in nits of
+the specific EV. You can perform this conversion yourself using the following formula, where \(L\)
+is the final intensity in nits: \( L = 2^{EV - 3} \).
+
+</p><p>
+
+The exposure weight carried in the alpha channel can be used to undo the camera exposure, and thus
+force an emissive surface to bloom. When the exposure weight is set to 0, the emissive intensity is
+not affected by the camera exposure. When the weight is set to 1, the intensity is multiplied by
+the camera exposure like with any regular light.
 
 </p>
 <a class="target" name="post-lightingcolor">&#xA0;</a><a class="target" name="materialmodels/litmodel/post-lightingcolor">&#xA0;</a><a class="target" name="toc3.1.17">&#xA0;</a><h3>Post-lighting color</h3>
@@ -1144,16 +1149,14 @@ The type and range of each property is described in <a href="#table_unlitpropert
 </p><div class="table">
 <table class="table"><tbody><tr><th style="text-align:right"> Property </th><th style="text-align:center"> Type </th><th style="text-align:center"> Range </th><th style="text-align:left"> Note </th></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">baseColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
-<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..1], a=N/A </td><td style="text-align:left"> Pre-multiplied linear RGB, alpha is ignored </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> rgb=[0..n], a=[0..1] </td><td style="text-align:left"> Linear RGB intensity in nits, alpha encodes the exposure weight </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:center"> [0..1] </td><td style="text-align:left"> Pre-multiplied linear RGB </td></tr>
 </tbody></table><div class="tablecaption"><a class="target" name="table_unlitpropertiestypes">&#xA0;</a><b style="font-style:normal;">Table&#xA0;10:</b> Range and type of the unlit model&apos;s properties</div></div>
 
 <p></p><p>
 
-The value of <code>emissive</code> is simply added to <code>baseColor</code> when present. The main use of <code>emissive</code>
-is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass. The value
-of <code>postLightingColor</code> is blended with the sum of <code>emissive</code> and <code>baseColor</code> according to the
-blending mode specified by the <code>postLightingBlending</code> material option.
+The value of <code>postLightingColor</code> is blended with the sum of <code>emissive</code> and <code>baseColor</code> according to
+the blending mode specified by the <code>postLightingBlending</code> material option.
 
 </p><p>
 
@@ -2166,7 +2169,7 @@ plastic with bump mapping:
 <a class="target" name="materialfragmentinputs">&#xA0;</a><a class="target" name="materialdefinitions/fragmentblock/materialfragmentinputs">&#xA0;</a><a class="target" name="toc4.4.2">&#xA0;</a><h3>Material fragment inputs</h3>
 <pre class="listing tilde"><code><span class="line">struct MaterialInputs {</span>
 <span class="line">    float4 baseColor;           <span class="hljs-comment">// default: float4(1.0)</span></span>
-<span class="line">    float4 emissive;            <span class="hljs-comment">// default: float4(0.0)</span></span>
+<span class="line">    float4 emissive;            <span class="hljs-comment">// default: float4(0.0, 0.0, 0.0, 1.0)</span></span>
 <span class="line">    float4 postLightingColor;   <span class="hljs-comment">// default: float4(0.0)</span></span>
 <span class="line"></span>
 <span class="line">    <span class="hljs-comment">// no other field is available with the unlit shading model</span></span>

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -114,7 +114,7 @@ The type and range of each property is described in table [standardPropertiesTyp
 **normal**              | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
 **bentNormal**          | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
 **clearCoatNormal**     | float3   |  [0..1]                  | Linear RGB, encodes a direction vector in tangent space
-**emissive**            | float4   |  rgb=[0..1], a=[-n..n]   | Alpha is the exposure compensation
+**emissive**            | float4   |  rgb=[0..n], a=[0..1]    | Linear RGB intensity in nits, alpha encodes the exposure weight
 **postLightingColor**   | float4   |  [0..1]                  | Pre-multiplied linear RGB
 **ior**                 | float    |  [1..n]                  | Optional, usually deduced from the reflectance
 **transmission**        | float    |  [0..1]                  |
@@ -433,18 +433,21 @@ map and a surface normal map](images/screenshot_clear_coat_normal.jpg)
 ### Emissive
 
 The `emissive` property can be used to simulate additional light emitted by the surface. It is
-defined as a `float4` value that contains an RGB color (in linear space) as well as an exposure
-compensation value (in the alpha channel).
+defined as a `float4` value that contains an RGB intensity in nits as well as an exposure
+weight (in the alpha channel).
 
-Even though an exposure value actually indicates combinations of camera settings, it is often used
-by photographers to describe light intensity. This is why cameras let photographers apply an
-exposure compensation to over or under-expose an image. This setting can be used for artistic
-control but also to achieve proper exposure (snow for instance will be exposed for as
-18% middle-grey).
+The intensity in nits allows an emissive surface to function as a light and can be used to recreate
+real world surfaces. For instance a computer display has an intensity between 200 and 1,000 nits.
 
-The exposure compensation value of the emissive property can be used to force the emissive color
-to be brighter (positive values) or darker (negative values) than the current exposure. If the bloom
-effect is enabled, using a positive exposure compensation can force the surface to bloom.
+If you prefer to work in EV (or f-stops), you can simplify multiply your emissive color by the
+output of the API `filament::Exposure::luminance(ev)`. This API returns the luminance in nits of
+the specific EV. You can perform this conversion yourself using the following formula, where $L$
+is the final intensity in nits: $ L = 2^{EV - 3} $.
+
+The exposure weight carried in the alpha channel can be used to undo the camera exposure, and thus
+force an emissive surface to bloom. When the exposure weight is set to 0, the emissive intensity is
+not affected by the camera exposure. When the weight is set to 1, the intensity is multiplied by
+the camera exposure like with any regular light.
 
 ### Post-lighting color
 
@@ -724,14 +727,12 @@ The type and range of each property is described in table [unlitPropertiesTypes]
        Property       |   Type   |            Range         |           Note
 ---------------------:|:--------:|:------------------------:|:-------------------------
 **baseColor**         | float4   |  [0..1]                  | Pre-multiplied linear RGB
-**emissive**          | float4   |  rgb=[0..1], a=N/A       | Pre-multiplied linear RGB, alpha is ignored
+**emissive**          | float4   |  rgb=[0..n], a=[0..1]    | Linear RGB intensity in nits, alpha encodes the exposure weight
 **postLightingColor** | float4   |  [0..1]                  | Pre-multiplied linear RGB
 [Table [unlitPropertiesTypes]: Range and type of the unlit model's properties]
 
-The value of `emissive` is simply added to `baseColor` when present. The main use of `emissive`
-is to force an unlit surface to bloom if the HDR pipeline is configured with a bloom pass. The value
-of `postLightingColor` is blended with the sum of `emissive` and `baseColor` according to the
-blending mode specified by the `postLightingBlending` material option.
+The value of `postLightingColor` is blended with the sum of `emissive` and `baseColor` according to
+the blending mode specified by the `postLightingBlending` material option.
 
 Figure [materialUnlit] shows an example of the unlit material model
 (click on the image to see a larger version).
@@ -1760,7 +1761,7 @@ fragment {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ GLSL
 struct MaterialInputs {
     float4 baseColor;           // default: float4(1.0)
-    float4 emissive;            // default: float4(0.0)
+    float4 emissive;            // default: float4(0.0, 0.0, 0.0, 1.0)
     float4 postLightingColor;   // default: float4(0.0)
 
     // no other field is available with the unlit shading model

--- a/libs/filamentapp/src/MeshAssimp.cpp
+++ b/libs/filamentapp/src/MeshAssimp.cpp
@@ -147,10 +147,7 @@ std::string shaderFromConfig(MaterialConfig config) {
             material.ambientOcclusion = texture(materialParams_aoMap, aoUV).r;
             material.emissive.rgb = texture(materialParams_emissiveMap, emissiveUV).rgb;
             material.emissive.rgb *= materialParams.emissiveFactor.rgb;
-
-            // The opinionated lighting model specified by glTF does not account for energy
-            // compensation, using this value basically disables it:
-            material.emissive.a = 3.0;
+            material.emissive.a = 0.0;
         )SHADER";
     }
 

--- a/libs/gltfio/materials/gltflite.mat.in
+++ b/libs/gltfio/materials/gltflite.mat.in
@@ -73,7 +73,7 @@ fragment {
             #endif
 
             material.emissive.rgb = materialParams.emissiveFactor.rgb;
-            material.emissive.a = 3.0;
+            material.emissive.a = 0.0;
 
             if (materialParams.metallicRoughnessIndex > -1) {
                 float2 uv = uvs[materialParams.metallicRoughnessIndex];

--- a/libs/gltfio/materials/ubershader.mat.in
+++ b/libs/gltfio/materials/ubershader.mat.in
@@ -121,7 +121,7 @@ fragment {
             #endif
 
             material.emissive.rgb = materialParams.emissiveFactor.rgb;
-            material.emissive.a = 3.0;
+            material.emissive.a = 0.0;
 
             #if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
                 material.glossiness = materialParams.glossinessFactor;

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -198,7 +198,7 @@ std::string shaderFromKey(const MaterialKey& config) {
             }
             shader += R"SHADER(
                 material.emissive.rgb *= texture(materialParams_emissiveMap, emissiveUV).rgb;
-                material.emissive.a = 3.0;
+                material.emissive.a = 0.0;
             )SHADER";
         }
         if (config.hasClearCoat) {

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -76,12 +76,13 @@ struct SandboxParameters {
     float transmission = 1.0f;
     float distance = 1.0f;
     float ior = 1.5;
-    float emissiveEC = 0.0f;
+    float emissiveExposureWeight = 1.0f;
+    float emissiveEV = 0.0f;
     filament::sRGBColor transmittanceColor =  { 1.0f };
-    filament::sRGBColor specularColor = {0.0f };
-    filament::sRGBColor subsurfaceColor = {0.0f };
-    filament::sRGBColor sheenColor = {0.83f, 0.0f, 0.0f };
-    filament::sRGBColor emissiveColor = {0.0f, 0.0f, 0.0f };
+    filament::sRGBColor specularColor = { 0.0f };
+    filament::sRGBColor subsurfaceColor = { 0.0f };
+    filament::sRGBColor sheenColor = { 0.83f, 0.0f, 0.0f };
+    filament::sRGBColor emissiveColor = { 0.0f, 0.0f, 0.0f };
     int currentMaterialModel = MATERIAL_MODEL_LIT;
     int currentBlending = BLENDING_OPAQUE;
     bool ssr = false;
@@ -122,6 +123,9 @@ struct SandboxParameters {
     bool screenSpaceContactShadows = false;
     int stepCount = 8;
     float maxShadowDistance = 0.3;
+    float cameraAperture = 16.0f;
+    float cameraSpeed = 125.0f;
+    float cameraISO = 100.0f;
 };
 
 inline void createInstances(SandboxParameters& params, filament::Engine& engine) {

--- a/shaders/src/material_inputs.fs
+++ b/shaders/src/material_inputs.fs
@@ -91,7 +91,7 @@ void initMaterial(out MaterialInputs material) {
 #endif
     material.ambientOcclusion = 1.0;
 #endif
-    material.emissive = vec4(0.0);
+    material.emissive = vec4(vec3(0.0), 1.0);
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)
     material.clearCoat = 1.0;

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -270,11 +270,8 @@ vec4 evaluateLights(const MaterialInputs material) {
 
 void addEmissive(const MaterialInputs material, inout vec4 color) {
 #if defined(MATERIAL_HAS_EMISSIVE)
-    // The emissive property applies independently of the shading model
-    // It is defined as a color + exposure compensation
     highp vec4 emissive = material.emissive;
-    highp float attenuation = computePreExposedIntensity(
-            pow(2.0, frameUniforms.ev100 + emissive.w - 3.0), frameUniforms.exposure);
+    highp float attenuation = mix(1.0, frameUniforms.exposure, emissive.w);
     color.rgb += emissive.rgb * attenuation;
 #endif
 }

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -1,12 +1,9 @@
 void addEmissive(const MaterialInputs material, inout vec4 color) {
-    #if defined(MATERIAL_HAS_EMISSIVE)
-    // The emissive property applies independently of the shading model
-    // It is defined as a color + exposure compensation
+#if defined(MATERIAL_HAS_EMISSIVE)
     highp vec4 emissive = material.emissive;
-    highp float attenuation = computePreExposedIntensity(
-    pow(2.0, frameUniforms.ev100 + emissive.w - 3.0), frameUniforms.exposure);
+    highp float attenuation = emissive.w * frameUniforms.exposure;
     color.rgb += emissive.rgb * attenuation;
-    #endif
+#endif
 }
 
 /**


### PR DESCRIPTION
Emissive was previously defined in exposure compensation stops, which
was confusing to many. It is now a value in nits, with the alpha
channel controlling how much the camera exposure affects the emissive.
At 0, the emissive value is just added to the final pixel color, at
1 the emissive value is multiplied by the exposure just like with
regular lights.

The intensity of the emissive property can be computed from an
exposure value (EV) easily with the following formula:

emissive.rgb = emissive.rgb * pow(2.0, EV - 3.0);

This formula is available as Exposure::luminance(float) already
in Filament.

