### PR TITLE
Fix, Metal validation error with SSR and post-processing turned off

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -49,6 +49,8 @@ static inline MTLTextureUsage getMetalTextureUsage(TextureUsage usage) {
 
 MetalSwapChain::MetalSwapChain(id<MTLDevice> device, CAMetalLayer* nativeWindow)
         : layer(nativeWindow) {
+    // Needed so we can use the SwapChain as a blit source.
+    nativeWindow.framebufferOnly = NO;
     layer.device = device;
 }
 


### PR DESCRIPTION
Fixes the validation assertion:

```
Validation error: Shader reads texture (sourceColor[0]) whose usage (0x04) doesn't specify MTLTextureUsageShaderRead.
```