### PR TITLE
PostProcessManager: call setMinMaxLevels for DoF mipmaps.

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1055,6 +1055,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
                 for (size_t level = 0 ; level < mipmapCount - 1u ; level++) {
                     auto const& out = resources.getRenderPassInfo(data.rp[level]);
+                    driver.setMinMaxLevels(inOutColor, level, level);
+                    driver.setMinMaxLevels(inOutCoc, level, level);
                     mi->setParameter("mip", uint32_t(level));
                     mi->setParameter("weightScale", 0.5f / float(1u<<level));   // FIXME: halfres?
                     mi->commit(driver);
@@ -1062,6 +1064,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                     driver.draw(pipeline, fullScreenRenderPrimitive);
                     driver.endRenderPass();
                 }
+                driver.setMinMaxLevels(inOutColor, 0, mipmapCount - 1u);
+                driver.setMinMaxLevels(inOutCoc, 0, mipmapCount - 1u);
             });
 
     /*


### PR DESCRIPTION
DoF now works on Vulkan, and with zero validation warnings:

![dof](https://user-images.githubusercontent.com/1288904/123311487-1844fc80-d4dc-11eb-9a4a-40abf8f80656.gif)

This is also required for OpenGL, for Intel drivers.