### PR TITLE
Vulkan: allow blit to default render target.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -495,8 +495,10 @@ void waitForIdle(VulkanContext& context) {
     }
 
     // Flush the work command buffer and wait for it to finish.
-    flushWorkCommandBuffer(context);
-    acquireWorkCommandBuffer(context);
+    if (!context.work.fence->submitted) {
+        flushWorkCommandBuffer(context);
+        acquireWorkCommandBuffer(context);
+    }
 
     // Wait for submitted command buffer(s) to finish.
     if (context.currentSurface) {

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -617,12 +617,8 @@ void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
             destinationStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
             break;
         case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
-            barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-            sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-            destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-            break;
         case VK_IMAGE_LAYOUT_GENERAL:
+        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
             barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
             sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;


### PR DESCRIPTION
This fixes a null pointer exception that we saw after disabling several
View -process effects.