### PR TITLE
DriverEnums: add usage flag for SUBPASS_INPUT

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -723,6 +723,8 @@ public class Texture {
         public static final int UPLOADABLE = 0x8;
         /** The texture can be read from a shader or blitted from */
         public static final int SAMPLEABLE = 0x10;
+        /** Texture can be used as a subpass input */
+        public static final int SUBPASS_INPUT = 0x20;
         /** by default textures are <code>UPLOADABLE</code> and <code>SAMPLEABLE</code>*/
         public static final int DEFAULT = UPLOADABLE | SAMPLEABLE;
     }

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -490,6 +490,7 @@ enum class TextureUsage : uint8_t {
     STENCIL_ATTACHMENT  = 0x4,                      //!< Texture can be used as a stencil attachment
     UPLOADABLE          = 0x8,                      //!< Data can be uploaded into this texture (default)
     SAMPLEABLE          = 0x10,                     //!< Texture can be sampled (default)
+    SUBPASS_INPUT       = 0x20,                     //!< Texture can be used as a subpass input
     DEFAULT             = UPLOADABLE | SAMPLEABLE   //!< Default texture usage
 };
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -391,6 +391,9 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     }
     if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
         imageInfo.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | blittable;
+        if (any(usage & TextureUsage::SUBPASS_INPUT)) {
+            imageInfo.usage |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+        }
     }
     if (any(usage & TextureUsage::STENCIL_ATTACHMENT)) {
         imageInfo.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -654,7 +654,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                     data.output = builder.createTexture("Tonemapped Buffer", {
                             .width = colorBufferDesc.width,
                             .height = colorBufferDesc.height,
-                            .format = colorGradingConfig.ldrFormat
+                            .format = colorGradingConfig.ldrFormat,
+                            .usage = backend::TextureUsage::SUBPASS_INPUT
                     });
                     data.output = builder.write(data.output);
                 }

--- a/filament/src/fg/FrameGraphHandle.h
+++ b/filament/src/fg/FrameGraphHandle.h
@@ -48,7 +48,7 @@ struct FrameGraphTexture {
         uint8_t samples = 0;    // 0=auto, 1=request not multisample, >1 only for NOT SAMPLEABLE
         backend::SamplerType type = backend::SamplerType::SAMPLER_2D;     // texture target type
         backend::TextureFormat format = backend::TextureFormat::RGBA8;    // resource internal format
-        backend::TextureUsage usage = (backend::TextureUsage)0; // don't need to set this one
+        backend::TextureUsage usage = (backend::TextureUsage)0;
     };
 
     void create(FrameGraph& fg, const char* name, Descriptor const& desc) noexcept;

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -778,6 +778,10 @@ export enum Texture$Usage {
     DEFAULT,
     COLOR_ATTACHMENT,
     DEPTH_ATTACHMENT,
+    STENCIL_ATTACHMENT,
+    UPLOADABLE,
+    SAMPLEABLE,
+    SUBPASS_INPUT,
 }
 
 export enum Texture$CubemapFace {

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -261,7 +261,8 @@ enum_<Texture::Usage>("Texture$Usage") // aka backend::TextureUsage
     .value("DEPTH_ATTACHMENT", Texture::Usage::DEPTH_ATTACHMENT)
     .value("STENCIL_ATTACHMENT", Texture::Usage::STENCIL_ATTACHMENT)
     .value("UPLOADABLE", Texture::Usage::UPLOADABLE)
-    .value("SAMPLEABLE", Texture::Usage::SAMPLEABLE);
+    .value("SAMPLEABLE", Texture::Usage::SAMPLEABLE)
+    .value("SUBPASS_INPUT", Texture::Usage::SUBPASS_INPUT);
 
 enum_<Texture::CubemapFace>("Texture$CubemapFace") // aka backend::TextureCubemapFace
     .value("POSITIVE_X", Texture::CubemapFace::POSITIVE_X)


### PR DESCRIPTION
We do not really need to expose this to the public but we expose all our other usage flags.