### PR TITLE
Vulkan: repair headless swap chains.

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -402,6 +402,7 @@ VulkanSwapChain::VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_
     swapchain = VK_NULL_HANDLE;
 
     // Somewhat arbitrarily, headless rendering is double-buffered.
+    color.reserve(2);
     color.resize(2);
 
     for (size_t i = 0; i < color.size(); ++i) {


### PR DESCRIPTION
I broke this when migrating to FixedCapacityVector.