### PR TITLE
Backend::DEFAULT now selects a backend most suited for the platform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@ A new header is inserted each time a *tag* is created.
 
 - engine: User materials can now provide custom lighting/surface shading, please consult
   the [materials documentation](https://google.github.io/filament/Materials.html) for details.
+- engine: `Backend::DEFAULT` now selects the most appropriate backend for the platform, rather than
+  always `OPENGL`. On Android the default is `OPENGL`, on Apple platforms the default is `METAL` and
+  on all other platforms that default is `VULKAN`.
 
 ## v1.10.4
 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -61,9 +61,9 @@ static constexpr size_t CONFIG_BINDING_COUNT = 8;
  */
 enum class Backend : uint8_t {
     DEFAULT = 0,  //!< Automatically selects an appropriate driver for the platform.
-    OPENGL = 1,   //!< Selects the OpenGL driver (which supports OpenGL ES as well).
-    VULKAN = 2,   //!< Selects the Vulkan driver if the platform supports it.
-    METAL = 3,    //!< Selects the Metal driver if the platform supports it.
+    OPENGL = 1,   //!< Selects the OpenGL/ES driver (default on Android)
+    VULKAN = 2,   //!< Selects the Vulkan driver if the platform supports it (default on Linux/Windows)
+    METAL = 3,    //!< Selects the Metal driver if the platform supports it (default on MacOS/iOS).
     NOOP = 4,     //!< Selects the no-op driver for testing purposes.
 };
 

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -93,7 +93,13 @@ DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
 #endif
 
     if (*backend == Backend::DEFAULT) {
+#if defined(ANDROID)
         *backend = Backend::OPENGL;
+#elif defined(IOS) || defined(__APPLE__)
+        *backend = Backend::METAL;
+#else
+        *backend = Backend::VULKAN;
+#endif
     }
     if (*backend == Backend::NOOP) {
         return new PlatformNoop();

--- a/libs/filamentapp/include/filamentapp/Config.h
+++ b/libs/filamentapp/include/filamentapp/Config.h
@@ -29,7 +29,7 @@ struct Config {
     std::string dirt;
     float scale = 1.0f;
     bool splitView = false;
-    filament::Engine::Backend backend = filament::Engine::Backend::OPENGL;
+    mutable filament::Engine::Backend backend = filament::Engine::Backend::DEFAULT;
     filament::camutils::Mode cameraMode = filament::camutils::Mode::ORBIT;
     bool resizeable = true;
     bool headless = false;

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -539,6 +539,9 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
         // current, rather than the one created by SDL.
         mFilamentApp->mEngine = Engine::create(config.backend);
 
+        // get the resolved backend
+        config.backend = mFilamentApp->mEngine->getBackend();
+
         void* nativeWindow = ::getNativeWindow(mWindow);
         void* nativeSwapChain = nativeWindow;
 


### PR DESCRIPTION
- OpenGL ES on Android
- Metal on MacOS/iOS
- Vulkan everywhere else (Linux/Windows)

The main change here is that OpenGL is no longer the default on
desktop.

Most of our samples have a `-a` option that can be use to specify the
desired backend.