### PR TITLE
new option to disable PRECONDITION checks at compile time

### DIFF
--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -77,10 +77,14 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
                 "Texture usage must contain DEPTH_ATTACHMENT")) {
             return nullptr;
         }
-        const uint32_t cWidth = FTexture::valueForLevel(color.mipLevel, cTexture->getWidth());
-        const uint32_t cHeight = FTexture::valueForLevel(color.mipLevel, cTexture->getHeight());
-        const uint32_t dWidth = FTexture::valueForLevel(depth.mipLevel, dTexture->getWidth());
-        const uint32_t dHeight = FTexture::valueForLevel(depth.mipLevel, dTexture->getHeight());
+        UTILS_UNUSED const uint32_t cWidth =
+                FTexture::valueForLevel(color.mipLevel, cTexture->getWidth());
+        UTILS_UNUSED const uint32_t cHeight =
+                FTexture::valueForLevel(color.mipLevel, cTexture->getHeight());
+        UTILS_UNUSED const uint32_t dWidth =
+                FTexture::valueForLevel(depth.mipLevel, dTexture->getWidth());
+        UTILS_UNUSED const uint32_t dHeight =
+                FTexture::valueForLevel(depth.mipLevel, dTexture->getHeight());
         if (!ASSERT_PRECONDITION_NON_FATAL(cWidth == dWidth && cHeight == dHeight,
                 "Attachment dimensions must match")) {
             return nullptr;

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -76,13 +76,11 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
 }
 
 Skybox* Skybox::Builder::build(Engine& engine) {
-    FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
-
+    UTILS_UNUSED FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
     if (!ASSERT_PRECONDITION_NON_FATAL(!cubemap || cubemap->isCubemap(),
             "environment maps must be a cubemap")) {
         return nullptr;
     }
-
     return upcast(engine).createSkybox(*this);
 }
 

--- a/filament/src/fg2/FrameGraph.cpp
+++ b/filament/src/fg2/FrameGraph.cpp
@@ -285,7 +285,7 @@ FrameGraphHandle FrameGraph::readInternal(FrameGraphHandle handle, PassNode* pas
     ResourceNode* const node = getActiveResourceNode(handle);
 
     // Check preconditions
-    bool passAlreadyAWriter = node->hasWriteFrom(passNode);
+    UTILS_UNUSED bool passAlreadyAWriter = node->hasWriteFrom(passNode);
     if (!ASSERT_PRECONDITION_NON_FATAL(!passAlreadyAWriter,
             "Pass \"%s\" already writes to \"%s\"",
             passNode->getName(), node->getName())) {

--- a/filament/src/fg2/FrameGraphResources.cpp
+++ b/filament/src/fg2/FrameGraphResources.cpp
@@ -37,15 +37,15 @@ VirtualResource& FrameGraphResources::getResource(FrameGraphHandle handle) const
     ASSERT_PRECONDITION(handle, "Uninitialized handle when using FrameGraphResources.");
 
     VirtualResource* const resource = mFrameGraph.getResource(handle);
+    assert_invariant(resource);
+    assert_invariant(resource->refcount);
 
-    auto& declaredHandles = mPassNode.mDeclaredHandles;
-    const bool hasReadOrWrite = declaredHandles.find(handle.index) != declaredHandles.cend();
-
+    UTILS_UNUSED auto& declaredHandles = mPassNode.mDeclaredHandles;
+    UTILS_UNUSED const bool hasReadOrWrite =
+            declaredHandles.find(handle.index) != declaredHandles.cend();
     ASSERT_PRECONDITION(hasReadOrWrite,
             "Pass \"%s\" didn't declare any access to resource \"%s\"",
             mPassNode.getName(), resource->name);
-
-    assert_invariant(resource->refcount);
 
     return *resource;
 }

--- a/filament/src/fg2/Resource.cpp
+++ b/filament/src/fg2/Resource.cpp
@@ -96,9 +96,9 @@ ImportedRenderTarget::ImportedRenderTarget(char const* resourceName,
 
 UTILS_NOINLINE
 bool ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
-    constexpr auto ANY_ATTACHMENT = FrameGraphTexture::Usage::COLOR_ATTACHMENT |
-                                    FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
-                                    FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
+    UTILS_UNUSED constexpr auto ANY_ATTACHMENT = FrameGraphTexture::Usage::COLOR_ATTACHMENT |
+                                                 FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
+                                                 FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
 
     return ASSERT_PRECONDITION_NON_FATAL(none(u & ~ANY_ATTACHMENT),
             "Imported render target resource \"%s\" can only be used as an attachment (usage=%s)",

--- a/libs/utils/src/Panic.cpp
+++ b/libs/utils/src/Panic.cpp
@@ -168,6 +168,5 @@ void panicLog(char const* function, char const* file, int line, const char* form
 
 template class UTILS_PUBLIC TPanic<PreconditionPanic>;
 template class UTILS_PUBLIC TPanic<PostconditionPanic>;
-template class UTILS_PUBLIC TPanic<ArithmeticPanic>;
 
 } // namespace utils


### PR DESCRIPTION
the new -DFILAMENT_PRECONDITION_CHECKS=0 flag can be used to disable
all preconditions checks that uses libutil's Panic.h facilities.

this saves about 21KiB from the android release aar.

also removed the PANIC_ARITHMETIC macros, as these are just a type
of post-condition panics and were not used anywhere.