### PR TITLE
API CHANGE: make ssao options work like all other options

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - MASKED mode now leaves destination alpha intact (useful for transparent targets).
 - Fixed several memory leaks in gltfio and the JavaScript bindings.
 - Added texture getters to Skybox and IndirectLight (C++, Java, JavaScript).
+- `View.setAmbientOcclusion()` is deprecated in favor of `View.setAmbientOcclusionOptions` (⚠️ **API change**)
 
 ## v1.8.1
 

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -178,19 +178,25 @@ Java_com_google_android_filament_View_nIsFrontFaceWindingInverted(JNIEnv*,
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetAmbientOcclusion(JNIEnv*, jclass, jlong nativeView, jint ordinal) {
     View* view = (View*) nativeView;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     view->setAmbientOcclusion((View::AmbientOcclusion) ordinal);
+#pragma clang diagnostic pop
 }
 
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_View_nGetAmbientOcclusion(JNIEnv*, jclass, jlong nativeView) {
     View* view = (View*) nativeView;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return (jint)view->getAmbientOcclusion();
+#pragma clang diagnostic pop
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclass,
     jlong nativeView, jfloat radius, jfloat bias, jfloat power, jfloat resolution, jfloat intensity,
-    jint quality, jint upsampling) {
+    jint quality, jint upsampling, jboolean enabled) {
     View* view = (View*) nativeView;
     View::AmbientOcclusionOptions options = {
             .radius = radius,
@@ -199,7 +205,8 @@ Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclas
             .resolution = resolution,
             .intensity = intensity,
             .quality = (View::QualityLevel)quality,
-            .upsampling = (View::QualityLevel)upsampling
+            .upsampling = (View::QualityLevel)upsampling,
+            .enabled = (bool)enabled
     };
     view->setAmbientOcclusionOptions(options);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -139,8 +139,7 @@ public class View {
     }
 
     /**
-     * Options for Ambient Occlusion
-     * @see #setAmbientOcclusion
+     * Options for screen space Ambient Occlusion
      */
     public static class AmbientOcclusionOptions {
         /**
@@ -184,6 +183,11 @@ public class View {
          */
         @NonNull
         public QualityLevel upsampling = QualityLevel.LOW;
+
+        /**
+         * enable or disable screen space ambient occlusion
+         */
+        public boolean enabled = false;
     }
 
     /**
@@ -420,9 +424,10 @@ public class View {
 
     /**
      * List of available ambient occlusion techniques.
-     *
+     * @deprecated use setAmbientOcclusionOptions instead
      * @see #setAmbientOcclusion
-    */
+     */
+    @Deprecated
     public enum AmbientOcclusion {
         NONE,
         SSAO
@@ -1017,18 +1022,20 @@ public class View {
 
     /**
      * Activates or deactivates ambient occlusion.
-     *
+     * @see #setAmbientOcclusionOptions
      * @param ao Type of ambient occlusion to use.
      */
+    @Deprecated
     public void setAmbientOcclusion(@NonNull AmbientOcclusion ao) {
         nSetAmbientOcclusion(getNativeObject(), ao.ordinal());
     }
 
     /**
      * Queries the type of ambient occlusion active for this View.
-     *
+     * @see #getAmbientOcclusionOptions
      * @return ambient occlusion type.
      */
+    @Deprecated
     @NonNull
     public AmbientOcclusion getAmbientOcclusion() {
         return AmbientOcclusion.values()[nGetAmbientOcclusion(getNativeObject())];
@@ -1042,7 +1049,8 @@ public class View {
     public void setAmbientOcclusionOptions(@NonNull AmbientOcclusionOptions options) {
         mAmbientOcclusionOptions = options;
         nSetAmbientOcclusionOptions(getNativeObject(), options.radius, options.bias, options.power,
-                options.resolution, options.intensity, options.quality.ordinal(), options.upsampling.ordinal());
+                options.resolution, options.intensity, options.quality.ordinal(), options.upsampling.ordinal(),
+                options.enabled);
     }
 
     /**
@@ -1206,7 +1214,7 @@ public class View {
     private static native boolean nIsFrontFaceWindingInverted(long nativeView);
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
-    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int upsampling);
+    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int upsampling, boolean enabled);
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -23,7 +23,6 @@ import android.view.Choreographer
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.SurfaceView
-import com.google.android.filament.View
 import com.google.android.filament.utils.KtxLoader
 import com.google.android.filament.utils.ModelViewer
 import com.google.android.filament.utils.Utils
@@ -62,16 +61,17 @@ class MainActivity : Activity() {
         createRenderables()
         createIndirectLight()
 
-        // enable dynamic resolution
-        val options = modelViewer.view.dynamicResolutionOptions
-        options.enabled = true
-        modelViewer.view.dynamicResolutionOptions = options
+        val dynamicResolutionOptions = modelViewer.view.dynamicResolutionOptions
+        dynamicResolutionOptions.enabled = true
+        modelViewer.view.dynamicResolutionOptions = dynamicResolutionOptions
 
-        modelViewer.view.ambientOcclusion = View.AmbientOcclusion.SSAO
+        val ssaoOptions = modelViewer.view.ambientOcclusionOptions
+        ssaoOptions.enabled = true
+        modelViewer.view.ambientOcclusionOptions = ssaoOptions
 
-        val bloom = modelViewer.view.bloomOptions
-        bloom.enabled = true
-        modelViewer.view.bloomOptions = bloom
+        val bloomOptions = modelViewer.view.bloomOptions
+        bloomOptions.enabled = true
+        modelViewer.view.bloomOptions = bloomOptions
     }
 
     private fun createRenderables() {

--- a/android/samples/sample-image-based-lighting/src/main/java/com/google/android/filament/ibl/MainActivity.kt
+++ b/android/samples/sample-image-based-lighting/src/main/java/com/google/android/filament/ibl/MainActivity.kt
@@ -117,7 +117,9 @@ class MainActivity : Activity() {
     }
 
     private fun setupView() {
-        view.ambientOcclusion = View.AmbientOcclusion.SSAO
+        val ssaoOptions = view.ambientOcclusionOptions
+        ssaoOptions.enabled = true
+        view.ambientOcclusionOptions = ssaoOptions
 
         // NOTE: Try to disable post-processing (tone-mapping, etc.) to see the difference
         // view.isPostProcessingEnabled = false

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -206,7 +206,7 @@ public:
     };
 
     /**
-     * Options for Ambient Occlusion
+     * Options for screen space Ambient Occlusion (SSAO)
      * @see setAmbientOcclusion()
      */
     struct AmbientOcclusionOptions {
@@ -217,6 +217,7 @@ public:
         float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
         QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
         QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality.
+        bool enabled = false;    //!< enables or disables screen-space ambient occlusion
     };
 
     /**
@@ -227,14 +228,6 @@ public:
         float filterWidth = 1.0f;   //!< reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
         float feedback = 0.04f;     //!< history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
         bool enabled = false;       //!< enables or disables temporal anti-aliasing
-    };
-
-    /**
-     * List of available ambient occlusion techniques
-    */
-    enum class AmbientOcclusion : uint8_t {
-        NONE = 0,       //!< No Ambient Occlusion
-        SSAO = 1        //!< Basic, sampling SSAO
     };
 
     /**
@@ -253,30 +246,6 @@ public:
         NONE = 0,       //!< No dithering
         TEMPORAL = 1    //!< Temporal dithering (default)
     };
-
-    /**
-     * List of available tone-mapping operators
-     *
-     * @deprecated See ColorGrading
-     */
-    enum class UTILS_DEPRECATED ToneMapping : uint8_t {
-        LINEAR = 0,     //!< Linear tone mapping (i.e. no tone mapping)
-        ACES = 1,       //!< ACES tone mapping
-    };
-
-    /**
-     * Activates or deactivates ambient occlusion.
-     *
-     * @param ambientOcclusion Type of ambient occlusion to use.
-     */
-    void setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept;
-
-    /**
-     * Queries the type of ambient occlusion active for this View.
-     *
-     * @return ambient occlusion type.
-     */
-    AmbientOcclusion getAmbientOcclusion() const noexcept;
 
     /**
      * Sets ambient occlusion options.
@@ -515,27 +484,6 @@ public:
     TemporalAntiAliasingOptions const& getTemporalAntiAliasingOptions() const noexcept;
 
     /**
-     * Enables or disables tone-mapping in the post-processing stage. Enabled by default.
-     *
-     * @param type Tone-mapping function.
-     *
-     * @deprecated Use setColorGrading instead
-     * @see setColorGrading
-     */
-    UTILS_DEPRECATED
-    void setToneMapping(ToneMapping type) noexcept;
-
-    /**
-     * Returns the tone-mapping function.
-     * @return tone-mapping function.
-     *
-     * @deprecated Use getColorGrading instead
-     * @see getColorGrading
-     */
-    UTILS_DEPRECATED
-    ToneMapping getToneMapping() const noexcept;
-
-    /**
      * Sets this View's color grading transforms.
      *
      * @param colorGrading Associate the specified ColorGrading to this View. A ColorGrading can be
@@ -735,6 +683,67 @@ public:
 
     //! debugging: returns a Camera from the point of view of *the* dominant directional light used for shadowing.
     Camera const* getDirectionalLightCamera() const noexcept;
+
+
+    /**
+     * List of available tone-mapping operators
+     *
+     * @deprecated See ColorGrading
+     */
+    enum class UTILS_DEPRECATED ToneMapping : uint8_t {
+        LINEAR = 0,     //!< Linear tone mapping (i.e. no tone mapping)
+        ACES = 1,       //!< ACES tone mapping
+    };
+
+    /**
+     * List of available ambient occlusion techniques
+     * @deprecated use AmbientOcclusionOptions::enabled instead
+     */
+    enum class UTILS_DEPRECATED AmbientOcclusion : uint8_t {
+        NONE = 0,       //!< No Ambient Occlusion
+        SSAO = 1        //!< Basic, sampling SSAO
+    };
+
+    /**
+      * Enables or disables tone-mapping in the post-processing stage. Enabled by default.
+      *
+      * @param type Tone-mapping function.
+      *
+      * @deprecated Use setColorGrading instead
+      * @see setColorGrading
+      */
+    UTILS_DEPRECATED
+    void setToneMapping(ToneMapping type) noexcept;
+
+    /**
+     * Returns the tone-mapping function.
+     * @return tone-mapping function.
+     *
+     * @deprecated Use getColorGrading instead
+     * @see getColorGrading
+     */
+    UTILS_DEPRECATED
+    ToneMapping getToneMapping() const noexcept;
+
+    /**
+     * Activates or deactivates ambient occlusion.
+     * @deprecated use setAmbientOcclusionOptions() instead
+     * @see setAmbientOcclusionOptions
+     *
+     * @param ambientOcclusion Type of ambient occlusion to use.
+     */
+    UTILS_DEPRECATED
+    void setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept;
+
+    /**
+     * Queries the type of ambient occlusion active for this View.
+     * @deprecated use getAmbientOcclusionOptions() instead
+     * @see getAmbientOcclusionOptions
+     *
+     * @return ambient occlusion type.
+     */
+    UTILS_DEPRECATED
+    AmbientOcclusion getAmbientOcclusion() const noexcept;
 };
 
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -377,7 +377,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // --------------------------------------------------------------------------------------------
     // SSAO pass
 
-    const bool useSSAO = view.getAmbientOcclusion() != View::AmbientOcclusion::NONE;
+    const bool useSSAO = aoOptions.enabled;
     if (useSSAO) {
         // we could rely on FrameGraph culling, but this creates unnecessary CPU work
         ppm.screenSpaceAmbientOclusion(fg, pass, svp, cameraInfo, aoOptions);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -640,11 +640,11 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
 
     // LINEAR filtering is only needed when AO is enabled and low-quality upsampling is used.
     mPerViewSb.setSampler(PerViewSib::SSAO, ssao, {
-            .filterMag = mAmbientOcclusion != AmbientOcclusion::NONE && !highQualitySampling ?
+            .filterMag = mAmbientOcclusionOptions.enabled && !highQualitySampling ?
                          SamplerMagFilter::LINEAR : SamplerMagFilter::NEAREST
     });
     mPerViewUb.setUniform(offsetof(PerViewUib, aoSamplingQuality),
-            mAmbientOcclusion != AmbientOcclusion::NONE && highQualitySampling ? 1.0f : 0.0f);
+            mAmbientOcclusionOptions.enabled && highQualitySampling ? 1.0f : 0.0f);
 }
 
 void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -273,11 +273,11 @@ public:
     }
 
     void setAmbientOcclusion(AmbientOcclusion ambientOcclusion) noexcept {
-        mAmbientOcclusion = ambientOcclusion;
+        mAmbientOcclusionOptions.enabled = ambientOcclusion == AmbientOcclusion::SSAO;
     }
 
     AmbientOcclusion getAmbientOcclusion() const noexcept {
-        return mAmbientOcclusion;
+        return mAmbientOcclusionOptions.enabled ? AmbientOcclusion::SSAO : AmbientOcclusion::NONE;
     }
 
     void setAmbientOcclusionOptions(AmbientOcclusionOptions options) noexcept {
@@ -447,7 +447,6 @@ private:
     Dithering mDithering = Dithering::TEMPORAL;
     bool mShadowingEnabled = true;
     bool mHasPostProcessPass = true;
-    AmbientOcclusion mAmbientOcclusion = AmbientOcclusion::NONE;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
     BloomOptions mBloomOptions;
     FogOptions mFogOptions;

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -154,7 +154,7 @@ public:
      * Enables screen-space ambient occlusion in the post-process pipeline.
      * Defaults to true.
      */
-    void enableSSAO(bool b) { mEnableSsao = b; }
+    void enableSSAO(bool b) { mSSAOOptions.enabled = b; }
 
     /**
      * Enables Bloom.
@@ -203,7 +203,7 @@ private:
     bool mEnableDithering = true;
     bool mEnableFxaa = true;
     bool mEnableMsaa = true;
-    bool mEnableSsao = true;
+    filament::View::AmbientOcclusionOptions mSSAOOptions = { .enabled = true };
     filament::View::BloomOptions mBloomOptions = { .enabled = true };
     filament::View::FogOptions mFogOptions = {};
     filament::View::TemporalAntiAliasingOptions mTAAOptions = {};
@@ -470,7 +470,7 @@ void SimpleViewer::updateUserInterface() {
         //ImGui::SliderFloat("filter", &mTAAOptions.filterWidth, 0.0f, 2.0f);
         //ImGui::Unindent();
         ImGui::Checkbox("FXAA", &mEnableFxaa);
-        ImGui::Checkbox("SSAO", &mEnableSsao);
+        ImGui::Checkbox("SSAO", &mSSAOOptions.enabled);
         ImGui::Checkbox("Bloom", &mBloomOptions.enabled);
         ImGui::Unindent();
     }
@@ -509,8 +509,7 @@ void SimpleViewer::updateUserInterface() {
     mView->setDithering(mEnableDithering ? View::Dithering::TEMPORAL : View::Dithering::NONE);
     mView->setAntiAliasing(mEnableFxaa ? View::AntiAliasing::FXAA : View::AntiAliasing::NONE);
     mView->setSampleCount(mEnableMsaa ? 4 : 1);
-    mView->setAmbientOcclusion(
-            mEnableSsao ? View::AmbientOcclusion::SSAO : View::AmbientOcclusion::NONE);
+    mView->setAmbientOcclusionOptions(mSSAOOptions);
     mView->setBloomOptions(mBloomOptions);
     mView->setFogOptions(mFogOptions);
     mView->setTemporalAntiAliasingOptions(mTAAOptions);

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -231,9 +231,9 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     lcm.setShadowOptions(lcm.getInstance(g_lights[0]), {
             .screenSpaceContactShadows = true });
 
-    view->setAmbientOcclusion(View::AmbientOcclusion::SSAO);
+    view->setAmbientOcclusionOptions({ .enabled = true });
     view->setBloomOptions({ .enabled = true });
-    view->setFogOptions({ .density=0.2, .enabled = true });
+    view->setFogOptions({ .density = 0.2f, .enabled = true });
 
 
     if (g_moreLights) {

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -603,7 +603,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderAngle("Rotation", &params.iblRotation);
             if (ImGui::CollapsingHeader("SSAO")) {
                 DebugRegistry& debug = engine->getDebugRegistry();
-                ImGui::Checkbox("Enabled##ssao", &params.ssao);
+                ImGui::Checkbox("Enabled##ssao", &params.ssaoOptions.enabled);
                 ImGui::SliderFloat("Radius", &params.ssaoOptions.radius, 0.05f, 5.0f);
                 ImGui::SliderFloat("Bias", &params.ssaoOptions.bias, 0.0f, 0.01f, "%.6f");
                 ImGui::SliderFloat("Intensity", &params.ssaoOptions.intensity, 0.0f, 4.0f);
@@ -934,8 +934,6 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
     view->setFogOptions(g_params.fogOptions);
     view->setTemporalAntiAliasingOptions(g_params.taaOptions);
     view->setSampleCount((uint8_t) (g_params.msaa ? 4 : 1));
-    view->setAmbientOcclusion(
-            g_params.ssao ? View::AmbientOcclusion::SSAO : View::AmbientOcclusion::NONE);
     view->setAmbientOcclusionOptions(g_params.ssaoOptions);
 
     if (g_params.colorGrading) {

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -166,7 +166,6 @@ struct SandboxParameters {
     float constantBias = 0.001;
     float polygonOffsetConstant = 0.5;
     float polygonOffsetSlope = 2.0;
-    bool ssao = false;
     View::AmbientOcclusionOptions ssaoOptions;
     View::BloomOptions bloomOptions;
     View::FogOptions fogOptions;


### PR DESCRIPTION
setAmbientOcclusion (and associates) is now deprecated (but still works),
in favor of the new .enabled field in AmbientOcclusionOptions.