### PR TITLE
Fix incorrect lightspace 2D bounds calculation for stable shadows

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -670,7 +670,7 @@ Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
 }
 
 Aabb ShadowMap::compute2DBounds(const mat4f& lightView, float4 const& sphere) noexcept {
-    // this assumes a rotation + translate only
+    // this assumes a rigid body transform
     float4 s;
     s.xyz = (lightView * float4{sphere.xyz, 1.0f}).xyz;
     s.w = sphere.w;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -349,7 +349,7 @@ void ShadowMap::computeShadowCameraDirectional(
 
         Aabb bounds;
         if (params.options.stable && viewVolumeBoundingSphere.w > 0) {
-            bounds = compute2DBounds(MpMv, wsViewFrustumVertices, 8);
+            bounds = compute2DBounds(Mv, viewVolumeBoundingSphere);
         } else {
             bounds = compute2DBounds(WLMpMv, mWsClippedShadowReceiverVolume.data(), vertexCount);
         }
@@ -667,6 +667,14 @@ Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
         bounds.max.xy = max(bounds.max.xy, v.xy);
     }
     return bounds;
+}
+
+Aabb ShadowMap::compute2DBounds(const mat4f& lightView, float4 const& sphere) noexcept {
+    // this assumes a rotation + translate only
+    float4 s;
+    s.xyz = (lightView * float4{sphere.xyz, 1.0f}).xyz;
+    s.w = sphere.w;
+    return Aabb{s.xyz - s.w, s.xyz + s.w};
 }
 
 void ShadowMap::intersectWithShadowCasters(Aabb& UTILS_RESTRICT lightFrustum,

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -349,7 +349,7 @@ void ShadowMap::computeShadowCameraDirectional(
 
         Aabb bounds;
         if (params.options.stable && viewVolumeBoundingSphere.w > 0) {
-            bounds = compute2DBounds(MpMv, viewVolumeBoundingSphere);
+            bounds = compute2DBounds(MpMv, wsViewFrustumVertices, 8);
         } else {
             bounds = compute2DBounds(WLMpMv, mWsClippedShadowReceiverVolume.data(), vertexCount);
         }
@@ -667,15 +667,6 @@ Aabb ShadowMap::compute2DBounds(const mat4f& lightView,
         bounds.max.xy = max(bounds.max.xy, v.xy);
     }
     return bounds;
-}
-
-Aabb ShadowMap::compute2DBounds(const mat4f& lightView, float4 const& sphere) noexcept {
-    // this assumes a uniform scale + rotation + translate only
-    // TODO: we need to handle perspective projections
-    float4 s;
-    s.xyz = (lightView * float4{sphere.xyz, 1.0f}).xyz;
-    s.w = std::abs(sphere.w * lightView[0][0]);
-    return Aabb{s.xyz - s.w, s.xyz + s.w};
 }
 
 void ShadowMap::intersectWithShadowCasters(Aabb& UTILS_RESTRICT lightFrustum,

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -148,9 +148,6 @@ private:
     static inline Aabb compute2DBounds(const math::mat4f& lightView,
             math::float3 const* wsVertices, size_t count) noexcept;
 
-    static inline Aabb compute2DBounds(const math::mat4f& lightView,
-            math::float4 const& sphere) noexcept;
-
     static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
             Aabb const& wsShadowCastersVolume) noexcept;
 

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -148,6 +148,9 @@ private:
     static inline Aabb compute2DBounds(const math::mat4f& lightView,
             math::float3 const* wsVertices, size_t count) noexcept;
 
+    static inline Aabb compute2DBounds(const math::mat4f& lightView,
+            math::float4 const& sphere) noexcept;
+
     static inline void intersectWithShadowCasters(Aabb& lightFrustum, const math::mat4f& lightView,
             Aabb const& wsShadowCastersVolume) noexcept;
 


### PR DESCRIPTION
This fixes an issue when using stable directional shadows. See how the shadows disappear when the light's direction becomes perfectly orthogonal to the camera:

https://drive.google.com/a/google.com/file/d/1qWTavtkbL2PO-oEVaTZ9bJwZGbMw7ZMt/view?usp=sharing