### PR TITLE
VSM: add support for mipmaps and anisotropic sampling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release (main branch)
 
+- Removed View::setShadowType in favor of View::setShadowOptions (experimental)
+- Add anisotropic shadow map sampling with VSM (experimental)
+
 ## v1.9.5
 
 - Added a new Live Wallpaper Android sample

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release (main branch)
 
-- Removed View::setShadowType in favor of View::setShadowOptions (experimental)
+- Added View::setVsmShadowOptions (experimental)
 - Add anisotropic shadow map sampling with VSM (experimental)
 
 ## v1.9.5

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -131,9 +131,13 @@ Java_com_google_android_filament_View_nSetDynamicResolutionOptions(JNIEnv*, jcla
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_View_nSetShadowType(JNIEnv*, jclass, jlong nativeView, jint type) {
+Java_com_google_android_filament_View_nSetShadowOptions(JNIEnv*, jclass, jlong nativeView, jint type,
+        jint vsmAnisotropyLog2) {
     View* view = (View*) nativeView;
-    view->setShadowType((View::ShadowType) type);
+    View::ShadowOptions options;
+    options.shadowType = (View::ShadowType) type;
+    options.vsmAnisotropyLog2 = (uint8_t) vsmAnisotropyLog2;
+    view->setShadowOptions(options);
 }
 
 extern "C"

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -131,13 +131,18 @@ Java_com_google_android_filament_View_nSetDynamicResolutionOptions(JNIEnv*, jcla
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_View_nSetShadowOptions(JNIEnv*, jclass, jlong nativeView, jint type,
-        jint vsmAnisotropy) {
+Java_com_google_android_filament_View_nSetShadowType(JNIEnv*, jclass, jlong nativeView, jint type) {
     View* view = (View*) nativeView;
-    View::ShadowOptions options;
-    options.shadowType = (View::ShadowType) type;
-    options.vsmAnisotropy = (uint8_t) vsmAnisotropy;
-    view->setShadowOptions(options);
+    view->setShadowType((View::ShadowType) type);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nSetVsmShadowOptions(JNIEnv*, jclass, jlong nativeView,
+        jint anisotropy) {
+    View* view = (View*) nativeView;
+    View::VsmShadowOptions options;
+    options.anisotropy = (uint8_t) anisotropy;
+    view->setVsmShadowOptions(options);
 }
 
 extern "C"

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -132,11 +132,11 @@ Java_com_google_android_filament_View_nSetDynamicResolutionOptions(JNIEnv*, jcla
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetShadowOptions(JNIEnv*, jclass, jlong nativeView, jint type,
-        jint vsmAnisotropyLog2) {
+        jint vsmAnisotropy) {
     View* view = (View*) nativeView;
     View::ShadowOptions options;
     options.shadowType = (View::ShadowType) type;
-    options.vsmAnisotropyLog2 = (uint8_t) vsmAnisotropyLog2;
+    options.vsmAnisotropy = (uint8_t) vsmAnisotropy;
     view->setShadowOptions(options);
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -604,14 +604,14 @@ public class View {
          *
          * <strong>Warning: This API is still experimental and subject to change.</strong>
          */
-        public ShadowType shadowType;
+        public @NonNull ShadowType shadowType = ShadowType.PCF;
 
         /**
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
          *
          * <p>
-         * The number of anisotropic samples = 2 ^ vsmAnisotropyLog2.
+         * The number of anisotropic samples = 2 ^ vsmAnisotropy.
          * </p>
          *
          * <p>
@@ -620,7 +620,7 @@ public class View {
          *
          * <strong>Warning: This API is still experimental and subject to change.</strong>
          */
-        public int vsmAnisotropyLog2;
+        public int vsmAnisotropy = 0;
     }
 
     /**
@@ -1215,7 +1215,7 @@ public class View {
     public void setShadowOptions(@NonNull ShadowOptions options) {
         mShadowOptions = options;
         nSetShadowOptions(getNativeObject(), options.shadowType.ordinal(),
-                options.vsmAnisotropyLog2);
+                options.vsmAnisotropy);
     }
 
     /**
@@ -1422,7 +1422,7 @@ public class View {
     private static native void nSetDynamicResolutionOptions(long nativeView, boolean enabled, boolean homogeneousScaling, float minScale, float maxScale, int quality);
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
-    private static native void nSetShadowOptions(long nativeView, int type, int vsmAnisotropyLog2);
+    private static native void nSetShadowOptions(long nativeView, int type, int vsmAnisotropy);
     private static native void nSetColorGrading(long nativeView, long nativeColorGrading);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -75,7 +75,7 @@ public class View {
     private VignetteOptions mVignetteOptions;
     private ColorGrading mColorGrading;
     private TemporalAntiAliasingOptions mTemporalAntiAliasingOptions;
-    private ShadowOptions mShadowOptions;
+    private VsmShadowOptions mVsmShadowOptions;
 
     /**
      * Generic quality level.
@@ -569,7 +569,7 @@ public class View {
     /**
      * List of available shadow mapping techniques.
      *
-     * @see ShadowOptions
+     * @see #setShadowType
      */
     public enum ShadowType {
         /**
@@ -584,28 +584,11 @@ public class View {
     }
 
     /**
-     * View-level options for Shadowing.
+     * View-level options for VSM shadowing.
      *
-     * @see View#setShadowOptions
+     * @see View#setVsmShadowOptions
      */
-    public static class ShadowOptions {
-        /**
-         * The shadow mapping technique this View uses.
-         *
-         * The ShadowType affects all the shadows seen within the View.
-         *
-         * <p>
-         * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow
-         * receivers (but not casters). To ensure correct shadowing with VSM, all shadow participant
-         * renderables should be marked as both receivers and casters. Objects that are guaranteed
-         * to not cast shadows on themselves or other objects (such as flat ground planes) can be
-         * set to not cast shadows, which might improve shadow quality.
-         * </p>
-         *
-         * <strong>Warning: This API is still experimental and subject to change.</strong>
-         */
-        public @NonNull ShadowType shadowType = ShadowType.PCF;
-
+    public static class VsmShadowOptions {
         /**
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
@@ -614,13 +597,9 @@ public class View {
          * The number of anisotropic samples = 2 ^ vsmAnisotropy.
          * </p>
          *
-         * <p>
-         * Only applicable when shadowType is set to ShadowType::VSM.
-         * </p>
-         *
          * <strong>Warning: This API is still experimental and subject to change.</strong>
          */
-        public int vsmAnisotropy = 0;
+        public int anisotropy = 0;
     }
 
     /**
@@ -1205,30 +1184,53 @@ public class View {
     }
 
     /**
-     * Sets shadowing options that apply across the entire View.
+     * Sets the shadow mapping technique this View uses.
      *
-     * Additional light-specific shadow options can be set with
-     * {@link LightManager.Builder#shadowOptions}.
+     * The ShadowType affects all the shadows seen within the View.
      *
-     * @param options Options for shadowing.
+     * <p>
+     * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow receivers
+     * (but not casters). To ensure correct shadowing with VSM, all shadow participant renderables
+     * should be marked as both receivers and casters. Objects that are guaranteed to not cast
+     * shadows on themselves or other objects (such as flat ground planes) can be set to not cast
+     * shadows, which might improve shadow quality.
+     * </p>
+     *
+     * <strong>Warning: This API is still experimental and subject to change.</strong>
      */
-    public void setShadowOptions(@NonNull ShadowOptions options) {
-        mShadowOptions = options;
-        nSetShadowOptions(getNativeObject(), options.shadowType.ordinal(),
-                options.vsmAnisotropy);
+    public void setShadowType(ShadowType type) {
+        nSetShadowType(getNativeObject(), type.ordinal());
     }
 
     /**
-     * Gets the shadow options.
-     * @see #setShadowOptions
-     * @return shadow options currently set.
+     * Sets VSM shadowing options that apply across the entire View.
+     *
+     * Additional light-specific VSM options can be set with
+     * {@link LightManager.Builder#shadowOptions}.
+     *
+     * Only applicable when shadow type is set to ShadowType::VSM.
+     *
+     * <strong>Warning: This API is still experimental and subject to change.</strong>
+     *
+     * @param options Options for shadowing.
+     * @see #setShadowType
+     */
+    public void setVsmShadowOptions(@NonNull VsmShadowOptions options) {
+        mVsmShadowOptions = options;
+        nSetVsmShadowOptions(getNativeObject(), options.anisotropy);
+    }
+
+    /**
+     * Gets the VSM shadowing options.
+     * @see #setVsmShadowOptions
+     * @return VSM shadow options currently set.
      */
     @NonNull
-    public ShadowOptions getShadowOptions() {
-        if (mShadowOptions == null) {
-            mShadowOptions = new ShadowOptions();
+    public VsmShadowOptions getVsmShadowOptions() {
+        if (mVsmShadowOptions == null) {
+            mVsmShadowOptions = new VsmShadowOptions();
         }
-        return mShadowOptions;
+        return mVsmShadowOptions;
     }
 
     /**
@@ -1422,7 +1424,8 @@ public class View {
     private static native void nSetDynamicResolutionOptions(long nativeView, boolean enabled, boolean homogeneousScaling, float minScale, float maxScale, int quality);
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
-    private static native void nSetShadowOptions(long nativeView, int type, int vsmAnisotropy);
+    private static native void nSetShadowType(long nativeView, int type);
+    private static native void nSetVsmShadowOptions(long nativeView, int anisotropy);
     private static native void nSetColorGrading(long nativeView, long nativeColorGrading);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -75,6 +75,7 @@ public class View {
     private VignetteOptions mVignetteOptions;
     private ColorGrading mColorGrading;
     private TemporalAntiAliasingOptions mTemporalAntiAliasingOptions;
+    private ShadowOptions mShadowOptions;
 
     /**
      * Generic quality level.
@@ -568,7 +569,7 @@ public class View {
     /**
      * List of available shadow mapping techniques.
      *
-     * @see #setShadowType
+     * @see ShadowOptions
      */
     public enum ShadowType {
         /**
@@ -580,6 +581,46 @@ public class View {
          * Variance shadows.
          */
         VSM
+    }
+
+    /**
+     * View-level options for Shadowing.
+     *
+     * @see View#setShadowOptions
+     */
+    public static class ShadowOptions {
+        /**
+         * The shadow mapping technique this View uses.
+         *
+         * The ShadowType affects all the shadows seen within the View.
+         *
+         * <p>
+         * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow
+         * receivers (but not casters). To ensure correct shadowing with VSM, all shadow participant
+         * renderables should be marked as both receivers and casters. Objects that are guaranteed
+         * to not cast shadows on themselves or other objects (such as flat ground planes) can be
+         * set to not cast shadows, which might improve shadow quality.
+         * </p>
+         *
+         * <strong>Warning: This API is still experimental and subject to change.</strong>
+         */
+        public ShadowType shadowType;
+
+        /**
+         * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
+         * than 0, mipmaps will automatically be generated each frame for all lights.
+         *
+         * <p>
+         * The number of anisotropic samples = 2 ^ vsmAnisotropyLog2.
+         * </p>
+         *
+         * <p>
+         * Only applicable when shadowType is set to ShadowType::VSM.
+         * </p>
+         *
+         * <strong>Warning: This API is still experimental and subject to change.</strong>
+         */
+        public int vsmAnisotropyLog2;
     }
 
     /**
@@ -1164,22 +1205,30 @@ public class View {
     }
 
     /**
-     * Sets the shadow mapping technique this View uses.
+     * Sets shadowing options that apply across the entire View.
      *
-     * The ShadowType affects all the shadows seen within the View.
+     * Additional light-specific shadow options can be set with
+     * {@link LightManager.Builder#shadowOptions}.
      *
-     * <p>
-     * {@link ShadowType#VSM} imposes a restriction on marking renderables as only shadow receivers
-     * (but not casters). To ensure correct shadowing with VSM, all shadow participant renderables
-     * should be marked as both receivers and casters. Objects that are guaranteed to not cast
-     * shadows on themselves or other objects (such as flat ground planes) can be set to not cast
-     * shadows, which might improve shadow quality.
-     * </p>
-     *
-     * <strong>Warning: This API is still experimental and subject to change.</strong>
+     * @param options Options for shadowing.
      */
-    public void setShadowType(ShadowType type) {
-        nSetShadowType(getNativeObject(), type.ordinal());
+    public void setShadowOptions(@NonNull ShadowOptions options) {
+        mShadowOptions = options;
+        nSetShadowOptions(getNativeObject(), options.shadowType.ordinal(),
+                options.vsmAnisotropyLog2);
+    }
+
+    /**
+     * Gets the shadow options.
+     * @see #setShadowOptions
+     * @return shadow options currently set.
+     */
+    @NonNull
+    public ShadowOptions getShadowOptions() {
+        if (mShadowOptions == null) {
+            mShadowOptions = new ShadowOptions();
+        }
+        return mShadowOptions;
     }
 
     /**
@@ -1373,7 +1422,7 @@ public class View {
     private static native void nSetDynamicResolutionOptions(long nativeView, boolean enabled, boolean homogeneousScaling, float minScale, float maxScale, int quality);
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
-    private static native void nSetShadowType(long nativeView, int type);
+    private static native void nSetShadowOptions(long nativeView, int type, int vsmAnisotropyLog2);
     private static native void nSetColorGrading(long nativeView, long nativeColorGrading);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -23,6 +23,7 @@ import android.view.Choreographer
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.SurfaceView
+import com.google.android.filament.View
 import com.google.android.filament.utils.KtxLoader
 import com.google.android.filament.utils.ModelViewer
 import com.google.android.filament.utils.Utils
@@ -72,6 +73,11 @@ class MainActivity : Activity() {
         val bloomOptions = modelViewer.view.bloomOptions
         bloomOptions.enabled = true
         modelViewer.view.bloomOptions = bloomOptions
+
+        val shadowOptions = View.ShadowOptions()
+        shadowOptions.shadowType = View.ShadowType.VSM
+        shadowOptions.vsmAnisotropyLog2 = 1
+        modelViewer.view.shadowOptions = shadowOptions
     }
 
     private fun createRenderables() {

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -23,7 +23,6 @@ import android.view.Choreographer
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.SurfaceView
-import com.google.android.filament.View
 import com.google.android.filament.utils.KtxLoader
 import com.google.android.filament.utils.ModelViewer
 import com.google.android.filament.utils.Utils
@@ -73,11 +72,6 @@ class MainActivity : Activity() {
         val bloomOptions = modelViewer.view.bloomOptions
         bloomOptions.enabled = true
         modelViewer.view.bloomOptions = bloomOptions
-
-        val shadowOptions = View.ShadowOptions()
-        shadowOptions.shadowType = View.ShadowType.VSM
-        shadowOptions.vsmAnisotropyLog2 = 1
-        modelViewer.view.shadowOptions = shadowOptions
     }
 
     private fun createRenderables() {

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -170,6 +170,7 @@ set(MATERIAL_SRCS
         src/materials/separableGaussianBlur.mat
         src/materials/antiAliasing/fxaa.mat
         src/materials/antiAliasing/taa.mat
+        src/materials/vsmMipmap.mat
 )
 
 # Embed the binary resource blob for materials.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -272,7 +272,7 @@ public:
 
     /**
      * List of available shadow mapping techniques.
-     * @see ShadowOptions
+     * @see setShadowType
      */
     enum class ShadowType : uint8_t {
         PCF,        //!< percentage-closer filtered shadows (default)
@@ -280,36 +280,19 @@ public:
     };
 
     /**
-     * View-level options for Shadowing.
-     * @see setShadowOptions()
+     * View-level options for VSM Shadowing.
+     * @see setVsmShadowOptions()
      */
-    struct ShadowOptions {
-        /*
-         * The shadow mapping technique this View uses.
-         *
-         * The ShadowType affects all the shadows seen within the View.
-         *
-         * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers
-         * (but not casters). To ensure correct shadowing with VSM, all shadow participant
-         * renderables should be marked as both receivers and casters. Objects that are guaranteed
-         * to not cast shadows on themselves or other objects (such as flat ground planes) can be
-         * set to not cast shadows, which might improve shadow quality.
-         *
-         * @warning This API is still experimental and subject to change.
-         */
-        ShadowType shadowType = ShadowType::PCF;
-
+    struct VsmShadowOptions {
         /**
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
          *
          * The number of anisotropic samples = 2 ^ vsmAnisotropy.
          *
-         * Only applicable when shadowType is set to ShadowType::VSM.
-         *
          * @warning This API is still experimental and subject to change.
          */
-        uint8_t vsmAnisotropy = 0;
+        uint8_t anisotropy = 0;
     };
 
     /**
@@ -720,21 +703,42 @@ public:
      */
     void setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept;
 
-    /**
-     * Sets shadowing options that apply across the entire View.
+    /*
+     * Set the shadow mapping technique this View uses.
      *
-     * Additional light-specific shadow options can be set with LightManager::setShadowOptions.
+     * The ShadowType affects all the shadows seen within the View.
      *
-     * @param options Options for shadowing.
+     * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers (but
+     * not casters). To ensure correct shadowing with VSM, all shadow participant renderables should
+     * be marked as both receivers and casters. Objects that are guaranteed to not cast shadows on
+     * themselves or other objects (such as flat ground planes) can be set to not cast shadows,
+     * which might improve shadow quality.
+     *
+     * @warning This API is still experimental and subject to change.
      */
-    void setShadowOptions(ShadowOptions const& options) noexcept;
+    void setShadowType(ShadowType shadow) noexcept;
 
     /**
-     * Returns the shadow options associated with this View.
+     * Sets VSM shadowing options that apply across the entire View.
      *
-     * @return value set by setShadowOptions().
+     * Additional light-specific VSM options can be set with LightManager::setShadowOptions.
+     *
+     * Only applicable when shadow type is set to ShadowType::VSM.
+     *
+     * @param options Options for shadowing.
+     *
+     * @see setShadowType
+     *
+     * @warning This API is still experimental and subject to change.
      */
-    ShadowOptions getShadowOptions() const noexcept;
+    void setVsmShadowOptions(VsmShadowOptions const& options) noexcept;
+
+    /**
+     * Returns the VSM shadowing options associated with this View.
+     *
+     * @return value set by setVsmShadowOptions().
+     */
+    VsmShadowOptions getVsmShadowOptions() const noexcept;
 
     /**
      * Enables or disables post processing. Enabled by default.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -303,13 +303,13 @@ public:
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
          *
-         * The number of anisotropic samples = 2 ^ vsmAnisotropyLog2.
+         * The number of anisotropic samples = 2 ^ vsmAnisotropy.
          *
          * Only applicable when shadowType is set to ShadowType::VSM.
          *
          * @warning This API is still experimental and subject to change.
          */
-        uint8_t vsmAnisotropyLog2 = 0;
+        uint8_t vsmAnisotropy = 0;
     };
 
     /**

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -272,11 +272,44 @@ public:
 
     /**
      * List of available shadow mapping techniques.
-     * @see setShadowType
+     * @see ShadowOptions
      */
     enum class ShadowType : uint8_t {
         PCF,        //!< percentage-closer filtered shadows (default)
         VSM         //!< variance shadows
+    };
+
+    /**
+     * View-level options for Shadowing.
+     * @see setShadowOptions()
+     */
+    struct ShadowOptions {
+        /*
+         * The shadow mapping technique this View uses.
+         *
+         * The ShadowType affects all the shadows seen within the View.
+         *
+         * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers
+         * (but not casters). To ensure correct shadowing with VSM, all shadow participant
+         * renderables should be marked as both receivers and casters. Objects that are guaranteed
+         * to not cast shadows on themselves or other objects (such as flat ground planes) can be
+         * set to not cast shadows, which might improve shadow quality.
+         *
+         * @warning This API is still experimental and subject to change.
+         */
+        ShadowType shadowType = ShadowType::PCF;
+
+        /**
+         * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
+         * than 0, mipmaps will automatically be generated each frame for all lights.
+         *
+         * The number of anisotropic samples = 2 ^ vsmAnisotropyLog2.
+         *
+         * Only applicable when shadowType is set to ShadowType::VSM.
+         *
+         * @warning This API is still experimental and subject to change.
+         */
+        uint8_t vsmAnisotropyLog2 = 0;
     };
 
     /**
@@ -687,20 +720,21 @@ public:
      */
     void setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept;
 
-    /*
-     * Set the shadow mapping technique this View uses.
+    /**
+     * Sets shadowing options that apply across the entire View.
      *
-     * The ShadowType affects all the shadows seen within the View.
+     * Additional light-specific shadow options can be set with LightManager::setShadowOptions.
      *
-     * ShadowType::VSM imposes a restriction on marking renderables as only shadow receivers (but
-     * not casters). To ensure correct shadowing with VSM, all shadow participant renderables should
-     * be marked as both receivers and casters. Objects that are guaranteed to not cast shadows on
-     * themselves or other objects (such as flat ground planes) can be set to not cast shadows,
-     * which might improve shadow quality.
-     *
-     * @warning This API is still experimental and subject to change.
+     * @param options Options for shadowing.
      */
-    void setShadowType(ShadowType shadow) noexcept;
+    void setShadowOptions(ShadowOptions const& options) noexcept;
+
+    /**
+     * Returns the shadow options associated with this View.
+     *
+     * @return value set by setShadowOptions().
+     */
+    ShadowOptions getShadowOptions() const noexcept;
 
     /**
      * Enables or disables post processing. Enabled by default.

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1985,6 +1985,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
                         });
                 mi->setParameter("level", uint32_t(level));
                 mi->setParameter("layer", uint32_t(layer));
+                mi->setParameter("uvscale", 1.0f / dim);
 
                 // When generating shadow map mip levels, we want to preserve the 1 texel border.
                 auto vpWidth = (uint32_t) std::max(0, dim - 2);

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1980,8 +1980,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
                 auto& material = getPostProcessMaterial("vsmMipmap");
                 FMaterialInstance* const mi = material.getMaterialInstance();
                 mi->setParameter("color", in, {
-                        .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST,
-                        .filterMag = SamplerMagFilter::LINEAR
+                        .filterMag = SamplerMagFilter::LINEAR,
+                        .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
                         });
                 mi->setParameter("level", uint32_t(level));
                 mi->setParameter("layer", uint32_t(layer));

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1962,8 +1962,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
 
                 data.rt = builder.createRenderTarget(name, {
                     .attachments = {{ data.out, uint8_t(level + 1), layer }},
-                    .clearFlags = TargetBufferFlags::COLOR,
-                    .clearColor = { 1.0f, 1.0f, 1.0f, 1.0f }
+                    .clearColor = { 1.0f, 1.0f, 1.0f, 1.0f },
+                    .clearFlags = TargetBufferFlags::COLOR
                 });
             },
             [=](FrameGraphPassResources const& resources,

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -123,6 +123,10 @@ public:
     FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
 
+    // VSM shadow mipmap pass
+    FrameGraphId<FrameGraphTexture> vsmMipmapPass(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t level) noexcept;
+
     backend::Handle<backend::HwTexture> getOneTexture() const { return mDummyOneTexture; }
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
     backend::Handle<backend::HwTexture> getOneTextureArray() const { return mDummyOneTextureArray; }

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -260,7 +260,7 @@ void ShadowMapManager::prepareShadow(backend::Handle<backend::HwTexture> texture
     uint8_t anisotropy = 0;
     SamplerMinFilter filterMin = SamplerMinFilter::LINEAR;
     if (view.hasVsm()) {
-        anisotropy = view.getShadowOptions().vsmAnisotropy;
+        anisotropy = view.getVsmShadowOptions().anisotropy;
         if (anisotropy > 0) {
             filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR;
         }
@@ -569,7 +569,7 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
     const uint8_t layersNeeded = layer;
 
     // Only generate mipmaps for VSM when anisotropy is enabled.
-    const bool useMipmapping = view.hasVsm() && view.getShadowOptions().vsmAnisotropy > 0;
+    const bool useMipmapping = view.hasVsm() && view.getVsmShadowOptions().anisotropy > 0;
 
     uint8_t mipLevels = 1u;
     if (useMipmapping) {

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -260,7 +260,7 @@ void ShadowMapManager::prepareShadow(backend::Handle<backend::HwTexture> texture
     uint8_t anisotropy = 0;
     SamplerMinFilter filterMin = SamplerMinFilter::LINEAR;
     if (view.hasVsm()) {
-        anisotropy = view.getShadowOptions().vsmAnisotropyLog2;
+        anisotropy = view.getShadowOptions().vsmAnisotropy;
         if (anisotropy > 0) {
             filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR;
         }
@@ -569,7 +569,7 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view
     const uint8_t layersNeeded = layer;
 
     // Only generate mipmaps for VSM when anisotropy is enabled.
-    const bool useMipmapping = view.hasVsm() && view.getShadowOptions().vsmAnisotropyLog2 > 0;
+    const bool useMipmapping = view.hasVsm() && view.getShadowOptions().vsmAnisotropy > 0;
 
     uint8_t mipLevels = 1u;
     if (useMipmapping) {

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -16,6 +16,7 @@
 
 #include "details/ShadowMap.h"
 #include "details/ShadowMapManager.h"
+#include "details/Texture.h"
 #include "details/View.h"
 
 #include "RenderPass.h"
@@ -47,7 +48,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
         FEngine& engine, FView& view, UniformBuffer& perViewUb,
         UniformBuffer& shadowUb, FScene::RenderableSoa& renderableData,
         FScene::LightSoa& lightData) noexcept {
-    calculateTextureRequirements(engine, lightData);
+    calculateTextureRequirements(engine, view, lightData);
     ShadowTechnique shadowTechnique = {};
     shadowTechnique |= updateCascadeShadowMaps(engine, view, perViewUb, renderableData, lightData);
     shadowTechnique |= updateSpotShadowMaps(engine, view, shadowUb, renderableData, lightData);
@@ -131,7 +132,7 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
                 FrameGraphTexture::Descriptor shadowTextureDesc {
                     .width = mTextureRequirements.size, .height = mTextureRequirements.size,
                     .depth = mTextureRequirements.layers,
-                    .levels = 1,
+                    .levels = mTextureRequirements.levels,
                     .type = SamplerType::SAMPLER_2D_ARRAY,
                     .format = mTextureFormat,
                     .usage = TextureUsage::DEPTH_ATTACHMENT | TextureUsage::SAMPLEABLE
@@ -240,15 +241,35 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
         shadows = debugPatternPass.getData().shadows;
     }
 
+    // If the shadow texture has more than one level, then anisotropy was specified and we should
+    // generate VSM mipmaps.
+    if (mTextureRequirements.levels > 1) {
+        auto& ppm = engine.getPostProcessManager();
+        for (uint8_t layer = 0; layer < mTextureRequirements.layers; layer++) {
+            for (size_t level = 0; level < mTextureRequirements.levels - 1; level++) {
+                shadows = ppm.vsmMipmapPass(fg, shadows, layer, level);
+            }
+        }
+    }
+
     fg.getBlackboard().put("shadows", shadows);
 }
 
 void ShadowMapManager::prepareShadow(backend::Handle<backend::HwTexture> texture,
-        backend::SamplerGroup& viewSib) const noexcept {
-    viewSib.setSampler(PerViewSib::SHADOW_MAP, {
+        FView const& view) const noexcept {
+    uint8_t anisotropy = 0;
+    SamplerMinFilter filterMin = SamplerMinFilter::LINEAR;
+    if (view.hasVsm()) {
+        anisotropy = view.getShadowOptions().vsmAnisotropyLog2;
+        if (anisotropy > 0) {
+            filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR;
+        }
+    }
+    view.getViewSamplers().setSampler(PerViewSib::SHADOW_MAP, {
             texture, {
                     .filterMag = SamplerMagFilter::LINEAR,
-                    .filterMin = SamplerMinFilter::LINEAR,
+                    .filterMin = filterMin,
+                    .anisotropyLog2 = anisotropy,
                     .compareMode = SamplerCompareMode::COMPARE_TO_TEXTURE,
                     .compareFunc = SamplerCompareFunc::GE
             }});
@@ -500,7 +521,7 @@ void ShadowMapManager::fillWithDebugPattern(backend::DriverApi& driverApi,
     }
 }
 
-void ShadowMapManager::calculateTextureRequirements(FEngine& engine,
+void ShadowMapManager::calculateTextureRequirements(FEngine& engine, FView& view,
         FScene::LightSoa& lightData) noexcept {
     auto& lcm = engine.getLightManager();
 
@@ -546,9 +567,22 @@ void ShadowMapManager::calculateTextureRequirements(FEngine& engine,
     }
 
     const uint8_t layersNeeded = layer;
+
+    // Only generate mipmaps for VSM when anisotropy is enabled.
+    const bool useMipmapping = view.hasVsm() && view.getShadowOptions().vsmAnisotropyLog2 > 0;
+
+    uint8_t mipLevels = 1u;
+    if (useMipmapping) {
+        // Limit the lowest mipmap level to 256x256.
+        // This avoids artifacts on high derivative tangent surfaces.
+        int lowMipmapLevel = 7;    // log2(256) - 1
+        mipLevels = std::max(1, FTexture::maxLevelCount(maxDimension) - lowMipmapLevel);
+    }
+
     mTextureRequirements = {
         maxDimension,
-        layersNeeded
+        layersNeeded,
+        mipLevels
     };
 }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -677,7 +677,7 @@ void FView::prepareStructure(backend::Handle<backend::HwTexture> structure) cons
 }
 
 void FView::prepareShadow(backend::Handle<backend::HwTexture> texture) const noexcept {
-    mShadowMapManager.prepareShadow(texture, mPerViewSb);
+    mShadowMapManager.prepareShadow(texture, *this);
 }
 
 void FView::cleanupRenderPasses() const noexcept {
@@ -993,6 +993,14 @@ void View::setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept
     upcast(this)->setDynamicLightingOptions(zLightNear, zLightFar);
 }
 
+void View::setShadowOptions(ShadowOptions const& options) noexcept {
+    upcast(this)->setShadowOptions(options);
+}
+
+View::ShadowOptions View::getShadowOptions() const noexcept {
+    return upcast(this)->getShadowOptions();
+}
+
 void View::setAmbientOcclusion(View::AmbientOcclusion ambientOcclusion) noexcept {
     upcast(this)->setAmbientOcclusion(ambientOcclusion);
 }
@@ -1003,10 +1011,6 @@ View::AmbientOcclusion View::getAmbientOcclusion() const noexcept {
 
 void View::setAmbientOcclusionOptions(View::AmbientOcclusionOptions const& options) noexcept {
     upcast(this)->setAmbientOcclusionOptions(options);
-}
-
-void View::setShadowType(View::ShadowType shadow) noexcept {
-    upcast(this)->setShadowType(shadow);
 }
 
 View::AmbientOcclusionOptions const& View::getAmbientOcclusionOptions() const noexcept {

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -993,12 +993,16 @@ void View::setDynamicLightingOptions(float zLightNear, float zLightFar) noexcept
     upcast(this)->setDynamicLightingOptions(zLightNear, zLightFar);
 }
 
-void View::setShadowOptions(ShadowOptions const& options) noexcept {
-    upcast(this)->setShadowOptions(options);
+void View::setShadowType(View::ShadowType shadow) noexcept {
+    upcast(this)->setShadowType(shadow);
 }
 
-View::ShadowOptions View::getShadowOptions() const noexcept {
-    return upcast(this)->getShadowOptions();
+void View::setVsmShadowOptions(VsmShadowOptions const& options) noexcept {
+    upcast(this)->setVsmShadowOptions(options);
+}
+
+View::VsmShadowOptions View::getVsmShadowOptions() const noexcept {
+    return upcast(this)->getVsmShadowOptions();
 }
 
 void View::setAmbientOcclusion(View::AmbientOcclusion ambientOcclusion) noexcept {

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -74,8 +74,8 @@ public:
             RenderPass& pass) noexcept;
 
     // Prepares the shadow sampler.
-    void prepareShadow(backend::Handle<backend::HwTexture> texture,
-            backend::SamplerGroup& viewSib) const noexcept;
+    void prepareShadow(backend::Handle<backend::HwTexture> texture, FView const& view)
+        const noexcept;
 
     const ShadowMap* getCascadeShadowMap(size_t c) const noexcept {
         return mCascadeShadowMapCache[c].get();
@@ -92,6 +92,7 @@ private:
     struct TextureRequirements {
         uint16_t size = 0;
         uint8_t layers = 0;
+        uint8_t levels = 0;
     } mTextureRequirements;
 
     ShadowTechnique updateCascadeShadowMaps(FEngine& engine, FView& view, UniformBuffer& perViewUb,
@@ -101,7 +102,7 @@ private:
     static void fillWithDebugPattern(backend::DriverApi& driverApi,
             backend::Handle<backend::HwTexture> texture, size_t dimensions) noexcept;
 
-    void calculateTextureRequirements(FEngine& engine, FScene::LightSoa& lightData) noexcept;
+    void calculateTextureRequirements(FEngine& engine, FView& view, FScene::LightSoa& lightData) noexcept;
 
     class ShadowMapEntry {
     public:

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -177,7 +177,7 @@ public:
     bool hasShadowing() const noexcept { return mHasShadowing; }
     bool needsShadowMap() const noexcept { return mNeedsShadowMap; }
     bool hasFog() const noexcept { return mFogOptions.enabled && mFogOptions.density > 0.0f; }
-    bool hasVsm() const noexcept { return mShadowOptions.shadowType == ShadowType::VSM; }
+    bool hasVsm() const noexcept { return mShadowType == ShadowType::VSM; }
 
     void renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
             RenderPass& pass) noexcept;
@@ -312,15 +312,19 @@ public:
     }
 
     ShadowType getShadowType() const noexcept {
-        return mShadowOptions.shadowType;
+        return mShadowType;
     }
 
-    void setShadowOptions(ShadowOptions const& options) noexcept {
-        mShadowOptions = options;
+    void setShadowType(ShadowType shadow) noexcept {
+        mShadowType = shadow;
     }
 
-    ShadowOptions getShadowOptions() const noexcept {
-        return mShadowOptions;
+    void setVsmShadowOptions(VsmShadowOptions const& options) noexcept {
+        mVsmShadowOptions = options;
+    }
+
+    VsmShadowOptions getVsmShadowOptions() const noexcept {
+        return mVsmShadowOptions;
     }
 
     AmbientOcclusionOptions const& getAmbientOcclusionOptions() const noexcept {
@@ -482,7 +486,8 @@ private:
     bool mScreenSpaceRefractionEnabled = true;
     bool mHasPostProcessPass = true;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
-    ShadowOptions mShadowOptions = {};
+    ShadowType mShadowType = ShadowType::PCF;
+    VsmShadowOptions mVsmShadowOptions = {};
     BloomOptions mBloomOptions;
     FogOptions mFogOptions;
     DepthOfFieldOptions mDepthOfFieldOptions;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -177,7 +177,7 @@ public:
     bool hasShadowing() const noexcept { return mHasShadowing; }
     bool needsShadowMap() const noexcept { return mNeedsShadowMap; }
     bool hasFog() const noexcept { return mFogOptions.enabled && mFogOptions.density > 0.0f; }
-    bool hasVsm() const noexcept { return mShadowType == ShadowType::VSM; }
+    bool hasVsm() const noexcept { return mShadowOptions.shadowType == ShadowType::VSM; }
 
     void renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
             RenderPass& pass) noexcept;
@@ -312,11 +312,15 @@ public:
     }
 
     ShadowType getShadowType() const noexcept {
-        return mShadowType;
+        return mShadowOptions.shadowType;
     }
 
-    void setShadowType(ShadowType shadow) noexcept {
-        mShadowType = shadow;
+    void setShadowOptions(ShadowOptions const& options) noexcept {
+        mShadowOptions = options;
+    }
+
+    ShadowOptions getShadowOptions() const noexcept {
+        return mShadowOptions;
     }
 
     AmbientOcclusionOptions const& getAmbientOcclusionOptions() const noexcept {
@@ -478,7 +482,7 @@ private:
     bool mScreenSpaceRefractionEnabled = true;
     bool mHasPostProcessPass = true;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
-    ShadowType mShadowType = ShadowType::PCF;
+    ShadowOptions mShadowOptions = {};
     BloomOptions mBloomOptions;
     FogOptions mFogOptions;
     DepthOfFieldOptions mDepthOfFieldOptions;

--- a/filament/src/materials/vsmMipmap.mat
+++ b/filament/src/materials/vsmMipmap.mat
@@ -1,0 +1,40 @@
+material {
+    name : vsmMipmap,
+    parameters : [
+        {
+            type : sampler2dArray,
+            name : color,
+            precision: high
+        },
+        {
+            type : int,
+            name : layer
+        },
+        {
+            type : int,
+            name : level
+        }
+    ],
+    outputs : [
+        {
+            name : color,
+            target : color,
+            type : float4
+        }
+    ],
+    domain : postprocess,
+    depthWrite : false,
+    depthCulling : false,
+    culling: none
+}
+
+fragment {
+    void postProcess(inout PostProcessInputs postProcess) {
+        highp vec2 uv = gl_FragCoord.xy * 2.0f /
+            vec2(textureSize(materialParams_color, materialParams.level).xy);
+
+        postProcess.color = textureLod(materialParams_color,
+                vec3(uv, materialParams.layer),
+                float(materialParams.level));
+    }
+}

--- a/filament/src/materials/vsmMipmap.mat
+++ b/filament/src/materials/vsmMipmap.mat
@@ -13,6 +13,10 @@ material {
         {
             type : int,
             name : level
+        },
+        {
+            type : float,
+            name : uvscale
         }
     ],
     outputs : [
@@ -30,9 +34,7 @@ material {
 
 fragment {
     void postProcess(inout PostProcessInputs postProcess) {
-        highp vec2 uv = gl_FragCoord.xy * 2.0f /
-            vec2(textureSize(materialParams_color, materialParams.level).xy);
-
+        highp vec2 uv = gl_FragCoord.xy * materialParams.uvscale;
         postProcess.color = textureLod(materialParams_color,
                 vec3(uv, materialParams.layer),
                 float(materialParams.level));

--- a/libs/filamat/src/Enums.cpp
+++ b/libs/filamat/src/Enums.cpp
@@ -83,6 +83,7 @@ std::unordered_map<std::string, UniformType>& Enums::getMap<UniformType>() noexc
 
 std::unordered_map<std::string, SamplerType> Enums::mStringToSamplerType = {
         { "sampler2d",       SamplerType::SAMPLER_2D },
+        { "sampler2dArray",  SamplerType::SAMPLER_2D_ARRAY },
         { "sampler3d",       SamplerType::SAMPLER_3D },
         { "samplerCubemap",  SamplerType::SAMPLER_CUBEMAP },
         { "samplerExternal", SamplerType::SAMPLER_EXTERNAL },

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -49,7 +49,7 @@ using ShadowType = filament::View::ShadowType;
 using TemporalAntiAliasingOptions = filament::View::TemporalAntiAliasingOptions;
 using ToneMapping = filament::ColorGrading::ToneMapping;
 using VignetteOptions = filament::View::VignetteOptions;
-using ShadowOptions = filament::View::ShadowOptions;
+using VsmShadowOptions = filament::View::VsmShadowOptions;
 
 // Reads the given JSON blob and updates the corresponding fields in the given Settings object.
 // - The given JSON blob need not specify all settings.
@@ -122,7 +122,8 @@ struct ViewSettings {
     Dithering dithering = Dithering::TEMPORAL;
     RenderQuality renderQuality;
     DynamicLightingSettings dynamicLighting;
-    ShadowOptions shadowOptions;
+    ShadowType shadowType = ShadowTypePCF;
+    VsmShadowOptions vsmShadowOptions;
     bool postProcessingEnabled = true;
 };
 

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -49,6 +49,7 @@ using ShadowType = filament::View::ShadowType;
 using TemporalAntiAliasingOptions = filament::View::TemporalAntiAliasingOptions;
 using ToneMapping = filament::ColorGrading::ToneMapping;
 using VignetteOptions = filament::View::VignetteOptions;
+using ShadowOptions = filament::View::ShadowOptions;
 
 // Reads the given JSON blob and updates the corresponding fields in the given Settings object.
 // - The given JSON blob need not specify all settings.
@@ -121,7 +122,7 @@ struct ViewSettings {
     Dithering dithering = Dithering::TEMPORAL;
     RenderQuality renderQuality;
     DynamicLightingSettings dynamicLighting;
-    ShadowType shadowType = ShadowType::PCF;
+    ShadowOptions shadowOptions;
     bool postProcessingEnabled = true;
 };
 

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -122,7 +122,7 @@ struct ViewSettings {
     Dithering dithering = Dithering::TEMPORAL;
     RenderQuality renderQuality;
     DynamicLightingSettings dynamicLighting;
-    ShadowType shadowType = ShadowTypePCF;
+    ShadowType shadowType = ShadowType::PCF;
     VsmShadowOptions vsmShadowOptions;
     bool postProcessingEnabled = true;
 };

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -200,8 +200,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
         CHECK_KEY(tok);
         if (0 == compare(tok, jsonChunk, "shadowType")) {
             i = parse(tokens, i + 1, jsonChunk, &out->shadowType);
-        } else if (0 == compare(tok, jsonChunk, "vsmAnisotropyLog2")) {
-            i = parse(tokens, i + 1, jsonChunk, &out->vsmAnisotropyLog2);
+        } else if (0 == compare(tok, jsonChunk, "vsmAnisotropy")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->vsmAnisotropy);
         } else {
             slog.w << "Invalid shadow options key: '" << STR(tok, jsonChunk) << "'" << io::endl;
             i = parse(tokens, i + 1);
@@ -1034,7 +1034,7 @@ std::string writeJson(const ShadowOptions& in) {
     std::ostringstream oss;
     oss << "{\n"
         << "\"shadowType\": " << writeJson(in.shadowType) << ",\n"
-        << "\"vsmAnisotropyLog2\": " << writeJson(in.vsmAnisotropyLog2) << "\n"
+        << "\"vsmAnisotropy\": " << writeJson(in.vsmAnisotropy) << "\n"
         << "}";
     return oss.str();
 }

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -192,16 +192,14 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ShadowTy
 }
 
 static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
-        ShadowOptions* out) {
+        VsmShadowOptions* out) {
     CHECK_TOKTYPE(tokens[i], JSMN_OBJECT);
     int size = tokens[i++].size;
     for (int j = 0; j < size; ++j) {
         const jsmntok_t tok = tokens[i];
         CHECK_KEY(tok);
-        if (0 == compare(tok, jsonChunk, "shadowType")) {
-            i = parse(tokens, i + 1, jsonChunk, &out->shadowType);
-        } else if (0 == compare(tok, jsonChunk, "vsmAnisotropy")) {
-            i = parse(tokens, i + 1, jsonChunk, &out->vsmAnisotropy);
+        if (0 == compare(tok, jsonChunk, "anisotropy")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->anisotropy);
         } else {
             slog.w << "Invalid shadow options key: '" << STR(tok, jsonChunk) << "'" << io::endl;
             i = parse(tokens, i + 1);
@@ -576,8 +574,10 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ViewSett
             i = parse(tokens, i + 1, jsonChunk, &out->renderQuality);
         } else if (compare(tok, jsonChunk, "dynamicLighting") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->dynamicLighting);
-        } else if (compare(tok, jsonChunk, "shadowOptions") == 0) {
-            i = parse(tokens, i + 1, jsonChunk, &out->shadowOptions);
+        } else if (compare(tok, jsonChunk, "shadowType") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->shadowType);
+        } else if (compare(tok, jsonChunk, "vsmShadowOptions") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->vsmShadowOptions);
         } else if (compare(tok, jsonChunk, "postProcessingEnabled") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->postProcessingEnabled);
         } else {
@@ -708,7 +708,8 @@ void applySettings(const ViewSettings& settings, View* dest) {
     dest->setRenderQuality(settings.renderQuality);
     dest->setDynamicLightingOptions(settings.dynamicLighting.zLightNear,
             settings.dynamicLighting.zLightFar);
-    dest->setShadowOptions(settings.shadowOptions);
+    dest->setShadowType(settings.shadowType);
+    dest->setVsmShadowOptions(settings.vsmShadowOptions);
     dest->setPostProcessingEnabled(settings.postProcessingEnabled);
 }
 
@@ -1030,11 +1031,10 @@ std::string writeJson(const DynamicLightingSettings& in) {
     return oss.str();
 }
 
-std::string writeJson(const ShadowOptions& in) {
+std::string writeJson(const VsmShadowOptions& in) {
     std::ostringstream oss;
     oss << "{\n"
-        << "\"shadowType\": " << writeJson(in.shadowType) << ",\n"
-        << "\"vsmAnisotropy\": " << writeJson(in.vsmAnisotropy) << "\n"
+        << "\"anisotropy\": " << writeJson(in.anisotropy) << "\n"
         << "}";
     return oss.str();
 }
@@ -1054,7 +1054,8 @@ std::string writeJson(const ViewSettings& in) {
         << "\"dithering\": " << writeJson(in.dithering) << ",\n"
         << "\"renderQuality\": " << writeJson(in.renderQuality) << ",\n"
         << "\"dynamicLighting\": " << writeJson(in.dynamicLighting) << ",\n"
-        << "\"shadowOptions\": " << writeJson(in.shadowOptions) << ",\n"
+        << "\"shadowType\": " << writeJson(in.shadowType) << ",\n"
+        << "\"vsmShadowOptions\": " << writeJson(in.vsmShadowOptions) << ",\n"
         << "\"postProcessingEnabled\": " << writeJson(in.postProcessingEnabled) << "\n"
         << "}";
     return oss.str();

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -54,7 +54,8 @@ SimpleViewer::SimpleViewer(filament::Engine* engine, filament::Scene* scene, fil
         mSunlight(utils::EntityManager::get().create()),
         mSidebarWidth(sidebarWidth) {
 
-    mSettings.view.shadowType = ShadowType::PCF;
+    mSettings.view.shadowOptions.shadowType = ShadowType::PCF;
+    mSettings.view.shadowOptions.vsmAnisotropyLog2 = 0;
     mSettings.view.dithering = Dithering::TEMPORAL;
     mSettings.view.antiAliasing = AntiAliasing::FXAA;
     mSettings.view.sampleCount = 4;
@@ -336,13 +337,18 @@ void SimpleViewer::updateUserInterface() {
         ImGui::Checkbox("Enable sunlight", &mEnableSunlight);
         ImGui::Checkbox("Enable shadows", &mEnableShadows);
 
-        bool enableVsm = mSettings.view.shadowType == ShadowType::VSM;
+        bool enableVsm = mSettings.view.shadowOptions.shadowType == ShadowType::VSM;
         ImGui::Checkbox("Enable VSM", &enableVsm);
-        mSettings.view.shadowType = enableVsm ? ShadowType::VSM : ShadowType::PCF;
+        mSettings.view.shadowOptions.shadowType = enableVsm ? ShadowType::VSM : ShadowType::PCF;
 
         char label[32];
         snprintf(label, 32, "%d", 1 << mVsmMsaaSamplesLog2);
         ImGui::SliderInt("VSM MSAA samples", &mVsmMsaaSamplesLog2, 0, 3, label);
+
+        int vsmAnisotropyLog2 = mSettings.view.shadowOptions.vsmAnisotropyLog2;
+        snprintf(label, 32, "%d", 1 << vsmAnisotropyLog2);
+        ImGui::SliderInt("VSM anisotropy", &vsmAnisotropyLog2, 0, 3, label);
+        mSettings.view.shadowOptions.vsmAnisotropyLog2 = vsmAnisotropyLog2;
 
         ImGui::SliderInt("Cascades", &mShadowCascades, 1, 4);
         ImGui::Checkbox("Debug cascades",

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -55,7 +55,7 @@ SimpleViewer::SimpleViewer(filament::Engine* engine, filament::Scene* scene, fil
         mSidebarWidth(sidebarWidth) {
 
     mSettings.view.shadowOptions.shadowType = ShadowType::PCF;
-    mSettings.view.shadowOptions.vsmAnisotropyLog2 = 0;
+    mSettings.view.shadowOptions.vsmAnisotropy = 0;
     mSettings.view.dithering = Dithering::TEMPORAL;
     mSettings.view.antiAliasing = AntiAliasing::FXAA;
     mSettings.view.sampleCount = 4;
@@ -345,10 +345,10 @@ void SimpleViewer::updateUserInterface() {
         snprintf(label, 32, "%d", 1 << mVsmMsaaSamplesLog2);
         ImGui::SliderInt("VSM MSAA samples", &mVsmMsaaSamplesLog2, 0, 3, label);
 
-        int vsmAnisotropyLog2 = mSettings.view.shadowOptions.vsmAnisotropyLog2;
-        snprintf(label, 32, "%d", 1 << vsmAnisotropyLog2);
-        ImGui::SliderInt("VSM anisotropy", &vsmAnisotropyLog2, 0, 3, label);
-        mSettings.view.shadowOptions.vsmAnisotropyLog2 = vsmAnisotropyLog2;
+        int vsmAnisotropy = mSettings.view.shadowOptions.vsmAnisotropy;
+        snprintf(label, 32, "%d", 1 << vsmAnisotropy);
+        ImGui::SliderInt("VSM anisotropy", &vsmAnisotropy, 0, 3, label);
+        mSettings.view.shadowOptions.vsmAnisotropy = vsmAnisotropy;
 
         ImGui::SliderInt("Cascades", &mShadowCascades, 1, 4);
         ImGui::Checkbox("Debug cascades",

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -54,8 +54,8 @@ SimpleViewer::SimpleViewer(filament::Engine* engine, filament::Scene* scene, fil
         mSunlight(utils::EntityManager::get().create()),
         mSidebarWidth(sidebarWidth) {
 
-    mSettings.view.shadowOptions.shadowType = ShadowType::PCF;
-    mSettings.view.shadowOptions.vsmAnisotropy = 0;
+    mSettings.view.shadowType = ShadowType::PCF;
+    mSettings.view.vsmShadowOptions.anisotropy = 0;
     mSettings.view.dithering = Dithering::TEMPORAL;
     mSettings.view.antiAliasing = AntiAliasing::FXAA;
     mSettings.view.sampleCount = 4;
@@ -337,18 +337,18 @@ void SimpleViewer::updateUserInterface() {
         ImGui::Checkbox("Enable sunlight", &mEnableSunlight);
         ImGui::Checkbox("Enable shadows", &mEnableShadows);
 
-        bool enableVsm = mSettings.view.shadowOptions.shadowType == ShadowType::VSM;
+        bool enableVsm = mSettings.view.shadowType == ShadowType::VSM;
         ImGui::Checkbox("Enable VSM", &enableVsm);
-        mSettings.view.shadowOptions.shadowType = enableVsm ? ShadowType::VSM : ShadowType::PCF;
+        mSettings.view.shadowType = enableVsm ? ShadowType::VSM : ShadowType::PCF;
 
         char label[32];
         snprintf(label, 32, "%d", 1 << mVsmMsaaSamplesLog2);
         ImGui::SliderInt("VSM MSAA samples", &mVsmMsaaSamplesLog2, 0, 3, label);
 
-        int vsmAnisotropy = mSettings.view.shadowOptions.vsmAnisotropy;
+        int vsmAnisotropy = mSettings.view.vsmShadowOptions.anisotropy;
         snprintf(label, 32, "%d", 1 << vsmAnisotropy);
         ImGui::SliderInt("VSM anisotropy", &vsmAnisotropy, 0, 3, label);
-        mSettings.view.shadowOptions.vsmAnisotropy = vsmAnisotropy;
+        mSettings.view.vsmShadowOptions.anisotropy = vsmAnisotropy;
 
         ImGui::SliderInt("Cascades", &mShadowCascades, 1, 4);
         ImGui::Checkbox("Debug cascades",

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -123,6 +123,9 @@ static const char* JSON_TEST_DEFAULTS = R"TXT(
             "zLightFar": 100,
         },
         "shadowType": "PCF",
+        "vsmShadowOptions": {
+            "anisotropy": 1
+        },
         "postProcessingEnabled": true
     }
 }


### PR DESCRIPTION
Anisotropic filtering helps improve VSM shadow quality at glancing angles.

![vsm-anisotropy](https://user-images.githubusercontent.com/5298046/95799455-f8eda280-0cb1-11eb-9401-d3206eca0980.gif)
