### PR TITLE
Make JNI constructors private unless they take Engine.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## Next release
 
 - MaterialInstances now have optional names.
+- JNI constructors are now "package private" unless they take an Engine.
 
 ## v1.6.0
 

--- a/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
@@ -86,7 +86,11 @@ import com.google.android.filament.proguard.UsedByReflection;
 public class IndirectLight {
     long mNativeObject;
 
-    public IndirectLight(long indirectLight) {
+    public IndirectLight(Engine engine, long indirectLight) {
+        mNativeObject = indirectLight;
+    }
+
+    IndirectLight(long indirectLight) {
         mNativeObject = indirectLight;
     }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
@@ -49,13 +49,17 @@ public class MaterialInstance {
         MAT4
     }
 
+    public MaterialInstance(Engine engine, long nativeMaterialInstance) {
+        mNativeObject = nativeMaterialInstance;
+        mNativeMaterial = nGetMaterial(mNativeObject);
+    }
+
     MaterialInstance(@NonNull Material material, long nativeMaterialInstance) {
         mMaterial = material;
         mNativeObject = nativeMaterialInstance;
     }
 
-    // public so that the gltfio Java layer can use this
-    public MaterialInstance(long nativeMaterialInstance) {
+    MaterialInstance(long nativeMaterialInstance) {
         mNativeObject = nativeMaterialInstance;
         mNativeMaterial = nGetMaterial(mNativeObject);
     }

--- a/android/filament-android/src/main/java/com/google/android/filament/Skybox.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Skybox.java
@@ -52,10 +52,13 @@ import com.google.android.filament.proguard.UsedByReflection;
 public class Skybox {
     private long mNativeObject;
 
-    public Skybox(long nativeSkybox) {
+    public Skybox(Engine engine, long nativeSkybox) {
         mNativeObject = nativeSkybox;
     }
 
+    Skybox(long nativeSkybox) {
+        mNativeObject = nativeSkybox;
+    }
 
     /**
      * Use <code>Builder</code> to construct a <code>Skybox</code> object instance.

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -73,9 +73,7 @@ import static com.google.android.filament.Texture.Type.COMPRESSED;
 public class Texture {
     private long mNativeObject;
 
-    /** @deprecated use {@link #Texture(Engine, long)} instead  */
-    @Deprecated
-    public Texture(long nativeTexture) {
+    Texture(long nativeTexture) {
         mNativeObject = nativeTexture;
     }
 

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KtxLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KtxLoader.kt
@@ -59,7 +59,7 @@ object KtxLoader {
     fun createIndirectLight(engine: Engine, buffer: Buffer, options: Options = Options()): IndirectLight {
         val nativeEngine = engine.nativeObject
         val nativeIndirectLight = nCreateIndirectLight(nativeEngine, buffer, buffer.remaining(), options.srgb)
-        return IndirectLight(nativeIndirectLight)
+        return IndirectLight(engine, nativeIndirectLight)
     }
 
     /**
@@ -73,7 +73,7 @@ object KtxLoader {
     fun createSkybox(engine: Engine, buffer: Buffer, options: Options = Options()): Skybox {
         val nativeEngine = engine.nativeObject
         val nativeSkybox = nCreateSkybox(nativeEngine, buffer, buffer.remaining(), options.srgb)
-        return Skybox(nativeSkybox)
+        return Skybox(engine, nativeSkybox)
     }
 
     private external fun nCreateTexture(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -77,6 +77,7 @@ import java.nio.Buffer;
  */
 public class AssetLoader {
     private long mNativeObject;
+    private Engine mEngine;
 
     /**
      * Constructs an <code>AssetLoader </code>that can be used to create and destroy instances of
@@ -97,6 +98,8 @@ public class AssetLoader {
         if (mNativeObject == 0) {
             throw new IllegalStateException("Unable to parse glTF asset.");
         }
+
+        mEngine = engine;
     }
 
     /**
@@ -113,7 +116,7 @@ public class AssetLoader {
     @Nullable
     public FilamentAsset createAssetFromBinary(@NonNull Buffer buffer) {
         long nativeAsset = nCreateAssetFromBinary(mNativeObject, buffer, buffer.remaining());
-        return nativeAsset != 0 ? new FilamentAsset(nativeAsset) : null;
+        return nativeAsset != 0 ? new FilamentAsset(mEngine, nativeAsset) : null;
     }
 
     /**
@@ -122,7 +125,7 @@ public class AssetLoader {
     @Nullable
     public FilamentAsset createAssetFromJson(@NonNull Buffer buffer) {
         long nativeAsset = nCreateAssetFromJson(mNativeObject, buffer, buffer.remaining());
-        return nativeAsset != 0 ? new FilamentAsset(nativeAsset) : null;
+        return nativeAsset != 0 ? new FilamentAsset(mEngine, nativeAsset) : null;
     }
 
     /**

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -20,6 +20,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.android.filament.Box;
+import com.google.android.filament.Engine;
 import com.google.android.filament.Entity;
 import com.google.android.filament.MaterialInstance;
 
@@ -46,8 +47,10 @@ import com.google.android.filament.MaterialInstance;
 public class FilamentAsset {
     private long mNativeObject;
     private Animator mAnimator;
+    private Engine mEngine;
 
-    FilamentAsset(long nativeObject) {
+    FilamentAsset(Engine engine, long nativeObject) {
+        mEngine = engine;
         mNativeObject = nativeObject;
         mAnimator = null;
     }
@@ -106,7 +109,7 @@ public class FilamentAsset {
         long[] natives = new long[count];
         nGetMaterialInstances(mNativeObject, natives);
         for (int i = 0; i < count; i++) {
-            result[i] = new MaterialInstance(natives[i]);
+            result[i] = new MaterialInstance(mEngine, natives[i]);
         }
         return result;
     }


### PR DESCRIPTION
This removes (rather than deprecates) all public constructors that
take a native pointer without an accompanying Engine.

Most notably, MaterialInstance had a public pointer constructor which
is now package private. This means that FilamentAsset needs an Engine,
so it now takes the one from AssetLoader.