### PR TITLE
demangle callstacks in debug builds (unixes only)

### DIFF
--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(${TARGET} PUBLIC tsl)
 
 if (ANDROID)
     target_link_libraries(${TARGET} PUBLIC log)
+    target_link_libraries(${TARGET} PRIVATE dl)
 endif()
 
 if (WIN32)
@@ -100,6 +101,7 @@ if (LINUX)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
     target_link_libraries(${TARGET} PRIVATE Threads::Threads)
+    target_link_libraries(${TARGET} PRIVATE dl)
 endif()
 
 # ==================================================================================================

--- a/libs/utils/include/utils/CallStack.h
+++ b/libs/utils/include/utils/CallStack.h
@@ -110,6 +110,8 @@ public:
 private:
     void update_gcc(size_t ignore) noexcept;
 
+    static utils::CString demangle(const char* mangled);
+
     static constexpr size_t NUM_FRAMES = 20;
 
     struct StackFrameInfo {


### PR DESCRIPTION
This requires dladdr() and __cxa_demangle().