### PR TITLE
Throw Java exception when using destroyed Animator.

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/Animator.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/Animator.java
@@ -24,7 +24,7 @@ import java.nio.Buffer;
 /**
  * Updates matrices according to glTF <code>animation</code> and <code>skin</code> definitions.
  *
- * <p>Animator can be used for two things:
+ * <p>Animator is owned by <code>FilamentAsset</code> and can be used for two things:
  * <ul>
  * <li>Updating matrices in <code>TransformManager</code> components according to glTF <code>animation</code> definitions.</li>
  * <li>Updating bone matrices in <code>RenderableManager</code> components according to glTF <code>skin</code> definitions.</li>
@@ -52,7 +52,7 @@ public class Animator {
      * @see #getAnimationCount
      */
     public void applyAnimation(@IntRange(from = 0) int animationIndex, float time) {
-        nApplyAnimation(mNativeObject, animationIndex, time);
+        nApplyAnimation(getNativeObject(), animationIndex, time);
     }
 
     /**
@@ -63,14 +63,14 @@ public class Animator {
      * <p>NOTE: this operation is independent of <code>animation</code>.</p>
      */
     public void updateBoneMatrices() {
-        nUpdateBoneMatrices(mNativeObject);
+        nUpdateBoneMatrices(getNativeObject());
     }
 
     /**
      * Returns the number of <code>animation</code> definitions in the glTF asset.
      */
     public int getAnimationCount() {
-        return nGetAnimationCount(mNativeObject);
+        return nGetAnimationCount(getNativeObject());
     }
 
     /**
@@ -81,7 +81,7 @@ public class Animator {
      * @see #getAnimationCount
      * */
     public float getAnimationDuration(@IntRange(from = 0) int animationIndex) {
-        return nGetAnimationDuration(mNativeObject, animationIndex);
+        return nGetAnimationDuration(getNativeObject(), animationIndex);
     }
 
     /**
@@ -93,7 +93,18 @@ public class Animator {
      * @see #getAnimationCount
      */
     public String getAnimationName(@IntRange(from = 0) int animationIndex) {
-        return nGetAnimationName(mNativeObject, animationIndex);
+        return nGetAnimationName(getNativeObject(), animationIndex);
+    }
+
+    long getNativeObject() {
+        if (mNativeObject == 0) {
+            throw new IllegalStateException("Using Animator on destroyed asset");
+        }
+        return mNativeObject;
+    }
+
+    void clearNativeObject() {
+        mNativeObject = 0;
     }
 
     private static native void nApplyAnimation(long nativeAnimator, int index, float time);

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -165,10 +165,11 @@ public class FilamentAsset {
     }
 
     /**
-     * Creates or retrieves the <code>Animator</code> for this asset.
+     * Creates or retrieves the <code>Animator</code> interface for this asset.
      *
      * <p>When calling this for the first time, this must be called after
-     * {@link ResourceLoader#loadResources}.</p>
+     * {@link ResourceLoader#loadResources}. When the asset is destroyed, its
+     * animator becomes invalid.</p>
      */
     public @NonNull Animator getAnimator() {
         if (mAnimator != null) {
@@ -198,6 +199,7 @@ public class FilamentAsset {
     }
 
     void clearNativeObject() {
+        mAnimator.clearNativeObject();
         mNativeObject = 0;
     }
 


### PR DESCRIPTION
Someone wise once said: "It is better to throw in Java than to crash in
Native."

Motivated by #2654.