### PR TITLE
VSM: render both shadow casters and receivers

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -268,6 +268,14 @@ public class RenderableManager {
 
         /**
          * Controls if this renderable casts shadows, false by default.
+         *
+         * If the View's shadow type is set to {@link View.ShadowType#VSM}, castShadows should only
+         * be disabled if either is true:
+         * <ul>
+         *   <li>{@link RenderableManager#setReceiveShadows} is also disabled</li>
+         *   <li>the object is guaranteed to not cast shadows on other objects (for example, a
+         *   ground plane)</li>
+         * </ul>
          */
         @NonNull
         public Builder castShadows(boolean enabled) {

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -273,7 +273,7 @@ public class RenderableManager {
          * be disabled if either is true:
          * <ul>
          *   <li>{@link RenderableManager#setReceiveShadows} is also disabled</li>
-         *   <li>the object is guaranteed to not cast shadows on themselves or other objects (for
+         *   <li>the object is guaranteed to not cast shadows on itself or other objects (for
          *   example, a ground plane)</li>
          * </ul>
          */

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -273,8 +273,8 @@ public class RenderableManager {
          * be disabled if either is true:
          * <ul>
          *   <li>{@link RenderableManager#setReceiveShadows} is also disabled</li>
-         *   <li>the object is guaranteed to not cast shadows on other objects (for example, a
-         *   ground plane)</li>
+         *   <li>the object is guaranteed to not cast shadows on themselves or other objects (for
+         *   example, a ground plane)</li>
          * </ul>
          */
         @NonNull

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1168,6 +1168,14 @@ public class View {
      *
      * The ShadowType affects all the shadows seen within the View.
      *
+     * <p>
+     * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow receivers
+     * (but not casters). To ensure correct shadowing with VSM, all shadow participant renderables
+     * should be marked as both receivers and casters. Objects that are guaranteed to not cast
+     * shadows on other objects (such as flat ground planes) can be set to not cast shadows, which
+     * might improve shadow quality.
+     * </p>
+     *
      * <strong>Warning: This API is still experimental and subject to change.</strong>
      */
     public void setShadowType(ShadowType type) {

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1172,8 +1172,8 @@ public class View {
      * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow receivers
      * (but not casters). To ensure correct shadowing with VSM, all shadow participant renderables
      * should be marked as both receivers and casters. Objects that are guaranteed to not cast
-     * shadows on other objects (such as flat ground planes) can be set to not cast shadows, which
-     * might improve shadow quality.
+     * shadows on themselves or other objects (such as flat ground planes) can be set to not cast
+     * shadows, which might improve shadow quality.
      * </p>
      *
      * <strong>Warning: This API is still experimental and subject to change.</strong>

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -218,6 +218,12 @@ public:
 
         /**
          * Controls if this renderable casts shadows, false by default.
+         *
+         * If the View's shadow type is set to ShadowType::VSM, castShadows should only be disabled
+         * if either is true:
+         *   - receiveShadows is also disabled
+         *   - the object is guaranteed to not cast shadows on other objects (for example, a ground
+         *     plane)
          */
         Builder& castShadows(bool enable) noexcept;
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -222,8 +222,8 @@ public:
          * If the View's shadow type is set to ShadowType::VSM, castShadows should only be disabled
          * if either is true:
          *   - receiveShadows is also disabled
-         *   - the object is guaranteed to not cast shadows on themselves or other objects (for
-         *     example, a ground plane)
+         *   - the object is guaranteed to not cast shadows on itself or other objects (for example,
+         *     a ground plane)
          */
         Builder& castShadows(bool enable) noexcept;
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -222,8 +222,8 @@ public:
          * If the View's shadow type is set to ShadowType::VSM, castShadows should only be disabled
          * if either is true:
          *   - receiveShadows is also disabled
-         *   - the object is guaranteed to not cast shadows on other objects (for example, a ground
-         *     plane)
+         *   - the object is guaranteed to not cast shadows on themselves or other objects (for
+         *     example, a ground plane)
          */
         Builder& castShadows(bool enable) noexcept;
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -695,8 +695,8 @@ public:
      * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers (but
      * not casters). To ensure correct shadowing with VSM, all shadow participant renderables should
      * be marked as both receivers and casters. Objects that are guaranteed to not cast shadows on
-     * other objects (such as flat ground planes) can be set to not cast shadows, which might
-     * improve shadow quality.
+     * themselves or other objects (such as flat ground planes) can be set to not cast shadows,
+     * which might improve shadow quality.
      *
      * (see LightManager::setReceiveShadows and LightManager::setCastShadows).
      *

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -698,9 +698,6 @@ public:
      * themselves or other objects (such as flat ground planes) can be set to not cast shadows,
      * which might improve shadow quality.
      *
-     * (see LightManager::setReceiveShadows and LightManager::setCastShadows).
-     *
-     *
      * @warning This API is still experimental and subject to change.
      */
     void setShadowType(ShadowType shadow) noexcept;

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -692,6 +692,15 @@ public:
      *
      * The ShadowType affects all the shadows seen within the View.
      *
+     * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers (but
+     * not casters). To ensure correct shadowing with VSM, all shadow participant renderables should
+     * be marked as both receivers and casters. Objects that are guaranteed to not cast shadows on
+     * other objects (such as flat ground planes) can be set to not cast shadows, which might
+     * improve shadow quality.
+     *
+     * (see LightManager::setReceiveShadows and LightManager::setCastShadows).
+     *
+     *
      * @warning This API is still experimental and subject to change.
      */
     void setShadowType(ShadowType shadow) noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -111,7 +111,7 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
             continue;
         }
 
-        pass.setVisibilityMask(VISIBLE_SPOT_SHADOW_CASTER_N(i));
+        pass.setVisibilityMask(VISIBLE_SPOT_SHADOW_RENDERABLE_N(i));
         map.getShadowMap()->render(driver, view.getVisibleSpotShadowCasters(), pass, view);
         pass.clearVisibilityMask();
 
@@ -288,7 +288,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(
                 layout, cascadeParams);
         Frustum const& frustum = map.getCamera().getFrustum();
         FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
-                VISIBLE_DIR_SHADOW_CASTER_BIT);
+                VISIBLE_DIR_SHADOW_RENDERABLE_BIT);
 
         // Set shadowBias, using the first directional cascade.
         const float texelSizeWorldSpace = map.getTexelSizeWorldSpace();
@@ -447,7 +447,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(
             UniformBuffer& u = shadowUb;
             Frustum const& frustum = shadowMap.getCamera().getFrustum();
             FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
-                    VISIBLE_SPOT_SHADOW_CASTER_N_BIT(i));
+                    VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(i));
 
             mat4f const& lightFromWorldMatrix =
                 view.hasVsm() ? shadowMap.getLightSpaceMatrixVsm() : shadowMap.getLightSpaceMatrix();

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -578,19 +578,22 @@ void FView::computeVisibilityMasks(
         //
         // It is written without if statements to avoid branches, which allows it to be vectorized 16x.
 
-        bool visRenderables   = (!v.culling || (mask & VISIBLE_RENDERABLE))    && inVisibleLayer;
-        bool visShadowRenderable =
-            (!v.culling || (mask & VISIBLE_DIR_SHADOW_RENDERABLE)) && inVisibleLayer
-            && (v.castShadows || (hasVsm && v.receiveShadows));
+        const bool visRenderables   = (!v.culling || (mask & VISIBLE_RENDERABLE))    && inVisibleLayer;
+        const bool vvsmRenderShadow = hasVsm && v.receiveShadows;
+        const bool visShadowParticipant = v.castShadows || vvsmRenderShadow;
+        const bool visShadowRenderable =
+            (!v.culling || (mask & VISIBLE_DIR_SHADOW_RENDERABLE)) && inVisibleLayer && visShadowParticipant;
         visibleMask[i] = Culler::result_type(visRenderables) |
                 Culler::result_type(visShadowRenderable << 1u);
         // this loop gets fully unrolled
         for (size_t j = 0; j < CONFIG_MAX_SHADOW_CASTING_SPOTS; ++j) {
-            bool vIsSpotShadowRenderable =
-                (!v.culling || (mask & VISIBLE_SPOT_SHADOW_RENDERABLE_N(j))) && inVisibleLayer
-                && (v.castShadows || (hasVsm && v.receiveShadows));
+            const bool vvsmSpotRenderShadow = hasVsm && v.receiveShadows;
+            const bool visSpotShadowParticipant = v.castShadows || vvsmSpotRenderShadow;
+            const bool visSpotShadowRenderable =
+                (!v.culling || (mask & VISIBLE_SPOT_SHADOW_RENDERABLE_N(j))) &&
+                        inVisibleLayer && visSpotShadowParticipant;
             visibleMask[i] |=
-                Culler::result_type(vIsSpotShadowRenderable << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(j));
+                Culler::result_type(visSpotShadowRenderable << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(j));
         }
     }
 }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -463,17 +463,17 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
         uint8_t const* layers = renderableData.data<FScene::LAYERS>();
         auto const* visibility = renderableData.data<FScene::VISIBILITY_STATE>();
         computeVisibilityMasks(getVisibleLayers(), layers, visibility, cullingMask.begin(),
-                renderableData.size());
+                renderableData.size(), hasVsm());
 
         auto const beginRenderables = renderableData.begin();
         auto beginCasters = partition(beginRenderables, renderableData.end(), VISIBLE_RENDERABLE);
         auto beginCastersOnly = partition(beginCasters, renderableData.end(),
-                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER);
+                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE);
         auto beginSpotLightCastersOnly = partition(beginCastersOnly, renderableData.end(),
-                VISIBLE_DIR_SHADOW_CASTER);
+                VISIBLE_DIR_SHADOW_RENDERABLE);
         auto endSpotLightCastersOnly = std::partition(beginSpotLightCastersOnly,
                 renderableData.end(), [](auto it) {
-                    return (it.template get<FScene::VISIBLE_MASK>() & VISIBLE_SPOT_SHADOW_CASTER);
+                    return (it.template get<FScene::VISIBLE_MASK>() & VISIBLE_SPOT_SHADOW_RENDERABLE);
                 });
 
         // convert to indices
@@ -555,7 +555,7 @@ void FView::computeVisibilityMasks(
         uint8_t visibleLayers,
         uint8_t const* UTILS_RESTRICT layers,
         FRenderableManager::Visibility const* UTILS_RESTRICT visibility,
-        uint8_t* UTILS_RESTRICT visibleMask, size_t count) {
+        uint8_t* UTILS_RESTRICT visibleMask, size_t count, bool hasVsm) {
     // __restrict__ seems to only be taken into account as function parameters. This is very
     // important here, otherwise, this loop doesn't get vectorized.
     // This is vectorized 16x.
@@ -573,18 +573,24 @@ void FView::computeVisibilityMasks(
         // else:
         //     set all bits in visibleMask to 0
         // if !v.castShadows:
-        //     set shadow visibility bits in visibleMask to 0
+        //     if !vsm or !v.receivesShadows:       // with vsm, we also render shadow receivers
+        //         set shadow visibility bits in visibleMask to 0
         //
         // It is written without if statements to avoid branches, which allows it to be vectorized 16x.
 
         bool visRenderables   = (!v.culling || (mask & VISIBLE_RENDERABLE))    && inVisibleLayer;
-        bool visShadowCasters = (!v.culling || (mask & VISIBLE_DIR_SHADOW_CASTER)) && inVisibleLayer && v.castShadows;
+        bool visShadowRenderable =
+            (!v.culling || (mask & VISIBLE_DIR_SHADOW_RENDERABLE)) && inVisibleLayer
+            && (v.castShadows || (hasVsm && v.receiveShadows));
         visibleMask[i] = Culler::result_type(visRenderables) |
-                Culler::result_type(visShadowCasters << 1u);
+                Culler::result_type(visShadowRenderable << 1u);
         // this loop gets fully unrolled
         for (size_t j = 0; j < CONFIG_MAX_SHADOW_CASTING_SPOTS; ++j) {
-            bool vIsSpotShadowCaster = (!v.culling || (mask & VISIBLE_SPOT_SHADOW_CASTER_N(j))) && inVisibleLayer && v.castShadows;
-            visibleMask[i] |= Culler::result_type(vIsSpotShadowCaster << (j + 2));
+            bool vIsSpotShadowRenderable =
+                (!v.culling || (mask & VISIBLE_SPOT_SHADOW_RENDERABLE_N(j))) && inVisibleLayer
+                && (v.castShadows || (hasVsm && v.receiveShadows));
+            visibleMask[i] |=
+                Culler::result_type(vIsSpotShadowRenderable << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(j));
         }
     }
 }
@@ -598,7 +604,7 @@ UTILS_NOINLINE
         // Mask VISIBLE_MASK to ignore higher bits related to spot shadows. We only partition based
         // on renderable and directional shadow visibility.
         return (it.template get<FScene::VISIBLE_MASK>() &
-                (VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_CASTER)) == mask;
+                (VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE)) == mask;
     });
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -71,26 +71,30 @@ class FScene;
 // The value of the 'VISIBLE_MASK' after culling. Each bit represents visibility in a frustum
 // (either camera or light).
 //
-// bits                          7 6 5 4 3 2 1 0
-// +-------------------------------------------+
-// VISIBLE_RENDERABLE                          X
-// VISIBLE_DIR_SHADOW_CASTER                 X
-// VISIBLE_SPOT_SHADOW_CASTER_0            X
-// VISIBLE_SPOT_SHADOW_CASTER_1          X
+// bits                               7 6 5 4 3 2 1 0
+// +------------------------------------------------+
+// VISIBLE_RENDERABLE                               X
+// VISIBLE_DIR_SHADOW_RENDERABLE                  X
+// VISIBLE_SPOT_SHADOW_RENDERABLE_0             X
+// VISIBLE_SPOT_SHADOW_RENDERABLE_1           X
 // ...
 
+// A "shadow renderable" is a renderable rendered to the shadow map during a shadow pass:
+// PCF shadows: only shadow casters
+// VSM shadows: both shadow casters and shadow receivers
+
 static constexpr size_t VISIBLE_RENDERABLE_BIT = 0u;
-static constexpr size_t VISIBLE_DIR_SHADOW_CASTER_BIT = 1u;
-static constexpr size_t VISIBLE_SPOT_SHADOW_CASTER_N_BIT(size_t n) { return n + 2; }
+static constexpr size_t VISIBLE_DIR_SHADOW_RENDERABLE_BIT = 1u;
+static constexpr size_t VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(size_t n) { return n + 2; }
 
 static constexpr uint8_t VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
-static constexpr uint8_t VISIBLE_DIR_SHADOW_CASTER = 1u << VISIBLE_DIR_SHADOW_CASTER_BIT;
-static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER_N(size_t n) {
-    return 1u << VISIBLE_SPOT_SHADOW_CASTER_N_BIT(n);
+static constexpr uint8_t VISIBLE_DIR_SHADOW_RENDERABLE = 1u << VISIBLE_DIR_SHADOW_RENDERABLE_BIT;
+static constexpr uint8_t VISIBLE_SPOT_SHADOW_RENDERABLE_N(size_t n) {
+    return 1u << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(n);
 }
 
-// ORing of all the VISIBLE_SPOT_SHADOW_CASTER bits
-static constexpr uint8_t VISIBLE_SPOT_SHADOW_CASTER =
+// ORing of all the VISIBLE_SPOT_SHADOW_RENDERABLE bits
+static constexpr uint8_t VISIBLE_SPOT_SHADOW_RENDERABLE =
         (0xFFu >> (sizeof(uint8_t) * 8u - CONFIG_MAX_SHADOW_CASTING_SPOTS)) << 2u;
 
 // Because we're using a uint8_t for the visibility mask, we're limited to 6 spot light shadows.
@@ -423,7 +427,7 @@ private:
     static void computeVisibilityMasks(
             uint8_t visibleLayers, uint8_t const* layers,
             FRenderableManager::Visibility const* visibility, uint8_t* visibleMask,
-            size_t count);
+            size_t count, bool hasVsm);
 
     void bindPerViewUniformsAndSamplers(FEngine::DriverApi& driver) const noexcept {
         driver.bindUniformBuffer(BindingPoints::PER_VIEW, mPerViewUbh);

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -360,6 +360,11 @@ highp float shadowVsm(const highp sampler2DArray shadowMap, const uint layer,
     highp vec2 moments = texture(shadowMap, vec3(shadowPosition.xy, layer)).xy;
     highp float depth = shadowPosition.z;
 
+    // depth must be clamped to support floating-point depth formats. This is to avoid comparing a
+    // value from the depth texture (which is never greater than 1.0) with a greater-than-one
+    // comparison value (which is possible with floating-point formats).
+    depth = min(depth, 1.0f);
+
     // TODO: bias and lightBleedReduction should be uniforms
     const float bias = 0.01;
     const float lightBleedReduction = 0.2;


### PR DESCRIPTION
VSM is unique in that both shadow casters AND shadow receivers must be rendered into the shadow map.  This differs slightly from PCF shadows:

|caster|receiver|PCF rendered|VSM rendered|example|
|--:|--:|--:|--:|--:|
|0|0|NO|NO|skybox|
|0|1|NO|YES|ground plane|
|1|0|YES|YES|an offscreen [cucoloris](https://en.wikipedia.org/wiki/Cucoloris)|
|1|1|YES|YES|typical object|

The second scenario, where PCF and VSM differ, is what is being updated here.

- Rename `VISIBLE_DIR_SHADOW_CASTER` type visibility bits to `VISIBLE_DIR_SHADOW_RENDERABLE`, to make them more general
- Update `computeVisibilityMasks` logic to mark all shadow receivers visible during VSM shadow passes.
