### PR TITLE
Add correct scheduleDestroy calls to Metal backend

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ A new header is inserted each time a *tag* is created.
 - SSAO now has an optional high(er) quality upsampler.
 - Tone mappping now uses the real ACES tone mapper, applied in the proper color space.
 - Tone mapping is now applied via a LUT, which will later enable color grading capabilities.
+- Fixed Metal issue with `BufferDescriptor` and `PixelBufferDescriptor`s not being called on application thread.
 
 ## v1.7.0
 

--- a/filament/backend/src/TextureReshaper.h
+++ b/filament/backend/src/TextureReshaper.h
@@ -37,6 +37,11 @@ public:
     explicit TextureReshaper(TextureFormat requestedFormat) noexcept;
 
     /**
+     * Returns true if the TextureFormat requires reshaping.
+     */
+    bool needsReshaping() const noexcept { return mNeedsReshaping; }
+
+    /**
      * Returns the graphics API-native TextureFormat that pixels will be reshaped into.
      * If the format does not need reshaping, the original requestedFormat is returned.
      */
@@ -48,15 +53,15 @@ public:
      * @param p The pixel buffer to reshape.
      * @return A new PixelBufferDescriptor containing the reshaped pixels.
      */
-    PixelBufferDescriptor reshape(PixelBufferDescriptor&& p) const;
+    PixelBufferDescriptor reshape(PixelBufferDescriptor& p) const;
 
     static bool canReshapeTextureFormat(TextureFormat format) noexcept;
 
 private:
 
-    std::function<PixelBufferDescriptor(PixelBufferDescriptor&& p)> reshapeFunction =
-            [](PixelBufferDescriptor&& p){ return std::move(p); };
-    TextureFormat reshapedFormat;
+    std::function<PixelBufferDescriptor(PixelBufferDescriptor& p)> mReshapeFunction;
+    TextureFormat mReshapedFormat;
+    bool mNeedsReshaping;
 
 };
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -584,6 +584,7 @@ void MetalDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
     assert(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers
     auto* vb = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     vb->buffers[index]->copyIntoBuffer(data.buffer, data.size);
+    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
@@ -591,6 +592,7 @@ void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&
     assert(byteOffset == 0);    // TODO: handle byteOffset for index buffers
     auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     ib->buffer.copyIntoBuffer(data.buffer, data.size);
+    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t xoffset,
@@ -598,7 +600,8 @@ void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t x
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
             "update2DImage must be called outside of a render pass.");
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->load2DImage(level, xoffset, yoffset, width, height, std::move(data));
+    tex->load2DImage(level, xoffset, yoffset, width, height, data);
+    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::update3DImage(Handle<HwTexture> th, uint32_t level,
@@ -608,7 +611,8 @@ void MetalDriver::update3DImage(Handle<HwTexture> th, uint32_t level,
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
             "update3DImage must be called outside of a render pass.");
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->load3DImage(level, xoffset, yoffset, zoffset, width, height, depth, std::move(data));
+    tex->load3DImage(level, xoffset, yoffset, zoffset, width, height, depth, data);
+    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
@@ -616,7 +620,8 @@ void MetalDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
             "updateCubeImage must be called outside of a render pass.");
     auto tex = handle_cast<MetalTexture>(mHandleMap, th);
-    tex->loadCubeImage(faceOffsets, level, std::move(data));
+    tex->loadCubeImage(faceOffsets, level, data);
+    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::setupExternalImage(void* image) {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -124,10 +124,10 @@ struct MetalTexture : public HwTexture {
     ~MetalTexture();
 
     void load2DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width,
-            uint32_t height, PixelBufferDescriptor&& p) noexcept;
+            uint32_t height, PixelBufferDescriptor& p) noexcept;
     void load3DImage(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
-            uint32_t width, uint32_t height, uint32_t depth, PixelBufferDescriptor&& p) noexcept;
-    void loadCubeImage(const FaceOffsets& faceOffsets, int miplevel, PixelBufferDescriptor&& p);
+            uint32_t width, uint32_t height, uint32_t depth, PixelBufferDescriptor& p) noexcept;
+    void loadCubeImage(const FaceOffsets& faceOffsets, int miplevel, PixelBufferDescriptor& p);
     void loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
             uint32_t width, uint32_t height, uint32_t depth, uint32_t byteOffset, uint32_t slice,
             PixelBufferDescriptor& data, id<MTLBlitCommandEncoder> blitCommandEncoder,


### PR DESCRIPTION
 `scheduleDestroy` wasn't being called in a lot of places.