### PR TITLE
gltfio: Fix "_maskThreshold not found" error.

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -977,7 +977,9 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
 
     mResult->mMaterialInstances.push_back(mi);
 
-    if (inputMat->alpha_mode == cgltf_alpha_mode_mask) {
+    // Check the material blending mode, not the cgltf blending mode, because the provider
+    // might have selected an alternative blend mode (e.g. to support transmission).
+    if (mi->getMaterial()->getBlendingMode() == filament::BlendingMode::MASKED) {
         mi->setMaskThreshold(inputMat->alpha_cutoff);
     }
 


### PR DESCRIPTION
MaterialGenerator selects a custom blend mode for transmissive models,
therefore the AssetLoader should look at the material's blend mode when
it sets up properties, not the one requested by the glTF file.

Fixes #3444.