### PR TITLE
rename .blurScale to .cocScale in dof options

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -262,9 +262,9 @@ Java_com_google_android_filament_View_nSetBlendMode(JNIEnv *, jclass , jlong nat
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetDepthOfFieldOptions(JNIEnv *, jclass ,
-        jlong nativeView, jfloat focusDistance, jfloat blurScale, jfloat maxApertureDiameter, jboolean enabled) {
+        jlong nativeView, jfloat focusDistance, jfloat cocScale, jfloat maxApertureDiameter, jboolean enabled) {
     View* view = (View*) nativeView;
-    view->setDepthOfFieldOptions({.focusDistance = focusDistance, .blurScale = blurScale,
+    view->setDepthOfFieldOptions({.focusDistance = focusDistance, .cocScale = cocScale,
             .maxApertureDiameter = maxApertureDiameter, .enabled = (bool)enabled});
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -360,8 +360,17 @@ public class View {
         /** focus distance in world units */
         public float focusDistance = 10.0f;
 
-        /** scale factor controlling the amount of blur (values other than 1.0 are not physically correct)*/
-        public float blurScale = 1.0f;
+        /**
+         * circle of confusion scale factor (amount of blur)
+         *
+         * <p>cocScale can be used to set the depth of field blur independently from the camera
+         * aperture, e.g. for artistic reasons. This can be achieved by setting:</p>
+         * <code>
+         *      cocScale = cameraAperture / desiredDoFAperture
+         * </code>
+         *
+         */
+        public float cocScale = 1.0f;
 
         /** maximum aperture diameter in meters (zero to disable bokeh rotation) */
         public float maxApertureDiameter = 0.01f;
@@ -1173,7 +1182,7 @@ public class View {
      */
     public void setDepthOfFieldOptions(@NonNull DepthOfFieldOptions options) {
         mDepthOfFieldOptions = options;
-        nSetDepthOfFieldOptions(getNativeObject(), options.focusDistance, options.blurScale, options.maxApertureDiameter, options.enabled);
+        nSetDepthOfFieldOptions(getNativeObject(), options.focusDistance, options.cocScale, options.maxApertureDiameter, options.enabled);
     }
 
     /**
@@ -1229,7 +1238,7 @@ public class View {
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);
-    private static native void nSetDepthOfFieldOptions(long nativeView, float focusDistance, float blurScale, float maxApertureDiameter, boolean enabled);
+    private static native void nSetDepthOfFieldOptions(long nativeView, float focusDistance, float cocScale, float maxApertureDiameter, boolean enabled);
     private static native void nSetVignetteOptions(long nativeView, float midPoint, float roundness, float feather, float r, float g, float b, float a, boolean enabled);
     private static native void nSetTemporalAntiAliasingOptions(long nativeView, float feedback, float filterWidth, boolean enabled);
 }

--- a/docs/webgl/filament.js
+++ b/docs/webgl/filament.js
@@ -318,11 +318,11 @@ Filament.loadClassExtensions = function() {
 
     /// setDepthOfFieldOptions ::method::
     /// overrides ::argument:: Dictionary with one or more of the following properties: \
-    /// focusDistance, blurScale, maxApertureDiameter, enabled.
+    /// focusDistance, cocScale, maxApertureDiameter, enabled.
     Filament.View.prototype.setDepthOfFieldOptions = function(overrides) {
         const options = {
             focusDistance: 10.0,
-            blurScale: 1.0,
+            cocScale: 1.0,
             maxApertureDiameter: 0.01,
             enabled: false
         };

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -167,10 +167,16 @@ public:
 
     /**
      * Options to control Depth of Field (DoF) effect in the scene.
+     *
+     * cocScale can be used to set the depth of field blur independently from the camera
+     * aperture, e.g. for artistic reasons. This can be achieved by setting:
+     *      cocScale = cameraAperture / desiredDoFAperture
+     *
+     * @see Camera
      */
     struct DepthOfFieldOptions {
         float focusDistance = 10.0f;        //!< focus distance in world units
-        float blurScale = 1.0f;             //!< a scale factor for the amount of blur
+        float cocScale = 1.0f;              //!< circle of confusion scale factor (amount of blur)
         float maxApertureDiameter = 0.01f;  //!< maximum aperture diameter in meters (zero to disable rotation)
         bool enabled = false;               //!< enable or disable depth of field effect
     };

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -792,8 +792,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
     float2 cocParams{
             // we use 1/zn instead of (zf - zn) / (zf * zn), because in reality we're using
             // a projection with an infinite far plane
-            (dofOptions.blurScale * Ks * Kc) * focusDistance / cameraInfo.zn,
-            (dofOptions.blurScale * Ks * Kc) * (1.0f - focusDistance / cameraInfo.zn)
+            (dofOptions.cocScale * Ks * Kc) * focusDistance / cameraInfo.zn,
+            (dofOptions.cocScale * Ks * Kc) * (1.0f - focusDistance / cameraInfo.zn)
     };
     // handle reversed z
     cocParams = float2{ -cocParams.x, cocParams.x + cocParams.y };

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -190,7 +190,7 @@ struct CameraInfo {
     float zf{};                     // distance (positive) to the far plane
     float ev100{};                  // exposure
     float f{};                      // focal length (in m)
-    float A{};                      // aperture diameter (in m)
+    float A{};                      // f / aperture diameter (in m)
     math::float3 worldOffset{};     // world offset, API-level camera position
     math::float3 const& getPosition() const noexcept { return model[3].xyz; }
     math::float3 getForwardVector() const noexcept { return normalize(-model[2].xyz); }

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -333,7 +333,7 @@ public:
 
     void setDepthOfFieldOptions(DepthOfFieldOptions options) noexcept {
         options.focusDistance = std::max(0.0f, options.focusDistance);
-        options.blurScale = std::max(0.0f, options.blurScale);
+        options.cocScale = std::max(0.0f, options.cocScale);
         options.maxApertureDiameter = std::max(0.0f, options.maxApertureDiameter);
         mDepthOfFieldOptions = options;
     }

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -721,7 +721,7 @@ int main(int argc, char** argv) {
                 ImGui::SliderFloat("ISO", &app.viewOptions.cameraISO, 25.0f, 6400.0f);
                 ImGui::Checkbox("DoF", &app.dofOptions.enabled);
                 ImGui::SliderFloat("Focus distance", &app.dofOptions.focusDistance, 0.0f, 30.0f);
-                ImGui::SliderFloat("Blur scale", &app.dofOptions.blurScale, 0.1f, 10.0f);
+                ImGui::SliderFloat("Blur scale", &app.dofOptions.cocScale, 0.1f, 10.0f);
 
                 if (ImGui::CollapsingHeader("Vignette")) {
                     ImGui::Checkbox("Enabled##vignetteEnabled", &app.vignetteOptions.enabled);

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -237,11 +237,11 @@ Filament.loadClassExtensions = function() {
 
     /// setDepthOfFieldOptions ::method::
     /// overrides ::argument:: Dictionary with one or more of the following properties: \
-    /// focusDistance, blurScale, maxApertureDiameter, enabled.
+    /// focusDistance, cocScale, maxApertureDiameter, enabled.
     Filament.View.prototype.setDepthOfFieldOptions = function(overrides) {
         const options = {
             focusDistance: 10.0,
-            blurScale: 1.0,
+            cocScale: 1.0,
             maxApertureDiameter: 0.01,
             enabled: false
         };

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -101,7 +101,7 @@ export interface View$AmbientOcclusionOptions {
 
 export interface View$DepthOfFieldOptions {
     focusDistance?: number;
-    blurScale?: number;
+    cocScale?: number;
     maxApertureDiameter?: number;
     enabled?: boolean;
 }

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -352,7 +352,7 @@ value_object<filament::View::AmbientOcclusionOptions>("View$AmbientOcclusionOpti
 
 value_object<filament::View::DepthOfFieldOptions>("View$DepthOfFieldOptions")
     .field("focusDistance", &filament::View::DepthOfFieldOptions::focusDistance)
-    .field("blurScale", &filament::View::DepthOfFieldOptions::blurScale)
+    .field("cocScale", &filament::View::DepthOfFieldOptions::cocScale)
     .field("maxApertureDiameter", &filament::View::DepthOfFieldOptions::maxApertureDiameter)
     .field("enabled", &filament::View::DepthOfFieldOptions::enabled);
 


### PR DESCRIPTION
.blurScale was in fact a scale factor applied to the circle of
confusion (which makes it indeed a "blur scale", but let's use
a more precise language here). 

Update comments to show how to  use .cocScale to control the DoF
effect independently from the camera aperture, which can be useful for
artistic reasons.