### PR TITLE
Improve build turnaround by breaking dependencies.

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -10,6 +10,7 @@ set(GENERATION_ROOT ${CMAKE_CURRENT_BINARY_DIR})
 # ==================================================================================================
 set(PUBLIC_HDRS
         include/backend/BufferDescriptor.h
+        include/backend/DriverEnums.h
         include/backend/Handle.h
         include/backend/PipelineState.h
         include/backend/PixelBufferDescriptor.h
@@ -181,6 +182,13 @@ add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 # specify where the public headers of this library are
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+
+# ==================================================================================================
+# Expose a header-only target to minimize dependencies.
+# ==================================================================================================
+
+add_library(${TARGET}_headers INTERFACE)
+target_include_directories(${TARGET}_headers INTERFACE ${PUBLIC_HDR_DIR})
 
 # ==================================================================================================
 # Dependencies

--- a/libs/filabridge/CMakeLists.txt
+++ b/libs/filabridge/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
 target_link_libraries(${TARGET} utils)
 target_link_libraries(${TARGET} math)
-target_link_libraries(${TARGET} backend)
+target_link_libraries(${TARGET} backend_headers)
 
 # ==================================================================================================
 # Compiler flags

--- a/libs/filaflat/CMakeLists.txt
+++ b/libs/filaflat/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(${PUBLIC_HDR_DIR})
 add_library(${TARGET} ${HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
-target_link_libraries(${TARGET} filabridge backend utils)
+target_link_libraries(${TARGET} filabridge utils)
 
 if (FILAMENT_SUPPORTS_VULKAN)
     target_link_libraries(${TARGET} smol-v)

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -214,42 +214,40 @@ endif()
 function(add_demo NAME)
     include_directories(${GENERATION_ROOT})
     add_executable(${NAME} ${NAME}.cpp)
-    target_link_libraries(${NAME} PRIVATE sample-resources filamentapp filameshio)
+    target_link_libraries(${NAME} PRIVATE sample-resources filamentapp)
     target_compile_options(${NAME} PRIVATE ${COMPILER_FLAGS})
 endfunction()
 
 if (NOT ANDROID)
+    add_demo(animation)
+    add_demo(depthtesting)
     add_demo(frame_generator)
     add_demo(gltf_viewer)
     add_demo(heightfield)
+    add_demo(hellopbr)
+    add_demo(hellotriangle)
     add_demo(lightbulb)
     add_demo(material_sandbox)
     add_demo(point_sprites)
     add_demo(sample_cloth)
     add_demo(sample_full_pbr)
     add_demo(sample_normal_map)
+    add_demo(shadowtest)
+    add_demo(strobecolor)
     add_demo(suzanne)
+    add_demo(texturedquad)
+    add_demo(vbotest)
+    add_demo(viewtest)
 
     # Sample app specific
     target_link_libraries(frame_generator PRIVATE imageio)
-    target_link_libraries(suzanne PRIVATE suzanne-resources)
     target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio)
+    target_link_libraries(hellopbr PRIVATE filameshio)
+    target_link_libraries(sample_cloth PRIVATE filameshio)
+    target_link_libraries(sample_normal_map PRIVATE filameshio)
+    target_link_libraries(suzanne PRIVATE filameshio suzanne-resources)
 
 endif()
-
-# ==================================================================================================
-# Build Executables
-# ==================================================================================================
-
-add_demo(animation)
-add_demo(depthtesting)
-add_demo(hellopbr)
-add_demo(hellotriangle)
-add_demo(shadowtest)
-add_demo(strobecolor)
-add_demo(texturedquad)
-add_demo(vbotest)
-add_demo(viewtest)
 
 # ==================================================================================================
 # Copy the MoltenVK dylibs and JSON on MacOS

--- a/tools/matc/CMakeLists.txt
+++ b/tools/matc/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(${TARGET} STATIC ${SRCS} ${HDRS})
 target_include_directories(${TARGET} PUBLIC src)
 target_include_directories(${TARGET} PRIVATE ${filamat_SOURCE_DIR}/src)
 
-target_link_libraries(${TARGET} getopt filamat filabridge backend utils)
+target_link_libraries(${TARGET} getopt filamat filabridge utils)
 
 # =================================================================================================
 # Licenses


### PR DESCRIPTION
This adds a new "backend_headers" target because small changes to any
backend cpp file was resulting in a huge build, causing materials to be
rebuilt, etc. Note that filabridge only needs DriverEnums, nothing else.