### PR TITLE
Do not pass texture id when renderbuffer id is expected.

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -929,10 +929,6 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
                 if (any(t->usage & TextureUsage::SAMPLEABLE)) {
                     glFramebufferTexture2D(GL_FRAMEBUFFER, attachment,
                             target, t->gl.id, binfo.level);
-                } else {
-                    assert(target == GL_TEXTURE_2D);
-                    glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment,
-                            GL_RENDERBUFFER, t->gl.id);
                 }
                 break;
             case GL_TEXTURE_2D_ARRAY:


### PR DESCRIPTION
glFramebufferRenderbuffer expects a renderbuffer, not a texture.
Trying to pass a texture results in INVALID_OPERATION on some platforms.

Fixes #3128.