### PR TITLE
get rid of our details namespace

### DIFF
--- a/filament/benchmark/benchmark_filament.cpp
+++ b/filament/benchmark/benchmark_filament.cpp
@@ -29,7 +29,6 @@
 #include <random>
 
 using namespace filament;
-using namespace filament::details;
 using namespace filament::math;
 using namespace utils;
 

--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -29,10 +29,7 @@
 namespace filament {
 
 class Box;
-
-namespace details {
 class Culler;
-} // namespace details;
 
 /**
  * A frustum defined by six planes
@@ -137,7 +134,7 @@ public:
     float contains(math::float3 p) const noexcept;
 
 private:
-    friend class details::Culler;
+    friend class Culler;
     math::float4 mPlanes[6];
 };
 

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -31,9 +31,7 @@
 
 namespace filament {
 
-namespace details {
 class FIndexBuffer;
-} // namespace details
 
 class Engine;
 
@@ -101,7 +99,7 @@ public:
          */
         IndexBuffer* build(Engine& engine);
     private:
-        friend class details::FIndexBuffer;
+        friend class FIndexBuffer;
     };
 
     /**

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -30,9 +30,7 @@ namespace filament {
 class Engine;
 class Texture;
 
-namespace details {
 class FIndirectLight;
-} // namespace details
 
 /**
  * IndirectLight is used to simulate environment lighting, a form of global illumination.
@@ -252,7 +250,7 @@ public:
         IndirectLight* build(Engine& engine);
 
     private:
-        friend class details::FIndirectLight;
+        friend class FIndirectLight;
     };
 
     /**

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -33,12 +33,8 @@ namespace utils {
 namespace filament {
 
 class Engine;
-
-namespace details {
 class FEngine;
 class FLightManager;
-} // namespace details
-
 
 /**
  * LightManager allows to create a light source in the scene, such as a sun or street lights.
@@ -526,8 +522,8 @@ public:
         Result build(Engine& engine, utils::Entity entity);
 
     private:
-        friend class details::FEngine;
-        friend class details::FLightManager;
+        friend class FEngine;
+        friend class FLightManager;
     };
 
     static constexpr float EFFICIENCY_INCANDESCENT = 0.0220f;   //!< Typical efficiency of an incandescent light bulb (2.2%)

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -39,10 +39,8 @@ namespace filament {
 class Texture;
 class TextureSampler;
 
-namespace details {
 class FEngine;
 class FMaterial;
-} // namespace details
 
 class Engine;
 
@@ -116,7 +114,7 @@ public:
          */
         Material* build(Engine& engine);
     private:
-        friend class details::FMaterial;
+        friend class FMaterial;
     };
 
     /**

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -27,9 +27,7 @@
 
 namespace filament {
 
-namespace details {
 class FRenderTarget;
-} // namespace details
 
 class Engine;
 class Texture;
@@ -116,7 +114,7 @@ public:
         RenderTarget* build(Engine& engine);
 
     private:
-        friend class details::FRenderTarget;
+        friend class FRenderTarget;
     };
 
     /**

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -43,11 +43,9 @@ class MaterialInstance;
 class Renderer;
 class VertexBuffer;
 
-namespace details {
 class FEngine;
 class FRenderPrimitive;
 class FRenderableManager;
-} // namespace details
 
 /**
  * Factory and manager for \em renderables, which are entities that can be drawn.
@@ -292,9 +290,9 @@ public:
         Result build(Engine& engine, utils::Entity entity);
 
     private:
-        friend class details::FEngine;
-        friend class details::FRenderPrimitive;
-        friend class details::FRenderableManager;
+        friend class FEngine;
+        friend class FRenderPrimitive;
+        friend class FRenderableManager;
         struct Entry {
             VertexBuffer* vertices = nullptr;
             IndexBuffer* indices = nullptr;

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -28,9 +28,7 @@
 
 namespace filament {
 
-namespace details {
 class FSkybox;
-} // namespace details
 
 class Engine;
 class Texture;
@@ -143,7 +141,7 @@ public:
         Skybox* build(Engine& engine);
 
     private:
-        friend class details::FSkybox;
+        friend class FSkybox;
     };
 
     void setColor(math::float4 color) noexcept;

--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -27,9 +27,7 @@
 
 namespace filament {
 
-namespace details {
 class FStream;
-} // namespace details
 
 class Engine;
 
@@ -114,7 +112,7 @@ public:
         Stream* build(Engine& engine);
 
     private:
-        friend class details::FStream;
+        friend class FStream;
     };
 
     /**

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -29,9 +29,7 @@
 
 namespace filament {
 
-namespace details {
 class FTexture;
-} // namespace details
 
 class Engine;
 class Stream;
@@ -206,7 +204,7 @@ public:
         Builder& import(intptr_t id) noexcept;
 
     private:
-        friend class details::FTexture;
+        friend class FTexture;
     };
 
     /**

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -33,9 +33,7 @@ class Entity;
 
 namespace filament {
 
-namespace details {
 class FTransformManager;
-} // namespace details
 
 /**
  * TransformManager is used to add transform components to entities.
@@ -73,7 +71,7 @@ public:
     using Instance = utils::EntityInstance<TransformManager>;
 
     class children_iterator : std::iterator<std::forward_iterator_tag, Instance> {
-        friend class details::FTransformManager;
+        friend class FTransformManager;
         TransformManager const& mManager;
         Instance mInstance;
         children_iterator(TransformManager const& mgr, Instance instance) noexcept

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -29,9 +29,7 @@
 
 namespace filament {
 
-namespace details {
 class FVertexBuffer;
-} // namespace details
 
 class Engine;
 
@@ -144,7 +142,7 @@ public:
         VertexBuffer* build(Engine& engine);
 
     private:
-        friend class details::FVertexBuffer;
+        friend class FVertexBuffer;
     };
 
     /**

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -31,7 +31,6 @@ using namespace filament::math;
 using namespace utils;
 
 namespace filament {
-namespace details {
 
 static constexpr const float MIN_APERTURE = 0.5f;
 static constexpr const float MAX_APERTURE = 64.0f;
@@ -225,7 +224,6 @@ math::details::TMat44<T> inverseProjection(const math::details::TMat44<T>& p) no
     return r;
 }
 
-
 UTILS_NOINLINE
 mat4f FCamera::getViewMatrix(mat4f const& model) noexcept {
     return FCamera::rigidTransformInverse(model);
@@ -264,19 +262,15 @@ CameraInfo::CameraInfo(FCamera const& camera, const math::mat4f& worldOriginCame
     worldOrigin        = worldOriginCamera;
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
 
-using namespace details;
-
 mat4f Camera::inverseProjection(const mat4f& p) noexcept {
-    return details::inverseProjection(p);
+    return filament::inverseProjection(p);
 }
 mat4 Camera::inverseProjection(const mat4 & p) noexcept {
-    return details::inverseProjection(p);
+    return filament::inverseProjection(p);
 }
 
 void Camera::setProjection(Camera::Projection projection, double left, double right, double bottom,

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -23,7 +23,6 @@
 using namespace filament::math;
 
 namespace filament {
-namespace details {
 
 void Culler::intersects(
         result_type* UTILS_RESTRICT results,
@@ -137,5 +136,4 @@ void Culler::Test::intersects(
     Culler::intersects(results, frustum, b, count);
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/DFG.cpp
+++ b/filament/src/DFG.cpp
@@ -20,7 +20,6 @@
 #include "details/Texture.h"
 
 namespace filament {
-namespace details {
 
 const uint16_t DFG::DFG_LUT[] = {
 #include "generated/data/dfg.inc"
@@ -52,5 +51,4 @@ void DFG::terminate() {
     }
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/DebugRegistry.cpp
+++ b/filament/src/DebugRegistry.cpp
@@ -30,7 +30,6 @@ using namespace filament::math;
 using namespace utils;
 
 namespace filament {
-namespace details {
 
 FDebugRegistry::FDebugRegistry() noexcept {
     mProperties.reserve(8);
@@ -84,13 +83,9 @@ inline bool FDebugRegistry::getProperty(const char* name, T* UTILS_RESTRICT p) c
     return false;
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 std::pair<DebugRegistry::Property const*, size_t> DebugRegistry::getProperties() const noexcept {
     return upcast(this)->getProperties();

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -58,8 +58,6 @@ namespace filament {
 using namespace backend;
 using namespace filaflat;
 
-namespace details {
-
 FEngine* FEngine::create(Backend backend, Platform* platform, void* sharedGLContext) {
     FEngine* instance = new FEngine(backend, platform, sharedGLContext);
 
@@ -791,13 +789,9 @@ void FEngine::destroy(FEngine* engine) {
     }
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 Engine* Engine::create(Backend backend, Platform* platform, void* sharedGLContext) {
     return FEngine::create(backend, platform, sharedGLContext);

--- a/filament/src/Exposure.cpp
+++ b/filament/src/Exposure.cpp
@@ -21,9 +21,6 @@
 #include <cmath>
 
 namespace filament {
-
-using namespace details;
-
 namespace Exposure {
 
 float ev100(const Camera& c) noexcept {

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -26,9 +26,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
-
 utils::Mutex FFence::sLock;
 utils::Condition FFence::sCondition;
 
@@ -144,13 +141,8 @@ Fence::FenceStatus FFence::FenceSignal::wait(uint64_t timeout) noexcept {
 }
 
 // ------------------------------------------------------------------------------------------------
-} // namespace details
-
-// ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 FenceStatus Fence::waitAndDestroy(Fence* fence, Mode mode) {
     return FFence::waitAndDestroy(upcast(fence), mode);

--- a/filament/src/FrameInfo.cpp
+++ b/filament/src/FrameInfo.cpp
@@ -25,9 +25,7 @@
 
 namespace filament {
 using namespace utils;
-using namespace details;
 
-namespace details {
 // this is to avoid a call to memmove
 template<class InputIterator, class OutputIterator>
 static inline
@@ -36,7 +34,6 @@ void move_backward(InputIterator first, InputIterator last, OutputIterator resul
         *--result = *--last;
     }
 }
-} // namespace details
 
 FrameInfoManager::FrameInfoManager(FEngine& engine) : mEngine(engine) {
     backend::DriverApi& driver = mEngine.getDriverApi();
@@ -77,7 +74,7 @@ void FrameInfoManager::update(Config const& config, FrameInfoManager::duration l
     auto& history = mFrameTimeHistory;
 
     // this is like doing { pop_back(); push_front(); }
-    details::move_backward(history.begin(), history.end() - 1, history.end());
+    filament::move_backward(history.begin(), history.end() - 1, history.end());
     history[0].frameTime = lastFrameTime;
 
     mFrameTimeHistorySize = std::min(++mFrameTimeHistorySize, uint32_t(MAX_FRAMETIME_HISTORY));

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -28,9 +28,7 @@
 #include <stdint.h>
 
 namespace filament {
-namespace details {
 class FEngine;
-} // namespace details
 
 struct FrameInfo {
     using duration = std::chrono::duration<float>;
@@ -58,7 +56,7 @@ public:
         uint32_t historySize;
     };
 
-    explicit FrameInfoManager(details::FEngine& engine);
+    explicit FrameInfoManager(FEngine& engine);
     ~FrameInfoManager() noexcept;
     void terminate();
     void beginFrame(Config const& config, uint32_t frameId);  // call this immediately after "make current"
@@ -75,7 +73,7 @@ public:
 
 private:
     void update(Config const& config, duration lastFrameTime);
-    details::FEngine& mEngine;
+    FEngine& mEngine;
     backend::Handle<backend::HwTimerQuery> mQueries[POOL_COUNT];
     duration mFrameTime{};
     uint32_t mIndex = 0;

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -19,7 +19,6 @@
 #include "details/Engine.h"
 
 namespace filament {
-namespace details {
 
 using namespace utils;
 using namespace backend;
@@ -68,6 +67,4 @@ void FrameSkipper::endFrame() noexcept {
     sync = driver.createSync();
 }
 
-
-} // namespace details
 } // namespace filament

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -42,8 +42,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
 /*
  * This enables froxels to be rectangular which allows us to use a bit more froxel
  * with the same amount of memory in the GPU.
@@ -926,5 +924,4 @@ void Froxelizer::computeLightTree(
             });
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -24,8 +24,6 @@ using namespace filament::math;
 
 namespace filament {
 
-using namespace details;
-
 Frustum::Frustum(const mat4f& pv) {
     Frustum::setProjection(pv);
 }

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -22,8 +22,6 @@
 
 namespace filament {
 
-using namespace details;
-
 struct IndexBuffer::BuilderDetails {
     uint32_t mIndexCount = 0;
     IndexType mIndexType = IndexType::UINT;
@@ -53,8 +51,6 @@ IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-namespace details {
-
 FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
         : mIndexCount(builder->mIndexCount) {
     FEngine::DriverApi& driver = engine.getDriverApi();
@@ -73,13 +69,9 @@ void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_
     engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 void IndexBuffer::setBuffer(Engine& engine,
         IndexBuffer::BufferDescriptor&& buffer, uint32_t byteOffset) {

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -37,8 +37,6 @@ using namespace filament::math;
 
 namespace filament {
 
-using namespace details;
-
 // ------------------------------------------------------------------------------------------------
 
 struct IndirectLight::BuilderDetails {
@@ -174,8 +172,6 @@ IndirectLight* IndirectLight::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-namespace details {
-
 FIndirectLight::FIndirectLight(FEngine& engine, const Builder& builder) noexcept {
     if (builder->mReflectionsMap) {
         mReflectionsMapHandle = upcast(builder->mReflectionsMap)->getHwHandle();
@@ -265,8 +261,6 @@ math::float3 FIndirectLight::getDirectionEstimate() const noexcept {
 float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
    return getColorEstimate(mIrradianceCoefs.data(), direction);
 }
-
-} // namespace details
 
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -44,7 +44,6 @@ using namespace filaflat;
 
 namespace filament {
 
-using namespace details;
 using namespace backend;
 
 
@@ -112,8 +111,6 @@ Material* Material::Builder::build(Engine& engine) {
 
     return result;
 }
-
-namespace details {
 
 static void addSamplerGroup(Program& pb, uint8_t bindingPoint, SamplerInterfaceBlock const& sib,
         SamplerBindingMap const& map) {
@@ -521,13 +518,9 @@ void FMaterial::destroyPrograms(FEngine& engine) {
     }
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 MaterialInstance* Material::createInstance(const char* name) const noexcept {
     return upcast(this)->createInstance(name);

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -37,8 +37,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
 FMaterialInstance::FMaterialInstance() noexcept = default;
 
 FMaterialInstance::FMaterialInstance(FEngine& engine, FMaterial const* material, const char* name) :
@@ -228,10 +226,6 @@ template UTILS_NOINLINE void FMaterialInstance::setParameter<float3>  (const cha
 template UTILS_NOINLINE void FMaterialInstance::setParameter<float4>  (const char* name, const float4   *v, size_t c) noexcept;
 template UTILS_NOINLINE void FMaterialInstance::setParameter<mat3f>   (const char* name, const mat3f    *v, size_t c) noexcept;
 template UTILS_NOINLINE void FMaterialInstance::setParameter<mat4f>   (const char* name, const mat4f    *v, size_t c) noexcept;
-
-} // namespace details
-
-using namespace details;
 
 Material const* MaterialInstance::getMaterial() const noexcept {
     return upcast(this)->getMaterial();

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -40,7 +40,6 @@ namespace filament {
 using namespace utils;
 using namespace math;
 using namespace backend;
-using namespace filament::details;
 
 static constexpr uint8_t kMaxBloomLevels = 12u;
 static_assert(kMaxBloomLevels >= 3, "We require at least 3 bloom levels");

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -28,18 +28,16 @@
 
 namespace filament {
 
-namespace details {
 class FMaterial;
 class FMaterialInstance;
 class FEngine;
 class FView;
 class RenderPass;
 struct CameraInfo;
-} // namespace details
 
 class PostProcessManager {
 public:
-    explicit PostProcessManager(details::FEngine& engine) noexcept;
+    explicit PostProcessManager(FEngine& engine) noexcept;
 
     void init() noexcept;
     void terminate(backend::DriverApi& driver) noexcept;
@@ -56,7 +54,7 @@ public:
     FrameGraphId<FrameGraphTexture> dof(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input,
             const View::DepthOfFieldOptions& dofOptions,
-            const details::CameraInfo& cameraInfo) noexcept;
+            const CameraInfo& cameraInfo) noexcept;
 
     FrameGraphId<FrameGraphTexture> opaqueBlit(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, FrameGraphTexture::Descriptor outDesc) noexcept;
@@ -68,12 +66,12 @@ public:
     FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
 
-    FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg, details::RenderPass const& pass,
+    FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg, RenderPass const& pass,
             uint32_t width, uint32_t height, float scale) noexcept;
 
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOclusion(FrameGraph& fg,
-            details::RenderPass& pass, filament::Viewport const& svp,
-            details::CameraInfo const& cameraInfo,
+            RenderPass& pass, filament::Viewport const& svp,
+            CameraInfo const& cameraInfo,
             View::AmbientOcclusionOptions const& options) noexcept;
 
     FrameGraphId<FrameGraphTexture> generateGaussianMipmap(FrameGraph& fg,
@@ -89,7 +87,7 @@ public:
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
 
 private:
-    details::FEngine& mEngine;
+    FEngine& mEngine;
 
     FrameGraphId<FrameGraphTexture> mipmapPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, size_t level) noexcept;
@@ -106,7 +104,7 @@ private:
     class PostProcessMaterial {
     public:
         PostProcessMaterial() noexcept = default;
-        PostProcessMaterial(details::FEngine& engine, uint8_t const* data, size_t size) noexcept;
+        PostProcessMaterial(FEngine& engine, uint8_t const* data, size_t size) noexcept;
 
         PostProcessMaterial(PostProcessMaterial const& rhs) = delete;
         PostProcessMaterial& operator=(PostProcessMaterial const& rhs) = delete;
@@ -116,17 +114,17 @@ private:
 
         ~PostProcessMaterial();
 
-        void terminate(details::FEngine& engine) noexcept;
+        void terminate(FEngine& engine) noexcept;
 
-        details::FMaterial* getMaterial() const { return mMaterial; }
-        details::FMaterialInstance* getMaterialInstance() const { return mMaterialInstance; }
+        FMaterial* getMaterial() const { return mMaterial; }
+        FMaterialInstance* getMaterialInstance() const { return mMaterialInstance; }
 
         backend::PipelineState getPipelineState(uint8_t variant) const noexcept;
         backend::PipelineState getPipelineState() const noexcept;
 
     private:
-        details::FMaterial* mMaterial = nullptr;
-        details::FMaterialInstance* mMaterialInstance = nullptr;
+        FMaterial* mMaterial = nullptr;
+        FMaterialInstance* mMaterialInstance = nullptr;
         backend::Handle<backend::HwProgram> mProgram;
     };
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -39,8 +39,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
 RenderPass::RenderPass(FEngine& engine,
         GrowingSlice<RenderPass::Command> commands) noexcept
         : mEngine(engine), mCommands(commands),
@@ -582,5 +580,4 @@ void RenderPass::updateSummedPrimitiveCounts(
     summedPrimitiveCount[vr.last] = count;
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -37,7 +37,6 @@ class JobSystem;
 }
 
 namespace filament {
-namespace details {
 
 class RenderPass {
 public:
@@ -352,7 +351,6 @@ private:
     size_t mCommandsHighWatermark = 0;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_UTILS_RENDERPASS_H

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -22,7 +22,6 @@
 #include "details/Material.h"
 
 namespace filament {
-namespace details {
 
 void FRenderPrimitive::init(backend::DriverApi& driver,
         const RenderableManager::Builder::Entry& entry) noexcept {
@@ -82,5 +81,4 @@ void FRenderPrimitive::set(FEngine& engine, RenderableManager::PrimitiveType typ
     mPrimitiveType = type;
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -26,7 +26,6 @@
 namespace filament {
 
 using namespace backend;
-using namespace details;
 
 struct RenderTarget::BuilderDetails {
     FRenderTarget::Attachment mAttachments[RenderTarget::ATTACHMENT_COUNT];
@@ -92,8 +91,6 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-namespace details {
-
 FRenderTarget::HwHandle FRenderTarget::createHandle(FEngine& engine, const Builder& builder) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     const Attachment& color = builder.mImpl->mAttachments[COLOR];
@@ -129,12 +126,8 @@ void FRenderTarget::terminate(FEngine& engine) {
     driver.destroyRenderTarget(mHandle);
 }
 
-} // namespace details
-
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 Texture* RenderTarget::getTexture(AttachmentPoint attachment) const noexcept {
     return upcast(this)->getAttachment(attachment).texture;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -53,8 +53,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
 FRenderer::FRenderer(FEngine& engine) :
         mEngine(engine),
         mFrameSkipper(engine, 1u),
@@ -939,13 +937,9 @@ Handle<HwRenderTarget> FRenderer::getRenderTarget(FView& view) const noexcept {
     return viewRenderTarget ? viewRenderTarget : mRenderTarget;
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 Engine* Renderer::getEngine() noexcept {
     return &upcast(this)->getEngine();

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -37,7 +37,6 @@ using namespace filament::math;
 using namespace utils;
 
 namespace filament {
-namespace details {
 
 // ------------------------------------------------------------------------------------------------
 
@@ -423,13 +422,9 @@ bool FScene::hasContactShadows() const noexcept {
     return hasContactShadows && mHasContactShadows;
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 void Scene::setSkybox(Skybox* skybox) noexcept {
     upcast(this)->setSkybox(upcast(skybox));

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -36,8 +36,6 @@ using namespace utils;
 namespace filament {
 using namespace backend;
 
-namespace details {
-
 // do this only if depth-clamp is available
 static constexpr bool USE_DEPTH_CLAMP = false;
 
@@ -86,7 +84,7 @@ void ShadowMap::render(DriverApi& driver, Handle<HwRenderTarget> rt,
     params.viewport = viewport;
 
     FCamera const& camera = getCamera();
-    details::CameraInfo cameraInfo(camera);
+    filament::CameraInfo cameraInfo(camera);
 
     pass.setCamera(cameraInfo);
     pass.setGeometry(scene.getRenderableData(), range, scene.getRenderableUBO());
@@ -104,7 +102,7 @@ void ShadowMap::render(DriverApi& driver, Handle<HwRenderTarget> rt,
 }
 
 void ShadowMap::update(const FScene::LightSoa& lightData, size_t index, FScene const* scene,
-        details::CameraInfo const& camera, uint8_t visibleLayers, ShadowMapLayout layout,
+        filament::CameraInfo const& camera, uint8_t visibleLayers, ShadowMapLayout layout,
         CascadeParameters cascadeParams) noexcept {
     // this is the hard part here, find a good frustum for our camera
 
@@ -1029,5 +1027,4 @@ void ShadowMap::visitScene(const FScene& scene, uint32_t visibleLayers,
     }
 }
 
-} // namespace details
 } // namespace filament

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -27,8 +27,6 @@ namespace filament {
 using namespace backend;
 using namespace math;
 
-namespace details {
-
 ShadowMapManager::ShadowMapManager(FEngine& engine) : mTextureState(0, 0) {
     for (size_t i = 0; i < mCascadeShadowMapCache.size(); i++) {
         mCascadeShadowMapCache[i] = std::make_unique<ShadowMap>(engine);
@@ -431,5 +429,4 @@ ShadowMapManager::CascadeSplits::CascadeSplits(Params p) : mSplitCount(p.cascade
     }
 }
 
-}
-}
+} // namespace filament

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -39,8 +39,6 @@
 using namespace filament::math;
 namespace filament {
 
-using namespace details;
-
 struct Skybox::BuilderDetails {
     Texture* mEnvironmentMap = nullptr;
     float4 mColor{0, 0, 0, 1};
@@ -89,8 +87,6 @@ Skybox* Skybox::Builder::build(Engine& engine) {
 }
 
 // ------------------------------------------------------------------------------------------------
-
-namespace details {
 
 FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
         : mSkyboxTexture(upcast(builder->mEnvironmentMap)),
@@ -155,13 +151,9 @@ void FSkybox::commit(backend::DriverApi& driver) noexcept {
     mSkyboxMaterialInstance->commit(driver);
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 void Skybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
     upcast(this)->setLayerMask(select, values);

--- a/filament/src/Stream.cpp
+++ b/filament/src/Stream.cpp
@@ -29,7 +29,6 @@
 
 namespace filament {
 
-using namespace details;
 using namespace backend;
 
 struct Stream::BuilderDetails {
@@ -78,8 +77,6 @@ Stream* Stream::Builder::build(Engine& engine) {
 }
 
 // ------------------------------------------------------------------------------------------------
-
-namespace details {
 
 FStream::FStream(FEngine& engine, const Builder& builder) noexcept
         : mEngine(engine),
@@ -150,14 +147,9 @@ int64_t FStream::getTimestamp() const noexcept {
     return driver.getStreamTimestamp(mStreamHandle);
 }
 
-
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 StreamType Stream::getStreamType() const noexcept {
     return upcast(this)->getStreamType();

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -19,7 +19,6 @@
 #include "details/Engine.h"
 
 namespace filament {
-namespace details {
 
 FSwapChain::FSwapChain(FEngine& engine, void* nativeWindow, uint64_t flags)
         : mNativeWindow(nativeWindow), mConfigFlags(flags) {
@@ -34,10 +33,6 @@ FSwapChain::FSwapChain(FEngine& engine, uint32_t width, uint32_t height, uint64_
 void FSwapChain::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroySwapChain(mSwapChain);
 }
-
-} // namespace details
-
-using namespace details;
 
 void* SwapChain::getNativeWindow() const noexcept {
     return upcast(this)->getNativeWindow();

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -35,7 +35,6 @@ using namespace utils;
 
 namespace filament {
 
-using namespace details;
 using namespace backend;
 
 struct Texture::BuilderDetails {
@@ -133,8 +132,6 @@ Texture* Texture::Builder::build(Engine& engine) {
 }
 
 // ------------------------------------------------------------------------------------------------
-
-namespace details {
 
 FTexture::FTexture(FEngine& engine, const Builder& builder) {
     mWidth  = static_cast<uint32_t>(builder->mWidth);
@@ -498,15 +495,9 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
     // by the caller (without being move()d here).
 }
 
-
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
-
 
 size_t Texture::getWidth(size_t level) const noexcept {
     return upcast(this)->getWidth(level);

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -30,7 +30,6 @@
 
 namespace filament {
 
-using namespace details;
 using namespace backend;
 using namespace filament::math;
 
@@ -142,8 +141,6 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
 
 // ------------------------------------------------------------------------------------------------
 
-namespace details {
-
 FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& builder)
         : mVertexCount(builder->mVertexCount), mBufferCount(builder->mBufferCount) {
     std::copy(std::begin(builder->mAttributes), std::end(builder->mAttributes), mAttributes.begin());
@@ -202,13 +199,9 @@ void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
     }
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace filament::details;
 
 size_t VertexBuffer::getVertexCount() const noexcept {
     return upcast(this)->getVertexCount();

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -52,8 +52,6 @@ namespace filament {
 
 using namespace backend;
 
-namespace details {
-
 FView::FView(FEngine& engine)
     : mFroxelizer(engine),
       mPerViewUb(PerViewUib::getUib().getSize()),
@@ -794,13 +792,9 @@ void FView::renderShadowMaps(FEngine& engine, FEngine::DriverApi& driver, Render
     mShadowMapManager.render(engine, *this, driver, pass);
 }
 
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 void View::setScene(Scene* scene) {
     return upcast(this)->setScene(upcast(scene));

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -28,7 +28,6 @@ using namespace utils;
 using namespace filament::math;
 
 namespace filament {
-namespace details {
 
 FCameraManager::FCameraManager(FEngine& engine) noexcept
         : mEngine(engine) {
@@ -89,14 +88,5 @@ void FCameraManager::destroy(Entity e) noexcept {
         manager.removeComponent(e);
     }
 }
-
-} // namespace details
-
-
-// ------------------------------------------------------------------------------------------------
-// Trampoline calling into private implementation
-// ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 } // namespace filament

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -32,8 +32,6 @@ public:
     using Instance = utils::EntityInstance<CameraManager>;
 };
 
-namespace details {
-
 class FEngine;
 class FCamera;
 
@@ -87,7 +85,6 @@ private:
     FEngine& mEngine;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_CAMERAMANAGER_H

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -30,8 +30,6 @@ using namespace utils;
 
 namespace filament {
 
-using namespace details;
-
 // ------------------------------------------------------------------------------------------------
 
 struct LightManager::BuilderDetails {
@@ -142,8 +140,6 @@ LightManager::Builder::Result LightManager::Builder::build(Engine& engine, Entit
 }
 
 // ------------------------------------------------------------------------------------------------
-
-namespace details {
 
 FLightManager::FLightManager(FEngine& engine) noexcept : mEngine(engine) {
     // DON'T use engine here in the ctor, because it's not fully constructed yet.
@@ -374,14 +370,9 @@ void FLightManager::setShadowCaster(Instance i, bool shadowCaster) noexcept {
     }
 }
 
-
-} // namespace details
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 size_t LightManager::getComponentCount() const noexcept {
     return upcast(this)->getComponentCount();

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -29,7 +29,6 @@
 #include <math/mat4.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FScene;
@@ -292,7 +291,6 @@ private:
 FILAMENT_UPCAST(LightManager)
 
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_LIGHTMANAGER_H

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -34,8 +34,6 @@ using namespace utils;
 
 namespace filament {
 
-using namespace details;
-
 struct RenderableManager::BuilderDetails {
     using Entry = RenderableManager::Builder::Entry;
     std::vector<Entry> mEntries;
@@ -244,9 +242,6 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
 }
 
 // ------------------------------------------------------------------------------------------------
-
-
-namespace details {
 
 FRenderableManager::FRenderableManager(FEngine& engine) noexcept : mEngine(engine) {
     // DON'T use engine here in the ctor, because it's not fully constructed yet.
@@ -536,14 +531,9 @@ void FRenderableManager::makeBone(PerRenderableUibBone* UTILS_RESTRICT out, mat4
     out->ns = is / max(abs(is));
 }
 
-} // namespace details
-
-
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
-
-using namespace details;
 
 bool RenderableManager::hasComponent(utils::Entity e) const noexcept {
     return upcast(this)->hasComponent(e);

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -39,7 +39,6 @@
 class FilamentTest_Bones_Test;
 
 namespace filament {
-namespace details {
 
 class FMaterialInstance;
 class FRenderPrimitive;
@@ -348,7 +347,6 @@ size_t FRenderableManager::getPrimitiveCount(Instance instance, uint8_t level) c
     return getRenderPrimitives(instance, level).size();
 }
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_RENDERABLECOMPONENTMANAGER_H

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -22,7 +22,6 @@ using namespace utils;
 using namespace filament::math;
 
 namespace filament {
-namespace details {
 
 FTransformManager::FTransformManager() noexcept = default;
 
@@ -378,10 +377,6 @@ void FTransformManager::gc(utils::EntityManager& em) noexcept {
                 destroy(e);
             });
 }
-
-} // namespace details
-
-using namespace details;
 
 TransformManager::children_iterator& TransformManager::children_iterator::operator++() {
     FTransformManager const& that = upcast(mManager);

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -29,7 +29,6 @@
 #include <math/mat4.h>
 
 namespace filament {
-namespace details {
 
 class UTILS_PRIVATE FTransformManager : public TransformManager {
 public:
@@ -160,7 +159,6 @@ private:
 
 FILAMENT_UPCAST(TransformManager)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_TRANSFORMMANAGER_H

--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -20,7 +20,6 @@
 #include <utils/Allocator.h>
 
 namespace filament {
-namespace details {
 
 // per render pass allocations
 // Froxelization needs about 1 MiB. Command buffer needs about 1 MiB.
@@ -63,7 +62,6 @@ using LinearAllocatorArena = utils::Arena<
 
 using ArenaScope = utils::ArenaScope<LinearAllocatorArena>;
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_ALLOCATORS_H

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -30,7 +30,6 @@
 #include <math/scalar.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -195,7 +194,6 @@ struct CameraInfo {
 
 FILAMENT_UPCAST(Camera)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_CAMERA_H

--- a/filament/src/details/Culler.h
+++ b/filament/src/details/Culler.h
@@ -26,7 +26,6 @@
 #include <math/vec2.h>
 
 namespace filament {
-namespace details {
 
 /*
  * This is where culling is implemented.
@@ -95,7 +94,6 @@ public:
     };
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_CULLER_H

--- a/filament/src/details/DFG.h
+++ b/filament/src/details/DFG.h
@@ -24,7 +24,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FTexture;
@@ -69,7 +68,6 @@ private:
 
 #undef FILAMENT_DFG_LUT_SIZE
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_DFG_H

--- a/filament/src/details/DebugRegistry.h
+++ b/filament/src/details/DebugRegistry.h
@@ -27,7 +27,6 @@
 #include <tsl/robin_map.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -67,7 +66,6 @@ private:
 
 FILAMENT_UPCAST(DebugRegistry)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_DEBUG_H

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -86,9 +86,6 @@ namespace fg {
 class ResourceAllocator;
 } // namespace fg
 
-
-namespace details {
-
 class FFence;
 class FMaterialInstance;
 class FRenderer;
@@ -124,10 +121,10 @@ public:
     static constexpr size_t CONFIG_FROXEL_SLICE_COUNT      = 16;
     static constexpr bool   CONFIG_IBL_USE_IRRADIANCE_MAP  = false;
 
-    static constexpr size_t CONFIG_PER_RENDER_PASS_ARENA_SIZE   = details::CONFIG_PER_RENDER_PASS_ARENA_SIZE;
-    static constexpr size_t CONFIG_PER_FRAME_COMMANDS_SIZE      = details::CONFIG_PER_FRAME_COMMANDS_SIZE;
-    static constexpr size_t CONFIG_MIN_COMMAND_BUFFERS_SIZE     = details::CONFIG_MIN_COMMAND_BUFFERS_SIZE;
-    static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE         = details::CONFIG_COMMAND_BUFFERS_SIZE;
+    static constexpr size_t CONFIG_PER_RENDER_PASS_ARENA_SIZE   = filament::CONFIG_PER_RENDER_PASS_ARENA_SIZE;
+    static constexpr size_t CONFIG_PER_FRAME_COMMANDS_SIZE      = filament::CONFIG_PER_FRAME_COMMANDS_SIZE;
+    static constexpr size_t CONFIG_MIN_COMMAND_BUFFERS_SIZE     = filament::CONFIG_MIN_COMMAND_BUFFERS_SIZE;
+    static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE         = filament::CONFIG_COMMAND_BUFFERS_SIZE;
 
 public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
@@ -396,7 +393,6 @@ public:
 
 FILAMENT_UPCAST(Engine)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_ENGINE_H

--- a/filament/src/details/Fence.h
+++ b/filament/src/details/Fence.h
@@ -31,8 +31,6 @@ namespace filament {
 
 struct HwFence;
 
-namespace details {
-
 class FEngine;
 
 class FFence : public Fence {
@@ -76,7 +74,6 @@ private:
 
 FILAMENT_UPCAST(Fence)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_FENCE_H

--- a/filament/src/details/FrameSkipper.h
+++ b/filament/src/details/FrameSkipper.h
@@ -22,7 +22,6 @@
 #include <array>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -46,7 +45,6 @@ private:
     size_t mLast;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_FRAMESKIPPER_H

--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -41,7 +41,6 @@
 #include <vector>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FCamera;
@@ -267,7 +266,6 @@ private:
     };
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_FROXEL_H

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -51,7 +50,6 @@ private:
 
 FILAMENT_UPCAST(IndexBuffer)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_INDEXBUFFER_H

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -31,7 +31,6 @@
 #include <array>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -67,7 +66,6 @@ private:
 
 FILAMENT_UPCAST(IndirectLight)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_INDIRECT_LIGHT_H

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -37,8 +37,6 @@ namespace filament {
 
 class MaterialParser;
 
-namespace details {
-
 class  FEngine;
 
 class FMaterial : public Material {
@@ -205,7 +203,6 @@ private:
 
 FILAMENT_UPCAST(Material)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_MATERIAL_H

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -32,7 +32,6 @@
 #include <filament/MaterialInstance.h>
 
 namespace filament {
-namespace details {
 
 class FMaterial;
 
@@ -170,7 +169,6 @@ private:
 
 FILAMENT_UPCAST(MaterialInstance)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_MATERIALINSTANCE_H

--- a/filament/src/details/RenderPrimitive.h
+++ b/filament/src/details/RenderPrimitive.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FVertexBuffer;
@@ -68,7 +67,6 @@ private:
     uint16_t mBlendOrder = 0;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_RENDERPRIMITIVE_H

--- a/filament/src/details/RenderTarget.h
+++ b/filament/src/details/RenderTarget.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FTexture;
@@ -63,7 +62,6 @@ private:
 
 FILAMENT_UPCAST(RenderTarget)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_RENDERTARGET_H

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -48,8 +48,6 @@ class Driver;
 
 class View;
 
-namespace details {
-
 class FEngine;
 class FView;
 class ShadowMap;
@@ -195,7 +193,6 @@ private:
 
 FILAMENT_UPCAST(Renderer)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_RENDERER_H

--- a/filament/src/details/ResourceList.h
+++ b/filament/src/details/ResourceList.h
@@ -27,7 +27,6 @@
 #include <mutex>
 
 namespace filament {
-namespace details {
 
 class ResourceListBase {
 public:
@@ -165,7 +164,6 @@ private:
     mutable LockingPolicy mLock;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_RESOURCELIST_H

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -39,7 +39,6 @@
 #include <tsl/robin_set.h>
 
 namespace filament {
-namespace details {
 
 struct CameraInfo;
 class FEngine;
@@ -233,7 +232,6 @@ private:
 
 FILAMENT_UPCAST(Scene)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_SCENE_H

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -31,7 +31,6 @@
 #include <math/vec4.h>
 
 namespace filament {
-namespace details {
 
 class FView;
 class RenderPass;
@@ -67,7 +66,7 @@ public:
     // Call once per frame if the light, scene (or visible layers) or camera changes.
     // This computes the light's camera.
     void update(const FScene::LightSoa& lightData, size_t index, FScene const* scene,
-            details::CameraInfo const& camera, uint8_t visibleLayers,
+            filament::CameraInfo const& camera, uint8_t visibleLayers,
             ShadowMapLayout layout, CascadeParameters cascadeParams) noexcept;
 
     void render(backend::DriverApi& driver, backend::Handle<backend::HwRenderTarget> rt,
@@ -222,7 +221,6 @@ private:
     const bool mTextureSpaceFlipped;
 };
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_SHADOWMAP_H

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -39,8 +39,6 @@ namespace filament {
 
 class FView;
 
-namespace details {
-
 class ShadowMap;
 class RenderPass;
 
@@ -173,7 +171,6 @@ private:
     std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASTING_SPOTS> mSpotShadowMapCache;
 };
 
-}
-}
+} // namespace filament
 
 #endif //TNT_FILAMENT_DETAILS_SHADOWMAPMANAGER_H

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -27,7 +27,6 @@
 #define TNT_FILAMENT_DETAILS_SKYBOX_H
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FTexture;
@@ -69,7 +68,6 @@ private:
 
 FILAMENT_UPCAST(Skybox)
 
-} // namespace details
 } // namespace filament
 
 

--- a/filament/src/details/Stream.h
+++ b/filament/src/details/Stream.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -64,7 +63,6 @@ private:
 
 FILAMENT_UPCAST(Stream)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_STREAM_H

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -68,7 +67,6 @@ private:
 
 FILAMENT_UPCAST(SwapChain)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_SWAPCHAIN_H

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -26,7 +26,6 @@
 #include <utils/compiler.h>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FStream;
@@ -121,7 +120,6 @@ private:
 
 FILAMENT_UPCAST(Texture)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_TEXTURE_H

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -31,7 +31,6 @@
 #include <type_traits>
 
 namespace filament {
-namespace details {
 
 class FEngine;
 
@@ -70,7 +69,6 @@ private:
 
 FILAMENT_UPCAST(VertexBuffer)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_VERTEXBUFFER_H

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -51,7 +51,6 @@ class JobSystem;
 } // namespace utils;
 
 namespace filament {
-namespace details {
 
 class FEngine;
 class FMaterialInstance;
@@ -415,7 +414,6 @@ private:
 
 FILAMENT_UPCAST(View)
 
-} // namespace details
 } // namespace filament
 
 #endif // TNT_FILAMENT_DETAILS_VIEW_H

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -37,7 +37,6 @@ namespace filament {
 
 using namespace backend;
 using namespace fg;
-using namespace details;
 
 // ------------------------------------------------------------------------------------------------
 

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -46,9 +46,7 @@
 
 namespace filament {
 
-namespace details {
 class FEngine;
-} // namespace details
 
 namespace fg {
 struct ResourceNode;
@@ -242,7 +240,7 @@ public:
     FrameGraph& compile() noexcept;
 
     // execute all referenced passes and flush the command queue after each pass
-    void execute(details::FEngine& engine, backend::DriverApi& driver) noexcept;
+    void execute(FEngine& engine, backend::DriverApi& driver) noexcept;
 
 
     /*
@@ -270,10 +268,10 @@ private:
     };
 
     template<typename T> using UniquePtr = std::unique_ptr<T, Deleter<T>>;
-    template<typename T> using Allocator = utils::STLAllocator<T, details::LinearAllocatorArena>;
+    template<typename T> using Allocator = utils::STLAllocator<T, LinearAllocatorArena>;
     template<typename T> using Vector = std::vector<T, Allocator<T>>; // 32 bytes
 
-    details::LinearAllocatorArena& getArena() noexcept { return mArena; }
+    LinearAllocatorArena& getArena() noexcept { return mArena; }
 
     fg::PassNode& createPass(const char* name, FrameGraphPassExecutor* base) noexcept;
 
@@ -322,7 +320,7 @@ private:
 
     Blackboard mBlackboard;
     fg::ResourceAllocatorInterface& mResourceAllocator;
-    details::LinearAllocatorArena mArena;
+    LinearAllocatorArena mArena;
     Vector<fg::PassNode> mPassNodes;                    // list of frame graph passes
     Vector<fg::ResourceNode *> mResourceNodes;          // list of resource nodes
     Vector<UniquePtr<fg::ResourceNode>> mResourceNodeEntries;

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -51,7 +51,7 @@ void FrameGraphTexture::create(FrameGraph& fg, const char* name,
     if (!(desc.usage & TextureUsage::SAMPLEABLE)) {
         levels = 1;
     }
-    assert(levels <= details::FTexture::maxLevelCount(desc.width, desc.height));
+    assert(levels <= FTexture::maxLevelCount(desc.width, desc.height));
 
     uint8_t samples = desc.samples;
     assert(samples <= 1 || none(desc.usage & TextureUsage::SAMPLEABLE));

--- a/filament/src/fg/FrameGraphPassResources.cpp
+++ b/filament/src/fg/FrameGraphPassResources.cpp
@@ -31,7 +31,6 @@ namespace filament {
 
 using namespace backend;
 using namespace fg;
-using namespace details;
 
 FrameGraphPassResources::FrameGraphPassResources(FrameGraph& fg, fg::PassNode const& pass) noexcept
         : mFrameGraph(fg), mPass(pass) {

--- a/filament/src/fg/ResourceAllocator.cpp
+++ b/filament/src/fg/ResourceAllocator.cpp
@@ -27,7 +27,6 @@ using namespace utils;
 namespace filament {
 
 using namespace backend;
-using namespace details;
 
 namespace fg {
 

--- a/filament/src/fg/fg/RenderTargetResourceEntry.cpp
+++ b/filament/src/fg/fg/RenderTargetResourceEntry.cpp
@@ -88,8 +88,8 @@ void RenderTargetResourceEntry::resolve(FrameGraph& fg) noexcept {
 
             // figure out the min/max dimensions across all attachments
             const size_t level = attachment.getLevel();
-            const uint32_t w = details::FTexture::valueForLevel(level, entry.descriptor.width);
-            const uint32_t h = details::FTexture::valueForLevel(level, entry.descriptor.height);
+            const uint32_t w = FTexture::valueForLevel(level, entry.descriptor.width);
+            const uint32_t h = FTexture::valueForLevel(level, entry.descriptor.height);
             minWidth = std::min(minWidth, w);
             maxWidth = std::max(maxWidth, w);
             minHeight = std::min(minHeight, h);

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -179,7 +179,7 @@ TEST(FilamentTest, SkinningMath) {
 }
 
 TEST(FilamentTest, TransformManager) {
-    filament::details::FTransformManager tcm;
+    filament::FTransformManager tcm;
     EntityManager& em = EntityManager::get();
     std::array<Entity, 3> entities;
     em.create(entities.size(), entities.data());
@@ -624,7 +624,6 @@ TEST(FilamentTest, ColorConversion) {
 
 TEST(FilamentTest, FroxelData) {
     using namespace filament;
-    using namespace filament::details;
 
     FEngine* engine = FEngine::create();
 
@@ -728,7 +727,6 @@ TEST(FilamentTest, FroxelData) {
 }
 
 TEST(FilamentTest, Bones) {
-    using namespace ::filament::details;
 
     struct Shader {
         static mat3f normal(PerRenderableUibBone const& bone) noexcept {


### PR DESCRIPTION
in practice it wasn't really useful, and it'll save some binary
space. everything is still isolated in the filament namespace.