### PR TITLE
ipbprefilter: simplify cpu side

### DIFF
--- a/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
+++ b/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
@@ -220,7 +220,6 @@ public:
         IBLPrefilterContext& mContext;
         filament::Material* mKernelMaterial = nullptr;
         filament::Texture* mKernelTexture = nullptr;
-        float* mKernelWeightArray = nullptr;
         uint32_t mSampleCount = 0u;
         uint8_t mLevelCount = 1u;
     };

--- a/libs/iblprefilter/src/materials/iblprefilter.mat
+++ b/libs/iblprefilter/src/materials/iblprefilter.mat
@@ -23,11 +23,6 @@ material {
         },
         {
             type : float,
-            name : invKernelWeight,
-            precision: high
-        },
-        {
-            type : float,
             name : lodOffset,
             precision: medium
         },
@@ -142,16 +137,20 @@ void postProcess(inout PostProcessInputs postProcess) {
     vec3 Ly = vec3(0);
     vec3 Lz = vec3(0);
 
+    float kernelWeight = 0.0;
     for (uint i = 0u ; i < materialParams.sampleCount ; i++) {
         // { L, lod }, with L.z == NoL
         mediump vec4 entry = texelFetch(materialParams_kernel, ivec2(materialParams.attachmentLevel, i), 0);
-        float l = entry.w + materialParams.lodOffset; // we don't need to clamp, the h/w does it for us
-        Lx += sampleEnvironment(materialParams_environment, Tx * entry.xyz, l) * entry.z;
-        Ly += sampleEnvironment(materialParams_environment, Ty * entry.xyz, l) * entry.z;
-        Lz += sampleEnvironment(materialParams_environment, Tz * entry.xyz, l) * entry.z;
+        if (entry.z > 0.0) {
+            float l = entry.w + materialParams.lodOffset;// we don't need to clamp, the h/w does it for us
+            Lx += sampleEnvironment(materialParams_environment, Tx * entry.xyz, l) * entry.z;
+            Ly += sampleEnvironment(materialParams_environment, Ty * entry.xyz, l) * entry.z;
+            Lz += sampleEnvironment(materialParams_environment, Tz * entry.xyz, l) * entry.z;
+            kernelWeight += entry.z;
+        }
     }
 
-    highp float invKernelWeight = materialParams.invKernelWeight;
+    float invKernelWeight = 1.0 / kernelWeight;
     Lx *= invKernelWeight;
     Ly *= invKernelWeight;
     Lz *= invKernelWeight;


### PR DESCRIPTION
- move kernel weight computation to the gpu side as a small cost, in
order to simplify the CPU side and reduce the binary size.

- skip samples with a weight of 0, which is a completely coherent 
check.

- fix a typo in move ctor