### PR TITLE
Add support for swizzling readPixels

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release (main branch)
 
+- Added support for readPixels swizzling (Metal only).
+
 ## v1.9.7
 
 ## v1.9.6

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -442,7 +442,11 @@ DECL_DRIVER_API_N(readPixels,
         uint32_t, y,
         uint32_t, width,
         uint32_t, height,
-        backend::PixelBufferDescriptor&&, data)
+        backend::PixelBufferDescriptor&&, data,
+        backend::TextureSwizzle, r,
+        backend::TextureSwizzle, g,
+        backend::TextureSwizzle, b,
+        backend::TextureSwizzle, a)
 
 DECL_DRIVER_API_N(readStreamPixels,
         backend::StreamHandle, sh,

--- a/filament/backend/src/metal/MetalBlitter.h
+++ b/filament/backend/src/metal/MetalBlitter.h
@@ -36,6 +36,29 @@ public:
 
     explicit MetalBlitter(MetalContext& context) noexcept;
 
+    struct SwizzleChannels {
+        TextureSwizzle r = TextureSwizzle::CHANNEL_0;
+        TextureSwizzle g = TextureSwizzle::CHANNEL_1;
+        TextureSwizzle b = TextureSwizzle::CHANNEL_2;
+        TextureSwizzle a = TextureSwizzle::CHANNEL_3;
+
+        SwizzleChannels() noexcept = default;
+
+        bool isDefaultSwizzle() const {
+            return r == TextureSwizzle::CHANNEL_0 &&
+                   g == TextureSwizzle::CHANNEL_1 &&
+                   b == TextureSwizzle::CHANNEL_2 &&
+                   a == TextureSwizzle::CHANNEL_3;
+        }
+
+        bool operator==(const SwizzleChannels& rhs) const noexcept {
+            return r == rhs.r &&
+                g == rhs.g &&
+                b == rhs.b &&
+                a == rhs.a;
+        }
+    };
+
     struct BlitArgs {
         struct Attachment {
             id<MTLTexture> color = nil;
@@ -46,6 +69,7 @@ public:
 
         Attachment source, destination;
         SamplerMagFilter filter;
+        SwizzleChannels swizzle;
 
         bool blitColor() const {
             return source.color != nil && destination.color != nil;
@@ -84,16 +108,22 @@ private:
         bool blitDepth;
         bool msaaColorSource;
         bool msaaDepthSource;
+        SwizzleChannels swizzle;
 
         bool operator==(const BlitFunctionKey& rhs) const noexcept {
             return blitColor == rhs.blitColor &&
                    blitDepth == rhs.blitDepth &&
                    msaaColorSource == rhs.msaaColorSource &&
-                   msaaDepthSource == rhs.msaaDepthSource;
+                   msaaDepthSource == rhs.msaaDepthSource &&
+                   swizzle == rhs.swizzle;
         }
 
         BlitFunctionKey() {
             std::memset(this, 0, sizeof(BlitFunctionKey));
+            swizzle.r = TextureSwizzle::CHANNEL_0;
+            swizzle.g = TextureSwizzle::CHANNEL_1;
+            swizzle.b = TextureSwizzle::CHANNEL_2;
+            swizzle.a = TextureSwizzle::CHANNEL_3;
         }
     };
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -865,7 +865,8 @@ void MetalDriver::stopCapture(int) {
 }
 
 void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y, uint32_t width,
-        uint32_t height, PixelBufferDescriptor&& data) {
+        uint32_t height, PixelBufferDescriptor&& data, backend::TextureSwizzle r,
+        backend::TextureSwizzle g, backend::TextureSwizzle b, backend::TextureSwizzle a) {
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
                         "readPixels must be called outside of a render pass.");
 
@@ -913,6 +914,10 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
     args.destination.region = MTLRegionMake2D(0, 0, readPixelsTexture.width, readPixelsTexture.height);
     args.source.color = srcTexture;
     args.destination.color = readPixelsTexture;
+    args.swizzle.r = r;
+    args.swizzle.g = g;
+    args.swizzle.b = b;
+    args.swizzle.a = a;
 
     mContext->blitter->blit(getPendingCommandBuffer(mContext), args);
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -272,7 +272,9 @@ void NoopDriver::stopCapture(int) {
 
 void NoopDriver::readPixels(Handle<HwRenderTarget> src,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
-        PixelBufferDescriptor&& p) {
+        PixelBufferDescriptor&& p, backend::TextureSwizzle r,
+        backend::TextureSwizzle g, backend::TextureSwizzle b,
+        backend::TextureSwizzle a) {
     scheduleDestroy(std::move(p));
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2725,7 +2725,8 @@ void OpenGLDriver::stopCapture(int) {
 
 void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         uint32_t x, uint32_t y, uint32_t width, uint32_t height,
-        PixelBufferDescriptor&& p) {
+        PixelBufferDescriptor&& p, backend::TextureSwizzle r, backend::TextureSwizzle g,
+        backend::TextureSwizzle b, backend::TextureSwizzle a) {
     DEBUG_MARKER()
     auto& gl = mContext;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1300,7 +1300,9 @@ void VulkanDriver::stopCapture(int) {
 }
 
 void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
-        uint32_t width, uint32_t height, PixelBufferDescriptor&& pbd) {
+        uint32_t width, uint32_t height, PixelBufferDescriptor&& pbd,
+        backend::TextureSwizzle r, backend::TextureSwizzle g, backend::TextureSwizzle b,
+        backend::TextureSwizzle a) {
     const VkDevice device = mContext.device;
     const VulkanRenderTarget* srcTarget = handle_cast<VulkanRenderTarget>(mHandleMap, src);
     const VulkanTexture* srcTexture = srcTarget->getColor(0).texture;

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -20,6 +20,7 @@
 #define TNT_FILAMENT_RENDERER_H
 
 #include <filament/FilamentAPI.h>
+#include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
 
@@ -273,6 +274,23 @@ public:
     void copyFrame(SwapChain* dstSwapChain, Viewport const& dstViewport,
             Viewport const& srcViewport, uint32_t flags = 0);
 
+    struct ReadPixelsOptions {
+        ReadPixelsOptions() noexcept {}
+
+        using Swizzle = backend::TextureSwizzle;
+
+        /**
+         * The swizzle to apply to the readPixels operation.
+         * Currently only supported by the Metal backend.
+         */
+        struct {
+            Swizzle r = Swizzle::CHANNEL_0;
+            Swizzle g = Swizzle::CHANNEL_1;
+            Swizzle b = Swizzle::CHANNEL_2;
+            Swizzle a = Swizzle::CHANNEL_3;
+        } swizzle;
+    };
+
     /**
      * Reads back the content of the SwapChain associated with this Renderer.
      *
@@ -295,6 +313,7 @@ public:
      *                  Other combination of format/type may be supported. If a combination is
      *                  not supported, this operation may fail silently. Use a DEBUG build
      *                  to get some logs about the failure.
+     * @param options   Additional options for the read-back operation.
      *
      *
      *  Framebuffer as seen on         User buffer (PixelBufferDescriptor&)
@@ -329,7 +348,7 @@ public:
      *
      */
     void readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            backend::PixelBufferDescriptor&& buffer);
+            backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options = {});
 
 
     /**
@@ -355,6 +374,7 @@ public:
      *                  Other combination of format/type may be supported. If a combination is
      *                  not supported, this operation may fail silently. Use a DEBUG build
      *                  to get some logs about the failure.
+     * @param options   Additional options for the read-back operation.
      *
      *
      *  Framebuffer as seen on         User buffer (PixelBufferDescriptor&)
@@ -390,7 +410,7 @@ public:
      */
     void readPixels(RenderTarget* renderTarget,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            backend::PixelBufferDescriptor&& buffer);
+            backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options = {});
 
     /**
      * Set-up a frame for this Renderer.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -1047,19 +1047,20 @@ void FRenderer::endFrame() {
 }
 
 void FRenderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        PixelBufferDescriptor&& buffer) {
-    readPixels(mRenderTarget, xoffset, yoffset, width, height, std::move(buffer));
+        PixelBufferDescriptor&& buffer, ReadPixelsOptions options) {
+    readPixels(mRenderTarget, xoffset, yoffset, width, height, std::move(buffer), options);
 }
 
 void FRenderer::readPixels(FRenderTarget* renderTarget,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        backend::PixelBufferDescriptor&& buffer) {
-    readPixels(renderTarget->getHwHandle(), xoffset, yoffset, width, height, std::move(buffer));
+        backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options) {
+    readPixels(renderTarget->getHwHandle(), xoffset, yoffset, width, height, std::move(buffer),
+            options);
 }
 
 void FRenderer::readPixels(Handle<HwRenderTarget> renderTargetHandle,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        backend::PixelBufferDescriptor&& buffer) {
+        backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options) {
     if (!ASSERT_POSTCONDITION_NON_FATAL(
             buffer.type != PixelDataType::COMPRESSED,
             "buffer.format cannot be COMPRESSED")) {
@@ -1091,7 +1092,8 @@ void FRenderer::readPixels(Handle<HwRenderTarget> renderTargetHandle,
 
     FEngine& engine = getEngine();
     FEngine::DriverApi& driver = engine.getDriverApi();
-    driver.readPixels(renderTargetHandle, xoffset, yoffset, width, height, std::move(buffer));
+    driver.readPixels(renderTargetHandle, xoffset, yoffset, width, height, std::move(buffer),
+            options.swizzle.r, options.swizzle.g, options.swizzle.b, options.swizzle.a);
 }
 
 Handle<HwRenderTarget> FRenderer::getRenderTarget(FView& view) const noexcept {
@@ -1122,15 +1124,15 @@ void Renderer::copyFrame(SwapChain* dstSwapChain, filament::Viewport const& dstV
 }
 
 void Renderer::readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        PixelBufferDescriptor&& buffer) {
-    upcast(this)->readPixels(xoffset, yoffset, width, height, std::move(buffer));
+        PixelBufferDescriptor&& buffer, ReadPixelsOptions options) {
+    upcast(this)->readPixels(xoffset, yoffset, width, height, std::move(buffer), options);
 }
 
 void Renderer::readPixels(RenderTarget* renderTarget,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-        PixelBufferDescriptor&& buffer) {
+        PixelBufferDescriptor&& buffer, ReadPixelsOptions options) {
     upcast(this)->readPixels(upcast(renderTarget),
-            xoffset, yoffset, width, height, std::move(buffer));
+            xoffset, yoffset, width, height, std::move(buffer), options);
 }
 
 void Renderer::endFrame() {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -82,11 +82,11 @@ public:
     void resetUserTime();
 
     void readPixels(uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            backend::PixelBufferDescriptor&& buffer);
+            backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options);
 
     void readPixels(FRenderTarget* renderTarget,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            backend::PixelBufferDescriptor&& buffer);
+            backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options);
 
     // Clean-up everything, this is typically called when the client calls Engine::destroyRenderer()
     void terminate(FEngine& engine);
@@ -125,7 +125,7 @@ private:
 
     void readPixels(backend::Handle<backend::HwRenderTarget> renderTargetHandle,
             uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
-            backend::PixelBufferDescriptor&& buffer);
+            backend::PixelBufferDescriptor&& buffer, ReadPixelsOptions options);
 
     struct ColorPassConfig {
         Viewport vp;


### PR DESCRIPTION
Add support for swizzling during a readPixel operation on Metal.

Question for reviewers: Would it make more sense to add a new `readPixelsSwizzle` driver method?