### PR TITLE
More code size optimizations

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SRCS
         src/Stream.cpp
         src/SwapChain.cpp
         src/Texture.cpp
+        src/ToneMapping.cpp
         src/UniformBuffer.cpp
         src/VertexBuffer.cpp
         src/View.cpp

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -40,13 +40,9 @@ public:
 
     template<typename T>
     using is_supported_parameter_t = typename std::enable_if<
-            std::is_same<bool, T>::value ||
             std::is_same<float, T>::value ||
             std::is_same<int32_t, T>::value ||
             std::is_same<uint32_t, T>::value ||
-            std::is_same<math::bool2, T>::value ||
-            std::is_same<math::bool3, T>::value ||
-            std::is_same<math::bool4, T>::value ||
             std::is_same<math::int2, T>::value ||
             std::is_same<math::int3, T>::value ||
             std::is_same<math::int4, T>::value ||
@@ -56,8 +52,13 @@ public:
             std::is_same<math::float2, T>::value ||
             std::is_same<math::float3, T>::value ||
             std::is_same<math::float4, T>::value ||
-            std::is_same<math::mat3f, T>::value ||
-            std::is_same<math::mat4f, T>::value
+            std::is_same<math::mat4f, T>::value ||
+            // these types are slower as they need a layout conversion
+            std::is_same<bool, T>::value ||
+            std::is_same<math::bool2, T>::value ||
+            std::is_same<math::bool3, T>::value ||
+            std::is_same<math::bool4, T>::value ||
+            std::is_same<math::mat3f, T>::value
     >::type;
 
     /**
@@ -78,7 +79,7 @@ public:
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
     template<typename T, typename = is_supported_parameter_t<T>>
-    void setParameter(const char* name, T value) noexcept;
+    void setParameter(const char* name, T const& value) noexcept;
 
     /**
      * Set a uniform array by name

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -69,11 +69,13 @@ MaterialParser::MaterialParserDetails::MaterialParserDetails(Backend backend, co
 }
 
 template<typename T>
-bool MaterialParser::MaterialParserDetails::getFromSimpleChunk(filamat::ChunkType type, T* value) const noexcept {
-    if (mChunkContainer.hasChunk(type)) {
-        Unflattener unflattener(
-                mChunkContainer.getChunkStart(type),
-                mChunkContainer.getChunkEnd(type));
+UTILS_NOINLINE
+bool MaterialParser::MaterialParserDetails::getFromSimpleChunk(
+        filamat::ChunkType type, T* value) const noexcept {
+    ChunkContainer const& chunkContainer = mChunkContainer;
+    ChunkContainer::ChunkDesc const* pChunkDesc;
+    if (chunkContainer.hasChunk(type, &pChunkDesc)) {
+        Unflattener unflattener(pChunkDesc->start, pChunkDesc->start + pChunkDesc->size);
         return unflattener.read(value);
     }
     return false;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -187,32 +187,45 @@ PostProcessManager::PostProcessMaterial& PostProcessManager::getPostProcessMater
 
 #define MATERIAL(n) MATERIALS_ ## n ## _DATA, MATERIALS_ ## n ## _SIZE
 
+struct MaterialInfo {
+    utils::StaticString name;
+    uint8_t const* data;
+    int size;
+};
+
+static const MaterialInfo sMaterialList[] = {
+        { "sao",                   MATERIAL(SAO) },
+        { "mipmapDepth",           MATERIAL(MIPMAPDEPTH) },
+        { "vsmMipmap",             MATERIAL(VSMMIPMAP) },
+        { "bilateralBlur",         MATERIAL(BILATERALBLUR) },
+        { "separableGaussianBlur", MATERIAL(SEPARABLEGAUSSIANBLUR) },
+        { "bloomDownsample",       MATERIAL(BLOOMDOWNSAMPLE) },
+        { "bloomUpsample",         MATERIAL(BLOOMUPSAMPLE) },
+        { "blitLow",               MATERIAL(BLITLOW) },
+        { "blitMedium",            MATERIAL(BLITMEDIUM) },
+        { "blitHigh",              MATERIAL(BLITHIGH) },
+        { "colorGrading",          MATERIAL(COLORGRADING) },
+        { "colorGradingAsSubpass", MATERIAL(COLORGRADINGASSUBPASS) },
+        { "fxaa",                  MATERIAL(FXAA) },
+        { "taa",                   MATERIAL(TAA) },
+        { "dofDownsample",         MATERIAL(DOFDOWNSAMPLE) },
+        { "dofMipmap",             MATERIAL(DOFMIPMAP) },
+        { "dofTiles",              MATERIAL(DOFTILES) },
+        { "dofDilate",             MATERIAL(DOFDILATE) },
+        { "dof",                   MATERIAL(DOF) },
+        { "dofMedian",             MATERIAL(DOFMEDIAN) },
+        { "dofCombine",            MATERIAL(DOFCOMBINE) },
+};
+
 void PostProcessManager::init() noexcept {
     auto& engine = mEngine;
     DriverApi& driver = engine.getDriverApi();
     mDisableFeedbackLoops = !driver.areFeedbackLoopsSupported();
 
-    registerPostProcessMaterial("sao", MATERIAL(SAO));
-    registerPostProcessMaterial("mipmapDepth", MATERIAL(MIPMAPDEPTH));
-    registerPostProcessMaterial("vsmMipmap", MATERIAL(VSMMIPMAP));
-    registerPostProcessMaterial("bilateralBlur", MATERIAL(BILATERALBLUR));
-    registerPostProcessMaterial("separableGaussianBlur", MATERIAL(SEPARABLEGAUSSIANBLUR));
-    registerPostProcessMaterial("bloomDownsample", MATERIAL(BLOOMDOWNSAMPLE));
-    registerPostProcessMaterial("bloomUpsample", MATERIAL(BLOOMUPSAMPLE));
-    registerPostProcessMaterial("blitLow", MATERIAL(BLITLOW));
-    registerPostProcessMaterial("blitMedium", MATERIAL(BLITMEDIUM));
-    registerPostProcessMaterial("blitHigh", MATERIAL(BLITHIGH));
-    registerPostProcessMaterial("colorGrading", MATERIAL(COLORGRADING));
-    registerPostProcessMaterial("colorGradingAsSubpass", MATERIAL(COLORGRADINGASSUBPASS));
-    registerPostProcessMaterial("fxaa", MATERIAL(FXAA));
-    registerPostProcessMaterial("taa", MATERIAL(TAA));
-    registerPostProcessMaterial("dofDownsample", MATERIAL(DOFDOWNSAMPLE));
-    registerPostProcessMaterial("dofMipmap", MATERIAL(DOFMIPMAP));
-    registerPostProcessMaterial("dofTiles", MATERIAL(DOFTILES));
-    registerPostProcessMaterial("dofDilate", MATERIAL(DOFDILATE));
-    registerPostProcessMaterial("dof", MATERIAL(DOF));
-    registerPostProcessMaterial("dofMedian", MATERIAL(DOFMEDIAN));
-    registerPostProcessMaterial("dofCombine", MATERIAL(DOFCOMBINE));
+    #pragma nounroll
+    for (auto const& info : sMaterialList) {
+        registerPostProcessMaterial(info.name, info.data, info.size);
+    }
 
     // UBO storage size.
     // The effective kernel size is (kMaxPositiveKernelSize - 1) * 4 + 1.

--- a/filament/src/ToneMapping.cpp
+++ b/filament/src/ToneMapping.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ToneMapping.h"
+
+namespace filament {
+namespace aces {
+
+inline float rgb_2_saturation(float3 rgb) {
+    // Input:  ACES
+    // Output: OCES
+    constexpr float TINY = 1e-5f;
+    float mi = min(rgb);
+    float ma = max(rgb);
+    return (max(ma, TINY) - max(mi, TINY)) / max(ma, 1e-2f);
+}
+
+inline float rgb_2_yc(float3 rgb) {
+    constexpr float ycRadiusWeight = 1.75f;
+
+    // Converts RGB to a luminance proxy, here called YC
+    // YC is ~ Y + K * Chroma
+    // Constant YC is a cone-shaped surface in RGB space, with the tip on the
+    // neutral axis, towards white.
+    // YC is normalized: RGB 1 1 1 maps to YC = 1
+    //
+    // ycRadiusWeight defaults to 1.75, although can be overridden in function
+    // call to rgb_2_yc
+    // ycRadiusWeight = 1 -> YC for pure cyan, magenta, yellow == YC for neutral
+    // of same value
+    // ycRadiusWeight = 2 -> YC for pure red, green, blue  == YC for  neutral of
+    // same value.
+
+    float r = rgb.r;
+    float g = rgb.g;
+    float b = rgb.b;
+
+    float chroma = std::sqrt(b * (b - g) + g * (g - r) + r * (r - b));
+
+    return (b + g + r + ycRadiusWeight * chroma) / 3.0f;
+}
+
+inline float sigmoid_shaper(float x) {
+    // Sigmoid function in the range 0 to 1 spanning -2 to +2.
+    float t = max(1.0f - std::abs(x / 2.0f), 0.0f);
+    float y = 1.0f + sign(x) * (1.0f - t * t);
+    return y / 2.0f;
+}
+
+inline float glow_fwd(float ycIn, float glowGainIn, float glowMid) {
+    float glowGainOut;
+
+    if (ycIn <= 2.0f / 3.0f * glowMid) {
+        glowGainOut = glowGainIn;
+    } else if ( ycIn >= 2.0f * glowMid) {
+        glowGainOut = 0.0f;
+    } else {
+        glowGainOut = glowGainIn * (glowMid / ycIn - 1.0f / 2.0f);
+    }
+
+    return glowGainOut;
+}
+
+inline float rgb_2_hue(float3 rgb) {
+    // Returns a geometric hue angle in degrees (0-360) based on RGB values.
+    // For neutral colors, hue is undefined and the function will return a quiet NaN value.
+    float hue = 0.0f;
+    // RGB triplets where RGB are equal have an undefined hue
+    if (!(rgb.x == rgb.y && rgb.y == rgb.z)) {
+        hue = f::RAD_TO_DEG * std::atan2(
+                std::sqrt(3.0f) * (rgb.y - rgb.z),
+                2.0f * rgb.x - rgb.y - rgb.z);
+    }
+    return (hue < 0.0f) ? hue + 360.0f : hue;
+}
+
+inline float center_hue(float hue, float centerH) {
+    float hueCentered = hue - centerH;
+    if (hueCentered < -180.0f) {
+        hueCentered = hueCentered + 360.0f;
+    } else if (hueCentered > 180.0f) {
+        hueCentered = hueCentered - 360.0f;
+    }
+    return hueCentered;
+}
+
+inline float3 darkSurround_to_dimSurround(float3 linearCV) {
+    constexpr float DIM_SURROUND_GAMMA = 0.9811f;
+
+    float3 XYZ = AP1_to_XYZ * linearCV;
+    float3 xyY = XYZ_to_xyY(XYZ);
+
+    xyY.z = clamp(xyY.z, 0.0f, (float)std::numeric_limits<math::half>::max());
+    xyY.z = std::pow(xyY.z, DIM_SURROUND_GAMMA);
+
+    XYZ = xyY_to_XYZ(xyY);
+    return XYZ_to_AP1 * XYZ;
+}
+
+float3 ACES(float3 color, float brightness) noexcept {
+    // Some bits were removed to adapt to our desired output
+    // Input:  ACEScg (AP1)
+    // Output: ACEScg (AP1)
+
+    // "Glow" module constants
+    constexpr float RRT_GLOW_GAIN = 0.05f;
+    constexpr float RRT_GLOW_MID = 0.08f;
+
+    // Red modifier constants
+    constexpr float RRT_RED_SCALE = 0.82f;
+    constexpr float RRT_RED_PIVOT = 0.03f;
+    constexpr float RRT_RED_HUE   = 0.0f;
+    constexpr float RRT_RED_WIDTH = 135.0f;
+
+    // Desaturation constants
+    constexpr float RRT_SAT_FACTOR = 0.96f;
+    constexpr float ODT_SAT_FACTOR = 0.93f;
+
+    float3 ap0 = AP1_to_AP0 * color;
+
+    // Glow module
+    float saturation = rgb_2_saturation(ap0);
+    float ycIn = rgb_2_yc(ap0);
+    float s = sigmoid_shaper((saturation - 0.4f) / 0.2f);
+    float addedGlow = 1.0f + glow_fwd(ycIn, RRT_GLOW_GAIN * s, RRT_GLOW_MID);
+    ap0 *= addedGlow;
+
+    // Red modifier
+    float hue = rgb_2_hue(ap0);
+    float centeredHue = center_hue(hue, RRT_RED_HUE);
+    float hueWeight = smoothstep(0.0f, 1.0f, 1.0f - std::abs(2.0f * centeredHue / RRT_RED_WIDTH));
+    hueWeight *= hueWeight;
+
+    ap0.r += hueWeight * saturation * (RRT_RED_PIVOT - ap0.r) * (1.0f - RRT_RED_SCALE);
+
+    // ACES to RGB rendering space
+    float3 ap1 = clamp(AP0_to_AP1 * ap0, 0.0f, (float) std::numeric_limits<math::half>::max());
+
+    // Global desaturation
+    ap1 = mix(float3(dot(ap1, LUMA_AP1)), ap1, RRT_SAT_FACTOR);
+
+    // NOTE: This is specific to Filament and added only to match ACES to our legacy tone mapper
+    //       which was a fit of ACES in Rec.709 but with a brightness boost.
+    ap1 *= brightness;
+
+    // Fitting of RRT + ODT (RGB monitor 100 nits dim) from:
+    // https://github.com/colour-science/colour-unity/blob/master/Assets/Colour/Notebooks/CIECAM02_Unity.ipynb
+    constexpr float a = 2.785085f;
+    constexpr float b = 0.107772f;
+    constexpr float c = 2.936045f;
+    constexpr float d = 0.887122f;
+    constexpr float e = 0.806889f;
+    float3 rgbPost = (ap1 * (a * ap1 + b)) / (ap1 * (c * ap1 + d) + e);
+
+    // Apply gamma adjustment to compensate for dim surround
+    float3 linearCV = darkSurround_to_dimSurround(rgbPost);
+
+    // Apply desaturation to compensate for luminance difference
+    linearCV = mix(float3(dot(linearCV, LUMA_AP1)), linearCV, ODT_SAT_FACTOR);
+
+    return linearCV;
+}
+
+} // namespace aces
+
+
+namespace tonemap {
+
+float3 ACES(float3 x) noexcept {
+    return aces::ACES(x, 1.0f);
+}
+
+float3 ACES_Legacy(float3 x) noexcept {
+    return aces::ACES(x, 1.0f / 0.6f);
+}
+
+float3 Uchimura(float3 x) noexcept {
+    // Uchimura 2017, "HDR theory and practice"
+    // Math: https://www.desmos.com/calculator/gslcdxvipg
+    // Source: https://www.slideshare.net/nikuque/hdr-theory-and-practicce-jp
+
+    constexpr float P = 1.0;  // max display brightness
+    constexpr float a = 1.0;  // contrast
+    constexpr float m = 0.22; // linear section start
+    constexpr float l = 0.4;  // linear section length
+    constexpr float c = 1.33; // black
+    constexpr float b = 0.0;  // pedestal
+
+    constexpr float l0 = ((P - m) * l) / a;
+    constexpr float S0 = m + l0;
+    constexpr float S1 = m + a * l0;
+    constexpr float C2 = (a * P) / (P - S1);
+    constexpr float CP = -C2 / P;
+
+    float3 w0 = 1.0f - smoothstep(0.0f, m, x);
+    float3 w2 = step(m + l0, x);
+    float3 w1 = 1.0f - w0 - w2;
+
+    float3 T = m * pow(x / m, c) + b;
+    float3 S = P - (P - S1) * exp(CP * (x - S0));
+    float3 L = m + a * (x - m);
+
+    return T * w0 + L * w1 + S * w2;
+}
+
+float3 DisplayRange(float3 x) noexcept {
+    // 16 debug colors + 1 duplicated at the end for easy indexing
+
+    constexpr float3 debugColors[17] = {
+            {0.0,     0.0,     0.0},         // black
+            {0.0,     0.0,     0.1647},      // darkest blue
+            {0.0,     0.0,     0.3647},      // darker blue
+            {0.0,     0.0,     0.6647},      // dark blue
+            {0.0,     0.0,     0.9647},      // blue
+            {0.0,     0.9255,  0.9255},      // cyan
+            {0.0,     0.5647,  0.0},         // dark green
+            {0.0,     0.7843,  0.0},         // green
+            {1.0,     1.0,     0.0},         // yellow
+            {0.90588, 0.75294, 0.0},         // yellow-orange
+            {1.0,     0.5647,  0.0},         // orange
+            {1.0,     0.0,     0.0},         // bright red
+            {0.8392,  0.0,     0.0},         // red
+            {1.0,     0.0,     1.0},         // magenta
+            {0.6,     0.3333,  0.7882},      // purple
+            {1.0,     1.0,     1.0},         // white
+            {1.0,     1.0,     1.0}          // white
+    };
+
+    // The 5th color in the array (cyan) represents middle gray (18%)
+    // Every stop above or below middle gray causes a color shift
+    float v = log2(dot(x, LUMA_REC709) / 0.18f);
+    v = clamp(v + 5.0f, 0.0f, 15.0f);
+
+    size_t index = size_t(v);
+    return mix(debugColors[index], debugColors[index + 1], saturate(v - float(index)));
+}
+
+} // namespace tonemap
+} // namespace filament

--- a/filament/src/ToneMapping.h
+++ b/filament/src/ToneMapping.h
@@ -35,161 +35,7 @@ using namespace math;
 
 namespace aces {
 
-inline float rgb_2_saturation(float3 rgb) {
-    // Input:  ACES
-    // Output: OCES
-    constexpr float TINY = 1e-5f;
-    float mi = min(rgb);
-    float ma = max(rgb);
-    return (max(ma, TINY) - max(mi, TINY)) / max(ma, 1e-2f);
-}
-
-inline float rgb_2_yc(float3 rgb) {
-    constexpr float ycRadiusWeight = 1.75f;
-
-    // Converts RGB to a luminance proxy, here called YC
-    // YC is ~ Y + K * Chroma
-    // Constant YC is a cone-shaped surface in RGB space, with the tip on the
-    // neutral axis, towards white.
-    // YC is normalized: RGB 1 1 1 maps to YC = 1
-    //
-    // ycRadiusWeight defaults to 1.75, although can be overridden in function
-    // call to rgb_2_yc
-    // ycRadiusWeight = 1 -> YC for pure cyan, magenta, yellow == YC for neutral
-    // of same value
-    // ycRadiusWeight = 2 -> YC for pure red, green, blue  == YC for  neutral of
-    // same value.
-
-    float r = rgb.r;
-    float g = rgb.g;
-    float b = rgb.b;
-
-    float chroma = std::sqrt(b * (b - g) + g * (g - r) + r * (r - b));
-
-    return (b + g + r + ycRadiusWeight * chroma) / 3.0f;
-}
-
-inline float sigmoid_shaper(float x) {
-    // Sigmoid function in the range 0 to 1 spanning -2 to +2.
-    float t = max(1.0f - std::abs(x / 2.0f), 0.0f);
-    float y = 1.0f + sign(x) * (1.0f - t * t);
-    return y / 2.0f;
-}
-
-inline float glow_fwd(float ycIn, float glowGainIn, float glowMid) {
-    float glowGainOut;
-
-    if (ycIn <= 2.0f / 3.0f * glowMid) {
-        glowGainOut = glowGainIn;
-    } else if ( ycIn >= 2.0f * glowMid) {
-        glowGainOut = 0.0f;
-    } else {
-        glowGainOut = glowGainIn * (glowMid / ycIn - 1.0f / 2.0f);
-    }
-
-    return glowGainOut;
-}
-
-inline float rgb_2_hue(float3 rgb) {
-    // Returns a geometric hue angle in degrees (0-360) based on RGB values.
-    // For neutral colors, hue is undefined and the function will return a quiet NaN value.
-    float hue = 0.0f;
-    // RGB triplets where RGB are equal have an undefined hue
-    if (!(rgb.x == rgb.y && rgb.y == rgb.z)) {
-        hue = f::RAD_TO_DEG * std::atan2(
-                std::sqrt(3.0f) * (rgb.y - rgb.z),
-                2.0f * rgb.x - rgb.y - rgb.z);
-    }
-    return (hue < 0.0f) ? hue + 360.0f : hue;
-}
-
-inline float center_hue(float hue, float centerH) {
-    float hueCentered = hue - centerH;
-    if (hueCentered < -180.0f) {
-        hueCentered = hueCentered + 360.0f;
-    } else if (hueCentered > 180.0f) {
-        hueCentered = hueCentered - 360.0f;
-    }
-    return hueCentered;
-}
-
-inline float3 darkSurround_to_dimSurround(float3 linearCV) {
-    constexpr float DIM_SURROUND_GAMMA = 0.9811f;
-
-    float3 XYZ = AP1_to_XYZ * linearCV;
-    float3 xyY = XYZ_to_xyY(XYZ);
-
-    xyY.z = clamp(xyY.z, 0.0f, (float)std::numeric_limits<math::half>::max());
-    xyY.z = std::pow(xyY.z, DIM_SURROUND_GAMMA);
-
-    XYZ = xyY_to_XYZ(xyY);
-    return XYZ_to_AP1 * XYZ;
-}
-
-UTILS_ALWAYS_INLINE
-inline float3 ACES(float3 color, float brightness) {
-    // Some bits were removed to adapt to our desired output
-    // Input:  ACEScg (AP1)
-    // Output: ACEScg (AP1)
-
-    // "Glow" module constants
-    constexpr float RRT_GLOW_GAIN = 0.05f;
-    constexpr float RRT_GLOW_MID = 0.08f;
-
-    // Red modifier constants
-    constexpr float RRT_RED_SCALE = 0.82f;
-    constexpr float RRT_RED_PIVOT = 0.03f;
-    constexpr float RRT_RED_HUE   = 0.0f;
-    constexpr float RRT_RED_WIDTH = 135.0f;
-
-    // Desaturation constants
-    constexpr float RRT_SAT_FACTOR = 0.96f;
-    constexpr float ODT_SAT_FACTOR = 0.93f;
-
-    float3 ap0 = AP1_to_AP0 * color;
-
-    // Glow module
-    float saturation = rgb_2_saturation(ap0);
-    float ycIn = rgb_2_yc(ap0);
-    float s = sigmoid_shaper((saturation - 0.4f) / 0.2f);
-    float addedGlow = 1.0f + glow_fwd(ycIn, RRT_GLOW_GAIN * s, RRT_GLOW_MID);
-    ap0 *= addedGlow;
-
-    // Red modifier
-    float hue = rgb_2_hue(ap0);
-    float centeredHue = center_hue(hue, RRT_RED_HUE);
-    float hueWeight = smoothstep(0.0f, 1.0f, 1.0f - std::abs(2.0f * centeredHue / RRT_RED_WIDTH));
-    hueWeight *= hueWeight;
-
-    ap0.r += hueWeight * saturation * (RRT_RED_PIVOT - ap0.r) * (1.0f - RRT_RED_SCALE);
-
-    // ACES to RGB rendering space
-    float3 ap1 = clamp(AP0_to_AP1 * ap0, 0.0f, (float) std::numeric_limits<math::half>::max());
-
-    // Global desaturation
-    ap1 = mix(float3(dot(ap1, LUMA_AP1)), ap1, RRT_SAT_FACTOR);
-
-    // NOTE: This is specific to Filament and added only to match ACES to our legacy tone mapper
-    //       which was a fit of ACES in Rec.709 but with a brightness boost.
-    ap1 *= brightness;
-
-    // Fitting of RRT + ODT (RGB monitor 100 nits dim) from:
-    // https://github.com/colour-science/colour-unity/blob/master/Assets/Colour/Notebooks/CIECAM02_Unity.ipynb
-    constexpr float a = 2.785085f;
-    constexpr float b = 0.107772f;
-    constexpr float c = 2.936045f;
-    constexpr float d = 0.887122f;
-    constexpr float e = 0.806889f;
-    float3 rgbPost = (ap1 * (a * ap1 + b)) / (ap1 * (c * ap1 + d) + e);
-
-    // Apply gamma adjustment to compensate for dim surround
-    float3 linearCV = darkSurround_to_dimSurround(rgbPost);
-
-    // Apply desaturation to compensate for luminance difference
-    linearCV = mix(float3(dot(linearCV, LUMA_AP1)), linearCV, ODT_SAT_FACTOR);
-
-    return linearCV;
-}
+float3 ACES(float3 color, float brightness) noexcept;
 
 } // namespace aces
 
@@ -217,42 +63,11 @@ constexpr float3 Filmic(float3 x) noexcept {
     return (x * (a * x + b)) / (x * (c * x + d) + e);
 }
 
-float3 ACES(float3 x) noexcept {
-    return aces::ACES(x, 1.0f);
-}
+float3 ACES(float3 x) noexcept;
 
-float3 ACES_Legacy(float3 x) noexcept {
-    return aces::ACES(x, 1.0f / 0.6f);
-}
+float3 ACES_Legacy(float3 x) noexcept;
 
-float3 Uchimura(float3 x) {
-    // Uchimura 2017, "HDR theory and practice"
-    // Math: https://www.desmos.com/calculator/gslcdxvipg
-    // Source: https://www.slideshare.net/nikuque/hdr-theory-and-practicce-jp
-
-    constexpr float P = 1.0;  // max display brightness
-    constexpr float a = 1.0;  // contrast
-    constexpr float m = 0.22; // linear section start
-    constexpr float l = 0.4;  // linear section length
-    constexpr float c = 1.33; // black
-    constexpr float b = 0.0;  // pedestal
-
-    constexpr float l0 = ((P - m) * l) / a;
-    constexpr float S0 = m + l0;
-    constexpr float S1 = m + a * l0;
-    constexpr float C2 = (a * P) / (P - S1);
-    constexpr float CP = -C2 / P;
-
-    float3 w0 = 1.0f - smoothstep(0.0f, m, x);
-    float3 w2 = step(m + l0, x);
-    float3 w1 = 1.0f - w0 - w2;
-
-    float3 T = m * pow(x / m, c) + b;
-    float3 S = P - (P - S1) * exp(CP * (x - S0));
-    float3 L = m + a * (x - m);
-
-    return T * w0 + L * w1 + S * w2;
-}
+float3 Uchimura(float3 x) noexcept;
 
 /**
  * Converts the input HDR RGB color into one of 16 debug colors that represent
@@ -279,37 +94,7 @@ float3 Uchimura(float3 x) {
  * +9EV  - purple
  * +10EV - white
  */
-float3 DisplayRange(float3 x) noexcept {
-    // 16 debug colors + 1 duplicated at the end for easy indexing
-
-    constexpr float3 debugColors[17] = {
-            {0.0,     0.0,     0.0},         // black
-            {0.0,     0.0,     0.1647},      // darkest blue
-            {0.0,     0.0,     0.3647},      // darker blue
-            {0.0,     0.0,     0.6647},      // dark blue
-            {0.0,     0.0,     0.9647},      // blue
-            {0.0,     0.9255,  0.9255},      // cyan
-            {0.0,     0.5647,  0.0},         // dark green
-            {0.0,     0.7843,  0.0},         // green
-            {1.0,     1.0,     0.0},         // yellow
-            {0.90588, 0.75294, 0.0},         // yellow-orange
-            {1.0,     0.5647,  0.0},         // orange
-            {1.0,     0.0,     0.0},         // bright red
-            {0.8392,  0.0,     0.0},         // red
-            {1.0,     0.0,     1.0},         // magenta
-            {0.6,     0.3333,  0.7882},      // purple
-            {1.0,     1.0,     1.0},         // white
-            {1.0,     1.0,     1.0}          // white
-    };
-
-    // The 5th color in the array (cyan) represents middle gray (18%)
-    // Every stop above or below middle gray causes a color shift
-    float v = log2(dot(x, LUMA_REC709) / 0.18f);
-    v = clamp(v + 5.0f, 0.0f, 15.0f);
-
-    size_t index = size_t(v);
-    return mix(debugColors[index], debugColors[index + 1], saturate(v - float(index)));
-}
+float3 DisplayRange(float3 x) noexcept;
 
 } // namespace tonemap
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -60,18 +60,6 @@ public:
         }
     }
 
-    template <typename T, typename = is_supported_parameter_t<T>>
-    void setParameter(const char* name, T value) noexcept;
-
-    template <typename T, typename = is_supported_parameter_t<T>>
-    void setParameter(const char* name, const T* value, size_t count) noexcept;
-
-    void setParameter(const char* name,
-            Texture const* texture, TextureSampler const& sampler) noexcept;
-
-    void setParameter(const char* name,
-            backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) noexcept;
-
     FMaterial const* getMaterial() const noexcept { return mMaterial; }
 
     uint64_t getSortingKey() const noexcept { return mMaterialSortingKey; }
@@ -110,33 +98,47 @@ public:
 
     backend::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
 
-    void setMaskThreshold(float threshold) noexcept {
-        setParameter("_maskThreshold", math::saturate(threshold));
-    }
+    void setMaskThreshold(float threshold) noexcept;
 
-    void setSpecularAntiAliasingVariance(float variance) noexcept {
-        setParameter("_specularAntiAliasingVariance", math::saturate(variance));
-    }
+    void setSpecularAntiAliasingVariance(float variance) noexcept;
 
-    void setSpecularAntiAliasingThreshold(float threshold) noexcept {
-        setParameter("_specularAntiAliasingThreshold", math::saturate(threshold * threshold));
-    }
+    void setSpecularAntiAliasingThreshold(float threshold) noexcept;
 
     void setDoubleSided(bool doubleSided) noexcept;
 
-    void setCullingMode(CullingMode culling) noexcept;
+    void setCullingMode(CullingMode culling) noexcept { mCulling = culling; }
 
-    void setColorWrite(bool enable) noexcept;
+    void setColorWrite(bool enable) noexcept { mColorWrite = enable; }
 
-    void setDepthWrite(bool enable) noexcept;
+    void setDepthWrite(bool enable) noexcept { mDepthWrite = enable; }
 
     void setDepthCulling(bool enable) noexcept;
 
     const char* getName() const noexcept;
 
+    void setParameter(const char* name,
+            backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) noexcept;
+
+    using MaterialInstance::setParameter;
+
 private:
     friend class FMaterial;
     friend class MaterialInstance;
+
+    template<size_t Size>
+    void setParameterUntypedImpl(const char* name, const void* value) noexcept;
+
+    template<size_t Size>
+    void setParameterUntypedImpl(const char* name, const void* value, size_t count) noexcept;
+
+    template<typename T>
+    void setParameterImpl(const char* name, T const& value) noexcept;
+
+    template<typename T>
+    void setParameterImpl(const char* name, const T* value, size_t count) noexcept;
+
+    void setParameterImpl(const char* name,
+            Texture const* texture, TextureSampler const& sampler) noexcept;
 
     FMaterialInstance() noexcept;
     void initDefaultInstance(FEngine& engine, FMaterial const* material);

--- a/filament/src/fg2/DependencyGraph.cpp
+++ b/filament/src/fg2/DependencyGraph.cpp
@@ -63,8 +63,9 @@ DependencyGraph::EdgeContainer DependencyGraph::getIncomingEdges(
     // TODO: we might need something more efficient
     EdgeContainer result;
     result.reserve(mEdges.size());
+    NodeID const nodeId = node->getId();
     for (auto* edge : mEdges) {
-        if (edge->to == node->getId()) {
+        if (edge->to == nodeId) {
             result.push_back(edge);
         }
     }
@@ -76,8 +77,9 @@ DependencyGraph::EdgeContainer DependencyGraph::getOutgoingEdges(
     // TODO: we might need something more efficient
     EdgeContainer result;
     result.reserve(mEdges.size());
+    NodeID const nodeId = node->getId();
     for (auto* edge : mEdges) {
-        if (edge->from == node->getId()) {
+        if (edge->from == nodeId) {
             result.push_back(edge);
         }
     }
@@ -235,21 +237,9 @@ uint32_t DependencyGraph::Node::getRefCount() const noexcept {
     return (mRefCount & TARGET) ? 1u : mRefCount;
 }
 
-uint32_t DependencyGraph::Node::getId() const noexcept {
-    return mId;
-}
-
-bool DependencyGraph::Node::isCulled() const noexcept {
-    return mRefCount == 0;
-}
-
 void DependencyGraph::Node::makeTarget() noexcept {
     assert_invariant(mRefCount == 0 || mRefCount == TARGET);
     mRefCount = TARGET;
-}
-
-bool DependencyGraph::Node::isTarget() const noexcept {
-    return mRefCount >= TARGET;
 }
 
 char const* DependencyGraph::Node::getName() const noexcept {

--- a/filament/src/fg2/details/DependencyGraph.h
+++ b/filament/src/fg2/details/DependencyGraph.h
@@ -86,20 +86,20 @@ public:
         virtual ~Node() noexcept = default;
 
         //! returns a unique id for this node
-        NodeID getId() const noexcept;
+        NodeID getId() const noexcept { return mId; }
 
         /** Prevents this node from being culled. Must be called before culling. */
         void makeTarget() noexcept;
 
         /** Returns true if this Node is a target */
-        bool isTarget() const noexcept;
+        bool isTarget() const noexcept { return mRefCount >= TARGET; }
 
         /**
          * Returns whether this node was culled.
          * This is only valid after DependencyGraph::cull() has been called.
          * @return true if the node has been culled, false otherwise.
          */
-        bool isCulled() const noexcept;
+        bool isCulled() const noexcept { return mRefCount == 0; }
 
         /**
          * return the reference count of this node. That is how many other nodes have links to us.

--- a/libs/filaflat/include/filaflat/ChunkContainer.h
+++ b/libs/filaflat/include/filaflat/ChunkContainer.h
@@ -35,7 +35,7 @@ public:
 
     ChunkContainer(void const* data, size_t size) : mData(data), mSize(size) {}
 
-    ~ChunkContainer() = default;
+    ~ChunkContainer() noexcept;
 
     // Must be called before trying to access any of the chunk. Fails and return false ONLY if
     // an incomplete chunk is found or if a chunk with bogus size is found.
@@ -66,11 +66,20 @@ public:
     }
 
     const uint8_t* getChunkEnd(Type type) const noexcept {
-        return mChunks.at(type).start + mChunks.at(type).size;
+        ChunkDesc const& chunkDesc = mChunks.at(type);
+        return chunkDesc.start + chunkDesc.size;
     }
 
-    bool hasChunk(Type type) const noexcept {
-        return mChunks.find(type) != mChunks.end();
+    bool hasChunk(Type type, ChunkDesc const** pChunkDesc = nullptr) const noexcept {
+        auto& chunks = mChunks;
+        auto pos = chunks.find(type);
+        if (pos != chunks.end()) {
+            if (pChunkDesc) {
+                *pChunkDesc = &pos.value();
+            }
+            return true;
+        }
+        return false;
     }
 
     void const* getData() const { return mData; }

--- a/libs/filaflat/include/filaflat/MaterialChunk.h
+++ b/libs/filaflat/include/filaflat/MaterialChunk.h
@@ -33,6 +33,7 @@ class ShaderBuilder;
 class MaterialChunk {
 public:
     explicit MaterialChunk(ChunkContainer const& container);
+    ~MaterialChunk() noexcept;
 
     // call this once after container.parse() has been called
     bool readIndex(filamat::ChunkType materialTag);

--- a/libs/filaflat/src/ChunkContainer.cpp
+++ b/libs/filaflat/src/ChunkContainer.cpp
@@ -20,6 +20,8 @@
 
 namespace filaflat {
 
+ChunkContainer::~ChunkContainer() noexcept = default;
+
 bool ChunkContainer::parseChunk(Unflattener& unflattener) {
     uint64_t type;
     if (!unflattener.read(&type)) {

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -31,6 +31,8 @@ MaterialChunk::MaterialChunk(ChunkContainer const& container)
         : mContainer(container) {
 }
 
+MaterialChunk::~MaterialChunk() noexcept = default;
+
 bool MaterialChunk::readIndex(filamat::ChunkType materialTag) {
 
     if (mBase != nullptr) {

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -537,10 +537,10 @@ public:
     // construct an arena with a name and forward argument to its allocator
     template<typename ... ARGS>
     Arena(const char* name, size_t size, ARGS&& ... args)
-            : mArea(size),
+            : mArenaName(name),
+              mArea(size),
               mAllocator(mArea, std::forward<ARGS>(args) ... ),
-              mListener(name, mArea.data(), size),
-              mArenaName(name) {
+              mListener(name, mArea.data(), size) {
     }
 
     // allocate memory from arena with given size and alignment
@@ -647,11 +647,12 @@ public:
     }
 
 private:
+    char const* mArenaName = nullptr;
     HeapArea mArea; // We might want to make that a template parameter too eventually.
+    // note: we should use something like compressed_pair for the members below
     AllocatorPolicy mAllocator;
     LockingPolicy mLock;
     TrackingPolicy mListener;
-    char const* mArenaName = nullptr;
 };
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
MaterialInstance: generate versions of setParameter() methods that
are templated on the parameter sizeof(), which allows us to
coalesce implementations, e.g. float4 and int4 are now
the same. We make the compiler generate non-inline version of all
these methods, the typed version just call through, taking
advantage of the tail-call optimization in clang.

MaterialParser: improve code to avoid calling multiple methods that
all did more or less the same thing and were inlined.

PostProcessManager: use a loop to initialize the materials

ToneMapping: de-dup ACES implementation

And other more minor optimizations.