### PR TITLE
DoF: implement "background hole filling"

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -308,8 +308,34 @@ void accumulateBackground(inout Bucket curr, inout Bucket prev, const highp vec2
 void accumulateBackgroundMirror(inout Bucket curr, inout Bucket prev,
         const highp vec2 center, const vec2 offset,
         const float radius, const float border, const float mip, const bool first) {
-    accumulateBackground(curr, prev, diaphragm(center,  offset), radius, border, mip, first);
-    accumulateBackground(curr, prev, diaphragm(center, -offset), radius, border, mip, first);
+    // The code below is equivalent (without hole filling) to:
+    //  accumulateBackground(curr, prev, diaphragm(center,  offset), radius, border, mip, first);
+    //  accumulateBackground(curr, prev, diaphragm(center, -offset), radius, border, mip, first);
+    //  return;
+    // We use the technique used by Jimenez for the foreground applied to the background, where
+    // we "guess" the missing background information from neighboring pixels. In several papers it's
+    // not deemed useful for the background, however, it does improve the blur quality a lot very
+    // shallow DoF, i.e. when a moderately blurred background sits over a strongly blured one.
+    Sample tap0;
+    Sample tap1;
+
+    highp vec2 pos0 = diaphragm(center,  offset);
+    tap0.coc = textureLod(materialParams_coc, pos0, mip).r;
+
+    highp vec2 pos1 = diaphragm(center, -offset);
+    tap1.coc = textureLod(materialParams_coc, pos1, mip).r;
+
+    float coc = min(tap0.coc, tap1.coc);
+    tap0.coc     =
+    tap1.coc     = coc;
+    tap0.inLayer =
+    tap1.inLayer = isBackground(coc);
+
+    tap0.s = textureLod(materialParams_color, pos0, mip);
+    accumulate(curr, prev, tap0, radius, border, mip, first);
+
+    tap1.s = textureLod(materialParams_color, pos1, mip);
+    accumulate(curr, prev, tap1, radius, border, mip, first);
 }
 
 void accumulateBackgroundCenter(inout Bucket prev,


### PR DESCRIPTION
We use the technique used by Jimenez for the foreground applied to the
background, where we "guess" the missing background information from
neighboring pixels. In several papers it's not deemed useful for the
background, however, it does improve the blur quality a lot very shallow
DoF, i.e. when a moderately blurred background sits over a strongly 
blured one.

before:
![before](https://user-images.githubusercontent.com/1240896/113201775-c400e800-921e-11eb-8228-03770d901fe7.png)

after:
![after](https://user-images.githubusercontent.com/1240896/113201816-d11dd700-921e-11eb-95d3-15c8a62d8fa8.png)
