### PR TITLE
Fix garbage in "Exceeded max sampler" message.

### DIFF
--- a/libs/filabridge/src/SamplerBindingMap.cpp
+++ b/libs/filabridge/src/SamplerBindingMap.cpp
@@ -71,7 +71,7 @@ void SamplerBindingMap::populate(const SamplerInterfaceBlock* perMaterialSib,
             if (sib) {
                 auto sibFields = sib->getSamplerInfoList();
                 for (auto sInfo : sibFields) {
-                    utils::slog.e << "  " << offset << " " << sInfo.name.c_str() << utils::io::endl;
+                    utils::slog.e << "  " << (int) offset << " " << sInfo.name.c_str() << utils::io::endl;
                     offset++;
                 }
             }


### PR DESCRIPTION
uint8_t is char, so it prints junk on the screen and wakes up your dog
with beeping sounds.