### PR TITLE
Vulkan: fix thread safety regression in Disposer.

### DIFF
--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -167,7 +167,7 @@ public:
     explicit DriverBase(Dispatcher* dispatcher) noexcept;
     ~DriverBase() noexcept override;
 
-    void purge() noexcept override;
+    void purge() noexcept final;
 
     Dispatcher& getDispatcher() noexcept final { return *mDispatcher; }
 

--- a/filament/backend/src/vulkan/VulkanDisposer.h
+++ b/filament/backend/src/vulkan/VulkanDisposer.h
@@ -61,7 +61,7 @@ public:
 
 private:
     struct Disposable {
-        size_t refcount = 1;
+        ssize_t refcount = 1;
         std::function<void()> destructor;
     };
     tsl::robin_map<Key, Disposable> mDisposables;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -77,17 +77,6 @@ private:
     VulkanDriver(VulkanDriver const&) = delete;
     VulkanDriver& operator = (VulkanDriver const&) = delete;
 
-    void purge() noexcept override {
-        // First we trigger garbage collection of Vulkan resources. This ensures that transient
-        // resources (e.g. the ReadPixels staging buffer) are removed if their refcount is 0, which
-        // allows related BufferDescriptors to move to the purge list.
-        mDisposer.gc();
-
-        // Next, allow the base class to clean up the purge list in order to trigger the
-        // BufferDescriptor destructors, which in turn triggers the user-provided callbacks.
-        DriverBase::purge();
-    }
-
 private:
     backend::VulkanPlatform& mContextManager;
 


### PR DESCRIPTION
This fixes a regression introduced by 548b28c6e manifesting as
intermittent assertions. The VulkanDisposer gc() should only be called
from the driver thread.