### PR TITLE
Introduce removeEntities API / fix leak in ModelViewer (!)

### DIFF
--- a/android/filament-android/src/main/cpp/Scene.cpp
+++ b/android/filament-android/src/main/cpp/Scene.cpp
@@ -62,6 +62,15 @@ Java_com_google_android_filament_Scene_nRemove(JNIEnv *env, jclass type, jlong n
     scene->remove((Entity&) entity);
 }
 
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Scene_nRemoveEntities(JNIEnv *env, jclass type, jlong nativeScene,
+        jintArray entities) {
+    Scene* scene = (Scene*) nativeScene;
+    Entity* nativeEntities = (Entity*) env->GetIntArrayElements(entities, nullptr);
+    scene->removeEntities(nativeEntities, env->GetArrayLength(entities));
+    env->ReleaseIntArrayElements(entities, (jint*) nativeEntities, JNI_ABORT);
+}
+
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Scene_nGetRenderableCount(JNIEnv *env, jclass type,
         jlong nativeScene) {

--- a/android/filament-android/src/main/java/com/google/android/filament/Scene.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Scene.java
@@ -133,6 +133,18 @@ public class Scene {
     }
 
     /**
+     * Removes a list of entities from the <code>Scene</code>.
+     *
+     * This is equivalent to calling remove in a loop.
+     * If any of the specified entities do not exist in the scene, they are skipped.
+     *
+     * @param entities array containing entities to remove from the <code>Scene</code>.
+     */
+    public void removeEntities(@Entity int[] entities) {
+        nRemoveEntities(getNativeObject(), entities);
+    }
+
+    /**
      * Returns the number of {@link RenderableManager} components in the <code>Scene</code>.
      *
      * @return number of {@link RenderableManager} components in the <code>Scene</code>..
@@ -166,6 +178,7 @@ public class Scene {
     private static native void nAddEntity(long nativeScene, int entity);
     private static native void nAddEntities(long nativeScene, int[] entities);
     private static native void nRemove(long nativeScene, int entity);
+    private static native void nRemoveEntities(long nativeScene, int[] entities);
     private static native int nGetRenderableCount(long nativeScene);
     private static native int nGetLightCount(long nativeScene);
 }

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -218,6 +218,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
      */
     fun destroyModel() {
         asset?.let { asset ->
+            this.scene.removeEntities(asset.entities)
             assetLoader.destroyAsset(asset)
             this.asset = null
             this.animator = null

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -96,7 +96,7 @@ public:
     void addEntity(utils::Entity entity);
 
     /**
-     * Adds a contiguous list of entities to the Scene.
+     * Adds a list of entities to the Scene.
      *
      * @param entities Array containing entities to add to the scene.
      * @param count Size of the entity array.
@@ -110,6 +110,17 @@ public:
      *                   \p entity doesn't exist, this call is ignored.
      */
     void remove(utils::Entity entity);
+
+    /**
+     * Removes a list of entities to the Scene.
+     *
+     * This is equivalent to calling remove in a loop.
+     * If any of the specified entities do not exist in the scene, they are skipped.
+     *
+     * @param entities Array containing entities to remove from the scene.
+     * @param count Size of the entity array.
+     */
+    void removeEntities(const utils::Entity* entities, size_t count);
 
     /**
      * Returns the number of Renderable objects in the Scene.

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -364,6 +364,12 @@ void FScene::remove(Entity entity) {
     mEntities.erase(entity);
 }
 
+void FScene::removeEntities(const Entity* entities, size_t count) {
+    for (size_t i = 0; i < count; ++i, ++entities) {
+        remove(*entities);
+    }
+}
+
 size_t FScene::getRenderableCount() const noexcept {
     FEngine& engine = mEngine;
     EntityManager& em = engine.getEntityManager();
@@ -444,6 +450,10 @@ void Scene::addEntities(const Entity* entities, size_t count) {
 
 void Scene::remove(Entity entity) {
     upcast(this)->remove(entity);
+}
+
+void Scene::removeEntities(const Entity* entities, size_t count) {
+    upcast(this)->removeEntities(entities, count);
 }
 
 size_t Scene::getRenderableCount() const noexcept {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -64,6 +64,7 @@ public:
     void addEntity(utils::Entity entity);
     void addEntities(const utils::Entity* entities, size_t count);
     void remove(utils::Entity entity);
+    void removeEntities(const utils::Entity* entities, size_t count);
 
     size_t getRenderableCount() const noexcept;
     size_t getLightCount() const noexcept;

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -111,6 +111,7 @@ struct AssetConfiguration {
  *      }
  * } while (!quit);
  *
+ * scene->removeEntities(asset->getEntities(), asset->getEntityCount());
  * loader->destroyAsset(asset);
  * materials->destroyMaterials();
  * delete materials;

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -305,11 +305,7 @@ void SimpleViewer::populateScene(FilamentAsset* asset, bool scale,
 
 void SimpleViewer::removeAsset() {
     if (mAsset) {
-        const auto *const begin = mAsset->getEntities();
-        const auto *const end = begin + mAsset->getEntityCount();
-        for (const auto *entity = begin; entity != end; ++entity) {
-            mScene->remove(*entity);
-        }
+        mScene->removeEntities(mAsset->getEntities(), mAsset->getEntityCount());
     }
     mAsset = nullptr;
     mAnimator = nullptr;

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -164,6 +164,17 @@ Filament.loadClassExtensions = function() {
         this._addEntities(vector);
     };
 
+    /// removeEntities ::method::
+    /// entities ::argument:: array of entities
+    /// This method is equivalent to calling `remove` on each item in the array.
+    Filament.Scene.prototype.removeEntities = function(entities) {
+        const vector = new Filament.EntityVector();
+        for (const entity of entities) {
+            vector.push_back(entity);
+        }
+        this._removeEntities(vector);
+    };
+
     /// setClearOptions ::method::
     /// overrides ::argument:: Dictionary with one or more of the following properties: \
     /// clearColor, clear, discard.

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -384,6 +384,7 @@ export class Scene {
     public getLightCount(): number;
     public getRenderableCount(): number;
     public remove(entity: Entity): void;
+    public removeEntities(entities: Entity[]): void;
     public setIndirectLight(ibl: IndirectLight|null): void;
     public setSkybox(sky: Skybox|null): void;
 }

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -559,6 +559,10 @@ class_<Scene>("Scene")
         self->addEntities(entities.data(), entities.size());
     }), allow_raw_pointers())
 
+    .function("_removeEntities", EMBIND_LAMBDA(void, (Scene* self, EntityVector entities), {
+        self->removeEntities(entities.data(), entities.size());
+    }), allow_raw_pointers())
+
     .function("hasEntity", &Scene::hasEntity)
     .function("remove", &Scene::remove)
     .function("setSkybox", &Scene::setSkybox, allow_raw_pointers())


### PR DESCRIPTION
For testing purposes, sample-gltf-viewer reloads the model when the
user double-taps the screen. This operation was causing a buildup of
blank entities in the Scene, because we were merely destroying the
components, not removing them from the Scene.