### PR TITLE
Vulkan + Android: Enable validation and build hints.

### DIFF
--- a/android/samples/sample-gltf-viewer/build.gradle
+++ b/android/samples/sample-gltf-viewer/build.gradle
@@ -24,6 +24,16 @@ clean.doFirst {
 
 android {
     compileSdkVersion versions.compileSdk
+
+    // The following lines enable validation layers with the Vulkan backend by copying
+    // the appropriate files from the NDK to the device. To trap validation errors, be
+    // sure to also use a debug build of Filament.
+    if (project.hasProperty("filament_supports_vulkan")) {
+        sourceSets.main.jniLibs {
+            srcDirs = ["${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"]
+        }
+    }
+
     defaultConfig {
         applicationId "com.google.android.filament.gltf"
         minSdkVersion 19

--- a/build.sh
+++ b/build.sh
@@ -765,6 +765,9 @@ while getopts ":hacfijmp:q:uvsw" opt; do
             VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
             VULKAN_ANDROID_GRADLE_OPTION="-Pfilament_supports_vulkan"
             echo "Enabling support for Vulkan in the core Filament library."
+            echo "To use Vulkan, pass Engine.Backend.VULKAN into Engine.create()."
+            echo ""
+            echo "If using Android Studio, add ${VULKAN_ANDROID_GRADLE_OPTION} to Preferences > Build > Compiler."
             echo ""
             ;;
         s)


### PR DESCRIPTION
Since Android Studio does not know about build.sh, users should manually
enable the Vulkan option before doing "Refresh Linked C++ Projects".