### PR TITLE
Revert "Support a maximum of 8 render buffers (from 4)"

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -86,37 +86,22 @@ static constexpr const char* backendToString(backend::Backend backend) {
 /**
  * Bitmask for selecting render buffers
  */
-enum class TargetBufferFlags : uint32_t {
+enum class TargetBufferFlags : uint8_t {
     NONE = 0x0u,                            //!< No buffer selected.
-    COLOR0 = 0x00000001u,                   //!< Color buffer selected.
-    COLOR1 = 0x00000002u,                   //!< Color buffer selected.
-    COLOR2 = 0x00000004u,                   //!< Color buffer selected.
-    COLOR3 = 0x00000008u,                   //!< Color buffer selected.
-    COLOR4 = 0x00000010u,                   //!< Color buffer selected.
-    COLOR5 = 0x00000020u,                   //!< Color buffer selected.
-    COLOR6 = 0x00000040u,                   //!< Color buffer selected.
-    COLOR7 = 0x00000080u,                   //!< Color buffer selected.
-
+    COLOR0 = 0x1u,                          //!< Color buffer selected.
+    COLOR1 = 0x2u,                          //!< Color buffer selected.
+    COLOR2 = 0x4u,                          //!< Color buffer selected.
+    COLOR3 = 0x8u,                          //!< Color buffer selected.
     COLOR = COLOR0,                         //!< \deprecated
-    COLOR_ALL = COLOR0 | COLOR1 | COLOR2 | COLOR3 | COLOR4 | COLOR5 | COLOR6 | COLOR7,
-    DEPTH   = 0x10000000u,                  //!< Depth buffer selected.
-    STENCIL = 0x20000000u,                  //!< Stencil buffer selected.
+    COLOR_ALL = COLOR0 | COLOR1 | COLOR2 | COLOR3,
+    DEPTH = 0x10u,                          //!< Depth buffer selected.
+    STENCIL = 0x20u,                        //!< Stencil buffer selected.
     DEPTH_AND_STENCIL = DEPTH | STENCIL,    //!< depth and stencil buffer selected.
     ALL = COLOR_ALL | DEPTH | STENCIL       //!< Color, depth and stencil buffer selected.
 };
 
-inline TargetBufferFlags getTargetBufferFlagsAt(size_t index) noexcept {
-    if (index == 0u) return TargetBufferFlags::COLOR0;
-    if (index == 1u) return TargetBufferFlags::COLOR1;
-    if (index == 2u) return TargetBufferFlags::COLOR2;
-    if (index == 3u) return TargetBufferFlags::COLOR3;
-    if (index == 4u) return TargetBufferFlags::COLOR4;
-    if (index == 5u) return TargetBufferFlags::COLOR5;
-    if (index == 6u) return TargetBufferFlags::COLOR6;
-    if (index == 7u) return TargetBufferFlags::COLOR7;
-    if (index == 8u) return TargetBufferFlags::DEPTH;
-    if (index == 9u) return TargetBufferFlags::STENCIL;
-    return TargetBufferFlags::NONE;
+inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept {
+    return TargetBufferFlags(1u << index);
 }
 
 /**

--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -54,8 +54,7 @@ public:
 
 class MRT {
 public:
-    static constexpr uint8_t MIN_SUPPORTED_RENDER_TARGET_COUNT = 4u;
-    static constexpr uint8_t MAX_SUPPORTED_RENDER_TARGET_COUNT = 8u;
+    static constexpr int MAX_SUPPORTED_RENDER_TARGET_COUNT = 4;
 
 private:
     TargetBufferInfo mInfos[MAX_SUPPORTED_RENDER_TARGET_COUNT];

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -298,7 +298,6 @@ DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::Text
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameBufferFetchSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, areFeedbackLoopsSupported)
-DECL_DRIVER_API_SYNCHRONOUS_0(uint8_t, getMaxDrawBuffers)
 DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)

--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -165,10 +165,6 @@ void MetalBlitter::blit(id<MTLCommandBuffer> cmdBuffer, const BlitArgs& args) {
             blitColor ? args.destination.color.pixelFormat : MTLPixelFormatInvalid,
             MTLPixelFormatInvalid,
             MTLPixelFormatInvalid,
-            MTLPixelFormatInvalid,
-            MTLPixelFormatInvalid,
-            MTLPixelFormatInvalid,
-            MTLPixelFormatInvalid,
             MTLPixelFormatInvalid
         },
         .depthAttachmentPixelFormat =

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -276,7 +276,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         const auto& buffer = color[i];
         if (!buffer.handle) {
-            ASSERT_POSTCONDITION(none(targetBufferFlags & getTargetBufferFlagsAt(i)),
+            ASSERT_POSTCONDITION(none(targetBufferFlags & getMRTColorFlag(i)),
                     "The COLOR%u flag was specified, but no color texture provided.", i);
             continue;
         }
@@ -670,10 +670,6 @@ bool MetalDriver::areFeedbackLoopsSupported() {
 math::float2 MetalDriver::getClipSpaceParams() {
     // z-coordinate of clip-space is in [0,w]
     return math::float2{ -0.5f, 0.5f };
-}
-
-uint8_t MetalDriver::getMaxDrawBuffers() {
-    return backend::MRT::MIN_SUPPORTED_RENDER_TARGET_COUNT; // TODO: query real value
 }
 
 void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
@@ -1182,11 +1178,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             colorPixelFormat[0],
             colorPixelFormat[1],
             colorPixelFormat[2],
-            colorPixelFormat[3],
-            colorPixelFormat[4],
-            colorPixelFormat[5],
-            colorPixelFormat[6],
-            colorPixelFormat[7]
+            colorPixelFormat[3]
         },
         .depthAttachmentPixelFormat = depthPixelFormat,
         .sampleCount = mContext->currentRenderTarget->getSamples(),

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -757,9 +757,8 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
         descriptor.colorAttachments[i].texture = attachment.texture;
         descriptor.colorAttachments[i].level = attachment.level;
         descriptor.colorAttachments[i].slice = attachment.layer;
-        descriptor.colorAttachments[i].loadAction = getLoadAction(params, getTargetBufferFlagsAt(i));
-        descriptor.colorAttachments[i].storeAction = getStoreAction(params,
-                getTargetBufferFlagsAt(i));
+        descriptor.colorAttachments[i].loadAction = getLoadAction(params, getMRTColorFlag(i));
+        descriptor.colorAttachments[i].storeAction = getStoreAction(params, getMRTColorFlag(i));
         descriptor.colorAttachments[i].clearColor = MTLClearColorMake(
                 params.clearColor.r, params.clearColor.g, params.clearColor.b, params.clearColor.a);
 
@@ -771,7 +770,7 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
             descriptor.colorAttachments[i].texture = multisampledColor[i];
             descriptor.colorAttachments[i].level = 0;
             descriptor.colorAttachments[i].slice = 0;
-            const bool discard = any(discardFlags & getTargetBufferFlagsAt(i));
+            const bool discard = any(discardFlags & getMRTColorFlag(i));
             if (!discard) {
                 descriptor.colorAttachments[i].resolveTexture = attachment.texture;
                 descriptor.colorAttachments[i].resolveLevel = attachment.level;

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -216,7 +216,7 @@ struct PipelineState {
     id<MTLFunction> vertexFunction = nil;                                      // 8 bytes
     id<MTLFunction> fragmentFunction = nil;                                    // 8 bytes
     VertexDescription vertexDescription;                                       // 528 bytes
-    MTLPixelFormat colorAttachmentPixelFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { MTLPixelFormatInvalid };  // 64 bytes
+    MTLPixelFormat colorAttachmentPixelFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { MTLPixelFormatInvalid };  // 32 bytes
     MTLPixelFormat depthAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
     NSUInteger sampleCount = 1;                                                // 8 bytes
     BlendState blendState;                                                     // 56 bytes
@@ -244,7 +244,7 @@ struct PipelineState {
 
 // This assert checks that the struct is the size we expect without any "hidden" padding bytes
 // inserted by the compiler.
-static_assert(sizeof(PipelineState) == 688, "PipelineState unexpected size.");
+static_assert(sizeof(PipelineState) == 656, "PipelineState unexpected size.");
 
 struct PipelineStateCreator {
     id<MTLRenderPipelineState> operator()(id<MTLDevice> device, const PipelineState& state)

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -175,10 +175,6 @@ math::float2 NoopDriver::getClipSpaceParams() {
     return math::float2{ -1.0f, 0.0f };
 }
 
-uint8_t NoopDriver::getMaxDrawBuffers() {
-    return backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
-}
-
 void NoopDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     scheduleDestroy(std::move(p));

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -120,8 +120,6 @@ OpenGLContext::OpenGLContext() noexcept {
     }
 #endif
 
-    assert_invariant(gets.max_draw_buffers >= 4); // minspec
-
 #if 0
     // this is useful for development, but too verbose even for debug builds
     slog.i

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1181,7 +1181,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     if (any(targets & TargetBufferFlags::COLOR_ALL)) {
         GLenum bufs[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { GL_NONE };
         for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-            if (any(targets & getTargetBufferFlagsAt(i))) {
+            if (any(targets & getMRTColorFlag(i))) {
                 rt->gl.color[i].texture = handle_cast<GLTexture*>(color[i].handle);
                 rt->gl.color[i].level = color[i].level;
                 framebufferTexture(color[i], rt, GL_COLOR_ATTACHMENT0 + i);
@@ -1708,10 +1708,6 @@ bool OpenGLDriver::areFeedbackLoopsSupported() {
 math::float2 OpenGLDriver::getClipSpaceParams() {
     return mContext.ext.EXT_clip_control ?
             math::float2{ -0.5f, 0.5f } : math::float2{ -1.0f, 0.0f };
-}
-
-uint8_t OpenGLDriver::getMaxDrawBuffers() {
-    return std::min(MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT, uint8_t(mContext.gets.max_draw_buffers));
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -865,10 +865,6 @@ math::float2 VulkanDriver::getClipSpaceParams() {
     return math::float2{ -0.5f, 0.5f };
 }
 
-uint8_t VulkanDriver::getMaxDrawBuffers() {
-    return backend::MRT::MIN_SUPPORTED_RENDER_TARGET_COUNT; // TODO: query real value
-}
-
 void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
         Handle<HwBufferObject> boh) {
     auto& vb = *handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -39,25 +39,25 @@ public:
     // RenderPassKey is a small POD representing the immutable state that is used to construct
     // a VkRenderPass. It is hashed and used as a lookup key.
     struct alignas(8) RenderPassKey {
-        VkImageLayout colorLayout[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];  // 32 bytes
-        VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
+        VkImageLayout colorLayout[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];  // 16 bytes
+        VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 16 bytes
         VkImageLayout depthLayout;  // 4 bytes
         VkFormat depthFormat; // 4 bytes
-        TargetBufferFlags clear; // 4 bytes
-        TargetBufferFlags discardStart; // 4 bytes
-        TargetBufferFlags discardEnd; // 4 bytes
+        TargetBufferFlags clear : 8; // 1 byte
+        TargetBufferFlags discardStart : 8; // 1 byte
+        TargetBufferFlags discardEnd : 8; // 1 byte
         uint8_t samples; // 1 byte
         uint8_t needsResolveMask; // 1 byte
         uint8_t subpassMask; // 1 bytes
-        uint8_t padding; // 1 bytes
+        uint16_t padding; // 2 bytes
     };
     struct RenderPassVal {
         VkRenderPass handle;
         uint32_t timestamp;
     };
-    static_assert(sizeof(TargetBufferFlags) == 4, "TargetBufferFlags has unexpected size.");
+    static_assert(sizeof(TargetBufferFlags) == 1, "TargetBufferFlags has unexpected size.");
     static_assert(sizeof(VkFormat) == 4, "VkFormat has unexpected size.");
-    static_assert(sizeof(RenderPassKey) == 88, "RenderPassKey has unexpected size.");
+    static_assert(sizeof(RenderPassKey) == 48, "RenderPassKey has unexpected size.");
     using RenderPassHash = utils::hash::MurmurHashFn<RenderPassKey>;
     struct RenderPassEq {
         bool operator()(const RenderPassKey& k1, const RenderPassKey& k2) const;
@@ -72,8 +72,8 @@ public:
         uint16_t height; // 2 bytes
         uint16_t layers; // 2 bytes
         uint16_t samples; // 2 bytes
-        VkImageView color[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 64 bytes
-        VkImageView resolve[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 64 bytes
+        VkImageView color[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
+        VkImageView resolve[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
         VkImageView depth; // 8 bytes
     };
     struct FboVal {
@@ -82,7 +82,7 @@ public:
     };
     static_assert(sizeof(VkRenderPass) == 8, "VkRenderPass has unexpected size.");
     static_assert(sizeof(VkImageView) == 8, "VkImageView has unexpected size.");
-    static_assert(sizeof(FboKey) == 152, "FboKey has unexpected size.");
+    static_assert(sizeof(FboKey) == 88, "FboKey has unexpected size.");
     using FboKeyHashFn = utils::hash::MurmurHashFn<FboKey>;
     struct FboKeyEqualFn {
         bool operator()(const FboKey& k1, const FboKey& k2) const;

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -47,14 +47,6 @@ class UTILS_PUBLIC RenderTarget : public FilamentAPI {
 public:
     using CubemapFace = backend::TextureCubemapFace;
 
-    /** Minimum number of color attachment supported */
-    static constexpr uint8_t MIN_SUPPORTED_COLOR_ATTACHMENTS_COUNT =
-            backend::MRT::MIN_SUPPORTED_RENDER_TARGET_COUNT;
-
-    /** Maximum number of color attachment supported */
-    static constexpr uint8_t MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT =
-            backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
-
     /**
      * Attachment identifiers
      */
@@ -63,7 +55,7 @@ public:
         COLOR1 = 1,          //!< identifies the 2nd color attachment
         COLOR2 = 2,          //!< identifies the 3rd color attachment
         COLOR3 = 3,          //!< identifies the 4th color attachment
-        DEPTH  = MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT,   //!< identifies the depth attachment
+        DEPTH  = backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT,   //!< identifies the depth attachment
         COLOR  = COLOR0,     //!< identifies the 1st color attachment
     };
 
@@ -156,14 +148,6 @@ public:
      * @return A texture layer. This is only relevant if the attachment's texture is a 3D texture.
      */
     uint32_t getLayer(AttachmentPoint attachment) const noexcept;
-
-    /**
-     * Returns the number of color attachments usable by this instance of Engine. This method is
-     * guaranteed to return at least MIN_SUPPORTED_COLOR_ATTACHMENTS_COUNT and at most
-     * MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT.
-     * @return Number of color attachments usable in a render target.
-     */
-    uint8_t getSupportedColorAttachmentsCount() const noexcept;
 };
 
 } // namespace filament

--- a/filament/src/details/RenderTarget.h
+++ b/filament/src/details/RenderTarget.h
@@ -55,17 +55,12 @@ public:
         return mAttachmentMask;
     }
 
-    uint8_t getSupportedColorAttachmentsCount() const noexcept {
-        return mSupportedColorAttachmentsCount;
-    }
-
 private:
     friend class RenderTarget;
-    static constexpr size_t ATTACHMENT_COUNT = MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT + 1u;
+    static constexpr size_t ATTACHMENT_COUNT = backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 1;
     Attachment mAttachments[ATTACHMENT_COUNT];
     HwHandle mHandle{};
     backend::TargetBufferFlags mAttachmentMask = {};
-    const uint8_t mSupportedColorAttachmentsCount;
 };
 
 FILAMENT_UPCAST(RenderTarget)

--- a/filament/src/fg2/PassNode.cpp
+++ b/filament/src/fg2/PassNode.cpp
@@ -141,7 +141,7 @@ void RenderPassNode::resolve() noexcept {
 
         for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 2; i++) {
             if (rt.descriptor.attachments.array[i]) {
-                const TargetBufferFlags target = getTargetBufferFlagsAt(i);
+                const TargetBufferFlags target = getMRTColorFlag(i);
 
                 rt.targetBufferFlags |= target;
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -568,7 +568,7 @@ public:
 
     static constexpr size_t MAX_COLOR_OUTPUT = filament::backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
     static constexpr size_t MAX_DEPTH_OUTPUT = 1;
-    static_assert(MAX_COLOR_OUTPUT == 8,
+    static_assert(MAX_COLOR_OUTPUT == 4,
             "When updating MRT::TARGET_COUNT, manually update post_process_inputs.fs"
             " and post_process.fs");
 

--- a/shaders/src/post_process.fs
+++ b/shaders/src/post_process.fs
@@ -17,18 +17,6 @@ void main() {
 #if defined(FRAG_OUTPUT3)
     inputs.FRAG_OUTPUT3 = clamp(inputs.FRAG_OUTPUT3, -MEDIUMP_FLT_MAX, MEDIUMP_FLT_MAX);
 #endif
-#if defined(FRAG_OUTPUT4)
-    inputs.FRAG_OUTPUT4 = clamp(inputs.FRAG_OUTPUT4, -MEDIUMP_FLT_MAX, MEDIUMP_FLT_MAX);
-#endif
-#if defined(FRAG_OUTPUT5)
-    inputs.FRAG_OUTPUT5 = clamp(inputs.FRAG_OUTPUT5, -MEDIUMP_FLT_MAX, MEDIUMP_FLT_MAX);
-#endif
-#if defined(FRAG_OUTPUT6)
-    inputs.FRAG_OUTPUT6 = clamp(inputs.FRAG_OUTPUT6, -MEDIUMP_FLT_MAX, MEDIUMP_FLT_MAX);
-#endif
-#if defined(FRAG_OUTPUT7)
-    inputs.FRAG_OUTPUT7 = clamp(inputs.FRAG_OUTPUT7, -MEDIUMP_FLT_MAX, MEDIUMP_FLT_MAX);
-#endif
 #endif
 
 #if defined(FRAG_OUTPUT0)
@@ -42,18 +30,6 @@ void main() {
 #endif
 #if defined(FRAG_OUTPUT3)
     FRAG_OUTPUT_AT3 = inputs.FRAG_OUTPUT3;
-#endif
-#if defined(FRAG_OUTPUT4)
-    FRAG_OUTPUT_AT4 = inputs.FRAG_OUTPUT4;
-#endif
-#if defined(FRAG_OUTPUT5)
-    FRAG_OUTPUT_AT5 = inputs.FRAG_OUTPUT5;
-#endif
-#if defined(FRAG_OUTPUT6)
-    FRAG_OUTPUT_AT6 = inputs.FRAG_OUTPUT6;
-#endif
-#if defined(FRAG_OUTPUT7)
-    FRAG_OUTPUT_AT7 = inputs.FRAG_OUTPUT7;
 #endif
 #if defined(FRAG_OUTPUT_DEPTH)
     gl_FragDepth = inputs.depth;

--- a/shaders/src/post_process_inputs.fs
+++ b/shaders/src/post_process_inputs.fs
@@ -18,18 +18,6 @@ struct PostProcessInputs {
 #if defined(FRAG_OUTPUT3)
     FRAG_OUTPUT_TYPE3 FRAG_OUTPUT3;
 #endif
-#if defined(FRAG_OUTPUT4)
-    FRAG_OUTPUT_TYPE4 FRAG_OUTPUT4;
-#endif
-#if defined(FRAG_OUTPUT5)
-    FRAG_OUTPUT_TYPE5 FRAG_OUTPUT5;
-#endif
-#if defined(FRAG_OUTPUT6)
-    FRAG_OUTPUT_TYPE6 FRAG_OUTPUT6;
-#endif
-#if defined(FRAG_OUTPUT7)
-    FRAG_OUTPUT_TYPE7 FRAG_OUTPUT7;
-#endif
 #if defined(FRAG_OUTPUT_DEPTH)
     float depth;
 #endif


### PR DESCRIPTION
This reverts commit 6f948c101f9eb817cc84761d6af30550c8c63d5a.

This is breaking rendering on Android when certain postprocessing
effects are disabled (e.g. bloom/msaa/dof).