### PR TITLE
Add signposts to Metal backend

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -131,6 +131,8 @@ if (FILAMENT_SUPPORTS_METAL)
             src/opengl/PlatformCocoaGL.mm
             PROPERTY COMPILE_FLAGS -fno-objc-exceptions)
     endif()
+
+    option(FILAMENT_METAL_PROFILING "Enable profiling for the Metal backend" OFF)
 endif()
 
 # ==================================================================================================
@@ -342,6 +344,10 @@ target_compile_options(${TARGET} PRIVATE
         $<$<CONFIG:Release>:${OPTIMIZATION_FLAGS}>
         $<$<AND:$<PLATFORM_ID:Darwin>,$<CONFIG:Release>>:${DARWIN_OPTIMIZATION_FLAGS}>
 )
+
+if (FILAMENT_SUPPORTS_METAL)
+    target_compile_definitions(${TARGET} PRIVATE $<$<BOOL:${FILAMENT_METAL_PROFILING}>:FILAMENT_METAL_PROFILING>)
+endif()
 
 target_link_libraries(${TARGET} PRIVATE
         $<$<AND:$<PLATFORM_ID:Linux>,$<CONFIG:Release>>:${LINUX_LINKER_OPTIMIZATION_FLAGS}>

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -27,6 +27,11 @@
 #include <array>
 #include <stack>
 
+#if defined(FILAMENT_METAL_PROFILING)
+#include <os/log.h>
+#include <os/signpost.h>
+#endif
+
 #include <tsl/robin_set.h>
 
 namespace filament {
@@ -106,6 +111,12 @@ struct MetalContext {
     TimerQueryInterface* timerQueryImpl;
 
     std::stack<const char*> groupMarkers;
+
+#if defined(FILAMENT_METAL_PROFILING)
+    // Logging and profiling.
+    os_log_t log;
+    os_signpost_id_t signpostId;
+#endif
 };
 
 id<MTLCommandBuffer> getPendingCommandBuffer(MetalContext* context);


### PR DESCRIPTION
This helps profiling CPU time to encode a frame.