### PR TITLE
mathio: add ostream operator for quaternions.

### DIFF
--- a/libs/mathio/include/mathio/ostream.h
+++ b/libs/mathio/include/mathio/ostream.h
@@ -20,6 +20,8 @@
 namespace filament {
 namespace math {
 
+namespace details { template<typename T> class TQuaternion; }
+
 template<typename T>
 std::ostream& operator<<(std::ostream& out, const details::TVec2<T>& v) noexcept;
 
@@ -37,6 +39,9 @@ std::ostream& operator<<(std::ostream& out, const details::TMat33<T>& v) noexcep
 
 template<typename T>
 std::ostream& operator<<(std::ostream& out, const details::TMat44<T>& v) noexcept;
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, const details::TQuaternion<T>& v) noexcept;
 
 }  // namespace math
 }  // namespace filament

--- a/libs/mathio/src/ostream.cpp
+++ b/libs/mathio/src/ostream.cpp
@@ -112,6 +112,11 @@ std::ostream& operator<<(std::ostream& out, const details::TMat44<T>& v) noexcep
     return printMatrix(out, v.asArray(), 4, 4);
 }
 
+template<typename T>
+std::ostream& operator<<(std::ostream& out, const details::TQuaternion<T>& v) noexcept {
+    return printQuat(out, v);
+}
+
 template std::ostream& operator<<(std::ostream& out, const details::TVec2<double>& v) noexcept;
 template std::ostream& operator<<(std::ostream& out, const details::TVec2<float>& v) noexcept;
 template std::ostream& operator<<(std::ostream& out, const details::TVec2<half>& v) noexcept;
@@ -153,6 +158,10 @@ template std::ostream& operator<<(std::ostream& out, const details::TMat33<float
 
 template std::ostream& operator<<(std::ostream& out, const details::TMat44<double>& v) noexcept;
 template std::ostream& operator<<(std::ostream& out, const details::TMat44<float>& v) noexcept;
+
+template std::ostream& operator<<(std::ostream& out, const details::TQuaternion<double>& v) noexcept;
+template std::ostream& operator<<(std::ostream& out, const details::TQuaternion<float>& v) noexcept;
+template std::ostream& operator<<(std::ostream& out, const details::TQuaternion<half>& v) noexcept;
 
 }  // namespace math
 }  // namespace filament


### PR DESCRIPTION
This functionality was accidentally lost when we created the mathio lib.