### PR TITLE
VertexBuffer cleanup and simplification.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -48,6 +48,11 @@ static constexpr uint64_t SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER = 0x8;
 
 static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 16; // This is guaranteed by OpenGL ES.
 static constexpr size_t MAX_SAMPLER_COUNT = 16;          // Matches the Adreno Vulkan driver.
+static constexpr size_t MAX_VERTEX_BUFFER_COUNT = 16;    // Max number of bound buffer objects.
+
+static_assert(MAX_VERTEX_BUFFER_COUNT <= MAX_VERTEX_ATTRIBUTE_COUNT,
+        "The number of buffer objects that can be attached to a VertexBuffer must be "
+        "less than or equal to the maximum number of vertex attributes.");
 
 static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
 static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -168,8 +168,7 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
         backend::AttributeArray, attributes,
-        backend::BufferUsage, usage,
-        bool, bufferObjectsEnabled)
+        backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
@@ -310,12 +309,6 @@ DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncH
  * Updating driver objects
  * -----------------------
  */
-
-DECL_DRIVER_API_N(updateVertexBuffer,
-        backend::VertexBufferHandle, vbh,
-        size_t, index,
-        backend::BufferDescriptor&&, data,
-        uint32_t, byteOffset)
 
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -55,21 +55,25 @@ struct HwVertexBuffer : public HwBase {
     uint32_t vertexCount{};               //   4
     uint8_t bufferCount{};                //   1
     uint8_t attributeCount{};             //   1
-    bool bufferObjectsEnabled{};          //   1
+    bool padding{};                       //   1
     uint8_t bufferObjectsVersion{};       //   1 -> total struct is 136 bytes
 
     HwVertexBuffer() noexcept = default;
     HwVertexBuffer(uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            AttributeArray const& attributes, bool bufferObjectsEnabled) noexcept
+            AttributeArray const& attributes) noexcept
             : attributes(attributes),
               vertexCount(elementCount),
               bufferCount(bufferCount),
-              attributeCount(attributeCount),
-              bufferObjectsEnabled(bufferObjectsEnabled) {
+              attributeCount(attributeCount) {
     }
 };
 
-struct HwBufferObject : public HwBase {};
+struct HwBufferObject : public HwBase {
+    uint32_t byteCount{};
+
+    HwBufferObject() noexcept = default;
+    HwBufferObject(uint32_t byteCount) noexcept : byteCount(byteCount) {}
+};
 
 struct HwIndexBuffer : public HwBase {
     uint32_t count{};

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -117,19 +117,18 @@ public:
     MetalBufferObject(MetalContext& context, uint32_t byteCount);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
-    const std::shared_ptr<MetalBuffer>& getBuffer() const { return buffer; }
+    MetalBuffer* getBuffer() const { return buffer.get(); }
 
 private:
-    uint32_t byteCount;
-    std::shared_ptr<MetalBuffer> buffer = nullptr;
+    std::unique_ptr<MetalBuffer> buffer = nullptr;
 
 };
 
 struct MetalVertexBuffer : public HwVertexBuffer {
     MetalVertexBuffer(MetalContext& context, uint8_t bufferCount, uint8_t attributeCount,
-            uint32_t vertexCount, AttributeArray const& attributes, bool bufferObjectsEnabled);
+            uint32_t vertexCount, AttributeArray const& attributes);
 
-    std::vector<std::shared_ptr<MetalBuffer>> buffers;
+    std::vector<MetalBuffer*> buffers;
 };
 
 struct MetalIndexBuffer : public HwIndexBuffer {

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -44,11 +44,11 @@ static constexpr uint32_t VERTEX_BUFFER_START = Program::UNIFORM_BINDING_COUNT;
 
 // The "zero" buffer is a small buffer for missing attributes that resides in the vertex slot
 // immediately following any user-provided vertex buffers.
-static constexpr uint32_t ZERO_VERTEX_BUFFER = MAX_VERTEX_ATTRIBUTE_COUNT;
+static constexpr uint32_t ZERO_VERTEX_BUFFER = backend::MAX_VERTEX_BUFFER_COUNT;
 
-// The total number of vertex buffers "slots" that the Metal backend can bind.
+// The total number of vertex buffer "slots" that the Metal backend can bind.
 // + 1 to account for the zero buffer.
-static constexpr uint32_t VERTEX_BUFFER_COUNT = MAX_VERTEX_ATTRIBUTE_COUNT + 1;
+static constexpr uint32_t VERTEX_BUFFER_COUNT = backend::MAX_VERTEX_BUFFER_COUNT + 1;
 
 // Forward declarations necessary here, definitions at end of file.
 inline bool operator==(const MTLViewport& lhs, const MTLViewport& rhs);

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -175,11 +175,6 @@ math::float2 NoopDriver::getClipSpaceParams() {
     return math::float2{ -1.0f, 0.0f };
 }
 
-void NoopDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh, size_t index,
-        BufferDescriptor&& p, uint32_t byteOffset) {
-    scheduleDestroy(std::move(p));
-}
-
 void NoopDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     scheduleDestroy(std::move(p));

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -482,13 +482,12 @@ void OpenGLDriver::createVertexBufferR(
         uint8_t attributeCount,
         uint32_t elementCount,
         AttributeArray attributes,
-        BufferUsage usage,
-        bool bufferObjectsEnabled) {
+        BufferUsage usage) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
     GLVertexBuffer* vb = construct<GLVertexBuffer>(vbh,
-            bufferCount, attributeCount, elementCount, attributes, bufferObjectsEnabled);
+            bufferCount, attributeCount, elementCount, attributes);
 
     GLsizei n = GLsizei(vb->bufferCount);
 
@@ -536,10 +535,11 @@ void OpenGLDriver::createBufferObjectR(
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    GLBufferObject* bo = construct<GLBufferObject>(boh);
+    GLBufferObject* bo = construct<GLBufferObject>(boh, byteCount);
     glGenBuffers(1, &bo->gl.id);
     gl.bindVertexArray(nullptr);
 
+    assert_invariant(byteCount > 0);
     assert_invariant(bindingType == BufferObjectBinding::VERTEX);
 
     gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
@@ -1718,29 +1718,11 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 // Updating driver objects
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::updateVertexBuffer(Handle<HwVertexBuffer> vbh,
-        size_t index, BufferDescriptor&& p, uint32_t byteOffset) {
-    DEBUG_MARKER()
-
-    auto& gl = mContext;
-    GLVertexBuffer* eb = handle_cast<GLVertexBuffer *>(vbh);
-    assert_invariant(!eb->bufferObjectsEnabled && "Please use setVertexBufferObject() instead.");
-
-    gl.bindBuffer(GL_ARRAY_BUFFER, eb->gl.buffers[index]);
-    glBufferSubData(GL_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
-
-    scheduleDestroy(std::move(p));
-
-    CHECK_GL_ERROR(utils::slog.e)
-}
-
 void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
         size_t index, Handle<HwBufferObject> boh) {
    DEBUG_MARKER()
 
     GLVertexBuffer* vb = handle_cast<GLVertexBuffer *>(vbh);
-    assert_invariant(vb->bufferObjectsEnabled && "Please use updateVertexBuffer() instead.");
-
     GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
 
     // If the specified VBO handle is different from what's already in the slot, then update the
@@ -1780,6 +1762,8 @@ void OpenGLDriver::updateBufferObject(
 
     auto& gl = mContext;
     GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
+
+    assert_invariant(bd.size + byteOffset <= bo->byteCount);
 
     gl.bindVertexArray(nullptr);
     gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
@@ -2520,9 +2504,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         CHECK_GL_ERROR(utils::slog.e)
 
         rp->gl.indicesType = ib->elementSize == 4 ? GL_UNSIGNED_INT : GL_UNSIGNED_SHORT;
-
-        rp->gl.vertexBufferWithObjects = eb->bufferObjectsEnabled ? vbh :
-                backend::Handle<backend::HwVertexBuffer> {};
+        rp->gl.vertexBufferWithObjects = vbh;
 
         // update the VBO bindings in the VAO
         updateVertexArrayObject(rp, eb);
@@ -3225,15 +3207,18 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
 
     GLRenderPrimitive* rp = handle_cast<GLRenderPrimitive *>(rph);
 
+    // Gracefully do nothing if the render primitive has not been set up.
+    VertexBufferHandle vb = rp->gl.vertexBufferWithObjects;
+    if (UTILS_UNLIKELY(!vb)) {
+        return;
+    }
+
     gl.bindVertexArray(&rp->gl);
 
     // If necessary, mutate the bindings in the VAO.
-    VertexBufferHandle vbwo = rp->gl.vertexBufferWithObjects;
-    if (UTILS_UNLIKELY(vbwo)) {
-        const GLVertexBuffer* vb = handle_cast<GLVertexBuffer*>(vbwo);
-        if (rp->gl.vertexBufferVersion != vb->bufferObjectsVersion) {
-            updateVertexArrayObject(rp, vb);
-        }
+    const GLVertexBuffer* glvb = handle_cast<GLVertexBuffer*>(vb);
+    if (UTILS_UNLIKELY(rp->gl.vertexBufferVersion != glvb->bufferObjectsVersion)) {
+        updateVertexArrayObject(rp, glvb);
     }
 
     setRasterState(state.rasterState);

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -70,6 +70,8 @@ public:
     };
 
     struct GLBufferObject : public backend::HwBufferObject {
+        using HwBufferObject::HwBufferObject;
+        GLBufferObject(uint32_t size) noexcept : HwBufferObject(size) {}
         struct {
             GLuint id = 0;
         } gl;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -403,21 +403,9 @@ bool VulkanRenderTarget::invalidate() {
 
 VulkanVertexBuffer::VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         VulkanDisposer& disposer,  uint8_t bufferCount, uint8_t attributeCount,
-        uint32_t elementCount, AttributeArray const& attributes, bool boEnabled) :
-        HwVertexBuffer(bufferCount, attributeCount, elementCount, attributes, boEnabled) {
-    buffers.reserve(bufferCount);
-    for (uint8_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
-        uint32_t size = 0;
-        for (auto const& item : attributes) {
-            if (item.buffer == bufferIndex) {
-                uint32_t end = item.offset + elementCount * item.stride;
-                size = std::max(size, end);
-            }
-        }
-        buffers.push_back(std::make_shared<VulkanBuffer>(context, stagePool, disposer, this,
-                VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, size));
-    }
-}
+        uint32_t elementCount, AttributeArray const& attributes) :
+        HwVertexBuffer(bufferCount, attributeCount, elementCount, attributes),
+        buffers(bufferCount) {}
 
 VulkanUniformBuffer::VulkanUniformBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         VulkanDisposer& disposer, uint32_t numBytes, backend::BufferUsage usage)

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -83,8 +83,8 @@ struct VulkanSwapChain : public HwSwapChain {
 struct VulkanVertexBuffer : public HwVertexBuffer {
     VulkanVertexBuffer(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
             uint8_t bufferCount, uint8_t attributeCount, uint32_t elementCount,
-            AttributeArray const& attributes, bool bufferObjectsEnabled);
-    std::vector<std::shared_ptr<VulkanBuffer>> buffers;
+            AttributeArray const& attributes);
+    std::vector<VulkanBuffer*> buffers;
 };
 
 struct VulkanIndexBuffer : public HwIndexBuffer {
@@ -99,10 +99,10 @@ struct VulkanIndexBuffer : public HwIndexBuffer {
 
 struct VulkanBufferObject : public HwBufferObject {
     VulkanBufferObject(VulkanContext& context, VulkanStagePool& stagePool, VulkanDisposer& disposer,
-            uint32_t byteCount) :
+            uint32_t byteCount) : HwBufferObject(byteCount),
             buffer(new VulkanBuffer(context, stagePool, disposer, this,
                     VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, byteCount)) {}
-    const std::shared_ptr<VulkanBuffer> buffer;
+    const std::unique_ptr<VulkanBuffer> buffer;
 };
 
 struct VulkanUniformBuffer : public HwUniformBuffer {

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -47,10 +47,13 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     AttributeBitset enabledAttributes;
     enabledAttributes.set(VertexAttribute::POSITION);
 
+    const size_t size = sizeof(math::float2) * 3;
+    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX);
     mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes,
-            BufferUsage::STATIC, false);
-    BufferDescriptor vertexBufferDesc(gVertices, sizeof(filament::math::float2) * 3, nullptr);
-    mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vertexBufferDesc), 0);
+            BufferUsage::STATIC);
+    mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
+    BufferDescriptor vertexBufferDesc(gVertices, size, nullptr);
+    mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
 
     mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
             BufferUsage::STATIC);
@@ -72,7 +75,7 @@ void TrianglePrimitive::updateVertices(const filament::math::float2 vertices[3])
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
-    mDriverApi.updateVertexBuffer(mVertexBuffer, 0, std::move(vBuffer), 0);
+    mDriverApi.updateBufferObject(mBufferObject, std::move(vBuffer), 0);
 }
 
 void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
@@ -88,6 +91,7 @@ void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
 }
 
 TrianglePrimitive::~TrianglePrimitive() {
+    mDriverApi.destroyBufferObject(mBufferObject);
     mDriverApi.destroyVertexBuffer(mVertexBuffer);
     mDriverApi.destroyIndexBuffer(mIndexBuffer);
     mDriverApi.destroyRenderPrimitive(mRenderPrimitive);

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -31,6 +31,7 @@ class TrianglePrimitive {
 public:
 
     using PrimitiveHandle = filament::backend::Handle<filament::backend::HwRenderPrimitive>;
+    using BufferObjectHandle = filament::backend::Handle<filament::backend::HwBufferObject>;
     using VertexHandle = filament::backend::Handle<filament::backend::HwVertexBuffer>;
     using IndexHandle = filament::backend::Handle<filament::backend::HwIndexBuffer>;
 
@@ -50,6 +51,7 @@ private:
     filament::backend::DriverApi& mDriverApi;
 
     PrimitiveHandle mRenderPrimitive;
+    BufferObjectHandle mBufferObject;
     VertexHandle mVertexBuffer;
     IndexHandle mIndexBuffer;
 

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -37,12 +37,15 @@ class FEngine;
 
 class FVertexBuffer : public VertexBuffer {
 public:
+    using VertexBufferHandle = backend::VertexBufferHandle;
+    using BufferObjectHandle = backend::BufferObjectHandle;
+
     FVertexBuffer(FEngine& engine, const Builder& builder);
 
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    backend::Handle<backend::HwVertexBuffer> getHwHandle() const noexcept { return mHandle; }
+    VertexBufferHandle getHwHandle() const noexcept { return mHandle; }
 
     size_t getVertexCount() const noexcept;
 
@@ -64,8 +67,9 @@ private:
         AttributeData() : backend::Attribute{ .type = backend::ElementType::FLOAT4 } {}
     };
 
-    backend::Handle<backend::HwVertexBuffer> mHandle;
+    VertexBufferHandle mHandle;
     std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
+    std::array<BufferObjectHandle, backend::MAX_VERTEX_BUFFER_COUNT> mBufferObjects;
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;


### PR DESCRIPTION
This includes changes to OpenGL, Metal, and Vulkan backends.

At the backend level, vertex buffers are now always composed of buffer
objects. This lets us simplify the Driver API and some bookkeeping in
the backends.

This change also splits MAX_VERTEX_ATTRIBUTE_COUNT into two constants
because the maximum number of bound buffers is a separate concept from
the maximum number of attribute semantics (e.g. consider interleaving).
For now these two constants are set to the same value.

We also now store a byte count in HwBufferObject, which allows us to
remove the byte count from the Metal-specific handle, and to add some
asserts to debug builds to prevent size overflow.