### PR TITLE
 gltfio: improve performance by assuming assets are well-formed.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## Next release
 
 - gltfio now supports simple instancing of entire assets.
+- For improved performance, gltfio now threads more tasks and assumes assets are well-formed.
 - Add missing JavaScript API for `View::setVisibleLayers()`.
 - Add support for DOF with Metal backend.
 - SSAO now has an optional high(er) quality upsampler.

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -100,7 +100,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
         view.camera = camera
 
         assetLoader = AssetLoader(engine, MaterialProvider(engine), EntityManager.get())
-        resourceLoader = ResourceLoader(engine)
+        resourceLoader = ResourceLoader(engine, false, false)
 
         // Always add a direct light source since it is required for shadowing.
         // We highly recommend adding an indirect light as well.

--- a/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
@@ -35,9 +35,10 @@ static void destroy(void*, size_t, void *userData) {
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_ResourceLoader_nCreateResourceLoader(JNIEnv*, jclass,
-        jlong nativeEngine) {
+        jlong nativeEngine, jboolean normalizeSkinningWeights, jboolean recomputeBoundingBoxes) {
     Engine* engine = (Engine*) nativeEngine;
-    return (jlong) new ResourceLoader({ engine, {}, true, true });
+    return (jlong) new ResourceLoader({ engine, {}, (bool) normalizeSkinningWeights,
+            (bool) recomputeBoundingBoxes });
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
@@ -46,7 +46,23 @@ public class ResourceLoader {
      */
     public ResourceLoader(@NonNull Engine engine) {
         long nativeEngine = engine.getNativeObject();
-        mNativeObject = nCreateResourceLoader(nativeEngine);
+        mNativeObject = nCreateResourceLoader(nativeEngine, false, false);
+    }
+
+    /**
+     * Constructs a resource loader tied to the given Filament engine.
+     *
+     * @param engine the engine that gets passed to all builder methods
+     * @param normalizeSkinningWeights scale non-conformant skinning weights so they sum to 1
+     * @param recomputeBoundingBoxes use computed bounding boxes rather than the ones in the asset
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    public ResourceLoader(@NonNull Engine engine, boolean normalizeSkinningWeights,
+            boolean recomputeBoundingBoxes) {
+        long nativeEngine = engine.getNativeObject();
+        mNativeObject = nCreateResourceLoader(nativeEngine, normalizeSkinningWeights,
+                recomputeBoundingBoxes);
     }
 
     /**
@@ -131,7 +147,8 @@ public class ResourceLoader {
         nAsyncUpdateLoad(mNativeObject);
     }
 
-    private static native long nCreateResourceLoader(long nativeEngine);
+    private static native long nCreateResourceLoader(long nativeEngine,
+            boolean normalizeSkinningWeights, boolean recomputeBoundingBoxes);
     private static native void nDestroyResourceLoader(long nativeLoader);
     private static native void nAddResourceData(long nativeLoader, String url, Buffer buffer,
             int remaining);

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -351,7 +351,7 @@ Filament.loadClassExtensions = function() {
         }
 
         // Construct a resource loader and start decoding after all textures are fetched.
-        const resourceLoader = new Filament.gltfio$ResourceLoader(engine);
+        const resourceLoader = new Filament.gltfio$ResourceLoader(engine, false, false);
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1561,12 +1561,13 @@ class_<AssetLoader>("gltfio$AssetLoader")
     }), allow_raw_pointers());
 
 class_<ResourceLoader>("gltfio$ResourceLoader")
-    .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine), {
+    .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine, bool normalizeSkinningWeights,
+            bool recomputeBoundingBoxes), {
         return new ResourceLoader({
             .engine = engine,
             .gltfPath = nullptr,
-            .normalizeSkinningWeights = true,
-            .recomputeBoundingBoxes = true
+            .normalizeSkinningWeights = normalizeSkinningWeights,
+            .recomputeBoundingBoxes = recomputeBoundingBoxes
         });
     }), allow_raw_pointers())
 


### PR DESCRIPTION
glTF assets are required to provide min/max attributes for POSITION,
so in theory we never need to compute the AABB. However the option is
still there.

This PR also makes it so that Java clients can choose this option,
previously it was hardcoded for all non-native clients.