### PR TITLE
Vulkan: add support for MSAA render targets.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -346,7 +346,8 @@ void VulkanBinder::bindRasterState(const RasterState& rasterState) noexcept {
             ds0.depthWriteEnable != ds1.depthWriteEnable ||
             ds0.depthCompareOp != ds1.depthCompareOp ||
             ds0.stencilTestEnable != ds1.stencilTestEnable ||
-            ms0.rasterizationSamples != ms1.rasterizationSamples
+            ms0.rasterizationSamples != ms1.rasterizationSamples ||
+            ms0.alphaToCoverageEnable != ms1.alphaToCoverageEnable
     ) {
         mDirtyPipeline = true;
         mPipelineKey.rasterState = rasterState;
@@ -727,6 +728,7 @@ static VulkanBinder::RasterState createDefaultRasterState() {
     multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     multisampling.pSampleMask = nullptr;
+    multisampling.alphaToCoverageEnable = true;
 
     return VulkanBinder::RasterState {
         rasterization,

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -252,6 +252,7 @@ void createLogicalDevice(VulkanContext& context) {
         .physicalDevice = context.physicalDevice,
         .device = context.device,
         .pVulkanFunctions = &funcs,
+        .pRecordSettings = nullptr,
         .instance = context.instance
     };
     vmaCreateAllocator(&allocatorInfo, &context.allocator);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1003,8 +1003,10 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         }
     }
     // Resolve attachments are not cleared but still have entries in the list, so skip over them.
-    if (rpkey.samples > 1) {
-        renderPassInfo.clearValueCount += renderPassInfo.clearValueCount;
+    for (int i = 0; i < MRT::TARGET_COUNT; i++) {
+        if (rpkey.needsResolveMask & (1 << i)) {
+            renderPassInfo.clearValueCount++;
+        }
     }
     if (fbkey.depth) {
         VkClearValue& clearValue = clearValues[renderPassInfo.clearValueCount++];

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -42,8 +42,9 @@ struct VulkanProgram : public HwProgram {
 // which are not representative when this is the default render target.
 struct VulkanRenderTarget : private HwRenderTarget {
     // Creates an offscreen render target.
-    VulkanRenderTarget(VulkanContext& context, uint32_t width, uint32_t height,
-            VulkanAttachment color[MRT::TARGET_COUNT], VulkanAttachment depthStencil[2]);
+    VulkanRenderTarget(VulkanContext& context, uint32_t width, uint32_t height, uint8_t samples,
+            VulkanAttachment color[MRT::TARGET_COUNT], VulkanAttachment depthStencil[2],
+            VulkanStagePool& stagePool);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
     explicit VulkanRenderTarget(VulkanContext& context);
@@ -54,14 +55,20 @@ struct VulkanRenderTarget : private HwRenderTarget {
     void transformClientRectToPlatform(VkViewport* bounds) const;
     VkExtent2D getExtent() const;
     VulkanAttachment getColor(int target) const;
+    VulkanAttachment getMsaaColor(int target) const;
     VulkanAttachment getDepth() const;
+    VulkanAttachment getMsaaDepth() const;
     int getColorTargetCount() const;
     bool invalidate();
+    uint8_t getSamples() const { return mSamples; }
 private:
     VulkanAttachment mColor[MRT::TARGET_COUNT] = {};
     VulkanAttachment mDepth = {};
     VulkanContext& mContext;
-    bool mOffscreen;
+    const bool mOffscreen;
+    const uint8_t mSamples;
+    VulkanAttachment mMsaaAttachments[MRT::TARGET_COUNT] = {};
+    VulkanAttachment mMsaaDepthAttachment = {};
 };
 
 struct VulkanSwapChain : public HwSwapChain {


### PR DESCRIPTION
This does not include lazy allocation or support for an MSAA swap chain.
Those features will come later.