### PR TITLE
texelFetch w/ LOD requires at least MIPMAP_NEAREST

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -286,7 +286,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::mipmapPass(FrameGraph& fg,
                 auto out = resources.get(data.rt);
 
                 FMaterialInstance* const mi = mMipmapDepth.getMaterialInstance();
-                mi->setParameter("depth", in, { /* uses texelFetch */ });
+                mi->setParameter("depth", in, { .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST });
                 mi->setParameter("level", uint32_t(level));
                 mi->commit(driver);
                 mi->use(driver);


### PR DESCRIPTION
if NEAREST or LINEAR min filter is used, texelFetch is actually
undefined when the LOD is not 0.