### PR TITLE
gltf_viewer: Add automation UI and functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ filament/docs/html/**
 civetweb.txt
 /TAGS
 settings.json
+test*.png
+test*.json

--- a/libs/viewer/CMakeLists.txt
+++ b/libs/viewer/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PUBLIC_HDR_DIR include)
 # Sources and headers
 # ==================================================================================================
 set(PUBLIC_HDRS
+        include/viewer/AutomationEngine.h
         include/viewer/AutomationSpec.h
         include/viewer/Settings.h
         include/viewer/SimpleViewer.h
@@ -15,6 +16,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/jsonParseUtils.h
+        src/AutomationEngine.cpp
         src/AutomationSpec.cpp
         src/Settings.cpp
         src/SimpleViewer.cpp
@@ -24,7 +26,7 @@ set(SRCS
 # Include and target definitions
 # ==================================================================================================
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
-target_link_libraries(${TARGET} PUBLIC imgui cgltf filament gltfio filagui jsmn)
+target_link_libraries(${TARGET} PUBLIC imgui filament gltfio filagui jsmn imageio)
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
 # ==================================================================================================

--- a/libs/viewer/include/viewer/AutomationEngine.h
+++ b/libs/viewer/include/viewer/AutomationEngine.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VIEWER_AUTOMATION_ENGINE_H
+#define VIEWER_AUTOMATION_ENGINE_H
+
+#include <viewer/AutomationSpec.h>
+
+namespace filament {
+
+class Renderer;
+class View;
+
+namespace viewer {
+
+/**
+ * Provides a convenient way to iterate through an AutomationSpec while pushing settings to Filament
+ * and exporting screenshots.
+ *
+ * Upon construction, the engine is given an immutable reference to an AutomationSpec. The engine is
+ * always in one of two states: running or idle. The running state can be entered either immediately
+ * (startRunning) or by requesting batch mode (startBatchMode).
+ *
+ * Clients must call tick() after each frame is rendered, which gives the engine an opportunity to
+ * increment the current test (if enough time has elapsed) and request an asychronous screenshot.
+ * The time to sleep between tests is configurable and can be set to zero. The engine also waits a
+ * specified minimum number of frames between tests.
+ *
+ * Batch mode is meant for non-interactive applications. In batch mode, the engine defers applying
+ * the first test case until the client unblocks it via signalBatchMode(). This is useful when
+ * waiting for a large model file to become fully loaded. Batch mode also offers a query
+ * (shouldClose) that is triggered after the last screenshot has been written to disk.
+ */
+class AutomationEngine {
+public:
+    AutomationEngine(const AutomationSpec* spec, Settings* settings) :
+            mSpec(spec), mSettings(settings) {}
+
+    // Enters the running state.
+    void startRunning();
+
+    // Enters the running state in batch mode.
+    void startBatchMode();
+
+    // Notifies the engine that time has passed and a new frame has been rendered.
+    // This is when settings get applied, screenshots are (optionally) exported, etc.
+    void tick(View* view, Renderer* renderer, float deltaTime);
+
+    // Signals that batch mode can begin. Call this after all meshes and textures finish loading.
+    void signalBatchMode() { mBatchModeAllowed = true; }
+
+    // Cancels an in-progress automation session.
+    void stopRunning() { mIsRunning = false; }
+
+    // Convenience function that writes out a JSON file to disk.
+    static void exportSettings(const Settings& settings, const char* filename);
+
+    struct Options {
+        // Minimum time that the engine waits between applying a settings object and subsequently
+        // taking a screenshot. After the screenshot is taken, the engine immediately advances to
+        // the next test case. Specified in seconds.
+        float sleepDuration = 0.2;
+
+        // If true, the tick function writes out a screenshot before advancing to the next test.
+        bool exportScreenshots = false;
+
+        // If true, the tick function writes out a settings JSON file before advancing.
+        bool exportSettings = false;
+
+        // Similar to sleepDuration, but expressed as a frame count. Both the minimum sleep time
+        // and the minimum frame count must be elapsed before the engine advances to the next test.
+        int minFrameCount = 2;
+    };
+
+    Options getOptions() const { return mOptions; }
+    void setOptions(Options options) { mOptions = options; }
+
+    bool isRunning() const { return mIsRunning; }
+    size_t currentTest() const { return mCurrentTest; }
+    size_t testCount() const { return mSpec->size(); }
+    bool shouldClose() const { return mShouldClose; }
+    bool isBatchModeEnabled() const { return mBatchModeEnabled; }
+    const char* getStatusMessage() const;
+
+private:
+    AutomationSpec const * const mSpec;
+    Settings * const mSettings;
+    Options mOptions;
+    size_t mCurrentTest;
+    float mElapsedTime;
+    int mElapsedFrames;
+    bool mIsRunning = false;
+    bool mBatchModeEnabled = false;
+    bool mRequestStart = false;
+    bool mShouldClose = false;
+    bool mBatchModeAllowed = false;
+
+public:
+    // For internal use from a screenshot callback.
+    void requestClose() { mShouldClose = true; }
+};
+
+} // namespace viewer
+} // namespace filament
+
+#endif // VIEWER_AUTOMATION_ENGINE_H

--- a/libs/viewer/include/viewer/AutomationSpec.h
+++ b/libs/viewer/include/viewer/AutomationSpec.h
@@ -22,12 +22,32 @@
 namespace filament {
 namespace viewer {
 
-// Immutable list of Settings objects generated from a JSON spec.
-//
-// Each top-level item in the JSON spec is an object with "name", "base" and "permute".
-// The "base" object specifies a single set of changes to apply to default settings.
-// The optional "permute" object specifies a cross product of changes to apply to the base.
-// See the unit test for an example.
+/**
+ * Immutable list of Settings objects generated from a JSON spec.
+ *
+ * Each top-level item in the JSON spec is an object with "name", "base" and "permute".
+ * The "base" object specifies a single set of changes to apply to default settings.
+ * The optional "permute" object specifies a cross product of changes to apply to the base.
+ *
+ * The following example generates a total of 5 test cases.
+ * [{
+ *    "name": "simple",
+ *    "base": {
+ *      "view.dof.focusDistance": 0.1,
+ *      "view.bloom.strength": 0.5
+ *   },
+ *   "permute": {
+ *     "view.bloom.enabled": [false, true],
+ *     "view.dof.enabled": [false, true]
+ *   }
+ * },
+ * {
+ *   "name": "ppoff",
+ *   "base": {
+ *     "view.postProcessingEnabled": false
+ *   }
+ * }]
+ */
 class AutomationSpec {
 public:
 

--- a/libs/viewer/include/viewer/SimpleViewer.h
+++ b/libs/viewer/include/viewer/SimpleViewer.h
@@ -177,6 +177,8 @@ public:
      */
     Settings& getSettings() { return mSettings; }
 
+    void stopAnimation() { mCurrentAnimation = 0; }
+
 private:
     void updateIndirectLight();
 

--- a/libs/viewer/src/AutomationEngine.cpp
+++ b/libs/viewer/src/AutomationEngine.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <viewer/AutomationEngine.h>
+
+#include <imageio/ImageEncoder.h>
+
+#include <image/ColorTransform.h>
+
+#include <filament/Renderer.h>
+#include <filament/Viewport.h>
+
+#include <backend/PixelBufferDescriptor.h>
+
+#include <utils/Path.h>
+
+#include <iomanip>
+#include <fstream>
+#include <sstream>
+
+using namespace image;
+using namespace utils;
+
+namespace filament {
+namespace viewer {
+
+static std::string gStatus;
+
+template<typename T>
+static LinearImage toLinear(size_t w, size_t h, size_t bpr, const uint8_t* src) {
+    LinearImage result(w, h, 3);
+    filament::math::float3* d = reinterpret_cast<filament::math::float3*>(result.getPixelRef(0, 0));
+    for (size_t y = 0; y < h; ++y) {
+        T const* p = reinterpret_cast<T const*>(src + y * bpr);
+        for (size_t x = 0; x < w; ++x, p += 3) {
+            filament::math::float3 sRGB(p[0], p[1], p[2]);
+            sRGB /= std::numeric_limits<T>::max();
+            *d++ = sRGBToLinear(sRGB);
+        }
+    }
+    return result;
+}
+
+struct ScreenshotState {
+    View* view;
+    std::string filename;
+    bool autoclose;
+    AutomationEngine* engine;
+};
+
+void exportScreenshot(View* view, Renderer* renderer, std::string filename,
+        bool autoclose, AutomationEngine* automationEngine) {
+    const Viewport& vp = view->getViewport();
+    const size_t byteCount = vp.width * vp.height * 3;
+
+    // Create a buffer descriptor that writes the PNG after the data becomes ready on the CPU.
+    backend::PixelBufferDescriptor buffer(
+        new uint8_t[byteCount], byteCount,
+        backend::PixelBufferDescriptor::PixelDataFormat::RGB,
+        backend::PixelBufferDescriptor::PixelDataType::UBYTE,
+        [](void* buffer, size_t size, void* user) {
+            ScreenshotState* state = static_cast<ScreenshotState*>(user);
+            const Viewport& vp = state->view->getViewport();
+            LinearImage image(toLinear<uint8_t>(vp.width, vp.height, vp.width * 3,
+                    static_cast<uint8_t*>(buffer)));
+            Path out(state->filename);
+            std::ofstream outputStream(out, std::ios::binary | std::ios::trunc);
+            ImageEncoder::encode(outputStream, ImageEncoder::Format::PNG, image, "",
+                    state->filename);
+            delete[] static_cast<uint8_t*>(buffer);
+            if (state->autoclose) {
+                state->engine->requestClose();
+            }
+            delete state;
+        },
+        new ScreenshotState { view, filename, autoclose, automationEngine }
+    );
+
+    // Invoke readPixels asynchronously.
+    renderer->readPixels((uint32_t) vp.left, (uint32_t) vp.bottom, vp.width, vp.height,
+            std::move(buffer));
+}
+
+void AutomationEngine::startRunning() {
+    mRequestStart = true;
+}
+
+void AutomationEngine::startBatchMode() {
+    mRequestStart = true;
+    mBatchModeEnabled = true;
+}
+
+void AutomationEngine::exportSettings(const Settings& settings, const char* filename) {
+    std::string contents = writeJson(settings);
+    std::ofstream out(filename);
+    if (!out) {
+        gStatus = "Failed to export settings file.";
+    }
+    out << contents << std::endl;
+    gStatus = "Exported to '" + std::string(filename) + "' in the current folder.";
+}
+
+void AutomationEngine::tick(View* view, Renderer* renderer, float deltaTime) {
+    if (!mIsRunning) {
+        if (mRequestStart) {
+            if ((mBatchModeEnabled && mBatchModeAllowed) || !mBatchModeEnabled) {
+                mIsRunning = true;
+                mCurrentTest = 0;
+                mElapsedTime = 0;
+                mElapsedFrames = 0;
+
+                mSpec->get(mCurrentTest, mSettings);
+                applySettings(mSettings->view, view);
+                mRequestStart = false;
+            }
+        }
+        return;
+    }
+
+    mElapsedTime += deltaTime;
+    mElapsedFrames++;
+
+    if (mElapsedTime < mOptions.sleepDuration || mElapsedFrames < mOptions.minFrameCount) {
+        return;
+    }
+
+    const bool isLastTest = mCurrentTest == mSpec->size() - 1;
+
+    const int digits = (int) log10 ((double) mSpec->size()) + 1;
+    std::ostringstream stringStream;
+    stringStream << "test"
+            << std::setfill('0') << std::setw(digits)
+            << std::to_string(mCurrentTest) << "_"
+            << mSpec->getName(mCurrentTest);
+    std::string prefix = stringStream.str();
+
+    if (mOptions.exportSettings) {
+        std::string filename = prefix + ".json";
+        exportSettings(*mSettings, filename.c_str());
+    }
+
+    if (mOptions.exportScreenshots) {
+        exportScreenshot(view, renderer, prefix + ".png", isLastTest, this);
+    }
+
+    if (isLastTest) {
+        mIsRunning = false;
+        if (mBatchModeEnabled && !mOptions.exportScreenshots) {
+            mShouldClose = true;
+        }
+        return;
+    }
+
+    // Increment the case number and apply the next round of settings.
+    mElapsedTime = 0;
+    mElapsedFrames = 0;
+    mCurrentTest++;
+    mSpec->get(mCurrentTest, mSettings);
+    applySettings(mSettings->view, view);
+}
+
+const char* AutomationEngine::getStatusMessage() const {
+    return gStatus.c_str();
+}
+
+} // namespace viewer
+} // namespace filament

--- a/libs/viewer/src/AutomationSpec.cpp
+++ b/libs/viewer/src/AutomationSpec.cpp
@@ -46,13 +46,16 @@ static const char* DEFAULT_AUTOMATION = R"TXT([
     },
     {
         "name": "viewopts",
+        "base": {
+            "view.dof.focusDistance": 0.1
+        }
         "permute": {
-            "view.dithering": ["NONE", "TEMPORAL"],
             "view.sampleCount": [1, 4],
             "view.taa.enabled": [false, true],
             "view.antiAliasing": ["NONE", "FXAA"],
             "view.ssao.enabled": [false, true],
-            "view.bloom.enabled": [false, true]
+            "view.bloom.enabled": [false, true],
+            "view.dof.enabled": [false, true]
         }
     }
 ]

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -155,7 +155,6 @@ TEST_F(ViewSettingsTest, AutomationSpec) {
 
     ASSERT_TRUE(specs->get(1, &settings));
     ASSERT_TRUE(settings.view.postProcessingEnabled);
-    ASSERT_EQ(settings.view.dithering, Dithering::NONE);
 
     ASSERT_TRUE(specs->get(64, &settings));
     ASSERT_FALSE(specs->get(65, &settings));

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -240,7 +240,7 @@ if (NOT ANDROID)
 
     # Sample app specific
     target_link_libraries(frame_generator PRIVATE imageio)
-    target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio viewer imageio)
+    target_link_libraries(gltf_viewer PRIVATE gltf-resources gltfio viewer)
     target_link_libraries(gltf_instances PRIVATE gltf-resources gltfio viewer)
     target_link_libraries(hellopbr PRIVATE filameshio suzanne-resources)
     target_link_libraries(sample_cloth PRIVATE filameshio)

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -23,21 +23,18 @@
 #include <filament/Engine.h>
 #include <filament/IndexBuffer.h>
 #include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
 #include <filament/Scene.h>
 #include <filament/Skybox.h>
 #include <filament/TransformManager.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
-#include <filament/Renderer.h>
 
 #include <gltfio/AssetLoader.h>
 #include <gltfio/FilamentAsset.h>
 #include <gltfio/ResourceLoader.h>
 
-#include <image/ColorTransform.h>
-
-#include <imageio/ImageEncoder.h>
-
+#include <viewer/AutomationEngine.h>
 #include <viewer/AutomationSpec.h>
 #include <viewer/SimpleViewer.h>
 
@@ -57,7 +54,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 #include "generated/resources/gltf_viewer.h"
@@ -67,7 +63,6 @@ using namespace filament::math;
 using namespace filament::viewer;
 
 using namespace gltfio;
-using namespace image;
 using namespace utils;
 
 struct App {
@@ -118,6 +113,10 @@ struct App {
 
     std::string messageBoxText;
     std::string settingsFile;
+    std::string batchFile;
+
+    AutomationSpec* automationSpec = nullptr;
+    AutomationEngine* automationEngine = nullptr;
 };
 
 static const char* DEFAULT_IBL = "default_env";
@@ -133,6 +132,8 @@ static void printUsage(char* name) {
         "       Prints this message\n\n"
         "   --api, -a\n"
         "       Specify the backend API: opengl (default), vulkan, or metal\n\n"
+        "   --batch=<path to JSON file or 'default'>, -b\n"
+        "       Start automation using the given JSON spec, then quit the app\n\n"
         "   --ibl=<path to cmgen IBL>, -i <path>\n"
         "       Override the built-in IBL\n\n"
         "   --actual-size, -s\n"
@@ -159,17 +160,23 @@ static void printUsage(char* name) {
     std::cout << usage;
 }
 
+static std::ifstream::pos_type getFileSize(const char* filename) {
+    std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
+    return in.tellg();
+}
+
 static int handleCommandLineArguments(int argc, char* argv[], App* app) {
-    static constexpr const char* OPTSTR = "ha:i:usc:rt:";
+    static constexpr const char* OPTSTR = "ha:i:usc:rt:b:";
     static const struct option OPTIONS[] = {
         { "help",         no_argument,       nullptr, 'h' },
         { "api",          required_argument, nullptr, 'a' },
+        { "batch",        required_argument, nullptr, 'b' },
         { "ibl",          required_argument, nullptr, 'i' },
         { "ubershader",   no_argument,       nullptr, 'u' },
         { "actual-size",  no_argument,       nullptr, 's' },
         { "camera",       required_argument, nullptr, 'c' },
         { "recompute-aabb", no_argument,     nullptr, 'r' },
-        { "settings",       optional_argument, nullptr, 't' },
+        { "settings",       required_argument, nullptr, 't' },
         { nullptr, 0, nullptr, 0 }
     };
     int opt;
@@ -214,19 +221,15 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 app->recomputeAabb = true;
                 break;
             case 't':
-                if (arg.empty()) {
-                    arg = "settings.json";
-                }
                 app->settingsFile = arg;
                 break;
+            case 'b': {
+                app->batchFile = arg;
+                break;
+            }
         }
     }
     return optind;
-}
-
-static std::ifstream::pos_type getFileSize(const char* filename) {
-    std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
-    return in.tellg();
 }
 
 static bool loadSettings(const char* filename, Settings* out) {
@@ -586,6 +589,7 @@ int main(int argc, char** argv) {
     app.config.iblDirectory = FilamentApp::getRootAssetsPath() + DEFAULT_IBL;
 
     int optionIndex = handleCommandLineArguments(argc, argv, &app);
+
     utils::Path filename;
     int num_args = argc - optionIndex;
     if (num_args >= 1) {
@@ -668,6 +672,44 @@ int main(int argc, char** argv) {
         app.names = new NameComponentManager(EntityManager::get());
         app.viewer = new SimpleViewer(engine, scene, view, 410);
 
+        const bool batchMode = !app.batchFile.empty();
+
+        // First check if a custom automation spec has been provided. If it fails to load, the app
+        // must be closed since it could be invoked from a script.
+        if (batchMode && app.batchFile != "default") {
+            auto size = getFileSize(app.batchFile.c_str());
+            if (size > 0) {
+                std::ifstream in(app.batchFile, std::ifstream::binary | std::ifstream::in);
+                std::vector<char> json(static_cast<unsigned long>(size));
+                in.read(json.data(), size);
+                app.automationSpec = AutomationSpec::generate(json.data(), size);
+                if (!app.automationSpec) {
+                    std::cerr << "Unable to parse automation spec: " << app.batchFile << std::endl;
+                    exit(1);
+                }
+            } else {
+                std::cerr << "Unable to load automation spec: " << app.batchFile << std::endl;
+                exit(1);
+            }
+        }
+
+        // If no custom spec has been provided, or if in interactive mode, load the default spec.
+        if (!app.automationSpec) {
+            app.automationSpec = AutomationSpec::generateDefaultTestCases();
+        }
+
+        app.automationEngine = new AutomationEngine(app.automationSpec, &app.viewer->getSettings());
+
+        if (batchMode) {
+            app.automationEngine->startBatchMode();
+            auto options = app.automationEngine->getOptions();
+            options.sleepDuration = 0.0;
+            options.exportScreenshots = true;
+            options.exportSettings = true;
+            app.automationEngine->setOptions(options);
+            app.viewer->stopAnimation();
+        }
+
         if (app.settingsFile.size() > 0) {
             bool success = loadSettings(app.settingsFile.c_str(), &app.viewer->getSettings());
             if (success) {
@@ -693,10 +735,62 @@ int main(int argc, char** argv) {
 
         createGroundPlane(engine, scene, app);
 
-        app.viewer->setUiCallback([&app, scene] () {
+        app.viewer->setUiCallback([&app, scene, view] () {
+            auto& automation = *app.automationEngine;
+
             float progress = app.resourceLoader->asyncGetLoadProgress();
             if (progress < 1.0) {
                 ImGui::ProgressBar(progress);
+            } else {
+                // The model is now fully loaded, so let automation know.
+                automation.signalBatchMode();
+            }
+
+            // The screenshots do not include the UI, but we auto-open the Automation UI group
+            // when in batch mode. This is useful when a human is observing progress.
+            const int flags = automation.isBatchModeEnabled() ? ImGuiTreeNodeFlags_DefaultOpen : 0;
+
+            if (ImGui::CollapsingHeader("Automation", flags)) {
+                ImGui::Indent();
+
+                const ImVec4 yellow(1.0f,1.0f,0.0f,1.0f);
+                if (automation.isRunning()) {
+                    ImGui::TextColored(yellow, "Test case %zu / %zu",
+                            automation.currentTest(), automation.testCount());
+                } else {
+                    ImGui::TextColored(yellow, "%zu test cases", automation.testCount());
+                }
+
+                auto options = automation.getOptions();
+
+                ImGui::PushItemWidth(150);
+                ImGui::SliderFloat("Sleep (seconds)", &options.sleepDuration, 0.0, 5.0);
+                ImGui::PopItemWidth();
+
+                // Hide the tooltip during automation to avoid photobombing the screenshot.
+                if (ImGui::IsItemHovered() && !automation.isRunning()) {
+                    ImGui::SetTooltip("Specifies the amount of time to sleep between test cases.");
+                }
+
+                ImGui::Checkbox("Export screenshot for each test", &options.exportScreenshots);
+                ImGui::Checkbox("Export settings JSON for each test", &options.exportSettings);
+
+                automation.setOptions(options);
+
+                if (automation.isRunning()) {
+                    if (ImGui::Button("Stop batch test")) {
+                        automation.stopRunning();
+                    }
+                } else if (ImGui::Button("Run batch test")) {
+                    automation.startRunning();
+                }
+
+                if (ImGui::Button("Export view settings")) {
+                    automation.exportSettings(app.viewer->getSettings(), "settings.json");
+                    app.messageBoxText = automation.getStatusMessage();
+                    ImGui::OpenPopup("MessageBox");
+                }
+                ImGui::Unindent();
             }
 
             if (ImGui::CollapsingHeader("Stats")) {
@@ -886,6 +980,15 @@ int main(int argc, char** argv) {
         }
     };
 
+    auto postRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
+        if (app.automationEngine->shouldClose()) {
+            FilamentApp::get().close();
+            return;
+        }
+        Settings* settings = &app.viewer->getSettings();
+        app.automationEngine->tick(view, renderer, ImGui::GetIO().DeltaTime);
+    };
+
     FilamentApp& filamentApp = FilamentApp::get();
     filamentApp.animate(animate);
     filamentApp.resize(resize);
@@ -897,7 +1000,7 @@ int main(int argc, char** argv) {
         loadResources(path);
     });
 
-    filamentApp.run(app.config, setup, cleanup, gui, preRender);
+    filamentApp.run(app.config, setup, cleanup, gui, preRender, postRender);
 
     return 0;
 }


### PR DESCRIPTION
This adds `AutomationEngine` to libs/viewer, which iterates through
`Settings` instances that were generated from a JSON spec and applies
them to a Filament `View`. It can be configured to sleep between tests
using a time delay or a frame count.

This also adds command line arguments and user-interface elements to
`gltf_viewer` for automated testing.