### PR TITLE
rework the "debugCommand" feature of backend

### DIFF
--- a/filament/backend/include/private/backend/Driver.h
+++ b/filament/backend/include/private/backend/Driver.h
@@ -37,12 +37,25 @@
 
 #include <stdint.h>
 
+// Command debugging off. debugging virtuals are not called.
+// This is automatically enabled in DEBUG builds.
+#define FILAMENT_DEBUG_COMMANDS_NONE         0x0
+// Command debugging enabled. No logging by default.
+#define FILAMENT_DEBUG_COMMANDS_ENABLE       0x1
+// Command debugging enabled. Every command logged to slog.d
+#define FILAMENT_DEBUG_COMMANDS_LOG          0x2
+// Command debugging enabled. Every command logged to systrace
+#define FILAMENT_DEBUG_COMMANDS_SYSTRACE     0x4
+
+#define FILAMENT_DEBUG_COMMANDS              FILAMENT_DEBUG_COMMANDS_NONE
+
 namespace filament {
 namespace backend {
 
 template<typename T>
 class ConcreteDispatcher;
 class Dispatcher;
+class CommandStream;
 
 class Driver {
 public:
@@ -64,9 +77,9 @@ public:
     // the default implementation simply calls fn
     virtual void execute(std::function<void(void)> fn) noexcept;
 
-#ifndef NDEBUG
-    virtual void debugCommand(const char* methodName) {}
-#endif
+    // This is called on debug build, or when enabled manually on the backend thread side.
+    virtual void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept = 0;
+    virtual void debugCommandEnd(CommandStream* cmds, bool synchronous, const char* methodName) noexcept = 0;
 
     /*
      * Asynchronous calls here only to provide a type to CommandStream. They must be non-virtual

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -192,6 +192,9 @@ protected:
 
     void scheduleRelease(AcquiredImage&& image) noexcept;
 
+    void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
+    void debugCommandEnd(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
+
 private:
     std::mutex mPurgeLock;
     std::vector<BufferDescriptor> mBufferToPurge;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -55,10 +55,6 @@ private:
 
     MetalContext* mContext;
 
-#ifndef NDEBUG
-    void debugCommand(const char* methodName) override;
-#endif
-
     ShaderModel getShaderModel() const noexcept final;
 
     // Overrides the default implementation by wrapping the call to fn in an @autoreleasepool block.

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -112,16 +112,6 @@ MetalDriver::~MetalDriver() noexcept {
     delete mContext;
 }
 
-#define METAL_DEBUG_COMMANDS 0
-#if !defined(NDEBUG)
-void MetalDriver::debugCommand(const char *methodName) {
-#if METAL_DEBUG_COMMANDS
-    utils::slog.d << methodName << utils::io::endl;
-#endif
-}
-#endif
-
-
 void MetalDriver::tick(int) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -241,7 +241,6 @@ private:
 
 #include "private/backend/DriverAPI.inc"
 
-
     // Memory management...
 
     class HandleAllocator {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1826,8 +1826,9 @@ void VulkanDriver::refreshSwapChain() {
     mFramebufferCache.reset();
 }
 
+void VulkanDriver::debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept {
+    DriverBase::debugCommandBegin(cmds, synchronous, methodName);
 #ifndef NDEBUG
-void VulkanDriver::debugCommand(const char* methodName) {
     static const std::set<utils::StaticString> OUTSIDE_COMMANDS = {
         "loadUniformBuffer",
         "updateVertexBuffer",
@@ -1850,8 +1851,8 @@ void VulkanDriver::debugCommand(const char* methodName) {
         utils::slog.e << command.c_str() << " issued inside a render pass." << utils::io::endl;
         utils::debug_trap();
     }
-}
 #endif
+}
 
 // explicit instantiation of the Dispatcher
 template class ConcreteDispatcher<VulkanDriver>;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -49,9 +49,7 @@ public:
 
 private:
 
-#ifndef NDEBUG
-    void debugCommand(const char* methodName) override;
-#endif
+    void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
 
     inline VulkanDriver(backend::VulkanPlatform* platform,
             const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount) noexcept;


### PR DESCRIPTION
- it was called on the main thread side, which didn't allow to,
  for instance, systrace commands on the backend thread side.

- moved to a begin/end callback model

- implemented basic logging/systracing for all backends in Driver.cpp
  (and removed this functionality for the metal driver).