### PR TITLE
don't use assert() inside filament

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -96,7 +96,6 @@ enum class TargetBufferFlags : uint8_t {
 };
 
 inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept {
-    assert(index < 4);
     return TargetBufferFlags(1u << index);
 }
 

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -19,8 +19,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Log.h>
-
-#include <assert.h>
+#include <utils/debug.h>
 
 namespace filament {
 namespace backend {
@@ -53,7 +52,7 @@ public:
     constexpr HandleBase() noexcept: object(nullid) {}
 
     explicit HandleBase(HandleId id) noexcept : object(id) {
-        assert(object != nullid); // usually means an uninitialized handle is used
+        assert_invariant(object != nullid); // usually means an uninitialized handle is used
     }
 
     HandleBase(HandleBase const& rhs) noexcept = default;

--- a/filament/backend/include/backend/PixelBufferDescriptor.h
+++ b/filament/backend/include/backend/PixelBufferDescriptor.h
@@ -23,8 +23,8 @@
 #include <backend/DriverEnums.h>
 
 #include <utils/compiler.h>
+#include <utils/debug.h>
 
-#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -117,7 +117,7 @@ public:
      */
     static constexpr size_t computeDataSize(PixelDataFormat format, PixelDataType type,
             size_t stride, size_t height, size_t alignment) noexcept {
-        assert(alignment);
+        assert_invariant(alignment);
 
         if (type == PixelDataType::COMPRESSED) {
             return 0;
@@ -166,17 +166,17 @@ public:
                 break;
             case PixelDataType::UINT_10F_11F_11F_REV:
                 // Special case, format must be RGB and uses 4 bytes
-                assert(format == PixelDataFormat::RGB);
+                assert_invariant(format == PixelDataFormat::RGB);
                 bpp = 4;
                 break;
             case PixelDataType::UINT_2_10_10_10_REV:
                 // Special case, format must be RGBA and uses 4 bytes
-                assert(format == PixelDataFormat::RGBA);
+                assert_invariant(format == PixelDataFormat::RGBA);
                 bpp = 4;
                 break;
             case PixelDataType::USHORT_565:
                 // Special case, format must be RGB and uses 2 bytes
-                assert(format == PixelDataFormat::RGB);
+                assert_invariant(format == PixelDataFormat::RGB);
                 bpp = 2;
                 break;
         }

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -179,7 +179,7 @@ struct CommandType<void (Driver::*)(ARGS...)> {
 
         // placement new declared as "throw" to avoid the compiler's null-check
         inline void* operator new(std::size_t size, void* ptr) {
-            assert(ptr);
+            assert_invariant(ptr);
             return ptr;
         }
     };
@@ -300,14 +300,14 @@ private:
     bool mUsePerformanceCounter = false;
 
     inline void* allocateCommand(size_t size) {
-        assert(mThreadId == std::this_thread::get_id());
+        assert_invariant(mThreadId == std::this_thread::get_id());
         return mCurrentBuffer->allocate(size);
     }
 };
 
 void* CommandStream::allocate(size_t size, size_t alignment) noexcept {
     // make sure alignment is a power of two
-    assert(alignment && !(alignment & alignment-1));
+    assert_invariant(alignment && !(alignment & alignment-1));
 
     // pad the requested size to accommodate NoopCommand and alignment
     const size_t s = CustomCommand::align(sizeof(NoopCommand) + size + alignment - 1);
@@ -318,7 +318,7 @@ void* CommandStream::allocate(size_t size, size_t alignment) noexcept {
 
     // calculate the "user" data pointer
     void* data = (void *)((uintptr_t(p) + sizeof(NoopCommand) + alignment - 1) & ~(alignment - 1));
-    assert(data >= p + sizeof(NoopCommand));
+    assert_invariant(data >= p + sizeof(NoopCommand));
     return data;
 }
 

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -19,7 +19,6 @@
 
 #include <array>
 #include <stddef.h>
-#include <assert.h>
 
 #include <utils/compiler.h>
 #include <utils/bitset.h>
@@ -101,7 +100,7 @@ private:
         }
 
         explicit static_vector(size_t count) noexcept : mSize(count) {
-            assert(count < N);
+            assert_invariant(count < N);
             std::uninitialized_fill_n(begin(), count, T{});
         }
 
@@ -129,12 +128,12 @@ private:
         }
 
         const T& operator[](size_t pos) const noexcept {
-            assert(pos < mSize);
+            assert_invariant(pos < mSize);
             return data()[pos];
         }
 
         T& operator[](size_t pos) noexcept {
-            assert(pos < mSize);
+            assert_invariant(pos < mSize);
             return data()[pos];
         }
 

--- a/filament/backend/src/Callable.cpp
+++ b/filament/backend/src/Callable.cpp
@@ -17,13 +17,14 @@
 #include <backend/PresentCallable.h>
 
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 namespace filament {
 namespace backend {
 
 PresentCallable::PresentCallable(PresentFn fn, void* user) noexcept
     : mPresentFn(fn), mUser(user) {
-    assert(fn != nullptr);
+    assert_invariant(fn != nullptr);
 }
 
 void PresentCallable::operator()(bool presentFrame) noexcept {

--- a/filament/backend/src/CircularBuffer.cpp
+++ b/filament/backend/src/CircularBuffer.cpp
@@ -29,6 +29,7 @@
 #include <utils/ashmem.h>
 #include <utils/Log.h>
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 using namespace utils;
 
@@ -146,7 +147,7 @@ void CircularBuffer::circularize() noexcept {
     if (mUsesAshmem > 0) {
         intptr_t overflow = intptr_t(mHead) - (intptr_t(mData) + ssize_t(mSize));
         if (overflow >= 0) {
-            assert(size_t(overflow) <= mSize);
+            assert_invariant(size_t(overflow) <= mSize);
             mHead = (void *) (intptr_t(mData) + overflow);
             #ifndef NDEBUG
             memset(mData, 0xA5, size_t(overflow));

--- a/filament/backend/src/CommandBufferQueue.cpp
+++ b/filament/backend/src/CommandBufferQueue.cpp
@@ -16,11 +16,10 @@
 
 #include "private/backend/CommandBufferQueue.h"
 
-#include <assert.h>
-
 #include <utils/Log.h>
 #include <utils/Systrace.h>
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 #include "private/backend/CommandStream.h"
 
@@ -33,11 +32,11 @@ CommandBufferQueue::CommandBufferQueue(size_t requiredSize, size_t bufferSize)
         : mRequiredSize((requiredSize + CircularBuffer::BLOCK_MASK) & ~CircularBuffer::BLOCK_MASK),
           mCircularBuffer(bufferSize),
           mFreeSpace(mCircularBuffer.size()) {
-    assert(mCircularBuffer.size() > requiredSize);
+    assert_invariant(mCircularBuffer.size() > requiredSize);
 }
 
 CommandBufferQueue::~CommandBufferQueue() {
-    assert(mCommandBuffersToExecute.empty());
+    assert_invariant(mCommandBuffersToExecute.empty());
 }
 
 void CommandBufferQueue::requestExit() {
@@ -81,7 +80,7 @@ void CommandBufferQueue::flush() noexcept {
     mCommandBuffersToExecute.push_back({ tail, head });
 
     // circular buffer is too small, we corrupted the stream
-    assert(used <= mFreeSpace);
+    assert_invariant(used <= mFreeSpace);
 
     // wait until there is enough space in the buffer
     mFreeSpace -= used;

--- a/filament/backend/src/DataReshaper.h
+++ b/filament/backend/src/DataReshaper.h
@@ -21,6 +21,8 @@
 
 #include <math/scalar.h>
 
+#include <utils/debug.h>
+
 namespace filament {
 namespace backend {
 
@@ -62,7 +64,7 @@ public:
         const srcComponentType srcMaxValue = getMaxValue<srcComponentType>();
         const size_t width = (srcBytesPerRow / sizeof(srcComponentType)) / srcChannelCount;
         const size_t minChannelCount = filament::math::min(srcChannelCount, dstChannelCount);
-        assert(minChannelCount <= 4);
+        assert_invariant(minChannelCount <= 4);
         const int inds[4] = {swizzle ? 2 : 0, 1, swizzle ? 0 : 2, 3};
 
         int srcStride;

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -32,7 +32,6 @@
 #include <mutex>
 #include <utility>
 
-#include <assert.h>
 #include <stdint.h>
 
 namespace filament {

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -17,6 +17,7 @@
 #include <backend/Platform.h>
 
 #include <utils/Systrace.h>
+#include <utils/debug.h>
 
 #if defined(ANDROID)
     #ifndef FILAMENT_USE_EXTERNAL_GLES3
@@ -78,7 +79,7 @@ Platform::~Platform() noexcept = default;
 // createDriver(). The passed-in backend hint is replaced with the resolved backend.
 DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
     SYSTRACE_CALL();
-    assert(backend);
+    assert_invariant(backend);
     if (*backend == Backend::DEFAULT) {
         *backend = Backend::OPENGL;
     }

--- a/filament/backend/src/TextureReshaper.cpp
+++ b/filament/backend/src/TextureReshaper.cpp
@@ -19,6 +19,7 @@
 #include "DataReshaper.h"
 
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 namespace filament {
 namespace backend {
@@ -71,7 +72,7 @@ TextureFormat TextureReshaper::getReshapedFormat() const noexcept {
 }
 
 PixelBufferDescriptor TextureReshaper::reshape(PixelBufferDescriptor& p) const {
-    assert(mReshapeFunction);
+    assert_invariant(mReshapeFunction);
     return mReshapeFunction(p);
 }
 

--- a/filament/backend/src/android/ExternalStreamManagerAndroid.cpp
+++ b/filament/backend/src/android/ExternalStreamManagerAndroid.cpp
@@ -103,7 +103,7 @@ void ExternalStreamManagerAndroid::release(Stream* handle) noexcept {
         ASurfaceTexture_release(stream->nSurfaceTexture);
     }
     JNIEnv* const env = getEnvironment();
-    assert(env); // we should have called attach() by now
+    assert_invariant(env); // we should have called attach() by now
     env->DeleteGlobalRef(stream->jSurfaceTexture);
     delete stream;
 }
@@ -124,7 +124,7 @@ void ExternalStreamManagerAndroid::attach(Stream* handle, intptr_t tname) noexce
         }
     } else {
         JNIEnv* const env = getEnvironment();
-        assert(env); // we should have called attach() by now
+        assert_invariant(env); // we should have called attach() by now
 
         // associate our GL texture to the SurfaceTexture
         jobject jSurfaceTexture = stream->jSurfaceTexture;
@@ -152,7 +152,7 @@ void ExternalStreamManagerAndroid::detach(Stream* handle) noexcept {
         ASurfaceTexture_detachFromGLContext(stream->nSurfaceTexture);
     } else {
         JNIEnv* const env = mVm.getEnvironment();
-        assert(env); // we should have called attach() by now
+        assert_invariant(env); // we should have called attach() by now
         env->CallVoidMethod(stream->jSurfaceTexture, mSurfaceTextureClass_detachFromGLContext);
         VirtualMachineEnv::handleException(env);
     }
@@ -170,7 +170,7 @@ void ExternalStreamManagerAndroid::updateTexImage(Stream* handle, int64_t* times
         }
     } else {
         JNIEnv* const env = mVm.getEnvironment();
-        assert(env); // we should have called attach() by now
+        assert_invariant(env); // we should have called attach() by now
         env->CallVoidMethod(stream->jSurfaceTexture, mSurfaceTextureClass_updateTexImage);
         VirtualMachineEnv::handleException(env);
         *timestamp = env->CallLongMethod(stream->jSurfaceTexture, mSurfaceTextureClass_getTimestamp);

--- a/filament/backend/src/android/VirtualMachineEnv.cpp
+++ b/filament/backend/src/android/VirtualMachineEnv.cpp
@@ -16,6 +16,7 @@
 
 #include "VirtualMachineEnv.h"
 
+#include <utils/debug.h>
 
 namespace filament {
 
@@ -44,7 +45,7 @@ void VirtualMachineEnv::handleException(JNIEnv* const env) noexcept {
 UTILS_NOINLINE
 JNIEnv* VirtualMachineEnv::getEnvironmentSlow() noexcept {
     mVirtualMachine->AttachCurrentThread(&mJniEnv, nullptr);
-    assert(mJniEnv);
+    assert_invariant(mJniEnv);
     return mJniEnv;
 }
 

--- a/filament/backend/src/android/VirtualMachineEnv.h
+++ b/filament/backend/src/android/VirtualMachineEnv.h
@@ -19,10 +19,9 @@
 
 #include <utils/compiler.h>
 #include <utils/ThreadLocal.h>
+#include <utils/debug.h>
 
 #include <jni.h>
-
-#include <assert.h>
 
 namespace filament {
 
@@ -39,7 +38,7 @@ public:
 
     static JNIEnv* getThreadEnvironment() noexcept {
         JNIEnv* env;
-        assert(sVirtualMachine);
+        assert_invariant(sVirtualMachine);
         if (sVirtualMachine->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
             return nullptr; // this should not happen
         }
@@ -59,7 +58,7 @@ public:
     }
 
     inline JNIEnv* getEnvironment() noexcept {
-        assert(mVirtualMachine);
+        assert_invariant(mVirtualMachine);
         JNIEnv* env = mJniEnv;
         if (UTILS_UNLIKELY(!env)) {
             return getEnvironmentSlow();

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -103,7 +103,7 @@ void MetalBufferPool::gc() noexcept {
 void MetalBufferPool::reset() noexcept {
     std::lock_guard<std::mutex> lock(mMutex);
 
-    assert(mUsedStages.empty());
+    assert_invariant(mUsedStages.empty());
     for (auto pair : mFreeStages) {
         delete pair.second;
     }

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -18,7 +18,7 @@
 
 #include "MetalHandles.h"
 
-#include <utils/Panic.h>
+#include <utils/debug.h>
 
 namespace filament {
 namespace backend {
@@ -42,7 +42,7 @@ void submitPendingCommands(MetalContext* context) {
     if (!context->pendingCommandBuffer) {
         return;
     }
-    assert(context->pendingCommandBuffer.status != MTLCommandBufferStatusCommitted);
+    assert_invariant(context->pendingCommandBuffer.status != MTLCommandBufferStatusCommitted);
     [context->pendingCommandBuffer commit];
     context->pendingCommandBuffer = nil;
 }

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -22,6 +22,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Log.h>
+#include <utils/debug.h>
 
 #include <tsl/robin_map.h>
 
@@ -114,33 +115,33 @@ private:
 
     template<typename Dp, typename B>
     Dp* handle_cast(HandleMap& handleMap, Handle<B> handle) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter.value();
         return reinterpret_cast<Dp*>(blob);
     }
 
     template<typename Dp, typename B>
     const Dp* handle_const_cast(HandleMap& handleMap, const Handle<B>& handle) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter.value();
         return reinterpret_cast<const Dp*>(blob);
     }
 
     template<typename Dp, typename B, typename ... ARGS>
     Dp* construct_handle(HandleMap& handleMap, Handle<B>& handle, ARGS&& ... args) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter.value();
         Dp* addr = reinterpret_cast<Dp*>(blob);
         new(addr) Dp(std::forward<ARGS>(args)...);
@@ -150,10 +151,10 @@ private:
     template<typename Dp, typename B>
     void destruct_handle(HandleMap& handleMap, Handle<B>& handle) noexcept {
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
-        assert(handle);
+        assert_invariant(handle);
         // Call the destructor, remove the blob, don't bother reclaiming the integer id.
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter.value();
         reinterpret_cast<Dp*>(blob)->~Dp();
         free(blob);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -46,7 +46,7 @@ namespace metal {
 
 UTILS_NOINLINE
 Driver* MetalDriver::create(MetalPlatform* const platform) {
-    assert(platform);
+    assert_invariant(platform);
     return new MetalDriver(platform);
 }
 
@@ -626,7 +626,7 @@ math::float2 MetalDriver::getClipSpaceParams() {
 
 void MetalDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
         BufferDescriptor&& data, uint32_t byteOffset) {
-    assert(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers
+    assert_invariant(byteOffset == 0);    // TODO: handle byteOffset for vertex buffers
     auto* vb = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     vb->buffers[index]->copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));
@@ -634,7 +634,7 @@ void MetalDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
 
 void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
         uint32_t byteOffset) {
-    assert(byteOffset == 0);    // TODO: handle byteOffset for index buffers
+    assert_invariant(byteOffset == 0);    // TODO: handle byteOffset for index buffers
     auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     ib->buffer.copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));
@@ -1135,7 +1135,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     if (mContext->pipelineState.stateChanged()) {
         id<MTLRenderPipelineState> pipeline =
                 mContext->pipelineStateCache.getOrCreateState(pipelineState);
-        assert(pipeline != nil);
+        assert_invariant(pipeline != nil);
         [mContext->currentRenderPassEncoder setRenderPipelineState:pipeline];
     }
 
@@ -1162,7 +1162,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     if (mContext->depthStencilState.stateChanged()) {
         id<MTLDepthStencilState> state =
                 mContext->depthStencilStateCache.getOrCreateState(depthState);
-        assert(state != nil);
+        assert_invariant(state != nil);
         [mContext->currentRenderPassEncoder setDepthStencilState:state];
     }
 
@@ -1296,7 +1296,7 @@ void MetalDriver::enumerateSamplerGroups(
             continue;
         }
         SamplerGroup* sb = metalSamplerGroup->sb.get();
-        assert(sb->getSize() == samplerGroup.size());
+        assert_invariant(sb->getSize() == samplerGroup.size());
         size_t samplerIdx = 0;
         for (const auto& sampler : samplerGroup) {
             size_t bindingPoint = sampler.binding;

--- a/filament/backend/src/metal/MetalExternalImage.mm
+++ b/filament/backend/src/metal/MetalExternalImage.mm
@@ -152,7 +152,7 @@ void MetalExternalImage::set(CVPixelBufferRef image, size_t plane) noexcept {
     };
 
     const MTLPixelFormat format = getPlaneFormat(plane);
-    assert(format != MTLPixelFormatInvalid);
+    assert_invariant(format != MTLPixelFormatInvalid);
     mTexture = createTextureFromImage(image, format, plane);
 }
 

--- a/filament/backend/src/metal/MetalResourceTracker.cpp
+++ b/filament/backend/src/metal/MetalResourceTracker.cpp
@@ -16,6 +16,8 @@
 
 #include "MetalResourceTracker.h"
 
+#include <utils/debug.h>
+
 namespace filament {
 namespace backend {
 namespace metal {
@@ -31,7 +33,7 @@ bool MetalResourceTracker::trackResource(CommandBuffer buffer, Resource resource
         return true;
     }
 
-    assert(found != mResources.end());
+    assert_invariant(found != mResources.end());
     Resources& resources = found.value();
     auto inserted = resources.insert({resource, deleter});
     return inserted.second;

--- a/filament/backend/src/opengl/CocoaTouchExternalImage.mm
+++ b/filament/backend/src/opengl/CocoaTouchExternalImage.mm
@@ -27,6 +27,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 namespace filament {
 
@@ -74,20 +75,20 @@ CocoaTouchExternalImage::SharedGl::SharedGl() noexcept {
     glShaderSource(vertexShader, 1, &s_vertexES, nullptr);
     glCompileShader(vertexShader);
     glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(fragmentShader, 1, &s_fragmentES, nullptr);
     glCompileShader(fragmentShader);
     glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     program = glCreateProgram();
     glAttachShader(program, vertexShader);
     glAttachShader(program, fragmentShader);
     glLinkProgram(program);
     glGetProgramiv(program, GL_LINK_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     // Save current program state.
     GLint currentProgram;
@@ -145,7 +146,7 @@ bool CocoaTouchExternalImage::set(CVPixelBufferRef image) noexcept {
     // The pixel buffer must be locked whenever we do rendering with it. We'll unlock it before
     // releasing.
     UTILS_UNUSED_IN_RELEASE CVReturn lockStatus = CVPixelBufferLockBaseAddress(image, 0);
-    assert(lockStatus == kCVReturnSuccess);
+    assert_invariant(lockStatus == kCVReturnSuccess);
 
     if (planeCount == 0) {
         mImage = image;
@@ -222,7 +223,7 @@ CVOpenGLESTextureRef CocoaTouchExternalImage::createTextureFromImage(CVPixelBuff
             CVOpenGLESTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
             mTextureCache, image, nullptr, GL_TEXTURE_2D, glFormat, width, height,
             glFormat, GL_UNSIGNED_BYTE, plane, &texture);
-    assert(success == kCVReturnSuccess);
+    assert_invariant(success == kCVReturnSuccess);
 
     return texture;
 }

--- a/filament/backend/src/opengl/OpenGLBlitter.cpp
+++ b/filament/backend/src/opengl/OpenGLBlitter.cpp
@@ -24,8 +24,6 @@
 
 #include <math/vec2.h>
 
-#include <assert.h>
-
 using namespace filament::math;
 using namespace utils;
 
@@ -81,20 +79,20 @@ void OpenGLBlitter::init() noexcept {
     glShaderSource(mVertexShader, 1, vsource + index, nullptr);
     glCompileShader(mVertexShader);
     glGetShaderiv(mVertexShader, GL_COMPILE_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     mFragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(mFragmentShader, 1, fsource + index, nullptr);
     glCompileShader(mFragmentShader);
     glGetShaderiv(mFragmentShader, GL_COMPILE_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     mProgram = glCreateProgram();
     glAttachShader(mProgram, mVertexShader);
     glAttachShader(mProgram, mFragmentShader);
     glLinkProgram(mProgram);
     glGetProgramiv(mProgram, GL_LINK_STATUS, &status);
-    assert(status == GL_TRUE);
+    assert_invariant(status == GL_TRUE);
 
     glUseProgram(mProgram);
     GLint loc = glGetUniformLocation(mProgram, "sampler");

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -113,7 +113,7 @@ OpenGLContext::OpenGLContext() noexcept {
         initExtensionsGL(major, minor, exts);
         features.multisample_texture = true;
     };
-    assert(shaderModel != ShaderModel::UNKNOWN);
+    assert_invariant(shaderModel != ShaderModel::UNKNOWN);
     mShaderModel = shaderModel;
 
     /*
@@ -263,7 +263,7 @@ void OpenGLContext::bindBuffer(GLenum target, GLuint buffer) noexcept {
     if (target == GL_ELEMENT_ARRAY_BUFFER) {
         // GL_ELEMENT_ARRAY_BUFFER is a special case, where the currently bound VAO remembers
         // the index buffer, unless there are no VAO bound (see: bindVertexArray)
-        assert(state.vao.p);
+        assert_invariant(state.vao.p);
         if (state.buffers.genericBinding[targetIndex] != buffer
             || ((state.vao.p != &mDefaultVAO) && (state.vao.p->elementArray != buffer))) {
             state.buffers.genericBinding[targetIndex] = buffer;

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -20,6 +20,7 @@
 #include <math/vec4.h>
 
 #include <utils/CString.h>
+#include <utils/debug.h>
 
 #include "GLUtils.h"
 
@@ -315,7 +316,7 @@ constexpr size_t OpenGLContext::getIndexForCap(GLenum cap) noexcept { //NOLINT
 #endif
         default: index = 13; break; // should never happen
     }
-    assert(index < 13 && index < state.enables.caps.size());
+    assert_invariant(index < 13 && index < state.enables.caps.size());
     return index;
 }
 
@@ -334,21 +335,21 @@ constexpr size_t OpenGLContext::getIndexForBufferTarget(GLenum target) noexcept 
         case GL_PIXEL_UNPACK_BUFFER:        index = 7; break;
         default: index = 8; break; // should never happen
     }
-    assert(index < sizeof(state.buffers.genericBinding)/sizeof(state.buffers.genericBinding[0])); // NOLINT(misc-redundant-expression)
+    assert_invariant(index < sizeof(state.buffers.genericBinding)/sizeof(state.buffers.genericBinding[0])); // NOLINT(misc-redundant-expression)
     return index;
 }
 
 // ------------------------------------------------------------------------------------------------
 
 void OpenGLContext::activeTexture(GLuint unit) noexcept {
-    assert(unit < MAX_TEXTURE_UNIT_COUNT);
+    assert_invariant(unit < MAX_TEXTURE_UNIT_COUNT);
     update_state(state.textures.active, unit, [&]() {
         glActiveTexture(GL_TEXTURE0 + unit);
     });
 }
 
 void OpenGLContext::bindSampler(GLuint unit, GLuint sampler) noexcept {
-    assert(unit < MAX_TEXTURE_UNIT_COUNT);
+    assert_invariant(unit < MAX_TEXTURE_UNIT_COUNT);
     update_state(state.textures.units[unit].sampler, sampler, [&]() {
         glBindSampler(unit, sampler);
     });
@@ -393,7 +394,7 @@ void OpenGLContext::bindVertexArray(RenderPrimitive const* p) noexcept {
 void OpenGLContext::bindBufferRange(GLenum target, GLuint index, GLuint buffer,
         GLintptr offset, GLsizeiptr size) noexcept {
     size_t targetIndex = getIndexForBufferTarget(target);
-    assert(targetIndex <= 1); // validity check
+    assert_invariant(targetIndex <= 1); // validity check
 
     // this ALSO sets the generic binding
     if (   state.buffers.targets[targetIndex].buffers[index].name != buffer
@@ -433,8 +434,8 @@ void OpenGLContext::bindFramebuffer(GLenum target, GLuint buffer) noexcept {
 }
 
 void OpenGLContext::bindTexture(GLuint unit, GLuint target, GLuint texId, size_t targetIndex) noexcept {
-    assert(targetIndex == getIndexForTextureTarget(target));
-    assert(targetIndex < TEXTURE_TARGET_COUNT);
+    assert_invariant(targetIndex == getIndexForTextureTarget(target));
+    assert_invariant(targetIndex < TEXTURE_TARGET_COUNT);
     update_state(state.textures.units[unit].targets[targetIndex].texture_id, texId, [&]() {
         activeTexture(unit);
         glBindTexture(target, texId);
@@ -452,8 +453,8 @@ void OpenGLContext::useProgram(GLuint program) noexcept {
 }
 
 void OpenGLContext::enableVertexAttribArray(GLuint index) noexcept {
-    assert(state.vao.p);
-    assert(index < state.vao.p->vertexAttribArray.size());
+    assert_invariant(state.vao.p);
+    assert_invariant(index < state.vao.p->vertexAttribArray.size());
     if (UTILS_UNLIKELY(!state.vao.p->vertexAttribArray[index])) {
         state.vao.p->vertexAttribArray.set(index);
         glEnableVertexAttribArray(index);
@@ -461,8 +462,8 @@ void OpenGLContext::enableVertexAttribArray(GLuint index) noexcept {
 }
 
 void OpenGLContext::disableVertexAttribArray(GLuint index) noexcept {
-    assert(state.vao.p);
-    assert(index < state.vao.p->vertexAttribArray.size());
+    assert_invariant(state.vao.p);
+    assert_invariant(index < state.vao.p->vertexAttribArray.size());
     if (UTILS_UNLIKELY(state.vao.p->vertexAttribArray[index])) {
         state.vao.p->vertexAttribArray.unset(index);
         glDisableVertexAttribArray(index);

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -30,8 +30,6 @@
 
 #include <set>
 
-#include <assert.h>
-
 #ifndef FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB
 #    define FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB 2
 #endif
@@ -289,12 +287,12 @@ private:
             std::is_pointer<Dp>::value &&
             std::is_base_of<B, typename std::remove_pointer<Dp>::type>::value, Dp>::type
     handle_cast(backend::Handle<B>& handle) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         char* const base = (char *)mHandleArena.getArea().begin();
         size_t offset = handle.getId() << HandleAllocator::MIN_ALIGNMENT_SHIFT;
         // assert that this handle is even a valid one
-        assert(base + offset + sizeof(typename std::remove_pointer<Dp>::type) <= (char *)mHandleArena.getArea().end());
+        assert_invariant(base + offset + sizeof(typename std::remove_pointer<Dp>::type) <= (char *)mHandleArena.getArea().end());
         return static_cast<Dp>(static_cast<void *>(base + offset));
     }
 
@@ -359,9 +357,9 @@ private:
     GLuint getSamplerSlow(backend::SamplerParams sp) const noexcept;
 
     inline GLuint getSampler(backend::SamplerParams sp) const noexcept {
-        assert(!sp.padding0);
-        assert(!sp.padding1);
-        assert(!sp.padding2);
+        assert_invariant(!sp.padding0);
+        assert_invariant(!sp.padding1);
+        assert_invariant(!sp.padding2);
         auto& samplerMap = mSamplerMap;
         auto pos = samplerMap.find(sp.u);
         if (UTILS_UNLIKELY(pos == samplerMap.end())) {

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -21,6 +21,7 @@
 #include <utils/Log.h>
 #include <utils/compiler.h>
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 #include <private/backend/BackendUtils.h>
 
@@ -210,7 +211,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
         SamplerGroup::Sampler const* const UTILS_RESTRICT samplers = sb.getSamplers();
         for (uint8_t j = 0, m = blockInfo.count ; j <= m; ++j, ++tmu) { // "<=" on purpose here
             const uint8_t index = indicesRun[tmu];
-            assert(index < sb.getSize());
+            assert_invariant(index < sb.getSize());
 
             Handle<HwTexture> th = samplers[index].t;
             if (UTILS_UNLIKELY(!th)) {

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -87,7 +87,7 @@ Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext) noexcept
 
     CVReturn success = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, nullptr,
             pImpl->mGLContext, nullptr, &pImpl->mTextureCache);
-    assert(success == kCVReturnSuccess);
+    assert_invariant(success == kCVReturnSuccess);
 
     pImpl->mExternalImageSharedGl = new CocoaTouchExternalImage::SharedGl();
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -26,9 +26,6 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
-#include <assert.h>
-
-
 using namespace utils;
 
 namespace filament {
@@ -85,7 +82,7 @@ PlatformEGL::PlatformEGL() noexcept = default;
 
 Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-    assert(mEGLDisplay != EGL_NO_DISPLAY);
+    assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
 
     EGLint major, minor;
     EGLBoolean initialized = eglInitialize(mEGLDisplay, &major, &minor);

--- a/filament/backend/src/opengl/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/PlatformEGLAndroid.cpp
@@ -33,8 +33,6 @@
 
 #include <sys/system_properties.h>
 
-#include <assert.h>
-
 #include <jni.h>
 
 

--- a/filament/backend/src/opengl/TimerQuery.cpp
+++ b/filament/backend/src/opengl/TimerQuery.cpp
@@ -21,6 +21,7 @@
 #include <utils/compiler.h>
 #include <utils/Log.h>
 #include <utils/Systrace.h>
+#include <utils/debug.h>
 
 namespace filament {
 
@@ -125,7 +126,7 @@ void TimerQueryFence::flush() {
 }
 
 void TimerQueryFence::beginTimeElapsedQuery(GLTimerQuery* query) {
-    assert(!mActiveQuery);
+    assert_invariant(!mActiveQuery);
     // We can't use a fence to figure out when a GPU operation starts (only when it finishes)
     // so instead, we use when glFlush() was issued as a proxy.
     if (UTILS_UNLIKELY(!query->gl.emulation)) {
@@ -137,7 +138,7 @@ void TimerQueryFence::beginTimeElapsedQuery(GLTimerQuery* query) {
 }
 
 void TimerQueryFence::endTimeElapsedQuery(GLTimerQuery* query) {
-    assert(mActiveQuery);
+    assert_invariant(mActiveQuery);
     Platform::Fence* fence = mPlatform.createFence();
     std::weak_ptr<GLTimerQuery::State> weak = query->gl.emulation;
     mActiveQuery = nullptr;

--- a/filament/backend/src/vulkan/VulkanBinder.cpp
+++ b/filament/backend/src/vulkan/VulkanBinder.cpp
@@ -77,7 +77,7 @@ bool VulkanBinder::getOrCreateDescriptors(VkDescriptorSet descriptorSets[3],
     // If no bindings have been dirtied, update the timestamp (most recent access) and return false
     // to indicate there's no need to re-bind.
     if (!mDirtyDescriptor) {
-        assert(mCurrentDescriptorBundle && mCurrentDescriptorBundle->bound);
+        assert_invariant(mCurrentDescriptorBundle && mCurrentDescriptorBundle->bound);
         descriptorSets[0] = mCurrentDescriptorBundle->handles[0];
         descriptorSets[1] = mCurrentDescriptorBundle->handles[1];
         descriptorSets[2] = mCurrentDescriptorBundle->handles[2];
@@ -196,12 +196,12 @@ bool VulkanBinder::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     // If no bindings have been dirtied, update the timestamp (most recent access) and return false
     // to indicate there's no need to re-bind.
     if (!mDirtyPipeline) {
-        assert(mCurrentPipeline && mCurrentPipeline->bound);
+        assert_invariant(mCurrentPipeline && mCurrentPipeline->bound);
         *pipeline = mCurrentPipeline->handle;
         mCurrentPipeline->timestamp = mCurrentTime;
         return false;
     }
-    assert(mPipelineKey.shaders[0] && "Vertex shader is not bound.");
+    assert_invariant(mPipelineKey.shaders[0] && "Vertex shader is not bound.");
 
     // Release the previously bound pipeline and update its time stamp.
     if (mCurrentPipeline) {

--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -106,7 +106,7 @@ void VulkanBlitter::blitFast(VkImageAspectFlags aspect, VkFilter filter,
             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, dst.level, 1, 1, aspect);
 
     if (src.texture && src.texture->samples > 1 && dst.texture && dst.texture->samples == 1) {
-        assert(aspect != VK_IMAGE_ASPECT_DEPTH_BIT && "Resolve with depth is not yet supported.");
+        assert_invariant(aspect != VK_IMAGE_ASPECT_DEPTH_BIT && "Resolve with depth is not yet supported.");
         vkCmdResolveImage(cmdbuffer, src.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst.image,
                 VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, resolveRegions);
     } else {
@@ -144,7 +144,7 @@ void VulkanBlitter::lazyInit() noexcept {
     if (mVertex) {
         return;
     }
-    assert(mContext.device);
+    assert_invariant(mContext.device);
 
     VkShaderModuleCreateInfo moduleInfo = {};
     moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;

--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -44,7 +44,7 @@ VulkanBuffer::~VulkanBuffer() {
 }
 
 void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_t numBytes) {
-    assert(byteOffset == 0);
+    assert_invariant(byteOffset == 0);
     VulkanStage const* stage = mStagePool.acquireStage(numBytes);
     void* mapped;
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -596,7 +596,7 @@ void waitForIdle(VulkanContext& context) {
         uint32_t nfences = 0;
         auto& surfaceContext = *context.currentSurface;
         for (auto& swapContext : surfaceContext.swapContexts) {
-            assert(nfences < 4);
+            assert_invariant(nfences < 4);
             if (swapContext.commands.fence && swapContext.commands.fence->submitted) {
                 fences[nfences++] = swapContext.commands.fence->fence;
                 swapContext.commands.fence->submitted = false;
@@ -638,7 +638,7 @@ bool acquireSwapCommandBuffer(VulkanContext& context) {
             return false;
         }
 
-        assert(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
+        assert_invariant(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
     }
 
     SwapContext& swap = getSwapContext(context);
@@ -767,7 +767,7 @@ void createFinalDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfac
         .usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
     };
     VkResult error = vkCreateImage(context.device, &imageInfo, VKALLOC, &depthImage);
-    assert(!error && "Unable to create depth image.");
+    assert_invariant(!error && "Unable to create depth image.");
 
     // Allocate memory for the VkImage and bind it.
     VkMemoryRequirements memReqs;
@@ -780,9 +780,9 @@ void createFinalDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfac
     };
     error = vkAllocateMemory(context.device, &allocInfo, nullptr,
             &surfaceContext.depth.memory);
-    assert(!error && "Unable to allocate depth memory.");
+    assert_invariant(!error && "Unable to allocate depth memory.");
     error = vkBindImageMemory(context.device, depthImage, surfaceContext.depth.memory, 0);
-    assert(!error && "Unable to bind depth memory.");
+    assert_invariant(!error && "Unable to bind depth memory.");
 
     // Create a VkImageView so that we can attach depth to the framebuffer.
     VkImageView depthView;
@@ -798,7 +798,7 @@ void createFinalDepthBuffer(VulkanContext& context, VulkanSurfaceContext& surfac
         },
     };
     error = vkCreateImageView(context.device, &viewInfo, VKALLOC, &depthView);
-    assert(!error && "Unable to create depth view.");
+    assert_invariant(!error && "Unable to create depth view.");
 
     // Unlike the color attachments (which are double-buffered or triple-buffered), we only need one
     // depth attachment in the entire chain.

--- a/filament/backend/src/vulkan/VulkanDisposer.cpp
+++ b/filament/backend/src/vulkan/VulkanDisposer.cpp
@@ -16,6 +16,8 @@
 
 #include "vulkan/VulkanDisposer.h"
 
+#include <utils/debug.h>
+
 namespace filament {
 namespace backend {
 
@@ -24,12 +26,12 @@ void VulkanDisposer::createDisposable(Key resource, std::function<void()> destru
 }
 
 void VulkanDisposer::addReference(Key resource) noexcept {
-    assert(mDisposables[resource].refcount > 0);
+    assert_invariant(mDisposables[resource].refcount > 0);
     ++mDisposables[resource].refcount;
 }
 
 void VulkanDisposer::removeReference(Key resource) noexcept {
-    assert(mDisposables[resource].refcount > 0);
+    assert_invariant(mDisposables[resource].refcount > 0);
     if (--mDisposables[resource].refcount == 0) {
         mGraveyard.emplace_back(std::move(mDisposables[resource]));
         mDisposables.erase(resource);
@@ -62,7 +64,7 @@ void VulkanDisposer::gc() noexcept {
 
 void VulkanDisposer::reset() noexcept {
     gc();
-    assert(mDisposables.empty());
+    assert_invariant(mDisposables.empty());
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -98,37 +98,37 @@ private:
 
     template<typename Dp, typename B>
     Dp* handle_cast(HandleMap& handleMap, Handle<B> handle) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter->second;
-        assert(blob.size() == sizeof(Dp));
+        assert_invariant(blob.size() == sizeof(Dp));
         return reinterpret_cast<Dp*>(blob.data());
     }
 
     template<typename Dp, typename B>
     const Dp* handle_const_cast(HandleMap& handleMap, const Handle<B>& handle) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter->second;
-        assert(blob.size() == sizeof(Dp));
+        assert_invariant(blob.size() == sizeof(Dp));
         return reinterpret_cast<const Dp*>(blob.data());
     }
 
     template<typename Dp, typename B, typename ... ARGS>
     Dp* construct_handle(HandleMap& handleMap, Handle<B>& handle, ARGS&& ... args) noexcept {
-        assert(handle);
+        assert_invariant(handle);
         if (!handle) return nullptr; // better to get a NPE than random behavior/corruption
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter->second;
-        assert(blob.size() == sizeof(Dp));
+        assert_invariant(blob.size() == sizeof(Dp));
         Dp* addr = reinterpret_cast<Dp*>(blob.data());
         new(addr) Dp(std::forward<ARGS>(args)...);
         return addr;
@@ -139,9 +139,9 @@ private:
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
         // Call the destructor, remove the blob, don't bother reclaiming the integer id.
         auto iter = handleMap.find(handle.getId());
-        assert(iter != handleMap.end());
+        assert_invariant(iter != handleMap.end());
         Blob& blob = iter->second;
-        assert(blob.size() == sizeof(Dp));
+        assert_invariant(blob.size() == sizeof(Dp));
         reinterpret_cast<Dp*>(blob.data())->~Dp();
         handleMap.erase(handle.getId());
     }

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -228,7 +228,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             // If there are subpasses, we require the input attachment to be the first attachment.
             // Breaking this assumption would likely require enhancements to the Driver API in order
             // to supply Vulkan with all the information needed.
-            assert(config.subpassMask == 1);
+            assert_invariant(config.subpassMask == 1);
 
             if (config.subpassMask & (1 << i)) {
                 index = subpasses[0].colorAttachmentCount++;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -245,8 +245,8 @@ VulkanSwapChain::VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_
             .tiling = VK_IMAGE_TILING_OPTIMAL,
             .usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
         };
-        assert(iCreateInfo.extent.width > 0);
-        assert(iCreateInfo.extent.height > 0);
+        assert_invariant(iCreateInfo.extent.width > 0);
+        assert_invariant(iCreateInfo.extent.height > 0);
         vkCreateImage(context.device, &iCreateInfo, VKALLOC, &image);
 
         VkMemoryRequirements memReqs = {};
@@ -638,7 +638,7 @@ void VulkanTexture::update2DImage(const PixelBufferDescriptor& data, uint32_t wi
 
 void VulkanTexture::update3DImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
         uint32_t depth, int miplevel) {
-    assert(width <= this->width && height <= this->height && depth <= this->depth);
+    assert_invariant(width <= this->width && height <= this->height && depth <= this->depth);
     const uint32_t srcBytesPerTexel = getBytesPerPixel(format);
     const bool reshape = srcBytesPerTexel == 3 || srcBytesPerTexel == 6;
     const void* cpuData = data.buffer;
@@ -690,7 +690,7 @@ void VulkanTexture::update3DImage(const PixelBufferDescriptor& data, uint32_t wi
 
 void VulkanTexture::updateCubeImage(const PixelBufferDescriptor& data,
         const FaceOffsets& faceOffsets, int miplevel) {
-    assert(this->target == SamplerType::SAMPLER_CUBEMAP);
+    assert_invariant(this->target == SamplerType::SAMPLER_CUBEMAP);
     const bool reshape = getBytesPerPixel(format) == 3;
     const void* cpuData = data.buffer;
     const uint32_t numSrcBytes = data.size;
@@ -824,7 +824,7 @@ void VulkanTexture::copyBufferToImage(VkCommandBuffer cmd, VkBuffer buffer, VkIm
         uint32_t width, uint32_t height, uint32_t depth, FaceOffsets const* faceOffsets, uint32_t miplevel) {
     VkExtent3D extent { width, height, depth };
     if (target == SamplerType::SAMPLER_CUBEMAP) {
-        assert(faceOffsets);
+        assert_invariant(faceOffsets);
         VkBufferImageCopy regions[6] = {{}};
         for (size_t face = 0; face < 6; face++) {
             auto& region = regions[face];
@@ -882,7 +882,7 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
     memset(varray.buffers, 0, sizeof(varray.buffers));
 
     // Position should always be present.
-    assert(enabledAttributes & 1);
+    assert_invariant(enabledAttributes & 1);
 
     // For each enabled attribute, append to each of the above lists. Note that a single VkBuffer
     // handle might be appended more than once, which is perfectly fine.
@@ -930,7 +930,7 @@ VulkanTimerQuery::VulkanTimerQuery(VulkanContext& context) : mContext(context) {
     std::unique_lock<utils::Mutex> lock(context.timestamps.mutex);
     utils::bitset32& bitset = context.timestamps.used;
     const size_t maxTimers = bitset.size();
-    assert(bitset.count() < maxTimers);
+    assert_invariant(bitset.count() < maxTimers);
     for (size_t timerIndex = 0; timerIndex < maxTimers; ++timerIndex) {
         if (!bitset.test(timerIndex)) {
             bitset.set(timerIndex);

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -93,7 +93,7 @@ void VulkanStagePool::gc() noexcept {
 }
 
 void VulkanStagePool::reset() noexcept {
-    assert(mUsedStages.empty());
+    assert_invariant(mUsedStages.empty());
     for (auto pair : mFreeStages) {
         vmaDestroyBuffer(mContext.allocator, pair.second->buffer, pair.second->memory);
         delete pair.second;

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -17,6 +17,7 @@
 #include "VulkanUtility.h"
 
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 #include "private/backend/BackendUtils.h"
 
@@ -374,7 +375,7 @@ PixelDataType getComponentType(VkFormat format) {
         case VK_FORMAT_R32G32B32A32_UINT: return PixelDataType::UINT;
         case VK_FORMAT_R32G32B32A32_SINT: return PixelDataType::INT;
         case VK_FORMAT_R32G32B32A32_SFLOAT: return PixelDataType::FLOAT;
-        default: assert(false && "Unknown data type, conversion is not supported.");
+        default: assert_invariant(false && "Unknown data type, conversion is not supported.");
     }
     return {};
 }

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -53,7 +53,7 @@ BackendTest::~BackendTest() {
 void BackendTest::initializeDriver() {
     auto backend = static_cast<filament::backend::Backend>(sBackend);
     DefaultPlatform* platform = DefaultPlatform::create(&backend);
-    assert(static_cast<uint8_t>(backend) == static_cast<uint8_t>(sBackend));
+    assert_invariant(static_cast<uint8_t>(backend) == static_cast<uint8_t>(sBackend));
     driver = platform->createDriver(nullptr);
     commandStream = CommandStream(*driver, commandBufferQueue.getCircularBuffer());
 }

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -128,14 +128,14 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
         std::cerr << "ERROR: Unable to parse " <<
             (stage == ShaderStage::VERTEX ? "vertex" : "fragment") << " shader:" << std::endl;
         std::cerr << tShader.getInfoLog() << std::endl;
-        assert(false);
+        assert_invariant(false);
     }
 
     program.addShader(&tShader);
     bool linkOk = program.link(msg);
     if (!linkOk) {
         std::cerr << tShader.getInfoLog() << std::endl;
-        assert(false);
+        assert_invariant(false);
     }
 
     SpirvBlob spirv;
@@ -144,7 +144,7 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
 
     std::string result;
 
-    assert(backend == Backend::OPENGL ||
+    assert_invariant(backend == Backend::OPENGL ||
            backend == Backend::METAL  ||
            backend == Backend::VULKAN);
 

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -278,7 +278,7 @@ TEST_F(BackendTest, ReadPixels) {
                 t.alignment, t.left, t.top, t.getPixelBufferStride(), [](void* buffer, size_t size,
                     void* user) {
                     const TestCase* test = (const TestCase*) user;
-                    assert(test);
+                    assert_invariant(test);
 
                     test->exportScreenshot(buffer);
 

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -470,7 +470,7 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
     PixelDataFormat format;
     PixelDataType type;
     selectLutTextureParams(builder->quality, textureFormat, format, type);
-     assert(FTexture::validatePixelFormatAndType(textureFormat, format, type));
+     assert_invariant(FTexture::validatePixelFormatAndType(textureFormat, format, type));
 
      void* converted = nullptr;
     if (type == PixelDataType::UINT_2_10_10_10_REV) {

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -44,6 +44,7 @@
 #include <utils/Log.h>
 #include <utils/Panic.h>
 #include <utils/Systrace.h>
+#include <utils/debug.h>
 
 #include <memory>
 
@@ -796,7 +797,7 @@ bool FEngine::destroy(const FMaterial* ptr) {
 bool FEngine::destroy(const FMaterialInstance* ptr) {
     if (ptr == nullptr) return true;
     auto pos = mMaterialInstances.find(ptr->getMaterial());
-    assert(pos != mMaterialInstances.cend());
+    assert_invariant(pos != mMaterialInstances.cend());
     if (pos != mMaterialInstances.cend()) {
         return terminateAndDestroy(ptr, pos->second);
     }

--- a/filament/src/Fence.cpp
+++ b/filament/src/Fence.cpp
@@ -21,6 +21,7 @@
 #include <filament/Fence.h>
 
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 namespace filament {
 
@@ -62,7 +63,7 @@ void FFence::terminate(FEngine& engine) noexcept {
 
 UTILS_NOINLINE
 FenceStatus FFence::waitAndDestroy(FFence* fence, Mode mode) noexcept {
-    assert(fence);
+    assert_invariant(fence);
     FenceStatus status = fence->wait(mode, FENCE_WAIT_FOR_EVER);
     fence->mEngine.destroy(fence);
     return status;

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -24,7 +24,6 @@
 #include <array>
 #include <chrono>
 
-#include <assert.h>
 #include <stdint.h>
 
 namespace filament {

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <utils/Log.h>
+#include <utils/debug.h>
+
 #include "details/FrameSkipper.h"
 #include "details/Engine.h"
 
@@ -25,7 +27,7 @@ using namespace backend;
 
 FrameSkipper::FrameSkipper(FEngine& engine, size_t latency) noexcept
         : mEngine(engine), mLast(latency) {
-    assert(latency <= MAX_FRAME_LATENCY);
+    assert_invariant(latency <= MAX_FRAME_LATENCY);
 }
 
 FrameSkipper::~FrameSkipper() noexcept {

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -25,6 +25,7 @@
 
 #include <utils/BinaryTreeArray.h>
 #include <utils/Systrace.h>
+#include <utils/debug.h>
 
 #include <math/mat4.h>
 #include <math/fast.h>
@@ -179,10 +180,10 @@ bool Froxelizer::prepare(
             uint32_t(GROUP_COUNT)
     };
 
-    assert(mFroxelBufferUser.begin());
-    assert(mRecordBufferUser.begin());
-    assert(mLightRecords.begin());
-    assert(mFroxelShardedData.begin());
+    assert_invariant(mFroxelBufferUser.begin());
+    assert_invariant(mRecordBufferUser.begin());
+    assert_invariant(mLightRecords.begin());
+    assert_invariant(mFroxelShardedData.begin());
 
     // initialize buffers that need to be
     memset(mLightRecords.data(), 0, mLightRecords.sizeInBytes());
@@ -218,9 +219,9 @@ void Froxelizer::computeFroxelLayout(
         froxelCountX = (width  + froxelDimension - 1) / froxelDimension;
         froxelCountY = (height + froxelDimension - 1) / froxelDimension;
 
-        assert(froxelCountX);
-        assert(froxelCountY);
-        assert(froxelCountX * froxelCountY <= froxelPlaneCount);
+        assert_invariant(froxelCountX);
+        assert_invariant(froxelCountY);
+        assert_invariant(froxelCountX * froxelCountY <= froxelPlaneCount);
 
         *dim = froxelDimension;
         *countX = uint16_t(froxelCountX);
@@ -287,10 +288,10 @@ bool Froxelizer::update() noexcept {
         mPlanesY         = mArena.alloc<float4>(froxelCountY + 1);
         mBoundingSpheres = mArena.alloc<float4>(froxelCount);
 
-        assert(mDistancesZ);
-        assert(mPlanesX);
-        assert(mPlanesY);
-        assert(mBoundingSpheres);
+        assert_invariant(mDistancesZ);
+        assert_invariant(mPlanesX);
+        assert_invariant(mPlanesY);
+        assert_invariant(mBoundingSpheres);
 
         mDistancesZ[0] = 0.0f;
         const float zLightNear = mZLightNear;
@@ -318,10 +319,10 @@ bool Froxelizer::update() noexcept {
     }
 
     if (UTILS_UNLIKELY(mDirtyFlags & (PROJECTION_CHANGED | VIEWPORT_CHANGED))) {
-        assert(mDistancesZ);
-        assert(mPlanesX);
-        assert(mPlanesY);
-        assert(mBoundingSpheres);
+        assert_invariant(mDistancesZ);
+        assert_invariant(mPlanesX);
+        assert_invariant(mPlanesY);
+        assert_invariant(mBoundingSpheres);
 
         // clip-space dimensions
         const float froxelWidthInClipSpace  = (2.0f * mFroxelDimension.x) / mViewport.width;
@@ -361,7 +362,7 @@ bool Froxelizer::update() noexcept {
         //                      n0.(n1 x n2)
 
         // use stack memory here, it's only 16 KiB max
-        assert(mFroxelCountX <= 2048);
+        assert_invariant(mFroxelCountX <= 2048);
         typename std::aligned_storage<sizeof(float2), alignof(float2)>::type stack[2048];
         float2* const UTILS_RESTRICT minMaxX = reinterpret_cast<float2*>(stack);
 
@@ -385,7 +386,7 @@ bool Froxelizer::update() noexcept {
             // the camera.
             minp.z = -planesZ[iz+1];
             maxp.z = -planesZ[iz];
-            assert(minp.z < maxp.z);
+            assert_invariant(minp.z < maxp.z);
 
             for (size_t ix = 0, nx = froxelCountX; ix < nx; ++ix) {
                 // left, right planes for all froxels at ix
@@ -401,7 +402,7 @@ bool Froxelizer::update() noexcept {
                     minp.x = std::min(minp.x, px);
                     maxp.x = std::max(maxp.x, px);
                 }
-                assert(minp.x < maxp.x);
+                assert_invariant(minp.x < maxp.x);
                 minMaxX[ix] = float2{ minp.x, maxp.x };
             }
 
@@ -419,11 +420,11 @@ bool Froxelizer::update() noexcept {
                     minp.y = std::min(minp.y, py);
                     maxp.y = std::max(maxp.y, py);
                 }
-                assert(minp.y < maxp.y);
+                assert_invariant(minp.y < maxp.y);
 
                 for (size_t ix = 0, nx = froxelCountX; ix < nx; ++ix) {
                     // note: clang vectorizes this loop!
-                    assert(getFroxelIndex(ix, iy, iz) == fi);
+                    assert_invariant(getFroxelIndex(ix, iy, iz) == fi);
                     minp.x = minMaxX[ix][0];
                     maxp.x = minMaxX[ix][1];
                     boundingSpheres[fi++] = { (maxp + minp) * 0.5f, length((maxp - minp) * 0.5f) };
@@ -461,15 +462,15 @@ bool Froxelizer::update() noexcept {
         }
         uniformsNeedUpdating = true;
     }
-    assert(mZLightNear >= mNear);
+    assert_invariant(mZLightNear >= mNear);
     mDirtyFlags = 0;
     return uniformsNeedUpdating;
 }
 
 Froxel Froxelizer::getFroxelAt(size_t x, size_t y, size_t z) const noexcept {
-    assert(x < mFroxelCountX);
-    assert(y < mFroxelCountY);
-    assert(z < mFroxelCountZ);
+    assert_invariant(x < mFroxelCountX);
+    assert_invariant(y < mFroxelCountY);
+    assert_invariant(z < mFroxelCountZ);
     Froxel froxel;
     froxel.planes[Froxel::LEFT]   =  mPlanesX[x];
     froxel.planes[Froxel::BOTTOM] =  mPlanesY[y];
@@ -539,13 +540,13 @@ void Froxelizer::froxelizeLights(FEngine& engine,
             // go through every lights for that froxel
             for (size_t i = 0; i < entry.count; i++) {
                 // get the light index
-                assert(entry.offset + i < RECORD_BUFFER_ENTRY_COUNT);
+                assert_invariant(entry.offset + i < RECORD_BUFFER_ENTRY_COUNT);
 
                 size_t lightIndex = recordBufferUser[entry.offset + i];
-                assert(lightIndex <= CONFIG_MAX_LIGHT_INDEX);
+                assert_invariant(lightIndex <= CONFIG_MAX_LIGHT_INDEX);
 
                 // make sure it corresponds to an existing light
-                assert(lightIndex < lightData.size() - FScene::DIRECTIONAL_LIGHTS_COUNT);
+                assert_invariant(lightIndex < lightData.size() - FScene::DIRECTIONAL_LIGHTS_COUNT);
             }
         }
     }
@@ -585,7 +586,7 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
 
             const size_t group = i % GROUP_COUNT;
             const size_t bit   = i / GROUP_COUNT;
-            assert(bit < LIGHT_PER_GROUP);
+            assert_invariant(bit < LIGHT_PER_GROUP);
 
             FroxelThreadData& threadData = froxelThreadData[group];
             froxelizePointAndSpotLight(threadData, bit, projection, light);
@@ -780,9 +781,9 @@ void Froxelizer::froxelizePointAndSpotLight(
     const size_t y1 = imax.second;      // y1 points to the last value
     const size_t z1 = findSliceZ(zfar); // z1 points to the last value
 
-    assert(x0 < x1);
-    assert(y0 <= y1);
-    assert(z0 <= z1);
+    assert_invariant(x0 < x1);
+    assert_invariant(y0 <= y1);
+    assert_invariant(z0 <= z1);
 #endif
 
     const size_t zcenter = findSliceZ(s.z);
@@ -848,7 +849,7 @@ void Froxelizer::froxelizePointAndSpotLight(
 
                     // the loops below assume 1-past the end for the right side of the range
                     ex++;
-                    assert(bx <= mFroxelCountX && ex <= mFroxelCountX);
+                    assert_invariant(bx <= mFroxelCountX && ex <= mFroxelCountX);
 
                     size_t fi = getFroxelIndex(bx, iy, iz);
                     if (light.invSin != std::numeric_limits<float>::infinity()) {

--- a/filament/src/GPUBuffer.cpp
+++ b/filament/src/GPUBuffer.cpp
@@ -17,6 +17,8 @@
 #include "GPUBuffer.h"
 #include "private/backend/DriverApi.h"
 
+#include <utils/debug.h>
+
 #include <math/half.h>
 
 namespace filament {
@@ -51,7 +53,7 @@ static backend::TextureFormat dataTypeToTextureFormat(GPUBuffer::Element element
     };
 
     size_t index = size_t(element.type);
-    assert(index < 8 && element.size > 0 && element.size <= 4);
+    assert_invariant(index < 8 && element.size > 0 && element.size <= 4);
     return formats[index][element.size - 1];
 }
 
@@ -119,7 +121,7 @@ void GPUBuffer::terminate(backend::DriverApi& driverApi) noexcept {
 
 void GPUBuffer::commitSlow(backend::DriverApi& driverApi, void const* begin, void const* end) noexcept {
     const uintptr_t sizeInBytes = uintptr_t(end) - uintptr_t(begin);
-    assert(sizeInBytes <= mRowSizeInBytes * mHeight);
+    assert_invariant(sizeInBytes <= mRowSizeInBytes * mHeight);
     driverApi.update2DImage(mTexture, 0, 0, 0, mWidth, mHeight,
             { begin, sizeInBytes, mFormat, mType });
 }

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -68,7 +68,7 @@ static MaterialParser* createParser(Backend backend, const void* data, size_t si
     ASSERT_PRECONDITION(version == MATERIAL_VERSION, "Material version mismatch. Expected %d but "
             "received %d.", MATERIAL_VERSION, version);
 
-    assert(backend != Backend::DEFAULT && "Default backend has not been resolved.");
+    assert_invariant(backend != Backend::DEFAULT && "Default backend has not been resolved.");
 
     return materialParser;
 }
@@ -150,7 +150,7 @@ static void addSamplerGroup(Program& pb, uint8_t bindingPoint, SamplerInterfaceB
                             list[i].name.c_str()));
             uint8_t binding = 0;
             UTILS_UNUSED bool ok = map.getSamplerBinding(bindingPoint, (uint8_t)i, &binding);
-            assert(ok);
+            assert_invariant(ok);
             const bool strict = (bindingPoint == filament::BindingPoints::PER_MATERIAL_INSTANCE);
             samplers[i] = { std::move(uniformName), binding, strict };
         }
@@ -166,13 +166,13 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     mMaterialParser = parser;
 
     UTILS_UNUSED_IN_RELEASE bool nameOk = parser->getName(&mName);
-    assert(nameOk);
+    assert_invariant(nameOk);
 
     UTILS_UNUSED_IN_RELEASE bool sibOK = parser->getSIB(&mSamplerInterfaceBlock);
-    assert(sibOK);
+    assert_invariant(sibOK);
 
     UTILS_UNUSED_IN_RELEASE bool uibOK = parser->getUIB(&mUniformInterfaceBlock);
-    assert(uibOK);
+    assert_invariant(uibOK);
 
     // Older materials will not have a subpass chunk; this should not be an error.
     if (!parser->getSubpasses(&mSubpassInfo)) {
@@ -358,9 +358,9 @@ Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
     const noexcept {
     // filterVariant() has already been applied in generateCommands(), shouldn't be needed here
     // if we're unlit, we don't have any bits that correspond to lit materials
-    assert( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );
+    assert_invariant( variantKey == Variant::filterVariant(variantKey, isVariantLit()) );
 
-    assert(!Variant::isReserved(variantKey));
+    assert_invariant(!Variant::isReserved(variantKey));
 
     uint8_t vertexVariantKey = Variant::filterVariantVertex(variantKey);
     uint8_t fragmentVariantKey = Variant::filterVariantFragment(variantKey);
@@ -442,7 +442,7 @@ Program FMaterial::getProgramBuilderWithVariants(
 Handle<HwProgram> FMaterial::createAndCacheProgram(Program&& p,
         uint8_t variantKey) const noexcept {
     auto program = mEngine.getDriverApi().createProgram(std::move(p));
-    assert(program);
+    assert_invariant(program);
 
     mCachedPrograms[variantKey] = program;
     return program;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -99,7 +99,7 @@ PostProcessManager::PostProcessMaterial& PostProcessManager::PostProcessMaterial
 }
 
 PostProcessManager::PostProcessMaterial::~PostProcessMaterial() {
-    assert(!mHasMaterial || mMaterial == nullptr);
+    assert_invariant(!mHasMaterial || mMaterial == nullptr);
 }
 
 void PostProcessManager::PostProcessMaterial::terminate(FEngine& engine) noexcept {
@@ -181,7 +181,7 @@ void PostProcessManager::registerPostProcessMaterial(utils::StaticString name, u
 }
 
 PostProcessManager::PostProcessMaterial& PostProcessManager::getPostProcessMaterial(utils::StaticString name) noexcept {
-    assert(mMaterialRegistry.find(name) != mMaterialRegistry.end());
+    assert_invariant(mMaterialRegistry.find(name) != mMaterialRegistry.end());
     return mMaterialRegistry[name];
 }
 
@@ -294,7 +294,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
 
     // We limit the lowest lod size to 32 pixels (which is where the -5 comes from)
     const size_t levelCount = FTexture::maxLevelCount(width, height) - 5;
-    assert(levelCount >= 1);
+    assert_invariant(levelCount >= 1);
 
     // generate depth pass at the requested resolution
     auto& structurePass = fg.addPass<StructurePassData>("Structure Pass",
@@ -380,7 +380,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
     Handle<HwRenderPrimitive> fullScreenRenderPrimitive = engine.getFullScreenRenderPrimitive();
 
     FrameGraphId<FrameGraphTexture> depth = fg.getBlackboard().get<FrameGraphTexture>("structure");
-    assert(depth.isValid());
+    assert_invariant(depth.isValid());
 
     const size_t levelCount = fg.getDescriptor(depth).levels;
 
@@ -603,7 +603,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bilateralBlurPass(
                         .width = desc.width, .height = desc.height, .format = format });
 
                 auto depth = fg.getBlackboard().get<FrameGraphTexture>("structure");
-                assert(depth.isValid());
+                assert_invariant(depth.isValid());
                 builder.read(depth);
 
                 // Here we use the depth test to skip pixels at infinity (i.e. the skybox)
@@ -792,8 +792,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::gaussianBlurPass(FrameGraph&
                 // vertical pass
                 auto width = FTexture::valueForLevel(dstLevel, outDesc.width);
                 auto height = FTexture::valueForLevel(dstLevel, outDesc.height);
-                assert(width == hwOutRT.params.viewport.width);
-                assert(height == hwOutRT.params.viewport.height);
+                assert_invariant(width == hwOutRT.params.viewport.width);
+                assert_invariant(height == hwOutRT.params.viewport.height);
 
                 mi->setParameter("source", hwTemp, {
                         .filterMag = SamplerMagFilter::LINEAR,
@@ -850,7 +850,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
     Blackboard& blackboard = fg.getBlackboard();
     auto depth = blackboard.get<FrameGraphTexture>("depth");
-    assert(depth.isValid());
+    assert_invariant(depth.isValid());
 
     // the downsampled target is multiple of 8, so we can have 4 clean mipmap levels
     constexpr const uint32_t maxMipLevels = 4u;
@@ -935,7 +935,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
         FrameGraphRenderTargetHandle rt[3];
     };
 
-    assert(mipmapCount - 1
+    assert_invariant(mipmapCount - 1
            <= sizeof(PostProcessDofMipmap::rt) / sizeof(FrameGraphRenderTargetHandle));
 
     auto& ppDoFMipmap = fg.addPass<PostProcessDofMipmap>("DoF Mipmap",
@@ -1880,7 +1880,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
 
     Blackboard& blackboard = fg.getBlackboard();
     auto depth = blackboard.get<FrameGraphTexture>("depth");
-    assert(depth.isValid());
+    assert_invariant(depth.isValid());
 
     struct TAAData {
         FrameGraphId<FrameGraphTexture> color;
@@ -2005,7 +2005,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::opaqueBlit(FrameGraph& fg,
 
                 // we currently have no use for this case, so we just assert. This is better for now to trap
                 // cases that we might not intend.
-                assert(inputDesc.samples <= 1);
+                assert_invariant(inputDesc.samples <= 1);
 
                 // FIXME: here we use sample() instead of read() because this forces the
                 //      backend to use a texture (instead of a renderbuffer). We need this because
@@ -2174,7 +2174,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::vsmMipmapPass(FrameGraph& fg
 
                 auto width = resources.getDescriptor(data.in).width;
                 UTILS_UNUSED_IN_RELEASE auto height = resources.getDescriptor(data.in).height;
-                assert(width == height);
+                assert_invariant(width == height);
                 int dim = width >> (level + 1);
 
                 driver.setMinMaxLevels(in, level, level);

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -90,7 +90,7 @@ RenderPass::Command* RenderPass::appendCommands(CommandTypeFlags const commandTy
     if (UTILS_UNLIKELY(vr.empty())) {
         return commands.end();
     }
-    assert(mRenderableSoa);
+    assert_invariant(mRenderableSoa);
 
     // trace the number of visible renderables
     SYSTRACE_VALUE32("visibleRenderables", vr.size());

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -29,6 +29,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Slice.h>
+#include <utils/debug.h>
 
 #include <limits>
 
@@ -194,7 +195,7 @@ public:
 
     template<typename T>
     static CommandKey makeField(T value, uint64_t mask, unsigned shift) noexcept {
-        assert(!((uint64_t(value) << shift) & ~mask));
+        assert_invariant(!((uint64_t(value) << shift) & ~mask));
         return uint64_t(value) << shift;
     }
 
@@ -225,7 +226,7 @@ public:
         bool operator < (Command const& rhs) const noexcept { return key < rhs.key; }
         // placement new declared as "throw" to avoid the compiler's null-check
         inline void* operator new (std::size_t size, void* ptr) {
-            assert(ptr);
+            assert_invariant(ptr);
             return ptr;
         }
     };

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -21,12 +21,14 @@
 #include "details/IndexBuffer.h"
 #include "details/Material.h"
 
+#include <utils/debug.h>
+
 namespace filament {
 
 void FRenderPrimitive::init(backend::DriverApi& driver,
         const RenderableManager::Builder::Entry& entry) noexcept {
 
-    assert(entry.materialInstance);
+    assert_invariant(entry.materialInstance);
 
     mHandle = driver.createRenderPrimitive();
     mMaterialInstance = upcast(entry.materialInstance);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -39,8 +39,7 @@
 #include <utils/Panic.h>
 #include <utils/Systrace.h>
 #include <utils/vector.h>
-
-#include <assert.h>
+#include <utils/debug.h>
 
 // this helps visualize what dynamic-scaling is doing
 #define DEBUG_DYNAMIC_SCALING false
@@ -159,7 +158,7 @@ TextureFormat FRenderer::getLdrFormat(bool translucent) const noexcept {
 void FRenderer::render(FView const* view) {
     SYSTRACE_CALL();
 
-    assert(mSwapChain);
+    assert_invariant(mSwapChain);
 
     if (mBeginFrameInternal) {
         mBeginFrameInternal();
@@ -696,7 +695,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 data.structure = blackboard.get<FrameGraphTexture>("structure");
 
                 if (config.hasContactShadows) {
-                    assert(data.structure.isValid());
+                    assert_invariant(data.structure.isValid());
                     data.structure = builder.sample(data.structure);
                 }
 
@@ -780,7 +779,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 view.prepareShadow(data.shadows.isValid() ?
                         resources.getTexture(data.shadows) : ppm.getOneTextureArray());
 
-                assert(data.structure.isValid());
+                assert_invariant(data.structure.isValid());
                 if (data.structure.isValid()) {
                     const auto& structure = resources.getTexture(data.structure);
                     view.prepareStructure(structure ? structure : ppm.getOneTexture());
@@ -827,8 +826,8 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
         filament::Viewport const& srcViewport, CopyFrameFlag flags) {
     SYSTRACE_CALL();
 
-    assert(mSwapChain);
-    assert(dstSwapChain);
+    assert_invariant(mSwapChain);
+    assert_invariant(dstSwapChain);
     FEngine& engine = getEngine();
     FEngine::DriverApi& driver = engine.getDriverApi();
 
@@ -853,7 +852,7 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
     driver.beginRenderPass(mRenderTarget, params);
 
     // Verify that the source swap chain is readable.
-    assert(mSwapChain->isReadable());
+    assert_invariant(mSwapChain->isReadable());
     driver.blit(TargetBufferFlags::COLOR,
             mRenderTarget, dstViewport, mRenderTarget, srcViewport, SamplerMagFilter::LINEAR);
     if (flags & SET_PRESENTATION_TIME) {
@@ -873,7 +872,7 @@ void FRenderer::copyFrame(FSwapChain* dstSwapChain, filament::Viewport const& ds
 
 bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano,
         backend::FrameScheduledCallback callback, void* user) {
-    assert(swapChain);
+    assert_invariant(swapChain);
 
     SYSTRACE_CALL();
 

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -21,6 +21,7 @@
 #include "details/Texture.h"
 
 #include <utils/Log.h>
+#include <utils/debug.h>
 
 using namespace utils;
 
@@ -82,12 +83,12 @@ ResourceAllocator::ResourceAllocator(DriverApi& driverApi) noexcept
 }
 
 ResourceAllocator::~ResourceAllocator() noexcept {
-    assert(!mTextureCache.size());
-    assert(!mInUseTextures.size());
+    assert_invariant(!mTextureCache.size());
+    assert_invariant(!mInUseTextures.size());
 }
 
 void ResourceAllocator::terminate() noexcept {
-    assert(!mInUseTextures.size());
+    assert_invariant(!mInUseTextures.size());
     auto& textureCache = mTextureCache;
     for (auto it = textureCache.begin(); it != textureCache.end();) {
         mBackend.destroyTexture(it->second.handle);
@@ -156,7 +157,7 @@ void ResourceAllocator::destroyTexture(TextureHandle h) noexcept {
     if (mEnabled) {
         // find the texture in the in-use list (it must be there!)
         auto it = mInUseTextures.find(h);
-        assert(it != mInUseTextures.end());
+        assert_invariant(it != mInUseTextures.end());
 
         // move it to the cache
         const TextureKey key = it->second;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -26,6 +26,8 @@
 
 #include <backend/DriverEnums.h>
 
+#include <utils/debug.h>
+
 #include <limits>
 
 using namespace filament::math;
@@ -385,8 +387,8 @@ void ShadowMap::computeShadowCameraDirectional(
             return;
         }
 
-        assert(lsLightFrustumBounds.min.x < lsLightFrustumBounds.max.x);
-        assert(lsLightFrustumBounds.min.y < lsLightFrustumBounds.max.y);
+        assert_invariant(lsLightFrustumBounds.min.x < lsLightFrustumBounds.max.x);
+        assert_invariant(lsLightFrustumBounds.min.y < lsLightFrustumBounds.max.y);
 
         // compute focus scale and offset
         float2 s = 2.0f / float2(lsLightFrustumBounds.max.xy - lsLightFrustumBounds.min.xy);
@@ -899,7 +901,7 @@ size_t ShadowMap::intersectFrustumWithBox(
         }
     }
 
-    assert(vertexCount <= outVertices.size());
+    assert_invariant(vertexCount <= outVertices.size());
 
     return vertexCount;
 }

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -97,7 +97,7 @@ Texture::Builder& Texture::Builder::usage(Texture::Usage usage) noexcept {
 }
 
 Texture::Builder& Texture::Builder::import(intptr_t id) noexcept {
-    assert(id); // imported id can't be zero
+    assert_invariant(id); // imported id can't be zero
     mImpl->mImportedId = id;
     return *this;
 }
@@ -555,7 +555,7 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
             // this cannot happen due to the checks above
             break;
     }
-    assert(bytesPerPixel);
+    assert_invariant(bytesPerPixel);
 
     Image temp;
     Cubemap cml = CubemapUtils::create(temp, size);

--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -24,6 +24,7 @@
 #include <utils/Allocator.h>
 #include <utils/compiler.h>
 #include <utils/Log.h>
+#include <utils/debug.h>
 
 #include <backend/BufferDescriptor.h>
 
@@ -31,8 +32,6 @@
 #include <math/mat4.h>
 
 #include <stddef.h>
-#include <assert.h>
-
 
 namespace filament {
 
@@ -68,7 +67,7 @@ public:
 
     // invalidate a range of uniforms and return a pointer to it. offset and size given in bytes
     void* invalidateUniforms(size_t offset, size_t size) {
-        assert(offset + size <= mSize);
+        assert_invariant(offset + size <= mSize);
         mSomethingDirty = true;
         return static_cast<char*>(mBuffer) + offset;
     }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -30,6 +30,7 @@
 
 #include <filament/Exposure.h>
 #include <filament/TextureSampler.h>
+#include <filament/View.h>
 
 #include <private/filament/SibGenerator.h>
 #include <private/filament/UibGenerator.h>
@@ -37,12 +38,12 @@
 #include <utils/Profiler.h>
 #include <utils/Slice.h>
 #include <utils/Systrace.h>
+#include <utils/debug.h>
 
 #include <math/scalar.h>
 #include <math/fast.h>
 
 #include <memory>
-#include <filament/View.h>
 
 using namespace filament::math;
 using namespace utils;
@@ -227,7 +228,7 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
     const bool hasDirectionalShadows = directionalLight && lcm.isShadowCaster(directionalLight);
     if (UTILS_UNLIKELY(hasDirectionalShadows)) {
         const auto& shadowOptions = lcm.getShadowOptions(directionalLight);
-        assert(shadowOptions.shadowCascades >= 1 &&
+        assert_invariant(shadowOptions.shadowCascades >= 1 &&
                 shadowOptions.shadowCascades <= CONFIG_MAX_SHADOW_CASCADES);
         mShadowMapManager.setShadowCascades(0, shadowOptions.shadowCascades);
     }
@@ -500,7 +501,7 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
             } else {
                 // TODO: should we shrink the underlying UBO at some point?
             }
-            assert(mRenderableUbh);
+            assert_invariant(mRenderableUbh);
             scene->updateUBOs(merged, mRenderableUbh);
         }
     }
@@ -806,7 +807,7 @@ void FView::prepareVisibleLights(FLightManager const& lcm, utils::JobSystem&,
                     [](auto const& it) {
                         return it.template get<FScene::VISIBILITY>() != 0;
                     });
-    assert(visibleLightCount == size_t(last - lightData.begin()));
+    assert_invariant(visibleLightCount == size_t(last - lightData.begin()));
 
     lightData.resize(visibleLightCount);
 }

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -21,6 +21,7 @@
 
 #include <utils/Entity.h>
 #include <utils/Log.h>
+#include <utils/debug.h>
 
 #include <math/mat4.h>
 
@@ -82,7 +83,7 @@ void FCameraManager::destroy(Entity e) noexcept {
     Instance i = manager.getInstance(e);
     if (i) {
         FCamera* camera = manager.elementAt<CAMERA>(i);
-        assert(camera);
+        assert_invariant(camera);
         camera->terminate(mEngine);
         mEngine.getHeapAllocator().destroy(camera);
         manager.removeComponent(e);

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -23,7 +23,7 @@
 #include <math/fast.h>
 #include <math/scalar.h>
 
-#include <assert.h>
+#include <utils/debug.h>
 
 using namespace filament::math;
 using namespace utils;
@@ -148,7 +148,7 @@ FLightManager::FLightManager(FEngine& engine) noexcept : mEngine(engine) {
 FLightManager::~FLightManager() {
     // all components should have been destroyed when we get here
     // (terminate should have been called from Engine's shutdown())
-    assert(mManager.getComponentCount() == 0);
+    assert_invariant(mManager.getComponentCount() == 0);
 }
 
 void FLightManager::init(FEngine& engine) noexcept {
@@ -161,7 +161,7 @@ void FLightManager::create(const FLightManager::Builder& builder, utils::Entity 
         destroy(entity);
     }
     Instance i = manager.addComponent(entity);
-    assert(i);
+    assert_invariant(i);
 
     if (i) {
         // This needs to happen before we call the set() methods below
@@ -228,13 +228,13 @@ void FLightManager::terminate() noexcept {
 }
 
 void FLightManager::setLocalPosition(Instance i, const float3& position) noexcept {
-    assert(i);
+    assert_invariant(i);
     auto& manager = mManager;
     manager[i].position = position;
 }
 
 void FLightManager::setLocalDirection(Instance i, float3 direction) noexcept {
-    assert(i);
+    assert_invariant(i);
     auto& manager = mManager;
     manager[i].direction = direction;
 }
@@ -264,7 +264,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
                     // li = lp / (4 * pi)
                     luminousIntensity = luminousPower * f::ONE_OVER_PI * 0.25f;
                 } else {
-                    assert(unit == IntensityUnit::CANDELA);
+                    assert_invariant(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
                     luminousIntensity = luminousPower;
                 }
@@ -277,7 +277,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
                     // li = lp / (2 * pi * (1 - cos(cone_outer / 2)))
                     luminousIntensity = luminousPower / (f::TAU * (1.0f - cosOuter));
                 } else {
-                    assert(unit == IntensityUnit::CANDELA);
+                    assert_invariant(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
                     luminousIntensity = luminousPower;
                     // lp = li * (2 * pi * (1 - cos(cone_outer / 2)))
@@ -291,7 +291,7 @@ void FLightManager::setIntensity(Instance i, float intensity, IntensityUnit unit
                     // li = lp / pi
                     luminousIntensity = luminousPower * f::ONE_OVER_PI;
                 } else {
-                    assert(unit == IntensityUnit::CANDELA);
+                    assert_invariant(unit == IntensityUnit::CANDELA);
                     // intensity specified directly in candela, no conversion needed
                     luminousIntensity = luminousPower;
                 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -28,6 +28,7 @@
 
 #include <utils/Log.h>
 #include <utils/Panic.h>
+#include <utils/debug.h>
 
 using namespace filament::math;
 using namespace utils;
@@ -60,7 +61,7 @@ struct RenderableManager::BuilderDetails {
 using BuilderType = RenderableManager;
 BuilderType::Builder::Builder(size_t count) noexcept
         : BuilderBase<RenderableManager::BuilderDetails>(count) {
-    assert(mImpl->mEntries.size() == count);
+    assert_invariant(mImpl->mEntries.size() == count);
 }
 BuilderType::Builder::~Builder() noexcept = default;
 BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
@@ -250,7 +251,7 @@ FRenderableManager::FRenderableManager(FEngine& engine) noexcept : mEngine(engin
 FRenderableManager::~FRenderableManager() {
     // all components should have been destroyed when we get here
     // (terminate should have been called from Engine's shutdown())
-    assert(mManager.getComponentCount() == 0);
+    assert_invariant(mManager.getComponentCount() == 0);
 }
 
 void FRenderableManager::create(
@@ -263,7 +264,7 @@ void FRenderableManager::create(
         destroy(entity);
     }
     Instance ci = manager.addComponent(entity);
-    assert(ci);
+    assert_invariant(ci);
 
     if (ci) {
         // create and initialize all needed RenderPrimitives
@@ -307,7 +308,7 @@ void FRenderableManager::create(
                     UniformBuffer{ count * sizeof(PerRenderableUibBone) },
                     count
             });
-            assert(bones);
+            assert_invariant(bones);
             if (bones) {
                 setSkinning(ci, count > 0);
                 if (builder->mUserBones) {
@@ -384,7 +385,7 @@ void FRenderableManager::prepare(
     std::unique_ptr<Bones>  const * const UTILS_RESTRICT bones = manager.raw_array<BONES>();
     for (uint32_t index : list) {
         size_t i = instances[index].asValue();
-        assert(i);  // we should never get the null instance here
+        assert_invariant(i);  // we should never get the null instance here
         if (UTILS_UNLIKELY(bones[i])) {
             if (bones[i]->bones.isDirty()) {
                 driver.loadUniformBuffer(bones[i]->handle, bones[i]->bones.toBufferDescriptor(driver));
@@ -470,7 +471,7 @@ void FRenderableManager::setBones(Instance ci,
         Bone const* UTILS_RESTRICT transforms, size_t boneCount, size_t offset) noexcept {
     if (ci) {
         std::unique_ptr<Bones> const& bones = mManager[ci].bones;
-        assert(bones && offset + boneCount <= bones->count);
+        assert_invariant(bones && offset + boneCount <= bones->count);
         if (bones) {
             boneCount = std::min(boneCount, bones->count - offset);
             PerRenderableUibBone* UTILS_RESTRICT out = (PerRenderableUibBone*)bones->bones.invalidateUniforms(
@@ -489,7 +490,7 @@ void FRenderableManager::setBones(Instance ci,
         mat4f const* UTILS_RESTRICT transforms, size_t boneCount, size_t offset) noexcept {
     if (ci) {
         std::unique_ptr<Bones> const& bones = mManager[ci].bones;
-        assert(bones && offset + boneCount <= bones->count);
+        assert_invariant(bones && offset + boneCount <= bones->count);
         if (bones) {
             boneCount = std::min(boneCount, bones->count - offset);
             PerRenderableUibBone* UTILS_RESTRICT out = (PerRenderableUibBone*)bones->bones.invalidateUniforms(

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -18,6 +18,8 @@
 
 #include <math/mat4.h>
 
+#include <utils/debug.h>
+
 using namespace utils;
 using namespace filament::math;
 
@@ -43,8 +45,8 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4f& loca
         destroy(entity);
     }
     Instance i = manager.addComponent(entity);
-    assert(i);
-    assert(i != parent);
+    assert_invariant(i);
+    assert_invariant(i != parent);
 
     if (i && i != parent) {
         manager[i].parent = 0;
@@ -148,7 +150,7 @@ void FTransformManager::updateNodeTransform(Instance i) noexcept {
 
     validateNode(i);
     auto& manager = mManager;
-    assert(i);
+    assert_invariant(i);
 
     // find our parent's world transform, if any
     // note: by using the raw_array() we don't need to check that parent is valid.
@@ -185,7 +187,7 @@ void FTransformManager::commitLocalTransformTransaction() noexcept {
                 swapNode(i, manager[i].parent);
             }
             Instance parent = manager[i].parent;
-            assert(parent < i);
+            assert_invariant(parent < i);
             manager[i].world = world[parent] * static_cast<mat4f const&>(manager[i].local);
         }
     }
@@ -195,7 +197,7 @@ void FTransformManager::commitLocalTransformTransaction() noexcept {
 void FTransformManager::insertNode(Instance i, Instance parent) noexcept {
     auto& manager = mManager;
 
-    assert(manager[i].parent == Instance{});
+    assert_invariant(manager[i].parent == Instance{});
 
     manager[i].parent = parent;
     manager[i].prev = 0;
@@ -231,7 +233,7 @@ void FTransformManager::swapNode(Instance i, Instance j) noexcept {
     // node to fix-up the linked-list pointers
     // Here we are guaranteed to have enough capacity for our temporary storage, so we
     // can safely use the item just past the end of the array.
-    assert(manager.getSoA().capacity() >= manager.getSoA().size() + 1);
+    assert_invariant(manager.getSoA().capacity() >= manager.getSoA().size() + 1);
 
     const Instance t = manager.end();
 
@@ -301,7 +303,7 @@ void FTransformManager::updateNode(Instance i) noexcept {
     // re-parent our children to us
     Instance child = manager[i].firstChild;
     while (child) {
-        assert(child != i);
+        assert_invariant(child != i);
         manager[child].parent = i;
         child = manager[child].next;
     }
@@ -338,35 +340,35 @@ void FTransformManager::validateNode(Instance i) noexcept {
         Instance firstChild = manager[i].firstChild;
         Instance prev = manager[i].prev;
         Instance next = manager[i].next;
-        assert(parent != i);
-        assert(prev != i);
-        assert(next != i);
-        assert(firstChild != i);
+        assert_invariant(parent != i);
+        assert_invariant(prev != i);
+        assert_invariant(next != i);
+        assert_invariant(firstChild != i);
         if (prev) {
             if (parent) {
-                assert(manager[parent].firstChild != i);
+                assert_invariant(manager[parent].firstChild != i);
             }
-            assert(manager[prev].next == i);
+            assert_invariant(manager[prev].next == i);
         } else {
             if (parent) {
-                assert(manager[parent].firstChild == i);
+                assert_invariant(manager[parent].firstChild == i);
             }
         }
         if (next) {
-            assert(manager[next].prev == i);
+            assert_invariant(manager[next].prev == i);
         }
         if (parent) {
             // make sure we are in the child list of our parent
             Instance child = manager[parent].firstChild;
-            assert(child);
+            assert_invariant(child);
             while (child && child != i) {
                 child = manager[child].next;
             }
-            assert(child);
+            assert_invariant(child);
         }
         if (firstChild) {
-            assert(manager[firstChild].parent == i);
-            assert(manager[firstChild].prev == 0);
+            assert_invariant(manager[firstChild].parent == i);
+            assert_invariant(manager[firstChild].prev == 0);
         }
     }
 #endif

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -209,7 +209,7 @@ public:
     }
 
     ResourceAllocator& getResourceAllocator() noexcept {
-        assert(mResourceAllocator);
+        assert_invariant(mResourceAllocator);
         return *mResourceAllocator;
     }
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -34,6 +34,7 @@
 #include <utils/Slice.h>
 #include <utils/StructureOfArrays.h>
 #include <utils/Range.h>
+#include <utils/debug.h>
 
 #include <cstddef>
 #include <tsl/robin_set.h>
@@ -166,8 +167,8 @@ public:
         //  layer            : 4
         //  -- MSB -------------
         uint32_t pack() const {
-            assert(index < 16);
-            assert(layer < 16);
+            assert_invariant(index < 16);
+            assert_invariant(layer < 16);
             return uint8_t(castsShadows)   << 0u    |
                    uint8_t(contactShadows) << 1u    |
                    index                   << 2u    |

--- a/filament/src/fg/FrameGraphHandle.cpp
+++ b/filament/src/fg/FrameGraphHandle.cpp
@@ -22,10 +22,8 @@
 
 
 #ifndef NDEBUG
-#include "details/Texture.h"    // only needed for assert()
+#include "details/Texture.h"    // only needed for assert_invariant()
 #endif
-
-#include <assert.h>
 
 namespace filament {
 
@@ -43,7 +41,7 @@ void FrameGraphTexture::create(ResourceAllocatorInterface& allocator, const char
         return;
     }
 
-    assert(any(desc.usage));
+    assert_invariant(any(desc.usage));
 
     // texture that can't be sampled can't have LOD -- they obviously can't be accessed
     // note: this could happen if a texture was created with LODs, but a later pass didn't
@@ -52,10 +50,10 @@ void FrameGraphTexture::create(ResourceAllocatorInterface& allocator, const char
     if (!(desc.usage & TextureUsage::SAMPLEABLE)) {
         levels = 1;
     }
-    assert(levels <= FTexture::maxLevelCount(desc.width, desc.height));
+    assert_invariant(levels <= FTexture::maxLevelCount(desc.width, desc.height));
 
     uint8_t samples = desc.samples;
-    assert(samples <= 1 || none(desc.usage & TextureUsage::SAMPLEABLE));
+    assert_invariant(samples <= 1 || none(desc.usage & TextureUsage::SAMPLEABLE));
     if (samples > 1 && any(desc.usage & TextureUsage::SAMPLEABLE)) {
         // Sampleable textures can't be multi-sampled
         // This should never happen (and will be caught by the assert above), but just to be safe,
@@ -66,7 +64,7 @@ void FrameGraphTexture::create(ResourceAllocatorInterface& allocator, const char
     texture = allocator.createTexture(name, desc.type, levels,
             desc.format, samples, desc.width, desc.height, desc.depth, desc.usage);
 
-    assert(texture);
+    assert_invariant(texture);
 }
 
 void FrameGraphTexture::destroy(ResourceAllocatorInterface& allocator) noexcept {

--- a/filament/src/fg/FrameGraphPassResources.cpp
+++ b/filament/src/fg/FrameGraphPassResources.cpp
@@ -44,7 +44,7 @@ fg::ResourceEntryBase const& FrameGraphPassResources::getResourceEntryBase(Frame
     ResourceNode& node = mFrameGraph.getResourceNodeUnchecked(r);
 
     fg::ResourceEntryBase const* const pResource = node.resource;
-    assert(pResource);
+    assert_invariant(pResource);
 
     // TODO: we should check for write to
     //    // check that this FrameGraphHandle is indeed used by this pass

--- a/filament/src/fg/fg/PassNode.cpp
+++ b/filament/src/fg/fg/PassNode.cpp
@@ -113,7 +113,7 @@ FrameGraphHandle PassNode::write(FrameGraph& fg, const FrameGraphHandle& handle)
 
     // record the write
     auto& newNode = fg.getResourceNodeUnchecked(r);
-    assert(!newNode.writerIndex.isValid());
+    assert_invariant(!newNode.writerIndex.isValid());
     newNode.writerIndex = FrameGraphHandle(this->id); // needed by move resources
 
     writes.push_back(r);

--- a/filament/src/fg/fg/RenderTargetResourceEntry.cpp
+++ b/filament/src/fg/fg/RenderTargetResourceEntry.cpp
@@ -166,7 +166,7 @@ void RenderTargetResourceEntry::update(FrameGraph& fg, PassNode const& pass) noe
 
 void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept {
     if (!imported) {
-        assert(any(attachments));
+        assert_invariant(any(attachments));
 
         // TODO: we could cache the result of this loop
         backend::TargetBufferInfo info[FrameGraphRenderTarget::Attachments::COUNT];
@@ -182,7 +182,7 @@ void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept 
                     TargetBufferFlags::STENCIL };
             static_assert(sizeof(flags)/sizeof(*flags) == FrameGraphRenderTarget::Attachments::COUNT,
                     "array sizes don't match");
-            assert(bool(attachments & flags[i]) == attachmentInfo.isValid());
+            assert_invariant(bool(attachments & flags[i]) == attachmentInfo.isValid());
 #endif
             if (attachmentInfo.isValid()) {
                 fg::ResourceEntry<FrameGraphTexture> const& entry =
@@ -191,11 +191,11 @@ void RenderTargetResourceEntry::preExecuteDevirtualize(FrameGraph& fg) noexcept 
                 info[i].level = attachmentInfo.getLevel();
                 info[i].layer = attachmentInfo.getLayer();
                 // the attachment buffer (texture or renderbuffer) must be valid
-                assert(info[i].handle);
+                assert_invariant(info[i].handle);
                 // the attachment level must be within range
-                assert(info[i].level < entry.descriptor.levels);
+                assert_invariant(info[i].level < entry.descriptor.levels);
                 // if the attachment is multisampled, then the rendertarget must be too
-                assert(entry.descriptor.samples <= 1 || entry.descriptor.samples == descriptor.samples);
+                assert_invariant(entry.descriptor.samples <= 1 || entry.descriptor.samples == descriptor.samples);
             }
         }
 

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -14,6 +14,7 @@ file(GLOB_RECURSE PUBLIC_HDRS ${PUBLIC_HDR_DIR}/${TARGET}/*.h)
 set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/algorithm.h
         ${PUBLIC_HDR_DIR}/${TARGET}/bitset.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/debug.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Allocator.h
         ${PUBLIC_HDR_DIR}/${TARGET}/BitmaskEnum.h
         ${PUBLIC_HDR_DIR}/${TARGET}/compiler.h
@@ -46,6 +47,7 @@ set(DIST_GENERIC_HDRS
 set(SRCS
         src/api_level.cpp
         src/ashmem.cpp
+        src/debug.cpp
         src/Allocator.cpp
         src/CallStack.cpp
         src/CString.cpp

--- a/libs/utils/include/utils/debug.h
+++ b/libs/utils/include/utils/debug.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_DEBUG_H
+#define TNT_UTILS_DEBUG_H
+
+#include <utils/compiler.h>
+
+namespace utils {
+void panic(const char *func, const char * file, int line, const char *assertion) noexcept;
+} // namespace filament
+
+#ifdef NDEBUG
+#   define	assert_invariant(e)	((void)0)
+#else
+#   define	assert_invariant(e) \
+            (UTILS_LIKELY(e) ? ((void)0) : utils::panic(__func__, __FILE__, __LINE__, #e))
+#endif // NDEBUG
+
+#endif //TNT_UTILS_DEBUG_H

--- a/libs/utils/src/debug.cpp
+++ b/libs/utils/src/debug.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utils/debug.h"
+
+#include <utils/Panic.h>
+
+namespace utils {
+
+void panic(const char *func, const char * file, int line, const char *assertion) noexcept {
+    PANIC_LOG("%s:%d: failed assertion `%s'\n", file, line, assertion);
+}
+
+} // namespace filament


### PR DESCRIPTION
assert() is now replaced by assert_invariant() which has the same
prototype and (currently) behaves the same than assert().

<assert.h> should not be used anymore, and is replaced by 
<utils/debug.h>, which is where assert_invariant() is found.

The main motivation for this is to be able to set a breakpoint on the
assertion as lldb doesn't handle abort() very well, and doesn't
permit to inspect the stack trace.

A secondary motivation is to be able (at some point) to enable 
assertions without necessarily doing a debug build.