### PR TITLE
Remove BufferUsage flag from createVertexBuffer driver API

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -167,8 +167,7 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
         uint8_t, bufferCount,
         uint8_t, attributeCount,
         uint32_t, vertexCount,
-        backend::AttributeArray, attributes,
-        backend::BufferUsage, usage)
+        backend::AttributeArray, attributes)
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -200,9 +200,7 @@ void MetalDriver::finish(int) {
 }
 
 void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
-        uint8_t attributeCount, uint32_t vertexCount, AttributeArray attributes,
-        BufferUsage usage) {
-    // TODO: Take BufferUsage into account when creating the buffer.
+        uint8_t attributeCount, uint32_t vertexCount, AttributeArray attributes) {
     construct_handle<MetalVertexBuffer>(vbh, *mContext, bufferCount,
             attributeCount, vertexCount, attributes);
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -399,8 +399,7 @@ void OpenGLDriver::createVertexBufferR(
         uint8_t bufferCount,
         uint8_t attributeCount,
         uint32_t elementCount,
-        AttributeArray attributes,
-        BufferUsage usage) {
+        AttributeArray attributes) {
     DEBUG_MARKER()
     construct<GLVertexBuffer>(vbh, bufferCount, attributeCount, elementCount, attributes);
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -412,8 +412,7 @@ void VulkanDriver::destroyRenderPrimitive(Handle<HwRenderPrimitive> rph) {
 }
 
 void VulkanDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t bufferCount,
-        uint8_t attributeCount, uint32_t elementCount, AttributeArray attributes,
-        BufferUsage usage) {
+        uint8_t attributeCount, uint32_t elementCount, AttributeArray attributes) {
     auto vertexBuffer = construct<VulkanVertexBuffer>(vbh, mContext, mStagePool,
             bufferCount, attributeCount, elementCount, attributes);
     mDisposer.createDisposable(vertexBuffer, [this, vbh] () {

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -55,8 +55,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
 
     const size_t size = sizeof(math::float2) * 3;
     mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, BufferUsage::STATIC);
-    mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes,
-            BufferUsage::STATIC);
+    mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes);
     mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
     BufferDescriptor vertexBufferDesc(gVertices, size, nullptr);
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -190,8 +190,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
     FEngine::DriverApi& driver = engine.getDriverApi();
 
     mHandle = driver.createVertexBuffer(
-            mBufferCount, attributeCount, mVertexCount, attributeArray,
-            backend::BufferUsage::STATIC);
+            mBufferCount, attributeCount, mVertexCount, attributeArray);
 
     // If buffer objects are not enabled at the API level, then we create them internally.
     if (!mBufferObjectsEnabled) {


### PR DESCRIPTION
`BufferUsage` is no longer needed as an argument to `createVertexBuffer`. Instead, usage can be set on the individual `BufferObject`s that make up the `VertexBuffer`.