### PR TITLE
Use "inverted-Z" depth buffer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ A new header is inserted each time a *tag* is created.
 - Many improvement and fixes in the Metal backend.
 - Fixed translucent views with custom render targets.
 - Improved MSAA implementation compatibility on Android devices.
+- Use "reverse-z" for the depth buffer.
 
 ## v1.8.1
 
@@ -46,7 +47,7 @@ A new header is inserted each time a *tag* is created.
   Google-style line directives in shaders.
 - Color grading now has a quality option which affects the size and bit depth of the 3D LUT.
 - Fixed crash in the Metal backend when more than 16 samplers are bound.
-- Added validation in Texture::setImage().
+- Added validation in `Texture::setImage()`.
 - Fixed refraction/transmission roughness when specular anti-aliasing is enabled.
 
 ## v1.8.0

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -856,7 +856,7 @@ struct RenderPassParams {
     filament::math::float4 clearColor = {};
 
     //! Depth value to clear the depth buffer with
-    double clearDepth = 1.0;
+    double clearDepth = 0.0;
 
     //! Stencil value to clear the stencil buffer with
     uint32_t clearStencil = 0;

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -283,6 +283,7 @@ DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::Texture
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameBufferFetchSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
+DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, cancelExternalImage, void*, image)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -601,6 +601,11 @@ bool MetalDriver::isFrameTimeSupported() {
     return false;
 }
 
+math::float2 MetalDriver::getClipSpaceParams() {
+    // z-coordinate of clip-space is in [0,w]
+    return math::float2{ -0.5f, 0.5f };
+}
+
 void MetalDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
         BufferDescriptor&& data, uint32_t byteOffset) {
     assert(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -151,6 +151,10 @@ bool NoopDriver::isFrameTimeSupported() {
     return true;
 }
 
+math::float2 NoopDriver::getClipSpaceParams() {
+    return math::float2{ -1.0f, 0.0f };
+}
+
 void NoopDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
         BufferDescriptor&& p, uint32_t byteOffset) {
     scheduleDestroy(std::move(p));

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -200,6 +200,12 @@ OpenGLContext::OpenGLContext() noexcept {
         glDebugMessageCallback(cb, nullptr);
     }
 #endif
+
+#if defined(GL_EXT_clip_control) || defined(GL_ARB_clip_control) || defined(GL_VERSION_4_5)
+    if (ext.EXT_clip_control) {
+        glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
+    }
+#endif
 }
 
 UTILS_NOINLINE
@@ -224,6 +230,7 @@ void OpenGLContext::initExtensionsGLES(GLint major, GLint minor, ExtentionSet co
     ext.KHR_debug = hasExtension(exts, "GL_KHR_debug");
     ext.EXT_texture_compression_s3tc_srgb = hasExtension(exts, "GL_EXT_texture_compression_s3tc_srgb");
     ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
+    ext.EXT_clip_control = hasExtension(exts, "GL_EXT_clip_control");
     // ES 3.2 implies EXT_color_buffer_float
     if (major >= 3 && minor >= 2) {
         ext.EXT_color_buffer_float = true;
@@ -242,6 +249,7 @@ void OpenGLContext::initExtensionsGL(GLint major, GLint minor, ExtentionSet cons
     ext.KHR_debug = major >= 4 && minor >= 3;
     ext.EXT_texture_sRGB = hasExtension(exts, "GL_EXT_texture_sRGB");
     ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
+    ext.EXT_clip_control = hasExtension(exts, "GL_ARB_clip_control") || (major == 4 && minor >= 5);
 }
 
 void OpenGLContext::bindBuffer(GLenum target, GLuint buffer) noexcept {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -128,6 +128,7 @@ public:
         bool EXT_texture_compression_s3tc_srgb = false;
         bool EXT_disjoint_timer_query = false;
         bool EXT_shader_framebuffer_fetch = false;
+        bool EXT_clip_control = false;
     } ext;
 
     struct {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1512,6 +1512,11 @@ bool OpenGLDriver::isFrameTimeSupported() {
     return mFrameTimeSupported;
 }
 
+math::float2 OpenGLDriver::getClipSpaceParams() {
+    return mContext.ext.EXT_clip_control ?
+            math::float2{ -0.5f, 0.5f } : math::float2{ -1.0f, 0.0f };
+}
+
 // ------------------------------------------------------------------------------------------------
 // Swap chains
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -45,6 +45,9 @@ PFNGLGETDEBUGMESSAGELOGKHRPROC glGetDebugMessageLogKHR;
 #ifdef GL_EXT_disjoint_timer_query
 PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 #endif
+#ifdef GL_EXT_clip_control
+PFNGLCLIPCONTROLEXTPROC glClipControl;
+#endif
 
 static std::once_flag sGlExtInitialized;
 
@@ -101,6 +104,11 @@ void importGLESExtensionsEntryPoints() {
                         "glGetQueryObjectui64vEXT");
 #endif
     });
+#ifdef GL_EXT_clip_control
+    glClipControl =
+            (PFNGLCLIPCONTROLEXTPROC)eglGetProcAddress(
+                    "glClipControlEXT");
+#endif
 }
 
 } // namespace glext

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -52,6 +52,15 @@
         extern PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
         #define GL_TIME_ELAPSED               0x88BF
 #endif
+#ifdef GL_EXT_clip_control
+        extern PFNGLCLIPCONTROLEXTPROC glClipControl;
+        #ifndef GL_LOWER_LEFT
+        #define GL_LOWER_LEFT GL_LOWER_LEFT_EXT
+        #endif
+        #ifndef GL_ZERO_TO_ONE
+        #define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
+        #endif
+#endif
     }
 
     // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -796,6 +796,11 @@ bool VulkanDriver::isFrameTimeSupported() {
     return true;
 }
 
+math::float2 VulkanDriver::getClipSpaceParams() {
+    // z-coordinate of clip-space is in [0,w]
+    return math::float2{ -0.5f, 0.5f };
+}
+
 void VulkanDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
         BufferDescriptor&& p, uint32_t byteOffset) {
     auto& vb = *handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -267,7 +267,7 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     bool colorWrite;
     parser->getColorWrite(&colorWrite);
     mRasterState.colorWrite = colorWrite;
-    mRasterState.depthFunc = depthTest ? DepthFunc::LE : DepthFunc::A;
+    mRasterState.depthFunc = depthTest ? DepthFunc::GE : DepthFunc::A;
     mRasterState.alphaToCoverage = mBlendingMode == BlendingMode::MASKED;
 
     parser->hasSpecularAntiAliasing(&mSpecularAntiAliasing);

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -176,7 +176,7 @@ void FMaterialInstance::setDepthWrite(bool enable) noexcept {
 }
 
 void FMaterialInstance::setDepthCulling(bool enable) noexcept {
-    mDepthFunc = enable ? RasterState::DepthFunc::LE : RasterState::DepthFunc::A;
+    mDepthFunc = enable ? RasterState::DepthFunc::GE : RasterState::DepthFunc::A;
 }
 
 const char* FMaterialInstance::getName() const noexcept {

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -376,7 +376,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     cmdDepth.primitive.rasterState = {};
     cmdDepth.primitive.rasterState.colorWrite = renderFlags & HAS_VSM;
     cmdDepth.primitive.rasterState.depthWrite = true;
-    cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::LE;
+    cmdDepth.primitive.rasterState.depthFunc = RasterState::DepthFunc::GE;
     cmdDepth.primitive.rasterState.alphaToCoverage = false;
 
     for (uint32_t i = range.first; i < range.last; ++i) {
@@ -515,7 +515,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
                     cmdColor.primitive.rasterState.colorWrite &= ~select(mode == TransparencyMode::TWO_PASSES_ONE_SIDE);
                     cmdColor.primitive.rasterState.depthFunc =
                             (mode == TransparencyMode::TWO_PASSES_ONE_SIDE) ?
-                            SamplerCompareFunc::LE : cmdColor.primitive.rasterState.depthFunc;
+                            SamplerCompareFunc::GE : cmdColor.primitive.rasterState.depthFunc;
                 } else {
                     // color pass:
                     // This will bucket objects by Z, front-to-back and then sort by material

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -731,7 +731,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                             // the tile depth buffer will be MS, but it'll be resolved to single
                             // sample automatically -- which is what we want.
                             .samples = colorBufferDesc.samples,
-                            .format = TextureFormat::DEPTH24,
+                            .format = TextureFormat::DEPTH32F,
                     });
                 }
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -174,8 +174,9 @@ void ShadowMap::update(const FScene::LightSoa& lightData, size_t index, FScene c
 
     FLightManager::ShadowParams params = lcm.getShadowParams(li);
     mPolygonOffset = {
-            .slope = params.options.polygonOffsetSlope,
-            .constant = params.options.polygonOffsetConstant
+            // handle reversed Z
+            .slope = -params.options.polygonOffsetSlope,
+            .constant = -params.options.polygonOffsetConstant
     };
     mat4f projection(camera.cullingProjection);
     if (params.options.shadowFar > 0.0f) {

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -144,7 +144,6 @@ void ShadowMapManager::prepare(FEngine& engine, DriverApi& driver, SamplerGroup&
     mRenderPassParams.flags.clear = TargetBufferFlags::DEPTH;
     mRenderPassParams.flags.discardStart = TargetBufferFlags::DEPTH;
     mRenderPassParams.flags.discardEnd = TargetBufferFlags::STENCIL;
-    mRenderPassParams.clearDepth = 1.0;
     if (mUseVsm) {
         mRenderPassParams.flags.discardStart |= TargetBufferFlags::COLOR0;
         mRenderPassParams.flags.clear |= TargetBufferFlags::COLOR0;
@@ -159,7 +158,7 @@ void ShadowMapManager::prepare(FEngine& engine, DriverApi& driver, SamplerGroup&
                     .filterMag = SamplerMagFilter::LINEAR,
                     .filterMin = SamplerMinFilter::LINEAR,
                     .compareMode = SamplerCompareMode::COMPARE_TO_TEXTURE,
-                    .compareFunc = SamplerCompareFunc::LE
+                    .compareFunc = SamplerCompareFunc::GE
             }});
 }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -80,6 +80,10 @@ FView::FView(FEngine& engine)
 
     mIsDynamicResolutionSupported = driver.isFrameTimeSupported();
 
+    // with a clip-space of [-w, w] ==> z' = -z
+    // with a clip-space of [0,  w] ==> z' = (w - z)/2
+    mClipControl = driver.getClipSpaceParams();
+
     mDefaultColorGrading = mColorGrading = engine.getDefaultColorGrading();
 }
 
@@ -623,6 +627,8 @@ void FView::prepareCamera(const CameraInfo& camera) const noexcept {
     u.setUniform(offsetof(PerViewUib, cameraPosition), float3{camera.getPosition()});
     u.setUniform(offsetof(PerViewUib, worldOffset), camera.worldOffset);
     u.setUniform(offsetof(PerViewUib, cameraFar), camera.zf);
+    u.setUniform(offsetof(PerViewUib, clipControl), mClipControl);
+
 }
 
 void FView::prepareViewport(const filament::Viewport &viewport) const noexcept {

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -104,7 +104,8 @@ public:
     backend::RasterState::DepthFunc getDepthFunc() const noexcept { return mDepthFunc; }
 
     void setPolygonOffset(float scale, float constant) noexcept {
-        mPolygonOffset = { scale, constant };
+        // handle reversed Z
+        mPolygonOffset = { -scale, -constant };
     }
 
     backend::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -457,7 +457,7 @@ private:
     bool mShadowingEnabled = true;
     bool mHasPostProcessPass = true;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
-    ShadowType mShadowType;
+    ShadowType mShadowType = ShadowType::PCF;
     BloomOptions mBloomOptions;
     FogOptions mFogOptions;
     DepthOfFieldOptions mDepthOfFieldOptions;
@@ -466,6 +466,7 @@ private:
     BlendMode mBlendMode = BlendMode::OPAQUE;
     const FColorGrading* mColorGrading = nullptr;
     const FColorGrading* mDefaultColorGrading = nullptr;
+    math::float2 mClipControl{};
 
     DynamicResolutionOptions mDynamicResolution;
     math::float2 mScale = 1.0f;

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -12,7 +12,7 @@ material {
             precision: high
         },
         {
-            type : float2,
+            type : float,
             name : depthParams,
             precision: high
         },
@@ -107,8 +107,8 @@ fragment {
         // Our far plane is at infinity, which causes a division by zero below, which in turn
         // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
         // value representable in  a 24 bit depth buffer.
-        const float preventDiv0 = -1.0 / 16777216.0;
-        return materialParams.depthParams.x / min(depth * materialParams.depthParams.y - 1.0, preventDiv0);
+        const float preventDiv0 = 1.0 / 16777216.0;
+        return materialParams.depthParams / max(depth, preventDiv0);
     }
 
     highp float sampleDepthLinear(const vec2 uv, float lod) {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 8;
+static constexpr size_t MATERIAL_VERSION = 9;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -125,8 +125,11 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float aoReserved2;
     float aoReserved3;
 
+    math::float2 clipControl;
+    math::float2 padding1;
+
     // bring PerViewUib to 2 KiB
-    filament::math::float4 padding2[61];
+    filament::math::float4 padding2[60];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -107,8 +107,11 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("aoReserved2",             1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved3",             1, UniformInterfaceBlock::Type::FLOAT)
 
+            .add("clipControl",             1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT2)
+
             // bring PerViewUib to 2 KiB
-            .add("padding2", 61, UniformInterfaceBlock::Type::FLOAT4)
+            .add("padding2", 60, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -33,8 +33,5 @@ void main() {
     gl_Position.y = -gl_Position.y;
 #endif
 
-#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
-    // In Vulkan and Metal, clip-space Z is [0,w] rather than [-w,+w].
-    gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
-#endif
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -120,8 +120,5 @@ void main() {
     gl_Position.y = -gl_Position.y;
 #endif
 
-#if defined(TARGET_VULKAN_ENVIRONMENT) || defined(TARGET_METAL_ENVIRONMENT)
-    // In Vulkan and Metal, clip-space Z is [0,w] rather than [-w,+w].
-    gl_Position.z = (gl_Position.z + gl_Position.w) * 0.5;
-#endif
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
 }

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -14,6 +14,9 @@ void main() {
 
     gl_Position = getPosition();
 
+    // Adjust clip-space
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
+
     // Invoke user code
     postProcessVertex(inputs);
 


### PR DESCRIPTION
This significantly improve the depth-buffer resolution utilization
through the near-infinity range on Metal and Vulkan.

On OpenGL, this benefit is only seen when glClipControl is available.

The user-facing clip plane is unchanged [-1,1], the conversion
happens in filament's vertex shaders.


The bulk of this change consists in:

- invert the clip space's z in the vertex shader
- clear the depth buffer with 0
- invert all depth function comparisons
- fix all screen-space effects, e.g. ssao, DoF
- fix shadows and shadow biases
- use floating-point depth
- add a driver API to query which clip-space is used
- add glClipControl support to the gl backend