### PR TITLE
Downgrade Linux GitHub Actions environment to fix error

### DIFF
--- a/.github/workflows/linux-continuous.yml
+++ b/.github/workflows/linux-continuous.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-linux:
     name: build-linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-18.04]
 
     steps:
       - uses: actions/checkout@v2.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-18.04]
 
     steps:
       - name: Decide Git ref


### PR DESCRIPTION
`ubuntu-latest` now points to `ubuntu-20.04`, which causes our Linux builds to fail with:

```
/usr/bin/ld: /usr/lib/llvm-8/bin/../lib/libc++abi.a: error adding symbols: archive has no index; run ranlib to add one
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```