### PR TITLE
Vulkan: fix bad depth clears.

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -208,7 +208,7 @@ VulkanAttachment VulkanRenderTarget::getColor() const {
 }
 
 VulkanAttachment VulkanRenderTarget::getDepth() const {
-    return mOffscreen ? mDepth : VulkanAttachment {};
+    return mOffscreen ? mDepth : mContext.currentSurface->depth;
 }
 
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,


### PR DESCRIPTION
The Vulkan backend was failing to clear the depth buffer in apps that do
not have a textured skybox, such as hellotriangle.