### PR TITLE
Fix memory leak inside utils::details::SafeString

### DIFF
--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -26,6 +26,8 @@
 #include <utils/EntityInstance.h>
 #include <utils/SingleInstanceComponentManager.h>
 
+#include <functional>
+
 namespace utils {
 
 class EntityManager;
@@ -37,9 +39,7 @@ public:
     explicit SafeString(const char* str) noexcept : mCStr(strdup(str)) { }
     SafeString(SafeString&& rhs) noexcept : mCStr(rhs.mCStr) { rhs.mCStr = nullptr; }
     SafeString& operator=(SafeString&& rhs) noexcept {
-        free((void*)mCStr);
-        mCStr = rhs.mCStr;
-        rhs.mCStr = nullptr;
+        std::swap(mCStr, rhs.mCStr);
         return *this;
     }
     ~SafeString() { free((void*)mCStr); }

--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -37,6 +37,7 @@ public:
     explicit SafeString(const char* str) noexcept : mCStr(strdup(str)) { }
     SafeString(SafeString&& rhs) noexcept : mCStr(rhs.mCStr) { rhs.mCStr = nullptr; }
     SafeString& operator=(SafeString&& rhs) noexcept {
+        free((void*)mCStr);
         mCStr = rhs.mCStr;
         rhs.mCStr = nullptr;
         return *this;


### PR DESCRIPTION
Calls to `strdup` must be balanced with calls to `free`.