### PR TITLE
Vulkan: fix color attachment list in first subpass.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -281,7 +281,7 @@ bool VulkanBinder::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     pipelineCreateInfo.pDynamicState = &dynamicState;
 
     // Filament assumes consistent blend state across all color attachments.
-    mColorBlendState.attachmentCount = mPipelineKey.rasterState.getColorTargetCount;
+    mColorBlendState.attachmentCount = mPipelineKey.rasterState.colorTargetCount;
     for (auto& target : mColorBlendAttachments) {
         target = mPipelineKey.rasterState.blending;
     }
@@ -333,7 +333,7 @@ void VulkanBinder::bindRasterState(const RasterState& rasterState) noexcept {
     VkPipelineMultisampleStateCreateInfo& ms0 = mPipelineKey.rasterState.multisampling;
     const VkPipelineMultisampleStateCreateInfo& ms1 = rasterState.multisampling;
     if (
-            mPipelineKey.rasterState.getColorTargetCount != rasterState.getColorTargetCount ||
+            mPipelineKey.rasterState.colorTargetCount != rasterState.colorTargetCount ||
             raster0.polygonMode != raster1.polygonMode ||
             raster0.cullMode != raster1.cullMode ||
             raster0.frontFace != raster1.frontFace ||

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -103,7 +103,7 @@ public:
         VkPipelineColorBlendAttachmentState blending;
         VkPipelineDepthStencilStateCreateInfo depthStencil;
         VkPipelineMultisampleStateCreateInfo multisampling;
-        uint32_t getColorTargetCount;
+        uint32_t colorTargetCount;
     };
     static_assert(std::is_pod<RasterState>::value, "RasterState must be a POD for fast hashing.");
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1622,7 +1622,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     vkraster.depthBiasConstantFactor = depthOffset.constant;
     vkraster.depthBiasSlopeFactor = depthOffset.slope;
 
-    mContext.rasterState.getColorTargetCount = rt->getColorTargetCount();
+    mContext.rasterState.colorTargetCount = rt->getColorTargetCount(mContext.currentRenderPass);
 
     VulkanBinder::ProgramBundle shaderHandles = program->bundle;
 

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -120,6 +120,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         return iter->second.handle;
     }
     const bool isSwapChain = config.colorLayout[0] == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    const bool hasSubpasses = config.subpassMask != 0;
 
     // Set up some const aliases for terseness.
     const VkAttachmentLoadOp kClear = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -149,7 +150,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     }
 
     VkAttachmentReference inputAttachmentRef[MRT::TARGET_COUNT] = {};
-    VkAttachmentReference colorAttachmentRef[MRT::TARGET_COUNT] = {};
+    VkAttachmentReference colorAttachmentRefs[2][MRT::TARGET_COUNT] = {};
     VkAttachmentReference resolveAttachmentRef[MRT::TARGET_COUNT] = {};
     VkAttachmentReference depthAttachmentRef = {};
 
@@ -157,14 +158,15 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
 
     VkSubpassDescription subpasses[2] = {{
         .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
-        .pColorAttachments = colorAttachmentRef,
+        .pInputAttachments = nullptr,
+        .pColorAttachments = colorAttachmentRefs[0],
         .pResolveAttachments = resolveAttachmentRef,
         .pDepthStencilAttachment = hasDepth ? &depthAttachmentRef : nullptr
     },
     {
         .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
         .pInputAttachments = inputAttachmentRef,
-        .pColorAttachments = colorAttachmentRef,
+        .pColorAttachments = colorAttachmentRefs[1],
         .pResolveAttachments = resolveAttachmentRef,
         .pDepthStencilAttachment = hasDepth ? &depthAttachmentRef : nullptr
     }};
@@ -173,24 +175,6 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     // For simplicity, create an array that can hold the maximum possible number of attachments.
     // Note that this needs to have the same ordering as the corollary array in getFramebuffer.
     VkAttachmentDescription attachments[MRT::TARGET_COUNT + MRT::TARGET_COUNT + 1] = {};
-
-    // Determine the number of color attachments based on whether the format has been initialized.
-    int colorAttachmentCount = 0;
-    for (VkFormat format : config.colorFormat) {
-        if (format != VK_FORMAT_UNDEFINED) {
-            ++colorAttachmentCount;
-        }
-    }
-    subpasses[0].colorAttachmentCount = colorAttachmentCount;
-    subpasses[1].colorAttachmentCount = colorAttachmentCount;
-
-    // Nulling out the zero-sized lists is necessary to avoid VK_ERROR_OUT_OF_HOST_MEMORY on Adreno.
-    if (colorAttachmentCount == 0) {
-        subpasses[0].pColorAttachments = nullptr;
-        subpasses[0].pResolveAttachments = nullptr;
-        subpasses[1].pColorAttachments = nullptr;
-        subpasses[1].pResolveAttachments = nullptr;
-    }
 
     // We support 2 subpasses, which means we need to supply 1 dependency struct.
     VkSubpassDependency dependencies[1] = {{
@@ -207,32 +191,56 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
         .attachmentCount = 0u,
         .pAttachments = attachments,
-        .subpassCount = config.subpassMask ? 2u : 1u,
+        .subpassCount = hasSubpasses ? 2u : 1u,
         .pSubpasses = subpasses,
-        .dependencyCount = config.subpassMask ? 1u : 0u,
+        .dependencyCount = hasSubpasses ? 1u : 0u,
         .pDependencies = dependencies
     };
 
     int attachmentIndex = 0;
 
     // Populate the Color Attachments.
-    VkAttachmentReference* pColorAttachment = colorAttachmentRef;
     for (int i = 0; i < MRT::TARGET_COUNT; i++) {
         if (config.colorFormat[i] == VK_FORMAT_UNDEFINED) {
             continue;
         }
-        TargetBufferFlags flag = TargetBufferFlags(int(TargetBufferFlags::COLOR0) << i);
-        bool clear = any(config.clear & flag);
-        bool discard = any(config.discardStart & flag);
-        if (config.subpassMask & (1 << i)) {
-            int subpassInputIndex = subpasses[1].inputAttachmentCount++;
-            inputAttachmentRef[subpassInputIndex].layout = colorLayouts[i].subpass;
-            inputAttachmentRef[subpassInputIndex].attachment = attachmentIndex;
+        const VkImageLayout subpassLayout = colorLayouts[i].subpass;
+        uint32_t index;
+
+        if (!hasSubpasses) {
+            index = subpasses[0].colorAttachmentCount++;
+            colorAttachmentRefs[0][index].layout = subpassLayout;
+            colorAttachmentRefs[0][index].attachment = attachmentIndex;
+        } else {
+
+            // The Driver API consolidates all color attachments from the first and second subpasses
+            // into a single list, and uses a bitmask to mark attachments that belong only to the
+            // second subpass and should be available as inputs. All color attachments in the first
+            // subpass are automatically made available to the second subpass.
+
+            // If there are subpasses, we require the input attachment to be the first attachment.
+            // Breaking this assumption would likely require enhancements to the Driver API in order
+            // to supply Vulkan with all the information needed.
+            assert(config.subpassMask == 1);
+
+            if (config.subpassMask & (1 << i)) {
+                index = subpasses[0].colorAttachmentCount++;
+                colorAttachmentRefs[0][index].layout = subpassLayout;
+                colorAttachmentRefs[0][index].attachment = attachmentIndex;
+
+                index = subpasses[1].inputAttachmentCount++;
+                inputAttachmentRef[index].layout = subpassLayout;
+                inputAttachmentRef[index].attachment = attachmentIndex;
+            }
+
+            index = subpasses[1].colorAttachmentCount++;
+            colorAttachmentRefs[1][index].layout = subpassLayout;
+            colorAttachmentRefs[1][index].attachment = attachmentIndex;
         }
 
-        pColorAttachment->layout = colorLayouts[i].subpass;
-        pColorAttachment->attachment = attachmentIndex;
-        ++pColorAttachment;
+        const TargetBufferFlags flag = TargetBufferFlags(int(TargetBufferFlags::COLOR0) << i);
+        const bool clear = any(config.clear & flag);
+        const bool discard = any(config.discardStart & flag);
 
         attachments[attachmentIndex++] = {
             .format = config.colorFormat[i],
@@ -244,6 +252,14 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .initialLayout = colorLayouts[i].initial,
             .finalLayout = colorLayouts[i].final
         };
+    }
+
+    // Nulling out the zero-sized lists is necessary to avoid VK_ERROR_OUT_OF_HOST_MEMORY on Adreno.
+    if (subpasses[0].colorAttachmentCount == 0) {
+        subpasses[0].pColorAttachments = nullptr;
+        subpasses[0].pResolveAttachments = nullptr;
+        subpasses[1].pColorAttachments = nullptr;
+        subpasses[1].pResolveAttachments = nullptr;
     }
 
     // Populate the Resolve Attachments.
@@ -304,7 +320,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     utils::slog.d << "Created render pass " << renderPass << " with "
         << "samples = " << int(config.samples) << ", "
         << "depth = " << (hasDepth ? 1 : 0) << ", "
-        << "colorAttachmentCount = " << colorAttachmentCount
+        << "colorAttachmentCount[0] = " << subpasses[0].colorAttachmentCount
         << utils::io::endl;
     #endif
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -374,14 +374,18 @@ VulkanAttachment VulkanRenderTarget::getMsaaDepth() const {
     return mMsaaDepthAttachment;
 }
 
-int VulkanRenderTarget::getColorTargetCount() const {
+int VulkanRenderTarget::getColorTargetCount(const VulkanRenderPass& pass) const {
     if (!mOffscreen) {
         return 1;
     }
     int count = 0;
     for (int i = 0; i < MRT::TARGET_COUNT; i++) {
-        if (mColor[i].format != VK_FORMAT_UNDEFINED) {
-            ++count;
+        if (mColor[i].format == VK_FORMAT_UNDEFINED) {
+            continue;
+        }
+        // NOTE: This must be consistent with VkRenderPass construction (see VulkanFboCache).
+        if (!(pass.subpassMask & (1 << i)) || pass.currentSubpass == 1) {
+            count++;
         }
     }
     return count;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -58,7 +58,7 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getMsaaColor(int target) const;
     VulkanAttachment getDepth() const;
     VulkanAttachment getMsaaDepth() const;
-    int getColorTargetCount() const;
+    int getColorTargetCount(const VulkanRenderPass& pass) const;
     bool invalidate();
     uint8_t getSamples() const { return mSamples; }
 private:


### PR DESCRIPTION
This fixes a slew of validation warnings and errors seen when multiple
subpasses are enabled, starting with:

    Attachment 1 not written by fragment shader; undefined values will
    be written to attachment

The Vulkan driver was using the same color attachment list for both
subpasses, so the first subpass had unused attachments.

Note that Vulkan makes a distinction between color attachments and input
attachments and requires separate lists to be supplied for each subpass,
but our Driver API consolidates everything into a single list. This
should perhaps be refactored at a later date.