### PR TITLE
minor fixes for matdbg

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -148,8 +148,8 @@ private:
                 uint8_t const* mData;
             };
         };
-        mutable backend::Handle<backend::HwProgram> mProgram{};
         uint32_t mSize{};
+        mutable bool mHasMaterial{};
     };
 
     PostProcessMaterial mMipmapDepth;

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -79,7 +79,7 @@ static void printStringChunk(ostream& json, const ChunkContainer& container,
         filamat::ChunkType type, const char* title) {
     CString value;
     if (read(container, type, &value)) {
-        json << "\"" << title << "\": \"" << value.c_str() << "\",\n";
+        json << "\"" << title << "\": \"" << value.c_str_safe() << "\",\n";
     }
 }
 


### PR DESCRIPTION
- don't crash when a material doesn't have a name
- don't cache the program in PostProcessManager so we can do live
  editing. Not needed anyways, because Material has a cache.