### PR TITLE
JavaScript bindings: fix TextureUsage bitmask.

### DIFF
--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -891,7 +891,10 @@ export enum Texture$Sampler {
     SAMPLER_EXTERNAL,
 }
 
-export enum Texture$Usage {
+// This enum is a bit different the others because it can be used in a bitfield.
+// It is a "const enum" which means TypeScript will simply create a constant for each member.
+// It does not contain the $ delimiter to avoid interference with the embind class.
+export const enum TextureUsage {
     DEFAULT,
     COLOR_ATTACHMENT,
     DEPTH_ATTACHMENT,

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1264,8 +1264,12 @@ class_<TexBuilder>("Texture$Builder")
         return &builder->sampler(target); })
     .BUILDER_FUNCTION("format", TexBuilder, (TexBuilder* builder, Texture::InternalFormat fmt), {
         return &builder->format(fmt); })
-    .BUILDER_FUNCTION("usage", TexBuilder, (TexBuilder* builder, Texture::Usage usage), {
-        return &builder->usage(usage); });
+
+    // This takes a bitfield that can be composed by or'ing constants.
+    // - JS clients should use the value member, as in: "Texture$Usage.SAMPLEABLE.value".
+    // - TypeScript clients can simply say "TextureUsage.SAMPLEABLE" (note the lack of $)
+    .BUILDER_FUNCTION("usage", TexBuilder, (TexBuilder* builder, uint8_t usage), {
+        return &builder->usage((Texture::Usage)usage); });
 
 class_<IndirectLight>("IndirectLight")
     .class_function("Builder", (IblBuilder (*)()) [] { return IblBuilder(); })


### PR DESCRIPTION
There's no really good solution, so this just keeps it simple and makes
is so that embind consumes an integer rather than an embind enum object.

Tested by hacking _createTextureFromImageFile.

Fixes #3028.