### PR TITLE
Revert "macOS: fix headless rendering."

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## Next release (main branch)
 
+- Fix EXC_BAD_INSTRUCTION seen when using headless SwapChains on macOS with OpenGL.
+
 ## v1.9.9
 
 ## v1.9.8

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -514,17 +514,22 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
         windowFlags |= SDL_WINDOW_RESIZABLE;
     }
 
+    if (config.headless) {
+        windowFlags |= SDL_WINDOW_HIDDEN;
+    }
+
     mBackend = config.backend;
 
+    // Even if we're in headless mode, we still need to create a window, otherwise SDL will not poll
+    // events.
+    mWindow = SDL_CreateWindow(title.c_str(), x, y, (int) w, (int) h, windowFlags);
+
     if (config.headless) {
-        mWindow = nullptr;
         mFilamentApp->mEngine = Engine::create(config.backend);
         mSwapChain = mFilamentApp->mEngine->createSwapChain((uint32_t) w, (uint32_t) h);
         mWidth = w;
         mHeight = h;
     } else {
-        mWindow = SDL_CreateWindow(title.c_str(), x, y, (int) w, (int) h, windowFlags);
-
         // Create the Engine after the window in case this happens to be a single-threaded platform.
         // For single-threaded platforms, we need to ensure that Filament's OpenGL context is
         // current, rather than the one created by SDL.


### PR DESCRIPTION
@prideout I'm fine with this if you are. I guess neither of us can remember why this change was needed. The Filament rendering tests still pass.

This reverts commit d5d77a46ec41283e1629dbd19031eb5609f41204.

Fixes #3264.