### PR TITLE
minor jobsystem fixes

### DIFF
--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -601,7 +601,7 @@ void Froxelizer::froxelizeLoop(FEngine& engine,
         auto *parent = js.createJob();
         for (size_t i = 0; i < GROUP_COUNT; i++) {
             js.run(jobs::createJob(js, parent, std::cref(process),
-                    lightData.size() - FScene::DIRECTIONAL_LIGHTS_COUNT, i, GROUP_COUNT));
+                    lightData.size() - FScene::DIRECTIONAL_LIGHTS_COUNT, i, GROUP_COUNT), JobSystem::DONT_SIGNAL);
         }
         js.runAndWait(parent);
     } else {

--- a/libs/utils/include/utils/JobSystem.h
+++ b/libs/utils/include/utils/JobSystem.h
@@ -256,7 +256,7 @@ public:
     void run(Job*& job, uint32_t flags = 0) noexcept;
     void run(Job*&& job, uint32_t flags = 0) noexcept { // allows run(createJob(...));
         Job* p = job;
-        run(p);
+        run(p, flags);
     }
 
     void signal() noexcept;


### PR DESCRIPTION
- one version of run() ignored the flags parameter
- don't immediately signal created jobs in froxelizer
  to avoid redundant calls to signal()