### PR TITLE
don't set sun parameters if we didn't have SH

### DIFF
--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -384,10 +384,12 @@ void SimpleViewer::setIndirectLight(filament::IndirectLight* ibl,
     if (ibl) {
         float3 d = filament::IndirectLight::getDirectionEstimate(sh3);
         float4 c = filament::IndirectLight::getColorEstimate(sh3, d);
-        mSettings.lighting.sunlightDirection = d;
-        mSettings.lighting.sunlightColor = c.rgb;
-        mSettings.lighting.sunlightIntensity = c[3] * ibl->getIntensity();
-        updateIndirectLight();
+        if (!std::isnan(d.x * d.y * d.z)) {
+            mSettings.lighting.sunlightDirection = d;
+            mSettings.lighting.sunlightColor = c.rgb;
+            mSettings.lighting.sunlightIntensity = c[3] * ibl->getIntensity();
+            updateIndirectLight();
+        }
     }
 }
 


### PR DESCRIPTION
The parameters would turn out as NaN.
We might need a better API for this, but it's
never okay to set NaN values.