### PR TITLE
don't use Vulkan subpasses on Apple M1

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -138,6 +138,7 @@ void VulkanContext::selectPhysicalDevice() {
         //     0x1010 - ImgTec
         //     0x10DE - NVIDIA
         //     0x13B5 - ARM
+        //     0x106B - APPLE
         //     0x5143 - Qualcomm
         //     0x8086 - INTEL
         //

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -806,6 +806,13 @@ bool VulkanDriver::isRenderTargetFormatSupported(TextureFormat format) {
 }
 
 bool VulkanDriver::isFrameBufferFetchSupported() {
+    // TODO: We might need a better way to handle vendor-specific workaround
+    // Disable framebuffer fetch on APPLE M1 (vendor 0x106b, device 0xa140)
+    // Subpasses, don't seen to work on M1, this possibly needs more investigation.
+    VkPhysicalDeviceProperties const& deviceProperties = mContext.physicalDeviceProperties;
+    if ((deviceProperties.vendorID == 0x106b) && (deviceProperties.deviceID == 0xa140)) {
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
It looks like they are not working, at least with the current version
of the drivers and/or MoltenVK. It is not impossible that we have a
bug in how we set the subpasses as well. This will need more investigation
later.