### PR TITLE
Fix FixedCapacityVector destructor.

### DIFF
--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -108,7 +108,7 @@ public:
 
     ~FixedCapacityVector() noexcept {
         destroy(begin(), end());
-        allocator().deallocate(data(), size());
+        allocator().deallocate(data(), capacity());
     }
 
     FixedCapacityVector& operator=(FixedCapacityVector const& rhs) {


### PR DESCRIPTION
std::allocator::deallocate() expects the same value that was given
during allocate().

Interestingly, this bug did not manifest any issues (even with ASAN) on
some platforms.