### PR TITLE
Add new async method to ModelViewer.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,9 @@ A new header is inserted each time a *tag* is created.
 ## Next release
 
 - gltfio now supports simple instancing of entire assets.
-- For improved performance, gltfio now threads more tasks and assumes assets are well-formed.
+- gltfio has improved performance and assumes assets are well-formed.
 - gltfio now supports name and prefix lookup for entities.
+- ModelViewer now allows resources to be fetched off the UI thread.
 - Add missing JavaScript API for `View::setVisibleLayers()`.
 - Add support for DOF with Metal backend.
 - SSAO now has an optional high(er) quality upsampler.

--- a/android/filament-utils-android/build.gradle
+++ b/android/filament-utils-android/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation deps.androidx.annotations
     implementation project(':filament-android')
 
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'
+
     fullImplementation module("com.google.android.filament:gltfio-android:${VERSION_NAME}")
     liteImplementation module("com.google.android.filament:gltfio-android-lite:${VERSION_NAME}")
 }

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -80,9 +80,8 @@ class MainActivity : Activity() {
             input.read(bytes)
             ByteBuffer.wrap(bytes)
         }
-        modelViewer.loadModelGltf(buffer) { uri ->
-            readCompressedAsset("models/$uri")
-        }
+
+        modelViewer.loadModelGltfAsync(buffer, { uri -> readCompressedAsset("models/$uri") })
         modelViewer.transformToUnitCube()
     }
 


### PR DESCRIPTION
If you now try loading Bistro, the skybox shows up fairly quickly.
This works by moving AssetManager uncompression off the UI thread.