### PR TITLE
Color grading: add saturation and contrast

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ A new header is inserted each time a *tag* is created.
 - Tone mappping now uses the real ACES tone mapper, applied in the proper color space.
 - Tone mapping is now applied via a LUT.
 - Color grading capabilities per View: white balance (temperature/tint), channel mixer,
-  tonal ranges (shadows/mid-tones/highlights).
+  tonal ranges (shadows/mid-tones/highlights), contrast, saturation.
 - Fixed bug in the Metal backend when SSR and MSAA were turned on
 - Fixed Metal issue with `BufferDescriptor` and `PixelBufferDescriptor`s not being called on application thread.
 

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -296,7 +296,6 @@ target_link_libraries(${TARGET} PUBLIC utils)
 target_link_libraries(${TARGET} PUBLIC geometry) # TODO: remove this dependency after deprecating VertexBuffer::populateTangentQuaternions
 target_link_libraries(${TARGET} PUBLIC filaflat)
 target_link_libraries(${TARGET} PUBLIC filabridge)
-target_link_libraries(${TARGET} PUBLIC image_headers)
 target_link_libraries(${TARGET} PUBLIC ibl)
 
 # Link in matdbg for Desktop + Debug only since it pulls in filamat and a web server.

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -81,7 +81,7 @@ class FColorGrading;
  *   ranges {0,0.333,0.550,1}
  * - Contrast: 1.0
  * - Saturation: 1.0
- * - Tone mapping: ACES
+ * - Tone mapping: ACES_LEGACY
  *
  * @see View
  */
@@ -94,10 +94,11 @@ public:
      */
     enum class ToneMapping : uint8_t {
         LINEAR        = 0,     //!< Linear tone mapping (i.e. no tone mapping)
-        ACES          = 1,     //!< ACES tone mapping, with a brightness modifier
-        FILMIC        = 2,     //!< Filmic tone mapping, modelled after ACES but applied in sRGB space
-        REINHARD      = 3,     //!< Reinhard luma-based tone mapping
-        DISPLAY_RANGE = 4,     //!< Tone mapping used to validate/debug scene exposure
+        ACES_LEGACY   = 1,     //!< ACES tone mapping, with a brightness modifier to match Filament's legacy tone mapper
+        ACES          = 2,     //!< ACES tone mapping
+        FILMIC        = 3,     //!< Filmic tone mapping, modelled after ACES but applied in sRGB space
+        REINHARD      = 4,     //!< Reinhard luma-based tone mapping
+        DISPLAY_RANGE = 5,     //!< Tone mapping used to validate/debug scene exposure
     };
 
     //! Use Builder to construct a ColorGrading object instance
@@ -115,7 +116,7 @@ public:
          * Selects the tone mapping operator to apply to the HDR color buffer as the last
          * operation of the color grading post-processing step.
          *
-         * The default tone mapping operator is ACES.
+         * The default tone mapping operator is ACES_LEGACY.
          *
          * @param toneMapping The tone mapping operator to apply to the HDR color buffer
          *

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -67,6 +67,8 @@ class FColorGrading;
  * - White balance
  * - Channel mixer
  * - Shadows/mid-tones/highlights
+ * - Contrast
+ * - Saturation
  * - Tone mapping
  *
  * Defaults
@@ -77,6 +79,8 @@ class FColorGrading;
  * - Channel mixer: red {1,0,0}, green {0,1,0}, blue {0,0,1}
  * - Shadows/mid-tones/highlights: shadows {1,1,1,0}, mid-tones {1,1,1,0}, highlights {1,1,1,0},
  *   ranges {0,0.333,0.550,1}
+ * - Contrast: 1.0
+ * - Saturation: 1.0
  * - Tone mapping: ACES
  *
  * @see View
@@ -201,6 +205,9 @@ public:
         Builder& shadowsMidtonesHighlights(
                 math::float4 shadows, math::float4 midtones, math::float4 highlights,
                 math::float4 ranges = math::float4{0.0f, 0.333f, 0.550f, 1.0f}) noexcept;
+
+        Builder& saturation(float saturation) noexcept;
+        Builder& contrast(float constrast) noexcept;
 
         /**
          * Creates the ColorGrading object and returns a pointer to it.

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -206,8 +206,33 @@ public:
                 math::float4 shadows, math::float4 midtones, math::float4 highlights,
                 math::float4 ranges = math::float4{0.0f, 0.333f, 0.550f, 1.0f}) noexcept;
 
-        Builder& saturation(float saturation) noexcept;
+        /**
+         * Adjusts the contrast of the image. Lower values decrease the contrast of the image
+         * (the tonal range is narrowed), and higher values increase the contrast of the image
+         * (the tonal range is widened). A value of 1.0 has no effect.
+         *
+         * The contrast is defined as a value in the range [0.0...2.0]. Values outside of that
+         * range will be clipped to that range.
+         *
+         * @param constrast Contrast expansion, between 0.0 and 2.0. 1.0 leaves contrast unaffected
+         *
+         * @return This Builder, for chaining calls
+         */
         Builder& contrast(float constrast) noexcept;
+
+        /**
+         * Adjusts the saturation of the image. Lower values decrease intensity of the colors
+         * present in the image, and higher values increase the intensity of the colors in the
+         * image. A value of 1.0 has no effect.
+         *
+         * The saturation is defined as a value in the range [0.0...2.0]. Values outside of that
+         * range will be clipped to that range.
+         *
+         * @param constrast Saturation, between 0.0 and 2.0. 1.0 leaves saturation unaffected
+         *
+         * @return This Builder, for chaining calls
+         */
+        Builder& saturation(float saturation) noexcept;
 
         /**
          * Creates the ColorGrading object and returns a pointer to it.

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -75,9 +75,13 @@ class FColorGrading;
  * Here are the default color grading options:
  * - White balance: temperature 0, and tint 0
  * - Channel mixer: red {1,0,0}, green {0,1,0}, blue {0,0,1}
+<<<<<<< HEAD
  * - Shadows/mid-tones/highlights: shadows {1,1,1,0}, mid-tones {1,1,1,0}, highlights {1,1,1,0},
  *   ranges {0,0.333,0.550,1}
  * - Tone mapping: ACES
+=======
+ * - Tonal range: shadows {1,1,1,0}, mid-tones {1,1,1,0}, hilights {1,1,1,0}, ranges {0,0.333,0.550,1}
+>>>>>>> Add new color grading feature: shadows/mid-tones/highlights
  *
  * @see View
  */

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -75,13 +75,9 @@ class FColorGrading;
  * Here are the default color grading options:
  * - White balance: temperature 0, and tint 0
  * - Channel mixer: red {1,0,0}, green {0,1,0}, blue {0,0,1}
-<<<<<<< HEAD
  * - Shadows/mid-tones/highlights: shadows {1,1,1,0}, mid-tones {1,1,1,0}, highlights {1,1,1,0},
  *   ranges {0,0.333,0.550,1}
  * - Tone mapping: ACES
-=======
- * - Tonal range: shadows {1,1,1,0}, mid-tones {1,1,1,0}, hilights {1,1,1,0}, ranges {0,0.333,0.550,1}
->>>>>>> Add new color grading feature: shadows/mid-tones/highlights
  *
  * @see View
  */

--- a/filament/src/Color.cpp
+++ b/filament/src/Color.cpp
@@ -18,22 +18,19 @@
 
 #include "ColorSpace.h"
 
-#include <image/ColorTransform.h>
-
 #include <math/mat3.h>
-
-#include <cmath>
+#include <math/scalar.h>
 
 namespace filament {
 
 using namespace math;
 
 float3 Color::sRGBToLinear(float3 color) noexcept {
-    return image::sRGBToLinear(color);
+    return EOCF_sRGB(color);
 }
 
 float3 Color::linearToSRGB(float3 color) noexcept {
-    return image::linearToSRGB(color);
+    return OECF_sRGB(color);
 }
 
 LinearColor Color::cct(float K) {
@@ -47,7 +44,7 @@ LinearColor Color::cct(float K) {
     float d = 1.0f / (2.0f * u - 8.0f * v + 4.0f);
     float3 linear = XYZ_to_sRGB * xyY_to_XYZ({3.0f * u * d, 2.0f * v * d, 1.0f});
     // normalize and saturate
-    return saturate(linear / std::max(1e-5f, max(linear)));
+    return saturate(linear / max(1e-5f, max(linear)));
 }
 
 LinearColor Color::illuminantD(float K) {
@@ -61,11 +58,11 @@ LinearColor Color::illuminantD(float K) {
 
     float3 linear = XYZ_to_sRGB * xyY_to_XYZ({x, y, 1.0f});
     // normalize and saturate
-    return saturate(linear / std::max(1e-5f, max(linear)));
+    return saturate(linear / max(1e-5f, max(linear)));
 }
 
 LinearColor Color::absorptionAtDistance(LinearColor const& color, float distance) {
-    return -log(clamp(color, 1e-5f, 1.0f)) / std::max(1e-5f, distance);
+    return -log(clamp(color, 1e-5f, 1.0f)) / max(1e-5f, distance);
 }
 
 } // namespace filament

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -245,7 +245,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
                     float3 v = float3{r, g, b} * (1.0f / (LUT_DIMENSION - 1u));
 
                     // LogC encoding
-                    v = logCToLinear(v);
+                    v = LogC_to_linear(v);
 
                     // White balance
                     v = chromaticAdaptation(v, builder->whiteBalance);

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -21,10 +21,7 @@
 #include "FilamentAPI-impl.h"
 
 #include "ColorSpace.h"
-// When defined, the ACES tone mapper will match the brightness of the filmic ("ACES sRGB")
-// tone mapper. It is *not* correct, but it helps for compatibility
-// TODO: Always enable this, expose a float to control this (1.0 == real ACES)
-#define TONEMAP_ACES_MATCH_BRIGHTNESS
+
 #include "ToneMapping.h"
 
 #include <math/vec2.h>
@@ -49,7 +46,7 @@ static constexpr size_t LUT_DIMENSION = 32u;
 //------------------------------------------------------------------------------
 
 struct ColorGrading::BuilderDetails {
-    ToneMapping toneMapping = ToneMapping::ACES;
+    ToneMapping toneMapping = ToneMapping::ACES_LEGACY;
     float2 whiteBalance     = {0.0f, 0.0f};
     float3 outRed           = {1.0f, 0.0f, 0.0f};
     float3 outGreen         = {0.0f, 1.0f, 0.0f};
@@ -158,6 +155,7 @@ using ColorTransform = float3(*)(float3);
 
 ColorTransform selectLinearToLogTransform(ColorGrading::ToneMapping toneMapping) {
     switch (toneMapping) {
+        case ColorGrading::ToneMapping::ACES_LEGACY:
         case ColorGrading::ToneMapping::ACES:
             return linearAP1_to_ACEScct;
         default:
@@ -167,6 +165,7 @@ ColorTransform selectLinearToLogTransform(ColorGrading::ToneMapping toneMapping)
 
 ColorTransform selectLogToLinearTransform(ColorGrading::ToneMapping toneMapping) {
     switch (toneMapping) {
+        case ColorGrading::ToneMapping::ACES_LEGACY:
         case ColorGrading::ToneMapping::ACES:
             return ACEScct_to_linearAP1;
         default:
@@ -176,6 +175,7 @@ ColorTransform selectLogToLinearTransform(ColorGrading::ToneMapping toneMapping)
 
 mat3f selectColorGradingTransform(ColorGrading::ToneMapping toneMapping) {
     switch (toneMapping) {
+        case ColorGrading::ToneMapping::ACES_LEGACY:
         case ColorGrading::ToneMapping::ACES:
             return sRGB_to_AP1;
         default:
@@ -185,6 +185,7 @@ mat3f selectColorGradingTransform(ColorGrading::ToneMapping toneMapping) {
 
 float3 selectLumaTransform(ColorGrading::ToneMapping toneMapping) {
     switch (toneMapping) {
+        case ColorGrading::ToneMapping::ACES_LEGACY:
         case ColorGrading::ToneMapping::ACES:
             return LUMA_AP1;
         default:
@@ -233,6 +234,8 @@ ColorTransform selectToneMapping(ColorGrading::ToneMapping toneMapping) {
     switch (toneMapping) {
         case ColorGrading::ToneMapping::LINEAR:
             return tonemap::Linear;
+        case ColorGrading::ToneMapping::ACES_LEGACY:
+            return tonemap::ACES_Legacy;
         case ColorGrading::ToneMapping::ACES:
             return tonemap::ACES;
         case ColorGrading::ToneMapping::FILMIC:

--- a/filament/src/ColorSpace.h
+++ b/filament/src/ColorSpace.h
@@ -121,6 +121,10 @@ constexpr float3 LUMA_AP1{0.272229f, 0.674082f, 0.0536895f};
 // RGB to luma coefficients for Rec.709, from sRGB_to_XYZ
 constexpr float3 LUMA_REC709{0.2126730f, 0.7151520f, 0.0721750f};
 
+constexpr float MIDDLE_GRAY_ACEScg = 0.18f;
+
+constexpr float MIDDLE_GRAY_ACEScct = 0.4135884f;
+
 //------------------------------------------------------------------------------
 // Chromaticity helpers
 //------------------------------------------------------------------------------
@@ -152,9 +156,9 @@ inline constexpr xyY XYZ_to_xyY(XYZ v) noexcept {
 // Decodes a linear value from LogC using the Alexa LogC EI 1000 curve
 inline float3 LogC_to_linear(float3 x) noexcept {
     const float ia = 1.0f / 5.555556f;
-    const float b = 0.047996f;
+    const float b  = 0.047996f;
     const float ic = 1.0f / 0.244161f;
-    const float d = 0.386036f;
+    const float d  = 0.386036f;
     return (pow(10.0f, (x - d) * ic) - b) * ia;
 }
 
@@ -183,8 +187,8 @@ inline float3 ACEScct_to_linearAP1(float3 x) noexcept {
 
 inline float3 linearAP1_to_ACEScct(float3 x) noexcept {
     for (size_t i = 0; i < 3; i++) {
-        x[i] = x[i] < 0.0078125f ?
-                  10.5402377416545f * x[i] + 0.0729055341958355f
+        x[i] = x[i] < 0.0078125f
+                ? 10.5402377416545f * x[i] + 0.0729055341958355f
                 : (log2(x[i]) + 9.72f) / 17.52f;
     }
     return x;
@@ -207,7 +211,7 @@ inline float3 EOCF_sRGB(float3 x) noexcept {
     constexpr float b  = 1.0f / 12.92f;
     constexpr float p  = 2.4f;
     for (size_t i = 0; i < 3; i++) {
-        x[i] = x[i] <= 0.04045f ? x[i] * b : std::pow((x[i] + a) / a1, p);
+        x[i] = x[i] <= 0.04045f ? x[i] * b : pow((x[i] + a) / a1, p);
     }
     return x;
 }

--- a/filament/src/ToneMapping.h
+++ b/filament/src/ToneMapping.h
@@ -127,7 +127,7 @@ inline float3 darkSurround_to_dimSurround(float3 linearCV) {
 }
 
 UTILS_ALWAYS_INLINE
-inline float3 ACES(float3 color) {
+inline float3 ACES(float3 color, float brightness) {
     // Some bits were removed to adapt to our desired output
     // Input:  ACEScg (AP1)
     // Output: linear sRGB
@@ -169,9 +169,9 @@ inline float3 ACES(float3 color) {
     // Global desaturation
     ap1 = mix(float3(dot(ap1, LUMA_AP1)), ap1, RRT_SAT_FACTOR);
 
-#if defined(TONEMAP_ACES_MATCH_BRIGHTNESS)
-    ap1 *= 1.0f / 0.6f;
-#endif
+    // NOTE: This is specific to Filament and added only to match ACES to our legacy tone mapper
+    //       which was a fit of ACES in Rec.709 but with a brightness boost.
+    ap1 *= brightness;
 
     // Fitting of RRT + ODT (RGB monitor 100 nits dim) from:
     // https://github.com/colour-science/colour-unity/blob/master/Assets/Colour/Notebooks/CIECAM02_Unity.ipynb
@@ -219,7 +219,11 @@ float3 Filmic(float3 x) noexcept {
 }
 
 float3 ACES(float3 x) noexcept {
-    return aces::ACES(x);
+    return aces::ACES(x, 1.0f);
+}
+
+float3 ACES_Legacy(float3 x) noexcept {
+    return aces::ACES(x, 1.0f / 0.6f);
 }
 
 /**

--- a/filament/src/details/ColorGrading.h
+++ b/filament/src/details/ColorGrading.h
@@ -44,9 +44,6 @@ public:
     backend::TextureHandle getHwHandle() const noexcept { return mLutHandle; }
 
 private:
-    static inline math::float3 lutToLinear(math::float3 x) noexcept;
-    static inline math::float3 linearToLut(math::float3 x) noexcept;
-
     backend::TextureHandle mLutHandle;
 };
 

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -491,6 +491,13 @@ private:
         return v;
     }
 
+    friend inline VECTOR<T> MATH_PURE log2(VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = std::log2(v[i]);
+        }
+        return v;
+    }
+
     friend inline constexpr VECTOR<T> MATH_PURE saturate(const VECTOR<T>& lv) {
         return clamp(lv, T(0), T(1));
     }

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -613,6 +613,10 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::PlotLines("Mid-tones curve", g_rangePlot + 1024, 1024);
                 ImGui::PlotLines("Highlights curve", g_rangePlot + 2048, 1024);
             }
+            if (ImGui::CollapsingHeader("Adjustments")) {
+                ImGui::SliderFloat("Contrast", &params.colorGradingOptions.contrast, 0.0f, 2.0f);
+                ImGui::SliderFloat("Saturation", &params.colorGradingOptions.saturation, 0.0f, 2.0f);
+            }
             ImGui::Unindent();
         }
 
@@ -740,6 +744,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
                             Color::toLinear(options.highlights),
                             options.ranges
                     )
+                    .contrast(options.contrast)
+                    .saturation(options.saturation)
                     .toneMapping(options.toneMapping)
                     .build(*engine);
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -589,7 +589,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::Checkbox("Enabled##colorGradin", &params.colorGrading);
             ImGui::Combo("Tone-mapping",
                     reinterpret_cast<int*>(&params.colorGradingOptions.toneMapping),
-                    "Linear\0ACES\0Filmic\0Reinhard\0Display Range\0\0");
+                    "Linear\0ACES (legacy)\0ACES\0Filmic\0Reinhard\0Display Range\0\0");
             ImGui::Indent();
             if (ImGui::CollapsingHeader("While balance")) {
                 ImGui::SliderInt("Temperature", &params.colorGradingOptions.temperature, -100, 100);

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -586,6 +586,7 @@ static void gui(filament::Engine* engine, filament::View*) {
         }
 
         if (ImGui::CollapsingHeader("Color grading")) {
+            ImGui::Checkbox("Enabled##colorGradin", &params.colorGrading);
             ImGui::Combo("Tone-mapping",
                     reinterpret_cast<int*>(&params.colorGradingOptions.toneMapping),
                     "Linear\0ACES\0Filmic\0Reinhard\0Display Range\0\0");
@@ -726,27 +727,32 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
             g_params.ssao ? View::AmbientOcclusion::SSAO : View::AmbientOcclusion::NONE);
     view->setAmbientOcclusionOptions(g_params.ssaoOptions);
 
-    if (memcmp(&g_params.colorGradingOptions, &g_lastColorGradingOptions, sizeof(ColorGradingOptions))) {
-        ColorGradingOptions& options = g_params.colorGradingOptions;
-        ColorGrading* colorGrading = ColorGrading::Builder()
-                .whiteBalance(options.temperature / 100.0f, options.tint / 100.0f)
-                .channelMixer(options.outRed, options.outGreen, options.outBlue)
-                .shadowsMidtonesHighlights(
-                        Color::toLinear(options.shadows),
-                        Color::toLinear(options.midtones),
-                        Color::toLinear(options.highlights),
-                        options.ranges
-                )
-                .toneMapping(options.toneMapping)
-                .build(*engine);
-        view->setColorGrading(colorGrading);
+    if (g_params.colorGrading) {
+        if (memcmp(&g_params.colorGradingOptions, &g_lastColorGradingOptions,
+                sizeof(ColorGradingOptions))) {
+            ColorGradingOptions &options = g_params.colorGradingOptions;
+            ColorGrading *colorGrading = ColorGrading::Builder()
+                    .whiteBalance(options.temperature / 100.0f, options.tint / 100.0f)
+                    .channelMixer(options.outRed, options.outGreen, options.outBlue)
+                    .shadowsMidtonesHighlights(
+                            Color::toLinear(options.shadows),
+                            Color::toLinear(options.midtones),
+                            Color::toLinear(options.highlights),
+                            options.ranges
+                    )
+                    .toneMapping(options.toneMapping)
+                    .build(*engine);
 
-        if (g_colorGrading) {
-            engine->destroy(g_colorGrading);
+            if (g_colorGrading) {
+                engine->destroy(g_colorGrading);
+            }
+
+            g_colorGrading = colorGrading;
+            g_lastColorGradingOptions = options;
         }
-
-        g_colorGrading = colorGrading;
-        g_lastColorGradingOptions = options;
+        view->setColorGrading(g_colorGrading);
+    } else {
+        view->setColorGrading(nullptr);
     }
 
     // Without an IBL, we must clear the swapchain to black before each frame.

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -141,6 +141,7 @@ struct SandboxParameters {
     float cameraAperture = 16.0f;
     float cameraSpeed = 125.0f;
     float cameraISO = 100.0f;
+    bool colorGrading = true;
     ColorGradingOptions colorGradingOptions;
 };
 

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -61,7 +61,7 @@ constexpr uint8_t BLENDING_SOLID_REFRACTION = 4;
 using namespace filament;
 
 struct ColorGradingOptions {
-    ColorGrading::ToneMapping toneMapping = ColorGrading::ToneMapping::ACES;
+    ColorGrading::ToneMapping toneMapping = ColorGrading::ToneMapping::ACES_LEGACY;
     int temperature = 0;
     int tint = 0;
     math::float3 outRed{1.0f, 0.0f, 0.0f};

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -71,6 +71,8 @@ struct ColorGradingOptions {
     math::float4 midtones{1.0f, 1.0f, 1.0f, 0.0f};
     math::float4 highlights{1.0f, 1.0f, 1.0f, 0.0f};
     math::float4 ranges{0.0f, 0.333f, 0.550f, 1.0f};
+    float saturation = 1.0f;
+    float contrast = 1.0f;
 };
 
 struct SandboxParameters {


### PR DESCRIPTION
Adds two new color adjustments: saturation and contrast.

Example of a scene before adjustments:

<img width="1623" alt="Screen Shot 2020-06-02 at 5 05 26 PM" src="https://user-images.githubusercontent.com/869684/83581582-159fef80-a4f4-11ea-9b16-57bed1627a83.png">

And after:

<img width="1623" alt="Screen Shot 2020-06-02 at 5 05 22 PM" src="https://user-images.githubusercontent.com/869684/83581589-1afd3a00-a4f4-11ea-9b39-2f1c81c72b2d.png">

This change also adds comments, renames/moves a few functions around to make the color grading code more precise and explicit.