### PR TITLE
Vulkan: Use custom VMA pools to speed up Mali.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -31,9 +31,8 @@ VulkanBuffer::VulkanBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         .size = numBytes,
         .usage = usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT
     };
-    VmaAllocationCreateInfo allocInfo {
-        .usage = VMA_MEMORY_USAGE_GPU_ONLY
-    };
+
+    VmaAllocationCreateInfo allocInfo { .pool = context.vmaPoolGPU };
     vmaCreateBuffer(context.allocator, &bufferInfo, &allocInfo, &mGpuBuffer, &mGpuMemory, nullptr);
 }
 

--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -47,6 +47,9 @@ constexpr struct VkAllocationCallbacks* VKALLOC = nullptr;
 constexpr static const int VK_REQUIRED_VERSION_MAJOR = 1;
 constexpr static const int VK_REQUIRED_VERSION_MINOR = 0;
 
+// Controls the block size for the VkBuffer pools that we use for vertex buffers.
+constexpr static const uint64_t VMA_BUFFER_POOL_BLOCK_SIZE_IN_MB = 128;
+
 // Maximum number of VkCommandBuffer handles managed simultaneously by VulkanCommands.
 //
 // This includes the "current" command buffer that is being written into, as well as any command

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -100,6 +100,8 @@ struct VulkanContext {
     VkViewport viewport;
     VkFormat finalDepthFormat;
     VmaAllocator allocator;
+    VmaPool vmaPoolGPU;
+    VmaPool vmaPoolCPU;
     VulkanTexture* emptyTexture = nullptr;
     VulkanCommands* commands = nullptr;
     std::string currentDebugMarker;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -332,7 +332,10 @@ void VulkanDriver::terminate() {
     mFramebufferCache.reset();
     mSamplerCache.reset();
 
+    vmaDestroyPool(mContext.allocator, mContext.vmaPoolGPU);
+    vmaDestroyPool(mContext.allocator, mContext.vmaPoolCPU);
     vmaDestroyAllocator(mContext.allocator);
+
     vkDestroyQueryPool(mContext.device, mContext.timestamps.pool, VKALLOC);
     vkDestroyCommandPool(mContext.device, mContext.commandPool, VKALLOC);
     vkDestroyDevice(mContext.device, VKALLOC);

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -50,9 +50,7 @@ VulkanStage const* VulkanStagePool::acquireStage(uint32_t numBytes) {
         .size = numBytes,
         .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
     };
-    VmaAllocationCreateInfo allocInfo {
-        .usage = VMA_MEMORY_USAGE_CPU_ONLY
-    };
+    VmaAllocationCreateInfo allocInfo { .pool = mContext.vmaPoolCPU };
     vmaCreateBuffer(mContext.allocator, &bufferInfo, &allocInfo, &stage->buffer, &stage->memory,
             nullptr);
 


### PR DESCRIPTION
This makes the car load in 3 seconds instead of 30 seconds on Mali.

On devices that have bufferImageGranularity set to 1 in the
VkPhysicalDeviceLimits caps structure, we observe that vmaCreateBuffer
can be two orders of magnitude faster than with devices that have a
higher value for their bufferImageGranularity.

According to the Vulkan spec, the bufferImageGranularity aligment
constraint needs to be honored only when linear and non-linear resources
live next to each other in memory.  Since all VkBuffer objects are
linear, we can allocate them all from the same pool and ignore the
alignment constraint.