### PR TITLE
add java API for Texture::Builder::import()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - engine: User materials can now use 9 samplers instead of 8 [⚠️ **Material breakage**].
 - engine: Remove `populateTangentQuaternions`  [⚠️ **API change**].
+- engine: Deprecate `Stream::Builder::stream(intptr_t)` [⚠️ **API Change**].
 
 ## v1.9.25
 

--- a/android/filament-android/src/main/cpp/Stream.cpp
+++ b/android/filament-android/src/main/cpp/Stream.cpp
@@ -102,7 +102,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_Stream_nBuilderStream(JNIEnv*, jclass,
         jlong nativeStreamBuilder, jlong externalTextureId) {
     StreamBuilder* builder = (StreamBuilder*) nativeStreamBuilder;
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     builder->builder()->stream(externalTextureId);
+#pragma clang diagnostic pop
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -129,6 +129,13 @@ Java_com_google_android_filament_Texture_nBuilderSwizzle(JNIEnv *, jclass ,
             (Texture::Swizzle)r, (Texture::Swizzle)g, (Texture::Swizzle)b, (Texture::Swizzle)a);
 }
 
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_Texture_nBuilderImportTexture(JNIEnv*, jclass, jlong nativeBuilder, jlong id) {
+    Texture::Builder *builder = (Texture::Builder *) nativeBuilder;
+    builder->import((intptr_t)id);
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_Texture_nBuilderBuild(JNIEnv*, jclass,
         jlong nativeBuilder, jlong nativeEngine) {

--- a/android/filament-android/src/main/java/com/google/android/filament/Stream.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Stream.java
@@ -166,7 +166,9 @@ public class Stream {
          *                          <code>GL_TEXTURE_EXTERNAL_OES.</code>
          * @return This Builder, for chaining calls.
          * @see Texture#setExternalStream
+         * @deprecated this method existed only for ARCore which doesn't need this anymore, use {@link Texture.Builder#importTexture(long)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder stream(long externalTextureId) {
             nBuilderStream(mNativeBuilder, externalTextureId);

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -696,6 +696,26 @@ public class Texture {
         }
 
         /**
+         * Specify a native texture to import as a Filament texture.
+         * <p>
+         * The texture id is backend-specific:
+         * <ul>
+         *   <li> OpenGL: GLuint texture ID </li>
+         * </ul>
+         * </p>
+         *
+         *
+         * @param id a backend specific texture identifier
+         *
+         * @return This Builder, for chaining calls.
+         */
+        @NonNull
+        public Builder importTexture(long id) {
+            nBuilderImportTexture(mNativeBuilder, id);
+            return this;
+        }
+
+        /**
          * Creates a new <code>Texture</code> instance.
          * @param engine The {@link Engine} to associate this <code>Texture</code> with.
          * @return A newly created <code>Texture</code>
@@ -1167,6 +1187,7 @@ public class Texture {
     private static native void nBuilderFormat(long nativeBuilder, int format);
     private static native void nBuilderUsage(long nativeBuilder, int flags);
     private static native void nBuilderSwizzle(long nativeBuilder, int r, int g, int b, int a);
+    private static native void nBuilderImportTexture(long nativeBuilder, long id);
     private static native long nBuilderBuild(long nativeBuilder, long nativeEngine);
 
     private static native int nGetWidth(long nativeTexture, int level);

--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -131,7 +131,9 @@ public:
          * @return This Builder, for chaining calls.
          *
          * @see Texture::setExternalStream()
+         * @deprecated this method existed only for ARCore which doesn't need this anymore, use Texture::import() instead.
          */
+        UTILS_DEPRECATED
         Builder& stream(intptr_t externalTextureId) noexcept;
 
         /**

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -217,7 +217,7 @@ public:
          *
          * With Metal, the id<MTLTexture> object should be cast to an intptr_t using
          * CFBridgingRetain to transfer ownership to Filament. Filament will release ownership of
-         * the textue object when the Filament texture is destroyed.
+         * the texture object when the Filament texture is destroyed.
          *
          * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
          *  id <MTLTexture> metalTexture = ...


### PR DESCRIPTION
deprecate Stream::stream(intptr_t).

This method was needed for ARCore back in the days, but there is now a
zero-copy way to achieve the same thing. This API shouldn't be used anymore.