### PR TITLE
Silence warnings in public headers

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -403,6 +403,7 @@ public:
      *
      * @return A camera component
      */
+    UTILS_DEPRECATED
     Camera* createCamera() noexcept;
 
     /**
@@ -411,6 +412,7 @@ public:
      * @param camera Camera component to destroy. The associated entity is also destroyed.
      * @deprecated use destroyCameraComponent(Entity) instead
      */
+    UTILS_DEPRECATED
     void destroy(const Camera* camera);
 
    /**

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -326,9 +326,11 @@ public:
 
 
     /** @deprecated use static versions instead */
+    UTILS_DEPRECATED
     math::float3 getDirectionEstimate() const noexcept;
 
     /** @deprecated use static versions instead */
+    UTILS_DEPRECATED
     math::float4 getColorEstimate(math::float3 direction) const noexcept;
 };
 

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -135,23 +135,17 @@ public:
     /**
      * Information about the display this Renderer is associated to. This information is needed
      * to accurately compute dynamic-resolution scaling and for frame-pacing.
-     *
-     * @param info
      */
     void setDisplayInfo(const DisplayInfo& info) noexcept;
 
     /**
      * Set options controlling the desired frame-rate.
-     *
-     * @param options
      */
     void setFrameRateOptions(FrameRateOptions const& options) noexcept;
 
     /**
      * Set ClearOptions which are used at the beginning of a frame to clear or retain the
      * SwapChain content.
-     *
-     * @param options
      */
     void setClearOptions(const ClearOptions& options);
 

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -208,6 +208,7 @@ public:
      * has additional capabilities and a daisy-chain API. Be sure to explicitly link libgeometry
      * since its dependency might be removed in future versions of libfilament.
      */
+    UTILS_DEPRECATED
     static void populateTangentQuaternions(const QuatTangentContext& ctx);
 };
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -238,7 +238,7 @@ public:
      *
      * @deprecated See ColorGrading
      */
-    enum class ToneMapping : uint8_t {
+    enum class UTILS_DEPRECATED ToneMapping : uint8_t {
         LINEAR = 0,     //!< Linear tone mapping (i.e. no tone mapping)
         ACES = 1,       //!< ACES tone mapping
     };
@@ -480,6 +480,7 @@ public:
      * @deprecated Use setColorGrading instead
      * @see setColorGrading
      */
+    UTILS_DEPRECATED
     void setToneMapping(ToneMapping type) noexcept;
 
     /**
@@ -489,6 +490,7 @@ public:
      * @deprecated Use getColorGrading instead
      * @see getColorGrading
      */
+    UTILS_DEPRECATED
     ToneMapping getToneMapping() const noexcept;
 
     /**

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -36,6 +36,12 @@
 #    define UTILS_PUBLIC  
 #endif
 
+#if __has_attribute(deprecated)
+#   define UTILS_DEPRECATED __attribute__((deprecated))
+#else
+#   define UTILS_DEPRECATED
+#endif
+
 #if __has_attribute(packed)
 #   define UTILS_PACKED __attribute__((packed))
 #else


### PR DESCRIPTION
This silences a few Clang warnings seen in Xcode when compiling Filament headers.

```
Declaration is marked with '\deprecated' command but does not have a deprecation attribute
Empty paragraph passed to '@param' command
```
