### PR TITLE
Add simple subpass support to the Driver API.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -838,8 +838,15 @@ struct RenderPassParams {
     //! Stencil value to clear the stencil buffer with
     uint32_t clearStencil = 0;
 
-    //! reserved, must be zero
-    uint32_t reserved1 = 0;
+    /**
+     * The subpass mask specifies which color attachments are designated for read-back in the second
+     * subpass. If this is zero, the render pass has only one subpass. The least significant bit
+     * specifies that the first color attachment in the render target is a subpass input.
+     *
+     * For now only 2 subpasses are supported, so only the lower 4 bits are used, one for each color
+     * attachment (see MRT::TARGET_COUNT).
+     */
+    uint32_t subpassMask = 0;
 };
 
 struct PolygonOffset {

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -361,6 +361,8 @@ DECL_DRIVER_API_N(beginRenderPass,
 
 DECL_DRIVER_API_0(endRenderPass)
 
+DECL_DRIVER_API_0(nextSubpass)
+
 DECL_DRIVER_API_N(setRenderPrimitiveBuffer,
         backend::RenderPrimitiveHandle, rph,
         backend::VertexBufferHandle, vbh,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -758,6 +758,8 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     mContext->cullModeState.invalidate();
 }
 
+void MetalDriver::nextSubpass(int dummy) {}
+
 void MetalDriver::endRenderPass(int dummy) {
     [mContext->currentRenderPassEncoder endEncoding];
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -222,6 +222,9 @@ void NoopDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassPar
 void NoopDriver::endRenderPass(int) {
 }
 
+void NoopDriver::nextSubpass(int) {
+}
+
 void NoopDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2192,6 +2192,9 @@ void OpenGLDriver::endRenderPass(int) {
 }
 
 
+void OpenGLDriver::nextSubpass(int) {}
+
+
 void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         backend::TargetBufferFlags discardFlags) noexcept {
     assert(rt->gl.fbo_read);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -992,6 +992,9 @@ void VulkanDriver::endRenderPass(int) {
     mContext.currentRenderPass.renderPass = VK_NULL_HANDLE;
 }
 
+void VulkanDriver::nextSubpass(int) {
+}
+
 void VulkanDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
         uint32_t enabledAttributes) {


### PR DESCRIPTION
This makes two changes to the Driver API:
1. Adds the beginSubpass() method.
2. Adds subpassMask to RenderPassParams.

Locally I've proven that this PR is sufficient by making a series of Vulkan changes; sneak peek is available at commit bfef6914a7d288bbd25926c02ec93d231a8c0d07.

Note that this PR also moves the new usage flag to a different texture because I had placed it on the wrong one.

See also #2780.