### PR TITLE
Prep for using new handle allocator in Vulkan.

### DIFF
--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -74,8 +74,7 @@ HandleBase::HandleId HandleAllocator::allocateHandleSlow(size_t size) noexcept {
 
     if (UTILS_UNLIKELY(id == (HEAP_HANDLE_FLAG|1u))) { // meaning id was zero
         PANIC_LOG("HandleAllocator arena is full, using slower system heap. Please increase "
-                  "FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB which is currently set to %u MiB.",
-                FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB);
+                  "the appropriate constant (e.g. FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB).");
     }
     return id;
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -660,7 +660,9 @@ Handle<HwFence> VulkanDriver::createFenceS() noexcept {
 }
 
 Handle<HwSync> VulkanDriver::createSyncS() noexcept {
-    return alloc_handle<VulkanSync, HwSync>();
+    Handle<HwSync> sh = alloc_handle<VulkanSync, HwSync>();
+    construct_handle<VulkanSync>(mHandleMap, sh);
+    return sh;
 }
 
 Handle<HwSwapChain> VulkanDriver::createSwapChainS() noexcept {

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -90,7 +90,7 @@ private:
     template<typename Dp, typename B>
     Handle<B> alloc_handle() {
         std::lock_guard<std::mutex> lock(mHandleMapMutex);
-        mHandleMap[mNextId] = Blob(sizeof(Dp), 0);
+        mHandleMap[mNextId] = Blob(sizeof(Dp));
         return Handle<B>(mNextId++);
     }
 

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -134,6 +134,7 @@ struct VulkanFence : public HwFence {
 };
 
 struct VulkanSync : public HwSync {
+    VulkanSync() {}
     VulkanSync(const VulkanCommandBuffer& commands) : fence(commands.fence) {}
     std::shared_ptr<VulkanCmdFence> fence;
 };
@@ -144,7 +145,7 @@ struct VulkanTimerQuery : public HwTimerQuery {
     uint32_t startingQueryIndex;
     uint32_t stoppingQueryIndex;
     VulkanContext& mContext;
-    std::atomic<VulkanCommandBuffer const*> cmdbuffer;
+    std::atomic<VulkanCommandBuffer const*> cmdbuffer = nullptr;
 };
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -37,28 +37,28 @@ struct VulkanSwapChain : public HwSwapChain {
     VulkanAttachment& getColor() { return color[currentSwapIndex]; }
 
     VulkanContext& context;
-    VkSurfaceKHR surface;
-    VkSwapchainKHR swapchain;
-    VkSurfaceFormatKHR surfaceFormat;
-    VkExtent2D clientSize;
-    VkQueue presentQueue;
-    VkQueue headlessQueue;
-    uint32_t currentSwapIndex;
+    VkSurfaceKHR surface = {};
+    VkSwapchainKHR swapchain = {};
+    VkSurfaceFormatKHR surfaceFormat = {};
+    VkExtent2D clientSize = {};
+    VkQueue presentQueue = {};
+    VkQueue headlessQueue = {};
+    uint32_t currentSwapIndex = {};
 
     // Color attachments are swapped, but depth is not. Typically there are 2 or 3 color attachments
     // in a swap chain.
     utils::FixedCapacityVector<VulkanAttachment> color;
-    VulkanAttachment depth;
+    VulkanAttachment depth = {};
 
     // This is signaled when vkAcquireNextImageKHR succeeds, and is waited on by the first
     // submission.
-    VkSemaphore imageAvailable;
+    VkSemaphore imageAvailable = {};
 
     // This is true after the swap chain image has been acquired, but before it has been presented.
-    bool acquired;
+    bool acquired = false;
 
-    bool suboptimal;
-    bool firstRenderPass;
+    bool suboptimal = false;
+    bool firstRenderPass = false;
 };
 
 } // namespace filament


### PR DESCRIPTION
Previously we were zero filling the data blob used to store all Vulkan
handles. This occured in VulkanDriver::alloc_handle().

There were several places that depended on the zero fill. These
have now been fixed up so that the handle can be constructed in a
more natural way.

Also: remove the OPENGL specific constant from HandleAllocator. This
breaks in non-CMake build systems (e.g. Bazel) that do not provide the
constant at a global level.