### PR TITLE
Add new color grading feature, vibrance

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,8 +16,8 @@ A new header is inserted each time a *tag* is created.
 - Tone mapping is now applied via a LUT.
 - `View::setToneMapping` is deprecated, use `View::setColorGrading` instead. (⚠️ **API change**)
 - Color grading capabilities per View: white balance (temperature/tint), channel mixer,
-  tonal ranges (shadows/mid-tones/highlights), ASC CDL (slope/offset/power), contrast, saturation,
-  and curves.
+  tonal ranges (shadows/mid-tones/highlights), ASC CDL (slope/offset/power), contrast, vibrance,
+  saturation, and curves.
 - Fixed bug in the Metal backend when SSR and MSAA were turned on.
 - Fixed Metal issue with `BufferDescriptor` and `PixelBufferDescriptor`s not being called on
   the application thread.

--- a/android/filament-android/src/main/cpp/ColorGrading.cpp
+++ b/android/filament-android/src/main/cpp/ColorGrading.cpp
@@ -130,6 +130,14 @@ Java_com_google_android_filament_ColorGrading_nBuilderContrast(JNIEnv*, jclass,
 
 extern "C"
 JNIEXPORT void JNICALL
+Java_com_google_android_filament_ColorGrading_nBuilderVibrance(JNIEnv*, jclass,
+        jlong nativeBuilder, jfloat vibrance) {
+    ColorGrading::Builder* builder = (ColorGrading::Builder*) nativeBuilder;
+    builder->vibrance(vibrance);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
 Java_com_google_android_filament_ColorGrading_nBuilderSaturation(JNIEnv*, jclass,
         jlong nativeBuilder, jfloat saturation) {
     ColorGrading::Builder* builder = (ColorGrading::Builder*) nativeBuilder;

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -59,6 +59,7 @@ import static com.google.android.filament.Asserts.assertFloat4In;
  * <li>Shadows/mid-tones/highlights</li>
  * <li>Slope/offset/power (CDL)</li>
  * <li>Contrast</li>
+ * <li>Vibrance</li>
  * <li>Saturation</li>
  * <li>Curves</li>
  * <li>Tone mapping</li>
@@ -74,6 +75,7 @@ import static com.google.android.filament.Asserts.assertFloat4In;
  * highlights <code>{1,1,1,0}</code>, ranges <code>{0,0.333,0.550,1}</code></li>
  * <li>Slope/offset/power: slope <code>1.0</code>, offset <code>0.0</code>, and power <code>1.0</code></li>
  * <li>Contrast: <code>1.0</code></li>
+ * <li>Vibrance: <code>1.0</code></li>
  * <li>Saturation: <code>1.0</code></li>
  * <li>Curves: gamma <code>{1,1,1}</code>, midPoint <code>{1,1,1}</code>, and scale <code>{1,1,1}</code></li>
  * <li>Tone mapping: {@link ToneMapping#ACES_LEGACY}</li>
@@ -313,6 +315,29 @@ public class ColorGrading {
         }
 
         /**
+         * Adjusts the saturation of the image based on the input color's saturation level.
+         * Colors with a high level of saturation are less affected than colors with low saturation
+         * levels.
+         *
+         * Lower vibrance values decrease intensity of the colors present in the image, and
+         * higher values increase the intensity of the colors in the image. A value of 1.0 has
+         * no effect.
+         *
+         * The vibrance is defined as a value in the range <code>[0.0...2.0]</code>. Values outside
+         * of that range will be clipped to that range.
+         *
+         * Vibrance adjustment is performed in linear space.
+         *
+         * @param vibrance Vibrance, between 0.0 and 2.0. 1.0 leaves vibrance unaffected
+         *
+         * @return This Builder, for chaining calls
+         */
+        Builder vibrance(float vibrance) {
+            nBuilderVibrance(mNativeBuilder, vibrance);
+            return this;
+        }
+
+        /**
          * Adjusts the saturation of the image. Lower values decrease intensity of the colors
          * present in the image, and higher values increase the intensity of the colors in the
          * image. A value of 1.0 has no effect.
@@ -320,7 +345,7 @@ public class ColorGrading {
          * The saturation is defined as a value in the range <code>[0.0...2.0]</code>.
          * Values outside of that range will be clipped to that range.
          *
-         * Saturation adjustment is performed in log space.
+         * Saturation adjustment is performed in linear space.
          *
          * @param saturation Saturation, between 0.0 and 2.0. 1.0 leaves saturation unaffected
          *
@@ -414,6 +439,7 @@ public class ColorGrading {
     private static native void nBuilderShadowsMidtonesHighlights(long nativeBuilder, float[] shadows, float[] midtones, float[] highlights, float[] ranges);
     private static native void nBuilderSlopeOffsetPower(long nativeBuilder, float[] slope, float[] offset, float[] power);
     private static native void nBuilderContrast(long nativeBuilder, float contrast);
+    private static native void nBuilderVibrance(long nativeBuilder, float vibrance);
     private static native void nBuilderSaturation(long nativeBuilder, float saturation);
     private static native void nBuilderCurves(long nativeBuilder, float[] gamma, float[] midPoint, float[] scale);
 

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -69,6 +69,7 @@ class FColorGrading;
  * - Shadows/mid-tones/highlights
  * - Slope/offset/power (CDL)
  * - Contrast
+ * - Vibrance
  * - Saturation
  * - Curves
  * - Tone mapping
@@ -83,6 +84,7 @@ class FColorGrading;
  *   ranges {0,0.333,0.550,1}
  * - Slope/offset/power: slope 1.0, offset 0.0, and power 1.0
  * - Contrast: 1.0
+ * - Vibrance: 1.0
  * - Saturation: 1.0
  * - Curves: gamma {1,1,1}, midPoint {1,1,1}, and scale {1,1,1}
  * - Tone mapping: ACES_LEGACY
@@ -256,6 +258,26 @@ public:
         Builder& contrast(float contrast) noexcept;
 
         /**
+         * Adjusts the saturation of the image based on the input color's saturation level.
+         * Colors with a high level of saturation are less affected than colors with low saturation
+         * levels.
+         *
+         * Lower vibrance values decrease intensity of the colors present in the image, and
+         * higher values increase the intensity of the colors in the image. A value of 1.0 has
+         * no effect.
+         *
+         * The vibrance is defined as a value in the range [0.0...2.0]. Values outside of that
+         * range will be clipped to that range.
+         *
+         * Vibrance adjustment is performed in linear space.
+         *
+         * @param vibrance Vibrance, between 0.0 and 2.0. 1.0 leaves vibrance unaffected
+         *
+         * @return This Builder, for chaining calls
+         */
+        Builder& vibrance(float vibrance) noexcept;
+
+        /**
          * Adjusts the saturation of the image. Lower values decrease intensity of the colors
          * present in the image, and higher values increase the intensity of the colors in the
          * image. A value of 1.0 has no effect.
@@ -263,7 +285,7 @@ public:
          * The saturation is defined as a value in the range [0.0...2.0]. Values outside of that
          * range will be clipped to that range.
          *
-         * Saturation adjustment is performed in log space.
+         * Saturation adjustment is performed in linear space.
          *
          * @param saturation Saturation, between 0.0 and 2.0. 1.0 leaves saturation unaffected
          *

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -277,7 +277,7 @@ inline constexpr float3 saturation(float3 v, float saturation) {
 UTILS_ALWAYS_INLINE
 inline float3 vibrance(float3 v, float vibrance) {
     float r = v.r - max(v.g, v.b);
-    float s = (vibrance - 1.0f) / (1.0f + exp(-r * 3.0f)) + 1.0f;
+    float s = (vibrance - 1.0f) / (1.0f + std::exp(-r * 3.0f)) + 1.0f;
     float3 l{(1.0f - s) * LUMA_REC709};
     return float3{
         dot(v, l + float3{s, 0.0f, 0.0f}),

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -704,6 +704,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             }
             if (ImGui::CollapsingHeader("Adjustments")) {
                 ImGui::SliderFloat("Contrast", &colorGrading.contrast, 0.0f, 2.0f);
+                ImGui::SliderFloat("Vibrance", &colorGrading.vibrance, 0.0f, 2.0f);
                 ImGui::SliderFloat("Saturation", &colorGrading.saturation, 0.0f, 2.0f);
             }
             if (ImGui::CollapsingHeader("Curves")) {
@@ -904,6 +905,7 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
                     )
                     .slopeOffsetPower(options.slope, options.offset, options.power)
                     .contrast(options.contrast)
+                    .vibrance(options.vibrance)
                     .saturation(options.saturation)
                     .curves(options.gamma, options.midPoint, options.scale)
                     .toneMapping(options.toneMapping)

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -71,8 +71,9 @@ struct ColorGradingOptions {
     math::float4 midtones{1.0f, 1.0f, 1.0f, 0.0f};
     math::float4 highlights{1.0f, 1.0f, 1.0f, 0.0f};
     math::float4 ranges{0.0f, 0.333f, 0.550f, 1.0f};
-    float saturation = 1.0f;
     float contrast = 1.0f;
+    float vibrance = 1.0f;
+    float saturation = 1.0f;
     math::float3 slope{1.0f};
     math::float3 offset{0.0f};
     math::float3 power{1.0f};


### PR DESCRIPTION
Compared to the saturation API, vibrance tries to not saturate already saturated colors and tries to preserve red hues. Vibrance also does not desaturate the image completely.

Saturation = 2.0
<img width="1546" alt="Screen Shot 2020-06-08 at 6 10 45 PM" src="https://user-images.githubusercontent.com/869684/84095393-0d442a80-a9b4-11ea-95e8-f0cf49880f85.png">

Vibrance = 2.0
<img width="1546" alt="Screen Shot 2020-06-08 at 6 10 48 PM" src="https://user-images.githubusercontent.com/869684/84095396-10d7b180-a9b4-11ea-9abe-2353fb260271.png">

Saturation = 0.0
<img width="1546" alt="Screen Shot 2020-06-08 at 6 11 03 PM" src="https://user-images.githubusercontent.com/869684/84095404-159c6580-a9b4-11ea-880c-b7df568684df.png">

Vibrance = 0.0
<img width="1546" alt="Screen Shot 2020-06-08 at 6 10 58 PM" src="https://user-images.githubusercontent.com/869684/84095410-19c88300-a9b4-11ea-9d21-4f38879e52f5.png">
