### PR TITLE
Add getVertexIndex API for vertex shaders

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1920,6 +1920,7 @@ The following APIs are only available from the vertex block:
 **getCustom0()** to **getCustom7()** | float4   |  Custom vertex attribute
 **getWorldFromModelMatrix()**        | float4x4 |  Matrix that converts from model (object) space to world space
 **getWorldFromModelNormalMatrix()**  | float3x3 |  Matrix that converts normals from model (object) space to world space
+**getVertexIndex()**                 | int      |  Index of the current vertex
 
 ### Fragment only
 

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -50,6 +50,7 @@ public:
     struct Config {
         filament::backend::ShaderType shaderType;
         filament::backend::ShaderModel shaderModel;
+        bool hasFramebufferFetch;
         struct {
             std::vector<std::pair<uint32_t, uint32_t>> subpassInputToColorLocation;
         } glsl;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -712,6 +712,8 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .glsl = {}
                 };
 
+                config.hasFramebufferFetch = mEnableFramebufferFetch;
+
                 if (mEnableFramebufferFetch) {
                     config.glsl.subpassInputToColorLocation.emplace_back(0, 0);
                 }

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -332,14 +332,20 @@ EShMessages GLSLTools::glslangFlagsFromTargetApi(MaterialBuilder::TargetApi targ
     return msg;
 }
 
-void GLSLTools::prepareShaderParser(glslang::TShader& shader, EShLanguage language,
-        int version, filamat::MaterialBuilder::Optimization optimization) {
+void GLSLTools::prepareShaderParser(MaterialBuilder::TargetApi targetApi, glslang::TShader& shader,
+        EShLanguage language, int version, filamat::MaterialBuilder::Optimization optimization) {
     // We must only setup the SPIRV environment when we actually need to output SPIRV
     if (optimization == filamat::MaterialBuilder::Optimization::SIZE ||
             optimization == filamat::MaterialBuilder::Optimization::PERFORMANCE) {
         shader.setAutoMapBindings(true);
-        shader.setEnvInput(EShSourceGlsl, language, EShClientVulkan, version);
-        shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_0);
+        if (targetApi == MaterialBuilder::TargetApi::VULKAN) {
+            shader.setEnvInput(EShSourceGlsl, language, EShClientVulkan, version);
+            shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_0);
+        } else {
+            assert(targetApi == MaterialBuilder::TargetApi::OPENGL);
+            shader.setEnvInput(EShSourceGlsl, language, EShClientOpenGL, version);
+            shader.setEnvClient(EShClientOpenGL, EShTargetOpenGL_450);
+        }
         shader.setEnvTarget(EShTargetSpv, EShTargetSpv_1_0);
     }
 }

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -147,8 +147,8 @@ public:
 
     static EShMessages glslangFlagsFromTargetApi(MaterialBuilder::TargetApi targetApi);
 
-    static void prepareShaderParser(glslang::TShader& shader, EShLanguage language,
-            int version, MaterialBuilder::Optimization optimization);
+    static void prepareShaderParser(MaterialBuilder::TargetApi targetApi, glslang::TShader& shader,
+            EShLanguage language, int version, MaterialBuilder::Optimization optimization);
 
 private:
 

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -116,6 +116,15 @@ vec4 getCustom6() { return mesh_custom6; }
 vec4 getCustom7() { return mesh_custom7; }
 #endif
 
+/** @public-api */
+int getVertexIndex() {
+#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+    return gl_VertexIndex;
+#else
+    return gl_VertexID;
+#endif
+}
+
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------


### PR DESCRIPTION
In order to support vertex indices (OpenGL: `gl_VertexID` or Vulkan: `gl_VertexIndex`), we need to
update some glslang options when compiling GLSL to SPIR-V under OpenGL semantics.

This change is a bit risky, and I'm still in the process of checking that nothing breaks.

As far as I can tell, there's only one scenario where we use GLSL Vulkan semantics but still compile
to OpenGL-flavored GLSL, and that's for framebuffer fetch. I treat this as a special case, which
we're already doing somewhat.
