### PR TITLE
Vulkan: fix final image barrier used for swap chain.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -160,7 +160,7 @@ void getPresentationQueue(VulkanContext& context, VulkanSurfaceContext& sc);
 
 void createSwapChain(VulkanContext& context, VulkanSurfaceContext& sc);
 void destroySwapChain(VulkanContext& context, VulkanSurfaceContext& sc, VulkanDisposer& disposer);
-void transitionSwapChain(VulkanContext& context);
+void makeSwapChainPresentable(VulkanContext& context);
 
 uint32_t selectMemoryType(VulkanContext& context, uint32_t flags, VkFlags reqs);
 SwapContext& getSwapContext(VulkanContext& context);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1153,7 +1153,7 @@ void VulkanDriver::commit(Handle<HwSwapChain> sch) {
 
     // Before swapping, transition the current swap chain image to the PRESENT layout. This cannot
     // be done as part of the render pass because it does not know if it is last pass in the frame.
-    transitionSwapChain(mContext);
+    makeSwapChainPresentable(mContext);
 
     // Finalize the command buffer and set the cmdbuffer pointer to null.
     VkResult result = vkEndCommandBuffer(mContext.currentCommands->cmdbuffer);

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -682,12 +682,12 @@ void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
             break;
         case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
         case VK_IMAGE_LAYOUT_GENERAL:
-        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
             barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
             sourceStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
             destinationStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
             break;
+        case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
         default:
            PANIC_POSTCONDITION("Unsupported layout transition.");
     }


### PR DESCRIPTION
This image barrier should wait until all write operations are complete. This was not set up correctly (src and dst flags were flipped) but this did not manifest in any visible problems or validation errors.

I also tried to document this better, since using an image barrier for the swap chain seems to be an unusual thing to do (e.g. the Sascha Willems demos do not do this).