### PR TITLE
fix a recent regression with contact shadows

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -262,7 +262,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
      * Shadow pass
      */
 
-    if (view.hasShadowing()) {
+    if (view.needsShadowMap()) {
         view.renderShadowMaps(fg, engine, driver, pass);
     }
 

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -48,6 +48,13 @@ class RenderPass;
 class ShadowMapManager {
 public:
 
+    enum class ShadowTechnique : uint8_t {
+        NONE = 0x0u,
+        SHADOW_MAP = 0x1u,
+        SCREEN_SPACE = 0x2u,
+    };
+
+
     explicit ShadowMapManager(FEngine& engine);
     ~ShadowMapManager();
 
@@ -59,7 +66,7 @@ public:
 
     // Updates all of the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
-    bool update(FEngine& engine, FView& view, UniformBuffer& perViewUb, UniformBuffer& shadowUb,
+    ShadowTechnique update(FEngine& engine, FView& view, UniformBuffer& perViewUb, UniformBuffer& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
 
     // Renders all of the shadow maps.
@@ -86,9 +93,9 @@ private:
         uint8_t layers = 0;
     } mTextureRequirements;
 
-    bool updateCascadeShadowMaps(FEngine& engine, FView& view, UniformBuffer& perViewUb,
+    ShadowTechnique updateCascadeShadowMaps(FEngine& engine, FView& view, UniformBuffer& perViewUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
-    bool updateSpotShadowMaps(FEngine& engine, FView& view, UniformBuffer& shadowUb,
+    ShadowTechnique updateSpotShadowMaps(FEngine& engine, FView& view, UniformBuffer& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
     static void fillWithDebugPattern(backend::DriverApi& driverApi,
             backend::Handle<backend::HwTexture> texture, size_t dimensions) noexcept;
@@ -174,5 +181,8 @@ private:
 };
 
 } // namespace filament
+
+template<> struct utils::EnableBitMaskOperators<filament::ShadowMapManager::ShadowTechnique>
+        : public std::true_type {};
 
 #endif //TNT_FILAMENT_DETAILS_SHADOWMAPMANAGER_H

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -171,6 +171,7 @@ public:
     bool hasDirectionalLight() const noexcept { return mHasDirectionalLight; }
     bool hasDynamicLighting() const noexcept { return mHasDynamicLighting; }
     bool hasShadowing() const noexcept { return mHasShadowing; }
+    bool needsShadowMap() const noexcept { return mNeedsShadowMap; }
     bool hasFog() const noexcept { return mFogOptions.enabled && mFogOptions.density > 0.0f; }
     bool hasVsm() const noexcept { return mShadowType == ShadowType::VSM; }
 
@@ -489,6 +490,7 @@ private:
     mutable bool mHasDirectionalLight = false;
     mutable bool mHasDynamicLighting = false;
     mutable bool mHasShadowing = false;
+    mutable bool mNeedsShadowMap = false;
 
     ShadowMapManager mShadowMapManager;
 };


### PR DESCRIPTION
contact shadows wouldn't work if shadowmap-based shadows were not
enabled, in this case the (unneeded) shadow pass would run and
attempt to create the shadow-map with an incorrect size (0), which
would later crash/assert in the backend.