### PR TITLE
Second memory leak fix in GL backend.

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1275,7 +1275,10 @@ void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, int) {
 
 void OpenGLDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     DEBUG_MARKER()
-    // Do nothing, because a VertexBuffer is just a collection of BufferObject handles.
+    if (vbh) {
+        GLVertexBuffer const* vb = handle_cast<const GLVertexBuffer*>(vbh);
+        destruct(vbh, vb);
+    }
 }
 
 void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {


### PR DESCRIPTION
The handle still needs to be destroyed.

Fixes #3888.