### PR TITLE
Changed ifdef WIN32 to WIN32 or _WIN32

### DIFF
--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -189,7 +189,7 @@
 
 
 // ssize_t is a POSIX type.
-#if defined(WIN32)
+#if defined(_WIN32)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif
@@ -200,7 +200,7 @@ typedef SSIZE_T ssize_t;
 #   define UTILS_EMPTY_BASES
 #endif
 
-#if defined(WIN32)
+#if defined(_WIN32)
     #define IMPORTSYMB __declspec(dllimport)
 #else
     #define IMPORTSYMB

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -189,7 +189,7 @@
 
 
 // ssize_t is a POSIX type.
-#if defined(_WIN32)
+#if defined(WIN32) || defined(_WIN32)
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #endif
@@ -200,7 +200,7 @@ typedef SSIZE_T ssize_t;
 #   define UTILS_EMPTY_BASES
 #endif
 
-#if defined(_WIN32)
+#if defined(WIN32) || defined(_WIN32)
     #define IMPORTSYMB __declspec(dllimport)
 #else
     #define IMPORTSYMB


### PR DESCRIPTION
Changed if defined WIN32 to if defined WIN32 or _WIN32 because MSVC doesn't define WIN32 or WIN64.