### PR TITLE
Metal/Vulkan: Fix reshaped image uploads with buffer padding or offsets

### DIFF
--- a/filament/backend/src/BackendUtils.cpp
+++ b/filament/backend/src/BackendUtils.cpp
@@ -343,7 +343,8 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
         case PixelDataType::UBYTE: {
             uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
             DataReshaper::reshape<uint8_t, 3, 4>(bytes, data.buffer, data.size);
-            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type, freeFunc);
+            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
+                    data.alignment, data.left, data.top, data.stride, freeFunc);
             reshaped = std::move(pbd);
             return true;
         }
@@ -352,7 +353,8 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
         case PixelDataType::HALF: {
             uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
             DataReshaper::reshape<uint16_t, 3, 4>(bytes, data.buffer, data.size);
-            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type, freeFunc);
+            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
+                    data.alignment, data.left, data.top, data.stride, freeFunc);
             reshaped = std::move(pbd);
             return true;
         }
@@ -360,14 +362,16 @@ bool reshape(const PixelBufferDescriptor& data, PixelBufferDescriptor& reshaped)
         case PixelDataType::UINT: {
             uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
             DataReshaper::reshape<uint32_t, 3, 4>(bytes, data.buffer, data.size);
-            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type, freeFunc);
+            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
+                    data.alignment, data.left, data.top, data.stride, freeFunc);
             reshaped = std::move(pbd);
             return true;
         }
         case PixelDataType::FLOAT: {
             uint8_t* bytes = (uint8_t*) malloc(reshapedSize);
             DataReshaper::reshape<float, 3, 4>(bytes, data.buffer, data.size);
-            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type, freeFunc);
+            PixelBufferDescriptor pbd(bytes, reshapedSize, reshapedFormat, data.type,
+                    data.alignment, data.left, data.top, data.stride, freeFunc);
             reshaped = std::move(pbd);
             return true;
         }

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -388,16 +388,14 @@ TEST_F(BackendTest, UpdateImage2D) {
     // TODO: Vulkan crashes with "Assertion failed: (offset + size <= allocationSize)"
     testCases.emplace_back("RGBA, UBYTE -> RGBA8 (with buffer padding)", PixelDataFormat::RGBA, PixelDataType::UBYTE, TextureFormat::RGBA8, 64u);
     testCases.emplace_back("RGBA, FLOAT -> RGBA16F (with buffer padding)", PixelDataFormat::RGBA, PixelDataType::FLOAT, TextureFormat::RGBA16F, 64u);
-    // TODO: Metal fails this one:
-    // testCases.emplace_back("RGB, FLOAT -> RGB32F (with buffer padding)", PixelDataFormat::RGB, PixelDataType::FLOAT, TextureFormat::RGB32F, 64u);
+    testCases.emplace_back("RGB, FLOAT -> RGB32F (with buffer padding)", PixelDataFormat::RGB, PixelDataType::FLOAT, TextureFormat::RGB32F, 64u);
 
     // Upload subregions separately.
     // TODO: Vulkan crashes with "Offsets not yet supported"
     testCases.emplace_back("RGBA, UBYTE -> RGBA8 (subregions)", PixelDataFormat::RGBA, PixelDataType::UBYTE, TextureFormat::RGBA8, 0u, true);
     testCases.emplace_back("RGBA, FLOAT -> RGBA16F (subregions)", PixelDataFormat::RGBA, PixelDataType::FLOAT, TextureFormat::RGBA16F, 0u, true);
     testCases.emplace_back("RGBA, UBYTE -> RGBA8 (subregions, buffer padding)", PixelDataFormat::RGBA, PixelDataType::UBYTE, TextureFormat::RGBA8, 64u, true);
-    // TODO: Metal fails this one:
-    // testCases.emplace_back("RGB, FLOAT -> RGB32F (subregions, buffer padding)", PixelDataFormat::RGB, PixelDataType::FLOAT, TextureFormat::RGB32F, 64u, true);
+    testCases.emplace_back("RGB, FLOAT -> RGB32F (subregions, buffer padding)", PixelDataFormat::RGB, PixelDataType::FLOAT, TextureFormat::RGB32F, 64u, true);
 
     // Test compresseed format upload.
 #ifndef IOS


### PR DESCRIPTION
When reshaping pixels, we need to make sure the new `PixelBufferDescriptor` has the same attributes, like stride, left, and top.