### PR TITLE
GL backend: Fix an issue with discardEnd flags

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -316,6 +316,8 @@ private:
 
     void setRasterStateSlow(backend::RasterState rs) noexcept;
     void setRasterState(backend::RasterState rs) noexcept {
+        mRenderPassColorWrite |= rs.colorWrite;
+        mRenderPassDepthWrite |= rs.depthWrite;
         if (UTILS_UNLIKELY(rs != mRasterState)) {
             setRasterStateSlow(rs);
         }
@@ -374,6 +376,8 @@ private:
     // state required to represent the current render pass
     backend::Handle<backend::HwRenderTarget> mRenderPassTarget;
     backend::RenderPassParams mRenderPassParams;
+    GLboolean mRenderPassColorWrite{};
+    GLboolean mRenderPassDepthWrite{};
 
     void clearWithRasterPipe(backend::TargetBufferFlags clearFlags,
             math::float4 const& linearColor, GLfloat depth, GLint stencil) noexcept;


### PR DESCRIPTION
In OpenGL with use glInvalidateFramebuffer() for hinting controlling
the load/store of tiles. However, glInvalidateFramebuffer() conceptually
destroys the content of the framebuffer attachment.

This causes a problem when we want for instance to use a buffer for
reading only (e.g. a depth buffer) in multiple passes. In such
scenario, the attachment will be marked as "discard" (which is a
misnomer for storeOp==DONT_CARE in vulkan parlance), without the
intention of making the buffer invalid.

We fix this by ignoring the discardEnd flags entirely if a buffer
has not been written. In this case, we relying on the driver to not
write the tiles out -- but we don't have any other way to express
this in GL.

This issue cannot be encountered currently because the framegraph 
is not aggressive enough setting the discardEnd flags.