### PR TITLE
Vulkan: fix several image layout issues

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -689,6 +689,8 @@ void createDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfaceCont
     };
     vkCmdPipelineBarrier(cmdbuffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    flushWorkCommandBuffer(context);
 }
 
 VkImageLayout getTextureLayout(TextureUsage usage) {

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -146,6 +146,7 @@ void getSurfaceCaps(VulkanContext& context, VulkanSurfaceContext& sc);
 
 void createSwapChain(VulkanContext& context, VulkanSurfaceContext& sc);
 void destroySwapChain(VulkanContext& context, VulkanSurfaceContext& sc, VulkanDisposer& disposer);
+void transitionSwapChain(VulkanContext& context);
 
 uint32_t selectMemoryType(VulkanContext& context, uint32_t flags, VkFlags reqs);
 SwapContext& getSwapContext(VulkanContext& context);

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -117,6 +117,7 @@ struct VulkanAttachment {
 struct SwapContext {
     VulkanAttachment attachment;
     VulkanCommandBuffer commands;
+    bool invalid;
 };
 
 // The SurfaceContext stores various state (including the swap chain) that we tightly associate

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -967,6 +967,10 @@ void VulkanDriver::commit(Handle<HwSwapChain> sch) {
     ASSERT_POSTCONDITION(mContext.currentCommands,
             "Vulkan driver requires at least one frame before a commit.");
 
+    // Before swapping, transition the current swap chain image to the PRESENT layout. This cannot
+    // be done as part of the render pass because it does not know if it is last pass in the frame.
+    transitionSwapChain(mContext);
+
     // Finalize the command buffer and set the cmdbuffer pointer to null.
     VkResult result = vkEndCommandBuffer(mContext.currentCommands->cmdbuffer);
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkEndCommandBuffer error.");

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -228,6 +228,14 @@ VulkanAttachment VulkanRenderTarget::getDepth() const {
     return mOffscreen ? mDepth : mContext.currentSurface->depth;
 }
 
+bool VulkanRenderTarget::invalidate() {
+    if (!mOffscreen && getSwapContext(mContext).invalid) {
+        getSwapContext(mContext).invalid = false;
+        return true;
+    }
+    return false;
+}
+
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
         AttributeArray const& attributes) :

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -58,6 +58,7 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VkExtent2D getExtent() const;
     VulkanAttachment getColor() const;
     VulkanAttachment getDepth() const;
+    bool invalidate();
     uint32_t getColorLevel() const { return mColorLevel; }
     uint32_t getDepthLevel() const { return mDepthLevel; }
 private:


### PR DESCRIPTION
This PR is comprised of three fixes:

(1) Fix intermittent InvalidImageLayout error for main depth buffer upon startup.

This was caused by the fact that we didn't bother flushing the work command buffer that is used for initial depth buffer transition, so the pipeline barrier didn't always have a chance to be processed before the first draw call.

(2) Allow LOAD_OP_LOAD when rendering to swap chain.

This was fixed by adding an "invalid" flag to the swap chain state that we track.

(3) Transition to PRESENT layout only once per frame.

This was fixed by performing the transition using a barrier rather than a render pass flag.  The render pass was a bad place because it cannot know if it is the last one in the frame.
