### PR TITLE
Disable VSM MSAA on Adreno devices

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -80,6 +80,7 @@ OpenGLContext::OpenGLContext() noexcept {
         // On Adreno (As of 3/20) timer query seem to return the CPU time, not the
         // GPU time.
         bugs.dont_use_timer_query = true;
+        bugs.disable_sidecar_blit = true;
     } else if (strstr(renderer, "Mali")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
         if (strstr(renderer, "Mali-T")) {

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -80,7 +80,7 @@ OpenGLContext::OpenGLContext() noexcept {
         // On Adreno (As of 3/20) timer query seem to return the CPU time, not the
         // GPU time.
         bugs.dont_use_timer_query = true;
-        bugs.disable_sidecar_blit = true;
+        bugs.disable_sidecar_blit_into_texture_array = true;
     } else if (strstr(renderer, "Mali")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
         if (strstr(renderer, "Mali-T")) {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -183,7 +183,7 @@ public:
 
         // Some drivers can't blit from a sidecar renderbuffer into a layer of a texture array.
         // This technique is used for VSM with MSAA turned on.
-        bool disable_sidecar_blit = false;
+        bool disable_sidecar_blit_into_texture_array = false;
     } bugs;
 
     // state getters -- as needed.

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -180,6 +180,10 @@ public:
 
         // Some drivers don't implement timer queries correctly
         bool dont_use_timer_query = false;
+
+        // Some drivers can't blit from a sidecar renderbuffer into a layer of a texture array.
+        // This technique is used for VSM with MSAA turned on.
+        bool disable_sidecar_blit = false;
     } bugs;
 
     // state getters -- as needed.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -941,7 +941,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     // EXT_multisampled_render_to_texture when the texture is a TEXTURE_2D_ARRAY, so we'll simply
     // fall back to non-MSAA rendering.
     const bool disableMultisampling =
-            gl.bugs.disable_sidecar_blit &&
+            gl.bugs.disable_sidecar_blit_into_texture_array &&
             rt->gl.samples > 1 && t->samples <= 1 &&
             target == GL_TEXTURE_2D_ARRAY;
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -937,8 +937,33 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         attachmentTypeNotSupportedByMSRTT = true;
     }
 
-    if (rt->gl.samples <= 1 ||
-        (rt->gl.samples > 1 && t->samples > 1 && gl.features.multisample_texture)) {
+    // The following 4 techniques are different mechanisms to provide storage to the FBO.
+    // We'll use the first technique that is sufficient.
+    // nonMSAA:         MSAA was not requested, or we're rendering to an MSAA texture which
+    //                  doesn't require any special setup here
+    // useMSRTT:        use the EXT_multisampled_render_to_texture extension
+    // renderDirect:    texture is not sampleable, render directly into a renderbuffer
+    // emulateMSRTT:    prior 3 techniques are unsuitable, emulate MSRTT extension support
+
+    const bool nonMSAA =
+            rt->gl.samples <= 1 ||
+            (rt->gl.samples > 1 && t->samples > 1 && gl.features.multisample_texture);
+
+    // EXT_multisampled_render_to_texture only support GL_COLOR_ATTACHMENT0
+    const bool useMSRTT =
+            !attachmentTypeNotSupportedByMSRTT && (t->depth <= 1) &&
+            ((gl.ext.EXT_multisampled_render_to_texture && attachment == GL_COLOR_ATTACHMENT0) ||
+             gl.ext.EXT_multisampled_render_to_texture2);
+
+    const bool renderDirect = !any(t->usage & TextureUsage::SAMPLEABLE) && t->samples > 1;
+
+    const bool emulateMSRTT = !nonMSAA && !useMSRTT && !renderDirect;
+
+    // There's a bug with certain drivers preventing us from emulating
+    // EXT_multisampled_render_to_texture, so we'll simply fall back to non-MSAA rendering.
+    const bool disableMultisampling = gl.bugs.disable_sidecar_blit && emulateMSRTT;
+
+    if (nonMSAA || disableMultisampling) {
         // on GL3.2 / GLES3.1 and above multisample is handled when creating the texture.
         // If multisampled textures are not supported and we end-up here, things should
         // still work, albeit without MSAA.
@@ -973,10 +998,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         CHECK_GL_ERROR(utils::slog.e)
     } else
 #ifdef GL_EXT_multisampled_render_to_texture
-        // EXT_multisampled_render_to_texture only support GL_COLOR_ATTACHMENT0
-    if (!attachmentTypeNotSupportedByMSRTT && (t->depth <= 1)
-        && ((gl.ext.EXT_multisampled_render_to_texture && attachment == GL_COLOR_ATTACHMENT0)
-            || gl.ext.EXT_multisampled_render_to_texture2)) {
+    if (useMSRTT) {
         assert_invariant(rt->gl.samples > 1);
         // We have a multi-sample rendertarget and we have EXT_multisampled_render_to_texture,
         // so, we can directly use a 1-sample texture as attachment, multi-sample resolve,
@@ -993,7 +1015,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
         CHECK_GL_ERROR(utils::slog.e)
     } else
 #endif
-    if (!any(t->usage & TextureUsage::SAMPLEABLE) && t->samples > 1) {
+    if (renderDirect) {
         assert_invariant(rt->gl.samples > 1);
         assert_invariant(glIsRenderbuffer(t->gl.id));
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -961,7 +961,10 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
 
     // There's a bug with certain drivers preventing us from emulating
     // EXT_multisampled_render_to_texture, so we'll simply fall back to non-MSAA rendering.
-    const bool disableMultisampling = gl.bugs.disable_sidecar_blit && emulateMSRTT;
+    const bool disableMultisampling =
+            gl.bugs.disable_sidecar_blit &&
+            emulateMSRTT &&
+            target == GL_TEXTURE_2D_ARRAY;
 
     if (nonMSAA || disableMultisampling) {
         // on GL3.2 / GLES3.1 and above multisample is handled when creating the texture.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -939,7 +939,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
 
     // The following 4 techniques are different mechanisms to provide storage to the FBO.
     // We'll use the first technique that is sufficient.
-    // nonMSAA:         MSAA was not requested, or we're rendering to an MSAA texture which
+    // nonMSAA:         MSAA was not requested, or we're rendering to an MS texture which
     //                  doesn't require any special setup here
     // useMSRTT:        use the EXT_multisampled_render_to_texture extension
     // renderDirect:    texture is not sampleable, render directly into a renderbuffer


### PR DESCRIPTION
On Adreno devices, a driver bug prevents bliting from a renderbuffer into certain layers of a texture array, which is precicely what we do for VSM MSAA. For now, we'll just disable support for MSAA and simply fallback to normal, non-MSAA rendering.

It'd be nice to not have to disable this for all Adreno devices, but for now I can only assume the bug is present on all of them. 😕 

I also attempted to clarify the logic inside `OpenGLDriver::framebufferTexture`.