### PR TITLE
Fix applyAnimation() scale when original scale is 0

### DIFF
--- a/libs/gltfio/src/math.h
+++ b/libs/gltfio/src/math.h
@@ -79,8 +79,8 @@ inline void decomposeMatrix(const filament::math::mat4f& mat, filament::math::fl
         *rotation = clone.toQuaternion();
     }
     else {
-      // Set to idendity if close to zero
-      *rotation = quatf(1);
+        // Set to idendity if close to zero
+        *rotation = quatf(1);
     }
 }
 

--- a/libs/gltfio/src/math.h
+++ b/libs/gltfio/src/math.h
@@ -80,7 +80,7 @@ inline void decomposeMatrix(const filament::math::mat4f& mat, filament::math::fl
     }
     else {
       // Set to idendity if close to zero
-      *rotation = filament::math::quatf(1);
+      *rotation = quatf(1);
     }
 }
 

--- a/libs/gltfio/src/math.h
+++ b/libs/gltfio/src/math.h
@@ -75,10 +75,13 @@ inline void decomposeMatrix(const filament::math::mat4f& mat, filament::math::fl
         clone[0] /= s.x;
         clone[1] /= s.y;
         clone[2] /= s.z;
+        // Extract rotation.
+        *rotation = clone.toQuaternion();
     }
-
-    // Extract rotation.
-    *rotation = clone.toQuaternion();
+    else {
+      // Set to idendity if close to zero
+      *rotation = filament::math::quatf(1);
+    }
 }
 
 inline filament::math::mat4f composeMatrix(const filament::math::float3& translation,


### PR DESCRIPTION
Fix wrong orientation when calling applyAnimation() with node scale close to 0. Originally it'll still compute orientation when scale is 0 which lead to a wrong initial quaternion(0.5,0,0,0). The fix gives default quaternion if scale is 0