### PR TITLE
Remove exceptions on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ endif()
 
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
-if (ANDROID OR WEBGL)
+if (ANDROID OR IOS OR WEBGL)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
 endif()
 

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 # ==================================================================================================
 
 if (FILAMENT_SUPPORTS_METAL)
-    list(APPEND SRCS
+    set(METAL_SRCS
             src/metal/MetalBlitter.mm
             src/metal/MetalBuffer.mm
             src/metal/MetalBufferPool.mm
@@ -117,6 +117,18 @@ if (FILAMENT_SUPPORTS_METAL)
             src/metal/MetalTimerQuery.mm
             src/metal/PlatformMetal.mm
     )
+
+    list(APPEND SRCS ${METAL_SRCS})
+
+    if (IOS)
+        # Objective-C++ sources need an additional compiler flag on iOS to disable exceptions.
+        set_property(SOURCE
+            ${METAL_SRCS}
+            src/opengl/PlatformCocoaTouchGL.mm
+            src/opengl/CocoaTouchExternalImage.mm
+            src/opengl/PlatformCocoaGL.mm
+            PROPERTY COMPILE_FLAGS -fno-objc-exceptions)
+    endif()
 endif()
 
 # ==================================================================================================


### PR DESCRIPTION
This adds `-fno-exceptions` to iOS builds, to mirror Android.

A better way to control exceptions, as @pixelflinger mentioned, is to make this a CMake setting, exposed to `build.sh`. I'll leave that work to a separate change.