### PR TITLE
Disable clear coat layer IOR change in glTF files

### DIFF
--- a/libs/gltfio/materials/ubershader.mat.in
+++ b/libs/gltfio/materials/ubershader.mat.in
@@ -8,6 +8,7 @@ material {
     flipUV : false,
     specularAmbientOcclusion : simple,
     specularAntiAliasing : true,
+    clearCoatIorChange : false,
     parameters : [
 
         { type : float3, name : specularFactor },

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -265,6 +265,7 @@ Material* createMaterial(Engine* engine, const MaterialKey& config, const UvMap&
             .flipUV(false)
             .specularAmbientOcclusion(MaterialBuilder::SpecularAmbientOcclusion::SIMPLE)
             .specularAntiAliasing(true)
+            .clearCoatIorChange(false)
             .material(shader.c_str())
             .doubleSided(config.doubleSided)
             .targetApi(filamat::targetApiFromBackend(engine->getBackend()));


### PR DESCRIPTION
The glTF spec doesn't call for this and there are extensions to deal with this manually.

<img width="1125" alt="Screen Shot 2020-09-21 at 5 07 44 PM" src="https://user-images.githubusercontent.com/869684/93833273-01136e80-fc2d-11ea-8522-078bcd393cbf.png">
