### PR TITLE
Add headless support to FilamentApp and frame_generator.

### DIFF
--- a/libs/filamentapp/include/filamentapp/Config.h
+++ b/libs/filamentapp/include/filamentapp/Config.h
@@ -32,6 +32,7 @@ struct Config {
     filament::Engine::Backend backend = filament::Engine::Backend::OPENGL;
     filament::camutils::Mode cameraMode = filament::camutils::Mode::ORBIT;
     bool resizeable = true;
+    bool headless = false;
 };
 
 #endif // TNT_FILAMENT_SAMPLE_CONFIG_H

--- a/samples/frame_generator.cpp
+++ b/samples/frame_generator.cpp
@@ -445,6 +445,7 @@ int main(int argc, char* argv[]) {
     }
 
     g_config.title = "Frame Generator";
+    g_config.headless = true;
     FilamentApp& filamentApp = FilamentApp::get();
     filamentApp.run(g_config,
             setup, cleanup, FilamentApp::ImGuiCallback(), render, postRender, 512, 512);


### PR DESCRIPTION
These changes make it easier to test headless rendering in macOS.

I verified that this works using the frame_generator tool, however
it requires the fixes in PR #2529.