### PR TITLE
Set Filament iOS support to iOS 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ creating the swap chain in the `onNativeWindowChanged()` callback.
 
 ### iOS
 
-Filament is supported on iOS 12.0 and above. See `ios/samples` for examples of using Filament on
+Filament is supported on iOS 11.0 and above. See `ios/samples` for examples of using Filament on
 iOS.
 
 Filament on iOS is largely the same as native rendering with C++. A `CAEAGLLayer` or `CAMetalLayer`

--- a/build.sh
+++ b/build.sh
@@ -477,7 +477,6 @@ function build_ios_target {
             -DCMAKE_INSTALL_PREFIX="../ios-${lc_target}/filament" \
             -DIOS_ARCH="${arch}" \
             -DPLATFORM_NAME="${platform}" \
-            -DIOS_MIN_TARGET=12.0 \
             -DIOS=1 \
             -DCMAKE_TOOLCHAIN_FILE=../../third_party/clang/iOS.cmake \
             ../..

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -424,7 +424,11 @@ void MetalTexture::loadSlice(uint32_t level, uint32_t xoffset, uint32_t yoffset,
     // Depending on the size of the required buffer, we either allocate a staging buffer or a
     // staging texture. Then the texture data is blited to the "real" texture.
     const size_t stagingBufferSize = bytesPerSlice * depth;
-    if (UTILS_LIKELY(stagingBufferSize <= context.device.maxBufferLength)) {
+    NSUInteger deviceMaxBufferLength = 0;
+    if (@available(macOS 10.14, iOS 12, *)) {
+        deviceMaxBufferLength = context.device.maxBufferLength;
+    }
+    if (UTILS_LIKELY(stagingBufferSize <= deviceMaxBufferLength)) {
         auto entry = context.bufferPool->acquireBuffer(stagingBufferSize);
         memcpy(entry->buffer.contents,
                 static_cast<uint8_t*>(data.buffer) + sourceOffset,

--- a/ios/CocoaPods/Filament.podspec
+++ b/ios/CocoaPods/Filament.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.homepage = "https://google.github.io/filament"
   spec.authors = "Google LLC."
   spec.summary = "Filament is a real-time physically based rendering engine for Android, iOS, Windows, Linux, macOS, and WASM/WebGL."
-  spec.platform = :ios, "12.0"
+  spec.platform = :ios, "11.0"
   spec.source = { :http => "https://github.com/google/filament/releases/download/v1.8.0/filament-20200709-ios.tgz" }
 
   spec.subspec "filament" do |ss|

--- a/ios/samples/HelloCocoaPods/Podfile
+++ b/ios/samples/HelloCocoaPods/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '11.0'
 
 target 'HelloCocoaPods' do
     pod 'Filament'

--- a/ios/samples/README.md
+++ b/ios/samples/README.md
@@ -12,7 +12,7 @@ Filament is kept up-to-date with Apple's latest SDK and thus must be built using
 Pre-built binaries can be accessed from [Filament
 releases](https://github.com/google/filament/releases).
 
-The iOS Metal backend is supported on iOS 12 and up. The OpenGL ES backend should be supported on iOS 7
+The iOS Metal backend is supported on iOS 11 and up. The OpenGL ES backend should be supported on iOS 7
 and up, though it is not regularly tested.
 
 The iOS simulator is also supported for both the OpenGL and Metal backends, but please be aware that

--- a/site/content/posts/cocoapods.md
+++ b/site/content/posts/cocoapods.md
@@ -36,7 +36,7 @@ If you haven't used CocoaPods before, I recommend watching [this Route 85 video]
 Create a Podfile in the Xcode project directory with the following:
 
 ```
-platform :ios, '12.0'
+platform :ios, '11.0'
 
 target 'HelloCocoaPods' do
     pod 'Filament'

--- a/third_party/clang/iOS.cmake
+++ b/third_party/clang/iOS.cmake
@@ -15,7 +15,7 @@ set(DIST_ARCH ${IOS_ARCH})
 
 add_definitions(-DIOS)
 
-set(IOS_MIN_TARGET "12.0")
+set(IOS_MIN_TARGET "11.0")
 
 if(PLATFORM_NAME STREQUAL "iphonesimulator")
     add_definitions(-DFILAMENT_IOS_SIMULATOR)


### PR DESCRIPTION
Internal Google clients already rely on Filament supporting iOS 11 and above, this makes it "official". This also fixes one usage of a newer API.