### PR TITLE
Minor Driver API simplification.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -724,9 +724,10 @@ struct Attribute {
     static constexpr uint8_t FLAG_NORMALIZED     = 0x1;
     //! attribute is an integer
     static constexpr uint8_t FLAG_INTEGER_TARGET = 0x2;
+    static constexpr uint8_t BUFFER_UNUSED = 0xFF;
     uint32_t offset = 0;                    //!< attribute offset in bytes
     uint8_t stride = 0;                     //!< attribute stride in bytes
-    uint8_t buffer = 0xFF;                  //!< attribute buffer index
+    uint8_t buffer = BUFFER_UNUSED;         //!< attribute buffer index
     ElementType type = ElementType::BYTE;   //!< attribute element type
     uint8_t flags = 0x0;                    //!< attribute flags
 };

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -381,8 +381,7 @@ DECL_DRIVER_API_0(nextSubpass)
 DECL_DRIVER_API_N(setRenderPrimitiveBuffer,
         backend::RenderPrimitiveHandle, rph,
         backend::VertexBufferHandle, vbh,
-        backend::IndexBufferHandle, ibh,
-        uint32_t, enabledAttributes)
+        backend::IndexBufferHandle, ibh)
 
 DECL_DRIVER_API_N(setRenderPrimitiveRange,
         backend::RenderPrimitiveHandle, rph,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -802,11 +802,11 @@ void MetalDriver::endRenderPass(int dummy) {
 }
 
 void MetalDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
-        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh, uint32_t enabledAttributes) {
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh) {
     auto primitive = handle_cast<MetalRenderPrimitive>(mHandleMap, rph);
     auto vertexBuffer = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     auto indexBuffer = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
-    primitive->setBuffers(vertexBuffer, indexBuffer, enabledAttributes);
+    primitive->setBuffers(vertexBuffer, indexBuffer);
 }
 
 void MetalDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -133,8 +133,7 @@ struct MetalUniformBuffer : public HwUniformBuffer {
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {
-    void setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer* indexBuffer,
-            uint32_t enabledAttributes);
+    void setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer* indexBuffer);
     // The pointers to MetalVertexBuffer and MetalIndexBuffer are "weak".
     // The MetalVertexBuffer and MetalIndexBuffer must outlive the MetalRenderPrimitive.
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -303,7 +303,7 @@ MetalUniformBuffer::MetalUniformBuffer(MetalContext& context, size_t size) : HwU
         buffer(context, size) { }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*
-        indexBuffer, uint32_t enabledAttributes) {
+        indexBuffer) {
     this->vertexBuffer = vertexBuffer;
     this->indexBuffer = indexBuffer;
 
@@ -318,8 +318,9 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
 
     uint32_t bufferIndex = 0;
     for (uint32_t attributeIndex = 0; attributeIndex < attributeCount; attributeIndex++) {
-        if (!(enabledAttributes & (1U << attributeIndex))) {
-            const uint8_t flags = vertexBuffer->attributes[attributeIndex].flags;
+        const auto& attribute = vertexBuffer->attributes[attributeIndex];
+        if (attribute.buffer != Attribute::BUFFER_UNUSED) {
+            const uint8_t flags = attribute.flags;
             const MTLVertexFormat format = (flags & Attribute::FLAG_INTEGER_TARGET) ?
                     MTLVertexFormatUInt4 : MTLVertexFormatFloat4;
 
@@ -336,7 +337,6 @@ void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalInde
             };
             continue;
         }
-        const auto& attribute = vertexBuffer->attributes[attributeIndex];
 
         buffers.push_back(vertexBuffer->buffers[attribute.buffer]);
         offsets.push_back(attribute.offset);

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -246,8 +246,7 @@ void NoopDriver::nextSubpass(int) {
 }
 
 void NoopDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
-        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        uint32_t enabledAttributes) {
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh) {
 }
 
 void NoopDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2358,8 +2358,7 @@ GLsizei OpenGLDriver::getAttachments(std::array<GLenum, 6>& attachments,
 }
 
 void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
-        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        uint32_t enabledAttributes) {
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh) {
     DEBUG_MARKER()
     auto& gl = mContext;
 
@@ -2376,11 +2375,11 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         rp->gl.indicesType = ib->elementSize == 4 ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
         rp->maxVertexCount = eb->vertexCount;
         for (size_t i = 0, n = eb->attributes.size(); i < n; i++) {
-            if (enabledAttributes & (1U << i)) {
-                uint8_t bi = eb->attributes[i].buffer;
-                assert_invariant(bi != 0xFF);
+            const auto& attribute = eb->attributes[i];
+            if (attribute.buffer != Attribute::BUFFER_UNUSED) {
+                uint8_t bi = attribute.buffer;
                 gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[bi]);
-                if (UTILS_UNLIKELY(eb->attributes[i].flags & Attribute::FLAG_INTEGER_TARGET)) {
+                if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
 
                     // Emscripten regressed at the following PR so we work around it for now.
                     // https://github.com/emscripten-core/emscripten/pull/11225
@@ -2389,17 +2388,17 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
                     #endif
 
                     glVertexAttribIPointer(GLuint(i),
-                            getComponentCount(eb->attributes[i].type),
-                            getComponentType(eb->attributes[i].type),
-                            eb->attributes[i].stride,
-                            (void*) uintptr_t(eb->attributes[i].offset));
+                            getComponentCount(attribute.type),
+                            getComponentType(attribute.type),
+                            attribute.stride,
+                            (void*) uintptr_t(attribute.offset));
                 } else {
                     glVertexAttribPointer(GLuint(i),
-                            getComponentCount(eb->attributes[i].type),
-                            getComponentType(eb->attributes[i].type),
-                            getNormalization(eb->attributes[i].flags & Attribute::FLAG_NORMALIZED),
-                            eb->attributes[i].stride,
-                            (void*) uintptr_t(eb->attributes[i].offset));
+                            getComponentCount(attribute.type),
+                            getComponentType(attribute.type),
+                            getNormalization(attribute.flags & Attribute::FLAG_NORMALIZED),
+                            attribute.stride,
+                            (void*) uintptr_t(attribute.offset));
                 }
 
                 gl.enableVertexAttribArray(GLuint(i));
@@ -2407,7 +2406,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
 
                 // In some OpenGL implementations, we must supply a properly-typed placeholder for
                 // every integer input that is declared in the vertex shader.
-                if (UTILS_UNLIKELY(eb->attributes[i].flags & Attribute::FLAG_INTEGER_TARGET)) {
+                if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
                     glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
                 } else {
                     glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1164,11 +1164,10 @@ void VulkanDriver::nextSubpass(int) {
 }
 
 void VulkanDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
-        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh,
-        uint32_t enabledAttributes) {
+        Handle<HwVertexBuffer> vbh, Handle<HwIndexBuffer> ibh) {
     auto primitive = handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
     primitive->setBuffers(handle_cast<VulkanVertexBuffer>(mHandleMap, vbh),
-            handle_cast<VulkanIndexBuffer>(mHandleMap, ibh), enabledAttributes);
+            handle_cast<VulkanIndexBuffer>(mHandleMap, ibh));
 }
 
 void VulkanDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -178,8 +178,7 @@ private:
 struct VulkanRenderPrimitive : public HwRenderPrimitive {
     explicit VulkanRenderPrimitive(VulkanContext& context) {}
     void setPrimitiveType(backend::PrimitiveType pt);
-    void setBuffers(VulkanVertexBuffer* vertexBuffer, VulkanIndexBuffer* indexBuffer,
-            uint32_t enabledAttributes);
+    void setBuffers(VulkanVertexBuffer* vertexBuffer, VulkanIndexBuffer* indexBuffer);
     VulkanVertexBuffer* vertexBuffer = nullptr;
     VulkanIndexBuffer* indexBuffer = nullptr;
     VkPrimitiveTopology primitiveTopology;

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -59,8 +59,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
 
     mRenderPrimitive = mDriverApi.createRenderPrimitive(0);
 
-    mDriverApi.setRenderPrimitiveBuffer(mRenderPrimitive, mVertexBuffer, mIndexBuffer,
-            enabledAttributes.getValue());
+    mDriverApi.setRenderPrimitiveBuffer(mRenderPrimitive, mVertexBuffer, mIndexBuffer);
     mDriverApi.setRenderPrimitiveRange(mRenderPrimitive, PrimitiveType::TRIANGLES, 0, 0, 2, 3);
 }
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -218,8 +218,7 @@ void FEngine::init() {
 
     mFullScreenTriangleRph = driverApi.createRenderPrimitive();
     driverApi.setRenderPrimitiveBuffer(mFullScreenTriangleRph,
-            mFullScreenTriangleVb->getHwHandle(), mFullScreenTriangleIb->getHwHandle(),
-            mFullScreenTriangleVb->getDeclaredAttributes().getValue());
+            mFullScreenTriangleVb->getHwHandle(), mFullScreenTriangleIb->getHwHandle());
     driverApi.setRenderPrimitiveRange(mFullScreenTriangleRph, PrimitiveType::TRIANGLES,
             0, 0, 2, (uint32_t)mFullScreenTriangleIb->getIndexCount());
 

--- a/filament/src/RenderPrimitive.cpp
+++ b/filament/src/RenderPrimitive.cpp
@@ -43,7 +43,7 @@ void FRenderPrimitive::init(backend::DriverApi& driver,
         auto const& ebh = vertexBuffer->getHwHandle();
         auto const& ibh = indexBuffer->getHwHandle();
 
-        driver.setRenderPrimitiveBuffer(mHandle, ebh, ibh, (uint32_t)enabledAttributes.getValue());
+        driver.setRenderPrimitiveBuffer(mHandle, ebh, ibh);
         driver.setRenderPrimitiveRange(mHandle, entry.type,
                 (uint32_t)entry.offset, (uint32_t)entry.minIndex, (uint32_t)entry.maxIndex,
                 (uint32_t)entry.count);
@@ -67,7 +67,7 @@ void FRenderPrimitive::set(FEngine& engine, RenderableManager::PrimitiveType typ
 
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    driver.setRenderPrimitiveBuffer(mHandle, ebh, ibh, (uint32_t)enabledAttributes.getValue());
+    driver.setRenderPrimitiveBuffer(mHandle, ebh, ibh);
     driver.setRenderPrimitiveRange(mHandle, type,
             (uint32_t)offset, (uint32_t)minIndex, (uint32_t)maxIndex, (uint32_t)count);
 


### PR DESCRIPTION
As far as I can tell, there is no need for the `enabledAttributes`
argument in `setRenderPrimitiveBuffer`. This helps pave the way for
the upcoming BufferObject API.