### PR TITLE
Fix, incorrect camera view matrix with non-rigid transformations

### DIFF
--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -230,7 +230,9 @@ math::details::TMat44<T> inverseProjection(const math::details::TMat44<T>& p) no
 
 UTILS_NOINLINE
 mat4f FCamera::getViewMatrix(mat4f const& model) noexcept {
-    return FCamera::rigidTransformInverse(model);
+    // We can't use rigidTransformInverse here. The camera's model matrix might have scaling, which
+    // would make it non-rigid.
+    return inverse(model);
 }
 
 Frustum FCamera::getFrustum(mat4 const& projection, mat4f const& viewMatrix) noexcept {


### PR DESCRIPTION
Saw this specifically with some glTF files that apply a root level scaling matrix to the entire scene, including the camera.