### PR TITLE
Fix sporadic data race warning seen in Google3

### DIFF
--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -437,6 +437,10 @@ struct Config {
     size_t lutDimension;
 };
 
+// Inside the FColorGrading constructor, TSAN sporadically detects a data race on the config struct;
+// the Filament thread writes and the Job thread reads. In practice there should be no data race, so
+// we force TSAN off to silence the warning.
+UTILS_NO_SANITIZE_THREAD
 FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     SYSTRACE_CALL();
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -64,6 +64,14 @@
 #    define UTILS_PRIVATE
 #endif
 
+#define UTILS_NO_SANITIZE_THREAD
+#if defined(__has_feature)
+#    if __has_feature(thread_sanitizer)
+#        undef UTILS_NO_SANITIZE_THREAD
+#        define UTILS_NO_SANITIZE_THREAD __attribute__((no_sanitize("thread")))
+#    endif
+#endif
+
 /*
  * helps the compiler's optimizer predicting branches
  */


### PR DESCRIPTION
This hopefully silences a false-positive TSAN warning seen when running presubmit tests.

```
WARNING: ThreadSanitizer: data race (pid=3367)
  Write of size 8 at 0x7ffc9caf90a0 by main thread:
    #0 memcpy third_party/llvm/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:810:5 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x12d0a90)
    #1 selectColorGradingTransformIn third_party/filament/filament/src/ColorGrading.cpp (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21ea269)
    #2 filament::FColorGrading::FColorGrading(filament::FEngine&, filament::ColorGrading::Builder const&) third_party/filament/filament/src/ColorGrading.cpp:446:37

 Previous read of size 8 at 0x7ffc9caf90a0 by thread T35:
    #0 operator*<float> third_party/filament/libs/math/include/math/TVecHelpers.h:203:43 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #1 operator*<float, void> third_party/filament/libs/math/include/math/TVecHelpers.h:211:19 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #2 operator*<float> third_party/filament/libs/math/include/math/TMatHelpers.h:568:32 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #3 operator() third_party/filament/filament/src/ColorGrading.cpp:495:56 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #4 utils::JobSystem::Job* utils::JobSystem::createJob<filament::FColorGrading::FColorGrading(filament::FEngine&, filament::ColorGrading::Builder const&)::$_0>(utils::JobSystem::Job*, 
```