### PR TITLE
Fix Filament remote file upload

### DIFF
--- a/web/samples/remote.html
+++ b/web/samples/remote.html
@@ -210,8 +210,10 @@ class App {
         const connection = this.websocket;
         if (connection && connection.readyState == connection.OPEN) {
             console.info(`Uploading ${file.name}`);
-            connection.send(file.name);
-            connection.send(file);
+            file.arrayBuffer().then(buffer => {
+                connection.send(file.name);
+                connection.send(buffer);
+            });
         } else {
             this.pendingFile = file;
         }


### PR DESCRIPTION
With the latest Chrome update, `websocket.send(file)` no longer works. Chrome sends a binary message of length 0 bytes. `.send` accepts a `Blob` object, which `File` supposedly inherits from, but I bet we have to actually _read_ the entire file stream before sending it.