### PR TITLE
optionally compress highlights before bloom

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -215,7 +215,7 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetBloomOptions(JNIEnv*, jclass,
         jlong nativeView, jlong nativeTexture,
         jfloat dirtStrength, jfloat strength, jint resolution, jfloat anamorphism, jint levels,
-        jint blendMode, jboolean threshold, jboolean enabled) {
+        jint blendMode, jboolean threshold, jboolean enabled, jfloat highlight) {
     View* view = (View*) nativeView;
     Texture* dirt = (Texture*) nativeTexture;
     View::BloomOptions options = {
@@ -227,7 +227,8 @@ Java_com_google_android_filament_View_nSetBloomOptions(JNIEnv*, jclass,
             .levels = (uint8_t)levels,
             .blendMode = (View::BloomOptions::BlendMode)blendMode,
             .threshold = (bool)threshold,
-            .enabled = (bool)enabled
+            .enabled = (bool)enabled,
+            .highlight = highlight
     };
     view->setBloomOptions(options);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -283,6 +283,12 @@ public class View {
          * enable or disable bloom
          */
         public boolean enabled = false;
+
+        /**
+         * limit highlights to this value before bloom. Use +inf for no limiting.
+         * minimum value is 10.0.
+         */
+        public float highlight = 1000.0f;
     }
 
     /**
@@ -1082,7 +1088,7 @@ public class View {
         nSetBloomOptions(getNativeObject(), options.dirt != null ? options.dirt.getNativeObject() : 0,
                 options.dirtStrength, options.strength, options.resolution,
                 options.anamorphism, options.levels, options.blendingMode.ordinal(),
-                options.threshold, options.enabled);
+                options.threshold, options.enabled, options.highlight);
     }
 
     /**
@@ -1220,7 +1226,7 @@ public class View {
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
     private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int upsampling, boolean enabled);
-    private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled);
+    private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);
     private static native void nSetDepthOfFieldOptions(long nativeView, float focusDistance, float blurScale, float maxApertureDiameter, boolean enabled);

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -146,6 +146,7 @@ public:
         BlendMode blendMode = BlendMode::ADD;   //!< how the bloom effect is applied
         bool threshold = true;                  //!< whether to threshold the source
         bool enabled = false;                   //!< enable or disable bloom
+        float highlight = 1000.0f;              //!< limit highlights to this value before bloom [10, +inf]
     };
 
     /**

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1264,6 +1264,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPass(FrameGraph& fg,
                 });
                 mi->setParameter("level", 0.0f);
                 mi->setParameter("threshold", bloomOptions.threshold ? 1.0f : 0.0f);
+                mi->setParameter("invHighlight", std::isinf(bloomOptions.highlight) ? 0.0f : 1.0f / bloomOptions.highlight);
 
                 for (size_t i = 0; i < bloomOptions.levels; i++) {
                     auto hwOutRT = resources.get(data.outRT[i]);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -307,6 +307,7 @@ public:
     void setBloomOptions(BloomOptions options) noexcept {
         options.dirtStrength = math::saturate(options.dirtStrength);
         options.levels = math::clamp(options.levels, uint8_t(3), uint8_t(12));
+        options.highlight = std::max(10.0f, options.highlight);
         mBloomOptions = options;
     }
 

--- a/filament/src/materials/bloom/bloomDownsample.mat
+++ b/filament/src/materials/bloom/bloomDownsample.mat
@@ -18,6 +18,10 @@ material {
         {
             type : float,
             name : threshold
+        },
+        {
+            type : float,
+            name : invHighlight
         }
     ],
     variables : [
@@ -36,7 +40,10 @@ vertex {
 
 fragment {
     void threshold(inout vec3 c) {
-        c *= step(1.0, max3(c));
+        float l = max3(c);
+        highp float f = l;
+        c *= 1.0 / (1.0 + f * materialParams.invHighlight);
+        c *= step(1.0, l);
     }
 
     vec3 box4x4(vec3 s0, vec3 s1, vec3 s2, vec3 s3) {


### PR DESCRIPTION
This avoid unrealistic looking bloom halos from very strong highlights.
This is enabled by default.