### PR TITLE
Vulkan: big refactor for command buffer management.

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -144,6 +144,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanBlitter.h
             src/vulkan/VulkanBuffer.cpp
             src/vulkan/VulkanBuffer.h
+            src/vulkan/VulkanCommands.cpp
+            src/vulkan/VulkanCommands.h
             src/vulkan/VulkanContext.cpp
             src/vulkan/VulkanContext.h
             src/vulkan/VulkanDisposer.cpp

--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -125,7 +125,7 @@ void VulkanBlitter::blitFast(VkImageAspectFlags aspect, VkFilter filter,
     // Determine the desired texture layout for the destination while ensuring that the default
     // render target is supported, which has no associated texture.
     const VkImageLayout desiredLayout = dst.texture ? getTextureLayout(dst.texture->usage) :
-            getSwapContext(mContext).attachment.layout;
+            getSwapChainAttachment(mContext).layout;
 
     VulkanTexture::transitionImageLayout(cmdbuffer, dst.image, VK_IMAGE_LAYOUT_UNDEFINED,
             desiredLayout, dst.level, 1, 1, aspect);

--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -55,7 +55,7 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
     auto copyToDevice = [this, numBytes, stage] (VulkanCommandBuffer& commands) {
         VkBufferCopy region { .size = numBytes };
         vkCmdCopyBuffer(commands.cmdbuffer, stage->buffer, mGpuBuffer, 1, &region);
-        mDisposer.acquire(mDisposerKey, commands.resources);
+        mDisposer.acquire(mDisposerKey);
 
         // Ensure that the copy finishes before the next draw call.
         VkBufferMemoryBarrier barrier {
@@ -73,14 +73,7 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
         mStagePool.releaseStage(stage, commands);
     };
 
-    // If inside beginFrame / endFrame, use the swap context, otherwise use the work cmdbuffer.
-    if (mContext.currentCommands) {
-        copyToDevice(*mContext.currentCommands);
-    } else {
-        acquireWorkCommandBuffer(mContext);
-        copyToDevice(mContext.work);
-        flushWorkCommandBuffer(mContext);
-    }
+    copyToDevice(mContext.commands->get());
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanCommands.h"
+
+#include <utils/Panic.h>
+
+using namespace bluevk;
+
+namespace filament {
+namespace backend {
+
+// All vkCreate* functions take an optional allocator. For now we select the default allocator by
+// passing in a null pointer, and we highlight the argument by using the VKALLOC constant.
+constexpr VkAllocationCallbacks* VKALLOC = nullptr;
+
+VulkanCmdFence::VulkanCmdFence(VkDevice device, bool signaled) : device(device) {
+    VkFenceCreateInfo fenceCreateInfo { .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO };
+    if (signaled) {
+        fenceCreateInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    }
+    vkCreateFence(device, &fenceCreateInfo, VKALLOC, &fence);
+
+    // Internally we use the VK_INCOMPLETE status to mean "not yet submitted". When this fence gets
+    // submitted, its status changes to VK_NOT_READY. Finally, when the GPU actually finishes
+    // executing the command buffer, the status changes to VK_SUCCESS.
+    status.store(VK_INCOMPLETE);
+}
+
+ VulkanCmdFence::~VulkanCmdFence() {
+    vkDestroyFence(device, fence, VKALLOC);
+}
+
+VulkanCommands::VulkanCommands(VkDevice device, uint32_t queueFamilyIndex, VulkanBinder& binder) :
+        mDevice(device), mBinder(binder) {
+    VkCommandPoolCreateInfo createInfo = {};
+    createInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    createInfo.flags =
+            VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+    createInfo.queueFamilyIndex = queueFamilyIndex;
+    vkCreateCommandPool(device, &createInfo, VKALLOC, &mPool);
+    vkGetDeviceQueue(device, queueFamilyIndex, 0, &mQueue);
+
+    VkSemaphoreCreateInfo sci { .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO };
+    for (auto& semaphore : mSubmissionSignals) {
+        vkCreateSemaphore(mDevice, &sci, nullptr, &semaphore);
+    }
+}
+
+VulkanCommands::~VulkanCommands() {
+    wait();
+    gc();
+    vkDestroyCommandPool(mDevice, mPool, VKALLOC);
+    for (VkSemaphore sema : mSubmissionSignals) {
+        vkDestroySemaphore(mDevice, sema, VKALLOC);
+    }
+}
+
+VulkanCommandBuffer& VulkanCommands::get() {
+    if (mCurrent) {
+        return *mCurrent;
+    }
+
+    // Find an available slot.
+    for (auto& wrapper : mStorage) {
+        if (wrapper.cmdbuffer == VK_NULL_HANDLE) {
+            mCurrent = &wrapper;
+            break;
+        }
+    }
+
+    // In theory, Filament could overflow the pool if it issues commit() an unreasonable number of
+    // times without presenting the swap chain or waiting on a fence.
+    ASSERT_POSTCONDITION(mCurrent, "Too many in-flight command buffers.");
+
+    // Create the low-level command buffer.
+    const VkCommandBufferAllocateInfo allocateInfo {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = mPool,
+        .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = 1
+    };
+    vkAllocateCommandBuffers(mDevice, &allocateInfo, &mCurrent->cmdbuffer);
+
+    // Note that the fence wrapper uses shared_ptr because a DriverAPI fence can also have ownership
+    // over it.  The destruction of the low-level fence occurs either in VulkanCommands::gc(), or in
+    // VulkanDriver::destroyFence(), both of which are safe spots.
+    mCurrent->fence = std::make_shared<VulkanCmdFence>(mDevice);
+
+    // Begin writing into the command buffer.
+    const VkCommandBufferBeginInfo binfo {
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+    };
+    vkBeginCommandBuffer(mCurrent->cmdbuffer, &binfo);
+
+    // NOTE: vkCmdBindPipeline and vkCmdBindDescriptorSets establish bindings to a specific command
+    // buffer; they are not global to the device. Since VulkanBinder doesn't have context about the
+    // current command buffer, we need to reset its bindings after swapping over to a new command
+    // buffer. This causes us to issue a few more vkBind* calls than strictly necessary, but only in
+    // the first draw call of the frame.
+
+    // TODO: consider instancing a separate VulkanBinder for each element in the swap chain, which
+    // would not only remove the need for this call, but would allow descriptor sets to be safely
+    // mutated.
+    mBinder.resetBindings();
+
+    return *mCurrent;
+}
+
+bool VulkanCommands::flush() {
+    // It's perfectly fine to call flush when no commands have been written.
+    if (mCurrent == nullptr) {
+        return false;
+    }
+
+    const int index = mCurrent - &mStorage[0];
+    VkSemaphore renderingFinished = mSubmissionSignals[index];
+
+    vkEndCommandBuffer(mCurrent->cmdbuffer);
+
+    // If the injected semaphore is an "image available" semaphore that has not yet been signaled,
+    // it is sometimes fine to start executing commands anyway, as along as we stall the GPU at the
+    // VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT stage. However we need to assume the worst
+    // here and use VK_PIPELINE_STAGE_ALL_COMMANDS_BIT. This is a more aggressive stall, but it is
+    // the only safe option because the previously submitted command buffer might have set up some
+    // state that the new command buffer depends on.
+    VkPipelineStageFlags waitDestStageMasks[2] = {
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+    };
+
+    VkSemaphore signals[2] = {
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+    };
+
+    VkSubmitInfo submitInfo {
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .waitSemaphoreCount = 0,
+        .pWaitSemaphores = signals,
+        .pWaitDstStageMask = waitDestStageMasks,
+        .commandBufferCount = 1,
+        .pCommandBuffers = &mCurrent->cmdbuffer,
+        .signalSemaphoreCount = 1u,
+        .pSignalSemaphores = &renderingFinished,
+    };
+
+    if (mSubmissionSignal) {
+        signals[submitInfo.waitSemaphoreCount++] = mSubmissionSignal;
+    }
+
+    if (mInjectedSignal) {
+        signals[submitInfo.waitSemaphoreCount++] = mInjectedSignal;
+    }
+
+    auto& cmdfence = mCurrent->fence;
+    std::unique_lock<utils::Mutex> lock(cmdfence->mutex);
+    cmdfence->status.store(VK_NOT_READY);
+    vkQueueSubmit(mQueue, 1, &submitInfo, cmdfence->fence);
+    lock.unlock();
+    cmdfence->condition.notify_all();
+
+    mSubmissionSignal = renderingFinished;
+    mInjectedSignal = VK_NULL_HANDLE;
+    mCurrent = nullptr;
+    return true;
+}
+
+VkSemaphore VulkanCommands::acquireFinishedSignal() {
+    VkSemaphore semaphore = mSubmissionSignal;
+    mSubmissionSignal = VK_NULL_HANDLE;
+    return semaphore;
+}
+
+void VulkanCommands::injectDependency(VkSemaphore next) {
+    assert_invariant(mInjectedSignal == VK_NULL_HANDLE);
+    mInjectedSignal = next;
+}
+
+void VulkanCommands::wait() {
+    VkFence fences[CAPACITY];
+    uint32_t count = 0;
+    for (auto& wrapper : mStorage) {
+        if (wrapper.cmdbuffer != VK_NULL_HANDLE) {
+            fences[count++] = wrapper.fence->fence;
+        }
+    }
+    if (count > 0) {
+        vkWaitForFences(mDevice, count, fences, VK_TRUE, UINT64_MAX);
+    }
+}
+
+void VulkanCommands::gc() {
+    for (auto& wrapper : mStorage) {
+        if (wrapper.cmdbuffer != VK_NULL_HANDLE) {
+            VkResult result = vkWaitForFences(mDevice, 1, &wrapper.fence->fence, VK_TRUE, 0);
+            if (result == VK_SUCCESS) {
+                vkFreeCommandBuffers(mDevice, mPool, 1, &wrapper.cmdbuffer);
+                wrapper.cmdbuffer = VK_NULL_HANDLE;
+                wrapper.fence->status.store(VK_SUCCESS);
+                wrapper.fence.reset();
+            }
+        }
+    }
+}
+
+void VulkanCommands::updateFences() {
+    for (auto& wrapper : mStorage) {
+        if (wrapper.cmdbuffer != VK_NULL_HANDLE) {
+            VulkanCmdFence* fence = wrapper.fence.get();
+            if (fence) {
+                VkResult status = vkGetFenceStatus(mDevice, fence->fence);
+                // This is either VK_SUCCESS, VK_NOT_READY, or VK_ERROR_DEVICE_LOST.
+                fence->status.store(status, std::memory_order_relaxed);
+            }
+        }
+    }
+}
+
+} // namespace filament
+} // namespace backend

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_DRIVER_VULKANCOMMANDS_H
+#define TNT_FILAMENT_DRIVER_VULKANCOMMANDS_H
+
+#include <bluevk/BlueVK.h>
+
+#include "VulkanBinder.h"
+
+#include <utils/Condition.h>
+#include <utils/Mutex.h>
+
+namespace filament {
+namespace backend {
+
+// Wrapper to enable use of shared_ptr for implementing shared ownership of low-level Vulkan fences.
+struct VulkanCmdFence {
+    VulkanCmdFence(VkDevice device, bool signaled = false);
+    ~VulkanCmdFence();
+    const VkDevice device;
+    VkFence fence;
+    utils::Condition condition;
+    utils::Mutex mutex;
+    std::atomic<VkResult> status;
+};
+
+// The submission fence has shared ownership semantics because it is potentially wrapped by a
+// DriverApi fence object and should not be destroyed until both the DriverApi object is freed and
+// we're done waiting on the most recent submission of the given command buffer.
+struct VulkanCommandBuffer {
+    VkCommandBuffer cmdbuffer;
+    std::shared_ptr<VulkanCmdFence> fence;
+};
+
+// Lazily creates command buffers and manages a set of submitted command buffers.
+// Submitted command buffers form a dependency chain using VkSemaphore.
+class VulkanCommands {
+    public:
+        VulkanCommands(VkDevice device, uint32_t queueFamilyIndex, VulkanBinder& binder);
+        ~VulkanCommands();
+
+        // Creates a "current" command buffer if none exists, otherwise returns the current one.
+        VulkanCommandBuffer& get();
+
+        // Submits the current command buffer if it exists, then sets "current" to null.
+        // If there are no outstanding commands then nothing happens and this returns false.
+        bool flush();
+
+        // Returns the "rendering finished" semaphore for the most recent flush and removes
+        // it from the existing dependency chain. This is especially useful for setting up
+        // vkQueuePresentKHR.
+        VkSemaphore acquireFinishedSignal();
+
+        // Takes a semaphore that signals when the next flush can occur. Only one injected
+        // semaphore is allowed per flush. Useful after calling vkAcquireNextImageKHR.
+        void injectDependency(VkSemaphore next);
+
+        // Destroys all command buffers that are no longer in use.
+        void gc();
+
+        // Waits for all outstanding command buffers to finish.
+        void wait();
+
+        // Updates the atomic "status" variable in every extant fence.
+        void updateFences();
+
+    private:
+        static constexpr int CAPACITY = 32;
+        const VkDevice mDevice;
+        VulkanBinder& mBinder;
+        VkQueue mQueue;
+        VkCommandPool mPool;
+        VulkanCommandBuffer* mCurrent = nullptr;
+        VkSemaphore mSubmissionSignal = {};
+        VkSemaphore mInjectedSignal = {};
+        VulkanCommandBuffer mStorage[CAPACITY] = {};
+        VkSemaphore mSubmissionSignals[CAPACITY] = {};
+};
+
+} // namespace filament
+} // namespace backend
+
+#endif // TNT_FILAMENT_DRIVER_VULKANCOMMANDS_H

--- a/filament/backend/src/vulkan/VulkanDisposer.cpp
+++ b/filament/backend/src/vulkan/VulkanDisposer.cpp
@@ -17,9 +17,14 @@
 #include "vulkan/VulkanDisposer.h"
 
 #include <utils/debug.h>
+#include <utils/Log.h>
 
 namespace filament {
 namespace backend {
+
+// Always wait at least 3 frames after a DriverAPI-level resource has been destroyed for safe
+// destruction, due to potential usage by outstanding command buffers and triple buffering.
+static constexpr uint32_t FRAMES_BEFORE_EVICTION = 3;
 
 void VulkanDisposer::createDisposable(Key resource, std::function<void()> destructor) noexcept {
     mDisposables[resource].destructor = destructor;
@@ -37,25 +42,25 @@ void VulkanDisposer::removeReference(Key resource) noexcept {
         mDisposables.erase(resource);
     }
 }
-void VulkanDisposer::acquire(Key resource, Set& resources) noexcept {
-    if (resource == nullptr) {
-        return;
-    }
-    auto iter = resources.find(resource);
-    if (iter == resources.end()) {
-        resources.insert(resource);
-        addReference(resource);
-    }
-}
 
-void VulkanDisposer::release(Set& resources) {
-    for (auto resource : resources) {
-        removeReference(resource);
-    }
-    resources.clear();
+void VulkanDisposer::acquire(Key resource) noexcept {
+    addReference(resource);
+    mDisposables[resource].remainingFrames = FRAMES_BEFORE_EVICTION;
 }
 
 void VulkanDisposer::gc() noexcept {
+    // First decrement the frame count of all resources that were held by a command buffer.
+    // If any of these reaches zero, decrement its reference count.
+    for (auto iter = mDisposables.begin(); iter != mDisposables.end(); ++iter) {
+        Disposable& disposable = iter.value();
+        if (disposable.remainingFrames > 0) {
+            if (--disposable.remainingFrames == 0) {
+                removeReference(iter.key());
+            }
+        }
+    }
+
+    // Next, destroy all resources with a zero refcount.
     for (auto& ptr : mGraveyard) {
         ptr.destructor();
     }
@@ -63,8 +68,14 @@ void VulkanDisposer::gc() noexcept {
 }
 
 void VulkanDisposer::reset() noexcept {
+#ifndef NDEBUG
+    utils::slog.i << mDisposables.size() << " disposables are outstanding." << utils::io::endl;
+#endif
+    for (auto iter = mDisposables.begin(); iter != mDisposables.end(); ++iter) {
+        mGraveyard.emplace_back(std::move(iter.value()));
+    }
+    mDisposables.clear();
     gc();
-    assert_invariant(mDisposables.empty());
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanDisposer.h
+++ b/filament/backend/src/vulkan/VulkanDisposer.h
@@ -18,7 +18,6 @@
 #define TNT_FILAMENT_DRIVER_VULKANDISPOSER_H
 
 #include <tsl/robin_map.h>
-#include <tsl/robin_set.h>
 
 #include <functional>
 #include <memory>
@@ -30,12 +29,10 @@ namespace backend {
 // VulkanDisposer tracks resources (such as textures or vertex buffers) that need deferred
 // destruction due to potential use by one or more reference holders. An example of a reference
 // holder is an active Vulkan command buffer. Resources are represented with void* to allow callers
-// to use any type of handle. Reference holders (e.g. VulkanCommandBuffer) have an associated
-// robin_set of resource handles.
+// to use any type of handle.
 class VulkanDisposer {
 public:
     using Key = const void*;
-    using Set = tsl::robin_set<Key>;
 
     // Adds the given resource to the disposer and sets its reference count to 1.
     void createDisposable(Key resource, std::function<void()> destructor) noexcept;
@@ -46,12 +43,9 @@ public:
     // Decrements the reference count and moves it to the graveyard if it becomes 0.
     void removeReference(Key resource) noexcept;
 
-    // If the given resource is not in the given set, then it gets added to the set and its
-    // reference count is incremented.
-    void acquire(Key resource, Set& resources) noexcept;
-
-    // Decrements the reference count for all resources in the set, then clears it.
-    void release(Set& resources);
+    // Increments the reference count and auto-decrements it after FRAMES_BEFORE_EVICTION frames.
+    // This is helpful when the current command buffer has a reference to the resource.
+    void acquire(Key resource) noexcept;
 
     // Invokes the destructor function for each disposable in the graveyard.
     void gc() noexcept;
@@ -61,8 +55,9 @@ public:
 
 private:
     struct Disposable {
-        int refcount = 1;
-        std::function<void()> destructor;
+        uint16_t refcount = 1;
+        uint16_t remainingFrames = 0;
+        std::function<void()> destructor = []() {};
     };
     tsl::robin_map<Key, Disposable> mDisposables;
     std::vector<Disposable> mGraveyard;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -22,6 +22,7 @@
 #include "VulkanDriverFactory.h"
 #include "VulkanHandles.h"
 #include "VulkanPlatform.h"
+#include "VulkanCommands.h"
 
 #include <utils/Panic.h>
 #include <utils/CString.h>
@@ -55,7 +56,6 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallback(VkDebugReportFlagsEXT flags,
         utils::slog.w << "VULKAN WARNING: (" << pLayerPrefix << ") "
                 << pMessage << utils::io::endl;
     }
-    // Return TRUE here if an abort is desired.
     return VK_FALSE;
 }
 
@@ -82,7 +82,6 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFla
         utils::slog.w << "VULKAN WARNING: (" << cbdata->pMessageIdName << ") "
                 << cbdata->pMessage << utils::io::endl;
     }
-    // Return TRUE here if an abort is desired.
     return VK_FALSE;
 }
 
@@ -209,6 +208,10 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
 
     // Initialize device and graphicsQueue.
     createLogicalDevice(mContext);
+
+    mContext.commands = new VulkanCommands(mContext.device, mContext.graphicsQueueFamilyIndex,
+            mBinder);
+
     mBinder.setDevice(mContext.device);
     createEmptyTexture(mContext, mStagePool);
 
@@ -261,24 +264,14 @@ void VulkanDriver::terminate() {
         return;
     }
 
-    // Flush the work command buffer.
-    acquireWorkCommandBuffer(mContext);
-
+    delete mContext.commands;
     delete mContext.emptyTexture;
 
     mBlitter.shutdown();
 
-    mDisposer.release(mContext.work.resources);
-
     // Allow the stage pool and disposer to clean up.
     mStagePool.gc();
     mDisposer.reset();
-
-    // Destroy the work command buffer and fence.
-    VulkanCommandBuffer& work = mContext.work;
-    VkDevice device = mContext.device;
-    vkFreeCommandBuffers(device, mContext.commandPool, 1, &work.cmdbuffer);
-    work.fence.reset();
 
     mStagePool.reset();
     mBinder.destroyCache();
@@ -301,82 +294,23 @@ void VulkanDriver::terminate() {
 }
 
 void VulkanDriver::tick(int) {
-    if (!mContext.currentSurface) {
-        return;
-    }
-    for (SwapContext& sc : mContext.currentSurface->swapContexts) {
-        VulkanCmdFence* fence = sc.commands.fence.get();
-        if (fence) {
-            VkResult status = vkGetFenceStatus(mContext.device, fence->fence);
-            fence->status.store(status, std::memory_order_relaxed);
-        }
-    }
+    mContext.commands->updateFences();
 }
 
-void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
-    // We allow multiple beginFrame / endFrame pairs before commit(), so gracefully return early
-    // if the swap chain has already been acquired.
-    if (mContext.currentCommands) {
-        return;
-    }
-
-    // After each command buffer acquisition, we know that the previous submission of the acquired
-    // command buffer has finished, so we can decrement the refcount for each of its referenced
-    // resources.
-
-    acquireWorkCommandBuffer(mContext);
-    mDisposer.release(mContext.work.resources);
-
-    // With MoltenVK, it might take several attempts to acquire a swap chain that is not marked as
-    // "out of date" after a resize event.
-    int attempts = 0;
-    while (!acquireSwapCommandBuffer(mContext)) {
-        refreshSwapChain();
-        if (attempts++ > SWAP_CHAIN_MAX_ATTEMPTS) {
-            PANIC_POSTCONDITION("Unable to acquire image from swap chain.");
-        }
-    }
-
-    #ifdef ANDROID
-    // Polling VkSurfaceCapabilitiesKHR is the most reliable way to detect a rotation change on
-    // Android. Checking for VK_SUBOPTIMAL_KHR is not sufficient on pre-Android 10 devices. Even
-    // on Android 10, we cannot rely on SUBOPTIMAL because we always use IDENTITY for the
-    // preTransform field in VkSwapchainCreateInfoKHR (see other comment in createSwapChain).
-    //
-    // NOTE: we support apps that have "orientation|screenSize" enabled in android:configChanges.
-    //
-    // NOTE: we poll the currentExtent rather than currentTransform. The transform seems to change
-    // before the extent (on a Pixel 4 anyway), which causes us to create a badly sized VkSwapChain.
-    const VulkanSurfaceContext* surface = mContext.currentSurface;
-    VkSurfaceCapabilitiesKHR caps;
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mContext.physicalDevice, surface->surface, &caps);
-    const VkExtent2D previous = surface->surfaceCapabilities.currentExtent;
-    const VkExtent2D current = caps.currentExtent;
-    if (current.width != previous.width || current.height != previous.height) {
-        refreshSwapChain();
-        acquireSwapCommandBuffer(mContext);
-    }
-    #endif
-
-    mDisposer.release(mContext.currentCommands->resources);
-
-    // vkCmdBindPipeline and vkCmdBindDescriptorSets establish bindings to a specific command
-    // buffer; they are not global to the device. Since VulkanBinder doesn't have context about the
-    // current command buffer, we need to reset its bindings after swapping over to a new command
-    // buffer. Note that the following reset causes us to issue a few more vkBind* calls than
-    // strictly necessary, but only in the first draw call of the frame. Alteneratively we could
-    // enhance VulkanBinder by adding a mapping from command buffers to bindings, but this would
-    // introduce complexity that doesn't seem worthwhile. Yet another design would be to instance a
-    // separate VulkanBinder for each element in the swap chain, which would also have the benefit
-    // of allowing us to safely mutate descriptor sets. For now we're avoiding that strategy in the
-    // interest of maintaining a small memory footprint.
-    mBinder.resetBindings();
-
-    // Free old unused objects.
+// Garbage collection should not occur too frequently, only about once per frame. Internally, the
+// eviction time of various resources is often measured in terms of an approximate frame number
+// rather than the wall clock, because we must wait 3 frames after a DriverAPI-level resource has
+// been destroyed for safe destruction, due to outstanding command buffers and triple buffering.
+void VulkanDriver::collectGarbage() {
     mStagePool.gc();
     mFramebufferCache.gc();
     mBinder.gc();
     mDisposer.gc();
+    mContext.commands->gc();
+}
+
+void VulkanDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
+    // Do nothing.
 }
 
 void VulkanDriver::setFrameScheduledCallback(Handle<HwSwapChain> sch,
@@ -393,15 +327,17 @@ void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 
 void VulkanDriver::endFrame(uint32_t frameId) {
-    // Do nothing here; see commit().
+    if (mContext.commands->flush()) {
+        collectGarbage();
+    }
 }
 
 void VulkanDriver::flush(int) {
-    // Todo: equivalent of glFlush()
+    mContext.commands->flush();
 }
 
-void VulkanDriver::finish(int) {
-    // Todo: equivalent of glFinish()
+void VulkanDriver::finish(int dummy) {
+    mContext.commands->flush();
 }
 
 void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t count) {
@@ -422,15 +358,11 @@ void VulkanDriver::destroyUniformBuffer(Handle<HwUniformBuffer> ubh) {
         auto buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
         mBinder.unbindUniformBuffer(buffer->getGpuBuffer());
 
-        // We do not know if any pending draw calls are making use of this uniform buffer,
-        // so assume the worst: that all command buffers are all using it.
-        if (mContext.currentSurface) {
-            for (auto& swapContext : mContext.currentSurface->swapContexts) {
-                mDisposer.acquire(buffer, swapContext.commands.resources);
-            }
-        }
-
+        // Decrement the refcount of the uniform buffer, but schedule it for destruction a few
+        // frames in the future. To be safe, we need to assume that the current command buffer is
+        // still using it somewhere.
         mDisposer.removeReference(buffer);
+        mDisposer.acquire(buffer);
     }
 }
 
@@ -589,21 +521,13 @@ void VulkanDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
 }
 
 void VulkanDriver::createFenceR(Handle<HwFence> fh, int) {
-    // We prefer the fence to be created inside a frame, otherwise there's no command buffer.
-    assert_invariant(mContext.currentCommands != nullptr && "Fences should be created within a frame.");
-
-     // As a fallback in release builds, trigger the fence based on the work command buffer.
-    if (mContext.currentCommands == nullptr) {
-        construct_handle<VulkanFence>(mHandleMap, fh, mContext.work);
-        return;
-    }
-
-     construct_handle<VulkanFence>(mHandleMap, fh, *mContext.currentCommands);
+    VulkanCommandBuffer& commandBuffer = mContext.commands->get();
+    construct_handle<VulkanFence>(mHandleMap, fh, commandBuffer);
 }
 
 void VulkanDriver::createSyncR(Handle<HwSync> sh, int) {
-    ASSERT_PRECONDITION(mContext.currentCommands, "Syncs must be created within a frame.");
-    construct_handle<VulkanSync>(mHandleMap, sh, *mContext.currentCommands);
+    VulkanCommandBuffer& commandBuffer = mContext.commands->get();
+    construct_handle<VulkanSync>(mHandleMap, sh, commandBuffer);
 }
 
 void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags) {
@@ -783,17 +707,15 @@ void VulkanDriver::destroyFence(Handle<HwFence> fh) {
 FenceStatus VulkanDriver::wait(Handle<HwFence> fh, uint64_t timeout) {
     auto& cmdfence = handle_cast<VulkanFence>(mHandleMap, fh)->fence;
 
-    // The condition variable is used only to guarantee that we're calling vkWaitForFences *after*
-    // calling vkQueueSubmit.
+    // Internally we use the VK_INCOMPLETE status to mean "not yet submitted".
+    // When this fence gets submitted, its status changes to VK_NOT_READY.
     std::unique_lock<utils::Mutex> lock(cmdfence->mutex);
-    if (!cmdfence->submitted) {
+    if (cmdfence->status.load() == VK_INCOMPLETE) {
+        // This will obviously timeout if Filament creates a fence and immediately waits on it
+        // without calling endFrame() or commit().
         cmdfence->condition.wait(lock);
-        assert_invariant(cmdfence->submitted);
     } else {
         lock.unlock();
-    }
-    if (cmdfence->swapChainDestroyed) {
-        return FenceStatus::ERROR;
     }
     VkResult result = vkWaitForFences(mContext.device, 1, &cmdfence->fence, VK_TRUE, timeout);
     return result == VK_SUCCESS ? FenceStatus::CONDITION_SATISFIED : FenceStatus::TIMEOUT_EXPIRED;
@@ -970,14 +892,15 @@ SyncStatus VulkanDriver::getSyncStatus(Handle<HwSync> sh) {
     if (sync->fence == nullptr) {
         return SyncStatus::NOT_SIGNALED;
     }
-    if (sync->fence->swapChainDestroyed) {
-        return SyncStatus::ERROR;
-    }
     VkResult status = sync->fence->status.load(std::memory_order_relaxed);
     switch (status) {
         case VK_SUCCESS: return SyncStatus::SIGNALED;
+        case VK_INCOMPLETE: return SyncStatus::NOT_SIGNALED;
         case VK_NOT_READY: return SyncStatus::NOT_SIGNALED;
-        default: return SyncStatus::ERROR;
+        case VK_ERROR_DEVICE_LOST: return SyncStatus::ERROR;
+        default:
+            // NOTE: In theory, the fence status must be one of the above values.
+            return SyncStatus::ERROR;
     }
 }
 
@@ -1011,7 +934,6 @@ void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 }
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {
-    assert_invariant(mContext.currentCommands);
     assert_invariant(mContext.currentSurface);
     VulkanSurfaceContext& surface = *mContext.currentSurface;
     mCurrentRenderTarget = handle_cast<VulkanRenderTarget>(mHandleMap, rth);
@@ -1026,8 +948,9 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     // first render pass. Note however that its contents are often preserved on subsequent render
     // passes, due to multiple views.
     TargetBufferFlags discardStart = params.flags.discardStart;
-    if (rt->invalidate()) {
+    if (rt->isSwapChain() && surface.firstRenderPass) {
         discardStart |= TargetBufferFlags::COLOR;
+        surface.firstRenderPass = false;
     }
 
     // Create the VkRenderPass or fetch it from cache.
@@ -1085,10 +1008,10 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     VkFramebuffer vkfb = mFramebufferCache.getFramebuffer(fbkey);
 
     // The current command buffer now owns a reference to the render target and its attachments.
-    mDisposer.acquire(rt, mContext.currentCommands->resources);
-    mDisposer.acquire(depth.texture, mContext.currentCommands->resources);
+    mDisposer.acquire(rt);
+    mDisposer.acquire(depth.texture);
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-        mDisposer.acquire(rt->getColor(i).texture, mContext.currentCommands->resources);
+        mDisposer.acquire(rt->getColor(i).texture);
     }
 
     // Populate the structures required for vkCmdBeginRenderPass.
@@ -1130,9 +1053,8 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     }
     renderPassInfo.pClearValues = &clearValues[0];
 
-    const SwapContext& swapContext = surface.swapContexts[surface.currentSwapIndex];
-
-    vkCmdBeginRenderPass(swapContext.commands.cmdbuffer, &renderPassInfo,
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
+    vkCmdBeginRenderPass(cmdbuffer, &renderPassInfo,
             VK_SUBPASS_CONTENTS_INLINE);
 
     VkViewport viewport = mContext.viewport = {
@@ -1145,7 +1067,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     };
 
     mCurrentRenderTarget->transformClientRectToPlatform(&viewport);
-    vkCmdSetViewport(swapContext.commands.cmdbuffer, 0, 1, &viewport);
+    vkCmdSetViewport(cmdbuffer, 0, 1, &viewport);
 
     mContext.currentRenderPass = {
         .renderPass = renderPassInfo.renderPass,
@@ -1155,10 +1077,9 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 }
 
 void VulkanDriver::endRenderPass(int) {
-    assert_invariant(mContext.currentCommands);
     assert_invariant(mContext.currentSurface);
     assert_invariant(mCurrentRenderTarget);
-    vkCmdEndRenderPass(mContext.currentCommands->cmdbuffer);
+    vkCmdEndRenderPass(mContext.commands->get().cmdbuffer);
     mCurrentRenderTarget = VK_NULL_HANDLE;
     if (mContext.currentRenderPass.currentSubpass > 0) {
         for (uint32_t i = 0; i < VulkanBinder::TARGET_BINDING_COUNT; i++) {
@@ -1173,12 +1094,11 @@ void VulkanDriver::nextSubpass(int) {
     ASSERT_PRECONDITION(mContext.currentRenderPass.currentSubpass == 0,
             "Only two subpasses are currently supported.");
 
-    assert_invariant(mContext.currentCommands);
     assert_invariant(mContext.currentSurface);
     assert_invariant(mCurrentRenderTarget);
     assert_invariant(mContext.currentRenderPass.subpassMask);
 
-    vkCmdNextSubpass(mContext.currentCommands->cmdbuffer, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdNextSubpass(mContext.commands->get().cmdbuffer, VK_SUBPASS_CONTENTS_INLINE);
 
     mBinder.bindRenderPass(mContext.currentRenderPass.renderPass,
             ++mContext.currentRenderPass.currentSubpass);
@@ -1216,69 +1136,75 @@ void VulkanDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
 void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
     ASSERT_PRECONDITION_NON_FATAL(drawSch == readSch,
                                   "Vulkan driver does not support distinct draw/read swap chains.");
-    VulkanSurfaceContext& sContext = handle_cast<VulkanSwapChain>(mHandleMap, drawSch)->surfaceContext;
-    mContext.currentSurface = &sContext;
-}
+    VulkanSurfaceContext& surf = handle_cast<VulkanSwapChain>(mHandleMap, drawSch)->surfaceContext;
+    mContext.currentSurface = &surf;
 
-void VulkanDriver::commit(Handle<HwSwapChain> sch) {
-    // Tell Vulkan we're done appending to the command buffer.
-    ASSERT_POSTCONDITION(mContext.currentCommands,
-            "Vulkan driver requires at least one frame before a commit.");
-
-    // Before swapping, transition the current swap chain image to the PRESENT layout. This cannot
-    // be done as part of the render pass because it does not know if it is last pass in the frame.
-    makeSwapChainPresentable(mContext);
-
-    // Finalize the command buffer and set the cmdbuffer pointer to null.
-    VkResult result = vkEndCommandBuffer(mContext.currentCommands->cmdbuffer);
-    ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkEndCommandBuffer error.");
-    mContext.currentCommands = nullptr;
-
-    // Submit the command buffer.
-    VkPipelineStageFlags waitDestStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
-    VulkanSurfaceContext& surfaceContext = *mContext.currentSurface;
-    SwapContext& swapContext = getSwapContext(mContext);
-    VkSubmitInfo submitInfo {
-            .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
-            .waitSemaphoreCount = 1u,
-            .pWaitSemaphores = &surfaceContext.imageAvailable,
-            .pWaitDstStageMask = &waitDestStageMask,
-            .commandBufferCount = 1,
-            .pCommandBuffers = &swapContext.commands.cmdbuffer,
-            .signalSemaphoreCount = 1u,
-            .pSignalSemaphores = &surfaceContext.renderingFinished,
-    };
-    if (surfaceContext.headlessQueue) {
-        submitInfo.waitSemaphoreCount = 0;
-        submitInfo.pWaitSemaphores = nullptr;
-        submitInfo.signalSemaphoreCount = 0;
-        submitInfo.pSignalSemaphores = nullptr;
-    }
-
-    auto& cmdfence = swapContext.commands.fence;
-    std::unique_lock<utils::Mutex> lock(cmdfence->mutex);
-    result = vkQueueSubmit(mContext.graphicsQueue, 1, &submitInfo, cmdfence->fence);
-    cmdfence->submitted = true;
-    lock.unlock();
-    ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkQueueSubmit error.");
-    swapContext.invalid = true;
-    cmdfence->condition.notify_all();
-
-    if (surfaceContext.headlessQueue) {
+    // Leave early if the swap chain image has already been acquired but not yet presented.
+    if (surf.acquired) {
         return;
     }
 
-    // Present the backbuffer.
+    // With MoltenVK, it might take several attempts to acquire a swap chain that is not marked as
+    // "out of date" after a resize event.
+    int attempts = 0;
+    while (!acquireSwapChain(mContext, surf)) {
+        refreshSwapChain();
+        if (attempts++ > SWAP_CHAIN_MAX_ATTEMPTS) {
+            PANIC_POSTCONDITION("Unable to acquire image from swap chain.");
+        }
+    }
+
+    #ifdef ANDROID
+    // Polling VkSurfaceCapabilitiesKHR is the most reliable way to detect a rotation change on
+    // Android. Checking for VK_SUBOPTIMAL_KHR is not sufficient on pre-Android 10 devices. Even
+    // on Android 10, we cannot rely on SUBOPTIMAL because we always use IDENTITY for the
+    // preTransform field in VkSwapchainCreateInfoKHR (see other comment in createSwapChain).
+    //
+    // NOTE: we support apps that have "orientation|screenSize" enabled in android:configChanges.
+    //
+    // NOTE: we poll the currentExtent rather than currentTransform. The transform seems to change
+    // before the extent (on a Pixel 4 anyway), which causes us to create a badly sized VkSwapChain.
+    VkSurfaceCapabilitiesKHR caps;
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(mContext.physicalDevice, surf.surface, &caps);
+    const VkExtent2D previous = surf.surfaceCapabilities.currentExtent;
+    const VkExtent2D current = caps.currentExtent;
+    if (current.width != previous.width || current.height != previous.height) {
+        refreshSwapChain();
+        acquireSwapChain(mContext, surf);
+    }
+    #endif
+}
+
+void VulkanDriver::commit(Handle<HwSwapChain> sch) {
     VulkanSurfaceContext& surface = handle_cast<VulkanSwapChain>(mHandleMap, sch)->surfaceContext;
+
+    // Before swapping, transition the current swap chain image to the PRESENT layout. This cannot
+    // be done as part of the render pass because it does not know if it is last pass in the frame.
+    makeSwapChainPresentable(mContext, surface);
+
+    if (mContext.commands->flush()) {
+        collectGarbage();
+    }
+
+    surface.firstRenderPass = true;
+
+    if (surface.headlessQueue) {
+        return;
+    }
+
+    surface.acquired = false;
+
+    // Present the backbuffer after the most recent command buffer submission has finished.
+    VkSemaphore renderingFinished = mContext.commands->acquireFinishedSignal();
     VkPresentInfoKHR presentInfo {
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
         .waitSemaphoreCount = 1,
-        .pWaitSemaphores = &surface.renderingFinished,
+        .pWaitSemaphores = &renderingFinished,
         .swapchainCount = 1,
         .pSwapchains = &surface.swapchain,
         .pImageIndices = &surface.currentSwapIndex,
     };
-    result = vkQueuePresentKHR(surface.presentQueue, &presentInfo);
+    VkResult result = vkQueuePresentKHR(surface.presentQueue, &presentInfo);
 
     // On Android Q and above, a suboptimal surface is always reported after screen rotation:
     // https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html
@@ -1313,52 +1239,49 @@ void VulkanDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
 
 void VulkanDriver::insertEventMarker(char const* string, size_t len) {
     constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
-    ASSERT_POSTCONDITION(mContext.currentCommands,
-            "Markers can only be inserted within a beginFrame / endFrame.");
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     if (mContext.debugUtilsSupported) {
         VkDebugUtilsLabelEXT labelInfo = {
             .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
             .pLabelName = string,
             .color = {1, 1, 0, 1},
         };
-        vkCmdInsertDebugUtilsLabelEXT(mContext.currentCommands->cmdbuffer, &labelInfo);
+        vkCmdInsertDebugUtilsLabelEXT(cmdbuffer, &labelInfo);
     } else if (mContext.debugMarkersSupported) {
         VkDebugMarkerMarkerInfoEXT markerInfo = {};
         markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
         memcpy(markerInfo.color, &MARKER_COLOR[0], sizeof(MARKER_COLOR));
         markerInfo.pMarkerName = string;
-        vkCmdDebugMarkerInsertEXT(mContext.currentCommands->cmdbuffer, &markerInfo);
+        vkCmdDebugMarkerInsertEXT(cmdbuffer, &markerInfo);
     }
 }
 
 void VulkanDriver::pushGroupMarker(char const* string, size_t len) {
     // TODO: Add group marker color to the Driver API
     constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
-    ASSERT_POSTCONDITION(mContext.currentCommands,
-            "Markers can only be inserted within a beginFrame / endFrame.");
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     if (mContext.debugUtilsSupported) {
         VkDebugUtilsLabelEXT labelInfo = {
             .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
             .pLabelName = string,
             .color = {0, 1, 0, 1},
         };
-        vkCmdBeginDebugUtilsLabelEXT(mContext.currentCommands->cmdbuffer, &labelInfo);
+        vkCmdBeginDebugUtilsLabelEXT(cmdbuffer, &labelInfo);
     } else if (mContext.debugMarkersSupported) {
         VkDebugMarkerMarkerInfoEXT markerInfo = {};
         markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
         memcpy(markerInfo.color, &MARKER_COLOR[0], sizeof(MARKER_COLOR));
         markerInfo.pMarkerName = string;
-        vkCmdDebugMarkerBeginEXT(mContext.currentCommands->cmdbuffer, &markerInfo);
+        vkCmdDebugMarkerBeginEXT(cmdbuffer, &markerInfo);
     }
 }
 
 void VulkanDriver::popGroupMarker(int) {
-    ASSERT_POSTCONDITION(mContext.currentCommands,
-            "Markers can only be inserted within a beginFrame / endFrame.");
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     if (mContext.debugUtilsSupported) {
-        vkCmdEndDebugUtilsLabelEXT(mContext.currentCommands->cmdbuffer);
+        vkCmdEndDebugUtilsLabelEXT(cmdbuffer);
     } else if (mContext.debugMarkersSupported) {
-        vkCmdDebugMarkerEndEXT(mContext.currentCommands->cmdbuffer);
+        vkCmdDebugMarkerEndEXT(cmdbuffer);
     }
 }
 
@@ -1410,12 +1333,13 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     vkAllocateMemory(device, &allocInfo, nullptr, &stagingMemory);
     vkBindImageMemory(device, stagingImage, stagingMemory, 0);
 
-    // TODO: replace waitForIdle with an image barrier coupled with acquireWorkCommandBuffer.
+    // TODO: replace waitForIdle with an image barrier.
     waitForIdle(mContext);
 
     // Transition the staging image layout.
 
-    VulkanTexture::transitionImageLayout(mContext.work.cmdbuffer, stagingImage,
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
+    VulkanTexture::transitionImageLayout(cmdbuffer, stagingImage,
             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0, 1, 1,
             VK_IMAGE_ASPECT_COLOR_BIT);
 
@@ -1445,13 +1369,13 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     // Transition the source image layout (which might be the swap chain)
 
     VkImage srcImage = srcTarget->getColor(0).image;
-    VulkanTexture::transitionImageLayout(mContext.work.cmdbuffer, srcImage,
+    VulkanTexture::transitionImageLayout(cmdbuffer, srcImage,
             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, srcMipLevel, 1, 1,
             VK_IMAGE_ASPECT_COLOR_BIT);
 
     // Perform the blit.
 
-    vkCmdCopyImage(mContext.work.cmdbuffer, srcTarget->getColor(0).image,
+    vkCmdCopyImage(cmdbuffer, srcTarget->getColor(0).image,
             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, stagingImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
             1, &imageCopyRegion);
 
@@ -1459,11 +1383,11 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
 
     if (srcTexture || mContext.currentSurface->presentQueue) {
         const VkImageLayout present = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-        VulkanTexture::transitionImageLayout(mContext.work.cmdbuffer, srcImage,
+        VulkanTexture::transitionImageLayout(cmdbuffer, srcImage,
                 VK_IMAGE_LAYOUT_UNDEFINED, srcTexture ? getTextureLayout(srcTexture->usage) : present,
                 srcMipLevel, 1, 1, VK_IMAGE_ASPECT_COLOR_BIT);
     } else {
-        VulkanTexture::transitionImageLayout(mContext.work.cmdbuffer, srcImage,
+        VulkanTexture::transitionImageLayout(cmdbuffer, srcImage,
                 VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL,
                 srcMipLevel, 1, 1, VK_IMAGE_ASPECT_COLOR_BIT);
     }
@@ -1488,13 +1412,12 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
         }
     };
 
-    vkCmdPipelineBarrier(mContext.work.cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+    vkCmdPipelineBarrier(cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 
     // Flush and wait.
-
-    flushWorkCommandBuffer(mContext);
-    acquireWorkCommandBuffer(mContext);
+    mContext.commands->flush();
+    mContext.commands->wait();
 
     VkImageSubresource subResource { .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT };
     VkSubresourceLayout subResourceLayout;
@@ -1549,12 +1472,7 @@ void VulkanDriver::blit(TargetBufferFlags buffers, Handle<HwRenderTarget> dst, V
     const int32_t dstTop = std::min(dstRect.bottom + dstRect.height, dstExtent.height);
     const VkOffset3D dstOffsets[2] = { { dstLeft, dstBottom, 0 }, { dstRight, dstTop, 1 }};
 
-    VkCommandBuffer cmdbuf;
-    if (mContext.currentCommands) {
-        cmdbuf = mContext.currentCommands->cmdbuffer;
-    } else {
-        cmdbuf = acquireWorkCommandBuffer(mContext);;
-    }
+    const VkCommandBuffer cmdbuf = mContext.commands->get().cmdbuffer;
 
     if (any(buffers & TargetBufferFlags::DEPTH) && srcTarget->hasDepth() && dstTarget->hasDepth()) {
         mBlitter.blitDepth(cmdbuf, {dstTarget, dstOffsets, srcTarget, srcOffsets});
@@ -1575,15 +1493,10 @@ void VulkanDriver::blit(TargetBufferFlags buffers, Handle<HwRenderTarget> dst, V
     if (any(buffers & TargetBufferFlags::COLOR3)) {
         mBlitter.blitColor(cmdbuf, {dstTarget, dstOffsets, srcTarget, srcOffsets, vkfilter, 3});
     }
-
-    if (!mContext.currentCommands) {
-        flushWorkCommandBuffer(mContext);
-    }
 }
 
 void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph) {
-    VulkanCommandBuffer* commands = mContext.currentCommands;
-    ASSERT_POSTCONDITION(commands, "Draw calls can occur only within a beginFrame / endFrame.");
+    VulkanCommandBuffer* commands = &mContext.commands->get();
     VkCommandBuffer cmdbuffer = commands->cmdbuffer;
     const VulkanRenderPrimitive& prim = *handle_cast<VulkanRenderPrimitive>(mHandleMap, rph);
 
@@ -1593,9 +1506,9 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     const Viewport& viewportScissor = pipelineState.scissor;
 
     auto* program = handle_cast<VulkanProgram>(mHandleMap, programHandle);
-    mDisposer.acquire(program, commands->resources);
-    mDisposer.acquire(prim.indexBuffer, commands->resources);
-    mDisposer.acquire(prim.vertexBuffer, commands->resources);
+    mDisposer.acquire(program);
+    mDisposer.acquire(prim.indexBuffer);
+    mDisposer.acquire(prim.vertexBuffer);
 
     // If this is a debug build, validate the current shader.
 #if !defined(NDEBUG)
@@ -1727,7 +1640,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 texture = mContext.emptyTexture;
             } else {
                 texture = handle_const_cast<VulkanTexture>(mHandleMap, boundSampler->t);
-                mDisposer.acquire(texture, commands->resources);
+                mDisposer.acquire(texture);
             }
 
             const SamplerParams& samplerParams = boundSampler->s;
@@ -1790,9 +1703,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
 }
 
 void VulkanDriver::beginTimerQuery(Handle<HwTimerQuery> tqh) {
-    VulkanCommandBuffer* commands = mContext.currentCommands;
-    ASSERT_POSTCONDITION(commands, "Timer queries can occur only within a beginFrame / endFrame.");
-
+    VulkanCommandBuffer* commands = &mContext.commands->get();
     VulkanTimerQuery* vtq = handle_cast<VulkanTimerQuery>(mHandleMap, tqh);
     const uint32_t index = vtq->startingQueryIndex;
     const VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
@@ -1803,9 +1714,7 @@ void VulkanDriver::beginTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 
 void VulkanDriver::endTimerQuery(Handle<HwTimerQuery> tqh) {
-    VulkanCommandBuffer* commands = mContext.currentCommands;
-    ASSERT_POSTCONDITION(commands, "Timer queries can occur only within a beginFrame / endFrame.");
-
+    VulkanCommandBuffer* commands = &mContext.commands->get();
     VulkanTimerQuery* vtq = handle_cast<VulkanTimerQuery>(mHandleMap, tqh);
     const uint32_t index = vtq->stoppingQueryIndex;
     const VkPipelineStageFlagBits stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -145,6 +145,7 @@ private:
     }
 
     void refreshSwapChain();
+    void collectGarbage();
 
     VulkanContext mContext = {};
     VulkanBinder mBinder;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -60,9 +60,9 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getDepth() const;
     VulkanAttachment getMsaaDepth() const;
     int getColorTargetCount(const VulkanRenderPass& pass) const;
-    bool invalidate();
     uint8_t getSamples() const { return mSamples; }
     bool hasDepth() const { return mDepth.format != VK_FORMAT_UNDEFINED; }
+    bool isSwapChain() const { return !mOffscreen; }
 
 private:
     VulkanAttachment mColor[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -69,7 +69,7 @@ void VulkanStagePool::releaseStage(VulkanStage const* stage, VulkanCommandBuffer
     // Replace the previous owner of the stage with the given command buffer.  When the command
     // buffer finishes execution, the stage will finally be released back into the pool.
     mDisposer.createDisposable(stage, [stage, this]() { this->releaseStage(stage); });
-    mDisposer.acquire(stage, cmd.resources);
+    mDisposer.acquire(stage);
     mDisposer.removeReference(stage);
 }
 


### PR DESCRIPTION
This removes a lot of caveats that we had in the Vulkan backend. Many driver API calls were unsupported due to a potential "missing" command buffer, but in the new scheme, a command buffer is always made available, and there's no weird separate "work and swap chain command buffers".

Here's how various driver API entry points now map into Vulkan actions:

```
makeCurrent => Acquire Swap Chain.
beginFrame => Do nothing.
endFrame => Submit command buffer and create a new one.
commit => Submit commit buffer again if necessary, Present Swap Chain.
```

This handles both `copyFrame` (which does not do beginFrame / endFrame) and `renderStandaloneView` (which does not do makeCurrent / commit).
