### PR TITLE
use systrace when EXT_debug_marker is not supported

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2581,27 +2581,33 @@ void OpenGLDriver::insertEventMarker(char const* string, size_t len) {
 void OpenGLDriver::pushGroupMarker(char const* string,  size_t len) {
 #ifdef GL_EXT_debug_marker
     auto& gl = mContext;
-    if (gl.ext.EXT_debug_marker) {
+    if (UTILS_LIKELY(gl.ext.EXT_debug_marker)) {
         glPushGroupMarkerEXT(GLsizei(len ? len : strlen(string)), string);
-    }
+    } else
 #endif
-}
-
-void OpenGLDriver::startCapture(int) {
-
-}
-
-void OpenGLDriver::stopCapture(int) {
-
+    {
+        SYSTRACE_CONTEXT();
+        SYSTRACE_NAME_BEGIN(string);
+    }
 }
 
 void OpenGLDriver::popGroupMarker(int) {
 #ifdef GL_EXT_debug_marker
     auto& gl = mContext;
-    if (gl.ext.EXT_debug_marker) {
+    if (UTILS_LIKELY(gl.ext.EXT_debug_marker)) {
         glPopGroupMarkerEXT();
-    }
+    } else
 #endif
+    {
+        SYSTRACE_CONTEXT();
+        SYSTRACE_NAME_END();
+    }
+}
+
+void OpenGLDriver::startCapture(int) {
+}
+
+void OpenGLDriver::stopCapture(int) {
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -52,6 +52,13 @@ class OpenGLDriver final : public backend::DriverBase {
 public:
     static backend::Driver* create(backend::OpenGLPlatform* platform, void* sharedGLContext) noexcept;
 
+    class DebugMarker {
+        OpenGLDriver& driver;
+    public:
+        DebugMarker(OpenGLDriver& driver, const char* string) noexcept;
+        ~DebugMarker() noexcept;
+    };
+
     // OpenGLDriver specific fields
     struct GLBuffer {
         GLuint id = 0;
@@ -114,13 +121,6 @@ public:
         } gl;
 
         void* platformPImpl = nullptr;
-    };
-
-    class DebugMarker {
-        OpenGLDriver& driver;
-    public:
-        DebugMarker(OpenGLDriver& driver, const char* string) noexcept;
-        ~DebugMarker() noexcept;
     };
 
     struct GLTimerQuery : public backend::HwTimerQuery {
@@ -194,20 +194,19 @@ public:
         backend::TargetBufferFlags targets = {};
     };
 
-struct GLSync : public backend::HwSync {
-    using HwSync::HwSync;
-    struct State {
-        std::atomic<GLenum> status{ GL_TIMEOUT_EXPIRED };
+    struct GLSync : public backend::HwSync {
+        using HwSync::HwSync;
+        struct State {
+            std::atomic<GLenum> status{ GL_TIMEOUT_EXPIRED };
+        };
+        struct {
+            GLsync sync;
+        } gl;
+        std::shared_ptr<State> result{ std::make_shared<GLSync::State>() };
     };
-    struct {
-        GLsync sync;
-    } gl;
-    std::shared_ptr<State> result{ std::make_shared<GLSync::State>() };
-};
 
     OpenGLDriver(OpenGLDriver const&) = delete;
     OpenGLDriver& operator=(OpenGLDriver const&) = delete;
-
 
 private:
     OpenGLContext mContext;

--- a/libs/utils/include/utils/Systrace.h
+++ b/libs/utils/include/utils/Systrace.h
@@ -66,6 +66,12 @@
 // SYSTRACE_CALL is an SYSTRACE_NAME that uses the current function name.
 #define SYSTRACE_CALL() SYSTRACE_NAME(__FUNCTION__)
 
+#define SYSTRACE_NAME_BEGIN(name) \
+        ___tracer.traceBegin(SYSTRACE_TAG, name)
+
+#define SYSTRACE_NAME_END() \
+        ___tracer.traceEnd(SYSTRACE_TAG)
+
 
 /**
  * Trace the beginning of an asynchronous event. Unlike ATRACE_BEGIN/ATRACE_END
@@ -143,9 +149,6 @@ public:
         }
     }
 
-private:
-    friend class ScopedTrace;
-
     inline void traceBegin(uint32_t tag, const char* name) noexcept {
         if (tag && UTILS_UNLIKELY(mIsTracingEnabled)) {
             begin_body(mMarkerFd, mPid, name);
@@ -158,6 +161,9 @@ private:
             write(mMarkerFd, &END_TAG, 1);
         }
     }
+
+private:
+    friend class ScopedTrace;
 
     static inline void init() noexcept {
         if (UTILS_UNLIKELY(!std::atomic_load_explicit(&sIsTracingReady, std::memory_order_acquire))) {
@@ -226,6 +232,8 @@ private:
 #define SYSTRACE_DISABLE()
 #define SYSTRACE_CONTEXT()
 #define SYSTRACE_NAME(name)
+#define SYSTRACE_NAME_BEGIN(name)
+#define SYSTRACE_NAME_END()
 #define SYSTRACE_CALL()
 #define SYSTRACE_ASYNC_BEGIN(name, cookie)
 #define SYSTRACE_ASYNC_END(name, cookie)


### PR DESCRIPTION
EXT_debug_marker is not supported GL debuggers won't show these
markers, so as an alternative, we dump them in systrace.