### PR TITLE
smooth out the transition from the background layer

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -529,6 +529,11 @@ void postProcess(inout PostProcessInputs postProcess) {
 
         background = prev.c;
         bgOpacity = cocToAlpha(prev.coc);
+#if defined(TARGET_MOBILE)
+        bgOpacity *= saturate((kernelSize - MAX_IN_FOCUS_COC) / (2.0 - MAX_IN_FOCUS_COC));
+#else
+        bgOpacity *= smoothstep(MAX_IN_FOCUS_COC, 2.0, kernelSize);
+#endif
 
         if (prev.cw < MEDIUMP_FLT_MIN) {
             background *= 0.0;


### PR DESCRIPTION
This is a bit of a hack but it helps a lot -- for some reason the
background layer often has a sharp transition to the in-focus plane and 
because we're calculating the DoF at 1/4 resolution these transitions
are quite visible. We work around this by fading out the transition over
a 1 CoC unit, specifically between a CoC of 2 to 1 pixel. Below 1 pixel,
we currently clamp to 0.

Before:
<img width="400" alt="before" src="https://user-images.githubusercontent.com/1240896/93564624-dbd9e400-f93e-11ea-85ee-fefb38772841.png">

After:
<img width="362" alt="after" src="https://user-images.githubusercontent.com/1240896/93564637-e0060180-f93e-11ea-9e65-cdb84985c32b.png">
