### PR TITLE
Fix RenderTarget slice bug

### DIFF
--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -28,7 +28,7 @@ namespace filament {
 using namespace backend;
 
 struct RenderTarget::BuilderDetails {
-    FRenderTarget::Attachment mAttachments[RenderTarget::ATTACHMENT_COUNT];
+    FRenderTarget::Attachment mAttachments[RenderTarget::ATTACHMENT_COUNT] = {};
 };
 
 using BuilderType = RenderTarget;
@@ -102,12 +102,14 @@ FRenderTarget::HwHandle FRenderTarget::createHandle(FEngine& engine, const Build
     // note that post-processing includes FXAA by default.
     const uint8_t samples = 1;
 
-    const TargetBufferInfo cinfo(upcast(color.texture)->getHwHandle(),
-            color.mipLevel, color.face);
+    const TargetBufferInfo cinfo =
+            upcast(color.texture)->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP ?
+            TargetBufferInfo(upcast(color.texture)->getHwHandle(), color.mipLevel, color.face) :
+            TargetBufferInfo(upcast(color.texture)->getHwHandle(), color.mipLevel, color.layer);
 
     const TargetBufferInfo dinfo(
             depth.texture ? upcast(depth.texture)->getHwHandle() : TextureHandle(),
-            color.mipLevel, color.face);
+            color.mipLevel, color.layer);
 
     const uint32_t width = FTexture::valueForLevel(color.mipLevel, color.texture->getWidth());
     const uint32_t height = FTexture::valueForLevel(color.mipLevel, color.texture->getHeight());

--- a/filament/src/RenderTarget.cpp
+++ b/filament/src/RenderTarget.cpp
@@ -107,9 +107,11 @@ FRenderTarget::HwHandle FRenderTarget::createHandle(FEngine& engine, const Build
             TargetBufferInfo(upcast(color.texture)->getHwHandle(), color.mipLevel, color.face) :
             TargetBufferInfo(upcast(color.texture)->getHwHandle(), color.mipLevel, color.layer);
 
-    const TargetBufferInfo dinfo(
-            depth.texture ? upcast(depth.texture)->getHwHandle() : TextureHandle(),
-            color.mipLevel, color.layer);
+    auto dtexture = depth.texture ? upcast(depth.texture)->getHwHandle() : TextureHandle();
+    const TargetBufferInfo dinfo =
+            upcast(depth.texture)->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP ?
+            TargetBufferInfo(dtexture, depth.mipLevel, depth.face) :
+            TargetBufferInfo(dtexture, depth.mipLevel, depth.layer);
 
     const uint32_t width = FTexture::valueForLevel(color.mipLevel, color.texture->getWidth());
     const uint32_t height = FTexture::valueForLevel(color.mipLevel, color.texture->getHeight());


### PR DESCRIPTION
Inside `RenderTarget`, we're only ever constructing `TargetBufferInfo` with a `TextureCubemapFace`. This is problematic, because `TargetBufferInfo` uses a `union` to keep track of the face or layer:

```
    union {
        // face if texture is a cubemap
        TextureCubemapFace face;
        // for 3D textures
        uint16_t layer = 0;
    };
```

`TextureCubemapFace` occupies only 8 bits, so even if we pass in `POSITIVE_X` (value of 0), the full 16 bits of the union aren't set, and when reading back `layer` we read garbage.