### PR TITLE
Metal: use explicit shader fixup for clip space Z.

### DIFF
--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -61,9 +61,6 @@ void SpvToGlsl(const SpirvBlob* spirv, std::string* outGlsl) {
 
 void SpvToMsl(const SpirvBlob* spirv, std::string* outMsl) {
     CompilerMSL mslCompiler(*spirv);
-    mslCompiler.set_common_options(CompilerGLSL::Options {
-        .vertex.fixup_clipspace = true
-    });
     mslCompiler.set_msl_options(CompilerMSL::Options {
         .msl_version = CompilerMSL::Options::make_msl_version(1, 1)
     });

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -13,8 +13,12 @@ void main() {
 #endif
 
 #if defined(TARGET_VULKAN_ENVIRONMENT)
-    // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
+    // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
     gl_Position.y = -gl_Position.y;
+#endif
+
+#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
+    // In Vulkan and Metal, clip-space Z is [0,w] rather than [-w,+w].
     gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
 #endif
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -116,8 +116,12 @@ void main() {
     vertex_position = gl_Position;
 
 #if defined(TARGET_VULKAN_ENVIRONMENT)
-    // In Vulkan, clip-space Z is [0,w] rather than [-w,+w] and Y is flipped.
+    // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
     gl_Position.y = -gl_Position.y;
+#endif
+
+#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
+    // In Vulkan and Metal, clip-space Z is [0,w] rather than [-w,+w].
     gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
 #endif
 }


### PR DESCRIPTION
This is more similar to the Vulkan shader pipeline and less magical.

There are 3 places in our shader code where we perform fixups like this:

- main.vs
- depth_main.vs
- post_process_getters.vs

That last one needs no change since it does not involve Z.