### PR TITLE
Dof: cleanup and improve significantly foreground layer

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -106,6 +106,29 @@ float sampleCount(const float ringCount) {
     return s * s;
 }
 
+float getMipLevel(const float ringCount, const float kernelSize) {
+    #if KERNEL_USE_MIPMAP
+    // note: the 0.5 is to convert from highres to our downslampled texture
+    float ringDistanceInTexels = 0.5 * kernelSize * rcp(ringCount - 0.5);
+    float mip = log2(ringDistanceInTexels);
+
+    // We should round-up to avoid too large gaps in the kernel. Small gaps are filled by the
+    // median pass. With round() below + noise, most gaps are handled by the median pass,
+    // and the quality is much better overall.
+
+    #if defined(TARGET_MOBILE)
+    // on mobile, the mip level is not used in computations in the shader,
+    // so we just let the texture unit pick the the "nearest" mipmap level.
+    #else
+    mip = max(0.0, floor(mip + 0.5));
+    #endif
+
+    return mip;
+    #else
+    return 0.0;
+    #endif
+}
+
 float sampleWeight(const float coc, const float mip) {
     // The contribution of sample is inversely proportional to *it's* area
     // (the larger area, the fainter it is).
@@ -134,10 +157,6 @@ float intersection(const float border, const float absCoc, const float mip) {
 #endif
 }
 
-float rcp(const float x) {
-    return 1.0 / x;
-}
-
 highp vec2 diaphragm(const highp vec2 center, const vec2 offset) {
 #if DOF_DIAPHRAGM == DOF_DIAPHRAGM_CIRCLE
     return center + offset;
@@ -154,6 +173,8 @@ highp vec2 diaphragm(const highp vec2 center, const vec2 offset) {
 }
 
 /*
+ * Background (CoC > 0) field
+ *
  * We use a lot of techniques described in:
  * "Life of a Bokeh" by Guillaume Abadie, SIGGRAPH 2018
  */
@@ -199,10 +220,6 @@ void initRing(const float i, const float ringCount, const float kernelSize, cons
     // it might be okay to do this only for the center sample (i.e.: offset = radius instead)
     offset = length(p + noise * kernelSize);
 }
-
-/*
- * Backgorund accumulator
- */
 
 void mergeRings(inout Bucket curr, inout Bucket prev, const float count) {
     if (curr.cw >= MEDIUMP_FLT_MIN) {
@@ -274,12 +291,13 @@ void accumulateBackground(inout Bucket curr, inout Bucket prev, const highp vec2
 void accumulateBackgroundMirror(inout Bucket curr, inout Bucket prev,
         const highp vec2 center, const vec2 offset,
         const float radius, const float border, const float mip, const bool first) {
-    accumulateBackground(curr, prev, diaphragm(center,   offset), radius, border, mip, first);
-    accumulateBackground(curr, prev, diaphragm(center,  -offset), radius, border, mip, first);
+    accumulateBackground(curr, prev, diaphragm(center,  offset), radius, border, mip, first);
+    accumulateBackground(curr, prev, diaphragm(center, -offset), radius, border, mip, first);
 }
 
 void accumulateBackgroundCenter(inout Bucket prev,
-        const highp vec2 pos, const float ringCount, const float kernelSize, const float noiseRadius, const float mip) {
+        const highp vec2 pos, const float ringCount,
+        const float kernelSize, const float noiseRadius, const float mip) {
     Bucket curr;
     initBucket(curr);
     float border = (kernelSize / (ringCount - 0.5)) * 0.5;
@@ -290,8 +308,9 @@ void accumulateBackgroundCenter(inout Bucket prev,
     mergeRings(curr, prev, 1.0);
 }
 
-void accumulateRing(inout Bucket prev, const float index, const float ringCount, const float kernelSize, const vec2 noise,
-        const highp vec2 uvCenter, const highp vec2 cocToTexelOffset, const float mip, const bool first) {
+void accumulateRing(inout Bucket prev, const float index, const float ringCount,
+        const float kernelSize, const vec2 noise, const highp vec2 uvCenter,
+        const highp vec2 cocToTexelOffset, const float mip, const bool first) {
 
     // we accumulate the larger rings first
     float i = (ringCount - 1.0) - index;
@@ -322,14 +341,29 @@ void accumulateRing(inout Bucket prev, const float index, const float ringCount,
 }
 
 /*
- * Foreground accumulator
+ * Foreground (CoC < 0) field
+ *
+ * Here implement the 2-layer accumultaion technique described in
+ * "Next Generation Post Processing in Call of Duty Advanced Warfare" by J. Jimenez
+ * TODO: Adapt Unreal's ring binning for the foreground field
  */
+
+struct Layer {
+    vec4 color;
+    float weight;
+};
+
+float computeLayer(float coc, vec2 tiles) {
+    const float invTransitionSize = 1.0 / 2.0;
+    const float frontLayerCocSize = 2.0;
+    return 	saturate((coc - tiles.r - frontLayerCocSize) * invTransitionSize);
+}
 
 float foregroundFadding(const float coc) {
     return saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
 }
 
-void accumulateForeground(inout vec4 foreground, inout float opacity, inout float weight,
+void accumulateForeground(inout Layer layer[2], const vec2 tiles,
         const highp vec2 pos, const float border, const float mip) {
     float coc = textureLod(materialParams_cocFgBg, pos, mip).r;
     vec4 s = textureLod(materialParams_foreground, pos, mip);
@@ -338,21 +372,24 @@ void accumulateForeground(inout vec4 foreground, inout float opacity, inout floa
     float i = intersection(border, abs(coc), mip) * sampleWeight(coc, mip);
     float w = i * inLayer;
 
-    foreground += s * w;
-    opacity    += inLayer;
-    weight     += w;
+    float inBackWeight  = w * computeLayer(coc, tiles);
+    float inFrontWeight = w - inBackWeight;
+    layer[0].color  += inFrontWeight * s;
+    layer[0].weight += inFrontWeight;
+    layer[1].color  += inBackWeight * s;
+    layer[1].weight += inBackWeight;
 }
 
-void accumulateForegroundCenter(inout vec4 foreground, inout float opacity, inout float weight,
+void accumulateForegroundCenter(inout Layer layer[2], const vec2 tiles,
         const highp vec2 pos, const float border, const float mip) {
-    accumulateForeground(foreground, opacity, weight, pos, border, mip);
+    accumulateForeground(layer, tiles, pos, border, mip);
 }
 
-void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inout float weight,
+void accumulateForegroundMirror(inout Layer layer[2], const vec2 tiles,
         const highp vec2 center, const vec2 offset, const float border, const float mip) {
     // The code below is equivalent to:
-    //  accumulateForeground(foreground, opacity, weight, diaphragm(center,  offset), border, mip);
-    //  accumulateForeground(foreground, opacity, weight, diaphragm(center, -offset), border, mip);
+    //  accumulateForeground(layer, tiles, diaphragm(center,  offset), border, mip);
+    //  accumulateForeground(layer, tiles, diaphragm(center, -offset), border, mip);
     //  return;
     // but selects the min coc of opposite samples as a way to guess the color occluded by
     // the geometry.
@@ -370,33 +407,14 @@ void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inou
     float i = intersection(border, abs(coc), mip) * sampleWeight(coc, mip);
     float w = i * inLayer;
 
-    foreground += s0 * w;
-    foreground += s1 * w;
-    opacity    += inLayer * 2.0;  // we're accumulating 2 samples
-    weight     += w * 2.0;
-}
-
-float getMipLevel(const float ringCount, const float kernelSize) {
-#if KERNEL_USE_MIPMAP
-    // note: the 0.5 is to convert from highres to our downslampled texture
-    float ringDistanceInTexels = 0.5 * kernelSize * rcp(ringCount - 0.5);
-    float mip = log2(ringDistanceInTexels);
-
-    // We should round-up to avoid too large gaps in the kernel. Small gaps are filled by the
-    // median pass. With round() below + noise, most gaps are handled by the median pass,
-    // and the quality is much better overall.
-
-#if defined(TARGET_MOBILE)
-    // on mobile, the mip level is not used in computations in the shader,
-    // so we just let the texture unit pick the the "nearest" mipmap level.
-#else
-    mip = max(0.0, floor(mip + 0.5));
-#endif
-
-    return mip;
-#else
-    return 0.0;
-#endif
+    float inBackWeight  = w * computeLayer(coc, tiles);
+    float inFrontWeight = w - inBackWeight;
+    layer[0].color  += inFrontWeight * s0;
+    layer[0].color  += inFrontWeight * s1;
+    layer[0].weight += inFrontWeight * 2.0;
+    layer[1].color  += inBackWeight  * s0;
+    layer[1].color  += inBackWeight  * s1;
+    layer[1].weight += inBackWeight  * 2.0;
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
@@ -409,6 +427,7 @@ void postProcess(inout PostProcessInputs postProcess) {
      */
 
     if (isTrivialTile(tiles)) {
+        // The whole tile is is focus
         postProcess.color = vec4(0.0);
         postProcess.alpha = 0.0;
         return;
@@ -433,6 +452,7 @@ void postProcess(inout PostProcessInputs postProcess) {
 #endif
 
     if (isFastTile(tiles)) {
+        // The whole tile has mostly the same CoC
         float kernelSize = (abs(tiles.r) + abs(tiles.g)) * 0.5;
         float mip = getMipLevel(ringCountFast, kernelSize);
 
@@ -482,17 +502,21 @@ void postProcess(inout PostProcessInputs postProcess) {
     const float noiseRadius = 0.0;
 #endif
 
-
     if (isForegroundTile(tiles)) {
         // Here we know that tiles.r < 0, by definition of a foreground tile.
         // For a foreground tile, the kernel size is the largest CoC radius of the whole tile.
         float kernelSize = -tiles.r;
         float mip = getMipLevel(ringCountGather, kernelSize);
         vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
-        float weight = 0.0;
+
+        Layer layer[2];
+        layer[0].color = vec4(0.0);
+        layer[0].weight = 0.0;
+        layer[1].color = vec4(0.0);
+        layer[1].weight = 0.0;
 
         // the center sample is handled separately, since it's by itself
-        accumulateForegroundCenter(foreground, fgOpacity, weight, uvCenter, 0.0, mip);
+        accumulateForegroundCenter(layer, tiles, uvCenter, 0.0, mip);
 
         for (float i = 1.0; i < ringCountGather; i += 1.0) {
 
@@ -504,22 +528,23 @@ void postProcess(inout PostProcessInputs postProcess) {
             initRing(i, ringCountGather, kernelSize, noise, radius, count, r, p);
 
             for (float j = 0.0; j < count; j += 2.0) {
-                accumulateForegroundMirror(foreground, fgOpacity, weight,
+                accumulateForegroundMirror(layer, tiles,
                         uvCenter, p * cocToTexelOffset, radius, mip);
                 p = r * p;
             }
         }
 
-        if (weight < MEDIUMP_FLT_MIN) {
-            foreground *= 0.0;
-            fgOpacity  *= 0.0;
-        } else {
-            foreground *= rcp(weight);
-            fgOpacity  *= rcp(sampleCount(ringCountGather));
-        }
+        // Area of all samples in the kernel
+        float kernelArea = sampleCount(ringCountGather) * sampleWeight(kernelSize * ((ringCountGather + 0.5) / ringCountGather), mip);
+        float frontLayerOpacity = saturate(layer[0].weight * rcp(kernelArea));
+        float backLayerOpacity  = saturate(layer[1].weight * rcp(kernelArea));
+        vec4 front = layer[0].color * rcpOrZero(layer[0].weight) * frontLayerOpacity;
+        vec4 back  = layer[1].color * rcpOrZero(layer[1].weight) * backLayerOpacity;
+        foreground = front + back * (1.0 - frontLayerOpacity);
+        fgOpacity = 1.0 - (1.0 - frontLayerOpacity) * (1.0 - backLayerOpacity);
+        // foreground here is already premultiplied by fgOpacity!
         //foreground.r += 0.1;
     }
-
 
     if (isBackgroundTile(tiles)) {
         vec2 centerCoc  = textureLod(materialParams_cocFgBg, uv, 0.0).rg;
@@ -550,12 +575,8 @@ void postProcess(inout PostProcessInputs postProcess) {
 #else
         bgOpacity *= smoothstep(MAX_IN_FOCUS_COC, 2.0, kernelSize);
 #endif
-
-        if (prev.cw < MEDIUMP_FLT_MIN) {
-            background *= 0.0;
-        } else {
-            background *= rcp(prev.cw);
-        }
+        background *= rcpOrZero(prev.cw);
+        background *= bgOpacity;
         //background.g += 0.1;
     }
 
@@ -568,9 +589,6 @@ void postProcess(inout PostProcessInputs postProcess) {
     // composite the foreground and background layers together.
     // the downside of doing this is that we couldn't use a different upscaler for each
     // layer, but this is a lot less costly
-
-    foreground *= fgOpacity;
-    background *= bgOpacity;
     postProcess.color = foreground + (1.0 - fgOpacity) * background;
     postProcess.alpha = fgOpacity  + (1.0 - fgOpacity) * bgOpacity;
 }

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -120,7 +120,7 @@ float sampleWeight(const float coc, const float mip) {
 #if defined(TARGET_MOBILE)
     const float pixelRadiusSquared = 2.0;   // (sqrt(2) * 0.5 * 2.0)^2
 #else
-    float pixelRadiusSquared = pow(2.0, mip);
+    float pixelRadiusSquared = 2.0 * pow(2.0, mip);     // 2^(mip+1)
 #endif
     return (MAX_COC_RADIUS * MAX_COC_RADIUS) / (max(coc * coc, pixelRadiusSquared));
 }
@@ -329,11 +329,10 @@ void accumulateForeground(inout vec4 foreground, inout float opacity, inout floa
         const highp vec2 pos, const float border, const float mip) {
     float coc = textureLod(materialParams_cocFgBg, pos, mip).r;
     vec4 s = textureLod(materialParams_foreground, pos, mip);
-    float inLayer = isForeground(coc);
-    float o = cocToAlpha(coc) * inLayer;
+    float inLayer = isForeground(coc) * saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
     float w = intersection(border, abs(coc), mip) * sampleWeight(coc, mip) * inLayer;
     foreground += s * w;
-    opacity += o;
+    opacity += inLayer;
     i += w;
 }
 
@@ -358,12 +357,11 @@ void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inou
     float coc1 = textureLod(materialParams_cocFgBg, pos1, mip).r;
     vec4 s1 = textureLod(materialParams_foreground, pos1, mip);
     float coc = min(coc0, coc1);
-    float inLayer = isForeground(coc);
-    float o = cocToAlpha(coc) * inLayer * 2.0;  // we're accumulating 2 samples
+    float inLayer = isForeground(coc) * saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
     float w = intersection(border, abs(coc), mip) * sampleWeight(coc, mip) * inLayer;
     foreground += s0 * w;
     foreground += s1 * w;
-    opacity += o;
+    opacity += inLayer * 2.0;  // we're accumulating 2 samples
     i += w * 2.0;
 }
 

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -475,8 +475,9 @@ void postProcess(inout PostProcessInputs postProcess) {
 
 
     if (isForegroundTile(tiles)) {
-        // for a foreground tile, the kernel size is the largest CoC radius
-        float kernelSize = -tiles.g;
+        // Here we know that tiles.r < 0, by definition of a foreground tile.
+        // For a foreground tile, the kernel size is the largest CoC radius of the whole tile.
+        float kernelSize = -tiles.r;
         float mip = getMipLevel(ringCountGather, kernelSize);
         vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
         float c = 0.0;

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -325,27 +325,34 @@ void accumulateRing(inout Bucket prev, const float index, const float ringCount,
  * Foreground accumulator
  */
 
-void accumulateForeground(inout vec4 foreground, inout float opacity, inout float i,
+float foregroundFadding(const float coc) {
+    return saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
+}
+
+void accumulateForeground(inout vec4 foreground, inout float opacity, inout float weight,
         const highp vec2 pos, const float border, const float mip) {
     float coc = textureLod(materialParams_cocFgBg, pos, mip).r;
     vec4 s = textureLod(materialParams_foreground, pos, mip);
-    float inLayer = isForeground(coc) * saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
-    float w = intersection(border, abs(coc), mip) * sampleWeight(coc, mip) * inLayer;
+
+    float inLayer = isForeground(coc) * foregroundFadding(coc);
+    float i = intersection(border, abs(coc), mip) * sampleWeight(coc, mip);
+    float w = i * inLayer;
+
     foreground += s * w;
-    opacity += inLayer;
-    i += w;
+    opacity    += inLayer;
+    weight     += w;
 }
 
-void accumulateForegroundCenter(inout vec4 foreground, inout float opacity, inout float i,
+void accumulateForegroundCenter(inout vec4 foreground, inout float opacity, inout float weight,
         const highp vec2 pos, const float border, const float mip) {
-    accumulateForeground(foreground, opacity, i, pos, border, mip);
+    accumulateForeground(foreground, opacity, weight, pos, border, mip);
 }
 
-void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inout float i,
+void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inout float weight,
         const highp vec2 center, const vec2 offset, const float border, const float mip) {
     // The code below is equivalent to:
-    //  accumulateForeground(foreground, opacity, i, diaphragm(center,  offset), border, mip);
-    //  accumulateForeground(foreground, opacity, i, diaphragm(center, -offset), border, mip);
+    //  accumulateForeground(foreground, opacity, weight, diaphragm(center,  offset), border, mip);
+    //  accumulateForeground(foreground, opacity, weight, diaphragm(center, -offset), border, mip);
     //  return;
     // but selects the min coc of opposite samples as a way to guess the color occluded by
     // the geometry.
@@ -353,16 +360,20 @@ void accumulateForegroundMirror(inout vec4 foreground, inout float opacity, inou
     vec2 pos0 = diaphragm(center, offset);
     float coc0 = textureLod(materialParams_cocFgBg, pos0, mip).r;
     vec4 s0 = textureLod(materialParams_foreground, pos0, mip);
+
     vec2 pos1 = diaphragm(center, -offset);
     float coc1 = textureLod(materialParams_cocFgBg, pos1, mip).r;
     vec4 s1 = textureLod(materialParams_foreground, pos1, mip);
+
     float coc = min(coc0, coc1);
-    float inLayer = isForeground(coc) * saturate(abs(coc) - (MAX_IN_FOCUS_COC - 1.0));
-    float w = intersection(border, abs(coc), mip) * sampleWeight(coc, mip) * inLayer;
+    float inLayer = isForeground(coc) * foregroundFadding(coc);
+    float i = intersection(border, abs(coc), mip) * sampleWeight(coc, mip);
+    float w = i * inLayer;
+
     foreground += s0 * w;
     foreground += s1 * w;
-    opacity += inLayer * 2.0;  // we're accumulating 2 samples
-    i += w * 2.0;
+    opacity    += inLayer * 2.0;  // we're accumulating 2 samples
+    weight     += w * 2.0;
 }
 
 float getMipLevel(const float ringCount, const float kernelSize) {
@@ -478,10 +489,10 @@ void postProcess(inout PostProcessInputs postProcess) {
         float kernelSize = -tiles.r;
         float mip = getMipLevel(ringCountGather, kernelSize);
         vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
-        float c = 0.0;
+        float weight = 0.0;
 
         // the center sample is handled separately, since it's by itself
-        accumulateForegroundCenter(foreground, fgOpacity, c, uvCenter, 0.0, mip);
+        accumulateForegroundCenter(foreground, fgOpacity, weight, uvCenter, 0.0, mip);
 
         for (float i = 1.0; i < ringCountGather; i += 1.0) {
 
@@ -493,17 +504,17 @@ void postProcess(inout PostProcessInputs postProcess) {
             initRing(i, ringCountGather, kernelSize, noise, radius, count, r, p);
 
             for (float j = 0.0; j < count; j += 2.0) {
-                accumulateForegroundMirror(foreground, fgOpacity, c,
+                accumulateForegroundMirror(foreground, fgOpacity, weight,
                         uvCenter, p * cocToTexelOffset, radius, mip);
                 p = r * p;
             }
         }
 
-        if (c < MEDIUMP_FLT_MIN) {
+        if (weight < MEDIUMP_FLT_MIN) {
             foreground *= 0.0;
             fgOpacity  *= 0.0;
         } else {
-            foreground *= rcp(c);
+            foreground *= rcp(weight);
             fgOpacity  *= rcp(sampleCount(ringCountGather));
         }
         //foreground.r += 0.1;

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -76,12 +76,10 @@ fragment {
 #define DOF_DIAPHRAGM                   DOF_DIAPHRAGM_CIRCLE
 
 // # of sample w.r.t. ring count and density of 8
-// 3 rings : 25
-// 4 rings : 49
-// 5 rings : 81
-
-// don't change density
-#define RING_DENSITY        8
+//  3 rings :   25 ( 5^2 grid)
+//  4 rings :   49 ( 7^2 grid)
+//  5 rings :   81 ( 9^2 grid)
+// 17 rings : 1089 (33^2 grid) -- maximum needed for a CoC of 32
 
 #if defined(TARGET_MOBILE)
 #define RING_COUNT_GATHER   3
@@ -104,8 +102,8 @@ fragment {
 void dummy(){}
 
 float sampleCount(const float ringCount) {
-    const float ringDensity = float(RING_DENSITY);
-    return (ringDensity * ringCount * (ringCount - 1.0)) * 0.5 + 1.0;
+    float s = (ringCount * 2.0 - 1.0);
+    return s * s;
 }
 
 float sampleWeight(const float coc, const float mip) {
@@ -181,11 +179,15 @@ void initBucket(out Bucket ring) {
 
 void initRing(const float i, const float ringCount, const float kernelSize, const vec2 noise,
         out float offset, out float count, out mat2 r, out vec2 p) {
-    const float ringDensity = float(RING_DENSITY);
     float radius = (kernelSize / (ringCount - 0.5)) * i;
 
-    // this is never called with i == 0
-    count = ringDensity * i;
+    // We want to create a (2k+1)(2k+1) box, that is a n*n grid with n odd.
+    // Each "ring" is the outside layer of that box. So ring 0 obviously is the 1x1 box,
+    // ring 1 is the 3x3 box, which has 8 samples on its outside layer. This is where the 8 below
+    // comes from, then all subsequent rings, are built from ring 1.
+    // Each box is then "morphed" to a circle, itself morphed to the shape we want for the bokeh
+    // (see diaphragm()).
+    count = 8.0 * i;    // this is never called with i == 0
 
     float inc = 2.0 * PI / count;
     vec2 t = vec2(cos(inc), sin(inc));

--- a/filament/src/materials/dof/dofDilate.mat
+++ b/filament/src/materials/dof/dofDilate.mat
@@ -48,8 +48,8 @@ vec2 dilate(inout vec2 center, const vec2 tap) {
     //    center.g = min(center.g, max(tap.g, maxDistance));
     //    center.r = max(center.r, max(tap.r, maxDistance));
 
-    center.g = min(center.g, tap.g);
-    center.r = max(center.r, tap.r);
+    center.r = min(center.r, tap.r);
+    center.g = max(center.g, tap.g);
     return center;
 }
 

--- a/filament/src/materials/dof/dofDownsample.mat
+++ b/filament/src/materials/dof/dofDownsample.mat
@@ -105,8 +105,7 @@ void postProcess(inout PostProcessInputs postProcess) {
     // abs() is not needed since bgCoc - w is guaranteed to be >= 0.
     float bgCoc = max2(max(w.xy, w.zw));
     vec4 bw = saturate(1.0 - (bgCoc - w)) * hdr;
-    float bgScale = 1.0 / (bw.x + bw.y + bw.z + bw.w);
-    vec4 background = (s01 * bw.x + s11 * bw.y + s10 * bw.z + s00 * bw.w) * bgScale;
+    vec4 background = (s01 * bw.x + s11 * bw.y + s10 * bw.z + s00 * bw.w) * (1.0 / (bw.x + bw.y + bw.z + bw.w));
 
     // If CoC is less that 0.5 full resolution pixel, we clamp to 0, this will reduce
     // artifacts in the "in focus" area and allow us to skip more tiles trivially.

--- a/filament/src/materials/dof/dofTiles.mat
+++ b/filament/src/materials/dof/dofTiles.mat
@@ -58,11 +58,11 @@ void postProcess(inout PostProcessInputs postProcess) {
     vec4 b = vec4(s01.g, s11.g, s10.g, s00.g);
 #endif
 
-    // compute tile's max CoC
-    postProcess.color.r = max4(max(f, b));
-
     // compute tile's min CoC
-    postProcess.color.g = min4(min(f, b));
+    postProcess.color.r = min4(min(f, b));
+
+    // compute tile's max CoC
+    postProcess.color.g = max4(max(f, b));
 }
 
 }

--- a/filament/src/materials/dof/dofUtils.fs
+++ b/filament/src/materials/dof/dofUtils.fs
@@ -62,12 +62,12 @@ float isBackground(const float coc) {
 
 bool isForegroundTile(const vec2 tiles) {
     // A foreground tile is one where the smallest CoC is negative
-    return tiles.g < 0.0;
+    return tiles.r < 0.0;
 }
 
 bool isBackgroundTile(const vec2 tiles) {
     // A background tile is one where the largest CoC is positive
-    return tiles.r > 0.0;
+    return tiles.g > 0.0;
 }
 
 bool isFastTile(const vec2 tiles) {
@@ -76,7 +76,7 @@ bool isFastTile(const vec2 tiles) {
     // We could cannot use the absolute value of the min/mac CoC -- which would categorize more
     // tiles as "fast" (e.g. when both the foreground and background have similar CoC), because
     // it doesn't tell us anything about objects that could be in between.
-    return (tiles.r - tiles.g) <= abs(tiles.r) * 0.05;
+    return (tiles.g - tiles.r) <= abs(tiles.g) * 0.05;
 }
 
 bool isTrivialTile(const vec2 tiles) {

--- a/filament/src/materials/dof/dofUtils.fs
+++ b/filament/src/materials/dof/dofUtils.fs
@@ -37,6 +37,14 @@ float min4(const vec4 v) {
     return min2(min(v.xy, v.zw));
 }
 
+float rcp(const float x) {
+    return 1.0 / x;
+}
+
+float rcpOrZero(const float x) {
+    return x > MEDIUMP_FLT_MIN ? (1.0 / x) : 0.0;
+}
+
 float cocToAlpha(const float coc) {
     // CoC is positive for background field.
     // CoC is negative for the foreground field.


### PR DESCRIPTION
We're implementing the two-layer technique described in
Jimenez DoF paper, where the foreground field is split in two layers, front
and back. In addition we compute accurately the foreground field alpha.

From a performance standpoint, most of the extra work is increased
register pressure and a bit of ALU.

![before](https://user-images.githubusercontent.com/1240896/112055487-26b5fd80-8b14-11eb-8cb1-c8957f40b3b3.png)
![after](https://user-images.githubusercontent.com/1240896/112055491-2a498480-8b14-11eb-903f-38283d10afae.png)
