### PR TITLE
fix LightManager::forEachComponent()

### DIFF
--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -753,7 +753,8 @@ public:
     void forEachComponent(F func) noexcept {
         utils::Entity const* const pEntity = getEntities();
         for (size_t i = 0, c = getComponentCount(); i < c; i++) {
-            func(pEntity[i], Instance(i));
+            // Instance 0 is the invalid instance
+            func(pEntity[i], Instance(i + 1));
         }
     }
 };


### PR DESCRIPTION
the Instance id was off-by-one and didn't match the
given entity.

in gltf_viewer this caused contact shadows to not work
when there was only a single directional light