### PR TITLE
fix a arithmetic error in SSR when a symmetry was present

### DIFF
--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -114,12 +114,13 @@ public:
     }
 
     float getFieldOfView(Camera::Fov direction) const noexcept {
+        // note: this is meaning less for an orthographic projection
         auto const& p = getProjectionMatrix();
         switch (direction) {
             case Fov::VERTICAL:
-                return 2.0f * std::atan(1.0f / float(p[1][1]));
+                return std::abs(2.0f * std::atan(1.0f / float(p[1][1])));
             case Fov::HORIZONTAL:
-                return 2.0f * std::atan(1.0f / float(p[0][0]));
+                return std::abs(2.0f * std::atan(1.0f / float(p[0][0])));
         }
     }
 


### PR DESCRIPTION
Make sure that Camera returns a positive field-of-view, even when
the projection matrix has a symmetry (negative scaling).