### PR TITLE
gltfio: introduce support for extras strings.

### DIFF
--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -192,6 +192,15 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetName(JNIEnv* env, jcla
     return val ? env->NewStringUTF(val) : nullptr;
 }
 
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetExtras(JNIEnv* env, jclass,
+        jlong nativeAsset, jint entityId) {
+    Entity entity = Entity::import(entityId);
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    const auto val = asset->getExtras(entity);
+    return val ? env->NewStringUTF(val) : nullptr;
+}
+
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetAnimator(JNIEnv* , jclass,
         jlong nativeAsset) {

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -187,6 +187,16 @@ public class FilamentAsset {
     }
 
     /**
+     * Gets the glTF extras string for the asset or a specific node.
+     *
+     * @param entity the entity corresponding to the glTF node, or 0 to get the asset-level string.
+     * @return the requested extras string, or null if it does not exist.
+     */
+    public @Nullable String getExtras(@Entity int entity) {
+        return nGetExtras(mNativeObject, entity);
+    }
+
+    /**
      * Creates or retrieves the <code>Animator</code> interface for this asset.
      *
      * <p>When calling this for the first time, this must be called after
@@ -252,6 +262,7 @@ public class FilamentAsset {
 
     private static native void nGetBoundingBox(long nativeAsset, float[] box);
     private static native String nGetName(long nativeAsset, int entity);
+    private static native String nGetExtras(long nativeAsset, int entity);
     private static native long nGetAnimator(long nativeAsset);
     private static native int nGetResourceUriCount(long nativeAsset);
     private static native void nGetResourceUris(long nativeAsset, String[] result);

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -189,6 +189,9 @@ public:
     size_t getEntitiesByPrefix(const char* prefix, utils::Entity* entities,
             size_t maxCount) const noexcept;
 
+    /** Gets the glTF extras string for a specific node, or for the asset, if it exists. */
+    const char* getExtras(utils::Entity entity = {}) const noexcept;
+
     /**
      * Lazily creates the animation engine or returns it from the cache.
      *

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -32,6 +32,8 @@
 
 #include <math/mat4.h>
 
+#include <utils/FixedCapacityVector.h>
+#include <utils/CString.h>
 #include <utils/Entity.h>
 
 #include <cgltf.h>
@@ -180,6 +182,8 @@ struct FFilamentAsset : public FilamentAsset {
 
     const char* getName(utils::Entity entity) const noexcept;
 
+    const char* getExtras(utils::Entity entity) const noexcept;
+
     utils::Entity getFirstEntityByName(const char* name) noexcept;
 
     size_t getEntitiesByName(const char* name, utils::Entity* entities,
@@ -243,6 +247,8 @@ struct FFilamentAsset : public FilamentAsset {
     bool mResourcesLoaded = false;
     DependencyGraph mDependencyGraph;
     tsl::htrie_map<char, std::vector<utils::Entity>> mNameToEntity;
+    tsl::robin_map<utils::Entity, utils::CString> mNodeExtras;
+    utils::CString mAssetExtras;
 
     // Sentinels for situations where ResourceLoader needs to generate data.
     const cgltf_accessor mGenerateNormals = {};
@@ -254,7 +260,7 @@ struct FFilamentAsset : public FilamentAsset {
         ~SourceAsset() { cgltf_free(hierarchy); }
         cgltf_data* hierarchy;
         DracoCache dracoCache;
-        std::vector<uint8_t> glbData;
+        utils::FixedCapacityVector<uint8_t> glbData;
     };
 
     // We used shared ownership for the raw cgltf data in order to permit ResourceLoader to

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -72,6 +72,14 @@ FFilamentAsset::~FFilamentAsset() {
     }
 }
 
+const char* FFilamentAsset::getExtras(utils::Entity entity) const noexcept {
+    if (entity.isNull()) {
+        return mAssetExtras.c_str();
+    }
+    const auto iter = mNodeExtras.find(entity);
+    return iter == mNodeExtras.cend() ? nullptr : iter->second.c_str();
+}
+
 Animator* FFilamentAsset::getAnimator() noexcept {
     if (!mAnimator) {
         if (!mResourcesLoaded) {
@@ -256,6 +264,10 @@ size_t FilamentAsset::getEntitiesByName(const char* name, Entity* entities,
 size_t FilamentAsset::getEntitiesByPrefix(const char* prefix, Entity* entities,
         size_t maxCount) const noexcept {
     return upcast(this)->getEntitiesByPrefix(prefix, entities, maxCount);
+}
+
+const char* FilamentAsset::getExtras(Entity entity) const noexcept {
+    return upcast(this)->getExtras(entity);
 }
 
 Animator* FilamentAsset::getAnimator() noexcept {

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -613,6 +613,7 @@ export class gltfio$FilamentAsset {
     public getResourceUris(): Vector<string>;
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
+    public getExtras(entity: Entity): string;
     public getAnimator(): gltfio$Animator;
     public getWireframe(): Entity;
     public getEngine(): Engine;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1804,6 +1804,9 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
     .function("getName", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
         return std::string(self->getName(entity));
     }), allow_raw_pointers())
+    .function("getExtras", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
+        return std::string(self->getExtras(entity));
+    }), allow_raw_pointers())
     .function("getAnimator", &FilamentAsset::getAnimator, allow_raw_pointers())
     .function("getWireframe", &FilamentAsset::getWireframe)
     .function("getEngine", &FilamentAsset::getEngine, allow_raw_pointers())


### PR DESCRIPTION
This allows clients to obtain the extras strings for the asset and
for individual nodes.  Note that extras for buffer views, accessors, etc
are not supported, although C++ clients can access the raw cgltf data
directly if they need to.