### PR TITLE
Add default precision qualifiers for special sampler types

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -82,6 +82,8 @@ io::sstream& CodeGenerator::generateProlog(io::sstream& out, ShaderType type,
     const char* precision = getPrecisionQualifier(defaultPrecision, Precision::DEFAULT);
     out << "precision " << precision << " float;\n";
     out << "precision " << precision << " int;\n";
+    out << "precision lowp sampler2DArray;\n";
+    out << "precision lowp sampler3D;\n";
 
     out << SHADERS_COMMON_TYPES_FS_DATA;
 


### PR DESCRIPTION
GLSL ES requires precision qualifiers on all sampler types. `sampler2DArray` and `sampler3D` have no default precision, so we get an error when compiling materials that include one of these as a parameter with no explicit precision qualifier:

```
ERROR: 0:166: 'sampler/image' : type requires declaration of default precision qualifier
```

This isn't needed for other sampler types. From the [OpenGL ES Shading Language spec](https://www.khronos.org/files/opengles_shading_language.pdf):


> The vertex language has the following predeclared globally scoped default precision statements:
>     precision highp float;
>     precision highp int;
>     precision lowp sampler2D;
>     precision lowp samplerCube;
> 
> The fragment language has the following predeclared globally scoped default precision statements:
>     precision mediump int;
>     precision lowp sampler2D;
>     precision lowp samplerCube;


I chose `lowp` to match the other defaults.

Fixes #3770