### PR TITLE
Vulkan: another fix to the UBO barrier.

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -447,7 +447,8 @@ void VulkanUniformBuffer::loadFromCpu(const void* cpuData, uint32_t numBytes) {
         };
 
         vkCmdPipelineBarrier(commands.cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+                VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0,
+                nullptr, 1, &barrier, 0, nullptr);
 
         mStagePool.releaseStage(stage, commands);
     };


### PR DESCRIPTION
Even though the vertex shader comes before the fragment shader,
both bits needs to be present in the barrier, since a Vulkan
implementation might partition its uniform cache between stages.

Thanks to Chris Forbes for pointing this out.