### PR TITLE
matinfo / matdbg: fix SPIRV version, add validation.

### DIFF
--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -106,10 +106,16 @@ CString ShaderExtractor::spirvToGLSL(const uint32_t* data, size_t wordCount) {
 // but please do not submit. We prefer to use the syntax that the standalone "spirv-dis" tool
 // uses, which lets us easily generate test cases for the spirv-cross project.
 CString ShaderExtractor::spirvToText(const uint32_t* begin, size_t wordCount) {
-    auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
+    if (SPV_SUCCESS != spvValidateBinary(context, begin, wordCount, nullptr)) {
+        spvContextDestroy(context);
+        return CString("Validation failure.");
+    }
+
     spv_text text = nullptr;
     const uint32_t options = SPV_BINARY_TO_TEXT_OPTION_INDENT |
             SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;
+
     spvBinaryToText(context, begin, wordCount, options, &text, nullptr);
     CString result(text->str);
     spvTextDestroy(text);

--- a/tools/matinfo/src/main.cpp
+++ b/tools/matinfo/src/main.cpp
@@ -73,7 +73,7 @@ static void printUsage(const char* name) {
             "   --print-glsl=[index], -g\n"
             "       Print GLSL for the nth shader (0 is the first OpenGL shader)\n\n"
             "   --print-spirv=[index], -s\n"
-            "       Print disasm for the nth shader (0 is the first Vulkan shader)\n\n"
+            "       Validate and print disasm for the nth shader (0 is the first Vulkan shader)\n\n"
             "   --print-metal=[index], -m\n"
             "       Print Metal Shading Language for the nth shader (0 is the first Metal shader)\n\n"
             "   --print-vkglsl=[index], -v\n"


### PR DESCRIPTION
The value we pass to spvContextCreate() is not SPV_ENV_UNIVERSAL_1_3,
which is what we use in GLSLPostProcessor.

Also add a call to spvValidateBinary(), which would have caught this
oversight.