### PR TITLE
DoF: fix tiles dilate pass edges

### DIFF
--- a/filament/src/materials/dofDilate.mat
+++ b/filament/src/materials/dofDilate.mat
@@ -30,8 +30,8 @@ void dummy(){}
 // Tiles of 16 pixels requires two dilate rounds to accomodate our max Coc of 32 pixels
 #define TILE_SIZE   16.0
 
-vec2 tap(const ivec2 uv, const ivec2 offset) {
-    return texelFetch(materialParams_tiles, uv + offset, 0).rg;
+vec2 tap(const vec2 uv, const vec2 offset) {
+    return textureLod(materialParams_tiles, uv + offset, 0.0).rg;
 }
 
 vec2 dilate(inout vec2 center, const vec2 tap) {
@@ -54,26 +54,32 @@ vec2 dilate(inout vec2 center, const vec2 tap) {
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
-    // highp is not needed here, because we now the resolution is very low
+    const float radius = 1.0;
+    // we need highp here just to maintain precision of 1/x
+    highp vec2 size = vec2(textureSize(materialParams_tiles, 0));
+    highp vec2 isize = 1.0 / size;
+
+    vec2 radii = float(radius) * isize;
+
     vec2 uv = variable_vertex.xy;
-    vec2 size = vec2(textureSize(materialParams_tiles, 0));
-    ivec2 xy = ivec2(uv * size);
 
-    vec2 center = tap(xy, ivec2(0, 0));
+    // center
+    vec2 center = tap(uv, vec2(0, 0));
 
-    const int radius = 1;
-
-    for (int j=-radius; j<=radius; j++) {
-        dilate(center, tap(xy, ivec2(-radius, j)));
-        dilate(center, tap(xy, ivec2( radius, j)));
+    // horizontal sides
+    for (float j = -radius ; j <= radius ; j += 1.0) {
+        float y = j * isize.y;
+        dilate(center, tap(uv, vec2(-radii.x, y)));
+        dilate(center, tap(uv, vec2( radii.x, y)));
     }
 
-    for (int i=-radius+1; i<=radius-1; i++) {
-        dilate(center, tap(xy, ivec2(i, -radius)));
-        dilate(center, tap(xy, ivec2(i,  radius)));
+    // vertical sides
+    for (float i = -radius + 1.0 ; i <= radius - 1.0 ; i += 1.0) {
+        float x = i * isize.x;
+        dilate(center, tap(uv, vec2(x, -radii.y)));
+        dilate(center, tap(uv, vec2(x,  radii.y)));
     }
 
     postProcess.color.rg = center;
 }
-
 }


### PR DESCRIPTION
We were using texelFetch which doesn't handle wrap modes, and this
resulted in all edge tiles to be undefined. Use textureLod() instead.