### PR TITLE
Fix Hierarchy Corruption

### DIFF
--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -199,6 +199,7 @@ void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
 
     manager[i].parent = parent;
     manager[i].prev = 0;
+    manager[i].next = 0;
     if (parent) {
         // we insert ourselves first in the parent's list
         Instance next = manager[parent].firstChild;


### PR DESCRIPTION
When a node is set to have no parent, its .next is not updated. The result is that later operations, such as removing this node from the graph result in what was previously its next sibling node being corrupted.

Note that this failure is masked in debug builds because removeNode sets parent/prev/next to 0 in those cases.