### PR TITLE
matdbg: fix large # of materials + autoselect variant

### DIFF
--- a/libs/matdbg/web/script.js
+++ b/libs/matdbg/web/script.js
@@ -64,7 +64,7 @@ document.querySelector("body").addEventListener("click", (evt) => {
 
     // Handle selection of a material.
     if (anchor.classList.contains("material")) {
-        selectMaterial(anchor.dataset.matid);
+        selectMaterial(anchor.dataset.matid, true);
         return;
     }
 
@@ -206,7 +206,7 @@ function fetchMaterials() {
             }
             gMaterialDatabase[matInfo.matid] = matInfo;
         }
-        selectMaterial(matJson[0].matid);
+        selectMaterial(matJson[0].matid, true);
     });
 }
 

--- a/libs/matdbg/web/style.css
+++ b/libs/matdbg/web/style.css
@@ -24,6 +24,10 @@ a.inactive {
     color: #aaa;
 }
 
+a.inactive.current {
+    color: #5af;
+}
+
 pre {
     font-family: Menlo, Monaco, "Courier New", monospace;
 }


### PR DESCRIPTION
This has two commits:
- Support scenes that have many materials.
  - To fix this, matdbg now downloads the source of each variant only after it gets selected, rather than flooding the server with a bunch of requests at startup.
- Autoselect a variant after clicking a material.
  - This prevents the weird mismatch that would occur between the editor and the highlighted material name.
