### PR TITLE
Vulkan: fix bloom on Android by supporting LOAD_OP_LOAD.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -369,7 +369,8 @@ void createSwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceContex
             .image = images[i],
             .view = {},
             .memory = {},
-            .offscreen = {}
+            .texture = {},
+            .layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
         };
     }
     utils::slog.i
@@ -667,6 +668,7 @@ void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfaceCont
     surfaceContext.depth.view = depthView;
     surfaceContext.depth.image = depthImage;
     surfaceContext.depth.format = depthFormat;
+    surfaceContext.depth.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
     // Begin a new command buffer solely for the purpose of transitioning the image layout.
     VkCommandBuffer cmdbuffer = acquireWorkCommandBuffer(context);
@@ -675,7 +677,7 @@ void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfaceCont
     VkImageMemoryBarrier barrier {
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-        .newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+        .newLayout = surfaceContext.depth.layout,
         .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .image = depthImage,

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -108,7 +108,8 @@ struct VulkanAttachment {
     VkImage image;
     VkImageView view;
     VkDeviceMemory memory;
-    VulkanTexture* offscreen = nullptr;
+    VulkanTexture* texture = nullptr;
+    VkImageLayout layout;
 };
 
 // The SwapContext is the set of objects that gets "swapped" at each beginFrame().

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -24,8 +24,8 @@ namespace backend {
 bool VulkanFboCache::RenderPassEq::operator()(const RenderPassKey& k1,
         const RenderPassKey& k2) const {
     return
-            k1.finalColorLayout == k2.finalColorLayout &&
-            k1.finalDepthLayout == k2.finalDepthLayout &&
+            k1.colorLayout == k2.colorLayout &&
+            k1.depthLayout == k2.depthLayout &&
             k1.colorFormat == k2.colorFormat &&
             k1.depthFormat == k2.depthFormat &&
             k1.flags.value == k2.flags.value;
@@ -84,17 +84,24 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     }
     const bool hasColor = config.colorFormat != VK_FORMAT_UNDEFINED;
     const bool hasDepth = config.depthFormat != VK_FORMAT_UNDEFINED;
+    const bool isSwapChain = config.colorLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-    // The subpass specifies the layout to transition to at the START of the render pass.
+    // In Vulkan, the subpass desc specifies the layout to transition to at the start of the render
+    // pass, and the attachment description specifies the layout to transition to at the end.
+    // However we use render passes to cause layout transitions only when drawing directly into the
+    // swap chain. We keep our offscreen images in GENERAL layout, which is simple and prevents
+    // thrashing the layout. Note that pipeline barriers are more powerful than render passes for
+    // performing layout transitions, because they allow for per-miplevel transitions.
+
     uint32_t numAttachments = 0;
     VkAttachmentReference colorAttachmentRef = {};
     if (hasColor) {
-        colorAttachmentRef.layout = VK_IMAGE_LAYOUT_GENERAL;
+        colorAttachmentRef.layout = isSwapChain ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : config.colorLayout;
         colorAttachmentRef.attachment = numAttachments++;
     }
     VkAttachmentReference depthAttachmentRef = {};
     if (hasDepth) {
-        depthAttachmentRef.layout = VK_IMAGE_LAYOUT_GENERAL;
+        depthAttachmentRef.layout = config.depthLayout;
         depthAttachmentRef.attachment = numAttachments++;
     }
     VkSubpassDescription subpass {
@@ -104,26 +111,46 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         .pDepthStencilAttachment = hasDepth ? &depthAttachmentRef : nullptr
     };
 
-    // The attachment description specifies the layout to transition to at the END of the render pass.
+    // Set up some const aliases for terseness.
+    const VkAttachmentLoadOp clear = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    const VkAttachmentLoadOp dontCare = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+
+    // TODO: For now we do not support LOAD_OP_LOAD for the swap chain due to the following
+    // complaint from validation:
+    //
+    //   Render pass has an attachment with loadOp == VK_ATTACHMENT_LOAD_OP_LOAD and
+    //   initialLayout == VK_IMAGE_LAYOUT_UNDEFINED.  This is probably not what you intended.
+    //
+    const VkAttachmentLoadOp keep = isSwapChain ? VK_ATTACHMENT_LOAD_OP_DONT_CARE :
+            VK_ATTACHMENT_LOAD_OP_LOAD;
+
+    const bool clearColor = any(config.flags.clear & TargetBufferFlags::COLOR);
+    const bool discardColor = any(config.flags.discardStart & TargetBufferFlags::COLOR);
+    const VkAttachmentLoadOp colorLoadOp = clearColor ? clear : (discardColor ? dontCare : keep);
+
+    const bool clearDepth = any(config.flags.clear & TargetBufferFlags::DEPTH);
+    const bool discardDepth = any(config.flags.discardStart & TargetBufferFlags::DEPTH);
+    const VkAttachmentLoadOp depthLoadOp = clearDepth ? clear : (discardDepth ? dontCare : keep);
+
     VkAttachmentDescription colorAttachment {
         .format = config.colorFormat,
         .samples = VK_SAMPLE_COUNT_1_BIT,
-        .loadOp = any(config.flags.clear & TargetBufferFlags::COLOR) ?
-                VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .loadOp = colorLoadOp,
         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
         .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
         .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-        .finalLayout = config.finalColorLayout
+        .initialLayout = isSwapChain ? VK_IMAGE_LAYOUT_UNDEFINED : config.colorLayout,
+        .finalLayout = isSwapChain ? VK_IMAGE_LAYOUT_PRESENT_SRC_KHR : config.colorLayout
     };
     VkAttachmentDescription depthAttachment {
         .format = config.depthFormat,
         .samples = VK_SAMPLE_COUNT_1_BIT,
-        .loadOp = any(config.flags.clear & TargetBufferFlags::DEPTH) ?
-                VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .loadOp = depthLoadOp,
         .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
         .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
         .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-        .finalLayout = config.finalDepthLayout
+        .initialLayout = config.depthLayout,
+        .finalLayout = config.depthLayout
     };
 
     // Finally, create the VkRenderPass.

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -38,8 +38,8 @@ public:
     // a VkRenderPass. It is hashed and used as a lookup key. Portions of this are extracted
     // from backend::RenderPassParams.
     struct alignas(8) RenderPassKey {
-        VkImageLayout finalColorLayout;  // 4 bytes
-        VkImageLayout finalDepthLayout;  // 4 bytes
+        VkImageLayout colorLayout;  // 4 bytes
+        VkImageLayout depthLayout;  // 4 bytes
         VkFormat colorFormat; // 4 bytes
         VkFormat depthFormat; // 4 bytes
         union {

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -88,18 +88,27 @@ VulkanProgram::~VulkanProgram() {
 }
 
 static VulkanAttachment createOffscreenAttachment(VulkanTexture* tex) {
-    if (!tex) {
-        return {};
-    }
-    return { tex->vkformat, tex->textureImage, tex->imageView, tex->textureImageMemory, tex };
+    return {
+        .format = tex->vkformat,
+        .image = tex->textureImage,
+        .view = tex->imageView,
+        .memory = tex->textureImageMemory,
+        .texture = tex,
+        .layout = getTextureLayout(tex->usage)
+    };
 }
+
+// Creates a special "default" render target (i.e. associated with the swap chain)
+// Note that the attachment structs are unused in this case in favor of VulkanSurfaceContext.
+VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0),
+        mContext(context), mOffscreen(false), mColorLevel(0), mDepthLevel(0) {}
 
 VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, uint32_t height,
         TargetBufferInfo colorInfo, VulkanTexture* color, TargetBufferInfo depthInfo,
         VulkanTexture* depth) : HwRenderTarget(width, height), mContext(context), mOffscreen(true),
         mColorLevel(colorInfo.level), mDepthLevel(depthInfo.level) {
-    mColor = createOffscreenAttachment(color);
-    mDepth = createOffscreenAttachment(depth);
+    mColor = color ? createOffscreenAttachment(color) : VulkanAttachment {};
+    mDepth = depth ? createOffscreenAttachment(depth) : VulkanAttachment {};
 
     // We cannot use the VkImageView that's in the texture because we need to select a single level.
     if (color) {
@@ -377,12 +386,15 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     error = vkBindImageMemory(context.device, textureImage, textureImageMemory, 0);
     ASSERT_POSTCONDITION(!error, "Unable to bind image.");
 
+    mAspect = any(usage & TextureUsage::DEPTH_ATTACHMENT) ? VK_IMAGE_ASPECT_DEPTH_BIT :
+            VK_IMAGE_ASPECT_COLOR_BIT;
+
     // Create a VkImageView so that shaders can sample from the image.
     VkImageViewCreateInfo viewInfo = {};
     viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     viewInfo.image = textureImage;
     viewInfo.format = vkformat;
-    viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    viewInfo.subresourceRange.aspectMask = mAspect;
     viewInfo.subresourceRange.baseMipLevel = 0;
     viewInfo.subresourceRange.levelCount = levels;
     viewInfo.subresourceRange.baseArrayLayer = 0;
@@ -399,20 +411,13 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
         viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
         viewInfo.subresourceRange.layerCount = 1;
     }
-    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
-        viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    }
     error = vkCreateImageView(context.device, &viewInfo, VKALLOC, &imageView);
     ASSERT_POSTCONDITION(!error, "Unable to create image view.");
 
-    // TODO: The following layout transition is a workaround for a potential validation bug. It
-    // lets us avoid an InvalidImageLayout validation error, which could be a false positive since
-    // we perform the necessary transition via beginRenderPass(). This comment block should be
-    // updated after investigating the LunarG validation layer.
-    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
+    if (any(usage & (TextureUsage::COLOR_ATTACHMENT | TextureUsage::DEPTH_ATTACHMENT))) {
         auto transition = [=](VulkanCommandBuffer commands) {
             VulkanTexture::transitionImageLayout(commands.cmdbuffer, textureImage,
-                    VK_IMAGE_LAYOUT_UNDEFINED, getTextureLayout(usage), 0, 1, levels);
+                    VK_IMAGE_LAYOUT_UNDEFINED, getTextureLayout(usage), 0, 1, levels, mAspect);
         };
         if (mContext.currentCommands) {
             transition(*mContext.currentCommands);
@@ -468,11 +473,11 @@ void VulkanTexture::update3DImage(const PixelBufferDescriptor& data, uint32_t wi
     // Create a copy-to-device functor.
     auto copyToDevice = [this, stage, width, height, depth, miplevel] (VulkanCommandBuffer& commands) {
         transitionImageLayout(commands.cmdbuffer, textureImage, VK_IMAGE_LAYOUT_UNDEFINED,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, miplevel, 1);
+                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, miplevel, 1, 1, mAspect);
         copyBufferToImage(commands.cmdbuffer, stage->buffer, textureImage, width, height, depth,
                 nullptr, miplevel);
         transitionImageLayout(commands.cmdbuffer, textureImage,VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-                getTextureLayout(usage), miplevel, 1);
+                getTextureLayout(usage), miplevel, 1, 1, mAspect);
 
         mStagePool.releaseStage(stage, commands);
     };
@@ -512,11 +517,12 @@ void VulkanTexture::updateCubeImage(const PixelBufferDescriptor& data,
         uint32_t width = std::max(1u, this->width >> miplevel);
         uint32_t height = std::max(1u, this->height >> miplevel);
         transitionImageLayout(commands.cmdbuffer, textureImage, VK_IMAGE_LAYOUT_UNDEFINED,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, miplevel, 6);
+                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, miplevel, 6, 1, mAspect);
         copyBufferToImage(commands.cmdbuffer, stage->buffer, textureImage, width, height, 1,
                 &faceOffsets, miplevel);
         transitionImageLayout(commands.cmdbuffer, textureImage,
-                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, getTextureLayout(usage), miplevel, 6);
+                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, getTextureLayout(usage), miplevel, 6,
+                1, mAspect);
 
         mStagePool.releaseStage(stage, commands);
     };
@@ -531,9 +537,10 @@ void VulkanTexture::updateCubeImage(const PixelBufferDescriptor& data,
     }
 }
 
+// TODO: replace the last 4 args with VkImageSubresourceRange
 void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
         VkImageLayout oldLayout, VkImageLayout newLayout, uint32_t miplevel,
-        uint32_t layerCount, uint32_t levelCount) {
+        uint32_t layerCount, uint32_t levelCount, VkImageAspectFlags aspect) {
     if (oldLayout == newLayout) {
         return;
     }
@@ -544,7 +551,7 @@ void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.image = image;
-    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.aspectMask = aspect;
     barrier.subresourceRange.baseMipLevel = miplevel;
     barrier.subresourceRange.levelCount = levelCount;
     barrier.subresourceRange.baseArrayLayer = 0;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -49,12 +49,10 @@ struct VulkanRenderTarget : private HwRenderTarget {
             VulkanTexture* color, TargetBufferInfo depthInfo, VulkanTexture* depth);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
-    explicit VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0), mContext(context),
-            mOffscreen(false), mColorLevel(0), mDepthLevel(0) {}
+    explicit VulkanRenderTarget(VulkanContext& context);
 
     ~VulkanRenderTarget();
 
-    bool isOffscreen() const { return mOffscreen; }
     void transformClientRectToPlatform(VkRect2D* bounds) const;
     void transformClientRectToPlatform(VkViewport* bounds) const;
     VkExtent2D getExtent() const;
@@ -125,7 +123,7 @@ struct VulkanTexture : public HwTexture {
     // layout to a GPU-readable layout.
     static void transitionImageLayout(VkCommandBuffer cmdbuffer, VkImage image,
             VkImageLayout oldLayout, VkImageLayout newLayout, uint32_t miplevel,
-            uint32_t layers, uint32_t levels = 1);
+            uint32_t layers, uint32_t levels, VkImageAspectFlags aspect);
 
     VkFormat vkformat;
     VkImageView imageView = VK_NULL_HANDLE;
@@ -139,6 +137,7 @@ private:
             uint32_t width, uint32_t height, uint32_t depth,
             FaceOffsets const* faceOffsets, uint32_t miplevel);
 
+    VkImageAspectFlags mAspect;
     VulkanContext& mContext;
     VulkanStagePool& mStagePool;
 };


### PR DESCRIPTION
If a render target attachment is not cleared or discarded, then it should be preserved and therefore requires VK_ATTACHMENT_LOAD_OP_LOAD.