### PR TITLE
gltfio: use the new material name feature.

### DIFF
--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -380,8 +380,7 @@ void SimpleViewer::updateUserInterface() {
         rm.setCastShadows(instance, scaster);
         size_t numPrims = rm.getPrimitiveCount(instance);
         for (size_t prim = 0; prim < numPrims; ++prim) {
-            const Material* mat = rm.getMaterialInstanceAt(instance, prim)->getMaterial();
-            const char* mname = mat->getName();
+            const char* mname = rm.getMaterialInstanceAt(instance, prim)->getName();
             if (mname) {
                 ImGui::Text("prim %zu: material %s", prim, mname);
             } else {

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -381,9 +381,9 @@ MaterialInstance* MaterialGenerator::createMaterialInstance(MaterialKey* config,
         Material* mat = createMaterial(mEngine, *config, *uvmap, label);
         mCache.emplace(std::make_pair(*config, mat));
         mMaterials.push_back(mat);
-        return mat->createInstance();
+        return mat->createInstance(label);
     }
-    return iter->second->createInstance();
+    return iter->second->createInstance(label);
 }
 
 } // anonymous namespace

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -149,7 +149,7 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
         return hasTexture ? int(uvmap->at(srcIndex)) - 1 : -1;
     };
     Material* material = getMaterial(*config);
-    MaterialInstance* mi = material->createInstance();
+    MaterialInstance* mi = material->createInstance(label);
     mi->setParameter("baseColorIndex",
             getUvIndex(config->baseColorUV, config->hasBaseColorTexture));
     mi->setParameter("normalIndex", getUvIndex(config->normalUV, config->hasNormalTexture));


### PR DESCRIPTION
To see proof that this works, use gltf_viewer with -u and examine the
node hierarchy. You will now see the correct material names instead of
the ubershader names.