### PR TITLE
DoF: document a typo

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -303,6 +303,9 @@ void accumulate(inout Bucket curr, inout Bucket prev, const Sample tap,
 void accumulateBackground(inout Bucket curr, inout Bucket prev, const highp vec2 pos,
         const float radius, const float border, const float mip, const bool first) {
     Sample tap;
+    // FIXME: there are typos below. We should use materialParams_background and
+    //        materialParams_cocFgBg's green (background coc) channel.
+    //        however doing so, looks much worse and is much more unstable.
     tap.s = textureLod(materialParams_foreground, pos, mip);
     tap.coc = textureLod(materialParams_cocFgBg, pos, mip).r;
     accumulate(curr, prev, tap, radius, border, mip, first);


### PR DESCRIPTION
there has been a typo in the DoF code a while, but fixing it looks
much worse. we need to understand why. so for now we at least
document the typo in the code.