### PR TITLE
Add shadow map A/B controls

### DIFF
--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -506,7 +506,7 @@ void SimpleViewer::updateUserInterface() {
             ImGui::SliderInt("Shadow map size", &o.shadowMapSizeExponent, 5, 13, label);
         };
 
-        if (ImGui::BeginTabBar("Shadow options")) {
+        if (ImGui::BeginTabBar("Shadow presets")) {
             if (ImGui::BeginTabItem("A")) {
                 shadowProperties(mShadowPropertiesA);
                 mShadowProperties = &mShadowPropertiesA;


### PR DESCRIPTION
This adds a tab to gltf_viewer that allows comparing two sets of shadow options:

![shadow-comparison](https://user-images.githubusercontent.com/5298046/89952640-762d6600-dbe2-11ea-9d71-71b2cb682c66.gif)