### PR TITLE
matdbg: fix edits for large shaders. 

### DIFF
--- a/libs/matdbg/README.md
+++ b/libs/matdbg/README.md
@@ -187,7 +187,7 @@ direction. In our homegrown protocol, every WebSocket message starts with a comm
 
 Currently we support only one command. It travels from client to server.
 
-    EDIT [material id] [api index] [shader index] [entire shader source....]
+    EDIT [material id] [api index] [shader index] [shader length] [entire shader source....]
 
 The `material id` is 8 hex digits.
 
@@ -197,6 +197,8 @@ zero is invalid).
 The `shader index` is a zero-based index into the list of variants using the order that
 they appear in the package, where each API (GL / VK / Metal) has its own list.
 
+The `shader length` is the number of bytes required for UTF-8 encoding of the shader source string,
+not including the terminating null.
 
 ## Wish List
 

--- a/libs/matdbg/include/matdbg/DebugServer.h
+++ b/libs/matdbg/include/matdbg/DebugServer.h
@@ -93,6 +93,10 @@ private:
     utils::CString mHtml;
     utils::CString mJavascript;
     utils::CString mCss;
+
+    utils::CString mChunkedMessage;
+    size_t mChunkedMessageRemaining = 0;
+
     EditCallback mEditCallback = nullptr;
     QueryCallback mQueryCallback = nullptr;
 

--- a/libs/matdbg/web/script.js
+++ b/libs/matdbg/web/script.js
@@ -53,8 +53,9 @@ function rebuildMaterial() {
     if ("glindex" in gCurrentShader)    { api = 1; index = gCurrentShader.glindex; }
     if ("vkindex" in gCurrentShader)    { api = 2; index = gCurrentShader.vkindex; }
     if ("metalindex" in gCurrentShader) { api = 3; index = gCurrentShader.metalindex; }
-    const text = getShaderRecord(gCurrentShader).text;
-    gSocket.send(`EDIT ${gCurrentShader.matid} ${api} ${index} ${text}`);
+    const editedText = getShaderRecord(gCurrentShader).text;
+    const byteCount = new Blob([editedText]).size;
+    gSocket.send(`EDIT ${gCurrentShader.matid} ${api} ${index} ${byteCount} ${editedText}`);
 }
 
 document.querySelector("body").addEventListener("click", (evt) => {

--- a/libs/matdbg/web/script.js
+++ b/libs/matdbg/web/script.js
@@ -325,11 +325,14 @@ function getShaderRecord(selection) {
 
 function renderShaderStatus() {
     const shader = getShaderRecord(gCurrentShader);
+    let statusString = "";
     if (shader && shader.modified) {
-        header.innerHTML = "matdbg &nbsp; <a class='rebuild'>[rebuild]</a>";
-    } else {
-        header.innerHTML = "matdbg";
+        statusString += " &nbsp; <a class='rebuild'>[rebuild]</a>";
     }
+    if (shader && !shader.active) {
+        statusString += " &nbsp; <span class='warning'> selected variant is inactive </span>";
+    }
+    header.innerHTML = "matdbg" + statusString;
 }
 
 function selectShader(selection) {

--- a/libs/matdbg/web/style.css
+++ b/libs/matdbg/web/style.css
@@ -20,6 +20,16 @@ a:hover, a.current {
     color: #07f;
 }
 
+a.rebuild {
+    color: #e4e682;
+}
+
+span.warning {
+    color: black;
+    background: orange;
+    font-size: small;
+}
+
 a.inactive {
     color: #aaa;
 }

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -202,8 +202,13 @@ public:
 
     CString() noexcept = default;
 
-    // cstr must be a null terminated string and length == strlen(cstr)
+    // Allocates memory and appends a null. This constructor can be used to hold arbitrary data
+    // inside the string (i.e. it can contain nulls or non-ASCII encodings).
     CString(const char* cstr, size_t length);
+
+    // Allocates memory and copies traditional C string content. Unlike the above constructor, this
+    // does not alllow embedded nulls. This is explicit because this operation is costly.
+    explicit CString(const char* cstr);
 
     template<size_t N>
     explicit CString(StringLiteral<N> const& other) noexcept // NOLINT(google-explicit-constructor)
@@ -218,10 +223,6 @@ public:
         this->swap(rhs);
     }
 
-
-    // this creates a CString from a null-terminated C string, this allocates memory and copies
-    // its content. this is explicit because this operation is costly.
-    explicit CString(const char* cstr);
 
     CString& operator=(const CString& rhs);
 

--- a/libs/utils/src/CString.cpp
+++ b/libs/utils/src/CString.cpp
@@ -36,7 +36,6 @@ int StaticString::compare(const StaticString& rhs) const noexcept {
 UTILS_NOINLINE
 CString::CString(const char* cstr, size_t length) {
     if (length && cstr) {
-        assert(length == strlen(cstr));
         Data* p = (Data*)malloc(sizeof(Data) + length + 1);
         p->length = (size_type)length;
         mCStr = (value_type*)(p + 1);


### PR DESCRIPTION
- Fixed edits for large shaders.
    - If the shader source exceeds the websocket max size, we might receive it in chunks.
    - We now allow for this by including a length prefix in the EDIT command.
- Added support for UTF-8 string encoding.
- Display an orange warning when editing an unused shader variant.

