### PR TITLE
gltfio: fix AssetLoader leak, remove unwanted destructor.

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -46,8 +46,8 @@ struct AssetConfiguration {
     class filament::Engine* engine;
 
     //! Controls whether the loader uses filamat to generate materials on the fly, or loads a small
-    //! set of precompiled ubershader materials. See createMaterialGenerator() and
-    //! createUbershaderLoader().
+    //! set of precompiled ubershader materials. Deleting the MaterialProvider is the client's
+    //! responsibility. See createMaterialGenerator() and createUbershaderLoader().
     MaterialProvider* materials;
 
     //! Optional manager for associating string names with entities in the transform hierarchy.

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -102,11 +102,9 @@ struct FAssetLoader : public AssetLoader {
         FilamentInstance** instances, size_t numInstances);
     FilamentInstance* createInstance(FFilamentAsset* primary);
 
-    bool createAssets(const uint8_t* bytes, uint32_t numBytes, FilamentAsset** assets,
-            size_t numAssets);
-
-    ~FAssetLoader() {
-        delete mMaterials;
+    static void destroy(FAssetLoader** loader) noexcept {
+        delete *loader;
+        *loader = nullptr;
     }
 
     void destroyAsset(const FFilamentAsset* asset) {
@@ -1268,8 +1266,9 @@ AssetLoader* AssetLoader::create(const AssetConfiguration& config) {
 }
 
 void AssetLoader::destroy(AssetLoader** loader) {
-    delete *loader;
-    *loader = nullptr;
+    FAssetLoader* temp(upcast(*loader));
+    FAssetLoader::destroy(&temp);
+    *loader = temp;
 }
 
 FilamentAsset* AssetLoader::createAssetFromJson(uint8_t const* bytes, uint32_t nbytes) {


### PR DESCRIPTION
This fixes two bugs that combined in a way that prevented a double-free
error.

The destructor of the impl class for AssetLoader was never called, which
was sort of good, because it should not destroy the material provider.
The asset loader was never meant to have ownership over the provider.