### PR TITLE
Avoid uninitialized reads in computeVisibilityMasks.

### DIFF
--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -72,6 +72,14 @@
 #    endif
 #endif
 
+#define UTILS_HAS_SANITIZE_MEMORY 0
+#if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+#        undef UTILS_HAS_SANITIZE_MEMORY
+#        define UTILS_HAS_SANITIZE_MEMORY 1
+#    endif
+#endif
+
 /*
  * helps the compiler's optimizer predicting branches
  */


### PR DESCRIPTION
I verified that this code is not enabled in our GitHub builds, and I
verified that the MSAN error goes away.