### PR TITLE
DriverAPI sample count should be > 0.

### DIFF
--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -112,7 +112,7 @@ struct HwTexture : public HwBase {
     uint32_t depth{};
     SamplerType target{};
     uint8_t levels : 4;  // This allows up to 15 levels (max texture size of 32768 x 32768)
-    uint8_t samples : 4; // In practice this is always 1.
+    uint8_t samples : 4; // Sample count per pixel (should always be a power of 2)
     TextureFormat format{};
     TextureUsage usage{};
     HwStream* hwStream = nullptr;

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -576,7 +576,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     //std::chrono::duration<float, std::milli> duration = std::chrono::steady_clock::now() - now;
     //slog.d << "LUT generation time: " << duration.count() << " ms" << io::endl;
 
-    mLutHandle = driver.createTexture(SamplerType::SAMPLER_3D, 1, textureFormat, 0,
+    mLutHandle = driver.createTexture(SamplerType::SAMPLER_3D, 1, textureFormat, 1,
             config.lutDimension, config.lutDimension, config.lutDimension, TextureUsage::DEFAULT);
 
     if (converted) {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -223,10 +223,10 @@ void PostProcessManager::init() noexcept {
     mSeparableGaussianBlurKernelStorageSize = separableGaussianBlur.getMaterial()->reflect("kernel")->size;
 
     mDummyOneTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
-            TextureFormat::RGBA8, 0, 1, 1, 1, TextureUsage::DEFAULT);
+            TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     mDummyZeroTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
-            TextureFormat::RGBA8, 0, 1, 1, 1, TextureUsage::DEFAULT);
+            TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     PixelBufferDescriptor dataOne(driver.allocate(4), 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
     PixelBufferDescriptor dataZero(driver.allocate(4), 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);


### PR DESCRIPTION
For single-sampled textures we were using 0 in some places and 1 in some
places. It's better to be consistent.