### PR TITLE
NOOP backend should not care about GLSL vs SPIRV.

### DIFF
--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -44,6 +44,34 @@ namespace filament {
 
 using namespace backend;
 
+static MaterialParser* createParser(Backend backend, const void* data, size_t size) {
+    MaterialParser* materialParser = new MaterialParser(backend, data, size);
+
+    MaterialParser::ParseResult materialResult = materialParser->parse();
+
+    if (backend == Backend::NOOP) {
+        return materialParser;
+    }
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult != MaterialParser::ParseResult::ERROR_MISSING_BACKEND,
+                "the material was not built for the %s backend\n", backendToString(backend))) {
+        return nullptr;
+    }
+
+    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult == MaterialParser::ParseResult::SUCCESS,
+                "could not parse the material package")) {
+        return nullptr;
+    }
+
+    uint32_t version = 0;
+    materialParser->getMaterialVersion(&version);
+    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
+            "received %d.", MATERIAL_VERSION, version);
+
+    assert(backend != Backend::DEFAULT && "Default backend has not been resolved.");
+
+    return materialParser;
+}
 
 struct Material::BuilderDetails {
     const void* mPayload = nullptr;
@@ -71,7 +99,7 @@ Material::Builder& Material::Builder::package(const void* payload, size_t size) 
 }
 
 Material* Material::Builder::build(Engine& engine) {
-    MaterialParser* materialParser = FMaterial::createParser(
+    MaterialParser* materialParser = createParser(
             upcast(engine).getBackend(), mImpl->mPayload, mImpl->mSize);
 
     uint32_t v = 0;
@@ -79,15 +107,15 @@ Material* Material::Builder::build(Engine& engine) {
     utils::bitset32 shaderModels;
     shaderModels.setValue(v);
 
-    backend::ShaderModel shaderModel = upcast(engine).getDriver().getShaderModel();
+    ShaderModel shaderModel = upcast(engine).getDriver().getShaderModel();
     if (!shaderModels.test(static_cast<uint32_t>(shaderModel))) {
         CString name;
         materialParser->getName(&name);
         slog.e << "The material '" << name.c_str_safe() << "' was not built for ";
         switch (shaderModel) {
-            case backend::ShaderModel::GL_ES_30: slog.e << "mobile.\n"; break;
-            case backend::ShaderModel::GL_CORE_41: slog.e << "desktop.\n"; break;
-            case backend::ShaderModel::UNKNOWN: /* should never happen */ break;
+            case ShaderModel::GL_ES_30: slog.e << "mobile.\n"; break;
+            case ShaderModel::GL_CORE_41: slog.e << "desktop.\n"; break;
+            case ShaderModel::UNKNOWN: /* should never happen */ break;
         }
         slog.e << "Compiled material contains shader models 0x"
                 << io::hex << shaderModels.getValue() << io::dec << "." << io::endl;
@@ -311,7 +339,7 @@ UniformInterfaceBlock::UniformInfo const* FMaterial::reflect(
     return p == list.end() ? nullptr : &static_cast<UniformInterfaceBlock::UniformInfo const&>(*p);
 }
 
-backend::Handle<backend::HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
+Handle<HwProgram> FMaterial::getProgramSlow(uint8_t variantKey) const noexcept {
     switch (getMaterialDomain()) {
         case MaterialDomain::SURFACE:
             return getSurfaceProgramSlow(variantKey);
@@ -321,7 +349,7 @@ backend::Handle<backend::HwProgram> FMaterial::getProgramSlow(uint8_t variantKey
     }
 }
 
-backend::Handle<backend::HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
+Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
     const noexcept {
     // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
     // if we're unlit, we don't have any bits that correspond to lit materials
@@ -351,7 +379,7 @@ backend::Handle<backend::HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t var
     return createAndCacheProgram(std::move(pb), variantKey);
 }
 
-backend::Handle<backend::HwProgram> FMaterial::getPostProcessProgramSlow(uint8_t variantKey)
+Handle<HwProgram> FMaterial::getPostProcessProgramSlow(uint8_t variantKey)
     const noexcept {
 
     Program pb = getProgramBuilderWithVariants(variantKey, variantKey, variantKey);
@@ -369,6 +397,7 @@ Program FMaterial::getProgramBuilderWithVariants(
         uint8_t vertexVariantKey,
         uint8_t fragmentVariantKey) const noexcept {
     const ShaderModel sm = mEngine.getDriver().getShaderModel();
+    const bool isNoop = mEngine.getBackend() == Backend::NOOP;
 
     /*
      * Vertex shader
@@ -379,7 +408,7 @@ Program FMaterial::getProgramBuilderWithVariants(
     UTILS_UNUSED_IN_RELEASE bool vsOK = mMaterialParser->getShader(vsBuilder, sm,
             vertexVariantKey, ShaderType::VERTEX);
 
-    ASSERT_POSTCONDITION(vsOK && vsBuilder.size() > 0,
+    ASSERT_POSTCONDITION(isNoop || (vsOK && vsBuilder.size() > 0),
             "The material '%s' has not been compiled to include the required "
             "GLSL or SPIR-V chunks for the vertex shader (variant=0x%x, filtered=0x%x).",
             mName.c_str(), variantKey, vertexVariantKey);
@@ -393,7 +422,7 @@ Program FMaterial::getProgramBuilderWithVariants(
     UTILS_UNUSED_IN_RELEASE bool fsOK = mMaterialParser->getShader(fsBuilder, sm,
             fragmentVariantKey, ShaderType::FRAGMENT);
 
-    ASSERT_POSTCONDITION(fsOK && fsBuilder.size() > 0,
+    ASSERT_POSTCONDITION(isNoop || (fsOK && fsBuilder.size() > 0),
             "The material '%s' has not been compiled to include the required "
             "GLSL or SPIR-V chunks for the fragment shader (variant=0x%x, filterer=0x%x).",
             mName.c_str(), variantKey, fragmentVariantKey);
@@ -405,7 +434,7 @@ Program FMaterial::getProgramBuilderWithVariants(
     return pb;
 }
 
-backend::Handle<backend::HwProgram> FMaterial::createAndCacheProgram(Program&& p,
+Handle<HwProgram> FMaterial::createAndCacheProgram(Program&& p,
         uint8_t variantKey) const noexcept {
     auto program = mEngine.getDriverApi().createProgram(std::move(p));
     assert(program);
@@ -463,7 +492,7 @@ void FMaterial::applyPendingEdits() noexcept {
 /**
  * Callback handlers for the debug server, potentially called from any thread. These methods are
  * never called during normal operation and exist for debugging purposes only.
- * 
+ *
  * @{
  */
 
@@ -474,8 +503,7 @@ void FMaterial::onEditCallback(void* userdata, const utils::CString& name, const
 
     // This is called on a web server thread so we defer clearing the program cache
     // and swapping out the MaterialParser until the next getProgram call.
-    material->mPendingEdits = FMaterial::createParser(engine.getBackend(), packageData,
-            packageSize);
+    material->mPendingEdits = createParser(engine.getBackend(), packageData, packageSize);
 }
 
 void FMaterial::onQueryCallback(void* userdata, uint64_t* pVariants) {
@@ -491,31 +519,6 @@ void FMaterial::onQueryCallback(void* userdata, uint64_t* pVariants) {
 }
 
  /** @}*/
-
-MaterialParser* FMaterial::createParser(backend::Backend backend, const void* data, size_t size) {
-    MaterialParser* materialParser = new MaterialParser(backend, data, size);
-
-    MaterialParser::ParseResult materialResult = materialParser->parse();
-
-    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult != MaterialParser::ParseResult::ERROR_MISSING_BACKEND,
-                "the material was not built for the %s backend\n", backendToString(backend))) {
-        return nullptr;
-    }
-
-    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult == MaterialParser::ParseResult::SUCCESS,
-                "could not parse the material package")) {
-        return nullptr;
-    }
-
-    uint32_t version = 0;
-    materialParser->getMaterialVersion(&version);
-    ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
-            "received %d.", MATERIAL_VERSION, version);
-
-    assert(backend != Backend::DEFAULT && "Default backend has not been resolved.");
-
-    return materialParser;
-}
 
 void FMaterial::destroyPrograms(FEngine& engine) {
     DriverApi& driverApi = engine.getDriverApi();

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -153,8 +153,6 @@ public:
 
     /** @}*/
 
-    static MaterialParser* createParser(backend::Backend backend, const void* data, size_t size);
-
 private:
     backend::Handle<backend::HwProgram> getProgramSlow(uint8_t variantKey) const noexcept;
     backend::Handle<backend::HwProgram> getSurfaceProgramSlow(uint8_t variantKey) const noexcept;


### PR DESCRIPTION
This fixes errors that would occur when using the NOOP backend with
materials that were built without OpenGL support.