### PR TITLE
tone mapping fast path on tilers

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -156,6 +156,7 @@ set(MATERIAL_SRCS
         src/materials/sao.mat
         src/materials/separableGaussianBlur.mat
         src/materials/tonemapping.mat
+        src/materials/tonemappingWithSubpass.mat
         src/materials/fxaa.mat
 )
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -281,6 +281,7 @@ DECL_DRIVER_API_SYNCHRONOUS_N(backend::FenceStatus, wait, backend::FenceHandle, 
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
+DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameBufferFetchSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -568,6 +568,10 @@ bool MetalDriver::isRenderTargetFormatSupported(TextureFormat format) {
     return mtlFormat != MTLPixelFormatInvalid && mtlFormat != MTLPixelFormatRGB9E5Float;
 }
 
+bool MetalDriver::isFrameBufferFetchSupported() {
+    return false;
+}
+
 bool MetalDriver::isFrameTimeSupported() {
     // Frame time is calculated via hard fences, which are only available on iOS 12 and above.
     if (@available(macOS 10.14, iOS 12, *)) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -143,6 +143,10 @@ bool NoopDriver::isRenderTargetFormatSupported(TextureFormat format) {
     return true;
 }
 
+bool NoopDriver::isFrameBufferFetchSupported() {
+    return false;
+}
+
 bool NoopDriver::isFrameTimeSupported() {
     return true;
 }

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -218,6 +218,7 @@ void OpenGLContext::initExtensionsGLES(GLint major, GLint minor, ExtentionSet co
     ext.EXT_disjoint_timer_query = hasExtension(exts, "GL_EXT_disjoint_timer_query");
     ext.KHR_debug = hasExtension(exts, "GL_KHR_debug");
     ext.EXT_texture_compression_s3tc_srgb = hasExtension(exts, "GL_EXT_texture_compression_s3tc_srgb");
+    ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
     // ES 3.2 implies EXT_color_buffer_float
     if (major >= 3 && minor >= 2) {
         ext.EXT_color_buffer_float = true;
@@ -235,6 +236,7 @@ void OpenGLContext::initExtensionsGL(GLint major, GLint minor, ExtentionSet cons
     ext.APPLE_color_buffer_packed_float = true;  // Assumes core profile.
     ext.KHR_debug = major >= 4 && minor >= 3;
     ext.EXT_texture_sRGB = hasExtension(exts, "GL_EXT_texture_sRGB");
+    ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
 }
 
 void OpenGLContext::bindBuffer(GLenum target, GLuint buffer) noexcept {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -124,6 +124,7 @@ public:
         bool EXT_texture_sRGB = false;
         bool EXT_texture_compression_s3tc_srgb = false;
         bool EXT_disjoint_timer_query = false;
+        bool EXT_shader_framebuffer_fetch = false;
     } ext;
 
     struct {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1482,6 +1482,11 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
     }
 }
 
+bool OpenGLDriver::isFrameBufferFetchSupported() {
+    auto& gl = mContext;
+    return gl.ext.EXT_shader_framebuffer_fetch;
+}
+
 bool OpenGLDriver::isFrameTimeSupported() {
     return mFrameTimeSupported;
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -696,6 +696,10 @@ bool VulkanDriver::isRenderTargetFormatSupported(TextureFormat format) {
     return (info.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) != 0;
 }
 
+bool VulkanDriver::isFrameBufferFetchSupported() {
+    return false;
+}
+
 bool VulkanDriver::isFrameTimeSupported() {
     return true;
 }

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -42,10 +42,13 @@ public:
     void init() noexcept;
     void terminate(backend::DriverApi& driver) noexcept;
 
-    FrameGraphId <FrameGraphTexture> toneMapping(FrameGraph& fg,
-            FrameGraphId <FrameGraphTexture> input,
+    FrameGraphId<FrameGraphTexture> toneMapping(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input,
             backend::TextureFormat outFormat, bool translucent, bool fxaa, math::float2 scale,
             View::BloomOptions bloomOptions, bool dithering) noexcept;
+
+    void toneMappingSubpass(backend::DriverApi& driver,
+            bool translucent, bool fxaa, bool dithering) noexcept;
 
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
@@ -136,6 +139,7 @@ private:
     PostProcessMaterial mBloomUpsample;
     PostProcessMaterial mBlit[3];
     PostProcessMaterial mTonemapping;
+    PostProcessMaterial mTonemappingWithSubpass;
     PostProcessMaterial mFxaa;
     PostProcessMaterial mDoFBlur;
     PostProcessMaterial mDoF;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -171,18 +171,16 @@ RenderPass::Command* RenderPass::sortCommands() noexcept {
 void RenderPass::execute(const char* name,
         backend::Handle<backend::HwRenderTarget> renderTarget,
         backend::RenderPassParams params) const noexcept {
-
     FEngine& engine = mEngine;
-    Command const* const first = mCommands.begin();
-    Command const* const last = mCommands.end();
-
-    // Take care not to upload data within the render pass (synchronize can commit froxel data)
     DriverApi& driver = engine.getDriverApi();
-
-    // Now, execute all commands
     driver.beginRenderPass(renderTarget, params);
-    RenderPass::recordDriverCommands(driver, first, last);
+    executeCommands(name);
     driver.endRenderPass();
+}
+
+void RenderPass::executeCommands(const char* name) const noexcept {
+    DriverApi& driver = mEngine.getDriverApi();
+    RenderPass::recordDriverCommands(driver, mCommands.begin(), mCommands.end());
 }
 
 UTILS_NOINLINE // no need to be inlined

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -280,6 +280,8 @@ public:
             backend::Handle<backend::HwRenderTarget> renderTarget,
             backend::RenderPassParams params) const noexcept;
 
+    void executeCommands(const char* name) const noexcept;
+
     utils::GrowingSlice<Command>& getCommands() { return mCommands; }
     utils::Slice<Command> const& getCommands() const { return mCommands; }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -139,12 +139,22 @@ private:
         bool hasContactShadows;
     };
 
+    struct ToneMappingConfig {
+        bool toneMappingAsSubpass = false;
+        bool translucent{};
+        bool fxaa{};
+        bool dithering{};
+        backend::TextureFormat ldrFormat{};
+    };
+
     FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg, const char* name,
             FrameGraphTexture::Descriptor const& colorBufferDesc,
-            ColorPassConfig const& config, RenderPass const& pass, FView const& view) const noexcept;
+            ColorPassConfig const& config, ToneMappingConfig const& toneMappingConfig,
+            RenderPass const& pass, FView const& view) const noexcept;
 
     FrameGraphId<FrameGraphTexture> refractionPass(FrameGraph& fg,
-            ColorPassConfig config, RenderPass const& pass, FView const& view) const noexcept;
+            ColorPassConfig config, ToneMappingConfig const& toneMappingConfig,
+            RenderPass const& pass, FView const& view) const noexcept;
 
     void recordHighWatermark(size_t watermark) noexcept {
         mCommandsHighWatermark = std::max(mCommandsHighWatermark, watermark);

--- a/filament/src/materials/tonemappingWithSubpass.mat
+++ b/filament/src/materials/tonemappingWithSubpass.mat
@@ -1,0 +1,81 @@
+material {
+    name : tonemap,
+    parameters : [
+        {
+            type : int,
+            name : dithering
+        },
+        {
+            type : int,
+            name : fxaa
+        },
+        {
+            type : float4,
+            name : bloom
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess,
+    framebufferFetch: true
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = postProcess.normalizedUV;
+    }
+}
+
+fragment {
+
+    // TODO: this should be specified as a parameter
+    layout (input_attachment_index = 0, set = 0, binding = 0) uniform mediump subpassInput colorBuffer;
+    layout(location = 1) out vec4 tonemappedOutput;
+
+#include "../../../shaders/src/tone_mapping.fs"
+#include "../../../shaders/src/conversion_functions.fs"
+#include "../../../shaders/src/dithering.fs"
+
+    vec3 resolveFragment(const ivec2 uv) {
+        return subpassLoad(colorBuffer).rgb;
+    }
+
+    vec4 resolveAlphaFragment(const ivec2 uv) {
+        return subpassLoad(colorBuffer);
+    }
+
+    vec4 resolve() {
+#if POST_PROCESS_OPAQUE
+        vec4 color = vec4(resolveFragment(ivec2(getUV())), 1.0);
+        color.rgb  = tonemap(color.rgb);
+        color.rgb  = OECF(color.rgb);
+        if (materialParams.fxaa > 0) {
+            color.a = luminance(color.rgb);
+        }
+#else
+        vec4 color = resolveAlphaFragment(ivec2(getUV()));
+        color.rgb /= color.a + FLT_EPS;
+        color.rgb  = tonemap(color.rgb);
+        color.rgb  = OECF(color.rgb);
+        color.rgb *= color.a + FLT_EPS;
+#endif
+        return color;
+    }
+
+    void postProcess(inout PostProcessInputs postProcess) {
+        postProcess.color = resolve();
+        if (materialParams.dithering > 0) {
+            vec4 dithered = dither(postProcess.color);
+#if POST_PROCESS_OPAQUE
+            postProcess.color.rgb = dithered.rgb;
+#else
+            postProcess.color = dithered;
+#endif
+        }
+        tonemappedOutput = postProcess.color;
+    }
+
+}

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -91,7 +91,7 @@ public:
 
 protected:
     // Looks at platform and target API, then decides on shader models and output formats.
-    void prepare();
+    void prepare(bool vulkanSemantics);
 
     using ShaderModel = filament::backend::ShaderModel;
     Platform mPlatform = Platform::DESKTOP;
@@ -427,6 +427,10 @@ public:
     //! Specifies a list of variants that should be filtered out during code generation.
     MaterialBuilder& variantFilter(uint8_t variantFilter) noexcept;
 
+
+    MaterialBuilder& enableFramebufferFetch() noexcept;
+
+
     //! Build the material.
     Package build() noexcept;
 
@@ -577,6 +581,8 @@ private:
 
     SpecularAmbientOcclusion mSpecularAO = SpecularAmbientOcclusion::NONE;
     bool mSpecularAOSet = false;
+
+    bool mEnableFramebufferFetch = false;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -44,16 +44,25 @@ public:
 
     ~GLSLPostProcessor();
 
-    bool process(const std::string& inputShader, filament::backend::ShaderType shaderType,
-            filament::backend::ShaderModel shaderModel, std::string* outputGlsl,
-            SpirvBlob* outputSpirv, std::string* outputMsl);
+    struct Config {
+        filament::backend::ShaderType shaderType;
+        filament::backend::ShaderModel shaderModel;
+        struct {
+            std::vector<std::pair<uint32_t, uint32_t>> subpassInputToColorLocation;
+        } glsl;
+    };
+
+    bool process(const std::string& inputShader, Config const& config,
+            std::string* outputGlsl,
+            SpirvBlob* outputSpirv,
+            std::string* outputMsl);
 
 private:
 
     void fullOptimization(const glslang::TShader& tShader,
-            filament::backend::ShaderModel shaderModel) const;
+            GLSLPostProcessor::Config const& config) const;
     void preprocessOptimization(glslang::TShader& tShader,
-            filament::backend::ShaderModel shaderModel) const;
+            GLSLPostProcessor::Config const& config) const;
 
     void registerSizePasses(spvtools::Optimizer& optimizer) const;
     void registerPerformancePasses(spvtools::Optimizer& optimizer) const;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -428,6 +428,13 @@ static bool processMultiBounceAO(MaterialBuilder& builder, const JsonishValue& v
     return true;
 }
 
+static bool processFramebufferFetch(MaterialBuilder& builder, const JsonishValue& value) {
+    if (value.toJsonBool()->getBool()) {
+        builder.enableFramebufferFetch();
+    }
+    return true;
+}
+
 static bool processSpecularAmbientOcclusion(MaterialBuilder& builder, const JsonishValue& value) {
     static const std::unordered_map<std::string, MaterialBuilder::SpecularAmbientOcclusion> strToEnum {
             { "none",        MaterialBuilder::SpecularAmbientOcclusion::NONE },
@@ -573,6 +580,7 @@ ParametersProcessor::ParametersProcessor() {
     mParameters["domain"]                        = { &processDomain, Type::STRING };
     mParameters["refractionMode"]                = { &processRefractionMode, Type::STRING };
     mParameters["refractionType"]                = { &processRefractionType, Type::STRING };
+    mParameters["framebufferFetch"]              = { &processFramebufferFetch, Type::BOOL };
 }
 
 bool ParametersProcessor::process(MaterialBuilder& builder, const JsonishObject& jsonObject) {


### PR DESCRIPTION
This allows to never store/load to main memory the HDR color buffer,
saving precious bandwidth. This mode relies on the
ext_framebuffer_fetch extension being present and can't be enabled
with certain features (currently MSAA, Bloom, DoF).

This will eventually be supported on Metal and Vulkan as well.

The current implementation is a slightly hackish: it uses a special tonemapping material which itself uses private material properties. Eventually we will find a better way to support Vulkan subpasses.