### PR TITLE
gltfio: add createInstance() to AssetLoader.

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -153,6 +153,32 @@ public class AssetLoader {
     }
 
     /**
+     * Adds a new instance to an instanced asset.
+     *
+     * Use this with caution. It is more efficient to pre-allocate a max number of instances, and
+     * gradually add them to the scene as needed. Instances can also be "recycled" by removing and
+     * re-adding them to the scene.
+     *
+     * NOTE: destroyInstance() does not exist because gltfio favors flat arrays for storage of
+     * entity lists and instance lists, which would be slow to shift. We also wish to discourage
+     * create/destroy churn, as noted above.
+     *
+     * This cannot be called after FilamentAsset#releaseSourceData().
+     * This cannot be called on a non-instanced asset.
+     * Animation is not supported in new instances.
+     * See also AssetLoader#createInstancedAsset().
+     */
+    @Nullable
+    @SuppressWarnings("unused")
+    public FilamentInstance createInstance(@NonNull FilamentAsset asset) {
+        long nativeInstance = nCreateInstance(mNativeObject, asset.getNativeObject());
+        if (nativeInstance == 0) {
+            return null;
+        }
+        return new FilamentInstance(nativeInstance);
+    }
+
+    /**
      * Allows clients to enable diagnostic shading on newly-loaded assets.
      */
     @SuppressWarnings("unused")
@@ -175,6 +201,7 @@ public class AssetLoader {
     private static native long nCreateAssetFromJson(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,
             long[] nativeInstances);
+    private static native long nCreateInstance(long nativeLoader, long nativeAsset);
     private static native void nEnableDiagnostics(long nativeLoader, boolean enable);
     private static native void nDestroyAsset(long nativeLoader, long nativeAsset);
 }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -197,7 +197,11 @@ public class FilamentAsset {
         if (mAnimator != null) {
             return mAnimator;
         }
-        mAnimator = new Animator(nGetAnimator(getNativeObject()));
+        long nativeAnimator = nGetAnimator(getNativeObject());
+        if (nativeAnimator == 0) {
+            throw new IllegalStateException("Unable to create animator");
+        }
+        mAnimator = new Animator(nativeAnimator);
         return mAnimator;
     }
 
@@ -215,6 +219,7 @@ public class FilamentAsset {
      *
      * This should only be called after ResourceLoader#loadResources().
      * If using Animator, this should be called after getAnimator().
+     * If this is an instanced asset, this prevents creation of new instances.
      */
     public void releaseSourceData() {
         nReleaseSourceData(mNativeObject);

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -179,6 +179,24 @@ public:
             FilamentInstance** instances, size_t numInstances);
 
     /**
+     * Adds a new instance to an instanced asset.
+     *
+     * Use this with caution. It is more efficient to pre-allocate a max number of instances, and
+     * gradually add them to the scene as needed. Instances can also be "recycled" by removing and
+     * re-adding them to the scene.
+     *
+     * NOTE: destroyInstance() does not exist because gltfio favors flat arrays for storage of
+     * entity lists and instance lists, which would be slow to shift. We also wish to discourage
+     * create/destroy churn, as noted above.
+     *
+     * This cannot be called after FilamentAsset::releaseSourceData().
+     * This cannot be called on a non-instanced asset.
+     * Animation is not supported in new instances.
+     * See also AssetLoader::createInstancedAsset().
+     */
+    FilamentInstance* createInstance(FilamentAsset* primary);
+
+    /**
      * Takes a pointer to an opaque pipeline object and returns a bundle of Filament objects.
      *
      * This exists solely for interop with AssetPipeline, which is optional according to the build

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -215,6 +215,7 @@ public:
      *
      * This should only be called after ResourceLoader::loadResources().
      * If using Animator, this should be called after getAnimator().
+     * If this is an instanced asset, this prevents creation of new instances.
      */
     void releaseSourceData() noexcept;
 

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -223,7 +223,7 @@ Animator::Animator(FFilamentAsset* asset, FFilamentInstance* instance) {
         // Import each glTF channel into a custom data structure.
         if (instance) {
             addChannels(instance->nodeMap, srcAnim, dstAnim);
-        } else if (asset->mInstances.empty()) {
+        } else if (!asset->isInstanced()) {
             addChannels(asset->mNodeMap, srcAnim, dstAnim);
         } else {
             for (FFilamentInstance* instance : asset->mInstances) {
@@ -413,7 +413,7 @@ void Animator::updateBoneMatrices() {
 
     if (mImpl->instance) {
         update(mImpl->instance->skins, mImpl->boneMatrices);
-    } else if (mImpl->asset->mInstances.empty()) {
+    } else if (!mImpl->asset->isInstanced()) {
         update(mImpl->asset->mSkins, mImpl->boneMatrices);
     } else {
         for (FFilamentInstance* instance : mImpl->asset->mInstances) {

--- a/libs/gltfio/src/DependencyGraph.h
+++ b/libs/gltfio/src/DependencyGraph.h
@@ -34,7 +34,7 @@ namespace gltfio {
 
 /**
  * Internal graph that enables FilamentAsset to discover "ready-to-render" entities by tracking
- * the Texture objects that each entity depends on.
+ * the loading status of Texture objects that each entity depends on.
  *
  * Renderables connect to a set of material instances, which in turn connect to a set of parameter
  * names, which in turn connect to a set of texture objects. These relationships are not easily
@@ -72,7 +72,12 @@ public:
     void addEdge(Material* material, const char* parameter);
 
     // This is called at the end of the initial asset loading phase.
+    // Makes a guarantee that no new material nodes or parameter nodes will be added to the graph.
     void finalize();
+
+    // This can be called after finalization to allow for dynamic addition of entities.
+    // It is slower than finalize() because it checks the readiness of existing materials.
+    void refinalize();
 
     // These are called after textures have created and decoded.
     void addEdge(filament::Texture* texture, Material* material, const char* parameter);
@@ -93,6 +98,7 @@ private:
         size_t numReadyMaterials = 0;
     };
 
+    void checkReadiness(Material* material);
     void markAsReady(Material* material);
     TextureNode* getStatus(filament::Texture* texture);
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -212,6 +212,10 @@ struct FFilamentAsset : public FilamentAsset {
         mDependencyGraph.addEdge(texture, tb.materialInstance, tb.materialParameter);
     }
 
+    bool isInstanced() const {
+        return mInstances.size() > 0;
+    }
+
     filament::Engine* mEngine;
     utils::NameComponentManager* mNameManager;
     utils::EntityManager* mEntityManager;

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -388,7 +388,7 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
         if (pImpl->mNormalizeSkinningWeights) {
             normalizeSkinningWeights(asset);
         }
-        if (asset->mInstances.empty()) {
+        if (!asset->isInstanced()) {
             importSkins(gltf, asset->mNodeMap, asset->mSkins);
         } else {
             for (FFilamentInstance* instance : asset->mInstances) {
@@ -996,7 +996,7 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
     SYSTRACE_CALL();
     auto& rm = pImpl->mEngine->getRenderableManager();
     auto& tm = pImpl->mEngine->getTransformManager();
-    NodeMap& nodeMap = asset->mInstances.empty() ? asset->mNodeMap : asset->mInstances[0]->nodeMap;
+    NodeMap& nodeMap = asset->isInstanced() ? asset->mInstances[0]->nodeMap : asset->mNodeMap;
 
     // The purpose of the root node is to give the client a place for custom transforms.
     // Since it is not part of the source model, it should be ignored when computing the

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -51,8 +51,6 @@ using namespace filament::viewer;
 using namespace gltfio;
 using namespace utils;
 
-using InstanceHandle = FilamentInstance*;
-
 struct App {
     Engine* engine;
     SimpleViewer* viewer;
@@ -63,9 +61,8 @@ struct App {
     MaterialProvider* materials;
     MaterialSource materialSource = GENERATE_SHADERS;
     ResourceLoader* resourceLoader = nullptr;
-    int numInstances = 5;
     int instanceToAnimate = -1;
-    InstanceHandle* instances;
+    std::vector<FilamentInstance*> instances;
 };
 
 static const char* DEFAULT_IBL = "default_env";
@@ -132,7 +129,7 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 app->instanceToAnimate = atoi(arg.c_str());
                 break;
             case 'n':
-                app->numInstances = atoi(arg.c_str());
+                app->instances.resize(atoi(arg.c_str()));
                 break;
             case 'i':
                 app->config.iblDirectory = arg;
@@ -141,6 +138,9 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 app->materialSource = LOAD_UBERSHADERS;
                 break;
         }
+    }
+    if (app->instances.empty()) {
+        app->instances.resize(5);
     }
     return optind;
 }
@@ -184,8 +184,8 @@ int main(int argc, char** argv) {
         }
 
         // Parse the glTF file and create Filament entities.
-        app.asset = app.loader->createInstancedAsset(buffer.data(), buffer.size(), app.instances,
-                app.numInstances);
+        app.asset = app.loader->createInstancedAsset(buffer.data(), buffer.size(),
+                app.instances.data(), app.instances.size());
         buffer.clear();
         buffer.shrink_to_fit();
 
@@ -213,11 +213,24 @@ int main(int argc, char** argv) {
         if (app.instanceToAnimate > -1) {
             app.instances[app.instanceToAnimate]->getAnimator();
         }
-        app.asset->releaseSourceData();
 
         auto ibl = FilamentApp::get().getIBL();
         if (ibl) {
             app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
+        }
+    };
+
+    auto arrangeIntoCircle = [&app]() {
+        auto& tcm = app.engine->getTransformManager();
+        auto extent = app.asset->getBoundingBox().extent();
+        float max_extent = std::max(std::max(extent.x,  extent.y), extent.z);
+        auto translation = mat4f::translation(float3(max_extent, 0, 0));
+        for (size_t inst = 0; inst < app.instances.size(); ++inst) {
+            FilamentInstance* instance = app.instances[inst];
+            auto transformRoot = tcm.getInstance(instance->getRoot());
+            float theta = inst * 2.0 * M_PI / app.instances.size();
+            auto rotation = mat4f::rotation(theta, float3(0, 0, 1));
+            tcm.setTransform(transformRoot, rotation * translation);
         }
     };
 
@@ -228,28 +241,15 @@ int main(int argc, char** argv) {
         app.materials = (app.materialSource == GENERATE_SHADERS) ?
                 createMaterialGenerator(engine) : createUbershaderLoader(engine);
         app.loader = AssetLoader::create({engine, app.materials, app.names });
-        app.instances = new InstanceHandle[app.numInstances];
         if (filename.isEmpty()) {
             app.asset = app.loader->createInstancedAsset(
                     GLTF_VIEWER_DAMAGEDHELMET_DATA, GLTF_VIEWER_DAMAGEDHELMET_SIZE,
-                    app.instances, app.numInstances);
+                    app.instances.data(), app.instances.size());
         } else {
             loadAsset(filename);
         }
 
-        // Arrange all instances into a circle.
-        auto& tcm = engine->getTransformManager();
-        auto extent = app.asset->getBoundingBox().extent();
-        float max_extent = std::max(std::max(extent.x,  extent.y), extent.z);
-        auto translation = mat4f::translation(float3(max_extent, 0, 0));
-        for (size_t inst = 0; inst < app.numInstances; ++inst) {
-            FilamentInstance* instance = app.instances[inst];
-            auto transformRoot = tcm.getInstance(instance->getRoot());
-            float theta = inst * 2.0 * M_PI / app.numInstances;
-            auto rotation = mat4f::rotation(theta, float3(0, 0, 1));
-            tcm.setTransform(transformRoot, rotation * translation);
-        }
-
+        arrangeIntoCircle();
         loadResources(filename);
     };
 
@@ -262,11 +262,9 @@ int main(int argc, char** argv) {
         delete app.names;
 
         AssetLoader::destroy(&app.loader);
-
-        delete[] app.instances;
     };
 
-    auto animate = [&app](Engine* engine, View* view, double now) {
+    auto animate = [&app, arrangeIntoCircle](Engine* engine, View* view, double now) {
         app.resourceLoader->asyncUpdateLoad();
         FilamentInstance* instance = nullptr;
         if (app.instanceToAnimate > -1) {
@@ -274,6 +272,14 @@ int main(int argc, char** argv) {
         }
         app.viewer->populateScene(app.asset, true, instance);
         app.viewer->applyAnimation(now);
+
+        static double previous = 0.0;
+        if (now - previous > 1.0) {
+            FilamentInstance* instance = app.loader->createInstance(app.asset);
+            app.instances.push_back(instance);
+            arrangeIntoCircle();
+            previous = now;
+        }
     };
 
     auto gui = [&app](Engine* engine, View* view) { };

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -568,6 +568,7 @@ export class gltfio$AssetLoader {
     public createInstancedAsset(urlOrBuffer: BufferReference,
             instances: (gltfio$FilamentInstance | null)[]): gltfio$FilamentAsset;
     public destroyAsset(asset: gltfio$FilamentAsset): void;
+    public createInstance(asset: gltfio$FilamentAsset): (gltfio$FilamentInstance | null);
     public delete(): void;
 }
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1782,6 +1782,10 @@ class_<AssetLoader>("gltfio$AssetLoader")
                 buffer.bd->size, instances.data(), numInstances);
     }), allow_raw_pointers())
 
+    // createInstance ::method::
+    // Adds a new instance to an instanced asset.
+    .function("createInstance", &AssetLoader::createInstance, allow_raw_pointers())
+
     // destroyAsset ::method::
     // Destroys the given asset and all of its associated Filament objects. This includes
     // components, material instances, vertex buffers, index buffers, and textures.


### PR DESCRIPTION
Note that this API is on the loader rather than the asset. This is
because the loader knows how to create Filament entities by traversing
a cgltf node hierarchy.

We did not add destroyInstance() because gltfio favors flat arrays for
long term storage of entity lists and instance lists, which would be
slow to shift. We also wish to discourage create/destroy churn since it
is more efficient to pre-allocate instances and selectively add them
into the scene.

Fixes #3137.