### PR TITLE
Introduce BufferObject API.

### DIFF
--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -56,6 +56,7 @@ set(VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/libfilament-jni.map")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${VERSION_SCRIPT}")
 
 add_library(filament-jni SHARED
+    src/main/cpp/BufferObject.cpp
     src/main/cpp/Camera.cpp
     src/main/cpp/Colors.cpp
     src/main/cpp/ColorGrading.cpp

--- a/android/filament-android/src/main/cpp/BufferObject.cpp
+++ b/android/filament-android/src/main/cpp/BufferObject.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include <functional>
+#include <stdlib.h>
+#include <string.h>
+
+#include <filament/BufferObject.h>
+
+#include <backend/BufferDescriptor.h>
+
+#include "common/CallbackUtils.h"
+#include "common/NioUtils.h"
+
+using namespace filament;
+using namespace backend;
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_BufferObject_nCreateBuilder(JNIEnv *env, jclass type) {
+    return (jlong) new BufferObject::Builder();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_BufferObject_nDestroyBuilder(JNIEnv *env, jclass type,
+        jlong nativeBuilder) {
+    BufferObject::Builder* builder = (BufferObject::Builder *) nativeBuilder;
+    delete builder;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_BufferObject_nBuilderSize(JNIEnv *env, jclass type,
+        jlong nativeBuilder, jint byteCount) {
+    BufferObject::Builder* builder = (BufferObject::Builder *) nativeBuilder;
+    builder->size((uint32_t) byteCount);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_BufferObject_nBuilderBindingType(JNIEnv *env, jclass type,
+        jlong nativeBuilder, jint bindingType) {
+    using BindingType = BufferObject::BindingType;
+    BufferObject::Builder* builder = (BufferObject::Builder *) nativeBuilder;
+    BindingType types[] = {BindingType::VERTEX};
+    builder->bindingType(types[bindingType]);
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_BufferObject_nBuilderBuild(JNIEnv *env, jclass type,
+        jlong nativeBuilder, jlong nativeEngine) {
+    BufferObject::Builder* builder = (BufferObject::Builder *) nativeBuilder;
+    Engine *engine = (Engine *) nativeEngine;
+    return (jlong) builder->build(*engine);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_BufferObject_nGetByteCount(JNIEnv *env, jclass type,
+        jlong nativeBufferObject) {
+    BufferObject *bufferObject = (BufferObject *) nativeBufferObject;
+    return (jint) bufferObject->getByteCount();
+}
+
+extern "C" JNIEXPORT int JNICALL
+Java_com_google_android_filament_BufferObject_nSetBuffer(JNIEnv *env, jclass type,
+        jlong nativeBufferObject, jlong nativeEngine, jobject buffer, int remaining,
+        jint destOffsetInBytes, jint count,
+        jobject handler, jobject runnable) {
+    BufferObject *bufferObject = (BufferObject *) nativeBufferObject;
+    Engine *engine = (Engine *) nativeEngine;
+
+    AutoBuffer nioBuffer(env, buffer, count);
+    void* data = nioBuffer.getData();
+    size_t sizeInBytes = nioBuffer.getSize();
+    if (sizeInBytes > (remaining << nioBuffer.getShift())) {
+        // BufferOverflowException
+        return -1;
+    }
+
+    auto* callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
+
+    BufferDescriptor desc(data, sizeInBytes, &JniBufferCallback::invoke, callback);
+
+    bufferObject->setBuffer(*engine, std::move(desc), (uint32_t) destOffsetInBytes);
+
+    return 0;
+}

--- a/android/filament-android/src/main/cpp/VertexBuffer.cpp
+++ b/android/filament-android/src/main/cpp/VertexBuffer.cpp
@@ -51,6 +51,13 @@ Java_com_google_android_filament_VertexBuffer_nBuilderVertexCount(JNIEnv *env, j
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_VertexBuffer_nBuilderEnableBufferObjects(JNIEnv *env, jclass type,
+        jlong nativeBuilder, jboolean enabled) {
+    VertexBuffer::Builder* builder = (VertexBuffer::Builder *) nativeBuilder;
+    builder->enableBufferObjects(enabled);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_VertexBuffer_nBuilderBufferCount(JNIEnv *env, jclass type,
         jlong nativeBuilder, jint bufferCount) {
     VertexBuffer::Builder* builder = (VertexBuffer::Builder *) nativeBuilder;
@@ -113,6 +120,15 @@ Java_com_google_android_filament_VertexBuffer_nSetBufferAt(JNIEnv *env, jclass t
             (uint32_t) destOffsetInBytes);
 
     return 0;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_VertexBuffer_nSetBufferObjectAt(JNIEnv *env, jclass type,
+        jlong nativeVertexBuffer, jlong nativeEngine, jint bufferIndex, jlong nativeBufferObject) {
+    VertexBuffer *vertexBuffer = (VertexBuffer *) nativeVertexBuffer;
+    Engine *engine = (Engine *) nativeEngine;
+    BufferObject *bufferObject = (BufferObject *) nativeBufferObject;
+    vertexBuffer->setBufferObjectAt(*engine, (uint8_t) bufferIndex, bufferObject);
 }
 
 extern "C" [[deprecated]] JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/BufferObject.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/BufferObject.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament;
+
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.nio.Buffer;
+import java.nio.BufferOverflowException;
+
+/**
+ * A generic GPU buffer containing data.
+ *
+ * Usage of this BufferObject is optional. For simple use cases it is not necessary. It is useful
+ * only when you need to share data between multiple VertexBuffer instances. It also allows you to
+ * efficiently swap-out the buffers in VertexBuffer.
+ *
+ * NOTE: For now this is only used for vertex data, but in the future we may use it for other things
+ * (e.g. compute).
+ *
+ * @see VertexBuffer
+ */
+public class BufferObject {
+    private long mNativeObject;
+
+    private BufferObject(long nativeBufferObject) {
+        mNativeObject = nativeBufferObject;
+    }
+
+    public static class Builder {
+        @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
+        // Keep to finalize native resources
+        private final BuilderFinalizer mFinalizer;
+        private final long mNativeBuilder;
+
+        public enum BindingType {
+            VERTEX,
+        }
+
+        public Builder() {
+            mNativeBuilder = nCreateBuilder();
+            mFinalizer = new BuilderFinalizer(mNativeBuilder);
+        }
+
+        /**
+         * Size of the buffer in bytes.
+         *
+         * @param byteCount Maximum number of bytes the BufferObject can hold.
+         * @return A reference to this Builder for chaining calls.
+         */
+        @NonNull
+        public Builder size(@IntRange(from = 1) int byteCount) {
+            nBuilderSize(mNativeBuilder, byteCount);
+            return this;
+        }
+
+        /**
+         * The binding type for this buffer object. (defaults to VERTEX)
+         *
+         * @param BindingType Distinguishes between SSBO, VBO, etc. For now this must be VERTEX.
+         * @return A reference to this Builder for chaining calls.
+         */
+        @NonNull
+        public Builder bindingType(@NonNull BindingType bindingType) {
+            nBuilderBindingType(mNativeBuilder, bindingType.ordinal());
+            return this;
+        }
+
+        /**
+         * Creates and returns the <code>BufferObject</code> object. After creation, the buffer
+         * is uninitialized. Use {@link #setBuffer} to initialize the <code>BufferObject</code>.
+         *
+         * @param engine reference to the {@link Engine} to associate this <code>BufferObject</code>
+         *               with
+         *
+         * @return the newly created <code>BufferObject</code> object
+         *
+         * @exception IllegalStateException if the BufferObject could not be created
+         *
+         * @see #setBuffer
+         */
+        @NonNull
+        public BufferObject build(@NonNull Engine engine) {
+            long nativeBufferObject = nBuilderBuild(mNativeBuilder, engine.getNativeObject());
+            if (nativeBufferObject == 0)
+                throw new IllegalStateException("Couldn't create BufferObject");
+            return new BufferObject(nativeBufferObject);
+        }
+
+        private static class BuilderFinalizer {
+            private final long mNativeObject;
+
+            BuilderFinalizer(long nativeObject) {
+                mNativeObject = nativeObject;
+            }
+
+            @Override
+            public void finalize() {
+                try {
+                    super.finalize();
+                } catch (Throwable t) { // Ignore
+                } finally {
+                    nDestroyBuilder(mNativeObject);
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the size of this <code>BufferObject</code> in elements.
+     *
+     * @return the number of bytes the <code>BufferObject</code> holds
+     */
+    @IntRange(from = 0)
+    public int getByteCount() {
+        return nGetByteCount(getNativeObject());
+    }
+
+    /**
+     * Asynchronously copy-initializes this <code>BufferObject</code> from the data provided.
+     *
+     * @param engine            reference to the {@link Engine} to associate this
+     *                          <code>BufferObject</code> with
+     * @param buffer            a CPU-side {@link Buffer} with the data used to initialize the
+     *                          <code>BufferObject</code>.
+     */
+    public void setBuffer(@NonNull Engine engine, @NonNull Buffer buffer) {
+        setBuffer(engine, buffer, 0, 0, null, null);
+    }
+
+    /**
+     * Asynchronously copy-initializes a region of this <code>BufferObject</code> from the data
+     * provided.
+     *
+     * @param engine            reference to the {@link Engine} to associate this
+     *                          <code>BufferObject</code> with
+     * @param buffer            a CPU-side {@link Buffer} with the data used to initialize the
+     *                          <code>BufferObject</code>.
+     * @param destOffsetInBytes offset in <i>bytes</i> into the <code>BufferObject</code>
+     * @param count             number of bytes to consume, defaults to
+     *                          <code>buffer.remaining()</code>
+     */
+    public void setBuffer(@NonNull Engine engine, @NonNull Buffer buffer,
+            @IntRange(from = 0) int destOffsetInBytes, @IntRange(from = 0) int count) {
+        setBuffer(engine, buffer, destOffsetInBytes, count, null, null);
+    }
+
+    /**
+     * Asynchronously copy-initializes a region of this <code>BufferObject</code> from the data
+     * provided.
+     *
+     * @param engine            reference to the {@link Engine} to associate this
+     *                          <code>BufferObject</code> with
+     * @param buffer            a CPU-side {@link Buffer} with the data used to initialize the
+     *                          <code>BufferObject</code>.
+     * @param destOffsetInBytes offset in <i>bytes</i> into the <code>BufferObject</code>
+     * @param count             number of bytes to consume, defaults to
+     *                          <code>buffer.remaining()</code>
+     * @param handler           an {@link java.util.concurrent.Executor Executor}. On Android this
+     *                          can also be a {@link android.os.Handler Handler}.
+     * @param callback          a callback executed by <code>handler</code> when <code>buffer</code>
+     *                          is no longer needed.
+     */
+    public void setBuffer(@NonNull Engine engine, @NonNull Buffer buffer,
+            @IntRange(from = 0) int destOffsetInBytes, @IntRange(from = 0) int count,
+            @Nullable Object handler, @Nullable Runnable callback) {
+        int result = nSetBuffer(getNativeObject(), engine.getNativeObject(), buffer, buffer.remaining(),
+                destOffsetInBytes, count == 0 ? buffer.remaining() : count, handler, callback);
+        if (result < 0) {
+            throw new BufferOverflowException();
+        }
+    }
+
+    public long getNativeObject() {
+        if (mNativeObject == 0) {
+            throw new IllegalStateException("Calling method on destroyed BufferObject");
+        }
+        return mNativeObject;
+    }
+
+    void clearNativeObject() {
+        mNativeObject = 0;
+    }
+
+    private static native long nCreateBuilder();
+    private static native void nDestroyBuilder(long nativeBuilder);
+    private static native void nBuilderSize(long nativeBuilder, int byteCount);
+    private static native void nBuilderBindingType(long nativeBuilder, int bindingType);
+    private static native long nBuilderBuild(long nativeBuilder, long nativeEngine);
+
+    private static native int nGetByteCount(long nativeBufferObject);
+    private static native int nSetBuffer(long nativeBufferObject, long nativeEngine,
+            Buffer buffer, int remaining,
+            int destOffsetInBytes, int count, Object handler, Runnable callback);
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/VertexBuffer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/VertexBuffer.java
@@ -171,6 +171,21 @@ public class VertexBuffer {
         }
 
         /**
+         * Allows buffers to be swapped out and shared using BufferObject.
+         *
+         * If buffer objects mode is enabled, clients must call setBufferObjectAt rather than
+         * setBufferAt. This allows sharing of data between VertexBuffer objects, but it may
+         * slightly increase the memory footprint of Filament's internal bookkeeping.
+         *
+         * @param enabled If true, enables buffer object mode.  False by default.
+         */
+        @NonNull
+        public Builder enableBufferObjects(boolean enabled) {
+            nBuilderEnableBufferObjects(mNativeBuilder, enabled);
+            return this;
+        }
+
+        /**
          * Defines how many buffers will be created in this vertex buffer set. These buffers are
          * later referenced by index from 0 to <code>bufferCount</code> - 1.
          *
@@ -397,6 +412,23 @@ public class VertexBuffer {
             throw new BufferOverflowException();
         }
     }
+
+    /**
+     * Swaps in the given buffer object.
+     *
+     * To use this, you must first call enableBufferObjects() on the Builder.
+     *
+     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
+     * @param bufferIndex Index of the buffer to initialize. Must be between 0
+     *                    and Builder::bufferCount() - 1.
+     * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
+     */
+    public void setBufferObjectAt(@NonNull Engine engine, int bufferIndex,
+            @NonNull BufferObject bufferObject) {
+        nSetBufferObjectAt(getNativeObject(), engine.getNativeObject(), bufferIndex,
+                bufferObject.getNativeObject());
+    }
+
     /**
      * Convenience function that consumes normal vectors (and, optionally, tangent vectors) and
      * produces quaternions that can be passed into a TANGENTS buffer.
@@ -443,6 +475,7 @@ public class VertexBuffer {
     private static native long nCreateBuilder();
     private static native void nDestroyBuilder(long nativeBuilder);
     private static native void nBuilderVertexCount(long nativeBuilder, int vertexCount);
+    private static native void nBuilderEnableBufferObjects(long nativeBuilder, boolean enabled);
     private static native void nBuilderBufferCount(long nativeBuilder, int bufferCount);
     private static native void nBuilderAttribute(long nativeBuilder, int attribute,
             int bufferIndex, int attributeType, int byteOffset, int byteStride);
@@ -454,6 +487,9 @@ public class VertexBuffer {
     private static native int nSetBufferAt(long nativeVertexBuffer, long nativeEngine,
             int bufferIndex, Buffer buffer, int remaining, int destOffsetInBytes, int count,
             Object handler, Runnable callback);
+
+    private static native void nSetBufferObjectAt(long nativeVertexBuffer, long nativeEngine,
+            int bufferIndex, long nativeBufferObject);
 
     private static native void nPopulateTangentQuaternions(int quatType, int quatCount,
             Buffer outBuffer, int outRemaining, int outStride, Buffer normals, int normalsRemaining,

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MATERIAL_DIR "${GENERATION_ROOT}/generated/material")
 
 set(PUBLIC_HDRS
         include/filament/Box.h
+        include/filament/BufferObject.h
         include/filament/Camera.h
         include/filament/Color.h
         include/filament/ColorGrading.h
@@ -44,6 +45,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/Box.cpp
+        src/BufferObject.cpp
         src/Camera.cpp
         src/Color.cpp
         src/ColorGrading.cpp
@@ -112,6 +114,7 @@ set(PRIVATE_HDRS
         src/components/RenderableManager.h
         src/components/TransformManager.h
         src/details/Allocators.h
+        src/details/BufferObject.h
         src/details/Camera.h
         src/details/ColorGrading.h
         src/details/Culler.h

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -263,6 +263,11 @@ enum class ElementType : uint8_t {
     HALF4,
 };
 
+//! Buffer object binding type
+enum class BufferObjectBinding : uint8_t {
+    VERTEX,
+};
+
 //! Face culling Mode
 enum class CullingMode : uint8_t {
     NONE,               //!< No culling, front and back faces are visible

--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -24,6 +24,7 @@
 namespace filament {
 namespace backend {
 
+struct HwBufferObject;
 struct HwFence;
 struct HwIndexBuffer;
 struct HwProgram;
@@ -96,6 +97,7 @@ private:
 
 // Types used by the command stream
 // (we use this renaming because the macro-system doesn't deal well with "<" and ">")
+using BufferObjectHandle    = Handle<HwBufferObject>;
 using FenceHandle           = Handle<HwFence>;
 using IndexBufferHandle     = Handle<HwIndexBuffer>;
 using ProgramHandle         = Handle<HwProgram>;

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -168,12 +168,17 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
         backend::AttributeArray, attributes,
-        backend::BufferUsage, usage)
+        backend::BufferUsage, usage,
+        bool, bufferObjectsEnabled)
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
         uint32_t, indexCount,
         backend::BufferUsage, usage)
+
+DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
+        uint32_t, byteCount,
+        backend::BufferObjectBinding, bindingType)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
@@ -261,6 +266,7 @@ DECL_DRIVER_API_R_0(backend::TimerQueryHandle, createTimerQuery)
 
 DECL_DRIVER_API_N(destroyVertexBuffer,    backend::VertexBufferHandle, vbh)
 DECL_DRIVER_API_N(destroyIndexBuffer,     backend::IndexBufferHandle, ibh)
+DECL_DRIVER_API_N(destroyBufferObject,    backend::BufferObjectHandle, ibh)
 DECL_DRIVER_API_N(destroyRenderPrimitive, backend::RenderPrimitiveHandle, rph)
 DECL_DRIVER_API_N(destroyProgram,         backend::ProgramHandle, ph)
 DECL_DRIVER_API_N(destroySamplerGroup,    backend::SamplerGroupHandle, sbh)
@@ -311,8 +317,18 @@ DECL_DRIVER_API_N(updateVertexBuffer,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
+DECL_DRIVER_API_N(setVertexBufferObject,
+        backend::VertexBufferHandle, vbh,
+        size_t, index,
+        backend::BufferObjectHandle, bufferObject)
+
 DECL_DRIVER_API_N(updateIndexBuffer,
         backend::IndexBufferHandle, ibh,
+        backend::BufferDescriptor&&, data,
+        uint32_t, byteOffset)
+
+DECL_DRIVER_API_N(updateBufferObject,
+        backend::BufferObjectHandle, ibh,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 

--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -606,6 +606,13 @@ io::ostream& operator<<(io::ostream& out, RenderPassParams const& params) {
     return out;
 }
 
+io::ostream& operator<<(io::ostream& out, BufferObjectBinding wrap) {
+    switch (wrap) {
+        CASE(BufferObjectBinding, VERTEX)
+    }
+    return out;
+}
+
 #undef CASE
 
 #endif // !NDEBUG

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -55,17 +55,21 @@ struct HwVertexBuffer : public HwBase {
     uint32_t vertexCount{};               //   4
     uint8_t bufferCount{};                //   1
     uint8_t attributeCount{};             //   1
-    uint8_t padding[2]{};                 //   2 -> total struct is 136 bytes
+    bool bufferObjectsEnabled{};          //   1
+    uint8_t bufferObjectsVersion{};       //   1 -> total struct is 136 bytes
 
     HwVertexBuffer() noexcept = default;
     HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            AttributeArray const& attributes) noexcept
+            AttributeArray const& attributes, bool bufferObjectsEnabled) noexcept
             : attributes(attributes),
               vertexCount(elementCount),
               bufferCount(bufferCount),
-              attributeCount(attributeCount) {
+              attributeCount(attributeCount),
+              bufferObjectsEnabled(bufferObjectsEnabled) {
     }
 };
+
+struct HwBufferObject : public HwBase {};
 
 struct HwIndexBuffer : public HwBase {
     uint32_t count{};

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -160,16 +160,21 @@ void MetalDriver::finish(int) {
 
 void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
         uint8_t attributeCount, uint32_t vertexCount, AttributeArray attributes,
-        BufferUsage usage) {
+        BufferUsage usage, bool bufferObjectsEnabled) {
     // TODO: Take BufferUsage into account when creating the buffer.
     construct_handle<MetalVertexBuffer>(mHandleMap, vbh, *mContext, bufferCount,
-            attributeCount, vertexCount, attributes);
+            attributeCount, vertexCount, attributes, bufferObjectsEnabled);
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
         uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     construct_handle<MetalIndexBuffer>(mHandleMap, ibh, *mContext, elementSize, indexCount);
+}
+
+void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
+        BufferObjectBinding bindingType) {
+    // TODO
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
@@ -321,6 +326,11 @@ Handle<HwIndexBuffer> MetalDriver::createIndexBufferS() noexcept {
     return alloc_handle<MetalIndexBuffer, HwIndexBuffer>();
 }
 
+Handle<HwBufferObject> MetalDriver::createBufferObjectS() noexcept {
+    // TODO
+    return {};
+}
+
 Handle<HwTexture> MetalDriver::createTextureS() noexcept {
     return alloc_handle<MetalTexture, HwTexture>();
 }
@@ -396,6 +406,12 @@ void MetalDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 void MetalDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         destruct_handle<MetalIndexBuffer>(mHandleMap, ibh);
+    }
+}
+
+void MetalDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
+    if (boh) {
+        // TODO
     }
 }
 
@@ -644,6 +660,16 @@ void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&
     auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
     ib->buffer.copyIntoBuffer(data.buffer, data.size);
     scheduleDestroy(std::move(data));
+}
+
+void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& data,
+        uint32_t byteOffset) {
+    // TODO
+}
+
+void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
+        Handle<HwBufferObject> boh) {
+    // TODO
 }
 
 void MetalDriver::update2DImage(Handle<HwTexture> th, uint32_t level, uint32_t xoffset,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -114,7 +114,7 @@ private:
 
 struct MetalVertexBuffer : public HwVertexBuffer {
     MetalVertexBuffer(MetalContext& context, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t vertexCount, AttributeArray const& attributes);
+            uint32_t vertexCount, AttributeArray const& attributes, bool bufferObjectsEnabled);
     ~MetalVertexBuffer();
 
     std::vector<MetalBuffer*> buffers;

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -267,8 +267,9 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
 }
 
 MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
-            uint8_t attributeCount, uint32_t vertexCount, AttributeArray const& attributes)
-    : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes) {
+            uint8_t attributeCount, uint32_t vertexCount, AttributeArray const& attributes,
+            bool bufferObjectsEnabled)
+    : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes, bufferObjectsEnabled) {
     buffers.reserve(bufferCount);
 
     for (uint8_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -85,6 +85,9 @@ void NoopDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 void NoopDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
 }
 
+void NoopDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
+}
+
 void NoopDriver::destroyTexture(Handle<HwTexture> th) {
 }
 
@@ -180,6 +183,15 @@ void NoopDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
 void NoopDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     scheduleDestroy(std::move(p));
+}
+
+void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor&& p,
+        uint32_t byteOffset) {
+    scheduleDestroy(std::move(p));
+}
+
+void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
+        Handle<HwBufferObject> boh) {
 }
 
 void NoopDriver::update2DImage(Handle<HwTexture> th,

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -22,6 +22,8 @@
 #include <utils/CString.h>
 #include <utils/debug.h>
 
+#include <backend/Handle.h>
+
 #include "GLUtils.h"
 
 #include <set>
@@ -35,11 +37,23 @@ public:
     typedef math::details::TVec4<GLint> vec4gli;
     typedef math::details::TVec2<GLclampf> vec2glf;
 
+    // TODO: the footprint of this structure can be reduced. We need only 1 bit for index type, 16
+    // bits for vertexAttribArray. We can also use fewer bits for vertexBufferVersion, although
+    // this will require a corollary update in OpenGLDriver::setVertexBufferObject().
     struct RenderPrimitive {
         GLuint vao = 0;
         GLenum indicesType = GL_UNSIGNED_INT;
         GLuint elementArray = 0;
         utils::bitset32 vertexAttribArray;
+
+        // The optional 32-bit handle to a GLVertexBuffer is necessary only if the referenced
+        // VertexBuffer supports buffer objects. If this is zero, then the VBO handles array is
+        // immutable.
+        backend::Handle<backend::HwVertexBuffer> vertexBufferWithObjects = {};
+
+        // If this version number does not match vertexBufferWithObjects->bufferObjectsVersion,
+        // then the VAO needs to be updated.
+        uint8_t vertexBufferVersion = 0;
     } gl;
 
     OpenGLContext() noexcept;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -412,6 +412,10 @@ Handle<HwIndexBuffer> OpenGLDriver::createIndexBufferS() noexcept {
     return initHandle<GLIndexBuffer>();
 }
 
+Handle<HwBufferObject> OpenGLDriver::createBufferObjectS() noexcept {
+    return initHandle<GLBufferObject>();
+}
+
 Handle<HwRenderPrimitive> OpenGLDriver::createRenderPrimitiveS() noexcept {
     return initHandle<GLRenderPrimitive>();
 }
@@ -478,12 +482,13 @@ void OpenGLDriver::createVertexBufferR(
         uint8_t attributeCount,
         uint32_t elementCount,
         AttributeArray attributes,
-        BufferUsage usage) {
+        BufferUsage usage,
+        bool bufferObjectsEnabled) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
     GLVertexBuffer* vb = construct<GLVertexBuffer>(vbh,
-            bufferCount, attributeCount, elementCount, attributes);
+            bufferCount, attributeCount, elementCount, attributes, bufferObjectsEnabled);
 
     GLsizei n = GLsizei(vb->bufferCount);
 
@@ -521,6 +526,24 @@ void OpenGLDriver::createIndexBufferR(
     gl.bindVertexArray(nullptr);
     gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
+    CHECK_GL_ERROR(utils::slog.e)
+}
+
+void OpenGLDriver::createBufferObjectR(
+        Handle<HwBufferObject> boh,
+        uint32_t byteCount,
+        BufferObjectBinding bindingType) {
+    DEBUG_MARKER()
+
+    auto& gl = mContext;
+    GLBufferObject* bo = construct<GLBufferObject>(boh);
+    glGenBuffers(1, &bo->gl.id);
+    gl.bindVertexArray(nullptr);
+
+    assert_invariant(bindingType == BufferObjectBinding::VERTEX);
+
+    gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
+    glBufferData(GL_ARRAY_BUFFER, byteCount, nullptr, GL_STATIC_DRAW);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
@@ -755,6 +778,57 @@ void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
     }
 
     CHECK_GL_ERROR(utils::slog.e)
+}
+
+void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer const* vb) {
+
+    auto& gl = mContext;
+
+    // NOTE: this is called from draw() and must be as efficient as possible.
+
+    // The VAO for the given render primitive must already be bound.
+    #ifndef NDEBUG
+    GLint vaoBinding;
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vaoBinding);
+    assert_invariant(vaoBinding == (GLint) rp->gl.vao);
+    #endif
+
+    rp->gl.vertexBufferVersion = vb->bufferObjectsVersion;
+    rp->maxVertexCount = vb->vertexCount;
+    for (size_t i = 0, n = vb->attributes.size(); i < n; i++) {
+        const auto& attribute = vb->attributes[i];
+        if (attribute.buffer != Attribute::BUFFER_UNUSED) {
+            uint8_t bi = attribute.buffer;
+            gl.bindBuffer(GL_ARRAY_BUFFER, vb->gl.buffers[bi]);
+            if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
+                glVertexAttribIPointer(GLuint(i),
+                        getComponentCount(attribute.type),
+                        getComponentType(attribute.type),
+                        attribute.stride,
+                        (void*) uintptr_t(attribute.offset));
+            } else {
+                glVertexAttribPointer(GLuint(i),
+                        getComponentCount(attribute.type),
+                        getComponentType(attribute.type),
+                        getNormalization(attribute.flags & Attribute::FLAG_NORMALIZED),
+                        attribute.stride,
+                        (void*) uintptr_t(attribute.offset));
+            }
+
+            gl.enableVertexAttribArray(GLuint(i));
+        } else {
+
+            // In some OpenGL implementations, we must supply a properly-typed placeholder for
+            // every integer input that is declared in the vertex shader.
+            if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
+                glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
+            } else {
+                glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);
+            }
+
+            gl.disableVertexAttribArray(GLuint(i));
+        }
+    }
 }
 
 void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
@@ -1223,6 +1297,17 @@ void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     }
 }
 
+void OpenGLDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
+    DEBUG_MARKER()
+
+    if (boh) {
+        auto& gl = mContext;
+        GLBufferObject const* bo = handle_cast<const GLBufferObject*>(boh);
+        gl.deleteBuffers(1, &bo->gl.id, GL_ARRAY_BUFFER);
+        destruct(boh, bo);
+    }
+}
+
 void OpenGLDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
     DEBUG_MARKER()
 
@@ -1633,11 +1718,35 @@ void OpenGLDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh,
 
     auto& gl = mContext;
     GLVertexBuffer* eb = handle_cast<GLVertexBuffer *>(vbh);
+    assert_invariant(!eb->bufferObjectsEnabled && "Please use setVertexBufferObject() instead.");
 
     gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[index]);
     glBufferSubData(GL_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
+
+    CHECK_GL_ERROR(utils::slog.e)
+}
+
+void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
+        size_t index, Handle<HwBufferObject> boh) {
+   DEBUG_MARKER()
+
+    GLVertexBuffer* vb = handle_cast<GLVertexBuffer *>(vbh);
+    assert_invariant(vb->bufferObjectsEnabled && "Please use updateVertexBuffer() instead.");
+
+    GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
+
+    // If the specified VBO handle is different from what's already in the slot, then update the
+    // slot and bump the cyclical version number. Dependent VAOs use the version number to detect
+    // when they should be updated.
+    if (vb->gl.buffers[index] != bo->gl.id) {
+        vb->gl.buffers[index] = bo->gl.id;
+        static constexpr uint32_t kMaxVersion =
+                std::numeric_limits<decltype(vb->bufferObjectsVersion)>::max();
+        const uint32_t version = vb->bufferObjectsVersion;
+        vb->bufferObjectsVersion = (version + 1) % kMaxVersion;
+    }
 
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -1655,6 +1764,22 @@ void OpenGLDriver::updateIndexBuffer(
     glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
+
+    CHECK_GL_ERROR(utils::slog.e)
+}
+
+void OpenGLDriver::updateBufferObject(
+        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t byteOffset) {
+    DEBUG_MARKER()
+
+    auto& gl = mContext;
+    GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
+
+    gl.bindVertexArray(nullptr);
+    gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
+    glBufferSubData(GL_ARRAY_BUFFER, byteOffset, bd.size, bd.buffer);
+
+    scheduleDestroy(std::move(bd));
 
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -2389,41 +2514,13 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         CHECK_GL_ERROR(utils::slog.e)
 
         rp->gl.indicesType = ib->elementSize == 4 ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
-        rp->maxVertexCount = eb->vertexCount;
-        for (size_t i = 0, n = eb->attributes.size(); i < n; i++) {
-            const auto& attribute = eb->attributes[i];
-            if (attribute.buffer != Attribute::BUFFER_UNUSED) {
-                uint8_t bi = attribute.buffer;
-                gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[bi]);
-                if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
-                    glVertexAttribIPointer(GLuint(i),
-                            getComponentCount(attribute.type),
-                            getComponentType(attribute.type),
-                            attribute.stride,
-                            (void*) uintptr_t(attribute.offset));
-                } else {
-                    glVertexAttribPointer(GLuint(i),
-                            getComponentCount(attribute.type),
-                            getComponentType(attribute.type),
-                            getNormalization(attribute.flags & Attribute::FLAG_NORMALIZED),
-                            attribute.stride,
-                            (void*) uintptr_t(attribute.offset));
-                }
 
-                gl.enableVertexAttribArray(GLuint(i));
-            } else {
+        rp->gl.vertexBufferWithObjects = eb->bufferObjectsEnabled ? vbh :
+                backend::Handle<backend::HwVertexBuffer> {};
 
-                // In some OpenGL implementations, we must supply a properly-typed placeholder for
-                // every integer input that is declared in the vertex shader.
-                if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
-                    glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
-                } else {
-                    glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);
-                }
+        // update the VBO bindings in the VAO
+        updateVertexArrayObject(rp, eb);
 
-                gl.disableVertexAttribArray(GLuint(i));
-            }
-        }
         // this records the index buffer into the currently bound VAO
         gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
 
@@ -3120,8 +3217,18 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
 
     useProgram(p);
 
-    const GLRenderPrimitive* rp = handle_cast<const GLRenderPrimitive *>(rph);
+    GLRenderPrimitive* rp = handle_cast<GLRenderPrimitive *>(rph);
+
     gl.bindVertexArray(&rp->gl);
+
+    // If necessary, mutate the bindings in the VAO.
+    VertexBufferHandle vbwo = rp->gl.vertexBufferWithObjects;
+    if (UTILS_UNLIKELY(vbwo)) {
+        const GLVertexBuffer* vb = handle_cast<GLVertexBuffer*>(vbwo);
+        if (rp->gl.vertexBufferVersion != vb->bufferObjectsVersion) {
+            updateVertexArrayObject(rp, vb);
+        }
+    }
 
     setRasterState(state.rasterState);
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -69,6 +69,12 @@ public:
         backend::BufferUsage usage = {};
     };
 
+    struct GLBufferObject : public backend::HwBufferObject {
+        struct {
+            GLuint id = 0;
+        } gl;
+    };
+
     struct GLVertexBuffer : public backend::HwVertexBuffer {
         using HwVertexBuffer::HwVertexBuffer;
         struct {
@@ -314,6 +320,8 @@ private:
     GetProcAddressType getProcAddress = nullptr;
 
     /* Misc... */
+
+    void updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer const* vb);
 
     void framebufferTexture(backend::TargetBufferInfo const& binfo,
             GLRenderTarget const* rt, GLenum attachment) noexcept;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -403,8 +403,8 @@ bool VulkanRenderTarget::invalidate() {
 
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         VulkanDisposer& disposer,  uint8_t bufferCount, uint8_t attributeCount,
-        uint32_t elementCount, AttributeArray const& attributes) :
-        HwVertexBuffer(bufferCount, attributeCount, elementCount, attributes) {
+        uint32_t elementCount, AttributeArray const& attributes, bool boEnabled) :
+        HwVertexBuffer(bufferCount, attributeCount, elementCount, attributes, boEnabled) {
     buffers.reserve(bufferCount);
     for (uint8_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
         uint32_t size = 0;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -410,11 +410,11 @@ VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& 
         uint32_t size = 0;
         for (auto const& item : attributes) {
             if (item.buffer == bufferIndex) {
-              uint32_t end = item.offset + elementCount * item.stride;
+                uint32_t end = item.offset + elementCount * item.stride;
                 size = std::max(size, end);
             }
         }
-        buffers.emplace_back(new VulkanBuffer(context, stagePool, disposer, this,
+        buffers.push_back(std::make_shared<VulkanBuffer>(context, stagePool, disposer, this,
                 VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, size));
     }
 }
@@ -868,56 +868,6 @@ void VulkanRenderPrimitive::setBuffers(VulkanVertexBuffer* vertexBuffer,
         VulkanIndexBuffer* indexBuffer) {
     this->vertexBuffer = vertexBuffer;
     this->indexBuffer = indexBuffer;
-    const size_t nattrs = vertexBuffer->attributes.size();
-
-    // These vectors are passed to vkCmdBindVertexBuffers at every draw call. This binds the
-    // VkBuffer objects, but does not describe the structure of a vertex.
-    buffers.clear();
-    buffers.reserve(nattrs);
-    offsets.clear();
-    offsets.reserve(nattrs);
-
-    // The following fixed-size arrays are consumed by VulkanBinder. They describe the vertex
-    // structure, but do not specify the actual buffer objects to bind.
-    memset(varray.attributes, 0, sizeof(varray.attributes));
-    memset(varray.buffers, 0, sizeof(varray.buffers));
-
-    // For each enabled attribute, append to each of the above lists. Note that a single VkBuffer
-    // handle might be appended more than once, which is perfectly fine.
-    uint32_t bufferIndex = 0;
-    for (uint32_t attribIndex = 0; attribIndex < nattrs; attribIndex++) {
-        Attribute attrib = vertexBuffer->attributes[attribIndex];
-        VkFormat vkformat = getVkFormat(attrib.type, attrib.flags & Attribute::FLAG_NORMALIZED);
-
-        // HACK: Re-use the positions buffer as a dummy buffer for disabled attributes.
-        // We know that position exists (see earlier assert)
-        if (attrib.buffer == Attribute::BUFFER_UNUSED) {
-
-            // HACK: Presently, Filament's vertex shaders declare all attributes as either vec4 or
-            // uvec4 (the latter is for bone indices), and positions are always at least 32 bits per
-            // element. Therefore we can assign a dummy type of either R8G8B8A8_UINT or
-            // R8G8B8A8_SNORM, depending on whether the shader expects to receive floats or ints.
-            const bool isInteger = attrib.flags & Attribute::FLAG_INTEGER_TARGET;
-            vkformat = isInteger ? VK_FORMAT_R8G8B8A8_UINT : VK_FORMAT_R8G8B8A8_SNORM;
-
-            attrib = vertexBuffer->attributes[0];
-        }
-
-        buffers.push_back(vertexBuffer->buffers[attrib.buffer]->getGpuBuffer());
-        offsets.push_back(attrib.offset);
-        varray.attributes[bufferIndex] = {
-            .location = attribIndex, // matches the GLSL layout specifier
-            .binding = bufferIndex,  // matches the position within vkCmdBindVertexBuffers
-            .format = vkformat,
-            .offset = 0
-        };
-        varray.buffers[bufferIndex] = {
-            .binding = bufferIndex,
-            .stride = attrib.stride,
-            .inputRate = VK_VERTEX_INPUT_RATE_VERTEX
-        };
-        bufferIndex++;
-    }
 }
 
 VulkanTimerQuery::VulkanTimerQuery(VulkanContext& context) : mContext(context) {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -83,7 +83,7 @@ struct VulkanSwapChain : public HwSwapChain {
 struct VulkanVertexBuffer : public HwVertexBuffer {
     VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
             uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            AttributeArray const& attributes);
+            AttributeArray const& attributes, bool bufferObjectsEnabled);
     std::vector<std::unique_ptr<VulkanBuffer>> buffers;
 };
 
@@ -94,6 +94,10 @@ struct VulkanIndexBuffer : public HwIndexBuffer {
             buffer(new VulkanBuffer(context, stagePool, disposer, this,
             VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount)) {}
     const VkIndexType indexType;
+    const std::unique_ptr<VulkanBuffer> buffer;
+};
+
+struct VulkanBufferObject : public HwBufferObject {
     const std::unique_ptr<VulkanBuffer> buffer;
 };
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -84,7 +84,7 @@ struct VulkanVertexBuffer : public HwVertexBuffer {
     VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
             uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
             AttributeArray const& attributes, bool bufferObjectsEnabled);
-    std::vector<std::unique_ptr<VulkanBuffer>> buffers;
+    std::vector<std::shared_ptr<VulkanBuffer>> buffers;
 };
 
 struct VulkanIndexBuffer : public HwIndexBuffer {
@@ -92,13 +92,17 @@ struct VulkanIndexBuffer : public HwIndexBuffer {
             uint8_t elementSize, uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
             indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32),
             buffer(new VulkanBuffer(context, stagePool, disposer, this,
-            VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount)) {}
+                    VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount)) {}
     const VkIndexType indexType;
     const std::unique_ptr<VulkanBuffer> buffer;
 };
 
 struct VulkanBufferObject : public HwBufferObject {
-    const std::unique_ptr<VulkanBuffer> buffer;
+    VulkanBufferObject(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
+            uint32_t byteCount) :
+            buffer(new VulkanBuffer(context, stagePool, disposer, this,
+                    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, byteCount)) {}
+    const std::shared_ptr<VulkanBuffer> buffer;
 };
 
 struct VulkanUniformBuffer : public HwUniformBuffer {
@@ -186,12 +190,6 @@ struct VulkanRenderPrimitive : public HwRenderPrimitive {
     VulkanVertexBuffer* vertexBuffer = nullptr;
     VulkanIndexBuffer* indexBuffer = nullptr;
     VkPrimitiveTopology primitiveTopology;
-    // The "varray" field describes the structure of the vertex and gets passed to VulkanBinder,
-    // which in turn passes it to vkCreateGraphicsPipelines. The "buffers" and "offsets" vectors are
-    // passed to vkCmdBindVertexBuffers at draw call time.
-    VulkanBinder::VertexArray varray;
-    std::vector<VkBuffer> buffers;
-    std::vector<VkDeviceSize> offsets;
 };
 
 struct VulkanFence : public HwFence {

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -48,7 +48,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     enabledAttributes.set(VertexAttribute::POSITION);
 
     mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes,
-            BufferUsage::STATIC);
+            BufferUsage::STATIC, false);
     BufferDescriptor vertexBufferDesc(gVertices, sizeof(filament::math::float2) * 3, nullptr);
     mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vertexBufferDesc), 0);
 

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! \file
+
+#ifndef TNT_FILAMENT_BUFFEROBJECT_H
+#define TNT_FILAMENT_BUFFEROBJECT_H
+
+#include <filament/FilamentAPI.h>
+
+#include <backend/DriverEnums.h>
+
+#include <backend/BufferDescriptor.h>
+
+#include <utils/compiler.h>
+
+namespace filament {
+
+class FBufferObject;
+
+class Engine;
+
+/**
+ * A generic GPU buffer containing data.
+ *
+ * Usage of this BufferObject is optional. For simple use cases it is not necessary. It is useful
+ * only when you need to share data between multiple VertexBuffer instances. It also allows you to
+ * efficiently swap-out the buffers in VertexBuffer.
+ *
+ * NOTE: For now this is only used for vertex data, but in the future we may use it for other things
+ * (e.g. compute).
+ *
+ * @see VertexBuffer
+ */
+class UTILS_PUBLIC BufferObject : public FilamentAPI {
+    struct BuilderDetails;
+
+public:
+    using BufferDescriptor = backend::BufferDescriptor;
+    using BindingType = backend::BufferObjectBinding;
+
+    class Builder : public BuilderBase<BuilderDetails> {
+        friend struct BuilderDetails;
+    public:
+        Builder() noexcept;
+        Builder(Builder const& rhs) noexcept;
+        Builder(Builder&& rhs) noexcept;
+        ~Builder() noexcept;
+        Builder& operator=(Builder const& rhs) noexcept;
+        Builder& operator=(Builder&& rhs) noexcept;
+
+        /**
+         * Size of the buffer in bytes.
+         * @param byteCount Maximum number of bytes the BufferObject can hold.
+         * @return A reference to this Builder for chaining calls.
+         */
+        Builder& size(uint32_t byteCount) noexcept;
+
+        /**
+         * The binding type for this buffer object. (defaults to VERTEX)
+         * @param BindingType Distinguishes between SSBO, VBO, etc. For now this must be VERTEX.
+         * @return A reference to this Builder for chaining calls.
+         */
+        Builder& bindingType(BindingType bindingType) noexcept;
+
+        /**
+         * Creates the BufferObject and returns a pointer to it. After creation, the buffer
+         * object is uninitialized. Use BufferObject::setBuffer() to initialize it.
+         *
+         * @param engine Reference to the filament::Engine to associate this BufferObject with.
+         *
+         * @return pointer to the newly created object or nullptr if exceptions are disabled and
+         *         an error occurred.
+         *
+         * @exception utils::PostConditionPanic if a runtime error occurred, such as running out of
+         *            memory or other resources.
+         * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
+         *
+         * @see IndexBuffer::setBuffer
+         */
+        BufferObject* build(Engine& engine);
+    private:
+        friend class FBufferObject;
+    };
+
+    /**
+     * Asynchronously copy-initializes a region of this BufferObject from the data provided.
+     *
+     * @param engine Reference to the filament::Engine associated with this BufferObject.
+     * @param buffer A BufferDescriptor representing the data used to initialize the BufferObject.
+     * @param byteOffset Offset in bytes into the BufferObject
+     */
+    void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
+
+    /**
+     * Returns the size of this BufferObject in elements.
+     * @return The maximum capacity of the BufferObject.
+     */
+    size_t getByteCount() const noexcept;
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_BUFFEROBJECT_H

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -28,6 +28,7 @@ class JobSystem;
 
 namespace filament {
 
+class BufferObject;
 class Camera;
 class ColorGrading;
 class DebugRegistry;
@@ -390,6 +391,7 @@ public:
      */
     Fence* createFence() noexcept;
 
+    bool destroy(const BufferObject* p);        //!< Destroys a BufferObject object.
     bool destroy(const VertexBuffer* p);        //!< Destroys an VertexBuffer object.
     bool destroy(const Fence* p);               //!< Destroys a Fence object.
     bool destroy(const IndexBuffer* p);         //!< Destroys an IndexBuffer object.

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -84,7 +84,7 @@ public:
 
         /**
          * Creates the IndexBuffer object and returns a pointer to it. After creation, the index
-         * buffer is uninitialized. Use IndexBuffer::setBuffer() to initialized the IndexBuffer.
+         * buffer is uninitialized. Use IndexBuffer::setBuffer() to initialize the IndexBuffer.
          *
          * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
          *

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -31,6 +31,7 @@ namespace filament {
 
 class FVertexBuffer;
 
+class BufferObject;
 class Engine;
 
 /**
@@ -85,6 +86,17 @@ public:
          * @return A reference to this Builder for chaining calls.
          */
         Builder& vertexCount(uint32_t vertexCount) noexcept;
+
+        /**
+         * Allows buffers to be swapped out and shared using BufferObject.
+         *
+         * If buffer objects mode is enabled, clients must call setBufferObjectAt rather than
+         * setBufferAt. This allows sharing of data between VertexBuffer objects, but it may
+         * slightly increase the memory footprint of Filament's internal bookkeeping.
+         *
+         * @param enabled If true, enables buffer object mode.  False by default.
+         */
+        Builder& enableBufferObjects(bool enabled = true) noexcept;
 
         /**
          * Sets up an attribute for this vertex buffer set.
@@ -154,6 +166,8 @@ public:
     /**
      * Asynchronously copy-initializes the specified buffer from the given buffer data.
      *
+     * Do not use this if you called enableBufferObjects() on the Builder.
+     *
      * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
      * @param bufferIndex Index of the buffer to initialize. Must be between 0
      *                    and Builder::bufferCount() - 1.
@@ -165,6 +179,18 @@ public:
      */
     void setBufferAt(Engine& engine, uint8_t bufferIndex, BufferDescriptor&& buffer,
             uint32_t byteOffset = 0);
+
+    /**
+     * Swaps in the given buffer object.
+     *
+     * To use this, you must first call enableBufferObjects() on the Builder.
+     *
+     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
+     * @param bufferIndex Index of the buffer to initialize. Must be between 0
+     *                    and Builder::bufferCount() - 1.
+     * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
+     */
+    void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
 
     /**
      * Specifies the quaternion type for the "populateTangentQuaternions" utility.

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "details/BufferObject.h"
+
+#include "details/Engine.h"
+
+#include "FilamentAPI-impl.h"
+
+namespace filament {
+
+struct BufferObject::BuilderDetails {
+    BindingType mBindingType = BindingType::VERTEX;
+    uint32_t mByteCount = 0;
+};
+
+using BuilderType = BufferObject;
+BuilderType::Builder::Builder() noexcept = default;
+BuilderType::Builder::~Builder() noexcept = default;
+BuilderType::Builder::Builder(BuilderType::Builder const& rhs) noexcept = default;
+BuilderType::Builder::Builder(BuilderType::Builder&& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder const& rhs) noexcept = default;
+BuilderType::Builder& BuilderType::Builder::operator=(BuilderType::Builder&& rhs) noexcept = default;
+
+BufferObject::Builder& BufferObject::Builder::size(uint32_t byteCount) noexcept {
+    mImpl->mByteCount = byteCount;
+    return *this;
+}
+
+BufferObject::Builder& BufferObject::Builder::bindingType(BindingType bindingType) noexcept {
+    mImpl->mBindingType = bindingType;
+    return *this;
+}
+
+BufferObject* BufferObject::Builder::build(Engine& engine) {
+    return upcast(engine).createBufferObject(*this);
+}
+
+// ------------------------------------------------------------------------------------------------
+
+FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& builder)
+        : mByteCount(builder->mByteCount), mBindingType(builder->mBindingType) {
+    FEngine::DriverApi& driver = engine.getDriverApi();
+    mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType);
+}
+
+void FBufferObject::terminate(FEngine& engine) {
+    FEngine::DriverApi& driver = engine.getDriverApi();
+    driver.destroyBufferObject(mHandle);
+}
+
+void FBufferObject::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
+    engine.getDriverApi().updateBufferObject(mHandle, std::move(buffer), byteOffset);
+}
+
+// ------------------------------------------------------------------------------------------------
+// Trampoline calling into private implementation
+// ------------------------------------------------------------------------------------------------
+
+void BufferObject::setBuffer(Engine& engine,
+        BufferObject::BufferDescriptor&& buffer, uint32_t byteOffset) {
+    upcast(this)->setBuffer(upcast(engine), std::move(buffer), byteOffset);
+}
+
+size_t BufferObject::getByteCount() const noexcept {
+    return upcast(this)->getByteCount();
+}
+
+} // namespace filament

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -20,6 +20,7 @@
 #include "ResourceAllocator.h"
 
 #include "backend/DriverEnums.h"
+#include "details/BufferObject.h"
 #include "details/DFG.h"
 #include "details/VertexBuffer.h"
 #include "details/Fence.h"
@@ -318,6 +319,7 @@ void FEngine::shutdown() {
     // this must be done after Skyboxes and before materials
     destroy(mSkyboxMaterial);
 
+    cleanupResourceList(mBufferObjects);
     cleanupResourceList(mIndexBuffers);
     cleanupResourceList(mVertexBuffers);
     cleanupResourceList(mTextures);
@@ -546,6 +548,10 @@ inline T* FEngine::create(ResourceList<T>& list, typename T::Builder const& buil
     return p;
 }
 
+FBufferObject* FEngine::createBufferObject(const BufferObject::Builder& builder) noexcept {
+    return create(mBufferObjects, builder);
+}
+
 FVertexBuffer* FEngine::createVertexBuffer(const VertexBuffer::Builder& builder) noexcept {
     return create(mVertexBuffers, builder);
 }
@@ -723,6 +729,10 @@ bool FEngine::terminateAndDestroy(const T* ptr, ResourceList<T, L>& list) {
 }
 
 // -----------------------------------------------------------------------------------------------
+
+bool FEngine::destroy(const FBufferObject* p) {
+    return terminateAndDestroy(p, mBufferObjects);
+}
 
 bool FEngine::destroy(const FVertexBuffer* p) {
     return terminateAndDestroy(p, mVertexBuffers);
@@ -923,6 +933,10 @@ SwapChain* Engine::createSwapChain(void* nativeWindow, uint64_t flags) noexcept 
 
 SwapChain* Engine::createSwapChain(uint32_t width, uint32_t height, uint64_t flags) noexcept {
     return upcast(this)->createSwapChain(width, height, flags);
+}
+
+bool Engine::destroy(const BufferObject* p) {
+    return upcast(this)->destroy(upcast(p));
 }
 
 bool Engine::destroy(const VertexBuffer* p) {

--- a/filament/src/details/BufferObject.h
+++ b/filament/src/details/BufferObject.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DETAILS_BUFFEROBJECT_H
+#define TNT_FILAMENT_DETAILS_BUFFEROBJECT_H
+
+#include "upcast.h"
+
+#include <backend/Handle.h>
+
+#include <filament/BufferObject.h>
+
+#include <utils/compiler.h>
+
+namespace filament {
+
+class FEngine;
+
+class FBufferObject : public BufferObject {
+public:
+    FBufferObject(FEngine& engine, const Builder& builder);
+
+    // frees driver resources, object becomes invalid
+    void terminate(FEngine& engine);
+
+    backend::Handle<backend::HwBufferObject> getHwHandle() const noexcept { return mHandle; }
+
+    size_t getByteCount() const noexcept { return mByteCount; }
+
+    void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
+
+    BindingType getBindingType() const noexcept { return mBindingType; }
+
+private:
+    friend class BufferObject;
+    backend::Handle<backend::HwBufferObject> mHandle;
+    uint32_t mByteCount;
+    BindingType mBindingType;
+};
+
+FILAMENT_UPCAST(BufferObject)
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_DETAILS_BUFFEROBJECT_H

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -26,6 +26,7 @@
 #include "components/RenderableManager.h"
 
 #include "details/Allocators.h"
+#include "details/BufferObject.h"
 #include "details/Camera.h"
 #include "details/DebugRegistry.h"
 #include "details/Fence.h"
@@ -223,6 +224,7 @@ public:
     template <typename T>
     T* create(ResourceList<T>& list, typename T::Builder const& builder) noexcept;
 
+    FBufferObject* createBufferObject(const BufferObject::Builder& builder) noexcept;
     FVertexBuffer* createVertexBuffer(const VertexBuffer::Builder& builder) noexcept;
     FIndexBuffer* createIndexBuffer(const IndexBuffer::Builder& builder) noexcept;
     FIndirectLight* createIndirectLight(const IndirectLight::Builder& builder) noexcept;
@@ -250,6 +252,7 @@ public:
     void destroyCameraComponent(utils::Entity entity) noexcept;
 
 
+    bool destroy(const FBufferObject* p);
     bool destroy(const FVertexBuffer* p);
     bool destroy(const FFence* p);
     bool destroy(const FIndexBuffer* p);
@@ -340,6 +343,7 @@ private:
     FCameraManager mCameraManager;
     ResourceAllocator* mResourceAllocator = nullptr;
 
+    ResourceList<FBufferObject> mBufferObjects{ "BufferObject" };
     ResourceList<FRenderer> mRenderers{ "Renderer" };
     ResourceList<FView> mViews{ "View" };
     ResourceList<FScene> mScenes{ "Scene" };

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -32,6 +32,7 @@
 
 namespace filament {
 
+class FBufferObject;
 class FEngine;
 
 class FVertexBuffer : public VertexBuffer {
@@ -53,6 +54,9 @@ public:
     void setBufferAt(FEngine& engine, uint8_t bufferIndex,
             backend::BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
+    void setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
+            FBufferObject const * bufferObject);
+
 private:
     friend class VertexBuffer;
 
@@ -65,6 +69,7 @@ private:
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
+    bool mBufferObjectsEnabled = false;
 };
 
 FILAMENT_UPCAST(VertexBuffer)

--- a/java/filament/CMakeLists.txt
+++ b/java/filament/CMakeLists.txt
@@ -40,6 +40,7 @@ set(COMMON_DIR ${ANDROID_DIR}/common)
 include_directories(${JNI_INCLUDE_DIRS} ${ANDROID_DIR})
 
 set(JNI_SOURCE_FILES
+        ${FILAMENT_DIR}/src/main/cpp/BufferObject.cpp
         ${FILAMENT_DIR}/src/main/cpp/Camera.cpp
         ${FILAMENT_DIR}/src/main/cpp/Colors.cpp
         ${FILAMENT_DIR}/src/main/cpp/ColorGrading.cpp
@@ -116,6 +117,7 @@ get_filename_component(FILAMENT_JAVA_DIR ${FILAMENT_JAVA_DIR} ABSOLUTE)
 set(JAVA_SOURCE_FILES
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Asserts.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Box.java
+        ${FILAMENT_JAVA_DIR}/com/google/android/filament/BufferObject.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Camera.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/Colors.java
         ${FILAMENT_JAVA_DIR}/com/google/android/filament/ColorGrading.java

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -306,6 +306,18 @@ Filament.loadClassExtensions = function() {
         this._setVignetteOptions(options);
     };
 
+    /// BufferObject ::core class::
+
+    /// setBuffer ::method::
+    /// engine ::argument:: [Engine]
+    /// buffer ::argument:: asset string, or Uint8Array, or [Buffer]
+    /// byteOffset ::argument:: non-negative integer
+    Filament.BufferObject.prototype.setBuffer = function(engine, buffer, byteOffset = 0) {
+        buffer = getBufferDescriptor(buffer);
+        this._setBuffer(engine, buffer, byteOffset);
+        buffer.delete();
+    };
+
     /// VertexBuffer ::core class::
 
     /// setBufferAt ::method::

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -225,6 +225,7 @@ export class VertexBuffer$Builder {
     public bufferCount(count: number): VertexBuffer$Builder;
     public attribute(attrib: VertexAttribute, bufindex: number, atype: VertexBuffer$AttributeType,
             offset: number, stride: number): VertexBuffer$Builder;
+    public enableBufferObjects(enabled: boolean): VertexBuffer$Builder;
     public normalized(attrib: VertexAttribute): VertexBuffer$Builder;
     public normalizedIf(attrib: VertexAttribute, normalized: boolean): VertexBuffer$Builder;
     public build(engine: Engine): VertexBuffer;
@@ -234,6 +235,12 @@ export class IndexBuffer$Builder {
     public indexCount(count: number): IndexBuffer$Builder;
     public bufferType(type: IndexBuffer$IndexType): IndexBuffer$Builder;
     public build(engine: Engine): IndexBuffer;
+}
+
+export class BufferObject$Builder {
+    public size(byteCount: number): BufferObject$Builder;
+    public bindingType(type: BufferObject$BindingType): BufferObject$Builder;
+    public build(engine: Engine): BufferObject;
 }
 
 export class RenderableManager$Builder {
@@ -364,6 +371,12 @@ export class VertexBuffer {
     public static Builder(): VertexBuffer$Builder;
     public setBufferAt(engine: Engine, bufindex: number, f32array: BufferReference,
             byteOffset?: number): void;
+    public setBufferObjectAt(engine: Engine, bufindex: number, bo: BufferObject): void;
+}
+
+export class BufferObject {
+    public static Builder(): BufferObject$Builder;
+    public setBuffer(engine: Engine, data: BufferReference, byteOffset?: number): void;
 }
 
 export class IndexBuffer {
@@ -719,6 +732,10 @@ export enum IndexBuffer$IndexType {
     UINT,
 }
 
+export enum BufferObject$BindingType {
+    VERTEX_BINDING,
+}
+
 export enum LightManager$Type {
     SUN,
     DIRECTIONAL,
@@ -953,6 +970,10 @@ export enum VertexAttribute {
     MORPH_TANGENTS_1 = CUSTOM5,
     MORPH_TANGENTS_2 = CUSTOM6,
     MORPH_TANGENTS_3 = CUSTOM7,
+}
+
+export enum BufferObject$BindingType {
+    VERTEX,
 }
 
 export enum VertexBuffer$AttributeType {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -34,6 +34,7 @@
 
 #include <filameshio/MeshReader.h>
 
+#include <filament/BufferObject.h>
 #include <filament/Camera.h>
 #include <filament/ColorGrading.h>
 #include <filament/Engine.h>
@@ -117,6 +118,7 @@ namespace emscripten {
     namespace internal {
         BIND(Animator)
         BIND(AssetLoader)
+        BIND(BufferObject)
         BIND(Camera)
         BIND(ColorGrading)
         BIND(Engine)
@@ -204,6 +206,7 @@ using SkyBuilder = Skybox::Builder;
 using SurfaceBuilder = SurfaceOrientation::Builder;
 using TexBuilder = Texture::Builder;
 using VertexBuilder = VertexBuffer::Builder;
+using BufferBuilder = BufferObject::Builder;
 
 // We avoid directly exposing backend::BufferDescriptor because embind does not support move
 // semantics and void* doesn't make sense to JavaScript anyway. This little wrapper class is exposed
@@ -1156,6 +1159,25 @@ class_<LightManager>("LightManager")
 class_<LightManager::Instance>("LightManager$Instance");
     /// delete ::method:: Frees an instance obtained via `getInstance`
 
+class_<BufferBuilder>("BufferObject$Builder")
+   .function("_build", EMBIND_LAMBDA(BufferObject*, (BufferBuilder* builder, Engine* engine), {
+       return builder->build(*engine);
+   }), allow_raw_pointers())
+   .BUILDER_FUNCTION("bindingType", BufferBuilder, (BufferBuilder* builder,
+           BufferObject::BindingType bt), {
+       return &builder->bindingType(bt); })
+   .BUILDER_FUNCTION("size", BufferBuilder, (BufferBuilder* builder, int byteCount), {
+       return &builder->size(byteCount); });
+
+/// BufferObject ::core class:: Represents a single GPU buffer.
+class_<BufferObject>("BufferObject")
+   .class_function("Builder", (BufferBuilder (*)()) [] { return BufferBuilder(); })
+   .function("getByteCount", &BufferObject::getByteCount)
+   .function("_setBuffer", EMBIND_LAMBDA(void, (BufferObject* self,
+           Engine* engine, BufferDescriptor bd, uint32_t byteOffset), {
+       self->setBuffer(*engine, std::move(*bd.bd), byteOffset);
+   }), allow_raw_pointers());
+
 class_<VertexBuilder>("VertexBuffer$Builder")
     .function("_build", EMBIND_LAMBDA(VertexBuffer*, (VertexBuilder* builder, Engine* engine), {
         return builder->build(*engine);
@@ -1169,6 +1191,8 @@ class_<VertexBuilder>("VertexBuffer$Builder")
         return &builder->attribute(attr, bufferIndex, attrType, byteOffset, byteStride); })
     .BUILDER_FUNCTION("vertexCount", VertexBuilder, (VertexBuilder* builder, int count), {
         return &builder->vertexCount(count); })
+    .BUILDER_FUNCTION("enableBufferObjects", VertexBuilder, (VertexBuilder* builder, bool enable), {
+        return &builder->enableBufferObjects(enable); })
     .BUILDER_FUNCTION("normalized", VertexBuilder, (VertexBuilder* builder,
             VertexAttribute attrib), {
         return &builder->normalized(attrib); })
@@ -1181,6 +1205,7 @@ class_<VertexBuilder>("VertexBuffer$Builder")
 /// VertexBuffer ::core class:: Bundle of buffers and associated vertex attributes.
 class_<VertexBuffer>("VertexBuffer")
     .class_function("Builder", (VertexBuilder (*)()) [] { return VertexBuilder(); })
+    .function("setBufferObjectAt", &VertexBuffer::setBufferObjectAt, allow_raw_pointers())
     .function("_setBufferAt", EMBIND_LAMBDA(void, (VertexBuffer* self,
             Engine* engine, uint8_t bufferIndex, BufferDescriptor vbd, uint32_t byteOffset), {
         self->setBufferAt(*engine, bufferIndex, std::move(*vbd.bd), byteOffset);

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <filament/BufferObject.h>
 #include <filament/Camera.h>
 #include <filament/ColorGrading.h>
 #include <filament/Color.h>
@@ -68,6 +69,9 @@ enum_<VertexAttribute>("VertexAttribute")
     .value("MORPH_TANGENTS_1", MORPH_TANGENTS_1)
     .value("MORPH_TANGENTS_2", MORPH_TANGENTS_2)
     .value("MORPH_TANGENTS_3", MORPH_TANGENTS_3);
+
+enum_<BufferObject::BindingType>("BufferObject$BindingType")
+    .value("VERTEX_BINDING", BufferObject::BindingType::VERTEX);
 
 enum_<VertexBuffer::AttributeType>("VertexBuffer$AttributeType")
     .value("BYTE", VertexBuffer::AttributeType::BYTE)


### PR DESCRIPTION
NOTE: after Metal and Vulkan support lands, we can potentially simplify
the Driver API by removing some of the old VertexBuffer entry points.

This introduces a new API-level object called `BufferObject`, and a new
backend-level object called `HwBufferObject`. This encapsulates a single
VBO. It's especially useful when clients need to share data between
multiple VertexBuffer objects. (e.g. for morphing).

In the future, buffer objects could perhaps be used for non-vertex data
(e.g. for compute).

The existing `VertexBuffer` class can now be configured to use buffer
objects by calling `enableBufferObjects` on the builder. By default its
API is unchanged. If buffer objects are enabled, then clients should use
`setBufferObjectAt` (which takes a buffer object) rather than
`setBufferAt` (which takes CPU data).

OpenGL is the trickiest backend for this, due to existence of VAOs.
The proposed implementation in this PR uses a version-tracking scheme to
figure out when to update the VAO.