### PR TITLE
Add gltf-viewer iOS sample

### DIFF
--- a/build/ios/build-samples.sh
+++ b/build/ios/build-samples.sh
@@ -10,7 +10,7 @@ XCODEBUILD_FLAGS='CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_AL
 # This sets the BUILD_DEBUG and BUILD_RELEASE variables based on the CI job.
 pushd `dirname $0`/../../ios/samples
 
-PROJECTS="hello-ar hello-gltf hello-pbr hello-triangle transparent-rendering"
+PROJECTS="gltf-viewer hello-ar hello-gltf hello-pbr hello-triangle transparent-rendering"
 
 function build_project {
     local project="$1"

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -42,6 +42,7 @@ using namespace backend;
 struct PlatformCocoaTouchGLImpl {
     EAGLContext* mGLContext = nullptr;
     CAEAGLLayer* mCurrentGlLayer = nullptr;
+    CGRect mCurrentGlLayerRect;
     GLuint mDefaultFramebuffer = 0;
     GLuint mDefaultColorbuffer = 0;
     GLuint mDefaultDepthbuffer = 0;
@@ -128,8 +129,10 @@ void PlatformCocoaTouchGL::makeCurrent(SwapChain* drawSwapChain, SwapChain* read
 
     [EAGLContext setCurrentContext:pImpl->mGLContext];
 
-    if (pImpl->mCurrentGlLayer != glLayer) {
+    if (pImpl->mCurrentGlLayer != glLayer ||
+                !CGRectEqualToRect(pImpl->mCurrentGlLayerRect, glLayer.bounds)) {
         pImpl->mCurrentGlLayer = glLayer;
+        pImpl->mCurrentGlLayerRect = glLayer.bounds;
 
         glBindFramebuffer(GL_FRAMEBUFFER, pImpl->mDefaultFramebuffer);
 

--- a/ios/samples/README.md
+++ b/ios/samples/README.md
@@ -60,6 +60,7 @@ When building for the simulator, the sample will then link against the libraries
 
 Open up one of the Xcode projects:
 
+- gltf-viewer/gltf-viewer.xcodeproj
 - hello-ar/hello-ar.xcodeproj
 - hello-gltf/hello-gltf.xcodeproj
 - hello-pbr/hello-pbr.xcodeproj

--- a/ios/samples/gltf-viewer/.gitignore
+++ b/ios/samples/gltf-viewer/.gitignore
@@ -1,0 +1,4 @@
+## User settings
+xcuserdata/
+/generated/
+

--- a/ios/samples/gltf-viewer/build-resources.sh
+++ b/ios/samples/gltf-viewer/build-resources.sh
@@ -1,0 +1,28 @@
+#/usr/bin/env/bash
+
+set -e
+
+# Compile resources.
+
+# The gltf-viewer app requires two resources:
+# 1. The IBL image
+# 2. The skybox image
+
+HOST_TOOLS_PATH="${HOST_TOOLS_PATH:-../../../out/release/filament/bin}"
+
+cmgen_path=`find ${HOST_TOOLS_PATH} -name cmgen -type f | head -n 1`
+
+# Ensure that the required tools are present in the out/ directory.
+# These can be built by running ./build.sh -p desktop -i release at Filament's root directory.
+
+if [[ ! -e "${cmgen_path}" ]]; then
+  echo "No cmgen binary could be found in ${HOST_TOOLS_PATH}."
+  echo "Ensure Filament has been built/installed before building this app."
+  exit 1
+fi
+
+# cmgen consumes an HDR environment map and generates two mipmapped KTX files (IBL and skybox)
+"${cmgen_path}" \
+    --deploy="${PROJECT_DIR}/generated/default_env" \
+    --format=ktx --size=256 --extract-blur=0.1 \
+    "${PROJECT_DIR}/../../../third_party/environments/lightroom_14b.hdr"

--- a/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.pbxproj
+++ b/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.pbxproj
@@ -1,0 +1,670 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		00101E55E74547D6C2FD8C03 /* default_env_ibl.ktx in Resources */ = {isa = PBXBuildFile; fileRef = A027015F6F283E92C379F0B1 /* default_env_ibl.ktx */; };
+		1297B48507BF2849751AE0E6 /* FILViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3B5A2C1598614ED63098A783 /* FILViewController.mm */; };
+		285A74424AF5E3014363F8E6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 14BA4B8B6A697847DA9934D2 /* Main.storyboard */; };
+		453F7CCB3A029F9604857C1C /* FILModelView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F16324F2F287CB27E1A84EB /* FILModelView.mm */; };
+		45F28F70A616F4B5C67FEC66 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF545E3F8FD553E334F5D6D6 /* Assets.xcassets */; };
+		4FE0C24C9B962C9F7439C9D4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FF7EE9D5DD74F1A740C0D88 /* main.m */; };
+		58EBAAC97B7EA63E102CDCDB /* BusterDrone in Resources */ = {isa = PBXBuildFile; fileRef = 7F78E613984102280C822052 /* BusterDrone */; };
+		5C706EF98086B64B4CB3EF9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A0A866F9B1B8D315E88D3D12 /* AppDelegate.m */; };
+		8A03666082048B85BDE1C1CE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 21CA7296309BBFADBB0B00C3 /* LaunchScreen.storyboard */; };
+		A7C7D42BDE57B77CB9D9C5D2 /* default_env_skybox.ktx in Resources */ = {isa = PBXBuildFile; fileRef = 5271315876D6BC61346DFD97 /* default_env_skybox.ktx */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		03A535A718B2F64A70C5F231 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1ED9318FEC158171D99C0857 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1F16324F2F287CB27E1A84EB /* FILModelView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FILModelView.mm; sourceTree = "<group>"; };
+		1FF7EE9D5DD74F1A740C0D88 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		2B973C3E0FE0EEED37D41D32 /* FILModelView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FILModelView.h; sourceTree = "<group>"; };
+		3B5A2C1598614ED63098A783 /* FILViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FILViewController.mm; sourceTree = "<group>"; };
+		5271315876D6BC61346DFD97 /* default_env_skybox.ktx */ = {isa = PBXFileReference; path = default_env_skybox.ktx; sourceTree = "<group>"; };
+		6E6BB885F2B193E786CD9F14 /* FILViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FILViewController.h; sourceTree = "<group>"; };
+		7F78E613984102280C822052 /* BusterDrone */ = {isa = PBXFileReference; lastKnownFileType = folder; name = BusterDrone; path = ../../../third_party/models/BusterDrone; sourceTree = SOURCE_ROOT; };
+		9ADEA6DE7305D0B8CCFFA53D /* gltf-viewer.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "gltf-viewer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A027015F6F283E92C379F0B1 /* default_env_ibl.ktx */ = {isa = PBXFileReference; path = default_env_ibl.ktx; sourceTree = "<group>"; };
+		A0A866F9B1B8D315E88D3D12 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		B9C391BBD90EB54D27F8E4FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C7ECAA95F4A55C69B948F806 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		DF545E3F8FD553E334F5D6D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		2678CEA2FDBFE6D6DC1D4D71 /* gltf-viewer */ = {
+			isa = PBXGroup;
+			children = (
+				03A535A718B2F64A70C5F231 /* AppDelegate.h */,
+				A0A866F9B1B8D315E88D3D12 /* AppDelegate.m */,
+				2B973C3E0FE0EEED37D41D32 /* FILModelView.h */,
+				1F16324F2F287CB27E1A84EB /* FILModelView.mm */,
+				6E6BB885F2B193E786CD9F14 /* FILViewController.h */,
+				3B5A2C1598614ED63098A783 /* FILViewController.mm */,
+				4904A2B5EF7E75CE42E88D69 /* SupportFiles */,
+			);
+			path = "gltf-viewer";
+			sourceTree = "<group>";
+		};
+		3BFD6EBD6D97D6F1C40F1C90 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9ADEA6DE7305D0B8CCFFA53D /* gltf-viewer.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4904A2B5EF7E75CE42E88D69 /* SupportFiles */ = {
+			isa = PBXGroup;
+			children = (
+				DF545E3F8FD553E334F5D6D6 /* Assets.xcassets */,
+				B9C391BBD90EB54D27F8E4FD /* Info.plist */,
+				21CA7296309BBFADBB0B00C3 /* LaunchScreen.storyboard */,
+				1FF7EE9D5DD74F1A740C0D88 /* main.m */,
+				14BA4B8B6A697847DA9934D2 /* Main.storyboard */,
+			);
+			path = SupportFiles;
+			sourceTree = "<group>";
+		};
+		7DB4500696DB13904CDF40C4 = {
+			isa = PBXGroup;
+			children = (
+				7F78E613984102280C822052 /* BusterDrone */,
+				E102A6C527928715EF7B0497 /* default_env */,
+				2678CEA2FDBFE6D6DC1D4D71 /* gltf-viewer */,
+				3BFD6EBD6D97D6F1C40F1C90 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E102A6C527928715EF7B0497 /* default_env */ = {
+			isa = PBXGroup;
+			children = (
+				A027015F6F283E92C379F0B1 /* default_env_ibl.ktx */,
+				5271315876D6BC61346DFD97 /* default_env_skybox.ktx */,
+			);
+			name = default_env;
+			path = generated/default_env;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		987920500DC7D07A827B5E34 /* gltf-viewer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B9DE609B1909C6A9AF36094D /* Build configuration list for PBXNativeTarget "gltf-viewer" */;
+			buildPhases = (
+				0B375996CE4EBC4A5B258C27 /* Build Resources */,
+				C8F38C978C83CD5335A21F72 /* Sources */,
+				7D3B1B99EEAFB6F53ECBAA5A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "gltf-viewer";
+			productName = "gltf-viewer";
+			productReference = 9ADEA6DE7305D0B8CCFFA53D /* gltf-viewer.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		853163F2C3C542863B842C0A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 90327DE42AE5DF12C4BD2113 /* Build configuration list for PBXProject "gltf-viewer" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 7DB4500696DB13904CDF40C4;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				987920500DC7D07A827B5E34 /* gltf-viewer */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7D3B1B99EEAFB6F53ECBAA5A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				45F28F70A616F4B5C67FEC66 /* Assets.xcassets in Resources */,
+				58EBAAC97B7EA63E102CDCDB /* BusterDrone in Resources */,
+				8A03666082048B85BDE1C1CE /* LaunchScreen.storyboard in Resources */,
+				285A74424AF5E3014363F8E6 /* Main.storyboard in Resources */,
+				00101E55E74547D6C2FD8C03 /* default_env_ibl.ktx in Resources */,
+				A7C7D42BDE57B77CB9D9C5D2 /* default_env_skybox.ktx in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0B375996CE4EBC4A5B258C27 /* Build Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../../../third_party/environments/lightroom_14b.hdr",
+			);
+			name = "Build Resources";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/generated/default_env/default_env_ibl.ktx",
+				"$(SRCROOT)/generated/default_env/default_env_skybox.ktx",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#/usr/bin/env/bash\n\nset -e\n\n# Compile resources.\n\n# The gltf-viewer app requires two resources:\n# 1. The IBL image\n# 2. The skybox image\n\nHOST_TOOLS_PATH=\"${HOST_TOOLS_PATH:-../../../out/release/filament/bin}\"\n\ncmgen_path=`find ${HOST_TOOLS_PATH} -name cmgen -type f | head -n 1`\n\n# Ensure that the required tools are present in the out/ directory.\n# These can be built by running ./build.sh -p desktop -i release at Filament's root directory.\n\nif [[ ! -e \"${cmgen_path}\" ]]; then\n  echo \"No cmgen binary could be found in ${HOST_TOOLS_PATH}.\"\n  echo \"Ensure Filament has been built/installed before building this app.\"\n  exit 1\nfi\n\n# cmgen consumes an HDR environment map and generates two mipmapped KTX files (IBL and skybox)\n\"${cmgen_path}\" \\\n    --deploy=\"${PROJECT_DIR}/generated/default_env\" \\\n    --format=ktx --size=256 --extract-blur=0.1 \\\n    \"${PROJECT_DIR}/../../../third_party/environments/lightroom_14b.hdr\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C8F38C978C83CD5335A21F72 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C706EF98086B64B4CB3EF9A /* AppDelegate.m in Sources */,
+				453F7CCB3A029F9604857C1C /* FILModelView.mm in Sources */,
+				1297B48507BF2849751AE0E6 /* FILViewController.mm in Sources */,
+				4FE0C24C9B962C9F7439C9D4 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		14BA4B8B6A697847DA9934D2 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1ED9318FEC158171D99C0857 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		21CA7296309BBFADBB0B00C3 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C7ECAA95F4A55C69B948F806 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		04030EADF3F0FDF8BCE5CFD8 /* OpenGL Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "OpenGL Debug";
+		};
+		2A0772F7B628564188F24694 /* Metal Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Metal Release";
+		};
+		5EB6349D263CAA0DCA7CE5CE /* OpenGL Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "OpenGL Release";
+		};
+		8FDE7F5CD5FA800D52917373 /* Metal Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_METAL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/include",
+					generated,
+				);
+				INFOPLIST_FILE = "gltf-viewer/SupportFiles/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/lib/$(CURRENT_ARCH)",
+					"../../../out/ios-release/filament/lib/universal",
+				);
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lbackend",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+					"-libl",
+					"-lgltfio_core",
+					"-lgltfio_resources",
+					"-limage",
+					"-lgeometry",
+					"-lcamutils",
+					"-ldracodec",
+					"-lviewer",
+					"-lcivetweb",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.gltf-viewer";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Metal Release";
+		};
+		9CA3515D91333909CD545D91 /* Metal Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_METAL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/include",
+					generated,
+				);
+				INFOPLIST_FILE = "gltf-viewer/SupportFiles/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/lib/$(CURRENT_ARCH)",
+					"../../../out/ios-debug/filament/lib/universal",
+				);
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lbackend",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+					"-libl",
+					"-lgltfio_core",
+					"-lgltfio_resources",
+					"-limage",
+					"-lgeometry",
+					"-lcamutils",
+					"-ldracodec",
+					"-lviewer",
+					"-lcivetweb",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.gltf-viewer";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Metal Debug";
+		};
+		D8B068BA3EBE715DCD780788 /* Metal Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Metal Debug";
+		};
+		DEEA1EF36DA04AB052462DD0 /* OpenGL Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_OPENGL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/include",
+					generated,
+				);
+				INFOPLIST_FILE = "gltf-viewer/SupportFiles/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../../../out/ios-release/filament/lib/$(CURRENT_ARCH)",
+					"../../../out/ios-release/filament/lib/universal",
+				);
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lbackend",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+					"-libl",
+					"-lgltfio_core",
+					"-lgltfio_resources",
+					"-limage",
+					"-lgeometry",
+					"-lcamutils",
+					"-ldracodec",
+					"-lviewer",
+					"-lcivetweb",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.gltf-viewer";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "OpenGL Release";
+		};
+		ECF5979730D72F53BD997A40 /* OpenGL Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"FILAMENT_APP_USE_OPENGL=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/include",
+					generated,
+				);
+				INFOPLIST_FILE = "gltf-viewer/SupportFiles/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"../../../out/ios-debug/filament/lib/$(CURRENT_ARCH)",
+					"../../../out/ios-debug/filament/lib/universal",
+				);
+				OTHER_LDFLAGS = (
+					"-lfilament",
+					"-lbackend",
+					"-lfilaflat",
+					"-lfilabridge",
+					"-lutils",
+					"-lsmol-v",
+					"-lgeometry",
+					"-libl",
+					"-lgltfio_core",
+					"-lgltfio_resources",
+					"-limage",
+					"-lgeometry",
+					"-lcamutils",
+					"-ldracodec",
+					"-lviewer",
+					"-lcivetweb",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "google.filament.gltf-viewer";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "OpenGL Debug";
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		90327DE42AE5DF12C4BD2113 /* Build configuration list for PBXProject "gltf-viewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D8B068BA3EBE715DCD780788 /* Metal Debug */,
+				2A0772F7B628564188F24694 /* Metal Release */,
+				04030EADF3F0FDF8BCE5CFD8 /* OpenGL Debug */,
+				5EB6349D263CAA0DCA7CE5CE /* OpenGL Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Metal Debug";
+		};
+		B9DE609B1909C6A9AF36094D /* Build configuration list for PBXNativeTarget "gltf-viewer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9CA3515D91333909CD545D91 /* Metal Debug */,
+				8FDE7F5CD5FA800D52917373 /* Metal Release */,
+				ECF5979730D72F53BD997A40 /* OpenGL Debug */,
+				DEEA1EF36DA04AB052462DD0 /* OpenGL Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Metal Debug";
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 853163F2C3C542863B842C0A /* Project object */;
+}

--- a/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:gltf-viewer.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/xcshareddata/xcschemes/gltf-viewer Metal.xcscheme
+++ b/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/xcshareddata/xcschemes/gltf-viewer Metal.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "987920500DC7D07A827B5E34"
+               BuildableName = "gltf-viewer.app"
+               BlueprintName = "gltf-viewer"
+               ReferencedContainer = "container:gltf-viewer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Metal Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Metal Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Metal Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Metal Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Metal Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/xcshareddata/xcschemes/gltf-viewer OpenGL.xcscheme
+++ b/ios/samples/gltf-viewer/gltf-viewer.xcodeproj/xcshareddata/xcschemes/gltf-viewer OpenGL.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "987920500DC7D07A827B5E34"
+               BuildableName = "gltf-viewer.app"
+               BlueprintName = "gltf-viewer"
+               ReferencedContainer = "container:gltf-viewer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "OpenGL Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "OpenGL Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "OpenGL Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "987920500DC7D07A827B5E34"
+            BuildableName = "gltf-viewer.app"
+            BlueprintName = "gltf-viewer"
+            ReferencedContainer = "container:gltf-viewer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "OpenGL Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "OpenGL Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/samples/gltf-viewer/gltf-viewer/AppDelegate.h
+++ b/ios/samples/gltf-viewer/gltf-viewer/AppDelegate.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property(strong, nonatomic) UIWindow* window;
+
+@end

--- a/ios/samples/gltf-viewer/gltf-viewer/AppDelegate.m
+++ b/ios/samples/gltf-viewer/gltf-viewer/AppDelegate.m
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "AppDelegate.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+@end

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+namespace filament {
+class Engine;
+class Scene;
+class View;
+class Renderer;
+};
+
+namespace gltfio {
+class Animator;
+class FilamentAsset;
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * FILModelView is a UIView that renders glTF models with an orbit controller.
+ *
+ * FILModelView owns a Filament engine, renderer, swapchain, view, and scene. It allows clients to
+ * access these objects via read-only properties. The view can display only one glTF scene at a
+ * time, which can be scaled and translated into the viewing frustum by calling transformToUnitCube.
+ * All ECS entities can be accessed and modified via the `asset` property.
+ *
+ * For GLB files, clients can call loadModelGlb and pass in an NSData* with the contents of the GLB
+ * file. For glTF files, clients can call loadModelGltf and pass in an NSData* with the JSON
+ * contents, as well as a callback for loading external resources.
+ *
+ * FILModelView reduces much of the boilerplate required for simple Filament applications, but
+ * clients still have the responsibility of adding an IndirectLight and Skybox to the scene.
+ * Additionally, clients should: call render and animator->applyAnimation from a CADisplayLink frame
+ * callback.
+ *
+ * See ios/samples/gltf-viewer for a usage example.
+ */
+@interface FILModelView : UIView
+
+@property(nonatomic, readonly) filament::Engine* engine;
+@property(nonatomic, readonly) filament::Scene* scene;
+@property(nonatomic, readonly) filament::View* view;
+@property(nonatomic, readonly) filament::Renderer* renderer;
+
+@property(nonatomic, readonly) gltfio::FilamentAsset* _Nullable asset;
+@property(nonatomic, readonly) gltfio::Animator* _Nullable animator;
+
+@property(nonatomic, readwrite) float cameraFocalLength;
+
+/**
+ * Loads a monolithic binary glTF and populates the Filament scene.
+ */
+- (void)loadModelGlb:(NSData*)buffer;
+
+/**
+ * Loads a JSON-style glTF file and populates the Filament scene.
+ *
+ * The given callback is triggered for each requested resource.
+ */
+typedef NSData* _Nonnull (^ResourceCallback)(NSString* _Nonnull);
+- (void)loadModelGltf:(NSData*)buffer callback:(ResourceCallback)callback;
+
+- (void)destroyModel;
+
+/**
+ * Sets up a root transform on the current model to make it fit into a unit cube.
+ */
+- (void)transformToUnitCube;
+
+/**
+ * Renders the model and updates the Filament camera.
+ */
+- (void)render;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -296,6 +296,11 @@ const float kSensitivity = 100.0f;
     const uint32_t height = self.bounds.size.height * self.contentScaleFactor;
     _view->setViewport({0, 0, width, height});
 
+#if FILAMENT_APP_USE_METAL
+    CAMetalLayer* metalLayer = (CAMetalLayer*)self.layer;
+    metalLayer.drawableSize = CGSizeMake(width, height);
+#endif
+
     const double aspect = (double)width / height;
     _camera->setLensProjection(self.cameraFocalLength, aspect, kNearPlane, kFarPlane);
 }

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -1,0 +1,337 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These defines are set in the "Preprocessor Macros" build setting for each scheme.
+#if !FILAMENT_APP_USE_METAL && !FILAMENT_APP_USE_OPENGL
+#error A valid FILAMENT_APP_USE_ backend define must be set.
+#endif
+
+#include "FILModelView.h"
+
+#import <Foundation/Foundation.h>
+
+#include <filament/Camera.h>
+#include <filament/Color.h>
+#include <filament/Engine.h>
+#include <filament/IndirectLight.h>
+#include <filament/LightManager.h>
+#include <filament/RenderableManager.h>
+#include <filament/Renderer.h>
+#include <filament/Scene.h>
+#include <filament/Skybox.h>
+#include <filament/TransformManager.h>
+#include <filament/View.h>
+#include <filament/Viewport.h>
+
+#include <gltfio/AssetLoader.h>
+#include <gltfio/ResourceLoader.h>
+
+#include <utils/EntityManager.h>
+#include <utils/NameComponentManager.h>
+
+#include <camutils/Manipulator.h>
+
+using namespace filament;
+using namespace utils;
+using namespace gltfio;
+using namespace camutils;
+
+const double kNearPlane = 0.05;   // 5 cm
+const double kFarPlane = 1000.0;  // 1 km
+const float kScaleMultiplier = 100.0f;
+const float kAperture = 16.0f;
+const float kShutterSpeed = 1.0f / 125.0f;
+const float kSensitivity = 100.0f;
+
+@interface FILModelView ()
+
+- (void)initCommon;
+- (void)updateViewportAndCameraProjection;
+- (void)didPan:(UIGestureRecognizer*)sender;
+- (void)didPinch:(UIGestureRecognizer*)sender;
+
+@end
+
+@implementation FILModelView {
+    Camera* _camera;
+    SwapChain* _swapChain;
+
+    struct {
+        Entity camera;
+    } _entities;
+
+    MaterialProvider* _materialProvider;
+    AssetLoader* _assetLoader;
+    ResourceLoader* _resourceLoader;
+
+    Manipulator<float>* _manipulator;
+
+    FilamentAsset* _asset;
+
+    UIPanGestureRecognizer* _panRecognizer;
+    UIPinchGestureRecognizer* _pinchRecognizer;
+    CGFloat _previousScale;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        [self initCommon];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder*)coder {
+    if (self = [super initWithCoder:coder]) {
+        [self initCommon];
+    }
+    return self;
+}
+
+- (void)initCommon {
+    self.contentScaleFactor = UIScreen.mainScreen.nativeScale;
+#if FILAMENT_APP_USE_OPENGL
+    [self initializeGLLayer];
+    _engine = Engine::create(Engine::Backend::OPENGL);
+#elif FILAMENT_APP_USE_METAL
+    [self initializeMetalLayer];
+    _engine = Engine::create(Engine::Backend::METAL);
+#endif
+
+    _renderer = _engine->createRenderer();
+    _scene = _engine->createScene();
+    _entities.camera = EntityManager::get().create();
+    _camera = _engine->createCamera(_entities.camera);
+    _view = _engine->createView();
+    _view->setScene(_scene);
+    _view->setCamera(_camera);
+
+    _cameraFocalLength = 28.0f;
+    _camera->setExposure(kAperture, kShutterSpeed, kSensitivity);
+
+    _swapChain = _engine->createSwapChain((__bridge void*)self.layer);
+
+    _materialProvider = createUbershaderLoader(_engine);
+    EntityManager& em = EntityManager::get();
+    NameComponentManager* ncm = new NameComponentManager(em);
+    _assetLoader = AssetLoader::create({_engine, _materialProvider, ncm, &em});
+    _resourceLoader = new ResourceLoader(
+            {.engine = _engine, .normalizeSkinningWeights = true, .recomputeBoundingBoxes = false});
+
+    _manipulator =
+            Manipulator<float>::Builder().orbitHomePosition(0.0f, 0.0f, 4.0f).build(Mode::ORBIT);
+
+    // Set up pan and pinch gesture recognizers, used to orbit, zoom, and translate the camera.
+    _panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(didPan:)];
+    _panRecognizer.minimumNumberOfTouches = 1;
+    _panRecognizer.maximumNumberOfTouches = 2;
+    _pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self
+                                                                 action:@selector(didPinch:)];
+
+    [self addGestureRecognizer:_panRecognizer];
+    [self addGestureRecognizer:_pinchRecognizer];
+    _previousScale = 1.0f;
+
+    _asset = nullptr;
+}
+
+#pragma mark UIView methods
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    [self updateViewportAndCameraProjection];
+}
+
+- (void)setContentScaleFactor:(CGFloat)contentScaleFactor {
+    [super setContentScaleFactor:contentScaleFactor];
+    [self updateViewportAndCameraProjection];
+}
+
+#pragma mark FILModelView methods
+
+- (void)destroyModel {
+    if (!_asset) {
+        return;
+    }
+    _scene->removeEntities(_asset->getEntities(), _asset->getEntityCount());
+    _assetLoader->destroyAsset(_asset);
+    _materialProvider->destroyMaterials();
+    _asset = nullptr;
+    _animator = nullptr;
+}
+
+- (void)transformToUnitCube {
+    if (!_asset) {
+        return;
+    }
+    auto& tm = _engine->getTransformManager();
+    auto aabb = _asset->getBoundingBox();
+    auto center = aabb.center();
+    auto halfExtent = aabb.extent();
+    auto maxExtent = max(halfExtent) * 2;
+    auto scaleFactor = 2.0f / maxExtent;
+    auto transform = math::mat4f::scaling(scaleFactor) * math::mat4f::translation(-center);
+    tm.setTransform(tm.getInstance(_asset->getRoot()), transform);
+}
+
+- (void)loadModelGlb:(NSData*)buffer {
+    [self destroyModel];
+    _asset = _assetLoader->createAssetFromBinary(
+            static_cast<const uint8_t*>(buffer.bytes), static_cast<uint32_t>(buffer.length));
+
+    if (!_asset) {
+        return;
+    }
+
+    _scene->addEntities(_asset->getEntities(), _asset->getEntityCount());
+    _resourceLoader->loadResources(_asset);
+    _animator = _asset->getAnimator();
+    _asset->releaseSourceData();
+}
+
+- (void)loadModelGltf:(NSData*)buffer callback:(ResourceCallback)callback {
+    [self destroyModel];
+    _asset = _assetLoader->createAssetFromJson(
+            static_cast<const uint8_t*>(buffer.bytes), static_cast<uint32_t>(buffer.length));
+
+    if (!_asset) {
+        return;
+    }
+
+    auto destroy = [](void*, size_t, void* userData) { CFBridgingRelease(userData); };
+
+    const char* const* const resourceUris = _asset->getResourceUris();
+    const size_t resourceUriCount = _asset->getResourceUriCount();
+    for (size_t i = 0; i < resourceUriCount; i++) {
+        const char* const uri = resourceUris[i];
+        NSString* uriString = [NSString stringWithCString:uri encoding:NSUTF8StringEncoding];
+        NSData* data = callback(uriString);
+        ResourceLoader::BufferDescriptor b(
+                data.bytes, data.length, destroy, (void*)CFBridgingRetain(data));
+        _resourceLoader->addResourceData(uri, std::move(b));
+    }
+
+    _resourceLoader->loadResources(_asset);
+    _animator = _asset->getAnimator();
+    _asset->releaseSourceData();
+
+    _scene->addEntities(_asset->getEntities(), _asset->getEntityCount());
+}
+
+- (void)render {
+    // Extract the camera basis from the helper and push it to the Filament camera.
+    math::float3 eye, target, upward;
+    _manipulator->getLookAt(&eye, &target, &upward);
+    _camera->lookAt(eye, target, upward);
+
+    // Render the scene, unless the renderer wants to skip the frame.
+    if (_renderer->beginFrame(_swapChain)) {
+        _renderer->render(_view);
+        _renderer->endFrame();
+    }
+}
+
+- (void)dealloc {
+    [self destroyModel];
+
+    delete _manipulator;
+
+    delete _materialProvider;
+    auto* ncm = _assetLoader->getNames();
+    delete ncm;
+    AssetLoader::destroy(&_assetLoader);
+    delete _resourceLoader;
+
+    _engine->destroy(_swapChain);
+    _engine->destroy(_view);
+    EntityManager::get().destroy(_entities.camera);
+    _engine->destroyCameraComponent(_entities.camera);
+    _engine->destroy(_scene);
+    _engine->destroy(_renderer);
+    _engine->destroy(&_engine);
+}
+
+#pragma mark ModelViewer properties
+
+- (void)setCameraFocalLength:(float)cameraFocalLength {
+    _cameraFocalLength = cameraFocalLength;
+    [self updateViewportAndCameraProjection];
+}
+
+#pragma mark Private
+
+- (void)initializeMetalLayer {
+#if METAL_AVAILABLE
+    CAMetalLayer* metalLayer = (CAMetalLayer*)self.layer;
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.opaque = YES;
+#endif
+}
+
+- (void)initializeGLLayer {
+    CAEAGLLayer* glLayer = (CAEAGLLayer*)self.layer;
+    glLayer.opaque = YES;
+}
+
+- (void)updateViewportAndCameraProjection {
+    if (!_view || !_camera || !_manipulator) {
+        return;
+    }
+
+    _manipulator->setViewport(self.bounds.size.width, self.bounds.size.height);
+
+    const uint32_t width = self.bounds.size.width * self.contentScaleFactor;
+    const uint32_t height = self.bounds.size.height * self.contentScaleFactor;
+    _view->setViewport({0, 0, width, height});
+
+    const double aspect = (double)width / height;
+    _camera->setLensProjection(self.cameraFocalLength, aspect, kNearPlane, kFarPlane);
+}
+
+- (void)didPan:(UIPanGestureRecognizer*)sender {
+    CGPoint location = [sender locationInView:self];
+    location.y = self.bounds.size.height - location.y;
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        const bool strafe = _panRecognizer.numberOfTouches == 2;
+        _manipulator->grabBegin(location.x, location.y, strafe);
+    } else if (sender.state == UIGestureRecognizerStateChanged) {
+        _manipulator->grabUpdate(location.x, location.y);
+    } else if (sender.state == UIGestureRecognizerStateEnded ||
+            sender.state == UIGestureRecognizerStateFailed) {
+        _manipulator->grabEnd();
+    }
+}
+
+- (void)didPinch:(UIGestureRecognizer*)sender {
+    CGPoint location = [sender locationInView:self];
+    location.y = self.bounds.size.height - location.y;
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        _previousScale = _pinchRecognizer.scale;
+    } else if (sender.state == UIGestureRecognizerStateChanged) {
+        CGFloat deltaScale = _pinchRecognizer.scale - _previousScale;
+        _manipulator->scroll(location.x, location.y, -deltaScale * kScaleMultiplier);
+        _previousScale = _pinchRecognizer.scale;
+    }
+}
+
++ (Class)layerClass {
+#if FILAMENT_APP_USE_OPENGL
+    return [CAEAGLLayer class];
+#elif FILAMENT_APP_USE_METAL
+    return [CAMetalLayer class];
+#endif
+}
+
+@end

--- a/ios/samples/gltf-viewer/gltf-viewer/FILViewController.h
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILViewController.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "FILModelView.h"
+
+@interface FILViewController : UIViewController
+
+@property(weak, nonatomic) IBOutlet FILModelView* modelView;
+
+@end

--- a/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FILViewController.h"
+
+#import "FILModelView.h"
+
+#include <filament/Scene.h>
+#include <filament/Skybox.h>
+
+#include <utils/EntityManager.h>
+
+#include <gltfio/Animator.h>
+
+#include <image/KtxUtility.h>
+
+#include <viewer/AutomationEngine.h>
+#include <viewer/RemoteServer.h>
+
+using namespace filament;
+using namespace utils;
+
+@interface FILViewController ()
+
+- (void)startDisplayLink;
+- (void)stopDisplayLink;
+
+- (void)createRenderables;
+- (void)createLights;
+
+@end
+
+@implementation FILViewController {
+    CADisplayLink* _displayLink;
+    viewer::RemoteServer* _server;
+    viewer::AutomationEngine* _automation;
+
+    Texture* _skyboxTexture;
+    Skybox* _skybox;
+    Texture* _iblTexture;
+    IndirectLight* _indirectLight;
+    Entity _sun;
+}
+
+#pragma mark UIViewController methods
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"https://google.github.io/filament/remote";
+
+    [self createRenderables];
+    [self createLights];
+
+    _server = new viewer::RemoteServer();
+    _automation = viewer::AutomationEngine::createDefault();
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [self startDisplayLink];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [self stopDisplayLink];
+}
+
+- (void)startDisplayLink {
+    [self stopDisplayLink];
+
+    // Call our render method 60 times a second.
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(render)];
+    _displayLink.preferredFramesPerSecond = 60;
+    [_displayLink addToRunLoop:NSRunLoop.currentRunLoop forMode:NSDefaultRunLoopMode];
+}
+
+- (void)stopDisplayLink {
+    [_displayLink invalidate];
+    _displayLink = nil;
+}
+
+#pragma mark Private
+
+- (void)createRenderables {
+    NSString* path = [[NSBundle mainBundle] pathForResource:@"scene"
+                                                     ofType:@"gltf"
+                                                inDirectory:@"BusterDrone"];
+    assert(path.length > 0);
+    NSData* buffer = [NSData dataWithContentsOfFile:path];
+    [self.modelView loadModelGltf:buffer
+                         callback:^NSData*(NSString* uri) {
+                             NSString* p = [[NSBundle mainBundle] pathForResource:uri
+                                                                           ofType:@""
+                                                                      inDirectory:@"BusterDrone"];
+                             return [NSData dataWithContentsOfFile:p];
+                         }];
+    [self.modelView transformToUnitCube];
+}
+
+- (void)createLights {
+    // Load Skybox.
+    NSString* skyboxPath = [[NSBundle mainBundle] pathForResource:@"default_env_skybox"
+                                                           ofType:@"ktx"];
+    assert(skyboxPath.length > 0);
+    NSData* skyboxBuffer = [NSData dataWithContentsOfFile:skyboxPath];
+
+    image::KtxBundle* skyboxBundle =
+            new image::KtxBundle(static_cast<const uint8_t*>(skyboxBuffer.bytes),
+                    static_cast<uint32_t>(skyboxBuffer.length));
+    _skyboxTexture = image::ktx::createTexture(self.modelView.engine, skyboxBundle, false);
+    _skybox = filament::Skybox::Builder().environment(_skyboxTexture).build(*self.modelView.engine);
+    self.modelView.scene->setSkybox(_skybox);
+
+    // Load IBL.
+    NSString* iblPath = [[NSBundle mainBundle] pathForResource:@"default_env_ibl" ofType:@"ktx"];
+    assert(iblPath.length > 0);
+    NSData* iblBuffer = [NSData dataWithContentsOfFile:iblPath];
+
+    image::KtxBundle* iblBundle = new image::KtxBundle(
+            static_cast<const uint8_t*>(iblBuffer.bytes), static_cast<uint32_t>(iblBuffer.length));
+    math::float3 harmonics[9];
+    iblBundle->getSphericalHarmonics(harmonics);
+    _iblTexture = image::ktx::createTexture(self.modelView.engine, iblBundle, false);
+    _indirectLight = IndirectLight::Builder()
+                             .reflections(_iblTexture)
+                             .irradiance(3, harmonics)
+                             .intensity(30000.0f)
+                             .build(*self.modelView.engine);
+    self.modelView.scene->setIndirectLight(_indirectLight);
+
+    // Always add a direct light source since it is required for shadowing.
+    _sun = EntityManager::get().create();
+    LightManager::Builder(LightManager::Type::DIRECTIONAL)
+            .color(Color::cct(6500.0f))
+            .intensity(100000.0f)
+            .direction(math::float3(0.0f, -1.0f, 0.0f))
+            .castShadows(true)
+            .build(*self.modelView.engine, _sun);
+    self.modelView.scene->addEntity(_sun);
+}
+
+- (void)loadSettings:(viewer::ReceivedMessage const*)message {
+    _automation->applySettings(message->buffer, message->bufferByteCount, self.modelView.view,
+            nullptr, 0u, _indirectLight, _sun, &self.modelView.engine->getLightManager(),
+            self.modelView.scene, self.modelView.renderer);
+    ColorGrading* const colorGrading = _automation->getColorGrading(self.modelView.engine);
+    self.modelView.view->setColorGrading(colorGrading);
+    self.modelView.cameraFocalLength = _automation->getViewerOptions().cameraFocalLength;
+}
+
+- (void)loadGlb:(viewer::ReceivedMessage const*)message {
+    [self.modelView destroyModel];
+    NSData* buffer = [NSData dataWithBytes:message->buffer length:message->bufferByteCount];
+    [self.modelView loadModelGlb:buffer];
+    [self.modelView transformToUnitCube];
+}
+
+- (void)render {
+    auto* animator = self.modelView.animator;
+    if (animator) {
+        if (animator->getAnimationCount() > 0) {
+            animator->applyAnimation(0, CACurrentMediaTime());
+        }
+        animator->updateBoneMatrices();
+    }
+
+    // Check if a new message has been fully received from the client.
+    viewer::ReceivedMessage const* message = _server->acquireReceivedMessage();
+    if (message && message->label) {
+        NSString* label = [NSString stringWithCString:message->label encoding:NSUTF8StringEncoding];
+        if ([label hasSuffix:@".json"]) {
+            [self loadSettings:message];
+        } else if ([label hasSuffix:@".glb"]) {
+            self.title = label;
+            [self loadGlb:message];
+        }
+
+        _server->releaseReceivedMessage(message);
+    }
+
+    [self.modelView render];
+}
+
+- (void)dealloc {
+    delete _server;
+    delete _automation;
+    self.modelView.engine->destroy(_indirectLight);
+    self.modelView.engine->destroy(_iblTexture);
+    self.modelView.engine->destroy(_skybox);
+    self.modelView.engine->destroy(_skyboxTexture);
+    self.modelView.scene->remove(_sun);
+    self.modelView.engine->destroy(_sun);
+}
+
+@end

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Assets.xcassets/Contents.json
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Base.lproj/LaunchScreen.storyboard
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Base.lproj/Main.storyboard
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Base.lproj/Main.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Oik-zy-I2A">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Filament-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="FILViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="FILModelView">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <navigationItem key="navigationItem" title="Filament" id="45G-c8-LFp"/>
+                    <connections>
+                        <outlet property="modelView" destination="8bC-Xf-vdC" id="pzL-xP-jpm"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-308" y="537"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="008-jV-BIl">
+            <objects>
+                <navigationController id="Oik-zy-I2A" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="LLE-lc-hvJ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="FMe-vj-dRr">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="dtj-cj-BgN"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pdU-fz-tDr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1348" y="537"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Info.plist
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Info.plist
@@ -29,6 +29,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Info.plist
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>gltf-viewer</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to display AR content.</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/main.m
+++ b/ios/samples/gltf-viewer/gltf-viewer/SupportFiles/main.m
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char* argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/ios/samples/gltf-viewer/project.yml
+++ b/ios/samples/gltf-viewer/project.yml
@@ -1,0 +1,31 @@
+name: gltf-viewer
+options:
+    bundleIdPrefix: google.filament
+include: ../app-template.yml
+targets:
+    gltf-viewer:
+        sources: gltf-viewer/
+        sources:
+            - path: '../../../third_party/models/BusterDrone'
+              type: folder
+              buildPhase: resources
+            - path: 'generated/default_env/default_env_ibl.ktx'
+              buildPhase: resources
+              optional: true
+            - path: 'generated/default_env/default_env_skybox.ktx'
+              buildPhase: resources
+              optional: true
+        templates:
+            - FilamentApp
+        settings:
+            base:
+                OTHER_LDFLAGS: ["-lgltfio_core", "-lgltfio_resources", "-limage", "-lgeometry",
+                                "-lcamutils", "-ldracodec", "-lviewer", "-lcivetweb"]
+        preBuildScripts:
+            - path: build-resources.sh
+              name: Build Resources
+              inputFiles:
+                - $(SRCROOT)/../../../third_party/environments/lightroom_14b.hdr
+              outputFiles:
+                - $(SRCROOT)/generated/default_env/default_env_ibl.ktx
+                - $(SRCROOT)/generated/default_env/default_env_skybox.ktx

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -45,7 +45,7 @@
 
 #include <string>
 
-#if defined(__EMSCRIPTEN__) || defined(ANDROID)
+#if defined(__EMSCRIPTEN__) || defined(ANDROID) || defined(IOS)
 #define USE_FILESYSTEM 0
 #else
 #define USE_FILESYSTEM 1
@@ -94,7 +94,7 @@ struct ResourceLoader::Impl {
     std::string mGltfPath;
 
     // User-provided resource data with URI string keys, populated with addResourceData().
-    // This is used on platforms without traditional file systems, such as Android and WebGL.
+    // This is used on platforms without traditional file systems, such as Android, iOS, and WebGL.
     UriDataCache mUriDataCache;
 
     // The two texture caches are populated while textures are being decoded, and they are no longer


### PR DESCRIPTION
This sample is akin to Android's `sample-gltf-viewer`. It allows loading glTF files and updating settings through the Filament Remote site. The idea is for this to replace the `hello-gltf` sample, which has grown stale. It doesn't have complete feature parity yet; namely loading zipped glTF files is not yet supported.

One hitch is that the Filament remote site will need to be updated to support specifying an IP address, as iOS does not have the equivalent of `adb forward`. I'll add this in a separate PR.

![Screen Shot 2021-04-28 at 3 00 58 PM](https://user-images.githubusercontent.com/5298046/116478257-a67d6900-a832-11eb-905d-6e1e00a78440.png)
