### PR TITLE
Generalize luminance scaling in color grading

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.11.1 (currently main branch)
 
+- engine: Luminance scaling can now be used with any tone mapping operator. It was previously tied
+  to the "EVILS" tone mapping operator.
+- engine: Removed the "EVILS" tone mapping operator [⚠️ **API Change**].
+
 ## v1.11.0
 
 - engine: Added support for transparent shadows. Add `transparentShadow : true` in the material file.

--- a/android/filament-android/src/main/cpp/ColorGrading.cpp
+++ b/android/filament-android/src/main/cpp/ColorGrading.cpp
@@ -61,6 +61,13 @@ Java_com_google_android_filament_ColorGrading_nBuilderToneMapping(JNIEnv*, jclas
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_ColorGrading_nBuilderLuminanceScaling(JNIEnv*, jclass,
+        jlong nativeBuilder, jboolean luminanceScaling) {
+    ColorGrading::Builder* builder = (ColorGrading::Builder*) nativeBuilder;
+    builder->luminanceScaling(luminanceScaling);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_ColorGrading_nBuilderExposure(JNIEnv*, jclass,
         jlong nativeBuilder, jfloat exposure) {
     ColorGrading::Builder* builder = (ColorGrading::Builder*) nativeBuilder;

--- a/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ColorGrading.java
@@ -64,6 +64,7 @@ import static com.google.android.filament.Asserts.assertFloat4In;
  * <li>Saturation</li>
  * <li>Curves</li>
  * <li>Tone mapping</li>
+ * <li>Luminance scaling</li>
  * </ul>
  *
  * <h1>Defaults</h1>
@@ -81,6 +82,7 @@ import static com.google.android.filament.Asserts.assertFloat4In;
  * <li>Saturation: <code>1.0</code></li>
  * <li>Curves: gamma <code>{1,1,1}</code>, midPoint <code>{1,1,1}</code>, and scale <code>{1,1,1}</code></li>
  * <li>Tone mapping: {@link ToneMapping#ACES_LEGACY}</li>
+ * <li>Luminance scaling: false</li>
  * </ul>
  *
  * @see View
@@ -111,8 +113,8 @@ public class ColorGrading {
         ACES,
         /** Filmic tone mapping, modelled after ACES but applied in sRGB space. */
         FILMIC,
-        /** Exposure value invariant luminance scaling tone mapping, offers the best behaviors in high intensity areas. */
-        EVILS,
+        /** Reserved for future use. */
+        RESERVED,
         /** Reinhard luma-based tone mapping. */
         REINHARD,
         /** Tone mapping used to validate/debug scene exposure. */
@@ -170,6 +172,25 @@ public class ColorGrading {
          */
         public Builder toneMapping(ToneMapping toneMapping) {
             nBuilderToneMapping(mNativeBuilder, toneMapping.ordinal());
+            return this;
+        }
+
+        /**
+         * Enables or disables the luminance scaling component (LICH) from the exposure value
+         * invariant luminance system (EVILS). When this setting is enabled, pixels with high
+         * chromatic values will roll-off to white to offer a more natural rendering. This step
+         * also helps avoid undesirable hue skews caused by out of gamut colors clipped
+         * to the destination color gamut.
+         *
+         * When luminance scaling is enabled, tone mapping is performed on the luminance of each
+         * pixel instead of per-channel.
+         *
+         * @param luminanceScaling Enables or disables EVILS post-tone mapping
+         *
+         * @return This Builder, for chaining calls
+         */
+        public Builder luminanceScaling(boolean luminanceScaling) {
+            nBuilderLuminanceScaling(mNativeBuilder, luminanceScaling);
             return this;
         }
 
@@ -482,6 +503,7 @@ public class ColorGrading {
 
     private static native void nBuilderQuality(long nativeBuilder, int quality);
     private static native void nBuilderToneMapping(long nativeBuilder, int toneMapper);
+    private static native void nBuilderLuminanceScaling(long nativeBuilder, boolean luminanceScaling);
     private static native void nBuilderExposure(long nativeBuilder, float exposure);
     private static native void nBuilderWhiteBalance(long nativeBuilder, float temperature, float tint);
     private static native void nBuilderChannelMixer(long nativeBuilder, float[] outRed, float[] outGreen, float[] outBlue);

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -74,6 +74,7 @@ class FColorGrading;
  * - Saturation
  * - Curves
  * - Tone mapping
+ * - Luminance scaling
  *
  * Defaults
  * ========
@@ -90,6 +91,7 @@ class FColorGrading;
  * - Saturation: 1.0
  * - Curves: gamma {1,1,1}, midPoint {1,1,1}, and scale {1,1,1}
  * - Tone mapping: ACES_LEGACY
+ * - Luminance scaling: false
  *
  * @see View
  */
@@ -111,7 +113,7 @@ public:
         ACES_LEGACY   = 1,     //!< ACES tone mapping, with a brightness modifier to match Filament's legacy tone mapper
         ACES          = 2,     //!< ACES tone mapping
         FILMIC        = 3,     //!< Filmic tone mapping, modelled after ACES but applied in sRGB space
-        EVILS         = 4,     //!< Exposure value invariant luminance scaling tone mapping, offers the best behaviors in high intensity areas
+        RESERVED      = 4,     //!< Currently unused
         REINHARD      = 5,     //!< Reinhard luma-based tone mapping
         DISPLAY_RANGE = 6,     //!< Tone mapping used to validate/debug scene exposure
     };
@@ -153,6 +155,22 @@ public:
          * @return This Builder, for chaining calls
          */
         Builder& toneMapping(ToneMapping toneMapping) noexcept;
+
+        /**
+         * Enables or disables the luminance scaling component (LICH) from the exposure value
+         * invariant luminance system (EVILS). When this setting is enabled, pixels with high
+         * chromatic values will roll-off to white to offer a more natural rendering. This step
+         * also helps avoid undesirable hue skews caused by out of gamut colors clipped
+         * to the destination color gamut.
+         *
+         * When luminance scaling is enabled, tone mapping is performed on the luminance of each
+         * pixel instead of per-channel.
+         *
+         * @param luminanceScaling Enables or disables EVILS post-tone mapping
+         *
+         * @return This Builder, for chaining calls
+         */
+        Builder& luminanceScaling(bool luminanceScaling) noexcept;
 
         /**
          * Adjusts the exposure of this image. The exposure is specified in stops:

--- a/filament/src/ToneMapping.h
+++ b/filament/src/ToneMapping.h
@@ -67,8 +67,6 @@ float3 ACES(float3 x) noexcept;
 
 float3 ACES_Legacy(float3 x) noexcept;
 
-float3 EVILS(float3 x) noexcept;
-
 /**
  * Converts the input HDR RGB color into one of 16 debug colors that represent
  * the pixel's exposure. When the output is cyan, the input color represents

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -98,6 +98,7 @@ struct ColorGradingSettings {
     bool enabled = true;
     filament::ColorGrading::QualityLevel quality = filament::ColorGrading::QualityLevel::MEDIUM;
     ToneMapping toneMapping = ToneMapping::ACES_LEGACY;
+    bool luminanceScaling = false;
     float exposure = 0.0f;
     float temperature = 0.0f;
     float tint = 0.0f;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -186,7 +186,7 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ToneMapp
     else if (0 == compare(tokens[i], jsonChunk, "ACES_LEGACY")) { *out = ToneMapping::ACES_LEGACY; }
     else if (0 == compare(tokens[i], jsonChunk, "ACES")) { *out = ToneMapping::ACES; }
     else if (0 == compare(tokens[i], jsonChunk, "FILMIC")) { *out = ToneMapping::FILMIC; }
-    else if (0 == compare(tokens[i], jsonChunk, "EVILS")) { *out = ToneMapping::EVILS; }
+    else if (0 == compare(tokens[i], jsonChunk, "RESERVED")) { *out = ToneMapping::RESERVED; }
     else if (0 == compare(tokens[i], jsonChunk, "REINHARD")) { *out = ToneMapping::REINHARD; }
     else if (0 == compare(tokens[i], jsonChunk, "DISPLAY_RANGE")) { *out = ToneMapping::DISPLAY_RANGE; }
     else {
@@ -279,6 +279,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ColorGra
             i = parse(tokens, i + 1, jsonChunk, &out->quality);
         } else if (compare(tok, jsonChunk, "toneMapping") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->toneMapping);
+        } else if (compare(tok, jsonChunk, "luminanceScaling") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->luminanceScaling);
         } else if (compare(tok, jsonChunk, "exposure") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->exposure);
         } else if (compare(tok, jsonChunk, "temperature") == 0) {
@@ -980,6 +982,7 @@ ColorGrading* createColorGrading(const ColorGradingSettings& settings, Engine* e
         .saturation(settings.saturation)
         .curves(settings.gamma, settings.midPoint, settings.scale)
         .toneMapping(settings.toneMapping)
+        .luminanceScaling(settings.luminanceScaling)
         .build(*engine);
 }
 
@@ -1049,7 +1052,7 @@ static std::ostream& operator<<(std::ostream& out, ToneMapping in) {
         case ToneMapping::ACES_LEGACY: return out << "\"ACES_LEGACY\"";
         case ToneMapping::ACES: return out << "\"ACES\"";
         case ToneMapping::FILMIC: return out << "\"FILMIC\"";
-        case ToneMapping::EVILS: return out << "\"EVILS\"";
+        case ToneMapping::RESERVED: return out << "\"RESERVED\"";
         case ToneMapping::REINHARD: return out << "\"REINHARD\"";
         case ToneMapping::DISPLAY_RANGE: return out << "\"DISPLAY_RANGE\"";
     }
@@ -1089,6 +1092,7 @@ static std::ostream& operator<<(std::ostream& out, const ColorGradingSettings& i
         << "\"enabled\": " << to_string(in.enabled) << ",\n"
         << "\"quality\": " << (in.quality) << ",\n"
         << "\"toneMapping\": " << (in.toneMapping) << ",\n"
+        << "\"luminanceScaling\": " << (in.luminanceScaling) << ",\n"
         << "\"exposure\": " << (in.exposure) << ",\n"
         << "\"temperature\": " << (in.temperature) << ",\n"
         << "\"tint\": " << (in.tint) << ",\n"
@@ -1347,6 +1351,7 @@ bool ColorGradingSettings::operator==(const ColorGradingSettings &rhs) const {
     return enabled == rhs.enabled &&
             quality == rhs.quality &&
             toneMapping == rhs.toneMapping &&
+            luminanceScaling == rhs.luminanceScaling &&
             exposure == rhs.exposure &&
             temperature == rhs.temperature &&
             tint == rhs.tint &&

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -151,8 +151,9 @@ static void colorGradingUI(Settings& settings, float* rangePlot, float* curvePlo
 
         int toneMapping = (int) colorGrading.toneMapping;
         ImGui::Combo("Tone-mapping", &toneMapping,
-                "Linear\0ACES (legacy)\0ACES\0Filmic\0EVILS\0Reinhard\0Display Range\0\0");
+                "Linear\0ACES (legacy)\0ACES\0Filmic\0Reserved\0Reinhard\0Display Range\0\0");
         colorGrading.toneMapping = (decltype(colorGrading.toneMapping)) toneMapping;
+        ImGui::Checkbox("Luminance scaling", &colorGrading.luminanceScaling);
 
         ImGui::SliderFloat("Exposure", &colorGrading.exposure, -10.0f, 10.0f);
 

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -37,6 +37,7 @@ static const char* JSON_TEST_DEFAULTS = R"TXT(
             "enabled": true,
             "quality": "MEDIUM",
             "toneMapping": "ACES_LEGACY",
+            "luminanceScaling": false,
             "exposure": 0,
             "temperature": 0,
             "tint": 0,

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -716,7 +716,8 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::Indent();
             ImGui::Checkbox("Enabled##colorGrading", &params.colorGrading);
             ImGui::Combo("Tone-mapping", &colorGrading.toneMapping,
-                    "Linear\0ACES (legacy)\0ACES\0Filmic\0EVILS\0Reinhard\0Display Range\0\0");
+                    "Linear\0ACES (legacy)\0ACES\0Filmic\0Reserved\0Reinhard\0Display Range\0\0");
+            ImGui::Checkbox("Luminance scaling", &colorGrading.luminanceScaling);
             if (ImGui::CollapsingHeader("While balance")) {
                 ImGui::SliderInt("Temperature", &colorGrading.temperature, -100, 100);
                 ImGui::SliderInt("Tint", &colorGrading.tint, -100, 100);
@@ -984,6 +985,7 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
                     .saturation(options.saturation)
                     .curves(options.gamma, options.midPoint, options.scale)
                     .toneMapping(static_cast<ColorGrading::ToneMapping>(options.toneMapping))
+                    .luminanceScaling(options.luminanceScaling)
                     .build(*engine);
 
             if (g_colorGrading) {

--- a/samples/material_sandbox.h
+++ b/samples/material_sandbox.h
@@ -62,6 +62,7 @@ using namespace filament;
 
 struct ColorGradingOptions {
     int toneMapping = static_cast<int>(ColorGrading::ToneMapping::ACES_LEGACY);
+    bool luminanceScaling = false;
     int temperature = 0;
     int tint = 0;
     math::float3 outRed{1.0f, 0.0f, 0.0f};
@@ -88,6 +89,7 @@ struct ColorGradingOptions {
 
     bool operator==(const ColorGradingOptions &rhs) const {
         return toneMapping == rhs.toneMapping &&
+               luminanceScaling == rhs.luminanceScaling &&
                temperature == rhs.temperature &&
                outRed == rhs.outRed &&
                outGreen == rhs.outGreen &&

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -164,7 +164,7 @@ enum_<ColorGrading::ToneMapping>("ColorGrading$ToneMapping")
     .value("ACES_LEGACY", ColorGrading::ToneMapping::ACES_LEGACY)
     .value("ACES", ColorGrading::ToneMapping::ACES)
     .value("FILMIC", ColorGrading::ToneMapping::FILMIC)
-    .value("EVILS", ColorGrading::ToneMapping::EVILS)
+    .value("RESERVED", ColorGrading::ToneMapping::RESERVED)
     .value("REINHARD", ColorGrading::ToneMapping::REINHARD)
     .value("DISPLAY_RANGE", ColorGrading::ToneMapping::DISPLAY_RANGE);
 


### PR DESCRIPTION
Previously the luminance scaling step was tied to a specific tone mapping operator, called "EVILS" in the API. This was however somewhat misleading as EVILS really is a color handling system that's independent of what we call tone mapping.

This change splits the luminance scaling step from the tone mapping step, allowing the use of luminance scaling (the LICH part of EVILS) with any tone mapping operator.

As a result, the operator known as EVILS is currently mapped to the linear operator and renamed to "RESERVED" until it is replaced by a proper — configurable — operator.

Here is for instance the `ACES (Legacy)` operator without and with luminance scaling:

<img width="1509" alt="ACES" src="https://user-images.githubusercontent.com/869684/125709509-bf2fa3f2-8a46-4f31-9f8b-f0ac3cd220fb.png">
<img width="1509" alt="ACES Luminance Scaled" src="https://user-images.githubusercontent.com/869684/125709514-6e3d59d5-3319-481d-98c5-6d64f342cd76.png">

And the `Filmic` operator without and with luminance scaling:

<img width="1509" alt="Screen Shot 2021-07-14 at 5 24 16 PM" src="https://user-images.githubusercontent.com/869684/125709534-f3ba01de-0c8e-4610-b2b5-cf5433415108.png">
<img width="1509" alt="Screen Shot 2021-07-14 at 5 24 18 PM" src="https://user-images.githubusercontent.com/869684/125709541-37aef9c9-5981-4c68-ba10-17552c09698e.png">
