### PR TITLE
Fix issues in test_FeedbackLoops and VulkanDriver.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1605,8 +1605,11 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     }
 
     vkUnmapMemory(device, stagingMemory);
-    vkFreeMemory(device, stagingMemory, nullptr);
-    vkDestroyImage(device, stagingImage, nullptr);
+
+    mDisposer.createDisposable((void*)stagingImage, [=] () {
+        vkDestroyImage(device, stagingImage, nullptr);
+        vkFreeMemory(device, stagingMemory, nullptr);
+    });
 
     scheduleDestroy(std::move(pbd));
 }

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -307,7 +307,8 @@ void VulkanSwapChain::makePresentable() {
 #ifdef ANDROID
         .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
 #else
-        .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        // If nothing was rendered, then the layout was never transitioned to COLOR_ATTACHMENT_OPTIMAL.
+        .oldLayout = firstRenderPass ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 #endif
 
         .newLayout = swapContext.layout,

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -46,6 +46,7 @@ BackendTest::~BackendTest() {
     if (sBackend == Backend::OPENGL) {
         return;
     }
+    flushAndWait();
     driver->terminate();
     delete driver;
 }
@@ -67,6 +68,15 @@ void BackendTest::executeCommands() {
             commandBufferQueue.releaseBuffer(item);
         }
     }
+}
+
+void BackendTest::flushAndWait(uint64_t timeout) {
+    auto& api = getDriverApi();
+    auto fence = api.createFence();
+    api.finish();
+    executeCommands();
+    api.wait(fence, timeout);
+    api.destroyFence(fence);
 }
 
 Handle<HwSwapChain> BackendTest::createSwapChain() {

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -45,6 +45,7 @@ protected:
 
     void initializeDriver();
     void executeCommands();
+    void flushAndWait(uint64_t timeout = 1000);
 
     filament::backend::Handle<filament::backend::HwSwapChain> createSwapChain();
 

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -250,6 +250,7 @@ TEST_F(BackendTest, FeedbackLoops) {
 
         api.destroyProgram(program);
         api.destroySwapChain(swapChain);
+        api.destroyTexture(texture);
         for (auto rt : renderTargets)  api.destroyRenderTarget(rt);
     }
 


### PR DESCRIPTION
1) Add a missing destroyTexture to the test, which I believe fixed
the Metal assert that I was seeing, as well as some Vulkan validation
warnings.

2) Add a flushAndWait() utility to BackendTest, which is useful for
diagnostics.

3) Fix a layout validation issue in VulkanSwapChain for empty render
passes.