### PR TITLE
gltfio: various improvements to skinning normalization.

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -70,6 +70,9 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     val progress
         get() = resourceLoader.asyncGetLoadProgress()
 
+    var normalizeSkinningWeights = true
+    var recomputeBoundingBoxes = false
+
     val scene: Scene
     val view: View
     val camera: Camera
@@ -101,7 +104,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
         view.camera = camera
 
         assetLoader = AssetLoader(engine, MaterialProvider(engine), EntityManager.get())
-        resourceLoader = ResourceLoader(engine, false, false)
+        resourceLoader = ResourceLoader(engine, normalizeSkinningWeights, recomputeBoundingBoxes)
 
         // Always add a direct light source since it is required for shadowing.
         // We highly recommend adding an indirect light as well.

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -620,6 +620,7 @@ int main(int argc, char** argv) {
         configuration.engine = app.engine;
         configuration.gltfPath = gltfPath.c_str();
         configuration.recomputeBoundingBoxes = app.recomputeAabb;
+        configuration.normalizeSkinningWeights = true;
         if (!app.resourceLoader) {
             app.resourceLoader = new gltfio::ResourceLoader(configuration);
         }

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -396,12 +396,20 @@ Filament.loadClassExtensions = function() {
     //
     // The optional asyncInterval argument allows clients to control how decoding is amortized
     // over time. It represents the number of milliseconds between each texture decoding task.
+    //
+    // The optional config argument is an object with boolean fields `normalizeSkinningWeights` and
+    // `recomputeBoundingBoxes`.
     Filament.gltfio$FilamentAsset.prototype.loadResources = function(onDone, onFetched, basePath,
-            asyncInterval) {
+            asyncInterval, config) {
         const asset = this;
         const engine = this.getEngine();
         const names = this.getResourceUris();
         const interval = asyncInterval || 30;
+        const defaults = {
+            normalizeSkinningWeights: true,
+            recomputeBoundingBoxes: false
+        };
+        config = Object.assign(defaults, config || {});
 
         basePath = basePath || document.location;
         onFetched = onFetched || ((name) => {});
@@ -420,7 +428,9 @@ Filament.loadClassExtensions = function() {
         }
 
         // Construct a resource loader and start decoding after all textures are fetched.
-        const resourceLoader = new Filament.gltfio$ResourceLoader(engine, false, false);
+        const resourceLoader = new Filament.gltfio$ResourceLoader(engine,
+                config.normalizeSkinningWeights,
+                config.recomputeBoundingBoxes);
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);
 

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -465,7 +465,7 @@ export class gltfio$AssetLoader {
 
 export class gltfio$FilamentAsset {
     public loadResources(onDone: () => void|null, onFetched: (s: string) => void|null,
-            basePath: string|null, asyncInterval: number|null): void;
+            basePath: string|null, asyncInterval: number|null, options?: object): void;
     public getEntities(): Entity[];
     public getEntitiesByName(name: string): Entity[];
     public getEntityByName(name: string): Entity;


### PR DESCRIPTION
- Allow JavaScript and Java / Kotlin clients to configure this setting.
- Opt in by default (this was disabled in #2621)
- Optimize large assets like Bistro by iterating through prims only when the asset actually has skins.

Fixes #2714.