### PR TITLE
Fix colorGradingAsSubpass when dithering is off.

### DIFF
--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -119,8 +119,8 @@ fragment {
 #else
             postProcess.color = dithered;
 #endif
-            postProcess.tonemappedOutput = postProcess.color;
         }
+        postProcess.tonemappedOutput = postProcess.color;
     }
 
 }


### PR DESCRIPTION
This fixes the blank screen seen with Vulkan when all view options are
disabled.