### PR TITLE
Fix: cannot use parts index for material index.

### DIFF
--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -355,16 +355,28 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
     builder.boundingBox(header->aabb);
     const auto defaultmi = materials.getMaterialInstance(utils::CString(DEFAULT_MATERIAL));
     for (size_t i = 0; i < header->parts; i++) {
+      
         builder.geometry(i, RenderableManager::PrimitiveType::TRIANGLES,
                             mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
                             parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
-        const utils::CString materialName(partsMaterial[i].c_str(), partsMaterial[i].size());
+
+        /* 
+           It may happen that there are more parts than materials 
+           therefore we have to use `Part::material` instead of `i`. 
+        */
+        uint32_t materialIndex = parts[i].material;
+        if (materialIndex >= partsMaterial.size()) {
+          utils::slog.e << "Material index (" << materialIndex << ") of mesh part (" << i << ") is out of bounds (" << partsMaterial.size() << ")" << utils::io::endl;
+          continue;
+        }
+        
+        const utils::CString materialName(partsMaterial[materialIndex].c_str(), partsMaterial[materialIndex].size());
         const auto mat = materials.getMaterialInstance(materialName);
         if (mat == nullptr) {
-            builder.material(i, defaultmi);
+            builder.material(materialIndex, defaultmi);
             materials.registerMaterialInstance(materialName, defaultmi);
         } else {
-            builder.material(i, mat);
+            builder.material(materialIndex, mat);
         }
     }
     builder.build(*engine, mesh.renderable);

--- a/libs/filameshio/src/MeshReader.cpp
+++ b/libs/filameshio/src/MeshReader.cpp
@@ -353,24 +353,24 @@ MeshReader::Mesh MeshReader::loadMeshFromBuffer(filament::Engine* engine,
 
     RenderableManager::Builder builder(header->parts);
     builder.boundingBox(header->aabb);
+
     const auto defaultmi = materials.getMaterialInstance(utils::CString(DEFAULT_MATERIAL));
     for (size_t i = 0; i < header->parts; i++) {
-      
         builder.geometry(i, RenderableManager::PrimitiveType::TRIANGLES,
-                            mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
-                            parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
+                mesh.vertexBuffer, mesh.indexBuffer, parts[i].offset,
+                parts[i].minIndex, parts[i].maxIndex, parts[i].indexCount);
 
-        /* 
-           It may happen that there are more parts than materials 
-           therefore we have to use `Part::material` instead of `i`. 
-        */
+        // It may happen that there are more parts than materials 
+        // therefore we have to use Part::material instead of i. 
         uint32_t materialIndex = parts[i].material;
         if (materialIndex >= partsMaterial.size()) {
-          utils::slog.e << "Material index (" << materialIndex << ") of mesh part (" << i << ") is out of bounds (" << partsMaterial.size() << ")" << utils::io::endl;
-          continue;
+            utils::slog.e << "Material index (" << materialIndex << ") of mesh part ("
+                    << i << ") is out of bounds (" << partsMaterial.size() << ")" << utils::io::endl;
+            continue;
         }
         
-        const utils::CString materialName(partsMaterial[materialIndex].c_str(), partsMaterial[materialIndex].size());
+        const utils::CString materialName(
+                partsMaterial[materialIndex].c_str(), partsMaterial[materialIndex].size());
         const auto mat = materials.getMaterialInstance(materialName);
         if (mat == nullptr) {
             builder.material(materialIndex, defaultmi);


### PR DESCRIPTION
Although I don't know the exact details of the `MeshWriter` and `MeshReader` I noticed that it's currently possible that there are more `Part`s in a filamesh file than that there are materials. This results in a segfault when using the `i` variable to select a material name. To fix this we have to use `parts[i].material` as that points to the correct and stored material.

To reproduce this, you have to create a particle system in blender and let it pick a random object from a collection. The number of used materials needs to be smaller then the number of objects in the collection. See the attached blend file; export this to .obj and convert that to .filamesh. 
[particles.tar.gz](https://github.com/google/filament/files/4740592/particles.tar.gz)

