### PR TITLE
Add callback API to SwapChain

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -22,6 +22,8 @@
 #include <utils/BitmaskEnum.h>
 #include <utils/unwindows.h> // Because we define ERROR in the FenceStatus enum.
 
+#include <backend/PresentCallable.h>
+
 #include <math/vec4.h>
 
 #include <array>    // FIXME: STL headers are not allowed in public headers
@@ -883,6 +885,11 @@ struct PolygonOffset {
     float slope = 0;        // factor in GL-speak
     float constant = 0;     // units in GL-speak
 };
+
+
+using FrameScheduledCallback = void(*)(backend::PresentCallable callable, void* user);
+
+using FrameCompletedCallback = void(*)(void* user);
 
 
 } // namespace backend

--- a/filament/backend/include/backend/PresentCallable.h
+++ b/filament/backend/include/backend/PresentCallable.h
@@ -36,7 +36,7 @@ namespace backend {
  * within a CATransation:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * void myFrameFinishedCallback(PresentCallable presentCallable, void* user) {
+ * void myFrameScheduledCallback(PresentCallable presentCallable, void* user) {
  *     [CATransaction begin];
  *     // Update other UI elements...
  *     presentCallable();
@@ -44,11 +44,13 @@ namespace backend {
  * }
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * To obtain a PresentCallable, pass a backend::FrameFinishedCallback to the beginFrame() function.
- * The callback is called with a PresentCallable object and optional user data:
+ * To obtain a PresentCallable, set a SwapChain::FrameScheduledCallback on a SwapChain with the
+ * SwapChain::setFrameScheduledCallback method. The callback is called with a PresentCallable object
+ * and optional user data:
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * if (renderer->beginFrame(swapChain, myFrameFinishedCallback, nullptr)) {
+ * swapChain->setFrameScheduledCallback(myFrameScheduledCallback, nullptr);
+ * if (renderer->beginFrame(swapChain)) {
  *     renderer->render(view);
  *     renderer->endFrame();
  * }
@@ -57,14 +59,14 @@ namespace backend {
  * @remark Only Filament's Metal backend supports PresentCallables and frame callbacks. Other
  * backends ignore the callback (which will never be called) and proceed normally.
  *
- * @remark The backend::FrameFinishedCallback is called on an arbitrary thread.
+ * @remark The SwapChain::FrameScheduledCallback is called on an arbitrary thread.
  *
  * Applications *must* call each PresentCallable they receive. Each PresentCallable represents a
  * frame that is waiting to be presented. If an application fails to call a PresentCallable, a
  * memory leak could occur. To "cancel" the presentation of a frame, pass false to the
  * PresentCallable, which will cancel the presentation of the frame and release associated memory.
  *
- * @see Renderer, SwapChain, Renderer.beginFrame
+ * @see Renderer, SwapChain::setFrameScheduledCallback
  */
 class UTILS_PUBLIC PresentCallable {
 public:
@@ -92,23 +94,9 @@ private:
 };
 
 /**
- * FrameScheduledCallback is a callback function that notifies an application when Filament has
- * completed processing a frame and that frame is ready to be scheduled for presentation.
- *
- * beginFrame() takes an optional FrameScheduledCallback. If the callback is provided, then that
- * frame will *not* automatically be scheduled for presentation. Instead, the application must call
- * the given PresentCallable.
- *
- * @remark The backend::FrameScheduledCallback is called on an arbitrary thread.
- *
- * @see PresentCallable, beginFrame()
+ * @deprecated, FrameFinishedCallback has been renamed to SwapChain::FrameScheduledCallback.
  */
-using FrameScheduledCallback = void(*)(PresentCallable callable, void* user);
-
-/**
- * @deprecated, renamed to FrameScheduledCallback
- */
-using FrameFinishedCallback UTILS_DEPRECATED = FrameScheduledCallback;
+using FrameFinishedCallback UTILS_DEPRECATED = void(*)(PresentCallable callable, void* user);
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/include/backend/PresentCallable.h
+++ b/filament/backend/include/backend/PresentCallable.h
@@ -92,18 +92,23 @@ private:
 };
 
 /**
- * FrameFinishedCallback is a callback function that notifies an application when Filament has
- * finished processing a frame and that frame is ready to be scheduled for presentation.
+ * FrameScheduledCallback is a callback function that notifies an application when Filament has
+ * completed processing a frame and that frame is ready to be scheduled for presentation.
  *
- * beginFrame() takes an optional FrameFinishedCallback. If the callback is provided, then that
+ * beginFrame() takes an optional FrameScheduledCallback. If the callback is provided, then that
  * frame will *not* automatically be scheduled for presentation. Instead, the application must call
  * the given PresentCallable.
  *
- * @remark The backend::FrameFinishedCallback is called on an arbitrary thread.
+ * @remark The backend::FrameScheduledCallback is called on an arbitrary thread.
  *
  * @see PresentCallable, beginFrame()
  */
-using FrameFinishedCallback = void(*)(PresentCallable callable, void* user);
+using FrameScheduledCallback = void(*)(PresentCallable callable, void* user);
+
+/**
+ * @deprecated, renamed to FrameScheduledCallback
+ */
+using FrameFinishedCallback UTILS_DEPRECATED = FrameScheduledCallback;
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -133,8 +133,16 @@ DECL_DRIVER_API_0(tick)
 
 DECL_DRIVER_API_N(beginFrame,
         int64_t, monotonic_clock_ns,
-        uint32_t, frameId,
+        uint32_t, frameId)
+
+DECL_DRIVER_API_N(setFrameScheduledCallback,
+        backend::SwapChainHandle, sch,
         backend::FrameScheduledCallback, callback,
+        void*, user)
+
+DECL_DRIVER_API_N(setFrameCompletedCallback,
+        backend::SwapChainHandle, sch,
+        backend::FrameCompletedCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(setPresentationTime,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -134,7 +134,7 @@ DECL_DRIVER_API_0(tick)
 DECL_DRIVER_API_N(beginFrame,
         int64_t, monotonic_clock_ns,
         uint32_t, frameId,
-        backend::FrameFinishedCallback, callback,
+        backend::FrameScheduledCallback, callback,
         void*, user)
 
 DECL_DRIVER_API_N(setPresentationTime,

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -28,6 +28,7 @@ namespace filament {
 namespace backend {
 namespace metal {
 
+class MetalDriver;
 class MetalBlitter;
 class MetalBufferPool;
 class MetalRenderTarget;
@@ -39,6 +40,7 @@ struct MetalSamplerGroup;
 struct MetalVertexBuffer;
 
 struct MetalContext {
+    MetalDriver* driver;
     id<MTLDevice> device = nullptr;
     id<MTLCommandQueue> commandQueue = nullptr;
 

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -48,6 +48,8 @@ public:
 
 private:
 
+    friend class MetalSwapChain;
+
     backend::MetalPlatform& mPlatform;
 
     MetalContext* mContext;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "backend/PresentCallable.h"
 #include "private/backend/CommandStream.h"
 #include "CommandStreamDispatcher.h"
 #include "metal/MetalDriver.h"
@@ -101,9 +102,19 @@ void MetalDriver::debugCommand(const char *methodName) {
 void MetalDriver::tick(int) {
 }
 
-void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
+void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
+}
+
+void MetalDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
         backend::FrameScheduledCallback callback, void* user) {
-    mContext->currentDrawSwapChain->setFrameScheduledCallback(callback, user);
+    auto* swapChain = handle_cast<MetalSwapChain>(mHandleMap, sch);
+    swapChain->setFrameScheduledCallback(callback, user);
+}
+
+void MetalDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
+        backend::FrameCompletedCallback callback, void* user) {
+    auto* swapChain = handle_cast<MetalSwapChain>(mHandleMap, sch);
+    swapChain->setFrameCompletedCallback(callback, user);
 }
 
 void MetalDriver::execute(std::function<void(void)> fn) noexcept {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -102,8 +102,8 @@ void MetalDriver::tick(int) {
 }
 
 void MetalDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameFinishedCallback callback, void* user) {
-    mContext->currentDrawSwapChain->setFrameFinishedCallback(callback, user);
+        backend::FrameScheduledCallback callback, void* user) {
+    mContext->currentDrawSwapChain->setFrameScheduledCallback(callback, user);
 }
 
 void MetalDriver::execute(std::function<void(void)> fn) noexcept {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -54,6 +54,7 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
         : DriverBase(new ConcreteDispatcher<MetalDriver>()),
         mPlatform(*platform),
         mContext(new MetalContext) {
+    mContext->driver = this;
     mContext->device = MTLCreateSystemDefaultDevice();
     mContext->commandQueue = [mContext->device newCommandQueue];
     mContext->commandQueue.label = @"Filament";

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -65,10 +65,10 @@ public:
 
     void releaseDrawable();
 
-    void setFrameFinishedCallback(FrameFinishedCallback callback, void* user);
+    void setFrameScheduledCallback(FrameScheduledCallback callback, void* user);
 
     // For CAMetalLayer-backed SwapChains, presents the drawable or schedules a
-    // FrameFinishedCallback.
+    // FrameScheduledCallback.
     void present();
 
     NSUInteger getSurfaceWidth() const;
@@ -85,7 +85,7 @@ private:
     bool isHeadless() const { return type == SwapChainType::HEADLESS; }
     bool isPixelBuffer() const { return type == SwapChainType::CVPIXELBUFFERREF; }
 
-    void scheduleFrameFinishedCallback();
+    void scheduleFrameScheduledCallback();
 
     MetalContext& context;
     id<CAMetalDrawable> drawable = nil;
@@ -99,12 +99,12 @@ private:
 
     // These two fields store a callback and user data to notify the client that a frame is ready
     // for presentation.
-    // If frameFinishedCallback is nullptr, then the Metal backend automatically calls
+    // If frameScheduledCallback is nullptr, then the Metal backend automatically calls
     // presentDrawable when the frame is commited.
     // Otherwise, the Metal backend will not automatically present the frame. Instead, clients bear
     // the responsibility of presenting the frame by calling the PresentCallable object.
-    FrameFinishedCallback frameFinishedCallback = nullptr;
-    void* frameFinishedUserData = nullptr;
+    FrameScheduledCallback frameScheduledCallback = nullptr;
+    void* frameScheduledUserData = nullptr;
 };
 
 struct MetalVertexBuffer : public HwVertexBuffer {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -66,6 +66,7 @@ public:
     void releaseDrawable();
 
     void setFrameScheduledCallback(FrameScheduledCallback callback, void* user);
+    void setFrameCompletedCallback(FrameCompletedCallback callback, void* user);
 
     // For CAMetalLayer-backed SwapChains, presents the drawable or schedules a
     // FrameScheduledCallback.
@@ -86,6 +87,7 @@ private:
     bool isPixelBuffer() const { return type == SwapChainType::CVPIXELBUFFERREF; }
 
     void scheduleFrameScheduledCallback();
+    void scheduleFrameCompletedCallback();
 
     MetalContext& context;
     id<CAMetalDrawable> drawable = nil;
@@ -105,6 +107,9 @@ private:
     // the responsibility of presenting the frame by calling the PresentCallable object.
     FrameScheduledCallback frameScheduledCallback = nullptr;
     void* frameScheduledUserData = nullptr;
+
+    FrameCompletedCallback frameCompletedCallback = nullptr;
+    void* frameCompletedUserData = nullptr;
 };
 
 struct MetalVertexBuffer : public HwVertexBuffer {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -183,15 +183,15 @@ id<MTLTexture> MetalSwapChain::acquireDepthTexture() {
     return depthTexture;
 }
 
-void MetalSwapChain::setFrameFinishedCallback(FrameFinishedCallback callback, void* user) {
-    frameFinishedCallback = callback;
-    frameFinishedUserData = user;
+void MetalSwapChain::setFrameScheduledCallback(FrameScheduledCallback callback, void* user) {
+    frameScheduledCallback = callback;
+    frameScheduledUserData = user;
 }
 
 void MetalSwapChain::present() {
     if (drawable) {
-        if (frameFinishedCallback) {
-            scheduleFrameFinishedCallback();
+        if (frameScheduledCallback) {
+            scheduleFrameScheduledCallback();
         } else  {
             [getPendingCommandBuffer(&context) presentDrawable:drawable];
         }
@@ -207,18 +207,18 @@ void presentDrawable(bool presentFrame, void* user) {
     // The drawable will be released here when the "drawable" variable goes out of scope.
 }
 
-void MetalSwapChain::scheduleFrameFinishedCallback() {
-    if (!frameFinishedCallback) {
+void MetalSwapChain::scheduleFrameScheduledCallback() {
+    if (!frameScheduledCallback) {
         return;
     }
 
     assert(drawable);
-    backend::FrameFinishedCallback callback = frameFinishedCallback;
+    backend::FrameScheduledCallback callback = frameScheduledCallback;
     // This block strongly captures drawable to keep it alive until the handler executes.
     // We cannot simply reference this->drawable inside the block because the block would then only
     // capture the _this_ pointer (MetalSwapChain*) instead of the drawable.
     id<CAMetalDrawable> d = drawable;
-    void* userData = frameFinishedUserData;
+    void* userData = frameScheduledUserData;
     [getPendingCommandBuffer(&context) addScheduledHandler:^(id<MTLCommandBuffer> cb) {
         // CFBridgingRetain is used here to give the drawable a +1 retain count before
         // casting it to a void*.

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -48,8 +48,17 @@ void NoopDriver::terminate() {
 void NoopDriver::tick(int) {
 }
 
-void NoopDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameScheduledCallback, void*) {
+void NoopDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
+}
+
+void NoopDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
+        backend::FrameScheduledCallback callback, void* user) {
+
+}
+
+void NoopDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
+        backend::FrameCompletedCallback callback, void* user) {
+
 }
 
 void NoopDriver::setPresentationTime(int64_t monotonic_clock_ns) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -49,7 +49,7 @@ void NoopDriver::tick(int) {
 }
 
 void NoopDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameFinishedCallback, void*) {
+        backend::FrameScheduledCallback, void*) {
 }
 
 void NoopDriver::setPresentationTime(int64_t monotonic_clock_ns) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2857,8 +2857,7 @@ void OpenGLDriver::tick(int) {
     executeEveryNowAndThenOps();
 }
 
-void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameScheduledCallback, void*) {
+void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     auto& gl = mContext;
     insertEventMarker("beginFrame");
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {
@@ -2874,6 +2873,16 @@ void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
             }
         }
     }
+}
+
+void OpenGLDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
+        backend::FrameScheduledCallback callback, void* user) {
+
+}
+
+void OpenGLDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
+        backend::FrameCompletedCallback callback, void* user) {
+
 }
 
 void OpenGLDriver::setPresentationTime(int64_t monotonic_clock_ns) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2858,7 +2858,7 @@ void OpenGLDriver::tick(int) {
 }
 
 void OpenGLDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameFinishedCallback, void*) {
+        backend::FrameScheduledCallback, void*) {
     auto& gl = mContext;
     insertEventMarker("beginFrame");
     if (UTILS_UNLIKELY(!mExternalStreams.empty())) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -292,8 +292,7 @@ void VulkanDriver::tick(int) {
     }
 }
 
-void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameScheduledCallback, void*) {
+void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
     // We allow multiple beginFrame / endFrame pairs before commit(), so gracefully return early
     // if the swap chain has already been acquired.
     if (mContext.currentCommands) {
@@ -357,6 +356,16 @@ void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
     mFramebufferCache.gc();
     mBinder.gc();
     mDisposer.gc();
+}
+
+void VulkanDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
+        backend::FrameScheduledCallback callback, void* user) {
+
+}
+
+void VulkanDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
+        backend::FrameCompletedCallback callback, void* user) {
+
 }
 
 void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -293,7 +293,7 @@ void VulkanDriver::tick(int) {
 }
 
 void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId,
-        backend::FrameFinishedCallback, void*) {
+        backend::FrameScheduledCallback, void*) {
     // We allow multiple beginFrame / endFrame pairs before commit(), so gracefully return early
     // if the swap chain has already been acquired.
     if (mContext.currentCommands) {

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -95,7 +95,7 @@ TEST_F(BackendTest, VertexBufferUpdate) {
         getDriverApi().startCapture(0);
 
         getDriverApi().makeCurrent(swapChain, swapChain);
-        getDriverApi().beginFrame(0, 0, nullptr, nullptr);
+        getDriverApi().beginFrame(0, 0);
 
         // Draw 10 triangles, updating the vertex buffer / index buffer each time.
         getDriverApi().beginRenderPass(defaultRenderTarget, params);

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -122,7 +122,7 @@ TEST_F(BackendTest, MRT) {
         getDriverApi().startCapture(0);
 
         getDriverApi().makeCurrent(swapChain, swapChain);
-        getDriverApi().beginFrame(0, 0, nullptr, nullptr);
+        getDriverApi().beginFrame(0, 0);
 
         // Draw a triangle.
         getDriverApi().beginRenderPass(renderTarget, params);

--- a/filament/backend/test/test_MissingRequiredAttributes.cpp
+++ b/filament/backend/test/test_MissingRequiredAttributes.cpp
@@ -100,7 +100,7 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
         getDriverApi().startCapture(0);
 
         getDriverApi().makeCurrent(swapChain, swapChain);
-        getDriverApi().beginFrame(0, 0, nullptr, nullptr);
+        getDriverApi().beginFrame(0, 0);
 
         // Render a triangle.
         getDriverApi().beginRenderPass(defaultRenderTarget, params);

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -238,7 +238,7 @@ TEST_F(BackendTest, ReadPixels) {
         params.viewport.width = t.getRenderTargetSize();
 
         getDriverApi().makeCurrent(swapChain, swapChain);
-        getDriverApi().beginFrame(0, 0, nullptr, nullptr);
+        getDriverApi().beginFrame(0, 0);
 
         // Render a white triangle over blue.
         getDriverApi().beginRenderPass(renderTarget, params);

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -411,7 +411,7 @@ public:
      * frame and not call endFrame(), or proceed as though true was returned.
      *
      * Typically, Filament is responsible for scheduling the frame's presentation to the SwapChain.
-     * If a backend::FrameFinishedCallback is provided, however, the application bares the
+     * If a backend::FrameScheduledCallback is provided, however, the application bares the
      * responsibility of scheduling a frame for presentation by calling the backend::PresentCallable
      * passed to the callback function. Currently this functionality is only supported by the Metal
      * backend.
@@ -436,11 +436,11 @@ public:
      * All calls to render() must happen *after* beginFrame().
      *
      * @see
-     * endFrame(), backend::PresentCallable, backend::FrameFinishedCallback
+     * endFrame(), backend::PresentCallable, backend::FrameSinishedCallback
      */
     bool beginFrame(SwapChain* swapChain,
             uint64_t vsyncSteadyClockTimeNano = 0u,
-            backend::FrameFinishedCallback callback = nullptr, void* user = nullptr);
+            backend::FrameScheduledCallback callback = nullptr, void* user = nullptr);
 
     /**
      * Finishes the current frame and schedules it for display.

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -19,6 +19,7 @@
 
 #include <filament/FilamentAPI.h>
 #include <backend/DriverEnums.h>
+#include <backend/PresentCallable.h>
 
 #include <utils/compiler.h>
 
@@ -142,6 +143,9 @@ namespace filament {
  */
 class UTILS_PUBLIC SwapChain : public FilamentAPI {
 public:
+    using FrameScheduledCallback = backend::FrameScheduledCallback;
+    using FrameCompletedCallback = backend::FrameCompletedCallback;
+
     static const uint64_t CONFIG_TRANSPARENT = backend::SWAP_CHAIN_CONFIG_TRANSPARENT;
     /**
      * This flag indicates that the swap chain may be used as a source surface
@@ -173,6 +177,50 @@ public:
             backend::SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER;
 
     void* getNativeWindow() const noexcept;
+
+    /**
+     * FrameScheduledCallback is a callback function that notifies an application when Filament has
+     * completed processing a frame and that frame is ready to be scheduled for presentation.
+     *
+     * Typically, Filament is responsible for scheduling the frame's presentation to the SwapChain.
+     * If a SwapChain::FrameScheduledCallback is set, however, the application bares the
+     * responsibility of scheduling a frame for presentation by calling the backend::PresentCallable
+     * passed to the callback function. Currently this functionality is only supported by the Metal
+     * backend.
+     *
+     * A FrameScheduledCallback can be set on an individual SwapChain through
+     * SwapChain::setFrameScheduledCallback. If the callback is set, then the SwapChain will *not*
+     * automatically schedule itself for presentation. Instead, the application must call the
+     * PresentCallable passed to the FrameScheduledCallback.
+     *
+     * @param callback    A callback, or nullptr to unset.
+     * @param user        An optional pointer to user data passed to the callback function.
+     *
+     * @remark Only Filament's Metal backend supports PresentCallables and frame callbacks. Other
+     * backends ignore the callback (which will never be called) and proceed normally.
+     *
+     * @remark The SwapChain::FrameScheduledCallback is called on an arbitrary thread.
+     *
+     * @see PresentCallable
+     */
+    void setFrameScheduledCallback(FrameScheduledCallback callback, void* user = nullptr);
+
+    /**
+     * FrameCompletedCallback is a callback function that notifies an application when a frame's
+     * contents have completed rendering on the GPU.
+     *
+     * Use SwapChain::setFrameCompletedCallback to set a callback on an individual SwapChain. Each
+     * time a frame completes GPU rendering, the callback will be called with optional user data.
+     *
+     * @param callback    A callback, or nullptr to unset.
+     * @param user        An optional pointer to user data passed to the callback function.
+     *
+     * @remark Only Filament's Metal backend supports frame callbacks. Other backends ignore the
+     * callback (which will never be called) and proceed normally.
+     *
+     * @remark The SwapChain::FrameCompletedCallback is called on an arbitrary thread.
+     */
+    void setFrameCompletedCallback(FrameCompletedCallback callback, void* user = nullptr);
 };
 
 } // namespace filament

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -212,13 +212,13 @@ public:
      * Use SwapChain::setFrameCompletedCallback to set a callback on an individual SwapChain. Each
      * time a frame completes GPU rendering, the callback will be called with optional user data.
      *
+     * The FrameCompletedCallback is guaranteed to be called on the main Filament thread.
+     *
      * @param callback    A callback, or nullptr to unset.
      * @param user        An optional pointer to user data passed to the callback function.
      *
      * @remark Only Filament's Metal backend supports frame callbacks. Other backends ignore the
      * callback (which will never be called) and proceed normally.
-     *
-     * @remark The SwapChain::FrameCompletedCallback is called on an arbitrary thread.
      */
     void setFrameCompletedCallback(FrameCompletedCallback callback, void* user = nullptr);
 };

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -866,7 +866,7 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
 }
 
 bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano,
-        backend::FrameFinishedCallback callback, void* user) {
+        backend::FrameScheduledCallback callback, void* user) {
     assert(swapChain);
 
     SYSTRACE_CALL();
@@ -1112,7 +1112,7 @@ void Renderer::render(View const* view) {
 }
 
 bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano,
-        backend::FrameFinishedCallback callback, void* user) {
+        backend::FrameScheduledCallback callback, void* user) {
     return upcast(this)->beginFrame(upcast(swapChain), vsyncSteadyClockTimeNano, callback, user);
 }
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -928,7 +928,10 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
         FEngine& engine = getEngine();
         FEngine::DriverApi& driver = engine.getDriverApi();
 
-        driver.beginFrame(appVsync.time_since_epoch().count(), mFrameId, callback, user);
+        if (callback) {
+            driver.setFrameScheduledCallback(swapChain->getHwHandle(), callback, user);
+        }
+        driver.beginFrame(appVsync.time_since_epoch().count(), mFrameId);
 
         // This need to occur after the backend beginFrame() because some backends need to start
         // a command buffer before creating a fence.
@@ -1109,6 +1112,10 @@ Engine* Renderer::getEngine() noexcept {
 
 void Renderer::render(View const* view) {
     upcast(this)->render(upcast(view));
+}
+
+bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano) {
+    return upcast(this)->beginFrame(upcast(swapChain), vsyncSteadyClockTimeNano, nullptr, nullptr);
 }
 
 bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano,

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -21,12 +21,12 @@
 namespace filament {
 
 FSwapChain::FSwapChain(FEngine& engine, void* nativeWindow, uint64_t flags)
-        : mNativeWindow(nativeWindow), mConfigFlags(flags) {
+        : mEngine(engine), mNativeWindow(nativeWindow), mConfigFlags(flags) {
     mSwapChain = engine.getDriverApi().createSwapChain(nativeWindow, flags);
 }
 
 FSwapChain::FSwapChain(FEngine& engine, uint32_t width, uint32_t height, uint64_t flags)
-        : mConfigFlags(flags) {
+        : mEngine(engine), mConfigFlags(flags) {
     mSwapChain = engine.getDriverApi().createSwapChainHeadless(width, height, flags);
 }
 
@@ -34,8 +34,24 @@ void FSwapChain::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroySwapChain(mSwapChain);
 }
 
+void FSwapChain::setFrameScheduledCallback(FrameScheduledCallback callback, void* user) {
+    mEngine.getDriverApi().setFrameScheduledCallback(mSwapChain, callback, user);
+}
+
+void FSwapChain::setFrameCompletedCallback(FrameCompletedCallback callback, void* user) {
+    mEngine.getDriverApi().setFrameCompletedCallback(mSwapChain, callback, user);
+}
+
 void* SwapChain::getNativeWindow() const noexcept {
     return upcast(this)->getNativeWindow();
+}
+
+void SwapChain::setFrameScheduledCallback(FrameScheduledCallback callback, void* user) {
+    return upcast(this)->setFrameScheduledCallback(callback, user);
+}
+
+void SwapChain::setFrameCompletedCallback(FrameCompletedCallback callback, void* user) {
+    return upcast(this)->setFrameCompletedCallback(callback, user);
 }
 
 } // namespace filament

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -76,7 +76,7 @@ public:
             Viewport const& srcViewport, CopyFrameFlag flags);
 
     bool beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano,
-            backend::FrameFinishedCallback callback, void* user);
+            backend::FrameScheduledCallback callback, void* user);
     void endFrame();
 
     void resetUserTime();

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -59,7 +59,12 @@ public:
       return mSwapChain;
     }
 
+    void setFrameScheduledCallback(FrameScheduledCallback callback, void* user);
+
+    void setFrameCompletedCallback(FrameCompletedCallback callback, void* user);
+
 private:
+    FEngine& mEngine;
     backend::Handle<backend::HwSwapChain> mSwapChain;
     void* mNativeWindow = nullptr;
     uint64_t mConfigFlags = 0;


### PR DESCRIPTION
This adds new new APIs to SwapChain:

- `FrameScheduledCallback` (previously `FrameFinishedCallback`). Called when a frame is scheduled by the OS for GPU execution. This is needed on iOS to correctly synchronize between UI elements and 3D rendering.
- `FrameCompletedCallback`. Called when a frame has completed on the GPU (similar to a hard fence).

