### PR TITLE
DoF: don't use hole filling for the background

### DIFF
--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -316,34 +316,8 @@ void accumulateBackground(inout Bucket curr, inout Bucket prev, const highp vec2
 void accumulateBackgroundMirror(inout Bucket curr, inout Bucket prev,
         const highp vec2 center, const vec2 offset,
         const float radius, const float border, const float mip, const bool first) {
-    // The code below is equivalent (without hole filling) to:
-    //  accumulateBackground(curr, prev, diaphragm(center,  offset), radius, border, mip, first);
-    //  accumulateBackground(curr, prev, diaphragm(center, -offset), radius, border, mip, first);
-    //  return;
-    // We use the technique used by Jimenez for the foreground applied to the background, where
-    // we "guess" the missing background information from neighboring pixels. In several papers it's
-    // not deemed useful for the background, however, it does improve the blur quality a lot very
-    // shallow DoF, i.e. when a moderately blurred background sits over a strongly blured one.
-    Sample tap0;
-    Sample tap1;
-
-    highp vec2 pos0 = diaphragm(center,  offset);
-    tap0.coc = textureLod(materialParams_coc, pos0, mip).r;
-
-    highp vec2 pos1 = diaphragm(center, -offset);
-    tap1.coc = textureLod(materialParams_coc, pos1, mip).r;
-
-    float coc = min(tap0.coc, tap1.coc);
-    tap0.coc     =
-    tap1.coc     = coc;
-    tap0.inLayer =
-    tap1.inLayer = isBackground(coc);
-
-    tap0.s = textureLod(materialParams_color, pos0, mip);
-    accumulate(curr, prev, tap0, radius, border, mip, first);
-
-    tap1.s = textureLod(materialParams_color, pos1, mip);
-    accumulate(curr, prev, tap1, radius, border, mip, first);
+    accumulateBackground(curr, prev, diaphragm(center,  offset), radius, border, mip, first);
+    accumulateBackground(curr, prev, diaphragm(center, -offset), radius, border, mip, first);
 }
 
 void accumulateBackgroundCenter(inout Bucket prev,


### PR DESCRIPTION
It did improve the look of the blur on far way geometry in some case,
but overall it hurts a lot more.
The case that falls appart is when everything is in the background layer
but there is a large depth difference anyways.
This creates a halo around edges.

Fixes #3221

Here an extreme example:

before:
![before](https://user-images.githubusercontent.com/1240896/117513816-65c6d380-af47-11eb-84b4-12cc42c2f9fc.png)

after:
![after](https://user-images.githubusercontent.com/1240896/117513823-68292d80-af47-11eb-8748-e2e0f5926904.png)
