### PR TITLE
Fix resizing issues with MoltenVK.

### DIFF
--- a/filament/backend/src/vulkan/PlatformVkAndroid.cpp
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.cpp
@@ -58,10 +58,4 @@ void* PlatformVkAndroid::createVkSurfaceKHR(void* nativeWindow, void* vkinstance
     return (void*) surface;
 }
 
-void PlatformVkAndroid::getClientExtent(void* window, uint32_t* width, uint32_t* height) noexcept {
-    ANativeWindow* aNativeWindow = (ANativeWindow*) window;
-    *width = ANativeWindow_getWidth(aNativeWindow);
-    *height = ANativeWindow_getHeight(aNativeWindow);
-}
-
 } // namespace filament

--- a/filament/backend/src/vulkan/PlatformVkAndroid.h
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.h
@@ -30,7 +30,6 @@ public:
     backend::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept override;
-    void getClientExtent(void* nativeWindow,  uint32_t* width, uint32_t* height) noexcept override;
 
     int getOSVersion() const noexcept override { return 0; }
 };

--- a/filament/backend/src/vulkan/PlatformVkCocoa.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.h
@@ -28,7 +28,6 @@ class PlatformVkCocoa final : public backend::VulkanPlatform {
 public:
     backend::Driver* createDriver(void* sharedContext) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept override;
-    void getClientExtent(void* nativeWindow,  uint32_t* width, uint32_t* height) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };
 

--- a/filament/backend/src/vulkan/PlatformVkCocoa.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.mm
@@ -67,19 +67,4 @@ void* PlatformVkCocoa::createVkSurfaceKHR(void* nativeWindow, void* instance) no
     return surface;
 }
 
-void PlatformVkCocoa::getClientExtent(void* window,  uint32_t* width, uint32_t* height) noexcept {
-    // Obtain the CAMetalLayer-backed view.
-    NSView* nsview = (__bridge NSView*) window;
-    ASSERT_POSTCONDITION(nsview, "Unable to obtain Metal-backed NSView.");
-
-    // The size that we return to VulkanDriver is consistent with what the macOS client sees for the
-    // view size, but it's not necessarily consistent with the surface caps currentExtent. We've
-    // observed that if the window was initially created on a high DPI display, then dragged to a
-    // low DPI display, the VkSurfaceKHR physical caps still have a high resolution, despite the
-    // fact that we've recreated it.
-    NSSize sz = [nsview convertSizeToBacking: nsview.frame.size];
-    *width = sz.width;
-    *height = sz.height;
-}
-
 } // namespace filament

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
@@ -28,7 +28,6 @@ class PlatformVkCocoaTouch final : public backend::VulkanPlatform {
 public:
     backend::Driver* createDriver(void* const sharedContext) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept override;
-    void getClientExtent(void* nativeWindow,  uint32_t* width, uint32_t* height) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };
 

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
@@ -67,12 +67,4 @@ void* PlatformVkCocoaTouch::createVkSurfaceKHR(void* nativeWindow, void* instanc
 #endif
 }
 
-void PlatformVkCocoaTouch::getClientExtent(void* window,  uint32_t* width, uint32_t* height) {
-#if METAL_AVAILABLE
-    CAMetalLayer* metalLayer = (CAMetalLayer*) nativeWindow;
-    *width = metalLayer.drawableSize.width;
-    *height = metalLayer.drawableSize.height;
-#endif
-}
-
 } // namespace filament

--- a/filament/backend/src/vulkan/PlatformVkLinux.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinux.cpp
@@ -78,14 +78,4 @@ void* PlatformVkLinux::createVkSurfaceKHR(void* nativeWindow, void* instance) no
     return surface;
 }
 
-void PlatformVkLinux::getClientExtent(void* window, uint32_t* width, uint32_t* height) noexcept {
-    Window root;
-    int x = 0;
-    int y = 0;
-    unsigned int border_width = 0;
-    unsigned int depth = 0;
-    g_x11.getGeometry(mDisplay, (Window) window, &root, &x, &y, width, height, &border_width,
-            &depth);
- }
-
 } // namespace filament

--- a/filament/backend/src/vulkan/PlatformVkLinux.h
+++ b/filament/backend/src/vulkan/PlatformVkLinux.h
@@ -32,7 +32,6 @@ public:
     backend::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept override;
-    void getClientExtent(void* nativeWindow,  uint32_t* width, uint32_t* height) noexcept override;
 
     int getOSVersion() const noexcept override { return 0; }
 

--- a/filament/backend/src/vulkan/PlatformVkWindows.cpp
+++ b/filament/backend/src/vulkan/PlatformVkWindows.cpp
@@ -55,13 +55,4 @@ void* PlatformVkWindows::createVkSurfaceKHR(void* nativeWindow, void* instance) 
     return surface;
 }
 
-void PlatformVkWindows::getClientExtent(void* win, uint32_t* width, uint32_t* height) noexcept {
-	HWND window = (HWND)win;
-	RECT rect;
-	BOOL success = GetClientRect(window, &rect);
-	ASSERT_POSTCONDITION(success, "GetWindowRect error.");
-	*width = rect.right - rect.left;
-	*height = rect.bottom - rect.top;
-}
-
 } // namespace filament

--- a/filament/backend/src/vulkan/PlatformVkWindows.h
+++ b/filament/backend/src/vulkan/PlatformVkWindows.h
@@ -30,7 +30,6 @@ public:
     backend::Driver* createDriver(void* const sharedContext) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept override;
-    void getClientExtent(void* nativeWindow, uint32_t* width, uint32_t* height) noexcept override;
 
     int getOSVersion() const noexcept override { return 0; }
 

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -299,7 +299,7 @@ void getPresentationQueue(VulkanContext& context, VulkanSurfaceContext& sc) {
     ASSERT_POSTCONDITION(sc.presentQueue, "Unable to obtain presentation queue.");
 }
 
-void getSurfaceCaps(VulkanContext& context, VulkanSurfaceContext& sc) {
+static VkSurfaceCapabilitiesKHR getSurfaceCaps(VulkanContext& context, VulkanSurfaceContext& sc) {
     VkResult result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(context.physicalDevice,
             sc.surface, &sc.surfaceCapabilities);
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR error.");
@@ -314,18 +314,19 @@ void getSurfaceCaps(VulkanContext& context, VulkanSurfaceContext& sc) {
     result = vkGetPhysicalDeviceSurfaceFormatsKHR(context.physicalDevice, sc.surface,
             &surfaceFormatsCount, sc.surfaceFormats.data());
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkGetPhysicalDeviceSurfaceFormatsKHR error.");
+    return sc.surfaceCapabilities;
 }
 
 void createSwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceContext) {
-    getSurfaceCaps(context, surfaceContext);
+    const auto caps = getSurfaceCaps(context, surfaceContext);
 
     // The general advice is to require one more than the minimum swap chain length, since the
     // absolute minimum could easily require waiting for a driver or presentation layer to release
     // the previous frame's buffer. The only situation in which we'd ask for the minimum length is
     // when using a MAILBOX presentation strategy for low-latency situations where tearing is
     // acceptable.
-    const uint32_t maxImageCount = surfaceContext.surfaceCapabilities.maxImageCount;
-    const uint32_t minImageCount = surfaceContext.surfaceCapabilities.minImageCount;
+    const uint32_t maxImageCount = caps.maxImageCount;
+    const uint32_t minImageCount = caps.minImageCount;
     uint32_t desiredImageCount = minImageCount + 1;
 
     // According to section 30.5 of VK 1.1, maxImageCount of zero means "that there is no limit on
@@ -342,12 +343,13 @@ void createSwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceContex
             break;
         }
     }
-    const auto compositionCaps = surfaceContext.surfaceCapabilities.supportedCompositeAlpha;
+    const auto compositionCaps = caps.supportedCompositeAlpha;
     const auto compositeAlpha = (compositionCaps & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) ?
             VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR : VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
 
     // Create the low-level swap chain.
-    const auto size = surfaceContext.surfaceCapabilities.currentExtent;
+    auto size = surfaceContext.clientSize = caps.currentExtent;
+
     VkSwapchainCreateInfoKHR createInfo {
         .sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR,
         .surface = surfaceContext.surface,
@@ -357,7 +359,17 @@ void createSwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceContex
         .imageExtent = size,
         .imageArrayLayers = 1,
         .imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+
+        // TODO: Setting the preTransform to IDENTITY means we are letting the Android Compositor
+        // handle the rotation. It is usually more efficient to handle this ourselves in the MVP
+        // by setting this field to be equal to the currentTransform mask in the caps.
+        // https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html
         .preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR,
+
+        // TODO: Setting the oldSwapchain parameter would avoid exiting and re-entering
+        // exclusive mode, which could result in a smoother orientation change.
+        .oldSwapchain = VK_NULL_HANDLE,
+
         .compositeAlpha = compositeAlpha,
         .presentMode = VK_PRESENT_MODE_FIFO_KHR,
         .clipped = VK_TRUE

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -154,7 +154,6 @@ struct VulkanSurfaceContext {
 void selectPhysicalDevice(VulkanContext& context);
 void createLogicalDevice(VulkanContext& context);
 void getPresentationQueue(VulkanContext& context, VulkanSurfaceContext& sc);
-void getSurfaceCaps(VulkanContext& context, VulkanSurfaceContext& sc);
 
 void createSwapChain(VulkanContext& context, VulkanSurfaceContext& sc);
 void destroySwapChain(VulkanContext& context, VulkanSurfaceContext& sc, VulkanDisposer& disposer);

--- a/filament/backend/src/vulkan/VulkanPlatform.h
+++ b/filament/backend/src/vulkan/VulkanPlatform.h
@@ -44,7 +44,6 @@ class VulkanPlatform : public DefaultPlatform {
 public:
     // Given a Vulkan instance and native window handle, creates the platform-specific surface.
     virtual void* createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept = 0;
-    virtual void getClientExtent(void* window,  uint32_t* width, uint32_t* height) noexcept = 0;
 
    ~VulkanPlatform() override;
 };

--- a/libs/filamentapp/src/NativeWindowHelperCocoa.mm
+++ b/libs/filamentapp/src/NativeWindowHelperCocoa.mm
@@ -42,6 +42,12 @@ void* setUpMetalLayer(void* nativeView) {
     // full-screen, we can skip the macOS compositor if the size matches the display size.
     metalLayer.drawableSize = [view convertSizeToBacking:view.bounds.size];
 
+    // In its implementation of vkGetPhysicalDeviceSurfaceCapabilitiesKHR, MoltenVK takes into
+    // consideration both the size (in points) of the bounds, and the contentsScale of the
+    // CAMetalLayer from which the Vulkan surface was created.
+    // See also https://github.com/KhronosGroup/MoltenVK/issues/428
+    metalLayer.contentsScale = view.window.backingScaleFactor;
+
     // This is set to NO by default, but is also important to ensure we can bypass the compositor
     // in full-screen mode
     // See "Direct to Display" http://metalkit.org/2017/06/30/introducing-metal-2.html.
@@ -58,5 +64,6 @@ void* resizeMetalLayer(void* nativeView) {
     CGSize viewSize = view.bounds.size;
     NSSize newDrawableSize = [view convertSizeToBacking:view.bounds.size];
     metalLayer.drawableSize = newDrawableSize;
+    metalLayer.contentsScale = view.window.backingScaleFactor;
     return metalLayer;
 }


### PR DESCRIPTION
This removes the old getClientExtent stuff that I added a while back,
and replaces it with the strategy espoused by the MoltenVK author found
here:

https://github.com/KhronosGroup/MoltenVK/issues/428

I tested this PR on macOS with Vulkan and Metal. I tested both on high
and low DPI displays. I also tried dragging the window between the two
displays.

Android still has issues with rotation, I will deal with that next.