### PR TITLE
Implement Screen Space Cone Tracing (SSCT)

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -196,7 +196,7 @@ Java_com_google_android_filament_View_nGetAmbientOcclusion(JNIEnv*, jclass, jlon
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclass,
     jlong nativeView, jfloat radius, jfloat bias, jfloat power, jfloat resolution, jfloat intensity,
-    jint quality, jint upsampling, jboolean enabled, jfloat minHorizonAngleRad) {
+    jint quality, jint lowPassFilter, jint upsampling, jboolean enabled, jfloat minHorizonAngleRad) {
     View* view = (View*) nativeView;
     View::AmbientOcclusionOptions options = {
             .radius = radius,
@@ -205,6 +205,7 @@ Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclas
             .resolution = resolution,
             .intensity = intensity,
             .quality = (View::QualityLevel)quality,
+            .lowPassFilter = (View::QualityLevel)lowPassFilter,
             .upsampling = (View::QualityLevel)upsampling,
             .enabled = (bool)enabled,
             .minHorizonAngleRad = minHorizonAngleRad

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -198,18 +198,40 @@ Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclas
     jlong nativeView, jfloat radius, jfloat bias, jfloat power, jfloat resolution, jfloat intensity,
     jint quality, jint lowPassFilter, jint upsampling, jboolean enabled, jfloat minHorizonAngleRad) {
     View* view = (View*) nativeView;
-    View::AmbientOcclusionOptions options = {
-            .radius = radius,
-            .power = power,
-            .bias = bias,
-            .resolution = resolution,
-            .intensity = intensity,
-            .quality = (View::QualityLevel)quality,
-            .lowPassFilter = (View::QualityLevel)lowPassFilter,
-            .upsampling = (View::QualityLevel)upsampling,
-            .enabled = (bool)enabled,
-            .minHorizonAngleRad = minHorizonAngleRad
-    };
+    View::AmbientOcclusionOptions options = view->getAmbientOcclusionOptions();
+    options.radius = radius;
+    options.power = power;
+    options.bias = bias;
+    options.resolution = resolution;
+    options.intensity = intensity;
+    options.quality = (View::QualityLevel)quality;
+    options.lowPassFilter = (View::QualityLevel)lowPassFilter;
+    options.upsampling = (View::QualityLevel)upsampling;
+    options.enabled = (bool)enabled;
+    options.minHorizonAngleRad = minHorizonAngleRad;
+    view->setAmbientOcclusionOptions(options);
+}
+
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nSetSSCTOptions(JNIEnv *, jclass, jlong nativeView,
+        jfloat ssctLightConeRad, jfloat ssctStartTraceDistance, jfloat ssctContactDistanceMax,
+        jfloat ssctIntensity, jfloat ssctLightDirX, jfloat ssctLightDirY, jfloat ssctLightDirZ,
+        jfloat ssctDepthBias, jfloat ssctDepthSlopeBias, jfloat ssctScale, jint ssctSampleCount,
+        jint ssctRayCount, jboolean ssctEnabled) {
+    View* view = (View*) nativeView;
+    View::AmbientOcclusionOptions options = view->getAmbientOcclusionOptions();
+    options.ssct.lightConeRad = ssctLightConeRad;
+    options.ssct.startTraceDistance = ssctStartTraceDistance;
+    options.ssct.contactDistanceMax = ssctContactDistanceMax;
+    options.ssct.intensity = ssctIntensity;
+    options.ssct.lightDirection = math::float3{ ssctLightDirX, ssctLightDirY, ssctLightDirZ };
+    options.ssct.depthBias = ssctDepthBias;
+    options.ssct.depthSlopeBias = ssctDepthSlopeBias;
+    options.ssct.scale = ssctScale;
+    options.ssct.sampleCount = (uint8_t)ssctSampleCount;
+    options.ssct.rayCount = (uint8_t)ssctRayCount;
+    options.ssct.enabled = (bool)ssctEnabled;
     view->setAmbientOcclusionOptions(options);
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -203,6 +203,69 @@ public class View {
          * For e.g. a good values to try could be around 0.2.
          */
         public float minHorizonAngleRad = 0.0f;
+
+
+       /**
+        * Full cone angle in radian, between 0 and pi/2. This affects the softness of the shadows,
+        * as well as how far they are cast. A smaller angle yields to sharper and shorter shadows.
+        * The default angle is about 60 degrees.
+        */
+       public float ssctLightConeRad = 1.0f;
+
+       /**
+        * Distance from where tracing starts.
+        * This affects how far shadows are cast.
+        */
+       public float ssctStartTraceDistance = 0.01f;
+
+       /**
+        * Maximum contact distance with the cone. Intersections between the traced cone and
+        * geometry samller than this distance are ignored.
+        */
+       public float ssctContactDistanceMax = 1.0f;
+
+       /**
+        * Intensity of the shadows.
+        */
+       public float ssctIntensity = 0.8f;
+
+       /**
+        * Light direction.
+        */
+       @NonNull @Size(min = 3)
+       public float[] ssctLightDirection = { 0, -1, 0 };
+
+       /**
+        * Depth bias in world units (mitigate self shadowing)
+        */
+       public float ssctDepthBias = 0.1f;
+
+       /**
+        * Depth slope bias (mitigate self shadowing)
+        */
+       public float ssctDepthSlopeBias = 0.1f;
+
+       /**
+        * Shadows scaling.
+        */
+       public float ssctScale = 1.0f;
+
+       /**
+        * Tracing sample count, between 1 and 255. This affects the quality as well as the
+        * distance of the shadows.
+        */
+       public int ssctSampleCount = 4;
+
+       /**
+        * Numbers of rays to trace, between 1 and 255. This affects the noise of the shadows.
+        * Performance degrades quickly with this value.
+        */
+       public int ssctRayCount = 1;
+
+       /**
+        * Enables or disables SSCT.
+        */
+       public boolean ssctEnabled = false;
     }
 
     /**
@@ -1119,6 +1182,10 @@ public class View {
         nSetAmbientOcclusionOptions(getNativeObject(), options.radius, options.bias, options.power,
                 options.resolution, options.intensity, options.quality.ordinal(), options.lowPassFilter.ordinal(), options.upsampling.ordinal(),
                 options.enabled, options.minHorizonAngleRad);
+        nSetSSCTOptions(getNativeObject(), options.ssctLightConeRad, options.ssctStartTraceDistance, options.ssctContactDistanceMax,  options.ssctIntensity,
+                options.ssctLightDirection[0], options.ssctLightDirection[1], options.ssctLightDirection[2],
+                options.ssctDepthBias, options.ssctDepthSlopeBias, options.ssctScale, options.ssctSampleCount,
+                options.ssctRayCount, options.ssctEnabled);
     }
 
     /**
@@ -1283,6 +1350,7 @@ public class View {
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
     private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int lowPassFilter, int upsampling, boolean enabled, float minHorizonAngleRad);
+    private static native void nSetSSCTOptions(long nativeView, float ssctLightConeRad, float ssctStartTraceDistance, float ssctContactDistanceMax, float ssctIntensity, float v, float v1, float v2, float ssctDepthBias, float ssctDepthSlopeBias, float ssctScale, int ssctSampleCount, int ssctRayCount, boolean ssctEnabled);
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -177,6 +177,14 @@ public class View {
         public QualityLevel quality = QualityLevel.LOW;
 
         /**
+         * The lowPassFilter setting controls the quality of the low pass filter applied to
+         * AO estimation. The default is QualityLevel.MEDIUM which is sufficient for most mobile
+         * applications. QualityLevel.LOW disables the filter entirely.
+         */
+        @NonNull
+        public QualityLevel lowPassFilter = QualityLevel.MEDIUM;
+
+        /**
          * The upsampling setting controls the quality of the ambient occlusion buffer upsampling.
          * The default is QualityLevel.LOW and uses bilinear filtering, a value of
          * QualityLevel.HIGH or more enables a better bilateral filter.
@@ -1109,7 +1117,7 @@ public class View {
     public void setAmbientOcclusionOptions(@NonNull AmbientOcclusionOptions options) {
         mAmbientOcclusionOptions = options;
         nSetAmbientOcclusionOptions(getNativeObject(), options.radius, options.bias, options.power,
-                options.resolution, options.intensity, options.quality.ordinal(), options.upsampling.ordinal(),
+                options.resolution, options.intensity, options.quality.ordinal(), options.lowPassFilter.ordinal(), options.upsampling.ordinal(),
                 options.enabled, options.minHorizonAngleRad);
     }
 
@@ -1274,7 +1282,7 @@ public class View {
     private static native boolean nIsFrontFaceWindingInverted(long nativeView);
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
-    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int upsampling, boolean enabled, float minHorizonAngleRad);
+    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int lowPassFilter, int upsampling, boolean enabled, float minHorizonAngleRad);
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -297,6 +297,12 @@ add_custom_command(
 )
 
 add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/sao.filamat"
+        DEPENDS src/materials/ssao/dominantLightShadowing.fs
+        APPEND
+)
+
+add_custom_command(
         OUTPUT ${RESGEN_OUTPUTS}
         COMMAND resgen ${RESGEN_FLAGS} ${MATERIAL_BINS}
         DEPENDS resgen ${MATERIAL_BINS}

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -291,6 +291,12 @@ add_custom_command(
 )
 
 add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/sao.filamat"
+        DEPENDS src/materials/ssao/ssaoUtils.fs
+        APPEND
+)
+
+add_custom_command(
         OUTPUT ${RESGEN_OUTPUTS}
         COMMAND resgen ${RESGEN_FLAGS} ${MATERIAL_BINS}
         DEPENDS resgen ${MATERIAL_BINS}

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -239,6 +239,7 @@ public:
             float depthSlopeBias = 0.1f;    //!< depth slope bias (mitigate self shadowing)
             float scale = 1.0f;             //!< cast shadows scaling
             uint8_t sampleCount = 4;        //!< tracing sample count, between 1 and 255
+            uint8_t rayCount = 1;           //!< # of rays to trace, between 1 and 255
             bool enabled = false;           //!< enables or disables SSCT
         } ssct;
     };

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -221,7 +221,8 @@ public:
         float resolution = 0.5f;//!< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
         float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
         QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
-        QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality.
+        QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
+        QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality
         bool enabled = false;    //!< enables or disables screen-space ambient occlusion
         float minHorizonAngleRad = 0.0f;  //!< min angle in radian to consider
     };

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -211,8 +211,8 @@ public:
     };
 
     /**
-     * Options for screen space Ambient Occlusion (SSAO)
-     * @see setAmbientOcclusion()
+     * Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+     * @see setAmbientOcclusionOptions()
      */
     struct AmbientOcclusionOptions {
         float radius = 0.3f;    //!< Ambient Occlusion radius in meters, between 0 and ~10.
@@ -225,6 +225,22 @@ public:
         QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality
         bool enabled = false;    //!< enables or disables screen-space ambient occlusion
         float minHorizonAngleRad = 0.0f;  //!< min angle in radian to consider
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        struct {
+            float lightConeRad = 1.0f;          //!< full cone angle in radian, between 0 and pi/2
+            float startTraceDistance = 0.01f;   //!< distance where tracing starts
+            float contactDistanceMax = 1.0f;    //!< max distance shadows are cast
+            float intensity = 0.8f;             //!< intensity
+            math::float3 lightDirection{ 0, -1, 0 };    //!< light direction
+            float depthBias = 0.1f;         //!< depth bias in world units (mitigate self shadowing)
+            float depthSlopeBias = 0.1f;    //!< depth slope bias (mitigate self shadowing)
+            float scale = 1.0f;             //!< cast shadows scaling
+            uint8_t sampleCount = 4;        //!< tracing sample count, between 1 and 255
+            bool enabled = false;           //!< enables or disables SSCT
+        } ssct;
     };
 
     /**

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -526,10 +526,17 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                         1.0f / options.ssct.contactDistanceMax
                 });
 
+                // light direction in view space
+                // (note: this is actually equivalent to using the camera view matrix -- before the
+                // world matrix is accounted for)
+                auto m = cameraInfo.view * cameraInfo.worldOrigin;
+                const float3 l = normalize(
+                        mat3f::getTransformForNormals(m.upperLeft())
+                                * options.ssct.lightDirection);
+
                 mi->setParameter("ssctIntensity",
                         options.ssct.intensity);
-                mi->setParameter("ssctVsLightDirection",
-                        -(cameraInfo.view * options.ssct.lightDirection).xyz);
+                mi->setParameter("ssctVsLightDirection", -l);
                 mi->setParameter("ssctDepthBias",
                         float2{ options.ssct.depthBias, options.ssct.depthSlopeBias });
                 mi->setParameter("ssctInvZoom", options.ssct.scale);

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -534,6 +534,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                         float2{ options.ssct.depthBias, options.ssct.depthSlopeBias });
                 mi->setParameter("ssctInvZoom", options.ssct.scale);
                 mi->setParameter("ssctSampleCount", uint32_t(options.ssct.sampleCount));
+                mi->setParameter("ssctRayCount",
+                        float2{ options.ssct.rayCount, 1.0 / options.ssct.rayCount });
 
                 mi->commit(driver);
                 mi->use(driver);

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -483,12 +483,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                 const auto invProjection = inverse(cameraInfo.projection);
                 const float inc = (1.0f / (sampleCount - 0.5f)) * spiralTurns * f::TAU;
 
-                constexpr mat4 screenFromClipMatrix {
-                        0.5, 0.0, 0.0, 0.0,
-                        0.0, 0.5, 0.0, 0.0,
-                        0.0, 0.0, 0.5, 0.0,
-                        0.5, 0.5, 0.5, 1.0
-                };
+                constexpr mat4 screenFromClipMatrix{ mat4::row_major_init{
+                        0.5, 0.0, 0.0, 0.5,
+                        0.0, 0.5, 0.0, 0.5,
+                        0.0, 0.0, 0.5, 0.5,
+                        0.0, 0.0, 0.0, 1.0
+                }};
 
                 auto& material = getPostProcessMaterial("sao");
                 FMaterialInstance* const mi = material.getMaterialInstance();

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -288,13 +288,22 @@ public:
 
     void setAmbientOcclusionOptions(AmbientOcclusionOptions options) noexcept {
         options.radius = math::max(0.0f, options.radius);
-        options.bias = math::clamp(0.0f, 0.1f, options.bias);
+        options.bias = math::clamp(options.bias, 0.0f, 0.1f);
         options.power = std::max(0.0f, options.power);
         // snap to the closer of 0.5 or 1.0
         options.resolution = std::floor(
-                math::clamp(1.0f, 2.0f, options.resolution * 2.0f) + 0.5f) * 0.5f;
+                math::clamp(options.resolution * 2.0f, 1.0f, 2.0f) + 0.5f) * 0.5f;
         options.intensity = std::max(0.0f, options.intensity);
-        options.minHorizonAngleRad = math::clamp(0.0f, math::f::PI_2, options.minHorizonAngleRad);
+        options.minHorizonAngleRad = math::clamp(options.minHorizonAngleRad, 0.0f, math::f::PI_2);
+        options.ssct.lightConeRad = math::clamp(options.ssct.lightConeRad, 0.0f, math::f::PI_2);
+        options.ssct.startTraceDistance = std::max(0.0f, options.ssct.startTraceDistance);
+        options.ssct.contactDistanceMax = std::max(0.0f, options.ssct.contactDistanceMax);
+        options.ssct.intensity = std::max(0.0f, options.ssct.intensity);
+        options.ssct.lightDirection = normalize(options.ssct.lightDirection);
+        options.ssct.depthBias = std::max(0.0f, options.ssct.depthBias);
+        options.ssct.depthSlopeBias = std::max(0.0f, options.ssct.depthSlopeBias);
+        options.ssct.scale = std::max(0.0f, options.ssct.scale);
+        options.ssct.sampleCount = math::clamp((unsigned)options.ssct.sampleCount, 1u, 255u);
         mAmbientOcclusionOptions = options;
     }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -304,6 +304,7 @@ public:
         options.ssct.depthSlopeBias = std::max(0.0f, options.ssct.depthSlopeBias);
         options.ssct.scale = std::max(0.0f, options.ssct.scale);
         options.ssct.sampleCount = math::clamp((unsigned)options.ssct.sampleCount, 1u, 255u);
+        options.ssct.rayCount = math::clamp((unsigned)options.ssct.rayCount, 1u, 255u);
         mAmbientOcclusionOptions = options;
     }
 

--- a/filament/src/materials/ssao/dominantLightShadowing.fs
+++ b/filament/src/materials/ssao/dominantLightShadowing.fs
@@ -57,7 +57,7 @@ float coneTraceOcclusion(in ConeTraceSetup setup, const sampler2D depthTexture) 
 
     // init trace distance and sample radius
     highp float invLinearDepth = 1.0 / -setup.vsStartPos.z;
-    float ssTracedDistance = max(setup.coneTraceParams.z, minTraceDistance) * invLinearDepth;
+    highp float ssTracedDistance = max(setup.coneTraceParams.z, minTraceDistance) * invLinearDepth;
 
     float ssSampleRadius = setup.coneTraceParams.y * ssTracedDistance;
     float ssEndRadius    = setup.coneTraceParams.y * ssConeLength;
@@ -81,11 +81,11 @@ float coneTraceOcclusion(in ConeTraceSetup setup, const sampler2D depthTexture) 
 
         // sample depth buffer
         highp vec2 ssSamplePos = perpConeDir * ssJitteredSampleRadius + ssConeDirection * ssJitteredTracedDistance + ssStartPos;
-        highp float vsSampleDepthLinear = -sampleDepthLinear(depthTexture, ssSamplePos, 0.0, setup.depthParams);
+        float vsSampleDepthLinear = -sampleDepthLinear(depthTexture, ssSamplePos, 0.0, setup.depthParams);
 
         // calculate depth of cone center
         float ratio = ssJitteredTracedDistance * ssInvConeLength;
-        highp float vsConeAxisDepth = 1.0 / mix(ssStartInvW, ssEndInvW, ratio);
+        float vsConeAxisDepth = 1.0 / mix(ssStartInvW, ssEndInvW, ratio);
 
         // calculate depth range of cone slice
         float vsConeRadius = (ratio * vsEndRadius) * vsConeAxisDepth;

--- a/filament/src/materials/ssao/dominantLightShadowing.fs
+++ b/filament/src/materials/ssao/dominantLightShadowing.fs
@@ -1,0 +1,110 @@
+/*
+ * Largely based on "Dominant Light Shadowing"
+ * "Lighting Technology of The Last of Us Part II" by Hawar Doghramachi, Naughty Dog, LLC
+ */
+
+#include "ssaoUtils.fs"
+
+struct ConeTraceSetup {
+    // runtime parameters
+    highp vec2 ssStartPos;
+    highp vec3 vsStartPos;
+    vec3 vsNormal;
+    highp mat4 screenFromViewMatrix;
+    vec2 jitterOffset;          // (x = direction offset, y = step offset)
+    highp float depthParams;
+    vec3 vsConeDirection;
+
+    // artistic/quality parameters
+    vec4 coneTraceParams;       // { tan(angle), sin(angle), start trace distance, inverse max contact distance }
+    float intensity;
+    float invZoom;
+    float depthBias;
+    float slopeScaledDepthBias;
+    uint sampleCount;
+};
+
+float coneTraceOcclusion(in ConeTraceSetup setup, const sampler2D depthTexture) {
+    // skip fragments that are back-facing trace direction
+    // (avoid overshadowing of translucent surfaces)
+    float NoL = dot(setup.vsNormal, setup.vsConeDirection);
+    if (NoL < 0.0) {
+        return 0.0;
+    }
+
+    // start position of cone trace
+    highp vec2 ssStartPos = setup.ssStartPos;
+    highp vec3 vsStartPos = setup.vsStartPos;
+    highp float ssStartInvW = 1.0 / (setup.screenFromViewMatrix * vec4(vsStartPos, 1.0)).w;
+
+    // end position of cone trace
+    highp vec3 vsEndPos = setup.vsConeDirection + vsStartPos;
+    highp vec4 ssEndPos = setup.screenFromViewMatrix * vec4(vsEndPos, 1.0);
+    highp float ssEndInvW = 1.0 / ssEndPos.w;
+    ssEndPos.xy *= ssEndInvW;
+
+    // cone trace direction in screen-space
+    float ssConeLength = length(ssEndPos.xy - ssStartPos);
+    float ssInvConeLength = 1.0 / ssConeLength;
+    vec2 ssConeDirection = (ssEndPos.xy - ssStartPos) * ssInvConeLength;
+
+    // direction perpendicular to cone trace direction
+    vec2 perpConeDir = vec2(ssConeDirection.y, -ssConeDirection.x);
+
+    // avoid self-occlusion and reduce banding artifacts by normal variation
+    vec3 vsViewVector = normalize(vsStartPos);
+    float minTraceDistance = (1.0 - abs(dot(setup.vsNormal, vsViewVector))) * 0.005;
+
+    // init trace distance and sample radius
+    highp float invLinearDepth = 1.0 / -setup.vsStartPos.z;
+    float ssTracedDistance = max(setup.coneTraceParams.z, minTraceDistance) * invLinearDepth;
+
+    float ssSampleRadius = setup.coneTraceParams.y * ssTracedDistance;
+    float ssEndRadius    = setup.coneTraceParams.y * ssConeLength;
+    float vsEndRadius    = ssEndRadius * setup.invZoom * invLinearDepth * ssEndPos.w;
+
+    // calculate depth bias
+    float vsDepthBias = saturate(1.0 - NoL) * setup.slopeScaledDepthBias + setup.depthBias;
+
+    float occlusion = 0.0;
+    for (uint i = 0u; i < setup.sampleCount; i++) {
+        // step along cone in screen space
+        float ssNextSampleRadius = ssSampleRadius * (ssSampleRadius + ssTracedDistance) / (ssTracedDistance - ssSampleRadius);
+        float ssStepDistance = ssSampleRadius + ssNextSampleRadius;
+        ssSampleRadius = ssNextSampleRadius;
+
+        // apply jitter offset
+        float ssJitterStepDistance = ssStepDistance * setup.jitterOffset.y;
+        float ssJitteredTracedDistance = ssTracedDistance + ssJitterStepDistance;
+        float ssJitteredSampleRadius = setup.jitterOffset.x * setup.coneTraceParams.x * ssJitteredTracedDistance;
+        ssTracedDistance += ssStepDistance;
+
+        // sample depth buffer
+        highp vec2 ssSamplePos = perpConeDir * ssJitteredSampleRadius + ssConeDirection * ssJitteredTracedDistance + ssStartPos;
+        highp float vsSampleDepthLinear = -sampleDepthLinear(depthTexture, ssSamplePos, 0.0, setup.depthParams);
+
+        // calculate depth of cone center
+        float ratio = ssJitteredTracedDistance * ssInvConeLength;
+        highp float vsConeAxisDepth = 1.0 / mix(ssStartInvW, ssEndInvW, ratio);
+
+        // calculate depth range of cone slice
+        float vsConeRadius = (ratio * vsEndRadius) * vsConeAxisDepth;
+        float vsJitteredSampleRadius = vsConeRadius * setup.jitterOffset.x;
+        float vsSliceHalfRange = sqrt(vsConeRadius * vsConeRadius - vsJitteredSampleRadius * vsJitteredSampleRadius);
+        float vsSampleDepthMax = vsConeAxisDepth + vsSliceHalfRange;
+
+        // calculate overlap of depth buffer height-field with trace cone
+        float vsDepthDifference = vsSampleDepthMax - vsSampleDepthLinear;
+        float overlap = saturate((vsDepthDifference - vsDepthBias) / (vsSliceHalfRange * 2.0));
+
+        // attenuate by distance to avoid false occlusion
+        float attenuation = saturate(1.0 - (vsDepthDifference * setup.coneTraceParams.w));
+        occlusion = max(occlusion, overlap * attenuation);
+
+        if (occlusion >= 1.0) {  // note: this can't get > 1.0 by construction
+            // fully occluded, early exit
+            break;
+        }
+    }
+    return occlusion * setup.intensity;
+}

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -7,6 +7,10 @@ material {
             precision: high
         },
         {
+            type : mat4,
+            name : screenFromViewMatrix
+        },
+        {
             type : float4,
             name : resolution,
             precision: high
@@ -68,6 +72,30 @@ material {
         {
             type : int,
             name : maxLevel
+        },
+        {
+            type : float4,
+            name : ssctConeTraceParams
+        },
+        {
+            type : float3,
+            name : ssctVsLightDirection
+        },
+        {
+            type : float,
+            name : ssctIntensity
+        },
+        {
+            type : float2,
+            name : ssctDepthBias
+        },
+        {
+            type : float,
+            name : ssctInvZoom
+        },
+        {
+            type : uint,
+            name : ssctSampleCount
         }
     ],
     variables : [
@@ -86,6 +114,7 @@ vertex {
 
 fragment {
     #include "ssaoUtils.fs"
+    #include "dominantLightShadowing.fs"
 
     const float kLog2LodRate = 3.0;
     const float kEdgeDistance = 0.0625; // this shouldn't be hardcoded
@@ -201,13 +230,7 @@ fragment {
         occlusion += w * max(0.0, vn + origin.z * materialParams.bias) / (vv + materialParams.peak2);
     }
 
-    void postProcess(inout PostProcessInputs postProcess) {
-        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
-
-        highp float depth = sampleDepthLinear(materialParams_depth, uv, 0.0, materialParams.depthParams);
-        highp vec3 origin = computeViewSpacePositionFromDepth(uv, depth);
-
-        vec3 normal = computeViewSpaceNormal(origin, uv);
+    float scalableAmbientObscurance(highp vec2 uv, highp vec3 origin, vec3 normal) {
         float noise = random(gl_FragCoord.xy);
         highp vec2 tapPosition = startPosition(noise);
         highp mat2 angleStep = tapAngleStep();
@@ -221,7 +244,45 @@ fragment {
             computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, tapPosition, noise);
             tapPosition = angleStep * tapPosition;
         }
-        occlusion = sqrt(occlusion * materialParams.intensity);
+        return sqrt(occlusion * materialParams.intensity);
+    }
+
+    float dominantLightShadowing(highp vec2 uv, highp vec3 origin, vec3 normal) {
+        ConeTraceSetup cone;
+        cone.ssStartPos = uv;
+        cone.vsStartPos = origin;
+        cone.vsNormal = normal;
+        cone.screenFromViewMatrix = materialParams.screenFromViewMatrix;
+        cone.depthParams = materialParams.depthParams;
+        cone.vsConeDirection = materialParams.ssctVsLightDirection;
+        cone.coneTraceParams = materialParams.ssctConeTraceParams;
+        cone.intensity = materialParams.ssctIntensity;
+        cone.invZoom = materialParams.ssctInvZoom;
+        cone.depthBias = materialParams.ssctDepthBias.x;
+        cone.slopeScaledDepthBias = materialParams.ssctDepthBias.y;
+        cone.sampleCount = materialParams.ssctSampleCount;
+        cone.jitterOffset.x = random(gl_FragCoord.xy) * 2.0 - 1.0;      // direction
+        cone.jitterOffset.y = random(gl_FragCoord.xy * vec2(11, 3));    // step
+        float occlusion = coneTraceOcclusion(cone, materialParams_depth);
+        return occlusion;
+    }
+
+    void postProcess(inout PostProcessInputs postProcess) {
+        highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
+
+        highp float depth = sampleDepthLinear(materialParams_depth, uv, 0.0, materialParams.depthParams);
+        highp vec3 origin = computeViewSpacePositionFromDepth(uv, depth);
+        vec3 normal = computeViewSpaceNormal(origin, uv);
+
+        float occlusion = 0.0;
+
+        if (materialParams.intensity > 0.0) {
+            occlusion = scalableAmbientObscurance(uv, origin, normal);
+        }
+
+        if (materialParams.ssctConeTraceParams.x > 0.0) {
+            occlusion = max(occlusion, dominantLightShadowing(uv, origin, normal));
+        }
 
         // occlusion to visibility
         float aoVisibility = pow(saturate(1.0 - occlusion), materialParams.power);

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -85,6 +85,8 @@ vertex {
 }
 
 fragment {
+    #include "ssaoUtils.fs"
+
     const float kLog2LodRate = 3.0;
     const float kEdgeDistance = 0.0625; // this shouldn't be hardcoded
 
@@ -105,18 +107,6 @@ fragment {
     float random(const highp vec2 w) {
         const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
         return fract(m.z * fract(dot(w, m.xy)));
-    }
-
-    highp float linearizeDepth(highp float depth) {
-        // Our far plane is at infinity, which causes a division by zero below, which in turn
-        // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
-        // value representable in  a 24 bit depth buffer.
-        const float preventDiv0 = 1.0 / 16777216.0;
-        return materialParams.depthParams / max(depth, preventDiv0);
-    }
-
-    highp float sampleDepthLinear(const vec2 uv, float lod) {
-        return linearizeDepth(textureLod(materialParams_depth, uv, lod).r);
     }
 
     highp vec3 computeViewSpacePositionFromDepth(highp vec2 uv, highp float linearDepth) {
@@ -142,8 +132,10 @@ fragment {
     highp vec3 computeViewSpaceNormal(const highp vec3 position, const highp vec2 uv) {
         highp vec2 uvdx = uv + vec2(materialParams.resolution.z, 0.0);
         highp vec2 uvdy = uv + vec2(0.0, materialParams.resolution.w);
-        highp vec3 px = computeViewSpacePositionFromDepth(uvdx, sampleDepthLinear(uvdx, 0.0));
-        highp vec3 py = computeViewSpacePositionFromDepth(uvdy, sampleDepthLinear(uvdy, 0.0));
+        highp vec3 px = computeViewSpacePositionFromDepth(uvdx,
+                sampleDepthLinear(materialParams_depth, uvdx, 0.0, materialParams.depthParams));
+        highp vec3 py = computeViewSpacePositionFromDepth(uvdy,
+                sampleDepthLinear(materialParams_depth, uvdy, 0.0, materialParams.depthParams));
         highp vec3 dpdx = px - position;
         highp vec3 dpdy = py - position;
         return faceNormal(dpdx, dpdy);
@@ -187,7 +179,7 @@ fragment {
         vec2 uvSamplePos = uv + vec2(ssRadius * tap.xy) * materialParams.resolution.zw;
 
         float level = clamp(floor(log2(ssRadius)) - kLog2LodRate, 0.0, float(materialParams.maxLevel));
-        highp float occlusionDepth = sampleDepthLinear(uvSamplePos, level);
+        highp float occlusionDepth = sampleDepthLinear(materialParams_depth, uvSamplePos, level, materialParams.depthParams);
         highp vec3 p = computeViewSpacePositionFromDepth(uvSamplePos, occlusionDepth);
 
         // now we have the sample, compute AO
@@ -212,7 +204,7 @@ fragment {
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
 
-        highp float depth = sampleDepthLinear(uv, 0.0);
+        highp float depth = sampleDepthLinear(materialParams_depth, uv, 0.0, materialParams.depthParams);
         highp vec3 origin = computeViewSpacePositionFromDepth(uv, depth);
 
         vec3 normal = computeViewSpaceNormal(origin, uv);
@@ -229,15 +221,16 @@ fragment {
             computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, tapPosition, noise);
             tapPosition = angleStep * tapPosition;
         }
+        occlusion = sqrt(occlusion * materialParams.intensity);
 
-        float ao = max(0.0, 1.0 - sqrt(occlusion * materialParams.intensity));
-        ao = pow(ao, materialParams.power);
+        // occlusion to visibility
+        float aoVisibility = pow(saturate(1.0 - occlusion), materialParams.power);
 
 #if defined(TARGET_MOBILE)
         // this line is needed to workaround what seems to be a bug on qualcomm hardware
-        ao += gl_FragCoord.x * MEDIUMP_FLT_MIN;
+        aoVisibility += gl_FragCoord.x * MEDIUMP_FLT_MIN;
 #endif
 
-        postProcess.color.rgb = vec3(ao, pack(origin.z));
+        postProcess.color.rgb = vec3(aoVisibility, pack(origin.z));
     }
 }

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -96,6 +96,10 @@ material {
         {
             type : uint,
             name : ssctSampleCount
+        },
+        {
+            type : float2,
+            name : ssctRayCount
         }
     ],
     variables : [
@@ -261,10 +265,13 @@ fragment {
         cone.depthBias = materialParams.ssctDepthBias.x;
         cone.slopeScaledDepthBias = materialParams.ssctDepthBias.y;
         cone.sampleCount = materialParams.ssctSampleCount;
-        cone.jitterOffset.x = random(gl_FragCoord.xy) * 2.0 - 1.0;      // direction
-        cone.jitterOffset.y = random(gl_FragCoord.xy * vec2(11, 3));    // step
-        float occlusion = coneTraceOcclusion(cone, materialParams_depth);
-        return occlusion;
+        float occlusion = 0.0;
+        for (float i = 1.0; i <= materialParams.ssctRayCount.x; i += 1.0) {
+            cone.jitterOffset.x = random(gl_FragCoord.xy * i) * 2.0 - 1.0;      // direction
+            cone.jitterOffset.y = random(gl_FragCoord.xy * i * vec2(11, 3));    // step
+            occlusion += coneTraceOcclusion(cone, materialParams_depth);
+        }
+        return occlusion * materialParams.ssctRayCount.y;
     }
 
     void postProcess(inout PostProcessInputs postProcess) {

--- a/filament/src/materials/ssao/ssaoUtils.fs
+++ b/filament/src/materials/ssao/ssaoUtils.fs
@@ -1,0 +1,17 @@
+#ifndef MATERIALS_SSAO_UTILS
+#define MATERIALS_SSAO_UTILS
+
+highp float linearizeDepth(highp float depth, highp float depthParams) {
+    // Our far plane is at infinity, which causes a division by zero below, which in turn
+    // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
+    // value representable in  a 24 bit depth buffer.
+    const float preventDiv0 = 1.0 / 16777216.0;
+    return depthParams / max(depth, preventDiv0);
+}
+
+highp float sampleDepthLinear(const sampler2D depthTexture, const vec2 uv, float lod, highp float depthParams) {
+    return linearizeDepth(textureLod(depthTexture, uv, lod).r, depthParams);
+}
+
+#endif // MATERIALS_SSAO_UTILS
+

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -484,6 +484,20 @@ void SimpleViewer::updateUserInterface() {
             mSSAOOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
             mSSAOOptions.quality = (View::QualityLevel) quality;
             mSSAOOptions.lowPassFilter = (View::QualityLevel) lowpass;
+            if (ImGui::CollapsingHeader("Dominant Light Shadows (experimental)")) {
+                int sampleCount = mSSAOOptions.ssct.sampleCount;
+                ImGui::Checkbox("Enabled##dls", &mSSAOOptions.ssct.enabled);
+                ImGui::SliderFloat("Cone angle", &mSSAOOptions.ssct.lightConeRad, 0.0f, (float)M_PI_2);
+                ImGui::SliderFloat("Start dist", &mSSAOOptions.ssct.startTraceDistance, 0.0f, 1.0f);
+                ImGui::SliderFloat("Contact dist max", &mSSAOOptions.ssct.contactDistanceMax, 0.0f, 100.0f);
+                ImGui::SliderFloat("Intensity##dls", &mSSAOOptions.ssct.intensity, 0.0f, 10.0f);
+                ImGui::SliderFloat("Depth bias", &mSSAOOptions.ssct.depthBias, 0.0f, 1.0f);
+                ImGui::SliderFloat("Depth slope bias", &mSSAOOptions.ssct.depthSlopeBias, 0.0f, 1.0f);
+                ImGui::SliderFloat("Scale", &mSSAOOptions.ssct.scale, 0.0f, 10.0f);
+                ImGui::SliderInt("Sample Count", &sampleCount, 1, 32);
+                ImGuiExt::DirectionWidget("Direction##dls", mSSAOOptions.ssct.lightDirection.v);
+                mSSAOOptions.ssct.sampleCount = sampleCount;
+            }
         }
         ImGui::Unindent();
     }

--- a/libs/gltfio/include/gltfio/SimpleViewer.h
+++ b/libs/gltfio/include/gltfio/SimpleViewer.h
@@ -475,12 +475,15 @@ void SimpleViewer::updateUserInterface() {
         ImGui::Checkbox("Bloom", &mBloomOptions.enabled);
         if (ImGui::CollapsingHeader("SSAO Options")) {
             int quality = (int) mSSAOOptions.quality;
+            int lowpass = (int) mSSAOOptions.lowPassFilter;
             bool upsampling = mSSAOOptions.upsampling != View::QualityLevel::LOW;
             ImGui::SliderInt("Quality", &quality, 0, 3);
+            ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
             ImGui::Checkbox("High quality upsampling", &upsampling);
             ImGui::SliderFloat("Min Horizon angle", &mSSAOOptions.minHorizonAngleRad, 0.0f, (float)M_PI_4);
             mSSAOOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
             mSSAOOptions.quality = (View::QualityLevel) quality;
+            mSSAOOptions.lowPassFilter = (View::QualityLevel) lowpass;
         }
         ImGui::Unindent();
     }

--- a/libs/math/include/math/scalar.h
+++ b/libs/math/include/math/scalar.h
@@ -18,6 +18,7 @@
 #define TNT_MATH_SCALAR_H
 
 #include <math/compiler.h>
+#include <assert.h>
 
 namespace filament {
 namespace math {
@@ -87,6 +88,7 @@ inline constexpr T MATH_PURE max(T a, T b) noexcept {
 
 template<typename T>
 inline constexpr T MATH_PURE clamp(T v, T min, T max) noexcept {
+    assert(min <= max);
     return T(math::min(max, math::max(min, v)));
 }
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -615,8 +615,12 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::SliderInt("Quality", &quality, 0, 3);
                 ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
                 ImGui::Checkbox("High quality upsampling", &upsampling);
+                params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
+                params.ssaoOptions.quality = (View::QualityLevel)quality;
+                params.ssaoOptions.lowPassFilter = (View::QualityLevel)lowpass;
                 if (ImGui::CollapsingHeader("Dominant Light Shadows")) {
                     int sampleCount = params.ssaoOptions.ssct.sampleCount;
+                    int rayCount = params.ssaoOptions.ssct.rayCount;
                     ImGui::Checkbox("Enabled##dls", &params.ssaoOptions.ssct.enabled);
                     ImGui::SliderFloat("Cone angle", &params.ssaoOptions.ssct.lightConeRad, 0.0f, (float)M_PI_2);
                     ImGui::SliderFloat("Start dist", &params.ssaoOptions.ssct.startTraceDistance, 0.0f, 1.0f);
@@ -626,12 +630,11 @@ static void gui(filament::Engine* engine, filament::View*) {
                     ImGui::SliderFloat("Depth slope bias", &params.ssaoOptions.ssct.depthSlopeBias, 0.0f, 1.0f);
                     ImGui::SliderFloat("Scale", &params.ssaoOptions.ssct.scale, 0.0f, 10.0f);
                     ImGui::SliderInt("Sample Count", &sampleCount, 1, 32);
+                    ImGui::SliderInt("Ray Count", &rayCount, 1, 8);
                     ImGuiExt::DirectionWidget("Direction##dls", params.ssaoOptions.ssct.lightDirection.v);
                     params.ssaoOptions.ssct.sampleCount = sampleCount;
+                    params.ssaoOptions.ssct.rayCount = rayCount;
                 }
-                params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
-                params.ssaoOptions.quality = (View::QualityLevel)quality;
-                params.ssaoOptions.lowPassFilter = (View::QualityLevel)lowpass;
             }
             ImGui::Unindent();
         }

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -615,6 +615,20 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::SliderInt("Quality", &quality, 0, 3);
                 ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
                 ImGui::Checkbox("High quality upsampling", &upsampling);
+                if (ImGui::CollapsingHeader("Dominant Light Shadows")) {
+                    int sampleCount = params.ssaoOptions.ssct.sampleCount;
+                    ImGui::Checkbox("Enabled##dls", &params.ssaoOptions.ssct.enabled);
+                    ImGui::SliderFloat("Cone angle", &params.ssaoOptions.ssct.lightConeRad, 0.0f, (float)M_PI_2);
+                    ImGui::SliderFloat("Start dist", &params.ssaoOptions.ssct.startTraceDistance, 0.0f, 1.0f);
+                    ImGui::SliderFloat("Contact dist max", &params.ssaoOptions.ssct.contactDistanceMax, 0.0f, 100.0f);
+                    ImGui::SliderFloat("Intensity##dls", &params.ssaoOptions.ssct.intensity, 0.0f, 10.0f);
+                    ImGui::SliderFloat("Depth bias", &params.ssaoOptions.ssct.depthBias, 0.0f, 1.0f);
+                    ImGui::SliderFloat("Depth slope bias", &params.ssaoOptions.ssct.depthSlopeBias, 0.0f, 1.0f);
+                    ImGui::SliderFloat("Scale", &params.ssaoOptions.ssct.scale, 0.0f, 10.0f);
+                    ImGui::SliderInt("Sample Count", &sampleCount, 1, 32);
+                    ImGuiExt::DirectionWidget("Direction##dls", params.ssaoOptions.ssct.lightDirection.v);
+                    params.ssaoOptions.ssct.sampleCount = sampleCount;
+                }
                 params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
                 params.ssaoOptions.quality = (View::QualityLevel)quality;
                 params.ssaoOptions.lowPassFilter = (View::QualityLevel)lowpass;

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -603,6 +603,7 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderAngle("Rotation", &params.iblRotation);
             if (ImGui::CollapsingHeader("SSAO")) {
                 int quality = (int)params.ssaoOptions.quality;
+                int lowpass = (int)params.ssaoOptions.lowPassFilter;
                 bool upsampling = params.ssaoOptions.upsampling != View::QualityLevel::LOW;
                 DebugRegistry& debug = engine->getDebugRegistry();
                 ImGui::Checkbox("Enabled##ssao", &params.ssaoOptions.enabled);
@@ -612,9 +613,11 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::SliderFloat("Intensity", &params.ssaoOptions.intensity, 0.0f, 4.0f);
                 ImGui::SliderFloat("Power", &params.ssaoOptions.power, 0.0f, 4.0f);
                 ImGui::SliderInt("Quality", &quality, 0, 3);
+                ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
                 ImGui::Checkbox("High quality upsampling", &upsampling);
                 params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
                 params.ssaoOptions.quality = (View::QualityLevel)quality;
+                params.ssaoOptions.lowPassFilter = (View::QualityLevel)lowpass;
             }
             ImGui::Unindent();
         }


### PR DESCRIPTION
This is a technique from Naughty Dog used in TLOU2, where we compute
the "ambient" shadowing of a dominant light in screen-space using cone
tracing.

This is currently integrated to the SSAO pass.

<img width="305" alt="ssct" src="https://user-images.githubusercontent.com/1240896/94319985-b3567900-ff40-11ea-89f9-3ba98346f55c.png">
