### PR TITLE
Jw/readPixels docs

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -343,14 +343,14 @@ public:
      *                      - PixelBufferDescriptor::PixelDataType::INT
      *                      - PixelBufferDescriptor::PixelDataType::FLOAT
      *
-     * Other combination of format/type may be supported. If a combination is
+     * Other combinations of format/type may be supported. If a combination is
      * not supported, this operation may fail silently. Use a DEBUG build
      * to get some logs about the failure.
      *
      *
      *  Framebuffer as seen on User buffer (PixelBufferDescriptor&)
      *  screen
-	 *  
+     *  
      *      +--------------------+
      *      |                    |                .stride         .alignment
      *      |                    |         ----------------------->-->
@@ -419,14 +419,14 @@ public:
      *                      - PixelBufferDescriptor::PixelDataType::INT
      *                      - PixelBufferDescriptor::PixelDataType::FLOAT
      *
-     * Other combination of format/type may be supported. If a combination is
+     * Other combinations of format/type may be supported. If a combination is
      * not supported, this operation may fail silently. Use a DEBUG build
      * to get some logs about the failure.
      *
      *
      *  Framebuffer as seen on User buffer (PixelBufferDescriptor&)
      *  screen
-	 *  
+     *  
      *      +--------------------+
      *      |                    |                .stride         .alignment
      *      |                    |         ----------------------->-->

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -333,38 +333,39 @@ public:
      * @param height    Height of the sub-region to read back.
      * @param buffer    Client-side buffer where the read-back will be written.
      *
-     *                  The following format are always supported:
+     * The following formats are always supported:
      *                      - PixelBufferDescriptor::PixelDataFormat::RGBA
      *                      - PixelBufferDescriptor::PixelDataFormat::RGBA_INTEGER
      *
-     *                  The following types are always supported:
+     * The following types are always supported:
      *                      - PixelBufferDescriptor::PixelDataType::UBYTE
      *                      - PixelBufferDescriptor::PixelDataType::UINT
      *                      - PixelBufferDescriptor::PixelDataType::INT
      *                      - PixelBufferDescriptor::PixelDataType::FLOAT
      *
-     *                  Other combination of format/type may be supported. If a combination is
-     *                  not supported, this operation may fail silently. Use a DEBUG build
-     *                  to get some logs about the failure.
+     * Other combination of format/type may be supported. If a combination is
+     * not supported, this operation may fail silently. Use a DEBUG build
+     * to get some logs about the failure.
      *
      *
-     *  Framebuffer as seen on         User buffer (PixelBufferDescriptor&)
+     *  Framebuffer as seen on User buffer (PixelBufferDescriptor&)
      *  screen
-     *  +--------------------+
-     *  |                    |                .stride         .alignment
-     *  |                    |         ----------------------->-->
-     *  |                    |         O----------------------+--+   low addresses
-     *  |                    |         |          |           |  |
-     *  |             w      |         |          | .top      |  |
-     *  |       <--------->  |         |          V           |  |
-     *  |       +---------+  |         |     +---------+      |  |
-     *  |       |     ^   |  | ======> |     |         |      |  |
-     *  |   x   |    h|   |  |         |.left|         |      |  |
-     *  +------>|     v   |  |         +---->|         |      |  |
-     *  |       +.........+  |         |     +.........+      |  |
-     *  |            ^       |         |                      |  |
-     *  |          y |       |         +----------------------+--+  high addresses
-     *  O------------+-------+
+	 *  
+     *      +--------------------+
+     *      |                    |                .stride         .alignment
+     *      |                    |         ----------------------->-->
+     *      |                    |         O----------------------+--+   low addresses
+     *      |                    |         |          |           |  |
+     *      |             w      |         |          | .top      |  |
+     *      |       <--------->  |         |          V           |  |
+     *      |       +---------+  |         |     +---------+      |  |
+     *      |       |     ^   |  | ======> |     |         |      |  |
+     *      |   x   |    h|   |  |         |.left|         |      |  |
+     *      +------>|     v   |  |         +---->|         |      |  |
+     *      |       +.........+  |         |     +.........+      |  |
+     *      |            ^       |         |                      |  |
+     *      |          y |       |         +----------------------+--+  high addresses
+     *      O------------+-------+
      *
      *
      * Typically readPixels() will be called after render() and before endFrame().
@@ -408,38 +409,39 @@ public:
      * @param height        Height of the sub-region to read back.
      * @param buffer        Client-side buffer where the read-back will be written.
      *
-     *                  The following format are always supported:
+     * The following formats are always supported:
      *                      - PixelBufferDescriptor::PixelDataFormat::RGBA
      *                      - PixelBufferDescriptor::PixelDataFormat::RGBA_INTEGER
      *
-     *                  The following types are always supported:
+     * The following types are always supported:
      *                      - PixelBufferDescriptor::PixelDataType::UBYTE
      *                      - PixelBufferDescriptor::PixelDataType::UINT
      *                      - PixelBufferDescriptor::PixelDataType::INT
      *                      - PixelBufferDescriptor::PixelDataType::FLOAT
      *
-     *                  Other combination of format/type may be supported. If a combination is
-     *                  not supported, this operation may fail silently. Use a DEBUG build
-     *                  to get some logs about the failure.
+     * Other combination of format/type may be supported. If a combination is
+     * not supported, this operation may fail silently. Use a DEBUG build
+     * to get some logs about the failure.
      *
      *
-     *  Framebuffer as seen on         User buffer (PixelBufferDescriptor&)
+     *  Framebuffer as seen on User buffer (PixelBufferDescriptor&)
      *  screen
-     *  +--------------------+
-     *  |                    |                .stride         .alignment
-     *  |                    |         ----------------------->-->
-     *  |                    |         O----------------------+--+   low addresses
-     *  |                    |         |          |           |  |
-     *  |             w      |         |          | .top      |  |
-     *  |       <--------->  |         |          V           |  |
-     *  |       +---------+  |         |     +---------+      |  |
-     *  |       |     ^   |  | ======> |     |         |      |  |
-     *  |   x   |    h|   |  |         |.left|         |      |  |
-     *  +------>|     v   |  |         +---->|         |      |  |
-     *  |       +.........+  |         |     +.........+      |  |
-     *  |            ^       |         |                      |  |
-     *  |          y |       |         +----------------------+--+  high addresses
-     *  O------------+-------+
+	 *  
+     *      +--------------------+
+     *      |                    |                .stride         .alignment
+     *      |                    |         ----------------------->-->
+     *      |                    |         O----------------------+--+   low addresses
+     *      |                    |         |          |           |  |
+     *      |             w      |         |          | .top      |  |
+     *      |       <--------->  |         |          V           |  |
+     *      |       +---------+  |         |     +---------+      |  |
+     *      |       |     ^   |  | ======> |     |         |      |  |
+     *      |   x   |    h|   |  |         |.left|         |      |  |
+     *      +------>|     v   |  |         +---->|         |      |  |
+     *      |       +.........+  |         |     +.........+      |  |
+     *      |            ^       |         |                      |  |
+     *      |          y |       |         +----------------------+--+  high addresses
+     *      O------------+-------+
      *
      *
      * Typically readPixels() will be called after render() and before endFrame().


### PR DESCRIPTION
Clean up doxygen formatting of `Renderer::readPixels`.