### PR TITLE
more debug code to help catch an ANR

### DIFF
--- a/filament/backend/include/private/backend/CommandBufferQueue.h
+++ b/filament/backend/include/private/backend/CommandBufferQueue.h
@@ -48,7 +48,9 @@ class CommandBufferQueue {
     mutable std::vector<Slice> mCommandBuffersToExecute;
     size_t mFreeSpace = 0;
     size_t mHighWatermark = 0;
-    bool mExitRequested = false;
+    uint32_t mExitRequested = 0;
+
+    static constexpr uint32_t EXIT_REQUESTED = 0x31415926;
 
 public:
     // requiredSize: guaranteed available space after flush()

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -207,6 +207,8 @@ void FEngine::init() {
     mPostProcessManager.init();
     mLightManager.init(*this);
     mDFG = std::make_unique<DFG>(*this);
+
+    mMainThreadId = std::this_thread::get_id();
 }
 
 FEngine::~FEngine() noexcept {
@@ -222,6 +224,9 @@ FEngine::~FEngine() noexcept {
 
 void FEngine::shutdown() {
     SYSTRACE_CALL();
+
+    ASSERT_PRECONDITION(std::this_thread::get_id() == mMainThreadId,
+            "Engine::shutdown() called from the wrong thread!");
 
 #ifndef NDEBUG
     // print out some statistics about this run

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -377,6 +377,8 @@ private:
     mutable filaflat::ShaderBuilder mFragmentShaderBuilder;
     FDebugRegistry mDebugRegistry;
 
+    std::thread::id mMainThreadId{};
+
 public:
     // these are the debug properties used by FDebug. They're accessed directly by modules who need them.
     struct {


### PR DESCRIPTION
- assert that shutdown() is called from the main thread
- attempt to catch whether CommandBufferQueue::mExitRequested gets corrupted
  (which could explain the ANR).