### PR TITLE
Fix swizzle error in WebGL.

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -687,6 +687,10 @@ void OpenGLDriver::createTextureSwizzledR(Handle<HwTexture> th,
 
     createTextureR(th, target, levels, format, samples, w, h, depth, usage);
 
+    // WebGL does not support swizzling. We assert for this in the Texture builder,
+    // so it is probably fine to silently ignore the swizzle state here.
+    #if !defined(__EMSCRIPTEN__)
+
     // the texture is still bound and active from createTextureR
     GLTexture* t = handle_cast<GLTexture *>(th);
 
@@ -694,6 +698,8 @@ void OpenGLDriver::createTextureSwizzledR(Handle<HwTexture> th,
     glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_G, getSwizzleChannel(g));
     glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_B, getSwizzleChannel(b));
     glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_A, getSwizzleChannel(a));
+
+    #endif
 
     CHECK_GL_ERROR(utils::slog.e)
 }

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -119,6 +119,10 @@ Texture* Texture::Builder::build(Engine& engine) {
     const bool swizzled = mImpl->mTextureIsSwizzled;
     const bool imported = mImpl->mImportedId;
 
+    #if defined(__EMSCRIPTEN__)
+    ASSERT_POSTCONDITION_NON_FATAL(!swizzled, "WebGL does not support texture swizzling.");
+    #endif
+
     ASSERT_POSTCONDITION_NON_FATAL((swizzled && sampleable) || !swizzled,
             "Swizzled texture must be SAMPLEABLE");
 


### PR DESCRIPTION
Chrome was dumping GL_INVALID_ENUM.  According to the spec, swizzling is not supported.

> Texture swizzles can not be implemented in a performant manner on Direct3D based WebGL implementations. Applications relying on this functionality would run significantly more slowly on those implementations. Applications are still able to swizzle results of texture fetches in shaders and swizzle texture data before uploading without this interface.