### PR TITLE
Vulkan: fix image view type for render target attachments.

### DIFF
--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -679,7 +679,7 @@ void VulkanTexture::setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel) 
     getImageView(mPrimaryViewRange);
 }
 
-VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range) {
+VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, bool force2D) {
     auto iter = mCachedImageViews.find(range);
     if (iter != mCachedImageViews.end()) {
         return iter->second;
@@ -689,7 +689,7 @@ VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range) {
         .pNext = nullptr,
         .flags = 0,
         .image = mTextureImage,
-        .viewType = mViewType,
+        .viewType = force2D ? VK_IMAGE_VIEW_TYPE_2D : mViewType,
         .format = mVkFormat,
         .components = mSwizzle,
         .subresourceRange = range

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -143,7 +143,9 @@ struct VulkanTexture : public HwTexture {
     void setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel);
 
     // Gets or creates a cached VkImageView for a range of miplevels and array layers.
-    VkImageView getImageView(VkImageSubresourceRange range);
+    // If force2D is true, this always returns an image view that has type = VK_IMAGE_VIEW_TYPE_2D,
+    // regardless of the type of the primary image view.
+    VkImageView getImageView(VkImageSubresourceRange range, bool force2D = false);
 
     // Convenient "single subresource" overload for the above method.
     VkImageView getImageView(int singleLevel, int singleLayer, VkImageAspectFlags aspect) {
@@ -153,7 +155,7 @@ struct VulkanTexture : public HwTexture {
             .levelCount = uint32_t(1),
             .baseArrayLayer = uint32_t(singleLayer),
             .layerCount = uint32_t(1),
-        });
+        }, true);
     }
 
     VkFormat getVkFormat() const { return mVkFormat; }


### PR DESCRIPTION
When rendering into a single cubemap face, we should use
VK_IMAGE_VIEW_TYPE_2D rather than VK_IMAGE_VIEW_TYPE_CUBE.