### PR TITLE
a way to keep the content of custom RenderTarget attachments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.10.1 (currently main branch)
 
+- -engine: Attachments of custom RendereTargets are not systematically discarded
+
 ## v1.10.0
 
 - engine: User materials can now use 9 samplers instead of 8 [⚠️ **Material breakage**].

--- a/android/samples/sample-multi-view/src/main/java/com/google/android/filament/multiview/MainActivity.kt
+++ b/android/samples/sample-multi-view/src/main/java/com/google/android/filament/multiview/MainActivity.kt
@@ -65,6 +65,7 @@ class MainActivity : Activity() {
     private lateinit var view1: View
     private lateinit var view2: View
     private lateinit var view3: View
+    private lateinit var view4: View
     // We need skybox to set the background color
     private lateinit var skybox: Skybox
     // Should be pretty obvious :)
@@ -119,11 +120,15 @@ class MainActivity : Activity() {
         view1 = engine.createView()
         view2 = engine.createView()
         view3 = engine.createView()
+        view4 = engine.createView()
 
         view0.setName("view0");
         view1.setName("view1");
         view2.setName("view2");
         view3.setName("view3");
+        view4.setName("view4");
+
+        view4.blendMode = View.BlendMode.TRANSLUCENT;
 
         skybox =  Skybox.Builder().build(engine);
         scene.skybox = skybox
@@ -136,11 +141,13 @@ class MainActivity : Activity() {
         view1.camera = camera
         view2.camera = camera
         view3.camera = camera
+        view4.camera = camera
 
         view0.scene = scene
         view1.scene = scene
         view2.scene = scene
         view3.scene = scene
+        view4.scene = scene
     }
 
     private fun setupScene() {
@@ -373,6 +380,7 @@ class MainActivity : Activity() {
         engine.destroyView(view1)
         engine.destroyView(view2)
         engine.destroyView(view3)
+        engine.destroyView(view4)
         engine.destroySkybox(skybox)
         engine.destroyScene(scene)
         engine.destroyCameraComponent(camera.entity)
@@ -411,6 +419,9 @@ class MainActivity : Activity() {
                     skybox.setColor(0.0f, 0.0f, 1.0f, 1.0f);
                     renderer.render(view3)
 
+                    skybox.setColor(0.0f, 0.0f, 0.0f, 0.0f);
+                    renderer.render(view4)
+
                     renderer.endFrame()
                 }
             }
@@ -443,6 +454,7 @@ class MainActivity : Activity() {
             view1.viewport = Viewport(width / 2, 0,          width / 2, height / 2)
             view2.viewport = Viewport(0,         height / 2, width / 2, height / 2)
             view3.viewport = Viewport(width / 2, height / 2, width / 2, height / 2)
+            view4.viewport = Viewport(width / 4, height / 4, width / 2, height / 2)
         }
     }
 

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -63,6 +63,10 @@ public:
         COLOR1 = 1,          //!< identifies the 2nd color attachment
         COLOR2 = 2,          //!< identifies the 3rd color attachment
         COLOR3 = 3,          //!< identifies the 4th color attachment
+        COLOR4 = 4,          //!< identifies the 5th color attachment
+        COLOR5 = 5,          //!< identifies the 6th color attachment
+        COLOR6 = 6,          //!< identifies the 7th color attachment
+        COLOR7 = 7,          //!< identifies the 8th color attachment
         DEPTH  = MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT,   //!< identifies the depth attachment
         COLOR  = COLOR0,     //!< identifies the 1st color attachment
     };

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -318,7 +318,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     if (currentRenderTarget) {
         // For custom RenderTarget, we look at each attachment flag and if they have their
-        // SAMPLEABLE usage bit set, we assume they most not be discarded after the render pass.
+        // SAMPLEABLE usage bit set, we assume they must not be discarded after the render pass.
         // "+1" to the cound for the DEPTH attachment (we don't have stencil for the public RenderTarget)
         for (size_t i = 0; i < RenderTarget::MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT + 1; i++) {
             auto attachment = currentRenderTarget->getAttachment((RenderTarget::AttachmentPoint)i);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -256,12 +256,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         return;
     }
 
-    FRenderTarget* currentRenderTarget = upcast(view.getRenderTarget());
-    if (mPreviousRenderTargets.find(currentRenderTarget) == mPreviousRenderTargets.end()) {
-        mPreviousRenderTargets.insert(currentRenderTarget);
-        initializeClearFlags();
-    }
-
     view.prepare(engine, driver, arena, svp, getShaderUserTime());
 
     // start froxelization immediately, it has no dependencies
@@ -306,15 +300,40 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         view.renderShadowMaps(fg, engine, driver, pass);
     }
 
-    const TargetBufferFlags discardedFlags = mDiscardedFlags;
-    const TargetBufferFlags clearFlags = mClearFlags;
+    // When we don't have a custom RenderTarget, currentRenderTarget below is nullptr and is
+    // recorded in the list of targets already rendered into -- this ensures that
+    // initializeClearFlags() is called only once for the default RenderTarget.
+    auto& previousRenderTargets = mPreviousRenderTargets;
+    FRenderTarget* const currentRenderTarget = upcast(view.getRenderTarget());
+    if (UTILS_LIKELY(
+            previousRenderTargets.find(currentRenderTarget) == previousRenderTargets.end())) {
+        previousRenderTargets.insert(currentRenderTarget);
+        initializeClearFlags();
+    }
+
     const float4 clearColor = mClearOptions.clearColor;
+    const TargetBufferFlags clearFlags = mClearFlags;
+    const TargetBufferFlags discardStartFlags = mDiscardStartFlags;
+    TargetBufferFlags keepOverrideEndFlags = TargetBufferFlags::NONE;
+
+    if (currentRenderTarget) {
+        // For custom RenderTarget, we look at each attachment flag and if they have their
+        // SAMPLEABLE usage bit set, we assume they most not be discarded after the render pass.
+        // "+1" to the cound for the DEPTH attachment (we don't have stencil for the public RenderTarget)
+        for (size_t i = 0; i < RenderTarget::MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT + 1; i++) {
+            auto attachment = currentRenderTarget->getAttachment((RenderTarget::AttachmentPoint)i);
+            if (any(attachment.texture->getUsage() &
+                    (TextureUsage::SAMPLEABLE | Texture::Usage::SUBPASS_INPUT))) {
+                keepOverrideEndFlags |= backend::getTargetBufferFlagsAt(i);
+            }
+        }
+    }
 
     // Renderer's ClearOptions apply once at the beginning of the frame (not for each View),
     // however, it's implemented as part of executing a render pass on the current render target,
     // and that happens for each View. So we need to disable clearing after the 1st View has
     // been processed.
-    mDiscardedFlags &= ~TargetBufferFlags::COLOR;
+    mDiscardStartFlags &= ~TargetBufferFlags::COLOR;
     mClearFlags &= ~TargetBufferFlags::COLOR;
 
     Handle<HwRenderTarget> viewRenderTarget;
@@ -327,9 +346,9 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                     .clearColor = clearColor,
                     .samples = 0,
                     .clearFlags = clearFlags,
-                    .discardStart = discardedFlags
+                    .discardStart = discardStartFlags,
+                    .keepOverrideEnd = keepOverrideEndFlags
             }, viewRenderTarget);
-
 
     const bool blendModeTranslucent = view.getBlendMode() == View::BlendMode::TRANSLUCENT;
     const bool hasCustomRenderTarget = viewRenderTarget != mRenderTarget;
@@ -931,7 +950,6 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     float l = float(time.count() - h);
     mShaderUserTime = { h, l, 0, 0 };
 
-    initializeClearFlags();
     mPreviousRenderTargets.clear();
 
     mBeginFrameInternal = {};
@@ -1133,9 +1151,9 @@ void FRenderer::getRenderTarget(FView const& view,
 void FRenderer::initializeClearFlags() {
     // We always discard and clear the depth+stencil buffers -- we don't allow sharing these
     // across views (clear implies discard)
-    mDiscardedFlags = ((mClearOptions.discard || mClearOptions.clear) ?
-              TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
-            | TargetBufferFlags::DEPTH_AND_STENCIL;
+    mDiscardStartFlags = ((mClearOptions.discard || mClearOptions.clear) ?
+                          TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
+                         | TargetBufferFlags::DEPTH_AND_STENCIL;
 
     mClearFlags = (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
             | TargetBufferFlags::DEPTH_AND_STENCIL;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -319,7 +319,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     if (currentRenderTarget) {
         // For custom RenderTarget, we look at each attachment flag and if they have their
         // SAMPLEABLE usage bit set, we assume they must not be discarded after the render pass.
-        // "+1" to the cound for the DEPTH attachment (we don't have stencil for the public RenderTarget)
+        // "+1" to the count for the DEPTH attachment (we don't have stencil for the public RenderTarget)
         for (size_t i = 0; i < RenderTarget::MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT + 1; i++) {
             auto attachment = currentRenderTarget->getAttachment((RenderTarget::AttachmentPoint)i);
             if (any(attachment.texture->getUsage() &

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -201,7 +201,7 @@ private:
     DisplayInfo mDisplayInfo;
     FrameRateOptions mFrameRateOptions;
     ClearOptions mClearOptions;
-    backend::TargetBufferFlags mDiscardedFlags{};
+    backend::TargetBufferFlags mDiscardStartFlags{};
     backend::TargetBufferFlags mClearFlags{};
     tsl::robin_set<FRenderTarget*> mPreviousRenderTargets;
     std::function<void()> mBeginFrameInternal;

--- a/filament/src/fg2/FrameGraphRenderPass.h
+++ b/filament/src/fg2/FrameGraphRenderPass.h
@@ -59,6 +59,7 @@ struct FrameGraphRenderPass {
         uint8_t samples = 0; // # of samples (0 = unset, default)
         backend::TargetBufferFlags clearFlags{};
         backend::TargetBufferFlags discardStart{};
+        backend::TargetBufferFlags keepOverrideEnd{};
     };
 
     uint32_t id = 0;


### PR DESCRIPTION
Until now, all attachments of RenderTarget beyond COLOR0 were discarded
after rendering.

With this change, attachment whose texture has the SAMPLEABLE usage
bit set will be kept.

Fixes #3962