### PR TITLE
don't kick the driver thread after each framegraph pass

### DIFF
--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -436,14 +436,6 @@ void FrameGraph::execute(FEngine& engine, DriverApi& driver) noexcept {
         if (node.refCount) {
             driver.pushGroupMarker(node.name);
             executeInternal(node, driver);
-            if (&node != &passNodes.back()) {
-                // wake-up the driver thread and consume data in the command queue, this helps with
-                // latency, parallelism and memory pressure in the command queue.
-                // As an optimization, we don't do this on the last execute() because
-                // 1) we're adding a driver flush command (below) and
-                // 2) an engine.flush() is always performed by Renderer at the end of a renderJob.
-                engine.flush();
-            }
             driver.popGroupMarker();
         }
     }


### PR DESCRIPTION
this was a misguided optimization, on low-end devices this actually
has a large overhead (presumably because of the smaller cache and
increased branch missprediction as well as extra synchronization).

on some low-end devices we see the gl thread go from ~40ms to ~10ms
with the gltf sample.