### PR TITLE
Fix colorgrading as subpass

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -481,9 +481,9 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     colorGradingConfigForColor.asSubpass = colorGradingConfigForColor.asSubpass && !taaOptions.enabled;
 
     if (colorGradingConfigForColor.asSubpass) {
-        // append colorgrading subpass after refraction pass
+        // append colorgrading subpass after all other passes
         pass.appendCustomCommand(
-                RenderPass::Pass::REFRACT,
+                RenderPass::Pass::BLENDED,
                 RenderPass::CustomCommand::EPILOG,
                 0, [&ppm, &driver, colorGradingConfigForColor](){
                     ppm.colorGradingSubpass(driver, colorGradingConfigForColor);


### PR DESCRIPTION
We were inserting the colorgrading subpass command between the
refracted and blended objects, instead of after all of them.

Another bad side effect of this was to trigger the refraction pass for
no reason.