### PR TITLE
Add public APIs for texture 3D and texture 2D arrays

### DIFF
--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -234,6 +234,76 @@ Java_com_google_android_filament_Texture_nSetImageCompressed(JNIEnv *env, jclass
 }
 
 extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Texture_nSetImage3D(JNIEnv* env, jclass, jlong nativeTexture,
+        jlong nativeEngine, jint level,
+        jint xoffset, jint yoffset, jint zoffset,
+        jint width, jint height, jint depth,
+        jobject storage,  jint remaining,
+        jint left, jint bottom, jint type, jint alignment,
+        jint stride, jint format,
+        jobject handler, jobject runnable) {
+    Texture* texture = (Texture*) nativeTexture;
+    Engine* engine = (Engine*) nativeEngine;
+
+    size_t sizeInBytes = getTextureDataSize(texture, (size_t) level, (Texture::Format) format,
+            (Texture::Type) type, (size_t) stride, (size_t) alignment);
+
+    AutoBuffer nioBuffer(env, storage, 0);
+    if (sizeInBytes > (size_t(remaining) << nioBuffer.getShift())) {
+        // BufferOverflowException
+        return -1;
+    }
+
+    void *buffer = nioBuffer.getData();
+    auto *callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
+
+    Texture::PixelBufferDescriptor desc(buffer, sizeInBytes, (backend::PixelDataFormat) format,
+            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) bottom,
+            (uint32_t) stride, &JniBufferCallback::invoke, callback);
+
+    texture->setImage(*engine, (size_t) level,
+            (uint32_t) xoffset, (uint32_t) yoffset, (uint32_t) zoffset,
+            (uint32_t) width, (uint32_t) height, (uint32_t) depth,
+            std::move(desc));
+
+    return 0;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Texture_nSetImage3DCompressed(JNIEnv *env, jclass,
+        jlong nativeTexture, jlong nativeEngine, jint level,
+        jint xoffset, jint yoffset, jint zoffset,
+        jint width, jint height, jint depth,
+        jobject storage,  jint remaining,
+        jint, jint, jint, jint, jint compressedSizeInBytes, jint compressedFormat,
+        jobject handler, jobject runnable) {
+    Texture *texture = (Texture *) nativeTexture;
+    Engine *engine = (Engine *) nativeEngine;
+
+    size_t sizeInBytes = (size_t) compressedSizeInBytes;
+
+    AutoBuffer nioBuffer(env, storage, 0);
+    if (sizeInBytes > (size_t(remaining) << nioBuffer.getShift())) {
+        // BufferOverflowException
+        return -1;
+    }
+
+    void *buffer = nioBuffer.getData();
+    auto *callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
+
+    Texture::PixelBufferDescriptor desc(buffer, sizeInBytes,
+            (backend::CompressedPixelDataType) compressedFormat, (uint32_t) compressedSizeInBytes,
+            &JniBufferCallback::invoke, callback);
+
+    texture->setImage(*engine, (size_t) level,
+            (uint32_t) xoffset, (uint32_t) yoffset, (uint32_t) zoffset,
+            (uint32_t) width, (uint32_t) height, (uint32_t) depth,
+            std::move(desc));
+
+    return 0;
+}
+
+extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Texture_nSetImageCubemap(JNIEnv *env, jclass,
         jlong nativeTexture, jlong nativeEngine, jint level, jobject storage, jint remaining,
         jint left, jint bottom, jint type, jint alignment, jint stride, jint format,

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -129,7 +129,7 @@ public:
          * effectively create a 3D texture.
          * @param depth Depth of the texture in texels (default: 1).
          * @return This Builder, for chaining calls.
-         * @attention This Texture instance must use Sampler::SAMPLER_2D_ARRAY or it has no effect.
+         * @attention This Texture instance must use Sampler::SAMPLER_3D or Sampler::SAMPLER_2D_ARRAY or it has no effect.
          */
         Builder& depth(uint32_t depth) noexcept;
 
@@ -305,7 +305,7 @@ public:
      *
      * @see Builder::sampler()
      */
-    void setImage(Engine& engine, size_t level, PixelBufferDescriptor&& buffer) const noexcept;
+    void setImage(Engine& engine, size_t level, PixelBufferDescriptor&& buffer) const;
 
     /**
      * Updates a sub-image of a 2D texture for a level.
@@ -331,7 +331,32 @@ public:
      */
     void setImage(Engine& engine, size_t level,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            PixelBufferDescriptor&& buffer) const noexcept;
+            PixelBufferDescriptor&& buffer) const;
+
+    /**
+     * Updates a sub-image of a 3D texture or 2D texture array for a level.
+     *
+     * @param engine    Engine this texture is associated to.
+     * @param level     Level to set the image for.
+     * @param xoffset   Left offset of the sub-region to update.
+     * @param yoffset   Bottom offset of the sub-region to update.
+     * @param zoffset   Depth offset of the sub-region to update.
+     * @param width     Width of the sub-region to update.
+     * @param height    Height of the sub-region to update.
+     * @param depth     Depth of the sub-region to update.
+     * @param buffer    Client-side buffer containing the image to set.
+     *
+     * @attention \p engine must be the instance passed to Builder::build()
+     * @attention \p level must be less than getLevels().
+     * @attention \p buffer's Texture::Format must match that of getFormat().
+     * @attention This Texture instance must use Sampler::SAMPLER_3D or Sampler::SAMPLER_2D_array.
+     *
+     * @see Builder::sampler()
+     */
+    void setImage(Engine& engine, size_t level,
+            uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
+            uint32_t width, uint32_t height, uint32_t depth,
+            PixelBufferDescriptor&& buffer) const;
 
     /**
      * Specify all six images of a cube map level.
@@ -352,7 +377,7 @@ public:
      * @see Texture::CubemapFace, Builder::sampler()
      */
     void setImage(Engine& engine, size_t level,
-            PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const noexcept;
+            PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const;
 
 
     /**

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -50,10 +50,15 @@ public:
 
     void setImage(FEngine& engine, size_t level,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            PixelBufferDescriptor&& buffer) const noexcept;
+            PixelBufferDescriptor&& buffer) const;
 
     void setImage(FEngine& engine, size_t level,
-            PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const noexcept;
+            uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
+            uint32_t width, uint32_t height, uint32_t depth,
+            PixelBufferDescriptor&& buffer) const;
+
+    void setImage(FEngine& engine, size_t level,
+            PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const;
 
     void generatePrefilterMipmap(FEngine& engine,
             PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets,


### PR DESCRIPTION
Also cleanup all setImage() error reporting. All error checks are
changed from silent to NON_FATAL_ASSERT, which means they'll throw
if exceptions are enabled or do a no-op and log a message otherwise.

Also added more precondition checks.