### PR TITLE
SamplerType JNI definition was out of step with the native definition.

### DIFF
--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -66,6 +66,7 @@ public class MaterialBuilder {
 
     public enum SamplerType {
         SAMPLER_2D,             // 2D texture
+        SAMPLER_2D_ARRAY,       // 2D array texture
         SAMPLER_CUBEMAP,        // Cube map texture
         SAMPLER_EXTERNAL,       // External texture
     }


### PR DESCRIPTION
When invoking MaterialBuilder.samplerParameter with Java enum SAMPLER_EXTERNAL it was wrongly recast as native enum SAMPLE_CUBEMAP in the JNI interface because the Java enum was missing SAMPLE_2D_ARRAY.