### PR TITLE
matc: detect missing end brace.

### DIFF
--- a/filament/src/materials/flare/flare.mat
+++ b/filament/src/materials/flare/flare.mat
@@ -160,3 +160,5 @@ void postProcess(inout PostProcessInputs postProcess) {
     }
     postProcess.color = vec4(color, 1.0);
 }
+
+}

--- a/tools/matc/src/matc/MaterialLexer.h
+++ b/tools/matc/src/matc/MaterialLexer.h
@@ -30,7 +30,7 @@ private:
 
     bool peek(MaterialType* type) const noexcept;
 
-    void readBlock() noexcept;
+    bool readBlock() noexcept;
     void readIdentifier() noexcept;
     void readUnknown() noexcept;
 };


### PR DESCRIPTION
matc was failing to report certain kinds of syntax errors and would
read out-of-bounds memory.

This change casuses the flare material to fail.