### PR TITLE
gltfio: remove hacky RTTI from MaterialProvider.

### DIFF
--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -101,11 +101,6 @@ inline uint8_t getNumUvSets(const UvMap& uvmap) {
     });
 };
 
-enum MaterialSource {
-    GENERATE_SHADERS,
-    LOAD_UBERSHADERS,
-};
-
 /**
  * \class MaterialProvider MaterialProvider.h gltfio/MaterialProvider.h
  * \brief Interface to a provider of glTF materials (has two implementations).
@@ -125,11 +120,6 @@ enum MaterialSource {
 class MaterialProvider {
 public:
     virtual ~MaterialProvider() {}
-
-    /**
-     * Returns the type of material provider (generator or ubershader).
-     */
-    virtual MaterialSource getSource() const noexcept = 0;
 
     /**
      * Creates or fetches a compiled Filament material, then creates an instance from it.
@@ -159,6 +149,14 @@ public:
      * clients to take ownership of the cache if desired.
      */
     virtual void destroyMaterials() = 0;
+
+    /**
+     * Returns true if the presence of the given vertex attribute is required.
+     *
+     * Some types of providers (e.g. ubershader) require dummy attribute values
+     * if the glTF model does not provide them.
+     */
+    virtual bool needsDummyData(filament::VertexAttribute attrib) const noexcept = 0;
 };
 
 void constrainMaterial(MaterialKey* key, UvMap* uvmap);

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -33,22 +33,24 @@ namespace {
 
 class MaterialGenerator : public MaterialProvider {
 public:
-    explicit MaterialGenerator(filament::Engine* engine, bool optimizeShaders);
+    explicit MaterialGenerator(Engine* engine, bool optimizeShaders);
     ~MaterialGenerator() override;
 
-    MaterialSource getSource() const noexcept override { return GENERATE_SHADERS; }
-
-    filament::MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+    MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label) override;
 
     size_t getMaterialsCount() const noexcept override;
-    const filament::Material* const* getMaterials() const noexcept override;
+    const Material* const* getMaterials() const noexcept override;
     void destroyMaterials() override;
 
-    using HashFn = utils::hash::MurmurHashFn<MaterialKey>;
-    tsl::robin_map<MaterialKey, filament::Material*, HashFn> mCache;
-    std::vector<filament::Material*> mMaterials;
-    filament::Engine* const mEngine;
+    bool needsDummyData(VertexAttribute attrib) const noexcept override {
+        return false;
+    }
+
+    using HashFn = hash::MurmurHashFn<MaterialKey>;
+    tsl::robin_map<MaterialKey, Material*, HashFn> mCache;
+    std::vector<Material*> mMaterials;
+    Engine* const mEngine;
     const bool mOptimizeShaders;
 };
 

--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -44,14 +44,23 @@ public:
     UbershaderLoader(filament::Engine* engine);
     ~UbershaderLoader() {}
 
-    MaterialSource getSource() const noexcept override { return LOAD_UBERSHADERS; }
-
-    filament::MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+    MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label) override;
 
     size_t getMaterialsCount() const noexcept override;
-    const filament::Material* const* getMaterials() const noexcept override;
+    const Material* const* getMaterials() const noexcept override;
     void destroyMaterials() override;
+
+    bool needsDummyData(VertexAttribute attrib) const noexcept override {
+        switch (attrib) {
+            case VertexAttribute::UV0:
+            case VertexAttribute::UV1:
+            case VertexAttribute::COLOR:
+                return true;
+            default:
+                return false;
+        }
+    }
 
     Material* getMaterial(const MaterialKey& config) const;
 
@@ -64,7 +73,7 @@ public:
     mutable Material* mMaterials[11] = {};
     Texture* mDummyTexture = nullptr;
 
-    filament::Engine* mEngine;
+    Engine* mEngine;
 };
 
 #if GLTFIO_LITE

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -51,6 +51,11 @@ using namespace filament::viewer;
 using namespace gltfio;
 using namespace utils;
 
+enum MaterialSource {
+    GENERATE_SHADERS,
+    LOAD_UBERSHADERS,
+};
+
 struct App {
     Engine* engine;
     SimpleViewer* viewer;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -65,6 +65,11 @@ using namespace filament::viewer;
 using namespace gltfio;
 using namespace utils;
 
+enum MaterialSource {
+    GENERATE_SHADERS,
+    LOAD_UBERSHADERS,
+};
+
 struct App {
     Engine* engine;
     SimpleViewer* viewer;


### PR DESCRIPTION
We want anybody to write their own class that descends from
MaterialProvider, so it doesn't make sense to have an enum of
concrete types.