### PR TITLE
fix a potential memory corruption when using more than 4 render targets

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -194,7 +194,7 @@ public:
                 uint8_t level = 0; // level when attached to a texture
             };
             // field ordering to optimize size on 64-bits
-            RenderBuffer color[4];
+            RenderBuffer color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
             RenderBuffer depth;
             RenderBuffer stencil;
             GLuint fbo = 0;

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -353,6 +353,10 @@ public:
     PoolAllocator(const PoolAllocator& rhs) = delete;
     PoolAllocator& operator=(const PoolAllocator& rhs) = delete;
 
+    // Allocators can be moved
+    PoolAllocator(PoolAllocator&& rhs) = default;
+    PoolAllocator& operator=(PoolAllocator&& rhs) = default;
+
     PoolAllocator() noexcept = default;
     ~PoolAllocator() noexcept = default;
 


### PR DESCRIPTION
The array size in the GL structure didn't match the number of supported
render targets.