### PR TITLE
Introduce a configurable test case generator.

### DIFF
--- a/libs/viewer/CMakeLists.txt
+++ b/libs/viewer/CMakeLists.txt
@@ -8,13 +8,15 @@ set(PUBLIC_HDR_DIR include)
 # Sources and headers
 # ==================================================================================================
 set(PUBLIC_HDRS
-        include/viewer/SimpleViewer.h
+        include/viewer/Automation.h
         include/viewer/Settings.h
+        include/viewer/SimpleViewer.h
 )
 
 set(SRCS
-        src/SimpleViewer.cpp
+        src/Automation.cpp
         src/Settings.cpp
+        src/SimpleViewer.cpp
 )
 
 # ==================================================================================================

--- a/libs/viewer/CMakeLists.txt
+++ b/libs/viewer/CMakeLists.txt
@@ -14,6 +14,7 @@ set(PUBLIC_HDRS
 )
 
 set(SRCS
+        src/jsonParseUtils.h
         src/Automation.cpp
         src/Settings.cpp
         src/SimpleViewer.cpp

--- a/libs/viewer/include/viewer/Automation.h
+++ b/libs/viewer/include/viewer/Automation.h
@@ -22,38 +22,32 @@
 namespace filament {
 namespace viewer {
 
-// Immutable list of settings permutations that are created and owned by AutomationList.
-struct AutomationSpec {
-    char const* name;
-    size_t count;
-    Settings const* settings;
-};
-
-// List of automation specs constructed from a JSON string.
+// Immutable list of Settings objects generated from a JSON spec.
 //
-// Each top-level item in the JSON is an object with "name", "base" and "permute".
+// Each top-level item in the JSON spec is an object with "name", "base" and "permute".
 // The "base" object specifies a single set of changes to apply to default settings.
 // The optional "permute" object specifies a cross product of changes to apply to the base.
 // See the unit test for an example.
 class AutomationList {
 public:
 
-    // Parses a JSON spec, then generates a set of Settings lists.
+    // Parses a JSON spec, then generates a list of Settings objects.
     // Returns null on failure (see utils log for warnings and errors).
     // Clients should release memory using "delete".
-    static AutomationList* generate(const char* jsonChunk, size_t size);
+    static AutomationList* generate(const char* jsonSpec, size_t size);
 
-    // Generates a default list of cases using an embedded JSON spec.
-    static AutomationList* generateDefault();
+    // Generates a list of Settings objects using an embedded JSON spec.
+    static AutomationList* generateDefaultTestCases();
 
-    // Returns the number of generated Settings lists.
+    // Returns the number of generated Settings objects.
     size_t size() const;
 
-    // Returns a view onto a generated Settings list.
-    AutomationSpec get(size_t index) const;
+    // Gets a generated Settings object and copies it out.
+    // Returns false if the given index is out of bounds.
+    bool get(size_t index, Settings* out) const;
 
-    // Returns the total number of Settings objects.
-    size_t totalCount() const;
+    // Returns the name of the JSON group for a given Settings object.
+    char const* getName(size_t index) const;
 
     // Frees all Settings objects and name strings.
     ~AutomationList();

--- a/libs/viewer/include/viewer/Automation.h
+++ b/libs/viewer/include/viewer/Automation.h
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/include/viewer/Automation.h
+++ b/libs/viewer/include/viewer/Automation.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by mIcable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VIEWER_AUTOMATION_H
+#define VIEWER_AUTOMATION_H
+
+#include <string>
+#include <vector>
+
+#include <viewer/Settings.h>
+
+namespace filament {
+namespace viewer {
+
+// Named list of settings permutations.
+struct AutomationSpec {
+    std::string name;
+    std::vector<Settings> cases;
+};
+
+// Consumes a JSON string and produces a list of automation specs using a counting algorithm.
+//
+// Each top-level item in the JSON is an object with "name", "base" and "permute".
+// The "base" object specifies a single set of changes to apply to default settings.
+// The optional "permute" object specifies a cross product of changes to apply to the base.
+// See the unit test for an example.
+//
+// - Returns true if successful.
+// - This function writes warnings and error messages into the utils log.
+bool generate(const char* jsonChunk, size_t size, std::vector<AutomationSpec>* out);
+
+} // namespace viewer
+} // namespace filament
+
+#endif // VIEWER_AUTOMATION_H

--- a/libs/viewer/include/viewer/Automation.h
+++ b/libs/viewer/include/viewer/Automation.h
@@ -43,11 +43,17 @@ public:
     // Clients should release memory using "delete".
     static AutomationList* generate(const char* jsonChunk, size_t size);
 
+    // Generates a default list of cases using an embedded JSON spec.
+    static AutomationList* generateDefault();
+
     // Returns the number of generated Settings lists.
     size_t size() const;
 
     // Returns a view onto a generated Settings list.
     AutomationSpec get(size_t index) const;
+
+    // Returns the total number of Settings objects.
+    size_t totalCount() const;
 
     // Frees all Settings objects and name strings.
     ~AutomationList();

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -46,7 +46,6 @@ using ToneMapping = filament::ColorGrading::ToneMapping;
 using VignetteOptions = filament::View::VignetteOptions;
 
 // Reads the given JSON blob and updates the corresponding fields in the given Settings object.
-//
 // - The given JSON blob need not specify all settings.
 // - Returns true if successful.
 // - This function writes warnings and error messages into the utils log.

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/include/viewer/SimpleViewer.h
+++ b/libs/viewer/include/viewer/SimpleViewer.h
@@ -37,7 +37,7 @@ namespace filament {
 namespace viewer {
 
 /**
- * \class SimpleViewer SimpleViewer.h gltfio/SimpleViewer.h
+ * \class SimpleViewer SimpleViewer.h viewer/SimpleViewer.h
  * \brief Manages the state for a simple glTF viewer with imgui controls and a tree view.
  *
  * This is a utility that can be used across multiple platforms, including web.

--- a/libs/viewer/include/viewer/SimpleViewer.h
+++ b/libs/viewer/include/viewer/SimpleViewer.h
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/src/Automation.cpp
+++ b/libs/viewer/src/Automation.cpp
@@ -18,7 +18,7 @@
 
 #include <viewer/Automation.h>
 
-#include "parse.h"
+#include "jsonParseUtils.h"
 
 #include <assert.h>
 

--- a/libs/viewer/src/Automation.cpp
+++ b/libs/viewer/src/Automation.cpp
@@ -37,6 +37,30 @@ static const bool VERBOSE = false;
 namespace filament {
 namespace viewer {
 
+static const char* DEFAULT_AUTOMATION = R"TXT([
+    {
+        "name": "ppoff",
+        "base": {
+            "view.postProcessingEnabled": false
+        }
+    },
+    {
+        "name": "viewopts",
+        "base": {
+            "view.postProcessingEnabled": true
+        }
+        "permute": {
+            "view.dithering": ["NONE", "TEMPORAL"],
+            "view.sampleCount": [1, 4],
+            "view.taa.enabled": [false, true],
+            "view.antiAliasing": ["FXAA", "NONE"],
+            "view.ssao.enabled": [false, true],
+            "view.bloom.enabled": [false, true]
+        }
+    }
+]
+)TXT";
+
 struct SpecImpl {
     std::string name;
     std::vector<Settings> cases;
@@ -245,6 +269,10 @@ AutomationList* AutomationList::generate(const char* jsonChunk, size_t size) {
     return new AutomationList(impl);
 }
 
+AutomationList* AutomationList::generateDefault() {
+    return generate(DEFAULT_AUTOMATION, strlen(DEFAULT_AUTOMATION));
+}
+
 AutomationSpec AutomationList::get(size_t index) const {
     const SpecImpl& spec = mImpl->specs[index];
     return {
@@ -252,6 +280,14 @@ AutomationSpec AutomationList::get(size_t index) const {
         .count = spec.cases.size(),
         .settings = spec.cases.data()
     };
+}
+
+size_t AutomationList::totalCount() const {
+    size_t count = 0;
+    for (const auto& spec : mImpl->specs) {
+        count += spec.cases.size();
+    }
+    return count;
 }
 
 size_t AutomationList::size() const { return mImpl->specs.size(); }

--- a/libs/viewer/src/Automation.cpp
+++ b/libs/viewer/src/Automation.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by mIcable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define JSMN_HEADER
+
+#include <viewer/Automation.h>
+
+#include "parse.h"
+
+#include <assert.h>
+
+#include <sstream>
+
+#include <utils/Log.h>
+
+using namespace utils;
+
+using std::vector;
+
+static const bool VERBOSE = false;
+
+namespace filament {
+namespace viewer {
+
+static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, std::string* val) {
+    CHECK_TOKTYPE(tokens[i], JSMN_STRING);
+    *val = STR(tokens[i], jsonChunk);
+    return i + 1;
+}
+
+static int parseBaseSettings(jsmntok_t const* tokens, int i, const char* jsonChunk, Settings* out) {
+    CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+    int size = tokens[i++].size;
+    for (int j = 0; j < size; ++j, i += 2) {
+        std::stringstream dk(STR(tokens[i], jsonChunk));
+        std::string token;
+        std::string prefix;
+        int depth = 0;
+
+        // Expand "foo.bar.baz" into "foo: { bar: { baz: "
+        while (getline(dk, token, '.')) {
+            prefix += "{ \"" + token + "\": ";
+            depth++;
+        }
+        std::string json = prefix + STR(tokens[i + 1], jsonChunk);
+        for (int d = 0; d < depth; d++) {  json += " } "; }
+        if (VERBOSE) {
+            slog.i << "  Base: " << json.c_str() << io::endl;
+        }
+
+        // Now that we have a complete JSON string, apply this property change.
+        readJson(json.c_str(), json.size(), out);
+    }
+    return i;
+}
+
+static int parsePermutationsSpec(jsmntok_t const* tokens, int i, const char* jsonChunk,
+        vector<vector<std::string>>* out) {
+    CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+    int size = tokens[i++].size;
+    out->resize(size);
+    for (int j = 0; j < size; ++j) {
+        std::stringstream dk(STR(tokens[i], jsonChunk));
+        std::string token;
+        std::string prefix;
+        int depth = 0;
+
+        // Expand "foo.bar.baz" into "foo: { bar: { baz: "
+        while (getline(dk, token, '.')) {
+            prefix += "{ \"" + token + "\": ";
+            depth++;
+        }
+        ++i;
+
+        // Build a complete JSON string for each requested property value.
+        const jsmntok_t valueArray = tokens[i++];
+        CHECK_TOKTYPE(valueArray, JSMN_ARRAY);
+        vector<std::string>& spec = (*out)[j];
+        spec.resize(valueArray.size);
+        for (int k = 0; k < valueArray.size; k++, i++) {
+            std::string json = prefix + STR(tokens[i], jsonChunk);
+            for (int d = 0; d < depth; d++) {  json += " } "; }
+            spec[k] = json;
+        }
+    }
+    return i;
+}
+
+static int parseAutomationSpec(jsmntok_t const* tokens, int i, const char* jsonChunk,
+        AutomationSpec* out) {
+    CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
+    int size = tokens[i++].size;
+    Settings base;
+    vector<vector<std::string>> permute;
+    for (int j = 0; j < size; ++j) {
+        const jsmntok_t tok = tokens[i];
+        CHECK_KEY(tok);
+        if (0 == compare(tok, jsonChunk, "name")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->name);
+            if (VERBOSE) {
+                slog.i << "Building spec [" << out->name << "]" << io::endl;
+            }
+        } else if (0 == compare(tok, jsonChunk, "base")) {
+            i = parseBaseSettings(tokens, i + 1, jsonChunk, &base);
+        } else if (0 == compare(tok, jsonChunk, "permute")) {
+            i = parsePermutationsSpec(tokens, i + 1, jsonChunk, &permute);
+        } else {
+            slog.w << "Invalid automation key: '" << STR(tok, jsonChunk) << "'" << io::endl;
+            i = parse(tokens, i + 1);
+        }
+        if (i < 0) {
+            slog.e << "Invalid automation value: '" << STR(tok, jsonChunk) << "'" << io::endl;
+            return i;
+        }
+    }
+
+    // Determine the number of permutations.
+    size_t caseCount = 1;
+    size_t propIndex = 0;
+    vector<vector<std::string>::const_iterator> iters(permute.size());
+    for (const auto& prop : permute) {
+        caseCount *= prop.size();
+        if (VERBOSE) {
+            for (const auto& s : prop) {
+                slog.i << "  Perm: " << s.c_str() << io::endl;
+            }
+        }
+        iters[propIndex++] = prop.begin();
+    }
+    out->cases.resize(caseCount);
+
+    if (VERBOSE) {
+        slog.i << "  Case count: " << caseCount << io::endl;
+    }
+
+    size_t caseIndex = 0;
+    while (true) {
+
+        // Append a copy of the current Settings object to the case list.
+        if (VERBOSE) {
+            slog.i << "  Appending case " << caseIndex << io::endl;
+        }
+        out->cases[caseIndex++] = base;
+
+        // Leave early if there are no permutations.
+        if (iters.empty()) {
+            return i;
+        }
+
+        // Use a basic counting algorithm to generate the next test case.
+        // Bump the first digit, if it rolls back to 0 then bump the next digit, etc.
+        // In this case, the "digit" is an iterator into a vector of JSON strings.
+        propIndex = 0;
+        for (auto& iter : iters) {
+            const auto& prop = permute[propIndex++];
+            if (++iter != prop.end()) {
+                break;
+            }
+            iter = prop.begin();
+
+            // Check if all permutations have been generated.
+            if (propIndex == permute.size()) {
+                assert(caseIndex == out->cases.size());
+                return i;
+            }
+        }
+
+        // Apply changes to the settings object.
+        for (const auto& iter : iters) {
+            const std::string& jsonString = *iter;
+            if (VERBOSE) {
+                slog.i << "  Applying " << jsonString.c_str() << io::endl;
+            }
+            if (!readJson(jsonString.c_str(), jsonString.size(), &base)) {
+                return -1;
+            }
+        }
+    }
+
+    return i;
+}
+
+static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
+        vector<AutomationSpec>* out) {
+    CHECK_TOKTYPE(tokens[i], JSMN_ARRAY);
+    int size = tokens[i++].size;
+    out->resize(size);
+    for (int j = 0; j < size && i >= 0; ++j) {
+        i = parseAutomationSpec(tokens, i, jsonChunk, &out->at(j));
+    }
+    return i;
+}
+
+bool generate(const char* jsonChunk, size_t size, vector<AutomationSpec>* out) {
+    jsmn_parser parser = { 0, 0, 0 };
+
+    int tokenCount = jsmn_parse(&parser, jsonChunk, size, nullptr, 0);
+    if (tokenCount <= 0) {
+        return false;
+    }
+
+    jsmntok_t* tokens = (jsmntok_t*) malloc(sizeof(jsmntok_t) * tokenCount);
+    assert(tokens);
+
+    jsmn_init(&parser);
+    tokenCount = jsmn_parse(&parser, jsonChunk, size, tokens, tokenCount);
+
+    if (tokenCount <= 0) {
+        free(tokens);
+        return false;
+    }
+
+    int i = parse(tokens, 0, jsonChunk, out);
+    free(tokens);
+    return i >= 0;
+}
+
+} // namespace viewer
+} // namespace filament

--- a/libs/viewer/src/Automation.cpp
+++ b/libs/viewer/src/Automation.cpp
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -18,7 +18,7 @@
 
 #include <utils/Log.h>
 
-#include "parse.h"
+#include "jsonParseUtils.h"
 
 #include <assert.h>
 

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -18,16 +18,12 @@
 
 #include <utils/Log.h>
 
-#include <sstream>
-#include <string>
+#include "parse.h"
 
 #include <assert.h>
 
-#include <jsmn.h>
-
-#define CHECK_TOKTYPE(tok_, type_) if ((tok_).type != (type_)) { return -1; }
-#define CHECK_KEY(tok_) if ((tok_).type != JSMN_STRING || (tok_).size == 0) { return -1; }
-#define STR(tok, jsonChunk) std::string(jsonChunk + tok.start, tok.end - tok.start)
+#include <sstream>
+#include <string>
 
 using namespace utils;
 
@@ -35,14 +31,14 @@ namespace filament {
 namespace viewer {
 
 // Compares a JSON string token against a C string.
-static int compare(jsmntok_t tok, const char* jsonChunk, const char* str) {
+int compare(jsmntok_t tok, const char* jsonChunk, const char* str) {
     size_t slen = strlen(str);
     size_t tlen = tok.end - tok.start;
     return (slen == tlen) ? strncmp(jsonChunk + tok.start, str, slen) : 128;
 }
 
 // Skips over an unused token.
-static int parse(jsmntok_t const* tokens, int i) {
+int parse(jsmntok_t const* tokens, int i) {
     int end = i + 1;
     while (i < end) {
         switch (tokens[i].type) {
@@ -573,7 +569,7 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ViewSett
     return i;
 }
 
-static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, Settings* out) {
+int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, Settings* out) {
     CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
     int size = tokens[i++].size;
     for (int j = 0; j < size; ++j) {

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/src/jsonParseUtils.h
+++ b/libs/viewer/src/jsonParseUtils.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef VIEWER_JSON_PARSE_UTILS_H
+#define VIEWER_JSON_PARSE_UTILS_H
+
 #include <jsmn.h>
 
 namespace filament {
@@ -31,3 +34,5 @@ int compare(jsmntok_t tok, const char* jsonChunk, const char* str);
 
 } // namespace viewer
 } // namespace filament
+
+#endif // VIEWER_JSON_PARSE_UTILS_H

--- a/libs/viewer/src/jsonParseUtils.h
+++ b/libs/viewer/src/jsonParseUtils.h
@@ -7,7 +7,7 @@
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by mIcable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/libs/viewer/src/parse.h
+++ b/libs/viewer/src/parse.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by mIcable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jsmn.h>
+
+namespace filament {
+namespace viewer {
+
+#define CHECK_TOKTYPE(tok_, type_) if ((tok_).type != (type_)) { return -1; }
+#define CHECK_KEY(tok_) if ((tok_).type != JSMN_STRING || (tok_).size == 0) { return -1; }
+#define STR(tok, jsonChunk) std::string(jsonChunk + tok.start, tok.end - tok.start)
+
+struct Settings;
+
+int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, Settings* out);
+int parse(jsmntok_t const* tokens, int i);
+int compare(jsmntok_t tok, const char* jsonChunk, const char* str);
+
+} // namespace viewer
+} // namespace filament

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -143,12 +143,23 @@ TEST_F(ViewSettingsTest, JsonTestDefaults) {
 }
 
 TEST_F(ViewSettingsTest, AutomationSpec) {
-    AutomationList* specs = AutomationList::generateDefault();
+    AutomationList* specs = AutomationList::generateDefaultTestCases();
     ASSERT_TRUE(specs);
-    ASSERT_EQ(specs->size(), 2);
-    ASSERT_EQ(specs->get(0).count, 1);
-    ASSERT_EQ(specs->get(1).count, 1 << 6);
-    ASSERT_EQ(specs->totalCount(), 1 + (1 << 6));
+    ASSERT_EQ(specs->size(), 65);
+
+    Settings settings;
+
+    ASSERT_TRUE(specs->get(0, &settings));
+    ASSERT_FALSE(settings.view.postProcessingEnabled);
+    ASSERT_EQ(settings.view.dithering, Dithering::TEMPORAL);
+
+    ASSERT_TRUE(specs->get(1, &settings));
+    ASSERT_TRUE(settings.view.postProcessingEnabled);
+    ASSERT_EQ(settings.view.dithering, Dithering::NONE);
+
+    ASSERT_TRUE(specs->get(64, &settings));
+    ASSERT_FALSE(specs->get(65, &settings));
+
     delete specs;
 }
 

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -128,30 +128,6 @@ static const char* JSON_TEST_DEFAULTS = R"TXT(
 }
 )TXT";
 
-static const char* JSON_AUTOMATION_TEST = R"TXT([
-    {
-        "name": "ppoff",
-        "base": {
-            "view.postProcessingEnabled": false
-        }
-    },
-    {
-        "name": "viewopts",
-        "base": {
-            "view.postProcessingEnabled": true
-        }
-        "permute": {
-            "view.dithering": ["NONE", "TEMPORAL"],
-            "view.sampleCount": [1, 4],
-            "view.taa.enabled": [false, true],
-            "view.antiAliasing": ["FXAA", "NONE"],
-            "view.ssao.enabled": [false, true],
-            "view.bloom.enabled": [false, true]
-        }
-    }
-]
-)TXT";
-
 TEST_F(ViewSettingsTest, JsonTestDefaults) {
     Settings settings1 = {0};
     ASSERT_TRUE(readJson(JSON_TEST_DEFAULTS, strlen(JSON_TEST_DEFAULTS), &settings1));
@@ -167,12 +143,12 @@ TEST_F(ViewSettingsTest, JsonTestDefaults) {
 }
 
 TEST_F(ViewSettingsTest, AutomationSpec) {
-    AutomationList* specs = AutomationList::generate(JSON_AUTOMATION_TEST,
-            strlen(JSON_AUTOMATION_TEST));
+    AutomationList* specs = AutomationList::generateDefault();
     ASSERT_TRUE(specs);
     ASSERT_EQ(specs->size(), 2);
     ASSERT_EQ(specs->get(0).count, 1);
     ASSERT_EQ(specs->get(1).count, 1 << 6);
+    ASSERT_EQ(specs->totalCount(), 1 + (1 << 6));
     delete specs;
 }
 

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -21,8 +21,6 @@
 
 using namespace filament::viewer;
 
-using std::vector;
-
 class ViewSettingsTest : public testing::Test {};
 
 static const char* JSON_TEST_DEFAULTS = R"TXT(
@@ -169,11 +167,13 @@ TEST_F(ViewSettingsTest, JsonTestDefaults) {
 }
 
 TEST_F(ViewSettingsTest, AutomationSpec) {
-    vector<AutomationSpec> specs;
-    ASSERT_TRUE(generate(JSON_AUTOMATION_TEST, strlen(JSON_AUTOMATION_TEST), &specs));
-    ASSERT_EQ(specs.size(), 2);
-    ASSERT_EQ(specs[0].cases.size(), 1);
-    ASSERT_EQ(specs[1].cases.size(), 1 << 6);
+    AutomationList* specs = AutomationList::generate(JSON_AUTOMATION_TEST,
+            strlen(JSON_AUTOMATION_TEST));
+    ASSERT_TRUE(specs);
+    ASSERT_EQ(specs->size(), 2);
+    ASSERT_EQ(specs->get(0).count, 1);
+    ASSERT_EQ(specs->get(1).count, 1 << 6);
+    delete specs;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This lets us generate long lists of settings permutations by writing a
simple JSON spec. For example, the following spec would generate six
`Settings` objects, all of which have SSAO enabled. See the unit test
for a larger example.

```
{
    "name": "viewopts",
    "base": { "view.ssao.enabled": true }
    "permute": {
        "view.dithering": ["NONE", "TEMPORAL"],
        "view.sampleCount": [1, 4, 8]
    }
}
```