### PR TITLE
Fix variant-limiting bug in matdbg

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -479,9 +479,9 @@ void FMaterial::onEditCallback(void* userdata, const utils::CString& name, const
             packageSize);
 }
 
-void FMaterial::onQueryCallback(void* userdata, uint16_t* pvariants) {
+void FMaterial::onQueryCallback(void* userdata, uint64_t* pvariants) {
     FMaterial* material = upcast((Material*) userdata);
-    uint16_t variants = 0;
+    uint64_t variants = 0;
     auto& cachedPrograms = material->mCachedPrograms;
     for (size_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
         if (cachedPrograms[i]) {

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -149,7 +149,7 @@ public:
             size_t packageSize);
 
     /** Queries the program cache to check which variants are resident. */
-    static void onQueryCallback(void* userdata, uint16_t* variants);
+    static void onQueryCallback(void* userdata, uint64_t* variants);
 
     /** @}*/
 

--- a/libs/matdbg/include/matdbg/DebugServer.h
+++ b/libs/matdbg/include/matdbg/DebugServer.h
@@ -47,7 +47,7 @@ public:
             void* userdata = nullptr);
 
     using EditCallback = void(*)(void* userdata, const utils::CString& name, const void*, size_t);
-    using QueryCallback = void(*)(void* userdata, uint16_t* variants);
+    using QueryCallback = void(*)(void* userdata, uint64_t* variants);
 
     /**
      * Sets up a callback that allows the Filament engine to listen for shader edits. The callback
@@ -72,7 +72,7 @@ private:
         size_t packageSize;
         utils::CString name;
         MaterialKey key;
-        uint16_t activeVariants;
+        uint64_t activeVariants;
     };
 
     const MaterialRecord* getRecord(const MaterialKey& key) const;

--- a/libs/matdbg/include/matdbg/JsonWriter.h
+++ b/libs/matdbg/include/matdbg/JsonWriter.h
@@ -45,7 +45,7 @@ public:
     // shader index is an active variant. Each bit in the activeVariants bitmask
     // represents one of the possible variant combinations.
     bool writeActiveInfo(const filaflat::ChunkContainer& package, backend::Backend backend,
-            uint16_t activeVariants);
+            uint64_t activeVariants);
 
 private:
     utils::CString mJsonString;

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -471,7 +471,7 @@ const DebugServer::MaterialRecord* DebugServer::getRecord(const MaterialKey& key
 void DebugServer::updateActiveVariants() {
     if (mQueryCallback) {
         for (auto& pair : mMaterialRecords) {
-            uint16_t& result = mMaterialRecords[pair.first].activeVariants;
+            uint64_t& result = mMaterialRecords[pair.first].activeVariants;
             mQueryCallback(pair.second.userdata, &result);
         }
     }

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -228,7 +228,7 @@ size_t JsonWriter::getJsonSize() const {
 }
 
 bool JsonWriter::writeActiveInfo(const filaflat::ChunkContainer& package,
-        Backend backend, uint16_t activeVariants) {
+        Backend backend, uint64_t activeVariants) {
     vector<ShaderInfo> shaders;
     ostringstream json;
     json << "[\"";


### PR DESCRIPTION
Noticed this when trying to edit depth shaders. `VARIANT_COUNT` is now 64, so we need a 64 bit int to hold a mask of active variants.