### PR TITLE
sample-gltf-viewer: fix lifetime cycle for RemoteServer.

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/RemoteServer.java
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/RemoteServer.java
@@ -81,6 +81,16 @@ public class RemoteServer {
         return message;
     }
 
+    /*
+     * Destroys the native WebSocket server and frees up the port.
+     *
+     * This might need to be done explicitly (as opposed to waiting for gc) to free up the port.
+     */
+    public void close() {
+        nDestroy(mNativeObject);
+        mNativeObject = 0;
+    }
+
     @Override
     protected void finalize() throws Throwable {
         nDestroy(mNativeObject);

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -289,6 +289,7 @@ class MainActivity : Activity() {
     override fun onDestroy() {
         super.onDestroy()
         choreographer.removeFrameCallback(frameScheduler)
+        remoteServer?.close()
     }
 
     fun loadModelData(message: RemoteServer.ReceivedMessage) {


### PR DESCRIPTION
The sample would crash when removing `orientation` from `configChanges`
and rotating the device, because the old RemoteServer would still be
alive when creating the second one, so the WebSocket port would be
unavailable.