### PR TITLE
Bloom: add optional ping-pong implementation.

### DIFF
--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -251,12 +251,13 @@ Filament.loadClassExtensions = function() {
 
     /// setBloomOptions ::method::
     /// overrides ::argument:: Dictionary with one or more of the following properties: \
-    /// dirtStrength, strength, resolution, anomorphism, levels, blendMode, threshold, enabled.
+    /// enabled, strength, resolution, anomorphism, levels, blendMode, threshold, highlight.
     /// NOTE: dirt texture is not yet supported in the JavaScript API.
     Filament.View.prototype.setBloomOptions = function(overrides) {
         const options = {
             dirtStrength: 0.2,
-            strength: 0.10,
+            highlight: 1000.0,
+            strength: 0.90,
             resolution: 360,
             anamorphism: 1.0,
             levels: 6,

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -257,7 +257,7 @@ Filament.loadClassExtensions = function() {
         const options = {
             dirtStrength: 0.2,
             highlight: 1000.0,
-            strength: 0.90,
+            strength: 0.10,
             resolution: 360,
             anamorphism: 1.0,
             levels: 6,

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -115,6 +115,7 @@ export interface View$BloomOptions {
     blendMode?: View$BloomOptions$BlendMode;
     threshold?: boolean;
     enabled?: boolean;
+    highlight?: number;
     // TODO: add support for dirt texture in BloomOptions.
 }
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -364,7 +364,8 @@ value_object<filament::View::BloomOptions>("View$BloomOptions")
     .field("levels", &filament::View::BloomOptions::levels)
     .field("threshold", &filament::View::BloomOptions::threshold)
     .field("enabled", &filament::View::BloomOptions::enabled)
-    .field("blendMode", &filament::View::BloomOptions::blendMode);
+    .field("blendMode", &filament::View::BloomOptions::blendMode)
+    .field("highlight", &filament::View::BloomOptions::highlight);
 
 // TODO: add support for dirt texture in BloomOptions.
 // Note that simply including the field in the above list causes binding errors for nullptr.

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -52,6 +52,12 @@ class App {
 
         indirectLight.setIntensity(iblIntensity);
 
+        // Rotate the IBL so that a bright light is behind the helmet, to show off bloom.
+        const mat = [];
+        const radians = 3.14;
+        mat3.fromRotation(mat, radians, [0, 1, 0]);
+        indirectLight.setRotation(mat);
+
         const skybox = engine.createSkyFromKtx(sky_url);
         this.scene.setSkybox(skybox);
 
@@ -106,6 +112,9 @@ class App {
         this.renderer = engine.createRenderer();
         this.view = engine.createView();
         this.view.setVignetteOptions({ midPoint: 0.8, enabled: true });
+
+        this.view.setBloomOptions({ stength: 0.2, enabled: true });
+
         this.view.setCamera(this.camera);
         this.view.setScene(this.scene);
         this.view.setColorGrading(colorGrading);


### PR DESCRIPTION
For now, this is only active for WebGL but we will likely activate it for Intel GPU's in an upcoming PR.

#2338