### PR TITLE
Fix texture swizzling crash with older Nvidia GPUs

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -51,6 +51,9 @@ struct MetalContext {
     id<MTLCommandBuffer> pendingCommandBuffer = nullptr;
     id<MTLRenderCommandEncoder> currentRenderPassEncoder = nullptr;
 
+    // Supported features.
+    bool supportsTextureSwizzling = false;
+
     // Tracks resources used by command buffers.
     MetalResourceTracker resourceTracker;
 

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -527,7 +527,10 @@ MetalTexture::MetalTexture(MetalContext& context, SamplerType target, uint8_t le
             a == TextureSwizzle::CHANNEL_3;
     // If texture is nil, then it must be a SAMPLER_EXTERNAL texture. We'll ignore this case for now.
     // TODO: implement swizzling for external textures.
-    if (!isDefaultSwizzle && texture) {
+    if (!isDefaultSwizzle && texture && context.supportsTextureSwizzling) {
+        // Even though we've already checked context.supportsTextureSwizzling, we still need to
+        // guard these calls with @availability, otherwise the API usage will generate compiler
+        // warnings.
         if (@available(macOS 10.15, iOS 13, *)) {
             NSUInteger slices = texture.arrayLength;
             if (texture.textureType == MTLTextureTypeCube ||


### PR DESCRIPTION
Not all GPUs support texture swizzling on Metal. Fixes #3754