### PR TITLE
Change back default AO's bilateral blur edge to 5cm

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -171,9 +171,13 @@ public class View {
 
         /**
          * Depth distance that constitute an edge for filtering. Must be positive.
-         * Default is 5mm.
+         * Default is 5cm.
+         * This must be adjusted with the scene's scale and/or units.
+         * A value too low will result in high frequency noise, while a value too high will
+         * result in the loss of geometry edges. For AO, it is generally better to be too
+         * blurry than not enough.
          */
-        public float bilateralThreshold = 0.005f;
+        public float bilateralThreshold = 0.05f;
 
         /**
          * The quality setting controls the number of samples used for evaluating Ambient

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -283,7 +283,7 @@ public:
         float bias = 0.0005f;   //!< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
         float resolution = 0.5f;//!< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
         float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
-        float bilateralThreshold = 0.005f; //!< depth distance that constitute an edge for filtering
+        float bilateralThreshold = 0.05f; //!< depth distance that constitute an edge for filtering
         QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
         QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
         QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality


### PR DESCRIPTION
Experimenting more with this, it seems better to be too blurry than
not enough for AO. The 5cm default seems to work better with more
scenes.