### PR TITLE
Add rudimentary cascading shadow map support

### DIFF
--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -22,6 +22,7 @@
 #include <utils/compiler.h>
 
 #include <math/mat4.h>
+#include <math/vec3.h>
 
 #include <utils/unwindows.h> // Because we define NEAR and FAR in the Plane enum.
 
@@ -58,6 +59,30 @@ public:
      * @param pv a 4x4 projection matrix
      */
     explicit Frustum(const math::mat4f& pv);
+
+    /**
+     * Creates a frustum from 8 corner coordinates.
+     * @param corners the corners of the frustum
+     *
+     * The corners should be specified in this order:
+     * 0. far bottom left
+     * 1. far bottom right
+     * 2. far top left
+     * 3. far top right
+     * 4. near bottom left
+     * 5. near bottom right
+     * 6. near top left
+     * 7. near top right
+     *
+     *     2----3
+     *    /|   /|
+     *   6----7 |
+     *   | 0--|-1      far
+     *   |/   |/       /
+     *   4----5      near
+     *
+     */
+    explicit Frustum(const math::float3 corners[8]);
 
     /**
      * Sets the frustum from the given projection matrix

--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -93,7 +93,7 @@ public:
     /**
      * Returns the plane equation parameters with normalized normals
      * @param plane Identifier of the plane to retrieve the equation of
-     * @return A plane equation encoded a float4 R such as R.x*x + R.y*y + R.z*z = R.w
+     * @return A plane equation encoded a float4 R such as R.x*x + R.y*y + R.z*z + R.w = 0
      */
     math::float4 getNormalizedPlane(Plane plane) const noexcept;
 

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -196,6 +196,22 @@ public:
         /** Size of the shadow map in texels. Must be a power-of-two. */
         uint32_t mapSize = 1024;
 
+        /**
+         * Number of shadow cascades to use for this light. Must be between 1 and 4 (inclusive).
+         * A value greater than 1 turns on cascaded shadow mapping (CSM).
+         * Only applicable to Type.SUN or Type.DIRECTIONAL lights.
+         *
+         * @warning This API is still experimental and subject to change.
+         */
+        uint8_t shadowCascades = 1;
+
+        /**
+         * Visualize the shadow cascades through different colors.
+         *
+         * @warning This API is still experimental and subject to change.
+         */
+        bool debugVisualizeCascades = false;
+
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.
          */

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -205,13 +205,6 @@ public:
          */
         uint8_t shadowCascades = 1;
 
-        /**
-         * Visualize the shadow cascades through different colors.
-         *
-         * @warning This API is still experimental and subject to change.
-         */
-        bool debugVisualizeCascades = false;
-
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.
          */

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -50,8 +50,8 @@ Frustum::Frustum(const float3 corners[8]) {
     auto plane = [](float3 p1, float3 p2, float3 p3) {
         auto v12 = p2 - p1;
         auto v23 = p3 - p2;
-        auto n = cross(v12, v23);
-        return float4{normalize(n), dot(n, p1)};
+        auto n = normalize(cross(v12, v23));
+        return float4{n, -dot(n, p1)};
     };
 
     mPlanes[0] = plane(a, e, g);   // left

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -30,6 +30,38 @@ Frustum::Frustum(const mat4f& pv) {
     Frustum::setProjection(pv);
 }
 
+Frustum::Frustum(const float3 corners[8]) {
+    float3 a = corners[0];
+    float3 b = corners[1];
+    float3 c = corners[2];
+    float3 d = corners[3];
+    float3 e = corners[4];
+    float3 f = corners[5];
+    float3 g = corners[6];
+    float3 h = corners[7];
+
+    //     c----d
+    //    /|   /|
+    //   g----h |
+    //   | a--|-b
+    //   |/   |/
+    //   e----f
+
+    auto plane = [](float3 p1, float3 p2, float3 p3) {
+        auto v12 = p2 - p1;
+        auto v23 = p3 - p2;
+        auto n = cross(v12, v23);
+        return float4{normalize(n), dot(n, p1)};
+    };
+
+    mPlanes[0] = plane(a, e, g);   // left
+    mPlanes[1] = plane(f, b, d);   // right
+    mPlanes[2] = plane(a, b, f);   // bottom
+    mPlanes[3] = plane(g, h, d);   // top
+    mPlanes[4] = plane(a, c, d);   // far
+    mPlanes[5] = plane(e, f, h);   // near
+}
+
 // NOTE: if we don't specify noinline here, LLVM inlines this huge function into
 // two (?!) version of the Frustum(const mat4f& pv) constructor!
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -29,7 +29,14 @@ using namespace math;
 
 namespace details {
 
-ShadowMapManager::ShadowMapManager() : mTextureState(0, 0) {}
+ShadowMapManager::ShadowMapManager(FEngine& engine) : mTextureState(0, 0) {
+    for (size_t i = 0; i < mCascadeShadowMapCache.size(); i++) {
+        mCascadeShadowMapCache[i] = std::make_unique<ShadowMap>(engine);
+    }
+    for (size_t i = 0; i < mSpotShadowMapCache.size(); i++) {
+        mSpotShadowMapCache[i] = std::make_unique<ShadowMap>(engine);
+    }
+}
 
 ShadowMapManager::~ShadowMapManager() {
     assert(mRenderTargets.empty());
@@ -50,19 +57,20 @@ void ShadowMapManager::prepare(FEngine& engine, DriverApi& driver, SamplerGroup&
     };
 
     // Lay out the shadow maps. For now, we take the largest requested dimension and allocate a
-    // texture of that size. Each shadow map gets its own layer in the array texture. The
-    // directional shadow map is always on layer 0.
+    // texture of that size. Each cascade / shadow map gets its own layer in the array texture.
+    // The directional shadow cascades start on layer 0, followed by spot lights.
     uint8_t layer = 0;
     uint32_t maxDimension = 0;
-    if (mDirectionalShadowMap) {
-        uint32_t dim = getShadowMapSize(mDirectionalShadowMap.getLightIndex());
+    for (auto& cascade : mCascadeShadowMaps) {
+        // Shadow map size should be the same for all cascades.
+        const uint32_t dim = getShadowMapSize(cascade.getLightIndex());
         maxDimension = std::max(maxDimension, dim);
-        mDirectionalShadowMap.setLayout({
+        cascade.setLayout({
             .layer = layer++,
             .size = dim
         });
     }
-    for (auto & spotShadowMap : mSpotShadowMaps) {
+    for (auto& spotShadowMap : mSpotShadowMaps) {
         uint32_t dim = getShadowMapSize(spotShadowMap.getLightIndex());
         maxDimension = std::max(maxDimension, dim);
         spotShadowMap.setLayout({
@@ -112,62 +120,167 @@ void ShadowMapManager::prepare(FEngine& engine, DriverApi& driver, SamplerGroup&
             }});
 }
 
-void ShadowMapManager::destroyResources(DriverApi& driver) noexcept {
-    for (auto r : mRenderTargets) {
-        driver.destroyRenderTarget(r);
-    }
-    mRenderTargets.clear();
-    if (mShadowMapTexture) {
-        driver.destroyTexture(mShadowMapTexture);
-    }
-}
-
 bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perViewUb,
         UniformBuffer& shadowUb, FScene::RenderableSoa& renderableData,
         FScene::LightSoa& lightData) noexcept {
+    bool hasShadowing = false;
+    hasShadowing |= updateCascadeShadowMaps(engine, view, perViewUb, renderableData, lightData);
+    hasShadowing |= updateSpotShadowMaps(engine, view, shadowUb, renderableData, lightData);
+    return hasShadowing;
+}
+
+void ShadowMapManager::reset() noexcept {
+    mCascadeShadowMaps.clear();
+    mSpotShadowMaps.clear();
+}
+
+void ShadowMapManager::setShadowCascades(size_t lightIndex, size_t cascades) noexcept {
+    assert(cascades <= CONFIG_MAX_SHADOW_CASCADES);
+    for (size_t c = 0; c < cascades; c++) {
+        mCascadeShadowMaps.emplace_back(mCascadeShadowMapCache[c].get(), lightIndex);
+    }
+}
+
+void ShadowMapManager::addSpotShadowMap(size_t lightIndex) noexcept {
+    const size_t maps = mSpotShadowMaps.size();
+    assert(maps < CONFIG_MAX_SHADOW_CASTING_SPOTS);
+    mSpotShadowMaps.emplace_back(mSpotShadowMapCache[maps].get(), lightIndex);
+}
+
+void ShadowMapManager::render(FEngine& engine, FView& view, backend::DriverApi& driver,
+        RenderPass& pass) noexcept {
+    if (UTILS_UNLIKELY(engine.debug.shadowmap.checkerboard)) {
+        // TODO: eventually this will be handled as a optional pass in the framegraph
+        fillWithDebugPattern(driver, mShadowMapTexture);
+        return;
+    }
+
+    size_t currentRt = 0;
+    for (size_t i = 0; i < mCascadeShadowMaps.size(); i++, currentRt++) {
+        const auto& map = mCascadeShadowMaps[i];
+        if (!map.hasVisibleShadows()) {
+            continue;
+        }
+
+        const uint32_t dim = map.getLayout().size;
+        filament::Viewport viewport{1, 1, dim - 2, dim - 2};
+        map.getShadowMap()->render(driver, mRenderTargets[currentRt],
+                viewport, view.getVisibleDirectionalShadowCasters(), pass, view);
+    }
+    assert(mShadowMapTexture);
+    for (size_t i = 0; i < mSpotShadowMaps.size(); i++, currentRt++) {
+        const auto& map = mSpotShadowMaps[i];
+        if (!map.hasVisibleShadows()) {
+            continue;
+        }
+        const uint32_t dim = map.getLayout().size;
+        // we set a viewport with a 1-texel border for when we index outside of the texture
+        // DON'T CHANGE this unless ShadowMap::getTextureCoordsMapping() is updated too.
+        // see: ShadowMap::getTextureCoordsMapping()
+        // For floating-point depth textures, the 1-texel border could be set to FLOAT_MAX to avoid
+        // clamping in the shadow shader (see sampleDepth inside shadowing.fs). Unfortunately, the APIs
+        // don't seem let us clear depth attachments to anything greater than 1.0, so we'd need a way to
+        // do this other than clearing.
+        filament::Viewport viewport {1, 1, dim - 2, dim - 2};
+        pass.setVisibilityMask(VISIBLE_SPOT_SHADOW_CASTER_N(i));
+        map.getShadowMap()->render(driver, mRenderTargets[currentRt], viewport,
+                view.getVisibleSpotShadowCasters(), pass, view);
+        pass.clearVisibilityMask();
+    }
+}
+
+bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
+            UniformBuffer& perViewUb, FScene::RenderableSoa& renderableData,
+            FScene::LightSoa& lightData) noexcept {
     bool hasShadowing = false;
 
     FScene* scene = view.getScene();
     const CameraInfo& viewingCameraInfo = view.getCameraInfo();
     uint8_t visibleLayers = view.getVisibleLayers();
     const uint16_t textureSize = mTextureState.size;
+    auto& lcm = engine.getLightManager();
+
+    if (mCascadeShadowMaps.size() > 0) {
+        // Even if we have more than one cascade, we cull directional shadow casters against the
+        // entire camera frustum, as if we only had a single cascade.
+        ShadowMap& map = *mCascadeShadowMaps[0].getShadowMap();
+        const size_t textureDimension = mCascadeShadowMaps[0].getLayout().size;
+        const ShadowMap::ShadowMapLayout layout {
+                .zResolution = mTextureZResolution,
+                .atlasDimension = textureSize,
+                .textureDimension = textureDimension,
+                .shadowDimension = textureDimension - 2
+        };
+        map.update(lightData, 0, scene, viewingCameraInfo, visibleLayers,
+                layout, {});
+        Frustum const& frustum = map.getCamera().getFrustum();
+        FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
+                VISIBLE_DIR_SHADOW_CASTER_BIT);
+
+        // Set shadowBias, using the first directional cascade.
+        const float texelSizeWorldSpace = map.getTexelSizeWorldSpace();
+        const float normalBias = lcm.getShadowNormalBias(0);
+        perViewUb.setUniform(offsetof(PerViewUib, shadowBias),
+                float3{0, normalBias * texelSizeWorldSpace, 0});
+    }
+
+    // We divide the camera frustum into N cascades. This gives us N + 1 split positions.
+    // The first split position is the near plane; the last split position is the far plane.
+    const CascadeSplits::Params p {
+        .proj = viewingCameraInfo.cullingProjection,
+        .near = -viewingCameraInfo.zn,
+        .far = -viewingCameraInfo.zf,
+        .cascadeCount = mCascadeShadowMaps.size()
+    };
+    if (p != mCascadeSplitParams) {
+        mCascadeSplits = CascadeSplits(p);
+        mCascadeSplitParams = p;
+    }
+
+    const CascadeSplits& splits = mCascadeSplits;
+
+    // The split positions uniform is a float4. To save space, we chop off the first split position
+    // (which is the near plane, and doesn't need to be communicated to the shaders).
+    float4 wsSplitPositionUniform;
+    std::fill_n(&wsSplitPositionUniform[0], 4, -std::numeric_limits<float>::infinity());
+    std::copy(splits.beginWs() + 1, splits.endWs(), &wsSplitPositionUniform[0]);
+
+    float csSplitPosition[CONFIG_MAX_SHADOW_CASCADES + 1];
+    std::copy(splits.beginCs(), splits.endCs(), csSplitPosition);
+
+    // Update cascade split uniform.
+    perViewUb.setUniform(offsetof(PerViewUib, cascadeSplits), wsSplitPositionUniform);
 
     uint32_t directionalShadows = 0;
     float screenSpaceShadowDistance = 0.0;
+    for (size_t i = 0; i < mCascadeShadowMaps.size(); i++) {
+        auto& entry = mCascadeShadowMaps[i];
 
-    auto& lcm = engine.getLightManager();
-    if (mDirectionalShadowMap) {
         // Compute the frustum for the directional light.
-        ShadowMap& shadowMap = *mDirectionalShadowMap.getShadowMap();
-        size_t l = mDirectionalShadowMap.getLightIndex();
+        ShadowMap& shadowMap = *entry.getShadowMap();
+        size_t l = entry.getLightIndex();
         assert(l == 0);
 
         FLightManager::Instance light = lightData.elementAt<FScene::LIGHT_INSTANCE>(l);
 
-        const size_t textureDimension = mDirectionalShadowMap.getLayout().size;
+        const size_t textureDimension = entry.getLayout().size;
         const ShadowMap::ShadowMapLayout layout{
                 .zResolution = mTextureZResolution,
                 .atlasDimension = textureSize,
                 .textureDimension = textureDimension,
                 .shadowDimension = textureDimension - 2
         };
-        shadowMap.update(lightData, 0, scene, viewingCameraInfo, visibleLayers, layout);
+        ShadowMap::CascadeParameters cascadeParams {
+            .csNear = csSplitPosition[i],
+            .csFar = csSplitPosition[i + 1]
+        };
+        shadowMap.update(lightData, 0, scene, viewingCameraInfo, visibleLayers, layout, cascadeParams);
         if (shadowMap.hasVisibleShadows()) {
-            mDirectionalShadowMap.setHasVisibleShadows(true);
-
-            // Cull shadow casters
-            UniformBuffer& u = perViewUb;
-            Frustum const& frustum = shadowMap.getCamera().getFrustum();
-            FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
-                    VISIBLE_DIR_SHADOW_CASTER_BIT);
+            entry.setHasVisibleShadows(true);
 
             mat4f const& lightFromWorldMatrix = shadowMap.getLightSpaceMatrix();
-            u.setUniform(offsetof(PerViewUib, lightFromWorldMatrix), lightFromWorldMatrix);
-
-            const float texelSizeWorldSpace = shadowMap.getTexelSizeWorldSpace();
-            const float normalBias = lcm.getShadowNormalBias(light);
-            u.setUniform(offsetof(PerViewUib, shadowBias),
-                    float3{0, normalBias * texelSizeWorldSpace, 0});
+            perViewUb.setUniform(offsetof(PerViewUib, lightFromWorldMatrix) +
+                    sizeof(mat4f) * i, lightFromWorldMatrix);
 
             hasShadowing = true;
             directionalShadows |= 0x1u;
@@ -187,7 +300,27 @@ bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perVi
     perViewUb.setUniform(offsetof(PerViewUib, directionalShadows), directionalShadows);
     perViewUb.setUniform(offsetof(PerViewUib, ssContactShadowDistance), screenSpaceShadowDistance);
 
+    uint32_t cascades = 0;
+    if (options.debugVisualizeCascades) {
+        cascades |= 0x10u;
+    }
+    cascades |= uint32_t(mCascadeShadowMaps.size());
+    perViewUb.setUniform(offsetof(PerViewUib, cascades), cascades);
+
+    return hasShadowing;
+}
+
+bool ShadowMapManager::updateSpotShadowMaps(FEngine& engine, FView& view, UniformBuffer& shadowUb,
+        FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept {
+    bool hasShadowing = false;
+
+    FScene* scene = view.getScene();
+    const CameraInfo& viewingCameraInfo = view.getCameraInfo();
+    uint8_t visibleLayers = view.getVisibleLayers();
+    const uint16_t textureSize = mTextureState.size;
+
     // shadow-map shadows for point/spot lights
+    auto& lcm = engine.getLightManager();
     FScene::ShadowInfo* const shadowInfo = lightData.data<FScene::SHADOW_INFO>();
     for (size_t i = 0, c = mSpotShadowMaps.size(); i < c; i++) {
         auto& entry = mSpotShadowMaps[i];
@@ -203,7 +336,7 @@ bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perVi
                 .textureDimension = textureDimension,
                 .shadowDimension = textureDimension - 2
         };
-        shadowMap.update(lightData, l, scene, viewingCameraInfo, visibleLayers, layout);
+        shadowMap.update(lightData, l, scene, viewingCameraInfo, visibleLayers, layout, {});
 
         FLightManager::Instance light = lightData.elementAt<FScene::LIGHT_INSTANCE>(l);
         if (shadowMap.hasVisibleShadows()) {
@@ -248,59 +381,6 @@ bool ShadowMapManager::update(FEngine& engine, FView& view, UniformBuffer& perVi
     return hasShadowing;
 }
 
-void ShadowMapManager::reset() noexcept {
-    mDirectionalShadowMap = {};
-    mSpotShadowMaps.clear();
-}
-
-void ShadowMapManager::setDirectionalShadowMap(ShadowMap& shadowMap, size_t lightIndex) noexcept {
-    mDirectionalShadowMap = {&shadowMap, lightIndex};
-}
-
-void ShadowMapManager::addSpotShadowMap(ShadowMap& shadowMap, size_t lightIndex) noexcept {
-    mSpotShadowMaps.emplace_back(&shadowMap, lightIndex);
-}
-
-void ShadowMapManager::render(FEngine& engine, FView& view, backend::DriverApi& driver,
-        RenderPass& pass) noexcept {
-    if (UTILS_UNLIKELY(engine.debug.shadowmap.checkerboard)) {
-        // TODO: eventually this will be handled as a optional pass in the framegraph
-        fillWithDebugPattern(driver, mShadowMapTexture);
-        return;
-    }
-
-    size_t currentRt = 0;
-    if (mDirectionalShadowMap) {
-        if (mDirectionalShadowMap.hasVisibleShadows()) {
-            const uint32_t dim = mDirectionalShadowMap.getLayout().size;
-            filament::Viewport viewport{1, 1, dim - 2, dim - 2};
-            mDirectionalShadowMap.getShadowMap()->render(driver, mRenderTargets[currentRt],
-                    viewport, view.getVisibleDirectionalShadowCasters(), pass, view);
-        }
-        currentRt++;
-    }
-    assert(mShadowMapTexture);
-    for (size_t i = 0; i < mSpotShadowMaps.size(); i++, currentRt++) {
-        const auto& map = mSpotShadowMaps[i];
-        if (!map.hasVisibleShadows()) {
-            continue;
-        }
-        const uint32_t dim = map.getLayout().size;
-        // we set a viewport with a 1-texel border for when we index outside of the texture
-        // DON'T CHANGE this unless ShadowMap::getTextureCoordsMapping() is updated too.
-        // see: ShadowMap::getTextureCoordsMapping()
-        // For floating-point depth textures, the 1-texel border could be set to FLOAT_MAX to avoid
-        // clamping in the shadow shader (see sampleDepth inside shadowing.fs). Unfortunately, the APIs
-        // don't seem let us clear depth attachments to anything greater than 1.0, so we'd need a way to
-        // do this other than clearing.
-        filament::Viewport viewport {1, 1, dim - 2, dim - 2};
-        pass.setVisibilityMask(VISIBLE_SPOT_SHADOW_CASTER_N(i));
-        map.getShadowMap()->render(driver, mRenderTargets[currentRt], viewport,
-                view.getVisibleSpotShadowCasters(), pass, view);
-        pass.clearVisibilityMask();
-    }
-}
-
 UTILS_NOINLINE
 void ShadowMapManager::fillWithDebugPattern(backend::DriverApi& driverApi,
         Handle<HwTexture> texture) const noexcept {
@@ -316,6 +396,32 @@ void ShadowMapManager::fillWithDebugPattern(backend::DriverApi& driverApi,
         for (size_t x = 0; x < dim; ++x) {
             ptr[x + y * dim] = ((x ^ y) & 0x8u) ? 0u : 0xFFu;
         }
+    }
+}
+
+void ShadowMapManager::destroyResources(DriverApi& driver) noexcept {
+    for (auto r : mRenderTargets) {
+        driver.destroyRenderTarget(r);
+    }
+    mRenderTargets.clear();
+    if (mShadowMapTexture) {
+        driver.destroyTexture(mShadowMapTexture);
+    }
+}
+
+ShadowMapManager::CascadeSplits::CascadeSplits(Params p) : mSplitCount(p.cascadeCount + 1) {
+    auto uniformSplit = [](float near, float far, size_t cascades) {
+        return [near, far, cascades](size_t split) {
+            if (cascades == 0) {
+                return 0.0f;
+            }
+            return near + (far - near) * ((float) split / cascades);
+        };
+    };
+    auto uniformSplitCalculator = uniformSplit(p.near, p.far, p.cascadeCount);
+    for (size_t s = 0; s < mSplitCount; s++) {
+        mSplitsWs[s] = uniformSplitCalculator(s);
+        mSplitsCs[s] = mat4f::project(p.proj, float3(0.0f, 0.0f, mSplitsWs[s])).z;
     }
 }
 

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -36,6 +36,9 @@ ShadowMapManager::ShadowMapManager(FEngine& engine) : mTextureState(0, 0) {
     for (size_t i = 0; i < mSpotShadowMapCache.size(); i++) {
         mSpotShadowMapCache[i] = std::make_unique<ShadowMap>(engine);
     }
+    FDebugRegistry& debugRegistry = engine.getDebugRegistry();
+    debugRegistry.registerProperty("d.shadowmap.visualize_cascades",
+            &engine.debug.shadowmap.visualize_cascades);
 }
 
 ShadowMapManager::~ShadowMapManager() {
@@ -303,7 +306,7 @@ bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
     perViewUb.setUniform(offsetof(PerViewUib, ssContactShadowDistance), screenSpaceShadowDistance);
 
     uint32_t cascades = 0;
-    if (options.debugVisualizeCascades) {
+    if (engine.debug.shadowmap.visualize_cascades) {
         cascades |= 0x10u;
     }
     cascades |= uint32_t(mCascadeShadowMaps.size());

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -241,6 +241,8 @@ bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
 
     // The split positions uniform is a float4. To save space, we chop off the first split position
     // (which is the near plane, and doesn't need to be communicated to the shaders).
+    static_assert(CONFIG_MAX_SHADOW_CASCADES <= 5,
+            "At most, a float4 can fit 4 split positions for 5 shadow cascades");
     float4 wsSplitPositionUniform;
     std::fill_n(&wsSplitPositionUniform[0], 4, -std::numeric_limits<float>::infinity());
     std::copy(splits.beginWs() + 1, splits.endWs(), &wsSplitPositionUniform[0]);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -224,8 +224,9 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
     const bool hasDirectionalShadows = directionalLight && lcm.isShadowCaster(directionalLight);
     if (UTILS_UNLIKELY(hasDirectionalShadows)) {
         const auto& shadowOptions = lcm.getShadowOptions(directionalLight);
-        uint8_t cascades = clamp<uint8_t>(shadowOptions.shadowCascades, 1, CONFIG_MAX_SHADOW_CASCADES);
-        mShadowMapManager.setShadowCascades(0, cascades);
+        assert(shadowOptions.shadowCascades >= 1 &&
+                shadowOptions.shadowCascades <= CONFIG_MAX_SHADOW_CASCADES);
+        mShadowMapManager.setShadowCascades(0, shadowOptions.shadowCascades);
     }
 
     // Find all shadow-casting spot lights.

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -177,7 +177,7 @@ void FLightManager::create(const FLightManager::Builder& builder, utils::Entity 
 
         ShadowParams& shadowParams = manager[i].shadowParams;
         shadowParams.options.mapSize = clamp(builder->mShadowOptions.mapSize, 0u, 2048u);
-        shadowParams.options.shadowCascades = clamp<uint8_t>(builder->mShadowOptions.shadowCascades, 1, 4);
+        shadowParams.options.shadowCascades = clamp<uint8_t>(builder->mShadowOptions.shadowCascades, 1, CONFIG_MAX_SHADOW_CASCADES);
         shadowParams.options.constantBias = clamp(builder->mShadowOptions.constantBias, 0.0f, 2.0f);
         shadowParams.options.normalBias = clamp(builder->mShadowOptions.normalBias, 0.0f, 3.0f);
         shadowParams.options.shadowFar = std::max(builder->mShadowOptions.shadowFar, 0.0f);

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -177,6 +177,7 @@ void FLightManager::create(const FLightManager::Builder& builder, utils::Entity 
 
         ShadowParams& shadowParams = manager[i].shadowParams;
         shadowParams.options.mapSize = clamp(builder->mShadowOptions.mapSize, 0u, 2048u);
+        shadowParams.options.shadowCascades = clamp<uint8_t>(builder->mShadowOptions.shadowCascades, 1, 4);
         shadowParams.options.constantBias = clamp(builder->mShadowOptions.constantBias, 0.0f, 2.0f);
         shadowParams.options.normalBias = clamp(builder->mShadowOptions.normalBias, 0.0f, 3.0f);
         shadowParams.options.shadowFar = std::max(builder->mShadowOptions.shadowFar, 0.0f);

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -379,6 +379,7 @@ public:
             bool focus_shadowcasters = true;
             bool checkerboard = false;
             bool lispsm = true;
+            bool visualize_cascades = false;
             float dzn = -1.0f;
             float dzf =  1.0f;
         } shadowmap;

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -58,11 +58,16 @@ public:
         size_t shadowDimension = 0;
     };
 
+    struct CascadeParameters {
+        // the near and far planes, in clip space, to use for this shadow map
+        float csNear = -1.0f, csFar = 1.0f;
+    };
+
     // Call once per frame if the light, scene (or visible layers) or camera changes.
     // This computes the light's camera.
     void update(const FScene::LightSoa& lightData, size_t index, FScene const* scene,
             details::CameraInfo const& camera, uint8_t visibleLayers,
-            ShadowMapLayout layout) noexcept;
+            ShadowMapLayout layout, CascadeParameters cascadeParams) noexcept;
 
     void render(backend::DriverApi& driver, backend::Handle<backend::HwRenderTarget> rt,
             filament::Viewport const& viewport, utils::Range<uint32_t> const& range,
@@ -115,7 +120,7 @@ private:
     void computeShadowCameraDirectional(
             math::float3 const& direction, FScene const* scene,
             CameraInfo const& camera, FLightManager::ShadowParams const& params,
-            uint8_t visibleLayers) noexcept;
+            uint8_t visibleLayers, CascadeParameters cascadeParams) noexcept;
     void computeShadowCameraSpot(math::float3 const& position, math::float3 const& dir,
             float outerConeAngle, float radius, CameraInfo const& camera,
             FLightManager::ShadowParams const& params) noexcept;
@@ -130,7 +135,7 @@ private:
             math::mat4f const& Mv, math::float3 worldOrigin, math::float2 shadowMapResolution) noexcept;
 
     static inline void computeFrustumCorners(math::float3* out,
-            const math::mat4f& projectionViewInverse) noexcept;
+            const math::mat4f& projectionViewInverse, float csNear = -1.0f, float csFar = 1.0f) noexcept;
 
     static inline math::float2 computeNearFar(math::mat4f const& view,
             Aabb const& wsShadowCastersVolume) noexcept;
@@ -167,12 +172,10 @@ private:
             math::float3 t0, math::float3 t1, math::float3 t2) noexcept;
 
     static size_t intersectFrustum(math::float3* out, size_t vertexCount,
-            math::float3 const* segmentsVertices, math::float3 const* quadsVertices,
-            Frustum const& frustum) noexcept;
+            math::float3 const* segmentsVertices, math::float3 const* quadsVertices) noexcept;
 
     static size_t intersectFrustumWithBox(
             FrustumBoxIntersection& outVertices,
-            const Frustum& frustum,
             const math::float3* wsFrustumCorners,
             Aabb const& wsBox);
 

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -60,7 +60,8 @@ public:
 
     struct CascadeParameters {
         // the near and far planes, in clip space, to use for this shadow map
-        float csNear = -1.0f, csFar = 1.0f;
+        float csNear = -1.0f;
+        float csFar = 1.0f;
     };
 
     // Call once per frame if the light, scene (or visible layers) or camera changes.

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -24,11 +24,15 @@
 #include <private/backend/SamplerGroup.h>
 #include <private/backend/SamplerGroup.h>
 
+#include <private/filament/EngineEnums.h>
+
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
 
 #include <math/vec3.h>
 
+#include <array>
+#include <memory>
 #include <vector>
 
 namespace filament {
@@ -43,7 +47,7 @@ class RenderPass;
 class ShadowMapManager {
 public:
 
-    ShadowMapManager();
+    ShadowMapManager(FEngine& engine);
     ~ShadowMapManager();
 
     void terminate(backend::DriverApi& driverApi) noexcept;
@@ -51,8 +55,8 @@ public:
     // Reset shadow map layout.
     void reset() noexcept;
 
-    void setDirectionalShadowMap(ShadowMap& shadowMap, size_t lightIndex) noexcept;
-    void addSpotShadowMap(ShadowMap& shadowMap, size_t lightIndex) noexcept;
+    void setShadowCascades(size_t lightIndex, size_t cascades) noexcept;
+    void addSpotShadowMap(size_t lightIndex) noexcept;
 
     // Allocates shadow texture based on the shadows maps and their requirements.
     void prepare(FEngine& engine, backend::DriverApi& driver, backend::SamplerGroup& samplerGroup,
@@ -66,8 +70,16 @@ public:
     // Renders all of the shadow maps.
     void render(FEngine& engine, FView& view, backend::DriverApi& driver, RenderPass& pass) noexcept;
 
+    const ShadowMap* getCascadeShadowMap(size_t c) const noexcept {
+        return mCascadeShadowMapCache[c].get();
+    }
+
 private:
 
+    bool updateCascadeShadowMaps(FEngine& engine, FView& view, UniformBuffer& perViewUb,
+            FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
+    bool updateSpotShadowMaps(FEngine& engine, FView& view, UniformBuffer& shadowUb,
+            FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
     void fillWithDebugPattern(backend::DriverApi& driverApi,
             backend::Handle<backend::HwTexture> texture) const noexcept;
     void destroyResources(backend::DriverApi& driver) noexcept;
@@ -114,6 +126,37 @@ private:
         }
     } mTextureState;
 
+    class CascadeSplits {
+    public:
+        struct Params {
+            math::mat4f proj = {};
+            float near = 0.0f;
+            float far = 0.0f;
+            size_t cascadeCount = 1;
+
+            bool operator!=(const Params& rhs) const {
+                return proj != rhs.proj ||
+                       near != rhs.near ||
+                       far != rhs.far ||
+                       cascadeCount != rhs.cascadeCount;
+            }
+        };
+
+        CascadeSplits(Params p = {});
+
+        const float* beginWs() const { return mSplitsWs; }
+        const float* endWs() const { return mSplitsWs + mSplitCount; }
+        const float* beginCs() const { return mSplitsCs; }
+        const float* endCs() const { return mSplitsCs + mSplitCount; }
+
+    private:
+        float mSplitsWs[CONFIG_MAX_SHADOW_CASCADES + 1];
+        float mSplitsCs[CONFIG_MAX_SHADOW_CASCADES + 1];
+        size_t mSplitCount;
+
+    } mCascadeSplits;
+    CascadeSplits::Params mCascadeSplitParams;
+
     // 16-bits seems enough.
     // TODO: make it an option.
     // TODO: iOS does not support the DEPTH16 texture format.
@@ -122,8 +165,11 @@ private:
 
     backend::Handle<backend::HwTexture> mShadowMapTexture;
     std::vector<backend::Handle<backend::HwRenderTarget>> mRenderTargets;
-    ShadowMapEntry mDirectionalShadowMap;
+    std::vector<ShadowMapEntry> mCascadeShadowMaps;
     std::vector<ShadowMapEntry> mSpotShadowMaps;
+
+    std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASCADES> mCascadeShadowMapCache;
+    std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASTING_SPOTS> mSpotShadowMapCache;
 };
 
 }

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -142,7 +142,8 @@ private:
             }
         };
 
-        CascadeSplits(Params p = {});
+        CascadeSplits() : CascadeSplits(Params {}) {}
+        CascadeSplits(Params p);
 
         const float* beginWs() const { return mSplitsWs; }
         const float* endWs() const { return mSplitsWs + mSplitCount; }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -46,9 +46,6 @@
 
 #include <math/scalar.h>
 
-#include <array>
-#include <memory>
-
 namespace utils {
 class JobSystem;
 } // namespace utils;
@@ -174,7 +171,7 @@ public:
     void setShadowsEnabled(bool enabled) noexcept { mShadowingEnabled = enabled; }
 
     FCamera const* getDirectionalLightCamera() const noexcept {
-        return &mDirectionalShadowMap.getDebugCamera();
+        return &mShadowMapManager.getCascadeShadowMap(0)->getDebugCamera();
     }
 
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
@@ -411,9 +408,8 @@ private:
     mutable bool mHasDirectionalLight = false;
     mutable bool mHasDynamicLighting = false;
     mutable bool mHasShadowing = false;
+
     ShadowMapManager mShadowMapManager;
-    mutable ShadowMap mDirectionalShadowMap;
-    mutable std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASTING_SPOTS> mSpotShadowMap;
 };
 
 FILAMENT_UPCAST(View)

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 6;
+static constexpr size_t MATERIAL_VERSION = 7;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -55,6 +55,9 @@ constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 // values may cause the number of varyings to exceed the driver limit.
 constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 2;
 
+// The maximum number of shadow cascades that can be used for directional lights.
+constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
+
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
 // We store 64 bytes per bone.
 constexpr size_t CONFIG_MAX_BONE_COUNT = 256;

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -53,6 +53,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     filament::math::mat4f worldFromClipMatrix;
     filament::math::mat4f lightFromWorldMatrix[CONFIG_MAX_SHADOW_CASCADES];
 
+    // position of cascade splits, in world space (not including the near plane)
+    // -Inf stored in unused components
     filament::math::float4 cascadeSplits;
 
     filament::math::float4 resolution; // viewport width, height, 1/width, 1/height

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -51,7 +51,9 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     filament::math::mat4f viewFromClipMatrix;
     filament::math::mat4f clipFromWorldMatrix;
     filament::math::mat4f worldFromClipMatrix;
-    filament::math::mat4f lightFromWorldMatrix;
+    filament::math::mat4f lightFromWorldMatrix[CONFIG_MAX_SHADOW_CASCADES];
+
+    filament::math::float4 cascadeSplits;
 
     filament::math::float4 resolution; // viewport width, height, 1/width, 1/height
 
@@ -107,12 +109,17 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float fogInscatteringStart;
     float fogInscatteringSize;
     float fogColorFromIbl;
-    float padding1;
 
-    // bring PerViewUib to 1 KiB
-    filament::math::float4 padding2[12];
+    // bit 0-4: cascade count
+    // bit 8: visualize cascades
+    uint32_t cascades;
+
+    // bring PerViewUib to 2 KiB
+    filament::math::float4 padding2[63];
 };
 
+// 2 KiB == 128 float4s
+static_assert(sizeof(PerViewUib) == sizeof(filament::math::float4) * 128);
 
 // PerRenderableUib must have an alignment of 256 to be compatible with all versions of GLES.
 struct alignas(256) PerRenderableUib {

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -119,7 +119,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 };
 
 // 2 KiB == 128 float4s
-static_assert(sizeof(PerViewUib) == sizeof(filament::math::float4) * 128);
+static_assert(sizeof(PerViewUib) == sizeof(filament::math::float4) * 128,
+        "PerViewUib should be exactly 2KiB");
 
 // PerRenderableUib must have an alignment of 256 to be compatible with all versions of GLES.
 struct alignas(256) PerRenderableUib {

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -31,6 +31,8 @@ static_assert(sizeof(PerRenderableUib) % 256 == 0,
 static_assert(CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone) <= 16384,
         "Bones exceed max UBO size");
 
+static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
+        "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
 UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     // IMPORTANT NOTE: Respect std140 layout, don't update without updating Engine::PerViewUib
@@ -43,7 +45,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("viewFromClipMatrix",      1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("clipFromWorldMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromClipMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("lightFromWorldMatrix",    CONFIG_MAX_SHADOW_CASCADES, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add("lightFromWorldMatrix",    4, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("cascadeSplits",           1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             // view
             .add("resolution",              1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -43,7 +43,8 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("viewFromClipMatrix",      1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("clipFromWorldMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromClipMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("lightFromWorldMatrix",    1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add("lightFromWorldMatrix",    CONFIG_MAX_SHADOW_CASCADES, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add("cascadeSplits",           1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             // view
             .add("resolution",              1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             // camera
@@ -92,7 +93,9 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("fogInscatteringSize",     1, UniformInterfaceBlock::Type::FLOAT)
             // more camera stuff
             .add("fogColorFromIbl",         1, UniformInterfaceBlock::Type::FLOAT)
-            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT)
+
+            // CSM information
+            .add("cascades",                1, UniformInterfaceBlock::Type::UINT)
 
             // bring size to 1 KiB
             .add("padding2",                12, UniformInterfaceBlock::Type::FLOAT4)

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -113,7 +113,6 @@ io::sstream& CodeGenerator::generateEpilog(io::sstream& out) const {
 
 io::sstream& CodeGenerator::generateShaderMain(io::sstream& out, ShaderType type) const {
     if (type == ShaderType::VERTEX) {
-        out << SHADERS_SHADOWING_VS_DATA;
         out << SHADERS_MAIN_VS_DATA;
     } else if (type == ShaderType::FRAGMENT) {
         out << SHADERS_MAIN_FS_DATA;
@@ -391,6 +390,7 @@ io::sstream& CodeGenerator::generateMaterialProperty(io::sstream& out,
 
 io::sstream& CodeGenerator::generateCommon(io::sstream& out, ShaderType type) const {
     out << SHADERS_COMMON_MATH_FS_DATA;
+    out << SHADERS_COMMON_SHADOWING_FS_DATA;
     if (type == ShaderType::VERTEX) {
     } else if (type == ShaderType::FRAGMENT) {
         out << SHADERS_COMMON_SHADING_FS_DATA;

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -25,6 +25,7 @@
 // to one of your CPP source files to create the implementation. See gltf_viewer.cpp for an example.
 
 #include <filament/Box.h>
+#include <filament/DebugRegistry.h>
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
 #include <filament/Scene.h>
@@ -195,6 +196,7 @@ private:
     bool mEnableWireframe = false;
     bool mEnableSunlight = true;
     bool mEnableShadows = true;
+    int mShadowCascades = 1;
     bool mEnableContactShadows = false;
     bool mEnableDithering = true;
     bool mEnableFxaa = true;
@@ -472,6 +474,8 @@ void SimpleViewer::updateUserInterface() {
         mCustomUI();
     }
 
+    DebugRegistry& debug = mEngine->getDebugRegistry();
+
     if (ImGui::CollapsingHeader("View")) {
         ImGui::Checkbox("Dithering", &mEnableDithering);
         ImGui::Checkbox("FXAA", &mEnableFxaa);
@@ -487,6 +491,8 @@ void SimpleViewer::updateUserInterface() {
         ImGuiExt::DirectionWidget("Sun direction", mSunlightDirection.v);
         ImGui::Checkbox("Enable sunlight", &mEnableSunlight);
         ImGui::Checkbox("Enable shadows", &mEnableShadows);
+        ImGui::SliderInt("Cascades", &mShadowCascades, 1, 4);
+        ImGui::Checkbox("Debug Cascades", debug.getPropertyAddress<bool>("d.shadowmap.visualize_cascades"));
         ImGui::Checkbox("Enable contact shadows", &mEnableContactShadows);
     }
 
@@ -524,6 +530,7 @@ void SimpleViewer::updateUserInterface() {
     lm.forEachComponent([this, &lm](utils::Entity e, LightManager::Instance ci) {
         auto options = lm.getShadowOptions(ci);
         options.screenSpaceContactShadows = mEnableContactShadows;
+        options.shadowCascades = mShadowCascades;
         lm.setShadowOptions(ci, options);
         lm.setShadowCaster(ci, mEnableShadows);
     });

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SHADERS
         src/common_material.fs
         src/common_math.fs
         src/common_shading.fs
+        src/common_shadowing.fs
         src/common_types.fs
         src/depth_main.fs
         src/depth_main.vs
@@ -45,8 +46,7 @@ set(SHADERS
         src/shading_model_subsurface.fs
         src/shading_parameters.fs
         src/shading_unlit.fs
-        src/shadowing.fs
-        src/shadowing.vs)
+        src/shadowing.fs)
 
 # These files aren't part of libshaders, but are included by materials inside
 # filament/src/materials:

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -97,3 +97,19 @@ vec3 heatmap(float v) {
     vec3 r = v * 2.1 - vec3(1.8, 1.14, 0.3);
     return 1.0 - r * r;
 }
+
+vec3 uintToColorDebug(uint v) {
+    if (v == 0) {
+        return vec3(0.0, 1.0, 0.0);     // green
+    } else if (v == 1) {
+        return vec3(0.0, 0.0, 1.0);     // blue
+    } else if (v == 2) {
+        return vec3(1.0, 1.0, 0.0);     // yellow
+    } else if (v == 3) {
+        return vec3(1.0, 0.0, 0.0);     // red
+    } else if (v == 4) {
+        return vec3(1.0, 0.0, 1.0);     // purple
+    } else if (v == 5) {
+        return vec3(0.0, 1.0, 1.0);     // cyan
+    }
+}

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -99,17 +99,17 @@ vec3 heatmap(float v) {
 }
 
 vec3 uintToColorDebug(uint v) {
-    if (v == 0) {
+    if (v == 0u) {
         return vec3(0.0, 1.0, 0.0);     // green
-    } else if (v == 1) {
+    } else if (v == 1u) {
         return vec3(0.0, 0.0, 1.0);     // blue
-    } else if (v == 2) {
+    } else if (v == 2u) {
         return vec3(1.0, 1.0, 0.0);     // yellow
-    } else if (v == 3) {
+    } else if (v == 3u) {
         return vec3(1.0, 0.0, 0.0);     // red
-    } else if (v == 4) {
+    } else if (v == 4u) {
         return vec3(1.0, 0.0, 1.0);     // purple
-    } else if (v == 5) {
+    } else if (v == 5u) {
         return vec3(0.0, 1.0, 1.0);     // cyan
     }
 }

--- a/shaders/src/common_shadowing.fs
+++ b/shaders/src/common_shadowing.fs
@@ -9,7 +9,7 @@
  * shadowing artifacts such as "acne". To achieve this, the world space
  * normal at the point must also be passed to this function.
  */
-vec4 getLightSpacePosition(const vec3 p, const vec3 n, const vec3 l, const float b,
+vec4 computeLightSpacePosition(const vec3 p, const vec3 n, const vec3 l, const float b,
         const mat4 lightFromWorldMatrix) {
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -115,7 +115,7 @@ bool isDoubleSided() {
 uint getShadowCascade() {
     vec3 viewPos = mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).xyz;
     bvec4 greaterZ = greaterThan(frameUniforms.cascadeSplits, vec4(viewPos.z));
-    uint cascadeCount = frameUniforms.cascades & 0xF;
+    uint cascadeCount = frameUniforms.cascades & 0xFu;
     return clamp(uint(dot(vec4(greaterZ), vec4(1.0))), 0u, cascadeCount - 1u);
 }
 
@@ -125,7 +125,7 @@ highp vec3 getCascadeLightSpacePosition(uint cascade) {
     // For the first cascade, return the interpolated light space position.
     // This branch will be coherent (mostly) for neighboring fragments, and it's worth avoiding
     // the matrix multiply inside computeLightSpacePosition.
-    if (cascade == 0) {
+    if (cascade == 0u) {
         return getLightSpacePosition();
     }
 

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -108,3 +108,31 @@ bool isDoubleSided() {
     return materialParams._doubleSided;
 }
 #endif
+
+/**
+ * Returns the cascade index for this fragment (between 0 and CONFIG_MAX_SHADOW_CASCADES - 1).
+ */
+uint getShadowCascade() {
+    vec3 viewPos = mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).xyz;
+    bvec4 greaterZ = greaterThan(frameUniforms.cascadeSplits, vec4(viewPos.z));
+    uint cascadeCount = frameUniforms.cascades & 0xF;
+    return clamp(uint(dot(vec4(greaterZ), vec4(1.0))), 0u, cascadeCount - 1u);
+}
+
+#if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
+
+highp vec3 getCascadeLightSpacePosition(uint cascade) {
+    // For the first cascade, return the interpolated light space position.
+    // This branch will be coherent (mostly) for neighboring fragments, and it's worth avoiding
+    // the matrix multiply inside computeLightSpacePosition.
+    if (cascade == 0) {
+        return getLightSpacePosition();
+    }
+
+    highp vec4 pos = computeLightSpacePosition(getWorldPosition(), getWorldNormalVector(),
+        frameUniforms.lightDirection, frameUniforms.shadowBias.y,
+        frameUniforms.lightFromWorldMatrix[cascade]);
+    return pos.xyz * (1.0 / pos.w);
+}
+
+#endif

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -3,7 +3,7 @@
 //------------------------------------------------------------------------------
 
 mat4 getLightFromWorldMatrix() {
-    return frameUniforms.lightFromWorldMatrix;
+    return frameUniforms.lightFromWorldMatrix[0];
 }
 
 #if defined(HAS_SHADOWING)

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -41,7 +41,9 @@ void evaluateDirectionalLight(const MaterialInputs material,
         float ssContactShadowOcclusion = 0.0;
 
         if ((frameUniforms.directionalShadows & 1u) != 0u) {
-            visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
+            uint cascade = getShadowCascade();
+            uint layer = cascade;
+            visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
         }
         if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
             if (objectUniforms.screenSpaceContactShadows != 0u) {

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -28,6 +28,11 @@ void main() {
 
     fragColor = evaluateMaterial(inputs);
 
+    bool visualizeCascades = bool(frameUniforms.cascades & 0x10);
+    if (visualizeCascades) {
+        fragColor.rgb *= uintToColorDebug(getShadowCascade());
+    }
+
 #if defined(HAS_FOG)
     vec3 view = getWorldPosition() - getWorldCameraPosition();
     fragColor = fog(fragColor, view);

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -28,7 +28,7 @@ void main() {
 
     fragColor = evaluateMaterial(inputs);
 
-    bool visualizeCascades = bool(frameUniforms.cascades & 0x10);
+    bool visualizeCascades = bool(frameUniforms.cascades & 0x10u);
     if (visualizeCascades) {
         fragColor.rgb *= uintToColorDebug(getShadowCascade());
     }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -88,7 +88,7 @@ void main() {
 #endif
 
 #if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
-    vertex_lightSpacePosition = getLightSpacePosition(vertex_worldPosition, vertex_worldNormal,
+    vertex_lightSpacePosition = computeLightSpacePosition(vertex_worldPosition, vertex_worldNormal,
             frameUniforms.lightDirection, frameUniforms.shadowBias.y, getLightFromWorldMatrix());
 #endif
 
@@ -96,7 +96,7 @@ void main() {
     for (uint l = 0u; l < uint(MAX_SHADOW_CASTING_SPOTS); l++) {
         vec3 dir = shadowUniforms.directionShadowBias[l].xyz;
         float bias = shadowUniforms.directionShadowBias[l].w;
-        vertex_spotLightSpacePosition[l] = getLightSpacePosition(vertex_worldPosition,
+        vertex_spotLightSpacePosition[l] = computeLightSpacePosition(vertex_worldPosition,
                 vertex_worldNormal, dir, bias, getSpotLightFromWorldMatrix(l));
     }
 #endif

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -35,7 +35,9 @@ vec4 evaluateMaterial(const MaterialInputs material) {
 #if defined(HAS_SHADOWING)
     float visibility = 1.0;
     if ((frameUniforms.directionalShadows & 1u) != 0u) {
-        visibility = shadow(light_shadowMap, 0u, getLightSpacePosition());
+        uint cascade = getShadowCascade();
+        uint layer = cascade;
+        visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
     }
     if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
         if (objectUniforms.screenSpaceContactShadows != 0u) {


### PR DESCRIPTION
![CSM](https://user-images.githubusercontent.com/5298046/81019143-de69f000-8e1a-11ea-97f8-6d6502323162.png)

This adds basic CSM support with a uniform split scheme, and no blending between cascades.