### PR TITLE
Fix AssetLoader to load name of node without mesh

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -54,6 +54,9 @@ struct AssetConfiguration {
     //! specified, AssetLoader will use the singleton EntityManager associated with the current
     //! process.
     utils::EntityManager* entities = nullptr;
+
+    //! Optional default node name for anonymous nodes
+    char* defaultNodeName = nullptr;
 };
 
 /**


### PR DESCRIPTION
Currently AssetLoader only load name with nodes contains mesh. The hotfix load every node's name no matter the mesh. It'll set the node name "node" if name not found.

Test
test with mac and gltf_viewer devtool