### PR TITLE
filament-utils-android: fix string literal conversions

### DIFF
--- a/android/filament-utils-android/src/main/cpp/Utils.cpp
+++ b/android/filament-utils-android/src/main/cpp/Utils.cpp
@@ -102,20 +102,25 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*) {
     jclass ktxloaderClass = env->FindClass("com/google/android/filament/utils/KTXLoader");
     if (ktxloaderClass == nullptr) return JNI_ERR;
     static const JNINativeMethod ktxMethods[] = {
-        {"nCreateKTXTexture", "(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateKTXTexture)},
-        {"nCreateIndirectLight", "(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateIndirectLight)},
-        {"nCreateSkybox", "(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateSkybox)},
-        {"nGetSphericalHarmonics", "(Ljava/nio/Buffer;I[F)Z", reinterpret_cast<void*>(nGetSphericalHarmonics)},
+        {strdup("nCreateKTXTexture"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateKTXTexture)},
+        {strdup("nCreateIndirectLight"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateIndirectLight)},
+        {strdup("nCreateSkybox"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateSkybox)},
+        {strdup("nGetSphericalHarmonics"), strdup("(Ljava/nio/Buffer;I[F)Z"), reinterpret_cast<void*>(nGetSphericalHarmonics)},
     };
     rc = env->RegisterNatives(ktxloaderClass, ktxMethods, sizeof(ktxMethods) / sizeof(JNINativeMethod));
+    free(ktxMethods[0].name); free(ktxMethods[0].signature);
+    free(ktxMethods[1].name); free(ktxMethods[1].signature);
+    free(ktxMethods[2].name); free(ktxMethods[2].signature);
+    free(ktxMethods[3].name); free(ktxMethods[3].signature);
     if (rc != JNI_OK) return rc;
 
     // HDRLoader
     jclass hdrloaderClass = env->FindClass("com/google/android/filament/utils/HDRLoader");
     if (hdrloaderClass == nullptr) return JNI_ERR;
     static const JNINativeMethod hdrMethods[] = {
-        {"nCreateHDRTexture", "(JLjava/nio/Buffer;II)J", reinterpret_cast<void*>(nCreateHDRTexture)},
+        {strdup("nCreateHDRTexture"), strdup("(JLjava/nio/Buffer;II)J"), reinterpret_cast<void*>(nCreateHDRTexture)},
     };
+    free(hdrMethods[0].name); free(hdrMethods[0].signature);
     rc = env->RegisterNatives(hdrloaderClass, hdrMethods, sizeof(hdrMethods) / sizeof(JNINativeMethod));
     if (rc != JNI_OK) return rc;
 

--- a/android/filament-utils-android/src/main/cpp/Utils.cpp
+++ b/android/filament-utils-android/src/main/cpp/Utils.cpp
@@ -102,25 +102,20 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void*) {
     jclass ktxloaderClass = env->FindClass("com/google/android/filament/utils/KTXLoader");
     if (ktxloaderClass == nullptr) return JNI_ERR;
     static const JNINativeMethod ktxMethods[] = {
-        {strdup("nCreateKTXTexture"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateKTXTexture)},
-        {strdup("nCreateIndirectLight"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateIndirectLight)},
-        {strdup("nCreateSkybox"), strdup("(JLjava/nio/Buffer;IZ)J"), reinterpret_cast<void*>(nCreateSkybox)},
-        {strdup("nGetSphericalHarmonics"), strdup("(Ljava/nio/Buffer;I[F)Z"), reinterpret_cast<void*>(nGetSphericalHarmonics)},
+        {(char*)"nCreateKTXTexture", (char*)"(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateKTXTexture)},
+        {(char*)"nCreateIndirectLight", (char*)"(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateIndirectLight)},
+        {(char*)"nCreateSkybox", (char*)"(JLjava/nio/Buffer;IZ)J", reinterpret_cast<void*>(nCreateSkybox)},
+        {(char*)"nGetSphericalHarmonics", (char*)"(Ljava/nio/Buffer;I[F)Z", reinterpret_cast<void*>(nGetSphericalHarmonics)},
     };
     rc = env->RegisterNatives(ktxloaderClass, ktxMethods, sizeof(ktxMethods) / sizeof(JNINativeMethod));
-    free(ktxMethods[0].name); free(ktxMethods[0].signature);
-    free(ktxMethods[1].name); free(ktxMethods[1].signature);
-    free(ktxMethods[2].name); free(ktxMethods[2].signature);
-    free(ktxMethods[3].name); free(ktxMethods[3].signature);
     if (rc != JNI_OK) return rc;
 
     // HDRLoader
     jclass hdrloaderClass = env->FindClass("com/google/android/filament/utils/HDRLoader");
     if (hdrloaderClass == nullptr) return JNI_ERR;
     static const JNINativeMethod hdrMethods[] = {
-        {strdup("nCreateHDRTexture"), strdup("(JLjava/nio/Buffer;II)J"), reinterpret_cast<void*>(nCreateHDRTexture)},
+        {(char*)"nCreateHDRTexture", (char*)"(JLjava/nio/Buffer;II)J", reinterpret_cast<void*>(nCreateHDRTexture)},
     };
-    free(hdrMethods[0].name); free(hdrMethods[0].signature);
     rc = env->RegisterNatives(hdrloaderClass, hdrMethods, sizeof(hdrMethods) / sizeof(JNINativeMethod));
     if (rc != JNI_OK) return rc;
 


### PR DESCRIPTION
This is annoying, but we're technically doing something bad here. The `JNINativeMethod` struct looks like this:
```
typedef struct {
    char *name;
    char *signature;
    void *fnPtr;
} JNINativeMethod;
```

To comply with Google3's stricter build rules, we have to provide a non-const `char*` (string literals are constant). Otherwise, I see the following error:
```
error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
```

Alternatively, if we assume that JNI won't try to mutate the string, we could just cast to a `char*`. I think that's a bit riskier though.
