### PR TITLE
RenderPass and ShadowMap code cleanup

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -312,10 +312,10 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
 // -- less than or equal to 208 bytes
 
 
-OpenGLDriver::HandleAllocator::HandleAllocator(const utils::HeapArea& area)
+OpenGLDriver::HandleAllocator::HandleAllocator(const utils::AreaPolicy::HeapArea& area)
 {
     // TODO: we probably need a better way to set the size of these pools
-    const size_t unit = area.getSize() / 32;
+    const size_t unit = area.size() / 32;
     const size_t offsetPool1 =      unit;
     const size_t offsetPool2 = 16 * unit;
     char* const p = (char*)area.begin();

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -253,7 +253,7 @@ private:
         utils::PoolAllocator<208, 32>   mPool2;
     public:
         static constexpr size_t MIN_ALIGNMENT_SHIFT = 4;
-        explicit HandleAllocator(const utils::HeapArea& area);
+        explicit HandleAllocator(const utils::AreaPolicy::HeapArea& area);
 
         // this is in fact always called with a constexpr size argument
         inline void* alloc(size_t size, size_t alignment, size_t extra) noexcept {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -299,7 +299,8 @@ void PostProcessManager::commitAndRender(FrameGraphResources::RenderPassInfo con
 // ------------------------------------------------------------------------------------------------
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
-        const RenderPass& pass, uint32_t width, uint32_t height, float scale) noexcept {
+        RenderPass const& pass, uint32_t width, uint32_t height, float scale) noexcept {
+
 
     // structure pass -- automatically culled if not used, currently used by:
     //    - ssao
@@ -332,7 +333,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
                         .clearFlags = TargetBufferFlags::DEPTH
                 });
             },
-            [=](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
+            [=](FrameGraphResources const& resources,
+                    auto const& data, DriverApi& driver) mutable {
                 auto out = resources.getRenderPassInfo();
                 pass.execute(resources.getPassName(), out.target, out.params);
             });
@@ -380,8 +382,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
     return depth;
 }
 
-FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
-        FrameGraph& fg, RenderPass& pass,
+FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(FrameGraph& fg,
         filament::Viewport const& svp, const CameraInfo& cameraInfo,
         View::AmbientOcclusionOptions options) noexcept {
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -24,10 +24,10 @@
 #include <fg2/FrameGraphId.h>
 #include <fg2/FrameGraphResources.h>
 
+#include <filament/View.h>
+
 #include <backend/DriverEnums.h>
 #include <backend/PipelineState.h>
-
-#include <filament/View.h>
 
 #include <utils/CString.h>
 
@@ -69,8 +69,7 @@ public:
 
     // SSAO
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOcclusion(FrameGraph& fg,
-            RenderPass& pass, filament::Viewport const& svp,
-            CameraInfo const& cameraInfo,
+            filament::Viewport const& svp, const CameraInfo& cameraInfo,
             View::AmbientOcclusionOptions options) noexcept;
 
     // Used in refraction pass

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -507,19 +507,15 @@ void RenderPass::Executor::execute(const char* name,
         backend::RenderPassParams params) const noexcept {
     FEngine& engine = mEngine;
     DriverApi& driver = engine.getDriverApi();
-    driver.beginRenderPass(renderTarget, params);
-    executeCommands(name);
-    driver.endRenderPass();
-}
 
-void RenderPass::Executor::executeCommands(const char* name) const noexcept {
     // this is a good time to flush the CommandStream, because we're about to potentially
     // output a lot of commands. This guarantees here that we have at least
     // FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB bytes (1MiB by default).
-    FEngine& engine = mEngine;
     engine.flush();
-    DriverApi& driver = engine.getDriverApi();
+
+    driver.beginRenderPass(renderTarget, params);
     recordDriverCommands(driver, mBegin, mEnd);
+    driver.endRenderPass();
 }
 
 UTILS_NOINLINE // no need to be inlined

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -332,8 +332,6 @@ public:
         void execute(const char* name,
                 backend::Handle<backend::HwRenderTarget> renderTarget,
                 backend::RenderPassParams params) const noexcept;
-
-        void executeCommands(const char* name) const noexcept;
     };
 
     // returns a new executor for this pass

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -863,7 +863,7 @@ void FView::updatePrimitivesLod(FEngine& engine, const CameraInfo&,
 }
 
 void FView::renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
-        RenderPass& pass) noexcept {
+        RenderPass const& pass) noexcept {
     mShadowMapManager.render(fg, engine, *this, driver, pass);
 }
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -226,7 +226,7 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
         const auto& shadowOptions = lcm.getShadowOptions(directionalLight);
         assert_invariant(shadowOptions.shadowCascades >= 1 &&
                 shadowOptions.shadowCascades <= CONFIG_MAX_SHADOW_CASCADES);
-        mShadowMapManager.setShadowCascades(0, shadowOptions.shadowCascades);
+        mShadowMapManager.setShadowCascades(0, &shadowOptions);
     }
 
     // Find all shadow-casting spot lights.
@@ -245,7 +245,8 @@ void FView::prepareShadowing(FEngine& engine, backend::DriverApi& driver,
             continue;
         }
 
-        mShadowMapManager.addSpotShadowMap(l);
+        const auto& shadowOptions = lcm.getShadowOptions(light);
+        mShadowMapManager.addSpotShadowMap(l, &shadowOptions);
 
         shadowCastingSpotCount++;
         if (shadowCastingSpotCount > CONFIG_MAX_SHADOW_CASTING_SPOTS - 1) {
@@ -864,7 +865,7 @@ void FView::updatePrimitivesLod(FEngine& engine, const CameraInfo&,
 
 void FView::renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
         RenderPass const& pass) noexcept {
-    mShadowMapManager.render(fg, engine, *this, driver, pass);
+    mShadowMapManager.render(fg, engine, driver, pass, *this);
 }
 
 void FView::commitFrameHistory(FEngine& engine) noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -155,7 +155,7 @@ private:
             FrameGraphTexture::Descriptor const& colorBufferDesc,
             ColorPassConfig const& config,
             PostProcessManager::ColorGradingConfig colorGradingConfig,
-            RenderPass const& pass, FView const& view) const noexcept;
+            RenderPass::Executor const& passExecutor, FView const& view) const noexcept;
 
     FrameGraphId<FrameGraphTexture> refractionPass(FrameGraph& fg,
             ColorPassConfig config,

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -38,6 +38,11 @@ class RenderPass;
 class ShadowMap {
 public:
     explicit ShadowMap(FEngine& engine) noexcept;
+
+    // ShadowMap is not copyable for now
+    ShadowMap(ShadowMap const& rhs) = delete;
+    ShadowMap& operator=(ShadowMap const& rhs) = delete;
+
     ~ShadowMap();
 
     struct ShadowMapInfo {
@@ -46,15 +51,15 @@ public:
         float zResolution = 0.0f;
 
         // the dimension of the encompassing texture atlas
-        size_t atlasDimension = 0;
+        uint16_t atlasDimension = 0;
 
         // the dimension of a single shadow map texture within the atlas
         // e.g., for at atlas size of 1024 split into 4 quadrants, textureDimension would be 512
-        size_t textureDimension = 0;
+        uint16_t textureDimension = 0;
 
         // the dimension of the actual shadow map, taking into account the 1 texel border
         // e.g., for a texture dimension of 512, shadowDimension would be 510
-        size_t shadowDimension = 0;
+        uint16_t shadowDimension = 0;
 
         // whether we're using vsm
         bool vsm = false;
@@ -232,23 +237,19 @@ private:
             { 2, 6, 7, 3 },  // top
     };
 
-    FCamera* mCamera = nullptr;
-    FCamera* mDebugCamera = nullptr;
-    math::mat4f mLightSpace;
-    float mTexelSizeWs = 0.0f;
+    FCamera* mCamera = nullptr;                 //  8
+    FCamera* mDebugCamera = nullptr;            //  8
+    math::mat4f mLightSpace;                    // 64
+    float mTexelSizeWs = 0.0f;                  //  4
 
     // set-up in update()
-    ShadowMapInfo mShadowMapInfo;
-    bool mHasVisibleShadows = false;
-    backend::PolygonOffset mPolygonOffset{};
+    ShadowMapInfo mShadowMapInfo;               // 12
+    bool mHasVisibleShadows = false;            //  1
+    backend::PolygonOffset mPolygonOffset{};    //  8
 
-    // use a member here (instead of stack) because we don't want to pay the
-    // initialization of the float3 each time
-    FrustumBoxIntersection mWsClippedShadowReceiverVolume;
-
-    FEngine& mEngine;
-    const bool mClipSpaceFlipped;
-    const bool mTextureSpaceFlipped;
+    FEngine& mEngine;                           //  8
+    const bool mClipSpaceFlipped;               //  1
+    const bool mTextureSpaceFlipped;            //  1
 };
 
 } // namespace filament

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -95,8 +95,8 @@ public:
             filament::CameraInfo const& camera,
             const ShadowMapInfo& shadowMapInfo, const SceneInfo& cascadeParams) noexcept;
 
-    void render(backend::DriverApi& driver, utils::Range<uint32_t> const& range, RenderPass& pass,
-            FView& view) noexcept;
+    void render(backend::DriverApi& driver, utils::Range<uint32_t> const& range,
+            RenderPass* pass, FView& view) noexcept;
 
     // Do we have visible shadows. Valid after calling update().
     bool hasVisibleShadows() const noexcept { return mHasVisibleShadows; }

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -75,7 +75,7 @@ public:
 
     // Renders all of the shadow maps.
     void render(FrameGraph& fg, FEngine& engine, FView& view, backend::DriverApi& driver,
-            RenderPass& pass) noexcept;
+            RenderPass const& pass) noexcept;
 
     const ShadowMap* getCascadeShadowMap(size_t c) const noexcept {
         assert_invariant(c < mCascadeShadowMapCache.size());

--- a/filament/src/details/ShadowMapManager.h
+++ b/filament/src/details/ShadowMapManager.h
@@ -19,19 +19,21 @@
 
 #include <filament/Viewport.h>
 
+#include "TypedUniformBuffer.h"
+#include "ShadowMap.h"
+
+#include "details/Engine.h"
+#include "details/Scene.h"
+
+#include <private/filament/EngineEnums.h>
+
 #include <private/backend/DriverApi.h>
 #include <private/backend/DriverApiForward.h>
 #include <private/backend/SamplerGroup.h>
 #include <private/backend/SamplerGroup.h>
 
-#include <private/filament/EngineEnums.h>
-
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>
-
-#include "fg2/FrameGraph.h"
-
-#include "TypedUniformBuffer.h"
 
 #include <utils/FixedCapacityVector.h>
 
@@ -44,7 +46,7 @@
 namespace filament {
 
 class FView;
-
+class FrameGraph;
 class ShadowMap;
 class RenderPass;
 
@@ -64,8 +66,8 @@ public:
     // Reset shadow map layout.
     void reset() noexcept;
 
-    void setShadowCascades(size_t lightIndex, size_t cascades) noexcept;
-    void addSpotShadowMap(size_t lightIndex) noexcept;
+    void setShadowCascades(size_t lightIndex, LightManager::ShadowOptions const* options) noexcept;
+    void addSpotShadowMap(size_t lightIndex, LightManager::ShadowOptions const* options) noexcept;
 
     // Updates all of the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
@@ -74,20 +76,16 @@ public:
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
 
     // Renders all of the shadow maps.
-    void render(FrameGraph& fg, FEngine& engine, FView& view, backend::DriverApi& driver,
-            RenderPass const& pass) noexcept;
+    void render(FrameGraph& fg, FEngine& engine, backend::DriverApi& driver,
+            RenderPass const& pass, FView& view) noexcept;
 
-    const ShadowMap* getCascadeShadowMap(size_t c) const noexcept {
-        assert_invariant(c < mCascadeShadowMapCache.size());
-        return mCascadeShadowMapCache[c].get();
+    const ShadowMap* getCascadeShadowMap(size_t cascade) const noexcept {
+        assert_invariant(cascade < CONFIG_MAX_SHADOW_CASCADES);
+        auto shadowMap = std::launder(reinterpret_cast<ShadowMap const*>(&mShadowMapCache[cascade]));
+        return shadowMap;
     }
 
 private:
-
-    struct ShadowLayout {
-        LightManager::ShadowOptions const* options = nullptr;
-        uint8_t layer = 0;
-    };
 
     struct TextureRequirements {
         uint16_t size = 0;
@@ -98,6 +96,7 @@ private:
     ShadowTechnique updateCascadeShadowMaps(FEngine& engine, FView& view,
             TypedUniformBuffer<PerViewUib>& perViewUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
+
     ShadowTechnique updateSpotShadowMaps(FEngine& engine, FView& view,
             TypedUniformBuffer<ShadowUib>& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
@@ -107,26 +106,27 @@ private:
     class ShadowMapEntry {
     public:
         ShadowMapEntry() = default;
-        ShadowMapEntry(ShadowMap* shadowMap, size_t light) :
-                mShadowMap(shadowMap),
-                mLightIndex(light) {
+        ShadowMapEntry(ShadowMap* shadowMap, size_t light,
+                LightManager::ShadowOptions const* options) :
+                mShadowMap(shadowMap), mOptions(options), mLightIndex(light) {
         }
 
         explicit operator bool() const { return mShadowMap != nullptr; }
 
+        void setLayer(uint8_t layer) noexcept { mLayer = layer; }
+        uint8_t getLayer() const noexcept { return mLayer; }
+
+        LightManager::ShadowOptions const* getShadowOptions() const noexcept { return mOptions; }
         ShadowMap& getShadowMap() const { return *mShadowMap; }
         size_t getLightIndex() const { return mLightIndex; }
-        const ShadowLayout& getLayout() const { return mLayout; }
-        bool hasVisibleShadows() const { return mHasVisibleShadows; }
 
-        void setHasVisibleShadows(bool hasVisibleShadows) { mHasVisibleShadows = hasVisibleShadows; }
-        void setLayout(const ShadowLayout& layout) { mLayout = layout; }
+        bool hasVisibleShadows() const { return mShadowMap->hasVisibleShadows(); }
 
     private:
         ShadowMap* mShadowMap = nullptr;
-        ShadowLayout mLayout = {};
-        size_t mLightIndex = 0; // TODO: does this need to be size_t?
-        bool mHasVisibleShadows = false;
+        LightManager::ShadowOptions const* mOptions = nullptr;
+        uint32_t mLightIndex = 0;
+        uint8_t mLayer = 0;
     };
 
     class CascadeSplits {
@@ -183,8 +183,12 @@ private:
             utils::FixedCapacityVector<ShadowMapEntry>::with_capacity(
                     CONFIG_MAX_SHADOW_CASTING_SPOTS) };
 
-    std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASCADES> mCascadeShadowMapCache;
-    std::array<std::unique_ptr<ShadowMap>, CONFIG_MAX_SHADOW_CASTING_SPOTS> mSpotShadowMapCache;
+    // inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
+    // because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.
+    // Each ShadowMap is currently 128 bytes.
+    using ShadowMapStorage = std::aligned_storage<sizeof(ShadowMap), alignof(ShadowMap)>::type;
+    std::array<ShadowMapStorage,
+            CONFIG_MAX_SHADOW_CASCADES + CONFIG_MAX_SHADOW_CASTING_SPOTS> mShadowMapCache;
 };
 
 } // namespace filament

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -183,7 +183,7 @@ public:
     bool hasVsm() const noexcept { return mShadowType == ShadowType::VSM; }
 
     void renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
-            RenderPass& pass) noexcept;
+            RenderPass const& pass) noexcept;
 
     void updatePrimitivesLod(
             FEngine& engine, const CameraInfo& camera,

--- a/filament/src/fg2/FrameGraphPass.h
+++ b/filament/src/fg2/FrameGraphPass.h
@@ -58,7 +58,7 @@ class FrameGraphPass : public FrameGraphPassBase {
     friend class FrameGraph;
 
     // allow our allocators to instantiate us
-    template<typename, typename, typename>
+    template<typename, typename, typename, typename>
     friend class utils::Arena;
 
     explicit FrameGraphPass(Execute&& execute) noexcept


### PR DESCRIPTION
This is split in 3 CLs, but the main changes are:
- rework RenderPass allocations
- simplify ShadowMap cpde
See each CL for details.