### PR TITLE
Migrate the SwiftShader build to Vulkan.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -88,7 +88,7 @@ The following CMake options are boolean options specific to Filament:
 - `FILAMENT_SUPPORTS_VULKAN`:      Include the Vulkan backend
 - `FILAMENT_INSTALL_BACKEND_TEST`: Install the backend test library so it can be consumed on iOS
 - `FILAMENT_USE_EXTERNAL_GLES3`:   Experimental: Compile Filament against OpenGL ES 3
-- `FILAMENT_USE_SWIFTSHADER`:      Experimental: Compile Filament against SwiftShader
+- `FILAMENT_USE_SWIFTSHADER`:      Compile Filament against SwiftShader
 - `FILAMENT_SKIP_SAMPLES`:         Don't build sample apps
 
 To turn an option on or off:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(FILAMENT_ENABLE_JAVA "Compile Java projects, requires a JDK and the JAVA_
 
 option(FILAMENT_USE_EXTERNAL_GLES3 "Experimental: Compile Filament against OpenGL ES 3" OFF)
 
-option(FILAMENT_USE_SWIFTSHADER "Experimental: Compile Filament against SwiftShader" OFF)
+option(FILAMENT_USE_SWIFTSHADER "Compile Filament against SwiftShader" OFF)
 
 option(FILAMENT_ENABLE_LTO "Enable link-time optimizations if supported by the compiler" OFF)
 
@@ -83,7 +83,7 @@ if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT WEBGL)
     set(LINUX TRUE)
 endif()
 
-if (ANDROID OR WEBGL OR IOS OR FILAMENT_USE_SWIFTSHADER)
+if (ANDROID OR WEBGL OR IOS)
     set(IS_MOBILE_TARGET TRUE)
 endif()
 
@@ -228,8 +228,7 @@ if (FILAMENT_USE_EXTERNAL_GLES3)
 endif()
 
 if (FILAMENT_USE_SWIFTSHADER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSWIFTSHADER")
-    set(EGL TRUE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFILAMENT_USE_SWIFTSHADER")
 endif()
 
 if (WIN32)
@@ -238,7 +237,7 @@ endif()
 
 if (LINUX)
     option(USE_STATIC_LIBCXX "Link against the static runtime libraries." ON)
-    if (${USE_STATIC_LIBCXX}) 
+    if (${USE_STATIC_LIBCXX})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
         link_libraries("-static-libgcc -static-libstdc++")
         link_libraries(libc++.a)
@@ -351,7 +350,7 @@ endif()
 
 # By default, build with Vulkan support on desktop platforms, although clients must request to use
 # it at run time.
-if (WIN32 OR WEBGL OR IOS OR FILAMENT_USE_SWIFTSHADER)
+if (WIN32 OR WEBGL OR IOS)
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" OFF)
 else()
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" ON)
@@ -484,20 +483,20 @@ endif()
 # "bluevk" and "samples" targets.
 # ==================================================================================================
 
-if (FILAMENT_SUPPORTS_VULKAN AND APPLE)
+if (FILAMENT_USE_SWIFTSHADER)
+    if (NOT FILAMENT_SUPPORTS_VULKAN)
+        message(ERROR "SwiftShader is only useful when Vulkan is enabled.")
+    endif()
+    find_library(SWIFTSHADER_VK NAMES vk_swiftshader HINTS "$ENV{SWIFTSHADER_LD_LIBRARY_PATH}")
+    message(STATUS "Found SwiftShader VK library in: ${SWIFTSHADER_VK}.")
+    add_definitions(-DFILAMENT_VKLIBRARY_PATH=\"${SWIFTSHADER_VK}\")
+elseif (FILAMENT_SUPPORTS_VULKAN AND APPLE)
     find_library(Vulkan_LIBRARY NAMES vulkan HINTS "$ENV{VULKAN_SDK}/lib" "$ENV{VULKAN_SDK}/macOS/lib")
     if (Vulkan_LIBRARY)
         set(Vulkan_FOUND ON)
         message(STATUS "Found Vulkan library in SDK: ${Vulkan_LIBRARY}.")
         add_definitions(-DFILAMENT_VKLIBRARY_PATH=\"${Vulkan_LIBRARY}\")
     endif()
-endif()
-
-if (FILAMENT_USE_SWIFTSHADER)
-    find_library(SWIFTSHADER_EGL NAMES EGL HINTS "$ENV{SWIFTSHADER_LD_LIBRARY_PATH}")
-    find_library(SWIFTSHADER_GLES NAMES GLESv3 GLESv2 HINTS "$ENV{SWIFTSHADER_LD_LIBRARY_PATH}")
-    message(STATUS "Found SwiftShader EGL library in: ${SWIFTSHADER_EGL}.")
-    message(STATUS "Found SwiftShader GLES library in: ${SWIFTSHADER_GLES}.")
 endif()
 
 # ==================================================================================================
@@ -629,10 +628,6 @@ if (IS_HOST_PLATFORM)
     add_subdirectory(${TOOLS}/resgen)
     add_subdirectory(${TOOLS}/roughness-prefilter)
     add_subdirectory(${TOOLS}/specular-color)
-endif()
-
-if (FILAMENT_USE_SWIFTSHADER)
-    add_subdirectory(${EXTERNAL}/swiftshader/tnt)
 endif()
 
 # Generate exported executables for cross-compiled builds (Android, WebGL, and iOS)

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,8 @@ function print_help {
     echo "        Exclude Vulkan support from the Android build."
     echo "    -s"
     echo "        Add iOS simulator support to the iOS build."
+    echo "    -t"
+    echo "        Enable SwiftShader support for Vulkan in desktop builds."
     echo "    -l"
     echo "        Combine iOS arm64 and x86_64 into universal libraries (implies -s)."
     echo "    -w"
@@ -116,6 +118,8 @@ INSTALL_COMMAND=
 VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
 VULKAN_ANDROID_GRADLE_OPTION=""
 
+SWIFTSHADER_OPTION="-DFILAMENT_USE_SWIFTSHADER=OFF"
+
 IOS_BUILD_SIMULATOR=false
 IOS_CREATE_UNIVERSAL_LIBRARIES=false
 
@@ -163,6 +167,7 @@ function build_desktop_target {
             -DCMAKE_BUILD_TYPE="$1" \
             -DCMAKE_INSTALL_PREFIX="../${lc_target}/filament" \
             -DFILAMENT_ENABLE_JAVA="${FILAMENT_ENABLE_JAVA}" \
+            ${SWIFTSHADER_OPTION} \
             ${deployment_target} \
             ../..
     fi
@@ -647,7 +652,7 @@ function run_tests {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacfijmp:q:uvslw" opt; do
+while getopts ":hacfijmp:q:uvslwt" opt; do
     case ${opt} in
         h)
             print_help
@@ -744,6 +749,10 @@ while getopts ":hacfijmp:q:uvslw" opt; do
         s)
             IOS_BUILD_SIMULATOR=true
             echo "iOS simulator support enabled."
+            ;;
+        t)
+            SWIFTSHADER_OPTION="-DFILAMENT_USE_SWIFTSHADER=ON"
+            echo "SwiftShader support enabled."
             ;;
         l)
             IOS_BUILD_SIMULATOR=true

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -55,7 +55,7 @@ set(PRIVATE_HDRS
 # OpenGL / OpenGL ES Sources
 # ==================================================================================================
 
-if (NOT FILAMENT_USE_EXTERNAL_GLES3)
+if (NOT FILAMENT_USE_EXTERNAL_GLES3 AND NOT FILAMENT_USE_SWIFTSHADER)
     list(APPEND SRCS
             src/opengl/gl_headers.cpp
             src/opengl/gl_headers.h
@@ -83,8 +83,6 @@ if (NOT FILAMENT_USE_EXTERNAL_GLES3)
         list(APPEND SRCS src/android/ExternalTextureManagerAndroid.cpp)
         list(APPEND SRCS src/android/VirtualMachineEnv.cpp)
         list(APPEND SRCS src/opengl/PlatformEGLAndroid.cpp)
-    elseif (FILAMENT_USE_SWIFTSHADER)
-        # no extra sources for SwiftShader, PlatformEGL is enough
     elseif (IOS)
         list(APPEND SRCS src/opengl/PlatformCocoaTouchGL.mm)
         list(APPEND SRCS src/opengl/CocoaTouchExternalImage.mm)
@@ -201,7 +199,7 @@ if (ANDROID)
 endif()
 
 if (FILAMENT_USE_SWIFTSHADER)
-    target_link_libraries(${TARGET} PRIVATE swiftshader PUBLIC ${SWIFTSHADER_EGL} ${SWIFTSHADER_GLES})
+    target_link_libraries(${TARGET} PUBLIC ${SWIFTSHADER_VK})
 endif()
 
 if (APPLE AND NOT IOS)
@@ -347,7 +345,7 @@ if (APPLE AND NOT IOS AND NOT FILAMENT_USE_SWIFTSHADER)
     target_link_libraries(backend_test_mac PRIVATE -force_load backend_test)
 endif()
 
-if (APPLE AND NOT Vulkan_LIBRARY)
+if (APPLE AND NOT Vulkan_LIBRARY AND NOT FILAMENT_USE_SWIFTSHADER)
     message(STATUS "No Vulkan SDK was found, using prebuilt MoltenVK.")
     set(MOLTENVK_DIR "../../third_party/moltenvk")
     configure_file(

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -25,8 +25,6 @@
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkAndroid.h"
     #endif
-#elif defined(SWIFTSHADER)
-    #include "opengl/PlatformEGL.h"
 #elif defined(IOS)
     #ifndef FILAMENT_USE_EXTERNAL_GLES3
         #include "opengl/PlatformCocoaTouchGL.h"
@@ -35,21 +33,21 @@
         #include "vulkan/PlatformVkCocoaTouch.h"
     #endif
 #elif defined(__APPLE__)
-    #ifndef FILAMENT_USE_EXTERNAL_GLES3
+    #if !defined(FILAMENT_USE_EXTERNAL_GLES3) && !defined(FILAMENT_USE_SWIFTSHADER)
         #include "opengl/PlatformCocoaGL.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkCocoa.h"
     #endif
 #elif defined(__linux__)
-    #ifndef FILAMENT_USE_EXTERNAL_GLES3
+    #if !defined(FILAMENT_USE_EXTERNAL_GLES3) && !defined(FILAMENT_USE_SWIFTSHADER)
         #include "opengl/PlatformGLX.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
         #include "vulkan/PlatformVkLinux.h"
     #endif
 #elif defined(WIN32)
-    #ifndef FILAMENT_USE_EXTERNAL_GLES3
+    #if !defined(FILAMENT_USE_EXTERNAL_GLES3) && !defined(FILAMENT_USE_SWIFTSHADER)
         #include "opengl/PlatformWGL.h"
     #endif
     #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
@@ -113,10 +111,8 @@ DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
         return nullptr;
 #endif
     }
-    #if defined(FILAMENT_USE_EXTERNAL_GLES3)
+    #if defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(FILAMENT_USE_SWIFTSHADER)
         return nullptr;
-    #elif defined(SWIFTSHADER)
-        return new PlatformEGL();
     #elif defined(ANDROID)
         return new PlatformEGLAndroid();
     #elif defined(IOS)

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if defined(ANDROID) || defined(SWIFTSHADER) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
+#if defined(ANDROID) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
 
 #include <EGL/egl.h>
 #include <GLES3/gl3.h>

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -17,7 +17,7 @@
 #ifndef TNT_FILAMENT_DRIVER_GL_HEADERS_H
 #define TNT_FILAMENT_DRIVER_GL_HEADERS_H
 
-#if defined(ANDROID) || defined(SWIFTSHADER) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
+#if defined(ANDROID) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
 
     #include <GLES3/gl3.h>
     #include <GLES2/gl2ext.h>

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -93,7 +93,6 @@ void selectPhysicalDevice(VulkanContext& context) {
                 continue;
             }
             if (props.queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-                assert(props.timestampValidBits > 0);
                 context.graphicsQueueFamilyIndex = j;
             }
         }

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 # Copy the MoltenVK dylibs and JSON on MacOS
 # ==================================================================================================
 
-if (APPLE AND NOT Vulkan_LIBRARY)
+if (APPLE AND NOT Vulkan_LIBRARY AND NOT FILAMENT_USE_SWIFTSHADER)
     message(STATUS "No Vulkan SDK was found, using prebuilt MoltenVK.")
     set(MOLTENVK_DIR "../third_party/moltenvk")
     configure_file(


### PR DESCRIPTION
This also adds a -t flag to the easy build script for convenience.

SwiftShader on Vulkan can now be used as follows.

    git clone https://github.com/google/swiftshader.git
    cd swiftshader/build
    cmake .. &&  make -j && export SWIFTSHADER_LD_LIBRARY_PATH=`pwd`
    cd ../filament
    ./build.sh -t debug && ./out/cmake-debug/samples/gltf_viewer -a vulkan

Note that `third_party/swiftshader` does not need to exist since we already have Vulkan headers. I will remove it in a subsequent PR.