### PR TITLE
Repair backend unit tests on macOS.

### DIFF
--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -151,21 +151,21 @@ void PlatformCocoaGLImpl::updateOpenGLContext(NSView *nsView, bool resetView) {
     // "update" to be called from the UI thread. This became a hard requirement with the arrival
     // of macOS 10.15 (Catalina). If we were to call these methods from the GL thread, we would
     // see EXC_BAD_INSTRUCTION.
-    #if UTILS_HAS_THREADING
-    dispatch_sync(dispatch_get_main_queue(), ^(void) {
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^(void) {
+            if (resetView) {
+                [glContext clearDrawable];
+                [glContext setView:nsView];
+            }
+            [glContext update];
+        });
+    } else {
         if (resetView) {
             [glContext clearDrawable];
             [glContext setView:nsView];
         }
         [glContext update];
-    });
-    #else
-        if (resetView) {
-            [glContext clearDrawable];
-            [glContext setView:nsView];
-        }
-        [glContext update];
-    #endif
+    }
 }
 
 } // namespace filament


### PR DESCRIPTION
This fixes "illegal hardware instruction" seen on my MacBook, which
is the same as #1839, but triggered only in a test environment where
the main thread is the same as the driver thread, and filament is built
with HAS_THREADING enabled.