### PR TITLE
Fix computeTangents

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -480,7 +480,7 @@ void ResourceLoader::computeTangents(FFilamentAsset* asset) const {
         } else {
             const cgltf_morph_target& morphTarget = prim.targets[morphTargetIndex];
             for (cgltf_size aindex = 0; aindex < morphTarget.attributes_count; aindex++) {
-                const cgltf_attribute& attr = prim.attributes[aindex];
+                const cgltf_attribute& attr = morphTarget.attributes[aindex];
                 if (attr.index == 0) {
                     accessors[attr.type] = attr.data;
                     vertexCount = attr.data->count;


### PR DESCRIPTION
I load a gltf, then crashed. Took a while to troubleshoot the issue.
I found this:
I add a log
![image](https://user-images.githubusercontent.com/4098790/100987620-b5b10100-3589-11eb-9db6-a8f51e13ff41.png)
This is the log's out puts:
![image](https://user-images.githubusercontent.com/4098790/100987646-bcd80f00-3589-11eb-8168-899a79d8e18f.png)
And the crash is asset failed at this point:
![image](https://user-images.githubusercontent.com/4098790/100987798-f0b33480-3589-11eb-8c29-1ad725085f4b.png)
