### PR TITLE
Add HDRLoader for JVM clients.

### DIFF
--- a/android/filament-utils-android/CMakeLists.txt
+++ b/android/filament-utils-android/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 project(filament-utils-android)
 
 set(FILAMENT_DIR ${FILAMENT_DIST_DIR})
+set(IMAGEIO_DIR ../../libs/imageio)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../gltfio-android ${CMAKE_CURRENT_BINARY_DIR}/gltfio-android)
 
@@ -35,14 +36,21 @@ add_library(filament-utils-jni SHARED
         src/main/cpp/Manipulator.cpp
         src/main/cpp/RemoteServer.cpp
 
+        ${IMAGEIO_DIR}/include/imageio/ImageDecoder.h
+        ${IMAGEIO_DIR}/include/imageio/HDRDecoder.h
+        ${IMAGEIO_DIR}/src/HDRDecoder.cpp
+
         ../common/CallbackUtils.cpp
         ../common/NioUtils.cpp
 )
+
+target_compile_definitions(filament-utils-jni PUBLIC IMAGEIO_LITE=1)
 
 target_include_directories(filament-utils-jni PRIVATE
         ${FILAMENT_DIR}/include
         ..
         ../../third_party/stb
+        ${IMAGEIO_DIR}/include
         ../../libs/utils/include)
 
 set_target_properties(filament-utils-jni PROPERTIES LINK_DEPENDS

--- a/android/filament-utils-android/CMakeLists.txt
+++ b/android/filament-utils-android/CMakeLists.txt
@@ -49,7 +49,6 @@ target_compile_definitions(filament-utils-jni PUBLIC IMAGEIO_LITE=1)
 target_include_directories(filament-utils-jni PRIVATE
         ${FILAMENT_DIR}/include
         ..
-        ../../third_party/stb
         ${IMAGEIO_DIR}/include
         ../../libs/utils/include)
 

--- a/android/filament-utils-android/CMakeLists.txt
+++ b/android/filament-utils-android/CMakeLists.txt
@@ -21,15 +21,16 @@ add_library(civetweb STATIC IMPORTED)
 set_target_properties(civetweb PROPERTIES IMPORTED_LOCATION
         ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libcivetweb.a)
 
-include_directories(${FILAMENT_DIR}/include
-        ..
-        ../../libs/utils/include)
+add_library(iblprefilter STATIC IMPORTED)
+set_target_properties(iblprefilter PROPERTIES IMPORTED_LOCATION
+        ${FILAMENT_DIR}/lib/${ANDROID_ABI}/libfilament-iblprefilter.a)
 
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libfilament-utils-jni.map")
 
 add_library(filament-utils-jni SHARED
         src/main/cpp/AutomationEngine.cpp
         src/main/cpp/Bookmark.cpp
+        src/main/cpp/HDRLoader.cpp
         src/main/cpp/Utils.cpp
         src/main/cpp/Manipulator.cpp
         src/main/cpp/RemoteServer.cpp
@@ -37,6 +38,12 @@ add_library(filament-utils-jni SHARED
         ../common/CallbackUtils.cpp
         ../common/NioUtils.cpp
 )
+
+target_include_directories(filament-utils-jni PRIVATE
+        ${FILAMENT_DIR}/include
+        ..
+        ../../third_party/stb
+        ../../libs/utils/include)
 
 set_target_properties(filament-utils-jni PROPERTIES LINK_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/libfilament-utils-jni.symbols)
@@ -46,6 +53,7 @@ target_link_libraries(filament-utils-jni
         gltfio-jni
         civetweb
         camutils
+        iblprefilter
         image
         viewer
 )

--- a/android/filament-utils-android/src/main/cpp/HDRLoader.cpp
+++ b/android/filament-utils-android/src/main/cpp/HDRLoader.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include <filament/Engine.h>
+#include <filament/Texture.h>
+
+#include <utils/Log.h>
+
+#include "common/NioUtils.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_HDR
+
+#include <stb_image.h>
+
+using namespace filament;
+using namespace utils;
+
+using PixelBufferDescriptor = Texture::PixelBufferDescriptor;
+
+jlong nCreateHDRTexture(JNIEnv* env, jclass,
+        jlong nativeEngine, jobject javaBuffer, jint remaining, jint internalFormat) {
+
+    Engine* engine = (Engine*) nativeEngine;
+    AutoBuffer buffer(env, javaBuffer, remaining);
+    Texture::InternalFormat textureFormat = (Texture::InternalFormat) internalFormat;
+
+    auto dataPtr = (const stbi_uc*) buffer.getData();
+    const size_t byteCount = buffer.getSize();
+
+    int width, height, nchan;
+
+    float* const floatsPtr = stbi_loadf_from_memory(dataPtr, byteCount, &width, &height, &nchan, 3);
+    if (floatsPtr == nullptr) {
+        slog.e << "Unable to decode HDR image: " << stbi_failure_reason() << io::endl;
+        return 0;
+    }
+
+    Texture* texture = Texture::Builder()
+        .width(width)
+        .height(height)
+        .levels(0xff)
+        .sampler(Texture::Sampler::SAMPLER_2D)
+        .format(textureFormat)
+        .build(*engine);
+
+    if (texture == nullptr) {
+        slog.e << "Unable to create Filament Texture from HDR image." << io::endl;
+        stbi_image_free(floatsPtr);
+        return 0;
+    }
+
+    PixelBufferDescriptor::Callback freeCallback = [](void* buf, size_t, void*) {
+        stbi_image_free(buf);
+    };
+
+    PixelBufferDescriptor pbd(
+        (void const* ) floatsPtr,
+        width * height * 3 * sizeof(float),
+        PixelBufferDescriptor::PixelDataFormat::RGB,
+        PixelBufferDescriptor::PixelDataType::FLOAT,
+        freeCallback);
+
+    // Note that the setImage call could fail (e.g. due to an invalid combination of internal format
+    // and PixelDataFormat) but there is no way of detecting such a failure.
+    texture->setImage(*engine, 0, std::move(pbd));
+
+    texture->generateMipmaps(*engine);
+
+    return (jlong) texture;
+}

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/HDRLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/HDRLoader.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.filament.utils
+
+import com.google.android.filament.Engine
+import com.google.android.filament.Texture
+
+import java.nio.Buffer
+
+/**
+ * Utility for decoding an HDR file and producing a Filament texture.
+ */
+object HDRLoader {
+    class Options {
+        var desiredFormat = Texture.InternalFormat.RGB16F
+    }
+
+    /**
+     * Consumes the content of an HDR file and produces a [Texture] object.
+     *
+     * @param engine Gets passed to the builder.
+     * @param buffer The content of the HDR File.
+     * @param options Loader options.
+     * @return The resulting Filament texture, or null on failure.
+     */
+    fun createTexture(engine: Engine, buffer: Buffer, options: Options = Options()): Texture? {
+        val nativeEngine = engine.nativeObject
+        val nativeTexture = nCreateHDRTexture(nativeEngine, buffer, buffer.remaining(), options.desiredFormat.ordinal)
+        if (nativeTexture == 0L) {
+            return null;
+        }
+        return Texture(nativeTexture)
+    }
+
+    private external fun nCreateHDRTexture(nativeEngine: Long, buffer: Buffer, remaining: Int, format: Int): Long
+}

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KTXLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KTXLoader.kt
@@ -29,7 +29,7 @@ import java.nio.Buffer
  * KTX is a simple container format that makes it easy to bundle miplevels and cubemap faces
  * into a single file.
  */
-object KtxLoader {
+object KTXLoader {
     class Options {
         var srgb = false
     }
@@ -44,7 +44,7 @@ object KtxLoader {
      */
     fun createTexture(engine: Engine, buffer: Buffer, options: Options = Options()): Texture {
         val nativeEngine = engine.nativeObject
-        val nativeTexture = nCreateTexture(nativeEngine, buffer, buffer.remaining(), options.srgb)
+        val nativeTexture = nCreateKTXTexture(nativeEngine, buffer, buffer.remaining(), options.srgb)
         return Texture(nativeTexture)
     }
 
@@ -76,7 +76,7 @@ object KtxLoader {
         return Skybox(nativeSkybox)
     }
 
-    private external fun nCreateTexture(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long
+    private external fun nCreateKTXTexture(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long
     private external fun nCreateIndirectLight(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long
     private external fun nCreateSkybox(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long
 }

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -115,11 +115,11 @@ class MainActivity : Activity() {
         val scene = modelViewer.scene
         val ibl = "default_env"
         readCompressedAsset("envs/$ibl/${ibl}_ibl.ktx").let {
-            scene.indirectLight = KtxLoader.createIndirectLight(engine, it)
+            scene.indirectLight = KTXLoader.createIndirectLight(engine, it)
             scene.indirectLight!!.intensity = 30_000.0f
         }
         readCompressedAsset("envs/$ibl/${ibl}_skybox.ktx").let {
-            scene.skybox = KtxLoader.createSkybox(engine, it)
+            scene.skybox = KTXLoader.createSkybox(engine, it)
         }
     }
 
@@ -153,6 +153,18 @@ class MainActivity : Activity() {
             modelViewer.destroyModel()
             modelViewer.loadModelGlb(message.buffer)
             modelViewer.transformToUnitCube()
+        }
+    }
+
+    private suspend fun loadHdr(message: RemoteServer.ReceivedMessage) {
+        withContext(Dispatchers.Main) {
+            val texture = HDRLoader.createTexture(modelViewer.engine, message.buffer)
+            if (texture == null) {
+                setStatusText("Could not decode HDR file.")
+            } else {
+                // TODO: Add Java bindings for IBLPrefilterContext and use them here.
+                setStatusText("Successfully decoded HDR file.")
+            }
         }
     }
 
@@ -266,6 +278,8 @@ class MainActivity : Activity() {
         CoroutineScope(Dispatchers.IO).launch {
             if (message.label.endsWith(".zip")) {
                 loadZip(message)
+            } else if (message.label.endsWith(".hdr")) {
+                loadHdr(message)
             } else {
                 loadGlb(message)
             }

--- a/android/samples/sample-textured-object/build.gradle
+++ b/android/samples/sample-textured-object/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     implementation deps.kotlin
     implementation project(':filament-android')
     implementation project(':gltfio-android')
-    implementation project(':filament-utils-android') // required for KtxLoader
+    implementation project(':filament-utils-android') // required for KTXLoader
 }

--- a/libs/imageio/CMakeLists.txt
+++ b/libs/imageio/CMakeLists.txt
@@ -9,6 +9,7 @@ set(PUBLIC_HDR_DIR include)
 # ==================================================================================================
 set(PUBLIC_HDRS
         include/imageio/BlockCompression.h
+        include/imageio/HDRDecoder.h
         include/imageio/ImageDecoder.h
         include/imageio/ImageDiffer.h
         include/imageio/ImageEncoder.h
@@ -16,6 +17,7 @@ set(PUBLIC_HDRS
 
 set(SRCS
         src/BlockCompression.cpp
+        src/HDRDecoder.cpp
         src/ImageDecoder.cpp
         src/ImageDiffer.cpp
         src/ImageEncoder.cpp

--- a/libs/imageio/include/imageio/HDRDecoder.h
+++ b/libs/imageio/include/imageio/HDRDecoder.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef IMAGE_HDRDECODER_H_
+#define IMAGE_HDRDECODER_H_
+
+#include <imageio/ImageDecoder.h>
+
+namespace image {
+
+class HDRDecoder : public ImageDecoder::Decoder {
+public:
+    static HDRDecoder* create(std::istream& stream);
+    static bool checkSignature(char const* buf);
+
+    HDRDecoder(const HDRDecoder&) = delete;
+    HDRDecoder& operator=(const HDRDecoder&) = delete;
+
+private:
+    explicit HDRDecoder(std::istream& stream);
+    ~HDRDecoder() override;
+
+    // ImageDecoder::Decoder interface
+    LinearImage decode() override;
+
+    static const char sigRadiance[];
+    static const char sigRGBE[];
+    std::istream& mStream;
+    std::streampos mStreamStartPos;
+};
+
+} // namespace image
+
+#endif /* IMAGE_IMAGEDECODER_H_ */

--- a/libs/imageio/src/HDRDecoder.cpp
+++ b/libs/imageio/src/HDRDecoder.cpp
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <imageio/HDRDecoder.h>
+
+#include <image/ImageOps.h>
+
+#include <math/vec3.h>
+
+#include <utils/Log.h>
+
+#include <limits>
+#include <memory>
+#include <sstream>
+
+// for ntohs
+#if defined(WIN32)
+#    include <Winsock2.h>
+#    include <utils/unwindows.h>
+#else
+#    include <arpa/inet.h>
+#endif
+
+using namespace utils;
+
+namespace image {
+
+const char HDRDecoder::sigRadiance[] = { '#', '?', 'R', 'A', 'D', 'I', 'A', 'N', 'C', 'E', 0xa };
+const char HDRDecoder::sigRGBE[]     = { '#', '?', 'R', 'G', 'B', 'E', 0xa };
+
+HDRDecoder* HDRDecoder::create(std::istream& stream) {
+    HDRDecoder* decoder = new HDRDecoder(stream);
+    return decoder;
+}
+
+bool HDRDecoder::checkSignature(char const* buf) {
+    return !memcmp(buf, sigRadiance, sizeof(sigRadiance)) ||
+            !memcmp(buf, sigRGBE, sizeof(sigRGBE));
+}
+
+HDRDecoder::HDRDecoder(std::istream& stream)
+    : mStream(stream), mStreamStartPos(stream.tellg()) {
+}
+
+HDRDecoder::~HDRDecoder() = default;
+
+LinearImage HDRDecoder::decode() {
+    float gamma;
+    float exposure;
+    char sy, sx;
+    unsigned int height = 0, width = 0;
+    {
+        char buf[1024];
+        do {
+            char format[128];
+            mStream.getline(buf, sizeof(buf), 0xa);
+            if (buf[0] == '#') continue;
+            sscanf(buf, "FORMAT=%127s", format); // NOLINT
+            sscanf(buf, "GAMMA=%f", &gamma); // NOLINT
+            sscanf(buf, "EXPOSURE=%f", &exposure); // NOLINT
+            if ((sscanf(buf, "%cY %u %cX %u", &sy, &height, &sx, &width) == 4)||   // NOLINT
+                (sscanf(buf, "%cX %u %cY %u", &sx, &width, &sy, &height) == 4)) {  // NOLINT
+                break;
+            }
+        } while (true);
+    }
+    LinearImage image(width, height, 3);
+
+    if (sx == '-') image = (image);
+    if (sy == '+') image = verticalFlip(image);
+
+    // Allocate memory to hold one row of decoded pixel data.
+    std::unique_ptr<uint8_t[]> rgbe(new uint8_t[width * 4]);
+
+    // First, test for non-RLE images.
+    const auto pos = mStream.tellg();
+    mStream.read((char*) rgbe.get(), 3);
+    mStream.seekg(pos);
+
+    if (rgbe[0] != 0x2 || rgbe[1] != 0x2 || (rgbe[2] & 0x80) || width < 8 || width > 32767) {
+        for (uint32_t y = 0; y < height; y++) {
+            filament::math::float3* dst = reinterpret_cast<filament::math::float3*>(image.getPixelRef(0, y));
+            mStream.read((char*) rgbe.get(), width * 4);
+            // (rgb/256) * 2^(e-128)
+            size_t pixel = 0;
+            for (size_t x = 0; x < width; x++, pixel += 4) {
+                if (rgbe[pixel + 3] == 0.0f) {
+                    dst[x] = filament::math::float3{0.0f};
+                } else {
+                    filament::math::float3 v(rgbe[pixel], rgbe[pixel + 1], rgbe[pixel + 2]);
+                    dst[x] = (v + 0.5f) * std::ldexp(1.0f, rgbe[pixel + 3] - (128 + 8));
+                }
+            }
+        }
+    } else {
+        for (uint32_t y = 0; y < height; y++) {
+            uint16_t magic;
+            mStream.read((char*) &magic, 2);
+            if (magic != 0x0202) {
+                slog.e << "invalid scanline (magic)" << io::endl;
+                return {};
+            }
+
+            uint16_t w;
+            mStream.read((char*) &w, 2);
+            if (ntohs(w) != width) {
+                slog.e << "invalid scanline (width)" << io::endl;
+                return {};
+            }
+
+            char* d = (char*) rgbe.get();
+            for (size_t p = 0; p < 4; p++) {
+                size_t num_bytes = 0;
+                while (num_bytes < width) {
+                    uint8_t rle_count;
+                    mStream.read((char*) &rle_count, 1);
+                    if (rle_count > 128) {
+                        char v;
+                        mStream.read(&v, 1);
+                        memset(d, v, size_t(rle_count - 128));
+                        d += rle_count - 128;
+                        num_bytes += rle_count - 128;
+                    } else {
+                        if (rle_count == 0) {
+                            slog.e << "run length is zero" << io::endl;
+                            return {};
+                        }
+                        mStream.read(d, rle_count);
+                        d += rle_count;
+                        num_bytes += rle_count;
+                    }
+                }
+            }
+
+            uint8_t const* r = &rgbe[0];
+            uint8_t const* g = &rgbe[width];
+            uint8_t const* b = &rgbe[2 * width];
+            uint8_t const* e = &rgbe[3 * width];
+            filament::math::float3* dst = reinterpret_cast<filament::math::float3*>(image.getPixelRef(0, y));
+            // (rgb/256) * 2^(e-128)
+            for (size_t x = 0; x < width; x++, r++, g++, b++, e++) {
+                if (e[0] == 0.0f) {
+                    dst[x] = filament::math::float3{0.0f};
+                } else {
+                    filament::math::float3 v(r[0], g[0], b[0]);
+                    dst[x] = (v + 0.5f) * std::ldexp(1.0f, e[0] - (128 + 8));
+                }
+            }
+        }
+    }
+
+    return image;
+}
+
+#ifdef IMAGEIO_LITE
+
+LinearImage ImageDecoder::decode(std::istream& stream, const std::string& sourceName,
+        ColorSpace sourceSpace) {
+
+    Format format = Format::NONE;
+
+    std::streampos pos = stream.tellg();
+    char buf[16];
+    stream.read(buf, sizeof(buf));
+
+    if (HDRDecoder::checkSignature(buf)) {
+        format = Format::HDR;
+    }
+
+    stream.seekg(pos);
+
+    std::unique_ptr<Decoder> decoder;
+    switch (format) {
+        case Format::HDR:
+            decoder.reset(HDRDecoder::create(stream));
+            decoder->setColorSpace(ColorSpace::LINEAR);
+            break;
+        default:
+            return LinearImage();
+    }
+
+    return decoder->decode();
+}
+
+#endif
+
+} // namespace image

--- a/web/samples/remote.html
+++ b/web/samples/remote.html
@@ -26,20 +26,6 @@ body {
     height: 100%;
 }
 
-.status-area {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-    max-width: 640px;
-    max-height: 32px;
-    background: burlywood;
-    border: solid 2px black;
-    border-bottom: none;
-    font-size: 12px;
-}
-
 .connection-settings {
     display: flex;
     justify-content: center;
@@ -102,8 +88,7 @@ canvas {
 }
 
 .dropbox-area p { text-align: center; }
-.instructions-area p { margin: 4px; }
-.instructions-area { margin-bottom: 12px; }
+.instructions-area { margin-top: 12px; }
 a { text-decoration: none; }
 a:visited { color: rgb(26, 65, 78); }
 .bad { background: lightcoral; }
@@ -118,15 +103,9 @@ a:visited { color: rgb(26, 65, 78); }
     <input id="connection-url" type="text" value="localhost" />
     <label class="port-label">: 8082</label>
 </div>
-<div id="status" class="status-area">Disconnected</div>
 <canvas id="webgl2-canvas"></canvas>
-<div id="dropbox" class="dropbox-area">
-    <div>
-        <p>Drop a <b>glb</b> or a <b>zip</b> file here.</p>
-    </div>
-</div>
+<div id="dropbox" class="dropbox-area"><p>Disconnected.</p></div>
 <div id="instructions" class="instructions-area">
-    <p><code>adb forward tcp:8082 tcp:8082</code></p>
     <button id="copyButton">Copy adb command to clipboard</button>
 </div>
 </div>
@@ -252,7 +231,6 @@ class App {
 
         this.connectionUrl = document.getElementById("connection-url");
         this.dropbox = document.getElementById("dropbox");
-        this.status = document.getElementById("status");
         this.canvas = document.getElementsByTagName("canvas")[0];
 
         const engine = this.engine = Filament.Engine.create(this.canvas);
@@ -339,7 +317,8 @@ class App {
             const file = event.dataTransfer.items[0].getAsFile();
             const is_glb = file.name.match(/\.(glb)$/i);
             const is_zip = file.name.match(/\.(zip)$/i);
-            if (!is_glb && !is_zip) return;
+            const is_hdr = file.name.match(/\.(hdr)$/i);
+            if (!is_glb && !is_zip && !is_hdr) return;
             const files = event.dataTransfer.files;
             ([...files]).forEach(upload);
         }, false);
@@ -373,9 +352,21 @@ class App {
     }
 
     updateDom() {
-        const connected = this.connection.isConnected();
-        this.status.innerHTML = connected ? "Connected" : "Disconnected";
-        this.status.style.backgroundColor = connected ? "#45d48d" : "burlywood";
+        const instructions = document.getElementById("instructions");
+        if (this.connection.isConnected()) {
+            instructions.style.visibility = "hidden";
+            this.dropbox.innerHTML = `<div>
+                <p>Connected.</p>
+                <p>Drop a <b>glb</b>, <b>zip</b>, or <b>hdr</b> file here.</p>
+            </div>`;
+        } else {
+            instructions.style.visibility = "visible";
+            this.dropbox.innerHTML = `<div>
+                <p>Disconnected.</p>
+                <p>Ensure app is active and port forwarding is enabled.</p>
+                <p><b>adb forward tcp:8082 tcp:8082</b></p>
+            </div>`;
+        }
     }
 
     startConnection() {


### PR DESCRIPTION
This adds support for decoding HDR files, dropping them into the remote
web page, and sending them over the wire.  However the decoded results
are not yet passed into IBLPrefilterContext, that will be subsequent
PR.

Rename KtxLoader to KTXLoader.

The remote UI has been tweaked a bit, so that it shows a more helpful
message when disconnected:

![disconnected](https://user-images.githubusercontent.com/1288904/118871171-2b8cf880-b89c-11eb-8533-21c4172f19c6.png)
![connected](https://user-images.githubusercontent.com/1288904/118871174-2d56bc00-b89c-11eb-8885-156ff2fe1675.png)
