### PR TITLE
WebGL: Upgrade emsdk and refactor initialization.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -366,7 +366,7 @@ same version that our continuous builds use.
 
 ```
 cd <your chosen parent folder for the emscripten SDK>
-curl -L https://github.com/emscripten-core/emsdk/archive/f5e21de.zip > emsdk.zip
+curl -L https://github.com/emscripten-core/emsdk/archive/1.39.19.zip > emsdk.zip
 unzip emsdk.zip ; mv emsdk-* emsdk ; cd emsdk
 python ./emsdk.py install latest
 python ./emsdk.py activate latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- Updated the Emscripten SDK to 1.39.19
+
 ## v1.8.0
 
 - Improved JavaScript API for SurfaceOrientation and Scene.

--- a/build/web/ci-common.sh
+++ b/build/web/ci-common.sh
@@ -9,7 +9,7 @@ export PATH="$PWD:$PATH"
 # npm install -g typescript
 
 # Install emscripten.
-curl -L https://github.com/emscripten-core/emsdk/archive/f5e21de.zip > emsdk.zip
+curl -L https://github.com/emscripten-core/emsdk/archive/1.39.19.zip > emsdk.zip
 unzip emsdk.zip ; mv emsdk-* emsdk ; cd emsdk
 ./emsdk install latest
 ./emsdk activate latest

--- a/web/filament-js/CMakeLists.txt
+++ b/web/filament-js/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COPTS}")
 add_executable(filament-js ${CPP_SRC})
 
 set_target_properties(filament-js PROPERTIES
-    LINK_DEPENDS "${EXTERN_POSTJS_SRC};${POSTJS_SRC}"
+    LINK_DEPENDS "${EXTERN_POSTJS_SRC}"
     OUTPUT_NAME filament)
 
 target_link_libraries(filament-js PRIVATE filament math utils image filameshio gltfio_core stb)


### PR DESCRIPTION
Since postRun can no longer be set from within the extern post JS, we
now use the promise rather than postRun.

This upgrades emsdk to 1.39.19 (see note in #2800).