### PR TITLE
Fix TypeScript binding

### DIFF
--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -154,7 +154,7 @@ export class Texture$Builder {
     public levels(levels: number): Texture$Builder;
     public sampler(sampler: Texture$Sampler): Texture$Builder;
     public format(format: Texture$InternalFormat): Texture$Builder;
-    public usage(usage: Texture$Usage): Texture$Builder;
+    public usage(usage: TextureUsage): Texture$Builder;
     public build(engine: Engine) : Texture;
 }
 


### PR DESCRIPTION
Fix a use of `Texture$Usage` to the new name `TextureUsage`.
This new name was introduced by the commit [5549adc](https://github.com/google/filament/commit/5549adc0206162b5fd26117b1b05b11c44990cde).