### PR TITLE
 Run MergeReturnPass only on mobile

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -384,9 +384,14 @@ void GLSLPostProcessor::optimizeSpirv(OptimizerPtr optimizer, SpirvBlob& spirv) 
 void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config const& config) {
     optimizer
             .RegisterPass(CreateWrapOpKillPass())
-            .RegisterPass(CreateDeadBranchElimPass())
-            // this triggers a segfault with AMD drivers on MacOS
-            //.RegisterPass(CreateMergeReturnPass())
+            .RegisterPass(CreateDeadBranchElimPass());
+
+    if (config.shaderModel != filament::backend::ShaderModel::GL_CORE_41) {
+        // this triggers a segfault with AMD drivers on MacOS
+        optimizer.RegisterPass(CreateMergeReturnPass());
+    }
+
+    optimizer
             .RegisterPass(CreateInlineExhaustivePass())
             .RegisterPass(CreateAggressiveDCEPass())
             .RegisterPass(CreatePrivateToLocalPass())
@@ -423,9 +428,14 @@ void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config c
 void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer, Config const& config) {
     optimizer
             .RegisterPass(CreateWrapOpKillPass())
-            .RegisterPass(CreateDeadBranchElimPass())
-            // this triggers a segfault with AMD drivers on MacOS
-            //.RegisterPass(CreateMergeReturnPass())
+            .RegisterPass(CreateDeadBranchElimPass());
+
+    if (config.shaderModel != filament::backend::ShaderModel::GL_CORE_41) {
+        // this triggers a segfault with AMD drivers on MacOS
+        optimizer.RegisterPass(CreateMergeReturnPass());
+    }
+
+    optimizer
             .RegisterPass(CreateInlineExhaustivePass())
             .RegisterPass(CreateEliminateDeadFunctionsPass())
             .RegisterPass(CreatePrivateToLocalPass())

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -28,6 +28,8 @@
 
 #include <spirv-tools/optimizer.hpp>
 
+#include <memory>
+
 namespace filamat {
 
 using SpirvBlob = std::vector<uint32_t>;
@@ -64,8 +66,18 @@ private:
     void preprocessOptimization(glslang::TShader& tShader,
             GLSLPostProcessor::Config const& config) const;
 
-    void registerSizePasses(spvtools::Optimizer& optimizer) const;
-    void registerPerformancePasses(spvtools::Optimizer& optimizer) const;
+    /**
+     * Retrieve an optimizer instance tuned for the given optimization level and shader configuration.
+     */
+    using OptimizerPtr = std::shared_ptr<spvtools::Optimizer>;
+    static OptimizerPtr createOptimizer(
+            MaterialBuilder::Optimization optimization,
+            Config const& config);
+
+    static void registerSizePasses(spvtools::Optimizer& optimizer, Config const& config);
+    static void registerPerformancePasses(spvtools::Optimizer& optimizer, Config const& config);
+
+    void optimizeSpirv(OptimizerPtr optimizer, SpirvBlob& spirv) const;
 
     const MaterialBuilder::Optimization mOptimization;
     const bool mPrintShaders;


### PR DESCRIPTION
If we don't run the MergeReturnPass, we see a bunch of warnings:

```
warning: :0:0:0: The function '%114 = OpFunction %18 None %106' could not be inlined because the return instruction is not at the end of the function. This could be fixed by running merge-return before inlining.
```

We still can't run the MergeReturnPass on desktop, due to an AMD driver crash. But we can at least run it on mobile.