### PR TITLE
fix memory leak issue in reource loader

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -927,10 +927,10 @@ void ResourceLoader::Impl::computeTangents(FFilamentAsset* asset) {
 }
 
 ResourceLoader::Impl::~Impl() {
-    releaseTexels();
     if (mDecoderRootJob) {
         mEngine->getJobSystem().waitAndRelease(mDecoderRootJob);
     }
+    releaseTexels();
 }
 
 void ResourceLoader::applySparseData(FFilamentAsset* asset) const {


### PR DESCRIPTION
shoule release texels before destory or reload

To Reproduce

1. start android sample-gltf-viewer
2. keep on double tabing the activity to reload the model
3. monitor the memory useage