### PR TITLE
WebGL: RGB16F is not color renderable.

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -31,7 +31,7 @@
 #include <utils/Panic.h>
 #include <utils/Systrace.h>
 
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__)
 #include <emscripten.h>
 #endif
 
@@ -1518,9 +1518,15 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
         case TextureFormat::RGBA16F:
             return gl.ext.EXT_color_buffer_float || gl.ext.EXT_color_buffer_half_float;
 
-        // RGB16F is only supported with EXT_color_buffer_half_float
+        // RGB16F is only supported with EXT_color_buffer_half_float, however
+        // some WebGL implementations do not consider this extension to be sufficient:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=941671#c10
         case TextureFormat::RGB16F:
+        #if defined(__EMSCRIPTEN__)
+            return false;
+        #else
             return gl.ext.EXT_color_buffer_half_float;
+        #endif
 
         // Float formats from GL_EXT_color_buffer_float
         case TextureFormat::R32F:


### PR DESCRIPTION
This was problematic with Chrome's ANGLE backend; more information at:
https://bugs.chromium.org/p/chromium/issues/detail?id=941671#c10

Fixes #3308