### PR TITLE
gltfio: fix morphing bugs uncovered by MorphStressTest.

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -695,6 +695,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                 VertexAttribute attr = (VertexAttribute) (baseTangentsAttr + targetIndex);
                 vbb.attribute(attr, slot, VertexBuffer::AttributeType::SHORT4);
                 vbb.normalized(attr);
+                outPrim->morphTangents[targetIndex] = slot;
                 addBufferSlot({&mResult->mGenerateTangents, atype, slot++, morphId});
                 continue;
             }
@@ -721,6 +722,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
             VertexAttribute attr = (VertexAttribute) (basePositionAttr + targetIndex);
             vbb.attribute(attr, slot, fatype, 0, stride);
             vbb.normalized(attr, accessor->normalized);
+            outPrim->morphPositions[targetIndex] = slot;
             addBufferSlot({accessor, atype, slot++, morphId});
         }
     }

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -94,7 +94,9 @@ struct Primitive {
     filament::VertexBuffer* vertices = nullptr;
     filament::IndexBuffer* indices = nullptr;
     filament::Aabb aabb; // object-space bounding box
-    UvMap uvmap; // small mapping from each glTF UV set to either UV0 or UV1
+    UvMap uvmap; // mapping from each glTF UV set to either UV0 or UV1 (8 bytes)
+    uint8_t morphPositions[4] = {};  // Buffer indices for MORPH_POSITION_0, MORPH_POSITION_1 etc.
+    uint8_t morphTangents[4] = {};   // Buffer indices for MORPH_TANGENTS_0, MORPH_TANGENTS_1, etc.
 };
 using MeshCache = tsl::robin_map<const cgltf_mesh*, std::vector<Primitive>>;
 

--- a/libs/gltfio/src/MorphHelper.h
+++ b/libs/gltfio/src/MorphHelper.h
@@ -58,7 +58,8 @@ private:
 
     struct GltfPrimitive {
         filament::VertexBuffer* vertexBuffer;
-        int baseSlot;
+        uint8_t positions[4];
+        uint8_t tangents[4];
         std::vector<GltfTarget> targets; // TODO: flatten this?
     };
 
@@ -67,7 +68,6 @@ private:
     };
 
     void addPrimitive(cgltf_mesh const* mesh, int primitiveIndex, TableEntry* entry);
-    int determineBaseSlot(const cgltf_primitive& prim) const;
 
     std::vector<float> mPartiallySortedWeights;
     tsl::robin_map<Entity, TableEntry> mMorphTable;


### PR DESCRIPTION
The code that determined the "base slot" (i.e. the buffer object index
for the first morphed attribute) was very fragile and buggy.
MorphHelper now simply looks up the slot index in a stored mapping,
rather than trying to mimic the AssetLoader to determine the base slot.

Until now, most of the models we tested against only morphed the
position attribute, and never had a large set of target weights that
could be non-zero in a given time slice.

Fixes #3961