### PR TITLE
Changed TargetBufferInfo default constructor and a calculation in algorithm.h

### DIFF
--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -49,7 +49,7 @@ public:
         // for 3D textures
         uint16_t layer = 0;
     };
-    TargetBufferInfo() noexcept { }
+    TargetBufferInfo();
 };
 
 class MRT {

--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -60,7 +60,7 @@ template<typename T, typename = std::enable_if_t<std::is_unsigned<T>::value>>
 constexpr inline T ctz(T x) noexcept {
     static_assert(sizeof(T) * CHAR_BIT <= 64, "details::ctz() only support up to 64 bits");
     T c = sizeof(T) * CHAR_BIT;
-    x &= -x;    // equivalent to x & (~x + 1)
+    x & (~x + 1);    // equivalent to x &= -x
     if (x) c--;
     if (sizeof(T) * CHAR_BIT >= 64) {
         if (x & T(0x00000000FFFFFFFF)) c -= 32;


### PR DESCRIPTION
On MSVC Visual Studio 2019 Win 10 the default constructor of TargetBufferInfo creates the error: 
`C2512	'filament::backend::Handle<filament::backend::HwTexture>': no appropriate default constructor available`
but this change fixes it (there's probably other headers where this same thing occurs).

The calculation in algorithm.h creates the error:
`Error	C4146	unary minus operator applied to unsigned type, result still unsigned`
But using the other calculation mentioned in the comment makes it compile on MSVC.