### PR TITLE
JavaScript bindings: fix a frequent 4-byte memory leak.

### DIFF
--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -126,6 +126,7 @@ export interface View$VignetteOptions {
 // TODO: Remove the entity type and just use integers for parity with Filament's Java bindings.
 export class Entity {
     public getId(): number;
+    public delete(): void;
 }
 
 export class Skybox {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -107,7 +107,7 @@ namespace em = emscripten;
         function(name, EMBIND_LAMBDA(btype*, arglist, impl), allow_raw_pointers())
 
 // Explicit instantiation of emscripten::internal::raw_destructor is required for binding classes
-// that have non-public destructors.
+// that have non-public destructors. To prevent leaks, do not include pass-by-value types here.
 #define BIND(T) template<> void raw_destructor<T>(T* ptr) {}
 namespace emscripten {
     namespace internal {
@@ -131,17 +131,9 @@ namespace emscripten {
         BIND(SwapChain)
         BIND(Texture)
         BIND(TransformManager)
-        BIND(utils::Entity)
         BIND(utils::EntityManager)
         BIND(VertexBuffer)
         BIND(View)
-
-        // Permit use of Texture* inside emscripten::value_object.
-        template<> struct TypeID<Texture*> {
-            static constexpr TYPEID get() {
-                return LightTypeID<Texture>::get();
-            }
-        };
     }
 }
 #undef BIND
@@ -1284,6 +1276,7 @@ class_<SkyBuilder>("Skybox$Builder")
 /// This would also be more consistent with Filament's Java bindings.
 class_<utils::Entity>("Entity")
     .function("getId", &utils::Entity::getId);
+    /// delete ::method:: Frees an entity.
 
 /// EntityManager ::core class:: Singleton used for constructing entities in Filament's ECS.
 class_<utils::EntityManager>("EntityManager")

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -71,6 +71,7 @@ class App {
 
         this.allowRefresh = false;
         const asset = this.asset = loader.createAssetFromJson(mesh_url);
+        this.assetRoot = this.asset.getRoot();
 
         const messages = document.getElementById('messages');
 
@@ -135,7 +136,7 @@ class App {
     render() {
         // Spin the model according to the trackball controller.
         const tcm = this.engine.getTransformManager();
-        const inst = tcm.getInstance(this.asset.getRoot());
+        const inst = tcm.getInstance(this.assetRoot);
         tcm.setTransform(inst, this.trackball.getMatrix());
         inst.delete();
 
@@ -147,7 +148,9 @@ class App {
         }
         while (popRenderable()) {
             this.scene.addEntity(entity);
+            entity.delete();
         }
+        entity.delete();
 
         // Render the scene and request the next animation frame.
         this.renderer.render(this.swapChain, this.view);


### PR DESCRIPTION
In retrospect, I should've exposed ints to JS instead of entities.
Making this fix is already a TODO, but it will be a tedious change. For
now, this PR fixes two issues that were causing tiny but frequent memory
leaks, according to the emscripten memory leak widget.

(1) Do not include Entity in the list of classes that should only be
passed around by pointer.

(2) Clients should always call delete() on returned Entities.