### PR TITLE
better handle anisotropic filtering with various drivers

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -169,7 +169,7 @@ public:
 
         // Some drivers declare GL_EXT_texture_filter_anisotropic but don't support
         // calling glSamplerParameter() with GL_TEXTURE_MAX_ANISOTROPY_EXT
-        bool disable_texture_filter_anisotropic = false;
+        bool texture_filter_anisotropic_broken_on_sampler = false;
 
         // Some drivers have issues when reading from a mip while writing to a different mip.
         // In the OpenGL ES 3.0 specification this is covered in section 4.4.3,

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -357,6 +357,7 @@ private:
     /* State tracking GL wrappers... */
 
            void bindTexture(GLuint unit, GLTexture const* t) noexcept;
+           void bindSampler(GLuint unit, backend::SamplerParams params) noexcept;
     inline void useProgram(OpenGLProgram* p) noexcept;
 
     enum class ResolveAction { LOAD, STORE };

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -195,11 +195,14 @@ OpenGLProgram::~OpenGLProgram() noexcept {
     }
 }
 
-void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
+void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
     using GLTexture = OpenGLDriver::GLTexture;
 
     // cache a few member variable locally, outside of the loop
-    auto const& UTILS_RESTRICT samplerBindings = gl->getSamplerBindings();
+    OpenGLContext& glc = gld->getContext();
+    const bool anisotropyWorkaround = glc.ext.EXT_texture_filter_anisotropic &&
+                                      glc.bugs.texture_filter_anisotropic_broken_on_sampler;
+    auto const& UTILS_RESTRICT samplerBindings = gld->getSamplerBindings();
     auto const& UTILS_RESTRICT indicesRun = mIndicesRuns;
     auto const& UTILS_RESTRICT blockInfos = mBlockInfos;
 
@@ -222,17 +225,27 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gl) noexcept {
                 continue;
             }
 
-            const GLTexture* const UTILS_RESTRICT t = gl->handle_cast<const GLTexture*>(th);
+            const GLTexture* const UTILS_RESTRICT t = gld->handle_cast<const GLTexture*>(th);
             if (UTILS_UNLIKELY(t->gl.fence)) {
                 glWaitSync(t->gl.fence, 0, GL_TIMEOUT_IGNORED);
                 glDeleteSync(t->gl.fence);
                 t->gl.fence = nullptr;
             }
 
-            gl->bindTexture(tmu, t);
+            gld->bindTexture(tmu, t);
+            gld->bindSampler(tmu, samplers[index].s);
 
-            GLuint sampler = gl->getSampler(samplers[index].s);
-            gl->getContext().bindSampler(tmu, sampler);
+#if defined(GL_EXT_texture_filter_anisotropic)
+            if (UTILS_UNLIKELY(anisotropyWorkaround)) {
+                // Driver claims to support anisotropic filtering, but it fails when set on
+                // the sampler, we have to set it on the texture instead.
+                // The texture is already bound here.
+                SamplerParams params = samplers[index].s;
+                GLfloat anisotropy = float(1u << params.anisotropyLog2);
+                glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+                        std::min(glc.gets.maxAnisotropy, anisotropy));
+            }
+#endif
         }
     }
     CHECK_GL_ERROR(utils::slog.e)

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -95,7 +95,7 @@ private:
     // runs of indices into SamplerGroup -- run start index and size given by BlockInfo
     std::array<uint8_t, TEXTURE_UNIT_COUNT> mIndicesRuns;    // 16 bytes
 
-    void updateSamplers(OpenGLDriver* gl) noexcept;
+    void updateSamplers(OpenGLDriver* gld) noexcept;
 };
 
 


### PR DESCRIPTION
Some drivers claim to support anisotropic filtering but don't allow
setting it via glSamplerParameter. Until now we were disabling 
anisotropic filtering entirely on these drivers at compile time.

With this change, we should detect at runtime which drivers have this
issue and use a workaround -- instead of disabling anisotropic 
filtering entirely.