### PR TITLE
PostProcessManager: call setMinMaxLevels in more places.

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -125,7 +125,7 @@ public:
 
     // VSM shadow mipmap pass
     FrameGraphId<FrameGraphTexture> vsmMipmapPass(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t level) noexcept;
+            FrameGraphId<FrameGraphTexture> input, uint8_t layer, size_t level, bool finalize) noexcept;
 
     backend::Handle<backend::HwTexture> getOneTexture() const { return mDummyOneTexture; }
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
@@ -140,7 +140,7 @@ private:
     class PostProcessMaterial;
 
     FrameGraphId<FrameGraphTexture> mipmapPass(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, size_t level) noexcept;
+            FrameGraphId<FrameGraphTexture> input, size_t level, bool finalize) noexcept;
 
     struct BilateralPassConfig {
         uint8_t kernelSize = 11;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -247,7 +247,8 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
         auto& ppm = engine.getPostProcessManager();
         for (uint8_t layer = 0; layer < mTextureRequirements.layers; layer++) {
             for (size_t level = 0; level < mTextureRequirements.levels - 1; level++) {
-                shadows = ppm.vsmMipmapPass(fg, shadows, layer, level);
+                const bool finalize = mTextureRequirements.levels - 2;
+                shadows = ppm.vsmMipmapPass(fg, shadows, layer, level, finalize);
             }
         }
     }


### PR DESCRIPTION
This fixes some OpenGL non-compliance (as per "Rendering Feedback
Loops" in the spec), as well as validation errors with Vulkan.

I'm hopeful this can be automatic in the new frame graph. :)