### PR TITLE
gltfio: fix depth writes for transmissive materials.

### DIFF
--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -389,6 +389,7 @@ Material* createMaterial(Engine* engine, const MaterialKey& config, const UvMap&
         }
 
         builder.blending(MaterialBuilder::BlendingMode::TRANSPARENT);
+        builder.depthWrite(true);
 
     } else {
 


### PR DESCRIPTION
This fixes the depth fighting in the column of red spheres in the test
model while in filamat mode. Thanks Romain for catching this.

It also makes filamat mode more consistent with ubershader mode.

before / after screenshots

![before](https://user-images.githubusercontent.com/1288904/88841006-2edeb880-d192-11ea-95d0-40baa786090a.png)
![after](https://user-images.githubusercontent.com/1288904/88841012-300fe580-d192-11ea-8f03-90dc1bae60d2.png)
