### PR TITLE
fix an issue where a sampler could fail to be updated

### DIFF
--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -74,7 +74,7 @@ public:
     void clean() const noexcept { mDirty.reset(); }
 
     // set sampler at given index
-    void setSampler(size_t index, Sampler const& sampler) noexcept;
+    void setSampler(size_t index, Sampler sampler) noexcept;
 
     inline void setSampler(size_t index, Handle<HwTexture> t, SamplerParams s)  {
         setSampler(index, { t, s });

--- a/filament/backend/src/SamplerGroup.cpp
+++ b/filament/backend/src/SamplerGroup.cpp
@@ -62,13 +62,10 @@ SamplerGroup& SamplerGroup::setSamplers(SamplerGroup const& rhs) noexcept {
     return *this;
 }
 
-void SamplerGroup::setSampler(size_t index, Sampler const& sampler) noexcept {
-    if (index < mBuffer.size()) {
-        auto& cur = mBuffer[index];
-        if (cur.t != sampler.t || cur.s.u != sampler.s.u) {
-            cur = sampler;
-            mDirty.set(index);
-        }
+void SamplerGroup::setSampler(size_t index, Sampler sampler) noexcept {
+    if (UTILS_LIKELY(index < mBuffer.size())) {
+        mBuffer[index] = sampler;
+        mDirty.set(index);
     }
 }
 


### PR DESCRIPTION
SamplerGroup was comparing texture handles to decide if a texture needed
to be updated, however, texture handles are (quickly) recycled and
therefore can't be used for that purpose. e.g. if a texture is destroyed,
its handle could be reused quickly by another texture, if that texture 
is now set on the SamplerGroup, it will ignore it, thinking it's not
different.