### PR TITLE
several fog fixes

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -335,9 +335,9 @@ public class View {
         public float inScatteringStart = 0.0f;
 
         /**
-         * size of in-scattering (>=0 to activate). Good values are >> 1 (e.g. ~10 - 100)
+         * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100)
          */
-        public float inScatteringSize = 0.0f;
+        public float inScatteringSize = -1.0f;
 
         /**
          * fog color will be modulated by the IBL color in the view direction

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -160,7 +160,7 @@ public:
         LinearColor color{0.5f};            //!< fog's color (linear), see fogColorFromIbl
         float density = 0.1f;               //!< fog's density at altitude given by 'height'
         float inScatteringStart = 0.0f;     //!< distance in world units from the camera where in-scattering starts
-        float inScatteringSize = -1.0f;     //!< size of in-scattering (>=0 to activate). Good values are >> 1 (e.g. ~10 - 100).
+        float inScatteringSize = -1.0f;     //!< size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
         bool fogColorFromIbl = false;       //!< Fog color will be modulated by the IBL color in the view direction.
         bool enabled = false;               //!< enable or disable fog
     };

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -95,7 +95,6 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("fogDensity",              1, UniformInterfaceBlock::Type::FLOAT)
             .add("fogInscatteringStart",    1, UniformInterfaceBlock::Type::FLOAT)
             .add("fogInscatteringSize",     1, UniformInterfaceBlock::Type::FLOAT)
-            // more camera stuff
             .add("fogColorFromIbl",         1, UniformInterfaceBlock::Type::FLOAT)
 
             // CSM information

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -510,7 +510,7 @@ void SimpleViewer::updateUserInterface() {
         ImGui::SliderFloat("Height", &mFogOptions.height, 0.0f, 100.0f);
         ImGui::SliderFloat("Height falloff", &mFogOptions.heightFalloff, 0.0f, 10.0f);
         ImGui::SliderFloat("Scattering start", &mFogOptions.inScatteringStart, 0.0f, 100.0f);
-        ImGui::SliderFloat("Scattering size", &mFogOptions.inScatteringSize, 0.0f, 100.0f);
+        ImGui::SliderFloat("Scattering size", &mFogOptions.inScatteringSize, 0.1f, 100.0f);
         ImGui::Checkbox("Color from IBL", &mFogOptions.fogColorFromIbl);
         ImGui::ColorPicker3("Color", mFogOptions.color.v);
         ImGui::Unindent();

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -656,7 +656,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderFloat("Height", &params.fogOptions.height, 0.0f, 100.0f);
             ImGui::SliderFloat("Height Falloff", &params.fogOptions.heightFalloff, 0.0f, 10.0f);
             ImGui::SliderFloat("Scattering Start", &params.fogOptions.inScatteringStart, 0.0f, 100.0f);
-            ImGui::SliderFloat("Scattering Size", &params.fogOptions.inScatteringSize, 0.0f, 100.0f);
+            ImGui::SliderFloat("Scattering Size", &params.fogOptions.inScatteringSize, 0.1f, 100.0f);
             ImGui::Checkbox("Color from IBL", &params.fogOptions.fogColorFromIbl);
             ImGui::ColorPicker3("Color", params.fogOptions.color.v);
             ImGui::Unindent();

--- a/shaders/src/fog.fs
+++ b/shaders/src/fog.fs
@@ -9,10 +9,9 @@ vec4 fog(vec4 color, vec3 view) {
 
         float d = length(view);
 
-        float h = view.y;
-        // The function below is continuous at h=0, so to avoid a divide-by-zero, we use the
-        // constant approximation 'B'. A better approximation would be B * (1 - 0.5 * B * h)
-        float fogIntegralFunctionOfDistance = A * ((abs(h) < 0.001) ? B : ((1.0 - exp(-B * h)) / h));
+        float h = max(0.001, view.y);
+        // The function below is continuous at h=0, so to avoid a divide-by-zero, we just clamp h
+        float fogIntegralFunctionOfDistance = A * ((1.0 - exp(-B * h)) / h);
         float fogIntegral = fogIntegralFunctionOfDistance * max(d - frameUniforms.fogStart, 0.0);
         float fogOpacity = max(1.0 - exp2(-fogIntegral), 0.0);
 
@@ -29,7 +28,7 @@ vec4 fog(vec4 color, vec3 view) {
         }
 
         fogColor *= fogOpacity;
-        if (frameUniforms.fogInscatteringSize >= 0.0) {
+        if (frameUniforms.fogInscatteringSize > 0.0) {
             // compute a new line-integral for a different start distance
             float inscatteringIntegral = fogIntegralFunctionOfDistance *
                     max(d - frameUniforms.fogInscatteringStart, 0.0);


### PR DESCRIPTION
- inScatteringSize actually cannot be set to zero because it produces
  a 0^0 in the shader. So with this change, in-scattering must be
  strictly > 0 to enable.

- inScatteringSize on the java side had an incorrect default value of
  zero (which of course, now doesn't matter anymore).

- also clamp the fog altitude to 1mm which simplifies the shader quite
  a bit for the same result.

Fixes #3069