### PR TITLE
fix use after free in the framegraph

### DIFF
--- a/filament/src/fg/fg/ResourceEntry.h
+++ b/filament/src/fg/fg/ResourceEntry.h
@@ -101,6 +101,9 @@ public:
     void postExecuteDestroy(FrameGraph& fg) noexcept override {
         if (!imported) {
             resource.destroy(getResourceAllocator(fg));
+            // make sure to clear the resource as some code might rely on e.g. handles to know
+            // if they need to be set or not
+            resource = {};
         }
     }
 };


### PR DESCRIPTION
resources structures where not cleared when destroyed, and some code
relies in the handles being set or not to decide if a texture should
be used.  in this case, the texture would be set in the shader after
it was destroyed, because its handle wasn't cleared.