### PR TITLE
Enable Vulkan for Android by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,9 +295,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebIn
 endif()
 
 # By default, build with Vulkan support on desktop platforms, although clients must request to use
-# it at run time. On Android, the build does not include Vulkan support unless CMake is invoked
-# with -DFILAMENT_SUPPORTS_VULKAN=ON.
-if (ANDROID OR WIN32 OR WEBGL OR IOS OR FILAMENT_USE_SWIFTSHADER)
+# it at run time.
+if (WIN32 OR WEBGL OR IOS OR FILAMENT_USE_SWIFTSHADER)
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" OFF)
 else()
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" ON)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,8 @@ buildscript {
     // variable, so here we convert the native path to a forward-slash path.
     filamentPath = filamentPath.replace(File.separator, '/')
 
-    def hasVulkan = project.hasProperty("filament_supports_vulkan")
+    // Warning: changing this property does not work well with incremental builds.
+    def excludeVulkan = project.hasProperty("filament_exclude_vulkan")
 
     def abis = ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
     if (project.hasProperty("filament_abis")) {
@@ -69,7 +70,7 @@ buildscript {
         "-DANDROID_PLATFORM=21",
         "-DANDROID_STL=c++_static",
         "-DFILAMENT_DIST_DIR=${filamentPath}".toString(),
-        "-DFILAMENT_SUPPORTS_VULKAN=${hasVulkan ? 'ON' : 'OFF'}".toString()
+        "-DFILAMENT_SUPPORTS_VULKAN=${excludeVulkan ? 'OFF' : 'ON'}".toString()
     ]
 
     ext.cppFlags = [

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ function print_help {
     echo "    -u"
     echo "        Run all unit tests, will trigger a debug build if needed."
     echo "    -v"
-    echo "        Add Vulkan support to the Android build."
+    echo "        Exclude Vulkan support from the Android build."
     echo "    -s"
     echo "        Add iOS simulator support to the iOS build."
     echo "    -w"
@@ -115,7 +115,7 @@ FILAMENT_ENABLE_JAVA=ON
 
 INSTALL_COMMAND=
 
-VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=OFF"
+VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
 VULKAN_ANDROID_GRADLE_OPTION=""
 
 IOS_BUILD_SIMULATOR=false
@@ -762,10 +762,10 @@ while getopts ":hacfijmp:q:uvsw" opt; do
             RUN_TESTS=true
             ;;
         v)
-            VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
-            VULKAN_ANDROID_GRADLE_OPTION="-Pfilament_supports_vulkan"
-            echo "Enabling support for Vulkan in the core Filament library."
-            echo ""
+            VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=OFF"
+            VULKAN_ANDROID_GRADLE_OPTION="-Pfilament_exclude_vulkan"
+            echo "Disabling support for Vulkan in the core Filament library."
+            echo "Consider using -c after changing this option to clear the Gradle cache."
             ;;
         s)
             IOS_BUILD_SIMULATOR=true

--- a/build/android/build.sh
+++ b/build/android/build.sh
@@ -11,6 +11,9 @@
 NDK_VERSION="ndk;21.0.6113669"
 ANDROID_NDK_VERSION=21
 
+# Exclude Vulkan from CI builds for Android. (It is enabled for other platforms.)
+EXCLUDE_VULKAN=-v
+
 echo "This script is intended to run in a CI environment and may modify your current environment."
 echo "Please refer to BUILDING.md for more information."
 
@@ -66,4 +69,4 @@ if [[ "$TARGET" == "presubmit" ]]; then
 fi
 
 pushd `dirname $0`/../.. > /dev/null
-./build.sh -p android $ANDROID_ABIS -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE
+./build.sh -p android $EXCLUDE_VULKAN $ANDROID_ABIS -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE


### PR DESCRIPTION
The presence of a special Gradle property is now used to exclude Vulkan
support from the build. By making Vulkan "always on" for local
development, we can avoid stale CMake cache issues that arise from
toggling the Gradle property. It also lets you avoid adding the flag
to Android Studio preferences.

This is motivated by testing and does not indicate production readiness.
Clients still need to pass VULKAN into the Engine constructor to select
the Vulkan backend.

To keep APK size down and keep CI fast, we are continuing to exclude
Vulkan from official Android builds.

After syncing this change, you might need to use `./build.sh -c` to
clobber various build caches.