### PR TITLE
Improve matc error reporting

### DIFF
--- a/libs/filamat/include/filamat/IncludeCallback.h
+++ b/libs/filamat/include/filamat/IncludeCallback.h
@@ -24,34 +24,45 @@
 namespace filamat {
 
 struct IncludeResult {
-    /**
-     * The full contents of the include file. This may contain additional, recursive include
-     * directives.
-     */
-    utils::CString source;
+    // The line number for the first line of source (first line is 0).
+    const size_t lineNumberOffset = 0;
 
-    /**
-     * The name of the include file. This gets passed as "includerName" for any includes inside
-     * of source. This field isn't used by the include system; it's up to the callback to give
-     * meaning to this value and interpret it accordingly.
-     * In the case of DirIncluder, this is an empty string to represent the root include file,
-     * and a canonical path for subsequent included files.
-     */
+    // The include name of the root file, as if it were being included.
+    // I.e., 'foobar.h' in the case of #include "foobar.h"
+    const utils::CString includeName;
+
+    // The following fields should be filled out by the IncludeCallback when processing an include,
+    // or when calling resolveIncludes for the root file.
+
+    // The full contents of the include file. This may contain additional, recursive include
+    // directives.
+    utils::CString text;
+
+    // The name of the include file. This gets passed as "includerName" for any includes inside of
+    // source. This field isn't used by the include system; it's up to the callback to give meaning
+    // to this value and interpret it accordingly.  In the case of DirIncluder, this is an empty
+    // string to represent the root include file, and a canonical path for subsequent included
+    // files.
     utils::CString name;
 };
 
 /**
  * A callback invoked by the include system when an #include "file.h" directive is found.
- * @param headerName is the name referenced within the quotes.
- * @param includerName is the value that was given to IncludeResult.name for this source file, or
+ *
+ * For example, if a file main.h includes file.h on line 10, then IncludeCallback would be called
+ * with the following:
+ *     includeCallback("main.h", {.lineNumberOffset = 10, .includeName = "file.h" })
+ * It's then up to the IncludeCallback to fill out the .text and .name fields.
+ *
+ * @param includedBy is the value that was given to IncludeResult.name for this source file, or
  *        the empty string for the root source file.
  * @param result is the IncludeResult that the callback should fill out.
  * @return true, if the include was resolved successfully, false otherwise.
+ *
  * For an example of implementing this callback, see tools/matc/src/matc/DirIncluder.h.
  */
 using IncludeCallback = std::function<bool(
-        const utils::CString& headerName,
-        const utils::CString& includerName,
+        const utils::CString& includedBy,
         IncludeResult& result)>;
 
 } // namespace filamat

--- a/libs/filamat/include/filamat/IncludeCallback.h
+++ b/libs/filamat/include/filamat/IncludeCallback.h
@@ -24,9 +24,6 @@
 namespace filamat {
 
 struct IncludeResult {
-    // The line number for the first line of source (first line is 0).
-    const size_t lineNumberOffset = 0;
-
     // The include name of the root file, as if it were being included.
     // I.e., 'foobar.h' in the case of #include "foobar.h"
     const utils::CString includeName;
@@ -37,6 +34,9 @@ struct IncludeResult {
     // The full contents of the include file. This may contain additional, recursive include
     // directives.
     utils::CString text;
+
+    // The line number for the first line of text (first line is 0).
+    size_t lineNumberOffset = 0;
 
     // The name of the include file. This gets passed as "includerName" for any includes inside of
     // source. This field isn't used by the include system; it's up to the callback to give meaning
@@ -51,8 +51,9 @@ struct IncludeResult {
  *
  * For example, if a file main.h includes file.h on line 10, then IncludeCallback would be called
  * with the following:
- *     includeCallback("main.h", {.lineNumberOffset = 10, .includeName = "file.h" })
- * It's then up to the IncludeCallback to fill out the .text and .name fields.
+ *     includeCallback("main.h", {.includeName = "file.h" })
+ * It's then up to the IncludeCallback to fill out the .text, .name, and (optionally)
+ * lineNumberOffset fields.
  *
  * @param includedBy is the value that was given to IncludeResult.name for this source file, or
  *        the empty string for the root source file.

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -195,6 +195,9 @@ public:
     //! Set the name of this material.
     MaterialBuilder& name(const char* name) noexcept;
 
+    //! Set the file name of this material file. Used in error reporting.
+    MaterialBuilder& fileName(const char* name) noexcept;
+
     //! Set the shading model.
     MaterialBuilder& shading(Shading shading) noexcept;
 
@@ -260,6 +263,10 @@ public:
      *     postProcess.color = float4(1.0);
      * }
      * ~~~~~
+     *
+     * @param code The source code of the material.
+     * @param line The line number offset of the material, where 0 is the first line. Used for error
+     *             reporting
      */
     MaterialBuilder& material(const char* code, size_t line = 0) noexcept;
 
@@ -291,6 +298,10 @@ public:
      *
      * }
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+     * @param code The source code of the material.
+     * @param line The line number offset of the material, where 0 is the first line. Used for error
+     *             reporting
      */
     MaterialBuilder& materialVertex(const char* code, size_t line = 0) noexcept;
 
@@ -509,6 +520,7 @@ private:
     bool isLit() const noexcept { return mShading != filament::Shading::UNLIT; }
 
     utils::CString mMaterialName;
+    utils::CString mFileName;
 
     class ShaderCode {
     public:
@@ -519,7 +531,7 @@ private:
         }
 
         // Resolve all the #include directives, returns true if successful.
-        bool resolveIncludes(IncludeCallback callback) noexcept;
+        bool resolveIncludes(IncludeCallback callback, const utils::CString& fileName) noexcept;
 
         const utils::CString& getResolved() const noexcept {
             assert(mIncludesResolved);

--- a/libs/filamat/src/Includes.cpp
+++ b/libs/filamat/src/Includes.cpp
@@ -144,7 +144,6 @@ bool resolveIncludes(IncludeResult& root, IncludeCallback callback,
             return false;
         }
         IncludeResult resolved {
-            .lineNumberOffset = 0,
             .includeName = include.name
         };
         if (!callback(root.name, resolved)) {

--- a/libs/filamat/src/Includes.cpp
+++ b/libs/filamat/src/Includes.cpp
@@ -17,6 +17,8 @@
 #include "Includes.h"
 
 #include <utils/Log.h>
+#include <utils/compiler.h>
+#include <utils/sstream.h>
 
 #include <string>
 
@@ -26,44 +28,151 @@ static bool isWhitespace(char c) {
     return (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v');
 }
 
-bool resolveIncludes(const utils::CString& rootName, utils::CString& source,
-        IncludeCallback callback, size_t depth) {
+bool resolveIncludes(IncludeResult& root, IncludeCallback callback,
+        const ResolveOptions& options, size_t depth) {
     if (depth > 30) {
         // This is probably an include cycle. Stop here and report an error so we don't overflow.
         utils::slog.e << "Include depth > 30. Include cycle?" << utils::io::endl;
         return false;
     }
 
-    std::vector<FoundInclude> includes = parseForIncludes(source);
-    while (!includes.empty()) {
+    const size_t lineNumberOffset = root.lineNumberOffset;
+    utils::CString& text = root.text;
+
+    std::vector<FoundInclude> includes = parseForIncludes(text);
+    bool sourceDirty = false;
+
+    // If we weren't given an include name, use "0", which is default when no #line directives are
+    // used.
+    const char* rootIncludeName = root.includeName.empty() ? "0" : root.includeName.c_str();
+
+    auto insertLineDirective = [&options](utils::io::ostream& stream, size_t line, const char* filename) {
+        if (options.insertLineDirectiveCheck) {
+            stream << "#if defined(GL_GOOGLE_cpp_style_line_directive)\n";
+            // The #endif itself will count as a line, so subtact 1.
+            line--;
+        }
+        stream << "#line " << line << " \"" << filename << '\"';
+        if (options.insertLineDirectiveCheck) {
+            stream << "\n#endif";
+        }
+    };
+
+    // The #line directive must be on its own line and works like so:
+    // #line 10 "file.h"
+    // any code on this line is now considered line 10 of file.h
+
+    // Add #line directives before / after each #include. We work backwards, otherwise we'd
+    // invalidate the offsets in FoundInclude.
+    for (auto it = includes.rbegin(); it < includes.rend() && options.insertLineDirectives; ++it) {
+        const auto include = *it;
+
+        // Remember that text editors consider the first line of a file to be line 1.
+        // Consider the following file, called "root.h":
+        // 1
+        // 2 #include "foo.h"
+        // 3
+
+        // We want to insert an opening and closing #line directive:
+        // 1
+        //   #line 1 "foo.h"
+        // 2 #include "foo.h"
+        //   #line 3 "root.h"
+        // 3
+
+        // We want to insert a closing directive with a line number of 3.
+        // In this example, include.line is 2 and lineNumberOffset is 0.
+        // So, the math works out as such:
+        const size_t lineDirectiveLine = include.line + lineNumberOffset + 1;
+
+        utils::io::sstream closingDirective;
+
+        // This first newline is to ensure that the #line directive falls on a fresh line.
+        closingDirective << '\n';
+
+        // If there's a newline after the include, we'll use that to terminate the #line directive.
+        const size_t newlineCharacter = include.startPosition + include.length;
+        if (text.length() > newlineCharacter && text[newlineCharacter] == '\n') {
+            insertLineDirective(closingDirective, lineDirectiveLine, rootIncludeName);
+        } else {
+            // If there isn't one, be sure to add one. The included source might not have an
+            // newline at the end of the file.
+
+            // We subtract 1 to handle additional code after the include directive.
+            // E.g., this include statement:
+            // #include "foobar.h"  more code on same line
+            //
+            // should get translated to:
+            // #line 1
+            // #include "foobar.h"
+            // #line 1
+            //  more code on same line
+
+            insertLineDirective(closingDirective, lineDirectiveLine - 1, rootIncludeName);
+            closingDirective << '\n';
+        }
+
+        text.insert(include.startPosition + include.length, utils::CString(closingDirective.c_str()));
+
+        // The included source always starts on line 1.
+        utils::io::sstream openingDirective;
+        insertLineDirective(openingDirective, 1, include.name.c_str());
+        openingDirective << '\n';
+        text.insert(include.startPosition, utils::CString(openingDirective.c_str()));
+        sourceDirty = true;
+    }
+
+    // Add a line directive on the first line for the root include.
+    if (options.insertLineDirectives && depth == 0) {
+        utils::io::sstream lineDirective;
+        insertLineDirective(lineDirective, lineNumberOffset + 1, rootIncludeName);
+        lineDirective << '\n';
+        text.insert(0, utils::CString(lineDirective.c_str()));
+        sourceDirty = true;
+    }
+
+    // Re-parse for includes. If we've inserted any #line directives, then the line numbers have
+    // changed.
+    if (UTILS_LIKELY(sourceDirty)) {
+        includes = parseForIncludes(text);
+    }
+
+    while (!includes.empty() && options.resolveIncludes) {
         const auto include = includes[0];
         // Ask the includer to resolve this include.
         if (!callback) {
             return false;
         }
-        IncludeResult result;
-        if (!callback(include.name, rootName, result)) {
+        IncludeResult resolved {
+            .lineNumberOffset = 0,
+            .includeName = include.name
+        };
+        if (!callback(root.name, resolved)) {
             utils::slog.e << "The included file \"" << include.name.c_str()
                           << "\" could not be found." << utils::io::endl;
             return false;
         }
 
         // Recursively resolve all of its includes.
-        if (!resolveIncludes(result.name, result.source, callback, depth + 1)) {
+        if (!resolveIncludes(resolved, callback, options, depth + 1)) {
             return false;
         }
 
-        source.replace(include.startPosition, include.length, result.source);
+        text.replace(include.startPosition, include.length, resolved.text);
 
-        includes = parseForIncludes(source);
+        includes = parseForIncludes(text);
     }
 
     return true;
 }
 
 std::vector<FoundInclude> parseForIncludes(const utils::CString& source) {
-    std::string sourceString = source.c_str();
     std::vector<FoundInclude> results;
+
+    if (source.empty()) {
+        return results;
+    }
+    std::string sourceString = source.c_str();
 
     size_t result = sourceString.find("#include");
 
@@ -102,7 +211,16 @@ std::vector<FoundInclude> parseForIncludes(const utils::CString& source) {
         // Grab the include name.
         const auto includeName = sourceString.substr(nameStart, nameEnd - nameStart + 1);
 
-        results.push_back({utils::CString(includeName.c_str()), includeStart, includeEnd - includeStart + 1});
+        // Calculate the line number of the include.
+        size_t lineNumber = 1;
+        for (size_t i = 0; i < includeStart; i++) {
+            if (source[i] == '\n') {
+                lineNumber++;
+            }
+        }
+
+        results.push_back({utils::CString(includeName.c_str()), includeStart,
+                includeEnd - includeStart + 1, lineNumber});
 
         // Find next occurrence.
         result = sourceString.find("#include", result);

--- a/libs/filamat/src/Includes.h
+++ b/libs/filamat/src/Includes.h
@@ -25,16 +25,30 @@
 
 namespace filamat {
 
-// Recursively handle all the includes inside of source.
+struct ResolveOptions {
+    // If true, insert #line directives before / after each include.
+    bool insertLineDirectives = false;
+
+    // Surrounds line directives with #if defined(GL_GOOGLE_cpp_style_line_directive)
+    // Some drivers may complain about the use of cpp style #line directives if they don't support
+    // it.
+    bool insertLineDirectiveCheck = false;
+
+    // If true, process #include directives.
+    bool resolveIncludes = true;
+};
+
+// Recursively handle all the includes inside of root.
 // Returns true if all includes were handled successfully, false otherwise.
 // callback may be null, in which case any #include directives found will result in a failure.
-bool resolveIncludes(const utils::CString& rootName, utils::CString& source,
-        IncludeCallback callback, size_t depth = 0);
+bool resolveIncludes(IncludeResult& root, IncludeCallback callback,
+        const ResolveOptions& options, size_t depth = 0);
 
 struct FoundInclude {
     utils::CString name;
     size_t startPosition;
     size_t length;
+    size_t line;        // the line number the include was found on (first line is 1)
 };
 
 std::vector<FoundInclude> parseForIncludes(const utils::CString& source);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -525,9 +525,9 @@ bool MaterialBuilder::ShaderCode::resolveIncludes(IncludeCallback callback,
             .insertLineDirectiveCheck = true
         };
         IncludeResult source {
-            .lineNumberOffset = getLineOffset(),
             .includeName = fileName,
             .text = mCode,
+            .lineNumberOffset = getLineOffset(),
             .name = utils::CString("")
         };
         if (!::filamat::resolveIncludes(source, callback, options)) {

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -64,6 +64,10 @@ io::sstream& CodeGenerator::generateProlog(io::sstream& out, ShaderType type,
             break;
     }
 
+    // This allows our includer system to use the #line directive to denote the source file for
+    // #included code. This way, glslang reports errors more accurately.
+    out << "#extension GL_GOOGLE_cpp_style_line_directive : enable\n\n";
+
     if (mTargetApi == TargetApi::VULKAN) {
         out << "#define TARGET_VULKAN_ENVIRONMENT\n";
     }

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -110,8 +110,7 @@ static void appendShader(utils::io::sstream& ss,
         const utils::CString& shader, size_t lineOffset) noexcept {
     if (!shader.empty()) {
         size_t lines = countLines(ss.c_str());
-        ss << "#line " << lineOffset;
-        if (shader[0] != '\n') ss << "\n";
+        ss << "#line " << lineOffset + 1 << '\n';
         ss << shader.c_str();
         if (shader[shader.size() - 1] != '\n') {
             ss << "\n";

--- a/libs/filamat/tests/MockIncluder.h
+++ b/libs/filamat/tests/MockIncluder.h
@@ -35,9 +35,8 @@ public:
         return *this;
     }
 
-    bool operator()(const utils::CString& headerName, const utils::CString& includerName,
-            filamat::IncludeResult& result) {
-        auto key = headerName.c_str();
+    bool operator()(const utils::CString& includedBy, filamat::IncludeResult& result) {
+        auto key = result.includeName.c_str();
         auto found = mIncludeMap.find(key);
 
         if (found == mIncludeMap.end()) {
@@ -47,12 +46,12 @@ public:
         auto include = found->second;
 
         if (!include.expectedIncluder.empty()) {
-            EXPECT_STREQ(includerName.c_str_safe(), include.expectedIncluder.c_str());
+            EXPECT_STREQ(includedBy.c_str_safe(), include.expectedIncluder.c_str());
         }
 
         if (!include.source.empty()) {
-            result.source = utils::CString(include.source.c_str());
-            result.name = headerName;
+            result.text = utils::CString(include.source.c_str());
+            result.name = result.includeName;
             return true;
         }
 

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -260,6 +260,7 @@ public:
     const_iterator cend() const noexcept { return end(); }
 
     CString& replace(size_type pos, size_type len, const CString& str) noexcept;
+    CString& insert(size_type pos, const CString& str) noexcept { return replace(pos, 0, str); }
 
     const_reference operator[](size_type pos) const noexcept {
         assert(pos < size());

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -66,11 +66,14 @@ foreach(SHADER_FILE ${SHADERS})
     get_filename_component(SHADER_NAME ${SHADER_FILE} NAME)
     set(SHADER_RAW ${CMAKE_CURRENT_SOURCE_DIR}/${SHADER_FILE})
     set(SHADER_MIN ${MINIFIED_DIR}/${SHADER_NAME})
-    # For Debug builds, pass the "-Onone" flag to perform no minification. This is helpful for
-    # debugging shaders.
+    # For Debug builds, pass two additional flags to help with debugging:
+    # -Onone        performs no minification.
+    # -lshader_name adds a #line directive at the beginning to help identify sources of errors.
+    set(OPT_FLAG "$<$<CONFIG:DEBUG>:-Onone>")
+    set(LINE_FLAG "$<$<CONFIG:DEBUG>:-l${SHADER_NAME}>")
     add_custom_command(
         OUTPUT ${SHADER_MIN}
-        COMMAND glslminifier "$<$<CONFIG:DEBUG>:-Onone>" -o ${SHADER_MIN} ${SHADER_RAW}
+        COMMAND glslminifier ${OPT_FLAG} ${LINE_FLAG} -o ${SHADER_MIN} ${SHADER_RAW}
         DEPENDS glslminifier ${SHADER_RAW}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Minifying shader ${SHADER_NAME}"

--- a/tools/matc/src/matc/DirIncluder.cpp
+++ b/tools/matc/src/matc/DirIncluder.cpp
@@ -22,20 +22,20 @@
 
 namespace matc {
 
-bool DirIncluder::operator()(const utils::CString& headerName, const utils::CString& includerName,
-        filamat::IncludeResult& result) {
-    auto getHeaderPath = [&includerName, &headerName, this]() {
-        // If includer name is empty, then search from the root include directory.
-        if (includerName.empty()) {
-            return mIncludeDirectory.concat(headerName.c_str());
+bool DirIncluder::operator()(const utils::CString& includedBy, filamat::IncludeResult& result) {
+    auto getHeaderPath = [&result, &includedBy, this]() {
+        // includedBy is the path to the file that's including result.includeName.
+        // If it's empty, then search from the root include directory.
+        if (includedBy.empty()) {
+            return mIncludeDirectory.concat(result.includeName.c_str());
         }
 
         // Otherwise, search relative to the includer file.
-        utils::Path includer(includerName.c_str());
+        utils::Path includer(includedBy.c_str());
         // TODO: this assert was firing only in CI during DirIncluder tests. Maybe because of
         // inadequate file permissions.
         // assert(includer.isFile());
-        return includer.getParent() + headerName.c_str();
+        return includer.getParent() + result.includeName.c_str();
     };
 
     const utils::Path headerPath = getHeaderPath();
@@ -60,7 +60,7 @@ bool DirIncluder::operator()(const utils::CString& headerName, const utils::CStr
 
     stream.close();
 
-    result.source = utils::CString(contents.c_str());
+    result.text = utils::CString(contents.c_str());
     result.name = utils::CString(headerPath.c_str());
 
     return true;

--- a/tools/matc/src/matc/DirIncluder.h
+++ b/tools/matc/src/matc/DirIncluder.h
@@ -31,8 +31,7 @@ public:
         mIncludeDirectory = dir;
     }
 
-    bool operator()(const utils::CString& headerName, const utils::CString& includerName,
-            filamat::IncludeResult& result);
+    bool operator()(const utils::CString& includedBy, filamat::IncludeResult& result);
 
 private:
     utils::Path mIncludeDirectory;

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -84,7 +84,9 @@ bool MaterialCompiler::processVertexShader(const MaterialLexeme& lexeme,
     MaterialLexeme trimmedLexeme = lexeme.trimBlockMarkers();
     std::string shaderStr = trimmedLexeme.getStringValue();
 
-    builder.materialVertex(shaderStr.c_str(), trimmedLexeme.getLine() + 1);
+    // getLine() returns a line number, with 1 being the first line, but .material wants a 0-based
+    // line number offset, where 0 is the first line.
+    builder.materialVertex(shaderStr.c_str(), trimmedLexeme.getLine() - 1);
     return true;
 }
 
@@ -94,7 +96,9 @@ bool MaterialCompiler::processFragmentShader(const MaterialLexeme& lexeme,
     MaterialLexeme trimmedLexeme = lexeme.trimBlockMarkers();
     std::string shaderStr = trimmedLexeme.getStringValue();
 
-    builder.material(shaderStr.c_str(), trimmedLexeme.getLine() + 1);
+    // getLine() returns a line number, with 1 being the first line, but .material wants a 0-based
+    // line number offset, where 0 is the first line.
+    builder.material(shaderStr.c_str(), trimmedLexeme.getLine() - 1);
     return true;
 }
 
@@ -276,6 +280,7 @@ bool MaterialCompiler::run(const Config& config) {
 
     builder
         .includeCallback(includer)
+        .fileName(materialFilePath.getName().c_str())
         .platform(config.getPlatform())
         .targetApi(config.getTargetApi())
         .optimization(config.getOptimizationLevel())

--- a/tools/matc/tests/test_includer.cpp
+++ b/tools/matc/tests/test_includer.cpp
@@ -28,14 +28,18 @@ const utils::Path root = utils::Path(__FILE__).getParent();
 TEST(DirIncluder, DISABLED_IncludeNonexistent) {
     matc::DirIncluder includer;
     {
-        IncludeResult _;
-        bool success = includer(CString("nonexistent.h"), CString(""), _);
+        IncludeResult i {
+            .includeName = CString("nonexistent.h")
+        };
+        bool success = includer(CString(""), i);
         EXPECT_FALSE(success);
     }
     {
         utils::CString includerFile((root + "Foo.h").getPath().c_str());
-        IncludeResult _;
-        bool success = includer(CString("nonexistent.h"), includerFile, _);
+        IncludeResult i {
+            .includeName = CString("nonexistent.h")
+        };
+        bool success = includer(includerFile, i);
         EXPECT_FALSE(success);
     }
 }
@@ -44,13 +48,15 @@ TEST(DirIncluder, DISABLED_IncludeFile) {
     matc::DirIncluder includer;
     includer.setIncludeDirectory(root);
 
-    IncludeResult result;
-    bool success = includer(CString("Foo.h"), CString(""), result);
+    IncludeResult result {
+        .includeName = CString("Foo.h")
+    };
+    bool success = includer(CString(""), result);
 
     EXPECT_TRUE(success);
 
     // The result's source should be set to the contents of the includer file.
-    EXPECT_STREQ("// test include file", result.source.c_str());
+    EXPECT_STREQ("// test include file", result.text.c_str());
 
     // The result's name should be set to the full path to the header file.
     EXPECT_STREQ((root + "Foo.h").c_str(), result.name.c_str());
@@ -62,10 +68,12 @@ TEST(DirIncluder, DISABLED_IncludeFileFromIncluder) {
 
     utils::CString includerFile((root + "Dir/Baz.h").c_str());
 
-    IncludeResult result;
-    bool success = includer(CString("Bar.h"), includerFile, result);
+    IncludeResult result {
+        .includeName = CString("Bar.h")
+    };
+    bool success = includer(includerFile, result);
 
-    EXPECT_STREQ("// Bar.h", result.source.c_str());
+    EXPECT_STREQ("// Bar.h", result.text.c_str());
 
     EXPECT_STREQ((root + "Dir/Bar.h").c_str(), result.name.c_str());
 }


### PR DESCRIPTION
When `matc` reports an error, it will now include the name of the material file and the correct line number. For example:

```
ERROR: sandboxUnlit.mat:20: 'bafeColor' : undeclared identifier
ERROR: sandboxUnlit.mat:20: '' : compilation terminated
ERROR: 2 compilation errors.  No code generated.
```

This works just as well with files `#include`d by a material:

```
ERROR: Unable to parse fragment shader:
ERROR: dofUtils.fs:30: 'assign' :  cannot convert from ' const 3-component vector of float' to ' temp 4-component vector of float'
ERROR: dofUtils.fs:30: '' : compilation terminated
ERROR: 2 compilation errors.  No code generated.
```

and even with errors in Filament shaders in debug builds:

```
ERROR: shadowing.fs:323: 'ShadowSample_PCF_Low' : no matching overloaded function found
ERROR: shadowing.fs:323: '' : missing #endif
ERROR: shadowing.fs:323: '' : compilation terminated
ERROR: 3 compilation errors.  No code generated.
```
