### PR TITLE
VulkanPipelineCache: add a descriptor set arena.

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -198,7 +198,7 @@ void VulkanCommands::wait() {
     VkFence fences[CAPACITY];
     uint32_t count = 0;
     for (auto& wrapper : mStorage) {
-        if (wrapper.cmdbuffer != VK_NULL_HANDLE) {
+        if (wrapper.cmdbuffer != VK_NULL_HANDLE && mCurrent != &wrapper) {
             fences[count++] = wrapper.fence->fence;
         }
     }

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -48,4 +48,9 @@ constexpr static const int VK_REQUIRED_VERSION_MINOR = 0;
 // We choose a capacity of 3 because this matches the needs of triple-buffering.
 constexpr static const int VK_MAX_COMMAND_BUFFERS = 3;
 
+// Maximum number of command buffer flush events that can occur before an unused pipeline is removed
+// from the cache. If this number is low, VkPipeline construction will occur frequently, which can
+// be extremely slow. If this number is high, the memory footprint will be large.
+constexpr static const int VK_MAX_PIPELINE_AGE = 5;
+
 #endif

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -698,7 +698,8 @@ VkImageLayout getTextureLayout(TextureUsage usage) {
 void createEmptyTexture(VulkanContext& context, VulkanStagePool& stagePool) {
     context.emptyTexture = new VulkanTexture(context, SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1,
-            TextureUsage::DEFAULT | TextureUsage::COLOR_ATTACHMENT, stagePool);
+            TextureUsage::DEFAULT | TextureUsage::COLOR_ATTACHMENT |
+            TextureUsage::SUBPASS_INPUT, stagePool);
     uint32_t black = 0;
     PixelBufferDescriptor pbd(&black, 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
     context.emptyTexture->update2DImage(pbd, 1, 1, 0);


### PR DESCRIPTION
This fixes the "descriptor set fragmentation" error that we would see on
Mali.

The pipeline cache now maintains an arena of descriptors that can be
re-used. We call this an "arena" to avoid confusion with
VkDescriptorPool.

Descriptors are returned to the arena only when they are not in use
by any pending command buffer. This allows them to be mutated safely
without worrying about synchronization.