### PR TITLE
add a warning log when there is no texture bound to a used texture unit

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -199,7 +199,8 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
 
             Handle<HwTexture> th = samplers[index].t;
             if (UTILS_UNLIKELY(!th)) {
-                continue; // this can happen if the SamplerGroup isn't initialized
+                slog.w << "no texture bound to unit " << +index << io::endl;
+                continue;
             }
 
             const GLTexture* const UTILS_RESTRICT t = gl->handle_cast<const GLTexture*>(th);


### PR DESCRIPTION
sometimes this happens because the shader actually doesn't use the
texture (e.g. in a uber shader model), however this is an error in
metal and vulkan.