### PR TITLE
replace all size_t with uint32_t in the backend API

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -215,10 +215,10 @@ DECL_DRIVER_API_R_N(backend::TextureHandle, importTexture,
         backend::TextureUsage, usage)
 
 DECL_DRIVER_API_R_N(backend::SamplerGroupHandle, createSamplerGroup,
-        size_t, size)
+        uint32_t, size)
 
 DECL_DRIVER_API_R_N(backend::UniformBufferHandle, createUniformBuffer,
-        size_t, size,
+        uint32_t, size,
         backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_0(backend::RenderPrimitiveHandle, createRenderPrimitive)
@@ -312,7 +312,7 @@ DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncH
 
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,
-        size_t, index,
+        uint32_t, index,
         backend::BufferObjectHandle, bufferObject)
 
 DECL_DRIVER_API_N(updateIndexBuffer,
@@ -374,7 +374,7 @@ DECL_DRIVER_API_N(setExternalImage,
 DECL_DRIVER_API_N(setExternalImagePlane,
         backend::TextureHandle, th,
         void*, image,
-        size_t, plane)
+        uint32_t, plane)
 
 DECL_DRIVER_API_N(setExternalStream,
         backend::TextureHandle, th,
@@ -426,26 +426,26 @@ DECL_DRIVER_API_N(commit,
  */
 
 DECL_DRIVER_API_N(bindUniformBuffer,
-        size_t, index,
+        uint32_t, index,
         backend::UniformBufferHandle, ubh)
 
 DECL_DRIVER_API_N(bindUniformBufferRange,
-        size_t, index,
+        uint32_t, index,
         backend::UniformBufferHandle, ubh,
-        size_t, offset,
-        size_t, size)
+        uint32_t, offset,
+        uint32_t, size)
 
 DECL_DRIVER_API_N(bindSamplers,
-        size_t, index,
+        uint32_t, index,
         backend::SamplerGroupHandle, sbh)
 
 DECL_DRIVER_API_N(insertEventMarker,
         const char*, string,
-        size_t, len = 0)
+        uint32_t, len = 0)
 
 DECL_DRIVER_API_N(pushGroupMarker,
         const char*, string,
-        size_t, len = 0)
+        uint32_t, len = 0)
 
 DECL_DRIVER_API_0(popGroupMarker)
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -239,11 +239,11 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
         width, height, depth, usage, metalTexture);
 }
 
-void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
+void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, uint32_t size) {
     mContext->samplerGroups.insert(construct_handle<MetalSamplerGroup>(mHandleMap, sbh, size));
 }
 
-void MetalDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
+void MetalDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, uint32_t size,
         BufferUsage usage) {
     construct_handle<MetalUniformBuffer>(mHandleMap, ubh, *mContext, size);
 }
@@ -680,7 +680,7 @@ void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescripto
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
+void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
     auto* vertexBuffer = handle_cast<MetalVertexBuffer>(mHandleMap, vbh);
     auto* bufferObject = handle_cast<MetalBufferObject>(mHandleMap, boh);
@@ -740,7 +740,7 @@ void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     texture->externalImage.set((CVPixelBufferRef) image);
 }
 
-void MetalDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+void MetalDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint32_t plane) {
     auto texture = handle_cast<MetalTexture>(mHandleMap, th);
     texture->externalImage.set((CVPixelBufferRef) image, plane);
 }
@@ -885,37 +885,37 @@ void MetalDriver::commit(Handle<HwSwapChain> sch) {
     swapChain->releaseDrawable();
 }
 
-void MetalDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
+void MetalDriver::bindUniformBuffer(uint32_t index, Handle<HwUniformBuffer> ubh) {
     mContext->uniformState[index] = UniformBufferState {
-        .bound = true,
+        .offset = 0,
         .ubh = ubh,
-        .offset = 0
+        .bound = true
     };
 }
 
-void MetalDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
-        size_t offset, size_t size) {
+void MetalDriver::bindUniformBufferRange(uint32_t index, Handle<HwUniformBuffer> ubh,
+        uint32_t offset, uint32_t size) {
     mContext->uniformState[index] = UniformBufferState {
-        .bound = true,
+        .offset = offset,
         .ubh = ubh,
-        .offset = offset
+        .bound = true
     };
 }
 
-void MetalDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
+void MetalDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
     auto sb = handle_cast<MetalSamplerGroup>(mHandleMap, sbh);
     mContext->samplerBindings[index] = sb;
 }
 
-void MetalDriver::insertEventMarker(const char* string, size_t len) {
+void MetalDriver::insertEventMarker(const char* string, uint32_t len) {
 
 }
 
-void MetalDriver::pushGroupMarker(const char* string, size_t len) {
+void MetalDriver::pushGroupMarker(const char* string, uint32_t len) {
     mContext->groupMarkers.push(string);
 }
 
-void MetalDriver::popGroupMarker(int dummy) {
+void MetalDriver::popGroupMarker(int) {
     assert_invariant(!mContext->groupMarkers.empty());
     mContext->groupMarkers.pop();
 }

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -185,7 +185,7 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
     scheduleDestroy(std::move(p));
 }
 
-void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
+void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
 }
 
@@ -227,7 +227,7 @@ SyncStatus NoopDriver::getSyncStatus(Handle<HwSync> sh) {
 void NoopDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 
-void NoopDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+void NoopDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint32_t plane) {
 }
 
 void NoopDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
@@ -271,20 +271,20 @@ void NoopDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> re
 void NoopDriver::commit(Handle<HwSwapChain> sch) {
 }
 
-void NoopDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
+void NoopDriver::bindUniformBuffer(uint32_t index, Handle<HwUniformBuffer> ubh) {
 }
 
-void NoopDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
-        size_t offset, size_t size) {
+void NoopDriver::bindUniformBufferRange(uint32_t index, Handle<HwUniformBuffer> ubh,
+        uint32_t offset, uint32_t size) {
 }
 
-void NoopDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
+void NoopDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
 }
 
-void NoopDriver::insertEventMarker(char const* string, size_t len) {
+void NoopDriver::insertEventMarker(char const* string, uint32_t len) {
 }
 
-void NoopDriver::pushGroupMarker(char const* string,  size_t len) {
+void NoopDriver::pushGroupMarker(char const* string,  uint32_t len) {
 }
 
 void NoopDriver::popGroupMarker(int) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -537,7 +537,7 @@ void OpenGLDriver::createProgramR(Handle<HwProgram> ph, Program&& program) {
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) {
+void OpenGLDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, uint32_t size) {
     DEBUG_MARKER()
 
     construct<GLSamplerGroup>(sbh, size);
@@ -545,7 +545,7 @@ void OpenGLDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t size) 
 
 void OpenGLDriver::createUniformBufferR(
         Handle<HwUniformBuffer> ubh,
-        size_t size,
+        uint32_t size,
         BufferUsage usage) {
     DEBUG_MARKER()
 
@@ -1706,7 +1706,7 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 // ------------------------------------------------------------------------------------------------
 
 void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
-        size_t index, Handle<HwBufferObject> boh) {
+        uint32_t index, Handle<HwBufferObject> boh) {
    DEBUG_MARKER()
 
     GLVertexBuffer* vb = handle_cast<GLVertexBuffer *>(vbh);
@@ -2122,8 +2122,7 @@ void OpenGLDriver::setExternalImage(Handle<HwTexture> th, void* image) {
     setExternalTexture(handle_cast<GLTexture*>(th), image);
 }
 
-void OpenGLDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
-
+void OpenGLDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint32_t plane) {
 }
 
 void OpenGLDriver::setExternalTexture(GLTexture* t, void* image) {
@@ -2771,7 +2770,7 @@ void OpenGLDriver::readStreamPixels(Handle<HwStream> sh,
 // Setting rendering state
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
+void OpenGLDriver::bindUniformBuffer(uint32_t index, Handle<HwUniformBuffer> ubh) {
     DEBUG_MARKER()
     auto& gl = mContext;
     GLUniformBuffer* ub = handle_cast<GLUniformBuffer *>(ubh);
@@ -2780,8 +2779,8 @@ void OpenGLDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) 
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
-        size_t offset, size_t size) {
+void OpenGLDriver::bindUniformBufferRange(uint32_t index, Handle<HwUniformBuffer> ubh,
+        uint32_t offset, uint32_t size) {
     DEBUG_MARKER()
     auto& gl = mContext;
 
@@ -2793,7 +2792,7 @@ void OpenGLDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> 
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
+void OpenGLDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
     assert_invariant(index < Program::BINDING_COUNT);
     GLSamplerGroup* sb = handle_cast<GLSamplerGroup *>(sbh);
@@ -2829,7 +2828,7 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     return s;
 }
 
-void OpenGLDriver::insertEventMarker(char const* string, size_t len) {
+void OpenGLDriver::insertEventMarker(char const* string, uint32_t len) {
 #ifdef GL_EXT_debug_marker
     auto& gl = mContext;
     if (gl.ext.EXT_debug_marker) {
@@ -2838,7 +2837,7 @@ void OpenGLDriver::insertEventMarker(char const* string, size_t len) {
 #endif
 }
 
-void OpenGLDriver::pushGroupMarker(char const* string,  size_t len) {
+void OpenGLDriver::pushGroupMarker(char const* string,  uint32_t len) {
 #ifdef GL_EXT_debug_marker
     auto& gl = mContext;
     if (UTILS_LIKELY(gl.ext.EXT_debug_marker)) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -385,11 +385,11 @@ void VulkanDriver::finish(int dummy) {
     mContext.commands->flush();
 }
 
-void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, size_t count) {
+void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, uint32_t count) {
     construct_handle<VulkanSamplerGroup>(mHandleMap, sbh, mContext, count);
 }
 
-void VulkanDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, size_t size,
+void VulkanDriver::createUniformBufferR(Handle<HwUniformBuffer> ubh, uint32_t size,
         BufferUsage usage) {
     auto uniformBuffer = construct_handle<VulkanUniformBuffer>(mHandleMap, ubh, mContext,
             mStagePool, mDisposer, size, usage);
@@ -828,7 +828,7 @@ uint8_t VulkanDriver::getMaxDrawBuffers() {
     return backend::MRT::MIN_SUPPORTED_RENDER_TARGET_COUNT; // TODO: query real value
 }
 
-void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, size_t index,
+void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
     auto& vb = *handle_cast<VulkanVertexBuffer>(mHandleMap, vbh);
     auto& bo = *handle_cast<VulkanBufferObject>(mHandleMap, boh);
@@ -948,7 +948,7 @@ SyncStatus VulkanDriver::getSyncStatus(Handle<HwSync> sh) {
 void VulkanDriver::setExternalImage(Handle<HwTexture> th, void* image) {
 }
 
-void VulkanDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, size_t plane) {
+void VulkanDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint32_t plane) {
 }
 
 void VulkanDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
@@ -1312,7 +1312,7 @@ void VulkanDriver::commit(Handle<HwSwapChain> sch) {
             result == VK_ERROR_OUT_OF_DATE_KHR);
 }
 
-void VulkanDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) {
+void VulkanDriver::bindUniformBuffer(uint32_t index, Handle<HwUniformBuffer> ubh) {
     auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
     // The driver API does not currently expose offset / range, but it will do so in the future.
     const VkDeviceSize offset = 0;
@@ -1320,18 +1320,18 @@ void VulkanDriver::bindUniformBuffer(size_t index, Handle<HwUniformBuffer> ubh) 
     mPipelineCache.bindUniformBuffer((uint32_t) index, buffer->getGpuBuffer(), offset, size);
 }
 
-void VulkanDriver::bindUniformBufferRange(size_t index, Handle<HwUniformBuffer> ubh,
-        size_t offset, size_t size) {
+void VulkanDriver::bindUniformBufferRange(uint32_t index, Handle<HwUniformBuffer> ubh,
+        uint32_t offset, uint32_t size) {
     auto* buffer = handle_cast<VulkanUniformBuffer>(mHandleMap, ubh);
     mPipelineCache.bindUniformBuffer((uint32_t)index, buffer->getGpuBuffer(), offset, size);
 }
 
-void VulkanDriver::bindSamplers(size_t index, Handle<HwSamplerGroup> sbh) {
+void VulkanDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
     auto* hwsb = handle_cast<VulkanSamplerGroup>(mHandleMap, sbh);
     mSamplerBindings[index] = hwsb;
 }
 
-void VulkanDriver::insertEventMarker(char const* string, size_t len) {
+void VulkanDriver::insertEventMarker(char const* string, uint32_t len) {
     constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     if (mContext.debugUtilsSupported) {
@@ -1350,7 +1350,7 @@ void VulkanDriver::insertEventMarker(char const* string, size_t len) {
     }
 }
 
-void VulkanDriver::pushGroupMarker(char const* string, size_t len) {
+void VulkanDriver::pushGroupMarker(char const* string, uint32_t len) {
     // TODO: Add group marker color to the Driver API
     constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;


### PR DESCRIPTION
this helps save a lot of space in the CommandStream, it especially
matters with scenes with a lot of draw calls.