### PR TITLE
Add new --mip-levels option to mipgen

### DIFF
--- a/tools/mipgen/src/main.cpp
+++ b/tools/mipgen/src/main.cpp
@@ -47,6 +47,7 @@ static bool g_grayscale = false;
 static bool g_ktxContainer = false;
 static bool g_linearized = false;
 static bool g_quietMode = false;
+static uint32_t g_mipLevelCount = 0;
 
 static const char* USAGE = R"TXT(
 MIPGEN generates mipmaps for an image down to the 1x1 level.
@@ -83,6 +84,9 @@ Options:
        if the source image has 3 channels, this adds a fourth channel filled with 1.0
    --strip-alpha
        ignore the alpha component of the input image
+   --mip-levels=N, -m N
+       specifies the number of mip levels to generate
+       if 0 (default), all levels are generated
    --compression=COMPRESSION, -c COMPRESSION
        format specific compression:
            KTX:
@@ -146,7 +150,7 @@ static void license() {
 }
 
 static int handleArguments(int argc, char* argv[]) {
-    static constexpr const char* OPTSTR = "hLlgpf:c:k:saq";
+    static constexpr const char* OPTSTR = "hLlgpf:c:k:saqm:";
     static const struct option OPTIONS[] = {
             { "help",                 no_argument, 0, 'h' },
             { "license",              no_argument, 0, 'L' },
@@ -159,6 +163,7 @@ static int handleArguments(int argc, char* argv[]) {
             { "strip-alpha",          no_argument, 0, 's' },
             { "add-alpha",            no_argument, 0, 'a' },
             { "quiet",                no_argument, 0, 'q' },
+            { "mip-levels",     required_argument, 0, 'm' },
             { 0, 0, 0, 0 }  // termination of the option list
     };
 
@@ -233,6 +238,13 @@ static int handleArguments(int argc, char* argv[]) {
             case 'c':
                 g_compression = arg;
                 break;
+            case 'm':
+                try {
+                    g_mipLevelCount = std::stoi(arg);
+                } catch (std::invalid_argument &e) {
+                    // keep default value
+                }
+                break;
         }
     }
 
@@ -287,6 +299,7 @@ int main(int argc, char* argv[]) {
 
     puts("Generating miplevels...");
     uint32_t count = getMipmapCount(sourceImage);
+    count = g_mipLevelCount == 0 ? count : min(g_mipLevelCount - 1, count);
     vector<LinearImage> miplevels(count);
     generateMipmaps(sourceImage, g_filter, miplevels.data(), count);
 


### PR DESCRIPTION
This option (short: -m) can be used to limit the number of mip
levels generated. Using -m 1 allows to use mipgen as a cheap-ish
image converter.

Fixes #2419.