### PR TITLE
Vulkan: Add support for VK_EXT_debug_utils.

### DIFF
--- a/filament/backend/src/vulkan/PlatformVkAndroid.cpp
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.cpp
@@ -34,16 +34,17 @@ constexpr VkAllocationCallbacks* VKALLOC = nullptr;
 
 Driver* PlatformVkAndroid::createDriver(void* const sharedContext) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
-    static const char* requestedExtensions[] = {
+    static const char* requiredInstanceExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_android_surface",
         "VK_KHR_get_physical_device_properties2",
+
 #if VK_ENABLE_VALIDATION
         "VK_EXT_debug_report",
 #endif
     };
-    return VulkanDriverFactory::create(this, requestedExtensions,
-            sizeof(requestedExtensions) / sizeof(requestedExtensions[0]));
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions,
+            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
 }
 
 void* PlatformVkAndroid::createVkSurfaceKHR(void* nativeWindow, void* vkinstance) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkCocoa.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.mm
@@ -39,16 +39,16 @@ constexpr VkAllocationCallbacks* VKALLOC = nullptr;
 
 Driver* PlatformVkCocoa::createDriver(void* sharedContext) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
-    static const char* requestedInstanceExtensions[] = {
+    static const char* requiredInstanceExtensions[] = {
         "VK_KHR_surface",
         "VK_MVK_macos_surface", // TODO: replace with VK_EXT_metal_surface
         "VK_KHR_get_physical_device_properties2",
 #if VK_ENABLE_VALIDATION
-        "VK_EXT_debug_report",
+        "VK_EXT_debug_utils",
 #endif
     };
-    return VulkanDriverFactory::create(this, requestedInstanceExtensions,
-            sizeof(requestedInstanceExtensions) / sizeof(requestedInstanceExtensions[0]));
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions,
+            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
 }
 
 void* PlatformVkCocoa::createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkLinux.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinux.cpp
@@ -48,11 +48,11 @@ struct X11Functions {
 
 Driver* PlatformVkLinux::createDriver(void* const sharedContext) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
-    const char* requestedExtensions[] = {
+    const char* requiredInstanceExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_xlib_surface",
 #if VK_ENABLE_VALIDATION
-        "VK_EXT_debug_report",
+        "VK_EXT_debug_utils",
 #endif
     };
     g_x11.library = dlopen(LIBRARY_X11, RTLD_LOCAL | RTLD_NOW);
@@ -62,8 +62,8 @@ Driver* PlatformVkLinux::createDriver(void* const sharedContext) noexcept {
     g_x11.getGeometry = (X11_GET_GEOMETRY) dlsym(g_x11.library, "XGetGeometry");
     mDisplay = g_x11.openDisplay(NULL);
     ASSERT_PRECONDITION(mDisplay, "Unable to open X11 display.");
-    return VulkanDriverFactory::create(this, requestedExtensions,
-            sizeof(requestedExtensions) / sizeof(requestedExtensions[0]));
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions,
+            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
 }
 
 void* PlatformVkLinux::createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkWindows.cpp
+++ b/filament/backend/src/vulkan/PlatformVkWindows.cpp
@@ -28,16 +28,16 @@ using namespace backend;
 
 Driver* PlatformVkWindows::createDriver(void* const sharedContext) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
-    const char* requestedExtensions[] = {
+    const char* requiredInstanceExtensions[] = {
         "VK_KHR_surface",
         "VK_KHR_win32_surface",
         "VK_KHR_get_physical_device_properties2",
 #if VK_ENABLE_VALIDATION
-        "VK_EXT_debug_report",
+        "VK_EXT_debug_utils",
 #endif
     };
-    return VulkanDriverFactory::create(this, requestedExtensions,
-        sizeof(requestedExtensions) / sizeof(requestedExtensions[0]));
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions,
+        sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
 }
 
 void* PlatformVkWindows::createVkSurfaceKHR(void* nativeWindow, void* instance) noexcept {

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -180,7 +180,7 @@ void createLogicalDevice(VulkanContext& context) {
     std::vector<const char*> deviceExtensionNames = {
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,
     };
-    if (context.debugMarkersSupported) {
+    if (context.debugMarkersSupported && !context.debugUtilsSupported) {
         deviceExtensionNames.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
     }
     deviceQueueCreateInfo->sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -102,6 +102,7 @@ struct VulkanContext {
     uint32_t graphicsQueueFamilyIndex;
     VkQueue graphicsQueue;
     bool debugMarkersSupported;
+    bool debugUtilsSupported;
     VulkanBinder::RasterState rasterState;
     VulkanCommandBuffer* currentCommands;
     VulkanSurfaceContext* currentSurface;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -156,6 +156,7 @@ private:
     VulkanRenderTarget* mCurrentRenderTarget = nullptr;
     VulkanSamplerGroup* mSamplerBindings[VulkanBinder::SAMPLER_BINDING_COUNT] = {};
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
+    VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;
 };
 
 } // namespace backend


### PR DESCRIPTION
Motivated by upcoming SwiftShader support, The old debug_report
extension is apparently deprecated but we need to keep it alive
for Android.