### PR TITLE
fix a moveResource which was broken recently

### DIFF
--- a/filament/src/fg/fg/PassNode.cpp
+++ b/filament/src/fg/fg/PassNode.cpp
@@ -114,7 +114,7 @@ FrameGraphHandle PassNode::write(FrameGraph& fg, const FrameGraphHandle& handle)
     // record the write
     auto& newNode = fg.getResourceNodeUnchecked(r);
     assert(!newNode.writerIndex.isValid());
-    newNode.writerIndex = r; // needed by move resources
+    newNode.writerIndex = FrameGraphHandle(this->id); // needed by move resources
 
     writes.push_back(r);
     return r;

--- a/filament/src/fg/fg/PassNode.h
+++ b/filament/src/fg/fg/PassNode.h
@@ -49,7 +49,7 @@ struct PassNode {
 
     // constants
     const char* const name = nullptr;                       // our name
-    const uint32_t id = 0;                                  // a unique id (only for debugging)
+    const uint32_t id = 0;                                  // index in the mPassNodes (for debugging and moveResource)
     FrameGraph::UniquePtr<FrameGraphPassExecutor> base;     // type eraser for calling execute()
 
     // set by the builder

--- a/filament/src/fg/fg/ResourceNode.h
+++ b/filament/src/fg/fg/ResourceNode.h
@@ -34,6 +34,8 @@ struct ResourceNode { // 24
     ResourceNode(ResourceNode&&) noexcept = default;
     ResourceNode& operator=(ResourceNode const&) = delete;
 
+    // we use a FrameGraphHandle to store an index, because conveniently is 'invalid' when
+    // default initialized (and doesn't use 0 as the invalid state).
     FrameGraphHandle writerIndex;   // only needed by moveResource
 
     // updated during compile()


### PR DESCRIPTION
a recent fix actually badly broke moveResource, we were using the
index of the newly created resource instead of the pass index.