### PR TITLE
Fix filament-utils-android build on Windows

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,9 +27,9 @@ buildscript {
     if (project.hasProperty("filament_dist_dir")) {
         filamentPath = file(project.property("filament_dist_dir")).absolutePath
     }
-    if (System.properties['os.name'] != null && System.properties['os.name'].toLowerCase().contains('windows')) {
-        filamentPath = filamentPath.replaceAll("\\\\", "/")
-    }
+    // CMake scripts require a forward-slash path for the FILAMENT_DIST_DIR
+    // variable, so here we convert the native path to a forward-slash path.
+    filamentPath = filamentPath.replace(File.separator, "/")
 
     def hasVulkan = project.hasProperty("filament_supports_vulkan")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
     // Our CMake scripts require a forward-slash path for the FILAMENT_DIST_DIR
     // variable, so here we convert the native path to a forward-slash path.
-    filamentPath = filamentPath.replace(File.separatorChar, '/')
+    filamentPath = filamentPath.replace(File.separator, '/')
 
     def hasVulkan = project.hasProperty("filament_supports_vulkan")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,9 @@ buildscript {
     if (project.hasProperty("filament_dist_dir")) {
         filamentPath = file(project.property("filament_dist_dir")).absolutePath
     }
+    if (System.properties['os.name'] != null && System.properties['os.name'].toLowerCase().contains('windows')) {
+        filamentPath = filamentPath.replaceAll("\\\\", "/")
+    }
 
     def hasVulkan = project.hasProperty("filament_supports_vulkan")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,9 +27,9 @@ buildscript {
     if (project.hasProperty("filament_dist_dir")) {
         filamentPath = file(project.property("filament_dist_dir")).absolutePath
     }
-    // CMake scripts require a forward-slash path for the FILAMENT_DIST_DIR
+    // Our CMake scripts require a forward-slash path for the FILAMENT_DIST_DIR
     // variable, so here we convert the native path to a forward-slash path.
-    filamentPath = filamentPath.replace(File.separator, "/")
+    filamentPath = filamentPath.replace(File.separatorChar, '/')
 
     def hasVulkan = project.hasProperty("filament_supports_vulkan")
 


### PR DESCRIPTION
Build on Windows fails due to incorrect path, backalshes instead of forward slashes.
```
* What went wrong:
Execution failed for task ':filament-utils-android:generateJsonModelFullRelease'.
> C:\Users\silentnuke\Projects\filament\android\filament-utils-android\CMakeLists.txt : C/C++ fullRelease|x86 : CMake Error at C:/Users/silentnuke/Projects/filament/android/gltfio-android/CMakeLists.txt:75 (add_library):
    Syntax error in cmake code when parsing string

      C:\Users\silentnuke\Projects\filament\out\android-release\filament/include/gltfio/resources/gltfresources_lite.h

    Invalid character escape '\U'.
```

There is a few approaches to fix that:
1. Normalize path in Cmake using `file(TO_CMAKE_PATH)`. However this would require more changes.
2. IMHO more preferable, fix once in Gradle before passing to Cmake.