### PR TITLE
ImGuiHelper: fix support for custom images.

### DIFF
--- a/libs/filagui/include/filagui/ImGuiHelper.h
+++ b/libs/filagui/include/filagui/ImGuiHelper.h
@@ -25,6 +25,7 @@
 #include <filament/Material.h>
 #include <filament/MaterialInstance.h>
 #include <filament/Texture.h>
+#include <filament/TextureSampler.h>
 #include <filament/VertexBuffer.h>
 #include <filament/View.h>
 
@@ -91,6 +92,7 @@ public:
       filament::Texture* mTexture = nullptr;
       bool mHasSynced = false;
       ImGuiContext* mImGuiContext;
+      filament::TextureSampler mSampler;
 };
 
 } // namespace filagui

--- a/libs/filagui/src/ImGuiHelper.cpp
+++ b/libs/filagui/src/ImGuiHelper.cpp
@@ -65,8 +65,8 @@ ImGuiHelper::ImGuiHelper(Engine* engine, filament::View* view, const Path& fontP
 
     // For proggy, switch to NEAREST for pixel-perfect text.
     if (fontPath.isEmpty() && !imGuiContext) {
-        TextureSampler sampler(MinFilter::NEAREST, MagFilter::NEAREST);
-        mMaterial->setDefaultParameter("albedo", mTexture, sampler);
+        mSampler = TextureSampler(MinFilter::NEAREST, MagFilter::NEAREST);
+        mMaterial->setDefaultParameter("albedo", mTexture, mSampler);
     }
 
     utils::EntityManager& em = utils::EntityManager::get();
@@ -108,8 +108,8 @@ void ImGuiHelper::createAtlasTexture(Engine* engine) {
             .build(*engine);
     mTexture->setImage(*engine, 0, std::move(pb));
 
-    TextureSampler sampler(MinFilter::LINEAR, MagFilter::LINEAR);
-    mMaterial->setDefaultParameter("albedo", mTexture, sampler);
+    mSampler = TextureSampler(MinFilter::LINEAR, MagFilter::LINEAR);
+    mMaterial->setDefaultParameter("albedo", mTexture, mSampler);
 }
 
 ImGuiHelper::~ImGuiHelper() {
@@ -220,6 +220,8 @@ void ImGuiHelper::processImGuiCommands(ImDrawData* commands, const ImGuiIO& io) 
                 if (pcmd.TextureId) {
                     TextureSampler sampler(MinFilter::LINEAR, MagFilter::LINEAR);
                     materialInstance->setParameter("albedo", (Texture const*)pcmd.TextureId, sampler);
+                } else {
+                    materialInstance->setParameter("albedo", mTexture, mSampler);
                 }
                 rbuilder
                         .geometry(primIndex, RenderableManager::PrimitiveType::TRIANGLES,


### PR DESCRIPTION
The texture binding in the material instance needs to be restored to the
glyph atlas when a custom image is not in use.