### PR TITLE
non-sampleable textures didn't support "magic resolve"

### DIFF
--- a/filament/backend/src/opengl/CocoaTouchExternalImage.mm
+++ b/filament/backend/src/opengl/CocoaTouchExternalImage.mm
@@ -258,7 +258,7 @@ GLuint CocoaTouchExternalImage::encodeColorConversionPass(GLuint yPlaneTexture,
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
 
     CHECK_GL_ERROR(utils::slog.e)
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 
     // geometry
     glBindVertexArray(0);

--- a/filament/backend/src/opengl/GLUtils.cpp
+++ b/filament/backend/src/opengl/GLUtils.cpp
@@ -56,8 +56,8 @@ void checkGLError(io::ostream& out, const char* function, size_t line) noexcept 
     debug_trap();
 }
 
-void checkFramebufferStatus(io::ostream& out, const char* function, size_t line) noexcept {
-    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+void checkFramebufferStatus(io::ostream& out, GLenum target, const char* function, size_t line) noexcept {
+    GLenum status = glCheckFramebufferStatus(target);
     const char* error = "unknown";
     switch (status) {
         case GL_FRAMEBUFFER_COMPLETE:

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -31,17 +31,17 @@ namespace filament {
 namespace GLUtils {
 
 void checkGLError(utils::io::ostream& out, const char* function, size_t line) noexcept;
-void checkFramebufferStatus(utils::io::ostream& out, const char* function, size_t line) noexcept;
+void checkFramebufferStatus(utils::io::ostream& out, GLenum target, const char* function, size_t line) noexcept;
 
 #ifdef NDEBUG
 #define CHECK_GL_ERROR(out)
-#define CHECK_GL_FRAMEBUFFER_STATUS(out)
+#define CHECK_GL_FRAMEBUFFER_STATUS(out, target)
 #else
 #ifdef _MSC_VER
     #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 #define CHECK_GL_ERROR(out) { GLUtils::checkGLError(out, __PRETTY_FUNCTION__, __LINE__); }
-#define CHECK_GL_FRAMEBUFFER_STATUS(out) { GLUtils::checkFramebufferStatus(out, __PRETTY_FUNCTION__, __LINE__); }
+#define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __PRETTY_FUNCTION__, __LINE__); }
 #endif
 
 constexpr inline GLuint getComponentCount(backend::ElementType type) noexcept {

--- a/filament/backend/src/opengl/OpenGLBlitter.cpp
+++ b/filament/backend/src/opengl/OpenGLBlitter.cpp
@@ -133,7 +133,7 @@ void OpenGLBlitter::blit(GLuint srcTextureExternal, GLuint dstTexture2d, GLuint 
     glBindFramebuffer(GL_FRAMEBUFFER, mFBO);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dstTexture2d, 0);
     CHECK_GL_ERROR(utils::slog.e)
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 
     // geometry
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -117,10 +117,10 @@ Driver* OpenGLDriver::create(
 // ------------------------------------------------------------------------------------------------
 
 OpenGLDriver::DebugMarker::DebugMarker(OpenGLDriver& driver, const char* string) noexcept
-: driver(driver) {
-        const char* const begin = string + sizeof("virtual void filament::OpenGLDriver::") - 1;
-        const char* const end = strchr(begin, '(');
-        driver.pushGroupMarker(begin, end - begin);
+        : driver(driver) {
+    const char* const begin = string + sizeof("virtual void filament::OpenGLDriver::") - 1;
+    const char* const end = strchr(begin, '(');
+    driver.pushGroupMarker(begin, end - begin);
 }
 
 OpenGLDriver::DebugMarker::~DebugMarker() noexcept {
@@ -773,6 +773,43 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     assert(rt->width  <= valueForLevel(binfo.level, t->width) &&
            rt->height <= valueForLevel(binfo.level, t->height));
 
+    GLRenderTarget::GL::RenderBuffer const* pRenderBuffer = nullptr;
+    switch (attachment) {
+        case GL_COLOR_ATTACHMENT0:
+            rt->gl.resolve |= TargetBufferFlags::COLOR0;
+            pRenderBuffer = &rt->gl.color[0];
+            break;
+        case GL_COLOR_ATTACHMENT1:
+            rt->gl.resolve |= TargetBufferFlags::COLOR1;
+            pRenderBuffer = &rt->gl.color[1];
+            break;
+        case GL_COLOR_ATTACHMENT2:
+            rt->gl.resolve |= TargetBufferFlags::COLOR2;
+            pRenderBuffer = &rt->gl.color[2];
+            break;
+        case GL_COLOR_ATTACHMENT3:
+            rt->gl.resolve |= TargetBufferFlags::COLOR3;
+            pRenderBuffer = &rt->gl.color[3];
+            break;
+        case GL_DEPTH_ATTACHMENT:
+            rt->gl.resolve |= TargetBufferFlags::DEPTH;
+            pRenderBuffer = &rt->gl.depth;
+            break;
+        case GL_STENCIL_ATTACHMENT:
+            rt->gl.resolve |= TargetBufferFlags::STENCIL;
+            pRenderBuffer = &rt->gl.stencil;
+            break;
+        case GL_DEPTH_STENCIL_ATTACHMENT:
+            rt->gl.resolve |= TargetBufferFlags::DEPTH;
+            rt->gl.resolve |= TargetBufferFlags::STENCIL;
+            pRenderBuffer = &rt->gl.depth;
+            break;
+        default:
+            break;
+    }
+
+    assert(pRenderBuffer);
+
     // depth/stencil attachment must match the rendertarget sample count
     // this is because EXT_multisampled_render_to_texture doesn't guarantee depth/stencil
     // is resolved.
@@ -865,15 +902,15 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     { // here we emulate ext.EXT_multisampled_render_to_texture
         assert(rt->gl.samples > 1);
 
-        // If the texture doesn't already have one, create a sidecar multi-sampled renderbuffer,
+        // Create a sidecar multi-sampled renderbuffer,
         // which is where drawing will actually take place, make that our attachment.
         gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
-        if (t->gl.rb == 0) {
-            glGenRenderbuffers(1, &t->gl.rb);
-            renderBufferStorage(t->gl.rb,
-                    t->gl.internalFormat, rt->width, rt->height, rt->gl.samples);
-        }
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, t->gl.rb);
+
+        glGenRenderbuffers(1, &pRenderBuffer->rb);
+        renderBufferStorage(pRenderBuffer->rb,
+                t->gl.internalFormat, rt->width, rt->height, rt->gl.samples);
+
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, pRenderBuffer->rb);
 
         // We also need a "read" sidecar fbo, used later for the resolve, which takes place in
         // endRenderPass().
@@ -908,21 +945,6 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         }
 
         CHECK_GL_ERROR(utils::slog.e)
-
-        switch (attachment) {
-            case GL_COLOR_ATTACHMENT0:  rt->gl.resolve |= TargetBufferFlags::COLOR0;    break;
-            case GL_COLOR_ATTACHMENT1:  rt->gl.resolve |= TargetBufferFlags::COLOR1;    break;
-            case GL_COLOR_ATTACHMENT2:  rt->gl.resolve |= TargetBufferFlags::COLOR2;    break;
-            case GL_COLOR_ATTACHMENT3:  rt->gl.resolve |= TargetBufferFlags::COLOR3;    break;
-            case GL_DEPTH_ATTACHMENT:   rt->gl.resolve |= TargetBufferFlags::DEPTH;     break;
-            case GL_STENCIL_ATTACHMENT: rt->gl.resolve |= TargetBufferFlags::STENCIL;   break;
-            case GL_DEPTH_STENCIL_ATTACHMENT:
-                rt->gl.resolve |= TargetBufferFlags::DEPTH;
-                rt->gl.resolve |= TargetBufferFlags::STENCIL;
-                break;
-            default:
-                break;
-        }
     }
 
     if (any(t->usage & TextureUsage::SAMPLEABLE)) {
@@ -933,7 +955,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     }
 
     CHECK_GL_ERROR(utils::slog.e)
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 }
 
 void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32_t width,
@@ -1212,9 +1234,6 @@ void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
                 if (UTILS_UNLIKELY(t->hwStream)) {
                     detachStream(t);
                 }
-                if (t->gl.rb) {
-                    glDeleteRenderbuffers(1, &t->gl.rb);
-                }
                 if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
                     mPlatform.destroyExternalImage(t);
                 } else {
@@ -1222,9 +1241,6 @@ void OpenGLDriver::destroyTexture(Handle<HwTexture> th) {
                 }
             } else {
                 assert(t->gl.target == GL_RENDERBUFFER);
-                if (t->gl.rb) {
-                    glDeleteRenderbuffers(1, &t->gl.rb);
-                }
                 glDeleteRenderbuffers(1, &t->gl.id);
             }
             if (t->gl.fence) {
@@ -1250,6 +1266,19 @@ void OpenGLDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
             // first unbind this framebuffer if needed
             gl.bindFramebuffer(GL_FRAMEBUFFER, 0);
             glDeleteFramebuffers(1, &rt->gl.fbo_read);
+        }
+
+        // free the sidecar renderbuffers if any
+        for (auto& renderBuffer : rt->gl.color) {
+            if (renderBuffer.rb) {
+                glDeleteRenderbuffers(1, &renderBuffer.rb);
+            }
+        }
+        if (rt->gl.depth.rb) {
+            glDeleteRenderbuffers(1, &rt->gl.depth.rb);
+        }
+        if (rt->gl.stencil.rb) {
+            glDeleteRenderbuffers(1, &rt->gl.stencil.rb);
         }
         destruct(rth, rt);
     }
@@ -2118,6 +2147,7 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     TargetBufferFlags discardFlags = params.flags.discardStart & rt->targets;
 
     gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 
     // glInvalidateFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
     // ignore it on GL (rather than having to do a runtime check).
@@ -2231,6 +2261,10 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         }
         gl.bindFramebuffer(GL_READ_FRAMEBUFFER, read);
         gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, draw);
+
+        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+
         gl.disable(GL_SCISSOR_TEST);
         glBlitFramebuffer(0, 0, rt->width, rt->height,
                 0, 0, rt->width, rt->height, mask, GL_NEAREST);
@@ -2967,6 +3001,10 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
 
         gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
         gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl.fbo);
+
+        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+
         gl.disable(GL_SCISSOR_TEST);
         glBlitFramebuffer(
                 srcRect.left, srcRect.bottom, srcRect.right(), srcRect.top(),

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -110,7 +110,6 @@ public:
         using HwTexture::HwTexture;
         struct {
             GLuint id = 0;          // texture or renderbuffer id
-            mutable GLuint rb = 0;  // multi-sample sidecar renderbuffer
             GLenum target = 0;
             GLenum internalFormat = 0;
             mutable GLsync fence = nullptr;
@@ -183,6 +182,7 @@ public:
         struct GL {
             struct RenderBuffer {
                 GLTexture* texture = nullptr;
+                mutable GLuint rb = 0;  // multi-sample sidecar renderbuffer
                 uint8_t level = 0; // level when attached to a texture
             };
             // field ordering to optimize size on 64-bits


### PR DESCRIPTION
There was an inconsistency in the gles backend where non-sampleable,
non-MS textures failed (assert) if they were used with a render target 
with MS (i.e. "magic resolve" case).

We fix this by taking the same code path for textures and renderbuffers,
the only difference being the calls to glFrameBufferRenderbuffer
instead of glFramebufferTexture2D.