### PR TITLE
Implement specular AO with screen space bent normals

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.11.3 (currently main branch)
 
+- engine: Option to automatically compute bent normals from SSAO & apply to specular AO
+  [⚠️ **Material breakage**].
+
 ## v1.11.2
 
 - engine: New API: `ColorGrading::Builder::toneMapper(const ToneMapper*)`.

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -217,7 +217,8 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclass,
     jlong nativeView, jfloat radius, jfloat bias, jfloat power, jfloat resolution, jfloat intensity,
     jfloat bilateralThreshold,
-    jint quality, jint lowPassFilter, jint upsampling, jboolean enabled, jfloat minHorizonAngleRad) {
+    jint quality, jint lowPassFilter, jint upsampling, jboolean enabled, jboolean bentNormals,
+    jfloat minHorizonAngleRad) {
     View* view = (View*) nativeView;
     View::AmbientOcclusionOptions options = view->getAmbientOcclusionOptions();
     options.radius = radius;
@@ -230,6 +231,7 @@ Java_com_google_android_filament_View_nSetAmbientOcclusionOptions(JNIEnv*, jclas
     options.lowPassFilter = (View::QualityLevel)lowPassFilter;
     options.upsampling = (View::QualityLevel)upsampling;
     options.enabled = (bool)enabled;
+    options.bentNormals = (bool)bentNormals;
     options.minHorizonAngleRad = minHorizonAngleRad;
     view->setAmbientOcclusionOptions(options);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -209,6 +209,11 @@ public class View {
         public boolean enabled = false;
 
         /**
+         * enables bent normals computation from AO, and specular AO
+         */
+        public boolean bentNormals = false;
+
+        /**
          * Minimal angle to consider in radian. This is used to reduce the creases that can
          * appear due to insufficiently tessellated geometry.
          * For e.g. a good values to try could be around 0.2.
@@ -1390,7 +1395,7 @@ public class View {
         nSetAmbientOcclusionOptions(getNativeObject(), options.radius, options.bias, options.power,
                 options.resolution, options.intensity, options.bilateralThreshold,
                 options.quality.ordinal(), options.lowPassFilter.ordinal(), options.upsampling.ordinal(),
-                options.enabled, options.minHorizonAngleRad);
+                options.enabled, options.bentNormals, options.minHorizonAngleRad);
         nSetSSCTOptions(getNativeObject(), options.ssctLightConeRad, options.ssctStartTraceDistance,
                 options.ssctContactDistanceMax,  options.ssctIntensity,
                 options.ssctLightDirection[0], options.ssctLightDirection[1], options.ssctLightDirection[2],
@@ -1567,7 +1572,7 @@ public class View {
     private static native boolean nIsFrontFaceWindingInverted(long nativeView);
     private static native void nSetAmbientOcclusion(long nativeView, int ordinal);
     private static native int nGetAmbientOcclusion(long nativeView);
-    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, float bilateralThreshold, int quality, int lowPassFilter, int upsampling, boolean enabled, float minHorizonAngleRad);
+    private static native void nSetAmbientOcclusionOptions(long nativeView, float radius, float bias, float power, float resolution, float intensity, float bilateralThreshold, int quality, int lowPassFilter, int upsampling, boolean enabled, boolean bentNormals, float minHorizonAngleRad);
     private static native void nSetSSCTOptions(long nativeView, float ssctLightConeRad, float ssctStartTraceDistance, float ssctContactDistanceMax, float ssctIntensity, float v, float v1, float v2, float ssctDepthBias, float ssctDepthSlopeBias, int ssctSampleCount, int ssctRayCount, boolean ssctEnabled);
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, float anamorphism, int levels, int blendMode, boolean threshold, boolean enabled, float highlight,
             boolean lensFlare, boolean starburst, float chromaticAberration, int ghostCount, float ghostSpacing, float ghostThreshold, float haloThickness, float haloRadius, float haloThreshold);

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -314,12 +314,17 @@ add_custom_command(
 add_custom_command(
         OUTPUT "${MATERIAL_DIR}/sao.filamat"
         DEPENDS src/materials/ssao/ssaoUtils.fs
+        DEPENDS src/materials/ssao/ssct.fs
+        DEPENDS src/materials/ssao/depthUtils.fs
+        DEPENDS src/materials/ssao/geometry.fs
+        DEPENDS src/materials/ssao/saoImpl.fs
+        DEPENDS src/materials/ssao/ssctImpl.fs
         APPEND
 )
 
 add_custom_command(
-        OUTPUT "${MATERIAL_DIR}/sao.filamat"
-        DEPENDS src/materials/ssao/ssct.fs
+        OUTPUT "${MATERIAL_DIR}/bilateralBlur.filamat"
+        DEPENDS src/materials/ssao/ssaoUtils.fs
         APPEND
 )
 

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -179,9 +179,11 @@ set(MATERIAL_SRCS
         src/materials/bloom/bloomDownsample.mat
         src/materials/bloom/bloomUpsample.mat
         src/materials/ssao/bilateralBlur.mat
+        src/materials/ssao/bilateralBlurBentNormals.mat
         src/materials/ssao/mipmapDepth.mat
         src/materials/skybox.mat
         src/materials/ssao/sao.mat
+        src/materials/ssao/saoBentNormals.mat
         src/materials/separableGaussianBlur.mat
         src/materials/antiAliasing/fxaa.mat
         src/materials/antiAliasing/taa.mat
@@ -323,7 +325,24 @@ add_custom_command(
 )
 
 add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/saoBentNormals.filamat"
+        DEPENDS src/materials/ssao/ssaoUtils.fs
+        DEPENDS src/materials/ssao/ssct.fs
+        DEPENDS src/materials/ssao/depthUtils.fs
+        DEPENDS src/materials/ssao/geometry.fs
+        DEPENDS src/materials/ssao/saoImpl.fs
+        DEPENDS src/materials/ssao/ssctImpl.fs
+        APPEND
+)
+
+add_custom_command(
         OUTPUT "${MATERIAL_DIR}/bilateralBlur.filamat"
+        DEPENDS src/materials/ssao/ssaoUtils.fs
+        APPEND
+)
+
+add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/bilateralBlurBentNormals.filamat"
         DEPENDS src/materials/ssao/ssaoUtils.fs
         APPEND
 )

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3026,7 +3026,7 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
             glFilterMode = GL_NEAREST;
         }
 
-        // note: for msaa RenderTargets withh non-msaa attachments, we copy from the msaa sidecar
+        // note: for msaa RenderTargets with non-msaa attachments, we copy from the msaa sidecar
         // buffer -- this should produce the same output that if we copied from the resolved
         // texture. EXT_multisampled_render_to_texture seems to allow both behaviours, and this
         // is an emulation of that.  We cannot use the resolved texture easily because it's not

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -288,6 +288,7 @@ public:
         QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
         QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality
         bool enabled = false;    //!< enables or disables screen-space ambient occlusion
+        bool bentNormals = false; //!< enables bent normals computation from AO, and specular AO
         float minHorizonAngleRad = 0.0f;  //!< min angle in radian to consider
         /**
          * Screen Space Cone Tracing (SSCT) options

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -467,6 +467,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                 data.ssao = builder.createTexture("SSAO Buffer", {
                         .width = desc.width,
                         .height = desc.height,
+                        .depth = 1,
+                        .type = Texture::Sampler::SAMPLER_2D_ARRAY,
                         .format = (lowPassFilterEnabled || highQualityUpsampling) ? TextureFormat::RGB8 : TextureFormat::R8
                 });
 
@@ -609,7 +611,11 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bilateralBlurPass(
                 data.input = builder.sample(input);
 
                 data.blurred = builder.createTexture("Blurred output", {
-                        .width = desc.width, .height = desc.height, .format = format });
+                        .width = desc.width,
+                        .height = desc.height,
+                        .depth = desc.depth,
+                        .type = desc.type,
+                        .format = format });
 
                 FrameGraphId<FrameGraphTexture> depth = fg.getBlackboard().get<FrameGraphTexture>("structure");
                 assert_invariant(depth);
@@ -619,7 +625,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bilateralBlurPass(
                 // We need to clear the buffers because we are skipping pixels at infinity (skybox)
                 data.blurred = builder.write(data.blurred, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 builder.declareRenderPass("Blurred target", {
-                        .attachments = { .color = { data.blurred }, . depth = depth },
+                        .attachments = { .color = { data.blurred }, .depth = depth },
                         .clearColor = { 1.0f },
                         .clearFlags = TargetBufferFlags::COLOR
                 });

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -152,6 +152,7 @@ private:
 
     struct BilateralPassConfig {
         uint8_t kernelSize = 11;
+        bool bentNormals = false;
         float standardDeviation = 1.0f;
         float bilateralThreshold = 0.0625f;
         float scale = 1.0f;

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -830,7 +830,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 // set samplers and uniforms
                 PostProcessManager& ppm = getEngine().getPostProcessManager();
                 view.prepareSSAO(data.ssao ?
-                        resources.getTexture(data.ssao) : ppm.getOneTexture());
+                        resources.getTexture(data.ssao) : ppm.getOneTextureArray());
 
                 // set shadow sampler
                 view.prepareShadow(data.shadows ?

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -682,10 +682,12 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
                          SamplerMagFilter::LINEAR : SamplerMagFilter::NEAREST
     });
 
-    const float edgeDistance = 1.0 / 0.0625;// TODO: don't hardcode this
+    const float edgeDistance = 1.0f / mAmbientOcclusionOptions.bilateralThreshold;
     auto& s = mPerViewUb.edit();
     s.aoSamplingQualityAndEdgeDistance =
             mAmbientOcclusionOptions.enabled && highQualitySampling ? edgeDistance : 0.0f;
+    s.aoBentNormals =
+            mAmbientOcclusionOptions.enabled && mAmbientOcclusionOptions.bentNormals ? 1.0f : 0.0f;
 }
 
 void FView::prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -432,6 +432,10 @@ public:
         } shadowmap;
         struct {
             bool enabled = true;
+            int sampleCount = 7;
+            int spiralTurns = 1;
+            int kernelSize = 23;
+            float stddev = 8.0f;
         } ssao;
         struct {
             bool camera_at_origin = true;

--- a/filament/src/materials/ssao/bilateralBlur.mat
+++ b/filament/src/materials/ssao/bilateralBlur.mat
@@ -2,7 +2,7 @@ material {
     name : bilateralBlur,
     parameters : [
         {
-            type : sampler2d,
+            type : sampler2dArray,
             name : ssao,
             precision: medium
         },
@@ -57,7 +57,7 @@ fragment {
 
     void tap(inout float sum, inout float totalWeight, float weight, float depth, vec2 position) {
         // ambient occlusion sample
-        vec3 data = textureLod(materialParams_ssao, position, 0.0).rgb;
+        vec3 data = textureLod(materialParams_ssao, vec3(position, 0.0), 0.0).rgb;
 
         // bilateral sample
         float bilateral = bilateralWeight(depth, unpack(data.gb));
@@ -69,7 +69,7 @@ fragment {
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy; // interpolated at pixel's center
 
-        vec3 data = textureLod(materialParams_ssao, uv, 0.0).rgb;
+        vec3 data = textureLod(materialParams_ssao, vec3(uv, 0.0), 0.0).rgb;
         if (data.g * data.b == 1.0) {
             // This is the skybox, skip
             postProcess.color.rgb = data;

--- a/filament/src/materials/ssao/bilateralBlur.mat
+++ b/filament/src/materials/ssao/bilateralBlur.mat
@@ -39,25 +39,19 @@ vertex {
 }
 
 fragment {
-    highp float unpack(highp vec2 depth) {
-        // depth here only has 8-bits of precision, but the unpacked depth is highp
-        // this is equivalent to (x8 * 256 + y8) / 65535, which gives a value between 0 and 1
-        return (depth.x * (256.0 / 257.0) + depth.y * (1.0 / 257.0));
-    }
+    #include "ssaoUtils.fs"
 
-    float random(const highp vec2 w) {
-        const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
-        return fract(m.z * fract(dot(w, m.xy)));
-    }
+    void dummy(){}
 
     float bilateralWeight(in highp float depth, in highp float sampleDepth) {
         float diff = (sampleDepth - depth) * materialParams.farPlaneOverEdgeDistance;
         return max(0.0, 1.0 - diff * diff);
     }
 
-    void tap(inout float sum, inout float totalWeight, float weight, float depth, vec2 position) {
+    void tap(const highp sampler2DArray saoTexture,
+            inout float sum, inout float totalWeight, float weight, float depth, vec2 position) {
         // ambient occlusion sample
-        vec3 data = textureLod(materialParams_ssao, vec3(position, 0.0), 0.0).rgb;
+        vec3 data = textureLod(saoTexture, vec3(position, 0.0), 0.0).rgb;
 
         // bilateral sample
         float bilateral = bilateralWeight(depth, unpack(data.gb));
@@ -85,8 +79,8 @@ fragment {
         vec2 offset = materialParams.axis;
         for (int i = 1; i < materialParams.sampleCount; i++) {
             float weight = materialParams.kernel[i];
-            tap(sum, totalWeight, weight, depth, uv + offset);
-            tap(sum, totalWeight, weight, depth, uv - offset);
+            tap(materialParams_ssao, sum, totalWeight, weight, depth, uv + offset);
+            tap(materialParams_ssao, sum, totalWeight, weight, depth, uv - offset);
             offset += materialParams.axis;
         }
 

--- a/filament/src/materials/ssao/bilateralBlurBentNormals.mat
+++ b/filament/src/materials/ssao/bilateralBlurBentNormals.mat
@@ -1,5 +1,5 @@
 material {
-    name : bilateralBlur,
+    name : bilateralBlurBentNormals,
     parameters : [
         {
             type : sampler2dArray,
@@ -22,6 +22,18 @@ material {
         {
             type : float[16],
             name : kernel
+        }
+    ],
+    outputs : [
+        {
+            name : aoData,
+            target : color,
+            type : float3
+        },
+        {
+            name : bnData,
+            target : color,
+            type : float3
         }
     ],
     variables : [
@@ -48,48 +60,76 @@ fragment {
         return max(0.0, 1.0 - diff * diff);
     }
 
-    void tap(const highp sampler2DArray saoTexture,
-            inout float sum, inout float totalWeight, float weight, float depth, vec2 position) {
-        // ambient occlusion sample
-        vec3 data = textureLod(saoTexture, vec3(position, 0.0), 0.0).rgb;
+    void tapAO(const highp sampler2DArray saoTexture, highp vec2 uv,
+            out float ao, out highp float sampleDepth) {
+        vec3 data = textureLod(saoTexture, vec3(uv, 0.0), 0.0).rgb;
+        ao = data.r;
+        sampleDepth = unpack(data.gb);
+    }
 
-        // bilateral sample
-        float bilateral = weight * bilateralWeight(depth, unpack(data.gb));
-        sum += data.r * bilateral;
-        totalWeight += bilateral;
+    void tapBN(const highp sampler2DArray saoTexture, highp vec2 uv,
+            out vec3 bentNormal) {
+        vec3 data = textureLod(saoTexture, vec3(uv, 1.0), 0.0).xyz;
+        bentNormal = unpackBentNormal(data);
     }
 
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy; // interpolated at pixel's center
 
+        float ao;
+        highp float depth;
+        highp float sampleDepth;
+        vec3 bn;
+
         vec3 data = textureLod(materialParams_ssao, vec3(uv, 0.0), 0.0).rgb;
+        ao = data.r;
+        depth = unpack(data.gb);
+
         if (data.g * data.b == 1.0) {
             // This is the skybox, skip
-            postProcess.color.rgb = data;
+            postProcess.aoData = data;
+            postProcess.bnData = vec3(0.0);
             return;
         }
 
+        tapBN(materialParams_ssao, uv, bn);
+
         // we handle the center pixel separately because it doesn't participate in
         // bilateral filtering
-        float depth = unpack(data.gb);
         float totalWeight = materialParams.kernel[0];
-        float sum = data.r * totalWeight;
+        float sumAO = ao * totalWeight;
+        vec3 sumBN = bn * totalWeight;
 
         vec2 offset = materialParams.axis;
         for (int i = 1; i < materialParams.sampleCount; i++) {
             float weight = materialParams.kernel[i];
-            tap(materialParams_ssao, sum, totalWeight, weight, depth, uv + offset);
-            tap(materialParams_ssao, sum, totalWeight, weight, depth, uv - offset);
+            float bilateral;
+
+            tapAO(materialParams_ssao, uv + offset, ao, sampleDepth);
+            bilateral = weight * bilateralWeight(depth, sampleDepth);
+            totalWeight += bilateral;
+            tapBN(materialParams_ssao, uv + offset, bn);
+            sumAO += ao * bilateral;
+            sumBN += bn * bilateral;
+
+            tapAO(materialParams_ssao, uv - offset, ao, sampleDepth);
+            bilateral = weight * bilateralWeight(depth, sampleDepth);
+            totalWeight += bilateral;
+            tapBN(materialParams_ssao, uv - offset, bn);
+            sumAO += ao * bilateral;
+            sumBN += bn * bilateral;
+
             offset += materialParams.axis;
         }
 
-        float ao = sum * (1.0 / totalWeight);
+        ao = sumAO * (1.0 / totalWeight);
+        bn = sumBN * (1.0 / totalWeight);
 
         // simple dithering helps a lot (assumes 8 bits target)
         // this is most useful with high quality/large blurs
         ao += ((random(gl_FragCoord.xy) - 0.5) / 255.0);
 
-        postProcess.color.r = ao;
-        postProcess.color.gb = data.gb;
+        postProcess.aoData = vec3(ao, data.gb);
+        postProcess.bnData = packBentNormal(bn);
     }
 }

--- a/filament/src/materials/ssao/depthUtils.fs
+++ b/filament/src/materials/ssao/depthUtils.fs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FILAMENT_MATERIALS_DEPTH_UTILS
+#define FILAMENT_MATERIALS_DEPTH_UTILS
+
+highp float linearizeDepth(highp float depth, highp float depthParams) {
+    // Our far plane is at infinity, which causes a division by zero below, which in turn
+    // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
+    // value representable in  a 24 bit depth buffer.
+    const float preventDiv0 = 1.0 / 16777216.0;
+    return depthParams / max(depth, preventDiv0);
+}
+
+highp float sampleDepth(const highp sampler2D depthTexture, const highp vec2 uv, float lod) {
+#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+    // On metal/vulkan, texture space is flipped vertically and we need to adjust the uv
+    // coordinates.
+    return textureLod(depthTexture, vec2(uv.x, 1.0 - uv.y), lod).r;
+#else
+    return textureLod(depthTexture, uv, lod).r;
+#endif
+}
+
+highp float sampleDepthLinear(const highp sampler2D depthTexture,
+        const highp vec2 uv, float lod, highp float depthParams) {
+    return linearizeDepth(sampleDepth(depthTexture, uv, lod), depthParams);
+}
+
+#endif // #define FILAMENT_MATERIALS_DEPTH_UTILS
+

--- a/filament/src/materials/ssao/geometry.fs
+++ b/filament/src/materials/ssao/geometry.fs
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FILAMENT_MATERIALS_GEOMETRY
+#define FILAMENT_MATERIALS_GEOMETRY
+
+#include "depthUtils.fs"
+
+// uv             : normalized coordinates
+// linearDepth    : linear depth at uv
+// positionParams : invProjection[0][0] * 2, invProjection[1][1] * 2
+//
+highp vec3 computeViewSpacePositionFromDepth(highp vec2 uv, highp float linearDepth,
+        highp vec2 positionParams) {
+    return vec3((0.5 - uv) * positionParams * linearDepth, linearDepth);
+}
+
+highp vec3 faceNormal(highp vec3 dpdx, highp vec3 dpdy) {
+    return normalize(cross(dpdx, dpdy));
+}
+
+// Compute normals using derivatives, which essentially results in half-resolution normals
+// this creates arifacts around geometry edges.
+// Note: when using the spirv optimizer, this results in much slower execution time because
+//       this whole expression is inlined in the AO loop below.
+highp vec3 computeViewSpaceNormalLowQ(const highp vec3 position) {
+    return faceNormal(dFdx(position), dFdy(position));
+}
+
+// Compute normals directly from the depth texture, resulting in full resolution normals
+// Note: This is actually as cheap as using derivatives because the texture fetches
+//       are essentially equivalent to textureGather (which we don't have on ES3.0),
+//       and this is executed just once.
+//
+// depthTexture   : the depth texture in reversed-Z
+// uv             : normalized coordinates
+// position       : view space position at uv
+// resolution     : width, height, 1/width, 1/height
+// positionParams : invProjection[0][0] * 2, invProjection[1][1] * 2
+// depthParams    : projection[3][2] / 2
+//
+highp vec3 computeViewSpaceNormalMediumQ(
+        const highp sampler2D depthTexture, const highp vec2 uv,
+        const highp vec3 position,
+        highp vec4 resolution, highp vec2 positionParams, highp float depthParams) {
+
+    precision highp float;
+
+    highp vec2 uvdx = uv + vec2(resolution.z, 0.0);
+    highp vec2 uvdy = uv + vec2(0.0, resolution.w);
+    vec3 px = computeViewSpacePositionFromDepth(uvdx,
+            sampleDepthLinear(depthTexture, uvdx, 0.0, depthParams), positionParams);
+    vec3 py = computeViewSpacePositionFromDepth(uvdy,
+            sampleDepthLinear(depthTexture, uvdy, 0.0, depthParams), positionParams);
+    vec3 dpdx = px - position;
+    vec3 dpdy = py - position;
+    return faceNormal(dpdx, dpdy);
+}
+
+// Accurate view-space normal reconstruction
+// Based on Yuwen Wu "Accurate Normal Reconstruction"
+// (https://atyuwen.github.io/posts/normal-reconstruction)
+//
+// depthTexture   : the depth texture in reversed-Z
+// uv             : normalized coordinates
+// depth          : linear depth at uv
+// position       : view space position at uv
+// resolution     : width, height, 1/width, 1/height
+// positionParams : invProjection[0][0] * 2, invProjection[1][1] * 2
+// depthParams    : projection[3][2] / 2
+//
+highp vec3 computeViewSpaceNormalHighQ(
+        const highp sampler2D depthTexture, const highp vec2 uv,
+        const highp float depth, const highp vec3 position,
+        highp vec4 resolution, highp vec2 positionParams, highp float depthParams) {
+
+    precision highp float;
+
+    vec3 pos_c = position;
+    highp vec2 dx = vec2(resolution.z, 0.0);
+    highp vec2 dy = vec2(0.0, resolution.w);
+
+    vec4 H;
+    H.x = sampleDepth(depthTexture, uv - dx, 0.0);
+    H.y = sampleDepth(depthTexture, uv + dx, 0.0);
+    H.z = sampleDepth(depthTexture, uv - dx * 2.0, 0.0);
+    H.w = sampleDepth(depthTexture, uv + dx * 2.0, 0.0);
+    vec2 he = abs((2.0 * H.xy - H.zw) - depth);
+    vec3 pos_l = computeViewSpacePositionFromDepth(uv - dx,
+            linearizeDepth(H.x, depthParams), positionParams);
+    vec3 pos_r = computeViewSpacePositionFromDepth(uv + dx,
+            linearizeDepth(H.y, depthParams), positionParams);
+    vec3 dpdx = (he.x < he.y) ? (pos_c - pos_l) : (pos_r - pos_c);
+
+    vec4 V;
+    V.x = sampleDepth(depthTexture, uv - dy, 0.0);
+    V.y = sampleDepth(depthTexture, uv + dy, 0.0);
+    V.z = sampleDepth(depthTexture, uv - dy * 2.0, 0.0);
+    V.w = sampleDepth(depthTexture, uv + dy * 2.0, 0.0);
+    vec2 ve = abs((2.0 * V.xy - V.zw) - depth);
+    vec3 pos_d = computeViewSpacePositionFromDepth(uv - dy,
+            linearizeDepth(V.x, depthParams), positionParams);
+    vec3 pos_u = computeViewSpacePositionFromDepth(uv + dy,
+            linearizeDepth(V.y, depthParams), positionParams);
+    vec3 dpdy = (ve.x < ve.y) ? (pos_c - pos_d) : (pos_u - pos_c);
+    return faceNormal(dpdx, dpdy);
+}
+
+// depthTexture   : the depth texture in reversed-Z
+// uv             : normalized coordinates
+// depth          : linear depth at uv
+// position       : view space position at uv
+// resolution     : width, height, 1/width, 1/height
+// positionParams : invProjection[0][0] * 2, invProjection[1][1] * 2
+// depthParams    : projection[3][2] / 2
+//
+highp vec3 computeViewSpaceNormal(
+        const highp sampler2D depthTexture, const highp vec2 uv,
+        const highp float depth, const highp vec3 position,
+        highp vec4 resolution, highp vec2 positionParams, highp float depthParams) {
+    // todo: maybe make this a quality parameter
+#if FILAMENT_QUALITY == FILAMENT_QUALITY_HIGH
+    vec3 normal = computeViewSpaceNormalHighQ(materialParams_depth, uv, depth, position,
+            resolution, positionParams, depthParams);
+#else
+    vec3 normal = computeViewSpaceNormalMediumQ(materialParams_depth, uv, position,
+            resolution, positionParams, depthParams);
+#endif
+    return normal;
+}
+
+#endif // FILAMENT_MATERIALS_GEOMETRY

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -135,226 +135,24 @@ vertex {
 }
 
 fragment {
+    #include "saoImpl.fs"
+    #include "ssctImpl.fs"
+    #include "geometry.fs"
     #include "ssaoUtils.fs"
-    #include "ssct.fs"
 
-    const float kLog2LodRate = 3.0;
-
-    vec2 sq(const vec2 a) {
-        return a * a;
-    }
-
-    vec2 pack(highp float depth) {
-        // we need 16-bits of precision
-        highp float z = clamp(depth * materialParams.invFarPlane, 0.0, 1.0);
-        highp float t = floor(256.0 * z);
-        mediump float hi = t * (1.0 / 256.0);   // we only need 8-bits of precision
-        mediump float lo = (256.0 * z) - t;     // we only need 8-bits of precision
-        return vec2(hi, lo);
-    }
-
-    // random number between 0 and 1, using interleaved gradient noise
-    float random(const highp vec2 w) {
-        const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
-        return fract(m.z * fract(dot(w, m.xy)));
-    }
-
-    // returns the frag coord in the GL convention with (0, 0) at the bottom-left
-    highp vec2 getFragCoord() {
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-        return vec2(gl_FragCoord.x, materialParams.resolution.y - gl_FragCoord.y);
-#else
-        return gl_FragCoord.xy;
-#endif
-    }
-
-    highp vec3 computeViewSpacePositionFromDepth(highp vec2 uv, highp float linearDepth) {
-        return vec3((0.5 - uv) * materialParams.positionParams.xy * linearDepth, linearDepth);
-    }
-
-    highp vec3 faceNormal(highp vec3 dpdx, highp vec3 dpdy) {
-        return normalize(cross(dpdx, dpdy));
-    }
-
-    // Compute normals using derivatives, which essentially results in half-resolution normals
-    // this creates arifacts around geometry edges.
-    // Note: when using the spirv optimizer, this results in much slower execution time because
-    //       this whole expression is inlined in the AO loop below.
-    highp vec3 computeViewSpaceNormal(const highp vec3 position) {
-        return faceNormal(dFdx(position), dFdy(position));
-    }
-
-    // Compute normals directly from the depth texture, resulting in full resolution normals
-    // Note: This is actually as cheap as using derivatives because the texture fetches
-    //       are essentially equivalent to textureGather (which we don't have on ES3.0),
-    //       and this is executed just once.
-    highp vec3 computeViewSpaceNormal(const highp vec3 position, const highp vec2 uv) {
-        precision highp float;
-        highp vec2 uvdx = uv + vec2(materialParams.resolution.z, 0.0);
-        highp vec2 uvdy = uv + vec2(0.0, materialParams.resolution.w);
-        vec3 px = computeViewSpacePositionFromDepth(uvdx,
-                sampleDepthLinear(materialParams_depth, uvdx, 0.0, materialParams.depthParams));
-        vec3 py = computeViewSpacePositionFromDepth(uvdy,
-                sampleDepthLinear(materialParams_depth, uvdy, 0.0, materialParams.depthParams));
-        vec3 dpdx = px - position;
-        vec3 dpdy = py - position;
-        return faceNormal(dpdx, dpdy);
-    }
-
-    // Accurate view-space normal reconstruction
-    // Based on Yuwen Wu "Accurate Normal Reconstruction"
-    // (https://atyuwen.github.io/posts/normal-reconstruction)
-    highp vec3 computeViewSpaceNormalAccurate(const highp float depth, const highp vec3 position, const highp vec2 uv) {
-        precision highp float;
-
-        vec3 pos_c = position;
-        highp vec2 dx = vec2(materialParams.resolution.z, 0.0);
-        highp vec2 dy = vec2(0.0, materialParams.resolution.w);
-
-        vec4 H;
-        H.x = sampleDepth(materialParams_depth, uv - dx, 0.0);
-        H.y = sampleDepth(materialParams_depth, uv + dx, 0.0);
-        H.z = sampleDepth(materialParams_depth, uv - dx * 2.0, 0.0);
-        H.w = sampleDepth(materialParams_depth, uv + dx * 2.0, 0.0);
-        vec2 he = abs((2.0 * H.xy - H.zw) - depth);
-        vec3 pos_l = computeViewSpacePositionFromDepth(uv - dx, linearizeDepth(H.x, materialParams.depthParams));
-        vec3 pos_r = computeViewSpacePositionFromDepth(uv + dx, linearizeDepth(H.y, materialParams.depthParams));
-        vec3 dpdx = (he.x < he.y) ? (pos_c - pos_l) : (pos_r - pos_c);
-
-        vec4 V;
-        V.x = sampleDepth(materialParams_depth, uv - dy, 0.0);
-        V.y = sampleDepth(materialParams_depth, uv + dy, 0.0);
-        V.z = sampleDepth(materialParams_depth, uv - dy * 2.0, 0.0);
-        V.w = sampleDepth(materialParams_depth, uv + dy * 2.0, 0.0);
-        vec2 ve = abs((2.0 * V.xy - V.zw) - depth);
-        vec3 pos_d = computeViewSpacePositionFromDepth(uv - dy, linearizeDepth(V.x, materialParams.depthParams));
-        vec3 pos_u = computeViewSpacePositionFromDepth(uv + dy, linearizeDepth(V.y, materialParams.depthParams));
-        vec3 dpdy = (ve.x < ve.y) ? (pos_c - pos_d) : (pos_u - pos_c);
-        return faceNormal(dpdx, dpdy);
-    }
-
-    // Ambient Occlusion, largely inspired from:
-    // "The Alchemy Screen-Space Ambient Obscurance Algorithm" by Morgan McGuire
-    // "Scalable Ambient Obscurance" by Morgan McGuire, Michael Mara and David Luebke
-
-    vec3 tapLocation(float i, const float noise) {
-        float offset = ((2.0 * PI) * 2.4) * noise;
-        float angle = ((i * materialParams.sampleCount.y) * materialParams.spiralTurns) * (2.0 * PI) + offset;
-        float radius = (i + noise + 0.5) * materialParams.sampleCount.y;
-        return vec3(cos(angle), sin(angle), radius * radius);
-    }
-
-    highp vec2 startPosition(const float noise) {
-        float angle = ((2.0 * PI) * 2.4) * noise;
-        return vec2(cos(angle), sin(angle));
-    }
-
-    highp mat2 tapAngleStep() {
-        highp vec2 t = materialParams.angleIncCosSin;
-        return mat2(t.x, t.y, -t.y, t.x);
-    }
-
-    vec3 tapLocationFast(float i, vec2 p, const float noise) {
-        float radius = (i + noise + 0.5) * materialParams.sampleCount.y;
-        return vec3(p, radius * radius);
-    }
-
-
-    void computeAmbientOcclusionSAO(inout float occlusion, float i, float ssDiskRadius,
-            const highp vec2 uv,  const highp vec3 origin, const vec3 normal,
-            const vec2 tapPosition, const float noise) {
-
-        vec3 tap = tapLocationFast(i, tapPosition, noise);
-
-        float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
-
-        vec2 uvSamplePos = uv + vec2(ssRadius * tap.xy) * materialParams.resolution.zw;
-
-        float level = clamp(floor(log2(ssRadius)) - kLog2LodRate, 0.0, float(materialParams.maxLevel));
-        highp float occlusionDepth = sampleDepthLinear(materialParams_depth, uvSamplePos, level, materialParams.depthParams);
-        highp vec3 p = computeViewSpacePositionFromDepth(uvSamplePos, occlusionDepth);
-
-        // now we have the sample, compute AO
-        highp vec3 v = p - origin;  // sample vector
-        float vv = dot(v, v);       // squared distance
-        float vn = dot(v, normal);  // distance * cos(v, normal)
-
-        // discard samples that are outside of the radius, preventing distant geometry to
-        // cast shadows -- there are many functions that work and choosing one is an artistic
-        // decision.
-        float w = sq(max(0.0, 1.0 - vv * materialParams.invRadiusSquared));
-
-        // discard samples that are too close to the horizon to reduce shadows cast by geometry
-        // not sufficently tessellated. The goal is to discard samples that form an angle 'beta'
-        // smaller than 'epsilon' with the horizon. We already have dot(v,n) which is equal to the
-        // sin(beta) * |v|. So the test simplifies to vn^2 < vv * sin(epsilon)^2.
-        w *= step(vv * materialParams.minHorizonAngleSineSquared, vn * vn);
-
-        occlusion += w * max(0.0, vn + origin.z * materialParams.bias) / (vv + materialParams.peak2);
-    }
-
-    float scalableAmbientObscurance(highp vec2 uv, highp vec3 origin, vec3 normal) {
-        float noise = random(getFragCoord());
-        highp vec2 tapPosition = startPosition(noise);
-        highp mat2 angleStep = tapAngleStep();
-
-        // Choose the screen-space sample radius
-        // proportional to the projected area of the sphere
-        float ssDiskRadius = -(materialParams.projectionScaleRadius / origin.z);
-
-        float occlusion = 0.0;
-        for (float i = 0.0; i < materialParams.sampleCount.x; i += 1.0) {
-            computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, tapPosition, noise);
-            tapPosition = angleStep * tapPosition;
-        }
-        return sqrt(occlusion * materialParams.intensity);
-    }
-
-    float dominantLightShadowing(highp vec2 uv, highp vec3 origin, vec3 normal) {
-        ConeTraceSetup cone;
-
-        cone.ssStartPos = uv * materialParams.resolution.xy;
-        cone.vsStartPos = origin;
-        cone.vsNormal = normal;
-
-        cone.vsConeDirection = materialParams.ssctVsLightDirection;
-        cone.shadowDistance = materialParams.ssctShadowDistance;
-        cone.coneAngleTangeant = materialParams.ssctConeAngleTangeant;
-        cone.contactDistanceMaxInv = materialParams.ssctContactDistanceMaxInv;
-
-        cone.screenFromViewMatrix = materialParams.screenFromViewMatrix;
-        cone.depthParams = materialParams.depthParams;
-        cone.projectionScale = materialParams.projectionScale;
-        cone.resolution = materialParams.resolution;
-        cone.maxLevel = float(materialParams.maxLevel);
-
-        cone.intensity = materialParams.ssctIntensity;
-        cone.depthBias = materialParams.ssctDepthBias.x;
-        cone.slopeScaledDepthBias = materialParams.ssctDepthBias.y;
-        cone.sampleCount = materialParams.ssctSampleCount;
-
-        float occlusion = 0.0;
-        for (float i = 1.0; i <= materialParams.ssctRayCount.x; i += 1.0) {
-            cone.jitterOffset.x = random(getFragCoord() * i) * 2.0 - 1.0;      // direction
-            cone.jitterOffset.y = random(getFragCoord() * i * vec2(3, 11));    // step
-            occlusion += coneTraceOcclusion(cone, materialParams_depth);
-        }
-        return occlusion * materialParams.ssctRayCount.y;
-    }
+    void dummy(){}
 
     void postProcess(inout PostProcessInputs postProcess) {
         highp vec2 uv = variable_vertex.xy; // interpolated to pixel center
 
         highp float depth = sampleDepth(materialParams_depth, uv, 0.0);
         highp float z = linearizeDepth(depth, materialParams.depthParams);
-        highp vec3 origin = computeViewSpacePositionFromDepth(uv, z);
+        highp vec3 origin = computeViewSpacePositionFromDepth(uv, z, materialParams.positionParams);
 
-        // todo: maybe make this a quality parameter of SSAO
-        #if FILAMENT_QUALITY == FILAMENT_QUALITY_HIGH
-            vec3 normal = computeViewSpaceNormalAccurate(depth, origin, uv);
-        #else
-            vec3 normal = computeViewSpaceNormal(origin, uv);
-        #endif
+        vec3 normal = computeViewSpaceNormal(materialParams_depth, uv, depth, origin,
+                materialParams.resolution,
+                materialParams.positionParams,
+                materialParams.depthParams);
 
         float occlusion = 0.0;
 
@@ -374,6 +172,6 @@ fragment {
         aoVisibility += gl_FragCoord.x * MEDIUMP_FLT_MIN;
 #endif
 
-        postProcess.color.rgb = vec3(aoVisibility, pack(origin.z));
+        postProcess.color.rgb = vec3(aoVisibility, pack(origin.z * materialParams.invFarPlane));
     }
 }

--- a/filament/src/materials/ssao/saoBentNormals.mat
+++ b/filament/src/materials/ssao/saoBentNormals.mat
@@ -1,5 +1,5 @@
 material {
-    name : sao,
+    name : saoBentNormals,
     parameters : [
         {
             type : sampler2d,
@@ -114,6 +114,18 @@ material {
             name : ssctSampleCount
         }
     ],
+    outputs : [
+        {
+            name : aoData,
+            target : color,
+            type : float3
+        },
+        {
+            name : bnData,
+            target : color,
+            type : float3
+        }
+    ],
     variables : [
          vertex
     ],
@@ -136,7 +148,7 @@ vertex {
 
 fragment {
 
-#define COMPUTE_BENT_NORMAL 0
+#define COMPUTE_BENT_NORMAL 1
 
     #include "saoImpl.fs"
     #include "ssctImpl.fs"
@@ -158,7 +170,7 @@ fragment {
                 materialParams.depthParams);
 
         float occlusion = 0.0;
-        vec3 bentNormal; // will be discarded
+        vec3 bentNormal = normal;
 
         if (materialParams.intensity > 0.0) {
             scalableAmbientObscurance(occlusion, bentNormal, uv, origin, normal);
@@ -176,6 +188,10 @@ fragment {
         aoVisibility += gl_FragCoord.x * MEDIUMP_FLT_MIN;
 #endif
 
-        postProcess.color.rgb = vec3(aoVisibility, pack(origin.z * materialParams.invFarPlane));
+        // transform to world space (we're guaranteed the view matrix is a rigid body transform)
+        vec3 bn = mat3(getWorldFromViewMatrix()) * bentNormal;
+
+        postProcess.aoData = vec3(aoVisibility, pack(origin.z * materialParams.invFarPlane));
+        postProcess.bnData = packBentNormal(bn);
     }
 }

--- a/filament/src/materials/ssao/saoImpl.fs
+++ b/filament/src/materials/ssao/saoImpl.fs
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This is our implementation of SAO -- it's not standalone because it uses materialParams
+ * directly. Therefore it must be included in *.mat file that has all these parameters.
+ * The main reason for using a separate file is to be able to have several version of the
+ * code with only minor changes.
+ */
+
+#include "ssaoUtils.fs"
+#include "geometry.fs"
+
+const float kLog2LodRate = 3.0;
+
+// Ambient Occlusion, largely inspired from:
+// "The Alchemy Screen-Space Ambient Obscurance Algorithm" by Morgan McGuire
+// "Scalable Ambient Obscurance" by Morgan McGuire, Michael Mara and David Luebke
+
+vec3 tapLocation(float i, const float noise) {
+    float offset = ((2.0 * PI) * 2.4) * noise;
+    float angle = ((i * materialParams.sampleCount.y) * materialParams.spiralTurns) * (2.0 * PI) + offset;
+    float radius = (i + noise + 0.5) * materialParams.sampleCount.y;
+    return vec3(cos(angle), sin(angle), radius * radius);
+}
+
+highp vec2 startPosition(const float noise) {
+    float angle = ((2.0 * PI) * 2.4) * noise;
+    return vec2(cos(angle), sin(angle));
+}
+
+highp mat2 tapAngleStep() {
+    highp vec2 t = materialParams.angleIncCosSin;
+    return mat2(t.x, t.y, -t.y, t.x);
+}
+
+vec3 tapLocationFast(float i, vec2 p, const float noise) {
+    float radius = (i + noise + 0.5) * materialParams.sampleCount.y;
+    return vec3(p, radius * radius);
+}
+
+void computeAmbientOcclusionSAO(inout float occlusion, float i, float ssDiskRadius,
+        const highp vec2 uv,  const highp vec3 origin, const vec3 normal,
+        const vec2 tapPosition, const float noise) {
+
+    vec3 tap = tapLocationFast(i, tapPosition, noise);
+
+    float ssRadius = max(1.0, tap.z * ssDiskRadius); // at least 1 pixel screen-space radius
+
+    vec2 uvSamplePos = uv + vec2(ssRadius * tap.xy) * materialParams.resolution.zw;
+
+    float level = clamp(floor(log2(ssRadius)) - kLog2LodRate, 0.0, float(materialParams.maxLevel));
+    highp float occlusionDepth = sampleDepthLinear(materialParams_depth, uvSamplePos, level, materialParams.depthParams);
+    highp vec3 p = computeViewSpacePositionFromDepth(uvSamplePos, occlusionDepth, materialParams.positionParams);
+
+    // now we have the sample, compute AO
+    highp vec3 v = p - origin;  // sample vector
+    float vv = dot(v, v);       // squared distance
+    float vn = dot(v, normal);  // distance * cos(v, normal)
+
+    // discard samples that are outside of the radius, preventing distant geometry to
+    // cast shadows -- there are many functions that work and choosing one is an artistic
+    // decision.
+    float w = sq(max(0.0, 1.0 - vv * materialParams.invRadiusSquared));
+
+    // discard samples that are too close to the horizon to reduce shadows cast by geometry
+    // not sufficently tessellated. The goal is to discard samples that form an angle 'beta'
+    // smaller than 'epsilon' with the horizon. We already have dot(v,n) which is equal to the
+    // sin(beta) * |v|. So the test simplifies to vn^2 < vv * sin(epsilon)^2.
+    w *= step(vv * materialParams.minHorizonAngleSineSquared, vn * vn);
+
+    occlusion += w * max(0.0, vn + origin.z * materialParams.bias) / (vv + materialParams.peak2);
+}
+
+float scalableAmbientObscurance(highp vec2 uv, highp vec3 origin, vec3 normal) {
+    float noise = random(getFragCoord(materialParams.resolution));
+    highp vec2 tapPosition = startPosition(noise);
+    highp mat2 angleStep = tapAngleStep();
+
+    // Choose the screen-space sample radius
+    // proportional to the projected area of the sphere
+    float ssDiskRadius = -(materialParams.projectionScaleRadius / origin.z);
+
+    float occlusion = 0.0;
+    for (float i = 0.0; i < materialParams.sampleCount.x; i += 1.0) {
+        computeAmbientOcclusionSAO(occlusion, i, ssDiskRadius, uv, origin, normal, tapPosition, noise);
+        tapPosition = angleStep * tapPosition;
+    }
+    return sqrt(occlusion * materialParams.intensity);
+}

--- a/filament/src/materials/ssao/ssaoUtils.fs
+++ b/filament/src/materials/ssao/ssaoUtils.fs
@@ -1,27 +1,54 @@
-#ifndef MATERIALS_SSAO_UTILS
-#define MATERIALS_SSAO_UTILS
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-highp float linearizeDepth(highp float depth, highp float depthParams) {
-    // Our far plane is at infinity, which causes a division by zero below, which in turn
-    // causes some issues on some GPU. We workaround it by replacing "infinity" by the closest
-    // value representable in  a 24 bit depth buffer.
-    const float preventDiv0 = 1.0 / 16777216.0;
-    return depthParams / max(depth, preventDiv0);
+#ifndef FILAMENT_MATERIALS_SSAO_UTILS
+#define FILAMENT_MATERIALS_SSAO_UTILS
+
+#include "depthUtils.fs"
+
+// random number between 0 and 1, using interleaved gradient noise
+float random(const highp vec2 w) {
+    const vec3 m = vec3(0.06711056, 0.00583715, 52.9829189);
+    return fract(m.z * fract(dot(w, m.xy)));
 }
 
-highp float sampleDepth(const highp sampler2D depthTexture, const highp vec2 uv, float lod) {
+// returns the frag coord in the GL convention with (0, 0) at the bottom-left
+// resolution : width, height, 1/width, 1/height
+highp vec2 getFragCoord(const highp vec4 resolution) {
 #if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    // On metal/vulkan, texture space is flipped vertically and we need to adjust the uv
-    // coordinates.
-    return textureLod(depthTexture, vec2(uv.x, 1.0 - uv.y), lod).r;
+    return vec2(gl_FragCoord.x, resolution.y - gl_FragCoord.y);
 #else
-    return textureLod(depthTexture, uv, lod).r;
+    return gl_FragCoord.xy;
 #endif
 }
 
-highp float sampleDepthLinear(const highp sampler2D depthTexture, const highp vec2 uv, float lod, highp float depthParams) {
-    return linearizeDepth(sampleDepth(depthTexture, uv, lod), depthParams);
+vec2 pack(highp float normalizedDepth) {
+    // we need 16-bits of precision
+    highp float z = clamp(normalizedDepth, 0.0, 1.0);
+    highp float t = floor(256.0 * z);
+    mediump float hi = t * (1.0 / 256.0);   // we only need 8-bits of precision
+    mediump float lo = (256.0 * z) - t;     // we only need 8-bits of precision
+    return vec2(hi, lo);
 }
 
-#endif // MATERIALS_SSAO_UTILS
+highp float unpack(highp vec2 depth) {
+    // depth here only has 8-bits of precision, but the unpacked depth is highp
+    // this is equivalent to (x8 * 256 + y8) / 65535, which gives a value between 0 and 1
+    return (depth.x * (256.0 / 257.0) + depth.y * (1.0 / 257.0));
+}
+
+#endif // FILAMENT_MATERIALS_SSAO_UTILS
 

--- a/filament/src/materials/ssao/ssaoUtils.fs
+++ b/filament/src/materials/ssao/ssaoUtils.fs
@@ -50,5 +50,14 @@ highp float unpack(highp vec2 depth) {
     return (depth.x * (256.0 / 257.0) + depth.y * (1.0 / 257.0));
 }
 
+vec3 packBentNormal(vec3 bn) {
+    return bn * 0.5 + 0.5;
+}
+
+vec3 unpackBentNormal(vec3 bn) {
+    return bn * 2.0 - 1.0;
+}
+
+
 #endif // FILAMENT_MATERIALS_SSAO_UTILS
 

--- a/filament/src/materials/ssao/ssct.fs
+++ b/filament/src/materials/ssao/ssct.fs
@@ -1,4 +1,23 @@
 /*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FILAMENT_MATERIALS_SSCT
+#define FILAMENT_MATERIALS_SSCT
+
+/*
  * Largely based on "Dominant Light Shadowing"
  * "Lighting Technology of The Last of Us Part II" by Hawar Doghramachi, Naughty Dog, LLC
  */
@@ -118,3 +137,19 @@ float coneTraceOcclusion(in ConeTraceSetup setup, const highp sampler2D depthTex
     }
     return occlusion * setup.intensity;
 }
+
+float ssctDominantLightShadowing(highp vec2 uv, highp vec3 origin, vec3 normal,
+        const highp sampler2D depthTexture, const highp vec2 fragCoord,
+        vec2 rayCount, ConeTraceSetup cone) {
+
+    float occlusion = 0.0;
+    for (float i = 1.0; i <= rayCount.x; i += 1.0) {
+        cone.jitterOffset.x = random(fragCoord * i) * 2.0 - 1.0;      // direction
+        cone.jitterOffset.y = random(fragCoord * i * vec2(3, 11));    // step
+        occlusion += coneTraceOcclusion(cone, depthTexture);
+    }
+    return occlusion * rayCount.y;
+}
+
+
+#endif // FILAMENT_MATERIALS_SSCT

--- a/filament/src/materials/ssao/ssctImpl.fs
+++ b/filament/src/materials/ssao/ssctImpl.fs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ssct.fs"
+
+float dominantLightShadowing(highp vec2 uv, highp vec3 origin, vec3 normal) {
+    ConeTraceSetup cone;
+
+    cone.ssStartPos = uv * materialParams.resolution.xy;
+    cone.vsStartPos = origin;
+    cone.vsNormal = normal;
+
+    cone.vsConeDirection = materialParams.ssctVsLightDirection;
+    cone.shadowDistance = materialParams.ssctShadowDistance;
+    cone.coneAngleTangeant = materialParams.ssctConeAngleTangeant;
+    cone.contactDistanceMaxInv = materialParams.ssctContactDistanceMaxInv;
+
+    cone.screenFromViewMatrix = materialParams.screenFromViewMatrix;
+    cone.depthParams = materialParams.depthParams;
+    cone.projectionScale = materialParams.projectionScale;
+    cone.resolution = materialParams.resolution;
+    cone.maxLevel = float(materialParams.maxLevel);
+
+    cone.intensity = materialParams.ssctIntensity;
+    cone.depthBias = materialParams.ssctDepthBias.x;
+    cone.slopeScaledDepthBias = materialParams.ssctDepthBias.y;
+    cone.sampleCount = materialParams.ssctSampleCount;
+
+    return ssctDominantLightShadowing(uv, origin, normal,
+            materialParams_depth, getFragCoord(materialParams.resolution),
+            materialParams.ssctRayCount, cone);
+}

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 11;
+static constexpr size_t MATERIAL_VERSION = 12;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -115,7 +115,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     uint32_t cascades;
 
     float aoSamplingQualityAndEdgeDistance;     // 0: bilinear, !0: bilateral edge distance
-    float aoReserved1;
+    float aoBentNormals;                        // 0: no AO bent normal, >0.0 AO bent normals
     float aoReserved2;
     float aoReserved3;
 

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -45,7 +45,7 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib(uint8_t variantKey) noe
             .add("froxels",       Type::SAMPLER_2D,         Format::UINT,    Precision::MEDIUM)
             .add("iblDFG",        Type::SAMPLER_2D,         Format::FLOAT,   Precision::MEDIUM)
             .add("iblSpecular",   Type::SAMPLER_CUBEMAP,    Format::FLOAT,   Precision::MEDIUM)
-            .add("ssao",          Type::SAMPLER_2D,         Format::FLOAT,   Precision::MEDIUM)
+            .add("ssao",          Type::SAMPLER_2D_ARRAY,   Format::FLOAT,   Precision::MEDIUM)
             .add("ssr",           Type::SAMPLER_2D,         Format::FLOAT,   Precision::MEDIUM)
             .add("structure",     Type::SAMPLER_2D,         Format::FLOAT,   Precision::MEDIUM)
             .build();

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -96,7 +96,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 
             // SSAO sampling parameters
             .add("aoSamplingQualityAndEdgeDistance", 1, UniformInterfaceBlock::Type::FLOAT)
-            .add("aoReserved1",             1, UniformInterfaceBlock::Type::FLOAT)
+            .add("aoBentNormals",           1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved2",             1, UniformInterfaceBlock::Type::FLOAT)
             .add("aoReserved3",             1, UniformInterfaceBlock::Type::FLOAT)
 

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -428,6 +428,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
             i = parse(tokens, i + 1, jsonChunk, &out->upsampling);
         } else if (compare(tok, jsonChunk, "enabled") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->enabled);
+        } else if (compare(tok, jsonChunk, "bentNormals") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->bentNormals);
         } else if (compare(tok, jsonChunk, "minHorizonAngleRad") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->minHorizonAngleRad);
         } else if (compare(tok, jsonChunk, "ssct") == 0) {
@@ -1204,6 +1206,7 @@ static std::ostream& operator<<(std::ostream& out, const AmbientOcclusionOptions
         << "\"lowPassFilter\": " << (in.lowPassFilter) << ",\n"
         << "\"upsampling\": " << (in.upsampling) << ",\n"
         << "\"enabled\": " << to_string(in.enabled) << ",\n"
+        << "\"bentNormals\": " << to_string(in.bentNormals) << ",\n"
         << "\"minHorizonAngleRad\": " << (in.minHorizonAngleRad) << ",\n"
         << "\"ssct\": " << (in.ssct) << "\n"
         << "}";

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -700,6 +700,7 @@ void SimpleViewer::updateUserInterface() {
 
             ImGui::SliderInt("Quality", &quality, 0, 3);
             ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
+            ImGui::Checkbox("Bent Normals", &ssao.bentNormals);
             ImGui::Checkbox("High quality upsampling", &upsampling);
             ImGui::SliderFloat("Min Horizon angle", &ssao.minHorizonAngleRad, 0.0f, (float)M_PI_4);
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -623,6 +623,17 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::SliderFloat("Bilateral Threshold", &params.ssaoOptions.bilateralThreshold, 0.0f, 0.5f);
                 ImGui::Checkbox("Bent Normals", &params.ssaoOptions.bentNormals);
                 ImGui::Checkbox("High quality upsampling", &upsampling);
+// Can be used to debug SSAO
+//                ImGui::SliderInt("SampleCount",
+//                        debug.getPropertyAddress<int>("d.ssao.sampleCount"), 1, 128);
+//                ImGui::SliderInt("spiralTurns",
+//                        debug.getPropertyAddress<int>("d.ssao.spiralTurns"), 1,
+//                                *debug.getPropertyAddress<int>("d.ssao.sampleCount"));
+//                ImGui::SliderInt("kernelSize",
+//                        debug.getPropertyAddress<int>("d.ssao.kernelSize"), 1, 23);
+//                ImGui::SliderFloat("stddev",
+//                        debug.getPropertyAddress<float>("d.ssao.stddev"), 0.0f, 8.0f);
+
                 params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
                 params.ssaoOptions.quality = (View::QualityLevel)quality;
                 params.ssaoOptions.lowPassFilter = (View::QualityLevel)lowpass;
@@ -656,7 +667,6 @@ static void gui(filament::Engine* engine, filament::View*) {
             ImGui::SliderFloat("Halo falloff", &params.sunHaloFalloff, 0.0f, 2048.0f);
             ImGuiExt::DirectionWidget("Direction", params.lightDirection.v);
             if (ImGui::CollapsingHeader("Contact Shadows")) {
-                DebugRegistry& debug = engine->getDebugRegistry();
                 ImGui::Checkbox("Enabled##contactShadows", &params.screenSpaceContactShadows);
                 ImGui::SliderInt("Steps", &params.stepCount, 0, 255);
                 ImGui::SliderFloat("Distance", &params.maxShadowDistance, 0.0f, 10.0f);

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -620,6 +620,8 @@ static void gui(filament::Engine* engine, filament::View*) {
                 ImGui::SliderFloat("Power", &params.ssaoOptions.power, 0.0f, 4.0f);
                 ImGui::SliderInt("Quality", &quality, 0, 3);
                 ImGui::SliderInt("Low Pass", &lowpass, 0, 2);
+                ImGui::SliderFloat("Bilateral Threshold", &params.ssaoOptions.bilateralThreshold, 0.0f, 0.5f);
+                ImGui::Checkbox("Bent Normals", &params.ssaoOptions.bentNormals);
                 ImGui::Checkbox("High quality upsampling", &upsampling);
                 params.ssaoOptions.upsampling = upsampling ? View::QualityLevel::HIGH : View::QualityLevel::LOW;
                 params.ssaoOptions.quality = (View::QualityLevel)quality;

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -241,6 +241,15 @@ static void setup(Engine* engine, View* view, Scene* scene) {
     Path path(g_pbrConfig.materialDir);
     std::string name(path.getName());
 
+    view->setAmbientOcclusionOptions({
+        .radius = 0.01f,
+        .bilateralThreshold = 0.005f,
+        .quality = View::QualityLevel::ULTRA,
+        .lowPassFilter = View::QualityLevel::MEDIUM,
+        .upsampling = View::QualityLevel::HIGH,
+        .enabled = true
+    });
+
     bool hasUV = false;
     for (auto& map: g_maps) {
         loadTexture(engine, path.concat(name + map.suffix + ".png"), &map.texture, map.sRGB);
@@ -377,6 +386,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             .targetApi(MaterialBuilder::TargetApi::ALL)
 #ifndef NDEBUG
             .optimization(MaterialBuilderBase::Optimization::NONE)
+            .generateDebugInfo(true)
 #endif
             .material(shader.c_str())
             .multiBounceAmbientOcclusion(true)

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -28,14 +28,14 @@ float evaluateSSAO() {
 
         // Read four AO samples and their depths values
 #if defined(FILAMENT_HAS_FEATURE_TEXTURE_GATHER)
-        vec4 ao = textureGather(light_ssao, uv, 0);
-        vec4 dg = textureGather(light_ssao, uv, 1);
-        vec4 db = textureGather(light_ssao, uv, 2);
+        vec4 ao = textureGather(light_ssao, vec3(uv, 0.0), 0);
+        vec4 dg = textureGather(light_ssao, vec3(uv, 0.0), 1);
+        vec4 db = textureGather(light_ssao, vec3(uv, 0.0), 2);
 #else
-        vec3 s01 = textureLodOffset(light_ssao, uv, 0.0, ivec2(0, 1)).rgb;
-        vec3 s11 = textureLodOffset(light_ssao, uv, 0.0, ivec2(1, 1)).rgb;
-        vec3 s10 = textureLodOffset(light_ssao, uv, 0.0, ivec2(1, 0)).rgb;
-        vec3 s00 = textureLodOffset(light_ssao, uv, 0.0, ivec2(0, 0)).rgb;
+        vec3 s01 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(0, 1)).rgb;
+        vec3 s11 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(1, 1)).rgb;
+        vec3 s10 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(1, 0)).rgb;
+        vec3 s00 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(0, 0)).rgb;
         vec4 ao = vec4(s01.r, s11.r, s10.r, s00.r);
         vec4 dg = vec4(s01.g, s11.g, s10.g, s00.g);
         vec4 db = vec4(s01.b, s11.b, s10.b, s00.b);
@@ -61,7 +61,7 @@ float evaluateSSAO() {
         w = max(vec4(MEDIUMP_FLT_MIN), 1.0 - w * w) * b;
         return dot(ao, w) * (1.0 / (w.x + w.y + w.z + w.w));
     } else {
-        return textureLod(light_ssao, uv, 0.0).r;
+        return textureLod(light_ssao, vec3(uv, 0.0), 0.0).r;
     }
 #else
     // SSAO is not applied when blending is enabled

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -573,9 +573,13 @@ void combineDiffuseAndSpecular(
 }
 
 void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout vec3 color) {
-    float ssao = evaluateSSAO();
+    SSAOInterpolationCache interpolationCache;
+
+    highp vec2 uv = uvToRenderTargetUV(getNormalizedViewportCoord().xy);
+    float ssao = evaluateSSAO(uv, interpolationCache);
     float diffuseAO = min(material.ambientOcclusion, ssao);
-    float specularAO = computeSpecularAO(shading_NoV, diffuseAO, pixel.roughness);
+    float specularAO = computeSpecularAO(uv, shading_NoV, diffuseAO, pixel.roughness,
+            interpolationCache);
 
     // specular layer
     vec3 Fr;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -365,7 +365,12 @@ value_object<filament::View::AmbientOcclusionOptions>("View$AmbientOcclusionOpti
     .field("resolution", &filament::View::AmbientOcclusionOptions::resolution)
     .field("intensity", &filament::View::AmbientOcclusionOptions::intensity)
     .field("bilateralThreshold", &filament::View::AmbientOcclusionOptions::bilateralThreshold)
-    .field("quality", &filament::View::AmbientOcclusionOptions::quality);
+    .field("quality", &filament::View::AmbientOcclusionOptions::quality)
+    .field("lowPassFilter", &filament::View::AmbientOcclusionOptions::lowPassFilter)
+    .field("upsampling", &filament::View::AmbientOcclusionOptions::upsampling)
+    .field("enabled", &filament::View::AmbientOcclusionOptions::enabled)
+    .field("bentNormals", &filament::View::AmbientOcclusionOptions::bentNormals)
+    .field("minHorizonAngleRad", &filament::View::AmbientOcclusionOptions::minHorizonAngleRad);
     // TODO: ssct options
 
 value_object<filament::View::DepthOfFieldOptions>("View$DepthOfFieldOptions")


### PR DESCRIPTION
SSAO is optionally augmented to evaluate bent normals, later used for specular AO.

before:
![before](https://user-images.githubusercontent.com/1240896/127218830-2a9129a7-8254-45eb-907f-d8c6b96733f2.png)
after:
![after](https://user-images.githubusercontent.com/1240896/127218826-ac62e939-58a9-4e49-8526-4ad5c4b2a1dc.png)
