### PR TITLE
Simplify lifetime management of cgltf_data.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -197,14 +197,6 @@ public:
     FilamentInstance* createInstance(FilamentAsset* primary);
 
     /**
-     * Takes a pointer to an opaque pipeline object and returns a bundle of Filament objects.
-     *
-     * This exists solely for interop with AssetPipeline, which is optional according to the build
-     * configuration.
-     */
-    FilamentAsset* createAssetFromHandle(const void* cgltf);
-
-    /**
      * Allows clients to enable diagnostic shading on newly-loaded assets.
      */
     void enableDiagnostics(bool enable = true);
@@ -213,7 +205,8 @@ public:
      * Destroys the given asset and all of its associated Filament objects.
      *
      * This destroys entities, components, material instances, vertex buffers, index buffers,
-     * and textures.
+     * and textures. This does not necessarily immediately free all source data, since
+     * texture decoding or GPU uploading might be underway.
      */
     void destroyAsset(const FilamentAsset* asset);
 

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -221,7 +221,7 @@ public:
 
     /**
      * Returns a weak reference to the underlying cgltf hierarchy. This becomes invalid after
-     * calling releaseSourceData();
+     * calling releaseSourceData().
      */
     const void* getSourceAsset() noexcept;
 

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -165,14 +165,14 @@ static bool validateAnimation(const cgltf_animation& anim) {
 }
 
 Animator::Animator(FFilamentAsset* asset, FFilamentInstance* instance) {
-    assert(asset->mResourcesLoaded && !asset->mIsReleased);
+    assert(asset->mResourcesLoaded && asset->mSourceAsset);
     mImpl = new AnimatorImpl();
     mImpl->asset = asset;
     mImpl->instance = instance;
     mImpl->renderableManager = &asset->mEngine->getRenderableManager();
     mImpl->transformManager = &asset->mEngine->getTransformManager();
 
-    const cgltf_data* srcAsset = asset->mSourceAsset;
+    const cgltf_data* srcAsset = asset->mSourceAsset->hierarchy;
     const cgltf_animation* srcAnims = srcAsset->animations;
     for (cgltf_size i = 0, len = srcAsset->animations_count; i < len; ++i) {
         const cgltf_animation& anim = srcAnims[i];

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -104,8 +104,10 @@ using MatInstanceCache = tsl::robin_map<intptr_t, MaterialEntry>;
 
 struct FFilamentAsset : public FilamentAsset {
     FFilamentAsset(filament::Engine* engine, utils::NameComponentManager* names,
-            utils::EntityManager* entityManager) :
-            mEngine(engine), mNameManager(names), mEntityManager(entityManager) {}
+            utils::EntityManager* entityManager, const cgltf_data* srcAsset) :
+            mEngine(engine), mNameManager(names), mEntityManager(entityManager) {
+        mSourceAsset.reset(new SourceAsset {(cgltf_data*)srcAsset});
+    }
 
     ~FFilamentAsset();
 
@@ -186,7 +188,7 @@ struct FFilamentAsset : public FilamentAsset {
     void releaseSourceData() noexcept;
 
     const void* getSourceAsset() noexcept {
-        return mSourceAsset;
+        return mSourceAsset.get() ? mSourceAsset->hierarchy : nullptr;
     }
 
     FilamentInstance** getAssetInstances() noexcept {
@@ -196,12 +198,6 @@ struct FFilamentAsset : public FilamentAsset {
     size_t getAssetInstanceCount() const noexcept {
         return mInstances.size();
     }
-
-    void acquireSourceAsset() {
-        ++mSourceAssetRefCount;
-    }
-
-    void releaseSourceAsset();
 
     void takeOwnership(filament::Texture* texture) {
         mTextures.push_back(texture);
@@ -219,7 +215,6 @@ struct FFilamentAsset : public FilamentAsset {
     filament::Engine* mEngine;
     utils::NameComponentManager* mNameManager;
     utils::EntityManager* mEntityManager;
-    std::vector<uint8_t> mGlbData;
     std::vector<utils::Entity> mEntities;
     std::vector<utils::Entity> mLightEntities;
     std::vector<utils::Entity> mCameraEntities;
@@ -233,27 +228,37 @@ struct FFilamentAsset : public FilamentAsset {
     SkinVector mSkins; // unused for instanced assets
     Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;
-    int mSourceAssetRefCount = 0;
     bool mResourcesLoaded = false;
-    bool mSharedSourceAsset = false;
     DependencyGraph mDependencyGraph;
-    DracoCache mDracoCache;
     tsl::htrie_map<char, std::vector<utils::Entity>> mNameToEntity;
 
     // Sentinels for situations where ResourceLoader needs to generate data.
     const cgltf_accessor mGenerateNormals = {};
     const cgltf_accessor mGenerateTangents = {};
 
+    // Encapsulates reference-counted source data, which includes the cgltf hierachy
+    // and potentially also includes buffer data that can be uploaded to the GPU.
+    struct SourceAsset {
+        ~SourceAsset() { cgltf_free(hierarchy); }
+        cgltf_data* hierarchy;
+        DracoCache dracoCache;
+        std::vector<uint8_t> glbData;
+    };
+
+    // We used shared ownership for the raw cgltf data in order to permit ResourceLoader to
+    // complete various asynchronous work (e.g. uploading buffers to the GPU) even after the asset
+    // or ResourceLoader have been destroyed.
+    using SourceHandle = std::shared_ptr<SourceAsset>;
+    SourceHandle mSourceAsset;
+
     // Transient source data that can freed via releaseSourceData:
     std::vector<BufferSlot> mBufferSlots;
     std::vector<TextureSlot> mTextureSlots;
     std::vector<const char*> mResourceUris;
-    const cgltf_data* mSourceAsset = nullptr;
     NodeMap mNodeMap; // unused for instanced assets
     std::vector<std::pair<const cgltf_primitive*, filament::VertexBuffer*> > mPrimitives;
     MatInstanceCache mMatInstanceCache;
     MeshCache mMeshCache;
-    bool mIsReleased = false;
 };
 
 FILAMENT_UPCAST(FilamentAsset)

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -32,7 +32,7 @@ Animator* FFilamentInstance::getAnimator() noexcept {
             slog.e << "Cannot create animator before resource loading." << io::endl;
             return nullptr;
         }
-        if (owner->mIsReleased) {
+        if (!owner->mSourceAsset) {
             slog.e << "Cannot create animator from frozen asset." << io::endl;
             return nullptr;
         }


### PR DESCRIPTION
The gltfio API allows users to destroy `ResourceLoader` or `FilamentAsset` even when various asynchronous work (e.g. uploading buffers to the GPU) has not yet been completed. This was achieved in an error-prone manner using manual reference counting and an internal management object called `AssetPool`.

This PR refactors gltfio by internally wrapping cgltf_data in `shared_ptr`, which I usually try to avoid. However in this case it provides the precisely the functionality that is needed.

I tested this PR for memory leaks and crashes by hacking gltf_viewer and monitoring memory usage in Activity Monitor.

This fixes #3383 and makes it easier to implement some missing features, such as animation support for instanced assets.