### PR TITLE
Another fix for FENCE_WAIT_FOR_EVER.

### DIFF
--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -71,6 +71,7 @@ FenceStatus FFence::waitAndDestroy(FFence* fence, Mode mode) noexcept {
 UTILS_NOINLINE
 FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
     ASSERT_PRECONDITION(UTILS_HAS_THREADING || timeout == 0, "Non-zero timeout requires threads.");
+    const bool waitForever = timeout == FENCE_WAIT_FOR_EVER;
     timeout = std::min(timeout, (uint64_t) ns::max().count());
 
     FEngine& engine = mEngine;
@@ -97,7 +98,7 @@ FenceStatus FFence::wait(Mode mode, uint64_t timeout) noexcept {
             }
             engine.pumpPlatformEvents();
             const auto elapsed = std::chrono::system_clock::now() - startTime;
-            if (timeout != Fence::FENCE_WAIT_FOR_EVER && elapsed >= ns(timeout)) {
+            if (!waitForever && elapsed >= ns(timeout)) {
                 break;
             }
         }


### PR DESCRIPTION
FFence::wait() has some logic that tests if "timeout" is equal to
FENCE_WAIT_FOR_EVER, which is actually impossible because it would
be modified by the clamp in this situation.

In practice I think this oversight would not cause any problems. I
noticed it while reviewing the code.

To recap why the clamp exists: according to the ISO C++ spec, the
"nanoseconds" duration in chrono is at least a signed 64-bit type, but
our sentinel constant might not (and does not) fit within this range.