### PR TITLE
rename .blurScale to .apertureScale in dof options

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -262,9 +262,9 @@ Java_com_google_android_filament_View_nSetBlendMode(JNIEnv *, jclass , jlong nat
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetDepthOfFieldOptions(JNIEnv *, jclass ,
-        jlong nativeView, jfloat focusDistance, jfloat blurScale, jfloat maxApertureDiameter, jboolean enabled) {
+        jlong nativeView, jfloat focusDistance, jfloat apertureScale, jfloat maxApertureDiameter, jboolean enabled) {
     View* view = (View*) nativeView;
-    view->setDepthOfFieldOptions({.focusDistance = focusDistance, .blurScale = blurScale,
+    view->setDepthOfFieldOptions({.focusDistance = focusDistance, .apertureScale = apertureScale,
             .maxApertureDiameter = maxApertureDiameter, .enabled = (bool)enabled});
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -360,8 +360,14 @@ public class View {
         /** focus distance in world units */
         public float focusDistance = 10.0f;
 
-        /** scale factor controlling the amount of blur (values other than 1.0 are not physically correct)*/
-        public float blurScale = 1.0f;
+        /**
+         * camera aperture scale (or circle of confusion scale factor)
+         * <p>It is possible to use the apertureScale parameter to set a DoF independently from the
+         * camera aperture by setting it to: apertureScale = desiredDofAperture / cameraAperture.</p>
+         * <p>apertureScale can also be seen as circle of confusion scale factor.</p>
+         * @see Camera
+         */
+        public float apertureScale = 1.0f;
 
         /** maximum aperture diameter in meters (zero to disable bokeh rotation) */
         public float maxApertureDiameter = 0.01f;
@@ -1173,7 +1179,7 @@ public class View {
      */
     public void setDepthOfFieldOptions(@NonNull DepthOfFieldOptions options) {
         mDepthOfFieldOptions = options;
-        nSetDepthOfFieldOptions(getNativeObject(), options.focusDistance, options.blurScale, options.maxApertureDiameter, options.enabled);
+        nSetDepthOfFieldOptions(getNativeObject(), options.focusDistance, options.apertureScale, options.maxApertureDiameter, options.enabled);
     }
 
     /**
@@ -1229,7 +1235,7 @@ public class View {
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);
-    private static native void nSetDepthOfFieldOptions(long nativeView, float focusDistance, float blurScale, float maxApertureDiameter, boolean enabled);
+    private static native void nSetDepthOfFieldOptions(long nativeView, float focusDistance, float apertureScale, float maxApertureDiameter, boolean enabled);
     private static native void nSetVignetteOptions(long nativeView, float midPoint, float roundness, float feather, float r, float g, float b, float a, boolean enabled);
     private static native void nSetTemporalAntiAliasingOptions(long nativeView, float feedback, float filterWidth, boolean enabled);
 }

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -167,10 +167,16 @@ public:
 
     /**
      * Options to control Depth of Field (DoF) effect in the scene.
+     *
+     * It is possible to use the apertureScale parameter to set a DoF independently from the
+     * camera aperture by setting it to: apertureScale = desiredDofAperture / cameraAperture.
+     * apertureScale can also be seen as circle of confusion scale factor.
+     *
+     * @see Camera
      */
     struct DepthOfFieldOptions {
-        float focusDistance = 10.0f;        //!< focus distance in world units
-        float blurScale = 1.0f;             //!< a scale factor for the amount of blur
+        float focusDistance = 10.0f;        //!< focus distance in world units (usually meters)
+        float apertureScale = 1.0f;         //!< camera aperture scale
         float maxApertureDiameter = 0.01f;  //!< maximum aperture diameter in meters (zero to disable rotation)
         bool enabled = false;               //!< enable or disable depth of field effect
     };

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -781,13 +781,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
     const float focusDistance = std::max(cameraInfo.zn, dofOptions.focusDistance);
     auto const& desc = fg.getDescriptor<FrameGraphTexture>(input);
-    const float Kc = (cameraInfo.A * cameraInfo.f) / (focusDistance - cameraInfo.f);
+    const float Kc = ((dofOptions.apertureScale * cameraInfo.A) * cameraInfo.f) / (focusDistance - cameraInfo.f);
     const float Ks = ((float)desc.height) / FCamera::SENSOR_SIZE;
     float2 cocParams{
             // we use 1/zn instead of (zf - zn) / (zf * zn), because in reality we're using
             // a projection with an infinite far plane
-            (dofOptions.blurScale * Ks * Kc) * focusDistance / cameraInfo.zn,
-            (dofOptions.blurScale * Ks * Kc) * (1.0f - focusDistance / cameraInfo.zn)
+            (Ks * Kc) * focusDistance / cameraInfo.zn,
+            (Ks * Kc) * (1.0f - focusDistance / cameraInfo.zn)
     };
     // handle reversed z
     cocParams = float2{ -cocParams.x, cocParams.x + cocParams.y };

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -331,7 +331,7 @@ public:
 
     void setDepthOfFieldOptions(DepthOfFieldOptions options) noexcept {
         options.focusDistance = std::max(0.0f, options.focusDistance);
-        options.blurScale = std::max(0.0f, options.blurScale);
+        options.apertureScale = std::max(0.0f, options.apertureScale);
         options.maxApertureDiameter = std::max(0.0f, options.maxApertureDiameter);
         mDepthOfFieldOptions = options;
     }

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -721,7 +721,7 @@ int main(int argc, char** argv) {
                 ImGui::SliderFloat("ISO", &app.viewOptions.cameraISO, 25.0f, 6400.0f);
                 ImGui::Checkbox("DoF", &app.dofOptions.enabled);
                 ImGui::SliderFloat("Focus distance", &app.dofOptions.focusDistance, 0.0f, 30.0f);
-                ImGui::SliderFloat("Blur scale", &app.dofOptions.blurScale, 0.1f, 10.0f);
+                ImGui::SliderFloat("Blur scale", &app.dofOptions.apertureScale, 0.1f, 10.0f);
 
                 if (ImGui::CollapsingHeader("Vignette")) {
                     ImGui::Checkbox("Enabled##vignetteEnabled", &app.vignetteOptions.enabled);


### PR DESCRIPTION
.blurScale was in fact a scale factor applied to the circle of
confusion, which makes it indeed a "blur scale". 

However, it can also be seen as an aperture scale factor, 
which I think is more useful because it makes it more obvious that it 
can be used to set the DoF blur independently from the camera settings.