### PR TITLE
A fixed capacity vector.

### DIFF
--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -20,8 +20,11 @@
 
 #include "details/Texture.h"
 
+#include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
 #include <utils/debug.h>
+
+#include <iterator>
 
 using namespace utils;
 
@@ -211,12 +214,10 @@ void ResourceAllocator::gc() noexcept {
     }
 
     if (UTILS_UNLIKELY(mCacheSize >= CACHE_CAPACITY)) {
-        // make a copy of our cache to a vector
-        std::vector<std::pair<TextureKey, TextureCachePayload>> cache;
-        cache.reserve(textureCache.size());
-        for (auto const& item : textureCache) {
-            cache.push_back(item);
-        }
+        // make a copy of our CacheContainer to a vector
+        using Vector = FixedCapacityVector<std::pair<TextureKey, TextureCachePayload>>;
+        auto cache = Vector::with_capacity(textureCache.size());
+        std::copy(textureCache.begin(), textureCache.end(), std::back_insert_iterator<Vector>(cache));
 
         // sort by least recently used
         std::sort(cache.begin(), cache.end(), [](auto const& lhs, auto const& rhs) {

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -24,6 +24,7 @@
 #include <private/filament/SibGenerator.h>
 
 #include <utils/debug.h>
+#include <utils/FixedCapacityVector.h>
 
 namespace filament {
 
@@ -86,8 +87,7 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, FView& view,
     };
 
     using ShadowPass = std::pair<const ShadowMapEntry*, RenderPass>;
-    std::vector<ShadowPass> passes;
-    passes.reserve(MAX_SHADOW_LAYERS);
+    auto passes = utils::FixedCapacityVector<ShadowPass>::with_capacity(MAX_SHADOW_LAYERS);
     uint8_t layerSampleCount[MAX_SHADOW_LAYERS] = {};
 
     assert_invariant(mTextureRequirements.layers <= MAX_SHADOW_LAYERS);

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -31,6 +31,8 @@
 
 #include "fg2/FrameGraph.h"
 
+#include <utils/FixedCapacityVector.h>
+
 #include <math/vec3.h>
 
 #include <array>
@@ -173,8 +175,14 @@ private:
     backend::TextureFormat mTextureFormat = backend::TextureFormat::DEPTH16;
     float mTextureZResolution = 1.0f / (1u << 16u);
 
-    std::vector<ShadowMapEntry> mCascadeShadowMaps;
-    std::vector<ShadowMapEntry> mSpotShadowMaps;
+    utils::FixedCapacityVector<ShadowMapEntry> mCascadeShadowMaps{
+            utils::FixedCapacityVector<ShadowMapEntry>::with_capacity(
+                    CONFIG_MAX_SHADOW_CASCADES) };
+
+    utils::FixedCapacityVector<ShadowMapEntry> mSpotShadowMaps{
+            utils::FixedCapacityVector<ShadowMapEntry>::with_capacity(
+                    CONFIG_MAX_SHADOW_CASTING_SPOTS) };
+
     backend::RenderPassParams mRenderPassParams;
 
     std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASCADES> mCascadeShadowMapCache;

--- a/filament/src/fg2/FrameGraph.h
+++ b/filament/src/fg2/FrameGraph.h
@@ -373,9 +373,6 @@ private:
     friend class ResourceNode;
     friend class RenderPassNode;
 
-    template<typename T> using Allocator = utils::STLAllocator<T, LinearAllocatorArena>;
-    template<typename T> using Vector = std::vector<T, Allocator<T>>; // 32 bytes
-
     LinearAllocatorArena& getArena() noexcept { return mArena; }
     DependencyGraph& getGraph() noexcept { return mGraph; }
     ResourceAllocatorInterface& getResourceAllocator() noexcept { return mResourceAllocator; }

--- a/filament/src/fg2/ResourceNode.cpp
+++ b/filament/src/fg2/ResourceNode.cpp
@@ -22,7 +22,7 @@ namespace filament {
 
 ResourceNode::ResourceNode(FrameGraph& fg, FrameGraphHandle h, FrameGraphHandle parent) noexcept
         : DependencyGraph::Node(fg.getGraph()),
-          resourceHandle(h), mFrameGraph(fg), mParentHandle(parent) {
+          resourceHandle(h), mFrameGraph(fg), mReaderPasses(fg.getArena()), mParentHandle(parent) {
 }
 
 ResourceNode::~ResourceNode() noexcept {

--- a/filament/src/fg2/details/DependencyGraph.h
+++ b/filament/src/fg2/details/DependencyGraph.h
@@ -18,10 +18,11 @@
 #define TNT_FILAMENT_FG2_GRAPH_H
 
 #include <utils/ostream.h>
+#include <utils/CString.h>
+#include <utils/FixedCapacityVector.h>
 #include <utils/debug.h>
 
 #include <vector>
-#include <utils/CString.h>
 
 namespace filament {
 
@@ -126,8 +127,8 @@ public:
         const NodeID mId;           // unique id
     };
 
-    using EdgeContainer = std::vector<Edge*>;
-    using NodeContainer = std::vector<Node*>;
+    using EdgeContainer = utils::FixedCapacityVector<Edge*, std::allocator<Edge*>, false>;
+    using NodeContainer = utils::FixedCapacityVector<Node*, std::allocator<Node*>, false>;
 
     /**
      * Removes all edges and nodes from the graph.

--- a/filament/src/fg2/details/ResourceNode.h
+++ b/filament/src/fg2/details/ResourceNode.h
@@ -88,7 +88,7 @@ public:
 
 private:
     FrameGraph& mFrameGraph;
-    std::vector<ResourceEdgeBase *> mReaderPasses;
+    Vector<ResourceEdgeBase *> mReaderPasses;
     ResourceEdgeBase* mWriterPass = nullptr;
     FrameGraphHandle mParentHandle;
     DependencyGraph::Edge* mParentReadEdge = nullptr;

--- a/libs/ibl/include/ibl/CubemapIBL.h
+++ b/libs/ibl/include/ibl/CubemapIBL.h
@@ -19,6 +19,8 @@
 
 #include <math/vec3.h>
 
+#include<utils/Slice.h>
+
 #include <vector>
 
 #include <stdint.h>
@@ -50,6 +52,11 @@ public:
      * @param maxNumSamples     number of samples for importance sampling
      * @param updater           a callback for the caller to track progress
      */
+    static void roughnessFilter(
+            utils::JobSystem& js, Cubemap& dst, const utils::Slice<Cubemap>& levels,
+            float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
+            Progress updater = nullptr, void* userdata = nullptr);
+
     static void roughnessFilter(
             utils::JobSystem& js, Cubemap& dst, const std::vector<Cubemap>& levels,
             float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,

--- a/libs/ibl/src/CubemapIBL.cpp
+++ b/libs/ibl/src/CubemapIBL.cpp
@@ -292,8 +292,17 @@ static float UTILS_UNUSED VisibilityAshikhmin(float NoV, float NoL, float /*a*/)
  *
  */
 
+UTILS_ALWAYS_INLINE
 void CubemapIBL::roughnessFilter(
         utils::JobSystem& js, Cubemap& dst, const std::vector<Cubemap>& levels,
+        float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
+        Progress updater, void* userdata) {
+    roughnessFilter(js, dst, { levels.data(), uint32_t(levels.size()) },
+            linearRoughness, maxNumSamples, mirror, prefilter, updater, userdata);
+}
+
+void CubemapIBL::roughnessFilter(
+        utils::JobSystem& js, Cubemap& dst, const utils::Slice<Cubemap>& levels,
         float linearRoughness, size_t maxNumSamples, math::float3 mirror, bool prefilter,
         Progress updater, void* userdata)
 {

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/Entity.h
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityInstance.h
         ${PUBLIC_HDR_DIR}/${TARGET}/EntityManager.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/FixedCapacityVector.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Log.h
         ${PUBLIC_HDR_DIR}/${TARGET}/memalign.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Mutex.h

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -164,14 +164,6 @@ public:
         free(p);
     }
 
-    // Allocators can't be copied
-    HeapAllocator(const HeapAllocator& rhs) = delete;
-    HeapAllocator& operator=(const HeapAllocator& rhs) = delete;
-
-    // Allocators can be moved
-    HeapAllocator(HeapAllocator&& rhs) noexcept = default;
-    HeapAllocator& operator=(HeapAllocator&& rhs) noexcept = default;
-
     ~HeapAllocator() noexcept = default;
 
     void swap(HeapAllocator& rhs) noexcept { }

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_FIXEDCAPACITYVECTOR_H
+#define TNT_UTILS_FIXEDCAPACITYVECTOR_H
+
+#include <utils/compressed_pair.h>
+#include <utils/Panic.h>
+
+#include <algorithm>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef NDEBUG
+#define FILAMENT_FORCE_CAPACITY_CHECK true
+#else
+#define FILAMENT_FORCE_CAPACITY_CHECK false
+#endif
+
+namespace utils {
+
+/**
+ * FixedCapacityVector is (almost) a drop-in replacement for std::vector<> except it has a
+ * fixed capacity decided at runtime. The vector storage is never reallocated unless reserve()
+ * is called. Operations that add elements to the vector can fail if there is not enough
+ * capacity.
+ *
+ * An empty vector with a given capacity is created with
+ *   FixedCapacityVector<T>::with_capacity( capacity );
+ *
+ */
+template<typename T, typename A = std::allocator<T>, bool CapacityCheck = true>
+class UTILS_PUBLIC FixedCapacityVector {
+public:
+    using allocator_type = A;
+    using value_type = T;
+    using reference = T&;
+    using const_reference = T const&;
+    using size_type = uint32_t;
+    using difference_type = int32_t;
+    using pointer = T*;
+    using const_pointer = T const*;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+private:
+    using storage_traits = std::allocator_traits<allocator_type>;
+
+public:
+    /** returns an empty vector with the specified capacity */
+    static FixedCapacityVector with_capacity(
+            size_type capacity, const allocator_type& allocator = allocator_type()) {
+        return FixedCapacityVector(construct_with_capacity, capacity, allocator);
+    }
+
+    FixedCapacityVector() = default;
+
+    explicit FixedCapacityVector(const allocator_type& allocator) noexcept
+            : mCapacityAllocator({}, allocator) {
+    }
+
+    explicit FixedCapacityVector(size_type size, const allocator_type& allocator = allocator_type())
+            : mSize(size),
+              mCapacityAllocator(size, allocator) {
+        mData = this->allocator().allocate(this->capacity());
+        construct(begin(), end());
+    }
+
+    FixedCapacityVector(size_type size, const_reference value,
+            const allocator_type& alloc = allocator_type())
+            : mSize(size),
+              mCapacityAllocator(size, alloc) {
+        mData = this->allocator().allocate(this->capacity());
+        construct(begin(), end(), value);
+    }
+
+    FixedCapacityVector(FixedCapacityVector const& rhs)
+            : mSize(rhs.mSize),
+              mCapacityAllocator(rhs.capacity(),
+                    storage_traits::select_on_container_copy_construction(rhs.allocator())) {
+        mData = allocator().allocate(capacity());
+        std::uninitialized_copy(rhs.begin(), rhs.end(), begin());
+    }
+
+    FixedCapacityVector(FixedCapacityVector&& rhs) noexcept {
+        this->swap(rhs);
+    }
+
+    ~FixedCapacityVector() noexcept {
+        destroy(begin(), end());
+        allocator().deallocate(data(), size());
+    }
+
+    FixedCapacityVector& operator=(FixedCapacityVector const& rhs) {
+        if (this != &rhs) {
+            FixedCapacityVector t(rhs);
+            this->swap(t);
+        }
+        return *this;
+    }
+
+    FixedCapacityVector& operator=(FixedCapacityVector&& rhs) noexcept {
+        this->swap(rhs);
+        return *this;
+    }
+
+    allocator_type get_allocator() const noexcept {
+        return mCapacityAllocator.second();
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    iterator begin() noexcept { return data(); }
+    iterator end() noexcept { return data() + size(); }
+    const_iterator begin() const noexcept { return data(); }
+    const_iterator end() const noexcept { return data() + size(); }
+    reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+    const_iterator cbegin() const noexcept { return begin(); }
+    const_iterator cend() const noexcept { return end(); }
+    const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+    const_reverse_iterator crend() const noexcept { return rend(); }
+
+    // --------------------------------------------------------------------------------------------
+
+    size_type size() const noexcept { return mSize; }
+    size_type capacity() const noexcept { return mCapacityAllocator.first(); }
+    bool empty() const noexcept { return size() == 0; }
+    size_type max_size() const noexcept {
+        return std::min(storage_traits::max_size(allocator()),
+                std::numeric_limits<size_type>::max());
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    reference operator[](size_type n) noexcept {
+        assert(n < size());
+        return *(begin() + n);
+    }
+
+    const_reference operator[](size_type n) const noexcept {
+        assert(n < size());
+        return *(begin() + n);
+    }
+
+    reference front() noexcept { return *begin(); }
+    const_reference front() const noexcept { return *begin(); }
+    reference back() noexcept { return *(end() - 1); }
+    const_reference back() const noexcept { return *(end() - 1); }
+    value_type* data() noexcept { return mData; }
+    const value_type* data() const noexcept { return mData; }
+
+    // --------------------------------------------------------------------------------------------
+
+    void push_back(const_reference v) {
+        auto pos = assertCapacityForSize(size() + 1);
+        ++mSize;
+        storage_traits::construct(allocator(), pos, v);
+    }
+
+    void push_back(value_type&& v) {
+        auto pos = assertCapacityForSize(size() + 1);
+        ++mSize;
+        storage_traits::construct(allocator(), pos, std::move(v));
+    }
+
+    template<typename ... ARGS>
+    reference emplace_back(ARGS&& ... args) {
+        auto pos = assertCapacityForSize(size() + 1);
+        ++mSize;
+        storage_traits::construct(allocator(), pos, std::forward<ARGS>(args)...);
+        return *pos;
+    }
+
+    void pop_back() {
+        assert(!empty());
+        --mSize;
+        destroy(end(), end() + 1);
+    }
+
+    iterator insert(const_iterator position, const_reference v) {
+        if (position == end()) {
+            push_back(v);
+        } else {
+            assertCapacityForSize(size() + 1);
+            pointer p = const_cast<pointer>(position);
+            move_range(p, end(), p + 1);
+            ++mSize;
+            // here we handle inserting an element of this vector!
+            const_pointer pv = std::addressof(v);
+            if (p <= pv && pv < end()) {
+                *p = *(pv + 1);
+            } else {
+                *p = v;
+            }
+        }
+        return const_cast<iterator>(position);
+    }
+
+    iterator insert(const_iterator position, value_type&& v) {
+        if (position == end()) {
+            push_back(std::move(v));
+        } else {
+            assertCapacityForSize(size() + 1);
+            pointer p = const_cast<pointer>(position);
+            move_range(p, end(), p + 1);
+            ++mSize;
+            *p = std::move(v);
+        }
+        return const_cast<iterator>(position);
+    }
+
+    iterator erase(const_iterator pos) {
+        assert(pos != end());
+        return erase(pos, pos + 1);
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        assert(first <= last);
+        auto e = std::move(const_cast<iterator>(last), end(), const_cast<iterator>(first));
+        destroy(e, end());
+        mSize -= std::distance(first, last);
+        return const_cast<iterator>(first);
+    }
+
+    void clear() noexcept {
+        destroy(begin(), end());
+        mSize = 0;
+    }
+
+    void resize(size_type count) {
+        assertCapacityForSize(count);
+        if constexpr(std::is_trivially_constructible_v<value_type> &&
+                     std::is_trivially_destructible_v<value_type>) {
+            // we check for triviality here so that the implementation could be non-inline
+            mSize = count;
+        } else {
+            resize_non_trivial(count);
+        }
+    }
+
+    void resize(size_type count, const_reference v) {
+        assertCapacityForSize(count);
+        resize_non_trivial(count, v);
+    }
+
+    void swap(FixedCapacityVector& other) {
+        using std::swap;
+        swap(mData, other.mData);
+        swap(mSize, other.mSize);
+        mCapacityAllocator.swap(other.mCapacityAllocator);
+    }
+
+    UTILS_NOINLINE
+    void reserve(size_type c) {
+        if (c > capacity()) {
+            FixedCapacityVector t(c, allocator());
+            t.mSize = size();
+            std::uninitialized_move(begin(), end(), t.begin());
+            this->swap(t);
+        }
+    }
+
+private:
+    enum construct_with_capacity_tag{ construct_with_capacity };
+
+    FixedCapacityVector(construct_with_capacity_tag,
+            size_type capacity, const allocator_type& allocator = allocator_type())
+            : mCapacityAllocator(capacity, allocator) {
+        mData = this->allocator().allocate(this->capacity());
+    }
+
+    allocator_type& allocator() noexcept {
+        return mCapacityAllocator.second();
+    }
+
+    allocator_type const& allocator() const noexcept {
+        return mCapacityAllocator.second();
+    }
+
+    iterator assertCapacityForSize(size_type s) {
+        if constexpr(CapacityCheck || FILAMENT_FORCE_CAPACITY_CHECK) {
+            ASSERT_PRECONDITION(capacity() >= s,
+                    "capacity exceeded: requested size %lu, available capacity %lu.",
+                    (unsigned long)s, (unsigned long)capacity());
+        }
+        return end();
+    }
+
+    inline void construct(iterator first, iterator last) noexcept {
+        // we check for triviality here so that the implementation could be non-inline
+        if constexpr(!std::is_trivially_constructible_v<value_type>) {
+            construct_non_trivial(first, last);
+        }
+    }
+
+    void construct(iterator first, iterator last, const_reference proto) noexcept {
+        #pragma nounroll
+        while (first != last) {
+            storage_traits::construct(allocator(), first++, proto);
+        }
+    }
+
+    // should this be NOINLINE?
+    void construct_non_trivial(iterator first, iterator last) noexcept {
+        #pragma nounroll
+        while (first != last) {
+            storage_traits::construct(allocator(), first++);
+        }
+    }
+
+
+    inline void destroy(iterator first, iterator last) noexcept {
+        // we check for triviality here so that the implementation could be non-inline
+        if constexpr(!std::is_trivially_destructible_v<value_type>) {
+            destroy_non_trivial(first, last);
+        }
+    }
+
+    // should this be NOINLINE?
+    void destroy_non_trivial(iterator first, iterator last) noexcept {
+        #pragma nounroll
+        while (first != last) {
+            storage_traits::destroy(allocator(), --last);
+        }
+    }
+
+    // should this be NOINLINE?
+    void resize_non_trivial(size_type count) {
+        if (count > size()) {
+            construct(end(), begin() + count);
+        } else if (count < size()) {
+            destroy(begin() + count, end());
+        }
+        mSize = count;
+    }
+
+    // should this be NOINLINE?
+    void resize_non_trivial(size_type count, const_reference v) {
+        if (count > size()) {
+            construct(end(), begin() + count, v);
+        } else if (count < size()) {
+            destroy(begin() + count, end());
+        }
+        mSize = count;
+    }
+
+    // should this be NOINLINE?
+    void move_range(pointer s, pointer e, pointer to) {
+        if constexpr(std::is_trivially_copy_assignable_v<value_type>
+                && std::is_trivially_destructible_v<value_type>) {
+            // this generates memmove -- which doesn't happen otherwise
+            std::move_backward(s, e, to + std::distance(s, e));
+        } else {
+            pointer our_end = end();
+            difference_type n = our_end - to;   // nb of elements to move by operator=
+            pointer i = s + n;                  // 1st element to move by move ctor
+            for (pointer d = our_end ; i < our_end ; ++i, ++d) {
+                storage_traits::construct(allocator(), d, std::move(*i));
+            }
+            std::move_backward(s, s + n, our_end);
+        }
+    }
+
+    template<typename TYPE>
+    class SizeTypeWrapper {
+        TYPE value{};
+    public:
+        SizeTypeWrapper() noexcept = default;
+        SizeTypeWrapper(SizeTypeWrapper const& rhs) noexcept = default;
+        explicit  SizeTypeWrapper(TYPE value) noexcept : value(value) { }
+        SizeTypeWrapper operator=(TYPE rhs) noexcept { value = rhs; return *this; }
+        operator TYPE() const noexcept { return value; }
+    };
+
+    pointer mData{};
+    size_type mSize{};
+    compressed_pair<SizeTypeWrapper<size_type>, allocator_type> mCapacityAllocator{};
+};
+
+} // namespace utils
+
+#endif //TNT_UTILS_FIXEDCAPACITYVECTOR_H

--- a/libs/utils/include/utils/Slice.h
+++ b/libs/utils/include/utils/Slice.h
@@ -44,15 +44,12 @@ public:
 
     Slice() noexcept = default;
 
-    template <typename Iter>
-    Slice(Iter begin, Iter end) noexcept
-            : mBegin(iterator(begin)),
-              mEndOffset(size_type(iterator(end)-iterator(begin))) {
+    Slice(const_iterator begin, const_iterator end) noexcept
+            : mBegin(const_cast<iterator>(begin)), mEndOffset(size_type(end - begin)) {
     }
 
-    template <typename Iter>
-    Slice(Iter begin, size_type count) noexcept
-            : mBegin(begin), mEndOffset(size_type(count)) {
+    Slice(const_pointer begin, size_type count) noexcept
+            : mBegin(const_cast<iterator>(begin)), mEndOffset(size_type(count)) {
     }
 
     Slice(Slice const& rhs) noexcept = default;
@@ -60,15 +57,13 @@ public:
     Slice& operator=(Slice const& rhs) noexcept = default;
     Slice& operator=(Slice&& rhs) noexcept = default;
 
-    template<typename Iter>
-    void set(Iter begin, size_type count) UTILS_RESTRICT noexcept {
-        mBegin = &*begin;
+    void set(pointer begin, size_type count) UTILS_RESTRICT noexcept {
+        mBegin = begin;
         mEndOffset = size_type(count);
     }
 
-    template<typename Iter>
-    void set(Iter begin, Iter end) UTILS_RESTRICT noexcept {
-        mBegin = &*begin;
+    void set(iterator begin, iterator end) UTILS_RESTRICT noexcept {
+        mBegin = begin;
         mEndOffset = size_type(end - begin);
     }
 

--- a/libs/utils/include/utils/compressed_pair.h
+++ b/libs/utils/include/utils/compressed_pair.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_COMPRESSED_PAIR_H
+#define TNT_UTILS_COMPRESSED_PAIR_H
+
+#include <type_traits>
+#include <utility>
+
+namespace utils {
+
+template<typename T, bool>
+struct dependent_type : public T {
+};
+
+template<typename T1, typename T2,
+        std::enable_if_t<!std::is_same_v<T1, T2>, bool> = true>
+struct compressed_pair : private T1, private T2 {
+
+    template<bool Dummy = true, typename = std::enable_if_t<
+            dependent_type<std::is_default_constructible<T1>, Dummy>::value &&
+            dependent_type<std::is_default_constructible<T2>, Dummy>::value>>
+    compressed_pair() : T1(), T2() {}
+
+    template<typename U1, typename U2>
+    compressed_pair(U1&& other1, U2&& other2)
+            : T1(std::forward<U1>(other1)),
+              T2(std::forward<U2>(other2)) {}
+
+    T1& first() noexcept {
+        return static_cast<T1&>(*this);
+    }
+
+    T2& second() noexcept {
+        return static_cast<T2&>(*this);
+    }
+
+    T1 const& first() const noexcept {
+        return static_cast<T1 const&>(*this);
+    }
+
+    T2 const& second() const noexcept {
+        return static_cast<T2 const&>(*this);
+    }
+
+    void swap(compressed_pair& other) noexcept {
+        using std::swap;
+        swap(first(), other.first());
+        swap(second(), other.second());
+    }
+};
+
+} // namespace utils
+
+#endif //TNT_UTILS_COMPRESSED_PAIR_H

--- a/libs/utils/src/EntityManagerImpl.h
+++ b/libs/utils/src/EntityManagerImpl.h
@@ -23,6 +23,7 @@
 #include <utils/Entity.h>
 #include <utils/Mutex.h>
 #include <utils/CallStack.h>
+#include <utils/FixedCapacityVector.h>
 
 #include <tsl/robin_set.h>
 
@@ -136,14 +137,12 @@ public:
         mListeners.erase(l);
     }
 
-    std::vector<EntityManager::Listener*> getListeners() const noexcept {
+    utils::FixedCapacityVector<EntityManager::Listener*> getListeners() const noexcept {
         std::unique_lock<Mutex> lock(mListenerLock);
         tsl::robin_set<Listener*> const& listeners = mListeners;
-        std::vector<EntityManager::Listener*> result(listeners.size()); // unfortunately this memset()
-        auto d = result.begin();
-        for (Listener* listener : listeners) {
-            *d++ = listener;
-        }
+        utils::FixedCapacityVector<EntityManager::Listener*> result(listeners.size());
+        result.resize(result.capacity()); // unfortunately this memset()
+        std::copy(listeners.begin(), listeners.end(), result.begin());
         return result; // the c++ standard guarantees a move
     }
 


### PR DESCRIPTION
This is (almost) drop-in replacement for std::vector, the main 
difference is that FixedCapacityVector has a fixed (at runtime)
capacity, which makes it a lot more efficient and small for operations
like push_back();

The capacity can be set (and re-set) as usual with reserve(),
but exceeding the capacity when adding items will throw.
The capacity is also set when creating the vector with a size.

In addition a FixedCapacityVector<> instance is only 16 bytes instead
of 24 for std::vector<>.

The aim here is to reduce code bloat.