### PR TITLE
Initialize DisplayHelper when using textureView in ModelViewer

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -141,6 +141,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
 
         this.textureView = textureView
         gestureDetector = GestureDetector(textureView, cameraManipulator)
+        displayHelper = DisplayHelper(textureView.context)
         uiHelper.renderCallback = SurfaceCallback()
         uiHelper.attachTo(textureView)
         addDetachListener(textureView)


### PR DESCRIPTION
Fixes: [#2599](https://github.com/google/filament/issues/2599)

When using ModelViewer with a TextureView instead of a SurfaceView, it throws an error because the displayHelper is not initialized. But the displayHelper is needed and is used here,  [ModelViewer.kt#L288](https://github.com/google/filament/blob/6d04ae250afd33dbdba0a222e42a4700777389a9/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt#L288).

I think this constructor it is not used very often but I am implementing filament inside an example where I have already a SurfaceView and wanted to try if it would work with TextureView

