### PR TITLE
Web tutorials now use a CDN for the npm package.

### DIFF
--- a/web/docs/demo_template.html
+++ b/web/docs/demo_template.html
@@ -12,9 +12,9 @@
 </head>
 <body>
     <canvas></canvas>
-    <script src="filament.js"></script>
-    <script src="gl-matrix-min.js"></script>
-    <script src="https://unpkg.com/gltumble@1.0.1/gltumble.js"></script>
+    <script src="//unpkg.com/filament/filament.js"></script>
+    <script src="//unpkg.com/gl-matrix@2.8.1"></script>
+    <script src="//unpkg.com/gltumble"></script>
     <script src="$SCRIPT"></script>
 </body>
 </html>

--- a/web/docs/tutorial_suzanne.md
+++ b/web/docs/tutorial_suzanne.md
@@ -142,7 +142,7 @@ class App {
 
         this.swapChain = this.engine.createSwapChain();
         this.renderer = this.engine.createRenderer();
-        this.camera = engine.createCamera(Filament.EntityManager.get().create());
+        this.camera = this.engine.createCamera(Filament.EntityManager.get().create());
         this.view = this.engine.createView();
         this.view.setCamera(this.camera);
         this.view.setScene(this.scene);
@@ -269,7 +269,7 @@ Add the following script tag to your HTML file. This imports a small third-party
 listens for drag events and computes a rotation matrix.
 
 ```html
-<script src="https://unpkg.com/gltumble"></script>
+<script src="//unpkg.com/gltumble"></script>
 ```
 
 Next, replace the **initialize gltumble** and **apply gltumble matrix** comments with the following

--- a/web/docs/tutorial_triangle.md
+++ b/web/docs/tutorial_triangle.md
@@ -18,7 +18,7 @@ a mobile-friendly page with a full-screen canvas.
 <body>
     <canvas></canvas>
     <script src="//unpkg.com/filament/filament.js"></script>
-    <script src="//unpkg.com/gl-matrix@2.8.1/dist/gl-matrix-min.js"></script>
+    <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="triangle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This makes the tutorials more consistent with the live demos and lets us
more easily ensure that the tutorials are kept up to date without
errors. In fact it caught an error in the Suzanne tutorial.

Since this affects source rather than served files, this PR is intended
for main.  The master branch will be updated in a subsequent PR.