### PR TITLE
minor improvements and cleanups

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -458,8 +458,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOclusion(
                         float4{ desc.width, desc.height, 1.0f / desc.width, 1.0f / desc.height });
                 mi->setParameter("invRadiusSquared", 1.0f / (data.options.radius * data.options.radius));
                 mi->setParameter("projectionScaleRadius", projectionScale * data.options.radius);
+
+                auto m22 = cameraInfo.projection[2][2];
+                auto m32 = cameraInfo.projection[3][2];
+                auto m23 = cameraInfo.projection[2][3];
                 mi->setParameter("depthParams", float2{
-                        -cameraInfo.projection[3].z, cameraInfo.projection[2].z - 1.0 } * 0.5f);
+                        m32 / (m22 + m23),
+                        2.0f * m23 / (m22 + m23) });
+
                 mi->setParameter("positionParams", float2{
                         invProjection[0][0], invProjection[1][1] } * 2.0f);
                 mi->setParameter("peak2", peak * peak);

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -385,7 +385,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     cmdDepth.primitive.rasterState = {};
     cmdDepth.primitive.rasterState.colorWrite = false;
     cmdDepth.primitive.rasterState.depthWrite = true;
-    cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::L;
+    cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::LE;
     cmdDepth.primitive.rasterState.alphaToCoverage = false;
 
     for (uint32_t i = range.first; i < range.last; ++i) {

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -35,7 +35,7 @@ fragment {
         if (materialParams.constantColor != 0) {
             sky = materialParams.color;
         } else {
-            sky = vec4(texture(materialParams_skybox, variable_eyeDirection.xyz).rgb, 1.0);
+            sky = vec4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
         }
         if (materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -108,7 +108,7 @@ fragment {
         // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
         // value representable in  a 24 bit depth buffer.
         const float preventDiv0 = -1.0 / 16777216.0;
-        return materialParams.depthParams.x / min(depth + materialParams.depthParams.y, preventDiv0);
+        return materialParams.depthParams.x / min(depth * materialParams.depthParams.y - 1.0, preventDiv0);
     }
 
     highp float sampleDepthLinear(const vec2 uv, float lod) {

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -64,7 +64,7 @@ float samplingBias(float depth, const vec2 rpdb, const vec2 texelSize) {
     return depth;
 }
 
-float sampleDepth(const lowp sampler2DArrayShadow map, const uint layer, vec2 base, vec2 dudv, float depth, vec2 rpdb) {
+float sampleDepth(const mediump sampler2DArrayShadow map, const uint layer, vec2 base, vec2 dudv, float depth, vec2 rpdb) {
 #if SHADOW_RECEIVER_PLANE_DEPTH_BIAS == SHADOW_RECEIVER_PLANE_DEPTH_BIAS_ENABLED
  #if SHADOW_SAMPLING_METHOD >= SHADOW_RECEIVER_PLANE_DEPTH_BIAS_MIN_SAMPLING_METHOD
     depth += dot(dudv, rpdb);
@@ -77,7 +77,7 @@ float sampleDepth(const lowp sampler2DArrayShadow map, const uint layer, vec2 ba
 }
 
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HARD
-float ShadowSample_Hard(const lowp sampler2DArrayShadow map, const uint layer, const vec2 size, const vec3 position) {
+float ShadowSample_Hard(const mediump sampler2DArrayShadow map, const uint layer, const vec2 size, const vec3 position) {
     vec2 rpdb = computeReceiverPlaneDepthBias(position);
     float depth = samplingBias(position.z, rpdb, vec2(1.0) / size);
     return texture(map, vec4(position.xy, layer, clamp(depth, 0.0, 1.0)));
@@ -85,7 +85,7 @@ float ShadowSample_Hard(const lowp sampler2DArrayShadow map, const uint layer, c
 #endif
 
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_LOW
-float ShadowSample_PCF_Low(const lowp sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
+float ShadowSample_PCF_Low(const mediump sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
     //  Castaño, 2013, "Shadow Mapping Summary Part 1"
     vec2 texelSize = vec2(1.0) / size;
 
@@ -122,7 +122,7 @@ float ShadowSample_PCF_Low(const lowp sampler2DArrayShadow map, const uint layer
 #endif
 
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_MEDIUM
-float ShadowSample_PCF_Medium(const lowp sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
+float ShadowSample_PCF_Medium(const mediump sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
     //  Castaño, 2013, "Shadow Mapping Summary Part 1"
     vec2 texelSize = vec2(1.0) / size;
 
@@ -165,7 +165,7 @@ float ShadowSample_PCF_Medium(const lowp sampler2DArrayShadow map, const uint la
 #endif
 
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HIGH
-float ShadowSample_PCF_High(const lowp sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
+float ShadowSample_PCF_High(const mediump sampler2DArrayShadow map, const uint layer, const vec2 size, vec3 position) {
     //  Castaño, 2013, "Shadow Mapping Summary Part 1"
     vec2 texelSize = vec2(1.0) / size;
 
@@ -341,7 +341,7 @@ highp float chebyshevUpperBound(const highp vec2 moments, const highp float mean
  * space. The output is a filtered visibility factor that can be used to multiply
  * the light intensity.
  */
-float shadow(const lowp sampler2DArrayShadow shadowMap, const uint layer, const vec3 shadowPosition) {
+float shadow(const mediump sampler2DArrayShadow shadowMap, const uint layer, const vec3 shadowPosition) {
     vec2 size = vec2(textureSize(shadowMap, 0));
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HARD
     return ShadowSample_Hard(shadowMap, layer, size, shadowPosition);


### PR DESCRIPTION
- more flexible linearization of depth, doesn't impact performance
  at all in the shader, but takes into account 3 parameters of
  the projection matrix instead of true. Mathematically identical
  to before.

- use depth test "less or equal" for depth only passes to be consistant
  with the color pass. Unsure if using "less" would be better.

- use textureLod() when sampling the skybox

- use mediump for all samplers in the shadowing.fs, which correspond to
  their actual definition.