### PR TITLE
silently clamp MSAA sample count to maximum allowed

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -114,11 +114,13 @@ public:
 
     // glGet*() values
     struct {
-        GLint max_renderbuffer_size = 0;
-        GLint max_uniform_block_size = 0;
-        GLint uniform_buffer_offset_alignment = 256;
-        GLfloat maxAnisotropy = 0.0f;
-    } gets;
+        GLfloat max_anisotropy;
+        GLint max_draw_buffers;
+        GLint max_renderbuffer_size;
+        GLint max_samples;
+        GLint max_uniform_block_size;
+        GLint uniform_buffer_offset_alignment;
+    } gets = {};
 
     // features supported by this version of GL or GLES
     struct {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -641,6 +641,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
     DEBUG_MARKER()
 
     auto& gl = mContext;
+    samples = std::min(samples, uint8_t(gl.gets.max_samples));
     GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
     if (UTILS_LIKELY(usage & TextureUsage::SAMPLEABLE)) {
         if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
@@ -1162,6 +1163,8 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
      *  (width, height) for each attachment. Contents of attachments outside this area are
      *  undefined after execution of a rendering command.
      */
+
+    samples = std::min(samples, uint8_t(mContext.gets.max_samples));
 
     rt->gl.samples = samples;
     rt->targets = targets;
@@ -2823,7 +2826,7 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
             !gl.bugs.texture_filter_anisotropic_broken_on_sampler) {
         GLfloat anisotropy = float(1u << params.anisotropyLog2);
         glSamplerParameterf(s, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-                std::min(gl.gets.maxAnisotropy, anisotropy));
+                std::min(gl.gets.max_anisotropy, anisotropy));
     }
 #endif
     CHECK_GL_ERROR(utils::slog.e)

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -243,7 +243,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
                 SamplerParams params = samplers[index].s;
                 GLfloat anisotropy = float(1u << params.anisotropyLog2);
                 glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-                        std::min(glc.gets.maxAnisotropy, anisotropy));
+                        std::min(glc.gets.max_anisotropy, anisotropy));
             }
 #endif
         }


### PR DESCRIPTION
It's an error to ask for a higher MSAA sample count than supported by
the gl driver, and results in corrupted rendering.
We now always clamp the requested sample count to the maximum allowed 
but the gl driver.

includes some minor refactoring.