### PR TITLE
Automation: fix segfault when closing the app early.

### DIFF
--- a/libs/viewer/include/viewer/AutomationEngine.h
+++ b/libs/viewer/include/viewer/AutomationEngine.h
@@ -67,6 +67,9 @@ public:
     // Cancels an in-progress automation session.
     void stopRunning() { mIsRunning = false; }
 
+    // Signals that the application is closing, so all pending screenshots should be cancelled.
+    void terminate();
+
     // Convenience function that writes out a JSON file to disk.
     static void exportSettings(const Settings& settings, const char* filename);
 
@@ -109,10 +112,12 @@ private:
     bool mRequestStart = false;
     bool mShouldClose = false;
     bool mBatchModeAllowed = false;
+    bool mTerminated = false;
 
 public:
     // For internal use from a screenshot callback.
     void requestClose() { mShouldClose = true; }
+    bool isTerminated() const { return mTerminated; }
 };
 
 } // namespace viewer

--- a/libs/viewer/src/AutomationEngine.cpp
+++ b/libs/viewer/src/AutomationEngine.cpp
@@ -73,6 +73,11 @@ void exportScreenshot(View* view, Renderer* renderer, std::string filename,
         backend::PixelBufferDescriptor::PixelDataType::UBYTE,
         [](void* buffer, size_t size, void* user) {
             ScreenshotState* state = static_cast<ScreenshotState*>(user);
+            if (state->engine->isTerminated()) {
+                delete[] static_cast<uint8_t*>(buffer);
+                delete state;
+                return;
+            }
             const Viewport& vp = state->view->getViewport();
             LinearImage image(toLinear<uint8_t>(vp.width, vp.height, vp.width * 3,
                     static_cast<uint8_t*>(buffer)));
@@ -101,6 +106,11 @@ void AutomationEngine::startRunning() {
 void AutomationEngine::startBatchMode() {
     mRequestStart = true;
     mBatchModeEnabled = true;
+}
+
+void AutomationEngine::terminate() {
+    stopRunning();
+    mTerminated = true;
 }
 
 void AutomationEngine::exportSettings(const Settings& settings, const char* filename) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -873,6 +873,7 @@ int main(int argc, char** argv) {
     };
 
     auto cleanup = [&app](Engine* engine, View*, Scene*) {
+        app.automationEngine->terminate();
         app.loader->destroyAsset(app.asset);
         app.materials->destroyMaterials();
 


### PR DESCRIPTION
The Filament View that gets passed to tick() is retained briefly when
screenshots are enabled, but it may be destroyed by the time the
PixelBufferDescriptor callback is invoked. So, we needed a way of
notifying the AutomationEngine.