### PR TITLE
gltf_viewer: call asyncCancelLoad in drop handler

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -100,7 +100,7 @@ struct ResourceLoader::Impl {
     int mNumDecoderTasks;
     int mNumDecoderTasksFinished;
     JobSystem::Job* mDecoderRootJob = nullptr;
-    FFilamentAsset* mCurrentAsset;
+    FFilamentAsset* mCurrentAsset = nullptr;
 
     void computeTangents(FFilamentAsset* asset);
     bool createTextures(bool async);


### PR DESCRIPTION
Fixes a crash when dropping a model while the old model is still decoding textures.

Relates to #3383