### PR TITLE
Improvements to SSAO quality

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -141,6 +141,7 @@ private:
         uint8_t kernelSize = 11;
         float standardDeviation = 1.0f;
         float bilateralThreshold = 0.0625f;
+        float scale = 1.0f;
     };
 
     FrameGraphId<FrameGraphTexture> bilateralBlurPass(

--- a/filament/src/materials/ssao/bilateralBlur.mat
+++ b/filament/src/materials/ssao/bilateralBlur.mat
@@ -44,6 +44,11 @@ fragment {
         return (depth.x * (256.0 / 257.0) + depth.y * (1.0 / 257.0));
     }
 
+    float random(const highp vec2 w) {
+        const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
+        return fract(m.z * fract(dot(w, m.xy)));
+    }
+
     float bilateralWeight(in float depth, in float sampleDepth) {
         float diff = (sampleDepth - depth) * materialParams.farPlaneOverEdgeDistance;
         return max(0.0, 1.0 - diff * diff);
@@ -84,7 +89,13 @@ fragment {
             offset += materialParams.axis;
         }
 
-        postProcess.color.r = sum * (1.0 / totalWeight);
+        float ao = sum * (1.0 / totalWeight);
+
+        // simple dithering helps a lot (assumes 8 bits target)
+        // this is most useful with high quality/large blurs
+        ao += ((random(gl_FragCoord.xy) - 0.5) / 255.0);
+
+        postProcess.color.r = ao;
         postProcess.color.gb = data.gb;
     }
 }

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -216,7 +216,7 @@ fragment {
             tapPosition = angleStep * tapPosition;
         }
 
-        float ao = max(0.0, 1.0 - occlusion * materialParams.intensity);
+        float ao = max(0.0, 1.0 - sqrt(occlusion * materialParams.intensity));
         ao = pow(ao, materialParams.power);
 
 #if defined(TARGET_MOBILE)


### PR DESCRIPTION
- simulate a standard deviation of 8 by skipping every other pixel
  when blurring the AO buffer at LOW or MEDIUM quality. This creates
  a faint checker pattern, but does look much better than the low
  frequency noise that is introduced otherwise.

- tweak AO parameters to give a more uniform and smooth AO effect by
  default. This also makes AO even more consistant between quality
  modes.

- add a simple dithering stage to AO blur to help eliminate banding
  artifacts at higher sample counts.


before:
<img width="574" alt="Screen Shot 2020-09-11 at 21 17 52" src="https://user-images.githubusercontent.com/1240896/92988411-17c50300-f480-11ea-9bd0-e54ae42110ec.png">
<img width="725" alt="Screen Shot 2020-09-11 at 22 22 37" src="https://user-images.githubusercontent.com/1240896/92988450-7e4a2100-f480-11ea-94fd-084c569ed83d.png">

after:

<img width="710" alt="Screen Shot 2020-09-11 at 21 18 17" src="https://user-images.githubusercontent.com/1240896/92988413-1e537a80-f480-11ea-896f-384b3ced710f.png">
<img width="725" alt="Screen Shot 2020-09-11 at 22 22 12" src="https://user-images.githubusercontent.com/1240896/92988460-8c983d00-f480-11ea-9075-bcc17b9368d5.png">

