### PR TITLE
BlueVK: optionally consult environment variable.

### DIFF
--- a/libs/bluevk/src/BlueVKLinuxAndroid.cpp
+++ b/libs/bluevk/src/BlueVKLinuxAndroid.cpp
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <utils/Log.h>
+
 namespace bluevk {
 
 static void* module = nullptr;
@@ -49,8 +51,7 @@ bool loadLibrary() {
 
     module = dlopen(path, RTLD_NOW | RTLD_LOCAL);
     if (module == nullptr) {
-        printf("Unable to load Vulkan from %s\n", path);
-        fflush(stdout);
+        utils::slog.e << "Unable to load Vulkan from " << path << utils::io::endl;
     }
     return module != nullptr;
 }

--- a/libs/bluevk/src/BlueVKLinuxAndroid.cpp
+++ b/libs/bluevk/src/BlueVKLinuxAndroid.cpp
@@ -16,25 +16,37 @@
 
 #include <dlfcn.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 namespace bluevk {
 
-#if defined(__ANDROID__)
-static const char* VKLIBRARY_PATH = "libvulkan.so";
+static void* module = nullptr;
+
+// Determines the file path to the Vulkan library and calls dlopen on it.
+// Returns false on failure.
+bool loadLibrary() {
+    const char* path = nullptr;
+
+    // For security, consult an environment variable only if Filament is built with this #define
+    // enabled. Our weekly GitHub releases do not have this enabled.
+#ifdef FILAMENT_VKLIBRARY_USE_ENV
+    path = getenv("FILAMENT_VKLIBRARY_PATH");
+#endif
+
+    // If the environment variable is not set, fall back to a config-specified path, which is either
+    // a custom path (common for SwiftShader), or "libvulkan.so" (common for Android).
+    if (path == nullptr) {
+#ifdef FILAMENT_VKLIBRARY_PATH
+        path = FILAMENT_VKLIBRARY_PATH;
+#elif defined(__ANDROID__)
+        path = "libvulkan.so";
 #elif defined(__linux__)
-static const char* VKLIBRARY_PATH = "libvulkan.so.1";
+        path = "libvulkan.so.1";
 #else
 #error "This file should only be compiled for Android or Linux"
 #endif
+    }
 
-static void* module = nullptr;
-
-bool loadLibrary() {
-#ifndef FILAMENT_VKLIBRARY_PATH
-    const char* path = VKLIBRARY_PATH;
-#else
-    const char* path = FILAMENT_VKLIBRARY_PATH;
-#endif
     module = dlopen(path, RTLD_NOW | RTLD_LOCAL);
     if (module == nullptr) {
         printf("Unable to load Vulkan from %s\n", path);


### PR DESCRIPTION
One of Filament's Linux clients at Google wishes to specify a special
path to the SwiftShader library that proffers Vulkan entry points, and
this path can only be determined at run time.

An environment variable seems like the easiest way to support this
functionality. To prevent a security hazard, the env var is checked only
if a special build-time flag is enabled.