### PR TITLE
gltf_viewer: fix sporadic crash when exiting.

### DIFF
--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -131,7 +131,7 @@ public:
     void asyncUpdateLoad();
 
     /**
-     * Cancels pending decoder jobs and frees all CPU-side texel data.
+     * Cancels pending decoder jobs, frees all CPU-side texel data, and flushes the Engine.
      *
      * Calling this is only necessary if the asyncBeginLoad API was used
      * and cancellation is required before progress reaches 100%.

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -454,6 +454,7 @@ bool ResourceLoader::asyncBeginLoad(FilamentAsset* asset) {
 
 void ResourceLoader::asyncCancelLoad() {
     pImpl->cancelTextureDecoding();
+    pImpl->mEngine->flushAndWait();
 }
 
 float ResourceLoader::asyncGetLoadProgress() const {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -893,6 +893,7 @@ int main(int argc, char** argv) {
 
     auto cleanup = [&app](Engine* engine, View*, Scene*) {
         app.automationEngine->terminate();
+        app.resourceLoader->asyncCancelLoad();
         app.assetLoader->destroyAsset(app.asset);
         app.materials->destroyMaterials();
 


### PR DESCRIPTION
This could occur when trying to exit the app while textures are still being decoded.