### PR TITLE
Metal: take BufferUsage into account

### DIFF
--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -20,6 +20,8 @@
 #include "MetalContext.h"
 #include "MetalBufferPool.h"
 
+#include <backend/DriverEnums.h>
+
 #include <Metal/Metal.h>
 
 namespace filament {
@@ -29,7 +31,7 @@ namespace metal {
 class MetalBuffer {
 public:
 
-    MetalBuffer(MetalContext& context, size_t size, bool forceGpuBuffer = false);
+    MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, bool forceGpuBuffer = false);
     ~MetalBuffer();
 
     MetalBuffer(const MetalBuffer& rhs) = delete;

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -22,12 +22,12 @@ namespace filament {
 namespace backend {
 namespace metal {
 
-MetalBuffer::MetalBuffer(MetalContext& context, size_t size, bool forceGpuBuffer)
+MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, bool forceGpuBuffer)
         : mBufferSize(size), mContext(context) {
-    // If the buffer is less than 4K in size, we don't use an explicit buffer and instead use
-    // immediate command encoder methods like setVertexBytes:length:atIndex:.
-    // TODO: we shouldn't do this if the data persists for multiple uses.
-    if (size <= 4 * 1024 && !forceGpuBuffer) {   // 4K
+    // If the buffer is less than 4K in size and is updated frequently, we don't use an explicit
+    // buffer. Instead, we use immediate command encoder methods like setVertexBytes:length:atIndex:.
+    const bool dynamicUsage = usage == BufferUsage::DYNAMIC || usage == BufferUsage::STREAM;
+    if (size <= 4 * 1024 && dynamicUsage && !forceGpuBuffer) {
         mBufferPoolEntry = nullptr;
         mCpuBuffer = malloc(size);
     }

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -206,14 +206,14 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t buffer
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage) {
+        uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
-    construct_handle<MetalIndexBuffer>(ibh, *mContext, elementSize, indexCount);
+    construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage) {
-    construct_handle<MetalBufferObject>(boh, *mContext, byteCount);
+        BufferObjectBinding bindingType, BufferUsage usage) {
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount);
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -114,7 +114,7 @@ private:
 
 class MetalBufferObject : public HwBufferObject {
 public:
-    MetalBufferObject(MetalContext& context, uint32_t byteCount);
+    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }
@@ -131,7 +131,8 @@ struct MetalVertexBuffer : public HwVertexBuffer {
 };
 
 struct MetalIndexBuffer : public HwIndexBuffer {
-    MetalIndexBuffer(MetalContext& context, uint8_t elementSize, uint32_t indexCount);
+    MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
+            uint32_t indexCount);
 
     MetalBuffer buffer;
 };

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -267,8 +267,8 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
     }];
 }
 
-MetalBufferObject::MetalBufferObject(MetalContext& context, uint32_t byteCount)
-        : HwBufferObject(byteCount), buffer(context, byteCount) {}
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount)
+        : HwBufferObject(byteCount), buffer(context, usage, byteCount) {}
 
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     buffer.copyIntoBuffer(data, size, byteOffset);
@@ -280,8 +280,9 @@ MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
     buffers.resize(bufferCount);
 }
 
-MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, uint8_t elementSize, uint32_t indexCount)
-    : HwIndexBuffer(elementSize, indexCount), buffer(context, elementSize * indexCount, true) { }
+MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
+        uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
+        buffer(context, usage, elementSize * indexCount, true) { }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*
         indexBuffer) {


### PR DESCRIPTION
Only use CPU buffers for `DYNAMIC` or `STREAM` buffer usages.