### PR TITLE
Vulkan: Improve refcounting for vertex buffers.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBuffer.h
+++ b/filament/backend/src/vulkan/VulkanBuffer.h
@@ -26,14 +26,16 @@ namespace backend {
 // Encapsulates a Vulkan buffer, its attached DeviceMemory and a staging area.
 class VulkanBuffer {
 public:
-    VulkanBuffer(VulkanContext& context, VulkanStagePool& stagePool, VkBufferUsageFlags usage,
-            uint32_t numBytes);
+    VulkanBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
+            VulkanDisposer::Key mDisposerKey, VkBufferUsageFlags usage, uint32_t numBytes);
     ~VulkanBuffer();
     void loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_t numBytes);
     VkBuffer getGpuBuffer() const { return mGpuBuffer; }
 private:
     VulkanContext& mContext;
     VulkanStagePool& mStagePool;
+    VulkanDisposer& mDisposer;
+    VulkanDisposer::Key mDisposerKey;
     VmaAllocation mGpuMemory = VK_NULL_HANDLE;
     VkBuffer mGpuBuffer = VK_NULL_HANDLE;
 };

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -78,31 +78,32 @@ struct VulkanSwapChain : public HwSwapChain {
 };
 
 struct VulkanVertexBuffer : public HwVertexBuffer {
-    VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, uint8_t bufferCount,
-            uint8_t attributeCount, uint32_t elementCount,
+    VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
+            uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
             AttributeArray const& attributes);
     std::vector<std::unique_ptr<VulkanBuffer>> buffers;
 };
 
 struct VulkanIndexBuffer : public HwIndexBuffer {
-    VulkanIndexBuffer(VulkanContext& context, VulkanStagePool& stagePool, uint8_t elementSize,
-            uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
+    VulkanIndexBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
+            uint8_t elementSize, uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
             indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32),
-            buffer(new VulkanBuffer(context, stagePool, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
-            elementSize * indexCount)) {}
+            buffer(new VulkanBuffer(context, stagePool, disposer, this,
+            VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount)) {}
     const VkIndexType indexType;
     const std::unique_ptr<VulkanBuffer> buffer;
 };
 
 struct VulkanUniformBuffer : public HwUniformBuffer {
-    VulkanUniformBuffer(VulkanContext& context, VulkanStagePool& stagePool, uint32_t numBytes,
-            backend::BufferUsage usage);
+    VulkanUniformBuffer(VulkanContext& context, VulkanStagePool& stagePool,
+            VulkanDisposer& disposer, uint32_t numBytes, backend::BufferUsage usage);
     ~VulkanUniformBuffer();
     void loadFromCpu(const void* cpuData, uint32_t numBytes);
     VkBuffer getGpuBuffer() const { return mGpuBuffer; }
 private:
     VulkanContext& mContext;
     VulkanStagePool& mStagePool;
+    VulkanDisposer& mDisposer;
     VkBuffer mGpuBuffer;
     VmaAllocation mGpuMemory;
 };


### PR DESCRIPTION
This avoids the following validation error when clients create then
immediately destroy vertex buffers, index buffers, and uniform buffers.

        VUID-vkDestroyBuffer-buffer-00922

        Cannot free VkBuffer that is in use by a command buffer.

Buffers that are used across multiple frames were fine, but
create-and-destroy scenarios were problematic.