### PR TITLE
Various changes to help clients upgrade Filament.

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -25,6 +25,8 @@
 
 #include <backend/PresentCallable.h>
 
+#include <math/vec4.h>
+
 #include <stdint.h>
 
 namespace filament {

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -66,13 +66,27 @@ class UTILS_PUBLIC Scene : public FilamentAPI {
 public:
 
     /**
-     * Sets the SkyBox.
+     * Sets the Skybox.
      *
      * The Skybox is drawn last and covers all pixels not touched by geometry.
      *
      * @param skybox The Skybox to use to fill untouched pixels, or nullptr to unset the Skybox.
      */
     void setSkybox(Skybox* skybox) noexcept;
+
+    /**
+     * Returns the Skybox associated with the Scene.
+     *
+     * @return The associated Skybox, or nullptr if there is none.
+     */
+    Skybox* getSkybox() noexcept;
+
+    /**
+     * Returns an immutable Skybox associated with the Scene.
+     *
+     * @return The associated Skybox, or nullptr if there is none.
+     */
+    Skybox const* getSkybox() const noexcept;
 
     /**
      * Set the IndirectLight to use when rendering the Scene.

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -442,6 +442,14 @@ void Scene::setSkybox(Skybox* skybox) noexcept {
     upcast(this)->setSkybox(upcast(skybox));
 }
 
+Skybox* Scene::getSkybox() noexcept {
+    return upcast(this)->getSkybox();
+}
+
+Skybox const* Scene::getSkybox() const noexcept {
+    return upcast(this)->getSkybox();
+}
+
 void Scene::setIndirectLight(IndirectLight const* ibl) noexcept {
     upcast(this)->setIndirectLight(upcast(ibl));
 }

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -190,7 +190,7 @@
 
 // ssize_t is a POSIX type.
 #if defined(WIN32) || defined(_WIN32)
-#include <BaseTsd.h>
+#include <Basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 

--- a/libs/utils/src/linux/futex.h
+++ b/libs/utils/src/linux/futex.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <unistd.h>
 
+#include <utils/compiler.h>
+
 struct timespec;
 
 namespace utils {


### PR DESCRIPTION
The non-const getSkybox() method is especially useful to client code
that needs to change the clear color, but does not have direct
access to the Renderer object.