### PR TITLE
Better handle GL_GOOGLE_cpp_style_line_directive

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -237,6 +237,7 @@ void OpenGLContext::initExtensionsGLES(GLint major, GLint minor, ExtentionSet co
     ext.EXT_texture_compression_s3tc_srgb = hasExtension(exts, "GL_EXT_texture_compression_s3tc_srgb");
     ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
     ext.EXT_clip_control = hasExtension(exts, "GL_EXT_clip_control");
+    ext.GOOGLE_cpp_style_line_directive = hasExtension(exts, "GL_GOOGLE_cpp_style_line_directive");
     // ES 3.2 implies EXT_color_buffer_float
     if (major >= 3 && minor >= 2) {
         ext.EXT_color_buffer_float = true;
@@ -256,6 +257,7 @@ void OpenGLContext::initExtensionsGL(GLint major, GLint minor, ExtentionSet cons
     ext.EXT_texture_sRGB = hasExtension(exts, "GL_EXT_texture_sRGB");
     ext.EXT_shader_framebuffer_fetch = hasExtension(exts, "GL_EXT_shader_framebuffer_fetch");
     ext.EXT_clip_control = hasExtension(exts, "GL_ARB_clip_control") || (major == 4 && minor >= 5);
+    ext.GOOGLE_cpp_style_line_directive = hasExtension(exts, "GL_GOOGLE_cpp_style_line_directive");
 }
 
 void OpenGLContext::bindBuffer(GLenum target, GLuint buffer) noexcept {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -144,6 +144,7 @@ public:
         bool EXT_disjoint_timer_query = false;
         bool EXT_shader_framebuffer_fetch = false;
         bool EXT_clip_control = false;
+        bool GOOGLE_cpp_style_line_directive = false;
     } ext;
 
     struct {

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -59,15 +59,15 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
             auto shader = shadersSource[i];
             GLint const length = (GLint)shader.size();
 
-#ifndef NDEBUG
-            // If usages of the Google-style line directive are present, remove them, as some
-            // drivers don't allow the quotation marks.
-            if (requestsGoogleLineDirectivesExtension((const char*) shader.data(), length)) {
-                auto temp = shader;
-                removeGoogleLineDirectives((char*) temp.data(), length);    // length is unaffected
-                shader = std::move(temp);
+            if (!gl->getContext().ext.GOOGLE_cpp_style_line_directive) {
+                // If usages of the Google-style line directive are present, remove them, as some
+                // drivers don't allow the quotation marks.
+                if (requestsGoogleLineDirectivesExtension((const char*)shader.data(), length)) {
+                    auto temp = shader;
+                    removeGoogleLineDirectives((char*)temp.data(), length); // length is unaffected
+                    shader = std::move(temp);
+                }
             }
-#endif
 
             const char * const source = (const char*)shader.data();
 


### PR DESCRIPTION
We now alwyas scrap this extension usage if the driver doesn't support
it, regardless of being in debug or release mode.