### PR TITLE
fix a possible crash when bloom is enabled

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -284,11 +284,11 @@ public class View {
      *
      * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
      * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
-     *              maximum is 12. This value together with resolution influences the spread of the
+     *              maximum is 11. This value together with resolution influences the spread of the
      *              blur effect. This value can be silently reduced to accommodate the original
      *              image size.
-     * resolution:  Resolution of bloom's minor axis. The minimum value is 2^levels and the
-     *              the maximum is lower of the original resolution and 4096. This parameter is
+     * resolution:  Resolution of bloom's vertical axis. The minimum value is 2^levels and the
+     *              the maximum is lower of the original resolution and 2048. This parameter is
      *              silently clamped to the minimum and maximum.
      *              It is highly recommended that this value be smaller than the target resolution
      *              after dynamic resolution is applied (horizontally and vertically).
@@ -329,7 +329,7 @@ public class View {
         public float strength = 0.10f;
 
         /**
-         * Resolution of minor axis (2^levels to 4096)
+         * Resolution of minor axis (2^levels to 2048)
          */
         public int resolution = 360;
 
@@ -339,7 +339,7 @@ public class View {
         public float anamorphism = 1.0f;
 
         /**
-         * Number of blur levels (3 to 12)
+         * Number of blur levels (3 to 11)
          */
         public int levels = 6;
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -152,9 +152,9 @@ public:
         Texture* dirt = nullptr;                //!< user provided dirt texture
         float dirtStrength = 0.2f;              //!< strength of the dirt texture
         float strength = 0.10f;                 //!< bloom's strength between 0.0 and 1.0
-        uint32_t resolution = 360;              //!< resolution of minor axis (2^levels to 4096)
+        uint32_t resolution = 360;              //!< resolution of vertical axis (2^levels to 2048)
         float anamorphism = 1.0f;               //!< bloom x/y aspect-ratio (1/32 to 32)
-        uint8_t levels = 6;                     //!< number of blur levels (3 to 12)
+        uint8_t levels = 6;                     //!< number of blur levels (3 to 11)
         BlendMode blendMode = BlendMode::ADD;   //!< how the bloom effect is applied
         bool threshold = true;                  //!< whether to threshold the source
         bool enabled = false;                   //!< enable or disable bloom

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -333,7 +333,9 @@ public:
 
     void setBloomOptions(BloomOptions options) noexcept {
         options.dirtStrength = math::saturate(options.dirtStrength);
-        options.levels = math::clamp(options.levels, uint8_t(3), uint8_t(12));
+        options.levels = math::clamp(options.levels, uint8_t(3), uint8_t(11));
+        options.resolution = math::clamp(options.resolution, 1u << options.levels, 2048u);
+        options.anamorphism = math::clamp(options.anamorphism, 1.0f/32.0f, 32.0f);
         options.highlight = std::max(10.0f, options.highlight);
         mBloomOptions = options;
     }


### PR DESCRIPTION
This reworks how we compute the bloom buffer size. The main changes are:

- The BloomOptions.resolution is changed to height instead of minor axis.
  This keeps a consistant look of the bloom regardless of the viewport.

- The anamorphism setting now dilates the bloom rather than to compress
  it (in the other direction), which maintains the same amount of bloom.
  However, the resolution decreases meaning that the user might need to
  adjust resolution and/or levels.

- limit the resolution do 2048 which is gles minspec.