### PR TITLE
spotlight light-space position moved to the fragment shader

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.10.7 (currently main branch)
 
+- engine: Spot-light position calculation moved to fragment shader.
+
 ## v1.10.6
 
 - engine: Use exponential VSM and improve VSM user settings [⚠️ **Recompile Materials for VSM**].

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -226,10 +226,6 @@ std::string ShaderGenerator::createVertexProgram(filament::backend::ShaderModel 
             BindingPoints::PER_VIEW, UibGenerator::getPerViewUib());
     cg.generateUniforms(vs, ShaderType::VERTEX,
             BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib());
-    if (litVariants && variant.hasShadowReceiver()) {
-        cg.generateUniforms(vs, ShaderType::VERTEX,
-                BindingPoints::SHADOW, UibGenerator::getShadowUib());
-    }
     if (variant.hasSkinningOrMorphing()) {
         cg.generateUniforms(vs, ShaderType::VERTEX,
                 BindingPoints::PER_RENDERABLE_BONES,
@@ -420,6 +416,10 @@ std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderMode
             BindingPoints::PER_RENDERABLE, UibGenerator::getPerRenderableUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::LIGHTS, UibGenerator::getLightsUib());
+    if (litVariants && variant.hasShadowReceiver()) {
+        cg.generateUniforms(fs, ShaderType::FRAGMENT,
+                BindingPoints::SHADOW, UibGenerator::getShadowUib());
+    }
     cg.generateUniforms(fs, ShaderType::FRAGMENT,
             BindingPoints::FROXEL_RECORDS, UibGenerator::getFroxelRecordUib());
     cg.generateUniforms(fs, ShaderType::FRAGMENT,

--- a/shaders/src/common_shadowing.fs
+++ b/shaders/src/common_shadowing.fs
@@ -9,16 +9,16 @@
  * shadowing artifacts such as "acne". To achieve this, the world space
  * normal at the point must also be passed to this function.
  */
-vec4 computeLightSpacePosition(const highp vec3 p, const highp vec3 n, const highp vec3 l,
+highp vec4 computeLightSpacePosition(const highp vec3 p, const highp vec3 n, const highp vec3 l,
         const float b, const highp mat4 lightFromWorldMatrix) {
 #if defined(HAS_VSM)
     // VSM don't apply the shadow bias
-    vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(p, 1.0));
+    highp vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(p, 1.0));
 #else
     float NoL = saturate(dot(n, l));
     float sinTheta = sqrt(1.0 - NoL * NoL);
-    vec3 offsetPosition = p + n * (sinTheta * b);
-    vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(offsetPosition, 1.0));
+    highp vec3 offsetPosition = p + n * (sinTheta * b);
+    highp vec4 lightSpacePosition = (lightFromWorldMatrix * vec4(offsetPosition, 1.0));
 #endif
     return lightSpacePosition;
 }

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -107,7 +107,11 @@ highp vec3 getNormalizedViewportCoord() {
 
 #if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
 highp vec3 getSpotLightSpacePosition(uint index) {
-    highp vec4 position = vertex_spotLightSpacePosition[index];
+    vec3 dir = shadowUniforms.directionShadowBias[index].xyz;
+    float bias = shadowUniforms.directionShadowBias[index].w;
+    highp vec4 position = computeLightSpacePosition(vertex_worldPosition,
+            vertex_worldNormal, dir, bias, shadowUniforms.spotLightFromWorldMatrix[index]);
+
 #if defined(HAS_VSM)
     // For VSM, do not project the Z coordinate. It remains as linear Z in light space.
     // See the computeVsmLightSpaceMatrix comments in ShadowMap.cpp.

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -6,12 +6,6 @@ mat4 getLightFromWorldMatrix() {
     return frameUniforms.lightFromWorldMatrix[0];
 }
 
-#if defined(HAS_SHADOWING)
-mat4 getSpotLightFromWorldMatrix(uint index) {
-    return shadowUniforms.spotLightFromWorldMatrix[index];
-}
-#endif
-
 /** @public-api */
 mat4 getWorldFromModelMatrix() {
     return objectUniforms.worldFromModelMatrix;

--- a/shaders/src/inputs.fs
+++ b/shaders/src/inputs.fs
@@ -27,8 +27,4 @@ LAYOUT_LOCATION(10) in highp vec4 vertex_uv01;
 LAYOUT_LOCATION(11) in highp vec4 vertex_lightSpacePosition;
 #endif
 
-#if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
-LAYOUT_LOCATION(12) in highp vec4 vertex_spotLightSpacePosition[MAX_SHADOW_CASTING_SPOTS];
-#endif
-
 // Note that fragColor is an output and is not declared here; see main.fs and depth_main.fs

--- a/shaders/src/inputs.vs
+++ b/shaders/src/inputs.vs
@@ -79,7 +79,3 @@ LAYOUT_LOCATION(10) out highp vec4 vertex_uv01;
 #if defined(HAS_SHADOWING) && defined(HAS_DIRECTIONAL_LIGHTING)
 LAYOUT_LOCATION(11) out highp vec4 vertex_lightSpacePosition;
 #endif
-
-#if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
-LAYOUT_LOCATION(12) out highp vec4 vertex_spotLightSpacePosition[MAX_SHADOW_CASTING_SPOTS];
-#endif

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -92,15 +92,6 @@ void main() {
             frameUniforms.lightDirection, frameUniforms.shadowBias.y, getLightFromWorldMatrix());
 #endif
 
-#if defined(HAS_SHADOWING) && defined(HAS_DYNAMIC_LIGHTING)
-    for (uint l = 0u; l < uint(MAX_SHADOW_CASTING_SPOTS); l++) {
-        vec3 dir = shadowUniforms.directionShadowBias[l].xyz;
-        float bias = shadowUniforms.directionShadowBias[l].w;
-        vertex_spotLightSpacePosition[l] = computeLightSpacePosition(vertex_worldPosition,
-                vertex_worldNormal, dir, bias, getSpotLightFromWorldMatrix(l));
-    }
-#endif
-
 #if defined(VERTEX_DOMAIN_DEVICE)
     // The other vertex domains are handled in initMaterialVertex()->computeWorldPosition()
     gl_Position = getPosition();


### PR DESCRIPTION
We have a limited number of interpolants, and 2 were used for spotlights,
but this is a fairly uncommon case, so we move the calculation to the
fragment shader. A side effect of this is that we are not limited to 
two spot-light anymore from the shader's point of view.

This essentially adds a vector transform per fragment, but on the other
hand, it removes communication between the vertex and fragment shader,
as well as interpolation of the position.