### PR TITLE
gltfio: expose getMaterialInstances to Java.

### DIFF
--- a/android/filament-android/src/main/cpp/MaterialInstance.cpp
+++ b/android/filament-android/src/main/cpp/MaterialInstance.cpp
@@ -356,3 +356,11 @@ Java_com_google_android_filament_MaterialInstance_nGetName(JNIEnv* env, jclass,
     MaterialInstance* instance = (MaterialInstance*) nativeMaterialInstance;
     return env->NewStringUTF(instance->getName());
 }
+
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_MaterialInstance_nGetMaterial(JNIEnv* env, jclass,
+        jlong nativeMaterialInstance) {
+    MaterialInstance* instance = (MaterialInstance*) nativeMaterialInstance;
+    return (jlong) instance->getMaterial();
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
@@ -54,9 +54,10 @@ public class MaterialInstance {
         mNativeObject = nativeMaterialInstance;
     }
 
-    MaterialInstance(long nativeMaterial, long nativeMaterialInstance) {
-        mNativeMaterial = nativeMaterial;
+    // public so that the gltfio Java layer can use this
+    public MaterialInstance(long nativeMaterialInstance) {
         mNativeObject = nativeMaterialInstance;
+        mNativeMaterial = nGetMaterial(mNativeObject);
     }
 
     /** @return the {@link Material} associated with this instance */
@@ -548,4 +549,5 @@ public class MaterialInstance {
     private static native void nSetDepthCulling(long nativeMaterialInstance, boolean enable);
 
     private static native String nGetName(long nativeMaterialInstance);
+    private static native long nGetMaterial(long nativeMaterialInstance);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -553,8 +553,7 @@ public class RenderableManager {
     public @NonNull MaterialInstance getMaterialInstanceAt(@EntityInstance int i,
             @IntRange(from = 0) int primitiveIndex) {
         long nativeMatInstance = nGetMaterialInstanceAt(mNativeObject, i, primitiveIndex);
-        long nativeMaterial = nGetMaterialAt(mNativeObject, i, primitiveIndex);
-        return new MaterialInstance(nativeMaterial, nativeMatInstance);
+        return new MaterialInstance(nativeMatInstance);
     }
 
     /**

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -65,6 +65,27 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetEntities(JNIEnv* env, 
     env->ReleaseIntArrayElements(result, (jint*) entities, 0);
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialInstanceCount(JNIEnv*, jclass,
+        jlong nativeAsset) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    return asset->getMaterialInstanceCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialInstances(JNIEnv* env, jclass,
+        jlong nativeAsset, jlongArray result) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    jsize available = env->GetArrayLength(result);
+    jsize count = std::min(available, (jsize) asset->getMaterialInstanceCount());
+    jlong* dst = env->GetLongArrayElements(result, nullptr);
+    const MaterialInstance * const* src = asset->getMaterialInstances();
+    for (jsize i = 0; i < count; i++) {
+        dst[i] = (jlong) src[i];
+    }
+    env->ReleaseLongArrayElements(result, dst, 0);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetBoundingBox(JNIEnv* env, jclass,
         jlong nativeAsset, jfloatArray result) {

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -21,6 +21,7 @@ import androidx.annotation.Nullable;
 
 import com.google.android.filament.Box;
 import com.google.android.filament.Entity;
+import com.google.android.filament.MaterialInstance;
 
 /**
  * Owns a bundle of Filament objects that have been created by <code>AssetLoader</code>.
@@ -99,6 +100,17 @@ public class FilamentAsset {
         return result;
     }
 
+    public @NonNull MaterialInstance[] getMaterialInstances() {
+        final int count = nGetMaterialInstanceCount(mNativeObject);
+        MaterialInstance[] result = new MaterialInstance[count];
+        long[] natives = new long[count];
+        nGetMaterialInstances(mNativeObject, natives);
+        for (int i = 0; i < count; i++) {
+            result[i] = new MaterialInstance(natives[i]);
+        }
+        return result;
+    }
+
     /**
      * Gets the bounding box computed from the supplied min / max values in glTF accessors.
      */
@@ -155,8 +167,13 @@ public class FilamentAsset {
     private static native int nGetRoot(long nativeAsset);
     private static native int nPopRenderable(long nativeAsset);
     private static native int nPopRenderables(long nativeAsset, int[] result);
+
     private static native int nGetEntityCount(long nativeAsset);
     private static native void nGetEntities(long nativeAsset, int[] result);
+
+    private static native int nGetMaterialInstanceCount(long nativeAsset);
+    private static native void nGetMaterialInstances(long nativeAsset, long[] nativeResults);
+
     private static native void nGetBoundingBox(long nativeAsset, float[] box);
     private static native String nGetName(long nativeAsset, int entity);
     private static native long nGetAnimator(long nativeAsset);


### PR DESCRIPTION
Tested locally by hacking gltf-viewer on Android, added the following
lines to MainActivity:

```kotlin
for (mat in modelViewer.asset!!.materialInstances) {
    Log.d("gltf-viewer", mat.name)
}
```