### PR TITLE
Vulkan: fix VK_FORMAT to correctly handle non-integer types.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1652,7 +1652,11 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     const uint32_t bufferCount = prim.vertexBuffer->attributes.size();
     for (uint32_t attribIndex = 0; attribIndex < bufferCount; attribIndex++) {
         Attribute attrib = prim.vertexBuffer->attributes[attribIndex];
-        VkFormat vkformat = getVkFormat(attrib.type, attrib.flags & Attribute::FLAG_NORMALIZED);
+
+        const bool isInteger = attrib.flags & Attribute::FLAG_INTEGER_TARGET;
+        const bool isNormalized = attrib.flags & Attribute::FLAG_NORMALIZED;
+
+        VkFormat vkformat = getVkFormat(attrib.type, isNormalized, isInteger);
 
         // HACK: Re-use the positions buffer as a dummy buffer for disabled attributes. Filament's
         // vertex shaders declare all attributes as either vec4 or uvec4 (the latter for bone
@@ -1660,7 +1664,6 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
         // a dummy type of either R8G8B8A8_UINT or R8G8B8A8_SNORM, depending on whether the shader
         // expects to receive floats or ints.
         if (attrib.buffer == Attribute::BUFFER_UNUSED) {
-            const bool isInteger = attrib.flags & Attribute::FLAG_INTEGER_TARGET;
             vkformat = isInteger ? VK_FORMAT_R8G8B8A8_UINT : VK_FORMAT_R8G8B8A8_SNORM;
             attrib = prim.vertexBuffer->attributes[0];
         }

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -33,7 +33,7 @@ void createSemaphore(VkDevice device, VkSemaphore *semaphore) {
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkCreateSemaphore error.");
 }
 
-VkFormat getVkFormat(ElementType type, bool normalized) {
+VkFormat getVkFormat(ElementType type, bool normalized, bool integer) {
     using ElementType = ElementType;
     if (normalized) {
         switch (type) {
@@ -64,19 +64,19 @@ VkFormat getVkFormat(ElementType type, bool normalized) {
     }
     switch (type) {
         // Single Component Types
-        case ElementType::BYTE: return VK_FORMAT_R8_SINT;
-        case ElementType::UBYTE: return VK_FORMAT_R8_UINT;
-        case ElementType::SHORT: return VK_FORMAT_R16_SINT;
-        case ElementType::USHORT: return VK_FORMAT_R16_UINT;
+        case ElementType::BYTE: return integer ? VK_FORMAT_R8_SINT : VK_FORMAT_R8_SSCALED;
+        case ElementType::UBYTE: return integer ? VK_FORMAT_R8_UINT : VK_FORMAT_R8_USCALED;
+        case ElementType::SHORT: return integer ? VK_FORMAT_R16_SINT : VK_FORMAT_R16_SSCALED;
+        case ElementType::USHORT: return integer ? VK_FORMAT_R16_UINT : VK_FORMAT_R16_USCALED;
         case ElementType::HALF: return VK_FORMAT_R16_SFLOAT;
         case ElementType::INT: return VK_FORMAT_R32_SINT;
         case ElementType::UINT: return VK_FORMAT_R32_UINT;
         case ElementType::FLOAT: return VK_FORMAT_R32_SFLOAT;
         // Two Component Types
-        case ElementType::BYTE2: return VK_FORMAT_R8G8_SINT;
-        case ElementType::UBYTE2: return VK_FORMAT_R8G8_UINT;
-        case ElementType::SHORT2: return VK_FORMAT_R16G16_SINT;
-        case ElementType::USHORT2: return VK_FORMAT_R16G16_UINT;
+        case ElementType::BYTE2: return integer ? VK_FORMAT_R8G8_SINT : VK_FORMAT_R8G8_SSCALED;
+        case ElementType::UBYTE2: return integer ? VK_FORMAT_R8G8_UINT : VK_FORMAT_R8G8_USCALED;
+        case ElementType::SHORT2: return integer ? VK_FORMAT_R16G16_SINT : VK_FORMAT_R16G16_SSCALED;
+        case ElementType::USHORT2: return integer ? VK_FORMAT_R16G16_UINT : VK_FORMAT_R16G16_USCALED;
         case ElementType::HALF2: return VK_FORMAT_R16G16_SFLOAT;
         case ElementType::FLOAT2: return VK_FORMAT_R32G32_SFLOAT;
         // Three Component Types
@@ -87,10 +87,10 @@ VkFormat getVkFormat(ElementType type, bool normalized) {
         case ElementType::HALF3: return VK_FORMAT_R16G16B16_SFLOAT; // NOT MINSPEC
         case ElementType::FLOAT3: return VK_FORMAT_R32G32B32_SFLOAT;
         // Four Component Types
-        case ElementType::BYTE4: return VK_FORMAT_R8G8B8A8_SINT;
-        case ElementType::UBYTE4: return VK_FORMAT_R8G8B8A8_UINT;
-        case ElementType::SHORT4: return VK_FORMAT_R16G16B16A16_SINT;
-        case ElementType::USHORT4: return VK_FORMAT_R16G16B16A16_UINT;
+        case ElementType::BYTE4: return integer ? VK_FORMAT_R8G8B8A8_SINT : VK_FORMAT_R8G8B8A8_SSCALED;
+        case ElementType::UBYTE4: return integer ? VK_FORMAT_R8G8B8A8_UINT : VK_FORMAT_R8G8B8A8_USCALED;
+        case ElementType::SHORT4: return integer ? VK_FORMAT_R16G16B16A16_SINT : VK_FORMAT_R16G16B16A16_SSCALED;
+        case ElementType::USHORT4: return integer ? VK_FORMAT_R16G16B16A16_UINT : VK_FORMAT_R16G16B16A16_USCALED;
         case ElementType::HALF4: return VK_FORMAT_R16G16B16A16_SFLOAT;
         case ElementType::FLOAT4: return VK_FORMAT_R32G32B32A32_SFLOAT;
     }

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -25,7 +25,7 @@ namespace filament {
 namespace backend {
 
 void createSemaphore(VkDevice device, VkSemaphore* semaphore);
-VkFormat getVkFormat(ElementType type, bool normalized);
+VkFormat getVkFormat(ElementType type, bool normalized, bool integer);
 VkFormat getVkFormat(TextureFormat format);
 uint32_t getBytesPerPixel(TextureFormat format);
 VkCompareOp getCompareOp(SamplerCompareFunc func);


### PR DESCRIPTION
The SCALED formats are useful when the shader consumes a float, but
you want to give it an integer.