### PR TITLE
matc: log error when input material definition is empty

### DIFF
--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -261,6 +261,7 @@ bool MaterialCompiler::run(const Config& config) {
     Config::Input* input = config.getInput();
     ssize_t size = input->open();
     if (size <= 0) {
+        std::cerr << "Input file is empty" << std::endl;
         return false;
     }
     auto buffer = input->read();


### PR DESCRIPTION
Fixes #3355