### PR TITLE
FilamentApp: do not recreate SwapChain upon resize.

### DIFF
--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -145,27 +145,30 @@ bool PlatformCocoaGL::pumpEvents() noexcept {
 }
 
 void PlatformCocoaGLImpl::updateOpenGLContext(NSView *nsView, bool resetView) {
+    auto& v = mHeadlessSwapChains;
+    const bool headless = std::find(v.begin(), v.end(), nsView) != v.end();
+
     NSOpenGLContext* glContext = mGLContext;
 
     // NOTE: This is not documented well (if at all) but NSOpenGLContext requires "setView" and
     // "update" to be called from the UI thread. This became a hard requirement with the arrival
     // of macOS 10.15 (Catalina). If we were to call these methods from the GL thread, we would
     // see EXC_BAD_INSTRUCTION.
-    #if UTILS_HAS_THREADING
-    dispatch_sync(dispatch_get_main_queue(), ^(void) {
+    if (!headless && UTILS_HAS_THREADING) {
+        dispatch_sync(dispatch_get_main_queue(), ^(void) {
+            if (resetView) {
+                [glContext clearDrawable];
+                [glContext setView:nsView];
+            }
+            [glContext update];
+        });
+    } else {
         if (resetView) {
             [glContext clearDrawable];
             [glContext setView:nsView];
         }
         [glContext update];
-    });
-    #else
-        if (resetView) {
-            [glContext clearDrawable];
-            [glContext setView:nsView];
-        }
-        [glContext update];
-    #endif
+    }
 }
 
 } // namespace filament

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -694,17 +694,12 @@ void FilamentApp::Window::fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) c
 }
 
 void FilamentApp::Window::resize() {
-    mFilamentApp->mEngine->destroy(mSwapChain);
     void* nativeWindow = ::getNativeWindow(mWindow);
-    void* nativeSwapChain = nativeWindow;
 
 #if defined(__APPLE__)
 
-    void* metalLayer = nullptr;
     if (mBackend == filament::Engine::Backend::METAL) {
-        metalLayer = resizeMetalLayer(nativeWindow);
-        // The swap chain on Metal is a CAMetalLayer.
-        nativeSwapChain = metalLayer;
+        resizeMetalLayer(nativeWindow);
     }
 
 #if defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
@@ -715,7 +710,6 @@ void FilamentApp::Window::resize() {
 
 #endif
 
-    mSwapChain = mFilamentApp->mEngine->createSwapChain(nativeSwapChain);
     configureCamerasForWindow();
 }
 


### PR DESCRIPTION
This is done for consistency with the Android samples. Tested with
gltf_viewer against Vulkan, Metal, and OpenGL. Dragged window between
high DPI and low DPI displays.

Since resizing does not trigger the "NSView has changed" handler in
PlatformCocoaGL, it now must to detect a resize in order to make the
required call to NSOpenGLContext::update() as per the following
documentation.

https://developer.apple.com/documentation/appkit/nsopenglcontext/1436135-update

Fixes #2528