### PR TITLE
Don't use gl_FragCoord anywhere as it breaks with custom viewports

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1884,24 +1884,25 @@ The following APIs are only available from the vertex block:
 
 The following APIs are only available from the fragment block:
 
-                 Name               |   Type   |            Description
-:-----------------------------------|:--------:|:------------------------------------
-**getWorldTangentFrame()**          | float3x3 |  Matrix containing in each column the `tangent` (`frame[0]`), `bi-tangent` (`frame[1]`) and `normal` (`frame[2]`) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the `normal` is valid in this matrix.
-**getWorldPosition()**              | float3   |  Position of the fragment in world space (see note below about world-space)
-**getWorldViewVector()**            | float3   |  Normalized vector in world space from the fragment position to the eye
-**getWorldNormalVector()**          | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
-**getWorldGeometricNormalVector()** | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
-**getWorldReflectedVector()**       | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
-**getNdotV()**                      | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
-**getColor()**                      | float4   |  Interpolated color of the fragment, if the color attribute is required
-**getUV0()**                        | float2   |  First interpolated set of UV coordinates, only available if the uv0 attribute is required
-**getUV1()**                        | float2   |  First interpolated set of UV coordinates, only available if the uv1 attribute is required
-**getMaskThreshold()**              | float    |  Returns the mask threshold, only available when `blending` is set to `masked`
-**inverseTonemap(float3)**          | float3   |  Applies the inverse tone mapping operator to the specified linear sRGB color and returns a linear sRGB color. This operation may be an approximation
-**inverseTonemapSRGB(float3)**      | float3   |  Applies the inverse tone mapping operator to the specified non-linear sRGB color and returns a linear sRGB color. This operation may be an approximation
-**luminance(float3)**               | float    |  Computes the luminance of the specified linear sRGB color
-**ycbcrToRgb(float, float2)**       | float3   |  Converts a luminance and CbCr pair to a sRGB color
-**uvToRenderTargetUV(float2)**      | float2   |  Transforms a UV coordinate to allow sampling from a `RenderTarget` attachment
+                 Name                   |   Type   |            Description
+:---------------------------------------|:--------:|:------------------------------------
+**getWorldTangentFrame()**              | float3x3 |  Matrix containing in each column the `tangent` (`frame[0]`), `bi-tangent` (`frame[1]`) and `normal` (`frame[2]`) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the `normal` is valid in this matrix.
+**getWorldPosition()**                  | float3   |  Position of the fragment in world space (see note below about world-space)
+**getWorldViewVector()**                | float3   |  Normalized vector in world space from the fragment position to the eye
+**getWorldNormalVector()**              | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
+**getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
+**getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
+**getNormalizedViewportCoord(float2)**  | float2   |  Normalized viewport position (i.e. clip-space position normalized to [0, 1], can be used before `prepareMaterial()`)
+**getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
+**getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required
+**getUV0()**                            | float2   |  First interpolated set of UV coordinates, only available if the uv0 attribute is required
+**getUV1()**                            | float2   |  First interpolated set of UV coordinates, only available if the uv1 attribute is required
+**getMaskThreshold()**                  | float    |  Returns the mask threshold, only available when `blending` is set to `masked`
+**inverseTonemap(float3)**              | float3   |  Applies the inverse tone mapping operator to the specified linear sRGB color and returns a linear sRGB color. This operation may be an approximation
+**inverseTonemapSRGB(float3)**          | float3   |  Applies the inverse tone mapping operator to the specified non-linear sRGB color and returns a linear sRGB color. This operation may be an approximation
+**luminance(float3)**                   | float    |  Computes the luminance of the specified linear sRGB color
+**ycbcrToRgb(float, float2)**           | float3   |  Converts a luminance and CbCr pair to a sRGB color
+**uvToRenderTargetUV(float2)**          | float2   |  Transforms a UV coordinate to allow sampling from a `RenderTarget` attachment
 
 !!! TIP: world space
     To obtain API-level world space coordinates, custom materials should add `getWorldOffset()` to

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -12,9 +12,7 @@
 //------------------------------------------------------------------------------
 
 float evaluateSSAO() {
-    // TODO: Don't use gl_FragCoord.xy, use the view bounds
-    vec2 uv = gl_FragCoord.xy * frameUniforms.resolution.zw;
-    return textureLod(light_ssao, uv, 0.0).r;
+    return textureLod(light_ssao, uvToRenderTargetUV(getNormalizedViewportCoord().xy), 0.0).r;
 }
 
 float SpecularAO_Lagarde(float NoV, float visibility, float roughness) {

--- a/shaders/src/common_shading.fs
+++ b/shaders/src/common_shading.fs
@@ -15,3 +15,5 @@ highp vec3  shading_position;         // position of the fragment in world space
 #if defined(MATERIAL_HAS_CLEAR_COAT)
       vec3  shading_clearCoatNormal;  // normalized clear coat layer normal, in world space
 #endif
+
+highp vec2 shading_normalizedViewportCoord;

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -87,6 +87,15 @@ highp vec3 getLightSpacePosition() {
 }
 #endif
 
+/**
+ * Returns the normalized [0, 1] viewport coordinates with the origin at the viewport's bottom-left.
+ *
+ * @public-api
+ */
+highp vec3 getNormalizedViewportCoord() {
+    return vec3(shading_normalizedViewportCoord, gl_FragCoord.z);
+}
+
 #if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
 highp vec3 getSpotLightSpacePosition(uint index) {
     highp vec4 position = vertex_spotLightSpacePosition[index];

--- a/shaders/src/inputs.fs
+++ b/shaders/src/inputs.fs
@@ -13,6 +13,8 @@ LAYOUT_LOCATION(6) SHADING_INTERPOLATION in mediump vec4 vertex_worldTangent;
 #endif
 #endif
 
+LAYOUT_LOCATION(7) in highp vec4 vertex_position;
+
 #if defined(HAS_ATTRIBUTE_COLOR)
 LAYOUT_LOCATION(9) in mediump vec4 vertex_color;
 #endif

--- a/shaders/src/inputs.vs
+++ b/shaders/src/inputs.vs
@@ -64,6 +64,8 @@ LAYOUT_LOCATION(6) SHADING_INTERPOLATION out mediump vec4 vertex_worldTangent;
 #endif
 #endif
 
+LAYOUT_LOCATION(7) out highp vec4 vertex_position;
+
 #if defined(HAS_ATTRIBUTE_COLOR)
 LAYOUT_LOCATION(9) out mediump vec4 vertex_color;
 #endif

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -27,17 +27,11 @@ struct FroxelParams {
 uvec3 getFroxelCoords(const highp vec3 fragCoords) {
     uvec3 froxelCoord;
 
-    highp vec3 adjustedFragCoords = fragCoords;
-// In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    adjustedFragCoords.y = frameUniforms.resolution.y - adjustedFragCoords.y;
-#endif
-
-    froxelCoord.xy = uvec2((adjustedFragCoords.xy - frameUniforms.origin.xy) *
+    froxelCoord.xy = uvec2(fragCoords.xy * frameUniforms.resolution.xy *
             vec2(frameUniforms.oneOverFroxelDimension, frameUniforms.oneOverFroxelDimensionY));
 
     froxelCoord.z = uint(max(0.0,
-            log2(frameUniforms.zParams.x * adjustedFragCoords.z + frameUniforms.zParams.y) *
+            log2(frameUniforms.zParams.x * fragCoords.z + frameUniforms.zParams.y) *
                     frameUniforms.zParams.z + frameUniforms.zParams.w));
 
     return froxelCoord;
@@ -158,7 +152,7 @@ Light getLight(const uint index) {
 void evaluatePunctualLights(const PixelParams pixel, inout vec3 color) {
     // Fetch the light information stored in the froxel that contains the
     // current fragment
-    FroxelParams froxel = getFroxelParams(getFroxelIndex(gl_FragCoord.xyz));
+    FroxelParams froxel = getFroxelParams(getFroxelIndex(getNormalizedViewportCoord()));
 
     // Each froxel contains how many lights can influence
     // the current fragment. A froxel also contains a record offset that

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -112,6 +112,9 @@ void main() {
     gl_Position = getClipSpaceTransform(material) * gl_Position;
 #endif
 
+    // this must happen before we compensate for vulkan below
+    vertex_position = gl_Position;
+
 #if defined(TARGET_VULKAN_ENVIRONMENT)
     // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
     gl_Position.y = -gl_Position.y;

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -34,6 +34,11 @@ void computeShadingParams() {
 
     shading_position = vertex_worldPosition;
     shading_view = normalize(frameUniforms.cameraPosition - shading_position);
+
+    // we do this so we avoid doing (matrix multiply), but we burn 4 varyings:
+    //    p = clipFromWorldMatrix * shading_position;
+    //    shading_normalizedViewportCoord = p.xy * 0.5 / p.w + 0.5
+    shading_normalizedViewportCoord = vertex_position.xy * (0.5 / vertex_position.w) + 0.5;
 }
 
 /**


### PR DESCRIPTION
This fixes dynamic lighting and SSAO when a viewport is not in 0,0.
In practice this currently happens only when all post-processing is
disabled.

Instead of using gl_FragCoord we introduce a new API, 
getNormalizedViewportCoord(), which as the name implies returns
normalized [0, 1] viewport coordinates with origin at the bottom-left,
on all platforms.

This is implemented in this PR by interpolating gl_Position.