### PR TITLE
gltfio: fix crash with non-triangles.

### DIFF
--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -873,10 +873,13 @@ void ResourceLoader::Impl::computeTangents(FFilamentAsset* asset) {
         baseTangents[slot.vertexBuffer] = slot.bufferIndex;
     }
 
-    // Create a job description for each primitive.
+    // Create a job description for each triangle-based primitive.
     using Params = TangentsJob::Params;
     std::vector<Params> jobParams;
     for (auto pair : asset->mPrimitives) {
+        if (UTILS_UNLIKELY(pair.first->type != cgltf_primitive_type_triangles)) {
+            continue;
+        }
         VertexBuffer* vb = pair.second;
         auto iter = baseTangents.find(vb);
         if (iter != baseTangents.end()) {


### PR DESCRIPTION
Fixes the "triangle count is zero" assertion with the big car model.

We do have nominal support for points and lines, but we should not
attempt to compute tangents for these.

As a reminder, glTF also supports loops, strips, and fans; this is the
only way in which Filament is non-conformant.

#3986