### PR TITLE
Fix, don't sample from cascades without visible shadows

### DIFF
--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -257,6 +257,7 @@ bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
     perViewUb.setUniform(offsetof(PerViewUib, cascadeSplits), wsSplitPositionUniform);
 
     uint32_t directionalShadows = 0;
+    uint32_t cascadeHasVisibleShadows = 0;
     float screenSpaceShadowDistance = 0.0;
     for (size_t i = 0; i < mCascadeShadowMaps.size(); i++) {
         auto& entry = mCascadeShadowMaps[i];
@@ -289,6 +290,7 @@ bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
 
             hasShadowing = true;
             directionalShadows |= 0x1u;
+            cascadeHasVisibleShadows |= 0x1u << i;
         }
     }
 
@@ -310,6 +312,7 @@ bool ShadowMapManager::updateCascadeShadowMaps(FEngine& engine, FView& view,
         cascades |= 0x10u;
     }
     cascades |= uint32_t(mCascadeShadowMaps.size());
+    cascades |= cascadeHasVisibleShadows << 8u;
     perViewUb.setUniform(offsetof(PerViewUib, cascades), cascades);
 
     return hasShadowing;

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -112,8 +112,9 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float fogInscatteringSize;
     float fogColorFromIbl;
 
-    // bit 0-4: cascade count
-    // bit 8: visualize cascades
+    // bit 0-3: cascade count
+    // bit 4: visualize cascades
+    // bit 8-11: cascade has visible shadows
     uint32_t cascades;
 
     // bring PerViewUib to 2 KiB

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -295,6 +295,7 @@ void SimpleViewer::populateScene(FilamentAsset* asset, bool scale) {
     while (size_t numWritten = mAsset->popRenderables(renderables, kNumAvailable)) {
         for (size_t i = 0; i < numWritten; i++) {
             auto ri = tcm.getInstance(renderables[i]);
+            tcm.setCastShadows(ri, false);
             tcm.setScreenSpaceContactShadows(ri, true);
         }
         mScene->addEntities(renderables, numWritten);
@@ -374,6 +375,9 @@ void SimpleViewer::updateUserInterface() {
             mScene->remove(entity);
         }
         auto instance = rm.getInstance(entity);
+        bool scaster = rm.isShadowCaster(instance);
+        ImGui::Checkbox("casts shadows", &scaster);
+        rm.setCastShadows(instance, scaster);
         size_t numPrims = rm.getPrimitiveCount(instance);
         for (size_t prim = 0; prim < numPrims; ++prim) {
             const Material* mat = rm.getMaterialInstanceAt(instance, prim)->getMaterial();

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -40,8 +40,10 @@ void evaluateDirectionalLight(const MaterialInputs material,
     if (light.NoL > 0.0) {
         float ssContactShadowOcclusion = 0.0;
 
-        if ((frameUniforms.directionalShadows & 1u) != 0u) {
-            uint cascade = getShadowCascade();
+        uint cascade = getShadowCascade();
+        bool cascadeHasVisibleShadows = bool(frameUniforms.cascades & (1u << cascade << 8u));
+        bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1u);
+        if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             uint layer = cascade;
             visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
         }


### PR DESCRIPTION
There were a few bugs sampling from an outdated shadow cascades. We should only sample from cascades that have visible shadows, otherwise the shadow layer may have garbage.