### PR TITLE
Fix Windows iterator issue in Zip2Iterator and StructureOfArrays

### DIFF
--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -181,7 +181,7 @@ public:
         Iterator(Iterator const& rhs) noexcept = default;
         Iterator& operator=(Iterator const& rhs) = default;
 
-        const reference operator*() const { return { soa, index }; }
+        reference operator*() const { return { soa, index }; }
         reference operator*() { return { soa, index }; }
         reference operator[](size_t n) { return *(*this + n); }
 

--- a/libs/utils/include/utils/Zip2Iterator.h
+++ b/libs/utils/include/utils/Zip2Iterator.h
@@ -60,8 +60,11 @@ public:
     Zip2Iterator(Zip2Iterator const& rhs) noexcept = default;
     Zip2Iterator& operator=(Zip2Iterator const& rhs) = default;
 
-    const value_type operator*() const { return { *mIt.first, *mIt.second }; }
-          reference  operator*()       { return { *mIt.first, *mIt.second }; }
+    // MSVC's implementation of std::sort performs
+    //   *iterator = ...
+    // so the return value for operator* overloads must be non-const and assignable.
+    value_type operator*() const { return { *mIt.first, *mIt.second }; }
+    reference  operator*()       { return { *mIt.first, *mIt.second }; }
 
     const value_type operator[](size_t n) const { return *(*this + n); }
           reference  operator[](size_t n)       { return *(*this + n); }

--- a/libs/utils/include/utils/Zip2Iterator.h
+++ b/libs/utils/include/utils/Zip2Iterator.h
@@ -60,9 +60,6 @@ public:
     Zip2Iterator(Zip2Iterator const& rhs) noexcept = default;
     Zip2Iterator& operator=(Zip2Iterator const& rhs) = default;
 
-    // MSVC's implementation of std::sort performs
-    //   *iterator = ...
-    // so the return value for operator* overloads must be non-const and assignable.
     value_type operator*() const { return { *mIt.first, *mIt.second }; }
     reference  operator*()       { return { *mIt.first, *mIt.second }; }
 


### PR DESCRIPTION
I <3 C++

This boils down to the differences between a `const iterator` and a `const_iterator`.

Dereferencing a `const iterator` should return a non-const reference, so it can be assigned:

```
const Zip2Iterator it;
const StructureOfArrays soa;

*it = ...
*soa = ...
```

Fixes #3319, #3327, #3312