### PR TITLE
matc: Use consistent params for semantic code analysis

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -111,7 +111,7 @@ protected:
         TargetLanguage targetLanguage;
     };
     std::vector<CodeGenParams> mCodeGenPermutations;
-    // For finding properties and running semantic analaysis, we always use the same code gen
+    // For finding properties and running semantic analysis, we always use the same code gen
     // permutation. This is the first permutation generated with default arguments passed to matc.
     CodeGenParams mSemanticCodeGenParams = {
         .shaderModel = (int) ShaderModel::GL_ES_30,

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -113,7 +113,7 @@ protected:
     std::vector<CodeGenParams> mCodeGenPermutations;
     // For finding properties and running semantic analysis, we always use the same code gen
     // permutation. This is the first permutation generated with default arguments passed to matc.
-    CodeGenParams mSemanticCodeGenParams = {
+    const CodeGenParams mSemanticCodeGenParams = {
         .shaderModel = (int) ShaderModel::GL_ES_30,
         .targetApi = TargetApi::OPENGL,
         .targetLanguage = TargetLanguage::SPIRV

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -111,6 +111,13 @@ protected:
         TargetLanguage targetLanguage;
     };
     std::vector<CodeGenParams> mCodeGenPermutations;
+    // For finding properties and running semantic analaysis, we always use the same code gen
+    // permutation. This is the first permutation generated with default arguments passed to matc.
+    CodeGenParams mSemanticCodeGenParams = {
+        .shaderModel = (int) ShaderModel::GL_ES_30,
+        .targetApi = TargetApi::OPENGL,
+        .targetLanguage = TargetLanguage::SPIRV
+    };
     uint8_t mVariantFilter = 0;
 
     // Keeps track of how many times MaterialBuilder::init() has been called without a call to


### PR DESCRIPTION
When running semantic analysis on a material, we were arbitrarily choosing the first code gen permutation to analyze. So, running `matc` with arguments `--api metal` versus `--api all` would run analysis on slightly different shader code. This causes bugs when flags passed to glslang differ during semantic analysis. This change updates all semantic analysis to always use the same shader code.