### PR TITLE
Fix a few issues with alpha-masked objects

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -758,8 +758,7 @@ struct RasterState {
 
     // note: clang reduces this entire function to a simple load/mask/compare
     bool hasBlending() const noexcept {
-        // there could be other cases where blending would end-up being disabled,
-        // but this is common and easy to check
+        // This is used to decide if blending needs to be enabled in the h/w
         return !(blendEquationRGB == BlendEquation::ADD &&
                  blendEquationAlpha == BlendEquation::ADD &&
                  blendFunctionSrcRGB == BlendFunction::ONE &&

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -315,7 +315,7 @@ private:
             RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward) noexcept;
 
-    static void setupColorCommand(Command& cmdDraw, bool hasDepthPass,
+    static void setupColorCommand(Command& cmdDraw,
             FMaterialInstance const* mi, bool inverseFrontFaces) noexcept;
 
     void recordDriverCommands(FEngine::DriverApi& driver, const Command* first,

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -17,6 +17,7 @@ float unpack(vec2 depth) {
 }
 
 float evaluateSSAO() {
+#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
     highp vec2 uv = uvToRenderTargetUV(getNormalizedViewportCoord().xy);
 
     // Upscale the SSAO buffer in real-time, in high quality mode we use a custom bilinear
@@ -66,6 +67,10 @@ float evaluateSSAO() {
     } else {
         return textureLod(light_ssao, uv, 0.0).r;
     }
+#else
+    // SSAO is not applied when blending is enabled
+    return 1.0;
+#endif
 }
 
 float SpecularAO_Lagarde(float NoV, float visibility, float roughness) {


### PR DESCRIPTION
- don't apply SSAO to blended objects
  these are not drawn into the structure buffer, so they don't 
  participate in SSAO.

- remove unused code that was needed for the depth prepass, which
  simplifies handling of blended objects.

- always treat alpha-masked objects as opaque.