### PR TITLE
Fix clear behavior with RenderTarget API.

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -228,6 +228,12 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         return;
     }
 
+    FRenderTarget* currentRenderTarget = upcast(view.getRenderTarget());
+    if (mPreviousRenderTarget != currentRenderTarget) {
+        initializeClearFlags();
+        mPreviousRenderTarget = currentRenderTarget;
+    }
+
     view.prepare(engine, driver, arena, svp, getShaderUserTime());
 
     // start froxelization immediately, it has no dependencies
@@ -899,14 +905,8 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     float l = float(time.count() - h);
     mShaderUserTime = { h, l, 0, 0 };
 
-    // We always discard and clear the depth+stencil buffers -- we don't allow sharing these
-    // across views (clear implies discard)
-    mDiscardedFlags = ((mClearOptions.discard || mClearOptions.clear) ?
-              TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
-            | TargetBufferFlags::DEPTH_AND_STENCIL;
-
-    mClearFlags = (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
-            | TargetBufferFlags::DEPTH_AND_STENCIL;
+    initializeClearFlags();
+    mPreviousRenderTarget = nullptr;
 
     mBeginFrameInternal = {};
 
@@ -1100,6 +1100,17 @@ void FRenderer::readPixels(Handle<HwRenderTarget> renderTargetHandle,
 Handle<HwRenderTarget> FRenderer::getRenderTarget(FView& view) const noexcept {
     Handle<HwRenderTarget> viewRenderTarget = view.getRenderTargetHandle();
     return viewRenderTarget ? viewRenderTarget : mRenderTarget;
+}
+
+void FRenderer::initializeClearFlags() {
+    // We always discard and clear the depth+stencil buffers -- we don't allow sharing these
+    // across views (clear implies discard)
+    mDiscardedFlags = ((mClearOptions.discard || mClearOptions.clear) ?
+              TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
+            | TargetBufferFlags::DEPTH_AND_STENCIL;
+
+    mClearFlags = (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
+            | TargetBufferFlags::DEPTH_AND_STENCIL;
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -49,6 +49,7 @@ class Driver;
 class View;
 
 class FEngine;
+class FRenderTarget;
 class FView;
 class ShadowMap;
 
@@ -161,6 +162,8 @@ private:
     backend::TextureFormat getHdrFormat(const View& view, bool translucent) const noexcept;
     backend::TextureFormat getLdrFormat(bool translucent) const noexcept;
 
+    void initializeClearFlags();
+
     using clock = std::chrono::steady_clock;
     using Epoch = clock::time_point;
     using duration = clock::duration;
@@ -189,6 +192,7 @@ private:
     ClearOptions mClearOptions;
     backend::TargetBufferFlags mDiscardedFlags{};
     backend::TargetBufferFlags mClearFlags{};
+    FRenderTarget* mPreviousRenderTarget = nullptr;
     std::function<void()> mBeginFrameInternal;
 
     // per-frame arena for this Renderer


### PR DESCRIPTION
This fixes a bug seen with client applications that use ClearOptions
instead of Skybox, and one or more offscreen RenderTarget objects.
These apps would see junk pixels because Filament would only clear the
first render target in the frame.

The fix is to factor some the flag-setting logic in `beginFrame()` into
a private method, and call this method from `render()` each time
the user-level RenderTarget has been changed.

I wrote a simple C++ demo to reproduce the issue and to verify that
this fix works.