### PR TITLE
Fix bug with Fence timeouts

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -684,6 +684,7 @@ void MetalFence::onSignal(MetalFenceSignalBlock block) {
 FenceStatus MetalFence::wait(uint64_t timeoutNs) {
     if (@available(macOS 10.14, iOS 12, *)) {
         std::unique_lock<std::mutex> guard(state->mutex);
+        timeoutNs = std::min(timeoutNs, (uint64_t) std::chrono::nanoseconds::max().count());
         while (state->status == FenceStatus::TIMEOUT_EXPIRED) {
             if (timeoutNs == 0 ||
                 state->cv.wait_for(guard, std::chrono::nanoseconds(timeoutNs)) ==

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -71,6 +71,7 @@ FenceStatus FFence::waitAndDestroy(FFence* fence, Mode mode) noexcept {
 UTILS_NOINLINE
 FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
     ASSERT_PRECONDITION(UTILS_HAS_THREADING || timeout == 0, "Non-zero timeout requires threads.");
+    timeout = std::min(timeout, (uint64_t) ns::max().count());
 
     FEngine& engine = mEngine;
 


### PR DESCRIPTION
We use the highest value of a `uint64_t` in nanoseconds to denote an infinite timeout for fences. However, `std::chrono::nanoseconds` uses a signed `int64_t`. This causes a negative timeout when passing the value to a `std::cv`.