### PR TITLE
Add a new free flight camera manipulator

### DIFF
--- a/android/filament-utils-android/src/main/cpp/Manipulator.cpp
+++ b/android/filament-utils-android/src/main/cpp/Manipulator.cpp
@@ -90,6 +90,36 @@ extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBu
     builder->mapMinDistance(arg);
 }
 
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightStartPosition(JNIEnv*, jclass, jlong nativeBuilder, jfloat x, jfloat y, jfloat z) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightStartPosition(x, y, z);
+}
+
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightStartOrientation(JNIEnv*, jclass, jlong nativeBuilder, jfloat pitch, jfloat yaw) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightStartOrientation(pitch, yaw);
+}
+
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightMaxMoveSpeed(JNIEnv*, jclass, jlong nativeBuilder, jfloat maxSpeed) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightMaxMoveSpeed(maxSpeed);
+}
+
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightSpeedSteps(JNIEnv*, jclass, jlong nativeBuilder, jint steps) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightSpeedSteps(steps);
+}
+
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightPanSpeed(JNIEnv*, jclass, jlong nativeBuilder, jfloat x, jfloat y) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightPanSpeed(x, y);
+}
+
+extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderFlightMoveDamping(JNIEnv*, jclass, jlong nativeBuilder, jfloat damping) {
+    Builder* builder = (Builder*) nativeBuilder;
+    builder->flightMoveDamping(damping);
+}
+
 extern "C" JNIEXPORT void Java_com_google_android_filament_utils_Manipulator_nBuilderGroundPlane(JNIEnv*, jclass, jlong nativeBuilder, jfloat a, jfloat b, jfloat c, jfloat d) {
     Builder* builder = (Builder*) nativeBuilder;
     builder->groundPlane(a, b, c, d);
@@ -170,9 +200,24 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipul
     manip->grabEnd();
 }
 
-extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipulator_nZoom(JNIEnv*, jclass, jlong nativeManip, jint x, jint y, jfloat scrolldelta) {
+extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipulator_nKeyDown(JNIEnv*, jclass, jlong nativeManip, jint key) {
     auto manip = (Manipulator<float>*) nativeManip;
-    manip->zoom(x, y, scrolldelta);
+    manip->keyDown((Manipulator<float>::Key) key);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipulator_nKeyUp(JNIEnv*, jclass, jlong nativeManip, jint key) {
+    auto manip = (Manipulator<float>*) nativeManip;
+    manip->keyUp((Manipulator<float>::Key) key);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipulator_nScroll(JNIEnv*, jclass, jlong nativeManip, jint x, jint y, jfloat scrolldelta) {
+    auto manip = (Manipulator<float>*) nativeManip;
+    manip->scroll(x, y, scrolldelta);
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_utils_Manipulator_nUpdate(JNIEnv*, jclass, jlong nativeManip, jfloat deltaTime) {
+    auto manip = (Manipulator<float>*) nativeManip;
+    manip->update(deltaTime);
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_com_google_android_filament_utils_Manipulator_nGetCurrentBookmark(JNIEnv*, jclass, jlong nativeManip) {

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/GestureDetector.kt
@@ -77,7 +77,7 @@ class GestureDetector(private val view: View, private val manipulator: Manipulat
                 if (currentGesture == Gesture.ZOOM) {
                     val d0 = previousTouch.separation
                     val d1 = touch.separation
-                    manipulator.zoom(touch.x, touch.y, (d0 - d1) * kZoomSpeed)
+                    manipulator.scroll(touch.x, touch.y, (d0 - d1) * kZoomSpeed)
                     previousTouch = touch
                     return
                 }

--- a/libs/camutils/CMakeLists.txt
+++ b/libs/camutils/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/Bookmark.cpp
+        src/FreeFlightManipulator.h
         src/Manipulator.cpp
         src/MapManipulator.h
         src/OrbitManipulator.h

--- a/libs/camutils/include/camutils/Bookmark.h
+++ b/libs/camutils/include/camutils/Bookmark.h
@@ -23,11 +23,12 @@
 namespace filament {
 namespace camutils {
 
+template <typename FLOAT> class FreeFlightManipulator;
 template <typename FLOAT> class OrbitManipulator;
 template <typename FLOAT> class MapManipulator;
 template <typename FLOAT> class Manipulator;
 
-enum class Mode { ORBIT, MAP };
+enum class Mode { ORBIT, MAP, FREE_FLIGHT };
 
 /**
  * Opaque memento to a viewing position and orientation (e.g. the "home" camera position).
@@ -62,9 +63,16 @@ private:
         FLOAT distance;
         filament::math::vec3<FLOAT> pivot;
     };
+    struct FlightParams {
+        FLOAT pitch;
+        FLOAT yaw;
+        filament::math::vec3<FLOAT> position;
+    };
     Mode mode;
     MapParams map;
     OrbitParams orbit;
+    FlightParams flight;
+    friend class FreeFlightManipulator<FLOAT>;
     friend class OrbitManipulator<FLOAT>;
     friend class MapManipulator<FLOAT>;
 };

--- a/libs/camutils/include/camutils/Manipulator.h
+++ b/libs/camutils/include/camutils/Manipulator.h
@@ -34,8 +34,9 @@ enum class Fov { VERTICAL, HORIZONTAL };
  * Helper that enables camera interaction similar to sketchfab or Google Maps.
  *
  * Clients notify the camera manipulator of various mouse or touch events, then periodically call
- * its getLookAt() method so that they can adjust their camera(s). Two modes are supported: ORBIT
- * and MAP. To construct a manipulator instance, the desired mode is passed into the create method.
+ * its getLookAt() method so that they can adjust their camera(s). Three modes are supported: ORBIT,
+ * MAP, and FREE_FLIGHT. To construct a manipulator instance, the desired mode is passed into the
+ * create method.
  *
  * Usage example:
  *
@@ -97,6 +98,13 @@ public:
         FLOAT farPlane;
         vec2 mapExtent;
         FLOAT mapMinDistance;
+        vec3 flightStartPosition;
+        FLOAT flightStartPitch;
+        FLOAT flightStartYaw;
+        FLOAT flightMaxSpeed;
+        FLOAT flightSpeedSteps;
+        vec2 flightPanSpeed;
+        FLOAT flightMoveDamping;
         vec4 groundPlane;
         RayCallback raycastCallback;
         void* raycastUserdata;
@@ -120,12 +128,22 @@ public:
         Builder& mapExtent(FLOAT worldWidth, FLOAT worldHeight); //! The ground size for computing home position
         Builder& mapMinDistance(FLOAT mindist);                  //! Constrains the zoom-in level
 
+        // Free flight properties
+        Builder& flightStartPosition(FLOAT x, FLOAT y, FLOAT z);     //! Initial eye position in world space, defaults to (0,0,0)
+        Builder& flightStartOrientation(FLOAT pitch, FLOAT yaw);     //! Initial orientation in pitch and yaw, defaults to (0,0)
+        Builder& flightMaxMoveSpeed(FLOAT maxSpeed);                 //! The maximum camera speed in world units per second, defaults to 10
+        Builder& flightSpeedSteps(int steps);                        //! The number of speed steps adjustable with zoom wheel, defaults to 80
+        Builder& flightPanSpeed(FLOAT x, FLOAT y);                   //! Multiplied with viewport delta, defaults to 0.01,0.01
+        Builder& flightMoveDamping(FLOAT damping);                   //! Applies a deceleration to camera movement, defaults to 0 (no damping)
+                                                                     //! Lower values give slower damping times, a good defaut is 15
+                                                                     //! Too high a value may lead to instability
+
         // Raycast properties
         Builder& groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d);  //! Plane equation used as a raycast fallback
         Builder& raycastCallback(RayCallback cb, void* userdata);  //! Raycast function for accurate grab-and-pan
 
         /**
-         * Creates a new camera manipulator, either ORBIT or MAP.
+         * Creates a new camera manipulator, either ORBIT, MAP, or FREE_FLIGHT.
          *
          * Clients can simply use "delete" to destroy the manipulator.
          */
@@ -165,7 +183,9 @@ public:
     /**
      * Starts a grabbing session (i.e. the user is dragging around in the viewport).
      *
-     * This starts a panning session in MAP mode, and starts either rotating or strafing in ORBIT.
+     * In MAP mode, this starts a panning session.
+     * In ORBIT mode, this starts either rotating or strafing.
+     * In FREE_FLIGHT mode, this starts a nodal panning session.
      *
      * @param x X-coordinate for point of interest in viewport space
      * @param y Y-coordinate for point of interest in viewport space
@@ -186,13 +206,52 @@ public:
     virtual void grabEnd() = 0;
 
     /**
-     * Dollys the camera along the viewing direction.
+     * Keys used to translate the camera in FREE_FLIGHT mode.
+     * UP and DOWN dolly the camera forwards and backwards.
+     * LEFT and RIGHT strafe the camera left and right.
+     */
+    enum class Key {
+        UP,
+        LEFT,
+        DOWN,
+        RIGHT,
+
+        COUNT
+    };
+
+    /**
+     * Signals that a key is now in the down state.
+     *
+     * In FREE_FLIGHT mode, the camera is translated forward and backward and strafed left and right
+     * depending on the depressed keys. This allows WASD-style movement.
+     */
+    virtual void keyDown(Key key);
+
+    /**
+     * Signals that a key is now in the up state.
+     *
+     * @see keyDown
+     */
+    virtual void keyUp(Key key);
+
+    /**
+     * In MAP and ORBIT modes, dollys the camera along the viewing direction.
+     * In FREE_FLIGHT mode, adjusts the move speed of the camera.
      *
      * @param x X-coordinate for point of interest in viewport space
      * @param y Y-coordinate for point of interest in viewport space
      * @param scrolldelta Negative means "zoom in", positive means "zoom out"
      */
     virtual void zoom(int x, int y, FLOAT scrolldelta) = 0;
+
+    /**
+     * Processes input and updates internal state.
+     *
+     * This must be called once every frame before getLookAt is valid.
+     *
+     * @param deltaTime The amount of time, in seconds, passed since the previous call to update.
+     */
+    virtual void update(FLOAT deltaTime);
 
     /**
      * Gets a handle that can be used to reset the manipulator back to its current position.

--- a/libs/camutils/include/camutils/Manipulator.h
+++ b/libs/camutils/include/camutils/Manipulator.h
@@ -132,10 +132,10 @@ public:
         Builder& flightStartPosition(FLOAT x, FLOAT y, FLOAT z);     //! Initial eye position in world space, defaults to (0,0,0)
         Builder& flightStartOrientation(FLOAT pitch, FLOAT yaw);     //! Initial orientation in pitch and yaw, defaults to (0,0)
         Builder& flightMaxMoveSpeed(FLOAT maxSpeed);                 //! The maximum camera speed in world units per second, defaults to 10
-        Builder& flightSpeedSteps(int steps);                        //! The number of speed steps adjustable with zoom wheel, defaults to 80
+        Builder& flightSpeedSteps(int steps);                        //! The number of speed steps adjustable with scroll wheel, defaults to 80
         Builder& flightPanSpeed(FLOAT x, FLOAT y);                   //! Multiplied with viewport delta, defaults to 0.01,0.01
         Builder& flightMoveDamping(FLOAT damping);                   //! Applies a deceleration to camera movement, defaults to 0 (no damping)
-                                                                     //! Lower values give slower damping times, a good defaut is 15
+                                                                     //! Lower values give slower damping times, a good default is 15
                                                                      //! Too high a value may lead to instability
 
         // Raycast properties
@@ -238,11 +238,12 @@ public:
      * In MAP and ORBIT modes, dollys the camera along the viewing direction.
      * In FREE_FLIGHT mode, adjusts the move speed of the camera.
      *
-     * @param x X-coordinate for point of interest in viewport space
-     * @param y Y-coordinate for point of interest in viewport space
-     * @param scrolldelta Negative means "zoom in", positive means "zoom out"
+     * @param x X-coordinate for point of interest in viewport space, ignored in FREE_FLIGHT mode
+     * @param y Y-coordinate for point of interest in viewport space, ignored in FREE_FLIGHT mode
+     * @param scrolldelta In MAP and ORBIT modes, negative means "zoom in", positive means "zoom out"
+     *                    In FREE_FLIGHT mode, negative means "slower", positive means "faster"
      */
-    virtual void zoom(int x, int y, FLOAT scrolldelta) = 0;
+    virtual void scroll(int x, int y, FLOAT scrolldelta) = 0;
 
     /**
      * Processes input and updates internal state.

--- a/libs/camutils/src/FreeFlightManipulator.h
+++ b/libs/camutils/src/FreeFlightManipulator.h
@@ -105,11 +105,11 @@ public:
         mGrabbing = false;
     }
 
-    void keyDown(Key key) override {
+    void keyDown(typename Base::Key key) override {
         mKeyDown[(int) key] = true;
     }
 
-    void keyUp(Key key) override {
+    void keyUp(typename Base::Key key) override {
         mKeyDown[(int) key] = false;
     }
 
@@ -125,16 +125,16 @@ public:
     void update(FLOAT deltaTime) override {
         vec3 forceLocal { 0.0, 0.0, 0.0 };
 
-        if (mKeyDown[(int) Key::UP]) {
+        if (mKeyDown[(int) Base::Key::UP]) {
             forceLocal += vec3{  0.0,  0.0, -1.0 };
         }
-        if (mKeyDown[(int) Key::LEFT]) {
+        if (mKeyDown[(int) Base::Key::LEFT]) {
             forceLocal += vec3{ -1.0,  0.0,  0.0 };
         }
-        if (mKeyDown[(int) Key::DOWN]) {
+        if (mKeyDown[(int) Base::Key::DOWN]) {
             forceLocal += vec3{  0.0,  0.0,  1.0 };
         }
-        if (mKeyDown[(int) Key::RIGHT]) {
+        if (mKeyDown[(int) Base::Key::RIGHT]) {
             forceLocal += vec3{  1.0,  0.0,  0.0 };
         }
 
@@ -187,7 +187,7 @@ private:
     vec2 mGrabWin;
     vec2 mTargetEuler;  // (pitch, yaw)
     vec2 mGrabEuler;    // (pitch, yaw)
-    bool mKeyDown[Key::COUNT] = {false};
+    bool mKeyDown[(int) Base::Key::COUNT] = {false};
     bool mGrabbing = false;
     FLOAT mScrollWheel = 0.0f;
     FLOAT mScrollPositionNormalized = 0.0f;

--- a/libs/camutils/src/FreeFlightManipulator.h
+++ b/libs/camutils/src/FreeFlightManipulator.h
@@ -113,7 +113,7 @@ public:
         mKeyDown[(int) key] = false;
     }
 
-    void zoom(int x, int y, FLOAT scrolldelta) override {
+    void scroll(int x, int y, FLOAT scrolldelta) override {
         const FLOAT halfSpeedSteps = Base::mProps.flightSpeedSteps / 2;
         mScrollWheel = clamp(mScrollWheel + scrolldelta, -halfSpeedSteps, halfSpeedSteps);
         // Normalize the scroll position from -1 to 1 and calculate the move speed, in world

--- a/libs/camutils/src/FreeFlightManipulator.h
+++ b/libs/camutils/src/FreeFlightManipulator.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CAMUTILS_FREEFLIGHT_MANIPULATOR_H
+#define CAMUTILS_FREEFLIGHT_MANIPULATOR_H
+
+#include <camutils/Manipulator.h>
+
+#include <math/scalar.h>
+#include <math/mat3.h>
+#include <math/mat4.h>
+#include <math/quat.h>
+
+#include <utils/Log.h>
+
+#include <cmath>
+
+namespace filament {
+namespace camutils {
+
+using namespace filament::math;
+
+template<typename FLOAT>
+class FreeFlightManipulator : public Manipulator<FLOAT> {
+public:
+    using vec2 = filament::math::vec2<FLOAT>;
+    using vec3 = filament::math::vec3<FLOAT>;
+    using vec4 = filament::math::vec4<FLOAT>;
+    using Bookmark = filament::camutils::Bookmark<FLOAT>;
+    using Base = Manipulator<FLOAT>;
+    using Config = typename Base::Config;
+
+    FreeFlightManipulator(Mode mode, const Config& props) : Base(mode, props) {
+        setProperties(props);
+        Base::mEye = Base::mProps.flightStartPosition;
+        const auto pitch = Base::mProps.flightStartPitch;
+        const auto yaw = Base::mProps.flightStartYaw;
+        mTargetEuler = {pitch, yaw};
+        updateTarget(pitch, yaw);
+    }
+
+    void setProperties(const Config& props) override {
+        Config resolved = props;
+
+        if (resolved.flightPanSpeed == vec2(0, 0)) {
+            resolved.flightPanSpeed = vec2(0.01, 0.01);
+        }
+        if (resolved.flightMaxSpeed == 0.0) {
+            resolved.flightMaxSpeed = 10.0;
+        }
+        if (resolved.flightSpeedSteps == 0) {
+            resolved.flightSpeedSteps = 80;
+        }
+
+        Base::setProperties(resolved);
+    }
+
+    void updateTarget(FLOAT pitch, FLOAT yaw) {
+        Base::mTarget = Base::mEye + (mat3::eulerZYX(0, yaw, pitch) * vec3(0.0, 0.0, -1.0));
+    }
+
+    void grabBegin(int x, int y, bool strafe) override {
+        mGrabWin = {x, y};
+        mGrabbing = true;
+        mGrabEuler = mTargetEuler;
+    }
+
+    void grabUpdate(int x, int y) override {
+        if (!mGrabbing) {
+            return;
+        }
+
+        const vec2 del = mGrabWin - vec2{x, y};
+
+        const auto& grabPitch = mGrabEuler.x;
+        const auto& grabYaw = mGrabEuler.y;
+        auto& pitch = mTargetEuler.x;
+        auto& yaw = mTargetEuler.y;
+
+        constexpr double EPSILON = 0.001;
+
+        auto panSpeed = Base::mProps.flightPanSpeed;
+        constexpr FLOAT minPitch = (-F_PI_2 + EPSILON);
+        constexpr FLOAT maxPitch = ( F_PI_2 - EPSILON);
+        pitch = clamp(grabPitch + del.y * -panSpeed.y, minPitch, maxPitch);
+        yaw = fmod(grabYaw + del.x * panSpeed.x, 2.0 * F_PI);
+
+        updateTarget(pitch, yaw);
+    }
+
+    void grabEnd() override {
+        mGrabbing = false;
+    }
+
+    void keyDown(Key key) override {
+        mKeyDown[(int) key] = true;
+    }
+
+    void keyUp(Key key) override {
+        mKeyDown[(int) key] = false;
+    }
+
+    void zoom(int x, int y, FLOAT scrolldelta) override {
+        const FLOAT halfSpeedSteps = Base::mProps.flightSpeedSteps / 2;
+        mScrollWheel = clamp(mScrollWheel + scrolldelta, -halfSpeedSteps, halfSpeedSteps);
+        // Normalize the scroll position from -1 to 1 and calculate the move speed, in world
+        // units per second.
+        mScrollPositionNormalized = (mScrollWheel + halfSpeedSteps) / halfSpeedSteps - 1.0;
+        mMoveSpeed = pow(Base::mProps.flightMaxSpeed, mScrollPositionNormalized);
+    }
+
+    void update(FLOAT deltaTime) override {
+        vec3 forceLocal { 0.0, 0.0, 0.0 };
+
+        if (mKeyDown[(int) Key::UP]) {
+            forceLocal += vec3{  0.0,  0.0, -1.0 };
+        }
+        if (mKeyDown[(int) Key::LEFT]) {
+            forceLocal += vec3{ -1.0,  0.0,  0.0 };
+        }
+        if (mKeyDown[(int) Key::DOWN]) {
+            forceLocal += vec3{  0.0,  0.0,  1.0 };
+        }
+        if (mKeyDown[(int) Key::RIGHT]) {
+            forceLocal += vec3{  1.0,  0.0,  0.0 };
+        }
+
+        forceLocal *= mMoveSpeed;
+
+        const mat4 orientation = mat4::lookAt(Base::mEye, Base::mTarget, Base::mProps.upVector);
+        const vec3 forceWorld = (orientation * vec4{ forceLocal, 0.0f }).xyz;
+
+        const auto dampingFactor = Base::mProps.flightMoveDamping;
+        if (dampingFactor == 0.0) {
+            // Without damping, we simply treat the force as our velocity.
+            mEyeVelocity = forceWorld;
+        } else {
+            // The dampingFactor acts as "friction", which acts upon the camera in the direction
+            // opposite its velocity.
+            // Force is also multiplied by the dampingFactor, to "make up" for the friction.
+            // This ensures that the max velocity still approaches mMoveSpeed;
+            vec3 velocityDelta = (forceWorld - mEyeVelocity) * dampingFactor;
+            mEyeVelocity += velocityDelta * deltaTime;
+        }
+
+        const vec3 positionDelta = mEyeVelocity * deltaTime;
+
+        Base::mEye += positionDelta;
+        Base::mTarget += positionDelta;
+    }
+
+    Bookmark getCurrentBookmark() const override {
+        Bookmark bookmark;
+        bookmark.flight.position = Base::mEye;
+        bookmark.flight.pitch = mTargetEuler.x;
+        bookmark.flight.yaw = mTargetEuler.y;
+        return bookmark;
+    }
+
+    Bookmark getHomeBookmark() const override {
+        Bookmark bookmark;
+        bookmark.flight.position = Base::mProps.flightStartPosition;;
+        bookmark.flight.pitch = Base::mProps.flightStartPitch;
+        bookmark.flight.yaw = Base::mProps.flightStartYaw;
+        return bookmark;
+    }
+
+    void jumpToBookmark(const Bookmark& bookmark) override {
+        Base::mEye = bookmark.flight.position;
+        updateTarget(bookmark.flight.pitch, bookmark.flight.yaw);
+    }
+
+private:
+    vec2 mGrabWin;
+    vec2 mTargetEuler;  // (pitch, yaw)
+    vec2 mGrabEuler;    // (pitch, yaw)
+    bool mKeyDown[Key::COUNT] = {false};
+    bool mGrabbing = false;
+    FLOAT mScrollWheel = 0.0f;
+    FLOAT mScrollPositionNormalized = 0.0f;
+    FLOAT mMoveSpeed = 1.0f;
+    vec3 mEyeVelocity;
+};
+
+} // namespace camutils
+} // namespace filament
+
+#endif /* CAMUTILS_FREEFLIGHT_MANIPULATOR_H */

--- a/libs/camutils/src/Manipulator.cpp
+++ b/libs/camutils/src/Manipulator.cpp
@@ -18,6 +18,7 @@
 
 #include <math/scalar.h>
 
+#include "FreeFlightManipulator.h"
 #include "MapManipulator.h"
 #include "OrbitManipulator.h"
 
@@ -94,6 +95,43 @@ Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::mapMinDistance(FLOAT m
 }
 
 template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightStartPosition(FLOAT x, FLOAT y, FLOAT z) {
+    details.flightStartPosition = {x, y, z};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightStartOrientation(FLOAT pitch, FLOAT yaw) {
+    details.flightStartPitch = pitch;
+    details.flightStartYaw = yaw;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightMaxMoveSpeed(FLOAT maxSpeed) {
+    details.flightMaxSpeed = maxSpeed;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightSpeedSteps(int steps) {
+    details.flightSpeedSteps = steps;
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightPanSpeed(FLOAT x, FLOAT y) {
+    details.flightPanSpeed = {x, y};
+    return *this;
+}
+
+template <typename FLOAT> typename
+Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::flightMoveDamping(FLOAT damping) {
+    details.flightMoveDamping = damping;
+    return *this;
+}
+
+template <typename FLOAT> typename
 Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::groundPlane(FLOAT a, FLOAT b, FLOAT c, FLOAT d) {
     details.groundPlane = {a, b, c, d};
     return *this;
@@ -106,13 +144,16 @@ Manipulator<FLOAT>::Builder& Manipulator<FLOAT>::Builder::raycastCallback(RayCal
     return *this;
 }
 
-
 template <typename FLOAT>
 Manipulator<FLOAT>* Manipulator<FLOAT>::Builder::build(Mode mode) {
-    if (mode == Mode::MAP) {
-        return new MapManipulator<FLOAT>(mode, details);
+    switch (mode) {
+        case Mode::FREE_FLIGHT:
+            return new FreeFlightManipulator<FLOAT>(mode, details);
+        case Mode::MAP:
+            return new MapManipulator<FLOAT>(mode, details);
+        case Mode::ORBIT:
+            return new OrbitManipulator<FLOAT>(mode, details);
     }
-    return new OrbitManipulator<FLOAT>(mode, details);
 }
 
 template <typename FLOAT>
@@ -266,6 +307,15 @@ filament::math::vec3<FLOAT> Manipulator<FLOAT>::raycastFarPlane(int x, int y) co
     }
     return mEye + dir * mProps.farPlane;
 }
+
+template <typename FLOAT>
+void Manipulator<FLOAT>::keyDown(Manipulator<FLOAT>::Key key) { }
+
+template <typename FLOAT>
+void Manipulator<FLOAT>::keyUp(Manipulator<FLOAT>::Key key) { }
+
+template <typename FLOAT>
+void Manipulator<FLOAT>::update(FLOAT deltaTime) { }
 
 template class Manipulator<float>;
 

--- a/libs/camutils/src/MapManipulator.h
+++ b/libs/camutils/src/MapManipulator.h
@@ -71,7 +71,7 @@ public:
         mGrabbing = false;
     }
 
-    void zoom(int x, int y, FLOAT scrolldelta) override {
+    void scroll(int x, int y, FLOAT scrolldelta) override {
         vec3 grabScene;
         if (!Base::raycast(x, y, &grabScene)) {
             return;

--- a/libs/camutils/src/OrbitManipulator.h
+++ b/libs/camutils/src/OrbitManipulator.h
@@ -111,7 +111,7 @@ public:
         mGrabState = INACTIVE;
     }
 
-    void zoom(int x, int y, FLOAT scrolldelta) override {
+    void scroll(int x, int y, FLOAT scrolldelta) override {
         const vec3 gaze = normalize(Base::mTarget - Base::mEye);
         const vec3 movement = gaze * Base::mProps.zoomSpeed * -scrolldelta;
         const vec3 v0 = mPivot - Base::mEye;

--- a/libs/filamentapp/include/filamentapp/FilamentApp.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp.h
@@ -19,8 +19,8 @@
 
 #include <functional>
 #include <memory>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <SDL.h>
@@ -109,6 +109,8 @@ private:
 
     using CameraManipulator = filament::camutils::Manipulator<float>;
 
+    static bool manipulatorKeyFromKeycode(SDL_Scancode scancode, CameraManipulator::Key& key);
+
     class CView {
     public:
         CView(filament::Renderer& renderer, std::string name);
@@ -123,9 +125,12 @@ private:
         virtual void mouseUp(ssize_t x, ssize_t y);
         virtual void mouseMoved(ssize_t x, ssize_t y);
         virtual void mouseWheel(ssize_t x);
+        virtual void keyDown(SDL_Scancode scancode);
+        virtual void keyUp(SDL_Scancode scancode);
 
         filament::View const* getView() const { return view; }
         filament::View* getView() { return view; }
+        CameraManipulator* getCameraManipulator() { return mCameraManipulator; }
 
     private:
         enum class Mode : uint8_t {
@@ -156,6 +161,8 @@ private:
         void mouseUp(ssize_t x, ssize_t y);
         void mouseMoved(ssize_t x, ssize_t y);
         void mouseWheel(ssize_t x);
+        void keyDown(SDL_Scancode scancode);
+        void keyUp(SDL_Scancode scancode);
         void resize();
 
         filament::Renderer* getRenderer() { return mRenderer; }
@@ -195,7 +202,11 @@ private:
         size_t mHeight = 0;
         ssize_t mLastX = 0;
         ssize_t mLastY = 0;
-        CView* mEventTarget = nullptr;
+
+        CView* mMouseEventTarget = nullptr;
+
+        // Keep track of which view should receive a key's keyUp event.
+        std::unordered_map<SDL_Scancode, CView*> mKeyEventTarget;
     };
 
     friend class Window;

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -804,7 +804,7 @@ void FilamentApp::CView::mouseMoved(ssize_t x, ssize_t y) {
 
 void FilamentApp::CView::mouseWheel(ssize_t x) {
     if (mCameraManipulator) {
-        mCameraManipulator->zoom(0, 0, x);
+        mCameraManipulator->scroll(0, 0, x);
     }
 }
 


### PR DESCRIPTION
This adds a new camera manipulator that allows WASD movement with nodal camera panning. This PR only adds the new manipulator type, it doesn't enable it yet inside of `FilamentApp` (we'll need to decide how we want to expose it, possibly through a command-line flag).

![free_flight](https://user-images.githubusercontent.com/5298046/79927551-f8f0a200-83f4-11ea-8748-7f8501a46543.gif)
