### PR TITLE
DoF: fix several mediump-related bugs

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -188,12 +188,18 @@ highp vec2 diaphragm(const highp vec2 center, const vec2 offset) {
  * "Life of a Bokeh" by Guillaume Abadie, SIGGRAPH 2018
  */
 
+// Qualcomm drivers don't seem to support precision qualifiers on member of a structure,
+// they are simply ignored.
+precision highp float;
+
 struct Bucket {
     vec4 c;     // accumulated, weighted color
     float cw;   // accumulated weight
     float o;    // # of miss for the ring
     float coc;  // accumulated, weighted coc
 };
+
+precision mediump float;
 
 struct Sample {
     vec4 s;                 // sample color
@@ -259,7 +265,7 @@ void accumulate(inout Bucket curr, inout Bucket prev, const Sample tap,
         const float radius, const float border, const float mip, const bool first) {
     float inLayer = isBackground(tap.coc);
     float coc = abs(tap.coc);
-    float w = intersection(radius, coc, mip) * sampleWeight(coc, mip) * inLayer;
+    float w = inLayer * intersection(radius, coc, mip) * sampleWeight(coc, mip);
 
     // Samples that have a CoC larger than the ring radius belong to the previous ring.
     // Samples that have a CoC similar to the ring radius belong to the current ring.
@@ -403,11 +409,11 @@ void accumulateForegroundMirror(inout Layer layer[2], const vec2 tiles,
     // but selects the min coc of opposite samples as a way to guess the color occluded by
     // the geometry.
 
-    vec2 pos0 = diaphragm(center, offset);
+    highp vec2 pos0 = diaphragm(center, offset);
     float coc0 = textureLod(materialParams_cocFgBg, pos0, mip).r;
     vec4 s0 = textureLod(materialParams_foreground, pos0, mip);
 
-    vec2 pos1 = diaphragm(center, -offset);
+    highp vec2 pos1 = diaphragm(center, -offset);
     float coc1 = textureLod(materialParams_cocFgBg, pos1, mip).r;
     vec4 s1 = textureLod(materialParams_foreground, pos1, mip);
 
@@ -416,14 +422,13 @@ void accumulateForegroundMirror(inout Layer layer[2], const vec2 tiles,
     float i = intersection(border, abs(coc), mip) * sampleWeight(coc, mip);
     float w = i * inLayer;
 
+    // for better results in mediump it's better to add s0 amd s1 first
     float inBackWeight  = w * computeLayer(coc, tiles);
     float inFrontWeight = w - inBackWeight;
-    layer[0].color  += inFrontWeight * s0;
-    layer[0].color  += inFrontWeight * s1;
-    layer[0].weight += inFrontWeight * 2.0;
-    layer[1].color  += inBackWeight  * s0;
-    layer[1].color  += inBackWeight  * s1;
+    layer[1].color  += inBackWeight  * (s0 + s1);
     layer[1].weight += inBackWeight  * 2.0;
+    layer[0].color  += inFrontWeight * (s0 + s1);
+    layer[0].weight += inFrontWeight * 2.0;
 }
 
 /*
@@ -440,7 +445,7 @@ void fastTile(inout vec4 color, inout float alpha,
     float ringCountFast = min(float(RING_COUNT_FAST), computeNeededRings(kernelSize * cocToPixelScale));
     float mip = getMipLevel(ringCountFast, kernelSize * cocToPixelScale);
 
-    vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
+    highp vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
 
     color = textureLod(materialParams_foregroundLinear, uvCenter, mip);
     for (float i = 1.0; i < ringCountFast; i += 1.0) {
@@ -449,13 +454,16 @@ void fastTile(inout vec4 color, inout float alpha,
         vec2 p;
         mat2 r;
         initRing(i, ringCountFast, kernelSize, noise, radius, count, r, p);
+        // we must use this temporary in order to accomodate mediump precision
+        vec4 t = vec4(0.0);
         for (float j = 0.0; j < count; j += 2.0) {
-            color += textureLod(materialParams_foregroundLinear,
-            diaphragm(uvCenter,  p * cocToTexelScale), mip);
-            color += textureLod(materialParams_foregroundLinear,
-            diaphragm(uvCenter, -p * cocToTexelScale), mip);
+            t += textureLod(materialParams_foregroundLinear,
+                    diaphragm(uvCenter,  p * cocToTexelScale), mip)
+               + textureLod(materialParams_foregroundLinear,
+                    diaphragm(uvCenter, -p * cocToTexelScale), mip);
             p = r * p;
         }
+        color += t;
     }
     alpha = cocToAlpha(kernelSize);
     color *= rcp(sampleCount(ringCountFast));
@@ -517,10 +525,10 @@ void backgroundTile(inout vec4 background, inout float bgOpacity,
     // we select a ring cound per tile, to avoid divergence between pixels
     float ringCountGather = min(float(RING_COUNT_GATHER), computeNeededRings(tiles.g * cocToPixelScale));
 
-    vec2 centerCoc  = textureLod(materialParams_cocFgBg, uv, 0.0).rg;
-    float kernelSize = abs(centerCoc.g);
+    float centerCoc  = textureLod(materialParams_cocFgBg, uv, 0.0).g;
+    float kernelSize = abs(centerCoc);
     float mip = getMipLevel(ringCountGather, kernelSize * cocToPixelScale);
-    vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
+    highp vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
 
     Bucket prev;
     initBucket(prev);
@@ -543,7 +551,7 @@ void backgroundTile(inout vec4 background, inout float bgOpacity,
 #if !defined(TARGET_MOBILE)
     bgOpacity *= smoothstep(MAX_IN_FOCUS_COC, 2.0, kernelSize);
 #endif
-    background = prev.c * (rcpOrZero(prev.cw) * bgOpacity);
+    background = prev.c * (rcpOrZeroHighp(prev.cw) * bgOpacity);
 }
 
 void postProcess(inout PostProcessInputs postProcess) {

--- a/filament/src/materials/dof/dofUtils.fs
+++ b/filament/src/materials/dof/dofUtils.fs
@@ -46,6 +46,10 @@ float rcpOrZero(const float x) {
     return x > MEDIUMP_FLT_MIN ? (1.0 / x) : 0.0;
 }
 
+highp float rcpOrZeroHighp(const highp float x) {
+    return x > MEDIUMP_FLT_MIN ? (1.0 / x) : 0.0;
+}
+
 float cocToAlpha(const float coc) {
     // CoC is positive for background field.
     // CoC is negative for the foreground field.


### PR DESCRIPTION
The gist of it is that we can't always accumulate samples naively, and
we have to use different strategies with different tile types.

For the fast tiles it seems enough to reorder the sum, accumulating each
ring first, and then accumulating that into the output, because all
samples have the same weight.

For the foreground tiles, for some reason I couldn't find any major
issue and I'm not sure why.

For the background tiles, we need to use highp intermediates because
every sample has different magnitudes (weights)