### PR TITLE
Vulkan: fix Android after pause / resume.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -436,7 +436,14 @@ void destroySwapChain(VulkanContext& context, VulkanSurfaceContext& surfaceConte
         disposer.release(swapContext.commands.resources);
         vkFreeCommandBuffers(context.device, context.commandPool, 1,
                 &swapContext.commands.cmdbuffer);
+
+        // The wrapper object for the submission fence has shared ownership semantics, so here
+        // we notify other owners that the swap chain (and its associated command buffers) have
+        // been destroyed.
+        swapContext.commands.fence->swapChainDestroyed = true;
+
         swapContext.commands.fence.reset();
+
         vkDestroyImageView(context.device, swapContext.attachment.view, VKALLOC);
         swapContext.commands.fence = VK_NULL_HANDLE;
         swapContext.attachment.view = VK_NULL_HANDLE;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -59,6 +59,7 @@ struct VulkanCmdFence {
     utils::Condition condition;
     utils::Mutex mutex;
     std::atomic<VkResult> status;
+    bool swapChainDestroyed = false;
 
     // TODO: for non-work buffers the following field indicates if the fence has EVER been
     // submitted, which is a bit misleading or un-useful. This needs to be refactored.


### PR DESCRIPTION
This fixes the visual hang that would occur after going to the task
switcher and back.

After recreating the swap chain, all of its associated fences and sync
objects become invalid. Since we were not tracking this, FrameSkipper
was going into an infinite wait after the swap chain was created.