### PR TITLE
Vulkan: change depth layout to permit feedback loops.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -56,6 +56,7 @@ struct VulkanRenderPass {
     VkRenderPass renderPass;
     uint32_t subpassMask;
     int currentSubpass;
+    VulkanTexture* depthFeedback;
 };
 
 // For now we only support a single-device, single-instance scenario. Our concept of "context" is a


### PR DESCRIPTION
Vulkan does not permit the GENERAL layout when the depth buffer that is
currently being used for depth testing is also sampled from.

This (finally) fixes the last validation error that we were silencing,
which would occur only when SSAO was enabled.