### PR TITLE
WebGL: repair beginFrame() bindings.

### DIFF
--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -346,7 +346,7 @@ export class Renderer {
     public render(swapChain: SwapChain, view: View): void;
     public setClearOptions(options: Renderer$ClearOptions): void;
     public renderView(view: View): void;
-    public beginFrame(swapChain: SwapChain, vsyncSteadyClockTimeNano: number): boolean;
+    public beginFrame(swapChain: SwapChain): boolean;
     public endFrame(): void;
 }
 
@@ -496,6 +496,7 @@ interface Filamesh {
 
 export class Engine {
     public static create(canvas: HTMLCanvasElement, contextOptions?: object): Engine;
+    public execute(): void;
     public createCamera(entity: Entity): Camera;
     public createIblFromKtx(urlOrBuffer: BufferReference): IndirectLight;
     public createMaterial(urlOrBuffer: BufferReference): Material;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -604,7 +604,9 @@ class_<Renderer>("Renderer")
         engine->execute();
     }), allow_raw_pointers())
     .function("_setClearOptions", &Renderer::setClearOptions, allow_raw_pointers())
-    .function("beginFrame", &Renderer::beginFrame, allow_raw_pointers())
+    .function("beginFrame", EMBIND_LAMBDA(bool, (Renderer* self, SwapChain* swapChain), {
+        return self->beginFrame(swapChain);
+    }), allow_raw_pointers())
     .function("endFrame", &Renderer::endFrame, allow_raw_pointers());
 
 /// View ::core class:: Encompasses all the state needed for rendering a Scene.

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -153,7 +153,12 @@ class App {
         entity.delete();
 
         // Render the scene and request the next animation frame.
-        this.renderer.render(this.swapChain, this.view);
+        if (this.renderer.beginFrame(this.swapChain)) {
+            this.renderer.renderView(this.view);
+            this.renderer.endFrame();
+        }
+        this.engine.execute();
+
         window.requestAnimationFrame(this.render);
     }
 


### PR DESCRIPTION
This regressed when we added a callback argument, because the callback
cannot be bound.

This commit also modifies the helmet example to use the low-level API
for testing purposes.

Note that this omits the optional nanoseconds argument. JavaScript
does not support overloading and this argument probably cannot be
accurately provided anyway in a web environment.

Fixes #3002.