### PR TITLE
Add per-view color grading LUT

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@ A new header is inserted each time a *tag* is created.
 - Add support for DOF with Metal backend.
 - SSAO now has an optional high(er) quality upsampler.
 - Tone mappping now uses the real ACES tone mapper, applied in the proper color space.
-- Tone mapping is now applied via a LUT, which will later enable color grading capabilities.
+- Tone mapping is now applied via a LUT.
+- Color grading capabilities per View: white balance (temperature/tint).
 - Fixed bug in the Metal backend when SSR and MSAA were turned on
 - Fixed Metal issue with `BufferDescriptor` and `PixelBufferDescriptor`s not being called on application thread.
 

--- a/docs/math/White Balance.nb
+++ b/docs/math/White Balance.nb
@@ -1,0 +1,1008 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 12.1' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[     43156,       1000]
+NotebookOptionsPosition[     41071,        958]
+NotebookOutlinePosition[     41467,        974]
+CellTagsIndexPosition[     41424,        971]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell[TextData[StyleBox["CIE 1931 2-deg, XYZ CMFs", "Subsection"]], \
+"Subsubsection",
+ CellChangeTimes->{{3.7996982241825457`*^9, 3.7996982477885103`*^9}, {
+  3.79969850262654*^9, 
+  3.799698508731106*^9}},ExpressionUUID->"1a2a6f85-9587-438e-baf4-\
+87fab9cfd47e"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{"\[Lambda]", ",", "x", ",", "y", ",", "z"}], "}"}], "=", 
+   RowBox[{
+    RowBox[{
+    "Import", "[", 
+     "\"\<http://www.cvrl.org/database/data/cmfs/ciexyzjv.csv\>\"", "]"}], 
+    "\[Transpose]"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{"ListLinePlot", "[", 
+  RowBox[{
+   RowBox[{"{", 
+    RowBox[{
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"\[Lambda]", ",", "x"}], "}"}], "\[Transpose]"}], ",", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"\[Lambda]", ",", "y"}], "}"}], "\[Transpose]"}], ",", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"\[Lambda]", ",", "z"}], "}"}], "\[Transpose]"}]}], "}"}], ",", 
+   RowBox[{"PlotLegends", "\[Rule]", 
+    RowBox[{"{", 
+     RowBox[{"\"\<X\>\"", ",", "\"\<Y\>\"", ",", "\"\<Z\>\""}], "}"}]}], ",", 
+   
+   RowBox[{"Filling", "\[Rule]", "Axis"}], ",", 
+   RowBox[{"PlotStyle", "\[Rule]", 
+    RowBox[{"{", 
+     RowBox[{"Red", ",", "Green", ",", "Blue"}], "}"}]}]}], "]"}]}], "Input",
+ CellChangeTimes->{{3.799635017508616*^9, 3.7996350175142593`*^9}, {
+  3.799693199593113*^9, 3.799693222600195*^9}, {3.7996932581163282`*^9, 
+  3.799693315664568*^9}, {3.7996934305363903`*^9, 3.79969346876785*^9}, {
+  3.799698464577858*^9, 3.79969847157952*^9}},
+ CellLabel->
+  "In[274]:=",ExpressionUUID->"151ac5d0-c087-4eac-b459-b03393d07da4"],
+
+Cell[BoxData[
+ TemplateBox[{
+   GraphicsBox[{{}, 
+     GraphicsComplexBox[CompressedData["
+1:eJzt2Hk4lO0eB3DZ8ioRpaKNiNNGHS0K3ZFCyd4rlShbkrTYtxkzzEwkei1t
+JIr0Im9FQlJChfe1ZWRJlsyULJXURHWeuu/zO+/5//xzrmueP7i+13PNzHM/
+3/v5zFw/lf1HrF1FRUREVKk/P/7/PMr9Uc39d3Iqv7ht/JnlApBEl06oX7kv
+zk4BKNvL3mbXjCic8wMQt0ueFm6WiLNIIGqbf6/b4FgGzpaBiHeMcXna0nyc
+0wJRzmlWWUniXZxHApFShq/t6k2PcEZB6Hfx6Ipz++pwjgtCtQ29n9Z8bcD5
+ZRC6pLes+Xx/E87awUg6Umodc8kznGnBSL7t2IpKO5Lrg1GZefjYIuNmnBeG
+oIG4C92SIY04+4SgONMtfz5Mrce5PASpn+G7zqghny8Ximx/Naj58PIpWX8o
+WjDdRpXjWEXWH4q8t1vY90x6QNYfhmL15HZd4dwh6w9D/pfv7li0PJesPwxl
+DXDypmxMI+sPQ6yoymuHBk+R9YejLV8yHDM7jpP1h6O1uiGNHPEDZP3hKEnU
+3zhRkoHzbBqyV/psJTOeQl5PQ76+1fsv2JL77UFDNe3Td0xxLCXvR0MOWlHH
+0vdW4lxEQzMkvmxOVSPrfUlDQT7+Ld4l5P5I0dETv7JLSlpccr/pKF+MF6M5
+2I6zPR1Nlurnvwt+Se4/HdkfpznFzu/F+Rodbcweex1Q+4r0QUftgjDP0hN8
+nD/TUbdmoG/spAHSTwTSmb5G7571IM4mEYh1f/GhZqNh0lcEih8M2bjacQTn
+sxHoZGzf+wWNJJdHoO6gGXlbu0nmR6AOLv34lgSS5Rjoq8KenGsPyPutYyDT
+9GSrZXfI5zkxkH7YkaZLX9/gzGagBO2msRs5PNI3A/X0hbHSUR/OrQxU0WoY
+x5DvJv0zkeX10PXz/9mBsyYTrWvvOJua30L2AxOVlYqM85vJfg5gIt2WysM6
+tBqyP5jotI/DSPoN8jw8ZqKTCw4MORiWkf3CRD057PP8DwWk/0g0db3KiXp1
+0jeKRJ6fFVtO+WeR/iORyIa1h6sOkv0WF4m2dybu1S5KIv1HolmFbku1BKdJ
+/5Gox8/DPqaYPN9SUcimQ9Rm1noa6T8KaeQPB97W8Cf9R6ESPV6Ri5sP6T8K
+Ff9mcGCmujvpPwq1J4d6aP/qRPqPQrN0v+yIGNxJ+o9Cht93XDGutiD9s1Br
+D9+FzTMm/bOQrdyyjmX6BqR/FkrzcOoYFV9N+meh908Dh/WTlpP+Wch34gLK
+HFYj/bMQjb4QRcXOI/2z0bRqvRHJ1hmkfzaat2Tn1RfuMqR/Nvp9UNtTqUSc
+9M9GvMiCTj+drwa4fzZyTnidyIoZxbmVjeIfZx8ofPkWZxEO8rKfk3dyax/O
+mhykeuv2o4yQDpwtOeimneCki2gzzgEcVHXJ+8GfarU4p3GQlPdsu957FTg/
+pl7/ZvfKF4ElOFM+LzeaO9CzZgn4XHU92Mj1rS74jM+bgc/mnhWlqja7wOfq
+4qJTkiNu4DNdNGGps/zx//ic27rPzyIMfOYk6aUmLWCDz2+tiuZHDsSDz5Mb
+HBr61yWDzxmL7k6wRi+Az1L8sovP89LA5+JDvwjS3DPA5xYls0Hj21fBZ/dn
+PM+lY1ngc1p3nVLpjevg849PtyrKA59z9Oj5Njk3wecQ2eS5/mZ3wGcvgzyZ
+mb2l4POtgjITj5oH4HO8hil3e1kl+Gw3fkLPLe0p+BylPCJwZtaDz4GvF6+U
+ymkGnydmH+fKv38OPodTuv02+yX4fLl9G/UV1ws+4+vvB59tklRifY++Bp+1
+OtUk6YkD4PNdqi1Fk0Hwudh0quhS1hD4/Obm2daQPcPgs9unPufLLcPg89Gc
+6HYPkRHwmZvhoy/NHQafrX9e0DD4LGeve/ux3xD4XNd34bD39kHwGb9+AHzG
+3r8Bn5vM91NvwQefF314vGCqXj/4/K05gLqDfeBzj2RI2GyVHvD5v+4f5TP+
+/u4Anyey3zWa728Fn1/kH7ZyYzSDz2Oae04//FgPPpsITAssqmvAZ7efRxX4
+zFvtx3mT++/9wERUuXMdXErA55AlWfrqvNvg88/TG26Az+Ft13ZMvpkJPuPr
+SwOfed7cbTbiZ8Hni48W5h/ziAefN2fxOu0t2eBzr41IjHs9DXy+syJu/I8r
+/uBz1coz+oZ1PuAz1zUl6dE3d/DZ836BgrqKM/i8SjVHpdbEHnzOEDuTf0TD
+CnxesSpTohmZgM9GlevCFaQ3gc+2y+uj3bLWgs9Xtl153m2rDT4XSy65XJG4
+GHw+OM/OXM53Afj8XKKSVb5CEXzG52XB53k3Dp2YtEkSfMbnv2PvKJ91WSJK
+TP0xnCmfZS31AzWPDONM+XxvuXaP/qp+8DniAJu20LILfLae7twrIdsCPnc2
+dDfdkv0LfGZkphtWd1WCz8lZxUoFf5WBz13zuLHjdwvAZ1HZM0ZlcXngczDH
+RU3Z9ir4rGbsYl+pzAGfpcf28TLrzoLPqcNZVdvWZoPPhgG3jz5yKAKfZSq2
+PkowqQKfr2W7HgqNbwSfzw/oNFoHdoLPVNjw8CAPfP5t/SRzpsw78HmLuq/o
+eamP4LOm7JSCzMBP4DNDa3um9BYB+Myn9E3uFIDPy1zn9NjPEoDPk/ed3T4z
+5hP4nGQU7cUb/wg+L+5jpNZdHwWfD4ocoYtXfgCf8e+1d+Azw8o0hbZ4CHz2
++SNdskmbDz4rjtcMPanoAZ9L6vdkxSd1gM9tYrnlcc+egc9ST0QX+wzUg89o
+dsCQ/p6n4DO+ngrw2SvR6ei6DyXgc7LuXkWFC7fA57lvzac+eZIDPn/7h136
+2+VXwefoI5ohhdNSweeuaK223sgE8FkiXcPV2igafB4d3uxwYoIOPq/+OPN7
+41d/8HlXlvof3xN9wOeHI7vLNg67g8+FQR/KvbL2g8/nUGHDVTUn8FnD8caX
+w+f2gs9F8j5l1Ra7wOfdCWHuCzfYgs9iTsl6Agtr8Jk132yWbK45+HyrZoO/
+ZcUW8Nl175m7fCU98Jk9+WLZpDYd8LnGJaj4cpU2+Hx0UK/1e4wa+Gw7s32R
+6sU54HPK7uz+cnl58Pm6TrAYapIGn5XyTXdOdIuCzw917HN3egrI88lEDZ9H
+3ieWviPPJxPpv1dcMfGJT55PJgr4WGjKV+zGmfLZW+eKzrlQLs6Uz0avBCsn
+JdXjTPksYxd+eJpnNc6Uz0Vxv98XUyzHmfI5vIEf6fNLIc6Uz6FqXbO8CogH
+lM9DinYuR0uIB5TPHtwG5hrlSzhTPg/ECTwSdyXhTPmcYpCiHyk4jTPl844V
+W2sV26Jwpnyuy92ksG0/DWfK594n92LeO/vjTPmskjKnRiPcB2fK5xN5G14s
+WuaOM+XzfJ6mtKGFE86UzzO1Al/fUfsVZ8rntjDl0bx0S+IXCz0YqG3wkzXB
+mfKZm6ViJu24CWfKZ4ZEqtipabrgs4JL2MIpiqvA53zzIa7ZnCXgs9wppp9b
+gyr4zP8W2qWnrAw+v3JuX8MLUwCfRStTmGzJqeDzZt2rmrVq4uBzdeDFv76N
+Tujj/jnok824Y9WzUZwpn01ta2SuvRrEmfJZZJ6ypqrxK5wpn0X+fvw4//fj
+f3BeOD8Rzk+E8xPh/AT3L5yfCOcnwvmJcH4inJ/g/SGcnwjnJ8L5iXB+Ipyf
+/MzC+YlwfvJ/Mj/5F2hruBQ=
+      "], {{{}, {
+         EdgeForm[], 
+         Directive[
+          RGBColor[1, 0, 0], 
+          Opacity[0.2]], 
+         GraphicsGroupBox[{
+           PolygonBox[CompressedData["
+1:eJwt0Mk2ggEABeCfisxTSEkazEOGzDNJhkhJOFYeQO+/83WOxXfvXd/MT7v+
+2x0EQRff/z0hYnzZn3zQ4p0mbzSo80qNF56p8sQjD9xT4Y4yt5S44ZorLrng
+nDNOOeGYIw45YJ89iuyywzZbFNhkg3XWWGWFZZZYZIE8ObJkmCfNHClmSZJg
+hjjTTDFJrPMR44wxygjDDDHIAP30EaWXHiKECdH5/Q8lQRI6
+            "]]}]}, {}, {
+         EdgeForm[], 
+         Directive[
+          RGBColor[0, 1, 0], 
+          Opacity[0.2]], 
+         GraphicsGroupBox[{
+           PolygonBox[CompressedData["
+1:eJwt0Nk2ggEAhdGfN6g38EpuRck8VJIGs8wkMyFzRJIpD2hfuNhrfef2dMVT
+3cnOIAg6iNBDyAjzq9v88M0Xn3zQ4p0mbzR45YU6zzxR45EH7rnjlhuuqXLF
+JRdUOOeMU0445ohDDtinzB4ldtlhmy022WCdNVYpssIySyyywDxzzFIgT44s
+M2SYJs0UKZIkmGSCccYYZYRhhhhkgDj9xIjSR+//33+iSzHa
+            "]]}]}, {}, {
+         EdgeForm[], 
+         Directive[
+          RGBColor[0, 0, 1], 
+          Opacity[0.2]], 
+         GraphicsGroupBox[{
+           PolygonBox[CompressedData["
+1:eJwlzEdSAgEARNEZMCAoegWvxNqVB9DTmUFQMWLOggkUM+YsiK/Kxatfvene
+/sHUQCQIgpA+hug2ekjSRScJ4nQQo502WmkhSoQw/D9ryi8N6vzwzReffPDO
+G6+88MwTjzxwT407brnhmisuuaDKOWdUKHPKCccccUiJIgfss8cuO2yzxSYb
+rLPGKissU2CJRRaYZ45Z8swwzRQ5skySIc0E44wxygjD/AH5YUKJ
+            
+            "]]}]}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}}, {{}, {}, {
+         Hue[0.67, 0.6, 0.6], 
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[1, 0, 0]], 
+         LineBox[{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 
+          18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 
+          35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 
+          52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 
+          69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 
+          86, 87, 88, 89, 90}]}, {
+         Hue[0.9060679774997897, 0.6, 0.6], 
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 1, 0]], 
+         LineBox[{91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104,
+           105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 
+          118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 
+          131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 
+          144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 
+          157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 
+          170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180}]}, {
+         Hue[0.1421359549995791, 0.6, 0.6], 
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 0, 1]], 
+         LineBox[CompressedData["
+1:eJwN0GciggEAANAvu8QdXMnPfjoAp7MSaVnJVplF9qwUMuL9eBd4YxNT45Oh
+IAhiTDPDLHPME2eBBIsskWSZFGkyZMmxwiprrLNBnk0KbLHNDrvssc8BhxQp
+UeaIY0445YxzKlS54JIaV1xzwy133PPAI08888IrdRo0eaNFm3c++KTDF9/8
+8EuXPwJpIXropY9+BhhkiDARhokywij/w5VCZA==
+          "]]}}, {{
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[1, 0, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 1, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 0, 1]]}}, {{
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[1, 0, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 1, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 0, 1]]}, {}, {}, {}, {}, {}, {}, {}}, {{
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[1, 0, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 1, 0]]}, {
+         Directive[
+          PointSize[
+           NCache[
+            Rational[1, 90], 0.011111111111111112`]], 
+          AbsoluteThickness[1.6], 
+          RGBColor[0, 0, 1]]}, {}, {}, {}, {}, {}, {}, {}}}], {{}, {}}}, {
+    DisplayFunction -> Identity, DisplayFunction -> Identity, AspectRatio -> 
+     NCache[GoldenRatio^(-1), 0.6180339887498948], Axes -> {True, True}, 
+     AxesLabel -> {None, None}, AxesOrigin -> {370.7291666666667, 0}, 
+     DisplayFunction :> Identity, Frame -> {{False, False}, {False, False}}, 
+     FrameLabel -> {{None, None}, {None, None}}, 
+     FrameTicks -> {{Automatic, Automatic}, {Automatic, Automatic}}, 
+     GridLines -> {None, None}, GridLinesStyle -> Directive[
+       GrayLevel[0.5, 0.4]], 
+     Method -> {
+      "OptimizePlotMarkers" -> True, "OptimizePlotMarkers" -> True, 
+       "CoordinatesToolOptions" -> {"DisplayFunction" -> ({
+           Identity[
+            Part[#, 1]], 
+           Identity[
+            Part[#, 2]]}& ), "CopiedValueFunction" -> ({
+           Identity[
+            Part[#, 1]], 
+           Identity[
+            Part[#, 2]]}& )}}, 
+     PlotRange -> {{370.7291666666667, 825.}, {0, 1.6166}}, PlotRangeClipping -> 
+     True, PlotRangePadding -> {{
+        Scaled[0.02], 
+        Scaled[0.02]}, {
+        Scaled[0.02], 
+        Scaled[0.05]}}, Ticks -> {Automatic, Automatic}}], 
+   FormBox[
+    FormBox[
+     TemplateBox[{"\"X\"", "\"Y\"", "\"Z\""}, "LineLegend", 
+      DisplayFunction -> (FormBox[
+        StyleBox[
+         StyleBox[
+          PaneBox[
+           TagBox[
+            GridBox[{{
+               TagBox[
+                GridBox[{{
+                   GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[1, 0, 0]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[1, 0, 0]], {}}}, AspectRatio -> Full, 
+                    ImageSize -> {20, 10}, PlotRangePadding -> None, 
+                    ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #}, {
+                   GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0, 1, 0]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0, 1, 0]], {}}}, AspectRatio -> Full, 
+                    ImageSize -> {20, 10}, PlotRangePadding -> None, 
+                    ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #2}, {
+                   GraphicsBox[{{
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0, 0, 1]], {
+                    LineBox[{{0, 10}, {20, 10}}]}}, {
+                    Directive[
+                    EdgeForm[
+                    Directive[
+                    Opacity[0.3], 
+                    GrayLevel[0]]], 
+                    PointSize[0.5], 
+                    AbsoluteThickness[1.6], 
+                    RGBColor[0, 0, 1]], {}}}, AspectRatio -> Full, 
+                    ImageSize -> {20, 10}, PlotRangePadding -> None, 
+                    ImagePadding -> Automatic, 
+                    BaselinePosition -> (Scaled[0.1] -> Baseline)], #3}}, 
+                 GridBoxAlignment -> {
+                  "Columns" -> {Center, Left}, "Rows" -> {{Baseline}}}, 
+                 AutoDelete -> False, 
+                 GridBoxDividers -> {
+                  "Columns" -> {{False}}, "Rows" -> {{False}}}, 
+                 GridBoxItemSize -> {"Columns" -> {{All}}, "Rows" -> {{All}}},
+                  GridBoxSpacings -> {
+                  "Columns" -> {{0.5}}, "Rows" -> {{0.8}}}], "Grid"]}}, 
+             GridBoxAlignment -> {"Columns" -> {{Left}}, "Rows" -> {{Top}}}, 
+             AutoDelete -> False, 
+             GridBoxItemSize -> {
+              "Columns" -> {{Automatic}}, "Rows" -> {{Automatic}}}, 
+             GridBoxSpacings -> {"Columns" -> {{1}}, "Rows" -> {{0}}}], 
+            "Grid"], Alignment -> Left, AppearanceElements -> None, 
+           ImageMargins -> {{5, 5}, {5, 5}}, ImageSizeAction -> 
+           "ResizeToFit"], LineIndent -> 0, StripOnInput -> False], {
+         FontFamily -> "Arial"}, Background -> Automatic, StripOnInput -> 
+         False], TraditionalForm]& ), 
+      InterpretationFunction :> (RowBox[{"LineLegend", "[", 
+         RowBox[{
+           RowBox[{"{", 
+             RowBox[{
+               RowBox[{"Directive", "[", 
+                 RowBox[{
+                   RowBox[{"PointSize", "[", 
+                    FractionBox["1", "90"], "]"}], ",", 
+                   RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                   InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[1, 0, 0], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, DefaultBaseStyle -> 
+                    "ColorSwatchGraphics", AspectRatio -> 1, Frame -> True, 
+                    FrameStyle -> RGBColor[0.6666666666666666, 0., 0.], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    StyleBox[
+                    RowBox[{"RGBColor", "[", 
+                    RowBox[{"1", ",", "0", ",", "0"}], "]"}], NumberMarks -> 
+                    False]], Appearance -> None, BaseStyle -> {}, 
+                    BaselinePosition -> Baseline, DefaultBaseStyle -> {}, 
+                    ButtonFunction :> With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[1, 0, 0]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[1, 0, 0], Editable -> False, Selectable -> 
+                    False]}], "]"}], ",", 
+               RowBox[{"Directive", "[", 
+                 RowBox[{
+                   RowBox[{"PointSize", "[", 
+                    FractionBox["1", "90"], "]"}], ",", 
+                   RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                   InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0, 1, 0], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, DefaultBaseStyle -> 
+                    "ColorSwatchGraphics", AspectRatio -> 1, Frame -> True, 
+                    FrameStyle -> RGBColor[0., 0.6666666666666666, 0.], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    StyleBox[
+                    RowBox[{"RGBColor", "[", 
+                    RowBox[{"0", ",", "1", ",", "0"}], "]"}], NumberMarks -> 
+                    False]], Appearance -> None, BaseStyle -> {}, 
+                    BaselinePosition -> Baseline, DefaultBaseStyle -> {}, 
+                    ButtonFunction :> With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0, 1, 0]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0, 1, 0], Editable -> False, Selectable -> 
+                    False]}], "]"}], ",", 
+               RowBox[{"Directive", "[", 
+                 RowBox[{
+                   RowBox[{"PointSize", "[", 
+                    FractionBox["1", "90"], "]"}], ",", 
+                   RowBox[{"AbsoluteThickness", "[", "1.6`", "]"}], ",", 
+                   InterpretationBox[
+                    ButtonBox[
+                    TooltipBox[
+                    GraphicsBox[{{
+                    GrayLevel[0], 
+                    RectangleBox[{0, 0}]}, {
+                    GrayLevel[0], 
+                    RectangleBox[{1, -1}]}, {
+                    RGBColor[0, 0, 1], 
+                    RectangleBox[{0, -1}, {2, 1}]}}, DefaultBaseStyle -> 
+                    "ColorSwatchGraphics", AspectRatio -> 1, Frame -> True, 
+                    FrameStyle -> RGBColor[0., 0., 0.6666666666666666], 
+                    FrameTicks -> None, PlotRangePadding -> None, ImageSize -> 
+                    Dynamic[{
+                    Automatic, 1.35 CurrentValue["FontCapHeight"]/
+                    AbsoluteCurrentValue[Magnification]}]], 
+                    StyleBox[
+                    RowBox[{"RGBColor", "[", 
+                    RowBox[{"0", ",", "0", ",", "1"}], "]"}], NumberMarks -> 
+                    False]], Appearance -> None, BaseStyle -> {}, 
+                    BaselinePosition -> Baseline, DefaultBaseStyle -> {}, 
+                    ButtonFunction :> With[{Typeset`box$ = EvaluationBox[]}, 
+                    If[
+                    Not[
+                    AbsoluteCurrentValue["Deployed"]], 
+                    SelectionMove[Typeset`box$, All, Expression]; 
+                    FrontEnd`Private`$ColorSelectorInitialAlpha = 1; 
+                    FrontEnd`Private`$ColorSelectorInitialColor = 
+                    RGBColor[0, 0, 1]; 
+                    FrontEnd`Private`$ColorSelectorUseMakeBoxes = True; 
+                    MathLink`CallFrontEnd[
+                    FrontEnd`AttachCell[Typeset`box$, 
+                    FrontEndResource["RGBColorValueSelector"], {
+                    0, {Left, Bottom}}, {Left, Top}, 
+                    "ClosingActions" -> {
+                    "SelectionDeparture", "ParentChanged", 
+                    "EvaluatorQuit"}]]]], BaseStyle -> Inherited, Evaluator -> 
+                    Automatic, Method -> "Preemptive"], 
+                    RGBColor[0, 0, 1], Editable -> False, Selectable -> 
+                    False]}], "]"}]}], "}"}], ",", 
+           RowBox[{"{", 
+             RowBox[{#, ",", #2, ",", #3}], "}"}], ",", 
+           RowBox[{"LegendMarkers", "\[Rule]", 
+             RowBox[{"{", 
+               RowBox[{
+                 RowBox[{"{", 
+                   RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                 RowBox[{"{", 
+                   RowBox[{"False", ",", "Automatic"}], "}"}], ",", 
+                 RowBox[{"{", 
+                   RowBox[{"False", ",", "Automatic"}], "}"}]}], "}"}]}], ",", 
+           RowBox[{"Joined", "\[Rule]", 
+             RowBox[{"{", 
+               RowBox[{"True", ",", "True", ",", "True"}], "}"}]}], ",", 
+           RowBox[{"LabelStyle", "\[Rule]", 
+             RowBox[{"{", "}"}]}], ",", 
+           RowBox[{"LegendLayout", "\[Rule]", "\"Column\""}]}], "]"}]& ), 
+      Editable -> True], TraditionalForm], TraditionalForm]},
+  "Legended",
+  DisplayFunction->(GridBox[{{
+      TagBox[
+       ItemBox[
+        PaneBox[
+         TagBox[#, "SkipImageSizeLevel"], Alignment -> {Center, Baseline}, 
+         BaselinePosition -> Baseline], DefaultBaseStyle -> "Labeled"], 
+       "SkipImageSizeLevel"], 
+      ItemBox[#2, DefaultBaseStyle -> "LabeledLabel"]}}, 
+    GridBoxAlignment -> {"Columns" -> {{Center}}, "Rows" -> {{Center}}}, 
+    AutoDelete -> False, GridBoxItemSize -> Automatic, 
+    BaselinePosition -> {1, 1}]& ),
+  Editable->True,
+  InterpretationFunction->(RowBox[{"Legended", "[", 
+     RowBox[{#, ",", 
+       RowBox[{"Placed", "[", 
+         RowBox[{#2, ",", "After"}], "]"}]}], "]"}]& )]], "Output",
+ CellChangeTimes->{{3.799693202154001*^9, 3.799693223818859*^9}, 
+   3.799693323819891*^9, {3.799693437467022*^9, 3.7996934751186037`*^9}, 
+   3.7996976291839943`*^9, 3.79969866589895*^9},
+ CellLabel->
+  "Out[275]=",ExpressionUUID->"256a4210-0eec-40f0-97c6-e83d6f913fde"]
+}, Open  ]],
+
+Cell[BoxData[
+ RowBox[{"(*", " ", 
+  RowBox[{
+   RowBox[{
+   "Color", " ", "temperature", " ", "in", " ", "XYZ", " ", "using", " ", 
+    RowBox[{"Planck", "'"}], "s", " ", "radiation", " ", 
+    RowBox[{"law", ".", "\[IndentingNewLine]", "See"}], " ", 
+    RowBox[{"https", ":"}]}], "//", 
+   RowBox[{
+    RowBox[{
+     RowBox[{
+      RowBox[{"en", ".", "wikipedia", ".", "org"}], "/", "wiki"}], "/", 
+     "Planck"}], "%27", "s_law", "#Different", "_forms", " ", 
+    RowBox[{
+     RowBox[{"(", "wavelength", ")"}], "."}]}]}], " ", "*)"}]], "Input",
+ CellChangeTimes->{{3.799698333760501*^9, 3.799698383375208*^9}, {
+  3.7996985894225903`*^9, 3.79969859018611*^9}, {3.7996987637937317`*^9, 
+  3.7996987796452913`*^9}},ExpressionUUID->"b641840e-051e-4b4e-b167-\
+bc3e6ad4ecd3"],
+
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{"\[Lambda]", "=", 
+   RowBox[{"\[Lambda]", " ", 
+    RowBox[{"10", "^", 
+     RowBox[{"-", "9"}]}]}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"XYZ", "[", "t_", "]"}], ":=", 
+  RowBox[{"Module", "[", 
+   RowBox[{
+    RowBox[{"{", 
+     RowBox[{
+      RowBox[{"h", "=", 
+       RowBox[{"6.62607", "*", 
+        RowBox[{"10", "^", 
+         RowBox[{"-", "34"}]}]}]}], ",", 
+      RowBox[{"c", "=", 
+       RowBox[{"2.998", "*", 
+        RowBox[{"10", "^", "8"}]}]}], ",", 
+      RowBox[{"k", "=", 
+       RowBox[{"1.38065", "*", 
+        RowBox[{"10", "^", 
+         RowBox[{"-", "23"}]}]}]}]}], "}"}], ",", 
+    RowBox[{
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"x", ",", "y", ",", "z"}], "}"}], ".", 
+      RowBox[{"(", 
+       RowBox[{
+        RowBox[{"(", 
+         RowBox[{"2", " ", "h", " ", 
+          RowBox[{"c", "^", "2"}]}], ")"}], "/", 
+        RowBox[{"(", 
+         RowBox[{
+          RowBox[{"(", 
+           RowBox[{
+            RowBox[{"-", "1"}], "+", 
+            RowBox[{"E", "^", 
+             RowBox[{"(", 
+              RowBox[{
+               RowBox[{"(", 
+                RowBox[{"h", " ", 
+                 RowBox[{"c", "/", "k"}]}], ")"}], "/", 
+               RowBox[{"(", 
+                RowBox[{"t", " ", "\[Lambda]"}], ")"}]}], ")"}]}]}], ")"}], 
+          " ", 
+          RowBox[{"\[Lambda]", "^", "5"}]}], ")"}]}], ")"}]}], "//", 
+     RowBox[{
+      RowBox[{"#", "/", 
+       RowBox[{"#", "[", 
+        RowBox[{"[", "2", "]"}], "]"}]}], "&"}]}]}], "]"}]}]}], "Input",
+ CellChangeTimes->{{3.799635026824547*^9, 3.7996350268313503`*^9}, 
+   3.799635657078288*^9, {3.799672669897991*^9, 3.799672683139142*^9}, {
+   3.799672737193862*^9, 3.7996727538126793`*^9}, {3.799672823495021*^9, 
+   3.799672851181918*^9}, {3.799672970031393*^9, 3.799673006668379*^9}, 
+   3.799698330596814*^9, {3.799698655146714*^9, 3.799698655760837*^9}},
+ CellLabel->
+  "In[277]:=",ExpressionUUID->"6457c5d8-ae11-4909-978d-b3e3a65b681d"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[TextData[StyleBox["Color balance", "Subsection"]], "Subsubsection",
+ CellChangeTimes->{{3.7996982241825457`*^9, 
+  3.7996982477885103`*^9}},ExpressionUUID->"1ed7ae1c-a39e-4675-bdce-\
+9ca04f3a5686"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"(*", " ", 
+   RowBox[{
+    RowBox[{
+    "xyY", " ", "y", " ", "coordinate", " ", "from", " ", "x", " ", 
+     "coordinate", " ", "for", " ", "series", " ", "D", " ", 
+     RowBox[{"illuminants", ".", "\[IndentingNewLine]", "See"}], " ", 
+     RowBox[{"https", ":"}]}], "//", 
+    RowBox[{
+     RowBox[{
+      RowBox[{
+       RowBox[{"en", ".", "wikipedia", ".", "org"}], "/", "wiki"}], "/", 
+      "Standard_illuminant"}], "#Illuminant", "_series", "_D"}]}], " ", 
+   "*)"}], "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"illuminant", "[", "x_", "]"}], ":=", 
+    RowBox[{
+     RowBox[{"2.87", "*", "x"}], "-", 
+     RowBox[{"3", "*", 
+      RowBox[{"x", "^", "2"}]}], "-", "0.275"}]}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"(*", " ", 
+    RowBox[{
+     RowBox[{"k", " ", "=", " ", "temperature"}], ",", " ", 
+     RowBox[{"from", " ", "-", 
+      RowBox[{"100", " ", "to"}], " ", "+", "100"}], ",", " ", 
+     RowBox[{"t", " ", "=", " ", "tint"}], ",", " ", 
+     RowBox[{"from", " ", "-", 
+      RowBox[{"100", " ", "to"}], " ", "+", "100"}]}], " ", "*)"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"colorBalance", "[", 
+     RowBox[{"k_", ",", "t_"}], "]"}], ":=", 
+    RowBox[{"Module", "[", "\[IndentingNewLine]", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"x", ",", "y"}], "}"}], ",", "\[IndentingNewLine]", 
+      RowBox[{
+       RowBox[{"x", "=", 
+        RowBox[{"0.31271", "-", 
+         RowBox[{
+          RowBox[{"k", "/", "100"}], "*", 
+          RowBox[{"If", "[", 
+           RowBox[{
+            RowBox[{"k", "<", "0"}], ",", "0.214", ",", "0.066"}], 
+           "]"}]}]}]}], ";", "\[IndentingNewLine]", 
+       RowBox[{"y", "=", 
+        RowBox[{
+         RowBox[{"illuminant", "[", "x", "]"}], "+", 
+         RowBox[{
+          RowBox[{"t", "/", "100"}], "*", "0.066"}]}]}], ";", 
+       "\[IndentingNewLine]", 
+       RowBox[{"XYZColor", "[", 
+        RowBox[{
+         RowBox[{"x", "/", "y"}], ",", "1", ",", 
+         RowBox[{
+          RowBox[{"(", 
+           RowBox[{"1", "-", "x", "-", "y"}], ")"}], "/", "y"}]}], "]"}]}]}], 
+     "\[IndentingNewLine]", "]"}]}]}]}]], "Input",
+ CellChangeTimes->{{3.799632571383841*^9, 3.799632608292733*^9}, {
+   3.799632676235901*^9, 3.799632681498097*^9}, {3.799632827958025*^9, 
+   3.799632925131782*^9}, {3.7996330903402863`*^9, 3.799633095618657*^9}, {
+   3.799633140723916*^9, 3.799633426512389*^9}, {3.799633460545279*^9, 
+   3.799633469273794*^9}, {3.799633640885653*^9, 3.799633650781673*^9}, {
+   3.799633727981271*^9, 3.799633847020423*^9}, {3.799633891310361*^9, 
+   3.7996339495947723`*^9}, {3.799634066192059*^9, 3.7996340683802757`*^9}, {
+   3.799634515764727*^9, 3.799634544153775*^9}, {3.799635040782217*^9, 
+   3.799635075804644*^9}, {3.7996351262414017`*^9, 3.799635128117138*^9}, 
+   3.799635205063448*^9, {3.799635264602023*^9, 3.799635269805664*^9}, 
+   3.799635418420905*^9, {3.7996360480112877`*^9, 3.799636061433045*^9}, {
+   3.799636569873048*^9, 3.799636652616926*^9}, {3.7996367000437202`*^9, 
+   3.7996367028166313`*^9}, {3.79963698849085*^9, 3.7996369976533203`*^9}, {
+   3.7996978422374897`*^9, 3.799697845864108*^9}, {3.799697900594455*^9, 
+   3.79969790429821*^9}, {3.7996980240918713`*^9, 3.799698043753441*^9}, {
+   3.799698254105238*^9, 3.799698309118058*^9}},
+ CellLabel->
+  "In[279]:=",ExpressionUUID->"91479455-511b-4796-93de-c39fff6c9cde"],
+
+Cell[TextData[StyleBox["Temperature/tint vs Planckian locus", "Subsection"]], \
+"Text",
+ CellChangeTimes->{{3.799698156809493*^9, 3.79969816321318*^9}, {
+  3.799698234739921*^9, 
+  3.7996982404248667`*^9}},ExpressionUUID->"b59472d3-1e5f-4fee-845e-\
+c26d6c717e5f"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"(*", " ", 
+   RowBox[{
+   "Reference", " ", "chromaticity", " ", "plot", " ", "with", " ", "sRGB", 
+    " ", "gamut", " ", "and", " ", "D65", " ", "white", " ", "point"}], " ", 
+   "*)"}], "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{"p1", "=", 
+    RowBox[{"ChromaticityPlot", "[", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"\"\<sRGB\>\"", ",", 
+        RowBox[{"Table", "[", 
+         RowBox[{
+          RowBox[{"XYZColor", "@", 
+           RowBox[{"XYZ", "[", "i", "]"}]}], ",", 
+          RowBox[{"{", 
+           RowBox[{"i", ",", "2000", ",", "50000", ",", "50"}], "}"}]}], 
+         "]"}]}], "}"}], ",", 
+      RowBox[{"ImageSize", "\[Rule]", "Large"}], ",", 
+      RowBox[{"Appearance", "\[Rule]", "\"\<VisibleSpectrum\>\""}], ",", 
+      RowBox[{"PlotPoints", "\[Rule]", "50"}], ",", 
+      RowBox[{"PlotTheme", "\[Rule]", "\"\<Marketing\>\""}]}], "]"}]}], 
+   ";"}]}]], "Input",
+ CellChangeTimes->{{3.799698313092388*^9, 3.799698325541086*^9}},
+ CellLabel->
+  "In[281]:=",ExpressionUUID->"f9b79059-5cb9-4951-917a-24c552fedc15"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"(*", " ", 
+   RowBox[{
+   "Plot", " ", "Planckian", " ", "locus", " ", "against", " ", 
+    "chromaticity", " ", 
+    RowBox[{"diagram", ".", " ", "Also"}], " ", "plots", " ", "the", " ", 
+    "position", " ", "of", " ", "the", " ", "illuminant", " ", "defined", " ",
+     "by", " ", "a", " ", "temperature", " ", "and", " ", "tint", " ", 
+    "offset", " ", "from", " ", 
+    RowBox[{"D65", "."}]}], " ", "*)"}], "\[IndentingNewLine]", 
+  RowBox[{"Manipulate", "[", "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"Show", "[", 
+     RowBox[{"p1", ",", 
+      RowBox[{"ChromaticityPlot", "[", 
+       RowBox[{
+        RowBox[{"colorBalance", "[", 
+         RowBox[{"k", ",", "t"}], "]"}], ",", 
+        RowBox[{"ImageSize", "\[Rule]", "Large"}], ",", 
+        RowBox[{"PlotPoints", "\[Rule]", "50"}], ",", 
+        RowBox[{"Appearance", "\[Rule]", "None"}], ",", 
+        RowBox[{"PlotStyle", "\[Rule]", 
+         RowBox[{"{", 
+          RowBox[{"Green", ",", 
+           RowBox[{"PointSize", "[", "0.01", "]"}]}], "}"}]}]}], "]"}]}], 
+     "\[IndentingNewLine]", "]"}], ",", "\[IndentingNewLine]", 
+    RowBox[{"{", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"k", ",", "0"}], "}"}], ",", 
+      RowBox[{"-", "100"}], ",", "100"}], "}"}], ",", 
+    RowBox[{"{", 
+     RowBox[{
+      RowBox[{"{", 
+       RowBox[{"t", ",", "0"}], "}"}], ",", 
+      RowBox[{"-", "100"}], ",", "100"}], "}"}]}], "\[IndentingNewLine]", 
+   "]"}]}]], "Input",
+ CellChangeTimes->{{3.799632571383841*^9, 3.799632608292733*^9}, {
+   3.799632676235901*^9, 3.799632681498097*^9}, {3.799632827958025*^9, 
+   3.799632925131782*^9}, {3.7996330903402863`*^9, 3.799633095618657*^9}, {
+   3.799633140723916*^9, 3.799633426512389*^9}, {3.799633460545279*^9, 
+   3.799633469273794*^9}, {3.799633640885653*^9, 3.799633650781673*^9}, {
+   3.799633727981271*^9, 3.799633847020423*^9}, {3.799633891310361*^9, 
+   3.7996339495947723`*^9}, {3.799634066192059*^9, 3.7996340683802757`*^9}, {
+   3.799634515764727*^9, 3.799634544153775*^9}, {3.799635040782217*^9, 
+   3.799635075804644*^9}, {3.7996351262414017`*^9, 3.799635128117138*^9}, 
+   3.799635205063448*^9, {3.799635264602023*^9, 3.799635269805664*^9}, {
+   3.799635418420905*^9, 3.7996355518067217`*^9}, {3.799698523595182*^9, 
+   3.799698556800757*^9}},
+ CellLabel->
+  "In[282]:=",ExpressionUUID->"a8d5ebad-752d-4a20-bf53-b51b85d0c7f4"],
+
+Cell[BoxData[
+ TagBox[
+  StyleBox[
+   DynamicModuleBox[{$CellContext`k$$ = 0, $CellContext`t$$ = 0, 
+    Typeset`show$$ = True, Typeset`bookmarkList$$ = {}, 
+    Typeset`bookmarkMode$$ = "Menu", Typeset`animator$$, Typeset`animvar$$ = 
+    1, Typeset`name$$ = "\"untitled\"", Typeset`specs$$ = {{{
+       Hold[$CellContext`k$$], 0}, -100, 100}, {{
+       Hold[$CellContext`t$$], 0}, -100, 100}}, Typeset`size$$ = {
+    576., {282., 287.}}, Typeset`update$$ = 0, Typeset`initDone$$, 
+    Typeset`skipInitDone$$ = True}, 
+    DynamicBox[Manipulate`ManipulateBoxes[
+     1, StandardForm, 
+      "Variables" :> {$CellContext`k$$ = 0, $CellContext`t$$ = 0}, 
+      "ControllerVariables" :> {}, 
+      "OtherVariables" :> {
+       Typeset`show$$, Typeset`bookmarkList$$, Typeset`bookmarkMode$$, 
+        Typeset`animator$$, Typeset`animvar$$, Typeset`name$$, 
+        Typeset`specs$$, Typeset`size$$, Typeset`update$$, Typeset`initDone$$,
+         Typeset`skipInitDone$$}, "Body" :> Show[$CellContext`p1, 
+        ChromaticityPlot[
+         $CellContext`colorBalance[$CellContext`k$$, $CellContext`t$$], 
+         ImageSize -> Large, PlotPoints -> 50, Appearance -> None, 
+         PlotStyle -> {Green, 
+           PointSize[0.01]}]], 
+      "Specifications" :> {{{$CellContext`k$$, 0}, -100, 
+         100}, {{$CellContext`t$$, 0}, -100, 100}}, "Options" :> {}, 
+      "DefaultOptions" :> {}],
+     ImageSizeCache->{621., {341., 347.}},
+     SingleEvaluation->True],
+    Deinitialization:>None,
+    DynamicModuleValues:>{},
+    SynchronousInitialization->True,
+    UndoTrackedVariables:>{Typeset`show$$, Typeset`bookmarkMode$$},
+    UnsavedVariables:>{Typeset`initDone$$},
+    UntrackedVariables:>{Typeset`size$$}], "Manipulate",
+   Deployed->True,
+   StripOnInput->False],
+  Manipulate`InterpretManipulate[1]]], "Output",
+ CellChangeTimes->{{3.79963548269405*^9, 3.799635552455084*^9}, 
+   3.79963584043777*^9, 3.799636131854322*^9, 3.799637001792697*^9, 
+   3.799672935690529*^9, {3.799672989095996*^9, 3.799673017848003*^9}, 
+   3.7996976302532787`*^9, {3.799697930480048*^9, 3.799697946728343*^9}, {
+   3.799698046634182*^9, 3.799698054798706*^9}, 3.799698666945218*^9},
+ CellLabel->
+  "Out[282]=",ExpressionUUID->"b4881322-a44e-49f9-9fc6-baa601b2a0cc"]
+}, Open  ]],
+
+Cell[TextData[StyleBox["Temperature scale factors", "Subsection"]], "Text",
+ CellChangeTimes->{{3.799698108679871*^9, 
+  3.799698112384754*^9}},ExpressionUUID->"17b39e86-24b9-4000-b2de-\
+4c786c8160f4"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"XYZ2xyY", "[", "xyz_", "]"}], ":=", 
+  RowBox[{"{", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"xyz", "[", 
+      RowBox[{"[", "1", "]"}], "]"}], "/", 
+     RowBox[{"(", 
+      RowBox[{
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "1", "]"}], "]"}], "+", 
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "2", "]"}], "]"}], "+", 
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "3", "]"}], "]"}]}], ")"}]}], ",", 
+    RowBox[{
+     RowBox[{"xyz", "[", 
+      RowBox[{"[", "2", "]"}], "]"}], "/", 
+     RowBox[{"(", 
+      RowBox[{
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "1", "]"}], "]"}], "+", 
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "2", "]"}], "]"}], "+", 
+       RowBox[{"xyz", "[", 
+        RowBox[{"[", "3", "]"}], "]"}]}], ")"}]}], ",", 
+    RowBox[{"xyz", "[", 
+     RowBox[{"[", "2", "]"}], "]"}]}], "}"}]}]], "Input",
+ CellLabel->
+  "In[283]:=",ExpressionUUID->"ae126839-0976-4ee1-9094-b08a95a24b31"],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"redFactor", "=", 
+  RowBox[{"Abs", "[", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"XYZ2xyY", "[", 
+      RowBox[{"XYZ", "[", "2000", "]"}], "]"}], "[", 
+     RowBox[{"[", "1", "]"}], "]"}], "-", "0.31271"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.7996728948277073`*^9, 3.799672959965103*^9}, {
+  3.799697311227035*^9, 3.79969732724277*^9}, {3.7996976681214333`*^9, 
+  3.799697713323945*^9}, {3.799697983550215*^9, 3.799698012435688*^9}, {
+  3.7996981173044367`*^9, 3.79969813956184*^9}},
+ CellLabel->
+  "In[284]:=",ExpressionUUID->"4159dcda-f489-44d3-afc5-1bc5a08422e7"],
+
+Cell[BoxData["0.2139756967699324`"], "Output",
+ CellChangeTimes->{{3.7996729538066807`*^9, 3.799673018189229*^9}, {
+   3.799697317869492*^9, 3.799697327943421*^9}, {3.799697620842779*^9, 
+   3.7996976305947247`*^9}, 3.7996976802338867`*^9, 3.7996977150586243`*^9, {
+   3.799697988194819*^9, 3.799698017291986*^9}, 3.799698139920917*^9, 
+   3.799698667273141*^9},
+ CellLabel->
+  "Out[284]=",ExpressionUUID->"df3b0df9-edf4-4a87-8543-c66bdda738a5"]
+}, Open  ]],
+
+Cell[CellGroupData[{
+
+Cell[BoxData[
+ RowBox[{"blueFactor", "=", 
+  RowBox[{"Abs", "[", 
+   RowBox[{
+    RowBox[{
+     RowBox[{"XYZ2xyY", "[", 
+      RowBox[{"XYZ", "[", "50000", "]"}], "]"}], "[", 
+     RowBox[{"[", "1", "]"}], "]"}], "-", "0.31271"}], "]"}]}]], "Input",
+ CellChangeTimes->{{3.799673023902585*^9, 3.799673024561625*^9}, {
+  3.7996976895675983`*^9, 3.7996977010552464`*^9}, {3.799697991920663*^9, 
+  3.7996980147773037`*^9}, {3.799698142742086*^9, 3.799698145035707*^9}},
+ CellLabel->
+  "In[285]:=",ExpressionUUID->"308ff37e-dfa4-4423-bf0c-95197c27a12f"],
+
+Cell[BoxData["0.06559976600982073`"], "Output",
+ CellChangeTimes->{
+  3.7996730258189983`*^9, {3.799697622670849*^9, 3.799697630600626*^9}, {
+   3.7996976933259783`*^9, 3.79969771633221*^9}, {3.799697992362425*^9, 
+   3.7996980150253353`*^9}, 3.7996981453755407`*^9, 3.799698667279005*^9},
+ CellLabel->
+  "Out[285]=",ExpressionUUID->"b923efcd-103e-4f0e-bbf8-aa38e144767d"]
+}, Open  ]]
+}, Open  ]]
+},
+WindowSize->{1115, 1647},
+WindowMargins->{{Automatic, 512}, {Automatic, 0}},
+FrontEndVersion->"12.1 for Mac OS X x86 (64-bit) (March 18, 2020)",
+StyleDefinitions->"Default.nb",
+ExpressionUUID->"48bd8ea1-5b3e-40ff-9c43-0731d1f417de"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[CellGroupData[{
+Cell[580, 22, 263, 5, 46, "Subsubsection",ExpressionUUID->"1a2a6f85-9587-438e-baf4-87fab9cfd47e"],
+Cell[CellGroupData[{
+Cell[868, 31, 1360, 36, 52, "Input",ExpressionUUID->"151ac5d0-c087-4eac-b459-b03393d07da4"],
+Cell[2231, 69, 23113, 490, 248, "Output",ExpressionUUID->"256a4210-0eec-40f0-97c6-e83d6f913fde"]
+}, Open  ]],
+Cell[25359, 562, 776, 18, 52, "Input",ExpressionUUID->"b641840e-051e-4b4e-b167-bc3e6ad4ecd3"],
+Cell[26138, 582, 1998, 57, 73, "Input",ExpressionUUID->"6457c5d8-ae11-4909-978d-b3e3a65b681d"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[28173, 644, 202, 3, 46, "Subsubsection",ExpressionUUID->"1ed7ae1c-a39e-4675-bdce-9ca04f3a5686"],
+Cell[28378, 649, 3430, 78, 241, "Input",ExpressionUUID->"91479455-511b-4796-93de-c39fff6c9cde"],
+Cell[31811, 729, 263, 5, 41, "Text",ExpressionUUID->"b59472d3-1e5f-4fee-845e-c26d6c717e5f"],
+Cell[32077, 736, 1081, 27, 73, "Input",ExpressionUUID->"f9b79059-5cb9-4951-917a-24c552fedc15"],
+Cell[CellGroupData[{
+Cell[33183, 767, 2395, 51, 178, "Input",ExpressionUUID->"a8d5ebad-752d-4a20-bf53-b51b85d0c7f4"],
+Cell[35581, 820, 2252, 45, 707, "Output",ExpressionUUID->"b4881322-a44e-49f9-9fc6-baa601b2a0cc"]
+}, Open  ]],
+Cell[37848, 868, 201, 3, 41, "Text",ExpressionUUID->"17b39e86-24b9-4000-b2de-4c786c8160f4"],
+Cell[38052, 873, 965, 30, 30, "Input",ExpressionUUID->"ae126839-0976-4ee1-9094-b08a95a24b31"],
+Cell[CellGroupData[{
+Cell[39042, 907, 593, 13, 30, "Input",ExpressionUUID->"4159dcda-f489-44d3-afc5-1bc5a08422e7"],
+Cell[39638, 922, 445, 7, 34, "Output",ExpressionUUID->"df3b0df9-edf4-4a87-8543-c66bdda738a5"]
+}, Open  ]],
+Cell[CellGroupData[{
+Cell[40120, 934, 548, 12, 30, "Input",ExpressionUUID->"308ff37e-dfa4-4423-bf0c-95197c27a12f"],
+Cell[40671, 948, 372, 6, 34, "Output",ExpressionUUID->"b923efcd-103e-4f0e-bbf8-aa38e144767d"]
+}, Open  ]]
+}, Open  ]]
+}
+]
+*)
+

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -470,12 +470,12 @@ enum class TextureFormat : uint16_t {
 
 //! Bitmask describing the intended Texture Usage
 enum class TextureUsage : uint8_t {
-    COLOR_ATTACHMENT    = 0x1,  //!< Texture can be used as a color attachment
-    DEPTH_ATTACHMENT    = 0x2,  //!< Texture can be used as a depth attachment
-    STENCIL_ATTACHMENT  = 0x4,  //!< Texture can be used as a stencil attachment
-    UPLOADABLE          = 0x8,  //!< Data can be uploaded into this texture (default)
-    SAMPLEABLE          = 0x10, //!< Texture can be sampled (default)
-    DEFAULT = UPLOADABLE | SAMPLEABLE   //!< Default texture usage
+    COLOR_ATTACHMENT    = 0x1,                      //!< Texture can be used as a color attachment
+    DEPTH_ATTACHMENT    = 0x2,                      //!< Texture can be used as a depth attachment
+    STENCIL_ATTACHMENT  = 0x4,                      //!< Texture can be used as a stencil attachment
+    UPLOADABLE          = 0x8,                      //!< Data can be uploaded into this texture (default)
+    SAMPLEABLE          = 0x10,                     //!< Texture can be sampled (default)
+    DEFAULT             = UPLOADABLE | SAMPLEABLE   //!< Default texture usage
 };
 
 //! Texture swizzle

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -35,7 +35,7 @@ class UTILS_PUBLIC ColorGrading : public FilamentAPI {
 public:
     enum class ToneMapping : uint8_t {
         LINEAR        = 0,     //!< Linear tone mapping (i.e. no tone mapping)
-        ACES          = 1,     //!< ACES tone mapping (ODT+RRT in )
+        ACES          = 1,     //!< ACES tone mapping, with a brightness modifier
         FILMIC        = 2,     //!< Filmic tone mapping, modelled after ACES but applied in sRGB space
         REINHARD      = 3,     //!< Reinhard luma-based tone mapping
         DISPLAY_RANGE = 4,     //!< Debug tone mapping to validate scene exposure
@@ -52,6 +52,9 @@ public:
         Builder& operator=(Builder&& rhs) noexcept;
 
         Builder& toneMapping(ToneMapping toneMapping) noexcept;
+
+        // TODO: document: temperature from -1 to +1, tint from -1 to +1; clipped otherwise
+        Builder& whiteBalance(float temperature, float tint) noexcept;
 
         ColorGrading* build(Engine& engine);
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -497,7 +497,8 @@ public:
      * @param colorGrading Associate the specified ColorGrading to this View. A ColorGrading can be
      *                     associated to several View instances.\n
      *                     \p colorGradingOptions can be nullptr to dissociate the currently set
-     *                     ColorGrading from this View.\n
+     *                     ColorGrading from this View. Doing so will revert to the use of the
+     *                     default color grading transforms.\n
      *                     The View doesn't take ownership of the ColorGrading pointer (which
      *                     acts as a reference).
      *

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -31,6 +31,7 @@
 namespace filament {
 
 class Camera;
+class ColorGrading;
 class MaterialInstance;
 class RenderTarget;
 class Scene;
@@ -477,6 +478,7 @@ public:
      * @param type Tone-mapping function.
      *
      * @deprecated Use setColorGrading instead
+     * @see setColorGrading
      */
     void setToneMapping(ToneMapping type) noexcept;
 
@@ -484,9 +486,32 @@ public:
      * Returns the tone-mapping function.
      * @return tone-mapping function.
      *
-     * @deprecated use getColorGrading instead
+     * @deprecated Use getColorGrading instead
+     * @see getColorGrading
      */
     ToneMapping getToneMapping() const noexcept;
+
+    /**
+     * Sets this View's color grading transforms.
+     *
+     * @param colorGrading Associate the specified ColorGrading to this View. A ColorGrading can be
+     *                     associated to several View instances.\n
+     *                     \p colorGradingOptions can be nullptr to dissociate the currently set
+     *                     ColorGrading from this View.\n
+     *                     The View doesn't take ownership of the ColorGrading pointer (which
+     *                     acts as a reference).
+     *
+     * @note
+     *  There is no reference-counting.
+     *  Make sure to dissociate a ColorGrading from all Views before destroying it.
+     */
+    void setColorGrading(ColorGrading* colorGrading) noexcept;
+
+    /**
+     * Returns the color grading transforms currently associated to this view.
+     * @return A pointer to the ColorGrading associated to this View.
+     */
+    const ColorGrading* getColorGrading() const noexcept;
 
     /**
      * Enables or disables bloom in the post-processing stage. Disabled by default.

--- a/filament/src/Color.cpp
+++ b/filament/src/Color.cpp
@@ -16,18 +16,17 @@
 
 #include <filament/Color.h>
 
+#include "ColorSpace.h"
+
 #include <image/ColorTransform.h>
 
 #include <math/mat3.h>
 
 #include <cmath>
 
-using namespace filament::math;
-
 namespace filament {
 
-using xyY = float3;
-using XYZ = float3;
+using namespace math;
 
 float3 Color::sRGBToLinear(float3 color) noexcept {
     return image::sRGBToLinear(color);
@@ -35,20 +34,6 @@ float3 Color::sRGBToLinear(float3 color) noexcept {
 
 float3 Color::linearToSRGB(float3 color) noexcept {
     return image::linearToSRGB(color);
-}
-
-static inline constexpr XYZ xyY_to_XYZ(xyY const& v) {
-    return XYZ{v.x / v.y, v.z, (1.0f - v.x - v.y) / v.y};
-}
-
-static inline LinearColor XYZ_to_sRGB(XYZ const& v) {
-    // XYZ to linear sRGB
-    const mat3f XYZ_sRGB{
-           3.2404542f, -0.9692660f,  0.0556434f,
-          -1.5371385f,  1.8760108f, -0.2040259f,
-          -0.4985314f,  0.0415560f,  1.0572252f
-    };
-    return XYZ_sRGB * v;
 }
 
 LinearColor Color::cct(float K) {
@@ -60,7 +45,7 @@ LinearColor Color::cct(float K) {
                (1.0f - 2.89741816e-5f * K + 1.61456053e-7f * K2);
 
     float d = 1.0f / (2.0f * u - 8.0f * v + 4.0f);
-    float3 linear = XYZ_to_sRGB(xyY_to_XYZ({3.0f * u * d, 2.0f * v * d, 1.0f}));
+    float3 linear = XYZ_to_sRGB * xyY_to_XYZ({3.0f * u * d, 2.0f * v * d, 1.0f});
     // normalize and saturate
     return saturate(linear / std::max(1e-5f, max(linear)));
 }
@@ -74,7 +59,7 @@ LinearColor Color::illuminantD(float K) {
             0.237040f + 0.24748e3f * iK + 1.9018e6f * iK2 - 2.0064e9f * iK2 * iK;
     float y = -3.0f * x * x + 2.87f * x - 0.275f;
 
-    float3 linear = XYZ_to_sRGB(xyY_to_XYZ({x, y, 1.0f}));
+    float3 linear = XYZ_to_sRGB * xyY_to_XYZ({x, y, 1.0f});
     // normalize and saturate
     return saturate(linear / std::max(1e-5f, max(linear)));
 }

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -108,7 +108,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
 
     // Multithreadedly generate the tone mapping 3D look-up table using 32 jobs
     // Slices are 8 KiB (128 cache lines) apart.
-    // This takes about 3-6ms on Android in Release mode on Pixel 4
+    // This takes about 3-6ms on Android in Release
     JobSystem& js = engine.getJobSystem();
     auto slices = js.createJob();
     for (size_t b = 0; b < LUT_DIMENSION; b++) {

--- a/filament/src/ColorSpace.h
+++ b/filament/src/ColorSpace.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_COLOR_SPACE_H
+#define TNT_FILAMENT_COLOR_SPACE_H
+
+#include <utils/compiler.h>
+
+#include <math/mat3.h>
+#include <math/vec3.h>
+#include <math/scalar.h>
+
+namespace filament {
+
+using namespace math;
+
+using xyY = float3;
+using XYZ = float3;
+
+constexpr mat3f XYZ_to_sRGB{
+     3.2404542f, -0.9692660f,  0.0556434f,
+    -1.5371385f,  1.8760108f, -0.2040259f,
+    -0.4985314f,  0.0415560f,  1.0572252f
+};
+
+constexpr mat3f sRGB_to_XYZ{
+     0.4124560f,  0.2126730f,  0.0193339f,
+     0.3575760f,  0.7151520f,  0.1191920f,
+     0.1804380f,  0.0721750f,  0.9503040f
+};
+
+constexpr mat3f XYZ_to_CIECAT02{
+     0.7328000f, -0.7036000f,  0.0030000f,
+     0.4296000f,  1.6975000f,  0.0136000f,
+    -0.1624000f,  0.0061000f,  0.9834000f
+};
+
+constexpr mat3f CIECAT02_to_XYZ{
+     1.0961200f,  0.4543690f, -0.0096276f,
+    -0.2788690f,  0.4735330f, -0.0056980f,
+     0.1827450f,  0.0720978f,  1.0153300f
+};
+
+// Standard CIE 1931 2° illuminant D65, in xyY space
+constexpr float3 ILLUMINANT_D65_xyY{0.31271f, 0.32902f, 1.0f};
+
+// Standard CIE 1931 2° illuminant D65, in LMS space (CIECAT02)
+// Result of: XYZ_to_CIECAT02 * xyY_to_XYZ(ILLUMINANT_D65_xyY);
+constexpr float3 ILLUMINANT_D65_LMS{0.949237f, 1.03542f, 1.08728f};
+
+constexpr mat3f sRGB_to_LMS = XYZ_to_CIECAT02 * sRGB_to_XYZ;
+
+constexpr mat3f LMS_to_sRGB = XYZ_to_sRGB * CIECAT02_to_XYZ;
+
+inline constexpr XYZ xyY_to_XYZ(xyY v) {
+    return XYZ{v.x / v.y, v.z, (1.0f - v.x - v.y) / v.y};
+}
+
+// Returns the y chromaticity coordinate in xyY for an illuminant series D,
+// given its x chromaticity coordinate.
+inline constexpr float illuminantD_y(float x) {
+    // See http://en.wikipedia.org/wiki/Standard_illuminant#Illuminant_series_D
+    return 2.87f * x - 3.0f * x * x - 0.275f;
+}
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_COLOR_SPACE_H

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1028,17 +1028,17 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
         }
     }
 
-    auto& ppColorGrading = fg.addPass<PostProcessColorGrading>("colorGradingOptions",
+    auto& ppColorGrading = fg.addPass<PostProcessColorGrading>("colorGrading",
             [&](FrameGraph::Builder& builder, auto& data) {
                 auto const& inputDesc = fg.getDescriptor(input);
                 data.input = builder.sample(input);
-                data.output = builder.createTexture("colorGradingOptions output", {
+                data.output = builder.createTexture("colorGrading output", {
                         .width = inputDesc.width,
                         .height = inputDesc.height,
                         .format = outFormat
                 });
                 data.output = builder.write(data.output);
-                data.rt = builder.createRenderTarget("colorGradingOptions Target", {
+                data.rt = builder.createRenderTarget("colorGrading Target", {
                         .attachments = { data.output } });
 
                 if (bloomBlur.isValid()) {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -24,10 +24,11 @@
 #include "RenderPass.h"
 
 #include "details/Camera.h"
+#include "details/ColorGrading.h"
 #include "details/Material.h"
 #include "details/MaterialInstance.h"
 #include "details/Texture.h"
-#include "details/ColorGrading.h"
+
 #include "generated/resources/materials.h"
 
 #include <private/filament/SibGenerator.h>
@@ -972,14 +973,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPass(FrameGraph& fg,
     return bloomUpsamplePass.getData().out;
 }
 
-void PostProcessManager::colorGradingSubpass(DriverApi& driver,
+void PostProcessManager::colorGradingSubpass(DriverApi& driver, const FColorGrading* colorGrading,
         bool translucent, bool fxaa, bool dithering) noexcept {
 
     FEngine& engine = mEngine;
     Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine.getFullScreenRenderPrimitive();
 
     FMaterialInstance* mi = mColorGradingAsSubpass.getMaterialInstance();
-    mi->setParameter("lut", mEngine.getDefaultColorGrading()->getHwHandle(), {
+    mi->setParameter("lut", colorGrading->getHwHandle(), {
             .filterMag = SamplerMagFilter::LINEAR,
             .filterMin = SamplerMinFilter::LINEAR
     });
@@ -994,7 +995,7 @@ void PostProcessManager::colorGradingSubpass(DriverApi& driver,
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> input,
+        FrameGraphId<FrameGraphTexture> input, const FColorGrading* colorGrading,
         TextureFormat outFormat, bool translucent, bool fxaa, float2 scale,
         View::BloomOptions bloomOptions, bool dithering) noexcept {
 
@@ -1027,17 +1028,17 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
         }
     }
 
-    auto& ppColorGrading = fg.addPass<PostProcessColorGrading>("colorGrading",
+    auto& ppColorGrading = fg.addPass<PostProcessColorGrading>("colorGradingOptions",
             [&](FrameGraph::Builder& builder, auto& data) {
                 auto const& inputDesc = fg.getDescriptor(input);
                 data.input = builder.sample(input);
-                data.output = builder.createTexture("colorGrading output", {
+                data.output = builder.createTexture("colorGradingOptions output", {
                         .width = inputDesc.width,
                         .height = inputDesc.height,
                         .format = outFormat
                 });
                 data.output = builder.write(data.output);
-                data.rt = builder.createRenderTarget("colorGrading Target", {
+                data.rt = builder.createRenderTarget("colorGradingOptions Target", {
                         .attachments = { data.output } });
 
                 if (bloomBlur.isValid()) {
@@ -1059,7 +1060,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                         data.dirt.isValid() ? resources.getTexture(data.dirt) : getOneTexture();
 
                 FMaterialInstance* mi = mColorGrading.getMaterialInstance();
-                mi->setParameter("lut", mEngine.getDefaultColorGrading()->getHwHandle(), {
+                mi->setParameter("lut", colorGrading->getHwHandle(), {
                         .filterMag = SamplerMagFilter::LINEAR,
                         .filterMin = SamplerMinFilter::LINEAR
                 });

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -28,6 +28,7 @@
 
 namespace filament {
 
+class FColorGrading;
 class FEngine;
 class FMaterial;
 class FMaterialInstance;
@@ -66,11 +67,11 @@ public:
             const CameraInfo& cameraInfo) noexcept;
 
     // Tone mapping
-    void colorGradingSubpass(backend::DriverApi& driver,
-                             bool translucent, bool fxaa, bool dithering) noexcept;
+    void colorGradingSubpass(backend::DriverApi& driver, const FColorGrading* colorGrading,
+            bool translucent, bool fxaa, bool dithering) noexcept;
 
     FrameGraphId<FrameGraphTexture> colorGrading(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> input, const FColorGrading* colorGrading,
             backend::TextureFormat outFormat, bool translucent, bool fxaa, math::float2 scale,
             View::BloomOptions bloomOptions, bool dithering) noexcept;
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -41,7 +41,6 @@
 #include <utils/vector.h>
 
 #include <assert.h>
-#include <private/filament/SibGenerator.h>
 
 // this helps visualize what dynamic-scaling is doing
 #define DEBUG_DYNAMIC_SCALING false
@@ -403,6 +402,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (colorGrading) {
             if (!colorGradingConfig.asSubpass) {
                 input = ppm.colorGrading(fg, input,
+                        view.getColorGrading(),
                         colorGradingConfig.ldrFormat,
                         colorGradingConfig.translucent,
                         colorGradingConfig.fxaa,
@@ -698,6 +698,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 if (colorGradingConfig.asSubpass) {
                     // post-processing....
                     ppm.colorGradingSubpass(driver,
+                            view.getColorGrading(),
                             colorGradingConfig.translucent,
                             colorGradingConfig.fxaa,
                             colorGradingConfig.dithering);

--- a/filament/src/ToneMapping.h
+++ b/filament/src/ToneMapping.h
@@ -320,7 +320,7 @@ float3 DisplayRange(float3 x) noexcept {
     float v = log2(dot(x, float3{0.2126f, 0.7152f, 0.0722f}) / 0.18f);
     v = clamp(v + 5.0f, 0.0f, 15.0f);
     size_t index = size_t(v);
-    return mix(debugColors[index], debugColors[index + 1], v - float(index));
+    return mix(debugColors[index], debugColors[index + 1], saturate(v - float(index)));
 }
 
 } // namespace tonemap

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -21,7 +21,6 @@
 #include "details/DFG.h"
 #include "details/Froxelizer.h"
 #include "details/IndirectLight.h"
-#include "details/MaterialInstance.h"
 #include "details/Renderer.h"
 #include "details/RenderTarget.h"
 #include "details/Scene.h"
@@ -33,7 +32,6 @@
 #include <private/filament/SibGenerator.h>
 #include <private/filament/UibGenerator.h>
 
-#include <utils/Allocator.h>
 #include <utils/Profiler.h>
 #include <utils/Slice.h>
 #include <utils/Systrace.h>
@@ -43,7 +41,6 @@
 
 #include <memory>
 #include <filament/View.h>
-
 
 using namespace filament::math;
 using namespace utils;
@@ -80,6 +77,8 @@ FView::FView(FEngine& engine)
     mShadowUbh = driver.createUniformBuffer(mShadowUb.getSize(), backend::BufferUsage::DYNAMIC);
 
     mIsDynamicResolutionSupported = driver.isFrameTimeSupported();
+
+    mColorGrading = engine.getDefaultColorGrading();
 }
 
 FView::~FView() noexcept = default;
@@ -822,7 +821,6 @@ Camera& View::getCamera() noexcept {
     return upcast(this)->getCameraUser();
 }
 
-
 void View::setViewport(filament::Viewport const& viewport) noexcept {
     upcast(this)->setViewport(viewport);
 }
@@ -893,6 +891,14 @@ void View::setToneMapping(ToneMapping type) noexcept {
 
 View::ToneMapping View::getToneMapping() const noexcept {
     return upcast(this)->getToneMapping();
+}
+
+void View::setColorGrading(ColorGrading* colorGrading) noexcept {
+    return upcast(this)->setColorGrading(upcast(colorGrading));
+}
+
+const ColorGrading* View::getColorGrading() const noexcept {
+    return upcast(this)->getColorGrading();
 }
 
 void View::setDithering(Dithering dithering) noexcept {

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -78,7 +78,7 @@ FView::FView(FEngine& engine)
 
     mIsDynamicResolutionSupported = driver.isFrameTimeSupported();
 
-    mColorGrading = engine.getDefaultColorGrading();
+    mDefaultColorGrading = mColorGrading = engine.getDefaultColorGrading();
 }
 
 FView::~FView() noexcept = default;

--- a/filament/src/details/ColorGrading.h
+++ b/filament/src/details/ColorGrading.h
@@ -24,6 +24,8 @@
 
 #include <filament/ColorGrading.h>
 
+#include <math/mathfwd.h>
+
 namespace filament {
 
 class FEngine;
@@ -42,8 +44,8 @@ public:
     backend::TextureHandle getHwHandle() const noexcept { return mLutHandle; }
 
 private:
-    static inline float lutToLinear(float x) noexcept;
-    static inline float linearToLut(float x) noexcept;
+    static inline math::float3 lutToLinear(math::float3 x) noexcept;
+    static inline math::float3 linearToLut(math::float3 x) noexcept;
 
     backend::TextureHandle mLutHandle;
 };

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -207,7 +207,7 @@ public:
     }
 
     void setColorGrading(FColorGrading* colorGrading) noexcept {
-        mColorGrading = colorGrading;
+        mColorGrading = colorGrading == nullptr ? mDefaultColorGrading : colorGrading;
     }
 
     const FColorGrading* getColorGrading() const noexcept {
@@ -399,6 +399,7 @@ private:
     DepthOfFieldOptions mDepthOfFieldOptions;
     BlendMode mBlendMode = BlendMode::OPAQUE;
     const FColorGrading* mColorGrading = nullptr;
+    const FColorGrading* mDefaultColorGrading = nullptr;
 
     DynamicResolutionOptions mDynamicResolution;
     math::float2 mScale = 1.0f;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -26,6 +26,7 @@
 
 #include "details/Allocators.h"
 #include "details/Camera.h"
+#include "details/ColorGrading.h"
 #include "details/Froxelizer.h"
 #include "details/RenderTarget.h"
 #include "details/ShadowMap.h"
@@ -203,6 +204,14 @@ public:
 
     ToneMapping getToneMapping() const noexcept {
         return mToneMapping;
+    }
+
+    void setColorGrading(FColorGrading* colorGrading) noexcept {
+        mColorGrading = colorGrading;
+    }
+
+    const FColorGrading* getColorGrading() const noexcept {
+        return mColorGrading;
     }
 
     void setDithering(Dithering dithering) noexcept {
@@ -389,6 +398,7 @@ private:
     FogOptions mFogOptions;
     DepthOfFieldOptions mDepthOfFieldOptions;
     BlendMode mBlendMode = BlendMode::OPAQUE;
+    const FColorGrading* mColorGrading = nullptr;
 
     DynamicResolutionOptions mDynamicResolution;
     math::float2 mScale = 1.0f;

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -470,9 +470,23 @@ private:
         return v;
     }
 
+    friend inline VECTOR<T> MATH_PURE pow(T v, VECTOR<T> p) {
+        for (size_t i = 0; i < p.size(); i++) {
+            p[i] = std::pow(v, p[i]);
+        }
+        return p;
+    }
+
     friend inline VECTOR<T> MATH_PURE log(VECTOR<T> v) {
         for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::log(v[i]);
+        }
+        return v;
+    }
+
+    friend inline VECTOR<T> MATH_PURE log10(VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = std::log10(v[i]);
         }
         return v;
     }

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -576,6 +576,8 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::Combo("Tone-mapping",
                     reinterpret_cast<int*>(&params.colorGradingOptions.toneMapping),
                     "Linear\0ACES\0Filmic\0Reinhard\0Display Range\0\0");
+            ImGui::SliderInt("Temperature", &params.colorGradingOptions.temperature, -100, 100);
+            ImGui::SliderInt("Tint", &params.colorGradingOptions.tint, -100, 100);
         }
 
         if (ImGui::CollapsingHeader("Debug")) {
@@ -690,8 +692,10 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
     view->setAmbientOcclusionOptions(g_params.ssaoOptions);
 
     if (memcmp(&g_params.colorGradingOptions, &g_lastColorGradingOptions, sizeof(ColorGradingOptions))) {
+        ColorGradingOptions& options = g_params.colorGradingOptions;
         ColorGrading* colorGrading = ColorGrading::Builder()
-                .toneMapping(g_params.colorGradingOptions.toneMapping)
+                .toneMapping(options.toneMapping)
+                .whiteBalance(options.temperature / 100.0f, options.tint / 100.0f)
                 .build(*engine);
         view->setColorGrading(colorGrading);
 
@@ -700,7 +704,7 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
         }
 
         g_colorGrading = colorGrading;
-        g_lastColorGradingOptions = g_params.colorGradingOptions;
+        g_lastColorGradingOptions = options;
     }
 
     // Without an IBL, we must clear the swapchain to black before each frame.

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -58,14 +58,18 @@ constexpr uint8_t BLENDING_FADE             = 2;
 constexpr uint8_t BLENDING_THIN_REFRACTION  = 3;
 constexpr uint8_t BLENDING_SOLID_REFRACTION = 4;
 
+using namespace filament;
+
 struct ColorGradingOptions {
-    filament::ColorGrading::ToneMapping toneMapping = filament::ColorGrading::ToneMapping::ACES;
+    ColorGrading::ToneMapping toneMapping = ColorGrading::ToneMapping::ACES;
+    int temperature = 0;
+    int tint = 0;
 };
 
 struct SandboxParameters {
-    const filament::Material* material[MATERIAL_COUNT];
-    filament::MaterialInstance* materialInstance[MATERIAL_COUNT];
-    filament::sRGBColor color = {0.69f, 0.69f, 0.69f};
+    const Material* material[MATERIAL_COUNT];
+    MaterialInstance* materialInstance[MATERIAL_COUNT];
+    sRGBColor color = {0.69f, 0.69f, 0.69f};
     float alpha = 1.0f;
     float roughness = 0.6f;
     float metallic = 0.0f;
@@ -83,18 +87,18 @@ struct SandboxParameters {
     float ior = 1.5;
     float emissiveExposureWeight = 1.0f;
     float emissiveEV = 0.0f;
-    filament::sRGBColor transmittanceColor =  { 1.0f };
-    filament::sRGBColor specularColor = { 0.0f };
-    filament::sRGBColor subsurfaceColor = { 0.0f };
-    filament::sRGBColor sheenColor = { 0.83f, 0.0f, 0.0f };
-    filament::sRGBColor emissiveColor = { 0.0f };
+    sRGBColor transmittanceColor =  { 1.0f };
+    sRGBColor specularColor = { 0.0f };
+    sRGBColor subsurfaceColor = { 0.0f };
+    sRGBColor sheenColor = { 0.83f, 0.0f, 0.0f };
+    sRGBColor emissiveColor = { 0.0f };
     int currentMaterialModel = MATERIAL_MODEL_LIT;
     int currentBlending = BLENDING_OPAQUE;
     bool ssr = false;
     bool castShadows = true;
-    filament::sRGBColor lightColor = {0.98f, 0.92f, 0.89f};
+    sRGBColor lightColor = {0.98f, 0.92f, 0.89f};
     float lightIntensity = 110000.0f;
-    filament::math::float3 lightDirection = {0.6f, -1.0f, -0.8f};
+    math::float3 lightDirection = {0.6f, -1.0f, -0.8f};
     float iblIntensity = 30000.0f;
     float iblRotation = 0.0f;
     float sunHaloSize = 10.0f;
@@ -105,10 +109,10 @@ struct SandboxParameters {
     utils::Entity spotLight;
     bool hasSpotLight = false;
     bool spotLightEnabled = false;
-    filament::sRGBColor spotLightColor = {1.0f, 1.0f, 1.0f};
+    sRGBColor spotLightColor = {1.0f, 1.0f, 1.0f};
     float spotLightIntensity = 200000.0f;
     bool spotLightCastShadows = true;
-    filament::math::float3 spotLightPosition;
+    math::float3 spotLightPosition;
     float spotLightConeAngle = 3.14159 / 4.0f;
     float spotLightConeFade = 0.9f;
     bool hasDirectionalLight = true;
@@ -121,9 +125,9 @@ struct SandboxParameters {
     float polygonOffsetConstant = 0.5;
     float polygonOffsetSlope = 2.0;
     bool ssao = false;
-    filament::View::AmbientOcclusionOptions ssaoOptions;
-    filament::View::BloomOptions bloomOptions;
-    filament::View::FogOptions fogOptions;
+    View::AmbientOcclusionOptions ssaoOptions;
+    View::BloomOptions bloomOptions;
+    View::FogOptions fogOptions;
     bool screenSpaceContactShadows = false;
     int stepCount = 8;
     float maxShadowDistance = 0.3;
@@ -133,8 +137,7 @@ struct SandboxParameters {
     ColorGradingOptions colorGradingOptions;
 };
 
-inline void createInstances(SandboxParameters& params, filament::Engine& engine) {
-    using namespace filament;
+inline void createInstances(SandboxParameters& params, Engine& engine) {
     using namespace utils;
     params.material[MATERIAL_UNLIT] = Material::Builder()
             .package(RESOURCES_SANDBOXUNLIT_DATA, RESOURCES_SANDBOXUNLIT_SIZE)

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_SAMPLES_MATERIAL_SANDBOX_H
 
 #include <filament/Color.h>
+#include <filament/ColorGrading.h>
 #include <filament/Engine.h>
 #include <filament/LightManager.h>
 #include <filament/Material.h>
@@ -56,6 +57,10 @@ constexpr uint8_t BLENDING_TRANSPARENT      = 1;
 constexpr uint8_t BLENDING_FADE             = 2;
 constexpr uint8_t BLENDING_THIN_REFRACTION  = 3;
 constexpr uint8_t BLENDING_SOLID_REFRACTION = 4;
+
+struct ColorGradingOptions {
+    filament::ColorGrading::ToneMapping toneMapping = filament::ColorGrading::ToneMapping::ACES;
+};
 
 struct SandboxParameters {
     const filament::Material* material[MATERIAL_COUNT];
@@ -125,6 +130,7 @@ struct SandboxParameters {
     float cameraAperture = 16.0f;
     float cameraSpeed = 125.0f;
     float cameraISO = 100.0f;
+    ColorGradingOptions colorGradingOptions;
 };
 
 inline void createInstances(SandboxParameters& params, filament::Engine& engine) {


### PR DESCRIPTION
Each View can now have its own `ColorGrading` object, which defines various color transforms.
These transforms currently include:
- Tone mapping (linear, Reinhard, ACES, Filmic and display range for debugging)
- White balance (temperature/tint offsets)

Here is an example of a scene rendered using ACES:
<img width="1633" alt="Screen Shot 2020-05-30 at 11 20 42 PM" src="https://user-images.githubusercontent.com/869684/83345944-2c183200-a2cd-11ea-987f-d52213520663.png">

And the same scene using ACES and a custom white balance to emphasize the sunset in the IBL:
<img width="1633" alt="Screen Shot 2020-05-30 at 11 20 38 PM" src="https://user-images.githubusercontent.com/869684/83345951-3c301180-a2cd-11ea-8c22-3c08346bd7cd.png">
