### PR TITLE
gltfio: Use the new Transcoder API in some cases.

### DIFF
--- a/android/filament-android/CMakeLists.txt
+++ b/android/filament-android/CMakeLists.txt
@@ -97,7 +97,6 @@ target_link_libraries(filament-jni
     PRIVATE backend
     PRIVATE filaflat
     PRIVATE filabridge
-    PRIVATE geometry
     PRIVATE ibl-lite
     PRIVATE log
     PRIVATE GLESv3
@@ -105,6 +104,10 @@ target_link_libraries(filament-jni
     PRIVATE android
     PRIVATE jnigraphics
     PRIVATE utils
+
+    # libgeometry is PUBLIC because gltfio uses it.
+    PUBLIC geometry
+
     $<$<STREQUAL:${FILAMENT_ENABLE_MATDBG},ON>:matdbg>
     $<$<STREQUAL:${FILAMENT_SUPPORTS_VULKAN},ON>:bluevk>
     $<$<STREQUAL:${FILAMENT_SUPPORTS_VULKAN},ON>:vkshaders>

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -644,15 +644,17 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
         }
 
         VertexBuffer::AttributeType fatype;
-        if (!getElementType(accessor->type, accessor->component_type, &fatype)) {
+        VertexBuffer::AttributeType actualType;
+        if (!getElementType(accessor->type, accessor->component_type, &fatype, &actualType)) {
             slog.e << "Unsupported accessor type in " << name << io::endl;
             return false;
         }
+        const int stride = (fatype == actualType) ? accessor->stride : 0;
 
         // The cgltf library provides a stride value for all accessors, even though they do not
         // exist in the glTF file. It is computed from the type and the stride of the buffer view.
         // As a convenience, cgltf also replaces zero (default) stride with the actual stride.
-        vbb.attribute(semantic, slot, fatype, 0, accessor->stride);
+        vbb.attribute(semantic, slot, fatype, 0, stride);
         vbb.normalized(semantic, accessor->normalized);
         addBufferSlot({accessor, atype, slot++});
     }
@@ -709,13 +711,15 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             outPrim->aabb.max = max(outPrim->aabb.max, float3(maxp[0], maxp[1], maxp[2]));
 
             VertexBuffer::AttributeType fatype;
-            if (!getElementType(accessor->type, accessor->component_type, &fatype)) {
+            VertexBuffer::AttributeType actualType;
+            if (!getElementType(accessor->type, accessor->component_type, &fatype, &actualType)) {
                 slog.e << "Unsupported accessor type in " << name << io::endl;
                 return false;
             }
+            const int stride = (fatype == actualType) ? accessor->stride : 0;
 
             VertexAttribute attr = (VertexAttribute) (basePositionAttr + targetIndex);
-            vbb.attribute(attr, slot, fatype, 0, accessor->stride);
+            vbb.attribute(attr, slot, fatype, 0, stride);
             vbb.normalized(attr, accessor->normalized);
             addBufferSlot({accessor, atype, slot++, morphId});
         }

--- a/libs/gltfio/src/GltfEnums.h
+++ b/libs/gltfio/src/GltfEnums.h
@@ -134,28 +134,42 @@ inline bool getPrimitiveType(cgltf_primitive_type in,
     return false;
 }
 
+// This converts a cgltf component type into a Filament Attribute type.
+//
+// This function has two out parameters. One result is a safe "permitted type" which we know is
+// universally accepted across GPU's and backends, but may require conversion (see Transcoder). The
+// other result is the "actual type" which requires no conversion.
+//
+// Returns false if the given component type is invalid.
 inline bool getElementType(cgltf_type type, cgltf_component_type ctype,
-        filament::VertexBuffer::AttributeType* atype) {
+        filament::VertexBuffer::AttributeType* permitType,
+        filament::VertexBuffer::AttributeType* actualType) {
     switch (type) {
 	    case cgltf_type_scalar:
             switch (ctype) {
                 case cgltf_component_type_r_8:
-                    *atype = filament::VertexBuffer::AttributeType::BYTE;
+                    *permitType = filament::VertexBuffer::AttributeType::BYTE;
+                    *actualType = filament::VertexBuffer::AttributeType::BYTE;
                     return true;
                 case cgltf_component_type_r_8u:
-                    *atype = filament::VertexBuffer::AttributeType::UBYTE;
+                    *permitType = filament::VertexBuffer::AttributeType::UBYTE;
+                    *actualType = filament::VertexBuffer::AttributeType::UBYTE;
                     return true;
                 case cgltf_component_type_r_16:
-                    *atype = filament::VertexBuffer::AttributeType::SHORT;
+                    *permitType = filament::VertexBuffer::AttributeType::SHORT;
+                    *actualType = filament::VertexBuffer::AttributeType::SHORT;
                     return true;
                 case cgltf_component_type_r_16u:
-                    *atype = filament::VertexBuffer::AttributeType::USHORT;
+                    *permitType = filament::VertexBuffer::AttributeType::USHORT;
+                    *actualType = filament::VertexBuffer::AttributeType::USHORT;
                     return true;
                 case cgltf_component_type_r_32u:
-                    *atype = filament::VertexBuffer::AttributeType::UINT;
+                    *permitType = filament::VertexBuffer::AttributeType::UINT;
+                    *actualType = filament::VertexBuffer::AttributeType::UINT;
                     return true;
                 case cgltf_component_type_r_32f:
-                    *atype = filament::VertexBuffer::AttributeType::FLOAT;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT;
+                    *actualType = filament::VertexBuffer::AttributeType::FLOAT;
                     return true;
                 default:
                     return false;
@@ -164,19 +178,24 @@ inline bool getElementType(cgltf_type type, cgltf_component_type ctype,
 	    case cgltf_type_vec2:
             switch (ctype) {
                 case cgltf_component_type_r_8:
-                    *atype = filament::VertexBuffer::AttributeType::BYTE2;
+                    *permitType = filament::VertexBuffer::AttributeType::BYTE2;
+                    *actualType = filament::VertexBuffer::AttributeType::BYTE2;
                     return true;
                 case cgltf_component_type_r_8u:
-                    *atype = filament::VertexBuffer::AttributeType::UBYTE2;
+                    *permitType = filament::VertexBuffer::AttributeType::UBYTE2;
+                    *actualType = filament::VertexBuffer::AttributeType::UBYTE2;
                     return true;
                 case cgltf_component_type_r_16:
-                    *atype = filament::VertexBuffer::AttributeType::SHORT2;
+                    *permitType = filament::VertexBuffer::AttributeType::SHORT2;
+                    *actualType = filament::VertexBuffer::AttributeType::SHORT2;
                     return true;
                 case cgltf_component_type_r_16u:
-                    *atype = filament::VertexBuffer::AttributeType::USHORT2;
+                    *permitType = filament::VertexBuffer::AttributeType::USHORT2;
+                    *actualType = filament::VertexBuffer::AttributeType::USHORT2;
                     return true;
                 case cgltf_component_type_r_32f:
-                    *atype = filament::VertexBuffer::AttributeType::FLOAT2;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT2;
+                    *actualType = filament::VertexBuffer::AttributeType::FLOAT2;
                     return true;
                 default:
                     return false;
@@ -185,19 +204,24 @@ inline bool getElementType(cgltf_type type, cgltf_component_type ctype,
 	    case cgltf_type_vec3:
             switch (ctype) {
                 case cgltf_component_type_r_8:
-                    *atype = filament::VertexBuffer::AttributeType::BYTE3;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *actualType = filament::VertexBuffer::AttributeType::BYTE3;
                     return true;
                 case cgltf_component_type_r_8u:
-                    *atype = filament::VertexBuffer::AttributeType::UBYTE3;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *actualType = filament::VertexBuffer::AttributeType::UBYTE3;
                     return true;
                 case cgltf_component_type_r_16:
-                    *atype = filament::VertexBuffer::AttributeType::SHORT3;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *actualType = filament::VertexBuffer::AttributeType::SHORT3;
                     return true;
                 case cgltf_component_type_r_16u:
-                    *atype = filament::VertexBuffer::AttributeType::USHORT3;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *actualType = filament::VertexBuffer::AttributeType::USHORT3;
                     return true;
                 case cgltf_component_type_r_32f:
-                    *atype = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT3;
+                    *actualType = filament::VertexBuffer::AttributeType::FLOAT3;
                     return true;
                 default:
                     return false;
@@ -206,19 +230,24 @@ inline bool getElementType(cgltf_type type, cgltf_component_type ctype,
 	    case cgltf_type_vec4:
             switch (ctype) {
                 case cgltf_component_type_r_8:
-                    *atype = filament::VertexBuffer::AttributeType::BYTE4;
+                    *permitType = filament::VertexBuffer::AttributeType::BYTE4;
+                    *actualType = filament::VertexBuffer::AttributeType::BYTE4;
                     return true;
                 case cgltf_component_type_r_8u:
-                    *atype = filament::VertexBuffer::AttributeType::UBYTE4;
+                    *permitType = filament::VertexBuffer::AttributeType::UBYTE4;
+                    *actualType = filament::VertexBuffer::AttributeType::UBYTE4;
                     return true;
                 case cgltf_component_type_r_16:
-                    *atype = filament::VertexBuffer::AttributeType::SHORT4;
+                    *permitType = filament::VertexBuffer::AttributeType::SHORT4;
+                    *actualType = filament::VertexBuffer::AttributeType::SHORT4;
                     return true;
                 case cgltf_component_type_r_16u:
-                    *atype = filament::VertexBuffer::AttributeType::USHORT4;
+                    *permitType = filament::VertexBuffer::AttributeType::USHORT4;
+                    *actualType = filament::VertexBuffer::AttributeType::USHORT4;
                     return true;
                 case cgltf_component_type_r_32f:
-                    *atype = filament::VertexBuffer::AttributeType::FLOAT4;
+                    *permitType = filament::VertexBuffer::AttributeType::FLOAT4;
+                    *actualType = filament::VertexBuffer::AttributeType::FLOAT4;
                     return true;
                 default:
                     return false;
@@ -228,6 +257,13 @@ inline bool getElementType(cgltf_type type, cgltf_component_type ctype,
             return false;
     }
     return false;
+}
+
+inline bool requiresConversion(cgltf_type type, cgltf_component_type ctype) {
+    filament::VertexBuffer::AttributeType permitted;
+    filament::VertexBuffer::AttributeType actual;
+    bool supported = getElementType(type, ctype, &permitted, &actual);
+    return supported && permitted != actual;
 }
 
 #endif // GLTFIO_GLTFENUMS_H


### PR DESCRIPTION
This fixes issues seen seen with Vulkan in conjunction with quantized model variants in the glTF samples repo such as the Avocado.

We already support the quantized glTF extension, which is when this
comes up. Technically this is only needed for Vulkan but gltfio does
not (and should not) know which backend is being used, so we simply
apply these transformations assuming the worst.

In practice this code usually won't be activated, and if even when it
is, it won't hurt loading time as much as other things like large
textures.