### PR TITLE
default to openGL when windows does not support VULKAN

### DIFF
--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -99,8 +99,10 @@ DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
         *backend = Backend::OPENGL;
 #elif defined(IOS) || defined(__APPLE__)
         *backend = Backend::METAL;
-#else
+#elif defined(FILAMENT_DRIVER_SUPPORTS_VULKAN)
         *backend = Backend::VULKAN;
+#else
+        * backend = Backend::OPENGL;
 #endif
     }
     if (*backend == Backend::NOOP) {


### PR DESCRIPTION
My windows laptop does not support vulkan (or at least the cmake does not detect it). That means the samples crash because the backend is defaulting to vulkan. This change just makes the backend default openGL in the case that Vulkan is not available.