### PR TITLE
Flip the shading normal when det < 0.

### DIFF
--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -199,6 +199,13 @@ void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Hand
         mat3f m = mat3f::getTransformForNormals(model.upperLeft());
         m *= mat3f(1.0f / std::sqrt(max(float3{length2(m[0]), length2(m[1]), length2(m[2])})));
 
+        // The shading normal must be flipped for mirror transformations.
+        // Basically we're shading the other side of the polygon and therefore need to negate the
+        // normal, similar to what we already do to support double-sided lighting.
+        if (sceneData.elementAt<REVERSED_WINDING_ORDER>(i)) {
+            m = -m;
+        }
+
         UniformBuffer::setUniform(buffer,
                 offset + offsetof(PerRenderableUib, worldFromModelNormalMatrix), m);
 

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -260,6 +260,26 @@ public:
     /**
      * Returns a matrix suitable for transforming normals
      *
+     * Note that the inverse-transpose of a matrix is equal to its cofactor matrix divided by its
+     * determinant:
+     *
+     *     transpose(inverse(M)) = cof(M) / det(M)
+     *
+     * The cofactor matrix is faster to compute than the inverse-transpose, and it can be argued
+     * that it is a more correct way of transforming normals anyway. Some references from Dale
+     * Weiler, Nathan Reed, Inigo Quilez, and Eric Lengyel:
+     *
+     *   - https://github.com/graphitemaster/normals_revisited
+     *   - http://www.reedbeta.com/blog/normals-inverse-transpose-part-1/
+     *   - https://www.shadertoy.com/view/3s33zj
+     *   - FGED Volume 1, section 1.7.5 "Inverses of Small Matrices"
+     *   - FGED Volume 1, section 3.2.2 "Transforming Normal Vectors"
+     *
+     * In "Transforming Normal Vectors", Lengyel notes that there are two types of transformed
+     * normals: one that uses the transposed adjugate (aka cofactor matrix) and one that uses the
+     * transposed inverse. He goes on to say that this difference is inconsequential, except when
+     * mirroring is involved.
+     *
      * @param m the transform applied to vertices
      * @return a matrix to apply to normals
      *

--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -588,6 +588,34 @@ do {                                                            \
     }                                                           \
 } while(0)
 
+TYPED_TEST(MatTestT, NormalsNegativeScale) {
+    typedef filament::math::details::TMat33<TypeParam> M33T;
+    typedef filament::math::details::TVec3<TypeParam> V3T;
+
+    M33T m(-1,  0,  0,
+            0,  1,  0,
+            0,  0,  1);
+
+    V3T n = V3T(0, 0, 1);
+    V3T n_prime = M33T::getTransformForNormals(m) * n;
+
+    // The normal should be flipped for mirroring transformations (ie when the det < 0).
+    //
+    // This is intuitive using Grassmann algebra, or when visualizing the mirroring of the
+    // tangent + bivector pair rather than the normal itself.
+    //
+    // Another way of thinking about this is in terms of polygon winding: since the winding is
+    // flipped, we render its underside and thus need to flip the shading normal.
+    //
+    // The following shadertoy is illuminating: https://www.shadertoy.com/view/3s33zj.
+    // The shadertoy is interesting for several reasons: (1) it uses the adjoint matrix for
+    // transforming normals and (2) it negates the normal when scale is negative (look for
+    // "isFlipped") and (3) it demonstrates that inverse-transpose computation is slow.
+
+    ASSERT_LT(det(m), 0);
+    EXPECT_VEC_EQ(n_prime, -n);
+}
+
 //------------------------------------------------------------------------------
 // Test some translation stuff.
 TYPED_TEST(MatTestT, Translation4) {

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -33,7 +33,7 @@ void main() {
 
         // We don't need to normalize here, even if there's a scale in the matrix
         // because we ensure the worldFromModelNormalMatrix pre-scales the normal such that
-        // all its components are < 1.0. This precents the bitangent to exceed the range of fp16
+        // all its components are < 1.0. This prevents the bitangent to exceed the range of fp16
         // in the fragment shader, where we renormalize after interpolation
         vertex_worldTangent.xyz = objectUniforms.worldFromModelNormalMatrix * vertex_worldTangent.xyz;
         vertex_worldTangent.w = mesh_tangents.w;


### PR DESCRIPTION
This is similar to my first attempt but now I'm more happy with the comments and explanations that I've added.

This was tested by replacing the node 0 scale in BusterDrone with [-1, 1, 1].

For future reference, commit f728776 shows when we switched from transpose(inverse()) to cof(). This was a good change, but before that particular change, we had a "two wrongs made a right" situation for mirrored normals.

Fixes #3001.

Before / After screenshots for Node_NegativeScale_07:

![bad](https://user-images.githubusercontent.com/1288904/93948787-320aa680-fcf4-11ea-8a4a-f312bfe3111a.png)
![good](https://user-images.githubusercontent.com/1288904/93948792-33d46a00-fcf4-11ea-9e22-c8175d7a50fd.png)
