### PR TITLE
Two fixes for MASKED blending mode.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release
 
+- MASKED mode now leaves destination alpha intact (useful for transparent targets).
+
 ## v1.8.1
 
 - New CocoaPods sample for iOS.

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -183,11 +183,17 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     using DepthFunc = RasterState::DepthFunc;
     switch (mBlendingMode) {
         case BlendingMode::OPAQUE:
-        case BlendingMode::MASKED:
             mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
             mRasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
             mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
             mRasterState.blendFunctionDstAlpha = BlendFunction::ZERO;
+            mRasterState.depthWrite = true;
+            break;
+        case BlendingMode::MASKED:
+            mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
+            mRasterState.blendFunctionSrcAlpha = BlendFunction::ZERO;
+            mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
+            mRasterState.blendFunctionDstAlpha = BlendFunction::ONE;
             mRasterState.depthWrite = true;
             break;
         case BlendingMode::TRANSPARENT:

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -6,6 +6,13 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #endif
 }
 
+#if defined(BLEND_MODE_MASKED)
+float computeMaskedAlpha(float a) {
+    // Use derivatives to smooth alpha tested edges
+    return (a - getMaskThreshold()) / max(fwidth(a), 1e-3) + 0.5;
+}
+#endif
+
 /**
  * Evaluates unlit materials. In this lighting model, only the base color and
  * emissive properties are taken into account:
@@ -24,7 +31,8 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     vec4 color = material.baseColor;
 
 #if defined(BLEND_MODE_MASKED)
-    if (color.a < getMaskThreshold()) {
+    color.a = computeMaskedAlpha(color.a);
+    if (color.a <= 0.0) {
         discard;
     }
 #endif


### PR DESCRIPTION
- Do not mutate alpha in the render target (useful for transparent render targets).
- Make non-lit behavior consistent with lit.
