### PR TITLE
VulkanDriver: clean up pipeline barrier for UBOs.

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -439,14 +439,15 @@ void VulkanUniformBuffer::loadFromCpu(const void* cpuData, uint32_t numBytes) {
         VkBufferMemoryBarrier barrier {
             .sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
             .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-            .dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT,
+            .dstAccessMask = VK_ACCESS_UNIFORM_READ_BIT,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .buffer = mGpuBuffer,
             .size = VK_WHOLE_SIZE
         };
+
         vkCmdPipelineBarrier(commands.cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+                VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
 
         mStagePool.releaseStage(stage, commands);
     };


### PR DESCRIPTION
After eyeballing this barrier that we issue after updating a UBO, I realized it was configured incorrectly and overly aggressive.

It merely needs to ensure that the UBO is fully updated before it gets consumed by the vertex shader associated with the next draw call.