### PR TITLE
Android: do not export internal symbols.

### DIFF
--- a/android/filament-android/libfilament-jni.map
+++ b/android/filament-android/libfilament-jni.map
@@ -1,4 +1,20 @@
 LIBFILAMENT {
-  global: *filament*; JNI*;
+  global:
+    Java_com_google_android_filament_*;
+    JNI*;
+    *filament*Camera*;
+    *filament*Skybox*;
+    *filament*Engine*;
+    *filament*RenderableManager*;
+    *filament*Aabb*;
+    *filament*IndirectLight*;
+    *filament*LightManager*;
+    *filament*Transform*;
+    *filament*Material*;
+    *filament*IndexBuffer*;
+    *filament*VertexBuffer*;
+    *filament*Texture*;
+    *filament*geometry*;
+
   local: *;
 };


### PR DESCRIPTION
We now export only two groups of symbols: (1) JNI and (2) dynamic linker
symbols used by the companion libraries.

This commit has the following impact:

- Shrinks the arm64 so from 1024 KiB to 954 KiB.
- Shrinks the arm64 aar from 560 KiB to 538 KiB.

Note that the patterns in the map file are tested against mangled names
and therefore should not be used to match the double-colon operator.