### PR TITLE
Adding support for openjdk 13

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
Updated gradle version to 6.3 for openjdk 13 support
`./build.sh -p android release` was getting error `FilamentPlugin.groovy' Unsupported class file major version 57` when java_home is set to openjdk 13
