### PR TITLE
spirv-tools: turn off warnings as errors to fix Windows build

### DIFF
--- a/third_party/spirv-tools/CMakeLists.txt
+++ b/third_party/spirv-tools/CMakeLists.txt
@@ -94,7 +94,10 @@ endif(SPIRV_BUILD_COMPRESSION)
 
 option(SPIRV_BUILD_FUZZER "Build spirv-fuzz" OFF)
 
-option(SPIRV_WERROR "Enable error on warning" ON)
+# Filament specific changes
+# option(SPIRV_WERROR "Enable error on warning" ON)
+set(SPIRV_WERROR OFF)
+# End Filament specific changes
 if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND (NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
   set(COMPILER_IS_LIKE_GNU TRUE)
 endif()

--- a/third_party/spirv-tools/filament-specific-changes.patch
+++ b/third_party/spirv-tools/filament-specific-changes.patch
@@ -1,5 +1,17 @@
+From f2c7730fd3246c70c6cb23f1637aa05a3a8b517a Mon Sep 17 00:00:00 2001
+From: Benjamin Doherty <bendoherty@google.com>
+Date: Tue, 1 Jun 2021 23:31:16 -0700
+Subject: [PATCH] Filament specific changes
+
+---
+ third_party/spirv-tools/CMakeLists.txt        | 86 ++++++++++++-------
+ .../spirv-tools/external/CMakeLists.txt       |  6 +-
+ .../external/spirv-headers/CMakeLists.txt     |  8 +-
+ third_party/spirv-tools/source/CMakeLists.txt | 26 ++++--
+ 4 files changed, 81 insertions(+), 45 deletions(-)
+
 diff --git a/third_party/spirv-tools/CMakeLists.txt b/third_party/spirv-tools/CMakeLists.txt
-index 6ed56a81..2392dfd8 100755
+index 55f84e6d8..41ae7897c 100755
 --- a/third_party/spirv-tools/CMakeLists.txt
 +++ b/third_party/spirv-tools/CMakeLists.txt
 @@ -24,8 +24,19 @@ if (POLICY CMP0054)
@@ -34,7 +46,32 @@ index 6ed56a81..2392dfd8 100755
  if(NOT ${SKIP_SPIRV_TOOLS_INSTALL})
    set(ENABLE_SPIRV_TOOLS_INSTALL ON)
  endif()
-@@ -231,11 +244,13 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
+@@ -81,7 +94,10 @@ endif(SPIRV_BUILD_COMPRESSION)
+ 
+ option(SPIRV_BUILD_FUZZER "Build spirv-fuzz" OFF)
+ 
+-option(SPIRV_WERROR "Enable error on warning" ON)
++# Filament specific changes
++# option(SPIRV_WERROR "Enable error on warning" ON)
++set(SPIRV_WERROR OFF)
++# End Filament specific changes
+ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") AND (NOT CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")))
+   set(COMPILER_IS_LIKE_GNU TRUE)
+ endif()
+@@ -230,7 +246,11 @@ if(NOT COMMAND find_host_program)
+ endif()
+ 
+ # Tests require Python3
+-find_host_package(PythonInterp 3 REQUIRED)
++if(CMAKE_VERSION VERSION_LESS "3.12" OR ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
++  find_host_package(PythonInterp 3 REQUIRED)
++else()
++  find_package(Python3 COMPONENTS Interpreter)
++endif()
+ 
+ # Check for symbol exports on Linux.
+ # At the moment, this check will fail on the OSX build machines for the Android NDK.
+@@ -273,11 +293,13 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
  endif()
  
  # Defaults to OFF if the user didn't set it.
@@ -50,7 +87,7 @@ index 6ed56a81..2392dfd8 100755
  if ("${SPIRV_SKIP_EXECUTABLES}")
    set(SPIRV_SKIP_TESTS ON)
  endif()
-@@ -279,8 +294,10 @@ endif()
+@@ -321,8 +343,10 @@ endif()
  add_subdirectory(source)
  add_subdirectory(tools)
  
@@ -63,7 +100,7 @@ index 6ed56a81..2392dfd8 100755
  
  if(ENABLE_SPIRV_TOOLS_INSTALL)
    install(
-@@ -305,28 +322,30 @@ set(SPIRV_SHARED_LIBRARIES "-lSPIRV-Tools-shared")
+@@ -347,28 +371,30 @@ set(SPIRV_SHARED_LIBRARIES "-lSPIRV-Tools-shared")
  
  # Build pkg-config file
  # Use a first-class target so it's regenerated when relevant files are updated.
@@ -116,19 +153,6 @@ index 6ed56a81..2392dfd8 100755
  
  # Install pkg-config file
  if (ENABLE_SPIRV_TOOLS_INSTALL)
-@@ -201,7 +201,11 @@ if(NOT COMMAND find_host_program)
- endif()
- 
- # Tests require Python3
--find_host_package(PythonInterp 3 REQUIRED)
-+if(CMAKE_VERSION VERSION_LESS "3.12" OR ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-+  find_host_package(PythonInterp 3 REQUIRED)
-+else()
-+  find_package(Python3 COMPONENTS Interpreter)
-+endif()
- 
- # Check for symbol exports on Linux.
- # At the moment, this check will fail on the OSX build machines for the Android NDK.
 diff --git a/third_party/spirv-tools/external/CMakeLists.txt b/third_party/spirv-tools/external/CMakeLists.txt
 index 179a4012f..152cfc421 100644
 --- a/third_party/spirv-tools/external/CMakeLists.txt
@@ -147,31 +171,31 @@ index 179a4012f..152cfc421 100644
    endif()
  else()
 diff --git a/third_party/spirv-tools/external/spirv-headers/CMakeLists.txt b/third_party/spirv-tools/external/spirv-headers/CMakeLists.txt
-index eb4694786..d3940532d 100644
+index 6f01ef098..ef2e56606 100644
 --- a/third_party/spirv-tools/external/spirv-headers/CMakeLists.txt
 +++ b/third_party/spirv-tools/external/spirv-headers/CMakeLists.txt
 @@ -49,11 +49,11 @@ add_custom_target(install-headers
      COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv
          $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/include/spirv)
-
+ 
 -option(SPIRV_HEADERS_SKIP_EXAMPLES "Skip building examples"
 -      ${SPIRV_HEADERS_SKIP_EXAMPLES})
 +# Filament specific changes
 +option(SPIRV_HEADERS_SKIP_EXAMPLES "Skip building examples" ON)
-
+ 
 -option(SPIRV_HEADERS_SKIP_INSTALL "Skip install"
 -      ${SPIRV_HEADERS_SKIP_INSTALL})
 +option(SPIRV_HEADERS_SKIP_INSTALL "Skip install" ON)
 +# End Filament specific changes
-
+ 
  if(NOT ${SPIRV_HEADERS_SKIP_EXAMPLES})
    set(SPIRV_HEADERS_ENABLE_EXAMPLES ON)
 diff --git a/third_party/spirv-tools/source/CMakeLists.txt b/third_party/spirv-tools/source/CMakeLists.txt
-index 65087f2c..38101ab2 100644
+index 6633bc916..5f5904567 100644
 --- a/third_party/spirv-tools/source/CMakeLists.txt
 +++ b/third_party/spirv-tools/source/CMakeLists.txt
 @@ -364,13 +364,15 @@ endfunction()
-
+ 
  # Always build ${SPIRV_TOOLS}-shared. This is expected distro packages, and
  # unlike the other SPIRV_TOOLS target, defaults to hidden symbol visibility.
 -add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
@@ -190,13 +214,13 @@ index 65087f2c..38101ab2 100644
 +#   PUBLIC SPIRV_TOOLS_SHAREDLIB
 +# )
 +# End Filament specific changes
-
+ 
  if(SPIRV_TOOLS_BUILD_STATIC)
    add_library(${SPIRV_TOOLS}-static STATIC ${SPIRV_SOURCES})
 @@ -386,11 +388,17 @@ if(SPIRV_TOOLS_BUILD_STATIC)
      add_library(${SPIRV_TOOLS} ALIAS ${SPIRV_TOOLS}-static)
    endif()
-
+ 
 -  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
 +# Filament specific changes
 +  # set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
@@ -211,5 +235,8 @@ index 65087f2c..38101ab2 100644
 +  set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS})
 +# End Filament specific changes
  endif()
-
+ 
  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+-- 
+2.32.0.rc0.204.g9fa02ecfa5-goog
+


### PR DESCRIPTION
This started happening with the Visual Studio 2019 16.10 update.