### PR TITLE
Vulkan: fix synchronization issues with timestamps.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -202,10 +202,13 @@ void createVirtualDevice(VulkanContext& context) {
     VkQueryPoolCreateInfo tqpCreateInfo = {};
     tqpCreateInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
     tqpCreateInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+
+    std::unique_lock<utils::Mutex> timestamps_lock(context.timestamps.mutex);
     tqpCreateInfo.queryCount = context.timestamps.used.size() * 2;
     result = vkCreateQueryPool(context.device, &tqpCreateInfo, VKALLOC, &context.timestamps.pool);
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkCreateQueryPool error.");
     context.timestamps.used.reset();
+    timestamps_lock.unlock();
 
     const VmaVulkanFunctions funcs {
         .vkGetPhysicalDeviceProperties = vkGetPhysicalDeviceProperties,

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -73,6 +73,7 @@ struct VulkanCommandBuffer {
 struct VulkanTimestamps {
     VkQueryPool pool;
     utils::bitset32 used;
+    utils::Mutex mutex;
 };
 
 // For now we only support a single-device, single-instance scenario. Our concept of "context" is a

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -678,7 +678,8 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
 }
 
 VulkanTimerQuery::VulkanTimerQuery(VulkanContext& context) : mContext(context) {
-    auto& bitset = context.timestamps.used;
+    std::unique_lock<utils::Mutex> lock(context.timestamps.mutex);
+    utils::bitset32& bitset = context.timestamps.used;
     const size_t maxTimers = bitset.size();
     assert(bitset.count() < maxTimers);
     for (size_t timerIndex = 0; timerIndex < maxTimers; ++timerIndex) {
@@ -695,6 +696,7 @@ VulkanTimerQuery::VulkanTimerQuery(VulkanContext& context) : mContext(context) {
 }
 
 VulkanTimerQuery::~VulkanTimerQuery() {
+    std::unique_lock<utils::Mutex> lock(mContext.timestamps.mutex);
     mContext.timestamps.used.unset(startingQueryIndex / 2);
 }
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -172,6 +172,7 @@ struct VulkanTimerQuery : public HwTimerQuery {
     uint32_t startingQueryIndex;
     uint32_t stoppingQueryIndex;
     VulkanContext& mContext;
+    std::atomic<bool> ready;
 };
 
 } // namespace filament


### PR DESCRIPTION
This contains the following two fixes, but the second fix is more
important because it prevents an actual validation error on Android.

1. The query pool bitset was written in the main thread but read
   in the driver thread, this is now protected with a mutex.

2. Querying a timestamp before it has been written into the command
   buffer was still causing validation errors, despite the fact
   that we are now properly using the AVAILABILTY flag. This is a
   CPU-side synchronization problem and can therefore be fixed using
   std::atomic<bool>.