### PR TITLE
Add new shader variants for VSM

### DIFF
--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 7;
+static constexpr size_t MATERIAL_VERSION = 8;
 
 /**
  * Supported shading models

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -349,6 +349,7 @@ std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderMode
     cg.generateDefine(fs, "HAS_SHADOWING", litVariants && variant.hasShadowReceiver());
     cg.generateDefine(fs, "HAS_SHADOW_MULTIPLIER", material.hasShadowMultiplier);
     cg.generateDefine(fs, "HAS_FOG", variant.hasFog());
+    cg.generateDefine(fs, "HAS_VSM", variant.hasVsm());
 
     // material defines
     cg.generateDefine(fs, "MATERIAL_HAS_DOUBLE_SIDED_CAPABILITY", material.hasDoubleSidedCapability);

--- a/libs/matdbg/src/CommonWriter.cpp
+++ b/libs/matdbg/src/CommonWriter.cpp
@@ -33,6 +33,7 @@ std::string formatVariantString(uint8_t variant) noexcept {
         if (variant & Variant::SKINNING_OR_MORPHING)  variantString += "SKN|";
         if (variant & Variant::DEPTH)                 variantString += "DEP|";
         if (variant & Variant::FOG)                   variantString += "FOG|";
+        if (variant & Variant::VSM)                   variantString += "VSM|";
         variantString = variantString.substr(0, variantString.length() - 1);
     }
 

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -63,8 +63,8 @@ static void usage(char* name) {
             "       Reflect the specified metadata as JSON: parameters\n\n"
             "   --variant-filter=<filter>, -V <filter>\n"
             "       Filter out specified comma-separated variants:\n"
-            "           directionalLighting, dynamicLighting, shadowReceiver, skinning\n"
-            "       This variant filter is merged the filter from the material, if any\n\n"
+            "           directionalLighting, dynamicLighting, shadowReceiver, skinning, vsm\n"
+            "       This variant filter is merged with the filter from the material, if any\n\n"
             "   --version, -v\n"
             "       Print the material version number\n\n"
             "Internal use and debugging only:\n"
@@ -110,6 +110,8 @@ static uint8_t parseVariantFilter(const std::string& arg) {
             variantFilter |= filament::Variant::SHADOW_RECEIVER;
         } else if (item == "skinning") {
             variantFilter |= filament::Variant::SKINNING_OR_MORPHING;
+        } else if (item == "vsm") {
+            variantFilter |= filament::Variant::VSM;
         }
     }
     return variantFilter;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -614,6 +614,7 @@ static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& v
         strToEnum["dynamicLighting"] = filament::Variant::DYNAMIC_LIGHTING;
         strToEnum["shadowReceiver"] = filament::Variant::SHADOW_RECEIVER;
         strToEnum["skinning"] = filament::Variant::SKINNING_OR_MORPHING;
+        strToEnum["vsm"] = filament::Variant::VSM;
         return strToEnum;
     }();
     uint8_t variantFilter = 0;


### PR DESCRIPTION
This reserves 7 new variants for VSM (no shader code change yet):

```
    #31  gl41   fs 0x45   DIR|SRE|VSM
    #32  gl41   fs 0x46   DYN|SRE|VSM
    #33  gl41   fs 0x47   DIR|DYN|SRE|VSM
    #34  gl41   fs 0x50   DEP|VSM
    #35  gl41   fs 0x65   DIR|SRE|FOG|VSM
    #36  gl41   fs 0x66   DYN|SRE|FOG|VSM
    #37  gl41   fs 0x67   DIR|DYN|SRE|FOG|VSM

```