### PR TITLE
 gltfio: Add support for "software instancing".

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- gltfio now supports simple instancing of entire assets.
 - Add missing JavaScript API for `View::setVisibleLayers()`.
 - Add support for DOF with Metal backend.
 - SSAO now has an optional high(er) quality upsampler.

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PUBLIC_HDRS
         include/gltfio/ResourceLoader.h
         include/gltfio/SimpleViewer.h
         include/gltfio/FilamentAsset.h
+        include/gltfio/FilamentInstance.h
 )
 
 set(SRCS
@@ -25,6 +26,8 @@ set(SRCS
         src/DracoCache.cpp
         src/FFilamentAsset.h
         src/FilamentAsset.cpp
+        src/FFilamentInstance.h
+        src/FilamentInstance.cpp
         src/GltfEnums.h
         src/MaterialProvider.cpp
         src/ResourceLoader.cpp

--- a/libs/gltfio/include/gltfio/Animator.h
+++ b/libs/gltfio/include/gltfio/Animator.h
@@ -18,10 +18,14 @@
 #define GLTFIO_ANIMATOR_H
 
 #include <gltfio/FilamentAsset.h>
+#include <gltfio/FilamentInstance.h>
 
 namespace gltfio {
 
-namespace details { struct FFilamentAsset; }
+namespace details {
+    struct FFilamentAsset;
+    struct FFilamentInstance;
+}
 
 struct AnimatorImpl;
 
@@ -71,9 +75,11 @@ private:
 
     /*! \cond PRIVATE */
     friend struct details::FFilamentAsset;
+    friend struct details::FFilamentInstance;
     /*! \endcond */
 
     Animator(FilamentAsset* asset);
+    Animator(FilamentInstance* instance);
     ~Animator();
     AnimatorImpl* mImpl;
 };

--- a/libs/gltfio/include/gltfio/Animator.h
+++ b/libs/gltfio/include/gltfio/Animator.h
@@ -78,8 +78,7 @@ private:
     friend struct details::FFilamentInstance;
     /*! \endcond */
 
-    Animator(FilamentAsset* asset);
-    Animator(FilamentInstance* instance);
+    Animator(details::FFilamentAsset* asset, details::FFilamentInstance* instance);
     ~Animator();
     AnimatorImpl* mImpl;
 };

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -21,6 +21,7 @@
 #include <filament/Material.h>
 
 #include <gltfio/FilamentAsset.h>
+#include <gltfio/FilamentInstance.h>
 #include <gltfio/MaterialProvider.h>
 
 namespace utils {
@@ -149,6 +150,32 @@ public:
      * of Filament objects. Returns null on failure.
      */
     FilamentAsset* createAssetFromBinary(const uint8_t* bytes, uint32_t nbytes);
+
+    /**
+     * Consumes the contents of a glTF 2.0 file and produces a master asset with one or more
+     * instances.
+     *
+     * The returned instances share their textures, material instances, and vertex buffers with the
+     * master asset. However each instance has its own unique set of entities, transform components,
+     * and renderable components. Instances are automatically freed when the master asset is freed.
+     *
+     * Light components are not instanced, they belong only to the master asset.
+     *
+     * Clients must use ResourceLoader to load resources on the master asset.
+     *
+     * The entity accessors and renderable stack in the returned FilamentAsset represent the union
+     * of all entities across all instances. Use the individual FilamentInstance objects to access
+     * each partition of entities.  Similarly, the Animator in the master asset controls all
+     * instances. To animate instances individually, use FilamentInstance::getAnimator().
+     *
+     * @param bytes the contents of a glTF 2.0 file (JSON or GLB)
+     * @param numBytes the number of bytes in "bytes"
+     * @param instances destination pointer, to be populated by the requested number of instances
+     * @param numInstances requested number of instances
+     * @return the master asset that has ownership over all instances
+     */
+    FilamentAsset* createInstancedAsset(const uint8_t* bytes, uint32_t numBytes,
+            FilamentInstance** instances, size_t numInstances);
 
     /**
      * Takes a pointer to an opaque pipeline object and returns a bundle of Filament objects.

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -40,8 +40,8 @@ class Animator;
  * For usage instructions, see the documentation for AssetLoader.
  *
  * This class owns a hierarchy of entities that have been loaded from a glTF asset. Every entity has
- * a filament::TransformManager component, and some entities also have \c Name and/or \c Renderable
- * components.
+ * a filament::TransformManager component, and some entities also have \c Name, \c Renderable, or
+ * \c Light components.
  *
  * In addition to the aforementioned entities, an asset has strong ownership over a list of
  * filament::VertexBuffer, filament::IndexBuffer, filament::MaterialInstance, filament::Texture,
@@ -77,7 +77,13 @@ public:
      */
     size_t getLightEntityCount() const noexcept;
 
-    /** Gets the transform root for the asset, which has no matching glTF node. */
+    /**
+     * Gets the transform root for the asset, which has no matching glTF node.
+     *
+     * This node exists for convenience, allowing users to transform the entire asset. For instanced
+     * assets, this is a "super root" where each of its children is a root in a particular instance.
+     * This allows users to transform all instances en masse if they wish to do so.
+     */
     utils::Entity getRoot() const noexcept;
 
     /**
@@ -132,7 +138,11 @@ public:
 
     /**
      * Lazily creates the animation engine or returns it from the cache.
+     *
      * The animator is owned by the asset and should not be manually deleted.
+     * The first time this is called, it must be called before FilamentAsset::releaseSourceData().
+     * If the asset is instanced, this returns a "master" animator that controls all instances.
+     * To animate each instance individually, use \see FilamentInstance.
      */
     Animator* getAnimator() noexcept;
 

--- a/libs/gltfio/include/gltfio/FilamentInstance.h
+++ b/libs/gltfio/include/gltfio/FilamentInstance.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_FILAMENTINSTANCE_H
+#define GLTFIO_FILAMENTINSTANCE_H
+
+#include <utils/Entity.h>
+
+namespace gltfio {
+
+class Animator;
+
+/**
+ * \class FilamentInstance FilamentInstance.h gltfio/FilamentInstance.h
+ * \brief Provides access to a hierarchy of entities that have been instanced from a glTF asset.
+ *
+ * Every entity has a filament::TransformManager component, and some entities also have \c Name or
+ * \c Renderable components.
+ *
+ * \see AssetLoader::createInstancedAsset()
+ */
+class FilamentInstance {
+public:
+    /**
+     * Gets the list of entities in this instance, one for each glTF node. All of these have a
+     * Transform component. Some of the returned entities may also have a Renderable component or
+     * Name component.
+     */
+    const utils::Entity* getEntities() const noexcept;
+
+    /**
+     * Gets the number of entities returned by getEntities().
+     */
+    size_t getEntityCount() const noexcept;
+
+    /** Gets the transform root for the instance, which has no matching glTF node. */
+    utils::Entity getRoot() const noexcept;
+
+    /**
+     * Lazily creates the animation engine for the instance, or returns it from the cache.
+     *
+     * The animator is owned by the asset and should not be manually deleted.
+     * The first time this is called, it must be called before FilamentAsset::releaseSourceData().
+     */
+    Animator* getAnimator() noexcept;
+};
+
+} // namespace gltfio
+
+#endif // GLTFIO_FILAMENTINSTANCE_H

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -78,8 +78,10 @@ public:
      *
      * @param asset The asset to view.
      * @param scale Adds a transform to the root to fit the asset into a unit cube at the origin.
+     * @param instanceToAnimate Optional instance from which to get the animator.
      */
-    void populateScene(FilamentAsset* asset, bool scale);
+    void populateScene(FilamentAsset* asset, bool scale,
+            FilamentInstance* instanceToAnimate = nullptr);
 
     /**
      * Removes the current asset from the viewer.
@@ -270,7 +272,8 @@ SimpleViewer::~SimpleViewer() {
     mEngine->destroy(mSunlight);
 }
 
-void SimpleViewer::populateScene(FilamentAsset* asset, bool scale) {
+void SimpleViewer::populateScene(FilamentAsset* asset, bool scale,
+        FilamentInstance* instanceToAnimate) {
     if (mAsset != asset) {
         removeAsset();
         mAsset = asset;
@@ -278,7 +281,7 @@ void SimpleViewer::populateScene(FilamentAsset* asset, bool scale) {
             mAnimator = nullptr;
             return;
         }
-        mAnimator = asset->getAnimator();
+        mAnimator = instanceToAnimate ? instanceToAnimate->getAnimator() : asset->getAnimator();
         if (scale) {
             auto& tcm = mEngine->getTransformManager();
             auto root = tcm.getInstance(mAsset->getRoot());

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -17,6 +17,7 @@
 #include <gltfio/Animator.h>
 
 #include "FFilamentAsset.h"
+#include "FFilamentInstance.h"
 #include "math.h"
 #include "upcast.h"
 
@@ -69,7 +70,8 @@ struct Animation {
 struct AnimatorImpl {
     vector<Animation> animations;
     vector<mat4f> boneMatrices;
-    FFilamentAsset* asset;
+    FFilamentAsset* asset = nullptr;
+    FFilamentInstance* instance = nullptr;
     RenderableManager* renderableManager;
     TransformManager* transformManager;
 };
@@ -136,6 +138,12 @@ static void setTransformType(const cgltf_animation_channel& src, Channel& dst) {
             break;
     }
 }
+
+Animator::Animator(FilamentInstance* publicInstance) {
+    mImpl = new AnimatorImpl();
+    FFilamentInstance* instance = mImpl->instance = upcast(publicInstance);
+    // TODO
+ }
 
 Animator::Animator(FilamentAsset* publicAsset) {
     mImpl = new AnimatorImpl();

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -47,6 +47,7 @@ using namespace details;
 
 using TimeValues = std::map<float, size_t>;
 using SourceValues = std::vector<float>;
+using BoneVector = std::vector<filament::math::mat4f>;
 
 struct Sampler {
     TimeValues times;
@@ -370,12 +371,12 @@ void Animator::updateBoneMatrices() {
     };
 
     if (mImpl->instance) {
-        update(mImpl->instance->skins, mImpl->instance->boneMatrices);
+        update(mImpl->instance->skins, mImpl->boneMatrices);
     } else if (mImpl->asset->mInstances.empty()) {
         update(mImpl->asset->mSkins, mImpl->boneMatrices);
     } else {
         for (FFilamentInstance* instance : mImpl->asset->mInstances) {
-            update(instance->skins, instance->boneMatrices);
+            update(instance->skins, mImpl->boneMatrices);
         }
     }
 }

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -69,7 +69,7 @@ struct Animation {
 
 struct AnimatorImpl {
     vector<Animation> animations;
-    vector<mat4f> boneMatrices;
+    BoneVector boneMatrices;
     FFilamentAsset* asset = nullptr;
     FFilamentInstance* instance = nullptr;
     RenderableManager* renderableManager;
@@ -139,17 +139,27 @@ static void setTransformType(const cgltf_animation_channel& src, Channel& dst) {
     }
 }
 
-Animator::Animator(FilamentInstance* publicInstance) {
+Animator::Animator(FFilamentAsset* asset, FFilamentInstance* instance) {
     mImpl = new AnimatorImpl();
-    FFilamentInstance* instance = mImpl->instance = upcast(publicInstance);
-    // TODO
- }
-
-Animator::Animator(FilamentAsset* publicAsset) {
-    mImpl = new AnimatorImpl();
-    FFilamentAsset* asset = mImpl->asset = upcast(publicAsset);
+    mImpl->asset = asset;
+    mImpl->instance = instance;
     mImpl->renderableManager = &asset->mEngine->getRenderableManager();
     mImpl->transformManager = &asset->mEngine->getTransformManager();
+
+    auto addChannels = [](const NodeMap& nodeMap, const cgltf_animation& srcAnim, Animation& dst) {
+        cgltf_animation_channel* srcChannels = srcAnim.channels;
+        cgltf_animation_sampler* srcSamplers = srcAnim.samplers;
+        const Sampler* samplers = dst.samplers.data();
+        for (cgltf_size j = 0, nchans = srcAnim.channels_count; j < nchans; ++j) {
+            const cgltf_animation_channel& srcChannel = srcChannels[j];
+            utils::Entity targetEntity = nodeMap.at(srcChannel.target_node);
+            Channel dstChannel;
+            dstChannel.sourceData = samplers + (srcChannel.sampler - srcSamplers);
+            dstChannel.targetEntity = targetEntity;
+            setTransformType(srcChannel, dstChannel);
+            dst.channels.push_back(dstChannel);
+        }
+    };
 
     // Loop over the glTF animation definitions.
     const cgltf_data* srcAsset = asset->mSourceAsset;
@@ -177,15 +187,14 @@ Animator::Animator(FilamentAsset* publicAsset) {
         }
 
         // Import each glTF channel into a custom data structure.
-        cgltf_animation_channel* srcChannels = srcAnim.channels;
-        dstAnim.channels.resize(srcAnim.channels_count);
-        for (cgltf_size j = 0, nchans = srcAnim.channels_count; j < nchans; ++j) {
-            const cgltf_animation_channel& srcChannel = srcChannels[j];
-            utils::Entity targetEntity = asset->mNodeMap[srcChannel.target_node];
-            Channel& dstChannel = dstAnim.channels[j];
-            dstChannel.sourceData = &dstAnim.samplers[srcChannel.sampler - srcSamplers];
-            dstChannel.targetEntity = targetEntity;
-            setTransformType(srcChannel, dstChannel);
+        if (instance) {
+            addChannels(instance->nodeMap, srcAnim, dstAnim);
+        } else if (asset->mInstances.empty()) {
+            addChannels(asset->mNodeMap, srcAnim, dstAnim);
+        } else {
+            for (FFilamentInstance* instance : asset->mInstances) {
+                addChannels(instance->nodeMap, srcAnim, dstAnim);
+            }
         }
     }
 }
@@ -329,33 +338,44 @@ void Animator::applyAnimation(size_t animationIndex, float time) const {
 }
 
 void Animator::updateBoneMatrices() {
-    vector<mat4f>& boneMatrices = mImpl->boneMatrices;
-    FFilamentAsset* asset = mImpl->asset;
     auto renderableManager = mImpl->renderableManager;
     auto transformManager = mImpl->transformManager;
-    for (const auto& skin : asset->mSkins) {
-        size_t njoints = skin.joints.size();
-        boneMatrices.resize(njoints);
-        for (const auto& entity : skin.targets) {
-            auto renderable = renderableManager->getInstance(entity);
-            if (!renderable) {
-                continue;
+
+    auto update = [=](const SkinVector& skins, BoneVector& boneVector) {
+        for (const auto& skin : skins) {
+            size_t njoints = skin.joints.size();
+            boneVector.resize(njoints);
+            for (const auto& entity : skin.targets) {
+                auto renderable = renderableManager->getInstance(entity);
+                if (!renderable) {
+                    continue;
+                }
+                mat4f inverseGlobalTransform;
+                auto xformable = transformManager->getInstance(entity);
+                if (xformable) {
+                    inverseGlobalTransform = inverse(transformManager->getWorldTransform(xformable));
+                }
+                for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
+                    const auto& joint = skin.joints[boneIndex];
+                    TransformManager::Instance jointInstance = transformManager->getInstance(joint);
+                    mat4f globalJointTransform = transformManager->getWorldTransform(jointInstance);
+                    boneVector[boneIndex] =
+                            inverseGlobalTransform *
+                            globalJointTransform *
+                            skin.inverseBindMatrices[boneIndex];
+                }
+                renderableManager->setBones(renderable, boneVector.data(), boneVector.size());
             }
-            mat4f inverseGlobalTransform;
-            auto xformable = transformManager->getInstance(entity);
-            if (xformable) {
-                inverseGlobalTransform = inverse(transformManager->getWorldTransform(xformable));
-            }
-            for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
-                const auto& joint = skin.joints[boneIndex];
-                TransformManager::Instance jointInstance = transformManager->getInstance(joint);
-                mat4f globalJointTransform = transformManager->getWorldTransform(jointInstance);
-                boneMatrices[boneIndex] =
-                        inverseGlobalTransform *
-                        globalJointTransform *
-                        skin.inverseBindMatrices[boneIndex];
-            }
-            renderableManager->setBones(renderable, boneMatrices.data(), boneMatrices.size());
+        }
+    };
+
+    if (mImpl->instance) {
+        update(mImpl->instance->skins, mImpl->instance->boneMatrices);
+    } else if (mImpl->asset->mInstances.empty()) {
+        update(mImpl->asset->mSkins, mImpl->boneMatrices);
+    } else {
+        for (FFilamentInstance* instance : mImpl->asset->mInstances) {
+            update(instance->skins, instance->boneMatrices);
         }
     }
 }

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -148,7 +148,7 @@ struct FAssetLoader : public AssetLoader {
 
     void createAsset(const cgltf_data* srcAsset, size_t numInstances);
     void createEntity(const cgltf_node* node, Entity parent, bool enableLight,
-            std::vector<Entity>* instance);
+            FFilamentInstance* instance);
     void createRenderable(const cgltf_node* node, Entity entity, const char* name);
     bool createPrimitive(const cgltf_primitive* inPrim, Primitive* outPrim, const UvMap& uvmap,
             const char* name);
@@ -300,7 +300,7 @@ void FAssetLoader::createAsset(const cgltf_data* srcAsset, size_t numInstances) 
             // For each scene root, recursively create all entities.
             for (cgltf_size i = 0, len = scene->nodes_count; i < len; ++i) {
                 cgltf_node** nodes = scene->nodes;
-                createEntity(nodes[i], instanceRoot, index == 0, &instance->entities);
+                createEntity(nodes[i], instanceRoot, index == 0, instance);
             }
         }
     }
@@ -336,7 +336,7 @@ void FAssetLoader::createAsset(const cgltf_data* srcAsset, size_t numInstances) 
 }
 
 void FAssetLoader::createEntity(const cgltf_node* node, Entity parent, bool enableLight,
-        std::vector<Entity>* instance) {
+        FFilamentInstance* instance) {
     Entity entity = mEntityManager.create();
 
     // Always create a transform component to reflect the original hierarchy.
@@ -355,9 +355,11 @@ void FAssetLoader::createEntity(const cgltf_node* node, Entity parent, bool enab
 
     // Update the asset's entity list and private node mapping.
     mResult->mEntities.push_back(entity);
-    mResult->mNodeMap[node] = entity;
     if (instance) {
-        instance->push_back(entity);
+        instance->entities.push_back(entity);
+        instance->nodeMap[node] = entity;
+    } else {
+        mResult->mNodeMap[node] = entity;
     }
 
     const char* name = getNodeName(node, mDefaultNodeName);

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -187,6 +187,9 @@ struct FFilamentAsset : public FilamentAsset {
         mBufferSlots = {};
         mTextureSlots = {};
         releaseSourceAsset();
+        for (FFilamentInstance* instance : mInstances) {
+            instance->nodeMap = {};
+        }
     }
 
     const void* getSourceAsset() noexcept {

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -50,13 +50,6 @@
 namespace gltfio {
 namespace details {
 
-struct Skin {
-    std::string name;
-    std::vector<filament::math::mat4f> inverseBindMatrices;
-    std::vector<utils::Entity> joints;
-    std::vector<utils::Entity> targets;
-};
-
 // Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
 struct BufferSlot {
     const cgltf_accessor* accessor;
@@ -168,7 +161,7 @@ struct FFilamentAsset : public FilamentAsset {
 
     Animator* getAnimator() noexcept {
         if (!mAnimator) {
-            mAnimator = new Animator(this);
+            mAnimator = new Animator(this, nullptr);
         }
         return mAnimator;
     }
@@ -240,7 +233,7 @@ struct FFilamentAsset : public FilamentAsset {
     filament::Aabb mBoundingBox;
     utils::Entity mRoot;
     std::vector<FFilamentInstance*> mInstances;
-    std::vector<Skin> mSkins;
+    SkinVector mSkins; // unused for instanced assets
     Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;
     int mSourceAssetRefCount = 0;
@@ -258,7 +251,7 @@ struct FFilamentAsset : public FilamentAsset {
     std::vector<TextureSlot> mTextureSlots;
     std::vector<const char*> mResourceUris;
     const cgltf_data* mSourceAsset = nullptr;
-    tsl::robin_map<const cgltf_node*, utils::Entity> mNodeMap;
+    NodeMap mNodeMap; // unused for instanced assets
     std::vector<std::pair<const cgltf_primitive*, filament::VertexBuffer*> > mPrimitives;
 };
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -40,6 +40,7 @@
 #include "Wireframe.h"
 #include "DependencyGraph.h"
 #include "DracoCache.h"
+#include "FFilamentInstance.h"
 
 #include <tsl/robin_map.h>
 
@@ -81,6 +82,14 @@ struct FFilamentAsset : public FilamentAsset {
 
     ~FFilamentAsset() {
         releaseSourceData();
+
+        // The only things we need to free in the instances are their animators.
+        // The union of all instance entities will be destroyed below.
+        for (FFilamentInstance* instance : mInstances) {
+            delete instance->animator;
+            delete instance;
+        }
+
         delete mAnimator;
         delete mWireframe;
         mEngine->destroy(mRoot);
@@ -230,6 +239,7 @@ struct FFilamentAsset : public FilamentAsset {
     std::vector<filament::Texture*> mTextures;
     filament::Aabb mBoundingBox;
     utils::Entity mRoot;
+    std::vector<FFilamentInstance*> mInstances;
     std::vector<Skin> mSkins;
     Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -47,7 +47,6 @@ struct Skin {
 
 using SkinVector = std::vector<Skin>;
 using NodeMap = tsl::robin_map<const cgltf_node*, utils::Entity>;
-using BoneVector = std::vector<filament::math::mat4f>;
 
 struct FFilamentInstance : public FilamentInstance {
     std::vector<utils::Entity> entities;
@@ -56,7 +55,6 @@ struct FFilamentInstance : public FilamentInstance {
     FFilamentAsset* owner;
     SkinVector skins;
     NodeMap nodeMap;
-    BoneVector boneMatrices;
 
     Animator* getAnimator() noexcept {
         if (!animator) {

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -22,24 +22,45 @@
 
 #include <utils/Entity.h>
 
+#include <math/mat4.h>
+
+#include <tsl/robin_map.h>
+
+#include <string>
 #include <vector>
 
 #include "upcast.h"
+
+struct cgltf_node;
 
 namespace gltfio {
 namespace details {
 
 struct FFilamentAsset;
 
+struct Skin {
+    std::string name;
+    std::vector<filament::math::mat4f> inverseBindMatrices;
+    std::vector<utils::Entity> joints;
+    std::vector<utils::Entity> targets;
+};
+
+using SkinVector = std::vector<Skin>;
+using NodeMap = tsl::robin_map<const cgltf_node*, utils::Entity>;
+using BoneVector = std::vector<filament::math::mat4f>;
+
 struct FFilamentInstance : public FilamentInstance {
     std::vector<utils::Entity> entities;
     utils::Entity root;
     Animator* animator;
     FFilamentAsset* owner;
+    SkinVector skins;
+    NodeMap nodeMap;
+    BoneVector boneMatrices;
 
     Animator* getAnimator() noexcept {
         if (!animator) {
-            animator = new Animator(this);
+            animator = new Animator(owner, this);
         }
         return animator;
     }

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_FFILAMENTINSTANCE_H
+#define GLTFIO_FFILAMENTINSTANCE_H
+
+#include <gltfio/FilamentInstance.h>
+#include <gltfio/Animator.h>
+
+#include <utils/Entity.h>
+
+#include <vector>
+
+#include "upcast.h"
+
+namespace gltfio {
+namespace details {
+
+struct FFilamentAsset;
+
+struct FFilamentInstance : public FilamentInstance {
+    std::vector<utils::Entity> entities;
+    utils::Entity root;
+    Animator* animator;
+    FFilamentAsset* owner;
+
+    Animator* getAnimator() noexcept {
+        if (!animator) {
+            animator = new Animator(this);
+        }
+        return animator;
+    }
+};
+
+FILAMENT_UPCAST(FilamentInstance)
+
+} // namespace details
+} // namespace gltfio
+
+#endif // GLTFIO_FFILAMENTINSTANCE_H

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "FFilamentInstance.h"
+
+#include <gltfio/Animator.h>
+
+using namespace filament;
+using namespace utils;
+
+namespace gltfio {
+
+using namespace details;
+
+size_t FilamentInstance::getEntityCount() const noexcept {
+    return upcast(this)->entities.size();
+}
+
+const Entity* FilamentInstance::getEntities() const noexcept {
+    const auto& entities = upcast(this)->entities;
+    return entities.empty() ? nullptr : entities.data();
+}
+
+Entity FilamentInstance::getRoot() const noexcept {
+    return upcast(this)->root;
+}
+
+Animator* FilamentInstance::getAnimator() noexcept {
+    return upcast(this)->getAnimator();
+}
+
+} // namespace gltfio

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -156,35 +156,47 @@ private:
 
 using namespace details;
 
-static void importSkinningData(Skin& dstSkin, const cgltf_skin& srcSkin, FFilamentAsset* asset) {
-    if (srcSkin.name) {
-        dstSkin.name = srcSkin.name;
-    }
-    const auto& nodeMap = asset->mNodeMap;
-
-    // Build a list of transformables for this skin, one for each joint.
-    // TODO: We've seen models with joint nodes that do not belong to the scene's node graph.
-    // e.g. BrainStem after Draco compression. That's why we have a fallback here. AssetManager
-    // should maybe create an Entity for every glTF node, period. (regardless of hierarchy)
-    // https://github.com/CesiumGS/gltf-pipeline/issues/532
-    dstSkin.joints.resize(srcSkin.joints_count);
-    for (cgltf_size i = 0, len = srcSkin.joints_count; i < len; ++i) {
-        auto iter = nodeMap.find(srcSkin.joints[i]);
-        if (iter == nodeMap.end()) {
-            dstSkin.joints[i] = nodeMap.begin()->second;
-        } else {
-            dstSkin.joints[i] = iter->second;
+static void importSkins(const cgltf_data* gltf, const NodeMap& nodeMap, SkinVector& dstSkins) {
+    dstSkins.resize(gltf->skins_count);
+    for (cgltf_size i = 0, len = gltf->nodes_count; i < len; ++i) {
+        const cgltf_node& node = gltf->nodes[i];
+        if (node.skin) {
+            int skinIndex = node.skin - &gltf->skins[0];
+            Entity entity = nodeMap.at(&node);
+            dstSkins[skinIndex].targets.push_back(entity);
         }
     }
+    for (cgltf_size i = 0, len = gltf->skins_count; i < len; ++i) {
+        Skin& dstSkin = dstSkins[i];
+        const cgltf_skin& srcSkin = gltf->skins[i];
+        if (srcSkin.name) {
+            dstSkin.name = srcSkin.name;
+        }
 
-    // Retain a copy of the inverse bind matrices because the source blob could be evicted later.
-    const cgltf_accessor* srcMatrices = srcSkin.inverse_bind_matrices;
-    dstSkin.inverseBindMatrices.resize(srcSkin.joints_count);
-    if (srcMatrices) {
-        auto dstMatrices = (uint8_t*) dstSkin.inverseBindMatrices.data();
-        uint8_t* bytes = (uint8_t*) srcMatrices->buffer_view->buffer->data;
-        auto srcBuffer = (void*) (bytes + srcMatrices->offset + srcMatrices->buffer_view->offset);
-        memcpy(dstMatrices, srcBuffer, srcSkin.joints_count * sizeof(mat4f));
+        // Build a list of transformables for this skin, one for each joint.
+        // TODO: We've seen models with joint nodes that do not belong to the scene's node graph.
+        // e.g. BrainStem after Draco compression. That's why we have a fallback here. AssetManager
+        // should maybe create an Entity for every glTF node, period. (regardless of hierarchy)
+        // https://github.com/CesiumGS/gltf-pipeline/issues/532
+        dstSkin.joints.resize(srcSkin.joints_count);
+        for (cgltf_size i = 0, len = srcSkin.joints_count; i < len; ++i) {
+            auto iter = nodeMap.find(srcSkin.joints[i]);
+            if (iter == nodeMap.end()) {
+                dstSkin.joints[i] = nodeMap.begin()->second;
+            } else {
+                dstSkin.joints[i] = iter->second;
+            }
+        }
+
+        // Retain a copy of the inverse bind matrices because the source blob could be evicted later.
+        const cgltf_accessor* srcMatrices = srcSkin.inverse_bind_matrices;
+        dstSkin.inverseBindMatrices.resize(srcSkin.joints_count);
+        if (srcMatrices) {
+            auto dstMatrices = (uint8_t*) dstSkin.inverseBindMatrices.data();
+            uint8_t* bytes = (uint8_t*) srcMatrices->buffer_view->buffer->data;
+            auto srcBuffer = (void*) (bytes + srcMatrices->offset + srcMatrices->buffer_view->offset);
+            memcpy(dstMatrices, srcBuffer, srcSkin.joints_count * sizeof(mat4f));
+        }
     }
 }
 
@@ -406,17 +418,13 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     }
 
     // For each skin, build a list of renderables that it affects.
-    asset->mSkins.resize(gltf->skins_count);
-    for (cgltf_size i = 0, len = gltf->nodes_count; i < len; ++i) {
-        const cgltf_node& node = gltf->nodes[i];
-        if (node.skin) {
-            int skinIndex = node.skin - &gltf->skins[0];
-            Entity entity = asset->mNodeMap[&node];
-            asset->mSkins[skinIndex].targets.push_back(entity);
+    const cgltf_data* const_gltf = gltf;
+    if (asset->mInstances.empty()) {
+        importSkins(const_gltf, asset->mNodeMap, asset->mSkins);
+    } else {
+        for (FFilamentInstance* instance : asset->mInstances) {
+            importSkins(const_gltf, instance->nodeMap, instance->skins);
         }
-    }
-    for (cgltf_size i = 0, len = gltf->skins_count; i < len; ++i) {
-        importSkinningData(asset->mSkins[i], gltf->skins[i], asset);
     }
 
     // Apply sparse data modifications to base arrays, then upload the result.

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -221,6 +221,7 @@ if (NOT ANDROID)
     add_demo(depthtesting)
     add_demo(frame_generator)
     add_demo(gltf_viewer)
+    add_demo(gltf_instances)
     add_demo(heightfield)
     add_demo(hellopbr)
     add_demo(hellotriangle)
@@ -240,6 +241,7 @@ if (NOT ANDROID)
     # Sample app specific
     target_link_libraries(frame_generator PRIVATE imageio)
     target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio)
+    target_link_libraries(gltf_instances PRIVATE gltf-resources gltfio)
     target_link_libraries(hellopbr PRIVATE filameshio suzanne-resources)
     target_link_libraries(sample_cloth PRIVATE filameshio)
     target_link_libraries(sample_normal_map PRIVATE filameshio)
@@ -293,9 +295,3 @@ add_dependencies(filament assets)
 
 add_custom_target(envs DEPENDS ${target_envmaps})
 add_dependencies(filament envs)
-
-add_custom_target(run_gltf_viewer DEPENDS gltf_viewer assets
-        COMMAND gltf_viewer)
-
-add_custom_target(run_material_sandbox DEPENDS material_sandbox assets
-        COMMAND material_sandbox --ibl=venetian_crossroads_2k assets/models/material_sphere/material_sphere.obj)

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define GLTFIO_SIMPLEVIEWER_IMPLEMENTATION
+
+#include <filamentapp/Config.h>
+#include <filamentapp/FilamentApp.h>
+#include <filamentapp/IBL.h>
+
+#include <filament/Engine.h>
+#include <filament/Scene.h>
+#include <filament/Skybox.h>
+#include <filament/View.h>
+
+#include <gltfio/AssetLoader.h>
+#include <gltfio/FilamentAsset.h>
+#include <gltfio/ResourceLoader.h>
+#include <gltfio/SimpleViewer.h>
+
+#include <camutils/Manipulator.h>
+
+#include <getopt/getopt.h>
+
+#include <utils/NameComponentManager.h>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include <math/mat4.h>
+
+#include "generated/resources/gltf_viewer.h"
+
+using namespace filament;
+using namespace filament::math;
+using namespace gltfio;
+using namespace utils;
+
+using InstanceHandle = FilamentInstance*;
+
+struct App {
+    Engine* engine;
+    SimpleViewer* viewer;
+    Config config;
+    AssetLoader* loader;
+    FilamentAsset* asset = nullptr;
+    NameComponentManager* names;
+    MaterialProvider* materials;
+    MaterialSource materialSource = GENERATE_SHADERS;
+    ResourceLoader* resourceLoader = nullptr;
+    int numInstances = 5;
+    int instanceToAnimate = -1;
+    InstanceHandle* instances;
+};
+
+static const char* DEFAULT_IBL = "venetian_crossroads_2k";
+
+static void printUsage(char* name) {
+    std::string exec_name(Path(name).getName());
+    std::string usage(
+        "SHOWCASE renders the specified glTF file with instancing\n"
+        "Usage:\n"
+        "    SHOWCASE [options] <gltf path>\n"
+        "Options:\n"
+        "   --help, -h\n"
+        "       Prints this message\n\n"
+        "   --api, -a\n"
+        "       Specify the backend API: opengl (default), vulkan, or metal\n\n"
+        "   --ibl=<path to cmgen IBL>, -i <path>\n"
+        "       Override the built-in IBL\n\n"
+        "   --num=<number of instances>, -n <num>\n"
+        "       Number of instances (defaults to 5)\n\n"
+        "   --animate=<instance index>, -m <num>\n"
+        "       Instance to animate (defaults to all instances)\n\n"
+        "   --ubershader, -u\n"
+        "       Enable ubershaders (improves load time, adds shader complexity)\n\n"
+    );
+    const std::string from("SHOWCASE");
+    for (size_t pos = usage.find(from); pos != std::string::npos; pos = usage.find(from, pos)) {
+        usage.replace(pos, from.length(), exec_name);
+    }
+    std::cout << usage;
+}
+
+static int handleCommandLineArguments(int argc, char* argv[], App* app) {
+    static constexpr const char* OPTSTR = "ha:i:un:m:";
+    static const struct option OPTIONS[] = {
+        { "help",         no_argument,       nullptr, 'h' },
+        { "api",          required_argument, nullptr, 'a' },
+        { "ibl",          required_argument, nullptr, 'i' },
+        { "num",          required_argument, nullptr, 'n' },
+        { "animate",      required_argument, nullptr, 'm' },
+        { "ubershader",   no_argument,       nullptr, 'u' },
+        { nullptr, 0, nullptr, 0 }
+    };
+    int opt;
+    int option_index = 0;
+    while ((opt = getopt_long(argc, argv, OPTSTR, OPTIONS, &option_index)) >= 0) {
+        std::string arg(optarg ? optarg : "");
+        switch (opt) {
+            default:
+            case 'h':
+                printUsage(argv[0]);
+                exit(0);
+            case 'a':
+                if (arg == "opengl") {
+                    app->config.backend = Engine::Backend::OPENGL;
+                } else if (arg == "vulkan") {
+                    app->config.backend = Engine::Backend::VULKAN;
+                } else if (arg == "metal") {
+                    app->config.backend = Engine::Backend::METAL;
+                } else {
+                    std::cerr << "Unrecognized backend. Must be 'opengl'|'vulkan'|'metal'.\n";
+                }
+                break;
+            case 'm':
+                app->instanceToAnimate = atoi(arg.c_str());
+                break;
+            case 'n':
+                app->numInstances = atoi(arg.c_str());
+                break;
+            case 'i':
+                app->config.iblDirectory = arg;
+                break;
+            case 'u':
+                app->materialSource = LOAD_UBERSHADERS;
+                break;
+        }
+    }
+    return optind;
+}
+
+static std::ifstream::pos_type getFileSize(const char* filename) {
+    std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
+    return in.tellg();
+}
+
+int main(int argc, char** argv) {
+    App app;
+
+    app.config.title = "glTF Instancing";
+    app.config.iblDirectory = FilamentApp::getRootAssetsPath() + DEFAULT_IBL;
+
+    int optionIndex = handleCommandLineArguments(argc, argv, &app);
+    utils::Path filename;
+    int num_args = argc - optionIndex;
+    if (num_args >= 1) {
+        filename = argv[optionIndex];
+        if (!filename.exists()) {
+            std::cerr << "file " << filename << " not found!" << std::endl;
+            return 1;
+        }
+    }
+
+    auto loadAsset = [&app](utils::Path filename) {
+        // Peek at the file size to allow pre-allocation.
+        long contentSize = static_cast<long>(getFileSize(filename.c_str()));
+        if (contentSize <= 0) {
+            std::cerr << "Unable to open " << filename << std::endl;
+            exit(1);
+        }
+
+        // Consume the glTF file.
+        std::ifstream in(filename.c_str(), std::ifstream::binary | std::ifstream::in);
+        std::vector<uint8_t> buffer(static_cast<unsigned long>(contentSize));
+        if (!in.read((char*) buffer.data(), contentSize)) {
+            std::cerr << "Unable to read " << filename << std::endl;
+            exit(1);
+        }
+
+        // Parse the glTF file and create Filament entities.
+        app.asset = app.loader->createInstancedAsset(buffer.data(), buffer.size(), app.instances,
+                app.numInstances);
+        buffer.clear();
+        buffer.shrink_to_fit();
+
+        if (!app.asset) {
+            std::cerr << "Unable to parse " << filename << std::endl;
+            exit(1);
+        }
+    };
+
+    auto loadResources = [&app] (utils::Path filename) {
+        // Load external textures and buffers.
+        std::string gltfPath = filename.getAbsolutePath();
+        ResourceConfiguration configuration;
+        configuration.engine = app.engine;
+        configuration.gltfPath = gltfPath.c_str();
+        configuration.normalizeSkinningWeights = true;
+        configuration.recomputeBoundingBoxes = false;
+        if (!app.resourceLoader) {
+            app.resourceLoader = new gltfio::ResourceLoader(configuration);
+        }
+        app.resourceLoader->asyncBeginLoad(app.asset);
+
+        // Load animation data then free the source hierarchy.
+        app.asset->getAnimator();
+        if (app.instanceToAnimate > -1) {
+            app.instances[app.instanceToAnimate]->getAnimator();
+        }
+        app.asset->releaseSourceData();
+
+        auto ibl = FilamentApp::get().getIBL();
+        if (ibl) {
+            app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
+        }
+    };
+
+    auto setup = [&](Engine* engine, View* view, Scene* scene) {
+        app.engine = engine;
+        app.names = new NameComponentManager(EntityManager::get());
+        app.viewer = new SimpleViewer(engine, scene, view, app.instanceToAnimate);
+        app.materials = (app.materialSource == GENERATE_SHADERS) ?
+                createMaterialGenerator(engine) : createUbershaderLoader(engine);
+        app.loader = AssetLoader::create({engine, app.materials, app.names });
+        app.instances = new InstanceHandle[app.numInstances];
+        if (filename.isEmpty()) {
+            app.asset = app.loader->createInstancedAsset(
+                    GLTF_VIEWER_DAMAGEDHELMET_DATA, GLTF_VIEWER_DAMAGEDHELMET_SIZE,
+                    app.instances, app.numInstances);
+        } else {
+            loadAsset(filename);
+        }
+
+        // Arrange all instances into a circle.
+        auto& tcm = engine->getTransformManager();
+        auto extent = app.asset->getBoundingBox().extent();
+        float max_extent = std::max(std::max(extent.x,  extent.y), extent.z);
+        auto translation = mat4f::translation(float3(max_extent, 0, 0));
+        for (size_t inst = 0; inst < app.numInstances; ++inst) {
+            FilamentInstance* instance = app.instances[inst];
+            auto transformRoot = tcm.getInstance(instance->getRoot());
+            float theta = inst * 2.0 * M_PI / app.numInstances;
+            auto rotation = mat4f::rotation(theta, float3(0, 0, 1));
+            tcm.setTransform(transformRoot, rotation * translation);
+        }
+
+        loadResources(filename);
+    };
+
+    auto cleanup = [&app](Engine* engine, View*, Scene*) {
+        app.loader->destroyAsset(app.asset);
+        app.materials->destroyMaterials();
+
+        delete app.viewer;
+        delete app.materials;
+        delete app.names;
+
+        AssetLoader::destroy(&app.loader);
+
+        delete[] app.instances;
+    };
+
+    auto animate = [&app](Engine* engine, View* view, double now) {
+        app.resourceLoader->asyncUpdateLoad();
+        FilamentInstance* instance = nullptr;
+        if (app.instanceToAnimate > -1) {
+            instance = app.instances[app.instanceToAnimate];
+        }
+        app.viewer->populateScene(app.asset, true, instance);
+        app.viewer->applyAnimation(now);
+    };
+
+    auto gui = [&app](Engine* engine, View* view) { };
+
+    auto preRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) { };
+
+    FilamentApp& filamentApp = FilamentApp::get();
+    filamentApp.animate(animate);
+
+    filamentApp.run(app.config, setup, cleanup, gui, preRender);
+
+    return 0;
+}


### PR DESCRIPTION
This adds createInstancedAsset() to AssetLoader, which creates a master asset and a set of slave instances. Vertex buffers, index buffers, textures, and material instances are shared. Entities and components are duplicated.

Instances have their own API object that exposes a subset of the master asset's entity hierarchy and an optional Animator object.

This also adds a new sample app called `gltf_instances`.  It is similar to `gltf_viewer` but with no GUI.  It has additional command line arguments for a number of instances and animation.

Java and JavaScript bindings will be added in a subsequent PR.

Fixes #1513

![curl 10 41 40 AM](https://user-images.githubusercontent.com/1288904/83191500-f7e41c00-a0e8-11ea-9889-f7efb50dd441.gif)
