### PR TITLE
fix translucent views with custom render targets

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -713,6 +713,11 @@ public class View {
      * SwapChain associated with the engine.
      * </p>
      *
+     * <p>
+     * A view with a custom render target cannot rely on Renderer.ClearOptions, which only applies
+     * to the SwapChain. Such view can use a Skybox instead.
+     * </p>
+     *
      * @param target render target associated with view, or null for the swap chain
      */
     public void setRenderTarget(@Nullable RenderTarget target) {

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -61,8 +61,6 @@ class Viewport;
  */
 class UTILS_PUBLIC View : public FilamentAPI {
 public:
-    using TargetBufferFlags = backend::TargetBufferFlags;
-
     enum class QualityLevel : uint8_t {
         LOW,
         MEDIUM,
@@ -410,6 +408,9 @@ public:
      *
      * By default, the view's associated render target is nullptr, which corresponds to the
      * SwapChain associated with the engine.
+     *
+     * A view with a custom render target cannot rely on Renderer::ClearOptions, which only apply
+     * to the SwapChain. Such view can use a Skybox instead.
      *
      * @param renderTarget Render target associated with view, or nullptr for the swap chain.
      */


### PR DESCRIPTION
Marking a view with a custom render target will now disable blending
for that view but require an alpha channel for intermediate buffers.
Blending is disabled because it is meaningless.

fixes #2802 