### PR TITLE
 CMake: build matdbg / civetweb only when enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,13 @@ else()
     option(FILAMENT_BUILD_FILAMAT "Build filamat and JNI buildings" OFF)
 endif()
 
+# By default, link in matdbg for Desktop + Debug only since it pulls in filamat and a web server.
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT IOS AND NOT ANDROID AND NOT WEBGL)
+    option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" ON)
+else()
+    option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" OFF)
+endif()
+
 # ==================================================================================================
 # Material compilation flags
 # ==================================================================================================
@@ -543,8 +550,10 @@ if (FILAMENT_BUILD_FILAMAT)
     add_subdirectory(${LIBRARIES}/filamat)
 
     # the material debugger requires filamat
-    add_subdirectory(${EXTERNAL}/civetweb/tnt)
-    add_subdirectory(${LIBRARIES}/matdbg)
+    if (FILAMENT_ENABLE_MATDBG)
+        add_subdirectory(${EXTERNAL}/civetweb/tnt)
+        add_subdirectory(${LIBRARIES}/matdbg)
+    endif()
 endif()
 
 if (FILAMENT_SUPPORTS_VULKAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ if (ANDROID OR WEBGL OR IOS OR FILAMENT_USE_SWIFTSHADER)
     set(IS_MOBILE_TARGET TRUE)
 endif()
 
+if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+    set(IS_HOST_PLATFORM TRUE)
+endif()
+
 if (IOS)
     # Remove the headerpad_max_install_names linker flag on iOS. It causes warnings when linking
     # executables with bitcode.
@@ -354,7 +358,7 @@ else()
 endif()
 
 # By default, link in matdbg for Desktop + Debug only since it pulls in filamat and a web server.
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT IOS AND NOT ANDROID AND NOT WEBGL)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND IS_HOST_PLATFORM)
     option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" ON)
 else()
     option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" OFF)
@@ -541,7 +545,7 @@ add_subdirectory(${EXTERNAL}/draco/tnt)
 add_subdirectory(${EXTERNAL}/stb/tnt)
 add_subdirectory(${EXTERNAL}/getopt)
 
-if (FILAMENT_BUILD_FILAMAT)
+if (FILAMENT_BUILD_FILAMAT OR IS_HOST_PLATFORM)
     # spirv-tools must come before filamat, as filamat relies on the presence of the
     # spirv-tools_SOURCE_DIR variable.
     add_subdirectory(${EXTERNAL}/spirv-tools)
@@ -550,7 +554,7 @@ if (FILAMENT_BUILD_FILAMAT)
     add_subdirectory(${LIBRARIES}/filamat)
 
     # the material debugger requires filamat
-    if (FILAMENT_ENABLE_MATDBG)
+    if (FILAMENT_ENABLE_MATDBG OR IS_HOST_PLATFORM)
         add_subdirectory(${EXTERNAL}/civetweb/tnt)
         add_subdirectory(${LIBRARIES}/matdbg)
     endif()
@@ -578,7 +582,7 @@ if (WEBGL)
     add_subdirectory(${EXTERNAL}/imgui/tnt)
 endif()
 
-if (NOT ANDROID AND NOT WEBGL AND NOT IOS)
+if (IS_HOST_PLATFORM)
     add_subdirectory(${LIBRARIES}/bluegl)
     add_subdirectory(${LIBRARIES}/filamentapp)
     add_subdirectory(${LIBRARIES}/filagui)

--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -33,10 +33,6 @@ add_library(filabridge STATIC IMPORTED)
 set_target_properties(filabridge PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilabridge.a)
 
-add_library(matdbg STATIC IMPORTED)
-set_target_properties(matdbg PROPERTIES IMPORTED_LOCATION
-        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libmatdbg.a)
-
 add_library(bluevk STATIC IMPORTED)
 set_target_properties(bluevk PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libbluevk.a)
@@ -44,6 +40,12 @@ set_target_properties(bluevk PROPERTIES IMPORTED_LOCATION
 add_library(smol-v STATIC IMPORTED)
 set_target_properties(smol-v PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libsmol-v.a)
+
+if (FILAMENT_ENABLE_MATDBG)
+    add_library(matdbg STATIC IMPORTED)
+    set_target_properties(matdbg PROPERTIES IMPORTED_LOCATION
+            ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libmatdbg.a)
+endif()
 
 set(VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/libfilament-jni.map")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${VERSION_SCRIPT}")

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -298,13 +298,6 @@ target_link_libraries(${TARGET} PUBLIC filaflat)
 target_link_libraries(${TARGET} PUBLIC filabridge)
 target_link_libraries(${TARGET} PUBLIC ibl)
 
-# By default, link in matdbg for Desktop + Debug only since it pulls in filamat and a web server.
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT IOS AND NOT ANDROID AND NOT WEBGL)
-    option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" ON)
-else()
-    option(FILAMENT_ENABLE_MATDBG "Enable the material debugger" OFF)
-endif()
-
 if (FILAMENT_ENABLE_MATDBG)
     target_link_libraries(${TARGET} PUBLIC matdbg)
     add_definitions(-DFILAMENT_ENABLE_MATDBG=1)

--- a/libs/matdbg/README.md
+++ b/libs/matdbg/README.md
@@ -22,9 +22,9 @@ http://localhost:8080. Skip ahead to **Debugger Usage**.
 ## Setup for Android
 
 Rebuild Filament for Android after enabling a CMake option called FILAMENT_ENABLE_MATDBG. Note that
-CMake is invoked from several places for Android (both gradle and our easy build script), so the
-most pragmatic and reliable way of doing this is to simply hack `filament/CMakeLists.txt` and
-`filament-android/CMakeLists.txt` by replacing OFF with ON.
+CMake is invoked from several places for Android (both gradle and our easy build script), so one
+pragmatic and reliable way of doing this is to simply hack `CMakeLists.txt` and
+`filament-android/CMakeLists.txt` by unconditionally setting FILAMENT_ENABLE_MATDBG to ON.
 
 After rebuilding Filament with the option enabled, ensure that internet permissions are enabled in
 your app by adding the following into your manifest as a child of the `<manifest>` element.


### PR DESCRIPTION
Also group FILAMENT_ENABLE_MATDBG with all our other CMake options.