### PR TITLE
Use 16 bit format for VSM

### DIFF
--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -140,8 +140,7 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
                 };
 
                 if (view.hasVsm()) {
-                    // TODO: support 16-bit VSM depth textures.
-                    shadowTextureDesc.format = TextureFormat::RG32F;
+                    shadowTextureDesc.format = TextureFormat::RG16F;
                 }
 
                 data.shadows = builder.createTexture("Shadow Texture", shadowTextureDesc);


### PR DESCRIPTION
iOS (and possibly Android) doesn't support filtering from RG32F textures. There is no discernible quality difference between 32 and 16 bit, so I'll just make this the default for now.