### PR TITLE
matdbg / matinfo: fix post-process variant string

### DIFF
--- a/libs/matdbg/src/CommonWriter.cpp
+++ b/libs/matdbg/src/CommonWriter.cpp
@@ -16,11 +16,20 @@
 
 #include "CommonWriter.h"
 
+#include <private/filament/EngineEnums.h>
 #include <private/filament/Variant.h>
 
 namespace filament::matdbg {
 
-std::string formatVariantString(uint8_t variant) noexcept {
+std::string formatVariantString(uint8_t variant, MaterialDomain domain) noexcept {
+    if (domain == MaterialDomain::POST_PROCESS) {
+        switch ((PostProcessVariant) variant) {
+            case PostProcessVariant::OPAQUE: return "OPA";
+            case PostProcessVariant::TRANSLUCENT: return "TRN";
+        }
+        return "UNK";
+    }
+
     std::string variantString = "";
 
     // NOTE: The 3-character nomenclature used here is consistent with the ASCII art seen in the

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -225,7 +225,7 @@ const char* toString(backend::SamplerFormat format) noexcept {
 
 // Returns a human-readable variant description.
 // For example: DYN|DIR
-std::string formatVariantString(uint8_t variant) noexcept;
+std::string formatVariantString(uint8_t variant, MaterialDomain domain) noexcept;
 
 } // namespace matdbg
 } // namespace filament

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -115,11 +115,12 @@ static bool printParametersInfo(ostream& json, const ChunkContainer& container) 
     return true;
 }
 
-static void printShaderInfo(ostream& json, const std::vector<ShaderInfo>& info) {
+static void printShaderInfo(ostream& json, const vector<ShaderInfo>& info, const ChunkContainer& container) {
+    MaterialDomain domain = MaterialDomain::SURFACE;
+    read(container, ChunkType::MaterialDomain, reinterpret_cast<uint8_t*>(&domain));
     for (uint64_t i = 0; i < info.size(); ++i) {
         const auto& item = info[i];
-
-        string variantString = formatVariantString(item.variant);
+        string variantString = formatVariantString(item.variant, domain);
         string ps = (item.pipelineStage == backend::ShaderType::VERTEX) ? "vertex  " : "fragment";
         json
             << "    {"
@@ -139,7 +140,7 @@ static bool printGlslInfo(ostream& json, const ChunkContainer& container) {
         return false;
     }
     json << "\"opengl\": [\n";
-    printShaderInfo(json, info);
+    printShaderInfo(json, info, container);
     json << "],\n";
     return true;
 }
@@ -151,7 +152,7 @@ static bool printVkInfo(ostream& json, const ChunkContainer& container) {
         return false;
     }
     json << "\"vulkan\": [\n";
-    printShaderInfo(json, info);
+    printShaderInfo(json, info, container);
     json << "],\n";
     return true;
 }
@@ -163,7 +164,7 @@ static bool printMetalInfo(ostream& json, const ChunkContainer& container) {
         return false;
     }
     json << "\"metal\": [\n";
-    printShaderInfo(json, info);
+    printShaderInfo(json, info, container);
     json << "],\n";
     return true;
 }

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -333,7 +333,10 @@ static void printChunks(ostream& text, const ChunkContainer& container) {
     }
 }
 
-static void printShaderInfo(ostream& text, const vector<ShaderInfo>& info) {
+static void printShaderInfo(ostream& text, const vector<ShaderInfo>& info,
+        const ChunkContainer& container) {
+    MaterialDomain domain = MaterialDomain::SURFACE;
+    read(container, ChunkType::MaterialDomain, reinterpret_cast<uint8_t*>(&domain));
     for (uint64_t i = 0; i < info.size(); ++i) {
         const auto& item = info[i];
         text << "    #";
@@ -346,7 +349,7 @@ static void printShaderInfo(ostream& text, const vector<ShaderInfo>& info) {
              << right << (int) item.variant;
         text << setfill(' ') << dec;
         text << "   ";
-        text << formatVariantString(item.variant);
+        text << formatVariantString(item.variant, domain);
         text << endl;
     }
     text << endl;
@@ -359,7 +362,7 @@ static bool printGlslInfo(ostream& text, const ChunkContainer& container) {
         return false;
     }
     text << "GLSL shaders:" << endl;
-    printShaderInfo(text, info);
+    printShaderInfo(text, info, container);
     return true;
 }
 
@@ -370,7 +373,7 @@ static bool printVkInfo(ostream& text, const ChunkContainer& container) {
         return false;
     }
     text << "Vulkan shaders:" << endl;
-    printShaderInfo(text, info);
+    printShaderInfo(text, info, container);
     return true;
 }
 
@@ -381,7 +384,7 @@ static bool printMetalInfo(ostream& text, const ChunkContainer& container) {
         return false;
     }
     text << "Metal shaders:" << endl;
-    printShaderInfo(text, info);
+    printShaderInfo(text, info, container);
     return true;
 }
 

--- a/libs/matdbg/web/index.html
+++ b/libs/matdbg/web/index.html
@@ -42,17 +42,13 @@
     <div style="white-space: pre">
 name = {{ name }}
 version = {{ version }}
+{{#required_attributes.length}}
 
 <b>Required attributes</b>
 {{#required_attributes}}
 {{.}}
 {{/required_attributes}}
-
-DIR = DIRECTIONAL_LIGHTING
-DYN = DYNAMIC_LIGHTING
-SRE = SHADOW_RECEIVER
-SKN = SKINNING_OR_MORPHING
-DEP = DEPTH
+{{/required_attributes.length}}
 
 <b>OpenGL shaders</b>
 {{#opengl}}


### PR DESCRIPTION
Also some minor HTML stuff:

- Hide "Required attributes" header when there are none.
- Remove legend for variants (takes too much space).