### PR TITLE
ssao code improvements and bug fixes

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -458,7 +458,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOclusion(
                         float4{ desc.width, desc.height, 1.0f / desc.width, 1.0f / desc.height });
                 mi->setParameter("invRadiusSquared", 1.0f / (data.options.radius * data.options.radius));
                 mi->setParameter("projectionScaleRadius", projectionScale * data.options.radius);
-                mi->setParameter("depthParams", cameraInfo.projection[3][2]);
+                mi->setParameter("depthParams", cameraInfo.projection[3][2] * 0.5f);
 
                 mi->setParameter("positionParams", float2{
                         invProjection[0][0], invProjection[1][1] } * 2.0f);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -651,8 +651,10 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
             .filterMag = mAmbientOcclusionOptions.enabled && !highQualitySampling ?
                          SamplerMagFilter::LINEAR : SamplerMagFilter::NEAREST
     });
-    mPerViewUb.setUniform(offsetof(PerViewUib, aoSamplingQuality),
-            mAmbientOcclusionOptions.enabled && highQualitySampling ? 1.0f : 0.0f);
+
+    const float edgeDistance = 1.0 / 0.0625;// TODO: don't hardcode this
+    mPerViewUb.setUniform(offsetof(PerViewUib, aoSamplingQualityAndEdgeDistance),
+            mAmbientOcclusionOptions.enabled && highQualitySampling ? edgeDistance : 0.0f);
 }
 
 void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 9;
+static constexpr size_t MATERIAL_VERSION = 10;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -120,7 +120,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // bit 8-11: cascade has visible shadows
     uint32_t cascades;
 
-    float aoSamplingQuality;     // 0: bilinear, !0: bilateral
+    float aoSamplingQualityAndEdgeDistance;     // 0: bilinear, !0: bilateral edge distance
     float aoReserved1;
     float aoReserved2;
     float aoReserved3;

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -102,7 +102,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("cascades",                1, UniformInterfaceBlock::Type::UINT)
 
             // SSAO sampling parameters
-            .add("aoSamplingQuality",       1, UniformInterfaceBlock::Type::FLOAT)
+            .add("aoSamplingQualityAndEdgeDistance", 1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved1",             1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved2",             1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved3",             1, UniformInterfaceBlock::Type::FLOAT)

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -602,12 +602,15 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderFloat("IBL", &params.iblIntensity, 0.0f, 50000.0f);
             ImGui::SliderAngle("Rotation", &params.iblRotation);
             if (ImGui::CollapsingHeader("SSAO")) {
+                bool upsampling = params.ssaoOptions.upsampling == View::QualityLevel::LOW ? false : true;
                 DebugRegistry& debug = engine->getDebugRegistry();
                 ImGui::Checkbox("Enabled##ssao", &params.ssaoOptions.enabled);
                 ImGui::SliderFloat("Radius", &params.ssaoOptions.radius, 0.05f, 5.0f);
                 ImGui::SliderFloat("Bias", &params.ssaoOptions.bias, 0.0f, 0.01f, "%.6f");
                 ImGui::SliderFloat("Intensity", &params.ssaoOptions.intensity, 0.0f, 4.0f);
                 ImGui::SliderFloat("Power", &params.ssaoOptions.power, 0.0f, 4.0f);
+                ImGui::Checkbox("High quality upsampling", &upsampling);
+                params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
             }
             ImGui::Unindent();
         }


### PR DESCRIPTION
- fix a recent typo that affected SSAO quality
- add a upsampling quality checkbox in material_sandbox
- make use of textureLodOffset instead of texelFetch, so that
  we emulate more closely textureGather
- don't hardcode bilateral filter edge-distance in the shader
  (still hardcoded on the cpu side)