### PR TITLE
Vulkan: support readPixels and headless swap chains.

### DIFF
--- a/filament/backend/src/DataReshaper.h
+++ b/filament/backend/src/DataReshaper.h
@@ -19,29 +19,56 @@
 
 #include <stddef.h>
 
+#include <math/scalar.h>
+
 namespace filament {
 namespace backend {
 
-// This little utility adds padding to multi-channel interleaved data by inserting dummy values.
-// This is very useful for platforms that only accept 4-component data, since users often wish to
-// submit 3-component data.
+// This little utility adds padding to multi-channel interleaved data by inserting dummy values, or
+// discards trailing channels. This is useful for platforms that only accept 4-component data, since
+// users often wish to submit (or receive) 3-component data.
 class DataReshaper {
 public:
-    template<typename componentType, int numSrcChannels, int numDstChannels,
+    template<typename componentType, size_t srcChannelCount, size_t dstChannelCount,
             componentType maxValue = std::numeric_limits<componentType>::max()>
     static void reshape(void* dest, const void* src, size_t numSrcBytes) {
         const componentType* in = (const componentType*) src;
         componentType* out = (componentType*) dest;
-        const size_t numWords = (numSrcBytes / sizeof(componentType)) / numSrcChannels;
-        for (size_t word = 0; word < numWords; ++word) {
-            for (size_t component = 0; component < numSrcChannels; ++component) {
-                out[component] = in[component];
+        const size_t srcWordCount = (numSrcBytes / sizeof(componentType)) / srcChannelCount;
+        const int minChannelCount = filament::math::min(srcChannelCount, dstChannelCount);
+        for (size_t word = 0; word < srcWordCount; ++word) {
+            for (size_t channel = 0; channel < minChannelCount; ++channel) {
+                out[channel] = in[channel];
             }
-            for (size_t component = (size_t)numSrcChannels; component < numDstChannels; ++component) {
-                out[component] = maxValue;
+            for (size_t channel = srcChannelCount; channel < dstChannelCount; ++channel) {
+                out[channel] = maxValue;
             }
-            in += numSrcChannels;
-            out += numDstChannels;
+            in += srcChannelCount;
+            out += dstChannelCount;
+        }
+    }
+
+    template<typename componentType, size_t srcChannelCount, size_t dstChannelCount,
+            componentType maxValue = std::numeric_limits<componentType>::max()>
+    static void reshapeImage(uint8_t* dest, const uint8_t* src, size_t srcBytesPerRow,
+            size_t dstBytesPerRow, size_t height) {
+        const size_t srcWordCount = (srcBytesPerRow / sizeof(componentType)) / srcChannelCount;
+        const int minChannelCount = filament::math::min(srcChannelCount, dstChannelCount);
+        for (size_t row = 0; row < height; ++row) {
+            const componentType* in = (const componentType*) src;
+            componentType* out = (componentType*) dest;
+            for (size_t word = 0; word < srcWordCount; ++word) {
+                for (size_t channel = 0; channel < minChannelCount; ++channel) {
+                    out[channel] = in[channel];
+                }
+                for (size_t channel = srcChannelCount; channel < dstChannelCount; ++channel) {
+                    out[channel] = maxValue;
+                }
+                in += srcChannelCount;
+                out += dstChannelCount;
+            }
+            src += srcBytesPerRow;
+            dest += dstBytesPerRow;
         }
     }
 };

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -145,18 +145,19 @@ struct VulkanSurfaceContext {
     VkExtent2D clientSize;
     std::vector<VkSurfaceFormatKHR> surfaceFormats;
     VkQueue presentQueue;
+    VkQueue headlessQueue;
     std::vector<SwapContext> swapContexts;
     uint32_t currentSwapIndex;
     VkSemaphore imageAvailable;
     VkSemaphore renderingFinished;
     VulkanAttachment depth;
     bool suboptimal;
-    void* nativeWindow;
 };
 
 void selectPhysicalDevice(VulkanContext& context);
 void createLogicalDevice(VulkanContext& context);
 void getPresentationQueue(VulkanContext& context, VulkanSurfaceContext& sc);
+void getHeadlessQueue(VulkanContext& context, VulkanSurfaceContext& sc);
 
 void createSwapChain(VulkanContext& context, VulkanSurfaceContext& sc);
 void destroySwapChain(VulkanContext& context, VulkanSurfaceContext& sc, VulkanDisposer& disposer);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1307,15 +1307,17 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src,
         .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
         .imageType = VK_IMAGE_TYPE_2D,
         .format = VK_FORMAT_R8G8B8A8_UNORM,
-        .extent.width = width,
-        .extent.height = height,
-        .extent.depth = 1,
-        .arrayLayers = 1,
+        .extent = {
+            .width = width,
+            .height = height,
+            .depth = 1,
+        },
         .mipLevels = 1,
-        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .arrayLayers = 1,
         .samples = VK_SAMPLE_COUNT_1_BIT,
         .tiling = VK_IMAGE_TILING_LINEAR,
-        .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT
+        .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
     };
 
     VkImage stagingImage;
@@ -1346,15 +1348,23 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src,
             VK_IMAGE_ASPECT_COLOR_BIT);
 
     VkImageCopy imageCopyRegion = {
-        .srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-        .srcSubresource.layerCount = 1,
-        .srcOffset.x = (int32_t) x,
-        .srcOffset.y = (int32_t) y,
-        .dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-        .dstSubresource.layerCount = 1,
-        .extent.width = width,
-        .extent.height = height,
-        .extent.depth = 1
+        .srcSubresource = {
+            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+            .layerCount = 1,
+        },
+        .srcOffset = {
+            .x = (int32_t) x,
+            .y = (int32_t) y,
+        },
+        .dstSubresource = {
+            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+            .layerCount = 1,
+        },
+        .extent = {
+            .width = width,
+            .height = height,
+            .depth = 1,
+        },
     };
 
     // Transition the source image layout (which might be the swap chain)
@@ -1389,18 +1399,20 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src,
 
     VkImageMemoryBarrier barrier = {
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
         .oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         .newLayout = VK_IMAGE_LAYOUT_GENERAL,
         .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .image = stagingImage,
-        .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .dstAccessMask = VK_ACCESS_MEMORY_READ_BIT,
-        .subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-        .subresourceRange.baseMipLevel = 0,
-        .subresourceRange.levelCount = 1,
-        .subresourceRange.baseArrayLayer = 0,
-        .subresourceRange.layerCount = 1
+        .subresourceRange = {
+            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+            .baseMipLevel = 0,
+            .levelCount = 1,
+            .baseArrayLayer = 0,
+            .layerCount = 1,
+        }
     };
 
     vkCmdPipelineBarrier(mContext.work.cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -232,9 +232,11 @@ VulkanSwapChain::VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_
             .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
             .imageType = VK_IMAGE_TYPE_2D,
             .format = surfaceContext.surfaceFormat.format,
-            .extent.width = width,
-            .extent.height = height,
-            .extent.depth = 1,
+            .extent = {
+                .width = width,
+                .height = height,
+                .depth = 1,
+            },
             .mipLevels = 1,
             .arrayLayers = 1,
             .samples = VK_SAMPLE_COUNT_1_BIT,
@@ -263,12 +265,14 @@ VulkanSwapChain::VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_
         };
         VkImageViewCreateInfo ivCreateInfo = {
             .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+            .image = image,
             .viewType = VK_IMAGE_VIEW_TYPE_2D,
             .format = surfaceContext.surfaceFormat.format,
-            .subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-            .subresourceRange.levelCount = 1,
-            .subresourceRange.layerCount = 1,
-            .image = image,
+            .subresourceRange = {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .levelCount = 1,
+                .layerCount = 1,
+            }
         };
         vkCreateImageView(context.device, &ivCreateInfo, VKALLOC,
                     &surfaceContext.swapContexts[i].attachment.view);

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -72,6 +72,8 @@ private:
 };
 
 struct VulkanSwapChain : public HwSwapChain {
+    VulkanSwapChain(VulkanContext& context, VkSurfaceKHR vksurface);
+    VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_t height);
     VulkanSurfaceContext surfaceContext;
 };
 


### PR DESCRIPTION
This adds support for headless rendering as well as readPixels. These features are necessary for automated testing.

NOTE: invoking readPixels with a non-headless SwapChain seems to fail with MoltenVK. I will investigate this later.