### PR TITLE
Fix Metal texture swizzling

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1219,8 +1219,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             return;
         }
         const auto metalTexture = handle_const_cast<MetalTexture>(mHandleMap, sampler->t);
-        texturesToBind[binding] = metalTexture->textureView ? metalTexture->textureView
-                                                            : metalTexture->texture;
+        texturesToBind[binding] = metalTexture->swizzledTextureView ? metalTexture->swizzledTextureView
+                                                                    : metalTexture->texture;
 
         if (metalTexture->externalImage.isValid()) {
             texturesToBind[binding] = metalTexture->externalImage.getMetalTextureForDraw();

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -551,7 +551,6 @@ bool MetalDriver::isTextureFormatSupported(TextureFormat format) {
 }
 
 bool MetalDriver::isTextureSwizzleSupported() {
-    return false; // FIXME: reenable once textures used as attachments are supported
     if (@available(macOS 10.15, iOS 13, *)) {
         return true;
     } else {
@@ -1220,7 +1219,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             return;
         }
         const auto metalTexture = handle_const_cast<MetalTexture>(mHandleMap, sampler->t);
-        texturesToBind[binding] = metalTexture->texture;
+        texturesToBind[binding] = metalTexture->textureView ? metalTexture->textureView
+                                                            : metalTexture->texture;
 
         if (metalTexture->externalImage.isValid()) {
             texturesToBind[binding] = metalTexture->externalImage.getMetalTextureForDraw();

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -183,6 +183,12 @@ struct MetalTexture : public HwTexture {
     MetalContext& context;
     MetalExternalImage externalImage;
     id<MTLTexture> texture = nil;
+
+    // If non-nil, a swizzled texture view to use instead of "texture".
+    // Filament swizzling only affects texture reads, so this should not be used when the texture is
+    // bound as a render target attachment.
+    id<MTLTexture> textureView = nil;
+
     uint8_t bytesPerElement; // The number of bytes per pixel, or block (for compressed texture formats).
     uint8_t blockWidth; // The number of horizontal pixels per block (only for compressed texture formats).
     uint8_t blockHeight; // The number of vertical pixels per block (only for compressed texture formats).

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -187,7 +187,7 @@ struct MetalTexture : public HwTexture {
     // If non-nil, a swizzled texture view to use instead of "texture".
     // Filament swizzling only affects texture reads, so this should not be used when the texture is
     // bound as a render target attachment.
-    id<MTLTexture> textureView = nil;
+    id<MTLTexture> swizzledTextureView = nil;
 
     uint8_t bytesPerElement; // The number of bytes per pixel, or block (for compressed texture formats).
     uint8_t blockWidth; // The number of horizontal pixels per block (only for compressed texture formats).

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -532,12 +532,13 @@ MetalTexture::MetalTexture(MetalContext& context, SamplerType target, uint8_t le
                 texture.textureType == MTLTextureTypeCubeArray) {
                 slices *= 6;
             }
-            textureView = [texture newTextureViewWithPixelFormat:texture.pixelFormat
-                                                     textureType:texture.textureType
-                                                          levels:NSMakeRange(0,
-                                                                  texture.mipmapLevelCount)
-                                                          slices:NSMakeRange(0, slices)
-                                                         swizzle:getSwizzleChannels(r, g, b, a)];
+            NSUInteger mips = texture.mipmapLevelCount;
+            MTLTextureSwizzleChannels swizzle = getSwizzleChannels(r, g, b, a);
+            swizzledTextureView = [texture newTextureViewWithPixelFormat:texture.pixelFormat
+                                                             textureType:texture.textureType
+                                                                  levels:NSMakeRange(0, mips)
+                                                                  slices:NSMakeRange(0, slices)
+                                                                 swizzle:swizzle];
         }
     }
 }


### PR DESCRIPTION
Metal textures can't have the `.swizzle` property set if they're used as render targets. So instead, we create a swizzled "texture view" which is used when binding the texture for sampling.