### PR TITLE
panic in release builds when command stream is corrupted

### DIFF
--- a/filament/backend/src/CommandBufferQueue.cpp
+++ b/filament/backend/src/CommandBufferQueue.cpp
@@ -80,7 +80,11 @@ void CommandBufferQueue::flush() noexcept {
     mCommandBuffersToExecute.push_back({ tail, head });
 
     // circular buffer is too small, we corrupted the stream
-    assert_invariant(used <= mFreeSpace);
+    ASSERT_POSTCONDITION(used <= mFreeSpace,
+            "Backend CommandStream overflow. Commands are corrupted and unrecoverable.\n"
+            "Please increase FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB (currently %u MiB).\n"
+            "Space used at this time: %u bytes",
+            (unsigned)FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB, (unsigned)used);
 
     // wait until there is enough space in the buffer
     mFreeSpace -= used;


### PR DESCRIPTION
the CommandStream is limited in size and can get corrupted if
that size (default 1 MiB) is exceeded. We used to catch this
only on Debug builds, but this is too serious and unrecoverable, so
it must be caught in Release builds too.

At the point of detection the stream is corrupted, which can cause
the backend to get in an unknown state. But worse, program execution
could end up anywhere because the stream contains function pointers.