### PR TITLE
Metal: use private instead of memoryless textures for MSAA

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -930,11 +930,7 @@ id<MTLTexture> MetalRenderTarget::createMultisampledTexture(id<MTLDevice> device
     descriptor.textureType = MTLTextureType2DMultisample;
     descriptor.sampleCount = samples;
     descriptor.usage = MTLTextureUsageRenderTarget;
-#if defined(IOS)
-    descriptor.resourceOptions = MTLResourceStorageModeMemoryless;
-#else
     descriptor.resourceOptions = MTLResourceStorageModePrivate;
-#endif
 
     return [device newTextureWithDescriptor:descriptor];
 }


### PR DESCRIPTION
When a render pass contains too much geometry, `MTLResourceStorageModeMemoryless` fails. For now, we'll prioritize correctness over performance and always use the private storage mode.

Fixes #4202