### PR TITLE
cleanup bloom

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -297,7 +297,6 @@ DECL_DRIVER_API_SYNCHRONOUS_N(bool, isTextureFormatMipmappable, backend::Texture
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isRenderTargetFormatSupported, backend::TextureFormat, format)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameBufferFetchSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, isFrameTimeSupported)
-DECL_DRIVER_API_SYNCHRONOUS_0(bool, areFeedbackLoopsSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(uint8_t, getMaxDrawBuffers)
 DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
 DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -663,10 +663,6 @@ bool MetalDriver::isFrameTimeSupported() {
     return false;
 }
 
-bool MetalDriver::areFeedbackLoopsSupported() {
-    return true;
-}
-
 math::float2 MetalDriver::getClipSpaceParams() {
     // z-coordinate of clip-space is in [0,w]
     return math::float2{ -0.5f, 0.5f };

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -167,10 +167,6 @@ bool NoopDriver::isFrameTimeSupported() {
     return true;
 }
 
-bool NoopDriver::areFeedbackLoopsSupported() {
-    return true;
-}
-
 math::float2 NoopDriver::getClipSpaceParams() {
     return math::float2{ -1.0f, 0.0f };
 }

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -102,11 +102,6 @@ OpenGLContext::OpenGLContext() noexcept {
     } else if (strstr(renderer, "Mozilla")) {
         bugs.disable_invalidate_framebuffer = true;
     }
-#if defined(__EMSCRIPTEN__)
-    // Chrome does not support feedback loops in WebGL 2.0. See also:
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1066201
-    bugs.disable_feedback_loops = true;
-#endif
 
     // now we can query getter and features
     glGetIntegerv(GL_MAX_RENDERBUFFER_SIZE, &gets.max_renderbuffer_size);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1702,10 +1702,6 @@ bool OpenGLDriver::isFrameTimeSupported() {
     return mFrameTimeSupported;
 }
 
-bool OpenGLDriver::areFeedbackLoopsSupported() {
-    return !mContext.bugs.disable_feedback_loops;
-}
-
 math::float2 OpenGLDriver::getClipSpaceParams() {
     return mContext.ext.EXT_clip_control ?
             math::float2{ -0.5f, 0.5f } : math::float2{ -1.0f, 0.0f };

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -778,10 +778,6 @@ bool VulkanDriver::isFrameTimeSupported() {
     return true;
 }
 
-bool VulkanDriver::areFeedbackLoopsSupported() {
-    return true;
-}
-
 math::float2 VulkanDriver::getClipSpaceParams() {
     // z-coordinate of clip-space is in [0,w]
     return math::float2{ -0.5f, 0.5f };

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -230,7 +230,6 @@ static const MaterialInfo sMaterialList[] = {
 void PostProcessManager::init() noexcept {
     auto& engine = mEngine;
     DriverApi& driver = engine.getDriverApi();
-    mDisableFeedbackLoops = !driver.areFeedbackLoopsSupported();
 
     #pragma nounroll
     for (auto const& info : sMaterialList) {
@@ -1341,9 +1340,27 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
     return ppDoFCombine->output;
 }
 
+FrameGraphId<FrameGraphTexture> PostProcessManager::bloom(FrameGraph& fg,
+        FrameGraphId<FrameGraphTexture> input, TextureFormat outFormat,
+        View::BloomOptions& bloomOptions, float2 scale) noexcept {
+    FrameGraphId<FrameGraphTexture> bloom = bloomPass(fg, input,
+            outFormat, bloomOptions, scale);
+
+    fg.getBlackboard().put("bloom", bloom);
+
+    return bloom;
+}
+
 FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPass(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> input, TextureFormat outFormat,
         View::BloomOptions& bloomOptions, float2 scale) noexcept {
+    // Chrome does not support feedback loops in WebGL 2.0. See also:
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1066201
+#if defined(__EMSCRIPTEN__)
+    constexpr bool isWebGL = true;
+#else
+    constexpr bool isWebGL = false;
+#endif
 
     Handle<HwRenderPrimitive> fullScreenRenderPrimitive = mEngine.getFullScreenRenderPrimitive();
 
@@ -1379,308 +1396,289 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPass(FrameGraph& fg,
         });
     }
 
-    struct BloomPassData {
-        FrameGraphId<FrameGraphTexture> in;
-        FrameGraphId<FrameGraphTexture> out;
-    };
+    if constexpr(!isWebGL) {
 
-    // downsample phase
-    auto& bloomDownsamplePass = fg.addPass<BloomPassData>("Bloom Downsample",
-            [&](FrameGraph::Builder& builder, auto& data) {
-                data.in = builder.sample(input);
-                data.out = builder.createTexture("Bloom Texture", {
-                        .width = width,
-                        .height = height,
-                        .levels = bloomOptions.levels,
-                        .format = outFormat
-                });
+        struct BloomPassData {
+            FrameGraphId<FrameGraphTexture> in;
+            FrameGraphId<FrameGraphTexture> out;
+        };
 
-                data.out = builder.sample(data.out);
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    auto out = builder.createSubresource(data.out, "Bloom Texture mip", { .level = uint8_t(i) });
-                    builder.declareRenderPass(out);
-                }
-            },
-            [=](FrameGraphResources const& resources,
-                    auto const& data, DriverApi& driver) {
-
-                auto const& material = getPostProcessMaterial("bloomDownsample");
-                FMaterialInstance* mi = material.getMaterialInstance();
-
-                const PipelineState pipeline(material.getPipelineState());
-
-                auto hwIn = resources.getTexture(data.in);
-                auto hwOut = resources.getTexture(data.out);
-                auto const& outDesc = resources.getDescriptor(data.out);
-
-                mi->use(driver);
-                mi->setParameter("source", hwIn,  {
-                        .filterMag = SamplerMagFilter::LINEAR,
-                        .filterMin = SamplerMinFilter::LINEAR /* level is always 0 */
-                });
-                mi->setParameter("level", 0.0f);
-                mi->setParameter("threshold", bloomOptions.threshold ? 1.0f : 0.0f);
-                mi->setParameter("invHighlight", std::isinf(bloomOptions.highlight) ? 0.0f : 1.0f / bloomOptions.highlight);
-
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    auto hwOutRT = resources.getRenderPassInfo(i);
-
-                    auto w = FTexture::valueForLevel(i, outDesc.width);
-                    auto h = FTexture::valueForLevel(i, outDesc.height);
-                    mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
-                    mi->commit(driver);
-
-                    hwOutRT.params.flags.discardStart = TargetBufferFlags::COLOR;
-                    hwOutRT.params.flags.discardEnd = TargetBufferFlags::NONE;
-                    driver.beginRenderPass(hwOutRT.target, hwOutRT.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive);
-                    driver.endRenderPass();
-
-                    // prepare the next level
-                    mi->setParameter("source", hwOut,  {
-                            .filterMag = SamplerMagFilter::LINEAR,
-                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+        // downsample phase
+        auto& bloomDownsamplePass = fg.addPass<BloomPassData>("Bloom Downsample",
+                [&](FrameGraph::Builder& builder, auto& data) {
+                    data.in = builder.sample(input);
+                    data.out = builder.createTexture("Bloom Texture", {
+                            .width = width,
+                            .height = height,
+                            .levels = bloomOptions.levels,
+                            .format = outFormat
                     });
-                    mi->setParameter("level", float(i));
-                    driver.setMinMaxLevels(hwOut, i, i); // safe because we're using LINEAR_MIPMAP_NEAREST
-                }
-            });
 
-    input = bloomDownsamplePass->out;
+                    data.out = builder.sample(data.out);
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        auto out = builder.createSubresource(data.out, "Bloom Texture mip",
+                                { .level = uint8_t(i) });
+                        builder.declareRenderPass(out);
+                    }
+                },
+                [=](FrameGraphResources const& resources,
+                        auto const& data, DriverApi& driver) {
 
-    // upsample phase
-    auto& bloomUpsamplePass = fg.addPass<BloomPassData>("Bloom Upsample",
-            [&](FrameGraph::Builder& builder, auto& data) {
-                data.in = builder.sample(input);
-                data.out = input;
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    auto out = builder.createSubresource(data.out, "Bloom Texture mip", { .level = uint8_t(i) });
-                    builder.declareRenderPass(out);
-                }
-            },
-            [=](FrameGraphResources const& resources,
-                    auto const& data, DriverApi& driver) {
+                    auto const& material = getPostProcessMaterial("bloomDownsample");
+                    FMaterialInstance* mi = material.getMaterialInstance();
 
-                auto hwIn = resources.getTexture(data.in);
-                auto const& outDesc = resources.getDescriptor(data.out);
+                    const PipelineState pipeline(material.getPipelineState());
 
-                auto const& material = getPostProcessMaterial("bloomUpsample");
-                FMaterialInstance* mi = material.getMaterialInstance();
-                PipelineState pipeline(material.getPipelineState());
-                pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
-                pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
+                    auto hwIn = resources.getTexture(data.in);
+                    auto hwOut = resources.getTexture(data.out);
+                    auto const& outDesc = resources.getDescriptor(data.out);
 
-                mi->use(driver);
-
-                for (size_t i = bloomOptions.levels - 1; i >= 1; i--) {
-                    auto hwDstRT = resources.getRenderPassInfo(i - 1);
-                    hwDstRT.params.flags.discardStart = TargetBufferFlags::NONE; // because we'll blend
-                    hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
-
-                    auto w = FTexture::valueForLevel(i - 1, outDesc.width);
-                    auto h = FTexture::valueForLevel(i - 1, outDesc.height);
-                    mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
+                    mi->use(driver);
                     mi->setParameter("source", hwIn, {
                             .filterMag = SamplerMagFilter::LINEAR,
-                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                            .filterMin = SamplerMinFilter::LINEAR /* level is always 0 */
                     });
-                    mi->setParameter("level", float(i));
-                    driver.setMinMaxLevels(hwIn, i, i);
-                    mi->commit(driver);
+                    mi->setParameter("level", 0.0f);
+                    mi->setParameter("threshold", bloomOptions.threshold ? 1.0f : 0.0f);
+                    mi->setParameter("invHighlight",
+                            std::isinf(bloomOptions.highlight) ? 0.0f : 1.0f
+                                                                        / bloomOptions.highlight);
 
-                    driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive);
-                    driver.endRenderPass();
-                }
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        auto hwOutRT = resources.getRenderPassInfo(i);
 
-                driver.setMinMaxLevels(hwIn, 0, bloomOptions.levels - 1);
-            });
+                        auto w = FTexture::valueForLevel(i, outDesc.width);
+                        auto h = FTexture::valueForLevel(i, outDesc.height);
+                        mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
+                        mi->commit(driver);
 
-    return bloomUpsamplePass->out;
-}
+                        hwOutRT.params.flags.discardStart = TargetBufferFlags::COLOR;
+                        hwOutRT.params.flags.discardEnd = TargetBufferFlags::NONE;
+                        driver.beginRenderPass(hwOutRT.target, hwOutRT.params);
+                        driver.draw(pipeline, fullScreenRenderPrimitive);
+                        driver.endRenderPass();
 
-FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPassPingPong(FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> input, TextureFormat outFormat,
-        View::BloomOptions& bloomOptions, float2 scale) noexcept {
-
-    Handle<HwRenderPrimitive> fullScreenRenderPrimitive = mEngine.getFullScreenRenderPrimitive();
-
-    // Figure out a good size for the bloom buffer. We pick the major axis lower
-    // power of two, and scale the minor axis accordingly taking dynamic scaling into account.
-    auto const& desc = fg.getDescriptor(input);
-    uint32_t width = desc.width / scale.x;
-    uint32_t height = desc.height / scale.y;
-    if (bloomOptions.anamorphism >= 1.0) {
-        height *= bloomOptions.anamorphism;
-    } else if (bloomOptions.anamorphism < 1.0) {
-        width *= 1.0f / std::max(bloomOptions.anamorphism, 1.0f / 4096.0f);
-    }
-    uint32_t& major = width > height ? width : height;
-    uint32_t& minor = width < height ? width : height;
-    uint32_t newMinor = clamp(bloomOptions.resolution,
-            1u << bloomOptions.levels, std::min(minor, 1u << kMaxBloomLevels));
-    major = major * uint64_t(newMinor) / minor;
-    minor = newMinor;
-
-    // we might need to adjust the max # of levels
-    const uint8_t maxLevels = FTexture::maxLevelCount(major);
-    bloomOptions.levels = std::min(bloomOptions.levels, maxLevels);
-    bloomOptions.levels = std::min(bloomOptions.levels, kMaxBloomLevels);
-
-    if (2 * width < desc.width || 2 * height < desc.height) {
-        // if we're scaling down by more than 2x, prescale the image with a blit to improve
-        // performance. This is important on mobile/tilers.
-        input = opaqueBlit(fg, input, {
-                .width = desc.width / 2,
-                .height = desc.height / 2,
-                .format = outFormat
-        });
-    }
-
-    struct BloomPassData {
-        FrameGraphId<FrameGraphTexture> in;
-        FrameGraphId<FrameGraphTexture> out;
-        FrameGraphId<FrameGraphTexture> stage;
-        uint32_t outRT[kMaxBloomLevels];
-        uint32_t stageRT[kMaxBloomLevels];
-    };
-
-    // downsample phase
-    auto& bloomDownsamplePass = fg.addPass<BloomPassData>("Bloom Downsample",
-            [&](FrameGraph::Builder& builder, auto& data) {
-                data.in = builder.sample(input);
-                data.out = builder.createTexture("Bloom Out Texture", {
-                        .width = width,
-                        .height = height,
-                        .levels = bloomOptions.levels,
-                        .format = outFormat
+                        // prepare the next level
+                        mi->setParameter("source", hwOut, {
+                                .filterMag = SamplerMagFilter::LINEAR,
+                                .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                        });
+                        mi->setParameter("level", float(i));
+                        driver.setMinMaxLevels(hwOut, i,
+                                i); // safe because we're using LINEAR_MIPMAP_NEAREST
+                    }
                 });
-                data.out = builder.sample(data.out);
 
-                data.stage = builder.createTexture("Bloom Stage Texture", {
-                        .width = width,
-                        .height = height,
-                        .levels = bloomOptions.levels,
-                        .format = outFormat
+        input = bloomDownsamplePass->out;
+
+        // upsample phase
+        auto& bloomUpsamplePass = fg.addPass<BloomPassData>("Bloom Upsample",
+                [&](FrameGraph::Builder& builder, auto& data) {
+                    data.in = builder.sample(input);
+                    data.out = input;
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        auto out = builder.createSubresource(data.out, "Bloom Texture mip",
+                                { .level = uint8_t(i) });
+                        builder.declareRenderPass(out);
+                    }
+                },
+                [=](FrameGraphResources const& resources,
+                        auto const& data, DriverApi& driver) {
+
+                    auto hwIn = resources.getTexture(data.in);
+                    auto const& outDesc = resources.getDescriptor(data.out);
+
+                    auto const& material = getPostProcessMaterial("bloomUpsample");
+                    FMaterialInstance* mi = material.getMaterialInstance();
+                    PipelineState pipeline(material.getPipelineState());
+                    pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
+                    pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
+
+                    mi->use(driver);
+
+                    for (size_t i = bloomOptions.levels - 1; i >= 1; i--) {
+                        auto hwDstRT = resources.getRenderPassInfo(i - 1);
+                        hwDstRT.params
+                               .flags
+                               .discardStart = TargetBufferFlags::NONE; // because we'll blend
+                        hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
+
+                        auto w = FTexture::valueForLevel(i - 1, outDesc.width);
+                        auto h = FTexture::valueForLevel(i - 1, outDesc.height);
+                        mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
+                        mi->setParameter("source", hwIn, {
+                                .filterMag = SamplerMagFilter::LINEAR,
+                                .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                        });
+                        mi->setParameter("level", float(i));
+                        driver.setMinMaxLevels(hwIn, i, i);
+                        mi->commit(driver);
+
+                        driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
+                        driver.draw(pipeline, fullScreenRenderPrimitive);
+                        driver.endRenderPass();
+                    }
+
+                    driver.setMinMaxLevels(hwIn, 0, bloomOptions.levels - 1);
                 });
-                data.stage = builder.sample(data.stage);
+        return bloomUpsamplePass->out;
 
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    auto out = builder.createSubresource(data.out, "Bloom Out Texture mip", { .level = uint8_t(i) });
-                    auto stage = builder.createSubresource(data.stage, "Bloom Stage Texture mip", { .level = uint8_t(i) });
-                    builder.declareRenderPass(out, &data.outRT[i]);
-                    builder.declareRenderPass(stage, &data.stageRT[i]);
-                }
-            },
-            [=](FrameGraphResources const& resources,
-                    auto const& data, DriverApi& driver) {
+    } else { // !isWebGL
 
-                auto const& material = getPostProcessMaterial("bloomDownsample");
-                FMaterialInstance* mi = material.getMaterialInstance();
+        struct BloomPassData {
+            FrameGraphId<FrameGraphTexture> in;
+            FrameGraphId<FrameGraphTexture> out;
+            FrameGraphId<FrameGraphTexture> stage;
+            uint32_t outRT[kMaxBloomLevels];
+            uint32_t stageRT[kMaxBloomLevels];
+        };
 
-                const PipelineState pipeline(material.getPipelineState());
+        // downsample phase
+        auto& bloomDownsamplePass = fg.addPass<BloomPassData>("Bloom Downsample",
+                [&](FrameGraph::Builder& builder, auto& data) {
+                    data.in = builder.sample(input);
+                    data.out = builder.createTexture("Bloom Out Texture", {
+                            .width = width,
+                            .height = height,
+                            .levels = bloomOptions.levels,
+                            .format = outFormat
+                    });
+                    data.out = builder.sample(data.out);
 
-                auto hwIn = resources.getTexture(data.in);
-                auto hwOut = resources.getTexture(data.out);
-                auto hwStage = resources.getTexture(data.stage);
-                auto const& outDesc = resources.getDescriptor(data.out);
+                    data.stage = builder.createTexture("Bloom Stage Texture", {
+                            .width = width,
+                            .height = height,
+                            .levels = bloomOptions.levels,
+                            .format = outFormat
+                    });
+                    data.stage = builder.sample(data.stage);
 
-                mi->use(driver);
-                mi->setParameter("source", hwIn,  {
-                        .filterMag = SamplerMagFilter::LINEAR,
-                        .filterMin = SamplerMinFilter::LINEAR /* level is always 0 */
-                });
-                mi->setParameter("level", 0.0f);
-                mi->setParameter("threshold", bloomOptions.threshold ? 1.0f : 0.0f);
-                mi->setParameter("invHighlight", std::isinf(bloomOptions.highlight) ? 0.0f : 1.0f / bloomOptions.highlight);
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        auto out = builder.createSubresource(data.out, "Bloom Out Texture mip",
+                                { .level = uint8_t(i) });
+                        auto stage = builder.createSubresource(data.stage,
+                                "Bloom Stage Texture mip", { .level = uint8_t(i) });
+                        builder.declareRenderPass(out, &data.outRT[i]);
+                        builder.declareRenderPass(stage, &data.stageRT[i]);
+                    }
+                },
+                [=](FrameGraphResources const& resources,
+                        auto const& data, DriverApi& driver) {
 
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    const bool parity = (i % 2) == 0;
-                    auto hwDstRT = resources.getRenderPassInfo(parity ? data.outRT[i] : data.stageRT[i]);
+                    auto const& material = getPostProcessMaterial("bloomDownsample");
+                    FMaterialInstance* mi = material.getMaterialInstance();
 
-                    auto w = FTexture::valueForLevel(i, outDesc.width);
-                    auto h = FTexture::valueForLevel(i, outDesc.height);
-                    mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
-                    mi->commit(driver);
+                    const PipelineState pipeline(material.getPipelineState());
 
-                    hwDstRT.params.flags.discardStart = TargetBufferFlags::COLOR;
-                    hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
-                    driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive);
-                    driver.endRenderPass();
+                    auto hwIn = resources.getTexture(data.in);
+                    auto hwOut = resources.getTexture(data.out);
+                    auto hwStage = resources.getTexture(data.stage);
+                    auto const& outDesc = resources.getDescriptor(data.out);
 
-                    // prepare the next level
-                    mi->setParameter("source", parity ? hwOut : hwStage,  {
+                    mi->use(driver);
+                    mi->setParameter("source", hwIn, {
                             .filterMag = SamplerMagFilter::LINEAR,
-                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                            .filterMin = SamplerMinFilter::LINEAR /* level is always 0 */
                     });
-                    mi->setParameter("level", float(i));
-                }
-            });
+                    mi->setParameter("level", 0.0f);
+                    mi->setParameter("threshold", bloomOptions.threshold ? 1.0f : 0.0f);
+                    mi->setParameter("invHighlight",
+                            std::isinf(bloomOptions.highlight) ? 0.0f : 1.0f
+                                                                        / bloomOptions.highlight);
 
-    FrameGraphId<FrameGraphTexture> output = bloomDownsamplePass->out;
-    FrameGraphId<FrameGraphTexture> stage = bloomDownsamplePass->stage;
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        const bool parity = (i % 2) == 0;
+                        auto hwDstRT = resources.getRenderPassInfo(
+                                parity ? data.outRT[i] : data.stageRT[i]);
 
-    // upsample phase
-    auto& bloomUpsamplePass = fg.addPass<BloomPassData>("Bloom Upsample",
-            [&](FrameGraph::Builder& builder, auto& data) {
-                data.out = builder.sample(output);
-                data.stage = builder.sample(stage);
-                for (size_t i = 0; i < bloomOptions.levels; i++) {
-                    auto out = builder.createSubresource(data.out, "Bloom Out Texture mip", { .level = uint8_t(i) });
-                    auto stage = builder.createSubresource(data.stage, "Bloom Stage Texture mip", { .level = uint8_t(i) });
-                    builder.declareRenderPass(out, &data.outRT[i]);
-                    builder.declareRenderPass(stage, &data.stageRT[i]);
-                }
-            },
-            [=](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
+                        auto w = FTexture::valueForLevel(i, outDesc.width);
+                        auto h = FTexture::valueForLevel(i, outDesc.height);
+                        mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
+                        mi->commit(driver);
 
-                auto hwOut = resources.getTexture(data.out);
-                auto hwStage = resources.getTexture(data.stage);
-                auto const& outDesc = resources.getDescriptor(data.out);
+                        hwDstRT.params.flags.discardStart = TargetBufferFlags::COLOR;
+                        hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
+                        driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
+                        driver.draw(pipeline, fullScreenRenderPrimitive);
+                        driver.endRenderPass();
 
-                auto const& material = getPostProcessMaterial("bloomUpsample");
-                FMaterialInstance* mi = material.getMaterialInstance();
-                PipelineState pipeline(material.getPipelineState());
-                pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
-                pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
+                        // prepare the next level
+                        mi->setParameter("source", parity ? hwOut : hwStage, {
+                                .filterMag = SamplerMagFilter::LINEAR,
+                                .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                        });
+                        mi->setParameter("level", float(i));
+                    }
+                });
 
-                mi->use(driver);
+        FrameGraphId<FrameGraphTexture> output = bloomDownsamplePass->out;
+        FrameGraphId<FrameGraphTexture> stage = bloomDownsamplePass->stage;
 
-                for (size_t j = bloomOptions.levels, i = j - 1; i >= 1; i--, j++) {
-                    const bool parity = (j % 2) == 0;
+        // upsample phase
+        auto& bloomUpsamplePass = fg.addPass<BloomPassData>("Bloom Upsample",
+                [&](FrameGraph::Builder& builder, auto& data) {
+                    data.out = builder.sample(output);
+                    data.stage = builder.sample(stage);
+                    for (size_t i = 0; i < bloomOptions.levels; i++) {
+                        auto out = builder.createSubresource(data.out, "Bloom Out Texture mip",
+                                { .level = uint8_t(i) });
+                        auto stage = builder.createSubresource(data.stage,
+                                "Bloom Stage Texture mip", { .level = uint8_t(i) });
+                        builder.declareRenderPass(out, &data.outRT[i]);
+                        builder.declareRenderPass(stage, &data.stageRT[i]);
+                    }
+                },
+                [=](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
 
-                    auto hwDstRT = resources.getRenderPassInfo(parity ? data.outRT[i - 1] : data.stageRT[i - 1]);
-                    hwDstRT.params.flags.discardStart = TargetBufferFlags::NONE; // because we'll blend
-                    hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
+                    auto hwOut = resources.getTexture(data.out);
+                    auto hwStage = resources.getTexture(data.stage);
+                    auto const& outDesc = resources.getDescriptor(data.out);
 
-                    auto w = FTexture::valueForLevel(i - 1, outDesc.width);
-                    auto h = FTexture::valueForLevel(i - 1, outDesc.height);
-                    mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
-                    mi->setParameter("source", parity ? hwStage : hwOut, {
-                            .filterMag = SamplerMagFilter::LINEAR,
-                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
-                    });
-                    mi->setParameter("level", float(i));
-                    mi->commit(driver);
+                    auto const& material = getPostProcessMaterial("bloomUpsample");
+                    FMaterialInstance* mi = material.getMaterialInstance();
+                    PipelineState pipeline(material.getPipelineState());
+                    pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
+                    pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE;
 
-                    driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
-                    driver.draw(pipeline, fullScreenRenderPrimitive);
-                    driver.endRenderPass();
-                }
+                    mi->use(driver);
 
-                // Every other level is missing from the out texture, so we need to do
-                // blits to complete the chain.
-                const SamplerMagFilter filter = SamplerMagFilter::NEAREST;
-                for (size_t i = 1; i < bloomOptions.levels; i += 2) {
-                    auto in = resources.getRenderPassInfo(data.stageRT[i]);
-                    auto out = resources.getRenderPassInfo(data.outRT[i]);
-                    driver.blit(TargetBufferFlags::COLOR, out.target, out.params.viewport,
-                            in.target, in.params.viewport, filter);
-                }
-            });
+                    for (size_t j = bloomOptions.levels, i = j - 1; i >= 1; i--, j++) {
+                        const bool parity = (j % 2) == 0;
 
-    return bloomUpsamplePass->out;
+                        auto hwDstRT = resources.getRenderPassInfo(
+                                parity ? data.outRT[i - 1] : data.stageRT[i - 1]);
+                        hwDstRT.params
+                               .flags
+                               .discardStart = TargetBufferFlags::NONE; // because we'll blend
+                        hwDstRT.params.flags.discardEnd = TargetBufferFlags::NONE;
+
+                        auto w = FTexture::valueForLevel(i - 1, outDesc.width);
+                        auto h = FTexture::valueForLevel(i - 1, outDesc.height);
+                        mi->setParameter("resolution", float4{ w, h, 1.0f / w, 1.0f / h });
+                        mi->setParameter("source", parity ? hwStage : hwOut, {
+                                .filterMag = SamplerMagFilter::LINEAR,
+                                .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                        });
+                        mi->setParameter("level", float(i));
+                        mi->commit(driver);
+
+                        driver.beginRenderPass(hwDstRT.target, hwDstRT.params);
+                        driver.draw(pipeline, fullScreenRenderPrimitive);
+                        driver.endRenderPass();
+                    }
+
+                    // Every other level is missing from the out texture, so we need to do
+                    // blits to complete the chain.
+                    const SamplerMagFilter filter = SamplerMagFilter::NEAREST;
+                    for (size_t i = 1; i < bloomOptions.levels; i += 2) {
+                        auto in = resources.getRenderPassInfo(data.stageRT[i]);
+                        auto out = resources.getRenderPassInfo(data.outRT[i]);
+                        driver.blit(TargetBufferFlags::COLOR, out.target, out.params.viewport,
+                                in.target, in.params.viewport, filter);
+                    }
+                });
+        return bloomUpsamplePass->out;
+    }
 }
 
 static float4 getVignetteParameters(View::VignetteOptions options, uint32_t width, uint32_t height) {
@@ -1712,8 +1710,8 @@ static float4 getVignetteParameters(View::VignetteOptions options, uint32_t widt
 }
 
 void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
-        const FColorGrading* colorGrading, View::VignetteOptions vignetteOptions, bool fxaa,
-        bool dithering, uint32_t width, uint32_t height) noexcept {
+        const FColorGrading* colorGrading, ColorGradingConfig const& colorGradingConfig,
+        View::VignetteOptions vignetteOptions, uint32_t width, uint32_t height) noexcept {
 
     float4 vignetteParameters = getVignetteParameters(vignetteOptions, width, height);
 
@@ -1728,13 +1726,14 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
 
     mi->setParameter("vignette", vignetteParameters);
     mi->setParameter("vignetteColor", vignetteOptions.color);
-    mi->setParameter("dithering", dithering);
-    mi->setParameter("fxaa", fxaa);
+    mi->setParameter("dithering", colorGradingConfig.dithering);
+    mi->setParameter("fxaa", colorGradingConfig.fxaa);
     mi->setParameter("temporalNoise", temporalNoise);
     mi->commit(driver);
 }
 
-void PostProcessManager::colorGradingSubpass(DriverApi& driver,  bool translucent) noexcept {
+void PostProcessManager::colorGradingSubpass(DriverApi& driver,
+        ColorGradingConfig const& colorGradingConfig) noexcept {
     FEngine& engine = mEngine;
     Handle<HwRenderPrimitive> const& fullScreenRenderPrimitive = engine.getFullScreenRenderPrimitive();
 
@@ -1742,7 +1741,7 @@ void PostProcessManager::colorGradingSubpass(DriverApi& driver,  bool translucen
     // the UBO has been set and committed in colorGradingPrepareSubpass()
     FMaterialInstance* mi = material.getMaterialInstance();
     mi->use(driver);
-    const uint8_t variant = uint8_t(translucent ?
+    const uint8_t variant = uint8_t(colorGradingConfig.translucent ?
             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
     driver.nextSubpass();
@@ -1750,29 +1749,21 @@ void PostProcessManager::colorGradingSubpass(DriverApi& driver,  bool translucen
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
-        FrameGraphId<FrameGraphTexture> input, const FColorGrading* colorGrading,
-        TextureFormat outFormat, bool translucent, bool fxaa, float2 scale,
-        View::BloomOptions bloomOptions, View::VignetteOptions vignetteOptions, bool dithering) noexcept {
+        FrameGraphId<FrameGraphTexture> input, float2 scale,
+        const FColorGrading* colorGrading, ColorGradingConfig const& colorGradingConfig,
+        View::BloomOptions bloomOptions, View::VignetteOptions vignetteOptions) noexcept
+{
+    Blackboard& blackboard = fg.getBlackboard();
 
-    struct PostProcessColorGrading {
-        FrameGraphId<FrameGraphTexture> input;
-        FrameGraphId<FrameGraphTexture> output;
-        FrameGraphId<FrameGraphTexture> bloom;
-        FrameGraphId<FrameGraphTexture> dirt;
-    };
-
-    FrameGraphId<FrameGraphTexture> bloomBlur;
     FrameGraphId<FrameGraphTexture> bloomDirt;
+    FrameGraphId<FrameGraphTexture> bloomBlur = blackboard.get<FrameGraphTexture>("bloom");
 
     float bloom = 0.0f;
     if (bloomOptions.enabled) {
         bloom = clamp(bloomOptions.strength, 0.0f, 1.0f);
-        bloomBlur = mDisableFeedbackLoops ?
-                bloomPassPingPong(fg, input, TextureFormat::R11F_G11F_B10F, bloomOptions, scale) :
-                bloomPass(fg, input, TextureFormat::R11F_G11F_B10F, bloomOptions, scale);
         if (bloomOptions.dirt) {
             FTexture* fdirt = upcast(bloomOptions.dirt);
-            FrameGraphTexture frameGraphTexture { .handle = fdirt->getHwHandle() };
+            FrameGraphTexture frameGraphTexture{ .handle = fdirt->getHwHandle() };
             bloomDirt = fg.import("dirt", {
                     .width = (uint32_t)fdirt->getWidth(0u),
                     .height = (uint32_t)fdirt->getHeight(0u),
@@ -1781,6 +1772,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
         }
     }
 
+    struct PostProcessColorGrading {
+        FrameGraphId<FrameGraphTexture> input;
+        FrameGraphId<FrameGraphTexture> output;
+        FrameGraphId<FrameGraphTexture> bloom;
+        FrameGraphId<FrameGraphTexture> dirt;
+    };
+
     auto& ppColorGrading = fg.addPass<PostProcessColorGrading>("colorGrading",
             [&](FrameGraph::Builder& builder, auto& data) {
                 auto const& inputDesc = fg.getDescriptor(input);
@@ -1788,7 +1786,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                 data.output = builder.createTexture("colorGrading output", {
                         .width = inputDesc.width,
                         .height = inputDesc.height,
-                        .format = outFormat
+                        .format = colorGradingConfig.ldrFormat
                 });
                 data.output = builder.declareRenderPass(data.output);
 
@@ -1843,14 +1841,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
 
                 const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
 
-                mi->setParameter("dithering", dithering);
+                mi->setParameter("dithering", colorGradingConfig.dithering);
                 mi->setParameter("bloom", bloomParameters);
                 mi->setParameter("vignette", vignetteParameters);
                 mi->setParameter("vignetteColor", vignetteOptions.color);
-                mi->setParameter("fxaa", fxaa);
+                mi->setParameter("fxaa", colorGradingConfig.fxaa);
                 mi->setParameter("temporalNoise", temporalNoise);
 
-                const uint8_t variant = uint8_t(translucent ?
+                const uint8_t variant = uint8_t(colorGradingConfig.translucent ?
                             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
                 commitAndRender(out, material, variant, driver);
@@ -2034,7 +2032,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
                 driver.beginRenderPass(out.target, out.params);
                 driver.draw(material.getPipelineState(variant), mEngine.getFullScreenRenderPrimitive());
                 if (colorGradingConfig.asSubpass) {
-                    colorGradingSubpass(driver, colorGradingConfig.translucent);
+                    colorGradingSubpass(driver, colorGradingConfig);
                 }
                 driver.endRenderPass();
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -83,17 +83,24 @@ public:
             const View::DepthOfFieldOptions& dofOptions, bool translucent,
             const CameraInfo& cameraInfo, math::float2 scale) noexcept;
 
-    // Color grading, tone mapping, etc.
+    // Bloom
+    FrameGraphId<FrameGraphTexture> bloom(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
+            View::BloomOptions& bloomOptions, math::float2 scale) noexcept;
+
+    // Color grading, tone mapping, dithering and bloom
+    FrameGraphId<FrameGraphTexture> colorGrading(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input, math::float2 scale,
+            const FColorGrading* colorGrading, ColorGradingConfig const& colorGradingConfig,
+            View::BloomOptions bloomOptions, View::VignetteOptions vignetteOptions) noexcept;
+
     void colorGradingPrepareSubpass(backend::DriverApi& driver, const FColorGrading* colorGrading,
-            View::VignetteOptions vignetteOptions, bool fxaa, bool dithering,
+            ColorGradingConfig const& colorGradingConfig,
+            View::VignetteOptions vignetteOptions,
             uint32_t width, uint32_t height) noexcept;
 
-    void colorGradingSubpass(backend::DriverApi& driver, bool translucent) noexcept;
-
-    FrameGraphId<FrameGraphTexture> colorGrading(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, const FColorGrading* colorGrading,
-            backend::TextureFormat outFormat, bool translucent, bool fxaa, math::float2 scale,
-            View::BloomOptions bloomOptions, View::VignetteOptions vignetteOptions, bool dithering) noexcept;
+    void colorGradingSubpass(backend::DriverApi& driver,
+            ColorGradingConfig const& colorGradingConfig) noexcept;
 
     // Anti-aliasing
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
@@ -158,10 +165,6 @@ private:
             FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
             View::BloomOptions& bloomOptions, math::float2 scale) noexcept;
 
-    FrameGraphId<FrameGraphTexture> bloomPassPingPong(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
-            View::BloomOptions& bloomOptions, math::float2 scale) noexcept;
-
     void commitAndRender(FrameGraphResources::RenderPassInfo const& out,
             PostProcessMaterial const& material, uint8_t variant,
             backend::DriverApi& driver) const noexcept;
@@ -221,7 +224,6 @@ private:
     std::uniform_real_distribution<float> mUniformDistribution{0.0f, 1.0f};
 
     const math::float2 mHaltonSamples[16];
-    bool mDisableFeedbackLoops;
 };
 
 

--- a/filament/src/materials/bloom/bloomDownsample.mat
+++ b/filament/src/materials/bloom/bloomDownsample.mat
@@ -39,11 +39,13 @@ vertex {
 }
 
 fragment {
+
+    void dummy(){}
+
     void threshold(inout vec3 c) {
         float l = max3(c);
         highp float f = l;
-        c *= 1.0 / (1.0 + f * materialParams.invHighlight);
-        c *= step(1.0, l);
+        c *= step(1.0, l) / (1.0 + f * materialParams.invHighlight);
     }
 
     vec3 box4x4(vec3 s0, vec3 s1, vec3 s2, vec3 s3) {


### PR DESCRIPTION
- remove areFeedbackLoopsSupported from backend API, since this is only
  a problem on WebGL

- binary only include either the regular or webgl version of the bloom
  code, never both, which should save some binary size

- bloom pass is now called outside of the colorGrading pass, which is
  cleaner and makes it available for other pass, should they need it
  (not the case right now).

- always pass ColorGradingConfig to all color grading related methods,
  instead of individual parameters

- very minor optimization in bloom shader