### PR TITLE
Add bilateral threshold in SSAO options.

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -216,6 +216,7 @@ Java_com_google_android_filament_View_nGetAmbientOcclusion(JNIEnv*, jclass, jlon
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclass,
     jlong nativeView, jfloat radius, jfloat bias, jfloat power, jfloat resolution, jfloat intensity,
+    jfloat bilateralThreshold,
     jint quality, jint lowPassFilter, jint upsampling, jboolean enabled, jfloat minHorizonAngleRad) {
     View* view = (View*) nativeView;
     View::AmbientOcclusionOptions options = view->getAmbientOcclusionOptions();
@@ -224,6 +225,7 @@ Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclas
     options.bias = bias;
     options.resolution = resolution;
     options.intensity = intensity;
+    options.bilateralThreshold = bilateralThreshold;
     options.quality = (View::QualityLevel)quality;
     options.lowPassFilter = (View::QualityLevel)lowPassFilter;
     options.upsampling = (View::QualityLevel)upsampling;

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -170,6 +170,12 @@ public class View {
         public float intensity = 1.0f;
 
         /**
+         * Depth distance that constitute an edge for filtering. Must be positive.
+         * Default is 5mm.
+         */
+        public float bilateralThreshold = 0.005f;
+
+        /**
          * The quality setting controls the number of samples used for evaluating Ambient
          * occlusion. The default is QualityLevel.LOW which is sufficient for most mobile
          * applications.
@@ -1378,9 +1384,11 @@ public class View {
     public void setAmbientOcclusionOptions(@NonNull AmbientOcclusionOptions options) {
         mAmbientOcclusionOptions = options;
         nSetAmbientOcclusionOptions(getNativeObject(), options.radius, options.bias, options.power,
-                options.resolution, options.intensity, options.quality.ordinal(), options.lowPassFilter.ordinal(), options.upsampling.ordinal(),
+                options.resolution, options.intensity, options.bilateralThreshold,
+                options.quality.ordinal(), options.lowPassFilter.ordinal(), options.upsampling.ordinal(),
                 options.enabled, options.minHorizonAngleRad);
-        nSetSSCTOptions(getNativeObject(), options.ssctLightConeRad, options.ssctStartTraceDistance, options.ssctContactDistanceMax,  options.ssctIntensity,
+        nSetSSCTOptions(getNativeObject(), options.ssctLightConeRad, options.ssctStartTraceDistance,
+                options.ssctContactDistanceMax,  options.ssctIntensity,
                 options.ssctLightDirection[0], options.ssctLightDirection[1], options.ssctLightDirection[2],
                 options.ssctDepthBias, options.ssctDepthSlopeBias, options.ssctSampleCount,
                 options.ssctRayCount, options.ssctEnabled);
@@ -1555,7 +1563,7 @@ public class View {
     private static native boolean nIsFrontFaceWindingInverted(long nativeView);
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
-    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, int quality, int lowPassFilter, int upsampling, boolean enabled, float minHorizonAngleRad);
+    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, float bilateralThreshold, int quality, int lowPassFilter, int upsampling, boolean enabled, float minHorizonAngleRad);
     private static native void nSetSSCTOptions(long nativeView, float ssctLightConeRad, float ssctStartTraceDistance, float ssctContactDistanceMax, float ssctIntensity, float v, float v1, float v2, float ssctDepthBias, float ssctDepthSlopeBias, int ssctSampleCount, int ssctRayCount, boolean ssctEnabled);
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight,
             boolean lensFlare, boolean starburst, float chromaticAberration, int ghostCount, float ghostSpacing, float ghostThreshold, float haloThickness, float haloRadius, float haloThreshold);

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -283,6 +283,7 @@ public:
         float bias = 0.0005f;   //!< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
         float resolution = 0.5f;//!< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
         float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
+        float bilateralThreshold = 0.005f; //!< depth distance that constitute an edge for filtering
         QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
         QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
         QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -399,9 +399,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
     // (see en.wikipedia.org/wiki/Gaussian_filter)
     // More intuitively, 2q is the width of the filter in pixels.
     BilateralPassConfig config = {
-            // TODO: "bilateralThreshold" should be a user-settable parameter
-            //       z-distance that constitute an edge for bilateral filtering
-            .bilateralThreshold = 0.0625f
+            .bilateralThreshold = options.bilateralThreshold
     };
 
     float sampleCount{};

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -295,12 +295,13 @@ public:
 
     void setAmbientOcclusionOptions(AmbientOcclusionOptions options) noexcept {
         options.radius = math::max(0.0f, options.radius);
-        options.bias = math::clamp(options.bias, 0.0f, 0.1f);
         options.power = std::max(0.0f, options.power);
+        options.bias = math::clamp(options.bias, 0.0f, 0.1f);
         // snap to the closer of 0.5 or 1.0
         options.resolution = std::floor(
                 math::clamp(options.resolution * 2.0f, 1.0f, 2.0f) + 0.5f) * 0.5f;
         options.intensity = std::max(0.0f, options.intensity);
+        options.bilateralThreshold = std::max(0.0f, options.bilateralThreshold);
         options.minHorizonAngleRad = math::clamp(options.minHorizonAngleRad, 0.0f, math::f::PI_2);
         options.ssct.lightConeRad = math::clamp(options.ssct.lightConeRad, 0.0f, math::f::PI_2);
         options.ssct.shadowDistance = std::max(0.0f, options.ssct.shadowDistance);

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -389,6 +389,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
             i = parse(tokens, i + 1, jsonChunk, &out->resolution);
         } else if (compare(tok, jsonChunk, "intensity") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->intensity);
+        } else if (compare(tok, jsonChunk, "bilateralThreshold") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->bilateralThreshold);
         } else if (compare(tok, jsonChunk, "quality") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->quality);
         } else if (compare(tok, jsonChunk, "lowPassFilter") == 0) {
@@ -1138,6 +1140,7 @@ static std::ostream& operator<<(std::ostream& out, const AmbientOcclusionOptions
         << "\"bias\": " << (in.bias) << ",\n"
         << "\"resolution\": " << (in.resolution) << ",\n"
         << "\"intensity\": " << (in.intensity) << ",\n"
+        << "\"bilateralThreshold\": " << (in.bilateralThreshold) << ",\n"
         << "\"quality\": " << (in.quality) << ",\n"
         << "\"lowPassFilter\": " << (in.lowPassFilter) << ",\n"
         << "\"upsampling\": " << (in.upsampling) << ",\n"

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -364,7 +364,9 @@ value_object<filament::View::AmbientOcclusionOptions>("View$AmbientOcclusionOpti
     .field("bias", &filament::View::AmbientOcclusionOptions::bias)
     .field("resolution", &filament::View::AmbientOcclusionOptions::resolution)
     .field("intensity", &filament::View::AmbientOcclusionOptions::intensity)
+    .field("bilateralThreshold", &filament::View::AmbientOcclusionOptions::bilateralThreshold)
     .field("quality", &filament::View::AmbientOcclusionOptions::quality);
+    // TODO: ssct options
 
 value_object<filament::View::DepthOfFieldOptions>("View$DepthOfFieldOptions")
     .field("cocScale", &filament::View::DepthOfFieldOptions::cocScale)


### PR DESCRIPTION
This can have a dramatic effect on SSAO and needs 
to be adjusted based on the scene's scale/units.

The default value used to be about 6cm, and has 
been changed to 5mm.