### PR TITLE
Filament should always bind an IBL texture.

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -237,7 +237,6 @@ void FEngine::init() {
     // 3 bands = 9 float3
     const float sh[9 * 3] = { 0.0f };
     mDefaultIbl = upcast(IndirectLight::Builder()
-            .reflections(mDefaultIblTexture)
             .irradiance(3, reinterpret_cast<const float3*>(sh))
             .build(*this));
 


### PR DESCRIPTION
This prevents a SwiftShader crash and/or a slew of "no texture bound"
warnings that would appear when the client provides an IBL without
providing reflections texture, which should be a valid thing to do.

Note that it is okay to declare a sampler in GLSL that never gets bound,
as long as it is never sampled from. Since we always sample from the
IBL specular texture, we should always bind something to it.