### PR TITLE
Plumbing for disabling feedback loops on Intel.

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -291,6 +291,7 @@ DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::Texture
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameBufferFetchSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
+DECL_DRIVER_API_SYNCHRONOUS_0(bool, areFeedbackLoopsSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -615,6 +615,10 @@ bool MetalDriver::isFrameTimeSupported() {
     return false;
 }
 
+bool MetalDriver::areFeedbackLoopsSupported() {
+    return true;
+}
+
 math::float2 MetalDriver::getClipSpaceParams() {
     // z-coordinate of clip-space is in [0,w]
     return math::float2{ -0.5f, 0.5f };

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -160,6 +160,10 @@ bool NoopDriver::isFrameTimeSupported() {
     return true;
 }
 
+bool NoopDriver::areFeedbackLoopsSupported() {
+    return true;
+}
+
 math::float2 NoopDriver::getClipSpaceParams() {
     return math::float2{ -1.0f, 0.0f };
 }

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -71,6 +71,13 @@ OpenGLContext::OpenGLContext() noexcept {
         }
     } else if (strstr(renderer, "Intel")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
+
+        // We have observed bloom flashing artifacts (as well as failure in test_FeedbackLoop) on a
+        // MacBook Air with an Intel GPU, as well as an Intel NUC Windows PC. For now we're assuming
+        // that all Intel GPU's cannot handle feedback loops properly.
+        // TODO: match a more specific string pattern after Intel discrete GPU's arrive.
+        bugs.disable_feedback_loops = true;
+
     } else if (strstr(renderer, "PowerVR") || strstr(renderer, "Apple")) {
     } else if (strstr(renderer, "Tegra") || strstr(renderer, "GeForce") || strstr(renderer, "NV")) {
     } else if (strstr(renderer, "Vivante")) {
@@ -78,6 +85,12 @@ OpenGLContext::OpenGLContext() noexcept {
     } else if (strstr(renderer, "Mozilla")) {
         bugs.disable_invalidate_framebuffer = true;
     }
+
+    // Chrome does not support feedback loops in WebGL 2.0. See also:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1066201
+#if defined(__EMSCRIPTEN__)
+    bugs.disable_feedback_loops = true;
+#endif
 
     // Figure out if we have the extension we need
     GLint n = 0;

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -155,6 +155,11 @@ public:
         // calling glSamplerParameter() with GL_TEXTURE_MAX_ANISOTROPY_EXT
         bool disable_texture_filter_anisotropic = false;
 
+        // Some drivers have issues when reading from a mip while writing to a different mip.
+        // In the OpenGL ES 3.0 specification this is covered in section 4.4.3,
+        // "Feedback Loops Between Textures and the Framebuffer".
+        bool disable_feedback_loops = false;
+
         // Some drivers don't implement timer queries correctly
         bool dont_use_timer_query = false;
     } bugs;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1552,6 +1552,10 @@ bool OpenGLDriver::isFrameTimeSupported() {
     return mFrameTimeSupported;
 }
 
+bool OpenGLDriver::areFeedbackLoopsSupported() {
+    return !mContext.bugs.disable_feedback_loops;
+}
+
 math::float2 OpenGLDriver::getClipSpaceParams() {
     return mContext.ext.EXT_clip_control ?
             math::float2{ -0.5f, 0.5f } : math::float2{ -1.0f, 0.0f };

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -814,6 +814,10 @@ bool VulkanDriver::isFrameTimeSupported() {
     return true;
 }
 
+bool VulkanDriver::areFeedbackLoopsSupported() {
+    return true;
+}
+
 math::float2 VulkanDriver::getClipSpaceParams() {
     // z-coordinate of clip-space is in [0,w]
     return math::float2{ -0.5f, 0.5f };

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -190,6 +190,7 @@ PostProcessManager::PostProcessMaterial& PostProcessManager::getPostProcessMater
 void PostProcessManager::init() noexcept {
     auto& engine = mEngine;
     DriverApi& driver = engine.getDriverApi();
+    mDisableFeedbackLoops = !driver.areFeedbackLoopsSupported();
 
     registerPostProcessMaterial("sao", MATERIAL(SAO));
     registerPostProcessMaterial("mipmapDepth", MATERIAL(MIPMAPDEPTH));

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -221,6 +221,7 @@ private:
     std::uniform_real_distribution<float> mUniformDistribution{0.0f, 1.0f};
 
     const math::float2 mHaltonSamples[16];
+    bool mDisableFeedbackLoops;
 };
 
 


### PR DESCRIPTION
This is a follow-on to #3451, which adds optional ping-pong support to the bloom generator.