### PR TITLE
rework a bit dithering noise

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1376,10 +1376,14 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
             .filterMag = SamplerMagFilter::LINEAR,
             .filterMin = SamplerMinFilter::LINEAR
     });
+
+    const float temporalNoise = mUniformDistribution(mRandomEngine);
+
     mi->setParameter("vignette", vignetteParameters);
     mi->setParameter("vignetteColor", vignetteOptions.color);
     mi->setParameter("dithering", dithering);
     mi->setParameter("fxaa", fxaa);
+    mi->setParameter("temporalNoise", temporalNoise);
     mi->commit(driver);
 }
 
@@ -1489,11 +1493,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                 float4 vignetteParameters = getVignetteParameters(
                         vignetteOptions, output.width, output.height);
 
+                const float temporalNoise = mUniformDistribution(mRandomEngine);
+
                 mi->setParameter("dithering", dithering);
                 mi->setParameter("bloom", bloomParameters);
                 mi->setParameter("vignette", vignetteParameters);
                 mi->setParameter("vignetteColor", vignetteOptions.color);
                 mi->setParameter("fxaa", fxaa);
+                mi->setParameter("temporalNoise", temporalNoise);
 
                 const uint8_t variant = uint8_t(translucent ?
                             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -32,6 +32,8 @@
 
 #include <tsl/robin_map.h>
 
+#include <random>
+
 namespace filament {
 
 class FrameGraph;
@@ -202,6 +204,9 @@ private:
     backend::Handle<backend::HwTexture> mDummyZeroTexture;
 
     size_t mSeparableGaussianBlurKernelStorageSize = 0;
+
+    std::default_random_engine mRandomEngine;
+    std::uniform_real_distribution<float> mUniformDistribution{0.0f, 1.0f};
 
     const math::float2 mHaltonSamples[16];
 };

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -30,6 +30,11 @@ material {
             name : fxaa
         },
         {
+            type : float,
+            name : temporalNoise,
+            precision: high
+        },
+        {
             type : float4,
             name : bloom
         },
@@ -113,7 +118,7 @@ fragment {
     void postProcess(inout PostProcessInputs postProcess) {
         postProcess.color = resolve();
         if (materialParams.dithering > 0) {
-            vec4 dithered = dither(postProcess.color);
+            vec4 dithered = dither(postProcess.color, materialParams.temporalNoise);
 #if POST_PROCESS_OPAQUE
             postProcess.color.rgb = dithered.rgb;
 #else

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -15,6 +15,11 @@ material {
             name : fxaa
         },
         {
+            type : float,
+            name : temporalNoise,
+            precision: high
+        },
+        {
             type : float4,
             name : vignette
         },
@@ -93,7 +98,7 @@ fragment {
     void postProcess(inout PostProcessInputs postProcess) {
         postProcess.color = resolve();
         if (materialParams.dithering > 0) {
-            vec4 dithered = dither(postProcess.color);
+            vec4 dithered = dither(postProcess.color, materialParams.temporalNoise);
 #if POST_PROCESS_OPAQUE
             postProcess.color.rgb = dithered.rgb;
 #else

--- a/shaders/src/dithering.fs
+++ b/shaders/src/dithering.fs
@@ -39,10 +39,9 @@ float interleavedGradientNoise(highp vec2 n) {
 // Dithering
 //------------------------------------------------------------------------------
 
-vec4 Dither_InterleavedGradientNoise(vec4 rgba) {
+vec4 Dither_InterleavedGradientNoise(vec4 rgba, const highp float temporalNoise01) {
     // Jimenez 2014, "Next Generation Post-Processing in Call of Duty"
-    highp vec2 uv = gl_FragCoord.xy;
-    uv += frameUniforms.time;
+    highp vec2 uv = gl_FragCoord.xy + temporalNoise01;
 
     // The noise variable must be highp to workaround Adreno bug #1096.
     highp float noise = interleavedGradientNoise(uv);
@@ -53,10 +52,10 @@ vec4 Dither_InterleavedGradientNoise(vec4 rgba) {
     return rgba + vec4(noise / 255.0);
 }
 
-vec4 Dither_TriangleNoise(vec4 rgba) {
+vec4 Dither_TriangleNoise(vec4 rgba, const highp float temporalNoise01) {
     // Gjøl 2016, "Banding in Games: A Noisy Rant"
     highp vec2 uv = gl_FragCoord.xy * frameUniforms.resolution.zw;
-    uv += vec2(0.07 * fract(frameUniforms.time));
+    uv += vec2(0.07 * temporalNoise01);
 
     // The noise variable must be highp to workaround Adreno bug #1096.
     highp float noise = triangleNoise(uv);
@@ -66,9 +65,9 @@ vec4 Dither_TriangleNoise(vec4 rgba) {
     return rgba + vec4(noise / 255.0);
 }
 
-vec4 Dither_Vlachos(vec4 rgba) {
+vec4 Dither_Vlachos(vec4 rgba, const highp float temporalNoise01) {
     // Vlachos 2016, "Advanced VR Rendering"
-    float noise = dot(vec2(171.0, 231.0), gl_FragCoord.xy + frameUniforms.time);
+    float noise = dot(vec2(171.0, 231.0), gl_FragCoord.xy + temporalNoise01);
     vec3 noiseRGB = fract(vec3(noise) / vec3(103.0, 71.0, 97.0));
 
     // remap from [0..1[ to [-0.5..0.5[
@@ -77,10 +76,10 @@ vec4 Dither_Vlachos(vec4 rgba) {
     return vec4(rgba.rgb + (noiseRGB / 255.0), rgba.a);
 }
 
-vec4 Dither_TriangleNoiseRGB(vec4 rgba) {
+vec4 Dither_TriangleNoiseRGB(vec4 rgba, const highp float temporalNoise01) {
     // Gjøl 2016, "Banding in Games: A Noisy Rant"
     highp vec2 uv = gl_FragCoord.xy * frameUniforms.resolution.zw;
-    uv += vec2(0.07 * fract(frameUniforms.time));
+    uv += vec2(0.07 * temporalNoise01);
 
     vec3 noiseRGB = vec3(
             triangleNoise(uv),
@@ -102,16 +101,16 @@ vec4 Dither_TriangleNoiseRGB(vec4 rgba) {
  * This dithering function assumes we are dithering to an 8-bit target.
  * This function dithers the alpha channel assuming premultiplied output
  */
-vec4 dither(vec4 rgba) {
+vec4 dither(vec4 rgba, const highp float temporalNoise01) {
 #if DITHERING_OPERATOR == DITHERING_NONE
     return rgba;
 #elif DITHERING_OPERATOR == DITHERING_INTERLEAVED_NOISE
-    return Dither_InterleavedGradientNoise(rgba);
+    return Dither_InterleavedGradientNoise(rgba, temporalNoise01);
 #elif DITHERING_OPERATOR == DITHERING_VLACHOS
-    return Dither_Vlachos(rgba);
+    return Dither_Vlachos(rgba, temporalNoise01);
 #elif DITHERING_OPERATOR  == DITHERING_TRIANGLE_NOISE
-    return Dither_TriangleNoise(rgba);
+    return Dither_TriangleNoise(rgba, temporalNoise01);
 #elif DITHERING_OPERATOR  == DITHERING_TRIANGLE_NOISE_RGB
-    return Dither_TriangleNoiseRGB(rgba);
+    return Dither_TriangleNoiseRGB(rgba, temporalNoise01);
 #endif
 }


### PR DESCRIPTION
- don't use frameUniform.time as the temporal noise seed because
  this has a cycle to it. It's not very visible on dithering but
  obvious when used for other things.

- don't use fract(time) since time was already in [0,1] -- though it's
  moot now.

- instead of time pass a random number in [0,1] generated on the CPU
  each frame.
  This will also allow to control temporal noise more easily if
  needed in the future (e.g. for accessibility or rendering tests)