### PR TITLE
Rework a bit UniformBuffer and friends

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -108,6 +108,7 @@ set(PRIVATE_HDRS
         src/RenderPass.h
         src/ResourceAllocator.h
         src/ToneMapping.h
+        src/TypedUniformBuffer.h
         src/UniformBuffer.h
         src/components/CameraManager.h
         src/components/LightManager.h

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -26,7 +26,7 @@
 #include <backend/DriverEnums.h>
 
 #include <private/filament/SibGenerator.h>
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 #include <private/filament/Variant.h>
 
 #include <private/filament/SamplerInterfaceBlock.h>
@@ -374,16 +374,15 @@ Handle<HwProgram> FMaterial::getSurfaceProgramSlow(uint8_t variantKey)
 
     Program pb = getProgramBuilderWithVariants(variantKey, vertexVariantKey, fragmentVariantKey);
     pb
-        .setUniformBlock(BindingPoints::PER_VIEW, UibGenerator::getPerViewUib().getName())
-        .setUniformBlock(BindingPoints::LIGHTS, UibGenerator::getLightsUib().getName())
-        .setUniformBlock(BindingPoints::SHADOW, UibGenerator::getShadowUib().getName())
-        .setUniformBlock(BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib().getName())
-        .setUniformBlock(BindingPoints::FROXEL_RECORDS, UibGenerator::getFroxelRecordUib().getName())
+        .setUniformBlock(BindingPoints::PER_VIEW, PerViewUib::_name)
+        .setUniformBlock(BindingPoints::PER_RENDERABLE, PerRenderableUib::_name)
+        .setUniformBlock(BindingPoints::LIGHTS, LightsUib::_name)
+        .setUniformBlock(BindingPoints::SHADOW, ShadowUib::_name)
+        .setUniformBlock(BindingPoints::FROXEL_RECORDS, FroxelRecordUib::_name)
         .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
 
     if (Variant(variantKey).hasSkinningOrMorphing()) {
-        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES,
-                UibGenerator::getPerRenderableBonesUib().getName());
+        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES, PerRenderableUibBone::_name);
     }
 
     addSamplerGroup(pb, BindingPoints::PER_VIEW, SibGenerator::getPerViewSib(variantKey), mSamplerBindings);
@@ -396,9 +395,8 @@ Handle<HwProgram> FMaterial::getPostProcessProgramSlow(uint8_t variantKey)
     const noexcept {
 
     Program pb = getProgramBuilderWithVariants(variantKey, variantKey, variantKey);
-    pb
-            .setUniformBlock(BindingPoints::PER_VIEW, UibGenerator::getPerViewUib().getName())
-            .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
+    pb.setUniformBlock(BindingPoints::PER_VIEW, PerViewUib::_name)
+      .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
 
     addSamplerGroup(pb, BindingPoints::PER_MATERIAL_INSTANCE, mSamplerInterfaceBlock, mSamplerBindings);
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -17,8 +17,6 @@
 #ifndef TNT_FILAMENT_POSTPROCESS_MANAGER_H
 #define TNT_FILAMENT_POSTPROCESS_MANAGER_H
 
-#include "UniformBuffer.h"
-
 #include "private/backend/DriverApiForward.h"
 
 #include "FrameHistory.h"
@@ -27,6 +25,8 @@
 #include <fg2/FrameGraphResources.h>
 
 #include <backend/DriverEnums.h>
+#include <backend/PipelineState.h>
+
 #include <filament/View.h>
 
 #include <utils/CString.h>

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -25,7 +25,7 @@
 // NOTE: We only need Renderer.h here because the definition of some FRenderer methods are here
 #include "details/Renderer.h"
 
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 
 #include <utils/JobSystem.h>
 #include <utils/Systrace.h>

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -19,7 +19,7 @@
 #include "components/LightManager.h"
 #include "components/RenderableManager.h"
 
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 
 #include "details/Engine.h"
 #include "details/IndirectLight.h"

--- a/filament/src/TypedUniformBuffer.h
+++ b/filament/src/TypedUniformBuffer.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_TYPEDUNIFORMBUFFER_H
+#define TNT_FILAMENT_TYPEDUNIFORMBUFFER_H
+
+#include "private/backend/DriverApi.h"
+
+#include <utils/compiler.h>
+
+#include <backend/BufferDescriptor.h>
+
+#include <stddef.h>
+
+namespace filament {
+
+template<typename T, size_t N = 1>
+class TypedUniformBuffer { // NOLINT(cppcoreguidelines-pro-type-member-init)
+public:
+
+    T& itemAt(size_t i) noexcept {
+        mSomethingDirty = true;
+        return mBuffer[i];
+    }
+
+    T& edit() noexcept {
+        return itemAt(0);
+    }
+
+    // size of the uniform buffer in bytes
+    size_t getSize() const noexcept { return sizeof(T) * N; }
+
+    // return if any uniform has been changed
+    bool isDirty() const noexcept { return mSomethingDirty; }
+
+    // mark the whole buffer as clean (no modified uniforms)
+    void clean() const noexcept { mSomethingDirty = false; }
+
+    // helper functions
+
+    backend::BufferDescriptor toBufferDescriptor(backend::DriverApi& driver) const noexcept {
+        return toBufferDescriptor(driver, 0, getSize());
+    }
+
+    // copy the UBO data and cleans the dirty bits
+    backend::BufferDescriptor toBufferDescriptor(
+            backend::DriverApi& driver, size_t offset, size_t size) const noexcept {
+        backend::BufferDescriptor p;
+        p.size = size;
+        p.buffer = driver.allocate(p.size); // TODO: use out-of-line buffer if too large
+        memcpy(p.buffer, reinterpret_cast<const char*>(mBuffer) + offset, p.size); // inlined
+        clean();
+        return p;
+    }
+
+private:
+    T mBuffer[N];
+    mutable bool mSomethingDirty = false;
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMENT_TYPEDUNIFORMBUFFER_H

--- a/filament/src/UniformBuffer.h
+++ b/filament/src/UniformBuffer.h
@@ -200,9 +200,6 @@ private:
 
     inline bool isLocalStorage() const noexcept { return mBuffer == mStorage; }
 
-    // TODO: we need a better way to calculate this local storage.
-    // Probably the better thing to do would be to use a special allocator.
-    // Local storage is limited by the total size of a handle (128 byte for GL)
     char mStorage[96];
     void *mBuffer = nullptr;
     uint32_t mSize = 0;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -33,7 +33,7 @@
 #include <filament/View.h>
 
 #include <private/filament/SibGenerator.h>
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 
 #include <utils/Profiler.h>
 #include <utils/Slice.h>
@@ -54,8 +54,6 @@ using namespace math;
 
 FView::FView(FEngine& engine)
     : mFroxelizer(engine),
-      mPerViewUb(PerViewUib::getUib().getSize()),
-      mShadowUb(ShadowUib::getUib().getSize()),
       mPerViewSb(PerViewSib::SAMPLER_COUNT),
       mShadowMapManager(engine) {
     DriverApi& driver = engine.getDriverApi();
@@ -265,7 +263,9 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
         filament::Viewport const& viewport) noexcept {
     SYSTRACE_CALL();
 
-    UniformBuffer& u = mPerViewUb;
+    auto& u = mPerViewUb;
+    auto& s = u.edit();
+
     const CameraInfo& camera = mViewingCameraInfo;
     FScene* const scene = mScene;
     auto const& lightData = scene->getLightData();
@@ -279,7 +279,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
         scene->prepareDynamicLights(camera, arena, mLightUbh);
         Froxelizer& froxelizer = mFroxelizer;
         if (froxelizer.prepare(driver, arena, viewport, camera.projection, camera.zn, camera.zf)) {
-            froxelizer.updateUniforms(u); // update our uniform buffer if needed
+            froxelizer.updateUniforms(s); // update our uniform buffer if needed
         }
     }
 
@@ -291,8 +291,8 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
      */
 
     const float exposure = Exposure::exposure(camera.ev100);
-    u.setUniform(offsetof(PerViewUib, exposure), exposure);
-    u.setUniform(offsetof(PerViewUib, ev100), camera.ev100);
+    s.exposure = exposure;
+    s.ev100 = camera.ev100;
 
     /*
      * Indirect light (IBL)
@@ -312,9 +312,11 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 
     // Set up uniforms and sampler for the IBL, guaranteed to be non-null at this point.
     float iblRoughnessOneLevel = ibl->getLevelCount() - 1.0f;
-    u.setUniform(offsetof(PerViewUib, iblRoughnessOneLevel), iblRoughnessOneLevel);
-    u.setUniform(offsetof(PerViewUib, iblLuminance), intensity * exposure);
-    u.setUniformArray(offsetof(PerViewUib, iblSH), ibl->getSH(), 9);
+    s.iblRoughnessOneLevel = iblRoughnessOneLevel;
+    s.iblLuminance = intensity * exposure;
+    std::transform(ibl->getSH(), ibl->getSH() + 9, s.iblSH, [](float3 v){
+        return float4(v, 0.0f);
+    });
 
     // We always sample from the reflection texture, so provide a dummy texture if necessary.
     backend::Handle<backend::HwTexture> reflection = ibl->getReflectionHwHandle();
@@ -338,8 +340,8 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
         const float4 colorIntensity = {
                 lcm.getColor(directionalLight), lcm.getIntensity(directionalLight) * exposure };
 
-        u.setUniform(offsetof(PerViewUib, lightDirection), l);
-        u.setUniform(offsetof(PerViewUib, lightColorIntensity), colorIntensity);
+        s.lightDirection = l;
+        s.lightColorIntensity = colorIntensity;
 
         const bool isSun = lcm.isSunLight(directionalLight);
         // The last parameter must be < 0.0f for regular directional lights
@@ -355,11 +357,10 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
             sun.z = 1.0f / (fast::cos(radius * haloSize) - sun.x);
             sun.w = haloFalloff;
         }
-        u.setUniform(offsetof(PerViewUib, sun), sun);
+        s.sun = sun;
     } else {
         // Disable the sun if there's no directional light
-        float4 sun{ 0.0f, 0.0f, 0.0f, -1.0f };
-        u.setUniform(offsetof(PerViewUib, sun), sun);
+        s.sun = float4{ 0.0f, 0.0f, 0.0f, -1.0f };
     }
 }
 
@@ -531,11 +532,12 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
      */
 
     auto& u = mPerViewUb;
+    auto& s = u.edit();
 
     const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
     const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
-    u.setUniform(offsetof(PerViewUib, time), fraction);
-    u.setUniform(offsetof(PerViewUib, userTime), userTime);
+    s.time = fraction;
+    s.userTime = userTime;
 
     auto const& fogOptions = mFogOptions;
 
@@ -549,15 +551,15 @@ void FView::prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& are
             std::exp(-heightFalloff * (camera->getPosition().y - fogOptions.height)))
                     * float(1.0f / F_LN2);
 
-    u.setUniform(offsetof(PerViewUib, fogStart),             fogOptions.distance);
-    u.setUniform(offsetof(PerViewUib, fogMaxOpacity),        fogOptions.maximumOpacity);
-    u.setUniform(offsetof(PerViewUib, fogHeight),            fogOptions.height);
-    u.setUniform(offsetof(PerViewUib, fogHeightFalloff),     heightFalloff);
-    u.setUniform(offsetof(PerViewUib, fogColor),             fogOptions.color);
-    u.setUniform(offsetof(PerViewUib, fogDensity),           density);
-    u.setUniform(offsetof(PerViewUib, fogInscatteringStart), fogOptions.inScatteringStart);
-    u.setUniform(offsetof(PerViewUib, fogInscatteringSize),  fogOptions.inScatteringSize);
-    u.setUniform(offsetof(PerViewUib, fogColorFromIbl),      fogOptions.fogColorFromIbl ? 1.0f : 0.0f);
+    s.fogStart             = fogOptions.distance;
+    s.fogMaxOpacity        = fogOptions.maximumOpacity;
+    s.fogHeight            = fogOptions.height;
+    s.fogHeightFalloff     = heightFalloff;
+    s.fogColor             = fogOptions.color;
+    s.fogDensity           = density;
+    s.fogInscatteringStart = fogOptions.inScatteringStart;
+    s.fogInscatteringSize  = fogOptions.inScatteringSize;
+    s.fogColorFromIbl      = fogOptions.fogColorFromIbl ? 1.0f : 0.0f;
 
     // upload the renderables's dirty UBOs
     engine.getRenderableManager().prepare(driver,
@@ -636,27 +638,27 @@ void FView::prepareCamera(const CameraInfo& camera) const noexcept {
     const mat4f clipFromWorld(clipFromView * viewFromWorld);
     const mat4f worldFromClip(worldFromView * viewFromClip);
 
-    UniformBuffer& u = mPerViewUb;
-    u.setUniform(offsetof(PerViewUib, viewFromWorldMatrix), viewFromWorld);    // view
-    u.setUniform(offsetof(PerViewUib, worldFromViewMatrix), worldFromView);    // model
-    u.setUniform(offsetof(PerViewUib, clipFromViewMatrix), clipFromView);      // projection
-    u.setUniform(offsetof(PerViewUib, viewFromClipMatrix), viewFromClip);      // 1/projection
-    u.setUniform(offsetof(PerViewUib, clipFromWorldMatrix), clipFromWorld);    // projection * view
-    u.setUniform(offsetof(PerViewUib, worldFromClipMatrix), worldFromClip);    // 1/(projection * view)
-    u.setUniform(offsetof(PerViewUib, cameraPosition), float3{camera.getPosition()});
-    u.setUniform(offsetof(PerViewUib, worldOffset), camera.worldOffset);
-    u.setUniform(offsetof(PerViewUib, cameraFar), camera.zf);
-    u.setUniform(offsetof(PerViewUib, clipControl), mClipControl);
+    auto& s = mPerViewUb.edit();
+    s.viewFromWorldMatrix = viewFromWorld;    // view
+    s.worldFromViewMatrix = worldFromView;    // model
+    s.clipFromViewMatrix = clipFromView;      // projection
+    s.viewFromClipMatrix = viewFromClip;      // 1/projection
+    s.clipFromWorldMatrix = clipFromWorld;    // projection * view
+    s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+    s.cameraPosition = float3{camera.getPosition()};
+    s.worldOffset = camera.worldOffset;
+    s.cameraFar = camera.zf;
+    s.clipControl = mClipControl;
 
 }
 
 void FView::prepareViewport(const filament::Viewport &viewport) const noexcept {
     SYSTRACE_CALL();
-    UniformBuffer& u = mPerViewUb;
     const float w = viewport.width;
     const float h = viewport.height;
-    u.setUniform(offsetof(PerViewUib, resolution), float4{ w, h, 1.0f / w, 1.0f / h });
-    u.setUniform(offsetof(PerViewUib, origin), float2{ viewport.left, viewport.bottom });
+    auto& s = mPerViewUb.edit();
+    s.resolution = float4{ w, h, 1.0f / w, 1.0f / h };
+    s.origin = float2{ viewport.left, viewport.bottom };
 }
 
 void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
@@ -672,8 +674,9 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
     });
 
     const float edgeDistance = 1.0 / 0.0625;// TODO: don't hardcode this
-    mPerViewUb.setUniform(offsetof(PerViewUib, aoSamplingQualityAndEdgeDistance),
-            mAmbientOcclusionOptions.enabled && highQualitySampling ? edgeDistance : 0.0f);
+    auto& s = mPerViewUb.edit();
+    s.aoSamplingQualityAndEdgeDistance =
+            mAmbientOcclusionOptions.enabled && highQualitySampling ? edgeDistance : 0.0f;
 }
 
 void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept {
@@ -681,7 +684,8 @@ void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refraction
             .filterMag = SamplerMagFilter::LINEAR,
             .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
     });
-    mPerViewUb.setUniform(offsetof(PerViewUib, refractionLodOffset), refractionLodOffset);
+    auto& s = mPerViewUb.edit();
+    s.refractionLodOffset = refractionLodOffset;
 }
 
 void FView::prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept {
@@ -712,13 +716,10 @@ void FView::prepareShadow(backend::Handle<backend::HwTexture> texture) const noe
 
 void FView::prepareShadowMap() const noexcept {
     auto const& vsmShadowOptions = mVsmShadowOptions;
-    // fp16: max 5.54f, fp32: max 42.0
-    float vsmExponent = vsmShadowOptions.exponent;
-    float vsmDepthScale = vsmShadowOptions.minVarianceScale * 0.01f * vsmExponent;
-    float vsmLightBleedReduction = vsmShadowOptions.lightBleedReduction;
-    mPerViewUb.setUniform(offsetof(PerViewUib, vsmExponent),            vsmExponent);
-    mPerViewUb.setUniform(offsetof(PerViewUib, vsmDepthScale),          vsmDepthScale);
-    mPerViewUb.setUniform(offsetof(PerViewUib, vsmLightBleedReduction), vsmLightBleedReduction);
+    auto& s = mPerViewUb.edit();
+    s.vsmExponent = vsmShadowOptions.exponent;  // fp16: max 5.54f, fp32: max 42.0
+    s.vsmDepthScale = vsmShadowOptions.minVarianceScale * 0.01f * vsmShadowOptions.exponent;
+    s.vsmLightBleedReduction = vsmShadowOptions.lightBleedReduction;
 }
 
 void FView::cleanupRenderPasses() const noexcept {

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -28,7 +28,7 @@
 #include <filament/Box.h>
 #include <filament/RenderableManager.h>
 
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 
 #include <utils/Entity.h>
 #include <utils/SingleInstanceComponentManager.h>

--- a/filament/src/details/Froxelizer.h
+++ b/filament/src/details/Froxelizer.h
@@ -122,12 +122,12 @@ public:
     void froxelizeLights(FEngine& engine, CameraInfo const& camera,
             const FScene::LightSoa& lightData) noexcept;
 
-    void updateUniforms(UniformBuffer& u) {
-        u.setUniform(offsetof(PerViewUib, zParams), mParamsZ);
-        u.setUniform(offsetof(PerViewUib, fParams), mParamsF.yz);
-        u.setUniform(offsetof(PerViewUib, fParamsX), mParamsF.x);
-        u.setUniform(offsetof(PerViewUib, oneOverFroxelDimensionX), mOneOverDimension.x);
-        u.setUniform(offsetof(PerViewUib, oneOverFroxelDimensionY), mOneOverDimension.y);
+    void updateUniforms(PerViewUib& s) {
+        s.zParams = mParamsZ;
+        s.fParams = mParamsF.yz;
+        s.fParamsX = mParamsF.x;
+        s.oneOverFroxelDimensionX = mOneOverDimension.x;
+        s.oneOverFroxelDimensionY = mOneOverDimension.y;
     }
 
     // send froxel data to GPU

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -31,6 +31,8 @@
 
 #include "fg2/FrameGraph.h"
 
+#include "TypedUniformBuffer.h"
+
 #include <utils/FixedCapacityVector.h>
 
 #include <math/vec3.h>
@@ -67,7 +69,8 @@ public:
 
     // Updates all of the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
-    ShadowTechnique update(FEngine& engine, FView& view, UniformBuffer& perViewUb, UniformBuffer& shadowUb,
+    ShadowTechnique update(FEngine& engine, FView& view,
+            TypedUniformBuffer<PerViewUib>& perViewUb, TypedUniformBuffer<ShadowUib>& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
 
     // Renders all of the shadow maps.
@@ -93,9 +96,11 @@ private:
         uint8_t levels = 0;
     } mTextureRequirements;
 
-    ShadowTechnique updateCascadeShadowMaps(FEngine& engine, FView& view, UniformBuffer& perViewUb,
+    ShadowTechnique updateCascadeShadowMaps(FEngine& engine, FView& view,
+            TypedUniformBuffer<PerViewUib>& perViewUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
-    ShadowTechnique updateSpotShadowMaps(FEngine& engine, FView& view, UniformBuffer& shadowUb,
+    ShadowTechnique updateSpotShadowMaps(FEngine& engine, FView& view,
+            TypedUniformBuffer<ShadowUib>& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
     static void fillWithDebugPattern(backend::DriverApi& driverApi,
             backend::Handle<backend::HwTexture> texture, size_t dimensions) noexcept;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -23,7 +23,7 @@
 
 #include "FrameInfo.h"
 #include "FrameHistory.h"
-#include "UniformBuffer.h"
+#include "TypedUniformBuffer.h"
 
 #include "details/Allocators.h"
 #include "details/Camera.h"
@@ -422,9 +422,9 @@ public:
     static void cullRenderables(utils::JobSystem& js, FScene::RenderableSoa& renderableData,
             Frustum const& frustum, size_t bit) noexcept;
 
-    UniformBuffer& getViewUniforms() const { return mPerViewUb; }
+    auto& getViewUniforms() const { return mPerViewUb; }
+    auto& getShadowUniforms() const { return mShadowUb; }
     backend::SamplerGroup& getViewSamplers() const { return mPerViewSb; }
-    UniformBuffer& getShadowUniforms() const { return mShadowUb; }
 
     // Returns the frame history FIFO. This is typically used by the FrameGraph to access
     // previous frame data.
@@ -517,8 +517,8 @@ private:
 
     RenderQuality mRenderQuality;
 
-    mutable UniformBuffer mPerViewUb;
-    mutable UniformBuffer mShadowUb;
+    mutable TypedUniformBuffer<PerViewUib> mPerViewUb;
+    mutable TypedUniformBuffer<ShadowUib> mShadowUb;
     mutable backend::SamplerGroup mPerViewSb;
 
     mutable FrameHistory mFrameHistory{};

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -33,7 +33,7 @@
 #include <filament/Engine.h>
 
 #include <private/filament/UniformInterfaceBlock.h>
-#include <private/filament/UibGenerator.h>
+#include <private/filament/UibStructs.h>
 #include <private/backend/BackendUtils.h>
 
 #include "details/Allocators.h"

--- a/libs/filabridge/CMakeLists.txt
+++ b/libs/filabridge/CMakeLists.txt
@@ -13,7 +13,6 @@ set(SRCS
         src/SamplerBindingMap.cpp
         src/SamplerInterfaceBlock.cpp
         src/UniformInterfaceBlock.cpp
-        src/UibGenerator.cpp
         src/SibGenerator.cpp
 )
 

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -40,9 +40,11 @@ set(COMMON_SRCS
         src/shaders/CodeGenerator.cpp
         src/shaders/ShaderGenerator.cpp
         src/Enums.cpp
+        src/Includes.cpp
         src/MaterialBuilder.cpp
         src/MaterialVariants.cpp
-        src/Includes.cpp)
+        src/UibGenerator.cpp
+)
 
 # Sources and headers for filamat
 

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-#include "private/filament/UibGenerator.h"
+#include "UibGenerator.h"
+#include "private/filament/UibStructs.h"
 
 #include "private/filament/UniformInterfaceBlock.h"
 
@@ -25,19 +26,13 @@ namespace filament {
 
 using namespace backend;
 
-static_assert(sizeof(PerRenderableUib) % 256 == 0,
-        "sizeof(Transform) should be a multiple of 256");
-
-static_assert(CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone) <= 16384,
-        "Bones exceed max UBO size");
-
 static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
         "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
 UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     // IMPORTANT NOTE: Respect std140 layout, don't update without updating Engine::PerViewUib
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name("FrameUniforms")
+            .name(PerViewUib::_name)
             // transforms
             .add("viewFromWorldMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromViewMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
@@ -121,7 +116,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 
 UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
     static UniformInterfaceBlock uib =  UniformInterfaceBlock::Builder()
-            .name("ObjectUniforms")
+            .name(PerRenderableUib::_name)
             .add("worldFromModelMatrix",       1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromModelNormalMatrix", 1, UniformInterfaceBlock::Type::MAT3, Precision::HIGH)
             .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
@@ -135,7 +130,7 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
 
 UniformInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name("LightsUniforms")
+            .name(LightsUib::_name)
             .add("lights", CONFIG_MAX_LIGHT_COUNT, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .build();
     return uib;
@@ -143,7 +138,7 @@ UniformInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
 
 UniformInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name("ShadowUniforms")
+            .name(ShadowUib::_name)
             .add("spotLightFromWorldMatrix", CONFIG_MAX_SHADOW_CASTING_SPOTS, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("directionShadowBias", CONFIG_MAX_SHADOW_CASTING_SPOTS, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             .build();
@@ -152,7 +147,7 @@ UniformInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
 
 UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name("BonesUniforms")
+            .name(PerRenderableUibBone::_name)
             .add("bones", CONFIG_MAX_BONE_COUNT * 4, UniformInterfaceBlock::Type::FLOAT4, Precision::MEDIUM)
             .build();
     return uib;
@@ -160,7 +155,7 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
 
 UniformInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name("FroxelRecordUniforms")
+            .name(FroxelRecordUib::_name)
             .add("records", 1024, UniformInterfaceBlock::Type::UINT4, Precision::HIGH)
             .build();
     return uib;

--- a/libs/filamat/src/UibGenerator.h
+++ b/libs/filamat/src/UibGenerator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMAT_UIBGENERATOR_H
+#define TNT_FILAMAT_UIBGENERATOR_H
+
+namespace filament {
+
+class UniformInterfaceBlock;
+
+class UibGenerator {
+public:
+    static UniformInterfaceBlock const& getPerViewUib() noexcept;
+    static UniformInterfaceBlock const& getPerRenderableUib() noexcept;
+    static UniformInterfaceBlock const& getLightsUib() noexcept;
+    static UniformInterfaceBlock const& getShadowUib() noexcept;
+    static UniformInterfaceBlock const& getPerRenderableBonesUib() noexcept;
+    static UniformInterfaceBlock const& getFroxelRecordUib() noexcept;
+    // When adding an UBO here, make sure to also update
+    //      FMaterial::getSurfaceProgramSlow and FMaterial::getPostProcessProgramSlow if needed
+};
+
+} // namespace filament
+
+#endif // TNT_FILAMAT_UIBGENERATOR_H

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -16,19 +16,17 @@
 
 #include "ShaderGenerator.h"
 
-#include <private/filament/SamplerInterfaceBlock.h>
-#include <private/filament/UniformInterfaceBlock.h>
 #include <filament/MaterialEnums.h>
 
 #include <private/filament/EngineEnums.h>
 #include <private/filament/SibGenerator.h>
-#include <private/filament/UibGenerator.h>
 #include <private/filament/Variant.h>
 
 #include <utils/CString.h>
 
 #include "filamat/MaterialBuilder.h"
 #include "CodeGenerator.h"
+#include "../UibGenerator.h"
 
 using namespace filament;
 using namespace filament::backend;

--- a/libs/utils/include/utils/CString.h
+++ b/libs/utils/include/utils/CString.h
@@ -82,8 +82,8 @@ public:
     constexpr StaticString() noexcept = default;
 
     // initialization from a string literal
-    template <size_t N>
-    StaticString(StringLiteral<N> const& other) noexcept // NOLINT(google-explicit-constructor)
+    template<size_t N>
+    constexpr StaticString(StringLiteral<N> const& other) noexcept // NOLINT(google-explicit-constructor)
         : mString(other),
           mLength(size_type(N - 1)),
           mHash(computeHash(other)) {


### PR DESCRIPTION
Filament uses a handful of known UBO, the code for creating their
interface block is not needed in filament (via filabridge), so
reorganize things so that we can move that code to filamat.

On the other hand, filament needs the C structure corresponding to
the UBO, to find the fields offset and ubo size and name.

We now have a UibStructs.h in filabridge which only defines C struct
with a static name for the interface block's.

This should slightly reduce the size of filament proper.

We also now have a new helper TypedUniformBuffer<> which simply holds
one of these structs (or an array), and allows to set the fields
directly and more naturally from C++. std140 alignment is now left to
the caller, when going through that class.