### PR TITLE
Ensure FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB is available.

### DIFF
--- a/filament/backend/include/private/backend/BackendUtils.h
+++ b/filament/backend/include/private/backend/BackendUtils.h
@@ -18,6 +18,10 @@
 
 #include <stddef.h>
 
+#ifndef FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB
+#    define FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB 1
+#endif
+
 namespace filament {
 namespace backend {
 

--- a/filament/backend/src/CommandBufferQueue.cpp
+++ b/filament/backend/src/CommandBufferQueue.cpp
@@ -21,6 +21,7 @@
 #include <utils/Panic.h>
 #include <utils/debug.h>
 
+#include "private/backend/BackendUtils.h"
 #include "private/backend/CommandStream.h"
 
 using namespace utils;

--- a/filament/src/details/Allocators.h
+++ b/filament/src/details/Allocators.h
@@ -19,6 +19,8 @@
 
 #include <utils/Allocator.h>
 
+#include "private/backend/BackendUtils.h"
+
 #ifndef FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB
 #    define FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB 2
 #endif
@@ -26,10 +28,6 @@
 #ifndef FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB
 #    define FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB 1
 #endif
-
-#ifndef FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB
-#    define FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB 1
-#endif 
 
 namespace filament {
 


### PR DESCRIPTION
If your build system does not provide a definition for this macro, then
you cannot compile this cpp file.  Since Allocators.h provides a
backup value, it needs to be included.

Note that this makes it so that the backend includes a file from
src/details, but I did not see any better alternative.