### PR TITLE
Vulkan: fix lifetime issue with image views.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -480,18 +480,16 @@ void VulkanBinder::bindUniformBuffer(uint32_t bindingIndex, VkBuffer uniformBuff
     }
 }
 
-void VulkanBinder::bindSampler(uint32_t bindingIndex, VkDescriptorImageInfo samplerInfo) noexcept {
-    assert(bindingIndex < SAMPLER_BINDING_COUNT);
-    if (bindingIndex >= SAMPLER_BINDING_COUNT) {
-        utils::slog.w << "Sampler bindings overflow: " << bindingIndex << " / "
-                << SAMPLER_BINDING_COUNT << utils::io::endl;
-        return;
-    }
-    VkDescriptorImageInfo& imageInfo = mDescriptorKey.samplers[bindingIndex];
-    if (imageInfo.sampler != samplerInfo.sampler || imageInfo.imageView != samplerInfo.imageView ||
-        imageInfo.imageLayout != samplerInfo.imageLayout) {
-        imageInfo = samplerInfo;
-        mDirtyDescriptor = true;
+void VulkanBinder::bindSamplers(VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT]) noexcept {
+    for (uint32_t bindingIndex = 0; bindingIndex < SAMPLER_BINDING_COUNT; bindingIndex++) {
+        const VkDescriptorImageInfo& requested = samplers[bindingIndex];
+        VkDescriptorImageInfo& existing = mDescriptorKey.samplers[bindingIndex];
+        if (existing.sampler != requested.sampler ||
+            existing.imageView != requested.imageView ||
+            existing.imageLayout != requested.imageLayout) {
+            existing = requested;
+            mDirtyDescriptor = true;
+        }
     }
 }
 

--- a/filament/backend/src/vulkan/VulkanBinder.h
+++ b/filament/backend/src/vulkan/VulkanBinder.h
@@ -133,7 +133,7 @@ public:
     void bindPrimitiveTopology(VkPrimitiveTopology topology) noexcept;
     void bindUniformBuffer(uint32_t bindingIndex, VkBuffer uniformBuffer,
             VkDeviceSize offset = 0, VkDeviceSize size = VK_WHOLE_SIZE) noexcept;
-    void bindSampler(uint32_t bindingIndex, VkDescriptorImageInfo imageInfo) noexcept;
+    void bindSamplers(VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT]) noexcept;
     void bindInputAttachment(uint32_t bindingIndex, VkDescriptorImageInfo imageInfo) noexcept;
     void bindVertexArray(const VertexArray& varray) noexcept;
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1611,6 +1611,8 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     // where "SamplerBinding" is the integer in the GLSL, and SamplerGroupBinding is the abstract
     // Filament concept used to form groups of samplers.
 
+    VkDescriptorImageInfo samplers[VulkanBinder::SAMPLER_BINDING_COUNT] = {};
+
     for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::SAMPLER_BINDING_COUNT; samplerGroupIdx++) {
         const auto& samplerGroup = program->samplerGroupInfo[samplerGroupIdx];
         if (samplerGroup.empty()) {
@@ -1651,13 +1653,15 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
             const SamplerParams& samplerParams = boundSampler->s;
             VkSampler vksampler = mSamplerCache.getSampler(samplerParams);
 
-            mBinder.bindSampler(bindingPoint, {
+            samplers[bindingPoint] = {
                 .sampler = vksampler,
                 .imageView = texture->imageView,
                 .imageLayout = getTextureLayout(texture->usage)
-            });
+            };
         }
     }
+
+    mBinder.bindSamplers(samplers);
 
     // Set scissoring.
     // Compute the intersection of the requested scissor rectangle with the current viewport.


### PR DESCRIPTION
This prevents an "Invalid VkImageView Object" error that would occur
after disabling bloom.

This was caused by the fact that we do not bother zeroing out all the
descriptor slots that are not used by the current draw call.