### PR TITLE
remove CreateEliminateDeadMembersPass which breaks UBO layout

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -421,7 +421,8 @@ void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer) const {
             .RegisterPass(CreateCopyPropagateArraysPass())
             .RegisterPass(CreateVectorDCEPass())
             .RegisterPass(CreateDeadInsertElimPass())
-            .RegisterPass(CreateEliminateDeadMembersPass())
+            // this breaks UBO layout
+            //.RegisterPass(CreateEliminateDeadMembersPass())
             .RegisterPass(CreateLocalSingleStoreElimPass())
             .RegisterPass(CreateBlockMergePass())
             .RegisterPass(CreateLocalMultiStoreElimPass())


### PR DESCRIPTION
this fixes a crasher when using --optimize-size