### PR TITLE
Vulkan: add support for 2D texture arrays.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -417,12 +417,11 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
-        backend::MRT color, TargetBufferInfo depth,
-        TargetBufferInfo stencil) {
+        backend::MRT color, TargetBufferInfo depth, TargetBufferInfo stencil) {
     auto colorTexture = color[0].handle ? handle_cast<VulkanTexture>(mHandleMap, color[0].handle) : nullptr;
     auto depthTexture = depth.handle ? handle_cast<VulkanTexture>(mHandleMap, depth.handle) : nullptr;
     auto renderTarget = construct_handle<VulkanRenderTarget>(mHandleMap, rth, mContext,
-            width, height, color[0].level, colorTexture, depth.level, depthTexture);
+            width, height, color[0], colorTexture, depth, depthTexture);
     mDisposer.createDisposable(renderTarget, [this, rth] () {
         destruct_handle<VulkanRenderTarget>(mHandleMap, rth);
     });

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -45,8 +45,8 @@ struct VulkanTexture;
 struct VulkanRenderTarget : private HwRenderTarget {
 
     // Creates an offscreen render target.
-    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, uint32_t colorLevel,
-            VulkanTexture* color, uint32_t depthLevel, VulkanTexture* depth);
+    VulkanRenderTarget(VulkanContext& context, uint32_t w, uint32_t h, TargetBufferInfo colorInfo,
+            VulkanTexture* color, TargetBufferInfo depthInfo, VulkanTexture* depth);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
     explicit VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0), mContext(context),


### PR DESCRIPTION
In Vulkan, the arrayness of a texture is an aspect of the "image view", not the image itself.

In my earlier attempt I used `VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT` on the image, which MoltenVK does not support. Confusingly, that flag is actually meant for rendering into a slice of a 3D texture, which we are not doing.

Vulkan is hard.