### PR TITLE
ssao: optimize sin/cos per sample

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -36,6 +36,7 @@
 #include <filament/MaterialEnums.h>
 
 #include <math/half.h>
+#include <math/mat2.h>
 
 #include <utils/Log.h>
 
@@ -400,6 +401,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOclusion(
                 }
 
                 const auto invProjection = inverse(cameraInfo.projection);
+                const float inc = (1.0f / (sampleCount - 0.5f)) * spiralTurns * 2.0f * float(math::F_PI);
 
                 FMaterialInstance* const mi = mSSAO.getMaterialInstance();
                 mi->setParameter("depth", depth, {
@@ -420,6 +422,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOclusion(
                 mi->setParameter("maxLevel", uint32_t(levelCount - 1));
                 mi->setParameter("sampleCount", float2{ sampleCount, 1.0f / (sampleCount - 0.5f) });
                 mi->setParameter("spiralTurns", spiralTurns);
+                mi->setParameter("angleIncCosSin", float2{ std::cos(inc), std::sin(inc) });
                 mi->setParameter("invFarPlane", 1.0f / -cameraInfo.zf);
                 mi->commit(driver);
                 mi->use(driver);

--- a/filament/src/materials/dof.mat
+++ b/filament/src/materials/dof.mat
@@ -154,7 +154,7 @@ void initRing(const float i, const float ringCount, const float kernelSize, out 
 
     float inc = 2.0 * PI / count;
     vec2 t = vec2(cos(inc), sin(inc));
-    r = mat2(t.x, -t.y, t.y, t.x);
+    r = mat2(t.x, t.y, -t.y, t.x);
 
     float firstSamplePosition = mod(i, 2.0) * 0.5 * inc;
     p = radius * vec2(cos(firstSamplePosition), sin(firstSamplePosition));

--- a/filament/src/materials/sao.mat
+++ b/filament/src/materials/sao.mat
@@ -54,6 +54,10 @@ material {
             name : spiralTurns
         },
         {
+            type : float2,
+            name : angleIncCosSin
+        },
+        {
             type : float,
             name : invFarPlane
         },
@@ -154,11 +158,23 @@ fragment {
         return vec3(cos(angle), sin(angle), radius);
     }
 
+    highp mat2 tapAngleStep() {
+        highp vec2 t = materialParams.angleIncCosSin;
+        return mat2(t.x, t.y, -t.y, t.x);
+    }
+
+    vec3 tapLocation(float i, vec2 p) {
+        float radius = (i + 0.5) * materialParams.sampleCount.y;
+        return vec3(p, radius);
+    }
+
+
     void computeAmbientOcclusionSAO(inout float occlusion, float i, float ssDiskRadius,
             const highp vec2 uv,  const highp vec3 origin, const vec3 normal,
-            const float noise) {
+            const vec2 tapPosition, const float noise) {
 
-        vec3 tap = tapLocation(i, noise);
+        vec3 tap = tapLocation(i, tapPosition);
+
         float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
 
         vec2 uvSamplePos = uv + vec2(ssRadius * tap.xy) * materialParams.resolution.zw;
@@ -184,6 +200,8 @@ fragment {
 
         vec3 normal = computeViewSpaceNormal(origin, uv);
         float noise = random(gl_FragCoord.xy);
+        highp vec2 tapPosition = tapLocation(0.0, noise).xy;
+        highp mat2 angleStep = tapAngleStep();
 
         // Choose the screen-space sample radius
         // proportional to the projected area of the sphere
@@ -191,7 +209,8 @@ fragment {
 
         float occlusion = 0.0;
         for (float i = 0.0; i < materialParams.sampleCount.x; i += 1.0) {
-            computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, noise);
+            computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, tapPosition, noise);
+            tapPosition = angleStep * tapPosition;
         }
 
         float ao = max(0.0, 1.0 - occlusion * (materialParams.intensity * materialParams.sampleCount.y));


### PR DESCRIPTION
We now get away with a sin/cos per fragment instead of per-sample,
this increases a little bit the ALU load but decreases the EFU's.
This is not necessarily faster, but sin/cos may cost more power or
have longer latencies.