### PR TITLE
Add asserts to avoid loading into the MSAA sidecar texture

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -557,6 +557,10 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
                 params.clearColor.r, params.clearColor.g, params.clearColor.b, params.clearColor.a);
 
         if (multisampledColor[i]) {
+            // We're rendering into our temporary MSAA texture and doing an automatic resolve.
+            // We should not be attempting to load anything into the MSAA texture.
+            assert(descriptor.colorAttachments[i].loadAction != MTLLoadActionLoad);
+
             descriptor.colorAttachments[i].texture = multisampledColor[i];
             descriptor.colorAttachments[i].level = 0;
             descriptor.colorAttachments[i].slice = 0;
@@ -579,6 +583,10 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
     descriptor.depthAttachment.clearDepth = params.clearDepth;
 
     if (multisampledDepth) {
+        // We're rendering into our temporary MSAA texture and doing an automatic resolve.
+        // We should not be attempting to load anything into the MSAA texture.
+        assert(descriptor.depthAttachment.loadAction != MTLLoadActionLoad);
+
         descriptor.depthAttachment.texture = multisampledDepth;
         descriptor.depthAttachment.level = 0;
         descriptor.depthAttachment.slice = 0;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -501,6 +501,9 @@ void FrameGraph::export_graphviz(utils::io::ostream& out, const char* viewName) 
         auto rendertarget = subresource->asRenderTargetResourceEntry();
         if (rendertarget) {
             out << ", " << "RenderTarget";
+            if (rendertarget->descriptor.samples > 1) {
+                out <<" MS";
+            }
         }
         out << "\", style=filled, fillcolor="
             << ((subresource->imported) ?


### PR DESCRIPTION
Related to #2984.

This isn't a fix, just moving the crash from the Metal validation layer to our codebase.