### PR TITLE
Fix Entity leaks with Camera

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -397,6 +397,8 @@ public:
     /**
      * helper for creating an Entity and Camera component in one call
      *
+     * @deprecated use createCamera(Entity) instead
+     *
      * @return A camera component
      */
     Camera* createCamera() noexcept;
@@ -404,8 +406,7 @@ public:
     /**
      * helper for destroying the Camera component and its Entity in one call
      *
-     * @param camera Camera component to destroy. The associated entity as well as all its
-     *               components managed by filament are destroyed.
+     * @param camera Camera component to destroy. The associated entity is also destroyed.
      * @deprecated use destroyCameraComponent(Entity) instead
      */
     void destroy(const Camera* camera);

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -960,11 +960,13 @@ DebugRegistry& Engine::getDebugRegistry() noexcept {
 }
 
 Camera* Engine::createCamera() noexcept {
-    return createCamera(utils::EntityManager::get().create());
+    return createCamera(upcast(this)->getEntityManager().create());
 }
 
 void Engine::destroy(const Camera* camera) {
-    destroy(camera->getEntity());
+    Entity e = camera->getEntity();
+    destroyCameraComponent(e);
+    upcast(this)->getEntityManager().destroy(e);
 }
 
 } // namespace filament

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -47,8 +47,10 @@ ShadowMap::ShadowMap(FEngine& engine) noexcept :
         mEngine(engine),
         mClipSpaceFlipped(engine.getBackend() == Backend::VULKAN),
         mTextureSpaceFlipped(engine.getBackend() == Backend::METAL) {
-    mCamera = mEngine.createCamera(engine.getEntityManager().create());
-    mDebugCamera = mEngine.createCamera(engine.getEntityManager().create());
+    Entity entities[2];
+    engine.getEntityManager().create(2, entities);
+    mCamera = mEngine.createCamera(entities[0]);
+    mDebugCamera = mEngine.createCamera((entities[1]));
     FDebugRegistry& debugRegistry = engine.getDebugRegistry();
     debugRegistry.registerProperty("d.shadowmap.focus_shadowcasters", &engine.debug.shadowmap.focus_shadowcasters);
     debugRegistry.registerProperty("d.shadowmap.far_uses_shadowcasters", &engine.debug.shadowmap.far_uses_shadowcasters);
@@ -61,8 +63,12 @@ ShadowMap::ShadowMap(FEngine& engine) noexcept :
 }
 
 ShadowMap::~ShadowMap() {
-    mEngine.destroy(mCamera->getEntity());
-    mEngine.destroy(mDebugCamera->getEntity());
+    FEngine& engine = mEngine;
+    Entity entities[] = { mCamera->getEntity(), mDebugCamera->getEntity() };
+    for (Entity e : entities) {
+        engine.destroyCameraComponent(e);
+    }
+    engine.getEntityManager().destroy(sizeof(entities) / sizeof(Entity), entities);
 }
 
 void ShadowMap::render(DriverApi& driver, Handle<HwRenderTarget> rt,


### PR DESCRIPTION
- When creating a Camera component, it is the responsibility of the caller
to destroy the Entity. ShadowMap didn't do that, so it would leak two
entities.

- When destroying a Camera component with the legacy (and deprecated)
API, Engine::destroyCamera() should destroy the associated Entity
(and was documented as doing so). However, it actually didn't.

- don't use the static EntityManager is ShadowMap.