### PR TITLE
Vulkan: fix swizzle support.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -206,6 +206,7 @@ void VulkanContext::createLogicalDevice() {
     VkPhysicalDevicePortabilitySubsetFeaturesKHR portability = {
         .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR,
         .pNext = nullptr,
+        .imageViewFormatSwizzle = VK_TRUE,
         .mutableComparisonSamplers = VK_TRUE,
     };
     if (portabilitySubsetSupported) {

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -130,7 +130,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
         if (texture == nullptr) {
             continue;
         }
-        mColor[index].view = texture->getImageView(spec.level, spec.layer,
+        mColor[index].view = texture->getAttachmentView(spec.level, spec.layer,
                 VK_IMAGE_ASPECT_COLOR_BIT);
     }
 
@@ -140,7 +140,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
     mDepth = createAttachment(context, depthSpec);
     VulkanTexture* depthTexture = mDepth.texture;
     if (depthTexture) {
-        mDepth.view = depthTexture->getImageView(mDepth.level, mDepth.layer,
+        mDepth.view = depthTexture->getAttachmentView(mDepth.level, mDepth.layer,
                 VK_IMAGE_ASPECT_DEPTH_BIT);
     }
 
@@ -160,7 +160,8 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
             VulkanTexture* msTexture = new VulkanTexture(context, texture->target, level,
                     texture->format, samples, width, height, depth, texture->usage, stagePool);
             mMsaaAttachments[index] = createAttachment(context, { .texture = msTexture });
-            mMsaaAttachments[index].view = msTexture->getImageView(0, 0, VK_IMAGE_ASPECT_COLOR_BIT);
+            mMsaaAttachments[index].view = msTexture->getAttachmentView(0, 0,
+                    VK_IMAGE_ASPECT_COLOR_BIT);
         }
         if (texture && texture->samples > 1) {
             mMsaaAttachments[index] = mColor[index];
@@ -190,7 +191,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
         .level = depthSpec.level,
         .layer = depthSpec.layer,
     });
-    mMsaaDepthAttachment.view = msTexture->getImageView(depthSpec.level, depthSpec.layer,
+    mMsaaDepthAttachment.view = msTexture->getAttachmentView(depthSpec.level, depthSpec.layer,
             VK_IMAGE_ASPECT_DEPTH_BIT);
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -402,7 +402,18 @@ void VulkanTexture::setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel) 
     getImageView(mPrimaryViewRange);
 }
 
-VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, bool force2D) {
+VkImageView VulkanTexture::getAttachmentView(int singleLevel, int singleLayer,
+        VkImageAspectFlags aspect) {
+    return getImageView({
+        .aspectMask = aspect,
+        .baseMipLevel = uint32_t(singleLevel),
+        .levelCount = uint32_t(1),
+        .baseArrayLayer = uint32_t(singleLayer),
+        .layerCount = uint32_t(1),
+    }, true);
+}
+
+VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, bool isAttachment) {
     auto iter = mCachedImageViews.find(range);
     if (iter != mCachedImageViews.end()) {
         return iter->second;
@@ -412,9 +423,9 @@ VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, bool forc
         .pNext = nullptr,
         .flags = 0,
         .image = mTextureImage,
-        .viewType = force2D ? VK_IMAGE_VIEW_TYPE_2D : mViewType,
+        .viewType = isAttachment ? VK_IMAGE_VIEW_TYPE_2D : mViewType,
         .format = mVkFormat,
-        .components = mSwizzle,
+        .components = isAttachment ? (VkComponentMapping{}) : mSwizzle,
         .subresourceRange = range
     };
     VkImageView imageView;

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -42,26 +42,19 @@ struct VulkanTexture : public HwTexture {
     // Sets the min/max range of miplevels in the primary image view.
     void setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel);
 
-    // Gets or creates a cached VkImageView for a range of miplevels and array layers.
-    // If force2D is true, this always returns an image view that has type = VK_IMAGE_VIEW_TYPE_2D,
-    // regardless of the type of the primary image view.
-    VkImageView getImageView(VkImageSubresourceRange range, bool force2D = false);
-
-    // Convenient "single subresource" overload for the above method.
-    VkImageView getImageView(int singleLevel, int singleLayer, VkImageAspectFlags aspect) {
-        return getImageView({
-            .aspectMask = aspect,
-            .baseMipLevel = uint32_t(singleLevel),
-            .levelCount = uint32_t(1),
-            .baseArrayLayer = uint32_t(singleLayer),
-            .layerCount = uint32_t(1),
-        }, true);
-    }
+    // Gets or creates a cached VkImageView for a single subresource that can be used as a render
+    // target attachment.  Unlike the primary image view, this always has type VK_IMAGE_VIEW_TYPE_2D
+    // and the identity swizzle.
+    VkImageView getAttachmentView(int singleLevel, int singleLayer, VkImageAspectFlags aspect);
 
     VkFormat getVkFormat() const { return mVkFormat; }
     VkImage getVkImage() const { return mTextureImage; }
 
 private:
+    // Gets or creates a cached VkImageView for a range of miplevels and array layers.
+    // If isAttachment is true, this always returns a 2D image view without swizzle.
+    VkImageView getImageView(VkImageSubresourceRange range, bool isAttachment = false);
+
     // Issues a copy from a VkBuffer to a specified miplevel in a VkImage. The given width and
     // height define a subregion within the miplevel.
     void copyBufferToImage(VkCommandBuffer cmdbuffer, VkBuffer buffer, VkImage image,


### PR DESCRIPTION
When creating a texture with a swizzle, the swizzle should be applied to
the image view only when sampling from that texture.  When a swizzled
texture is used as a render target attachment, the image view should not
have any swizzle applied.