### PR TITLE
When IOR=1.0, there should be no transmission roughness

### DIFF
--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -511,7 +511,8 @@ void applyRefraction(const PixelParams pixel,
 
     // When IOR = 1.0, roughness cannot apply
     // TODO: we should check material.ior instead of etaRI (material.ior / air.ior)
-    float perceptualRoughness = pixel.etaRI == 1.0 ? 0.0 : pixel.perceptualRoughnessUnclamped;
+    float perceptualRoughness = mix(pixel.perceptualRoughnessUnclamped, 0.0,
+            saturate(pixel.etaIR * 3.0 - 2.0));
 #if REFRACTION_TYPE == REFRACTION_TYPE_THIN
     // Roughness remaping for thin layers, see Burley 2012, "Physically-Based Shading at Disney"
     perceptualRoughness = saturate((0.65 * pixel.etaRI - 0.35) * perceptualRoughness);

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -509,14 +509,11 @@ void applyRefraction(const PixelParams pixel,
 #endif
 #endif
 
-    // When IOR = 1.0, roughness cannot apply
-    // TODO: we should check material.ior instead of etaRI (material.ior / air.ior)
+    // Roughness remapping so that an IOR of 1.0 means no microfacet refraction and an IOR
+    // of 1.5 has full microfacet refraction
     float perceptualRoughness = mix(pixel.perceptualRoughnessUnclamped, 0.0,
             saturate(pixel.etaIR * 3.0 - 2.0));
 #if REFRACTION_TYPE == REFRACTION_TYPE_THIN
-    // Roughness remaping for thin layers, see Burley 2012, "Physically-Based Shading at Disney"
-    perceptualRoughness = saturate((0.65 * pixel.etaRI - 0.35) * perceptualRoughness);
-
     // For thin surfaces, the light will bounce off at the second interface in the direction of
     // the reflection, effectively adding to the specular, but this process will repeat itself.
     // Each time the ray exits the surface on the front side after the first bounce,

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -509,7 +509,9 @@ void applyRefraction(const PixelParams pixel,
 #endif
 #endif
 
-    float perceptualRoughness = pixel.perceptualRoughnessUnclamped;
+    // When IOR = 1.0, roughness cannot apply
+    // TODO: we should check material.ior instead of etaRI (material.ior / air.ior)
+    float perceptualRoughness = pixel.etaRI == 1.0 ? 0.0 : pixel.perceptualRoughnessUnclamped;
 #if REFRACTION_TYPE == REFRACTION_TYPE_THIN
     // Roughness remaping for thin layers, see Burley 2012, "Physically-Based Shading at Disney"
     perceptualRoughness = saturate((0.65 * pixel.etaRI - 0.35) * perceptualRoughness);


### PR DESCRIPTION
See https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/TransmissionRoughnessTest
for details.