### PR TITLE
Adjust VK_MAX_COMMAND_BUFFERS to prevent a 5 ms stall.

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -89,6 +89,11 @@ VulkanCommandBuffer const& VulkanCommands::get() {
     // It occurs only when Filament invokes commit() or endFrame() a large number of times without
     // presenting the swap chain or waiting on a fence.
     while (mAvailableCount == 0) {
+#if VK_REPORT_STALLS
+        slog.i  << "VulkanCommands has stalled. "
+                << "If this occurs frequently, consider increasing VK_MAX_COMMAND_BUFFERS."
+                << io::endl;
+#endif
         wait();
         gc();
     }

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -682,7 +682,6 @@ void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) 
 
     // Evict any pipelines that have not been used in a while.
     // Any pipeline older than VK_MAX_COMMAND_BUFFERS can be safely destroyed.
-    static_assert(VK_MAX_PIPELINE_AGE >= VK_MAX_COMMAND_BUFFERS);
     using ConstPipeIterator = decltype(mPipelines)::const_iterator;
     for (ConstPipeIterator iter = mPipelines.begin(); iter != mPipelines.end();) {
         if (iter.value().age > VK_MAX_PIPELINE_AGE) {


### PR DESCRIPTION
This constant was previously set to 3 because of triple buffering, which
does not account for the fact that Filament may issue multiple commit()
calls during a single frame.

This new number was determined via experimentation.

On a Pixel 4, this reduces a 4.5 ms gap in "GPU Queue 0" to 420 us.