### PR TITLE
Improve the "unbound texture" warnings.

### DIFF
--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -43,7 +43,8 @@ public:
 
     struct Sampler {
         utils::CString name = {};   // name of the sampler in the shader
-        size_t binding = 0;         // binding point of the sampler in the shader
+        uint16_t binding = 0;       // binding point of the sampler in the shader
+        bool strict = false;        // if true, this sampler must always have a bound texture
     };
 
     using SamplerGroupInfo = std::array<std::vector<Sampler>, SAMPLER_BINDING_COUNT>;

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -215,6 +215,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
             Handle<HwTexture> th = samplers[index].t;
             if (UTILS_UNLIKELY(!th)) {
 #ifndef NDEBUG
+                slog.w << "In material " << name.c_str() << ": ";
                 slog.w << "no texture bound to unit " << +index << io::endl;
 #endif
                 continue;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1611,8 +1611,14 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
             // not allow sampling from a non-bound texture.
             const VulkanTexture* texture;
             if (UTILS_UNLIKELY(!boundSampler->t)) {
-                utils::slog.w << "Warning: no texture bound at binding point "
-                        << (size_t) bindingPoint << "." << utils::io::endl;
+                if (!sampler.strict) {
+                    continue;
+                }
+                utils::slog.w << "No texture bound to '" << sampler.name.c_str() << "'";
+#ifndef NDEBUG
+                utils::slog.w << " in material '" << program->name.c_str() << "'";
+#endif
+                utils::slog.w << " at binding point " << +bindingPoint << utils::io::endl;
                 texture = mContext.emptyTexture;
             } else {
                 texture = handle_const_cast<VulkanTexture>(mHandleMap, boundSampler->t);

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -151,7 +151,8 @@ static void addSamplerGroup(Program& pb, uint8_t bindingPoint, SamplerInterfaceB
             uint8_t binding = 0;
             UTILS_UNUSED bool ok = map.getSamplerBinding(bindingPoint, (uint8_t)i, &binding);
             assert(ok);
-            samplers[i] = { std::move(uniformName), binding };
+            const bool strict = (bindingPoint == filament::BindingPoints::PER_MATERIAL_INSTANCE);
+            samplers[i] = { std::move(uniformName), binding, strict };
         }
         pb.setSamplerGroup(bindingPoint, samplers.data(), samplers.size());
     }


### PR DESCRIPTION
With Vulkan, this warning would sometimes be a false positive. It could trigger for internal samplers like `ssao` and `structure`, even though they were not declared in SPIR-V.

With OpenGL, this warning would never be a false positive because it has the luxury of calling `glGetUniformLocation`.

This adds an internal field to samplers called `strict` that indicates whether or not a sampler should always have a bound texture. For now the only strict samplers are the custom ones declared in the user's material.

In the future, we should consider adding [spirv-reflect](https://github.com/KhronosGroup/SPIRV-Reflect) to our tree to help with problems like this.