### PR TITLE
Automation: add support for materials.

### DIFF
--- a/libs/viewer/include/viewer/AutomationEngine.h
+++ b/libs/viewer/include/viewer/AutomationEngine.h
@@ -21,6 +21,7 @@
 
 namespace filament {
 
+class MaterialInstance;
 class Renderer;
 class View;
 
@@ -57,7 +58,8 @@ public:
 
     // Notifies the engine that time has passed and a new frame has been rendered.
     // This is when settings get applied, screenshots are (optionally) exported, etc.
-    void tick(View* view, Renderer* renderer, float deltaTime);
+    void tick(View* view, MaterialInstance* const* materials, size_t materialCount,
+            Renderer* renderer, float deltaTime);
 
     // Signals that batch mode can begin. Call this after all meshes and textures finish loading.
     void signalBatchMode() { mBatchModeAllowed = true; }

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -17,19 +17,24 @@
 #ifndef VIEWER_SETTINGS_H
 #define VIEWER_SETTINGS_H
 
+#include <filament/ColorGrading.h>
+#include <filament/MaterialInstance.h>
+#include <filament/View.h>
+
+#include <math/vec3.h>
+#include <math/vec4.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
 #include <string>
-
-#include <filament/ColorGrading.h>
-#include <filament/View.h>
 
 namespace filament {
 namespace viewer {
 
 struct ColorGradingSettings;
 struct DynamicLightingSettings;
+struct MaterialSettings;
 struct Settings;
 struct ViewSettings;
 
@@ -51,8 +56,9 @@ using VignetteOptions = filament::View::VignetteOptions;
 // - This function writes warnings and error messages into the utils log.
 bool readJson(const char* jsonChunk, size_t size, Settings* out);
 
-// Pushes all properties to a Filament View modulo the immutable ones (e.g. ColorGrading).
+// These functions push all editable property values to their respective Filament objects.
 void applySettings(const ViewSettings& settings, View* dest);
+void applySettings(const MaterialSettings& settings, MaterialInstance* dest);
 
 // Creates a new ColorGrading object based on the given settings.
 ColorGrading* createColorGrading(const ColorGradingSettings& settings, Engine* engine);
@@ -64,6 +70,7 @@ std::string writeJson(const ColorGradingSettings& in);
 std::string writeJson(const DepthOfFieldOptions& in);
 std::string writeJson(const DynamicLightingSettings& in);
 std::string writeJson(const FogOptions& in);
+std::string writeJson(const MaterialSettings& in);
 std::string writeJson(const RenderQuality& in);
 std::string writeJson(const Settings& in);
 std::string writeJson(const TemporalAntiAliasingOptions& in);
@@ -118,8 +125,20 @@ struct ViewSettings {
     bool postProcessingEnabled = true;
 };
 
+template <typename T>
+struct MaterialProperty { std::string name; T value; };
+
+// This struct has a fixed size for simplicity. Each non-empty property name is an override.
+struct MaterialSettings {
+    static constexpr size_t MAX_COUNT = 4;
+    MaterialProperty<float> scalar[MAX_COUNT];
+    MaterialProperty<math::float3> float3[MAX_COUNT];
+    MaterialProperty<math::float4> float4[MAX_COUNT];
+};
+
 struct Settings {
     ViewSettings view;
+    MaterialSettings material;
 };
 
 } // namespace viewer

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -128,6 +128,22 @@ static const char* JSON_TEST_DEFAULTS = R"TXT(
 }
 )TXT";
 
+static const char* JSON_TEST_MATERIAL = R"TXT(
+"material": {
+  "scalar": { "foo": 5.0, "bar": 2.0 },
+  "float3": { "baz": [1, 2, 3] }
+})TXT";
+
+static const char* JSON_TEST_AUTOMATION = R"TXT([{
+    "name": "test_72_cases",
+    "base": { "view.bloom.strength": 0.5 },
+    "permute": {
+        "view.bloom.enabled": [false, true],
+        "material.scalar.metallicFactor": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        "material.scalar.roughnessFactor": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    }
+}])TXT";
+
 TEST_F(ViewSettingsTest, JsonTestDefaults) {
     Settings settings1 = {0};
     ASSERT_TRUE(readJson(JSON_TEST_DEFAULTS, strlen(JSON_TEST_DEFAULTS), &settings1));
@@ -142,7 +158,15 @@ TEST_F(ViewSettingsTest, JsonTestDefaults) {
     ASSERT_EQ(writeJson(settings2), writeJson(settings3));
 }
 
-TEST_F(ViewSettingsTest, AutomationSpec) {
+TEST_F(ViewSettingsTest, JsonTestMaterial) {
+    Settings settings = {0};
+    std::string js = "{" + std::string(JSON_TEST_MATERIAL) + "}";
+    ASSERT_TRUE(readJson(js.c_str(), js.size(), &settings));
+    std::string serialized = writeJson(settings);
+    ASSERT_PRED_FORMAT2(testing::IsSubstring, "\"baz\": [1, 2, 3]", serialized);
+}
+
+TEST_F(ViewSettingsTest, DefaultAutomationSpec) {
     AutomationSpec* specs = AutomationSpec::generateDefaultTestCases();
     ASSERT_TRUE(specs);
     ASSERT_EQ(specs->size(), 65);
@@ -160,6 +184,14 @@ TEST_F(ViewSettingsTest, AutomationSpec) {
     ASSERT_FALSE(specs->get(65, &settings));
 
     delete specs;
+}
+
+TEST_F(ViewSettingsTest, CustomAutomationSpec) {
+    AutomationSpec* spec = AutomationSpec::generate(JSON_TEST_AUTOMATION,
+            strlen(JSON_TEST_AUTOMATION));
+    ASSERT_TRUE(spec);
+    ASSERT_EQ(spec->size(), 72);
+    delete spec;
 }
 
 int main(int argc, char** argv) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -986,7 +986,10 @@ int main(int argc, char** argv) {
             return;
         }
         Settings* settings = &app.viewer->getSettings();
-        app.automationEngine->tick(view, renderer, ImGui::GetIO().DeltaTime);
+        MaterialInstance* const* materials = app.asset->getMaterialInstances();
+        size_t materialCount = app.asset->getMaterialInstanceCount();
+        app.automationEngine->tick(view, materials, materialCount, renderer,
+                ImGui::GetIO().DeltaTime);
     };
 
     FilamentApp& filamentApp = FilamentApp::get();


### PR DESCRIPTION
This adds a `material` key to `Settings`, as a sister to `view`.

The image attached to this PR description was generated with the following commands.

```
gltf_viewer --batch=batch.json third_party/models/shader_ball/shader_ball.gltf
montage -border 0 -geometry 660x -tile 3x2 test*.png atlas.png
```

Contents of `batch.json`:

```json
    [{
      "name": "metallic_vs_roughness",
      "permute": {
          "material.scalar.roughnessFactor": [0.0, 0.5, 1.0],
          "material.scalar.metallicFactor": [0.0, 1.0]
      }
    }]
```

Currently this is limited to float, vec3, and vec4 parameters.


![atlas](https://user-images.githubusercontent.com/1288904/94955291-332f9680-049f-11eb-8eb1-a9e28122d6f6.jpg)
