### PR TITLE
Install Filament LICENSE alongside README

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -376,6 +376,7 @@ set(INSTALL_TYPE ARCHIVE)
 install(TARGETS ${TARGET} ${INSTALL_TYPE} DESTINATION lib/${DIST_DIR})
 install(DIRECTORY ${PUBLIC_HDR_DIR}/filament DESTINATION include)
 install(FILES "README.md" DESTINATION .)
+install(FILES "../LICENSE" DESTINATION .)
 
 # ==================================================================================================
 # Sub-projects


### PR DESCRIPTION
CocoaPods distribution requires a LICENSE file in the archive.