### PR TITLE
Revert "improve logs and tls support"

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -180,7 +180,7 @@ OpenGLContext::OpenGLContext() noexcept {
     if (ext.KHR_debug) {
         auto cb = [](GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
                 const GLchar* message, const void *userParam) {
-            io::ostream* stream = nullptr;
+            io::LogStream* stream = nullptr;
             switch (severity) {
                 case GL_DEBUG_SEVERITY_HIGH:
                     stream = &slog.e;
@@ -196,7 +196,7 @@ OpenGLContext::OpenGLContext() noexcept {
                     stream = &slog.i;
                     break;
             }
-            io::ostream& out = *stream;
+            io::LogStream& out = *stream;
             out << "KHR_debug ";
             switch (type) {
                 case GL_DEBUG_TYPE_ERROR:

--- a/libs/utils/include/utils/Log.h
+++ b/libs/utils/include/utils/Log.h
@@ -17,27 +17,49 @@
 #ifndef TNT_UTILS_LOG_H
 #define TNT_UTILS_LOG_H
 
-#include <utils/compiler.h>
-#include <utils/ostream.h>
+#include <string>
+
 #include <utils/ThreadLocal.h>
+#include <utils/bitset.h>
+#include <utils/compiler.h> // ssize_t is a POSIX type.
+
+#include <utils/ostream.h>
 
 namespace utils {
+namespace io {
+
+class UTILS_PUBLIC LogStream : public ostream {
+public:
+
+    enum Priority {
+        LOG_DEBUG, LOG_ERROR, LOG_WARNING, LOG_INFO
+    };
+
+    explicit LogStream(Priority p) noexcept : mPriority(p) {}
+
+    ostream& flush() noexcept override;
+
+private:
+    Priority mPriority;
+};
+
+} // namespace io
 
 struct UTILS_PUBLIC Loggers {
     // DEBUG level logging stream
-    io::ostream& d;
+    io::LogStream& d;
 
     // ERROR level logging stream
-    io::ostream& e;
+    io::LogStream& e;
 
     // WARNING level logging stream
-    io::ostream& w;
+    io::LogStream& w;
 
     // INFORMATION level logging stream
-    io::ostream& i;
+    io::LogStream& i;
 };
 
-extern UTILS_PUBLIC UTILS_DECLARE_TLS(Loggers) const slog;
+extern UTILS_PUBLIC const Loggers slog;
 
 } // namespace utils
 

--- a/libs/utils/include/utils/ThreadLocal.h
+++ b/libs/utils/include/utils/ThreadLocal.h
@@ -26,9 +26,173 @@
 
 #else // UTILS_HAS_FEATURE_CXX_THREAD_LOCAL
 
-#warning "thread_local not supported by this platform"
-#define UTILS_DECLARE_TLS(clazz) clazz
-#define UTILS_DEFINE_TLS(clazz) clazz
+#define UTILS_DECLARE_TLS(clazz) utils::ThreadLocal<clazz>
+#define UTILS_DEFINE_TLS(clazz) utils::ThreadLocal<clazz>
+
+#include <algorithm>
+#include <pthread.h>
+
+namespace utils {
+
+/* ------------------------------------------------------------------------------------------------
+ * ThreadLocal is a workaround for compilers/platforms that don't support C++0x11 thread_local
+ * e.g.:
+ *      static ThreadLocal<Foo> s_current_thread(args);
+ *
+ * is equivalent to:
+ *
+ *      static thread_local Foo s_current_thread(args);
+ *
+ */
+
+// TODO: Specialization for basic types (to avoid heap-allocation)
+
+template <typename T>
+class ThreadLocal {
+public:
+    ThreadLocal() noexcept {
+        pthread_key_create(&mKey, destructor);
+    }
+
+    // construct from the arguments of T ctor
+    template<typename ... ARGS>
+    explicit ThreadLocal(ARGS&&... args) noexcept : ThreadLocal() {
+        T* ptr = new T(std::forward<ARGS>(args)...);
+        pthread_setspecific(mKey, ptr);
+    }
+
+    ~ThreadLocal() {
+        pthread_key_delete(mKey);
+    }
+
+    ThreadLocal(const ThreadLocal& rhs) = delete;
+    ThreadLocal(ThreadLocal&&  rhs) = delete;
+    ThreadLocal& operator=(const ThreadLocal& rhs) = delete;
+    ThreadLocal& operator=(ThreadLocal&&  rhs) = delete;
+
+    // assign a T
+    T& operator=(T value) noexcept {
+        T& r = getRef();
+        std::swap(r, value);
+        return r;
+    }
+
+    // convert to a T
+    operator T&() noexcept {
+        T& r = getRef();
+        return r;
+    }
+
+    operator T const&() const noexcept {
+        T const& r = const_cast<ThreadLocal*>(this)->getRef();
+        return r;
+    }
+
+    // pointer-like access, in case T is a smart pointer for instance
+    T* operator->() noexcept {
+        T& r = getRef();
+        return &r;
+    }
+
+    T const* operator->() const noexcept {
+        T const& r = const_cast<ThreadLocal*>(this)->getRef();
+        return &r;
+    }
+
+private:
+    // destructor called at thread exit
+    static void destructor(void *specific) {
+        T* ptr = static_cast<T*>(specific);
+        delete ptr;
+    }
+
+    UTILS_NOINLINE
+    T& getRef() noexcept {
+        T* ptr = static_cast<T*>(pthread_getspecific(mKey));
+        if (UTILS_LIKELY(ptr)) {
+            return *ptr;
+        }
+        return allocRef();
+    }
+
+    UTILS_NOINLINE
+    T& allocRef() noexcept {
+        T* ptr = new T();
+        pthread_setspecific(mKey, ptr);
+        return *ptr;
+    }
+
+    pthread_key_t mKey;
+};
+
+
+/*
+ * Specialization for pointers
+ */
+
+template <typename T>
+class ThreadLocal<T *> {
+public:
+    ThreadLocal() noexcept {
+        pthread_key_create(&mKey, nullptr);
+    }
+
+    // construct from the arguments of T ctor
+    explicit ThreadLocal(T* rhs) noexcept : ThreadLocal() {
+        pthread_setspecific(mKey, rhs);
+    }
+
+    ~ThreadLocal() {
+        pthread_key_delete(mKey);
+    }
+
+    ThreadLocal(const ThreadLocal& rhs) = delete;
+    ThreadLocal(ThreadLocal&&  rhs) = delete;
+    ThreadLocal& operator=(const ThreadLocal& rhs) = delete;
+    ThreadLocal& operator=(ThreadLocal&&  rhs) = delete;
+
+
+    ThreadLocal& operator = (T const * rhs) noexcept {
+        pthread_setspecific(mKey, rhs);
+        return *this;
+    }
+
+
+    operator bool() noexcept {
+        return pthread_getspecific(mKey) != nullptr;
+    }
+
+    // convert to a T*
+    operator T*() noexcept {
+        return static_cast<T*>(pthread_getspecific(mKey));
+    }
+
+    operator T const*() const noexcept {
+        return static_cast<T const*>(pthread_getspecific(mKey));
+    }
+
+    // access like a pointer
+    T* operator->() noexcept {
+        return static_cast<T*>(pthread_getspecific(mKey));
+    }
+
+    T const* operator->() const noexcept {
+        return static_cast<T const*>(pthread_getspecific(mKey));
+    }
+
+    T& operator*() noexcept {
+        return *static_cast<T*>(pthread_getspecific(mKey));
+    }
+
+    T const& operator*() const noexcept {
+        return *static_cast<T const*>(pthread_getspecific(mKey));
+    }
+
+private:
+    pthread_key_t mKey;
+};
+
+}  // namespace utils
 
 #endif // UTILS_HAS_FEATURE_CXX_THREAD_LOCAL
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -160,7 +160,12 @@
 #if defined(_MSC_VER) && _MSC_VER >= 1900
 #       define UTILS_HAS_FEATURE_CXX_THREAD_LOCAL 1
 #elif __has_feature(cxx_thread_local)
-#   define UTILS_HAS_FEATURE_CXX_THREAD_LOCAL 1
+#   ifdef ANDROID
+#       // Android NDK lies about supporting cxx_thread_local
+#       define UTILS_HAS_FEATURE_CXX_THREAD_LOCAL 0
+#   else // ANDROID
+#       define UTILS_HAS_FEATURE_CXX_THREAD_LOCAL 1
+#   endif // ANDROID
 #else
 #   define UTILS_HAS_FEATURE_CXX_THREAD_LOCAL 0
 #endif

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -70,14 +70,14 @@ protected:
         Buffer(const Buffer&) = delete;
         Buffer& operator=(const Buffer&) = delete;
 
-        char* buffer = nullptr;     // buffer address
-        char* curr = nullptr;       // current pointer
-        size_t size = 0;            // size remaining
-        size_t capacity = 0;        // total capacity of the buffer
+        char* buffer;
+        char* curr;
+        size_t size = 0;
+        size_t capacity = 0;
         const char* get() const noexcept { return buffer; }
         void advance(ssize_t n) noexcept;
         void reset() noexcept;
-        void reserve(size_t newSize) noexcept;
+        void resize(size_t newSize) noexcept;
     };
 
     Buffer mData;

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -18,7 +18,6 @@
 
 #include <string>
 #include <utils/compiler.h>
-#include <utils/ThreadLocal.h>
 
 #ifdef ANDROID
 #   include <android/log.h>
@@ -30,21 +29,6 @@
 namespace utils {
 
 namespace io {
-
-class LogStream : public ostream {
-public:
-
-    enum Priority {
-        LOG_DEBUG, LOG_ERROR, LOG_WARNING, LOG_INFO
-    };
-
-    explicit LogStream(Priority p) noexcept : mPriority(p) {}
-
-    ostream& flush() noexcept override;
-
-private:
-    Priority mPriority;
-};
 
 ostream& LogStream::flush() noexcept {
     Buffer& buf = getBuffer();
@@ -79,15 +63,15 @@ ostream& LogStream::flush() noexcept {
     return *this;
 }
 
-UTILS_DEFINE_TLS(LogStream) cout(LogStream::Priority::LOG_DEBUG);
-UTILS_DEFINE_TLS(LogStream) cerr(LogStream::Priority::LOG_ERROR);
-UTILS_DEFINE_TLS(LogStream) cwarn(LogStream::Priority::LOG_WARNING);
-UTILS_DEFINE_TLS(LogStream) cinfo(LogStream::Priority::LOG_INFO);
+static LogStream cout(LogStream::Priority::LOG_DEBUG);
+static LogStream cerr(LogStream::Priority::LOG_ERROR);
+static LogStream cwarn(LogStream::Priority::LOG_WARNING);
+static LogStream cinfo(LogStream::Priority::LOG_INFO);
 
 } // namespace io
 
 
-UTILS_DEFINE_TLS(Loggers) const slog = {
+const Loggers slog = {
         io::cout,   // debug
         io::cerr,   // error
         io::cwarn,  // warning

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -15,10 +15,9 @@
  */
 
 #include <utils/ostream.h>
-#include <utils/compiler.h>
 
-#include <algorithm>
 #include <string>
+#include <utils/compiler.h>
 
 namespace utils {
 
@@ -26,12 +25,18 @@ namespace io {
 
 ostream::~ostream() = default;
 
-// don't allocate any memory before we actually use the log because one of these is created
-// per thread.
-ostream::Buffer::Buffer() noexcept = default;
+ostream::Buffer::Buffer() noexcept {
+    constexpr size_t initialSize = 1024;
+    buffer = (char*) malloc(initialSize);
+    assert(buffer);
+    // Set the first byte to 0 as this buffer might be used as a C string.
+    buffer[0] = 0;
+    curr = buffer;
+    capacity = initialSize;
+    size = initialSize;
+}
 
 ostream::Buffer::~Buffer() noexcept {
-    // note: on Android pre r14, thread_local destructors are not called
     free(buffer);
 }
 
@@ -45,13 +50,9 @@ void ostream::Buffer::advance(ssize_t n) noexcept {
 }
 
 UTILS_NOINLINE
-void ostream::Buffer::reserve(size_t newSize) noexcept {
+void ostream::Buffer::resize(size_t newSize) noexcept {
     size_t offset = curr - buffer;
-    if (buffer == nullptr) {
-        buffer = (char*)malloc(newSize);
-    } else {
-        buffer = (char*)realloc(buffer, newSize);
-    }
+    buffer = (char*) realloc(buffer, newSize);
     assert(buffer);
     capacity = newSize;
     curr = buffer + offset;
@@ -60,12 +61,6 @@ void ostream::Buffer::reserve(size_t newSize) noexcept {
 
 UTILS_NOINLINE
 void ostream::Buffer::reset() noexcept {
-    // aggressively shrink the buffer
-    if (capacity > 1024) {
-        free(buffer);
-        buffer = (char*)malloc(1024);
-        capacity = 1024;
-    }
     curr = buffer;
     size = capacity;
 }
@@ -89,10 +84,13 @@ const char* ostream::getFormat(ostream::type t) const noexcept {
 
 void ostream::growBufferIfNeeded(size_t s) noexcept {
     Buffer& buf = getBuffer();
+    const size_t used = buf.curr - buf.buffer;  // space currently used in buffer
     if (UTILS_UNLIKELY(buf.size < s)) {
-        size_t used = buf.curr - buf.buffer;
-        size_t newCapacity = std::max(size_t(32), used + (s * 3 + 1) / 2); // 32 bytes minimum
-        buf.reserve(newCapacity);
+        size_t newSize = buf.capacity * 2;
+        while (UTILS_UNLIKELY((newSize - used) < s)) {
+            newSize *= 2;
+        }
+        buf.resize(newSize);
         assert(buf.size >= s);
     }
 }


### PR DESCRIPTION
This reverts commit cc6201b0db0ac487115464629a29b920b20f9b37.

On Android the loggers are not always initialized when several .so are
used, leading to crashes. It's not completely clear what is exactly 
happening.