### PR TITLE
Use a UBO instead of a texture for froxels data structure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,9 @@
 This file contains one line summaries of commits that are worthy of mentioning in release notes.
 A new header is inserted each time a *tag* is created.
 
-## v1.9.26 (currently main branch)
+## v1.10.0 (currently main branch)
+
+- engine: User materials can now use 9 samplers instead of 8 [⚠️ **Material breakage**].
 
 ## v1.9.25
 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -54,8 +54,7 @@ static_assert(MAX_VERTEX_BUFFER_COUNT <= MAX_VERTEX_ATTRIBUTE_COUNT,
         "The number of buffer objects that can be attached to a VertexBuffer must be "
         "less than or equal to the maximum number of vertex attributes.");
 
-static constexpr size_t CONFIG_UNIFORM_BINDING_COUNT = 6;
-static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 6;
+static constexpr size_t CONFIG_BINDING_COUNT = 8;
 
 /**
  * Selects which driver a particular Engine should use.

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -28,7 +28,6 @@
 #include <backend/PresentCallable.h>
 #include <backend/TargetBufferInfo.h>
 
-#include "private/backend/DriverApi.h"
 #include "private/backend/Program.h"
 #include "private/backend/SamplerGroup.h"
 

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -33,8 +33,7 @@ class Program {
 public:
 
     static constexpr size_t SHADER_TYPE_COUNT = 2;
-    static constexpr size_t UNIFORM_BINDING_COUNT = CONFIG_UNIFORM_BINDING_COUNT;
-    static constexpr size_t SAMPLER_BINDING_COUNT = CONFIG_SAMPLER_BINDING_COUNT;
+    static constexpr size_t BINDING_COUNT = CONFIG_BINDING_COUNT;
 
     enum class Shader : uint8_t {
         VERTEX = 0,
@@ -47,8 +46,8 @@ public:
         bool strict = false;        // if true, this sampler must always have a bound texture
     };
 
-    using SamplerGroupInfo = std::array<std::vector<Sampler>, SAMPLER_BINDING_COUNT>;
-    using UniformBlockInfo = std::array<utils::CString, UNIFORM_BINDING_COUNT>;
+    using SamplerGroupInfo = std::array<std::vector<Sampler>, BINDING_COUNT>;
+    using UniformBlockInfo = std::array<utils::CString, BINDING_COUNT>;
 
     Program() noexcept;
     Program(const Program& rhs) = delete;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1253,8 +1253,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     //  must be intersected with viewport (see OpenGLDriver.cpp for implementation details)
 
     // Bind uniform buffers.
-    MetalBuffer* uniformsToBind[Program::UNIFORM_BINDING_COUNT] = { nil };
-    NSUInteger offsets[Program::UNIFORM_BINDING_COUNT] = { 0 };
+    MetalBuffer* uniformsToBind[Program::BINDING_COUNT] = { nil };
+    NSUInteger offsets[Program::BINDING_COUNT] = { 0 };
 
     enumerateBoundUniformBuffers([&uniformsToBind, &offsets](const UniformBufferState& state,
             MetalUniformBuffer* uniform, uint32_t index) {
@@ -1263,7 +1263,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     });
     MetalBuffer::bindBuffers(getPendingCommandBuffer(mContext), mContext->currentRenderPassEncoder,
             0, MetalBuffer::Stage::VERTEX | MetalBuffer::Stage::FRAGMENT, uniformsToBind, offsets,
-            Program::UNIFORM_BINDING_COUNT);
+            Program::BINDING_COUNT);
 
     // Enumerate all the sampler buffers for the program and check which textures and samplers need
     // to be bound.
@@ -1411,7 +1411,7 @@ void MetalDriver::enumerateSamplerGroups(
 
 void MetalDriver::enumerateBoundUniformBuffers(
         const std::function<void(const UniformBufferState&, MetalUniformBuffer*, uint32_t)>& f) {
-    for (uint32_t i = 0; i < Program::UNIFORM_BINDING_COUNT; i++) {
+    for (uint32_t i = 0; i < Program::BINDING_COUNT; i++) {
         auto& thisUniform = mContext->uniformState[i];
         if (!thisUniform.bound) {
             continue;

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -38,9 +38,9 @@ inline bool operator==(const backend::SamplerParams& lhs, const backend::Sampler
 namespace metal {
 
 static constexpr uint32_t MAX_VERTEX_ATTRIBUTE_COUNT = backend::MAX_VERTEX_ATTRIBUTE_COUNT;
-static constexpr uint32_t SAMPLER_GROUP_COUNT = Program::UNIFORM_BINDING_COUNT;
+static constexpr uint32_t SAMPLER_GROUP_COUNT = Program::BINDING_COUNT;
 static constexpr uint32_t SAMPLER_BINDING_COUNT = backend::MAX_SAMPLER_COUNT;
-static constexpr uint32_t VERTEX_BUFFER_START = Program::UNIFORM_BINDING_COUNT;
+static constexpr uint32_t VERTEX_BUFFER_START = Program::BINDING_COUNT;
 
 // The "zero" buffer is a small buffer for missing attributes that resides in the vertex slot
 // immediately following any user-provided vertex buffers.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2785,9 +2785,8 @@ void OpenGLDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> 
 
 void OpenGLDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
-
+    assert_invariant(index < Program::BINDING_COUNT);
     GLSamplerGroup* sb = handle_cast<GLSamplerGroup *>(sbh);
-    assert_invariant(index < Program::SAMPLER_BINDING_COUNT);
     mSamplerBindings[index] = sb;
     CHECK_GL_ERROR(utils::slog.e)
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -378,7 +378,7 @@ private:
         return pos->second;
     }
 
-    const std::array<backend::HwSamplerGroup*, backend::Program::SAMPLER_BINDING_COUNT>& getSamplerBindings() const {
+    const std::array<backend::HwSamplerGroup*, backend::Program::BINDING_COUNT>& getSamplerBindings() const {
         return mSamplerBindings;
     }
 
@@ -399,7 +399,7 @@ private:
     void setViewportScissor(backend::Viewport const& viewportScissor) noexcept;
 
     // sampler buffer binding points (nullptr if not used)
-    std::array<backend::HwSamplerGroup*, backend::Program::SAMPLER_BINDING_COUNT> mSamplerBindings = {};   // 8 pointers
+    std::array<backend::HwSamplerGroup*, backend::Program::BINDING_COUNT> mSamplerBindings = {};   // 8 pointers
 
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
     mutable std::vector<GLTexture*> mExternalStreams;

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -87,7 +87,7 @@ private:
         static_assert(TEXTURE_UNIT_COUNT <= 16, "TEXTURE_UNIT_COUNT must be <= 16");
 
         // if SAMPLER_BINDING_COUNT > 8, the binding bitfield must be increased accordingly
-        static_assert(backend::Program::SAMPLER_BINDING_COUNT <= 8, "SAMPLER_BINDING_COUNT must be <= 8");
+        static_assert(backend::Program::BINDING_COUNT <= 8, "BINDING_COUNT must be <= 8");
     };
 
     uint8_t mUsedBindingsCount = 0;
@@ -95,7 +95,7 @@ private:
     bool mIsValid = false;
 
     // information about each USED sampler buffer (no gaps)
-    std::array<BlockInfo, backend::Program::SAMPLER_BINDING_COUNT> mBlockInfos;   // 8 bytes
+    std::array<BlockInfo, backend::Program::BINDING_COUNT> mBlockInfos;   // 8 bytes
 
     // runs of indices into SamplerGroup -- run start index and size given by BlockInfo
     std::array<uint8_t, TEXTURE_UNIT_COUNT> mIndicesRuns;    // 16 bytes

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1672,7 +1672,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
 
     VkDescriptorImageInfo samplers[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
 
-    for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::SAMPLER_BINDING_COUNT; samplerGroupIdx++) {
+    for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::BINDING_COUNT; samplerGroupIdx++) {
         const auto& samplerGroup = program->samplerGroupInfo[samplerGroupIdx];
         if (samplerGroup.empty()) {
             continue;

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -50,7 +50,7 @@ public:
     VulkanPipelineCache(VulkanPipelineCache const&) = delete;
     VulkanPipelineCache& operator=(VulkanPipelineCache const&) = delete;
 
-    static constexpr uint32_t UBUFFER_BINDING_COUNT = Program::UNIFORM_BINDING_COUNT;
+    static constexpr uint32_t UBUFFER_BINDING_COUNT = Program::BINDING_COUNT;
     static constexpr uint32_t SAMPLER_BINDING_COUNT = backend::MAX_SAMPLER_COUNT;
     static constexpr uint32_t TARGET_BINDING_COUNT = MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
     static constexpr uint32_t SHADER_MODULE_COUNT = 2;

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -378,6 +378,7 @@ Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
         .setUniformBlock(BindingPoints::LIGHTS, UibGenerator::getLightsUib().getName())
         .setUniformBlock(BindingPoints::SHADOW, UibGenerator::getShadowUib().getName())
         .setUniformBlock(BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib().getName())
+        .setUniformBlock(BindingPoints::FROXEL_RECORDS, UibGenerator::getFroxelRecordUib().getName())
         .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
 
     if (Variant(variantKey).hasSkinningOrMorphing()) {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -39,8 +39,6 @@
 
 #include "generated/resources/materials.h"
 
-#include <private/filament/SibGenerator.h>
-
 #include <filament/MaterialEnums.h>
 
 #include <math/half.h>

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -65,7 +65,6 @@ FView::FView(FEngine& engine)
             &engine.debug.view.camera_at_origin);
 
     // set-up samplers
-    mFroxelizer.getRecordBuffer().setSampler(PerViewSib::RECORDS, mPerViewSb);
     mFroxelizer.getFroxelBuffer().setSampler(PerViewSib::FROXELS, mPerViewSb);
     if (engine.getDFG()->isValid()) {
         TextureSampler sampler(TextureSampler::MagFilter::LINEAR);

--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -17,19 +17,15 @@
 #ifndef TNT_FILAMENT_DETAILS_FROXEL_H
 #define TNT_FILAMENT_DETAILS_FROXEL_H
 
-#include "UniformBuffer.h"
-
 #include "details/Allocators.h"
 #include "details/Scene.h"
 #include "details/Engine.h"
-
-#include <backend/Handle.h>
 
 #include "GPUBuffer.h"
 
 #include <filament/Viewport.h>
 
-#include <private/filament/UibGenerator.h>
+#include <backend/Handle.h>
 
 #include <utils/compiler.h>
 #include <utils/bitset.h>
@@ -37,8 +33,6 @@
 
 #include <math/mat4.h>
 #include <math/vec4.h>
-
-#include <vector>
 
 namespace filament {
 
@@ -94,7 +88,9 @@ public:
     void terminate(backend::DriverApi& driverApi) noexcept;
 
     // gpu buffer containing records. valid after construction.
-    GPUBuffer const& getRecordBuffer() const noexcept { return mRecordsBuffer; }
+    backend::Handle<backend::HwUniformBuffer> getRecordBuffer() const noexcept {
+        return mRecordsBuffer;
+    }
 
     // gpu buffer containing froxels. valid after construction.
     GPUBuffer const& getFroxelBuffer() const noexcept { return mFroxelBuffer; }
@@ -192,8 +188,8 @@ private:
 
     using FroxelThreadData = std::array<LightGroupType, FROXEL_BUFFER_ENTRY_COUNT_MAX>;
 
-    void setViewport(Viewport const& viewport) noexcept;
-    void setProjection(const math::mat4f& projection, float near, float far) noexcept;
+    inline void setViewport(Viewport const& viewport) noexcept;
+    inline void setProjection(const math::mat4f& projection, float near, float far) noexcept;
     bool update() noexcept;
 
     void froxelizeLoop(FEngine& engine,
@@ -232,7 +228,7 @@ private:
     utils::Slice<FroxelEntry> mFroxelBufferUser;        //  32 KiB w/ 8192 froxels
 
     // max 32 KiB  (actual: resolution dependant)
-    utils::Slice<RecordBufferType> mRecordBufferUser;   //  64 KiB
+    utils::Slice<RecordBufferType> mRecordBufferUser;   //  16 KiB
     utils::Slice<LightRecord> mLightRecords;            // 256 KiB w/ 256 lights
 
     uint16_t mFroxelCountX = 0;
@@ -247,7 +243,7 @@ private:
     float mClipToFroxelX = 0.0f;
     float mClipToFroxelY = 0.0f;
     math::float2 mOneOverDimension = {};
-    GPUBuffer mRecordsBuffer;
+    backend::UniformBufferHandle mRecordsBuffer;
     GPUBuffer mFroxelBuffer;
 
     // needed for update()

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -449,6 +449,7 @@ private:
         driver.bindUniformBuffer(BindingPoints::PER_VIEW, mPerViewUbh);
         driver.bindUniformBuffer(BindingPoints::LIGHTS, mLightUbh);
         driver.bindUniformBuffer(BindingPoints::SHADOW, mShadowUbh);
+        driver.bindUniformBuffer(BindingPoints::FROXEL_RECORDS, mFroxelizer.getRecordBuffer());
         driver.bindSamplers(BindingPoints::PER_VIEW, mPerViewSbh);
     }
 

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 10;
+static constexpr size_t MATERIAL_VERSION = 11;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_ENGINE_ENUM_H
 #define TNT_FILAMENT_ENGINE_ENUM_H
 
+#include <backend/DriverEnums.h>
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -36,10 +38,13 @@ namespace BindingPoints {
     constexpr uint8_t PER_RENDERABLE_BONES    = 2;    // bones data, per renderable
     constexpr uint8_t LIGHTS                  = 3;    // lights data array
     constexpr uint8_t SHADOW                  = 4;    // punctual shadow data
-    constexpr uint8_t PER_MATERIAL_INSTANCE   = 5;    // uniforms/samplers updates per material
-    constexpr uint8_t COUNT                   = 6;
-    // These are limited by Program::UNIFORM_BINDING_COUNT (currently 6)
+    constexpr uint8_t FROXEL_RECORDS          = 5;
+    constexpr uint8_t PER_MATERIAL_INSTANCE   = 6;    // uniforms/samplers updates per material
+    constexpr uint8_t COUNT                   = 7;
+    // These are limited by Program::UNIFORM_BINDING_COUNT (currently 8)
 }
+
+static_assert(BindingPoints::COUNT <= backend::CONFIG_BINDING_COUNT);
 
 static_assert(BindingPoints::PER_MATERIAL_INSTANCE == BindingPoints::COUNT - 1,
         "Dynamically sized sampler buffer must be the last binding point.");

--- a/libs/filabridge/include/private/filament/SibGenerator.h
+++ b/libs/filabridge/include/private/filament/SibGenerator.h
@@ -31,20 +31,21 @@ class SibGenerator {
 public:
     static SamplerInterfaceBlock const& getPerViewSib(uint8_t variantKey) noexcept;
     static SamplerInterfaceBlock const* getSib(uint8_t bindingPoint, uint8_t variantKey) noexcept;
+    // When adding a sampler block here, make sure to also update
+    //      FMaterial::getSurfaceProgramSlow and FMaterial::getPostProcessProgramSlow if needed
 };
 
 struct PerViewSib {
     // indices of each samplers in this SamplerInterfaceBlock (see: getPerViewSib())
-    static constexpr size_t SHADOW_MAP     = 0;
-    static constexpr size_t RECORDS        = 1;
-    static constexpr size_t FROXELS        = 2;
-    static constexpr size_t IBL_DFG_LUT    = 3;
-    static constexpr size_t IBL_SPECULAR   = 4;
-    static constexpr size_t SSAO           = 5;
-    static constexpr size_t SSR            = 6;
-    static constexpr size_t STRUCTURE      = 7;
+    static constexpr size_t SHADOW_MAP     = 0;     // user defined (1024x1024) DEPTH, array
+    static constexpr size_t FROXELS        = 1;     // 64x2048, RG16 {index, count, reserved}
+    static constexpr size_t IBL_DFG_LUT    = 2;     // user defined (128x128), RGB16F
+    static constexpr size_t IBL_SPECULAR   = 3;     // user defined, user defined, CUBEMAP
+    static constexpr size_t SSAO           = 4;     // variable, RGB8 {AO, [depth]}
+    static constexpr size_t SSR            = 5;     // variable, RGB_11_11_10, mipmapped
+    static constexpr size_t STRUCTURE      = 6;     // variable, DEPTH
 
-    static constexpr size_t SAMPLER_COUNT  = 8;
+    static constexpr size_t SAMPLER_COUNT  = 7;
 };
 
 }

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -33,6 +33,9 @@ public:
     static UniformInterfaceBlock const& getLightsUib() noexcept;
     static UniformInterfaceBlock const& getShadowUib() noexcept;
     static UniformInterfaceBlock const& getPerRenderableBonesUib() noexcept;
+    static UniformInterfaceBlock const& getFroxelRecordUib() noexcept;
+    // When adding an UBO here, make sure to also update
+    //      FMaterial::getSurfaceProgramSlow and FMaterial::getPostProcessProgramSlow if needed
 };
 
 /*
@@ -159,6 +162,7 @@ struct LightsUib {
     uint32_t               shadow;            // { shadow bits (see ShadowInfo) }
     uint32_t               type;              // { 0=point, 1=spot }
 };
+static_assert(sizeof(LightsUib) == 64, "the actual UBO is an array of 256 mat4");
 
 // UBO for punctual (spot light) shadows.
 struct ShadowUib {
@@ -168,6 +172,15 @@ struct ShadowUib {
 
     filament::math::mat4f spotLightFromWorldMatrix[CONFIG_MAX_SHADOW_CASTING_SPOTS];
     filament::math::float4 directionShadowBias[CONFIG_MAX_SHADOW_CASTING_SPOTS]; // light direction, normal bias
+};
+
+// UBO froxel record buffer.
+struct FroxelRecordUib {
+    static const UniformInterfaceBlock& getUib() noexcept {
+        return UibGenerator::getFroxelRecordUib();
+    }
+
+    filament::math::uint4 records[1024];
 };
 
 // This is not the UBO proper, but just an element of a bone array.

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -42,7 +42,6 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib(uint8_t variantKey) noe
         }
 
         return builder
-            .add("records",       Type::SAMPLER_2D,         Format::UINT,    Precision::MEDIUM)
             .add("froxels",       Type::SAMPLER_2D,         Format::UINT,    Precision::MEDIUM)
             .add("iblDFG",        Type::SAMPLER_2D,         Format::FLOAT,   Precision::MEDIUM)
             .add("iblSpecular",   Type::SAMPLER_CUBEMAP,    Format::FLOAT,   Precision::MEDIUM)

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -154,4 +154,12 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     return uib;
 }
 
+UniformInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
+    static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
+            .name("FroxelRecordUniforms")
+            .add("records", 1024, UniformInterfaceBlock::Type::UINT4, Precision::HIGH)
+            .build();
+    return uib;
+}
+
 } // namespace filament

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -421,6 +421,8 @@ std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderMode
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::LIGHTS, UibGenerator::getLightsUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
+            BindingPoints::FROXEL_RECORDS, UibGenerator::getFroxelRecordUib());
+    cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::PER_MATERIAL_INSTANCE, material.uib);
     cg.generateSeparator(fs);
     cg.generateSamplers(fs,


### PR DESCRIPTION
MATERIAL BREAKAGE: this change breaks materials

In order to use one less sampler, we now use a UBO instead of a texture
to store the "froxel records". Currently this UBO is limited to 16KiB
vs. 64KiB before with the texture.

We also handle running out of record space better, by using a predefined
record that has all the lights in the scene. This way the scene will be
rendered properly, albeit at a potentially large performance cost.