### PR TITLE
filamat: generate spirv 1.0 rather than spirv 1.3

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -304,7 +304,7 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
     GlslangToSpv(*tShader.getIntermediate(), spirv, &options);
 
     // Run the SPIR-V optimizer
-    Optimizer optimizer(SPV_ENV_UNIVERSAL_1_3);
+    Optimizer optimizer(SPV_ENV_UNIVERSAL_1_0);
     optimizer.SetMessageConsumer([](spv_message_level_t level,
             const char* source, const spv_position_t& position, const char* message) {
         utils::slog.e << stringifySpvOptimizerMessage(level, source, position, message)

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -339,8 +339,8 @@ void GLSLTools::prepareShaderParser(glslang::TShader& shader, EShLanguage langua
             optimization == filamat::MaterialBuilder::Optimization::PERFORMANCE) {
         shader.setAutoMapBindings(true);
         shader.setEnvInput(EShSourceGlsl, language, EShClientVulkan, version);
-        shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_1);
-        shader.setEnvTarget(EShTargetSpv, EShTargetSpv_1_3);
+        shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_0);
+        shader.setEnvTarget(EShTargetSpv, EShTargetSpv_1_0);
     }
 }
 

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -278,7 +278,7 @@ public:
             mg_printf(conn, kSuccessHeader.c_str(), "application/text");
 
             if (true) {
-                auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+                auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
                 spv_text text = nullptr;
                 const uint32_t options = SPV_BINARY_TO_TEXT_OPTION_INDENT |
                         SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -106,7 +106,7 @@ CString ShaderExtractor::spirvToGLSL(const uint32_t* data, size_t wordCount) {
 // but please do not submit. We prefer to use the syntax that the standalone "spirv-dis" tool
 // uses, which lets us easily generate test cases for the spirv-cross project.
 CString ShaderExtractor::spirvToText(const uint32_t* begin, size_t wordCount) {
-    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
+    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
     if (SPV_SUCCESS != spvValidateBinary(context, begin, wordCount, nullptr)) {
         spvContextDestroy(context);
         return CString("Validation failure.");


### PR DESCRIPTION
Since we are still on Vulkan 1.0, we cannot use SPIR-V 1.3.
If we try to do so, this error is generated:

    Invalid SPIR-V binary version 1.3 for target environment SPIR-V 1.0

In non-optimized builds, we were already generating spirv 1.0, but
when we enabled the shader optimizer, we generated spirv 1.3.

This bug has actually been around forever, but we did not notice because
we were only invoking the optimizer in release builds, which does not
enable validation.

We cannot upgrade to Vulkan 1.1 because the latest LunarG SDK for macOS
does not support it.