### PR TITLE
VulkanSwapChain: simplify and repair swap chain resizing.

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -31,14 +31,13 @@ struct VulkanSwapChain : public HwSwapChain {
     void create();
     void destroy();
     void makePresentable();
+    bool hasResized() const;
 
     VulkanContext& context;
     VkSurfaceKHR surface;
     VkSwapchainKHR swapchain;
-    VkSurfaceCapabilitiesKHR surfaceCapabilities;
     VkSurfaceFormatKHR surfaceFormat;
     VkExtent2D clientSize;
-    std::vector<VkSurfaceFormatKHR> surfaceFormats;
     VkQueue presentQueue;
     VkQueue headlessQueue;
     std::vector<VulkanAttachment> attachments;

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -524,6 +524,10 @@ bool equivalent(const VkRect2D& a, const VkRect2D& b) {
             a.offset.x == b.offset.x && a.offset.y == b.offset.y;
 }
 
+bool equivalent(const VkExtent2D& a, const VkExtent2D& b) {
+    return a.height == b.height && a.width == b.width;
+}
+
 } // namespace filament
 } // namespace backend
 

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -49,6 +49,7 @@ PixelDataType getComponentType(VkFormat format);
 VkComponentMapping getSwizzleMap(TextureSwizzle swizzle[4]);
 void transitionImageLayout(VkCommandBuffer cmdbuffer, VulkanLayoutTransition transition);
 bool equivalent(const VkRect2D& a, const VkRect2D& b);
+bool equivalent(const VkExtent2D& a, const VkExtent2D& b);
 
 } // namespace filament
 } // namespace backend


### PR DESCRIPTION
Newer versions of MoltenVK seem to behave similarly to Android,
so there's no need to separate codepaths. I tested this by not only
resizing the window, but also dragging between displays with different
pixel ratios, and rotating on Android with & without `orientation` in
`configChanges`. I also tried our headless unit tests.