### PR TITLE
Fix several FrameGraph issues related to imported render targets

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -760,11 +760,11 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 }
 
                 if (!data.color) {
-                    if (view.isSkyboxVisible()) {
-                        // if the skybox is visible, then we don't need to clear at all
-                        clearColorFlags &= ~TargetBufferFlags::COLOR;
-                    }
-
+                    // FIXME: this works only when the viewport is full
+                    //  if (view.isSkyboxVisible()) {
+                    //      // if the skybox is visible, then we don't need to clear at all
+                    //      clearColorFlags &= ~TargetBufferFlags::COLOR;
+                    //  }
                     data.color = builder.createTexture("Color Buffer", colorBufferDesc);
                 }
 

--- a/filament/src/fg2/FrameGraphRenderPass.h
+++ b/filament/src/fg2/FrameGraphRenderPass.h
@@ -55,9 +55,9 @@ struct FrameGraphRenderPass {
     struct ImportDescriptor {
         backend::TargetBufferFlags attachments = backend::TargetBufferFlags::COLOR0;
         Viewport viewport{};
-        math::float4 clearColor{};
-        uint8_t samples = 0; // # of samples (0 = unset, default)
-        backend::TargetBufferFlags clearFlags{};
+        math::float4 clearColor{};  // this overrides Descriptor::clearColor
+        uint8_t samples = 0;        // # of samples (0 = unset, default)
+        backend::TargetBufferFlags clearFlags{}; // this overrides Descriptor::clearFlags
         backend::TargetBufferFlags keepOverrideStart{};
         backend::TargetBufferFlags keepOverrideEnd{};
     };

--- a/filament/src/fg2/FrameGraphRenderPass.h
+++ b/filament/src/fg2/FrameGraphRenderPass.h
@@ -58,7 +58,7 @@ struct FrameGraphRenderPass {
         math::float4 clearColor{};
         uint8_t samples = 0; // # of samples (0 = unset, default)
         backend::TargetBufferFlags clearFlags{};
-        backend::TargetBufferFlags discardStart{};
+        backend::TargetBufferFlags keepOverrideStart{};
         backend::TargetBufferFlags keepOverrideEnd{};
     };
 

--- a/filament/src/fg2/PassNode.cpp
+++ b/filament/src/fg2/PassNode.cpp
@@ -204,25 +204,21 @@ void RenderPassNode::resolve() noexcept {
             rt.imported = true;
 
             // override the values we just calculated with the actual values from the imported target
-            rt.targetBufferFlags = pImportedRenderTarget->importedDesc.attachments;
-            rt.descriptor.viewport = pImportedRenderTarget->importedDesc.viewport;
+            rt.targetBufferFlags     = pImportedRenderTarget->importedDesc.attachments;
+            rt.descriptor.viewport   = pImportedRenderTarget->importedDesc.viewport;
             rt.descriptor.clearColor = pImportedRenderTarget->importedDesc.clearColor;
-            rt.descriptor.samples = pImportedRenderTarget->importedDesc.samples;
             rt.descriptor.clearFlags = pImportedRenderTarget->importedDesc.clearFlags;
-            rt.descriptor.discardStart = pImportedRenderTarget->importedDesc.discardStart;
-
-            rt.backend.target = pImportedRenderTarget->target;
-
-            // discard start is also taken from the imported target
-            rt.backend.params.flags.discardStart = rt.descriptor.discardStart & rt.targetBufferFlags;
+            rt.descriptor.samples    = pImportedRenderTarget->importedDesc.samples;
+            rt.backend.target        = pImportedRenderTarget->target;
 
             // but don't discard attachments the imported target tells us to keep
-            rt.backend.params.flags.discardEnd &= ~pImportedRenderTarget->importedDesc.keepOverrideEnd;
+            rt.backend.params.flags.discardStart &= ~pImportedRenderTarget->importedDesc.keepOverrideStart;
+            rt.backend.params.flags.discardEnd   &= ~pImportedRenderTarget->importedDesc.keepOverrideEnd;
         }
 
+        rt.backend.params.viewport = rt.descriptor.viewport;
         rt.backend.params.clearColor = rt.descriptor.clearColor;
         rt.backend.params.flags.clear = rt.descriptor.clearFlags & rt.targetBufferFlags;
-        rt.backend.params.viewport = rt.descriptor.viewport;
     }
 }
 

--- a/filament/src/fg2/PassNode.cpp
+++ b/filament/src/fg2/PassNode.cpp
@@ -194,8 +194,6 @@ void RenderPassNode::resolve() noexcept {
             rt.descriptor.viewport.height = height;
         }
 
-        rt.backend.params.clearColor = rt.descriptor.clearColor;
-
         /*
          * Handle the special imported render target
          * To do this we check the first color attachment for an ImportedRenderTarget
@@ -222,6 +220,7 @@ void RenderPassNode::resolve() noexcept {
             rt.backend.params.flags.discardEnd &= ~pImportedRenderTarget->importedDesc.keepOverrideEnd;
         }
 
+        rt.backend.params.clearColor = rt.descriptor.clearColor;
         rt.backend.params.flags.clear = rt.descriptor.clearFlags & rt.targetBufferFlags;
         rt.backend.params.viewport = rt.descriptor.viewport;
     }

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -600,9 +600,14 @@ void SimpleViewer::updateUserInterface() {
     if (ImGui::CollapsingHeader("View")) {
         ImGui::Indent();
 
-        bool dither = mSettings.view.dithering == Dithering::TEMPORAL;
-        ImGui::Checkbox("Dithering", &dither);
-        enableDithering(dither);
+        ImGui::Checkbox("Post-processing", &mSettings.view.postProcessingEnabled);
+        ImGui::Indent();
+            bool dither = mSettings.view.dithering == Dithering::TEMPORAL;
+            ImGui::Checkbox("Dithering", &dither);
+            enableDithering(dither);
+            ImGui::Checkbox("Bloom", &mSettings.view.bloom.enabled);
+            ImGui::Checkbox("Flare", &mSettings.view.bloom.lensFlare);
+        ImGui::Unindent();
 
         bool msaa = mSettings.view.sampleCount != 1;
         ImGui::Checkbox("MSAA 4x", &msaa);
@@ -621,8 +626,6 @@ void SimpleViewer::updateUserInterface() {
         enableFxaa(fxaa);
 
         ImGui::Checkbox("SSAO", &mSettings.view.ssao.enabled);
-        ImGui::Checkbox("Bloom", &mSettings.view.bloom.enabled);
-        ImGui::Checkbox("Flare", &mSettings.view.bloom.lensFlare);
 
         if (ImGui::CollapsingHeader("SSAO Options")) {
             auto& ssao = mSettings.view.ssao;


### PR DESCRIPTION
Imported render targets are a special case in the frame graph, in particular, the texture resource that refers to them is not a real texture with a HwTexture handle, it can be converted back to the render target, but it can never be used as an actual texture -- in particular it can't be used to create a HwRenderTarget.

There was other problem related to clearing render targets, individual fixes are explained in their respective CL.

This should fix #4085
