### PR TITLE
Add (improved) color grading UI to gltf-viewer

### DIFF
--- a/libs/filagui/include/filagui/ImGuiExtensions.h
+++ b/libs/filagui/include/filagui/ImGuiExtensions.h
@@ -17,12 +17,13 @@
 #ifndef FILAGUI_IMGUIEXTENSIONS_H
 #define FILAGUI_IMGUIEXTENSIONS_H
 
+struct ImVec2;
+
 /**
  * Namespace for custom widgets that follow the API conventions used by ImGui.
  * For example, the prototype for ImGuiExt::DirectionWidget is similar to ImGui::DragFloat3.
  */
 namespace ImGuiExt {
-
     /*
      * Draws an arrow widget for manipulating a unit vector (inspired by AntTweakBar).
      *
@@ -34,6 +35,21 @@ namespace ImGuiExt {
      * surprises for users who attempt to type in individual components.
      */
     bool DirectionWidget(const char* label, float v[3]);
+
+    /**
+     * Draws a plot with multiple series. The parameters are the same as for ImGui::ImPlotLines
+     * except for the following:
+     * - series_start: called when a new series starts rendering, this can be used to customize
+     *   the series' style for instance
+     * - series_end: called when a series is done rendering
+     * - values_getter: the first parameter indicates which series is being rendered
+     */
+    void PlotLinesSeries(const char* label, int series_count,
+            void (*series_start)(int series),
+            float (*values_getter)(int series, void* data, int idx),
+            void (*series_end)(int series),
+            void* data, int values_count, int values_offset, const char* overlay_text,
+            float scale_min, float scale_max, ImVec2 graph_size);
 }
 
 #endif // FILAGUI_IMGUIEXTENSIONS_H

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -483,14 +483,17 @@ void SimpleViewer::updateUserInterface() {
     DebugRegistry& debug = mEngine->getDebugRegistry();
 
     if (ImGui::CollapsingHeader("View")) {
+        ImGui::Indent();
         ImGui::Checkbox("Dithering", &mEnableDithering);
         ImGui::Checkbox("FXAA", &mEnableFxaa);
         ImGui::Checkbox("MSAA 4x", &mEnableMsaa);
         ImGui::Checkbox("SSAO", &mEnableSsao);
         ImGui::Checkbox("Bloom", &mBloomOptions.enabled);
+        ImGui::Unindent();
     }
 
     if (ImGui::CollapsingHeader("Light", headerFlags)) {
+        ImGui::Indent();
         ImGui::SliderFloat("IBL intensity", &mIblIntensity, 0.0f, 100000.0f);
         ImGui::SliderAngle("IBL rotation", &mIblRotation);
         ImGui::SliderFloat("Sun intensity", &mSunlightIntensity, 50000.0, 150000.0f);
@@ -500,9 +503,11 @@ void SimpleViewer::updateUserInterface() {
         ImGui::SliderInt("Cascades", &mShadowCascades, 1, 4);
         ImGui::Checkbox("Debug Cascades", debug.getPropertyAddress<bool>("d.shadowmap.visualize_cascades"));
         ImGui::Checkbox("Enable contact shadows", &mEnableContactShadows);
+        ImGui::Unindent();
     }
 
     if (ImGui::CollapsingHeader("Fog")) {
+        ImGui::Indent();
         ImGui::Checkbox("Enable Fog", &mFogOptions.enabled);
         ImGui::SliderFloat("Start", &mFogOptions.distance, 0.0f, 100.0f);
         ImGui::SliderFloat("Density", &mFogOptions.density, 0.0f, 1.0f);
@@ -512,6 +517,7 @@ void SimpleViewer::updateUserInterface() {
         ImGui::SliderFloat("Scattering Size", &mFogOptions.inScatteringSize, 0.0f, 100.0f);
         ImGui::Checkbox("Color from IBL", &mFogOptions.fogColorFromIbl);
         ImGui::ColorPicker3("Color", mFogOptions.color.v);
+        ImGui::Unindent();
     }
 
     mView->setDithering(mEnableDithering ? View::Dithering::TEMPORAL : View::Dithering::NONE);

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -21,6 +21,7 @@
 #include <filamentapp/IBL.h>
 
 #include <filament/Camera.h>
+#include <filament/ColorGrading.h>
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/Scene.h>
@@ -91,6 +92,37 @@ struct App {
         IndexBuffer* groundIndexBuffer;
         Material* groundMaterial;
     } scene;
+
+    struct ColorGradingOptions {
+        bool enabled = false;
+        int toneMapping = static_cast<int>(ColorGrading::ToneMapping::ACES_LEGACY);
+        int temperature = 0;
+        int tint = 0;
+        math::float3 outRed{1.0f, 0.0f, 0.0f};
+        math::float3 outGreen{0.0f, 1.0f, 0.0f};
+        math::float3 outBlue{0.0f, 0.0f, 1.0f};
+        math::float4 shadows{1.0f, 1.0f, 1.0f, 0.0f};
+        math::float4 midtones{1.0f, 1.0f, 1.0f, 0.0f};
+        math::float4 highlights{1.0f, 1.0f, 1.0f, 0.0f};
+        math::float4 ranges{0.0f, 0.333f, 0.550f, 1.0f};
+        float contrast = 1.0f;
+        float vibrance = 1.0f;
+        float saturation = 1.0f;
+        math::float3 slope{1.0f};
+        math::float3 offset{0.0f};
+        math::float3 power{1.0f};
+        math::float3 gamma{1.0f};
+        math::float3 midPoint{1.0f};
+        math::float3 scale{1.0f};
+        bool linkedCurves = false;
+    } colorGradingOptions;
+
+    ColorGradingOptions lastColorGradingOptions;
+
+    ColorGrading* colorGrading = nullptr;
+
+    float rangePlot[1024 * 3];
+    float curvePlot[1024 * 3];
 };
 
 static const char* DEFAULT_IBL = "venetian_crossroads_2k";
@@ -282,6 +314,236 @@ static void createGroundPlane(Engine* engine, Scene* scene, App& app) {
     app.scene.groundMaterial = shadowMaterial;
 }
 
+static void computeRangePlot(App& app, float* rangePlot) {
+    float4& ranges = app.colorGradingOptions.ranges;
+    ranges.y = clamp(ranges.y, ranges.x + 1e-5f, ranges.w - 1e-5f); // darks
+    ranges.z = clamp(ranges.z, ranges.x + 1e-5f, ranges.w - 1e-5f); // lights
+
+    for (size_t i = 0; i < 1024; i++) {
+        float x = i / 1024.0f;
+        float s = 1.0f - smoothstep(ranges.x, ranges.y, x);
+        float h = smoothstep(ranges.z, ranges.w, x);
+        rangePlot[i]        = s;
+        rangePlot[1024 + i] = 1.0f - s - h;
+        rangePlot[2048 + i] = h;
+    }
+}
+
+static void rangePlotSeriesStart(int series) {
+    switch (series) {
+        case 0:
+            ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.4f, 0.25f, 1.0f));
+            break;
+        case 1:
+            ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.8f, 0.25f, 1.0f));
+            break;
+        case 2:
+            ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.17f, 0.21f, 1.0f));
+            break;
+    }
+}
+
+static void rangePlotSeriesEnd(int series) {
+    if (series < 3) {
+        ImGui::PopStyleColor();
+    }
+}
+
+static float getRangePlotValue(int series, void* data, int index) {
+    return ((float*) data)[series * 1024 + index];
+}
+
+inline float3 curves(float3 v, float3 shadowGamma, float3 midPoint, float3 highlightScale) {
+    float3 d = 1.0f / (pow(midPoint, shadowGamma - 1.0f));
+    float3 dark = pow(v, shadowGamma) * d;
+    float3 light = highlightScale * (v - midPoint) + midPoint;
+    return float3{
+            v.r <= midPoint.r ? dark.r : light.r,
+            v.g <= midPoint.g ? dark.g : light.g,
+            v.b <= midPoint.b ? dark.b : light.b,
+    };
+}
+
+static void computeCurvePlot(App& app, float* curvePlot) {
+    for (size_t i = 0; i < 1024; i++) {
+        float3 x{i / 1024.0f * 2.0f};
+        float3 y = curves(x,
+                app.colorGradingOptions.gamma,
+                app.colorGradingOptions.midPoint,
+                app.colorGradingOptions.scale);
+        curvePlot[i]        = y.r;
+        curvePlot[1024 + i] = y.g;
+        curvePlot[2048 + i] = y.b;
+    }
+}
+
+static void tooltipFloat(float value) {
+    if (ImGui::IsItemActive() || ImGui::IsItemHovered()) {
+        ImGui::SetTooltip("%.2f", value);
+    }
+}
+
+static void pushSliderColors(float hue) {
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, (ImVec4) ImColor::HSV(hue, 0.5f, 0.5f));
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, (ImVec4) ImColor::HSV(hue, 0.6f, 0.5f));
+    ImGui::PushStyleColor(ImGuiCol_FrameBgActive, (ImVec4) ImColor::HSV(hue, 0.7f, 0.5f));
+    ImGui::PushStyleColor(ImGuiCol_SliderGrab, (ImVec4) ImColor::HSV(hue, 0.9f, 0.9f));
+}
+
+static void popSliderColors() { ImGui::PopStyleColor(4); }
+
+static void colorGradingUI(App& app) {
+    const static ImVec2 verticalSliderSize(18.0f, 160.0f);
+    const static ImVec2 plotLinesSize(260.0f, 160.0f);
+    const static ImVec2 plotLinesWideSize(350.0f, 120.0f);
+
+    if (ImGui::CollapsingHeader("Color grading")) {
+        App::ColorGradingOptions& colorGrading = app.colorGradingOptions;
+
+        ImGui::Indent();
+        ImGui::Checkbox("Enabled##colorGrading", &colorGrading.enabled);
+        ImGui::Combo("Tone-mapping", &colorGrading.toneMapping,
+                "Linear\0ACES (legacy)\0ACES\0Filmic\0Uchimura\0Reinhard\0Display Range\0\0");
+        if (ImGui::CollapsingHeader("While balance")) {
+            ImGui::SliderInt("Temperature", &colorGrading.temperature, -100, 100);
+            ImGui::SliderInt("Tint", &colorGrading.tint, -100, 100);
+        }
+        if (ImGui::CollapsingHeader("Channel mixer")) {
+            pushSliderColors(0.0f / 7.0f);
+            ImGui::VSliderFloat("##outRed.r", verticalSliderSize, &colorGrading.outRed.r, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outRed.r);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outRed.g", verticalSliderSize, &colorGrading.outRed.g, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outRed.g);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outRed.b", verticalSliderSize, &colorGrading.outRed.b, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outRed.b);
+            ImGui::SameLine(0.0f, 18.0f);
+            popSliderColors();
+
+            pushSliderColors(2.0f / 7.0f);
+            ImGui::VSliderFloat("##outGreen.r", verticalSliderSize, &colorGrading.outGreen.r, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outGreen.r);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outGreen.g", verticalSliderSize, &colorGrading.outGreen.g, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outGreen.g);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outGreen.b", verticalSliderSize, &colorGrading.outGreen.b, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outGreen.b);
+            ImGui::SameLine(0.0f, 18.0f);
+            popSliderColors();
+
+            pushSliderColors(4.0f / 7.0f);
+            ImGui::VSliderFloat("##outBlue.r", verticalSliderSize, &colorGrading.outBlue.r, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outBlue.r);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outBlue.g", verticalSliderSize, &colorGrading.outBlue.g, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outBlue.g);
+            ImGui::SameLine();
+            ImGui::VSliderFloat("##outBlue.b", verticalSliderSize, &colorGrading.outBlue.b, -2.0f, 2.0f, "");
+            tooltipFloat(colorGrading.outBlue.b);
+            popSliderColors();
+        }
+        if (ImGui::CollapsingHeader("Tonal ranges")) {
+            ImGui::ColorEdit3("Shadows", &colorGrading.shadows.x);
+            ImGui::SliderFloat("Weight##shadowsWeight", &colorGrading.shadows.w, -2.0f, 2.0f);
+            ImGui::ColorEdit3("Mid-tones", &colorGrading.midtones.x);
+            ImGui::SliderFloat("Weight##midTonesWeight", &colorGrading.midtones.w, -2.0f, 2.0f);
+            ImGui::ColorEdit3("Highlights", &colorGrading.highlights.x);
+            ImGui::SliderFloat("Weight##highlightsWeight", &colorGrading.highlights.w, -2.0f, 2.0f);
+            ImGui::SliderFloat4("Ranges", &colorGrading.ranges.x, 0.0f, 1.0f);
+            computeRangePlot(app, app.rangePlot);
+            ImGuiExt::PlotLinesSeries("", 3,
+                    rangePlotSeriesStart, getRangePlotValue, rangePlotSeriesEnd,
+                    app.rangePlot, 1024, 0, "", 0.0f, 1.0f, plotLinesWideSize);
+        }
+        if (ImGui::CollapsingHeader("Color decision list")) {
+            ImGui::SliderFloat3("Slope", &colorGrading.slope.x, 0.0f, 2.0f);
+            ImGui::SliderFloat3("Offset", &colorGrading.offset.x, -0.5f, 0.5f);
+            ImGui::SliderFloat3("Power", &colorGrading.power.x, 0.0f, 2.0f);
+        }
+        if (ImGui::CollapsingHeader("Adjustments")) {
+            ImGui::SliderFloat("Contrast", &colorGrading.contrast, 0.0f, 2.0f);
+            ImGui::SliderFloat("Vibrance", &colorGrading.vibrance, 0.0f, 2.0f);
+            ImGui::SliderFloat("Saturation", &colorGrading.saturation, 0.0f, 2.0f);
+        }
+        if (ImGui::CollapsingHeader("Curves")) {
+            ImGui::Checkbox("Linked curves", &colorGrading.linkedCurves);
+
+            computeCurvePlot(app, app.curvePlot);
+
+            if (!colorGrading.linkedCurves) {
+                pushSliderColors(0.0f / 7.0f);
+                ImGui::VSliderFloat("##curveGamma.r", verticalSliderSize, &colorGrading.gamma.r, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.gamma.r);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveMid.r", verticalSliderSize, &colorGrading.midPoint.r, 0.0f, 2.0f, "");
+                tooltipFloat(colorGrading.midPoint.r);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveScale.r", verticalSliderSize, &colorGrading.scale.r, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.scale.r);
+                ImGui::SameLine(0.0f, 18.0f);
+                popSliderColors();
+
+                ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.0f, 0.7f, 0.8f));
+                ImGui::PlotLines("", app.curvePlot, 1024, 0, "Red", 0.0f, 2.0f, plotLinesSize);
+                ImGui::PopStyleColor();
+
+                pushSliderColors(2.0f / 7.0f);
+                ImGui::VSliderFloat("##curveGamma.g", verticalSliderSize, &colorGrading.gamma.g, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.gamma.g);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveMid.g", verticalSliderSize, &colorGrading.midPoint.g, 0.0f, 2.0f, "");
+                tooltipFloat(colorGrading.midPoint.g);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveScale.g", verticalSliderSize, &colorGrading.scale.g, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.scale.g);
+                ImGui::SameLine(0.0f, 18.0f);
+                popSliderColors();
+
+                ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.3f, 0.7f, 0.8f));
+                ImGui::PlotLines("", app.curvePlot + 1024, 1024, 0, "Green", 0.0f, 2.0f, plotLinesSize);
+                ImGui::PopStyleColor();
+
+                pushSliderColors(4.0f / 7.0f);
+                ImGui::VSliderFloat("##curveGamma.b", verticalSliderSize, &colorGrading.gamma.b, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.gamma.b);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveMid.b", verticalSliderSize, &colorGrading.midPoint.b, 0.0f, 2.0f, "");
+                tooltipFloat(colorGrading.midPoint.b);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveScale.b", verticalSliderSize, &colorGrading.scale.b, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.scale.b);
+                ImGui::SameLine(0.0f, 18.0f);
+                popSliderColors();
+
+                ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.6f, 0.7f, 0.8f));
+                ImGui::PlotLines("", app.curvePlot + 2048, 1024, 0, "Blue", 0.0f, 2.0f, plotLinesSize);
+                ImGui::PopStyleColor();
+            } else {
+                ImGui::VSliderFloat("##curveGamma", verticalSliderSize, &colorGrading.gamma.r, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.gamma.r);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveMid", verticalSliderSize, &colorGrading.midPoint.r, 0.0f, 2.0f, "");
+                tooltipFloat(colorGrading.midPoint.r);
+                ImGui::SameLine();
+                ImGui::VSliderFloat("##curveScale", verticalSliderSize, &colorGrading.scale.r, 0.0f, 4.0f, "");
+                tooltipFloat(colorGrading.scale.r);
+                ImGui::SameLine(0.0f, 18.0f);
+
+                colorGrading.gamma = float3{colorGrading.gamma.r};
+                colorGrading.midPoint = float3{colorGrading.midPoint.r};
+                colorGrading.scale = float3{colorGrading.scale.r};
+
+                ImGui::PushStyleColor(ImGuiCol_PlotLines, (ImVec4) ImColor::HSV(0.17f, 0.21f, 0.9f));
+                ImGui::PlotLines("", app.curvePlot, 1024, 0, "RGB", 0.0f, 2.0f, plotLinesSize);
+                ImGui::PopStyleColor();
+            }
+        }
+        ImGui::Unindent();
+    }
+}
+
 static LinearColor inverseTonemapSRGB(sRGBColor x) {
     return (x * -0.155) / (x - 1.019);
 }
@@ -372,7 +634,7 @@ int main(int argc, char** argv) {
     auto setup = [&](Engine* engine, View* view, Scene* scene) {
         app.engine = engine;
         app.names = new NameComponentManager(EntityManager::get());
-        app.viewer = new SimpleViewer(engine, scene, view);
+        app.viewer = new SimpleViewer(engine, scene, view, 0, 410);
         app.materials = (app.materialSource == GENERATE_SHADERS) ?
                 createMaterialGenerator(engine) : createUbershaderLoader(engine);
         app.loader = AssetLoader::create({engine, app.materials, app.names });
@@ -395,21 +657,26 @@ int main(int argc, char** argv) {
             }
 
             if (ImGui::CollapsingHeader("Stats")) {
+                ImGui::Indent();
                 ImGui::Text("%zu entities in the asset", app.asset->getEntityCount());
                 ImGui::Text("%zu renderables (excluding UI)", scene->getRenderableCount());
                 ImGui::Text("%zu skipped frames", FilamentApp::get().getSkippedFrameCount());
+                ImGui::Unindent();
             }
 
             if (ImGui::CollapsingHeader("Scene")) {
+                ImGui::Indent();
                 ImGui::Checkbox("Show skybox", &app.viewOptions.skyboxEnabled);
                 ImGui::ColorEdit3("Background color", &app.viewOptions.backgroundColor.r);
                 ImGui::Checkbox("Ground shadow", &app.viewOptions.groundPlaneEnabled);
                 ImGui::Indent();
                 ImGui::SliderFloat("Strength", &app.viewOptions.groundShadowStrength, 0.0f, 1.0f);
                 ImGui::Unindent();
+                ImGui::Unindent();
             }
 
             if (ImGui::CollapsingHeader("Camera")) {
+                ImGui::Indent();
                 ImGui::SliderFloat("Focal length (mm)", &FilamentApp::get().getCameraFocalLength(), 16.0f, 90.0f);
                 ImGui::SliderFloat("Aperture", &app.viewOptions.cameraAperture, 1.0f, 32.0f);
                 ImGui::SliderFloat("Speed (1/s)", &app.viewOptions.cameraSpeed, 1000.0f, 1.0f);
@@ -417,7 +684,10 @@ int main(int argc, char** argv) {
                 ImGui::Checkbox("DoF", &app.dofOptions.enabled);
                 ImGui::SliderFloat("Focus distance", &app.dofOptions.focusDistance, 0.0f, 30.0f);
                 ImGui::SliderFloat("Blur scale", &app.dofOptions.blurScale, 0.1f, 10.0f);
+                ImGui::Unindent();
             }
+
+            colorGradingUI(app);
         });
 
         // Leave FXAA enabled but we also enable MSAA for a nice result. The wireframe looks
@@ -482,7 +752,41 @@ int main(int argc, char** argv) {
         // a skybox on the ui scene, because the ui view is always full screen.
         renderer->setClearOptions({
                 .clearColor = { inverseTonemapSRGB(app.viewOptions.backgroundColor), 1.0f },
-                .clear = true  });
+                .clear = true
+        });
+
+        if (app.colorGradingOptions.enabled) {
+            if (memcmp(&app.colorGradingOptions, &app.lastColorGradingOptions,
+                    sizeof(App::ColorGradingOptions))) {
+                App::ColorGradingOptions& options = app.colorGradingOptions;
+                ColorGrading* colorGrading = ColorGrading::Builder()
+                        .whiteBalance(options.temperature / 100.0f, options.tint / 100.0f)
+                        .channelMixer(options.outRed, options.outGreen, options.outBlue)
+                        .shadowsMidtonesHighlights(
+                                Color::toLinear(options.shadows),
+                                Color::toLinear(options.midtones),
+                                Color::toLinear(options.highlights),
+                                options.ranges
+                        )
+                        .slopeOffsetPower(options.slope, options.offset, options.power)
+                        .contrast(options.contrast)
+                        .vibrance(options.vibrance)
+                        .saturation(options.saturation)
+                        .curves(options.gamma, options.midPoint, options.scale)
+                        .toneMapping(static_cast<ColorGrading::ToneMapping>(options.toneMapping))
+                        .build(*engine);
+
+                if (app.colorGrading) {
+                    engine->destroy(app.colorGrading);
+                }
+
+                app.colorGrading = colorGrading;
+                app.lastColorGradingOptions = options;
+            }
+            view->setColorGrading(app.colorGrading);
+        } else {
+            view->setColorGrading(nullptr);
+        }
     };
 
     FilamentApp& filamentApp = FilamentApp::get();

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -61,7 +61,7 @@ constexpr uint8_t BLENDING_SOLID_REFRACTION = 4;
 using namespace filament;
 
 struct ColorGradingOptions {
-    ColorGrading::ToneMapping toneMapping = ColorGrading::ToneMapping::ACES_LEGACY;
+    int toneMapping = static_cast<int>(ColorGrading::ToneMapping::ACES_LEGACY);
     int temperature = 0;
     int tint = 0;
     math::float3 outRed{1.0f, 0.0f, 0.0f};

--- a/third_party/imgui/tnt/CMakeLists.txt
+++ b/third_party/imgui/tnt/CMakeLists.txt
@@ -29,4 +29,4 @@ set(SRCS
 
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
-target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
+target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR} ${PRIVATE_HDR_DIR})


### PR DESCRIPTION
This change also changes the default sidebar width because it was clipping some of the UI elements.

<img width="1607" alt="Screen Shot 2020-06-11 at 5 40 59 PM" src="https://user-images.githubusercontent.com/869684/84452815-bd5fa080-ac0b-11ea-84ee-24092c89bcdf.png">
