### PR TITLE
Makes it possible to have multiple instances of ImGuiHelper at the sa…

### DIFF
--- a/libs/filagui/include/filagui/ImGuiHelper.h
+++ b/libs/filagui/include/filagui/ImGuiHelper.h
@@ -33,6 +33,7 @@
 
 struct ImDrawData;
 struct ImGuiIO;
+struct ImGuiContext;
 
 namespace filagui {
 
@@ -87,6 +88,7 @@ public:
       utils::Entity mRenderable;
       filament::Texture* mTexture = nullptr;
       bool mHasSynced = false;
+      ImGuiContext* mImGuiContext;
 };
 
 } // namespace filagui

--- a/libs/filagui/src/ImGuiHelper.cpp
+++ b/libs/filagui/src/ImGuiHelper.cpp
@@ -43,8 +43,8 @@ namespace filagui {
 #include "generated/resources/filagui_resources.h"
 
 ImGuiHelper::ImGuiHelper(Engine* engine, filament::View* view, const Path& fontPath) :
-        mEngine(engine), mView(view), mScene(engine->createScene()) {
-    ImGui::CreateContext();
+        mEngine(engine), mView(view), mScene(engine->createScene()),
+        mImGuiContext(ImGui::CreateContext()) {
     ImGuiIO& io = ImGui::GetIO();
 
     // Create a simple alpha-blended 2D blitting material.
@@ -111,7 +111,8 @@ ImGuiHelper::~ImGuiHelper() {
     for (auto& ib : mIndexBuffers) {
         mEngine->destroy(ib);
     }
-    ImGui::DestroyContext();
+    ImGui::DestroyContext(mImGuiContext);
+    mImGuiContext = nullptr;
 }
 
 void ImGuiHelper::setDisplaySize(int width, int height, float scaleX, float scaleY) {
@@ -122,6 +123,7 @@ void ImGuiHelper::setDisplaySize(int width, int height, float scaleX, float scal
 }
 
 void ImGuiHelper::render(float timeStepInSeconds, Callback imguiCommands) {
+    ImGui::SetCurrentContext(mImGuiContext);
     ImGuiIO& io = ImGui::GetIO();
     io.DeltaTime = timeStepInSeconds;
     // First, let ImGui process events and increment its internal frame count.
@@ -137,6 +139,8 @@ void ImGuiHelper::render(float timeStepInSeconds, Callback imguiCommands) {
 }
 
 void ImGuiHelper::processImGuiCommands(ImDrawData* commands, const ImGuiIO& io) {
+    ImGui::SetCurrentContext(mImGuiContext);
+
     mHasSynced = false;
     auto& rcm = mEngine->getRenderableManager();
 


### PR DESCRIPTION
…me time

This change fixes an issue where ImGuiHelper would crash on destruction if you created more than one instance at the same time.

This crash occurred when ImGui::DestroyContext() was called, because when the second instance was destroyed there was no current context causing it to crash.

This fixes it by making ImGuiHelper store and manage it's own context.

Having two instances of ImGuiHelper is useful in cases where you want to use imgui with multiple views.