### PR TITLE
Make material compilation deterministic

### DIFF
--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -735,7 +735,6 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                     glslEntry.stage = v.stage;
                     glslEntry.shader = shader;
 
-                    textDictionary.addText(glslEntry.shader);
                     glslEntries.push_back(glslEntry);
                 }
 
@@ -743,8 +742,8 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 if (targetApi == TargetApi::VULKAN) {
                     assert(!spirv.empty());
                     spirvEntry.stage = v.stage;
+                    spirvEntry.spirv = std::move(spirv);
 
-                    spirvEntry.dictionaryIndex = spirvDictionary.addBlob(spirv);
                     spirvEntries.push_back(spirvEntry);
                 }
 
@@ -754,7 +753,6 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                     metalEntry.stage = v.stage;
                     metalEntry.shader = msl;
 
-                    textDictionary.addText(metalEntry.shader);
                     metalEntries.push_back(metalEntry);
                 }
 #endif
@@ -776,6 +774,28 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 
     if (cancelJobs.load()) {
         return false;
+    }
+
+    // Sort the variants.
+    auto compare = [](const auto& a, const auto& b) {
+        const uint32_t akey = a.shaderModel << 16 | a.variant << 8 | a.stage;
+        const uint32_t bkey = b.shaderModel << 16 | b.variant << 8 | b.stage;
+        return akey < bkey;
+    };
+    std::sort(glslEntries.begin(), glslEntries.end(), compare);
+    std::sort(spirvEntries.begin(), spirvEntries.end(), compare);
+    std::sort(metalEntries.begin(), metalEntries.end(), compare);
+
+    // Generate the dictionaries.
+    for (const auto& s : glslEntries) {
+        textDictionary.addText(s.shader);
+    }
+    for (auto& s : spirvEntries) {
+        std::vector<uint32_t> spirv = std::move(s.spirv);
+        s.dictionaryIndex = spirvDictionary.addBlob(spirv);
+    }
+    for (const auto& s : metalEntries) {
+        textDictionary.addText(s.shader);
     }
 
     // Emit dictionary chunk (TextDictionaryReader and DictionaryTextChunk)

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMAT_SHADER_ENTRY_H
 
 #include <string>
+#include <vector>
 
 namespace filamat {
 
@@ -34,6 +35,9 @@ struct SpirvEntry {
     uint8_t variant;
     uint8_t stage;
     size_t dictionaryIndex;
+
+    // temporarily holds this entry's spirv until added to the dictionary
+    std::vector<uint32_t> spirv;
 };
 
 }  // namespace filamat

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -36,8 +36,10 @@ struct SpirvEntry {
     uint8_t stage;
     size_t dictionaryIndex;
 
+#ifndef FILAMAT_LITE
     // temporarily holds this entry's spirv until added to the dictionary
     std::vector<uint32_t> spirv;
+#endif
 };
 
 }  // namespace filamat


### PR DESCRIPTION
With multithreaded variant compilation, compiled materials differ based on which variants finish first. This change ensures that compiled materials are always bit-for-bit identical.

This is helpful when comparing two compiled materials. Hashing the material files can be used to check for equality. It's also convenient for variants to occupy the same index when using matinfo's `--print-glsl` flag, for example.