### PR TITLE
Remove unused SPIRV-Tools-shared library

### DIFF
--- a/third_party/spirv-tools/FILAMENT_README.md
+++ b/third_party/spirv-tools/FILAMENT_README.md
@@ -1,5 +1,5 @@
 When updating spirv-tools to a new version, make sure to preserve all the changes marked with
-the following in `CMakeLists.txt`:
+the following in `CMakeLists.txt` and `source/CMakeLists.txt`:
 
 `# Filament specific changes`
 

--- a/third_party/spirv-tools/source/CMakeLists.txt
+++ b/third_party/spirv-tools/source/CMakeLists.txt
@@ -360,29 +360,33 @@ set_property(TARGET ${SPIRV_TOOLS} PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(${SPIRV_TOOLS})
 add_dependencies( ${SPIRV_TOOLS} core_tables enum_string_mapping extinst_tables )
 
-add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
-spvtools_default_compile_options(${SPIRV_TOOLS}-shared)
-target_include_directories(${SPIRV_TOOLS}-shared
-  PUBLIC
-    $<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  PRIVATE ${spirv-tools_BINARY_DIR}
-  PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
-  )
-set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_property(TARGET ${SPIRV_TOOLS}-shared PROPERTY FOLDER "SPIRV-Tools libraries")
-spvtools_check_symbol_exports(${SPIRV_TOOLS}-shared)
-target_compile_definitions(${SPIRV_TOOLS}-shared
-  PRIVATE SPIRV_TOOLS_IMPLEMENTATION
-  PUBLIC SPIRV_TOOLS_SHAREDLIB
-)
-add_dependencies( ${SPIRV_TOOLS}-shared core_tables enum_string_mapping extinst_tables )
+# Filament specific changes
+# add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
+# spvtools_default_compile_options(${SPIRV_TOOLS}-shared)
+# target_include_directories(${SPIRV_TOOLS}-shared
+#   PUBLIC
+#     $<BUILD_INTERFACE:${spirv-tools_SOURCE_DIR}/include>
+#     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+#   PRIVATE ${spirv-tools_BINARY_DIR}
+#   PRIVATE ${SPIRV_HEADER_INCLUDE_DIR}
+#   )
+# set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# set_property(TARGET ${SPIRV_TOOLS}-shared PROPERTY FOLDER "SPIRV-Tools libraries")
+# spvtools_check_symbol_exports(${SPIRV_TOOLS}-shared)
+# target_compile_definitions(${SPIRV_TOOLS}-shared
+#   PRIVATE SPIRV_TOOLS_IMPLEMENTATION
+#   PUBLIC SPIRV_TOOLS_SHAREDLIB
+# )
+# add_dependencies( ${SPIRV_TOOLS}-shared core_tables enum_string_mapping extinst_tables )
+# End Filament specific changes
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   find_library(LIBRT rt)
   if(LIBRT)
     target_link_libraries(${SPIRV_TOOLS} ${LIBRT})
-    target_link_libraries(${SPIRV_TOOLS}-shared ${LIBRT})
+# Filament specific changes
+    # target_link_libraries(${SPIRV_TOOLS}-shared ${LIBRT})
+# End Filament specific changes
   endif()
 endif()
 


### PR DESCRIPTION
This target gets added to "ALL" but we don't depend on it anywhere in Filament (only the static variant). It causes issues on Linux.