### PR TITLE
Sort and discard lights early

### DIFF
--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -206,9 +206,6 @@ private:
     static inline void computeLightRanges(math::float2* zrange,
             CameraInfo const& camera, const math::float4* spheres, size_t count) noexcept;
 
-    static inline void computeLightCameraPlaneDistances(float* distances,
-            const CameraInfo& camera, const math::float4* spheres, size_t count) noexcept;
-
     FEngine& mEngine;
     FSkybox* mSkybox = nullptr;
     FIndirectLight const* mIndirectLight = nullptr;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -440,9 +440,12 @@ private:
     void prepareVisibleRenderables(utils::JobSystem& js,
             Frustum const& frustum, FScene::RenderableSoa& renderableData) const noexcept;
 
-    static void prepareVisibleLights(
-            FLightManager const& lcm, utils::JobSystem& js, Frustum const& frustum,
+    static void prepareVisibleLights(FLightManager const& lcm, ArenaScope& rootArena,
+            const CameraInfo& camera, Frustum const& frustum,
             FScene::LightSoa& lightData) noexcept;
+
+    static inline void computeLightCameraDistances(float* distances,
+            const CameraInfo& camera, const math::float4* spheres, size_t count) noexcept;
 
     static void computeVisibilityMasks(
             uint8_t visibleLayers, uint8_t const* layers,


### PR DESCRIPTION
We always may need to discard lights because we have a limited 
number we can use in the shader. We now do this earlier, in particular
before we set up the shadowmaps.

Because we also have a limited (smaller) number of shadowmap, this 
allows us to automatically select the ones that are closer to the 
camera, which gives better results.