### PR TITLE
Skybox now binds dummy texture.

### DIFF
--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -102,9 +102,8 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
 
     TextureSampler sampler(TextureSampler::MagFilter::LINEAR, TextureSampler::WrapMode::REPEAT);
     auto pInstance = static_cast<MaterialInstance*>(mSkyboxMaterialInstance);
-    if (mSkyboxTexture != nullptr) {
-        pInstance->setParameter("skybox", mSkyboxTexture, sampler);
-    }
+    FTexture const* texture = mSkyboxTexture ? mSkyboxTexture : engine.getDummyCubemap();
+    pInstance->setParameter("skybox", texture, sampler);
     pInstance->setParameter("showSun", builder->mShowSun);
     pInstance->setParameter("constantColor", mSkyboxTexture == nullptr);
     pInstance->setParameter("color", builder->mColor);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -152,6 +152,7 @@ public:
     const FMaterial* getDefaultMaterial() const noexcept { return mDefaultMaterial; }
     const FMaterial* getSkyboxMaterial() const noexcept;
     const FIndirectLight* getDefaultIndirectLight() const noexcept { return mDefaultIbl; }
+    const FTexture* getDummyCubemap() const noexcept { return mDefaultIblTexture; }
 
     backend::Handle<backend::HwRenderPrimitive> getFullScreenRenderPrimitive() const noexcept {
         return mFullScreenTriangleRph;


### PR DESCRIPTION
This fixes unbound sampler warnings, as seen in our hellotriangle app.