### PR TITLE
JobSystem: work around hang on 2-CPU machines

### DIFF
--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -119,8 +119,8 @@ JobSystem::JobSystem(const size_t userThreadCount, const size_t adoptableThreads
             // since we assumed HT, always round-up to an even number of cores (to play it safe)
             hwThreads = (hwThreads + 1) / 2;
         }
-        // make sure we have at least one h/w thread (could be an assert instead)
-        hwThreads = std::max(0, hwThreads);
+        // make sure we have at least one thread in the thread pool
+        hwThreads = std::max(2, hwThreads);
         // one of the thread will be the user thread
         threadPoolCount = hwThreads - 1;
     }


### PR DESCRIPTION
If hardware_concurrency() returned 2 while UTILS_HAS_HYPER_THREADING was
enabled, `mThreadCount` was resulting in zero, so jobs (such as texture
decoding) would simply never start. This problem was noticed with
GitHub Actions.

I tested this fix locally by replacing `hardware_concurrency()` with
fixed values like 1 or 2, and verified that the hang went away.