### PR TITLE
Add gltf_viewer and material_sandbox to release archives

### DIFF
--- a/filament/README.md
+++ b/filament/README.md
@@ -7,10 +7,14 @@ Filament. Latest versions are available on the [project page](https://github.com
 
 - `cmgen`, Image-based lighting asset generator
 - `filamesh`, Mesh converter
+- `glslminifier`, Tool to minify GLSL shaders
+- `gltf_viewer`, glTF 2.0 viewer that lets you explore many features of Filament
 - `matc`, Material compiler
+- `material_sandbox`, simple mesh viewer that lets you explore material and lighting features
 - `matinfo`, Displays information about materials compiled with `matc`
 - `mipgen`, Generates a series of miplevels from a source image.
 - `normal-blending`, Tool to blend normal maps
+- `resgen`, Tool to convert files into binary resources to be embedded at compie time
 - `roughness-prefilter`, Pre-filters a roughness map from a normal map to reduce aliasing
 - `specular-color`, Computes the specular color of conductors based on spectral data
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -254,6 +254,11 @@ if (NOT ANDROID)
     target_link_libraries(sample_normal_map PRIVATE filameshio)
     target_link_libraries(suzanne PRIVATE filameshio suzanne-resources)
 
+    # ==============================================================================================
+    # Installation
+    # ==============================================================================================
+    install(TARGETS gltf_viewer RUNTIME DESTINATION bin)
+    install(TARGETS material_sandbox RUNTIME DESTINATION bin)
 endif()
 
 # ==================================================================================================


### PR DESCRIPTION
This helps users try out Filament without having to compile it themselves.