### PR TITLE
enable up to 6 spot shadows

### DIFF
--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -55,10 +55,9 @@ constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
 constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 
 // The maximum number of spot lights in a scene that can cast shadows.
-// Light space coordinates are computed in the vertex shader and interpolated across fragments.
-// Thus, each additional shadow-casting spot light adds 4 additional varying components. Higher
-// values may cause the number of varyings to exceed the driver limit.
-constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 2;
+// There is currently a limit to 6 spot shadow due to how we store the culling result
+// (see View.h).
+constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 6;
 
 // The maximum number of shadow cascades that can be used for directional lights.
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;


### PR DESCRIPTION
This is a trivial change since we moved the lightspace computation
in the fragment shader. The limitation to 6 is due to how we're storing
the culling result.