### PR TITLE
use "debug" namespace for system properties

### DIFF
--- a/filament/backend/src/CommandStream.cpp
+++ b/filament/backend/src/CommandStream.cpp
@@ -66,7 +66,7 @@ CommandStream::CommandStream(Driver& driver, CircularBuffer& buffer) noexcept
 {
 #ifdef ANDROID
     char property[PROP_VALUE_MAX];
-    __system_property_get("filament.perfcounters", property);
+    __system_property_get("debug.filament.perfcounters", property);
     mUsePerformanceCounter = bool(atoi(property));
 #endif
 }


### PR DESCRIPTION
"filament.perfcounters" is renamed to "debug.filament.perfcounters", 
because otherwise it can't be set by users on recent Android 
versions.