### PR TITLE
Add back proguard file for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ dependencies {
 }
 ```
 
-#### ProGuard
-
-Filament references a few classes from native code and by reflections. Depending on your
-R8/ProGuard/DexGuard config and usage, you may refer to the [proguard-rules](android/proguard-rules.pro) in your projects.
-
 Here are all the libraries available in the group `com.google.android.filament`:
 
 [![filament-android](https://maven-badges.herokuapp.com/maven-central/com.google.android.filament/filament-android/badge.svg?subject=filament-android)](https://maven-badges.herokuapp.com/maven-central/com.google.android.filament/filament-android)  

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ dependencies {
 }
 ```
 
+#### ProGuard
+
+Filament references a few classes from native code and by reflections. Depending on your
+R8/ProGuard/DexGuard config and usage, you may refer to the [proguard-rules](android/proguard-rules.pro) in your projects.
+
 Here are all the libraries available in the group `com.google.android.filament`:
 
 [![filament-android](https://maven-badges.herokuapp.com/maven-central/com.google.android.filament/filament-android/badge.svg?subject=filament-android)](https://maven-badges.herokuapp.com/maven-central/com.google.android.filament/filament-android)  

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,12 +1,6 @@
 # Add project specific ProGuard rules here.
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# JNI is an entry point that's hard to keep track of, so there's
-# an annotation to mark fields and methods used by native code.
 
 # Keep the annotations that proguard needs to process.
 -keep class com.google.android.filament.proguard.UsedBy*

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,22 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# JNI is an entry point that's hard to keep track of, so there's
+# an annotation to mark fields and methods used by native code.
+
+# Keep the annotations that proguard needs to process.
+-keep class com.google.android.filament.proguard.UsedBy*
+
+# Just because native code accesses members of a class, does not mean that the
+# class itself needs to be annotated - only annotate classes that are
+# referenced themselves in native code.
+-keep @com.google.android.filament.proguard.UsedBy* class * {
+  <init>();
+}
+-keepclassmembers class * {
+  @com.google.android.filament.proguard.UsedBy* *;
+}


### PR DESCRIPTION
The proguard-rules.pro file provided by @jwmcglynn  [#1207](https://github.com/google/filament/pull/1207)
works perfectly for Android projects with minifyEnabled.
Add the config file back to the repository and update README.md
to help other Android users setup release build.