### PR TITLE
Fix Automation test_settings

### DIFF
--- a/libs/viewer/src/AutomationSpec.cpp
+++ b/libs/viewer/src/AutomationSpec.cpp
@@ -38,7 +38,7 @@ static const bool VERBOSE = false;
 namespace filament {
 namespace viewer {
 
-// The default spec generates 65 test cases.
+// The default spec generates 66 test cases.
 static const char* DEFAULT_AUTOMATION = R"TXT([
     {
         "name": "ppoff",

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -190,7 +190,7 @@ TEST_F(ViewSettingsTest, JsonTestMaterial) {
 TEST_F(ViewSettingsTest, DefaultAutomationSpec) {
     AutomationSpec* specs = AutomationSpec::generateDefaultTestCases();
     ASSERT_TRUE(specs);
-    ASSERT_EQ(specs->size(), 65);
+    ASSERT_EQ(specs->size(), 66);
 
     Settings settings;
 
@@ -201,8 +201,8 @@ TEST_F(ViewSettingsTest, DefaultAutomationSpec) {
     ASSERT_TRUE(specs->get(1, &settings));
     ASSERT_TRUE(settings.view.postProcessingEnabled);
 
-    ASSERT_TRUE(specs->get(64, &settings));
-    ASSERT_FALSE(specs->get(65, &settings));
+    ASSERT_TRUE(specs->get(65, &settings));
+    ASSERT_FALSE(specs->get(66, &settings));
 
     delete specs;
 }


### PR DESCRIPTION
~This fixes the test, though I'm not sure why it's required. I also don't understand why the original test had 65 test cases, instead of only 64 (2^8). It seems only settings with a "permute" key would affect the number of automation combinations.~

Oh, maybe I do understand. Each top-level entry in the automation spec generates a _independent_ set of test cases.