### PR TITLE
fix output location in fragment shaders

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -232,7 +232,7 @@ utils::io::sstream& CodeGenerator::generateOutput(utils::io::sstream& out, Shade
     out << "\n#define FRAG_OUTPUT" << index << " " << name.c_str() << "\n";
     out << "\n#define FRAG_OUTPUT_AT" << index << " output_" << name.c_str() << "\n";
     out << "\n#define FRAG_OUTPUT_TYPE" << index << " " << typeString << "\n";
-    out << "LAYOUT_LOCATION(" << index << ") out " << typeString <<
+    out << "layout(location=" << index << ") out " << typeString <<
         " output_" << name.c_str() << ";\n";
 
     return out;


### PR DESCRIPTION
It looks like the layout(location) is needed for output parameters of
the fragment shader in GLES. Adreno dirver didn't seem to care, but
Mali drivers do. 

This fixes shaders that use multiple out buffers in debug mode.