### PR TITLE
Multi-thread shaders generation when compiling materials

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,7 +8,7 @@ A new header is inserted each time a *tag* is created.
 - Added `sheenColor` and `sheenRoughness` properties to materials to create cloth/fabric
 - gltfio: added support for `KHR_materials_sheen`
 - gltfio: shader optimizations are now disabled by default, unless opting in or using ubershaders
-- `MaterialBuilder::build()` now excepts a reference to a `JobSystem` to multi-thread shaders
+- `MaterialBuilder::build()` now expects a reference to a `JobSystem` to multi-thread shaders
   generation. A `JobSystem` can be obtained with `Engine::getJobSystem()` when using Filament,
   or created directly otherwise (⚠️ **API change**).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,9 @@ A new header is inserted each time a *tag* is created.
 - Added `sheenColor` and `sheenRoughness` properties to materials to create cloth/fabric
 - gltfio: added support for `KHR_materials_sheen`
 - gltfio: shader optimizations are now disabled by default, unless opting in or using ubershaders
+- `MaterialBuilder::build()` now excepts a reference to a `JobSystem` to multi-thread shaders
+  generation. A `JobSystem` can be obtained with `Engine::getJobSystem()` when using Filament,
+  or created directly otherwise (⚠️ **API change**).
 
 ## v1.9.10
 

--- a/android/filamat-android/CMakeLists.txt
+++ b/android/filamat-android/CMakeLists.txt
@@ -33,13 +33,16 @@ add_library(shaders STATIC IMPORTED)
 set_target_properties(shaders PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libshaders.a)
 
+set(FILAMAT_INCLUDE_DIRS
+        ../../libs/utils/include
+        )
+
 include_directories(${FILAMENT_DIR}/include)
 
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_SOURCE_DIR}/libfilamat-jni.map")
 
-add_library(filamat-jni SHARED
-        src/main/cpp/MaterialBuilder.cpp
-)
+add_library(filamat-jni SHARED src/main/cpp/MaterialBuilder.cpp)
+target_include_directories(filamat-jni PRIVATE ${FILAMAT_INCLUDE_DIRS})
 
 target_link_libraries(filamat-jni
         ${FILAMAT_FLAVOR}

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -17,17 +17,29 @@
 package com.google.android.filament.filamat;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 
 public class MaterialBuilder {
-
     @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
     // Keep to finalize native resources
     private final BuilderFinalizer mFinalizer;
     private final long mNativeObject;
 
+    private static Class<?> sEngineClass = null;
+    private static Method sGetNativeJobSystemMethod = null;
+
     static {
         System.loadLibrary("filamat-jni");
+        try {
+            sEngineClass = Class.forName("com.google.android.filament.Engine");
+            sGetNativeJobSystemMethod = sEngineClass.getDeclaredMethod("getNativeJobSystem");
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            // It's okay if we don't find it, this is to avoid creating dependencies
+        }
     }
 
     public enum Shading {
@@ -421,9 +433,53 @@ public class MaterialBuilder {
         return this;
     }
 
+    /**
+     * Validates, builds, and returns the compiled material. While this method never
+     * returns null, the returned {@link MaterialPackage} may be invalid. Call
+     * {@link MaterialPackage#isValid()} before using it.
+     *
+     * Calling this method is equivalent to calling {@link #build(Object)} and passing
+     * <code>null</code> as the job system provider.
+     *
+     * @see #build(Object)
+     */
     @NonNull
     public MaterialPackage build() {
-        long nativePackage = nBuilderBuild(mNativeObject);
+        return build(null);
+    }
+
+    /**
+     * Validates, builds, and returns the compiled material. While this method never
+     * returns null, the returned {@link MaterialPackage} may be invalid. Call
+     * {@link MaterialPackage#isValid()} before using it.
+     *
+     * You can pass a job system provider to this method, or null. When passing null
+     * or an invalid job system provider, a temporary job system will be created which
+     * is less efficient than reusing an existing job system.
+     *
+     * Currently the only valid type of job system provider is an <code>Engine</code>
+     * instance from the main Filament library (<code>com.google.android.filament.Engine</code>).
+     *
+     * If you are using Filament and the filamat library together you <em>must</em> pass an
+     * <code>Engine</code> as the job system provider.
+     *
+     * @param jobSystemProvider An <code>Engine</code> instance or null
+     */
+    @NonNull
+    public MaterialPackage build(@Nullable Object jobSystemProvider) {
+        long nativeJobSystem = 0;
+        if (jobSystemProvider != null && sEngineClass != null) {
+            if (sEngineClass.isInstance(jobSystemProvider) && sGetNativeJobSystemMethod != null) {
+                try {
+                    //noinspection ConstantConditions
+                    nativeJobSystem = (Long) sGetNativeJobSystemMethod.invoke(jobSystemProvider);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    // Ignore
+                }
+            }
+        }
+
+        long nativePackage = nBuilderBuild(mNativeObject, nativeJobSystem);
         byte[] data = nGetPackageBytes(nativePackage);
         MaterialPackage result =
                 new MaterialPackage(ByteBuffer.wrap(data), nGetPackageIsValid(nativePackage));
@@ -455,7 +511,7 @@ public class MaterialBuilder {
     private static native long nCreateMaterialBuilder();
     private static native void nDestroyMaterialBuilder(long nativeBuilder);
 
-    private static native long nBuilderBuild(long nativeBuilder);
+    private static native long nBuilderBuild(long nativeBuilder, long nativeJobSystem);
     private static native byte[] nGetPackageBytes(long nativePackage);
     private static native boolean nGetPackageIsValid(long nativePackage);
     private static native void nDestroyPackage(long nativePackage);

--- a/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
+++ b/android/filamat-android/src/main/java/com/google/android/filament/filamat/MaterialBuilder.java
@@ -461,7 +461,9 @@ public class MaterialBuilder {
      * instance from the main Filament library (<code>com.google.android.filament.Engine</code>).
      *
      * If you are using Filament and the filamat library together you <em>must</em> pass an
-     * <code>Engine</code> as the job system provider.
+     * <code>Engine</code> as the job system provider, <em>or</em> invoke
+     * <code>MaterialBuilder</code> from a thread other than the thread used to invoke Filament
+     * APIs.
      *
      * @param jobSystemProvider An <code>Engine</code> instance or null
      */

--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -306,3 +306,9 @@ Java_com_google_android_filament_Engine_nGetRenderableManager(JNIEnv*, jclass,
     Engine* engine = (Engine*) nativeEngine;
     return (jlong) &engine->getRenderableManager();
 }
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_Engine_nGetJobSystem(JNIEnv*, jclass, jlong nativeEngine) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jlong) &engine->getJobSystem();
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -654,13 +654,21 @@ public class Engine {
         return mNativeObject;
     }
 
+    @UsedByReflection("MaterialBuilder.java")
+    public long getNativeJobSystem() {
+        if (mNativeObject == 0) {
+            throw new IllegalStateException("Calling method on destroyed Engine");
+        }
+        return nGetJobSystem(getNativeObject());
+    }
+
     private void clearNativeObject() {
         mNativeObject = 0;
     }
 
     private static void assertDestroy(boolean success) {
         if (!success) {
-            throw new IllegalStateException("Object couldn't be destoyed (double destroy()?)");
+            throw new IllegalStateException("Object couldn't be destroyed (double destroy()?)");
         }
     }
 
@@ -698,4 +706,5 @@ public class Engine {
     private static native long nGetTransformManager(long nativeEngine);
     private static native long nGetLightManager(long nativeEngine);
     private static native long nGetRenderableManager(long nativeEngine);
+    private static native long nGetJobSystem(long nativeEngine);
 }

--- a/android/samples/sample-material-builder/src/main/java/com/google/android/filament/material_builder/MainActivity.kt
+++ b/android/samples/sample-material-builder/src/main/java/com/google/android/filament/material_builder/MainActivity.kt
@@ -216,7 +216,7 @@ class MainActivity : Activity() {
                 // variant of the filamat library.
                 .optimization(MaterialBuilder.Optimization.NONE)
 
-                // When compiling more than one material it is more efficient to pass an Engine
+                // When compiling more than one material variant, it is more efficient to pass an Engine
                 // instance to reuse the Engine's job system
                 .build(engine)
 

--- a/android/samples/sample-material-builder/src/main/java/com/google/android/filament/material_builder/MainActivity.kt
+++ b/android/samples/sample-material-builder/src/main/java/com/google/android/filament/material_builder/MainActivity.kt
@@ -216,7 +216,9 @@ class MainActivity : Activity() {
                 // variant of the filamat library.
                 .optimization(MaterialBuilder.Optimization.NONE)
 
-                .build()
+                // When compiling more than one material it is more efficient to pass an Engine
+                // instance to reuse the Engine's job system
+                .build(engine)
 
         if (matPackage.isValid) {
             val buffer = matPackage.buffer

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -474,7 +474,6 @@ public:
 
     MaterialBuilder& enableFramebufferFetch() noexcept;
 
-
     //! Build the material.
     Package build() noexcept;
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -478,7 +478,10 @@ public:
 
     MaterialBuilder& enableFramebufferFetch() noexcept;
 
-    //! Build the material.
+    /**
+     * Build the material. If you are using the Filament engine with this library, you should use
+     * the job system provided by Engine.
+     */
     Package build(utils::JobSystem& jobSystem) noexcept;
 
 public:

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -38,6 +38,10 @@
 #include <utils/compiler.h>
 #include <utils/CString.h>
 
+namespace utils {
+class JobSystem;
+}
+
 namespace filamat {
 
 struct MaterialInfo;
@@ -475,7 +479,7 @@ public:
     MaterialBuilder& enableFramebufferFetch() noexcept;
 
     //! Build the material.
-    Package build() noexcept;
+    Package build(utils::JobSystem& jobSystem) noexcept;
 
 public:
     // The methods and types below are for internal use
@@ -594,7 +598,9 @@ private:
     void writeCommonChunks(ChunkContainer& container, MaterialInfo& info) const noexcept;
     void writeSurfaceChunks(ChunkContainer& container) const noexcept;
 
-    bool generateShaders(const std::vector<Variant>& variants, ChunkContainer& container,
+    bool generateShaders(
+            utils::JobSystem& jobSystem,
+            const std::vector<Variant>& variants, ChunkContainer& container,
             const MaterialInfo& info) const noexcept;
 
     bool isLit() const noexcept { return mShading != filament::Shading::UNLIT; }

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -38,7 +38,6 @@ using SpirvBlob = std::vector<uint32_t>;
 
 class GLSLPostProcessor {
 public:
-
     enum Flags : uint32_t {
         PRINT_SHADERS = 1 << 0,
         GENERATE_DEBUG_INFO = 1 << 1,
@@ -62,11 +61,19 @@ public:
             std::string* outputMsl);
 
 private:
+    struct InternalConfig {
+        std::string* glslOutput = nullptr;
+        SpirvBlob* spirvOutput = nullptr;
+        std::string* mslOutput = nullptr;
+        EShLanguage shLang = EShLangFragment;
+        int langVersion = 0;
+        ShaderMinifier minifier;
+    };
 
     void fullOptimization(const glslang::TShader& tShader,
-            GLSLPostProcessor::Config const& config) const;
+            GLSLPostProcessor::Config const& config, InternalConfig& internalConfig) const;
     void preprocessOptimization(glslang::TShader& tShader,
-            GLSLPostProcessor::Config const& config) const;
+            GLSLPostProcessor::Config const& config, InternalConfig& internalConfig) const;
 
     /**
      * Retrieve an optimizer instance tuned for the given optimization level and shader configuration.
@@ -80,18 +87,12 @@ private:
     static void registerPerformancePasses(spvtools::Optimizer& optimizer, Config const& config);
 
     void optimizeSpirv(OptimizerPtr optimizer, SpirvBlob& spirv) const;
-    void spirvToToMsl(const SpirvBlob* spirv, std::string* outMsl,
-            const GLSLPostProcessor::Config& config) const;
+    void spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl, const Config &config,
+            ShaderMinifier& minifier) const;
 
     const MaterialBuilder::Optimization mOptimization;
     const bool mPrintShaders;
     const bool mGenerateDebugInfo;
-    std::string* mGlslOutput = nullptr;
-    SpirvBlob* mSpirvOutput = nullptr;
-    std::string* mMslOutput = nullptr;
-    EShLanguage mShLang = EShLangFragment;
-    ShaderMinifier mShaderMinifier;
-    int mLangVersion = 0;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -16,10 +16,13 @@
 
 #include "filamat/MaterialBuilder.h"
 
+#include <atomic>
 #include <vector>
 
-#include <utils/Panic.h>
+#include <utils/JobSystem.h>
 #include <utils/Log.h>
+#include <utils/Mutex.h>
+#include <utils/Panic.h>
 
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>
@@ -596,8 +599,8 @@ static void showErrorMessage(const char* materialName, uint8_t variant,
             << shaderCode;
 }
 
-bool MaterialBuilder::generateShaders(const std::vector<Variant>& variants, ChunkContainer& container,
-        const MaterialInfo& info) const noexcept {
+bool MaterialBuilder::generateShaders(const std::vector<Variant>& variants,
+        ChunkContainer& container, const MaterialInfo& info) const noexcept {
     // Create a postprocessor to optimize / compile to Spir-V if necessary.
 #ifndef FILAMAT_LITE
     uint32_t flags = 0;
@@ -606,21 +609,19 @@ bool MaterialBuilder::generateShaders(const std::vector<Variant>& variants, Chun
     GLSLPostProcessor postProcessor(mOptimization, flags);
 #endif
 
-    // Generate all shaders.
+    // Start: must be protected by lock
+    Mutex entriesLock;
     std::vector<TextEntry> glslEntries;
     std::vector<SpirvEntry> spirvEntries;
     std::vector<TextEntry> metalEntries;
-
-    // Dictionary used to compress text-based shading languages (GLSL and MSL).
     LineDictionary textDictionary;
-
 #ifndef FILAMAT_LITE
     BlobDictionary spirvDictionary;
 #endif
-    std::vector<uint32_t> spirv;
-    std::string msl;
+    // End: must be protected by lock
 
-    ShaderGenerator sg(mProperties, mVariables, mOutputs, mDefines, mMaterialCode.getResolved(),
+    ShaderGenerator sg(
+            mProperties, mVariables, mOutputs, mDefines, mMaterialCode.getResolved(),
             mMaterialCode.getLineOffset(), mMaterialVertexCode.getResolved(),
             mMaterialVertexCode.getLineOffset(), mMaterialDomain);
 
@@ -629,7 +630,18 @@ bool MaterialBuilder::generateShaders(const std::vector<Variant>& variants, Chun
             mBlendingMode == BlendingMode::MASKED || !emptyVertexCode;
     container.addSimpleChild<bool>(ChunkType::MaterialHasCustomDepthShader, customDepth);
 
+    // TODO: PASS THE JOBSYSTEM!
+    JobSystem js;
+    js.adopt();
+
+    std::atomic_bool cancelJobs(false);
+    bool firstJob = true;
+
     for (const auto& params : mCodeGenPermutations) {
+        if (cancelJobs.load()) {
+            return false;
+        }
+
         const ShaderModel shaderModel = ShaderModel(params.shaderModel);
         const TargetApi targetApi = params.targetApi;
         const TargetLanguage targetLanguage = params.targetLanguage;
@@ -641,101 +653,138 @@ bool MaterialBuilder::generateShaders(const std::vector<Variant>& variants, Chun
                 (targetApi == TargetApi::VULKAN || targetApi == TargetApi::METAL);
         const bool targetApiNeedsMsl = targetApi == TargetApi::METAL;
         const bool targetApiNeedsGlsl = targetApi == TargetApi::OPENGL;
-        std::vector<uint32_t>* pSpirv = targetApiNeedsSpirv ? &spirv : nullptr;
-        std::string* pMsl = targetApiNeedsMsl ? &msl : nullptr;
 
-        TextEntry glslEntry{0};
-        SpirvEntry spirvEntry{0};
-        TextEntry metalEntry{0};
-
-        glslEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
-        spirvEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
-        metalEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
+        // Set when a job fails
+        JobSystem::Job* parent = js.createJob();
 
         for (const auto& v : variants) {
-            glslEntry.variant = v.variant;
-            spirvEntry.variant = v.variant;
-            metalEntry.variant = v.variant;
-
-            // Generate raw shader code.
-            // The quotes in Google-style line directives cause problems with certain drivers. These
-            // directives are optimized away when using the full filamat, so down below we
-            // explicitly remove them when using filamat lite.
-            std::string shader;
-            if (v.stage == filament::backend::ShaderType::VERTEX) {
-                shader = sg.createVertexProgram(
-                        shaderModel, targetApi, targetLanguage, info, v.variant,
-                        mInterpolation, mVertexDomain);
-#ifdef FILAMAT_LITE
-                GLSLToolsLite glslTools;
-                glslTools.removeGoogleLineDirectives(shader);
-#endif
-            } else if (v.stage == filament::backend::ShaderType::FRAGMENT) {
-                shader = sg.createFragmentProgram(
-                        shaderModel, targetApi, targetLanguage, info, v.variant, mInterpolation);
-#ifdef FILAMAT_LITE
-                GLSLToolsLite glslTools;
-                glslTools.removeGoogleLineDirectives(shader);
-#endif
-            }
-
-            std::string* pGlsl = nullptr;
-            if (targetApiNeedsGlsl) {
-                pGlsl = &shader;
-            }
-
-#ifndef FILAMAT_LITE
-
-            GLSLPostProcessor::Config config{
-                    .shaderType = v.stage,
-                    .shaderModel = shaderModel,
-                    .glsl = {}
-            };
-
-            if (mEnableFramebufferFetch) {
-                config.glsl.subpassInputToColorLocation.emplace_back(0, 0);
-            }
-
-            bool ok = postProcessor.process(shader, config, pGlsl, pSpirv, pMsl);
-#else
-            bool ok = true;
-#endif
-            if (!ok) {
-                showErrorMessage(mMaterialName.c_str_safe(), v.variant, targetApi, v.stage, shader);
-                return false;
-            }
-
-            if (targetApi == TargetApi::OPENGL) {
-                if (targetLanguage == TargetLanguage::SPIRV) {
-                    sg.fixupExternalSamplers(shaderModel, shader, info);
+            JobSystem::Job* job = jobs::createJob(js, parent, [&]() {
+                if (cancelJobs.load()) {
+                    return;
                 }
 
-                glslEntry.stage = v.stage;
-                glslEntry.shader = shader;
-                textDictionary.addText(glslEntry.shader);
-                glslEntries.push_back(glslEntry);
-            }
+                // TODO: avoid allocations when not required
+                std::vector<uint32_t> spirv;
+                std::string msl;
+
+                std::vector<uint32_t>* pSpirv = targetApiNeedsSpirv ? &spirv : nullptr;
+                std::string* pMsl = targetApiNeedsMsl ? &msl : nullptr;
+
+                TextEntry glslEntry{0};
+                SpirvEntry spirvEntry{0};
+                TextEntry metalEntry{0};
+
+                glslEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
+                spirvEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
+                metalEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
+
+                glslEntry.variant = v.variant;
+                spirvEntry.variant = v.variant;
+                metalEntry.variant = v.variant;
+
+                // Generate raw shader code.
+                // The quotes in Google-style line directives cause problems with certain drivers. These
+                // directives are optimized away when using the full filamat, so down below we
+                // explicitly remove them when using filamat lite.
+                std::string shader;
+                if (v.stage == filament::backend::ShaderType::VERTEX) {
+                    shader = sg.createVertexProgram(
+                            shaderModel, targetApi, targetLanguage, info, v.variant,
+                            mInterpolation, mVertexDomain);
+#ifdef FILAMAT_LITE
+                    GLSLToolsLite glslTools;
+                    glslTools.removeGoogleLineDirectives(shader);
+#endif
+                } else if (v.stage == filament::backend::ShaderType::FRAGMENT) {
+                    shader = sg.createFragmentProgram(
+                            shaderModel, targetApi, targetLanguage, info, v.variant, mInterpolation);
+#ifdef FILAMAT_LITE
+                    GLSLToolsLite glslTools;
+                    glslTools.removeGoogleLineDirectives(shader);
+#endif
+                }
+
+                std::string* pGlsl = nullptr;
+                if (targetApiNeedsGlsl) {
+                    pGlsl = &shader;
+                }
 
 #ifndef FILAMAT_LITE
-            if (targetApi == TargetApi::VULKAN) {
-                assert(!spirv.empty());
-                spirvEntry.stage = v.stage;
-                spirvEntry.dictionaryIndex = spirvDictionary.addBlob(spirv);
-                spirv.clear();
-                spirvEntries.push_back(spirvEntry);
-            }
-            if (targetApi == TargetApi::METAL) {
-                assert(!spirv.empty());
-                assert(msl.length() > 0);
-                metalEntry.stage = v.stage;
-                metalEntry.shader = msl;
-                spirv.clear();
-                msl.clear();
-                textDictionary.addText(metalEntry.shader);
-                metalEntries.push_back(metalEntry);
-            }
+                GLSLPostProcessor::Config config{
+                        .shaderType = v.stage,
+                        .shaderModel = shaderModel,
+                        .glsl = {}
+                };
+
+                if (mEnableFramebufferFetch) {
+                    config.glsl.subpassInputToColorLocation.emplace_back(0, 0);
+                }
+
+                bool ok = postProcessor.process(shader, config, pGlsl, pSpirv, pMsl);
+#else
+                bool ok = true;
 #endif
+                if (!ok) {
+                    showErrorMessage(mMaterialName.c_str_safe(), v.variant, targetApi, v.stage, shader);
+                    cancelJobs = true;
+                    return;
+                }
+
+                if (targetApi == TargetApi::OPENGL) {
+                    if (targetLanguage == TargetLanguage::SPIRV) {
+                        sg.fixupExternalSamplers(shaderModel, shader, info);
+                    }
+                }
+
+                // NOTE: Everything below touches shared structures protected by a lock
+                // NOTE: do not execute expensive work from here on!
+                std::unique_lock<utils::Mutex> lock(entriesLock);
+
+                if (targetApi == TargetApi::OPENGL) {
+                    glslEntry.stage = v.stage;
+                    glslEntry.shader = shader;
+
+                    textDictionary.addText(glslEntry.shader);
+                    glslEntries.push_back(glslEntry);
+                }
+
+#ifndef FILAMAT_LITE
+                if (targetApi == TargetApi::VULKAN) {
+                    assert(!spirv.empty());
+                    spirvEntry.stage = v.stage;
+
+                    spirvEntry.dictionaryIndex = spirvDictionary.addBlob(spirv);
+                    spirvEntries.push_back(spirvEntry);
+                }
+
+                if (targetApi == TargetApi::METAL) {
+                    assert(!spirv.empty());
+                    assert(msl.length() > 0);
+                    metalEntry.stage = v.stage;
+                    metalEntry.shader = msl;
+
+                    textDictionary.addText(metalEntry.shader);
+                    metalEntries.push_back(metalEntry);
+                }
+#endif
+            });
+
+            // NOTE: We run the first job separately to work the lack of thread safety
+            //       guarantees in glslang. This library performs unguarded global
+            //       operations on first use.
+            if (firstJob) {
+                js.runAndWait(job);
+                firstJob = false;
+            } else {
+                js.run(job);
+            }
         }
+
+        js.runAndWait(parent);
+    }
+
+    if (cancelJobs.load()) {
+        return false;
     }
 
     // Emit dictionary chunk (TextDictionaryReader and DictionaryTextChunk)

--- a/libs/filamentapp/src/MeshAssimp.cpp
+++ b/libs/filamentapp/src/MeshAssimp.cpp
@@ -190,7 +190,7 @@ Material* createMaterialFromConfig(Engine& engine, MaterialConfig config ) {
 
     builder.shading(config.unlit ? Shading::UNLIT : Shading::LIT);
 
-    Package pkg = builder.build();
+    Package pkg = builder.build(engine.getJobSystem());
     return Material::Builder().package(pkg.getData(), pkg.getSize()).build(engine);
 }
 

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -18,7 +18,6 @@
 
 #include <filamat/MaterialBuilder.h>
 
-#include <utils/Log.h>
 #include <utils/Hash.h>
 
 #include <tsl/robin_map.h>
@@ -469,7 +468,7 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
         builder.shading(Shading::LIT);
     }
 
-    Package pkg = builder.build();
+    Package pkg = builder.build(engine->getJobSystem());
     return Material::Builder().package(pkg.getData(), pkg.getSize()).build(*engine);
 }
 

--- a/samples/sample_cloth.cpp
+++ b/samples/sample_cloth.cpp
@@ -208,7 +208,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             )SHADER")
             .shading(Shading::CLOTH);
 
-    Package pkg = builder.build();
+    Package pkg = builder.build(engine->getJobSystem());
 
     g_material = Material::Builder().package(pkg.getData(), pkg.getSize())
             .build(*engine);

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -375,7 +375,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
         }
     }
 
-    Package pkg = builder.build();
+    Package pkg = builder.build(engine->getJobSystem());
 
     g_material = Material::Builder().package(pkg.getData(), pkg.getSize()).build(*engine);
     g_materialInstances["DefaultMaterial"] = g_material->createInstance();

--- a/samples/sample_normal_map.cpp
+++ b/samples/sample_normal_map.cpp
@@ -299,7 +299,7 @@ static void setup(Engine* engine, View*, Scene* scene) {
             .parameter(MaterialBuilder::SamplerType::SAMPLER_2D, "baseColorMap");
     }
 
-    Package pkg = builder.build();
+    Package pkg = builder.build(engine->getJobSystem());
 
     g_material = Material::Builder().package(pkg.getData(), pkg.getSize())
             .build(*engine);

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -24,6 +24,8 @@
 
 #include <filamat/Enums.h>
 
+#include <utils/JobSystem.h>
+
 #include "DirIncluder.h"
 #include "MaterialLexeme.h"
 #include "MaterialLexer.h"
@@ -299,9 +301,15 @@ bool MaterialCompiler::run(const Config& config) {
         builder.shaderDefine(define.first.c_str(), define.second.c_str());
     }
 
+    JobSystem js;
+    js.adopt();
+
     // Write builder.build() to output.
-    Package package = builder.build();
+    Package package = builder.build(js);
+
+    js.emancipate();
     MaterialBuilder::shutdown();
+
     if (!package.isValid()) {
         std::cerr << "Could not compile material " << input->getName() << std::endl;
         return false;


### PR DESCRIPTION
We currently generate 128 shader variants per target API per material. On a 12-core MacPro, running `matc` on
`sandboxCloth.mat` takes ~12 seconds. After multi-threading using `JobSystem` it takes ~2 seconds. There are
many optimizations we could do to further improve these numbers, mainly around allocations, especially in
`GLSLPostProcessor`.

Unfortunately we rely on `glslang` and `spirv-*` which don't make any thread safety guarantees. Actually `glslang`
is particularly hostile since it uses globals in unsafe ways in various places. This is worked around by first running
a single job by itself that ensures `glslang` is properly initialized.