### PR TITLE
Skip lighting/shadowing when possible

### DIFF
--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -35,6 +35,12 @@ void evaluateDirectionalLight(const MaterialInputs material,
 
     Light light = getDirectionalLight();
 
+#if defined(MATERIAL_CAN_SKIP_LIGHTING)
+    if (light.NoL <= 0.0) {
+        return;
+    }
+#endif
+
     float visibility = 1.0;
 #if defined(HAS_SHADOWING)
     if (light.NoL > 0.0) {
@@ -58,13 +64,12 @@ void evaluateDirectionalLight(const MaterialInputs material,
         #if defined(MATERIAL_HAS_AMBIENT_OCCLUSION)
         visibility *= computeMicroShadowing(light.NoL, material.ambientOcclusion);
         #endif
-    } else {
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
-        return;
+        if (visibility <= 0.0) {
+            return;
+        }
 #endif
     }
-#elif defined(MATERIAL_CAN_SKIP_LIGHTING)
-    if (light.NoL <= 0.0) return;
 #endif
 
 #if defined(MATERIAL_HAS_CUSTOM_SURFACE_SHADING)

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -175,9 +175,15 @@ void evaluatePunctualLights(const MaterialInputs material,
     // Iterate point lights
     for ( ; index < end; index++) {
         Light light = getLight(index);
+#if defined(MATERIAL_CAN_SKIP_LIGHTING)
+        if (light.NoL <= 0.0 || light.attenuation <= 0.0) {
+            continue;
+        }
+#endif
+
         float visibility = 1.0;
 #if defined(HAS_SHADOWING)
-        if (light.NoL > 0.0){
+        if (light.NoL > 0.0) {
             if (light.castsShadows) {
                 visibility = shadow(light_shadowMap, light.shadowLayer,
                     getSpotLightSpacePosition(light.shadowIndex));
@@ -187,11 +193,11 @@ void evaluatePunctualLights(const MaterialInputs material,
                     visibility *= 1.0 - screenSpaceContactShadow(light.l);
                 }
             }
-        }
-#endif
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
-        if (light.NoL <= 0.0 || light.attenuation <= 0.0) {
-            continue;
+            if (visibility <= 0.0) {
+                continue;
+            }
+#endif
         }
 #endif
 


### PR DESCRIPTION
We can skip lighting in the areas fully shadowed, we can also skip
shadowing outside the radius of punctual lights.