### PR TITLE
Specify sampler precision only on GLES

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -92,8 +92,10 @@ io::sstream& CodeGenerator::generateProlog(io::sstream& out, ShaderType type,
     const char* precision = getPrecisionQualifier(defaultPrecision, Precision::DEFAULT);
     out << "precision " << precision << " float;\n";
     out << "precision " << precision << " int;\n";
-    out << "precision lowp sampler2DArray;\n";
-    out << "precision lowp sampler3D;\n";
+    if (mShaderModel == ShaderModel::GL_ES_30) {
+        out << "precision lowp sampler2DArray;\n";
+        out << "precision lowp sampler3D;\n";
+    }
 
     out << SHADERS_COMMON_TYPES_FS_DATA;
 


### PR DESCRIPTION
#3786 added default sampler precision specifiers, but these specifiers are only valid in ES.

Fixes #3823