### PR TITLE
associate sidecar MS buffer to its texture instead of RenderTarget

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -113,7 +113,8 @@ public:
             GLuint id = 0;          // texture or renderbuffer id
             GLenum target = 0;
             GLenum internalFormat = 0;
-            mutable GLsync fence = nullptr;
+            GLuint sidecarRenderBufferMS = 0;  // multi-sample sidecar renderbuffer
+            mutable GLsync fence = {};
 
             // texture parameters go here too
             GLfloat anisotropy = 1.0;
@@ -181,15 +182,10 @@ public:
     struct GLRenderTarget : public backend::HwRenderTarget {
         using HwRenderTarget::HwRenderTarget;
         struct GL {
-            struct RenderBuffer {
-                GLTexture* texture = nullptr;
-                mutable GLuint rb = 0;  // multi-sample sidecar renderbuffer
-                uint8_t level = 0; // level when attached to a texture
-            };
             // field ordering to optimize size on 64-bits
-            RenderBuffer color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
-            RenderBuffer depth;
-            RenderBuffer stencil;
+            GLTexture* color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
+            GLTexture* depth;
+            GLTexture* stencil;
             GLuint fbo = 0;
             mutable GLuint fbo_read = 0;
             mutable backend::TargetBufferFlags resolve = backend::TargetBufferFlags::NONE; // attachments in fbo_draw to resolve

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -78,6 +78,8 @@ size_t ResourceAllocator::TextureKey::getSize() const noexcept {
         // if we have mip-maps we assume the full pyramid
         size += size / 3;
     }
+    // TODO: this is not taking into account the potential sidecar MS buffer
+    //  but we have not way to know about its existence at this point.
     return size;
 }
 


### PR DESCRIPTION
this allows the sidecar buffer to have the same lifetime than the
texture it represents, and therefore participate to the caching of
that texture.

Fixes #4338