### PR TITLE
Vk: Fix some synchronization validation warnings.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -58,19 +58,24 @@ void VulkanBuffer::loadFromCpu(const void* cpuData, uint32_t byteOffset, uint32_
     vkCmdCopyBuffer(cmdbuffer, stage->buffer, mGpuBuffer, 1, &region);
     mDisposer.acquire(mDisposerKey);
 
-    // Ensure that the copy finishes before the next draw call.
+    // Firstly, ensure that the copy finishes before the next draw call.
+    // Secondly, in case the user decides to upload another chunk (without ever using the first one)
+    // we need to ensure that this upload completes first.
     VkBufferMemoryBarrier barrier {
         .sType = VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER,
         .srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
-        .dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT,
+        .dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT |
+                         VK_ACCESS_TRANSFER_WRITE_BIT,
         .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .buffer = mGpuBuffer,
         .size = VK_WHOLE_SIZE
     };
 
-    vkCmdPipelineBarrier(cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+    vkCmdPipelineBarrier(cmdbuffer,
+            VK_PIPELINE_STAGE_TRANSFER_BIT,
+            VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+            0, 0, nullptr, 1, &barrier, 0, nullptr);
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_DRIVER_VULKANCONSTANTS_H
 
 #define FILAMENT_VULKAN_VERBOSE 0
+#define FILAMENT_VULKAN_DUMP_API 0
 
 // In debug builds, we enable validation layers and set up a debug callback.
 //


### PR DESCRIPTION
This fixes most of the warnings that are emitted by the relatively new
SYNCHRONIZATION_VALIDATION feature that LunarG provides.

This commit does not fix a warning that is emitted when SSAO is enabled,
when we sample from the currently bound depth attachment. This one is
tricky to fix.