### PR TITLE
Add swap() methods to Allocator.h

### DIFF
--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -416,6 +416,12 @@ public:
     void* end() const noexcept { return mEnd; }
     size_t getSize() const noexcept { return uintptr_t(mEnd) - uintptr_t(mBegin); }
 
+    friend void swap(HeapArea& lhs, HeapArea& rhs) {
+        using std::swap;
+        swap(lhs.mBegin, rhs.mBegin);
+        swap(lhs.mEnd, rhs.mEnd);
+    }
+
 private:
     void* mBegin = nullptr;
     void* mEnd = nullptr;
@@ -630,6 +636,15 @@ public:
     // An arena can't be copied
     Arena(Arena const& rhs) noexcept = delete;
     Arena& operator=(Arena const& rhs) noexcept = delete;
+
+    friend void swap(Arena& lhs, Arena& rhs) {
+        using std::swap;
+        swap(lhs.mArea, rhs.mArea);
+        swap(lhs.mAllocator, rhs.mAllocator);
+        swap(lhs.mLock, rhs.mLock);
+        swap(lhs.mListener, rhs.mListener);
+        swap(lhs.mArenaName, rhs.mArenaName);
+    }
 
 private:
     HeapArea mArea; // We might want to make that a template parameter too eventually.

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -71,9 +71,9 @@ public:
         mData.push_back();
     }
 
-    SingleInstanceComponentManager(SingleInstanceComponentManager&& rhs) noexcept {/* = default */}
+    SingleInstanceComponentManager(SingleInstanceComponentManager&& rhs) noexcept = default;
     SingleInstanceComponentManager& operator=(SingleInstanceComponentManager&& rhs) noexcept {/* = default */}
-    ~SingleInstanceComponentManager() noexcept = default;
+    ~SingleInstanceComponentManager() noexcept {/* = default */}
 
     // not copyable
     SingleInstanceComponentManager(SingleInstanceComponentManager const& rhs) = delete;


### PR DESCRIPTION
This allows StructureOfArraysBase's move constructor to compile.
Removed an apparent workaround in SingleInstanceComponentManager.