### PR TITLE
Modulate emissive by alpha on blended objects

### DIFF
--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -299,7 +299,7 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #if defined(MATERIAL_HAS_EMISSIVE)
     highp vec4 emissive = material.emissive;
     highp float attenuation = mix(1.0, frameUniforms.exposure, emissive.w);
-    color.rgb += emissive.rgb * attenuation;
+    color.rgb += emissive.rgb * (attenuation * color.a);
 #endif
 }
 

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -2,7 +2,7 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #if defined(MATERIAL_HAS_EMISSIVE)
     highp vec4 emissive = material.emissive;
     highp float attenuation = mix(1.0, frameUniforms.exposure, emissive.w);
-    color.rgb += emissive.rgb * attenuation;
+    color.rgb += emissive.rgb * (attenuation * color.a);
 #endif
 }
 


### PR DESCRIPTION
This prevents light from being emitted from completely transparent pixels.

Fixes #3454.