### PR TITLE
Revert GL backend handle tracking

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -361,10 +361,7 @@ template<typename D, typename ... ARGS>
 backend::Handle<D> OpenGLDriver::initHandle(ARGS&& ... args) noexcept {
     static_assert(sizeof(D) <= 208, "Handle<> too large");
     backend::Handle<D> h{ allocateHandle(sizeof(D)) };
-    registerHandleId(h.getId());
-
     D* addr = handle_cast<D *>(h);
-
     new(addr) D(std::forward<ARGS>(args)...);
 #if !defined(NDEBUG) && UTILS_HAS_RTTI
     addr->typeId = typeid(D).name();
@@ -404,7 +401,6 @@ void OpenGLDriver::destruct(Handle<B>& handle, D const* p) noexcept {
 #endif
         p->~D();
         mHandleArena.free(const_cast<D*>(p), sizeof(D));
-        unregisterHandleId(handle.getId());
     }
 }
 


### PR DESCRIPTION
This wasn't very useful in the first place because we're recycling
handles very quickly. Additionally there was a race condition
which cause false positives.

This reverts commit bc6acd5c5a1d7ee4b703fe9facfd8bf695b617d0.
This reverts commit 3a15756c78605395c4bdd2fa29d25587cc37e9f7.