### PR TITLE
gltfio: fix some small memory leaks.

### DIFF
--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -40,11 +40,18 @@ FFilamentAsset::~FFilamentAsset() {
 
     delete mAnimator;
     delete mWireframe;
+
     mEngine->destroy(mRoot);
+    mEntityManager->destroy(mRoot);
+
     for (auto entity : mEntities) {
-        // Destroys the entity's renderable, light, transform, and camera components.
+        // Destroy the entity's renderable, light, transform, and camera components.
         mEngine->destroy(entity);
-        // Destroys the actual entity.
+        // Destroy the name component.
+        if (mNameManager) {
+            mNameManager->removeComponent(entity);
+        }
+        // Destroy the actual entity.
         mEntityManager->destroy(entity);
     }
     for (auto mi : mMaterialInstances) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -775,6 +775,7 @@ int main(int argc, char** argv) {
         engine->destroy(app.scene.groundVertexBuffer);
         engine->destroy(app.scene.groundIndexBuffer);
         engine->destroy(app.scene.groundMaterial);
+        engine->destroy(app.colorGrading);
 
         delete app.viewer;
         delete app.materials;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1284,6 +1284,13 @@ class_<utils::EntityManager>("EntityManager")
     /// ::retval:: the one and only entity manager
     .class_function("get", (utils::EntityManager* (*)()) []
         { return &utils::EntityManager::get(); }, allow_raw_pointers())
+
+#if FILAMENT_UTILS_TRACK_ENTITIES
+    .function("getActiveEntityCount", EMBIND_LAMBDA(size_t, (utils::EntityManager* self), {
+        return self->getActiveEntities().size();
+    }), allow_raw_pointers())
+#endif
+
     /// create ::method::
     /// ::retval:: an [Entity] without any components
     .function("create", select_overload<utils::Entity()>(&utils::EntityManager::create))


### PR DESCRIPTION
This fixes two oversights in the FilamentAsset destructor:

- Destroy the faux root Entity.
- If it exists, remove the name component from each Entity.