### PR TITLE
Fade specular AO from bent normals at grazing angles

### DIFF
--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -1444,7 +1444,9 @@ non-shader data.
 </p><dl><dt>Type</dt><dd><p>     array of parameter objects
 
 </p></dd><dt>Value</dt><dd><p>      Each entry is an object with the properties <code>name</code> and <code>type</code>, both of <code>string</code> type. The
-      name must be a valid GLSL identifier. The type must be one of the types described in
+      name must be a valid GLSL identifier. Entries also have an optional <code>precision</code>, which can be
+      one of <code>default</code> (best precision for the platform, typically <code>high</code> on desktop, <code>medium</code> on
+      mobile), <code>low</code>, <code>medium</code>, <code>high</code>. The type must be one of the types described in
       <a href="#table_materialparamstypes">table&nbsp;13</a>.
 
 </p></dd></dl><div class="table">
@@ -1474,10 +1476,8 @@ non-shader data.
 
 <p></p><p>
 
-</p><dl><dt>Samplers</dt><dd><p>      Sampler types can also specify a <code>format</code> (defaults to <code>float</code>) and a <code>precision</code> (defaults
-      to <code>default</code>). The format can be one of <code>int</code>, <code>float</code>. The precision can be one of <code>default</code>
-      (best precision for the platform, typically <code>high</code> on desktop, <code>medium</code> on mobile),
-      <code>low</code>, <code>medium</code>, <code>high</code>.
+</p><dl><dt>Samplers</dt><dd><p>      Sampler types can also specify a <code>format</code> which can be either <code>int</code> or <code>float</code> (defaults to
+      <code>float</code>).
 
 </p></dd><dt>Arrays</dt><dd><p>      A parameter can define an array of values by appending <code>[size]</code> after the type name, where
       <code>size</code> is a positive integer. For instance: <code>float[9]</code> declares an array of nine <code>float</code>
@@ -2022,7 +2022,7 @@ and sorting issues are minimized or eliminated</span></center></div></center>
 <span class="line">    }</span>
 <span class="line">}</span></code></pre><p>
 
-</p><center><div class="image" style=""><a href="images/screenshot_transparent_shadows.jpg" target="_blank"><img class="markdeep" src="images/screenshot_transparent_shadows.jpg"></a><center><span class="imagecaption"><a class="target" name="figure_transparentshadows">&nbsp;</a><b style="font-style:normal;">Figure&nbsp;36:</b> Objects rendered with transparent shadows and blurry VSM with a
+</p><center><div class="image" style=""><a href="images/screenshot_transparent_shadows.jpg" target="_blank"><img class="markdeep" src="images/screenshot_transparent_shadows.jpg"></a><center><span class="imagecaption"><a class="target" name="figure_transparentshadow">&nbsp;</a><b style="font-style:normal;">Figure&nbsp;36:</b> Objects rendered with transparent shadows and blurry VSM with a
 radius of 4. Model <a href="https://sketchfab.com/3d-models/bottle-of-water-48fd4f6e90d84d89b5740ee78587d0ff">Bottle of Water</a>
 by <a href="https://sketchfab.com/person-x">T-Art</a>.</span></center></div></center>
 
@@ -2094,9 +2094,7 @@ occclusion enabled and disabled.</span></center></div></center>
      This effect helps remove unwanted specular reflections as shown in <a href="#figure_specularao">figure&nbsp;40</a>.
      When this value is set to <code>simple</code>, Filament uses a cheap but approximate method of computing
      the specular ambient occlusion term. If this value is set to <code>bentNormals</code>, Filament will use
-     a much more accurate but much more expensive method. <code>bentNormals</code> only works if the material
-     sets the <code>bentNormal</code> property inside the fragment shader. If that property isn't set,
-     <code>bentNormals</code> will behave like <code>simple</code>.
+     a much more accurate but much more expensive method.
 
 </p></dd></dl><p></p><pre class="listing tilde"><code><span class="line">material {</span>
 <span class="line">    specularAmbientOcclusion : simple</span>

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1647,9 +1647,7 @@ Description
      This effect helps remove unwanted specular reflections as shown in figure [specularAO].
      When this value is set to `simple`, Filament uses a cheap but approximate method of computing
      the specular ambient occlusion term. If this value is set to `bentNormals`, Filament will use
-     a much more accurate but much more expensive method. `bentNormals` only works if the material
-     sets the `bentNormal` property inside the fragment shader. If that property isn't set,
-     `bentNormals` will behave like `simple`.
+     a much more accurate but much more expensive method.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -415,6 +415,7 @@ void evaluateClearCoatIBL(const PixelParams pixel, float specularAO, inout vec3 
     vec3 clearCoatR = shading_reflected;
 #endif
     // The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+    // TODO: Should we apply specularAO to the attenuation as well?
     float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixel.clearCoat;
     float attenuation = 1.0 - Fc;
     Fd *= attenuation;


### PR DESCRIPTION
This helps prevent over-darkening but it's an artistic hack.
We need to check how we compute the bent normals as it seems we
find occlusion where there is no occlusion. The effect is
particularly visible on clear coat materials like a car's body.
