### PR TITLE
Vulkan: fix intermittent InvalidQuery on Android.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -58,6 +58,9 @@ struct VulkanCmdFence {
     utils::Condition condition;
     utils::Mutex mutex;
     std::atomic<VkResult> status;
+
+    // TODO: for non-work buffers the following field indicates if the fence has EVER been
+    // submitted, which is a bit misleading or un-useful. This needs to be refactored.
     bool submitted = false;
 };
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -175,7 +175,7 @@ struct VulkanTimerQuery : public HwTimerQuery {
     uint32_t startingQueryIndex;
     uint32_t stoppingQueryIndex;
     VulkanContext& mContext;
-    std::atomic<bool> ready;
+    std::atomic<VulkanCommandBuffer*> cmdbuffer;
 };
 
 } // namespace filament


### PR DESCRIPTION
This prevents the following validation error:

    Cannot get query results on queryPool 0x2 with index 0 as data has
    not been collected for this index.

This was occasionally triggered when we attempted to query a timer that
had not yet been inserted into any command stream. (The error seems
bogus to me since we've enabled the AVAILABILITY flag, but we might as
well fix it anyway.)