### PR TITLE
Implement light channels

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ A new header is inserted each time a *tag* is created.
 
 - engine: Option to automatically compute bent normals from SSAO & apply to specular AO
   [⚠️ **Material breakage**].
+- engine: New APIs: Light channels. Geometry and lights now have a channel associated to them, at 
+  least one channel must match for lighting to occur [⚠️ **Material breakage**].
 
 ## v1.11.2
 

--- a/android/filament-android/src/main/cpp/LightManager.cpp
+++ b/android/filament-android/src/main/cpp/LightManager.cpp
@@ -190,6 +190,23 @@ Java_com_google_android_filament_LightManager_nBuilderHaloFalloff(JNIEnv*, jclas
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_LightManager_nBuilderLightChannel(JNIEnv*, jclass,
+        jlong nativeBuilder, jint channel, jboolean enable) {
+    LightManager::Builder *builder = (LightManager::Builder *) nativeBuilder;
+    builder->lightChannel(channel, (bool)enable);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_LightManager_nBuilderBuild(JNIEnv*, jclass,
+        jlong nativeBuilder, jlong nativeEngine, jint entity) {
+    LightManager::Builder *builder = (LightManager::Builder *) nativeBuilder;
+    Engine *engine = (Engine *) nativeEngine;
+    return jboolean(builder->build(*engine, (Entity &) entity) == LightManager::Builder::Success);
+}
+
+// ------------------------------------------------------------------------------------------------
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_LightManager_nComputeUniformSplits(JNIEnv* env, jclass,
         jfloatArray splitPositions, jint cascades) {
     jfloat *nativeSplits = env->GetFloatArrayElements(splitPositions, NULL);
@@ -213,13 +230,7 @@ Java_com_google_android_filament_LightManager_nComputePracticalSplits(JNIEnv* en
     env->ReleaseFloatArrayElements(splitPositions, nativeSplits, 0);
 }
 
-extern "C" JNIEXPORT jboolean JNICALL
-Java_com_google_android_filament_LightManager_nBuilderBuild(JNIEnv*, jclass,
-        jlong nativeBuilder, jlong nativeEngine, jint entity) {
-    LightManager::Builder *builder = (LightManager::Builder *) nativeBuilder;
-    Engine *engine = (Engine *) nativeEngine;
-    return jboolean(builder->build(*engine, (Entity &) entity) == LightManager::Builder::Success);
-}
+// ------------------------------------------------------------------------------------------------
 
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_LightManager_nGetType(JNIEnv* env,
@@ -393,4 +404,18 @@ Java_com_google_android_filament_LightManager_nGetInnerConeAngle(JNIEnv*, jclass
         jlong nativeLightManager, jint i) {
     LightManager *lm = (LightManager *) nativeLightManager;
     return (jfloat)lm->getSpotLightInnerCone((LightManager::Instance) i);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_LightManager_nSetLightChannel(JNIEnv*, jclass,
+        jlong nativeLightManager, jint i, jint channel, jboolean enable) {
+    LightManager *lm = (LightManager *) nativeLightManager;
+    lm->setLightChannel((LightManager::Instance) i, channel, (bool)enable);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_LightManager_nGetLightChannel(JNIEnv*, jclass,
+        jlong nativeLightManager, jint i, jint channel) {
+    LightManager const *lm = (LightManager const *) nativeLightManager;
+    return lm->getLightChannel((LightManager::Instance) i, channel);
 }

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -215,6 +215,15 @@ Java_com_google_android_filament_RenderableManager_nBuilderMorphing(JNIEnv*, jcl
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderLightChannel(JNIEnv*, jclass,
+        jlong nativeBuilder, jint channel, jboolean enable) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->lightChannel(channel, (bool)enable);
+}
+
+// ------------------------------------------------------------------------------------------------
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_RenderableManager_nSetSkinningBuffer(JNIEnv*, jclass,
         jlong nativeRenderableManager, jint i, jlong nativeSkinningBuffer, jint count, jint offset) {
     RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
@@ -403,4 +412,18 @@ Java_com_google_android_filament_RenderableManager_nGetEnabledAttributesAt(JNIEn
     RenderableManager const *rm = (RenderableManager const *) nativeRenderableManager;
     AttributeBitset enabled = rm->getEnabledAttributesAt((RenderableManager::Instance) i, (size_t) primitiveIndex);
     return enabled.getValue();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSetLightChannel(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jint channel, jboolean enable) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    rm->setLightChannel((RenderableManager::Instance) i, channel, (bool)enable);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_RenderableManager_nGetLightChannel(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jint channel) {
+    RenderableManager const *rm = (RenderableManager const *) nativeRenderableManager;
+    return rm->getLightChannel((RenderableManager::Instance) i, channel);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -431,6 +431,18 @@ public class LightManager {
         }
 
         /**
+         * Enables or disables a light channel. Light channel 0 is enabled by default.
+         *
+         * @param channel Light channel to enable or disable, between 0 and 7.
+         * @param enable Whether to enable or disable the light channel.
+         */
+        @NonNull
+        public Builder lightChannel(@IntRange(from = 0, to = 7) int channel, boolean enable) {
+            nBuilderLightChannel(mNativeBuilder, channel, enable);
+            return this;
+        }
+
+        /**
          * Whether this Light casts shadows (disabled by default)
          *
          * <p>
@@ -786,6 +798,30 @@ public class LightManager {
     }
 
     /**
+     * Enables or disables a light channel.
+     * Light channel 0 is enabled by default.
+     *
+     * @param i        Instance of the component obtained from getInstance().
+     * @param channel  Light channel to set
+     * @param enable   true to enable, false to disable
+     *
+     * @see Builder#lightChannel
+     */
+    public void setLightChannel(@EntityInstance int i, @IntRange(from = 0, to = 7) int channel, boolean enable) {
+        nSetLightChannel(mNativeObject, i, channel, enable);
+    }
+
+    /**
+     * Returns whether a light channel is enabled on a specified renderable.
+     * @param i        Instance of the component obtained from getInstance().
+     * @param channel  Light channel to query
+     * @return         true if the light channel is enabled, false otherwise
+     */
+    public boolean getLightChannel(@EntityInstance int i, @IntRange(from = 0, to = 7) int channel) {
+        return nGetLightChannel(mNativeObject, i, channel);
+    }
+
+    /**
      * Dynamically updates the light's position.
      *
      * <p>
@@ -1108,6 +1144,7 @@ public class LightManager {
     private static native void nBuilderAngularRadius(long nativeBuilder, float angularRadius);
     private static native void nBuilderHaloSize(long nativeBuilder, float haloSize);
     private static native void nBuilderHaloFalloff(long nativeBuilder, float haloFalloff);
+    private static native void nBuilderLightChannel(long nativeBuilder, int channel, boolean enable);
 
     private static native void nComputeUniformSplits(float[] splitPositions, int cascades);
     private static native void nComputeLogSplits(float[] splitPositions, int cascades, float near, float far);
@@ -1137,4 +1174,6 @@ public class LightManager {
     private static native boolean nIsShadowCaster(long nativeLightManager, int i);
     private static native float nGetOuterConeAngle(long nativeLightManager, int i);
     private static native float nGetInnerConeAngle(long nativeLightManager, int i);
+    private static native void nSetLightChannel(long nativeLightManager, int i, int channel, boolean enable);
+    private static native boolean nGetLightChannel(long nativeLightManager, int i, int channel);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -267,6 +267,18 @@ public class RenderableManager {
         }
 
         /**
+         * Enables or disables a light channel. Light channel 0 is enabled by default.
+         *
+         * @param channel Light channel to enable or disable, between 0 and 7.
+         * @param enable Whether to enable or disable the light channel.
+         */
+        @NonNull
+        public Builder lightChannel(@IntRange(from = 0, to = 7) int channel, boolean enable) {
+            nBuilderLightChannel(mNativeBuilder, channel, enable);
+            return this;
+        }
+
+        /**
          * Controls if this renderable casts shadows, false by default.
          *
          * If the View's shadow type is set to {@link View.ShadowType#VSM}, castShadows should only
@@ -532,6 +544,30 @@ public class RenderableManager {
     }
 
     /**
+     * Enables or disables a light channel.
+     * Light channel 0 is enabled by default.
+     *
+     * @param i        Instance of the component obtained from getInstance().
+     * @param channel  Light channel to set
+     * @param enable   true to enable, false to disable
+     *
+     * @see Builder#lightChannel
+     */
+    public void setLightChannel(@EntityInstance int i, @IntRange(from = 0, to = 7) int channel, boolean enable) {
+        nSetLightChannel(mNativeObject, i, channel, enable);
+    }
+
+    /**
+     * Returns whether a light channel is enabled on a specified renderable.
+     * @param i        Instance of the component obtained from getInstance().
+     * @param channel  Light channel to query
+     * @return         true if the light channel is enabled, false otherwise
+     */
+    public boolean getLightChannel(@EntityInstance int i, @IntRange(from = 0, to = 7) int channel) {
+        return nGetLightChannel(mNativeObject, i, channel);
+    }
+
+    /**
      * Changes whether or not the renderable casts shadows.
      *
      * @see Builder#castShadows
@@ -718,6 +754,7 @@ public class RenderableManager {
     private static native void nBuilderSkinningBuffer(long nativeBuilder, long nativeSkinningBuffer, int boneCount, int offset);
     private static native void nBuilderMorphing(long nativeBuilder, boolean enabled);
     private static native void nEnableSkinningBuffers(long nativeBuilder, boolean enabled);
+    private static native void nBuilderLightChannel(long nativeRenderableManager, int channel, boolean enable);
 
     private static native void nSetSkinningBuffer(long nativeObject, int i, long nativeSkinningBuffer, int count, int offset);
     private static native int nSetBonesAsMatrices(long nativeObject, int i, Buffer matrices, int remaining, int boneCount, int offset);
@@ -727,6 +764,8 @@ public class RenderableManager {
     private static native void nSetLayerMask(long nativeRenderableManager, int i, int select, int value);
     private static native void nSetPriority(long nativeRenderableManager, int i, int priority);
     private static native void nSetCulling(long nativeRenderableManager, int i, boolean enabled);
+    private static native void nSetLightChannel(long nativeRenderableManager, int i, int channel, boolean enable);
+    private static native boolean nGetLightChannel(long nativeRenderableManager, int i, int channel);
     private static native void nSetCastShadows(long nativeRenderableManager, int i, boolean enabled);
     private static native void nSetReceiveShadows(long nativeRenderableManager, int i, boolean enabled);
     private static native void nSetScreenSpaceContactShadows(long nativeRenderableManager, int i, boolean enabled);

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -273,6 +273,7 @@ void OpenGLContext::initExtensionsGLES(GLint major, GLint minor, ExtentionSet co
 
 void OpenGLContext::initExtensionsGL(GLint major, GLint minor, ExtentionSet const& exts) {
     ext.APPLE_color_buffer_packed_float = true;  // Assumes core profile.
+    ext.ARB_shading_language_packing = hasExtension(exts, "GL_ARB_shading_language_packing") || (major == 4 && minor >= 2);
     ext.EXT_clip_control = hasExtension(exts, "GL_ARB_clip_control") || (major == 4 && minor >= 5);
     ext.EXT_color_buffer_float = true;  // Assumes core profile.
     ext.EXT_color_buffer_half_float = true;  // Assumes core profile.

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -129,27 +129,28 @@ public:
 
     // supported extensions detected at runtime
     struct {
-        bool EXT_texture_compression_etc2 = false;
-        bool EXT_texture_filter_anisotropic = false;
-        bool QCOM_tiled_rendering = false;
-        bool OES_EGL_image_external_essl3 = false;
-        bool EXT_debug_marker = false;
-        bool EXT_color_buffer_half_float = false;
-        bool EXT_color_buffer_float = false;
         bool APPLE_color_buffer_packed_float = false;
+        bool ARB_shading_language_packing = false;
+        bool EXT_clip_control = false;
+        bool EXT_color_buffer_float = false;
+        bool EXT_color_buffer_half_float = false;
+        bool EXT_debug_marker = false;
+        bool EXT_disjoint_timer_query = false;
         bool EXT_multisampled_render_to_texture = false;
         bool EXT_multisampled_render_to_texture2 = false;
-        bool KHR_debug = false;
-        bool EXT_texture_sRGB = false;
-        bool EXT_disjoint_timer_query = false;
         bool EXT_shader_framebuffer_fetch = false;
-        bool EXT_clip_control = false;
-        bool GOOGLE_cpp_style_line_directive = false;
+        bool EXT_texture_compression_etc2 = false;
         bool EXT_texture_compression_s3tc = false;
         bool EXT_texture_compression_s3tc_srgb = false;
+        bool EXT_texture_filter_anisotropic = false;
+        bool EXT_texture_sRGB = false;
+        bool GOOGLE_cpp_style_line_directive = false;
+        bool KHR_debug = false;
+        bool OES_EGL_image_external_essl3 = false;
+        bool QCOM_tiled_rendering = false;
+        bool WEBGL_compressed_texture_etc = false;
         bool WEBGL_compressed_texture_s3tc = false;
         bool WEBGL_compressed_texture_s3tc_srgb = false;
-        bool WEBGL_compressed_texture_etc = false;
     } ext;
 
     struct {

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -39,6 +39,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
     using Shader = Program::Shader;
 
     const auto& shadersSource = programBuilder.getShadersSource();
+    OpenGLContext& context = gl->getContext();
 
     // build all shaders
     #pragma nounroll
@@ -57,19 +58,52 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
         if (!shadersSource[i].empty()) {
             GLint status;
             auto shader = shadersSource[i];
-            GLint const length = (GLint)shader.size();
+            std::string temp;
+            std::string_view shaderView((const char*)shader.data(), shader.size());
 
-            if (!gl->getContext().ext.GOOGLE_cpp_style_line_directive) {
+            if (!context.ext.GOOGLE_cpp_style_line_directive) {
                 // If usages of the Google-style line directive are present, remove them, as some
                 // drivers don't allow the quotation marks.
-                if (requestsGoogleLineDirectivesExtension((const char*)shader.data(), length)) {
-                    auto temp = shader;
-                    removeGoogleLineDirectives((char*)temp.data(), length); // length is unaffected
-                    shader = std::move(temp);
+                if (UTILS_UNLIKELY(requestsGoogleLineDirectivesExtension(shaderView.data(), shaderView.size()))) {
+                    temp = shaderView; // copy string
+                    removeGoogleLineDirectives(temp.data(), temp.size()); // length is unaffected
+                    shaderView = temp;
                 }
             }
 
-            const char * const source = (const char*)shader.data();
+            if (UTILS_UNLIKELY(context.getShaderModel() == ShaderModel::GL_CORE_41 &&
+                !context.ext.ARB_shading_language_packing)) {
+                // Tragically, OpenGL 4.1 doesn't support unpackHalf2x16 and
+                // MacOS doesn't support GL_ARB_shading_language_packing
+                if (temp.empty()) {
+                    temp = shaderView; // copy string
+                }
+
+                std::string unpackHalf2x16{ R"(
+
+float u16tofp32(highp uint v) {
+    // this doesn't handle denormals, NaNs or inf
+    v <<= 16u;
+    highp uint s = v & 0x80000000u;
+    highp uint n = v & 0x7FFFFFFFu;
+    highp uint nz = n == 0u ? 0u : 0xFFFFFFFF;
+    return uintBitsToFloat(s | ((((n >> 3u) + (0x70u << 23))) & nz));
+}
+vec2 unpackHalf2x16(highp uint v) {
+    return vec2(u16tofp32(v&0xFFFFu), u16tofp32(v>>16u));
+}
+
+)"};
+                // a good point for insertion is just before the first occurence of an uniform block
+                auto pos = temp.find("layout(std140)");
+                if (pos != std::string_view::npos) {
+                    temp.insert(pos, unpackHalf2x16);
+                }
+                shaderView = temp;
+            }
+
+            const char * const source = shaderView.data();
+            GLint length = (GLint)shaderView.length();
 
             GLuint shaderId = glCreateShader(glShaderType);
             glShaderSource(shaderId, 1, &source, &length);
@@ -126,7 +160,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
         if (programBuilder.hasSamplers()) {
             // if we have samplers, we need to do a bit of extra work
             // activate this program so we can set all its samplers once and for all (glUniform1i)
-            gl->getContext().useProgram(program);
+            context.useProgram(program);
 
             auto const& samplerGroupInfo = programBuilder.getSamplerGroupInfo();
             auto& indicesRun = mIndicesRuns;

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -396,6 +396,15 @@ public:
         Builder& operator=(Builder&& rhs) noexcept;
 
         /**
+         * Enables or disables a light channel. Light channel 0 is enabled by default.
+         *
+         * @param channel Light channel to enable or disable, between 0 and 7.
+         * @param enable Whether to enable or disable the light channel.
+         * @return This Builder, for chaining calls.
+         */
+        Builder& lightChannel(unsigned int channel, bool enable = true) noexcept;
+
+        /**
          * Whether this Light casts shadows (disabled by default)
          *
          * @param enable Enables or disables casting shadows from this Light.
@@ -660,6 +669,21 @@ public:
         Type type = getType(i);
         return type == Type::SPOT || type == Type::FOCUSED_SPOT;
     }
+
+    /**
+     * Enables or disables a light channel. Light channel 0 is enabled by default.
+     * @param channel light channel to enable or disable, between 0 and 7.
+     * @param enable whether to enable (true) or disable (false) the specified light channel.
+     */
+    void setLightChannel(Instance i, unsigned int channel, bool enable = true) noexcept;
+
+    /**
+     * Returns whether a light channel is enabled on a specified light.
+     * @param i        Instance of the component obtained from getInstance().
+     * @param channel  Light channel to query
+     * @return         true if the light channel is enabled, false otherwise
+     */
+    bool getLightChannel(Instance i, unsigned int channel) const noexcept;
 
     /**
      * Dynamically updates the light's position.

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -219,6 +219,14 @@ public:
         Builder& culling(bool enable) noexcept;
 
         /**
+         * Enables or disables a light channel. Light channel 0 is enabled by default.
+         *
+         * @param channel Light channel to enable or disable, between 0 and 7.
+         * @param enable Whether to enable or disable the light channel.
+         */
+        Builder& lightChannel(unsigned int channel, bool enable = true) noexcept;
+
+        /**
          * Controls if this renderable casts shadows, false by default.
          *
          * If the View's shadow type is set to ShadowType::VSM, castShadows should only be disabled
@@ -380,6 +388,22 @@ public:
      * \see Builder::culling()
      */
     void setCulling(Instance instance, bool enable) noexcept;
+
+    /**
+     * Enables or disables a light channel.
+     * Light channel 0 is enabled by default.
+     *
+     * \see Builder::lightChannel()
+     */
+    void setLightChannel(Instance instance, unsigned int channel, bool enable) noexcept;
+
+    /**
+     * Returns whether a light channel is enabled on a specified renderable.
+     * @param instance Instance of the component obtained from getInstance().
+     * @param channel  Light channel to query
+     * @return         true if the light channel is enabled, false otherwise
+     */
+    bool getLightChannel(Instance instance, unsigned int channel) const noexcept;
 
     /**
      * Changes whether or not the renderable casts shadows.

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -305,11 +305,17 @@ void FScene::prepareDynamicLights(const CameraInfo& camera, ArenaScope& rootAren
         const size_t gpuIndex = i - DIRECTIONAL_LIGHTS_COUNT;
         auto li = instances[i];
         lp[gpuIndex].positionFalloff      = { spheres[i].xyz, lcm.getSquaredFalloffInv(li) };
-        lp[gpuIndex].colorIntensity       = { lcm.getColor(li), lcm.getIntensity(li) };
+        lp[gpuIndex].color                = { lcm.getColor(li), 0.0f };
         lp[gpuIndex].directionIES         = { directions[i], 0.0f };
         lp[gpuIndex].spotScaleOffset      = lcm.getSpotParams(li).scaleOffset;
-        lp[gpuIndex].shadow               = { shadowInfo[i].pack() };
-        lp[gpuIndex].type                 = lcm.isPointLight(li) ? 0u : 1u;
+        lp[gpuIndex].intensity            = lcm.getIntensity(li);
+        lp[gpuIndex].typeShadow           = LightsUib::packTypeShadow(
+                lcm.isPointLight(li) ? 0u : 1u,
+                shadowInfo[i].contactShadows,
+                shadowInfo[i].index,
+                shadowInfo[i].layer);
+        lp[gpuIndex].channels             = LightsUib::packChannels(1, shadowInfo[i].castsShadows);
+        lp[gpuIndex].reserved             = {};
     }
 
     driver.updateBufferObject(lightUbh, { lp, positionalLightCount * sizeof(LightsUib) }, 0);

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -240,16 +240,11 @@ void FScene::updateUBOs(utils::Range<uint32_t> visibleRenderables, backend::Hand
         FRenderableManager::Visibility visibility = sceneData.elementAt<VISIBILITY_STATE>(i);
         hasContactShadows = hasContactShadows || visibility.screenSpaceContactShadows;
         UniformBuffer::setUniform(buffer,
-                offset + offsetof(PerRenderableUib, skinningEnabled),
-                uint32_t(visibility.skinning));
-
-        UniformBuffer::setUniform(buffer,
-                offset + offsetof(PerRenderableUib, morphingEnabled),
-                uint32_t(visibility.morphing));
-
-        UniformBuffer::setUniform(buffer,
-                offset + offsetof(PerRenderableUib, screenSpaceContactShadows),
-                uint32_t(visibility.screenSpaceContactShadows));
+                offset + offsetof(PerRenderableUib, flags),
+                PerRenderableUib::packFlags(
+                        visibility.skinning,
+                        visibility.morphing,
+                        visibility.screenSpaceContactShadows));
 
         UniformBuffer::setUniform(buffer,
                 offset + offsetof(PerRenderableUib, morphWeights),

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -355,6 +355,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 
         s.lightDirection = l;
         s.lightColorIntensity = colorIntensity;
+        s.lightChannels = lcm.getLightChannels(directionalLight);
 
         const bool isSun = lcm.isSunLight(directionalLight);
         // The last parameter must be < 0.0f for regular directional lights

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -96,6 +96,7 @@ public:
 
     UTILS_NOINLINE void setLocalPosition(Instance i, const math::float3& position) noexcept;
     UTILS_NOINLINE void setLocalDirection(Instance i, math::float3 direction) noexcept;
+    UTILS_NOINLINE void setLightChannel(Instance i, unsigned int channel, bool enable) noexcept;
     UTILS_NOINLINE void setColor(Instance i, const LinearColor& color) noexcept;
     UTILS_NOINLINE void setSpotLightCone(Instance i, float inner, float outer) noexcept;
     UTILS_NOINLINE void setIntensity(Instance i, float intensity, IntensityUnit unit) noexcept;
@@ -104,6 +105,8 @@ public:
     UTILS_NOINLINE void setSunAngularRadius(Instance i, float angularRadius) noexcept;
     UTILS_NOINLINE void setSunHaloSize(Instance i, float haloSize) noexcept;
     UTILS_NOINLINE void setSunHaloFalloff(Instance i, float haloFalloff) noexcept;
+
+    UTILS_NOINLINE bool getLightChannel(Instance i, unsigned int channel) const noexcept;
 
     LightType const& getLightType(Instance i) const noexcept {
         return mManager[i].lightType;
@@ -209,6 +212,10 @@ public:
         return getSpotParams(i).radius;
     }
 
+    uint8_t getLightChannels(Instance i) const noexcept {
+        return mManager[i].channels;
+    }
+
     const math::float3& getLocalPosition(Instance i) const noexcept {
         return mManager[i].position;
     }
@@ -238,6 +245,7 @@ private:
         SUN_HALO_FALLOFF,   // state for the directional light sun
         INTENSITY,
         FALLOFF,
+        CHANNELS,
     };
 
     using Base = utils::SingleInstanceComponentManager<  // 120 bytes
@@ -251,7 +259,8 @@ private:
             float,          //  4
             float,          //  4
             float,          //  4
-            float           //  4
+            float,          //  4
+            uint8_t         //  1
     >;
 
     struct Sim : public Base {
@@ -277,6 +286,7 @@ private:
                 Field<SUN_HALO_FALLOFF>     sunHaloFalloff;
                 Field<INTENSITY>            intensity;
                 Field<FALLOFF>              squaredFallOffInv;
+                Field<CHANNELS>             channels;
             };
         };
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -108,6 +108,9 @@ public:
     inline void setMorphWeights(Instance instance, const math::float4& weights) noexcept;
     inline void setSkinningBuffer(Instance instance, FSkinningBuffer* skinningBuffer,
             size_t count, size_t offset) noexcept;
+    inline void setLightChannel(Instance instance, unsigned int channel, bool enable) noexcept;
+
+    inline bool getLightChannel(Instance instance, unsigned int channel) const noexcept;
 
     inline bool isShadowCaster(Instance instance) const noexcept;
     inline bool isShadowReceiver(Instance instance) const noexcept;
@@ -120,6 +123,7 @@ public:
     inline uint8_t getLayerMask(Instance instance) const noexcept;
     inline uint8_t getPriority(Instance instance) const noexcept;
     inline math::float4 getMorphWeights(Instance instance) const noexcept;
+    inline uint8_t getChannels(Instance instance) const noexcept;
 
     struct SkinningBindingInfo {
         backend::Handle<backend::HwBufferObject> handle;
@@ -163,6 +167,7 @@ private:
         AABB,               // user data
         LAYERS,             // user data
         MORPH_WEIGHTS,      // user data
+        CHANNELS,           // user data
         VISIBILITY,         // user data
         PRIMITIVES,         // user data
         BONES,              // filament data, UBO storing a pointer to the bones information
@@ -172,6 +177,7 @@ private:
             Box,                             // AABB
             uint8_t,                         // LAYERS
             math::float4,                    // MORPH_WEIGHTS
+            uint8_t,                         // CHANNELS
             Visibility,                      // VISIBILITY
             utils::Slice<FRenderPrimitive>,  // PRIMITIVES
             Bones                            // BONES
@@ -192,6 +198,7 @@ private:
                 Field<AABB>         aabb;
                 Field<LAYERS>       layers;
                 Field<MORPH_WEIGHTS> morphWeights;
+                Field<CHANNELS>     channels;
                 Field<VISIBILITY>   visibility;
                 Field<PRIMITIVES>   primitives;
                 Field<BONES>        bones;
@@ -315,6 +322,10 @@ uint8_t FRenderableManager::getPriority(Instance instance) const noexcept {
 
 math::float4 FRenderableManager::getMorphWeights(Instance instance) const noexcept {
     return mManager[instance].morphWeights;
+}
+
+uint8_t FRenderableManager::getChannels(Instance instance) const noexcept {
+    return mManager[instance].channels;
 }
 
 Box const& FRenderableManager::getAABB(Instance instance) const noexcept {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -165,21 +165,6 @@ public:
         bool contactShadows = false;    // whether this light casts contact shadows
         uint8_t index = 0;              // an index into the arrays in the Shadows uniform buffer
         uint8_t layer = 0;              // which layer of the shadow texture array to sample from
-
-        //  -- LSB -------------
-        //  castsShadows     : 1
-        //  contactShadows   : 1
-        //  index            : 4
-        //  layer            : 4
-        //  -- MSB -------------
-        uint32_t pack() const {
-            assert_invariant(index < 16);
-            assert_invariant(layer < 16);
-            return uint8_t(castsShadows)   << 0u    |
-                   uint8_t(contactShadows) << 1u    |
-                   index                   << 2u    |
-                   layer                   << 6u;
-        }
     };
 
     enum {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -108,6 +108,7 @@ public:
         WORLD_AABB_CENTER,      // 12 | world-space bounding box center of the renderable
         VISIBLE_MASK,           //  1 | each bit represents a visibility in a pass
         MORPH_WEIGHTS,          //  4 | floats for morphing
+        CHANNELS,               //  1 | currently light channels only
 
         // These are not needed anymore after culling
         LAYERS,                 //  1 | layers
@@ -130,6 +131,7 @@ public:
             math::float3,                               // WORLD_AABB_CENTER
             VisibleMaskType,                            // VISIBLE_MASK
             math::float4,                               // MORPH_WEIGHTS
+            uint8_t,                                    // CHANNELS
             uint8_t,                                    // LAYERS
             math::float3,                               // WORLD_AABB_EXTENT
             utils::Slice<FRenderPrimitive>,             // PRIMITIVES

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -139,14 +139,19 @@ static_assert(sizeof(PerViewUib) == sizeof(filament::math::float4) * 128,
 struct alignas(256) PerRenderableUib {
     static constexpr utils::StaticString _name{ "ObjectUniforms" };
     filament::math::mat4f worldFromModelMatrix;
-    filament::math::mat3f worldFromModelNormalMatrix; // this gets expanded to 48 bytes during the copy to the UBO
-    alignas(16) filament::math::float4 morphWeights;
-    // TODO: we can pack all the boolean bellow
-    int32_t skinningEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
-    int32_t morphingEnabled; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
-    uint32_t screenSpaceContactShadows; // 0=disabled, 1=enabled, ignored unless variant & SKINNING_OR_MORPHING
+    filament::math::mat3f worldFromModelNormalMatrix;   // this gets expanded to 48 bytes during the copy to the UBO
+    alignas(16) filament::math::float4 morphWeights;    // morph weights (we could easily have 8 using half)
+    uint32_t flags;                                     // see packFlags() below
+    uint32_t reserved0;                                 // 0
+    uint32_t reserved1;                                 // 0
     // TODO: We need a better solution, this currently holds the average local scale for the renderable
     float userData;
+
+    static uint32_t packFlags(bool skinning, bool morphing, bool contactShadows) noexcept {
+        return (skinning ? 1 : 0) |
+               (morphing ? 2 : 0) |
+               (contactShadows ? 4 : 0);
+    }
 };
 static_assert(sizeof(PerRenderableUib) % 256 == 0, "sizeof(Transform) should be a multiple of 256");
 

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -64,7 +64,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     filament::math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
-    filament::math::float4 padding0;
+    filament::math::float3 padding0;
+    uint32_t lightChannels;
 
     filament::math::float3 lightDirection;
     uint32_t fParamsX; // stride-x
@@ -142,7 +143,7 @@ struct alignas(256) PerRenderableUib {
     filament::math::mat3f worldFromModelNormalMatrix;   // this gets expanded to 48 bytes during the copy to the UBO
     alignas(16) filament::math::float4 morphWeights;    // morph weights (we could easily have 8 using half)
     uint32_t flags;                                     // see packFlags() below
-    uint32_t reserved0;                                 // 0
+    uint32_t channels;                                  // 0x000000ll
     uint32_t reserved1;                                 // 0
     // TODO: We need a better solution, this currently holds the average local scale for the renderable
     float userData;

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -51,7 +51,8 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // directional light
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT4)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT3)
+            .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
             .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)
             // shadow
@@ -121,7 +122,7 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
             .add("worldFromModelNormalMatrix", 1, UniformInterfaceBlock::Type::MAT3, Precision::HIGH)
             .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             .add("flags", 1, UniformInterfaceBlock::Type::UINT)
-            .add("reserved0", 1, UniformInterfaceBlock::Type::UINT)
+            .add("channels", 1, UniformInterfaceBlock::Type::UINT)
             .add("reserved1", 1, UniformInterfaceBlock::Type::UINT)
             .add("userData", 1, UniformInterfaceBlock::Type::FLOAT)
             .build();

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -120,9 +120,9 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
             .add("worldFromModelMatrix",       1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromModelNormalMatrix", 1, UniformInterfaceBlock::Type::MAT3, Precision::HIGH)
             .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
-            .add("skinningEnabled", 1, UniformInterfaceBlock::Type::INT)
-            .add("morphingEnabled", 1, UniformInterfaceBlock::Type::INT)
-            .add("screenSpaceContactShadows", 1, UniformInterfaceBlock::Type::UINT)
+            .add("flags", 1, UniformInterfaceBlock::Type::UINT)
+            .add("reserved0", 1, UniformInterfaceBlock::Type::UINT)
+            .add("reserved1", 1, UniformInterfaceBlock::Type::UINT)
             .add("userData", 1, UniformInterfaceBlock::Type::FLOAT)
             .build();
     return uib;

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -111,30 +111,6 @@ io::sstream& CodeGenerator::generateProlog(io::sstream& out, ShaderType type,
 
     out << SHADERS_COMMON_TYPES_FS_DATA;
 
-    if (mTargetApi == TargetApi::OPENGL && mShaderModel == ShaderModel::GL_CORE_41) {
-        // Tragically, OpenGL 4.1 doesn't support unpackHalf2x16 and
-        // MacOS doesn't support GL_ARB_shading_language_packing
-
-        // TODO: inject this from the backend based on the GL version and extension presence
-
-        out << R"(
-
-float u16tofp32(highp uint v) {
-    // this doesn't handle denormals, NaNs or inf
-    v <<= 16u;
-    highp uint s = v & 0x80000000u;
-    highp uint n = v & 0x7FFFFFFFu;
-    highp uint nz = n == 0u ? 0u : 0xFFFFFFFF;
-    return uintBitsToFloat(s | ((((n >> 3u) + (0x70u << 23))) & nz));
-}
-
-vec2 unpackHalf2x16(highp uint v) {
-    return vec2(u16tofp32(v&0xFFFFu), u16tofp32(v>>16u));
-}
-
-)";
-    }
-
     out << "\n";
     return out;
 }

--- a/shaders/src/common_getters.fs
+++ b/shaders/src/common_getters.fs
@@ -2,6 +2,10 @@
 // Uniforms access
 //------------------------------------------------------------------------------
 
+#define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x1u
+#define FILAMENT_OBJECT_MORPHING_ENABLED_BIT   0x2u
+#define FILAMENT_OBJECT_CONTACT_SHADOWS_BIT    0x4u
+
 /** @public-api */
 highp mat4 getViewFromWorldMatrix() {
     return frameUniforms.viewFromWorldMatrix;

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -8,6 +8,7 @@ struct Light {
     bool contactShadows;
     uint shadowIndex;
     uint shadowLayer;
+    uint channels;
 };
 
 struct PixelParams {

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -69,14 +69,14 @@ vec4 getPosition() {
 
 #if defined(HAS_SKINNING_OR_MORPHING)
 
-    if (objectUniforms.morphingEnabled == 1) {
+    if ((objectUniforms.flags & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
         pos += objectUniforms.morphWeights.x * mesh_custom0;
         pos += objectUniforms.morphWeights.y * mesh_custom1;
         pos += objectUniforms.morphWeights.z * mesh_custom2;
         pos += objectUniforms.morphWeights.w * mesh_custom3;
     }
 
-    if (objectUniforms.skinningEnabled == 1) {
+    if ((objectUniforms.flags & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
         skinPosition(pos.xyz, mesh_bone_indices, mesh_bone_weights);
     }
 

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -54,7 +54,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
             visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
         }
         if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
-            if (objectUniforms.screenSpaceContactShadows != 0u) {
+            if ((objectUniforms.flags & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
                 ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
             }
         }

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -27,6 +27,7 @@ Light getDirectionalLight() {
     light.l = sampleSunAreaLight(frameUniforms.lightDirection);
     light.attenuation = 1.0;
     light.NoL = saturate(dot(shading_normal, light.l));
+    light.channels = frameUniforms.lightChannels & 0xFFu;
     return light;
 }
 
@@ -34,6 +35,11 @@ void evaluateDirectionalLight(const MaterialInputs material,
         const PixelParams pixel, inout vec3 color) {
 
     Light light = getDirectionalLight();
+
+    uint channels = objectUniforms.channels & 0xFFu;
+    if ((light.channels & channels) == 0u) {
+        return;
+    }
 
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
     if (light.NoL <= 0.0) {

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -193,6 +193,7 @@ void evaluatePunctualLights(const MaterialInputs material,
 
     uint index = froxel.recordOffset;
     uint end = index + froxel.count;
+    uint channels = objectUniforms.channels & 0xFFu;
 
     // Iterate point lights
     for ( ; index < end; index++) {
@@ -211,7 +212,7 @@ void evaluatePunctualLights(const MaterialInputs material,
                     getSpotLightSpacePosition(light.shadowIndex));
             }
             if (light.contactShadows && visibility > 0.0) {
-                if (objectUniforms.screenSpaceContactShadows != 0u) {
+                if ((objectUniforms.flags & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
                     visibility *= 1.0 - screenSpaceContactShadow(light.l);
                 }
             }

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -160,6 +160,7 @@ Light getLight(const uint index) {
     light.contactShadows = false;
     light.shadowIndex = 0u;
     light.shadowLayer = 0u;
+    light.channels = channels;
 
     uint type = typeShadow & 0x1u;
     if (type == LIGHT_TYPE_SPOT) {
@@ -198,6 +199,10 @@ void evaluatePunctualLights(const MaterialInputs material,
     // Iterate point lights
     for ( ; index < end; index++) {
         Light light = getLight(index);
+        if ((light.channels & channels) == 0u) {
+            continue;
+        }
+
 #if defined(MATERIAL_CAN_SKIP_LIGHTING)
         if (light.NoL <= 0.0 || light.attenuation <= 0.0) {
             continue;

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -12,7 +12,7 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal, vertex_worldTangent.xyz);
 
         #if defined(HAS_SKINNING_OR_MORPHING)
-        if (objectUniforms.morphingEnabled == 1) {
+        if ((objectUniforms.flags & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
             vec3 normal0, normal1, normal2, normal3;
             toTangentFrame(mesh_custom4, normal0);
             toTangentFrame(mesh_custom5, normal1);
@@ -25,7 +25,7 @@ void main() {
             material.worldNormal = normalize(material.worldNormal);
         }
 
-        if (objectUniforms.skinningEnabled == 1) {
+        if ((objectUniforms.flags & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
             skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
             skinNormal(vertex_worldTangent.xyz, mesh_bone_indices, mesh_bone_weights);
         }
@@ -43,7 +43,7 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal);
 
         #if defined(HAS_SKINNING_OR_MORPHING)
-            if (objectUniforms.skinningEnabled == 1) {
+            if ((objectUniforms.flags & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
                 skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
             }
         #endif

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -48,7 +48,7 @@ vec4 evaluateMaterial(const MaterialInputs material) {
         visibility = shadow(light_shadowMap, layer, getCascadeLightSpacePosition(cascade));
     }
     if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
-        if (objectUniforms.screenSpaceContactShadows != 0u) {
+        if ((objectUniforms.flags & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
             visibility *= (1.0 - screenSpaceContactShadow(frameUniforms.lightDirection));
         }
     }

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -980,6 +980,10 @@ class_<RenderableBuilder>("RenderableManager$Builder")
             (RenderableBuilder* builder, size_t index, uint16_t order), {
         return &builder->blendOrder(index, order); })
 
+    .BUILDER_FUNCTION("lightChannel", RenderableBuilder,
+            (RenderableBuilder* builder, unsigned int channel, bool enable), {
+        return &builder->lightChannel(channel, enable); })
+
     .function("_build", EMBIND_LAMBDA(int, (RenderableBuilder* builder,
             Engine* engine, utils::Entity entity), {
         return (int) builder->build(*engine, entity);
@@ -1006,6 +1010,8 @@ class_<RenderableManager>("RenderableManager")
     .function("setReceiveShadows", &RenderableManager::setReceiveShadows)
     .function("isShadowCaster", &RenderableManager::isShadowCaster)
     .function("isShadowReceiver", &RenderableManager::isShadowReceiver)
+    .function("setLightChannel", &RenderableManager::setLightChannel)
+    .function("getLightChannel", &RenderableManager::getLightChannel)
 
     .function("setBones", EMBIND_LAMBDA(void, (RenderableManager* self,
             RenderableManager::Instance instance, emscripten::val transforms, size_t offset), {
@@ -1144,7 +1150,10 @@ class_<LightBuilder>("LightManager$Builder")
     .BUILDER_FUNCTION("sunHaloSize", LightBuilder,
             (LightBuilder* builder, float value), { return &builder->sunHaloSize(value); })
     .BUILDER_FUNCTION("sunHaloFalloff", LightBuilder,
-            (LightBuilder* builder, float value), { return &builder->sunHaloFalloff(value); });
+            (LightBuilder* builder, float value), { return &builder->sunHaloFalloff(value); })
+    .BUILDER_FUNCTION("lightChannel", LightBuilder,
+            (LightBuilder* builder, unsigned int channel, bool enable), {
+        return &builder->lightChannel(channel, enable); });
 
 class_<LightManager>("LightManager")
     .function("hasComponent", &LightManager::hasComponent)
@@ -1191,6 +1200,8 @@ class_<LightManager>("LightManager")
     .function("getSunHaloFalloff", &LightManager::getSunHaloFalloff)
     .function("setShadowCaster", &LightManager::setShadowCaster)
     .function("isShadowCaster", &LightManager::isShadowCaster)
+    .function("setLightChannel", &LightManager::setLightChannel)
+    .function("getLightChannel", &LightManager::getLightChannel)
     ;
 
 /// LightManager$Instance ::class:: Component instance returned by [LightManager]


### PR DESCRIPTION
We use fp16 for most values (e.g.: direction, color), which 
ultimately frees a vec4 (Currently unused) and a few other bits.