### PR TITLE
workaround drivers that don't implement textureSize() properly

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1040,6 +1040,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
             [=](FrameGraphResources const& resources,
                     auto const& data, DriverApi& driver) {
 
+                auto desc       = resources.getDescriptor(data.inOutColor);
                 auto inOutColor = resources.getTexture(data.inOutColor);
                 auto inOutCoc   = resources.getTexture(data.inOutCoc);
 
@@ -1052,11 +1053,15 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                 const PipelineState pipeline(material.getPipelineState(variant));
 
                 for (size_t level = 0 ; level < mipmapCount - 1u ; level++) {
+                    uint32_t w = FTexture::valueForLevel(level, desc.width);
+                    uint32_t h = FTexture::valueForLevel(level, desc.height);
+
                     auto const& out = resources.getRenderPassInfo(data.rp[level]);
                     driver.setMinMaxLevels(inOutColor, level, level);
                     driver.setMinMaxLevels(inOutCoc, level, level);
                     mi->setParameter("mip", uint32_t(level));
                     mi->setParameter("weightScale", 0.5f / float(1u<<level));   // FIXME: halfres?
+                    mi->setParameter("pixelSize", 1.0f / float2{w, h});
                     mi->commit(driver);
                     driver.beginRenderPass(out.target, out.params);
                     driver.draw(pipeline, fullScreenRenderPrimitive);

--- a/filament/src/materials/dof/dofMipmap.mat
+++ b/filament/src/materials/dof/dofMipmap.mat
@@ -18,6 +18,10 @@ material {
         {
             type : float,
             name : weightScale
+        },
+        {
+            type : float2,
+            name : pixelSize
         }
     ],
     variables : [
@@ -42,7 +46,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = postProcess.normalizedUV - materialParams.pixelSize * 0.5;
     }
 }
 
@@ -53,8 +57,7 @@ fragment {
 void dummy(){}
 
 void postProcess(inout PostProcessInputs postProcess) {
-    highp vec2 pixelSize = 1.0 / vec2(textureSize(materialParams_color, materialParams.mip));
-    highp vec2 uv = variable_vertex.xy - pixelSize.xy * 0.5;
+    highp vec2 uv = variable_vertex.xy;
 
     // the source is guaranteed to be a multiple of two, so we now the bilinear weights are 0.25
 


### PR DESCRIPTION
On some qualcomm drivers, textureSize() with a level != 0 aborts the
pixel shader.