### PR TITLE
Fix refracted objects drawing order

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -599,6 +599,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 data.ssr  = blackboard.get<FrameGraphTexture>("ssr");
                 data.ssao = blackboard.get<FrameGraphTexture>("ssao");
                 data.color = blackboard.get<FrameGraphTexture>("color");
+                data.depth = blackboard.get<FrameGraphTexture>("depth");
                 data.structure = blackboard.get<FrameGraphTexture>("structure");
 
                 if (config.hasContactShadows) {


### PR DESCRIPTION
Refracted objects could be drawn on top of opaque objects that were
closer to the camera.

Du to a typo, we were not reusing the existing depth buffer during the
refraction pass.

Fixes #2576