### PR TITLE
DoF: fix noise radius calculation

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -106,6 +106,11 @@ fragment {
 
 void dummy(){}
 
+struct NoiseState {
+    float randomUniformDiskRadius;
+    vec2  randomDisk;
+};
+
 float sampleCount(const float ringCount) {
     float s = (ringCount * 2.0 - 1.0);
     return s * s;
@@ -227,7 +232,7 @@ void initRing(const float i, const float ringCount, const float kernelSize, cons
     p = radius * vec2(cos(firstSamplePosition), sin(firstSamplePosition));
 
     // it might be okay to do this only for the center sample (i.e.: offset = radius instead)
-    offset = length(p + noise * kernelSize);
+    offset = length(p + noise);
 }
 
 void mergeRings(inout Bucket curr, inout Bucket prev, const float count) {
@@ -312,8 +317,7 @@ void accumulateBackgroundCenter(inout Bucket prev,
     float border = (kernelSize / (ringCount - 0.5)) * 0.5;
     // the ring radius is zero here, but the intersection radius is not when we add noise, this
     // seems to make a visible difference on edges
-    float radius = noiseRadius * kernelSize;
-    accumulateBackground(curr, prev, pos, radius, border, mip, false);
+    accumulateBackground(curr, prev, pos, noiseRadius, border, mip, false);
     mergeRings(curr, prev, 1.0);
 }
 
@@ -431,7 +435,7 @@ void accumulateForegroundMirror(inout Layer layer[2], const vec2 tiles,
  */
 
 void fastTile(inout vec4 color, inout float alpha,
-        const highp vec2 uv, const vec2 tiles, const vec2 noise) {
+        const highp vec2 uv, const vec2 tiles, const NoiseState noiseState) {
     highp vec2 cocToTexelScale = materialParams.cocToTexelScale;
     float cocToPixelScale = materialParams.cocToPixelScale;
 
@@ -439,8 +443,14 @@ void fastTile(inout vec4 color, inout float alpha,
     float kernelSize = (abs(tiles.r) + abs(tiles.g)) * 0.5;
     float ringCountFast = min(float(RING_COUNT_FAST), computeNeededRings(kernelSize * cocToPixelScale));
     float mip = getMipLevel(ringCountFast, kernelSize * cocToPixelScale);
+    vec2 noise = vec2(0.0);
 
-    vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
+#if KERNEL_USE_NOISE
+    noise = noiseState.randomDisk *
+            (kernelSize * noiseState.randomUniformDiskRadius * rcp(ringCountFast - 0.5));
+#endif
+
+    highp vec2 uvCenter = uv + noise * cocToTexelScale;
 
     color = textureLod(materialParams_foregroundLinear, uvCenter, mip);
     for (float i = 1.0; i < ringCountFast; i += 1.0) {
@@ -462,7 +472,7 @@ void fastTile(inout vec4 color, inout float alpha,
 }
 
 void foregroundTile(inout vec4 foreground, inout float fgOpacity,
-        const highp vec2 uv, const vec2 tiles, const vec2 noise) {
+        const highp vec2 uv, const vec2 tiles, const NoiseState noiseState) {
     highp vec2 cocToTexelScale = materialParams.cocToTexelScale;
     float cocToPixelScale = materialParams.cocToPixelScale;
 
@@ -471,7 +481,14 @@ void foregroundTile(inout vec4 foreground, inout float fgOpacity,
     float kernelSize = -tiles.r;
     float ringCountGather = min(float(RING_COUNT_GATHER), computeNeededRings(kernelSize * cocToPixelScale));
     float mip = getMipLevel(ringCountGather, kernelSize * cocToPixelScale);
-    vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
+    vec2 noise = vec2(0.0);
+
+#if KERNEL_USE_NOISE
+    noise = (noiseState.randomDisk) *
+            (kernelSize * noiseState.randomUniformDiskRadius * rcp(ringCountGather - 0.5));
+#endif
+
+    highp vec2 uvCenter = uv + noise * cocToTexelScale;
 
     Layer layer[2];
     layer[0].color = vec4(0.0);
@@ -510,7 +527,7 @@ void foregroundTile(inout vec4 foreground, inout float fgOpacity,
 }
 
 void backgroundTile(inout vec4 background, inout float bgOpacity,
-        const highp vec2 uv, const vec2 tiles, const vec2 noise, const float noiseRadius) {
+        const highp vec2 uv, const vec2 tiles, const NoiseState noiseState) {
     highp vec2 cocToTexelScale = materialParams.cocToTexelScale;
     float cocToPixelScale = materialParams.cocToPixelScale;
 
@@ -520,7 +537,15 @@ void backgroundTile(inout vec4 background, inout float bgOpacity,
     vec2 centerCoc  = textureLod(materialParams_cocFgBg, uv, 0.0).rg;
     float kernelSize = abs(centerCoc.g);
     float mip = getMipLevel(ringCountGather, kernelSize * cocToPixelScale);
-    vec2 uvCenter = uv + noise * kernelSize * cocToTexelScale;
+    float noiseRadius = 0.0;
+    vec2 noise = vec2(0.0);
+
+#if KERNEL_USE_NOISE
+    noiseRadius = kernelSize * noiseState.randomUniformDiskRadius * rcp(ringCountGather - 0.5);
+    noise = noiseState.randomDisk * noiseRadius;
+#endif
+
+    highp vec2 uvCenter = uv + noise * cocToTexelScale;
 
     Bucket prev;
     initBucket(prev);
@@ -547,8 +572,6 @@ void backgroundTile(inout vec4 background, inout float bgOpacity,
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
-    const float ringCountFast   = float(RING_COUNT_FAST);
-    const float ringCountGather = float(RING_COUNT_GATHER);
     vec2 tiles = textureLod(materialParams_tiles, variable_vertex.zw, 0.0).rg;
 
     /*
@@ -565,17 +588,15 @@ void postProcess(inout PostProcessInputs postProcess) {
     highp vec2 uv = variable_vertex.xy;
     vec4 foreground = vec4(0.0);
     vec4 background = vec4(0.0);
-    vec2 noise = vec2(0.0);
-    float noiseRadius = 0.0;
+    NoiseState noiseState;
 
 #if KERNEL_USE_NOISE
-    // When using mipmaping the noise seems to hurt more than it helps
     // A good random generator is essential, this one is okay.
     vec2 fragCoords = gl_FragCoord.xy;
     float randomAngle = random(fragCoords) * (2.0 * PI);
     float random01 = random(fragCoords * vec2(5099.0, 3499.0)); // large primes seem to work ok
-    float randomUniformDiskRadius = 0.5 * sqrt(random01);
-    vec2  randomDisk = vec2(cos(randomAngle), sin(randomAngle));
+    noiseState.randomUniformDiskRadius = 0.5 * sqrt(random01);
+    noiseState.randomDisk = vec2(cos(randomAngle), sin(randomAngle));
 #endif
 
     /*
@@ -583,13 +604,9 @@ void postProcess(inout PostProcessInputs postProcess) {
      */
 
     if (isFastTile(tiles)) {
-#if KERNEL_USE_NOISE
-        noiseRadius = randomUniformDiskRadius * rcp(ringCountFast - 0.5);
-        noise = noiseRadius * randomDisk;
-#endif
         vec4 color;
         float alpha;
-        fastTile(color, alpha, uv, tiles, noise);
+        fastTile(color, alpha, uv, tiles, noiseState);
         //color.b += 0.1;
 
 #if POST_PROCESS_OPAQUE
@@ -607,18 +624,14 @@ void postProcess(inout PostProcessInputs postProcess) {
 
     float fgOpacity = 0.0;
     float bgOpacity = 0.0;
-#if KERNEL_USE_NOISE
-    noiseRadius = randomUniformDiskRadius * rcp(ringCountGather - 0.5);
-    noise = noiseRadius * randomDisk;
-#endif
 
     if (isForegroundTile(tiles)) {
-        foregroundTile(foreground, fgOpacity, uv, tiles, noise);
+        foregroundTile(foreground, fgOpacity, uv, tiles, noiseState);
         //foreground.r += 0.1;
     }
 
     if (isBackgroundTile(tiles)) {
-        backgroundTile(background, bgOpacity, uv, tiles, noise, noiseRadius);
+        backgroundTile(background, bgOpacity, uv, tiles, noiseState);
         //background.g += 0.1;
     }
 


### PR DESCRIPTION
This small bug was introduced recently with the dynamic kernel size
changes, the noise radius depends on the number of rings in the kernel.