### PR TITLE
Use light space Z as VSM depth metric

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -91,35 +91,9 @@ void ShadowMap::computeSceneCascadeParams(const FScene::LightSoa& lightData, siz
         FView const& view, filament::CameraInfo const& camera, uint8_t visibleLayers,
         CascadeParameters& cascadeParams) {
     // Calculate the directional light's "position".
-    // For VSM, we pick a point on the sphere that bounds the camera's culling frustum.
-    if (view.hasVsm()) {
-        // Calculate view frustum vertices in world-space.
-        // TODO: take shadowFar into account.
-        float3 wsViewFrustumVertices[8];
-        computeFrustumCorners(wsViewFrustumVertices,
-                camera.model * FCamera::inverseProjection(camera.cullingProjection));
-
-        // Find the centroid of the frustum in world-space.
-        float3 wsCentroid { 0.0, 0.0, 0.0 };
-        for (float3 v : wsViewFrustumVertices) {
-            wsCentroid += v;
-        }
-        wsCentroid *= (1.0 / 8.0);
-
-        // Find the radius of the frustum's bounding sphere.
-        float wsRadius = 0.0f;
-        for (float3 v : wsViewFrustumVertices) {
-            float distance = length(v - wsCentroid);
-            wsRadius = max(wsRadius, distance);
-        }
-
-        const float3 l = lightData.elementAt<FScene::DIRECTION>(0); // guaranteed normalized
-        cascadeParams.wsLightPosition = wsCentroid - (l * wsRadius);
-    } else {
-        // For PCF, we could choose any position; we pick the camera position so we have a fixed
-        // reference -- that's "not too far" from the scene.
-        cascadeParams.wsLightPosition = camera.getPosition();
-    }
+    // We could choose any position; we pick the camera position so we have a fixed
+    // reference -- that's "not too far" from the scene.
+    cascadeParams.wsLightPosition = camera.getPosition();
 
     // Compute the light's model matrix.
     const float3 lightPosition = cascadeParams.wsLightPosition;
@@ -453,6 +427,18 @@ void ShadowMap::computeShadowCameraDirectional(
         }
         mLightSpace = St;
 
+        // The mLightSpace matrix transforms coordinates from world space into (u, v, z)
+        // coordinates, where (u, v) are used to access the shadow map, and z is the PCF
+        // comparison value between 0 and 1.
+        // For VSM, we don't want to project the z coordinate, but do want to transform it to linear
+        // light space. We then scale the z by zfar, which prevents us from overflowing when we
+        // square z in the depth shader.
+        mLightSpaceVsm = mLightSpace;
+        mLightSpaceVsm[0][2] = Mv[0][2] / std::abs(zfar);
+        mLightSpaceVsm[1][2] = Mv[1][2] / std::abs(zfar);
+        mLightSpaceVsm[2][2] = Mv[2][2] / std::abs(zfar);
+        mLightSpaceVsm[3][2] = Mv[3][2] / std::abs(zfar);
+
         // We apply the constant bias in world space (as opposed to light-space) to account
         // for perspective and lispsm shadow maps. This also allows us to do this at zero-cost
         // by baking it in the shadow-map itself.
@@ -485,13 +471,14 @@ void ShadowMap::computeShadowCameraSpot(math::float3 const& position, math::floa
 
     // Choose a reasonable value for the near plane.
     const float nearPlane = 0.1f;
+    const float farPlane = radius;
 
     const float3 lightPosition = position;
     const mat4f M = mat4f::lookAt(lightPosition, lightPosition + dir, float3{0, 1, 0});
     const mat4f Mv = FCamera::rigidTransformInverse(M);
 
     float outerConeAngleDegrees = outerConeAngle * f::RAD_TO_DEG;
-    const mat4f Mp = mat4f::perspective(outerConeAngleDegrees * 2, 1.0f, nearPlane, radius,
+    const mat4f Mp = mat4f::perspective(outerConeAngleDegrees * 2, 1.0f, nearPlane, farPlane,
             mat4f::Fov::HORIZONTAL);
 
     const mat4f MpMv(Mp * Mv);
@@ -504,6 +491,18 @@ void ShadowMap::computeShadowCameraSpot(math::float3 const& position, math::floa
     mTexelSizeWs = texelSizeWorldSpace(Mp, MbMt);
     mLightSpace = St;
 
+    // The mLightSpace matrix transforms coordinates from world space into (u, v, z) coordinates,
+    // where (u, v) are used to access the shadow map, and z is the PCF comparison value between 0
+    // and 1.
+    // For VSM, we don't want to project the z coordinate, but do want to transform it to linear
+    // light space. We then scale the z by farPlane, which prevents us from overflowing when we
+    // square z in the depth shader.
+    mLightSpaceVsm = mLightSpace;
+    mLightSpaceVsm[0][2] = Mv[0][2] / farPlane;
+    mLightSpaceVsm[1][2] = Mv[1][2] / farPlane;
+    mLightSpaceVsm[2][2] = Mv[2][2] / farPlane;
+    mLightSpaceVsm[3][2] = Mv[3][2] / farPlane;
+
     const mat4f b = mat4f::translation(dir * params.options.constantBias);
     const mat4f Sb = S * b;
 
@@ -513,7 +512,7 @@ void ShadowMap::computeShadowCameraSpot(math::float3 const& position, math::floa
     // baked in.
 
     mCamera->setModelMatrix(FCamera::rigidTransformInverse(b) * M);
-    mCamera->setCustomProjection(mat4(Mp), nearPlane, radius);
+    mCamera->setCustomProjection(mat4(Mp), nearPlane, farPlane);
 
     // for the debug camera, we need to undo the world origin
     mDebugCamera->setCustomProjection(mat4(Sb * camera.worldOrigin), nearPlane, radius);

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -155,6 +155,7 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
                     if (view.hasVsm()) {
                         renderTarget.attachments = { { data.shadows, 0u, i }, { data.tempShadow } };
                         renderTarget.clearFlags = TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH;
+                        renderTarget.clearColor = { 1.0f, 1.0f, 0.0f, 0.0f };
                     } else {
                         renderTarget.attachments = { {}, { data.shadows, 0u, i } };
                         renderTarget.clearFlags = TargetBufferFlags::DEPTH;
@@ -350,7 +351,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(
         if (shadowMap.hasVisibleShadows()) {
             entry.setHasVisibleShadows(true);
 
-            mat4f const& lightFromWorldMatrix = shadowMap.getLightSpaceMatrix();
+            mat4f const& lightFromWorldMatrix =
+                view.hasVsm() ? shadowMap.getLightSpaceMatrixVsm() : shadowMap.getLightSpaceMatrix();
             perViewUb.setUniform(offsetof(PerViewUib, lightFromWorldMatrix) +
                     sizeof(mat4f) * i, lightFromWorldMatrix);
 
@@ -426,9 +428,10 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(
             FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
                     VISIBLE_SPOT_SHADOW_CASTER_N_BIT(i));
 
-            mat4f const& lightFromWorldMatrix = shadowMap.getLightSpaceMatrix();
+            mat4f const& lightFromWorldMatrix =
+                view.hasVsm() ? shadowMap.getLightSpaceMatrixVsm() : shadowMap.getLightSpaceMatrix();
             u.setUniform(offsetof(ShadowUib, spotLightFromWorldMatrix) +
-                         sizeof(mat4f) * i, lightFromWorldMatrix);
+                    sizeof(mat4f) * i, lightFromWorldMatrix);
 
             shadowInfo[l].castsShadows = true;
             shadowInfo[l].index = i;

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -209,6 +209,9 @@ private:
 
     math::mat4f getTextureCoordsMapping() const noexcept;
 
+    static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpace,
+            const math::mat4f& Mv, float zfar) noexcept;
+
     float texelSizeWorldSpace(const math::mat3f& worldToShadowTexture) const noexcept;
     float texelSizeWorldSpace(const math::mat4f& W, const math::mat4f& MbMtF) const noexcept;
 

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -98,6 +98,10 @@ public:
     // Valid after calling update().
     math::mat4f const& getLightSpaceMatrix() const noexcept { return mLightSpace; }
 
+    // Computes the transform to use in the shader to access the shadow map for VSM.
+    // Valid after calling update().
+    math::mat4f const& getLightSpaceMatrixVsm() const noexcept { return mLightSpaceVsm; }
+
     // return the size of a texel in world space (pre-warping)
     float getTexelSizeWorldSpace() const noexcept { return mTexelSizeWs; }
 
@@ -225,6 +229,7 @@ private:
     FCamera* mCamera = nullptr;
     FCamera* mDebugCamera = nullptr;
     math::mat4f mLightSpace;
+    math::mat4f mLightSpaceVsm;
     float mTexelSizeWs = 0.0f;
 
     // set-up in update()

--- a/shaders/src/common_shadowing.fs
+++ b/shaders/src/common_shadowing.fs
@@ -9,8 +9,8 @@
  * shadowing artifacts such as "acne". To achieve this, the world space
  * normal at the point must also be passed to this function.
  */
-vec4 computeLightSpacePosition(const vec3 p, const vec3 n, const vec3 l, const float b,
-        const mat4 lightFromWorldMatrix) {
+vec4 computeLightSpacePosition(const vec3 p, const vec3 n, const vec3 l,
+        const float b, const mat4 lightFromWorldMatrix) {
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
     vec3 offsetPosition = p + n * (sinTheta * b);

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -15,11 +15,13 @@ void main() {
 #endif
 
 #if defined(HAS_VSM)
-    // Since we're rendering from the perspective of the light, frameUniforms.cameraPosition is the
-    // light position, in world space.
-    // We use "distance to the light" as the depth metric, which works for both directional and spot
-    // lights.
-    highp float depth = length(frameUniforms.cameraPosition.xyz - vertex_worldPosition);
+    // For VSM, we use the linear light space Z coordinate as the depth metric, which works for both
+    // directional and spot lights.
+    // We negate it, because we're using a right-handed coordinate system (-Z points forward).
+    highp float depth = -mulMat4x4Float3(frameUniforms.viewFromWorldMatrix, vertex_worldPosition).z;
+
+    // Scale by cameraFar to help prevent a floating point overflow below when squaring the depth.
+    depth /= abs(frameUniforms.cameraFar);
 
     highp float dx = dFdx(depth);
     highp float dy = dFdy(depth);

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -83,7 +83,14 @@ highp vec2 uvToRenderTargetUV(highp vec2 uv) {
 
 #if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
 highp vec3 getLightSpacePosition() {
+#if defined(HAS_VSM)
+    // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
+    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    return vec3(vertex_lightSpacePosition.xy * (1.0 / vertex_lightSpacePosition.w),
+            vertex_lightSpacePosition.z);
+#else
     return vertex_lightSpacePosition.xyz * (1.0 / vertex_lightSpacePosition.w);
+#endif
 }
 #endif
 
@@ -101,7 +108,13 @@ highp vec3 getNormalizedViewportCoord() {
 #if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
 highp vec3 getSpotLightSpacePosition(uint index) {
     highp vec4 position = vertex_spotLightSpacePosition[index];
+#if defined(HAS_VSM)
+    // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
+    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    return vec3(position.xy * (1.0 / position.w), position.z);
+#else
     return position.xyz * (1.0 / position.w);
+#endif
 }
 #endif
 
@@ -134,7 +147,13 @@ highp vec3 getCascadeLightSpacePosition(uint cascade) {
     highp vec4 pos = computeLightSpacePosition(getWorldPosition(), getWorldNormalVector(),
         frameUniforms.lightDirection, frameUniforms.shadowBias.y,
         frameUniforms.lightFromWorldMatrix[cascade]);
+#if defined(HAS_VSM)
+    // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
+    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    return vec3(pos.xy * (1.0 / pos.w), pos.z);
+#else
     return pos.xyz * (1.0 / pos.w);
+#endif
 }
 
 #endif

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -85,7 +85,7 @@ highp vec2 uvToRenderTargetUV(highp vec2 uv) {
 highp vec3 getLightSpacePosition() {
 #if defined(HAS_VSM)
     // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
-    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    // See the computeVsmLightSpaceMatrix comments in ShadowMap.cpp.
     return vec3(vertex_lightSpacePosition.xy * (1.0 / vertex_lightSpacePosition.w),
             vertex_lightSpacePosition.z);
 #else
@@ -110,7 +110,7 @@ highp vec3 getSpotLightSpacePosition(uint index) {
     highp vec4 position = vertex_spotLightSpacePosition[index];
 #if defined(HAS_VSM)
     // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
-    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    // See the computeVsmLightSpaceMatrix comments in ShadowMap.cpp.
     return vec3(position.xy * (1.0 / position.w), position.z);
 #else
     return position.xyz * (1.0 / position.w);
@@ -149,7 +149,7 @@ highp vec3 getCascadeLightSpacePosition(uint cascade) {
         frameUniforms.lightFromWorldMatrix[cascade]);
 #if defined(HAS_VSM)
     // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
-    // See the mLightSpaceVsm comments in ShadowMap.cpp.
+    // See the computeVsmLightSpaceMatrix comments in ShadowMap.cpp.
     return vec3(pos.xy * (1.0 / pos.w), pos.z);
 #else
     return pos.xyz * (1.0 / pos.w);

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -46,8 +46,10 @@ void evaluateDirectionalLight(const MaterialInputs material,
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             uint layer = cascade;
 #if defined(HAS_VSM)
-            highp float fragDepth = length(vertex_worldPosition - frameUniforms.lightPosition.xyz);
-            visibility = shadowVsm(light_shadowMap, layer, getCascadeLightSpacePosition(cascade), fragDepth);
+            highp vec3 lightSpacePosition = getCascadeLightSpacePosition(cascade);
+            // Flip the sign of the Z coordinate; -Z is forward in light space.
+            lightSpacePosition.z *= -1.0;
+            visibility = shadowVsm(light_shadowMap, layer, lightSpacePosition);
 #else
             visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
 #endif

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -46,10 +46,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             uint layer = cascade;
 #if defined(HAS_VSM)
-            highp vec3 lightSpacePosition = getCascadeLightSpacePosition(cascade);
-            // Flip the sign of the Z coordinate; -Z is forward in light space.
-            lightSpacePosition.z *= -1.0;
-            visibility = shadowVsm(light_shadowMap, layer, lightSpacePosition);
+            visibility = shadowVsm(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
 #else
             visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
 #endif

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -172,10 +172,8 @@ void evaluatePunctualLights(const PixelParams pixel, inout vec3 color) {
         if (light.NoL > 0.0){
             if (light.castsShadows) {
 #if defined(HAS_VSM)
-                highp vec3 lightSpacePosition = getSpotLightSpacePosition(light.shadowIndex);
-                // Flip the sign of the Z coordinate; -Z is forward in light space.
-                lightSpacePosition.z *= -1.0;
-                visibility = shadowVsm(light_shadowMap, light.shadowLayer, lightSpacePosition);
+                visibility = shadowVsm(light_shadowMap, light.shadowLayer,
+                        getSpotLightSpacePosition(light.shadowIndex));
 #else
                 visibility = shadow(light_shadowMap, light.shadowLayer,
                     getSpotLightSpacePosition(light.shadowIndex));

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -172,9 +172,10 @@ void evaluatePunctualLights(const PixelParams pixel, inout vec3 color) {
         if (light.NoL > 0.0){
             if (light.castsShadows) {
 #if defined(HAS_VSM)
-                highp float fragDepth = length(vertex_worldPosition - light.worldPosition);
-                visibility = shadowVsm(light_shadowMap, light.shadowLayer,
-                    getSpotLightSpacePosition(light.shadowIndex), fragDepth);
+                highp vec3 lightSpacePosition = getSpotLightSpacePosition(light.shadowIndex);
+                // Flip the sign of the Z coordinate; -Z is forward in light space.
+                lightSpacePosition.z *= -1.0;
+                visibility = shadowVsm(light_shadowMap, light.shadowLayer, lightSpacePosition);
 #else
                 visibility = shadow(light_shadowMap, light.shadowLayer,
                     getSpotLightSpacePosition(light.shadowIndex));

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -355,14 +355,15 @@ float shadow(const mediump sampler2DArrayShadow shadowMap, const uint layer, vec
 #endif
 }
 
-float shadowVsm(const highp sampler2DArray shadowMap, const uint layer, const highp vec3 shadowPosition,
-        const highp float fragDepth) {
+highp float shadowVsm(const highp sampler2DArray shadowMap, const uint layer,
+        const highp vec3 shadowPosition) {
     highp vec2 moments = texture(shadowMap, vec3(shadowPosition.xy, layer)).xy;
+    highp float depth = shadowPosition.z;
 
     // TODO: bias and lightBleedReduction should be uniforms
     const float bias = 0.01;
     const float lightBleedReduction = 0.2;
 
-    const float minVariance = bias * 0.01;
-    return chebyshevUpperBound(moments, fragDepth, minVariance, lightBleedReduction);
+    const float minVariance = bias * 0.001;
+    return chebyshevUpperBound(moments, depth, minVariance, lightBleedReduction);
 }


### PR DESCRIPTION
This switches to using the light space Z coordinate as the VSM depth metric. This fixes precision issues seen with a distant camera far plane.