### PR TITLE
VSM improvements and fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ This file contains one line summaries of commits that are worthy of mentioning i
 A new header is inserted each time a *tag* is created.
 
 ## v1.10.6 (currently main branch)
+- engine: Use exponential VSM and improve VSM user settings [⚠️ **Recompile Materials for VSM**].
 
 ## v1.10.5
 

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -138,10 +138,15 @@ Java_com_google_android_filament_View_nSetShadowType(JNIEnv*, jclass, jlong nati
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetVsmShadowOptions(JNIEnv*, jclass, jlong nativeView,
-        jint anisotropy) {
+        jint anisotropy, jboolean mipmapping, jfloat exponent, jfloat minVarianceScale,
+        jfloat lightBleedReduction) {
     View* view = (View*) nativeView;
     View::VsmShadowOptions options;
-    options.anisotropy = (uint8_t) anisotropy;
+    options.anisotropy = (uint8_t)anisotropy;
+    options.mipmapping = (bool)mipmapping;
+    options.exponent = exponent;
+    options.minVarianceScale = minVarianceScale;
+    options.lightBleedReduction = lightBleedReduction;
     view->setVsmShadowOptions(options);
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -242,15 +242,17 @@ public class LightManager {
 
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.
+         * This is ignored when the View's ShadowType is set to VSM.
          */
         public float constantBias = 0.05f;
 
         /** Amount by which the maximum sampling error is scaled. The resulting value is used
          * to move the shadow away from the fragment normal. Should be 1.0.
+         * This is ignored when the View's ShadowType is set to VSM.
          */
         public float normalBias = 0.4f;
 
-        /** Distance from the camera after which shadows are clipped. this is used to clip
+        /** Distance from the camera after which shadows are clipped. This is used to clip
          * shadows that are too far and wouldn't contribute to the scene much, improving
          * performance and quality. This value is always positive.
          * Use 0.0f to use the camera far distance.

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -687,20 +687,44 @@ public class View {
     /**
      * View-level options for VSM shadowing.
      *
+     * <strong>Warning: This API is still experimental and subject to change.</strong>
+     *
      * @see View#setVsmShadowOptions
      */
     public static class VsmShadowOptions {
         /**
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
+         * This implies mipmapping below.
          *
          * <p>
          * The number of anisotropic samples = 2 ^ vsmAnisotropy.
          * </p>
          *
-         * <strong>Warning: This API is still experimental and subject to change.</strong>
          */
         public int anisotropy = 0;
+
+        /**
+         * Whether to generate mipmaps for all VSM shadow maps.
+         */
+        public boolean mipmapping = false;
+
+        /**
+         * EVSM exponent
+         * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
+         * shadow map in fp32. Currently the shadow map bit depth is always fp16.
+         */
+        public float exponent = 5.54f;
+
+        /**
+         * VSM minimum variance scale, must be positive.
+         */
+        public float minVarianceScale = 1.0f;
+
+        /**
+         * VSM light bleeding reduction amount, between 0 and 1.
+         */
+        public float lightBleedReduction = 0.2f;
     }
 
     /**
@@ -1308,7 +1332,8 @@ public class View {
      */
     public void setVsmShadowOptions(@NonNull VsmShadowOptions options) {
         mVsmShadowOptions = options;
-        nSetVsmShadowOptions(getNativeObject(), options.anisotropy);
+        nSetVsmShadowOptions(getNativeObject(), options.anisotropy, options.mipmapping,
+                options.exponent, options.minVarianceScale, options.lightBleedReduction);
     }
 
     /**
@@ -1522,7 +1547,7 @@ public class View {
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
     private static native void nSetShadowType(long nativeView, int type);
-    private static native void nSetVsmShadowOptions(long nativeView, int anisotropy);
+    private static native void nSetVsmShadowOptions(long nativeView, int anisotropy, boolean mipmapping, float exponent, float minVarianceScale, float lightBleedReduction);
     private static native void nSetColorGrading(long nativeView, long nativeColorGrading);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -80,6 +80,10 @@ public:
         setSampler(index, { t, s });
     }
 
+    inline void clearSampler(size_t index)  {
+        setSampler(index, {});
+    }
+
 private:
 #if !defined(NDEBUG)
     friend utils::io::ostream& operator<<(utils::io::ostream& out, const SamplerGroup& rhs);

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -230,15 +230,17 @@ public:
 
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.
+         * This is ignored when the View's ShadowType is set to VSM.
          */
         float constantBias = 0.001f;
 
         /** Amount by which the maximum sampling error is scaled. The resulting value is used
          * to move the shadow away from the fragment normal. Should be 1.0.
+         * This is ignored when the View's ShadowType is set to VSM.
          */
         float normalBias = 1.0f;
 
-        /** Distance from the camera after which shadows are clipped. this is used to clip
+        /** Distance from the camera after which shadows are clipped. This is used to clip
          * shadows that are too far and wouldn't contribute to the scene much, improving
          * performance and quality. This value is always positive.
          * Use 0.0f to use the camera far distance.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -345,6 +345,7 @@ public:
     /**
      * View-level options for VSM Shadowing.
      * @see setVsmShadowOptions()
+     * @warning This API is still experimental and subject to change.
      */
     struct VsmShadowOptions {
         /**
@@ -352,10 +353,30 @@ public:
          * than 0, mipmaps will automatically be generated each frame for all lights.
          *
          * The number of anisotropic samples = 2 ^ vsmAnisotropy.
-         *
-         * @warning This API is still experimental and subject to change.
          */
         uint8_t anisotropy = 0;
+
+        /**
+         * Whether to generate mipmaps for all VSM shadow maps.
+         */
+        bool mipmapping = false;
+
+        /**
+         * EVSM exponent.
+         * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
+         * shadow map in fp32. Currently the shadow map bit depth is always fp16.
+         */
+        float exponent = 5.54f;
+
+        /**
+         * VSM minimum variance scale, must be positive.
+         */
+        float minVarianceScale = 0.5f;
+
+        /**
+         * VSM light bleeding reduction amount, between 0 and 1.
+         */
+         float lightBleedReduction = 0.15f;
     };
 
     /**

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -47,7 +47,7 @@ FScene::FScene(FEngine& engine) :
 FScene::~FScene() noexcept = default;
 
 
-void FScene::prepare(const mat4f& worldOriginTransform) {
+void FScene::prepare(const mat4f& worldOriginTransform, bool shadowReceiversAreCasters) noexcept {
     // TODO: can we skip this in most cases? Since we rely on indices staying the same,
     //       we could only skip, if nothing changed in the RCM.
 
@@ -119,12 +119,17 @@ void FScene::prepare(const mat4f& worldOriginTransform) {
             // compute the world AABB so we can perform culling
             const Box worldAABB = rigidTransform(rcm.getAABB(ri), worldTransform);
 
+            auto visibility = rcm.getVisibility(ri);
+            if (shadowReceiversAreCasters && visibility.receiveShadows) {
+                visibility.castShadows = true;
+            }
+
             // we know there is enough space in the array
             sceneData.push_back_unsafe(
                     ri,                       // RENDERABLE_INSTANCE
                     worldTransform,           // WORLD_TRANSFORM
                     reversedWindingOrder,     // REVERSED_WINDING_ORDER
-                    rcm.getVisibility(ri),    // VISIBILITY_STATE
+                    visibility,               // VISIBILITY_STATE
                     rcm.getBonesUbh(ri),      // BONES_UBH
                     worldAABB.center,         // WORLD_AABB_CENTER
                     0,                        // VISIBLE_MASK

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -84,8 +84,9 @@ public:
     ~FScene() noexcept;
     void terminate(FEngine& engine);
 
-    void prepare(const math::mat4f& worldOriginTransform);
-    void prepareDynamicLights(const CameraInfo& camera, ArenaScope& arena, backend::Handle<backend::HwUniformBuffer> lightUbh) noexcept;
+    void prepare(const math::mat4f& worldOriginTransform, bool shadowReceiversAreCasters) noexcept;
+    void prepareDynamicLights(const CameraInfo& camera, ArenaScope& arena,
+            backend::Handle<backend::HwUniformBuffer> lightUbh) noexcept;
 
 
     filament::backend::Handle<backend::HwUniformBuffer> getRenderableUBO() const noexcept {

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -74,11 +74,8 @@ public:
     void render(FrameGraph& fg, FEngine& engine, FView& view, backend::DriverApi& driver,
             RenderPass& pass) noexcept;
 
-    // Prepares the shadow sampler.
-    void prepareShadow(backend::Handle<backend::HwTexture> texture, FView const& view)
-        const noexcept;
-
     const ShadowMap* getCascadeShadowMap(size_t c) const noexcept {
+        assert_invariant(c < mCascadeShadowMapCache.size());
         return mCascadeShadowMapCache[c].get();
     }
 
@@ -108,14 +105,14 @@ private:
     class ShadowMapEntry {
     public:
         ShadowMapEntry() = default;
-        ShadowMapEntry(ShadowMap* shadowMap, const size_t light) :
+        ShadowMapEntry(ShadowMap* shadowMap, size_t light) :
                 mShadowMap(shadowMap),
-                mLightIndex(light),
-                mLayout({}) {}
+                mLightIndex(light) {
+        }
 
         explicit operator bool() const { return mShadowMap != nullptr; }
 
-        ShadowMap* getShadowMap() const { return mShadowMap; }
+        ShadowMap& getShadowMap() const { return *mShadowMap; }
         size_t getLightIndex() const { return mLightIndex; }
         const ShadowLayout& getLayout() const { return mLayout; }
         bool hasVisibleShadows() const { return mHasVisibleShadows; }
@@ -125,8 +122,8 @@ private:
 
     private:
         ShadowMap* mShadowMap = nullptr;
-        size_t mLightIndex = 0;
         ShadowLayout mLayout = {};
+        size_t mLightIndex = 0; // TODO: does this need to be size_t?
         bool mHasVisibleShadows = false;
     };
 
@@ -135,7 +132,7 @@ private:
         constexpr static size_t SPLIT_COUNT = CONFIG_MAX_SHADOW_CASCADES + 1;
 
         struct Params {
-            math::mat4f proj = {};
+            math::mat4f proj;
             float near = 0.0f;
             float far = 0.0f;
             size_t cascadeCount = 1;
@@ -150,8 +147,8 @@ private:
             }
         };
 
-        CascadeSplits() : CascadeSplits(Params {}) {}
-        explicit CascadeSplits(Params p);
+        CascadeSplits() noexcept : CascadeSplits(Params{}) {}
+        explicit CascadeSplits(Params const& params) noexcept;
 
         // Split positions in world-space.
         const float* beginWs() const { return mSplitsWs; }
@@ -165,9 +162,10 @@ private:
         float mSplitsWs[SPLIT_COUNT];
         float mSplitsCs[SPLIT_COUNT];
         size_t mSplitCount;
+    };
 
-    } mCascadeSplits;
     CascadeSplits::Params mCascadeSplitParams;
+    CascadeSplits mCascadeSplits;
 
     // 16-bits seems enough.
     // TODO: make it an option.
@@ -182,8 +180,6 @@ private:
     utils::FixedCapacityVector<ShadowMapEntry> mSpotShadowMaps{
             utils::FixedCapacityVector<ShadowMapEntry>::with_capacity(
                     CONFIG_MAX_SHADOW_CASTING_SPOTS) };
-
-    backend::RenderPassParams mRenderPassParams;
 
     std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASCADES> mCascadeShadowMapCache;
     std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASTING_SPOTS> mSpotShadowMapCache;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -163,10 +163,13 @@ public:
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
     void prepareLighting(FEngine& engine, FEngine::DriverApi& driver,
             ArenaScope& arena, Viewport const& viewport) noexcept;
+
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept;
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
     void prepareShadow(backend::Handle<backend::HwTexture> structure) const noexcept;
+    void prepareShadowMap() const noexcept;
+
     void cleanupRenderPasses() const noexcept;
     void froxelize(FEngine& engine) const noexcept;
     void commitUniforms(backend::DriverApi& driver) const noexcept;
@@ -497,7 +500,7 @@ private:
     bool mHasPostProcessPass = true;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
     ShadowType mShadowType = ShadowType::PCF;
-    VsmShadowOptions mVsmShadowOptions = {};
+    VsmShadowOptions mVsmShadowOptions = {}; // FIXME: this should probably be per-light
     BloomOptions mBloomOptions;
     FogOptions mFogOptions;
     DepthOfFieldOptions mDepthOfFieldOptions;

--- a/libs/filabridge/include/private/filament/UibGenerator.h
+++ b/libs/filabridge/include/private/filament/UibGenerator.h
@@ -72,8 +72,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     filament::math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
-    filament::math::float3 lightPosition;
-    uint32_t padding;
+    filament::math::float4 padding0;
 
     filament::math::float3 lightDirection;
     uint32_t fParamsX; // stride-x
@@ -131,8 +130,13 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::float2 clipControl;
     math::float2 padding1;
 
+    float vsmExponent;
+    float vsmDepthScale;
+    float vsmLightBleedReduction;
+    float vsmReserved0;
+
     // bring PerViewUib to 2 KiB
-    filament::math::float4 padding2[60];
+    filament::math::float4 padding2[59];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filabridge/src/UibGenerator.cpp
+++ b/libs/filabridge/src/UibGenerator.cpp
@@ -56,8 +56,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // directional light
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
-            .add("lightPosition",           1, UniformInterfaceBlock::Type::FLOAT3)
-            .add("padding0",                1, UniformInterfaceBlock::Type::UINT)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT4)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
             .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)
             // shadow
@@ -109,8 +108,13 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("clipControl",             1, UniformInterfaceBlock::Type::FLOAT2)
             .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT2)
 
+            .add("vsmExponent",             1, UniformInterfaceBlock::Type::FLOAT)
+            .add("vsmDepthScale",           1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
+            .add("vsmLightBleedReduction",  1, UniformInterfaceBlock::Type::FLOAT)
+            .add("vsmReserved0",            1, UniformInterfaceBlock::Type::FLOAT)
+
             // bring PerViewUib to 2 KiB
-            .add("padding2", 60, UniformInterfaceBlock::Type::FLOAT4)
+            .add("padding2", 59, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -222,6 +222,14 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
         CHECK_KEY(tok);
         if (0 == compare(tok, jsonChunk, "anisotropy")) {
             i = parse(tokens, i + 1, jsonChunk, &out->anisotropy);
+        } else if (0 == compare(tok, jsonChunk, "mipmapping")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->mipmapping);
+        } else if (0 == compare(tok, jsonChunk, "exponent")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->exponent);
+        } else if (0 == compare(tok, jsonChunk, "minVarianceScale")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->minVarianceScale);
+        } else if (0 == compare(tok, jsonChunk, "lightBleedReduction")) {
+            i = parse(tokens, i + 1, jsonChunk, &out->lightBleedReduction);
         } else {
             slog.w << "Invalid shadow options key: '" << STR(tok, jsonChunk) << "'" << io::endl;
             i = parse(tokens, i + 1);
@@ -1275,7 +1283,11 @@ static std::ostream& operator<<(std::ostream& out, const DynamicLightingSettings
 
 static std::ostream& operator<<(std::ostream& out, const VsmShadowOptions& in) {
     return out << "{\n"
-        << "\"anisotropy\": " << int(in.anisotropy) << "\n"
+        << "\"anisotropy\": " << int(in.anisotropy) << ",\n"
+        << "\"mipmapping\": " << int(in.mipmapping) << ",\n"
+        << "\"exponent\": " << int(in.exponent) << ",\n"
+        << "\"minVarianceScale\": " << int(in.minVarianceScale) << ",\n"
+        << "\"lightBleedReduction\": " << int(in.lightBleedReduction) << "\n"
         << "}";
 }
 

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -669,6 +669,10 @@ void SimpleViewer::updateUserInterface() {
         ImGuiExt::DirectionWidget("Sun direction", light.sunlightDirection.v);
         ImGui::Checkbox("Enable sunlight", &light.enableSunlight);
         ImGui::Checkbox("Enable shadows", &light.enableShadows);
+        int mapSize = light.shadowOptions.mapSize;
+        ImGui::SliderInt("Shadow map size", &mapSize, 32, 1024);
+        light.shadowOptions.mapSize = mapSize;
+
 
         bool enableVsm = mSettings.view.shadowType == ShadowType::VSM;
         ImGui::Checkbox("Enable VSM", &enableVsm);
@@ -683,6 +687,12 @@ void SimpleViewer::updateUserInterface() {
         snprintf(label, 32, "%d", 1 << vsmAnisotropy);
         ImGui::SliderInt("VSM anisotropy", &vsmAnisotropy, 0, 3, label);
         mSettings.view.vsmShadowOptions.anisotropy = vsmAnisotropy;
+        ImGui::Checkbox("VSM mipmapping", &mSettings.view.vsmShadowOptions.mipmapping);
+
+        // These are not very useful in practice (defaults are good), but we keep them here for debugging
+        //ImGui::SliderFloat("VSM exponent", &mSettings.view.vsmShadowOptions.exponent, 0.0, 6.0f);
+        //ImGui::SliderFloat("VSM Light bleed", &mSettings.view.vsmShadowOptions.lightBleedReduction, 0.0, 1.0f);
+        //ImGui::SliderFloat("VSM min variance scale", &mSettings.view.vsmShadowOptions.minVarianceScale, 0.0, 10.0f);
 
         int shadowCascades = light.shadowOptions.shadowCascades;
         ImGui::SliderInt("Cascades", &shadowCascades, 1, 4);

--- a/shaders/src/common_shadowing.fs
+++ b/shaders/src/common_shadowing.fs
@@ -9,12 +9,17 @@
  * shadowing artifacts such as "acne". To achieve this, the world space
  * normal at the point must also be passed to this function.
  */
-vec4 computeLightSpacePosition(const vec3 p, const vec3 n, const vec3 l,
-        const float b, const mat4 lightFromWorldMatrix) {
+vec4 computeLightSpacePosition(const highp vec3 p, const highp vec3 n, const highp vec3 l,
+        const float b, const highp mat4 lightFromWorldMatrix) {
+#if defined(HAS_VSM)
+    // VSM don't apply the shadow bias
+    vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(p, 1.0));
+#else
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
     vec3 offsetPosition = p + n * (sinTheta * b);
     vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(offsetPosition, 1.0));
+#endif
     return lightSpacePosition;
 }
 #endif

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -21,20 +21,30 @@ void main() {
 #if defined(HAS_VSM)
     // For VSM, we use the linear light space Z coordinate as the depth metric, which works for both
     // directional and spot lights.
-    // We negate it, because we're using a right-handed coordinate system (-Z points forward).
-    highp float depth = -mulMat4x4Float3(frameUniforms.viewFromWorldMatrix, vertex_worldPosition).z;
+    // The value is guaranteed to be between [0, -zfar] by construction of viewFromWorldMatrix,
+    // (see ShadowMap.cpp).
+    highp float z = (frameUniforms.viewFromWorldMatrix * vec4(vertex_worldPosition, 1.0)).z;
 
-    // Scale by cameraFar to help prevent a floating point overflow below when squaring the depth.
-    depth /= abs(frameUniforms.cameraFar);
+    // rescale the depth between [0, 1]
+    highp float depth = -z / abs(frameUniforms.cameraFar);
 
+    // We use positive only EVSM which helps a lot with light bleeding.
+    depth = depth * 2.0 - 1.0;
+    depth = exp(frameUniforms.vsmExponent * depth);
+
+    // computes the moments
+    // See GPU Gems 3
+    // https://developer.nvidia.com/gpugems/gpugems3/part-ii-light-and-shadows/chapter-8-summed-area-variance-shadow-maps
+    highp vec2 moments;
+
+    // the first moment is just the depth (average)
+    moments.x = depth;
+
+    // compute the 2nd moment over the pixel extents.
     highp float dx = dFdx(depth);
     highp float dy = dFdy(depth);
+    moments.y = depth * depth + 0.25 * (dx * dx + dy * dy);
 
-    // Output the first and second depth moments.
-    // The first moment is mean depth.
-    // The second moment is mean depth squared.
-    // These values are retrieved when sampling the shadow map to compute variance.
-    highp float bias = 0.25 * (dx * dx + dy * dy);
-    fragColor = vec4(depth, depth * depth + bias, 0.0, 0.0);
+    fragColor = vec4(moments, 0.0, 0.0);
 #endif
 }

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -141,6 +141,7 @@ highp vec3 getCascadeLightSpacePosition(uint cascade) {
     // This branch will be coherent (mostly) for neighboring fragments, and it's worth avoiding
     // the matrix multiply inside computeLightSpacePosition.
     if (cascade == 0u) {
+        // Note: this branch may cause issues with derivatives
         return getLightSpacePosition();
     }
 

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -45,11 +45,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
         bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1u);
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             uint layer = cascade;
-#if defined(HAS_VSM)
-            visibility = shadowVsm(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
-#else
             visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
-#endif
         }
         if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
             if (objectUniforms.screenSpaceContactShadows != 0u) {

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -179,13 +179,8 @@ void evaluatePunctualLights(const MaterialInputs material,
 #if defined(HAS_SHADOWING)
         if (light.NoL > 0.0){
             if (light.castsShadows) {
-#if defined(HAS_VSM)
-                visibility = shadowVsm(light_shadowMap, light.shadowLayer,
-                        getSpotLightSpacePosition(light.shadowIndex));
-#else
                 visibility = shadow(light_shadowMap, light.shadowLayer,
                     getSpotLightSpacePosition(light.shadowIndex));
-#endif
             }
             if (light.contactShadows && visibility > 0.0) {
                 if (objectUniforms.screenSpaceContactShadows != 0u) {

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -45,11 +45,7 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     if ((frameUniforms.directionalShadows & 1u) != 0u) {
         uint cascade = getShadowCascade();
         uint layer = cascade;
-#if defined(HAS_VSM)
-        visibility = shadowVsm(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
-#else
         visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
-#endif
     }
     if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
         if (objectUniforms.screenSpaceContactShadows != 0u) {

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -304,23 +304,26 @@ float screenSpaceContactShadow(vec3 lightDirection) {
 // VSM
 //------------------------------------------------------------------------------
 
-highp float linstep(const highp float a, const highp float b, const highp float v) {
-    return clamp((v - a) / (b - a), 0.0, 1.0);
+float linstep(const float min, const float max, const float v) {
+    // we could use smoothstep() too
+    return clamp((v - min) / (max - min), 0.0, 1.0);
 }
 
-highp float reduceLightBleed(const highp float pMax, const highp float amount) {
+float reduceLightBleed(const float pMax, const float amount) {
+    // Remove the [0, amount] tail and linearly rescale (amount, 1].
     return linstep(amount, 1.0, pMax);
 }
 
-highp float chebyshevUpperBound(const highp vec2 moments, const highp float mean,
-        const highp float minVariance, const highp float lightBleedReduction) {
+float chebyshevUpperBound(const highp vec2 moments, const highp float mean,
+        const highp float minVariance, const float lightBleedReduction) {
     // Donnelly and Lauritzen 2006, "Variance Shadow Maps"
 
     highp float variance = moments.y - (moments.x * moments.x);
     variance = max(variance, minVariance);
 
     highp float d = mean - moments.x;
-    highp float pMax = variance / (variance + d * d);
+    float pMax = variance / (variance + d * d);
+
     pMax = reduceLightBleed(pMax, lightBleedReduction);
 
     return mean <= moments.x ? 1.0 : pMax;
@@ -335,7 +338,10 @@ highp float chebyshevUpperBound(const highp vec2 moments, const highp float mean
  * space. The output is a filtered visibility factor that can be used to multiply
  * the light intensity.
  */
-float shadow(const mediump sampler2DArrayShadow shadowMap, const uint layer, vec3 shadowPosition) {
+
+// PCF sampling
+float shadow(const mediump sampler2DArrayShadow shadowMap,
+        const uint layer, vec3 shadowPosition) {
     vec2 size = vec2(textureSize(shadowMap, 0));
     // note: shadowPosition.z is in the [1, 0] range (reversed Z)
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HARD
@@ -349,20 +355,23 @@ float shadow(const mediump sampler2DArrayShadow shadowMap, const uint layer, vec
 #endif
 }
 
-highp float shadowVsm(const highp sampler2DArray shadowMap, const uint layer,
-        const highp vec3 shadowPosition) {
+// VSM sampling
+float shadow(const mediump sampler2DArray shadowMap,
+        const uint layer, const highp vec3 shadowPosition) {
+    // note: shadowPosition.z is in linear light space normalized to [0, 1]
+    //  see: ShadowMap::computeVsmLightSpaceMatrix() in ShadowMap.cpp
+    //  see: computeLightSpacePosition() in common_shadowing.fs
+
+    // Read the shadow map with all available filtering
     highp vec2 moments = texture(shadowMap, vec3(shadowPosition.xy, layer)).xy;
     highp float depth = shadowPosition.z;
 
-    // depth must be clamped to support floating-point depth formats. This is to avoid comparing a
-    // value from the depth texture (which is never greater than 1.0) with a greater-than-one
-    // comparison value (which is possible with floating-point formats).
-    depth = min(depth, 1.0f);
+    // EVSM depth warping
+    depth = depth * 2.0 - 1.0;
+    depth = exp(frameUniforms.vsmExponent * depth);
 
-    // TODO: bias and lightBleedReduction should be uniforms
-    const float bias = 0.01;
-    const float lightBleedReduction = 0.2;
-
-    const float minVariance = bias * 0.001;
+    highp float depthScale = frameUniforms.vsmDepthScale * depth;
+    highp float minVariance = depthScale * depthScale;
+    float lightBleedReduction = frameUniforms.vsmLightBleedReduction;
     return chebyshevUpperBound(moments, depth, minVariance, lightBleedReduction);
 }


### PR DESCRIPTION
- use EVSM (exponential VSM), helps a lot with light bleeding
- don't apply shadow biases with VSM
- improve VSM user settings: added more controls, expose to java
- minor code cleanups:
   - rename some structures
   - remove unused parameters
   - remove unused uniforms