### PR TITLE
CoroutineScope job should be canceled before destory

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -85,6 +85,8 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     private var surfaceView: SurfaceView? = null
     private var textureView: TextureView? = null
 
+    private var fetchResourcesJob: Job? = null
+
     private val renderer: Renderer
     private var swapChain: SwapChain? = null
     private var assetLoader: AssetLoader
@@ -190,7 +192,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     fun loadModelGltfAsync(buffer: Buffer, callback: (String) -> Buffer) {
         destroyModel()
         asset = assetLoader.createAssetFromJson(buffer)
-        CoroutineScope(Dispatchers.IO).launch {
+        fetchResourcesJob = CoroutineScope(Dispatchers.IO).launch {
             fetchResources(asset!!, callback)
         }
     }
@@ -217,6 +219,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
      * Frees all entities associated with the most recently-loaded model.
      */
     fun destroyModel() {
+        fetchResourcesJob?.cancel()
         asset?.let { asset ->
             this.scene.removeEntities(asset.entities)
             assetLoader.destroyAsset(asset)


### PR DESCRIPTION
tombstone happens if run destory while loadModelGltfAsync in ModelViewer.kt

To Reproduce
1.loadModelGltfAsync
2.detach from the winodw quickly
3.tombstone ..