### PR TITLE
Remove libSPIRV-Tools-shared from spirv-tools

### DIFF
--- a/third_party/spirv-tools/filament-specific-changes.patch
+++ b/third_party/spirv-tools/filament-specific-changes.patch
@@ -166,3 +166,50 @@ index eb4694786..d3940532d 100644
 
  if(NOT ${SPIRV_HEADERS_SKIP_EXAMPLES})
    set(SPIRV_HEADERS_ENABLE_EXAMPLES ON)
+diff --git a/third_party/spirv-tools/source/CMakeLists.txt b/third_party/spirv-tools/source/CMakeLists.txt
+index 65087f2c..38101ab2 100644
+--- a/third_party/spirv-tools/source/CMakeLists.txt
++++ b/third_party/spirv-tools/source/CMakeLists.txt
+@@ -364,13 +364,15 @@ endfunction()
+
+ # Always build ${SPIRV_TOOLS}-shared. This is expected distro packages, and
+ # unlike the other SPIRV_TOOLS target, defaults to hidden symbol visibility.
+-add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
+-spirv_tools_default_target_options(${SPIRV_TOOLS}-shared)
+-set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
+-target_compile_definitions(${SPIRV_TOOLS}-shared
+-  PRIVATE SPIRV_TOOLS_IMPLEMENTATION
+-  PUBLIC SPIRV_TOOLS_SHAREDLIB
+-)
++# Filament specific changes
++# add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
++# spirv_tools_default_target_options(${SPIRV_TOOLS}-shared)
++# set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
++# target_compile_definitions(${SPIRV_TOOLS}-shared
++#   PRIVATE SPIRV_TOOLS_IMPLEMENTATION
++#   PUBLIC SPIRV_TOOLS_SHAREDLIB
++# )
++# End Filament specific changes
+
+ if(SPIRV_TOOLS_BUILD_STATIC)
+   add_library(${SPIRV_TOOLS}-static STATIC ${SPIRV_SOURCES})
+@@ -386,11 +388,17 @@ if(SPIRV_TOOLS_BUILD_STATIC)
+     add_library(${SPIRV_TOOLS} ALIAS ${SPIRV_TOOLS}-static)
+   endif()
+
+-  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
++# Filament specific changes
++  # set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
++  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static)
++# End Filament specific changes
+ else()
+   add_library(${SPIRV_TOOLS} ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_SOURCES})
+   spirv_tools_default_target_options(${SPIRV_TOOLS})
+-  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared)
++# Filament specific changes
++  # set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared)
++  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS})
++# End Filament specific changes
+ endif()
+
+ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")

--- a/third_party/spirv-tools/source/CMakeLists.txt
+++ b/third_party/spirv-tools/source/CMakeLists.txt
@@ -364,13 +364,15 @@ endfunction()
 
 # Always build ${SPIRV_TOOLS}-shared. This is expected distro packages, and
 # unlike the other SPIRV_TOOLS target, defaults to hidden symbol visibility.
-add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
-spirv_tools_default_target_options(${SPIRV_TOOLS}-shared)
-set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${SPIRV_TOOLS}-shared
-  PRIVATE SPIRV_TOOLS_IMPLEMENTATION
-  PUBLIC SPIRV_TOOLS_SHAREDLIB
-)
+# Filament specific changes
+# add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
+# spirv_tools_default_target_options(${SPIRV_TOOLS}-shared)
+# set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# target_compile_definitions(${SPIRV_TOOLS}-shared
+#   PRIVATE SPIRV_TOOLS_IMPLEMENTATION
+#   PUBLIC SPIRV_TOOLS_SHAREDLIB
+# )
+# End Filament specific changes
 
 if(SPIRV_TOOLS_BUILD_STATIC)
   add_library(${SPIRV_TOOLS}-static STATIC ${SPIRV_SOURCES})
@@ -386,11 +388,17 @@ if(SPIRV_TOOLS_BUILD_STATIC)
     add_library(${SPIRV_TOOLS} ALIAS ${SPIRV_TOOLS}-static)
   endif()
 
-  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
+# Filament specific changes
+  # set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
+  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static)
+# End Filament specific changes
 else()
   add_library(${SPIRV_TOOLS} ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_SOURCES})
   spirv_tools_default_target_options(${SPIRV_TOOLS})
-  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared)
+# Filament specific changes
+  # set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared)
+  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS})
+# End Filament specific changes
 endif()
 
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")


### PR DESCRIPTION
This library causes issues on Linux. We had removed it previously, but it got reintroduced during the last spirv-tools upgrade.