### PR TITLE
Add optional XCB support to PlatformVkLinux.

### DIFF
--- a/filament/backend/src/vulkan/PlatformVkLinux.h
+++ b/filament/backend/src/vulkan/PlatformVkLinux.h
@@ -22,7 +22,11 @@
 #include <backend/DriverEnums.h>
 #include "VulkanPlatform.h"
 
+#ifdef FILAMENT_SUPPORTS_XCB
+#include <xcb/xcb.h>
+#else
 #include <X11/Xlib.h>
+#endif
 
 namespace filament {
 
@@ -36,7 +40,11 @@ public:
     int getOSVersion() const noexcept override { return 0; }
 
 private:
+#ifdef FILAMENT_SUPPORTS_XCB
+    xcb_connection_t* mConnection;
+#else
     Display* mDisplay;
+#endif
 };
 
 } // namespace filament

--- a/libs/bluevk/include/vulkan/vk_platform.h
+++ b/libs/bluevk/include/vulkan/vk_platform.h
@@ -26,7 +26,11 @@
 #elif defined(IOS)
 #define VK_USE_PLATFORM_IOS_MVK 1
 #elif defined(__linux__)
+#if defined(FILAMENT_SUPPORTS_XCB)
+#define VK_USE_PLATFORM_XCB_KHR 1
+#else
 #define VK_USE_PLATFORM_XLIB_KHR 1
+#endif
 #elif defined(__APPLE__)
 #define VK_USE_PLATFORM_MACOS_MVK 1
 #elif defined(WIN32)


### PR DESCRIPTION
This allows clients to build the Vulkan backend with either XLIB or XCB
support. I did a quick smoke test of the XCB option, but for now we are
continuing to default to XLIB. Note that the native window type used to
create the swap chain differs between these two API's.