### PR TITLE
Attempt at improving bloom/emissive with glTF files

### DIFF
--- a/android/filament-android/libfilament-jni.map
+++ b/android/filament-android/libfilament-jni.map
@@ -3,6 +3,7 @@ LIBFILAMENT {
     Java_com_google_android_filament_*;
     JNI*;
     *filament*Camera*;
+    *filament*Exposure*;
     *filament*Skybox*;
     *filament*Engine*;
     *filament*RenderableManager*;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -24,6 +24,7 @@
 #include <filament/Box.h>
 #include <filament/Camera.h>
 #include <filament/Engine.h>
+#include <filament/Exposure.h>
 #include <filament/IndexBuffer.h>
 #include <filament/LightManager.h>
 #include <filament/Material.h>
@@ -984,7 +985,10 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
     }
 
     const float* e = inputMat->emissive_factor;
-    mi->setParameter("emissiveFactor", float3(e[0], e[1], e[2]));
+    // To force emissive to bloom when emissiveFactor is at 1, we multiply by a luminance
+    // of 6EV. At 6EV, the luminance will be 2^(6-3) = 8 which is about the HDR range of
+    // our default tone mappers.
+    mi->setParameter("emissiveFactor", float3(e[0], e[1], e[2]) * Exposure::luminance(6.0f));
 
     const float* c = mrConfig.base_color_factor;
     mi->setParameter("baseColorFactor", float4(c[0], c[1], c[2], c[3]));


### PR DESCRIPTION
Without this change, a valid glTF file only supplies values between 0 and 1 for `emissiveFactor` which means emissive surfaces never bloom. I used a somewhat arbitrary EV factor (see comment for reasons) but we could also apply the inverse tonemap operator to `emissiveFactor`.