### PR TITLE
Unbind texture from all sampler groups upon destroy

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -24,6 +24,8 @@
 #include <Metal/Metal.h>
 #include <QuartzCore/QuartzCore.h>
 
+#include <tsl/robin_set.h>
+
 namespace filament {
 namespace backend {
 namespace metal {
@@ -65,6 +67,9 @@ struct MetalContext {
     SamplerStateCache samplerStateCache;
 
     MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
+
+    // Keeps track of all alive sampler groups.
+    tsl::robin_set<MetalSamplerGroup*> samplerGroups;
 
     MetalBufferPool* bufferPool;
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -213,7 +213,7 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
 }
 
 void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
-    construct_handle<MetalSamplerGroup>(mHandleMap, sbh, size);
+    mContext->samplerGroups.insert(construct_handle<MetalSamplerGroup>(mHandleMap, sbh, size));
 }
 
 void MetalDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
@@ -420,6 +420,7 @@ void MetalDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
             samplerBinding = {};
         }
     }
+    mContext->samplerGroups.erase(metalSampler);
     destruct_handle<MetalSamplerGroup>(mHandleMap, sbh);
 }
 
@@ -439,19 +440,18 @@ void MetalDriver::destroyTexture(Handle<HwTexture> th) {
     if (!th) {
         return;
     }
+
     // Unbind this texture from any sampler groups that currently reference it.
-    for (auto& samplerBinding : mContext->samplerBindings) {
-        if (!samplerBinding) {
-            continue;
-        }
-        const SamplerGroup::Sampler* samplers = samplerBinding->sb->getSamplers();
-        for (size_t i = 0; i < samplerBinding->sb->getSize(); i++) {
+    for (auto* metalSamplerGroup : mContext->samplerGroups) {
+        const SamplerGroup::Sampler* samplers = metalSamplerGroup->sb->getSamplers();
+        for (size_t i = 0; i < metalSamplerGroup->sb->getSize(); i++) {
             const SamplerGroup::Sampler* sampler = samplers + i;
             if (sampler->t == th) {
-                samplerBinding->sb->setSampler(i, {{}, {}});
+                metalSamplerGroup->sb->setSampler(i, {{}, {}});
             }
         }
     }
+
     destruct_handle<MetalTexture>(mHandleMap, th);
 }
 


### PR DESCRIPTION
When deleting a texture, we previously only unbound that texture from sampler groups that were bound. This caused a bug when a deleted texture lingered in a sampler group that happened to be unbound at the time of texture deletion. The fix is to check all sampler groups for references to the texture.

Fixes #3384