### PR TITLE
Vulkan: fix layout mismatch after blits to swap chain.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -871,7 +871,7 @@ static void blit(VkImageAspectFlags aspect, VkFilter filter, VulkanContext* cont
                 getTextureLayout(src.texture->usage), src.level, 1, 1, aspect);
     } else if  (!context->currentSurface->headlessQueue) {
         VulkanTexture::transitionImageLayout(cmdbuffer, src.image, VK_IMAGE_LAYOUT_UNDEFINED,
-                VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, src.level, 1, 1, aspect);
+                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, src.level, 1, 1, aspect);
     }
 
     // Determine the desired texture layout for the destination while ensuring that the default

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -36,6 +36,8 @@
 
 #include <utils/Panic.h>
 
+#define FILAMENT_VULKAN_CHECK_BLIT_FORMAT 0
+
 namespace filament {
 namespace backend {
 
@@ -890,8 +892,7 @@ void blitDepth(VulkanContext* context, const VulkanRenderTarget* dstTarget,
     const VulkanAttachment dst = dstTarget->getDepth();
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-    // In debug builds, verify that the two render targets have blittable formats.
-#ifndef NDEBUG
+#if FILAMENT_VULKAN_CHECK_BLIT_FORMAT
     const VkPhysicalDevice gpu = context->physicalDevice;
     VkFormatProperties info;
     vkGetPhysicalDeviceFormatProperties(gpu, src.format, &info);
@@ -923,8 +924,7 @@ void blitColor(VulkanContext* context, const VulkanRenderTarget* dstTarget,
     const VulkanAttachment dst = dstTarget->getColor(0);
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    // In debug builds, verify that the two render targets have blittable formats.
-#ifndef NDEBUG
+#if FILAMENT_VULKAN_CHECK_BLIT_FORMAT
     const VkPhysicalDevice gpu = context->physicalDevice;
     VkFormatProperties info;
     vkGetPhysicalDeviceFormatProperties(gpu, src.format, &info);

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -139,7 +139,12 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     struct { VkImageLayout subpass, initial, final; } colorLayouts[MRT::TARGET_COUNT];
     if (isSwapChain) {
         colorLayouts[0].subpass = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        colorLayouts[0].initial = discard ? VK_IMAGE_LAYOUT_UNDEFINED : colorLayouts[0].subpass;
+
+        // It is legal to always use UNDEFINED for "initial", but we wish to avoid warnings
+        // when the load op is LOAD.
+        colorLayouts[0].initial = discard ? VK_IMAGE_LAYOUT_UNDEFINED :
+                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
         colorLayouts[0].final = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     } else {
         for (int i = 0; i < MRT::TARGET_COUNT; i++) {

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -773,6 +773,7 @@ VkImageView VulkanTexture::getImageView(int level, int layer, VkImageAspectFlags
 }
 
 // TODO: replace the last 4 args with VkImageSubresourceRange
+// TODO: replace this function with a flexible thin wrapper over image barrier creation
 void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
         VkImageLayout oldLayout, VkImageLayout newLayout, uint32_t miplevel,
         uint32_t layerCount, uint32_t levelCount, VkImageAspectFlags aspect) {
@@ -816,6 +817,7 @@ void VulkanTexture::transitionImageLayout(VkCommandBuffer cmd, VkImage image,
 
         // We support PRESENT as a target layout to allow blitting from the swap chain.
         // See also makeSwapChainPresentable().
+        case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
         case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
             barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
             barrier.dstAccessMask = 0;


### PR DESCRIPTION
After a blit that targets the swap chain, we were transitioning it straight to VK_IMAGE_LAYOUT_PRESENT_SRC_KHR.  This became incorrect when we changed our layout strategy such that swap chain images are normally kept in VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL until the end of the frame.