### PR TITLE
Flush the CommandStream in a few strategic places

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -183,7 +183,12 @@ void RenderPass::execute(const char* name,
 }
 
 void RenderPass::executeCommands(const char* name) const noexcept {
-    DriverApi& driver = mEngine.getDriverApi();
+    // this is a good time to flush the CommandStream, because we're about to potentially
+    // output a lot of commands. This guarantees here that we have at least
+    // FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB bytes (1MiB by default).
+    FEngine& engine = mEngine;
+    engine.flush();
+    DriverApi& driver = engine.getDriverApi();
     RenderPass::recordDriverCommands(driver, mCommands.begin(), mCommands.end());
 }
 

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -323,6 +323,7 @@ void FRenderableManager::create(
             }
         }
     }
+    engine.flushIfNeeded();
 }
 
 // this destroys a single component from an entity

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -282,6 +282,17 @@ public:
     // flush the current buffer
     void flush();
 
+    // flush the current buffer based on some heuristics
+    void flushIfNeeded() {
+        auto counter = mFlushCounter + 1;
+        if (UTILS_LIKELY(counter < 128)) {
+            mFlushCounter = counter;
+        } else {
+            mFlushCounter = 0;
+            flush();
+        }
+    }
+
     /**
      * Processes the platform's event queue when called from the platform's event-handling thread.
      * Returns false when called from any other thread.
@@ -375,6 +386,7 @@ private:
     std::thread mDriverThread;
     backend::CommandBufferQueue mCommandBufferQueue;
     DriverApi mCommandStream;
+    uint32_t mFlushCounter = 0;
 
     LinearAllocatorArena mPerRenderPassAllocator;
     HeapAllocatorArena mHeapAllocator;


### PR DESCRIPTION
The CommandStream hold backend commands, but it has a limited size.
With some large models, we can run out of space especially during
initialization.

We can combat this by flushing the command stream regularly. With this
change, we do this every 128 renderable creation.

We also flush the CommandStream just before generating the draw
commands for the frame.

If the buffer is not sized correctly (currently at compile time), this
could cause stalls, which will be logged in DEBUG builds.