### PR TITLE
fix typo that prevented fxaa to work properly

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -411,7 +411,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             }
         }
         if (fxaa) {
-            input = ppm.fxaa(fg, input, colorGradingConfig.ldrFormat, colorGrading || translucent);
+            input = ppm.fxaa(fg, input, colorGradingConfig.ldrFormat, !colorGrading || translucent);
         }
         if (scaled) {
             if (UTILS_LIKELY(!blending && upscalingQuality == View::QualityLevel::LOW)) {


### PR DESCRIPTION
It caused the wrong fxaa variant to be chosen, in turn causing
flickering due to temporal dithering.