### PR TITLE
JNI Cleanup: Remove useless constructors, publicize RenderTarget.

### DIFF
--- a/android/filament-android/libfilament-jni.map
+++ b/android/filament-android/libfilament-jni.map
@@ -13,6 +13,7 @@ LIBFILAMENT {
     *filament*IndirectLight*;
     *filament*LightManager*;
     *filament*Renderer*;
+    *filament*RenderTarget*;
     *filament*Scene*;
     *filament*Transform*;
     *filament*Material*;

--- a/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/IndirectLight.java
@@ -84,11 +84,7 @@ import androidx.annotation.Size;
 public class IndirectLight {
     long mNativeObject;
 
-    public IndirectLight(Engine engine, long indirectLight) {
-        mNativeObject = indirectLight;
-    }
-
-    IndirectLight(long indirectLight) {
+    public IndirectLight(long indirectLight) {
         mNativeObject = indirectLight;
     }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/Skybox.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Skybox.java
@@ -51,11 +51,7 @@ import static com.google.android.filament.Colors.LinearColor;
 public class Skybox {
     private long mNativeObject;
 
-    public Skybox(Engine engine, long nativeSkybox) {
-        mNativeObject = nativeSkybox;
-    }
-
-    Skybox(long nativeSkybox) {
+    public Skybox(long nativeSkybox) {
         mNativeObject = nativeSkybox;
     }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -73,11 +73,7 @@ import static com.google.android.filament.Texture.Type.COMPRESSED;
 public class Texture {
     private long mNativeObject;
 
-    Texture(long nativeTexture) {
-        mNativeObject = nativeTexture;
-    }
-
-    public Texture(Engine engine, long nativeTexture) {
+    public Texture(long nativeTexture) {
         mNativeObject = nativeTexture;
     }
 

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KtxLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/KtxLoader.kt
@@ -45,7 +45,7 @@ object KtxLoader {
     fun createTexture(engine: Engine, buffer: Buffer, options: Options = Options()): Texture {
         val nativeEngine = engine.nativeObject
         val nativeTexture = nCreateTexture(nativeEngine, buffer, buffer.remaining(), options.srgb)
-        return Texture(engine, nativeTexture)
+        return Texture(nativeTexture)
     }
 
     /**
@@ -59,7 +59,7 @@ object KtxLoader {
     fun createIndirectLight(engine: Engine, buffer: Buffer, options: Options = Options()): IndirectLight {
         val nativeEngine = engine.nativeObject
         val nativeIndirectLight = nCreateIndirectLight(nativeEngine, buffer, buffer.remaining(), options.srgb)
-        return IndirectLight(engine, nativeIndirectLight)
+        return IndirectLight(nativeIndirectLight)
     }
 
     /**
@@ -73,7 +73,7 @@ object KtxLoader {
     fun createSkybox(engine: Engine, buffer: Buffer, options: Options = Options()): Skybox {
         val nativeEngine = engine.nativeObject
         val nativeSkybox = nCreateSkybox(nativeEngine, buffer, buffer.remaining(), options.srgb)
-        return Skybox(engine, nativeSkybox)
+        return Skybox(nativeSkybox)
     }
 
     private external fun nCreateTexture(nativeEngine: Long, buffer: Buffer, remaining: Int, srgb: Boolean): Long


### PR DESCRIPTION
(1)
The C++ RenderTarget API might be used by an external Android library
such as filament-utils-android and therefore needs to be in the map
file.

(2)
Texture, Skybox, and IndirectLight each had two "nativeObject"
constructors which exist for the benefit of filament-utils-android,
but each of these classes only need one nativeObject constructor.