### PR TITLE
DoF: support full-resolution DoF

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -159,6 +159,7 @@ set(MATERIAL_SRCS
         src/materials/colorGrading/colorGradingAsSubpass.mat
         src/materials/defaultMaterial.mat
         src/materials/dof/dof.mat
+        src/materials/dof/dofCoc.mat
         src/materials/dof/dofDownsample.mat
         src/materials/dof/dofCombine.mat
         src/materials/dof/dofTiles.mat

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -209,6 +209,7 @@ static const MaterialInfo sMaterialList[] = {
         { "fxaa",                  MATERIAL(FXAA) },
         { "taa",                   MATERIAL(TAA) },
         { "dofDownsample",         MATERIAL(DOFDOWNSAMPLE) },
+        { "dofCoc",                MATERIAL(DOFCOC) },
         { "dofMipmap",             MATERIAL(DOFMIPMAP) },
         { "dofTiles",              MATERIAL(DOFTILES) },
         { "dofDilate",             MATERIAL(DOFDILATE) },
@@ -915,12 +916,17 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
     auto depth = blackboard.get<FrameGraphTexture>("depth");
     assert_invariant(depth);
 
-    // the downsampled target is multiple of 8, so we can have 4 clean mipmap levels
-    constexpr const uint32_t maxMipLevels = 4u;
+    /*
+     * dofResolution is used (at compile time for now) to chose between full- or quarter-resolution
+     * for the DoF calculations. Set to [1] for full resolution or [2] for quarter-resolution.
+     */
+    const uint32_t dofResolution = 2;
+
+    constexpr const uint32_t maxMipLevels = 4u; // mip levels at full-resolution
     constexpr const uint32_t maxMipLevelsMask = (1u << maxMipLevels) - 1u;
     auto const& colorDesc = fg.getDescriptor(input);
-    const uint32_t width  = ((colorDesc.width  + maxMipLevelsMask) & ~maxMipLevelsMask) / 2;
-    const uint32_t height = ((colorDesc.height + maxMipLevelsMask) & ~maxMipLevelsMask) / 2;
+    const uint32_t width  = ((colorDesc.width  + maxMipLevelsMask) & ~maxMipLevelsMask) / dofResolution;
+    const uint32_t height = ((colorDesc.height + maxMipLevelsMask) & ~maxMipLevelsMask) / dofResolution;
     const uint8_t maxLevelCount = FTexture::maxLevelCount(width, height);
     uint8_t mipmapCount = min(maxLevelCount, uint8_t(maxMipLevels));
 
@@ -956,7 +962,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 });
                 data.outForeground = builder.write(data.outForeground, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 data.outBackground = builder.write(data.outBackground, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                data.outCocFgBg    = builder.write(data.outCocFgBg, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                data.outCocFgBg    = builder.write(data.outCocFgBg,    FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 builder.declareRenderPass("DoF Target", { .attachments = {
                                 .color = { data.outForeground, data.outBackground, data.outCocFgBg }
                         }
@@ -966,12 +972,15 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 auto const& out = resources.getRenderPassInfo();
                 auto color = resources.getTexture(data.color);
                 auto depth = resources.getTexture(data.depth);
-                auto const& material = getPostProcessMaterial("dofDownsample");
+                auto const& material = (dofResolution == 1) ?
+                        getPostProcessMaterial("dofCoc") :
+                        getPostProcessMaterial("dofDownsample");
                 FMaterialInstance* const mi = material.getMaterialInstance();
                 mi->setParameter("color", color, { .filterMin = SamplerMinFilter::NEAREST });
                 mi->setParameter("depth", depth, { .filterMin = SamplerMinFilter::NEAREST });
                 mi->setParameter("cocParams", cocParams);
-                mi->setParameter("uvscale", float4{ width, height, 1.0f / colorDesc.width, 1.0f / colorDesc.height });
+                mi->setParameter("uvscale", float4{ width, height,
+                        1.0f / colorDesc.width, 1.0f / colorDesc.height });
                 commitAndRender(out, material, driver);
             });
 
@@ -984,7 +993,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> inOutForeground;
         FrameGraphId<FrameGraphTexture> inOutBackground;
         FrameGraphId<FrameGraphTexture> inOutCocFgBg;
-        uint32_t rp[3];
+        uint32_t rp[maxMipLevels];
     };
 
     assert_invariant(mipmapCount - 1 <= sizeof(PostProcessDofMipmap::rp) / sizeof(uint32_t));
@@ -997,8 +1006,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 for (size_t i = 0; i < mipmapCount - 1u; i++) {
                     // make sure inputs are always multiple of two (should be true by construction)
                     // (this is so that we can compute clean mip levels)
-                    assert((FTexture::valueForLevel(uint8_t(i), fg.getDescriptor(data.inOutForeground).width ) & 0x1u) == 0);
-                    assert((FTexture::valueForLevel(uint8_t(i), fg.getDescriptor(data.inOutForeground).height) & 0x1u) == 0);
+                    assert_invariant((FTexture::valueForLevel(uint8_t(i), fg.getDescriptor(data.inOutForeground).width ) & 0x1u) == 0);
+                    assert_invariant((FTexture::valueForLevel(uint8_t(i), fg.getDescriptor(data.inOutForeground).height) & 0x1u) == 0);
 
                     auto inOutForeground = builder.createSubresource(data.inOutForeground, "Forground mip",  { .level = uint8_t(i + 1) });
                     auto inOutBackground = builder.createSubresource(data.inOutBackground, "Background mip", { .level = uint8_t(i + 1) });
@@ -1006,7 +1015,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
                     inOutForeground = builder.write(inOutForeground, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                     inOutBackground = builder.write(inOutBackground, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                    inOutCocFgBg    = builder.write(inOutCocFgBg, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
+                    inOutCocFgBg    = builder.write(inOutCocFgBg,    FrameGraphTexture::Usage::COLOR_ATTACHMENT);
 
                     data.rp[i] = builder.declareRenderPass("DoF Target", { .attachments = {
                                 .color = { inOutForeground, inOutBackground, inOutCocFgBg  }
@@ -1033,7 +1042,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 for (size_t level = 0 ; level < mipmapCount - 1u ; level++) {
                     auto const& out = resources.getRenderPassInfo(data.rp[level]);
                     mi->setParameter("mip", uint32_t(level));
-                    mi->setParameter("weightScale", 0.5f / float(1u<<level));
+                    mi->setParameter("weightScale", 0.5f / float(1u<<level));   // FIXME: halfres?
                     mi->commit(driver);
                     driver.beginRenderPass(out.target, out.params);
                     driver.draw(pipeline, fullScreenRenderPrimitive);
@@ -1048,11 +1057,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
     auto inTilesCocMaxMin = ppDoFDownsample->outCocFgBg;
 
-    // Match this with TILE_SIZE in dofDilate.mat
-    const size_t tileSize = 16; // size of the tile in full resolution pixel
-    const uint32_t tileBufferWidth  = ((colorDesc.width  + (tileSize - 1u)) & ~(tileSize - 1u)) / 4u;
-    const uint32_t tileBufferHeight = ((colorDesc.height + (tileSize - 1u)) & ~(tileSize - 1u)) / 4u;
-    const size_t tileReductionCount = std::log2(tileSize) - 1.0; // -1 because we start from half-resolution
+    // TODO: Should the tile size be in real pixels? i.e. always 16px instead of being dependant on
+    //       the DoF effect resolution?
+    // Size of a tile in full-resolution pixels -- must match TILE_SIZE in dofDilate.mat
+    const size_t tileSize = 16;
+    // round the width/height to 16 (tile size), divide by scale (1 or 2) for halfres
+    const uint32_t tileBufferWidth  = ((colorDesc.width  + (tileSize - 1u)) & ~(tileSize - 1u)) / dofResolution;
+    const uint32_t tileBufferHeight = ((colorDesc.height + (tileSize - 1u)) & ~(tileSize - 1u)) / dofResolution;
+    const size_t tileReductionCount = std::log2(tileSize / dofResolution);
 
     struct PostProcessDofTiling1 {
         FrameGraphId<FrameGraphTexture> inCocMaxMin;
@@ -1062,12 +1074,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
     for (size_t i = 0; i < tileReductionCount; i++) {
         auto& ppDoFTiling = fg.addPass<PostProcessDofTiling1>("DoF Tiling",
                 [&](FrameGraph::Builder& builder, auto& data) {
-                    assert((tileBufferWidth  & 1u) == 0);
-                    assert((tileBufferHeight & 1u) == 0);
+                    assert_invariant(((tileBufferWidth  >> i) & 1u) == 0);
+                    assert_invariant(((tileBufferHeight >> i) & 1u) == 0);
                     data.inCocMaxMin = builder.sample(inTilesCocMaxMin);
                     data.outTilesCocMaxMin = builder.createTexture("dof tiles output", {
-                            .width  = tileBufferWidth  >> i,
-                            .height = tileBufferHeight >> i,
+                            .width  = tileBufferWidth  >> (i + 1u),
+                            .height = tileBufferHeight >> (i + 1u),
                             .format = TextureFormat::RG16F
                     });
                     data.outTilesCocMaxMin = builder.declareRenderPass(data.outTilesCocMaxMin);
@@ -1120,7 +1132,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
         return ppDoFDilate->outTilesCocMaxMin;
     };
 
-    // Tiles of 16 pixels requires two dilate rounds to accommodate our max Coc of 32 pixels
+    // Tiles of 16 full-resolution pixels requires two dilate rounds to accommodate our max Coc of 32 pixels
+    // (note: when running at half-res, the tiles are 8 half-resolution pixels, and still need two
+    //  dilate rounds to accommodate the mac CoC pf 16 half-resolution pixels)
     auto dilated = dilate(inTilesCocMaxMin);
     dilated = dilate(dilated);
 
@@ -1148,13 +1162,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 // The DoF buffer (output) doesn't need to be a multiple of 8 because it's not
                 // mipmapped. We just need to adjust the uv properly.
                 data.outForeground = builder.createTexture("dof color output", {
-                        .width  = (colorDesc.width  + 1) / 2,
-                        .height = (colorDesc.height + 1) / 2,
+                        .width  = (colorDesc.width  + (dofResolution / 2u)) / dofResolution,
+                        .height = (colorDesc.height + (dofResolution / 2u)) / dofResolution,
                         .format = fg.getDescriptor(data.foreground).format
                 });
                 data.outAlpha = builder.createTexture("dof alpha output", {
-                        .width  = (colorDesc.width  + 1) / 2,
-                        .height = (colorDesc.height + 1) / 2,
+                        .width  = builder.getDescriptor(data.outForeground).width,
+                        .height = builder.getDescriptor(data.outForeground).height,
                         .format = TextureFormat::R8
                 });
                 data.outForeground  = builder.write(data.outForeground, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
@@ -1188,12 +1202,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                         { .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST });
                 mi->setParameter("tiles", tilesCocMaxMin,
                         { .filterMin = SamplerMinFilter::NEAREST });
-                mi->setParameter("cocToTexelOffset", 0.5f / float2{ inputDesc.width, inputDesc.height });
+                mi->setParameter("cocToTexelScale", (1.0f / dofResolution) / float2{ inputDesc.width, inputDesc.height });
+                mi->setParameter("cocToPixelScale", (1.0f / dofResolution));
                 mi->setParameter("uvscale", float4{
                     outputDesc.width  / float(inputDesc.width),
                     outputDesc.height / float(inputDesc.height),
-                    outputDesc.width  / (tileSize * 0.5f * tilesDesc.width),
-                    outputDesc.height / (tileSize * 0.5f * tilesDesc.height)
+                    outputDesc.width  / float(tileSize / dofResolution * tilesDesc.width),
+                    outputDesc.height / float(tileSize / dofResolution * tilesDesc.height)
                 });
                 mi->setParameter("bokehAngle",  bokehAngle);
                 commitAndRender(out, material, driver);
@@ -1243,8 +1258,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 mi->setParameter("alpha", inAlpha,        { .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST });
                 mi->setParameter("tiles", tilesCocMaxMin, { .filterMin = SamplerMinFilter::NEAREST });
                 mi->setParameter("uvscale", float2{
-                        outputDesc.width  / (tileSize * 0.5f * tilesDesc.width),
-                        outputDesc.height / (tileSize * 0.5f * tilesDesc.height)
+                        outputDesc.width  / float(tileSize / dofResolution * tilesDesc.width),
+                        outputDesc.height / float(tileSize / dofResolution * tilesDesc.height)
                 });
                 commitAndRender(out, material, driver);
             });
@@ -1297,8 +1312,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 mi->setParameter("alpha", alpha, { .filterMag = SamplerMagFilter::NEAREST });
                 mi->setParameter("tiles", tilesCocMaxMin, { .filterMin = SamplerMinFilter::NEAREST });
                 mi->setParameter("uvscale", float4{
-                    colorDesc.width  / (dofDesc.width    *  2.0f),
-                    colorDesc.height / (dofDesc.height   *  2.0f),
+                    colorDesc.width  / (dofDesc.width    * float(dofResolution)),
+                    colorDesc.height / (dofDesc.height   * float(dofResolution)),
                     colorDesc.width  / (tilesDesc.width  * float(tileSize)),
                     colorDesc.height / (tilesDesc.height * float(tileSize))
                 });

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -28,8 +28,13 @@ material {
         },
         {
            type : float2,
-           name : cocToTexelOffset,
+           name : cocToTexelScale,
            precision: high
+        },
+        {
+           type : float,
+           name : cocToPixelScale,
+           precision: medium
         },
         {
            type : float4,
@@ -106,31 +111,31 @@ float sampleCount(const float ringCount) {
     return s * s;
 }
 
-float getMipLevel(const float ringCount, const float kernelSize) {
-    #if KERNEL_USE_MIPMAP
+float getMipLevel(const float ringCount, const float kernelSizeInPixels) {
+#if KERNEL_USE_MIPMAP
     // note: the 0.5 is to convert from highres to our downslampled texture
-    float ringDistanceInTexels = 0.5 * kernelSize * rcp(ringCount - 0.5);
+    float ringDistanceInTexels = kernelSizeInPixels * rcp(ringCount - 0.5);
     float mip = log2(ringDistanceInTexels);
 
     // We should round-up to avoid too large gaps in the kernel. Small gaps are filled by the
     // median pass. With round() below + noise, most gaps are handled by the median pass,
     // and the quality is much better overall.
 
-    #if defined(TARGET_MOBILE)
+#if defined(TARGET_MOBILE)
     // on mobile, the mip level is not used in computations in the shader,
     // so we just let the texture unit pick the the "nearest" mipmap level.
-    #else
+#else
     mip = max(0.0, floor(mip + 0.5));
-    #endif
+#endif
 
     return mip;
-    #else
+#else
     return 0.0;
-    #endif
+#endif
 }
 
 float sampleWeight(const float coc, const float mip) {
-    // The contribution of sample is inversely proportional to *it's* area
+    // The contribution of sample is inversely proportional to *its* area
     // (the larger area, the fainter it is).
     // In theory this factor should be 1 / pi * radius^2, however 1/pi is a constant, and
     // because we divide by the total weight eventually, it can be ommited, in fact, any
@@ -310,7 +315,7 @@ void accumulateBackgroundCenter(inout Bucket prev,
 
 void accumulateRing(inout Bucket prev, const float index, const float ringCount,
         const float kernelSize, const vec2 noise, const highp vec2 uvCenter,
-        const highp vec2 cocToTexelOffset, const float mip, const bool first) {
+        const highp vec2 cocToTexelScale, const float mip, const bool first) {
 
     // we accumulate the larger rings first
     float i = (ringCount - 1.0) - index;
@@ -329,7 +334,7 @@ void accumulateRing(inout Bucket prev, const float index, const float ringCount,
 
     float border = (kernelSize / (ringCount - 0.5)) * (i + 0.5);
     for (float j = 0.0; j < count; j += 2.0) {
-        accumulateBackgroundMirror(curr, prev, uvCenter, p * cocToTexelOffset, radius, border, mip, first);
+        accumulateBackgroundMirror(curr, prev, uvCenter, p * cocToTexelScale, radius, border, mip, first);
         p = r * p;
     }
 
@@ -438,7 +443,7 @@ void postProcess(inout PostProcessInputs postProcess) {
 
     // we use the full resolution pixel size because that's the unit the CoC is in
     highp vec2 uv = variable_vertex.xy;
-    highp vec2 cocToTexelOffset = materialParams.cocToTexelOffset;
+    highp vec2 cocToTexelScale = materialParams.cocToTexelScale;
 
 #if KERNEL_USE_NOISE
     // When using mipmaping the noise seems to hurt more than it helps
@@ -454,13 +459,14 @@ void postProcess(inout PostProcessInputs postProcess) {
     if (isFastTile(tiles)) {
         // The whole tile has mostly the same CoC
         float kernelSize = (abs(tiles.r) + abs(tiles.g)) * 0.5;
-        float mip = getMipLevel(ringCountFast, kernelSize);
+        float cocToPixelScale = materialParams.cocToPixelScale;
+        float mip = getMipLevel(ringCountFast, kernelSize * cocToPixelScale);
 
 #if KERNEL_USE_NOISE
         float noiseRadius = randomUniformDiskRadius * rcp(ringCountFast - 0.5);
         vec2  noise = noiseRadius * randomDisk;
 #endif
-        vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
+        vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
 
         foreground = textureLod(materialParams_foregroundLinear, uvCenter, mip);
         for (float i = 1.0; i < ringCountFast; i += 1.0) {
@@ -471,9 +477,9 @@ void postProcess(inout PostProcessInputs postProcess) {
             initRing(i, ringCountFast, kernelSize, noise, radius, count, r, p);
             for (float j = 0.0; j < count; j += 2.0) {
                 foreground += textureLod(materialParams_foregroundLinear,
-                        diaphragm(uvCenter,  p * cocToTexelOffset), mip);
+                        diaphragm(uvCenter,  p * cocToTexelScale), mip);
                 foreground += textureLod(materialParams_foregroundLinear,
-                        diaphragm(uvCenter, -p * cocToTexelOffset), mip);
+                        diaphragm(uvCenter, -p * cocToTexelScale), mip);
                 p = r * p;
             }
         }
@@ -506,8 +512,9 @@ void postProcess(inout PostProcessInputs postProcess) {
         // Here we know that tiles.r < 0, by definition of a foreground tile.
         // For a foreground tile, the kernel size is the largest CoC radius of the whole tile.
         float kernelSize = -tiles.r;
-        float mip = getMipLevel(ringCountGather, kernelSize);
-        vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
+        float cocToPixelScale = materialParams.cocToPixelScale;
+        float mip = getMipLevel(ringCountGather, kernelSize * cocToPixelScale);
+        vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
 
         Layer layer[2];
         layer[0].color = vec4(0.0);
@@ -529,7 +536,7 @@ void postProcess(inout PostProcessInputs postProcess) {
 
             for (float j = 0.0; j < count; j += 2.0) {
                 accumulateForegroundMirror(layer, tiles,
-                        uvCenter, p * cocToTexelOffset, radius, mip);
+                        uvCenter, p * cocToTexelScale, radius, mip);
                 p = r * p;
             }
         }
@@ -549,20 +556,21 @@ void postProcess(inout PostProcessInputs postProcess) {
     if (isBackgroundTile(tiles)) {
         vec2 centerCoc  = textureLod(materialParams_cocFgBg, uv, 0.0).rg;
         float kernelSize = abs(centerCoc.g);
-        float mip = getMipLevel(ringCountGather, kernelSize);
-        vec2 uvCenter = uv + noise * kernelSize * cocToTexelOffset;
+        float cocToPixelScale = materialParams.cocToPixelScale;
+        float mip = getMipLevel(ringCountGather, kernelSize * cocToPixelScale);
+        vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
 
         Bucket prev;
         initBucket(prev);
 
-        accumulateRing(prev, 0.0, ringCountGather, kernelSize, noise, uvCenter, cocToTexelOffset, mip, true);
+        accumulateRing(prev, 0.0, ringCountGather, kernelSize, noise, uvCenter, cocToTexelScale, mip, true);
 
         // the optimizer is not able to remove this loop when it has only one iteration
 #if RING_COUNT_GATHER == 3
-        accumulateRing(prev, 1.0, ringCountGather, kernelSize, noise, uvCenter, cocToTexelOffset, mip, false);
+        accumulateRing(prev, 1.0, ringCountGather, kernelSize, noise, uvCenter, cocToTexelScale, mip, false);
 #else
         for (float i = 1.0; i < ringCountGather - 1.0 ; i += 1.0) {
-            accumulateRing(prev, i, ringCountGather, kernelSize, noise, uvCenter, cocToTexelOffset, mip, false);
+            accumulateRing(prev, i, ringCountGather, kernelSize, noise, uvCenter, cocToTexelScale, mip, false);
         }
 #endif
 

--- a/filament/src/materials/dof/dofCoc.mat
+++ b/filament/src/materials/dof/dofCoc.mat
@@ -1,0 +1,89 @@
+material {
+    name : dofCoc,
+    parameters : [
+        {
+            type : sampler2d,
+            name : color,
+            precision: medium
+        },
+        {
+            type : sampler2d,
+            name : depth,
+            precision: medium
+        },
+        {
+            type : float2,
+            name : cocParams
+        },
+        {
+            type : float4,
+            name : uvscale,
+            precision: high
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    outputs : [
+        {
+            name : color,
+            target : color,
+            type : float4
+        },
+        {
+            name : background,
+            target : color,
+            type : float4
+        },
+        {
+            name : cocFgBg,
+            target : color,
+            type : float2
+        }
+    ],
+    domain : postprocess,
+    depthWrite : false,
+    depthCulling : false
+}
+
+vertex {
+
+    void dummy(){}
+
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = (postProcess.normalizedUV * materialParams.uvscale.xy) * materialParams.uvscale.zw;
+    }
+}
+
+fragment {
+
+#include "dofUtils.fs"
+
+void dummy(){}
+
+void postProcess(inout PostProcessInputs postProcess) {
+    highp vec2 uv = variable_vertex.xy;
+
+    vec4 color = textureLod(materialParams_color, uv, 0.0);
+    float d = textureLod(materialParams_depth, uv, 0.0).r;
+
+    // Get the CoC radius.
+    // We multiply by 0.5 to convert from diameter to radius.
+    float coc = getCOC(d, materialParams.cocParams) * 0.5;
+
+    // If CoC is less that 0.5 full resolution pixel, we clamp to 0, this will reduce
+    // artifacts in the "in focus" area and allow us to skip more tiles trivially.
+    if (abs(coc) < MAX_IN_FOCUS_COC) {
+        coc = 0.0;
+    }
+
+    // Clamp to maximum allowable CoC radius.
+    coc = clamp(coc, -MAX_COC_RADIUS, MAX_COC_RADIUS);
+
+    // Output to MRTs
+    postProcess.color       = color;
+    postProcess.background  = color;
+    postProcess.cocFgBg     = vec2(coc, coc);
+}
+
+}

--- a/filament/src/materials/dof/dofDilate.mat
+++ b/filament/src/materials/dof/dofDilate.mat
@@ -27,7 +27,7 @@ fragment {
 
 void dummy(){}
 
-// Tiles of 16 pixels requires two dilate rounds to accomodate our max Coc of 32 pixels
+// Size of a tile in full-resolution pixels -- must match tileSize in PostProcessManager.cpp
 #define TILE_SIZE   16.0
 
 vec2 tap(const vec2 uv, const vec2 offset) {
@@ -35,7 +35,8 @@ vec2 tap(const vec2 uv, const vec2 offset) {
 }
 
 vec2 dilate(inout vec2 center, const vec2 tap) {
-    // 2.24 (sqrt(5) is the longest distance between 2 pixels of adjacent tiles).
+    // 2.24 tiles is the longest distance between 2 pixels of adjacent tiles.
+    // sqrt(2^2 + 1^2) = 2.24
     const float maxDistance = max(-MAX_COC_RADIUS, -2.24 * TILE_SIZE);
 
     // Tiles that can affect us need to transfer their CoC to us (for the foreground it's

--- a/filament/src/materials/dof/dofUtils.fs
+++ b/filament/src/materials/dof/dofUtils.fs
@@ -6,6 +6,7 @@
 // Below this value we transition to the in-focus image. This value is chosen as a compromise
 // between allowing slight out-of-focus and reducing sampling artifacts around blurry objects
 // on sharp background. Based on experiments, it should be between 1.0 and 2.0.
+// This value is in high-resolution pixels.
 #define MAX_IN_FOCUS_COC    1.0
 
 // The maximum circle-of-confusion radius we allow in high-resolution pixels.
@@ -13,7 +14,7 @@
 // too large, the rings start to appear; but worse, the median pass will start erasing pixels
 // if the gaps between rings becomes too large. This is also limited by the dilate pass.
 // With a minimum ring count of 3 and 4 mip levels, 48 seems to be the maximum allowable.
-// Currently out dilate pass is set-up for 32 max.
+// Currently our dilate pass is set-up for 32 max.
 #define MAX_COC_RADIUS      32.0
 
 float random(const highp vec2 w) {


### PR DESCRIPTION
This is mostly used for debugging and having somewhat of a reference.
Change to the shader are minimal because all CoC values were always
treated as full-resolution. We just need to replace the downsampling
shader by one that just calculates the CoC. And we need to introduce
a CoC scale factor to compute the LOD to use (this was hardcoded
before).

On the C++ side, it's mostly a matter of replacing hardcoded buffer size
scales by a runtime or compile time variable.