### PR TITLE
fix JNI setImage and friends buffer size calculation

### DIFF
--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -34,12 +34,13 @@
 using namespace filament;
 using namespace backend;
 
-static size_t getTextureDataSize(const Texture *texture, size_t level,
-        Texture::Format format, Texture::Type type, size_t stride, size_t alignment) {
+static size_t getTextureDataSize(const Texture *texture,
+        size_t level, Texture::Format format, Texture::Type type,
+        size_t stride, size_t height, size_t alignment) {
     // Zero stride implies tight row-to-row packing.
-    stride = stride == 0 ? texture->getWidth(level) : std::max(size_t(1), stride >> level);
-    return Texture::computeTextureDataSize(format, type,
-            stride, texture->getHeight(level), alignment);
+    stride = stride == 0 ? texture->getWidth(level)  : std::max(size_t(1), stride >> level);
+    height = height == 0 ? texture->getHeight(level) : std::max(size_t(1), height >> level);
+    return Texture::computeTextureDataSize(format, type, stride, height, alignment);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
@@ -175,14 +176,14 @@ extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Texture_nSetImage(JNIEnv* env, jclass, jlong nativeTexture,
         jlong nativeEngine, jint level, jint xoffset, jint yoffset, jint width, jint height,
         jobject storage,  jint remaining,
-        jint left, jint bottom, jint type, jint alignment,
+        jint left, jint top, jint type, jint alignment,
         jint stride, jint format,
         jobject handler, jobject runnable) {
     Texture* texture = (Texture*) nativeTexture;
     Engine* engine = (Engine*) nativeEngine;
 
     size_t sizeInBytes = getTextureDataSize(texture, (size_t) level, (Texture::Format) format,
-            (Texture::Type) type, (size_t) stride, (size_t) alignment);
+            (Texture::Type) type, (size_t) stride, (size_t) height, (size_t) alignment);
 
     AutoBuffer nioBuffer(env, storage, 0);
     if (sizeInBytes > (size_t(remaining) << nioBuffer.getShift())) {
@@ -194,7 +195,7 @@ Java_com_google_android_filament_Texture_nSetImage(JNIEnv* env, jclass, jlong na
     auto *callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
 
     Texture::PixelBufferDescriptor desc(buffer, sizeInBytes, (backend::PixelDataFormat) format,
-            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) bottom,
+            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) top,
             (uint32_t) stride, &JniBufferCallback::invoke, callback);
 
     texture->setImage(*engine, (size_t) level, (uint32_t) xoffset, (uint32_t) yoffset,
@@ -239,14 +240,14 @@ Java_com_google_android_filament_Texture_nSetImage3D(JNIEnv* env, jclass, jlong 
         jint xoffset, jint yoffset, jint zoffset,
         jint width, jint height, jint depth,
         jobject storage,  jint remaining,
-        jint left, jint bottom, jint type, jint alignment,
+        jint left, jint top, jint type, jint alignment,
         jint stride, jint format,
         jobject handler, jobject runnable) {
     Texture* texture = (Texture*) nativeTexture;
     Engine* engine = (Engine*) nativeEngine;
 
     size_t sizeInBytes = getTextureDataSize(texture, (size_t) level, (Texture::Format) format,
-            (Texture::Type) type, (size_t) stride, (size_t) alignment);
+            (Texture::Type) type, (size_t) stride, (size_t) height, (size_t) alignment) * depth;
 
     AutoBuffer nioBuffer(env, storage, 0);
     if (sizeInBytes > (size_t(remaining) << nioBuffer.getShift())) {
@@ -258,7 +259,7 @@ Java_com_google_android_filament_Texture_nSetImage3D(JNIEnv* env, jclass, jlong 
     auto *callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
 
     Texture::PixelBufferDescriptor desc(buffer, sizeInBytes, (backend::PixelDataFormat) format,
-            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) bottom,
+            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) top,
             (uint32_t) stride, &JniBufferCallback::invoke, callback);
 
     texture->setImage(*engine, (size_t) level,
@@ -306,7 +307,7 @@ Java_com_google_android_filament_Texture_nSetImage3DCompressed(JNIEnv *env, jcla
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Texture_nSetImageCubemap(JNIEnv *env, jclass,
         jlong nativeTexture, jlong nativeEngine, jint level, jobject storage, jint remaining,
-        jint left, jint bottom, jint type, jint alignment, jint stride, jint format,
+        jint left, jint top, jint type, jint alignment, jint stride, jint format,
         jintArray faceOffsetsInBytes_,
         jobject handler, jobject runnable) {
     Texture *texture = (Texture *) nativeTexture;
@@ -318,7 +319,7 @@ Java_com_google_android_filament_Texture_nSetImageCubemap(JNIEnv *env, jclass,
     env->ReleaseIntArrayElements(faceOffsetsInBytes_, faceOffsetsInBytes, JNI_ABORT);
 
     size_t sizeInBytes = 6 * getTextureDataSize(texture, (size_t) level, (Texture::Format) format,
-            (Texture::Type) type, (size_t) stride, (size_t) alignment);
+            (Texture::Type) type, (size_t) stride, 0, (size_t) alignment);
 
     AutoBuffer nioBuffer(env, storage, 0);
     if (sizeInBytes > (size_t(remaining) << nioBuffer.getShift())) {
@@ -330,7 +331,7 @@ Java_com_google_android_filament_Texture_nSetImageCubemap(JNIEnv *env, jclass,
     auto *callback = JniBufferCallback::make(engine, env, handler, runnable, std::move(nioBuffer));
 
     Texture::PixelBufferDescriptor desc(buffer, sizeInBytes, (backend::PixelDataFormat) format,
-            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) bottom,
+            (backend::PixelDataType) type, (uint8_t) alignment, (uint32_t) left, (uint32_t) top,
             (uint32_t) stride, &JniBufferCallback::invoke, callback);
 
     texture->setImage(*engine, (size_t) level, std::move(desc), faceOffsets);
@@ -341,7 +342,7 @@ Java_com_google_android_filament_Texture_nSetImageCubemap(JNIEnv *env, jclass,
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Texture_nSetImageCubemapCompressed(JNIEnv *env, jclass,
         jlong nativeTexture, jlong nativeEngine, jint level, jobject storage, jint remaining,
-        jint left, jint bottom, jint type, jint alignment,
+        jint left, jint top, jint type, jint alignment,
         jint compressedSizeInBytes, jint compressedFormat, jintArray faceOffsetsInBytes_,
         jobject handler, jobject runnable) {
 

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -1160,35 +1160,35 @@ public class Texture {
 
     private static native int nSetImage(long nativeTexture, long nativeEngine,
             int level, int xoffset, int yoffset, int width, int height,
-            Buffer storage, int remaining, int left, int bottom, int type, int alignment,
+            Buffer storage, int remaining, int left, int top, int type, int alignment,
             int stride, int format,
             Object handler, Runnable callback);
 
     private static native int nSetImageCompressed(long nativeTexture, long nativeEngine,
             int level, int xoffset, int yoffset, int width, int height,
-            Buffer storage, int remaining, int left, int bottom, int type, int alignment,
+            Buffer storage, int remaining, int left, int top, int type, int alignment,
             int compressedSizeInBytes, int compressedFormat,
             Object handler, Runnable callback);
 
     private static native int nSetImage3D(long nativeTexture, long nativeEngine,
             int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
-            Buffer storage, int remaining, int left, int bottom, int type, int alignment,
+            Buffer storage, int remaining, int left, int top, int type, int alignment,
             int stride, int format,
             Object handler, Runnable callback);
 
     private static native int nSetImage3DCompressed(long nativeTexture, long nativeEngine,
             int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
-            Buffer storage, int remaining, int left, int bottom, int type, int alignment,
+            Buffer storage, int remaining, int left, int top, int type, int alignment,
             int compressedSizeInBytes, int compressedFormat,
             Object handler, Runnable callback);
 
     private static native int nSetImageCubemap(long nativeTexture, long nativeEngine,
-            int level, Buffer storage, int remaining, int left, int bottom, int type,
+            int level, Buffer storage, int remaining, int left, int top, int type,
             int alignment, int stride, int format,
             int[] faceOffsetsInBytes, Object handler, Runnable callback);
 
     private static native int nSetImageCubemapCompressed(long nativeTexture, long nativeEngine,
-            int level, Buffer storage, int remaining, int left, int bottom, int type,
+            int level, Buffer storage, int remaining, int left, int top, int type,
             int alignment, int compressedSizeInBytes, int compressedFormat,
             int[] faceOffsetsInBytes, Object handler, Runnable callback);
 


### PR DESCRIPTION
- setImage() used the width of the texture for calculating the required
  user buffer size, but this was too large when only updating a
  portion of the texture. It would result in a BufferOverFlowException.

- setImage3D() had the opposite problem where it didn't take into
  account the depth of the texture.

- the offset in the user buffer was called "bottom" on the C++ JNI side,
  but it is called "top" on the java and filament side.

Fixes #3685