### PR TITLE
New API to create an Engine asynchronously

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ A new header is inserted each time a *tag* is created.
 - Fixed translucent views with custom render targets.
 - Improved MSAA implementation compatibility on Android devices.
 - Use "reverse-z" for the depth buffer.
+- Add a way to create an Engine asynchronously.
 
 ## v1.8.1
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -129,6 +129,14 @@ public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
             Platform* platform = nullptr, void* sharedGLContext = nullptr);
 
+#if UTILS_HAS_THREADING
+    static void createAsync(CreateCallback callback, void* user,
+            Backend backend = Backend::DEFAULT,
+            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+
+    static FEngine* getEngine(void* token);
+#endif
+
     static void destroy(FEngine* engine);
 
     ~FEngine() noexcept;


### PR DESCRIPTION
Because initializing the backend can be relatively slow, creating an
Engine can block the main thread, is this is a problem, this new API
can be used instead; while a bit more complex, it allow the engine to
be initialized asynchronously.