### PR TITLE
fix a use after free in filamat

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -274,6 +274,11 @@ void GLSLPostProcessor::preprocessOptimization(glslang::TShader& tShader,
     if (mSpirvOutput) {
         TProgram program;
         TShader spirvShader(mShLang);
+
+        // The cleaner must be declared after the TShader/TProgram which are setting the current
+        // pool in the tls
+        GLSLangCleaner cleaner;
+
         const char* shaderCString = glsl.c_str();
         spirvShader.setStrings(&shaderCString, 1);
         GLSLTools::prepareShaderParser(spirvShader, mShLang, mLangVersion, mOptimization);


### PR DESCRIPTION
This would happen when using math -E -a vulkan. GLSLangCleaner lifetime
must be shorter than TProgram/TShader.
I think we can fix this by using another scoped GLSLangCleaner.

Tested successfully with ASAN.