### PR TITLE
Vulkan: refactor the ENABLE_VALIDATION flag.

### DIFF
--- a/filament/backend/src/vulkan/PlatformVkAndroid.cpp
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.cpp
@@ -37,7 +37,7 @@ Driver* PlatformVkAndroid::createDriver(void* const sharedContext) noexcept {
     static const char* requestedExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_android_surface",
-#if !defined(NDEBUG)
+#if VK_ENABLE_VALIDATION
         "VK_EXT_debug_report",
 #endif
     };

--- a/filament/backend/src/vulkan/PlatformVkCocoa.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.mm
@@ -42,7 +42,7 @@ Driver* PlatformVkCocoa::createDriver(void* sharedContext) noexcept {
     static const char* requestedExtensions[] = {
         "VK_KHR_surface",
         "VK_MVK_macos_surface",
-#if !defined(NDEBUG)
+#if VK_ENABLE_VALIDATION
         "VK_EXT_debug_report",
 #endif
     };

--- a/filament/backend/src/vulkan/PlatformVkLinux.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinux.cpp
@@ -51,7 +51,7 @@ Driver* PlatformVkLinux::createDriver(void* const sharedContext) noexcept {
     const char* requestedExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_xlib_surface",
-#if !defined(NDEBUG)
+#if VK_ENABLE_VALIDATION
         "VK_EXT_debug_report",
 #endif
     };

--- a/filament/backend/src/vulkan/PlatformVkWindows.cpp
+++ b/filament/backend/src/vulkan/PlatformVkWindows.cpp
@@ -31,7 +31,7 @@ Driver* PlatformVkWindows::createDriver(void* const sharedContext) noexcept {
     const char* requestedExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_win32_surface",
-#if !defined(NDEBUG)
+#if VK_ENABLE_VALIDATION
         "VK_EXT_debug_report",
 #endif
     };

--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -579,7 +579,7 @@ void VulkanBinder::destroyLayoutsAndDescriptors() noexcept {
     // Our current descriptor set strategy can cause the # of descriptor sets to explode in certain
     // situations, so it's interesting to report the number that get stuffed into the cache.
     #ifndef NDEBUG
-    utils::slog.i << "Destroying " << mDescriptorSets.size() << " descriptor sets."
+    utils::slog.d << "Destroying " << mDescriptorSets.size() << " descriptor sets."
             << utils::io::endl;
     #endif
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -46,15 +46,10 @@
 //   srcDirs = ["${android.ndkDirectory}/sources/third_party/vulkan/src/build-android/jniLibs"]
 // } } }
 //
-#if !defined(NDEBUG)
-#define ENABLE_VALIDATION 1
-#else
-#define ENABLE_VALIDATION 0
-#endif
 
 static constexpr int SWAP_CHAIN_MAX_ATTEMPTS = 16;
 
-#if ENABLE_VALIDATION
+#if VK_ENABLE_VALIDATION
 
 namespace {
 
@@ -95,7 +90,7 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
     ASSERT_POSTCONDITION(bluevk::initialize(), "BlueVK is unable to load entry points.");
 
     VkInstanceCreateInfo instanceCreateInfo = {};
-#if ENABLE_VALIDATION
+#if VK_ENABLE_VALIDATION
     const utils::StaticString DESIRED_LAYERS[] = {
 #if defined(ANDROID)
         // TODO: use VK_LAYER_KHRONOS_validation instead of these layers after it becomes available
@@ -138,7 +133,7 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
                 << "Please ensure that VK_LAYER_PATH is set correctly." << utils::io::endl;
 #endif
     }
-#endif // ENABLE_VALIDATION
+#endif // VK_ENABLE_VALIDATION
 
     // Create the Vulkan instance.
     VkApplicationInfo appInfo = {};
@@ -154,7 +149,7 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
     UTILS_UNUSED const PFN_vkCreateDebugReportCallbackEXT createDebugReportCallback =
             vkCreateDebugReportCallbackEXT;
 
-#if ENABLE_VALIDATION
+#if VK_ENABLE_VALIDATION
     if (createDebugReportCallback) {
         const VkDebugReportCallbackCreateInfoEXT cbinfo = {
             VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,

--- a/filament/backend/src/vulkan/VulkanPlatform.h
+++ b/filament/backend/src/vulkan/VulkanPlatform.h
@@ -19,12 +19,13 @@
 
 #include <backend/Platform.h>
 
+#if !defined(NDEBUG)
+#define VK_ENABLE_VALIDATION 1
+#else
+#define VK_ENABLE_VALIDATION 0
+#endif
+
 namespace filament {
-
-namespace backend {
-class Driver;
-} // namespace backend
-
 namespace backend {
 
 class VulkanPlatform : public DefaultPlatform {


### PR DESCRIPTION
It is convenient to control the debug_info extension and the validation
layers from one central place. This makes it easier to force-enable
validation in Release builds to validate optimized shaders.