### PR TITLE
add float versions of math constants to libmath

### DIFF
--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -61,8 +61,7 @@ void UTILS_NOINLINE FCamera::setProjection(double fov, double aspect, double nea
 void FCamera::setLensProjection(double focalLength, double aspect, double near, double far) noexcept {
     // a 35mm camera has a 36x24mm wide frame size
     double theta = 2.0 * std::atan(SENSOR_SIZE * 1000.0f / (2.0 * focalLength));
-    theta *= 180.0 / math::F_PI;
-    FCamera::setProjection(theta, aspect, near, far, Fov::VERTICAL);
+    FCamera::setProjection(theta * math::d::RAD_TO_DEG, aspect, near, far, Fov::VERTICAL);
 }
 
 /*

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -451,12 +451,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOclusion(
                 // Where the falloff function peaks
                 const float peak = 0.1f * options.radius;
                 // We further scale the user intensity by 2, for a better default at intensity=1
-                const float intensity = (2.0f * float(F_PI) * peak) * options.intensity * 2.0f;
+                const float intensity = (f::TAU * peak) * options.intensity * 2.0f;
                 // always square AO result, as it looks much better
                 const float power = options.power * 2.0f;
 
                 const auto invProjection = inverse(cameraInfo.projection);
-                const float inc = (1.0f / (sampleCount - 0.5f)) * spiralTurns * 2.0f * float(F_PI);
+                const float inc = (1.0f / (sampleCount - 0.5f)) * spiralTurns * f::TAU;
 
                 auto& material = getPostProcessMaterial("sao");
                 FMaterialInstance* const mi = material.getMaterialInstance();
@@ -774,9 +774,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                                              : TextureFormat::R11F_G11F_B10F;
 
     // rotate the bokeh based on the aperture diameter (i.e. angle of the blades)
-    float bokehAngle = float(F_PI) / 6.0f;
+    float bokehAngle = f::PI / 6.0f;
     if (dofOptions.maxApertureDiameter > 0.0f) {
-        bokehAngle += float(F_PI_2) * saturate(cameraInfo.A / dofOptions.maxApertureDiameter);
+        bokehAngle += f::PI_2 * saturate(cameraInfo.A / dofOptions.maxApertureDiameter);
     }
 
     const float focusDistance = std::max(cameraInfo.zn, dofOptions.focusDistance);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -602,7 +602,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
         // sigma is: lod = log2(sigma/sigma0).
         // sigma is deduced from the roughness: roughness = sqrt(2) * s * sigma
         // In the end we get: lod = 2 * log2(perceptualRoughness) - log2(sigma0 * s * sqrt2)
-        const float refractionLodOffset = -std::log2(sigma0 * s * (float)F_SQRT2);
+        const float refractionLodOffset = -std::log2(sigma0 * s * f::SQRT2);
         const float maxPerceptualRoughness = 0.5f;
         const uint8_t maxLod = std::ceil(2.0f * std::log2(maxPerceptualRoughness) + refractionLodOffset);
 

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -497,7 +497,7 @@ void ShadowMap::computeShadowCameraSpot(math::float3 const& position, math::floa
     const mat4f M = mat4f::lookAt(lightPosition, lightPosition + dir, float3{0, 1, 0});
     const mat4f Mv = FCamera::rigidTransformInverse(M);
 
-    float outerConeAngleDegrees = outerConeAngle / (2.0f * F_PI) * 360.0f;
+    float outerConeAngleDegrees = outerConeAngle * f::RAD_TO_DEG;
     const mat4f Mp = mat4f::perspective(outerConeAngleDegrees * 2, 1.0f, nearPlane, radius,
             mat4f::Fov::HORIZONTAL);
 

--- a/filament/src/ToneMapping.h
+++ b/filament/src/ToneMapping.h
@@ -96,7 +96,7 @@ inline float rgb_2_hue(float3 rgb) {
     float hue = 0.0f;
     // RGB triplets where RGB are equal have an undefined hue
     if (!(rgb.x == rgb.y && rgb.y == rgb.z)) {
-        hue = (180.0f / float(F_PI)) * std::atan2(
+        hue = f::RAD_TO_DEG * std::atan2(
                 std::sqrt(3.0f) * (rgb.y - rgb.z),
                 2.0f * rgb.x - rgb.y - rgb.z);
     }

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -42,7 +42,7 @@ struct LightManager::BuilderDetails {
     float mIntensity = 100000.0f;
     FLightManager::IntensityUnit mIntensityUnit = FLightManager::IntensityUnit::LUMEN_LUX;
     float3 mDirection = { 0.0f, -1.0f, 0.0f };
-    float2 mSpotInnerOuter = { (float) F_PI, (float) F_PI };
+    float2 mSpotInnerOuter = { f::PI, f::PI };
     float mSunAngle = 0.00951f; // 0.545° in radians
     float mSunHaloSize = 10.0f;
     float mSunHaloFalloff = 80.0f;
@@ -262,7 +262,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
             case Type::POINT:
                 if (unit == IntensityUnit::LUMEN_LUX) {
                     // li = lp / (4 * pi)
-                    luminousIntensity = luminousPower * float(F_1_PI) * 0.25f;
+                    luminousIntensity = luminousPower * f::ONE_OVER_PI * 0.25f;
                 } else {
                     assert(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
@@ -275,13 +275,13 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
                 float cosOuter = std::sqrt(spotParams.cosOuterSquared);
                 if (unit == IntensityUnit::LUMEN_LUX) {
                     // li = lp / (2 * pi * (1 - cos(cone_outer / 2)))
-                    luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosOuter));
+                    luminousIntensity = luminousPower / (f::TAU * (1.0f - cosOuter));
                 } else {
                     assert(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
                     luminousIntensity = luminousPower;
                     // lp = li * (2 * pi * (1 - cos(cone_outer / 2)))
-                    luminousPower = luminousIntensity * (2.0f * float(F_PI) * (1.0f - cosOuter));
+                    luminousPower = luminousIntensity * (f::TAU * (1.0f - cosOuter));
                 }
                 spotParams.luminousPower = luminousPower;
                 break;
@@ -289,7 +289,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
             case Type::SPOT:
                 if (unit == IntensityUnit::LUMEN_LUX) {
                     // li = lp / pi
-                    luminousIntensity = luminousPower * float(F_1_PI);
+                    luminousIntensity = luminousPower * f::ONE_OVER_PI;
                 } else {
                     assert(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
@@ -315,8 +315,8 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
     auto& manager = mManager;
     if (i && isSpotLight(i)) {
         // clamp the inner/outer angles to pi
-        float innerClamped = std::min(std::abs(inner), float(F_PI_2));
-        float outerClamped = std::min(std::abs(outer), float(F_PI_2));
+        float innerClamped = std::min(std::abs(inner), f::PI_2);
+        float outerClamped = std::min(std::abs(outer), f::PI_2);
 
         // outer must always be bigger than inner
         outerClamped = std::max(innerClamped, outerClamped);
@@ -338,7 +338,7 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
         if (type == Type::FOCUSED_SPOT) {
             // li = lp / (2 * pi * (1 - cos(cone_outer / 2)))
             float luminousPower = spotParams.luminousPower;
-            float luminousIntensity = luminousPower / (2.0f * float(F_PI) * (1.0f - cosOuter));
+            float luminousIntensity = luminousPower / (f::TAU * (1.0f - cosOuter));
             manager[i].intensity = luminousIntensity;
         }
     }
@@ -347,7 +347,7 @@ void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexc
 void FLightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept {
     if (i && isSunLight(i)) {
         angularRadius = clamp(angularRadius, 0.25f, 20.0f);
-        mManager[i].sunAngularRadius = angularRadius * float(F_PI / 180.0);
+        mManager[i].sunAngularRadius = angularRadius * f::DEG_TO_RAD;
     }
 }
 
@@ -488,7 +488,7 @@ void LightManager::setSunAngularRadius(Instance i, float angularRadius) noexcept
 
 float LightManager::getSunAngularRadius(Instance i) const noexcept {
     float radius = upcast(this)->getSunAngularRadius(i);
-    return radius * float(180.0 / F_PI);
+    return radius * f::RAD_TO_DEG;
 }
 
 void LightManager::setSunHaloSize(Instance i, float haloSize) noexcept {

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -130,7 +130,7 @@ public:
     }
 
     float getFieldOfViewInDegrees(Camera::Fov direction) const noexcept {
-        return getFieldOfView(direction) * float(180.0f / math::F_PI);
+        return getFieldOfView(direction) * math::f::RAD_TO_DEG;
     }
 
     // returns a Frustum object in world space
@@ -169,8 +169,8 @@ private:
     math::mat4 mProjectionForCulling;  // projection matrix (with far plane)
     math::double4 mScaling = {1.0f};   // additional scaling applied to projection
 
-    float mNear;
-    float mFar;
+    float mNear{};
+    float mFar{};
     // exposure settings
     float mAperture = 16.0f;
     float mShutterSpeed = 1.0f / 125.0f;

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -166,7 +166,7 @@ TEST(FilamentTest, SkinningMath) {
 
     std::default_random_engine generator(82828); // NOLINT
     std::uniform_real_distribution<float> distribution(-4, 4);
-    std::uniform_real_distribution<float> dangle(-2.0 * F_PI, 2.0 * F_PI);
+    std::uniform_real_distribution<float> dangle(-f::TAU, f::TAU);
     auto rand_gen = std::bind(distribution, generator);
 
     for (size_t i = 0; i < 100; ++i) {

--- a/libs/math/include/math/scalar.h
+++ b/libs/math/include/math/scalar.h
@@ -35,6 +35,45 @@ constexpr const double F_2_PI     = 0.636619772367581343075535053490057448;
 constexpr const double F_2_SQRTPI = 1.12837916709551257389615890312154517;
 constexpr const double F_SQRT2    = 1.41421356237309504880168872420969808;
 constexpr const double F_SQRT1_2  = 0.707106781186547524400844362104849039;
+constexpr const double F_TAU      = 2.0 * F_PI;
+
+namespace d {
+constexpr const double E                = F_E;
+constexpr const double LOG2E            = F_LOG2E;
+constexpr const double LOG10E           = F_LOG10E;
+constexpr const double LN2              = F_LN2;
+constexpr const double LN10             = F_LN10;
+constexpr const double PI               = F_PI;
+constexpr const double PI_2             = F_PI_2;
+constexpr const double PI_4             = F_PI_4;
+constexpr const double ONE_OVER_PI      = F_1_PI;
+constexpr const double TWO_OVER_PI      = F_2_PI;
+constexpr const double TWO_OVER_SQRTPI  = F_2_SQRTPI;
+constexpr const double SQRT2            = F_SQRT2;
+constexpr const double SQRT1_2          = F_SQRT1_2;
+constexpr const double TAU              = F_TAU;
+constexpr const double DEG_TO_RAD       = F_PI / 180.0;
+constexpr const double RAD_TO_DEG       = 180.0 / F_PI;
+} // namespace d
+
+namespace f {
+constexpr const float E                = (float)d::E;
+constexpr const float LOG2E            = (float)d::LOG2E;
+constexpr const float LOG10E           = (float)d::LOG10E;
+constexpr const float LN2              = (float)d::LN2;
+constexpr const float LN10             = (float)d::LN10;
+constexpr const float PI               = (float)d::PI;
+constexpr const float PI_2             = (float)d::PI_2;
+constexpr const float PI_4             = (float)d::PI_4;
+constexpr const float ONE_OVER_PI      = (float)d::ONE_OVER_PI;
+constexpr const float TWO_OVER_PI      = (float)d::TWO_OVER_PI;
+constexpr const float TWO_OVER_SQRTPI  = (float)d::TWO_OVER_SQRTPI;
+constexpr const float SQRT2            = (float)d::SQRT2;
+constexpr const float SQRT1_2          = (float)d::SQRT1_2;
+constexpr const float TAU              = (float)d::TAU;
+constexpr const float DEG_TO_RAD       = (float)d::DEG_TO_RAD;
+constexpr const float RAD_TO_DEG       = (float)d::RAD_TO_DEG;
+} // namespace f
 
 template<typename T>
 inline constexpr T MATH_PURE min(T a, T b) noexcept {


### PR DESCRIPTION
e.g. `F_PI` is also available as `d::PI` and `f::PI` as `double` or
`float` respectively.

Most of our uses of those constants are `float` and it was error prone
and cumbersome to have to cast to that each time we used them.

The `F_` constants are intended to mimic `math.h`, however these new
constants are not, and all the "n over" constants are named
`N_OVER_` instead of `N_`, which helps avoiding the confusion that e.g.:
`F_2_PI` is actually `2/pi` and not `2*pi`.

Also added `F_TAU` which is 2 * PI.