### PR TITLE
Make CI scripts safer

### DIFF
--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/android && yes | ./build.sh continuous
+          cd build/android && printf "y" | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-android

--- a/.github/workflows/android-continuous.yml
+++ b/.github/workflows/android-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/android && ./build.sh continuous
+          cd build/android && yes | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-android

--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/ios && yes | ./build.sh continuous
+          cd build/ios && printf "y" | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-ios

--- a/.github/workflows/ios-continuous.yml
+++ b/.github/workflows/ios-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/ios && ./build.sh continuous
+          cd build/ios && yes | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-ios

--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/linux && yes | ./build.sh continuous
+          cd build/linux && printf "y" | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-linux

--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/linux && ./build.sh continuous
+          cd build/linux && yes | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-linux

--- a/.github/workflows/mac-continuous.yml
+++ b/.github/workflows/mac-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/mac && yes | ./build.sh continuous
+          cd build/mac && printf "y" | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-mac

--- a/.github/workflows/mac-continuous.yml
+++ b/.github/workflows/mac-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/mac && ./build.sh continuous
+          cd build/mac && yes | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-mac

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run build script
         run: |
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
-          cd build/$WORKFLOW_OS && ./build.sh presubmit
+          cd build/$WORKFLOW_OS && yes | ./build.sh presubmit 
       - name: Test material parser
         run: |
           out/cmake-release/filament/test/test_material_parser
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/android && ./build.sh presubmit
+          cd build/android && yes | ./build.sh presubmit 
 
   build-ios:
     name: build-iOS
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/ios && ./build.sh presubmit
+          cd build/ios && yes | ./build.sh presubmit 
       - name: Build iOS samples
         run: |
           cd build/ios && ./build-samples.sh presubmit
@@ -63,4 +63,4 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/web && ./build.sh presubmit
+          cd build/web && yes | ./build.sh presubmit 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run build script
         run: |
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
-          cd build/$WORKFLOW_OS && yes | ./build.sh presubmit 
+          cd build/$WORKFLOW_OS && printf "y" | ./build.sh presubmit
       - name: Test material parser
         run: |
           out/cmake-release/filament/test/test_material_parser
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/android && yes | ./build.sh presubmit 
+          cd build/android && printf "y" | ./build.sh presubmit
 
   build-ios:
     name: build-iOS
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/ios && yes | ./build.sh presubmit 
+          cd build/ios && printf "y" | ./build.sh presubmit
       - name: Build iOS samples
         run: |
           cd build/ios && ./build-samples.sh presubmit
@@ -63,4 +63,4 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/web && yes | ./build.sh presubmit 
+          cd build/web && printf "y" | ./build.sh presubmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run build script
         run: |
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
-          cd build/$WORKFLOW_OS && yes | ./build.sh release 
+          cd build/$WORKFLOW_OS && printf "y" | ./build.sh release
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/web && yes | ./build.sh release 
+          cd build/web && printf "y" | ./build.sh release
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/android && yes | ./build.sh release 
+          cd build/android && printf "y" | ./build.sh release
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -133,7 +133,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/ios && yes | ./build.sh release 
+          cd build/ios && printf "y" | ./build.sh release
       - name: Upload release assets
         run: |
           pip3 install setuptools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run build script
         run: |
           WORKFLOW_OS=`echo \`uname\` | sed "s/Darwin/mac/" | tr [:upper:] [:lower:]`
-          cd build/$WORKFLOW_OS && ./build.sh release
+          cd build/$WORKFLOW_OS && yes | ./build.sh release 
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/web && ./build.sh release
+          cd build/web && yes | ./build.sh release 
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/android && ./build.sh release
+          cd build/android && yes | ./build.sh release 
       - name: Upload release assets
         run: |
           pip3 install setuptools
@@ -133,7 +133,7 @@ jobs:
           ref: ${{ steps.git_ref.outputs.ref }}
       - name: Run build script
         run: |
-          cd build/ios && ./build.sh release
+          cd build/ios && yes | ./build.sh release 
       - name: Upload release assets
         run: |
           pip3 install setuptools

--- a/.github/workflows/web-continuous.yml
+++ b/.github/workflows/web-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/web && yes | ./build.sh continuous
+          cd build/web && printf "y" | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-web

--- a/.github/workflows/web-continuous.yml
+++ b/.github/workflows/web-continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - name: Run build script
         run: |
-          cd build/web && ./build.sh continuous
+          cd build/web && yes | ./build.sh continuous
       - uses: actions/upload-artifact@v1.0.0
         with:
           name: filament-web

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,11 +15,6 @@ To build the Java based components of the project you can optionally install (re
 Additional dependencies may be required for your operating system. Please refer to the appropriate
 section below.
 
-Building the `rays` library (used for light baking) is optional and requires the following packages:
-
-- embree 3.0+
-- libtbb-dev
-
 To build Filament for Android you must also install the following:
 
 - Android Studio 3.6 or more recent

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,5 @@
+# Important note
+
+The scripts found in the subdirectories are intended to be used by Filament's continuous
+integration environments only. They are not meant to be run directly. Please refer to
+our [build instructions](../BUILDING.md) on how to proceed instead.

--- a/build/android/build.sh
+++ b/build/android/build.sh
@@ -8,11 +8,27 @@
 #
 # The default is release
 
-set -e
-set -x
-
 NDK_VERSION="ndk;21.0.6113669"
 ANDROID_NDK_VERSION=21
+
+echo "This script is intended to run in a CI environment and may modify your current environment."
+echo "Please refer to ./BUILDING.md for more information."
+
+read -r -p "Do you wish to proceed (y/n)? " choice
+case "${choice}" in
+    y|Y)
+	      echo "Build will proceed..."
+	      ;;
+    n|N)
+    	  exit 0
+    	  ;;
+	  *)
+        exit 0
+        ;;
+esac
+
+set -e
+set -x
 
 UNAME=`echo $(uname)`
 LC_UNAME=`echo $UNAME | tr '[:upper:]' '[:lower:]'`

--- a/build/android/build.sh
+++ b/build/android/build.sh
@@ -12,7 +12,7 @@ NDK_VERSION="ndk;21.0.6113669"
 ANDROID_NDK_VERSION=21
 
 echo "This script is intended to run in a CI environment and may modify your current environment."
-echo "Please refer to ./BUILDING.md for more information."
+echo "Please refer to BUILDING.md for more information."
 
 read -r -p "Do you wish to proceed (y/n)? " choice
 case "${choice}" in

--- a/build/ios/build.sh
+++ b/build/ios/build.sh
@@ -9,7 +9,7 @@
 # The default is release
 
 echo "This script is intended to run in a CI environment and may modify your current environment."
-echo "Please refer to ./BUILDING.md for more information."
+echo "Please refer to BUILDING.md for more information."
 
 read -r -p "Do you wish to proceed (y/n)? " choice
 case "${choice}" in

--- a/build/ios/build.sh
+++ b/build/ios/build.sh
@@ -8,6 +8,22 @@
 #
 # The default is release
 
+echo "This script is intended to run in a CI environment and may modify your current environment."
+echo "Please refer to ./BUILDING.md for more information."
+
+read -r -p "Do you wish to proceed (y/n)? " choice
+case "${choice}" in
+    y|Y)
+	      echo "Build will proceed..."
+	      ;;
+    n|N)
+    	  exit 0
+    	  ;;
+	  *)
+        exit 0
+        ;;
+esac
+
 set -e
 set -x
 

--- a/build/linux/build.sh
+++ b/build/linux/build.sh
@@ -9,7 +9,7 @@
 # The default is release
 
 echo "This script is intended to run in a CI environment and may modify your current environment."
-echo "Please refer to ./BUILDING.md for more information."
+echo "Please refer to BUILDING.md for more information."
 
 read -r -p "Do you wish to proceed (y/n)? " choice
 case "${choice}" in

--- a/build/linux/build.sh
+++ b/build/linux/build.sh
@@ -8,6 +8,22 @@
 #
 # The default is release
 
+echo "This script is intended to run in a CI environment and may modify your current environment."
+echo "Please refer to ./BUILDING.md for more information."
+
+read -r -p "Do you wish to proceed (y/n)? " choice
+case "${choice}" in
+    y|Y)
+	      echo "Build will proceed..."
+	      ;;
+    n|N)
+    	  exit 0
+    	  ;;
+	  *)
+        exit 0
+        ;;
+esac
+
 set -e
 set -x
 

--- a/build/linux/ci-common.sh
+++ b/build/linux/ci-common.sh
@@ -1,33 +1,30 @@
 #!/bin/bash
 
 # version of clang we want to use
-CLANG_VERSION=7
 GITHUB_CLANG_VERSION=8
-# version of libcxx and libcxxabi we want to use
-CXX_VERSION=7.0.0
 # version of CMake to use instead of the default one
 CMAKE_VERSION=3.13.4
 # version of ninja to use
 NINJA_VERSION=1.8.2
 
-# Install ninja
-wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip
-unzip -q ninja-linux.zip
-export PATH="$PWD:$PATH"
-
-# Install CMake
-mkdir -p cmake
-cd cmake
-
-sudo wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh
-sudo chmod +x ./cmake-$CMAKE_VERSION-Linux-x86_64.sh
-sudo ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license > /dev/null
-sudo update-alternatives --install /usr/bin/cmake cmake `pwd`/bin/cmake 1000 --force
-
-cd ..
-
 # Steps for GitHub Workflows
 if [[ "$GITHUB_WORKFLOW" ]]; then
+    # Install ninja
+    wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip
+    unzip -q ninja-linux.zip
+    export PATH="$PWD:$PATH"
+
+    # Install CMake
+    mkdir -p cmake
+    cd cmake
+
+    sudo wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-Linux-x86_64.sh
+    sudo chmod +x ./cmake-$CMAKE_VERSION-Linux-x86_64.sh
+    sudo ./cmake-$CMAKE_VERSION-Linux-x86_64.sh --skip-license > /dev/null
+    sudo update-alternatives --install /usr/bin/cmake cmake $(pwd)/bin/cmake 1000 --force
+
+    cd ..
+
     sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
     sudo apt-get update
     sudo apt-get install clang-$GITHUB_CLANG_VERSION libc++-$GITHUB_CLANG_VERSION-dev libc++abi-$GITHUB_CLANG_VERSION-dev

--- a/build/mac/build.sh
+++ b/build/mac/build.sh
@@ -9,7 +9,7 @@
 # The default is release
 
 echo "This script is intended to run in a CI environment and may modify your current environment."
-echo "Please refer to ./BUILDING.md for more information."
+echo "Please refer to BUILDING.md for more information."
 
 read -r -p "Do you wish to proceed (y/n)? " choice
 case "${choice}" in

--- a/build/mac/build.sh
+++ b/build/mac/build.sh
@@ -8,6 +8,22 @@
 #
 # The default is release
 
+echo "This script is intended to run in a CI environment and may modify your current environment."
+echo "Please refer to ./BUILDING.md for more information."
+
+read -r -p "Do you wish to proceed (y/n)? " choice
+case "${choice}" in
+    y|Y)
+	      echo "Build will proceed..."
+	      ;;
+    n|N)
+    	  exit 0
+    	  ;;
+	  *)
+        exit 0
+        ;;
+esac
+
 set -e
 set -x
 

--- a/build/web/build.sh
+++ b/build/web/build.sh
@@ -9,7 +9,7 @@
 # The default is release
 
 echo "This script is intended to run in a CI environment and may modify your current environment."
-echo "Please refer to ./BUILDING.md for more information."
+echo "Please refer to BUILDING.md for more information."
 
 read -r -p "Do you wish to proceed (y/n)? " choice
 case "${choice}" in

--- a/build/web/build.sh
+++ b/build/web/build.sh
@@ -8,6 +8,22 @@
 #
 # The default is release
 
+echo "This script is intended to run in a CI environment and may modify your current environment."
+echo "Please refer to ./BUILDING.md for more information."
+
+read -r -p "Do you wish to proceed (y/n)? " choice
+case "${choice}" in
+    y|Y)
+	      echo "Build will proceed..."
+	      ;;
+    n|N)
+    	  exit 0
+    	  ;;
+	  *)
+        exit 0
+        ;;
+esac
+
 set -e
 set -x
 


### PR DESCRIPTION
Fixes #2455.

- Display a prompt and require user confirmation
- Only runs system install commands in GitHub CI environments
- Add extra README file detailing what the scripts are for
