### PR TITLE
Add JS bindings to gltfio camera funcs

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -409,4 +409,8 @@ Filament.loadClassExtensions = function() {
     Filament.gltfio$FilamentAsset.prototype.getLightEntities = function() {
         return Filament.vectorToArray(this._getLightEntities());
     };
+
+    Filament.gltfio$FilamentAsset.prototype.getCameraEntities = function() {
+        return Filament.vectorToArray(this._getCameraEntities());
+    };
 };

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -34,6 +34,7 @@ export const assets: {[url: string]: Uint8Array};
 export type float2 = glm.vec2|number[];
 export type float3 = glm.vec3|number[];
 export type float4 = glm.vec4|number[];
+export type double4 = glm.vec4|number[];
 export type mat3 = glm.mat3|number[];
 export type mat4 = glm.mat4|number[];
 export type quat = glm.quat|number[];
@@ -316,8 +317,10 @@ export class Camera {
             near: number, far: number, fov: Camera$Fov): void;
     public setLensProjection(focalLength: number, aspect: number, near: number, far: number): void;
     public setCustomProjection(projection: mat4, near: number, far: number): void;
+    public setScaling(scale: double4): void;
     public getProjectionMatrix(): mat4;
     public getCullingProjectionMatrix(): mat4;
+    public getScaling(): double4;
     public getNear(): number;
     public getCullingFar(): number;
     public setModelMatrix(view: mat4): void;
@@ -468,6 +471,7 @@ export class gltfio$FilamentAsset {
     public getEntityByName(name: string): Entity;
     public getEntitiesByPrefix(name: string): Entity[];
     public getLightEntities(): Entity[];
+    public getCameraEntities(): Entity[];
     public getRoot(): Entity;
     public popRenderable(): Entity;
     public getMaterialInstances(): MaterialInstanceVector;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -260,6 +260,12 @@ value_array<filament::math::float4>("float4")
     .element(&filament::math::float4::z)
     .element(&filament::math::float4::w);
 
+value_array<filament::math::double4>("double4")
+    .element(&filament::math::double4::x)
+    .element(&filament::math::double4::y)
+    .element(&filament::math::double4::z)
+    .element(&filament::math::double4::w);
+
 value_array<filament::math::quat>("quat")
     .element(&filament::math::quat::x)
     .element(&filament::math::quat::y)
@@ -431,6 +437,9 @@ class_<Engine>("Engine")
     /// ::retval:: an instance of [Camera]
     .function("createCamera", select_overload<Camera*(void)>(&Engine::createCamera),
             allow_raw_pointers())
+    /// getCameraComponent ::method::
+    /// ::retval:: an instance of [Camera]
+    .function("getCameraComponent", &Engine::getCameraComponent, allow_raw_pointers())
     /// destroyCamera ::method::
     /// camera ::argument:: an instance of [Camera]
     .function("destroyCamera", (void (*)(Engine*, Camera*)) []
@@ -591,6 +600,8 @@ class_<Camera>("Camera")
         self->setCustomProjection(filament::math::mat4(m.m), near, far);
     }), allow_raw_pointers())
 
+    .function("setScaling", &Camera::setScaling)
+
     .function("getProjectionMatrix", EMBIND_LAMBDA(flatmat4, (Camera* self), {
         return flatmat4 { filament::math::mat4f(self->getProjectionMatrix()) };
     }), allow_raw_pointers())
@@ -598,6 +609,8 @@ class_<Camera>("Camera")
     .function("getCullingProjectionMatrix", EMBIND_LAMBDA(flatmat4, (Camera* self), {
         return flatmat4 { filament::math::mat4f(self->getCullingProjectionMatrix()) };
     }), allow_raw_pointers())
+
+    .function("getScaling", &Camera::getScaling)
 
     .function("getNear", &Camera::getNear)
     .function("getCullingFar", &Camera::getCullingFar)
@@ -1492,6 +1505,11 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
     .function("_getLightEntities", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self), {
         const utils::Entity* ptr = self->getLightEntities();
         return EntityVector(ptr, ptr + self->getLightEntityCount());
+    }), allow_raw_pointers())
+
+    .function("_getCameraEntities", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self), {
+        const utils::Entity* ptr = self->getCameraEntities();
+        return EntityVector(ptr, ptr + self->getCameraEntityCount());
     }), allow_raw_pointers())
 
     .function("getRoot", &FilamentAsset::getRoot)


### PR DESCRIPTION
Fixes #1988

Example loading a glTF camera:

```
const cameras = asset.getCameraEntities();
const c = engine.getCameraComponent(cameras[0]);
// adjust aspect ratio
c.setScaling([1, window.innerWidth / window.innerHeight, 1, 1]);
view.setCamera(c);
```