### PR TITLE
Vulkan: fix zealous frame skipping on Android.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -798,7 +798,7 @@ bool VulkanDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint64_t* elapse
 
     uint64_t results[4] = {};
     size_t dataSize = sizeof(results);
-    VkDeviceSize stride = sizeof(uint64_t);
+    VkDeviceSize stride = sizeof(uint64_t) * 2;
 
     VkResult result = vkGetQueryPoolResults(mContext.device, mContext.timestamps.pool,
             vtq->startingQueryIndex, 2, dataSize, (void*) results, stride,


### PR DESCRIPTION
The stride passed to Vulkan for query pools is the stride between
queries, not the stride between individual values. I realized this after
seeing the SwiftShader implementation of queries.

I also used log statements to confirm that this fixes bogus frame
skipping on my Pixel 4.