### PR TITLE
debug option to track Entities

### DIFF
--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -28,7 +28,7 @@
 #endif
 
 #if FILAMENT_UTILS_TRACK_ENTITIES
-#include <utils/Log.h>
+#include <utils/ostream.h>
 #include <vector>
 #endif
 

--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -23,6 +23,15 @@
 #include <utils/Entity.h>
 #include <utils/compiler.h>
 
+#ifndef FILAMENT_UTILS_TRACK_ENTITIES
+#define FILAMENT_UTILS_TRACK_ENTITIES false
+#endif
+
+#if FILAMENT_UTILS_TRACK_ENTITIES
+#include <utils/Log.h>
+#include <vector>
+#endif
+
 namespace utils {
 
 class UTILS_PUBLIC EntityManager {
@@ -34,9 +43,8 @@ public:
     class Listener {
     public:
         virtual void onEntitiesDestroyed(size_t n, Entity const* entities) noexcept = 0;
-        virtual void onAllEntitiesDestroyed() noexcept = 0;
     protected:
-        ~Listener() noexcept = default;
+        ~Listener() noexcept;
     };
 
 
@@ -89,6 +97,11 @@ public:
     // singleton, can't be copied
     EntityManager(const EntityManager& rhs) = delete;
     EntityManager& operator=(const EntityManager& rhs) = delete;
+
+#if FILAMENT_UTILS_TRACK_ENTITIES
+    std::vector<Entity> getActiveEntities() const;
+    void dumpActiveEntities(utils::io::ostream& out) const;
+#endif
 
 private:
     friend class EntityManagerImpl;

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <utils/EntityManager.h>
+
 #include "EntityManagerImpl.h"
 
 namespace utils {
@@ -27,6 +29,8 @@ EntityManager::EntityManager()
 EntityManager::~EntityManager() {
     delete [] mGens;
 }
+
+EntityManager::Listener::~Listener() noexcept = default;
 
 EntityManager& EntityManager::get() noexcept {
     // note: we leak the EntityManager because it's more important that it survives everything else
@@ -50,5 +54,16 @@ void EntityManager::registerListener(EntityManager::Listener* l) noexcept {
 void EntityManager::unregisterListener(EntityManager::Listener* l) noexcept {
     static_cast<EntityManagerImpl *>(this)->unregisterListener(l);
 }
+
+#if FILAMENT_UTILS_TRACK_ENTITIES
+std::vector<Entity> EntityManager::getActiveEntities() const {
+    return static_cast<EntityManagerImpl const *>(this)->getActiveEntities();
+}
+
+void EntityManager::dumpActiveEntities(utils::io::ostream& out) const {
+    static_cast<EntityManagerImpl const *>(this)->dumpActiveEntities(out);
+}
+
+#endif
 
 } // namespace utils


### PR DESCRIPTION
Set FILAMENT_UTILS_TRACK_ENTITIES to true when building libutils to
activate entity tracking. This adds two public methods:

getActiveEntities() and dumpActiveEntities() the later displays the
stack trace of where the remaining entities were allocated.

This is useful for tracking leaks.