### PR TITLE
perfcounters are now disabled by default

### DIFF
--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -297,6 +297,8 @@ private:
     std::thread::id mThreadId;
 #endif
 
+    bool mUsePerformanceCounter = false;
+
     inline void* allocateCommand(size_t size) {
         assert(mThreadId == std::this_thread::get_id());
         return mCurrentBuffer->allocate(size);


### PR DESCRIPTION
To enable some basic profiling of the gl thread using performance
counters, the "filament.perfcounters" property must be set to 1
(before the Filament Engine is created):

    adb shell setprop filament.perfcounters 1

This is so that filament doesn't interfere with simpleperf by default.