### PR TITLE
Vulkan: use EXT_debug_utils for custom labels.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -94,6 +94,7 @@ struct VulkanContext {
     VmaAllocator allocator;
     VulkanTexture* emptyTexture = nullptr;
     VulkanCommands* commands = nullptr;
+    std::string currentDebugMarker;
 };
 
 void selectPhysicalDevice(VulkanContext& context);


### PR DESCRIPTION
Vulkan group markers do not show up in an AGI system trace, but we can sneak in the top string in the marker stack by using debug_utils to assign labels to VkFramebuffer, which shows up in the "Surface" slices.  See screenshot below.

Note that the debug_utils extension is enabled only when launching your app from AGI.

<img width="683" alt="Screen Shot 2021-06-10 at 1 20 07 AM" src="https://user-images.githubusercontent.com/1288904/121491883-36aee200-c98b-11eb-8478-8428e0f744ef.png">

Many thanks to @pmuetschard for fixing this feature in AGI.
