### PR TITLE
Remove monkey mesh dependency from samples.

### DIFF
--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -68,7 +68,7 @@ target_link_libraries(${TARGET} PUBLIC
         utils
         filaflat
         filabridge
-        backend
+        backend_headers
         civetweb
         utils
         SPIRV

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -13,23 +13,6 @@ set(TEXTURE_DIR "${GENERATION_ROOT}/generated/texture")
 set(RESOURCE_BINS)
 
 # ==================================================================================================
-# Convert OBJ files into filamesh files.
-# ==================================================================================================
-
-function(add_mesh SOURCE TARGET)
-    set(source_mesh "${ROOT_DIR}/${SOURCE}")
-    set(target_mesh "${RESOURCE_DIR}/${TARGET}")
-    set(RESOURCE_BINS ${RESOURCE_BINS} ${target_mesh} PARENT_SCOPE)
-    add_custom_command(
-        OUTPUT ${target_mesh}
-        COMMAND filamesh --compress ${source_mesh} ${target_mesh}
-        MAIN_DEPENDENCY ${source_mesh}
-        DEPENDS filamesh)
-endfunction()
-
-add_mesh("assets/models/monkey/monkey.obj" "suzanne.filamesh")
-
-# ==================================================================================================
 # Build materials
 # ==================================================================================================
 
@@ -129,7 +112,7 @@ add_envmap("third_party/environments/venetian_crossroads_2k.hdr" "venetian_cross
 function(add_ktxfiles SOURCE TARGET EXTRA_ARGS)
     set(source_path "${ROOT_DIR}/${SOURCE}")
     set(target_path "${TEXTURE_DIR}/${TARGET}")
-    set(TEXTURE_FILES ${TEXTURE_FILES} ${target_path} PARENT_SCOPE)
+    set(MONKEY_FILES ${MONKEY_FILES} ${target_path} PARENT_SCOPE)
     add_custom_command(
         OUTPUT ${target_path}
         COMMAND mipgen --quiet --strip-alpha ${EXTRA_ARGS} ${source_path} ${target_path}
@@ -140,12 +123,25 @@ endfunction()
 function(add_pngfile SOURCE TARGET)
     set(source_path "${ROOT_DIR}/${SOURCE}")
     set(target_path "${TEXTURE_DIR}/${TARGET}")
-    set(TEXTURE_FILES ${TEXTURE_FILES} ${target_path} PARENT_SCOPE)
+    set(MONKEY_FILES ${MONKEY_FILES} ${target_path} PARENT_SCOPE)
     add_custom_command(
         OUTPUT ${target_path}
         COMMAND ${CMAKE_COMMAND} -E copy ${source_path} ${target_path}
         MAIN_DEPENDENCY ${source_path})
 endfunction()
+
+function(add_mesh SOURCE TARGET)
+    set(source_mesh "${ROOT_DIR}/${SOURCE}")
+    set(target_mesh "${RESOURCE_DIR}/${TARGET}")
+    set(MONKEY_FILES ${MESH_BINS} ${target_mesh} PARENT_SCOPE)
+    add_custom_command(
+        OUTPUT ${target_mesh}
+        COMMAND filamesh --compress ${source_mesh} ${target_mesh}
+        MAIN_DEPENDENCY ${source_mesh}
+        DEPENDS filamesh)
+endfunction()
+
+add_mesh("assets/models/monkey/monkey.obj" "suzanne.filamesh")
 
 add_ktxfiles("assets/models/monkey/albedo.png" "albedo_s3tc.ktx" "--compression=s3tc_rgb_dxt1")
 add_ktxfiles("assets/models/monkey/roughness.png" "roughness.ktx" "--grayscale")
@@ -154,13 +150,13 @@ add_ktxfiles("assets/models/monkey/ao.png" "ao.ktx" "--grayscale")
 
 add_pngfile("assets/models/monkey/normal.png" "normal.png")
 
-get_resgen_vars(${RESOURCE_DIR} textures)
+get_resgen_vars(${RESOURCE_DIR} monkey)
 
 add_custom_command(
         OUTPUT ${RESGEN_OUTPUTS}
-        COMMAND resgen ${RESGEN_FLAGS} ${TEXTURE_FILES}
-        DEPENDS resgen ${TEXTURE_FILES}
-        COMMENT "Aggregating textures"
+        COMMAND resgen ${RESGEN_FLAGS} ${MONKEY_FILES}
+        DEPENDS resgen ${MONKEY_FILES}
+        COMMENT "Aggregating monkey resources"
 )
 
 if (DEFINED RESGEN_SOURCE_FLAGS)
@@ -242,7 +238,7 @@ if (NOT ANDROID)
     # Sample app specific
     target_link_libraries(frame_generator PRIVATE imageio)
     target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio)
-    target_link_libraries(hellopbr PRIVATE filameshio)
+    target_link_libraries(hellopbr PRIVATE filameshio suzanne-resources)
     target_link_libraries(sample_cloth PRIVATE filameshio)
     target_link_libraries(sample_normal_map PRIVATE filameshio)
     target_link_libraries(suzanne PRIVATE filameshio suzanne-resources)

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -30,6 +30,7 @@
 #include <filamentapp/FilamentApp.h>
 
 #include "generated/resources/resources.h"
+#include "generated/resources/monkey.h"
 
 using namespace filament;
 using namespace filamesh;
@@ -68,7 +69,7 @@ int main(int argc, char** argv) {
         mi->setParameter("reflectance", 0.5f);
 
         // Add geometry into the scene.
-        app.mesh = MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr, nullptr, mi);
+        app.mesh = MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr, nullptr, mi);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);
         rcm.setCastShadows(rcm.getInstance(app.mesh.renderable), false);

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -38,7 +38,7 @@
 #include <stb_image.h>
 
 #include "generated/resources/resources.h"
-#include "generated/resources/textures.h"
+#include "generated/resources/monkey.h"
 
 using namespace filament;
 using namespace image;
@@ -87,15 +87,15 @@ int main(int argc, char** argv) {
         auto& em = utils::EntityManager::get();
 
         // Create textures. The KTX bundles are freed by KtxUtility.
-        auto albedo = new image::KtxBundle(TEXTURES_ALBEDO_S3TC_DATA, TEXTURES_ALBEDO_S3TC_SIZE);
-        auto ao = new image::KtxBundle(TEXTURES_AO_DATA, TEXTURES_AO_SIZE);
-        auto metallic = new image::KtxBundle(TEXTURES_METALLIC_DATA, TEXTURES_METALLIC_SIZE);
-        auto roughness = new image::KtxBundle(TEXTURES_ROUGHNESS_DATA, TEXTURES_ROUGHNESS_SIZE);
+        auto albedo = new image::KtxBundle(MONKEY_ALBEDO_S3TC_DATA, MONKEY_ALBEDO_S3TC_SIZE);
+        auto ao = new image::KtxBundle(MONKEY_AO_DATA, MONKEY_AO_SIZE);
+        auto metallic = new image::KtxBundle(MONKEY_METALLIC_DATA, MONKEY_METALLIC_SIZE);
+        auto roughness = new image::KtxBundle(MONKEY_ROUGHNESS_DATA, MONKEY_ROUGHNESS_SIZE);
         app.albedo = ktx::createTexture(engine, albedo, true);
         app.ao = ktx::createTexture(engine, ao, false);
         app.metallic = ktx::createTexture(engine, metallic, false);
         app.roughness = ktx::createTexture(engine, roughness, false);
-        app.normal = loadNormalMap(engine, TEXTURES_NORMAL_DATA, TEXTURES_NORMAL_SIZE);
+        app.normal = loadNormalMap(engine, MONKEY_NORMAL_DATA, MONKEY_NORMAL_SIZE);
         TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
                 TextureSampler::MagFilter::LINEAR);
 
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
         ibl->setRotation(mat3f::rotation(0.5f, float3{ 0, 1, 0 }));
 
         // Add geometry into the scene.
-        app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, RESOURCES_SUZANNE_DATA, nullptr,
+        app.mesh = filamesh::MeshReader::loadMeshFromBuffer(engine, MONKEY_SUZANNE_DATA, nullptr,
                 nullptr, app.materialInstance);
         auto ti = tcm.getInstance(app.mesh.renderable);
         app.transform = mat4f{ mat3f(1), float3(0, 0, -4) } * tcm.getWorldTransform(ti);

--- a/third_party/civetweb/tnt/CMakeLists.txt
+++ b/third_party/civetweb/tnt/CMakeLists.txt
@@ -29,4 +29,6 @@ add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
+target_link_libraries(${TARGET} ${CMAKE_DL_LIBS})
+
 target_compile_options(${TARGET} PRIVATE $<$<PLATFORM_ID:Linux>:-fPIC>)

--- a/tools/matinfo/CMakeLists.txt
+++ b/tools/matinfo/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SRCS src/main.cpp)
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
 
-target_link_libraries(${TARGET} matdbg filaflat backend utils getopt SPIRV-Tools spirv-cross-glsl)
+target_link_libraries(${TARGET} matdbg filaflat backend_headers utils getopt SPIRV-Tools spirv-cross-glsl)
 
 # glslang contains a copy of the SPIRV headers, so let's just use those. The leading ".." in the
 # following variable refers to the project name that we define in glslang/tnt, and the trailing ".."


### PR DESCRIPTION
This change allows us to modify + test Filament without re-invoking resgen.

The only apps that need the monkey filamesh are `suzanne` and `hellopbr`, so they are now the only apps that have it as a dependency.
