### PR TITLE
Vulkan: conform to PORTABILITY_SUBSET for Molten.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -107,7 +107,7 @@ bool VulkanBinder::getOrCreateDescriptors(VkDescriptorSet descriptorSets[3],
         return true;
     }
 
-    // Allocate one descriptor set for each type: uniforms, samplers, and input attachments.
+    // Allocate one descriptor set for each type: uniforms, combined image samplers, and input attachments.
     VkDescriptorSetAllocateInfo allocInfo = {};
     allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
     allocInfo.descriptorPool = mDescriptorPool;

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -41,6 +41,10 @@ static const PFN_vkGetDeviceProcAddr& vkGetDeviceProcAddr = bluevk::vkGetDeviceP
 
 #include <utils/Panic.h>
 
+#ifndef VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+#define VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME "VK_KHR_portability_subset"
+#endif
+
 using namespace bluevk;
 
 namespace filament {
@@ -125,6 +129,9 @@ void selectPhysicalDevice(VulkanContext& context) {
             if (!strcmp(extensions[k].extensionName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
                 context.debugMarkersSupported = true;
             }
+            if (!strcmp(extensions[k].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+                context.portabilitySubsetSupported = true;
+            }
         }
         if (!supportsSwapchain) continue;
 
@@ -170,9 +177,9 @@ void selectPhysicalDevice(VulkanContext& context) {
         utils::slog.i << "Selected physical device '"
                 << context.physicalDeviceProperties.deviceName
                 << "' from " << physicalDeviceCount << " physical devices. "
-                << "(vendor 0x" << utils::io::hex << vendorID << ", "
-                << "device 0x" << deviceID << ", "
-                << "driver 0x" << driverVersion << ", "
+                << "(vendor " << utils::io::hex << vendorID << ", "
+                << "device " << deviceID << ", "
+                << "driver " << driverVersion << ", "
                 << utils::io::dec << "api " << major << "." << minor << ")"
                 << utils::io::endl;
         return;
@@ -189,6 +196,9 @@ void createLogicalDevice(VulkanContext& context) {
     };
     if (context.debugMarkersSupported && !context.debugUtilsSupported) {
         deviceExtensionNames.push_back(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+    }
+    if (context.portabilitySubsetSupported) {
+        deviceExtensionNames.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     }
     deviceQueueCreateInfo->sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
     deviceQueueCreateInfo->queueFamilyIndex = context.graphicsQueueFamilyIndex;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -105,6 +105,7 @@ struct VulkanContext {
     VkQueue graphicsQueue;
     bool debugMarkersSupported;
     bool debugUtilsSupported;
+    bool portabilitySubsetSupported;
     VulkanBinder::RasterState rasterState;
     VulkanCommandBuffer* currentCommands;
     VulkanSurfaceContext* currentSurface;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -62,12 +62,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallback(VkDebugReportFlagsEXT flags,
 VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
         VkDebugUtilsMessageTypeFlagsEXT types, const VkDebugUtilsMessengerCallbackDataEXT* cbdata,
         void* pUserData) {
-    // TODO: this is temporary workaround to allow running validation with MoltenVK
-    // even though we do not conform to the portability subset.
-    if (!strcmp(cbdata->pMessageIdName, "VUID-VkDeviceCreateInfo-pProperties-04451")) {
+    // TODO: For now, we are silencing an error message relating to mutable comparison samplers.
+    // It is likely that the internal "depthSampleCompare" feature flag is mistakenly set to false
+    // by the Molten implementation. In my case, the GPU is an AMD Radeon Pro 5500M. See this bug:
+    // https://vulkan.lunarg.com/issue/view/602578385df1127a24f3cb4b
+    if (!strcmp(cbdata->pMessageIdName, "VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450")) {
         return VK_FALSE;
     }
-
     if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
         utils::slog.e << "VULKAN ERROR: (" << cbdata->pMessageIdName << ") "
                 << cbdata->pMessage << utils::io::endl;


### PR DESCRIPTION
According to the portability spec: "If this extension is supported by
the Vulkan implementation, the application must enable this extension."

On my 2019 MacBook, enabling this extension triggers errors relating to
depth comparison samplers which I believe to be bogus, so I filed a
LunarG bug. For now we silence this specific error message.