### PR TITLE
Enable Vulkan in our Android Release package.

### DIFF
--- a/build/android/build.sh
+++ b/build/android/build.sh
@@ -11,9 +11,6 @@
 NDK_VERSION="ndk;22.0.7026061"
 ANDROID_NDK_VERSION=22
 
-# Exclude Vulkan from CI builds for Android. (It is enabled for other platforms.)
-EXCLUDE_VULKAN=-v
-
 echo "This script is intended to run in a CI environment and may modify your current environment."
 echo "Please refer to BUILDING.md for more information."
 
@@ -50,11 +47,6 @@ elif [[ "$LC_UNAME" == "darwin" ]]; then
 fi
 source `dirname $0`/../common/build-common.sh
 
-# For continuous builds, do not exclude Vulkan.
-if [[ "$TARGET" == "continuous" ]]; then
-    EXCLUDE_VULKAN=
-fi
-
 # Only update and install the NDK if necessary, as this can be slow
 ndk_side_by_side="${ANDROID_HOME}/ndk/"
 if [[ -d $ndk_side_by_side ]]; then
@@ -74,4 +66,4 @@ if [[ "$TARGET" == "presubmit" ]]; then
 fi
 
 pushd `dirname $0`/../.. > /dev/null
-./build.sh -p android $EXCLUDE_VULKAN $ANDROID_ABIS -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE
+./build.sh -p android $ANDROID_ABIS -c $GENERATE_ARCHIVES $BUILD_DEBUG $BUILD_RELEASE


### PR DESCRIPTION
This makes release builds consistent with continuous builds and default
local builds. It also makes it easier to test the Vulkan backend.
Clients who need a smaller APK size can always make their own build.

This also makes filament-android-release.aar go from 1.8M to 2.3M.
Note that we are now including bluevk, vkshaders (for the blit shader),
smol-v (for SPIRV decompression) and vk_mem_alloc (for mem allocation).