### PR TITLE
Fix TSAN issue by using lock in ColorGrading constructor

### DIFF
--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -30,6 +30,7 @@
 #include <math/vec4.h>
 
 #include <utils/JobSystem.h>
+#include <utils/SpinLock.h>
 #include <utils/Systrace.h>
 
 #include <functional>
@@ -446,17 +447,22 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
 
     DriverApi& driver = engine.getDriverApi();
 
-    Config config{
-        .colorGradingTransformIn  = selectColorGradingTransformIn(builder->toneMapping),
-        .colorGradingTransformOut = selectColorGradingTransformOut(builder->toneMapping),
-        .lumaTransform            = selectLumaTransform(builder->toneMapping),
-        .linearToLogTransform     = selectLinearToLogTransform(builder->toneMapping),
-        .logToLinearTransform     = selectLogToLinearTransform(builder->toneMapping),
-        .toneMapper               = selectToneMapping(builder->toneMapping),
-        .lutDimension             = selectLutDimension(builder->quality)
-    };
+    Config c;
+    // This lock protects the data inside Config, which is written to by the Filament thread,
+    // and read from multiple Job threads.
+    utils::SpinLock configLock;
+    {
+        std::lock_guard<utils::SpinLock> lock(configLock);
+        c.colorGradingTransformIn  = selectColorGradingTransformIn(builder->toneMapping);
+        c.colorGradingTransformOut = selectColorGradingTransformOut(builder->toneMapping);
+        c.lumaTransform            = selectLumaTransform(builder->toneMapping);
+        c.linearToLogTransform     = selectLinearToLogTransform(builder->toneMapping);
+        c.logToLinearTransform     = selectLogToLinearTransform(builder->toneMapping);
+        c.toneMapper               = selectToneMapping(builder->toneMapping);
+        c.lutDimension             = selectLutDimension(builder->quality);
+    }
 
-    size_t lutElementCount = config.lutDimension * config.lutDimension * config.lutDimension;
+    size_t lutElementCount = c.lutDimension * c.lutDimension * c.lutDimension;
     size_t elementSize = sizeof(half4);
     void* data = malloc(lutElementCount * elementSize);
 
@@ -479,8 +485,14 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     // This takes about 3-6ms on Android in Release
     JobSystem& js = engine.getJobSystem();
     auto *slices = js.createJob();
-    for (size_t b = 0; b < config.lutDimension; b++) {
-        auto *job = js.createJob(slices, [data, converted, b, &config, builder](JobSystem&, JobSystem::Job*) {
+    for (size_t b = 0; b < c.lutDimension; b++) {
+        auto *job = js.createJob(slices,
+                [data, converted, b, &c, &configLock, builder](JobSystem&, JobSystem::Job*) {
+            Config config;
+            {
+                std::lock_guard<utils::SpinLock> lock(configLock);
+                config = c;
+            }
             half4* UTILS_RESTRICT p = (half4*) data + b * config.lutDimension * config.lutDimension;
             for (size_t g = 0; g < config.lutDimension; g++) {
                 for (size_t r = 0; r < config.lutDimension; r++) {
@@ -581,7 +593,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     //slog.d << "LUT generation time: " << duration.count() << " ms" << io::endl;
 
     mLutHandle = driver.createTexture(SamplerType::SAMPLER_3D, 1, textureFormat, 1,
-            config.lutDimension, config.lutDimension, config.lutDimension, TextureUsage::DEFAULT);
+            c.lutDimension, c.lutDimension, c.lutDimension, TextureUsage::DEFAULT);
 
     if (converted) {
         free(data);
@@ -591,7 +603,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
 
     driver.update3DImage(mLutHandle, 0,
             0, 0, 0,
-            config.lutDimension, config.lutDimension, config.lutDimension,
+            c.lutDimension, c.lutDimension, c.lutDimension,
             PixelBufferDescriptor{
                     data, lutElementCount * elementSize,format, type,
                     [](void* buffer, size_t, void*) { free(buffer); }


### PR DESCRIPTION
This is a second attempt to fix Google3 TSAN failures seen inside of the `ColorGrading` constructor.

```
WARNING: ThreadSanitizer: data race (pid=3367)
  Write of size 8 at 0x7ffc9caf90a0 by main thread:
    #0 memcpy third_party/llvm/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:810:5 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x12d0a90)
    #1 selectColorGradingTransformIn third_party/filament/filament/src/ColorGrading.cpp (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21ea269)
    #2 filament::FColorGrading::FColorGrading(filament::FEngine&, filament::ColorGrading::Builder const&) third_party/filament/filament/src/ColorGrading.cpp:446:37

 Previous read of size 8 at 0x7ffc9caf90a0 by thread T35:
    #0 operator*<float> third_party/filament/libs/math/include/math/TVecHelpers.h:203:43 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #1 operator*<float, void> third_party/filament/libs/math/include/math/TVecHelpers.h:211:19 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #2 operator*<float> third_party/filament/libs/math/include/math/TMatHelpers.h:568:32 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #3 operator() third_party/filament/filament/src/ColorGrading.cpp:495:56 (3144f0fc6ff5d690d2d6dd958acc0500298d9d65e2370c148d7cfe62f7c06bb4_020008bb7de0+0x21eaf5a)
    #4 utils::JobSystem::Job* utils::JobSystem::createJob<filament::FColorGrading::FColorGrading(filament::FEngine&, filament::ColorGrading::Builder const&)::$_0>(utils::JobSystem::Job*, 
```

Related first attempt: #3462