### PR TITLE
Add support for KHR_materials_specular to glTF

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.10.2 (currently main branch)
 
+- gltfio: added support for `KHR_materials_ior`.
+
 ## v1.10.1
 
 - engine: Attachments of custom RendereTargets are not systematically discarded

--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -246,7 +246,7 @@ in <a href="#table_standardproperties">table&nbsp;1</a>.
 <tr><td style="text-align:right"> <strong class="asterisk">clearCoatNormal</strong> </td><td style="text-align:left"> A detail normal used to perturb the clear coat layer using <em class="underscore">bump mapping</em> (<em class="underscore">normal mapping</em>) </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">emissive</strong> </td><td style="text-align:left"> Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">postLightingColor</strong> </td><td style="text-align:left"> Additional color that can be blended with the result of the lighting computations. See <code>postLightingBlending</code> </td></tr>
-<tr><td style="text-align:right"> <strong class="asterisk">ior</strong> </td><td style="text-align:left"> Index of refraction for refractive objects </td></tr>
+<tr><td style="text-align:right"> <strong class="asterisk">ior</strong> </td><td style="text-align:left"> Index of refraction, either for refractive objects or as an alternative to reflectance </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">transmission</strong> </td><td style="text-align:left"> Defines how much of the diffuse light of a dielectric is transmitted through the object, in other words this defines how transparent an object is </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">absorption</strong> </td><td style="text-align:left"> Absorption factor for refractive objects </td></tr>
 <tr><td style="text-align:right"> <strong class="asterisk">microThickness</strong> </td><td style="text-align:left"> Thickness of the thin layer of refractive objects </td></tr>
@@ -317,7 +317,7 @@ The type and range of each property is described in <a href="#table_standardprop
 <p></p><p>
 
     The index of refraction (IOR) and the reflectance represent the same physical attribute,
-    therefore they don't need to be both specified. Typically, only the reflectance is specified
+    therefore they don't need to be both specified. Typically, only the reflectance is specified,
     and the IOR is deduced automatically. When only the IOR is specified, the reflectance is then
     deduced automatically. It is possible to specify both, in which case their values are kept
     as-is, which can lead to physically impossible materials, however, this might be desirable
@@ -844,7 +844,8 @@ this option for more information.
 The <code>ior</code> property only affects non-metallic surfaces. This property can be used to control the
 index of refraction and the specular intensity of materials. The <code>ior</code> property is intended to
 be used with refractive (transmissive) materials, which are enabled when the <code>refractionMode</code> is
-set to <code>cubemap</code> or <code>screenspace</code>.
+set to <code>cubemap</code> or <code>screenspace</code>. It can also be used on non-refractive objects as an alternative
+to setting the reflectance.
 
 </p><p>
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -93,7 +93,7 @@ in table [standardProperties].
 **clearCoatNormal**     | A detail normal used to perturb the clear coat layer using _bump mapping_ (_normal mapping_)
 **emissive**            | Additional diffuse albedo to simulate emissive surfaces (such as neons, etc.) This property is mostly useful in an HDR pipeline with a bloom pass
 **postLightingColor**   | Additional color that can be blended with the result of the lighting computations. See `postLightingBlending`
-**ior**                 | Index of refraction for refractive objects
+**ior**                 | Index of refraction, either for refractive objects or as an alternative to reflectance
 **transmission**        | Defines how much of the diffuse light of a dielectric is transmitted through the object, in other words this defines how transparent an object is
 **absorption**          | Absorption factor for refractive objects
 **microThickness**      | Thickness of the thin layer of refractive objects
@@ -146,7 +146,7 @@ The type and range of each property is described in table [standardPropertiesTyp
 
 !!! Note: About `ior` and `reflectance`
     The index of refraction (IOR) and the reflectance represent the same physical attribute,
-    therefore they don't need to be both specified. Typically, only the reflectance is specified
+    therefore they don't need to be both specified. Typically, only the reflectance is specified,
     and the IOR is deduced automatically. When only the IOR is specified, the reflectance is then
     deduced automatically. It is possible to specify both, in which case their values are kept
     as-is, which can lead to physically impossible materials, however, this might be desirable
@@ -507,7 +507,8 @@ this option for more information.
 The `ior` property only affects non-metallic surfaces. This property can be used to control the
 index of refraction and the specular intensity of materials. The `ior` property is intended to
 be used with refractive (transmissive) materials, which are enabled when the `refractionMode` is
-set to `cubemap` or `screenspace`.
+set to `cubemap` or `screenspace`. It can also be used on non-refractive objects as an alternative
+to setting the reflectance.
 
 The index of refraction (or refractive index) of a material is a dimensionless number that describes
 how fast light travels through that material. The higher the number, the slower light travels

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -83,7 +83,6 @@ struct alignas(4) MaterialKey {
     uint8_t sheenRoughnessUV : 7;
     bool hasSheen : 1;
     bool hasIOR : 1;
-    bool hasReflectance : 1;
 };
 
 static_assert(sizeof(MaterialKey) == 16, "MaterialKey has unexpected padding.");

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -82,6 +82,7 @@ struct alignas(4) MaterialKey {
     bool hasSheenRoughnessTexture : 1;
     uint8_t sheenRoughnessUV : 7;
     bool hasSheen : 1;
+    bool hasIOR : 1;
 };
 
 static_assert(sizeof(MaterialKey) == 16, "MaterialKey has unexpected padding.");

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -83,6 +83,7 @@ struct alignas(4) MaterialKey {
     uint8_t sheenRoughnessUV : 7;
     bool hasSheen : 1;
     bool hasIOR : 1;
+    bool hasReflectance : 1;
 };
 
 static_assert(sizeof(MaterialKey) == 16, "MaterialKey has unexpected padding.");

--- a/libs/gltfio/materials/gltflite.mat.in
+++ b/libs/gltfio/materials/gltflite.mat.in
@@ -34,7 +34,10 @@ material {
         // Emissive Map
         { type : int, name : emissiveIndex },
         { type : float3, name : emissiveFactor },
-        { type : sampler2d, name : emissiveMap }
+        { type : sampler2d, name : emissiveMap },
+
+        // Reflectance
+        { type : float, name : reflectance }
     ],
 }
 
@@ -67,10 +70,10 @@ fragment {
         material.baseColor *= getColor();
 
         #if !defined(SHADING_MODEL_UNLIT)
-
             #if defined(SHADING_MODEL_LIT)
                 material.roughness = materialParams.roughnessFactor;
                 material.metallic = materialParams.metallicFactor;
+                material.reflectance = materialParams.reflectance;
             #endif
 
             material.emissive = vec4(materialParams.emissiveFactor.rgb, 0.0);

--- a/libs/gltfio/materials/sheen.mat.in
+++ b/libs/gltfio/materials/sheen.mat.in
@@ -49,7 +49,10 @@ material {
         { type : int, name : sheenRoughnessIndex },
         { type : float, name : sheenRoughnessFactor },
         { type : sampler2d, name : sheenRoughnessMap },
-        { type : mat3, name : sheenRoughnessUvMatrix }
+        { type : mat3, name : sheenRoughnessUvMatrix },
+
+        // Reflectance
+        { type : float, name : reflectance }
     ],
 }
 
@@ -86,6 +89,7 @@ fragment {
         material.emissive = vec4(materialParams.emissiveFactor.rgb, 0.0);
         material.sheenColor = materialParams.sheenColorFactor;
         material.sheenRoughness = materialParams.sheenRoughnessFactor;
+        material.reflectance = materialParams.reflectance;
 
         if (materialParams.sheenColorIndex > -1) {
             highp float2 uv = uvs[materialParams.sheenColorIndex];

--- a/libs/gltfio/materials/transmission.mat.in
+++ b/libs/gltfio/materials/transmission.mat.in
@@ -47,7 +47,10 @@ material {
         { type : int, name : transmissionIndex },
         { type : float, name : transmissionFactor },
         { type : sampler2d, name : transmissionMap },
-        { type : mat3, name : transmissionUvMatrix }
+        { type : mat3, name : transmissionUvMatrix },
+
+        // IOR
+        { type : float, name : ior }
     ],
 }
 
@@ -84,6 +87,7 @@ fragment {
         material.emissive = vec4(materialParams.emissiveFactor.rgb, 0.0);
         material.transmission = materialParams.transmissionFactor;
         material.absorption = 1.0 - material.baseColor.rgb;
+        material.ior = materialParams.ior;
 
         if (materialParams.transmissionIndex > -1) {
             highp float2 uv = uvs[materialParams.transmissionIndex];

--- a/libs/gltfio/materials/ubershader.mat.in
+++ b/libs/gltfio/materials/ubershader.mat.in
@@ -57,7 +57,10 @@ material {
         { type : int, name : clearCoatNormalIndex },
         { type : sampler2d, name : clearCoatNormalMap },
         { type : mat3, name : clearCoatNormalUvMatrix },
-        { type : float, name : clearCoatNormalScale }
+        { type : float, name : clearCoatNormalScale },
+
+        // Reflectance
+        { type : float, name : reflectance }
     ],
 }
 
@@ -127,6 +130,8 @@ fragment {
             #if defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
                 material.glossiness = materialParams.glossinessFactor;
                 material.specularColor = materialParams.specularFactor;
+            #else
+                material.reflectance = materialParams.reflectance;
             #endif
 
             if (materialParams.metallicRoughnessIndex > -1) {

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1138,7 +1138,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
         }
     }
 
-    // IOR can be implemented either has IOR or reflectance because of ubershaders
+    // IOR can be implemented as either IOR or reflectance because of ubershaders
     if (matkey.hasIOR) {
         if (mi->getMaterial()->hasParameter("ior")) {
             mi->setParameter("ior", inputMat->ior.ior);

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -926,17 +926,17 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
         .doubleSided = !!inputMat->double_sided,
         .unlit = !!inputMat->unlit,
         .hasVertexColors = vertexColor,
-        .hasBaseColorTexture = !!baseColorTexture.texture,
-        .hasNormalTexture = !!inputMat->normal_texture.texture,
-        .hasOcclusionTexture = !!inputMat->occlusion_texture.texture,
-        .hasEmissiveTexture = !!inputMat->emissive_texture.texture,
+        .hasBaseColorTexture = baseColorTexture.texture != nullptr,
+        .hasNormalTexture = inputMat->normal_texture.texture != nullptr,
+        .hasOcclusionTexture = inputMat->occlusion_texture.texture != nullptr,
+        .hasEmissiveTexture = inputMat->emissive_texture.texture != nullptr,
         .enableDiagnostics = mDiagnosticsEnabled,
         .baseColorUV = (uint8_t) baseColorTexture.texcoord,
-        .hasClearCoatTexture = !!ccConfig.clearcoat_texture.texture,
+        .hasClearCoatTexture = ccConfig.clearcoat_texture.texture != nullptr,
         .clearCoatUV = (uint8_t) ccConfig.clearcoat_texture.texcoord,
-        .hasClearCoatRoughnessTexture = !!ccConfig.clearcoat_roughness_texture.texture,
+        .hasClearCoatRoughnessTexture = ccConfig.clearcoat_roughness_texture.texture != nullptr,
         .clearCoatRoughnessUV = (uint8_t) ccConfig.clearcoat_roughness_texture.texcoord,
-        .hasClearCoatNormalTexture = !!ccConfig.clearcoat_normal_texture.texture,
+        .hasClearCoatNormalTexture = ccConfig.clearcoat_normal_texture.texture != nullptr,
         .clearCoatNormalUV = (uint8_t) ccConfig.clearcoat_normal_texture.texcoord,
         .hasClearCoat = !!inputMat->has_clearcoat,
         .hasTransmission = !!inputMat->has_transmission,
@@ -944,13 +944,14 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
         .emissiveUV = (uint8_t) inputMat->emissive_texture.texcoord,
         .aoUV = (uint8_t) inputMat->occlusion_texture.texcoord,
         .normalUV = (uint8_t) inputMat->normal_texture.texcoord,
-        .hasTransmissionTexture = !!trConfig.transmission_texture.texture,
+        .hasTransmissionTexture = trConfig.transmission_texture.texture != nullptr,
         .transmissionUV = (uint8_t) trConfig.transmission_texture.texcoord,
-        .hasSheenColorTexture = !!shConfig.sheen_color_texture.texture,
+        .hasSheenColorTexture = shConfig.sheen_color_texture.texture != nullptr,
         .sheenColorUV = (uint8_t) shConfig.sheen_color_texture.texcoord,
-        .hasSheenRoughnessTexture = !!shConfig.sheen_roughness_texture.texture,
+        .hasSheenRoughnessTexture = shConfig.sheen_roughness_texture.texture != nullptr,
         .sheenRoughnessUV = (uint8_t) shConfig.sheen_roughness_texture.texcoord,
         .hasSheen = !!inputMat->has_sheen,
+        .hasIOR = !!inputMat->has_ior,
     };
 
     if (inputMat->has_pbr_specular_glossiness) {
@@ -966,7 +967,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
             matkey.specularGlossinessUV = (uint8_t) metallicRoughnessTexture.texcoord;
         }
     } else {
-        matkey.hasMetallicRoughnessTexture = !!metallicRoughnessTexture.texture;
+        matkey.hasMetallicRoughnessTexture = metallicRoughnessTexture.texture != nullptr;
         matkey.metallicRoughnessUV = (uint8_t) metallicRoughnessTexture.texcoord;
     }
 
@@ -1134,6 +1135,10 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_material* inp
                 mi->setParameter("transmissionUvMatrix", uvmat);
             }
         }
+    }
+
+    if (matkey.hasIOR) {
+        mi->setParameter("ior", inputMat->ior.ior);
     }
 
     mResult->mMatInstanceCache[key] = {mi, *uvmap};

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -280,6 +280,12 @@ std::string shaderFromKey(const MaterialKey& config) {
                 )SHADER";
             }
         }
+
+        if (config.hasIOR) {
+            shader += R"SHADER(
+                material.ior = materialParams.ior;
+            )SHADER";
+        }
     }
 
     shader += "}\n";
@@ -419,7 +425,6 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
 
     // TRANSMISSION
     if (config.hasTransmission) {
-
         // According to KHR_materials_transmission, the minimum expectation for a compliant renderer
         // is to at least render any opaque objects that lie behind transmitting objects.
         builder.refractionMode(RefractionMode::SCREEN_SPACE);
@@ -439,9 +444,7 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
 
         builder.blending(MaterialBuilder::BlendingMode::FADE);
         builder.depthWrite(true);
-
     } else {
-
         // BLENDING
         switch (config.alphaMode) {
             case AlphaMode::OPAQUE:
@@ -458,6 +461,11 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
                 // Ignore
                 break;
         }
+    }
+
+    // IOR
+    if (config.hasIOR) {
+        builder.parameter(MaterialBuilder::UniformType::FLOAT, "ior");
     }
 
     if (config.unlit) {

--- a/libs/gltfio/src/MaterialProvider.cpp
+++ b/libs/gltfio/src/MaterialProvider.cpp
@@ -52,7 +52,8 @@ bool operator==(const MaterialKey& k1, const MaterialKey& k2) {
         (k1.sheenColorUV == k2.sheenColorUV) &&
         (k1.hasSheenRoughnessTexture == k2.hasSheenRoughnessTexture) &&
         (k1.sheenRoughnessUV == k2.sheenRoughnessUV) &&
-        (k1.hasSheen == k2.hasSheen);
+        (k1.hasSheen == k2.hasSheen) &&
+        (k1.hasIOR == k2.hasIOR);
 }
 
 // Filament supports up to 2 UV sets. glTF has arbitrary texcoord set indices, but it allows

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -252,6 +252,13 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
         }
     }
 
+    if (mi->getMaterial()->hasParameter("ior")) {
+        mi->setParameter("ior", 1.5f);
+    }
+    if (mi->getMaterial()->hasParameter("reflectance")) {
+        mi->setParameter("reflectance", 0.5f);
+    }
+
     return mi;
 }
 

--- a/shaders/src/material_inputs.fs
+++ b/shaders/src/material_inputs.fs
@@ -68,6 +68,7 @@ struct MaterialInputs {
     vec4  postLightingColor;
 #endif
 
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SUBSURFACE) && !defined(SHADING_MODEL_UNLIT)
 #if defined(HAS_REFRACTION)
 #if defined(MATERIAL_HAS_ABSORPTION)
     vec3 absorption;
@@ -80,6 +81,11 @@ struct MaterialInputs {
 #endif
 #if defined(MATERIAL_HAS_MICRO_THICKNESS) && (REFRACTION_TYPE == REFRACTION_TYPE_THIN)
     float microThickness;
+#endif
+#elif !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
+#if defined(MATERIAL_HAS_IOR)
+    float ior;
+#endif
 #endif
 #endif
 };
@@ -149,6 +155,7 @@ void initMaterial(out MaterialInputs material) {
     material.postLightingColor = vec4(0.0);
 #endif
 
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SUBSURFACE) && !defined(SHADING_MODEL_UNLIT)
 #if defined(HAS_REFRACTION)
 #if defined(MATERIAL_HAS_ABSORPTION)
     material.absorption = vec3(0.0);
@@ -161,6 +168,11 @@ void initMaterial(out MaterialInputs material) {
 #endif
 #if defined(MATERIAL_HAS_MICRO_THICKNESS) && (REFRACTION_TYPE == REFRACTION_TYPE_THIN)
     material.microThickness = 0.0;
+#endif
+#elif !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
+#if defined(MATERIAL_HAS_IOR)
+    material.ior = 1.5;
+#endif
 #endif
 #endif
 }

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -71,18 +71,14 @@ void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel
     pixel.diffuseColor = computeDiffuseColor(baseColor, metallic);
     pixel.f0 = specularColor;
 #elif !defined(SHADING_MODEL_CLOTH)
-#if defined(HAS_REFRACTION) && (!defined(MATERIAL_HAS_REFLECTANCE) && defined(MATERIAL_HAS_IOR))
-    pixel.diffuseColor = baseColor.rgb;
-    // If refraction is enabled, and reflectance is not set in the material, but ior is,
-    // then use it -- othterwise proceed as usual.
-    pixel.f0 = vec3(iorToF0(material.ior, 1.0));
-#else
     pixel.diffuseColor = computeDiffuseColor(baseColor, material.metallic);
+#if !defined(SHADING_MODEL_SUBSURFACE) && (!defined(MATERIAL_HAS_REFLECTANCE) && defined(MATERIAL_HAS_IOR))
+    float reflectance = iorToF0(max(1.0, material.ior), 1.0);
+#else
     // Assumes an interface from air to an IOR of 1.5 for dielectrics
     float reflectance = computeDielectricF0(material.reflectance);
-    pixel.f0 = computeF0(baseColor, material.metallic, reflectance);
 #endif
-
+    pixel.f0 = computeF0(baseColor, material.metallic, reflectance);
 #else
     pixel.diffuseColor = baseColor.rgb;
     pixel.f0 = material.sheenColor;
@@ -91,6 +87,7 @@ void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel
 #endif
 #endif
 
+#if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SUBSURFACE)
 #if defined(HAS_REFRACTION)
     // Air's Index of refraction is 1.000277 at STP but everybody uses 1.0
     const float airIor = 1.0;
@@ -124,6 +121,7 @@ void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel
     pixel.uThickness = max(0.0, material.microThickness);
 #else
     pixel.uThickness = 0.0;
+#endif
 #endif
 #endif
 }


### PR DESCRIPTION
This change makes available the existing IOR material parameter to materials that don't have refraction enabled.

Here is a glTF model with an IOR of 1:
<img width="1299" alt="Screen Shot 2021-05-27 at 3 06 58 PM" src="https://user-images.githubusercontent.com/869684/119903454-93c38600-befd-11eb-8003-4f6f5d3504e8.png">

And the same model with an IOR of 2:
<img width="1305" alt="Screen Shot 2021-05-27 at 3 06 36 PM" src="https://user-images.githubusercontent.com/869684/119903470-9920d080-befd-11eb-87ff-a9e4b2fd1e8f.png">

Note that using this parameter on a non-refractive object is equivalent to setting the reflectance parameter.

IOR support is implemented either as IOR or reflectance in ubershaders to use a more optimized code path
for the common case (no IOR set).
