### PR TITLE
fix JNI objects allocation and memory corruption

### DIFF
--- a/android/common/CallbackUtils.cpp
+++ b/android/common/CallbackUtils.cpp
@@ -34,8 +34,7 @@ static void initCallbackJni(JNIEnv* env, CallbackJni& callbackUtils) {
 
 JniBufferCallback* JniBufferCallback::make(filament::Engine* engine,
         JNIEnv* env, jobject handler, jobject callback, AutoBuffer&& buffer) {
-    void* that = engine->streamAlloc(sizeof(JniBufferCallback), alignof(JniBufferCallback));
-    return new (that) JniBufferCallback(env, handler, callback, std::move(buffer));
+    return new JniBufferCallback(env, handler, callback, std::move(buffer));
 }
 
 JniBufferCallback::JniBufferCallback(JNIEnv* env, jobject handler, jobject callback,
@@ -68,14 +67,14 @@ JniBufferCallback::~JniBufferCallback() {
 
 void JniBufferCallback::invoke(void*, size_t, void* user) {
     JniBufferCallback* data = reinterpret_cast<JniBufferCallback*>(user);
-    // don't call delete here, because we don't own the storage
-    data->~JniBufferCallback();
+    delete data;
 }
+
+// -----------------------------------------------------------------------------------------------
 
 JniImageCallback* JniImageCallback::make(filament::Engine* engine,
         JNIEnv* env, jobject handler, jobject callback, long image) {
-    void* that = engine->streamAlloc(sizeof(JniImageCallback), alignof(JniImageCallback));
-    return new (that) JniImageCallback(env, handler, callback, image);
+    return new JniImageCallback(env, handler, callback, image);
 }
 
 JniImageCallback::JniImageCallback(JNIEnv* env, jobject handler, jobject callback, long image)
@@ -106,5 +105,6 @@ JniImageCallback::~JniImageCallback() {
 }
 
 void JniImageCallback::invoke(void*, void* user) {
-    reinterpret_cast<JniImageCallback*>(user)->~JniImageCallback();
+    JniImageCallback* data = reinterpret_cast<JniImageCallback*>(user);
+    delete data;
 }

--- a/android/common/CallbackUtils.h
+++ b/android/common/CallbackUtils.h
@@ -40,6 +40,8 @@ struct JniBufferCallback {
 
 private:
     JniBufferCallback(JNIEnv* env, jobject handler, jobject callback, AutoBuffer&& buffer);
+    JniBufferCallback(JniBufferCallback const &) = delete;
+    JniBufferCallback(JniBufferCallback&&) = delete;
     ~JniBufferCallback();
 
     JNIEnv* mEnv;
@@ -57,6 +59,8 @@ struct JniImageCallback {
 
 private:
     JniImageCallback(JNIEnv* env, jobject handler, jobject runnable, long image);
+    JniImageCallback(JniBufferCallback const &) = delete;
+    JniImageCallback(JniBufferCallback&&) = delete;
     ~JniImageCallback();
 
     JNIEnv* mEnv;

--- a/android/common/NioUtils.cpp
+++ b/android/common/NioUtils.cpp
@@ -112,6 +112,7 @@ AutoBuffer::AutoBuffer(AutoBuffer &&rhs) noexcept {
     std::swap(mShift, rhs.mShift);
     std::swap(mBuffer, rhs.mBuffer);
     std::swap(mBaseArray, rhs.mBaseArray);
+    std::swap(mNioUtils, rhs.mNioUtils);
 }
 
 AutoBuffer::~AutoBuffer() noexcept {

--- a/android/common/NioUtils.h
+++ b/android/common/NioUtils.h
@@ -72,5 +72,5 @@ private:
         jmethodID getBaseArray;
         jmethodID getBaseArrayOffset;
         jmethodID getBufferType;
-    } mNioUtils;
+    } mNioUtils{};
 };

--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -446,12 +446,11 @@ public:
 
     static void invoke(void* buffer, size_t n, void* user) {
         AutoBitmap* data = reinterpret_cast<AutoBitmap*>(user);
-        data->~AutoBitmap();
+        delete data;
     }
 
     static AutoBitmap* make(Engine* engine, JNIEnv* env, jobject bitmap) {
-        void* that = engine->streamAlloc(sizeof(AutoBitmap), alignof(AutoBitmap));
-        return new (that) AutoBitmap(env, bitmap);
+        return new AutoBitmap(env, bitmap);
     }
 
 private:


### PR DESCRIPTION
- we were allocating objects with a destructor in the command stream
  which is always invalid because there is no guarantee that when 
  the callback is called, the underlaying memory is still valid
  (and it wasn't).

- AutoBuffer move-ctor wasn't moving some of its state, which would
  lead to destroying the same ref several times.