### PR TITLE
sample-gltf-viewer: more improvements for zip files.

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -176,12 +176,17 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
      *
      * The given callback is triggered for each requested resource.
      */
-    fun loadModelGltf(buffer: Buffer, callback: (String) -> Buffer) {
+    fun loadModelGltf(buffer: Buffer, callback: (String) -> Buffer?) {
         destroyModel()
         asset = assetLoader.createAssetFromJson(buffer)
         asset?.let { asset ->
             for (uri in asset.resourceUris) {
-                resourceLoader.addResourceData(uri, callback(uri))
+                val resourceBuffer = callback(uri)
+                if (resourceBuffer == null) {
+                    this.asset = null
+                    return
+                }
+                resourceLoader.addResourceData(uri, resourceBuffer)
             }
             resourceLoader.asyncBeginLoad(asset)
             animator = asset.animator


### PR DESCRIPTION
- If a resource file is missing, show toast instead of crashing.
- Allow glb files in zip files.
- Run blocking calls like createTempFile() on IO thread.