### PR TITLE
Metal: support Apple GPU pixel formats on M1 Macs

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -110,12 +110,13 @@ if (FILAMENT_SUPPORTS_METAL)
             src/metal/MetalBufferPool.mm
             src/metal/MetalContext.mm
             src/metal/MetalDriver.mm
+            src/metal/MetalEnums.mm
             src/metal/MetalExternalImage.mm
             src/metal/MetalHandles.mm
+            src/metal/MetalPlatform.mm
             src/metal/MetalResourceTracker.cpp
             src/metal/MetalState.mm
             src/metal/MetalTimerQuery.mm
-            src/metal/MetalPlatform.mm
     )
 
     list(APPEND SRCS ${METAL_SRCS})

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -62,6 +62,11 @@ struct MetalContext {
     // Supported features.
     bool supportsTextureSwizzling = false;
     uint8_t maxColorRenderTargets = 4;
+    struct {
+        uint8_t common;
+        uint8_t apple;
+        uint8_t mac;
+    } highestSupportedGpuFamily;
 
     // sampleCountLookup[requestedSamples] gives a <= sample count supported by the device.
     std::array<uint8_t, MAX_SAMPLE_COUNT + 1> sampleCountLookup;
@@ -118,6 +123,8 @@ struct MetalContext {
     os_signpost_id_t signpostId;
 #endif
 };
+
+void initializeSupportedGpuFamilies(MetalContext* context);
 
 id<MTLCommandBuffer> getPendingCommandBuffer(MetalContext* context);
 

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -19,10 +19,88 @@
 #include "MetalHandles.h"
 
 #include <utils/debug.h>
+#include <utils/FixedCapacityVector.h>
+
+#include <utility>
 
 namespace filament {
 namespace backend {
 namespace metal {
+
+void initializeSupportedGpuFamilies(MetalContext* context) {
+    auto& highestSupportedFamily = context->highestSupportedGpuFamily;
+
+    assert_invariant(context->device);
+    id<MTLDevice> device = context->device;
+
+    highestSupportedFamily.common = 0u;
+    highestSupportedFamily.apple = 0u;
+    highestSupportedFamily.mac = 0u;
+
+    if (@available(iOS 13.0, macOS 10.15, *)) {
+        if ([device supportsFamily:MTLGPUFamilyApple7]) {
+            highestSupportedFamily.apple = 7;
+        } else if ([device supportsFamily:MTLGPUFamilyApple6]) {
+            highestSupportedFamily.apple = 6;
+        } else if ([device supportsFamily:MTLGPUFamilyApple5]) {
+            highestSupportedFamily.apple = 5;
+        } else if ([device supportsFamily:MTLGPUFamilyApple4]) {
+            highestSupportedFamily.apple = 4;
+        } else if ([device supportsFamily:MTLGPUFamilyApple3]) {
+            highestSupportedFamily.apple = 3;
+        } else if ([device supportsFamily:MTLGPUFamilyApple2]) {
+            highestSupportedFamily.apple = 2;
+        } else if ([device supportsFamily:MTLGPUFamilyApple1]) {
+            highestSupportedFamily.apple = 1;
+        }
+
+        if ([device supportsFamily:MTLGPUFamilyCommon3]) {
+            highestSupportedFamily.common = 3;
+        } else if ([device supportsFamily:MTLGPUFamilyCommon2]) {
+            highestSupportedFamily.common = 2;
+        } else if ([device supportsFamily:MTLGPUFamilyCommon1]) {
+            highestSupportedFamily.common = 1;
+        }
+
+        if ([device supportsFamily:MTLGPUFamilyMac2]) {
+            highestSupportedFamily.mac = 2;
+        } else if ([device supportsFamily:MTLGPUFamilyMac1]) {
+            highestSupportedFamily.mac = 1;
+        }
+    } else {
+        using FeatureSet = std::pair<MTLFeatureSet, uint8_t>;
+        auto testFeatureSets = [device] (const auto& featureSets,
+                uint8_t& outHighestSupported) {
+            for (const auto& set : featureSets) {
+                if ([device supportsFeatureSet:set.first]) {
+                    outHighestSupported = set.second;
+                    break;
+                }
+            }
+        };
+
+#if TARGET_OS_IOS
+        // Apple GPUs
+        auto appleFeatureSets = utils::FixedCapacityVector<FeatureSet>::with_capacity(5);
+        if (@available(iOS 12.0, *)) {
+            appleFeatureSets.emplace_back(MTLFeatureSet_iOS_GPUFamily5_v1, 5u);
+        }
+        appleFeatureSets.emplace_back(MTLFeatureSet_iOS_GPUFamily4_v1, 4u);
+        appleFeatureSets.emplace_back(MTLFeatureSet_iOS_GPUFamily3_v2, 3u);
+        appleFeatureSets.emplace_back(MTLFeatureSet_iOS_GPUFamily2_v4, 2u);
+        appleFeatureSets.emplace_back(MTLFeatureSet_iOS_GPUFamily1_v4, 1u);
+
+        testFeatureSets(appleFeatureSets, highestSupportedFamily.apple);
+#elif TARGET_OS_OSX
+        // macOS GPUS
+        auto macFeatureSets = utils::FixedCapacityVector<FeatureSet>::with_capacity(2);
+        macFeatureSets.emplace_back(MTLFeatureSet_macOS_GPUFamily2_v1, 2u);
+        macFeatureSets.emplace_back(MTLFeatureSet_macOS_GPUFamily1_v4, 1u);
+
+        testFeatureSets(macFeatureSets, highestSupportedFamily.mac);
+#endif
+    }
+}
 
 id<MTLCommandBuffer> getPendingCommandBuffer(MetalContext* context) {
     if (context->pendingCommandBuffer) {

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -27,6 +27,9 @@
 
 namespace filament {
 namespace backend {
+namespace metal {
+
+struct MetalContext;
 
 constexpr inline MTLCompareFunction getMetalCompareFunction(RasterState::DepthFunc func)
         noexcept {
@@ -126,172 +129,7 @@ constexpr inline MTLVertexFormat getMetalFormat(ElementType type, bool normalize
     return MTLVertexFormatInvalid;
 }
 
-inline MTLPixelFormat getMetalFormat(TextureFormat format) noexcept {
-#if defined(IOS)
-    // Only iOS 13.0 and above supports the ASTC HDR profile. Older versions of iOS fallback to LDR.
-    // The HDR profile is a superset of the LDR profile.
-    if (@available(iOS 13, *)) {
-        switch (format) {
-            case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_HDR;
-            case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_HDR;
-            case TextureFormat::RGBA_ASTC_5x5: return MTLPixelFormatASTC_5x5_HDR;
-            case TextureFormat::RGBA_ASTC_6x5: return MTLPixelFormatASTC_6x5_HDR;
-            case TextureFormat::RGBA_ASTC_6x6: return MTLPixelFormatASTC_6x6_HDR;
-            case TextureFormat::RGBA_ASTC_8x5: return MTLPixelFormatASTC_8x5_HDR;
-            case TextureFormat::RGBA_ASTC_8x6: return MTLPixelFormatASTC_8x6_HDR;
-            case TextureFormat::RGBA_ASTC_8x8: return MTLPixelFormatASTC_8x8_HDR;
-            case TextureFormat::RGBA_ASTC_10x5: return MTLPixelFormatASTC_10x5_HDR;
-            case TextureFormat::RGBA_ASTC_10x6: return MTLPixelFormatASTC_10x6_HDR;
-            case TextureFormat::RGBA_ASTC_10x8: return MTLPixelFormatASTC_10x8_HDR;
-            case TextureFormat::RGBA_ASTC_10x10: return MTLPixelFormatASTC_10x10_HDR;
-            case TextureFormat::RGBA_ASTC_12x10: return MTLPixelFormatASTC_12x10_HDR;
-            case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_HDR;
-            default: break;
-        }
-    } else {
-        switch (format) {
-            case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_LDR;
-            case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_LDR;
-            case TextureFormat::RGBA_ASTC_5x5: return MTLPixelFormatASTC_5x5_LDR;
-            case TextureFormat::RGBA_ASTC_6x5: return MTLPixelFormatASTC_6x5_LDR;
-            case TextureFormat::RGBA_ASTC_6x6: return MTLPixelFormatASTC_6x6_LDR;
-            case TextureFormat::RGBA_ASTC_8x5: return MTLPixelFormatASTC_8x5_LDR;
-            case TextureFormat::RGBA_ASTC_8x6: return MTLPixelFormatASTC_8x6_LDR;
-            case TextureFormat::RGBA_ASTC_8x8: return MTLPixelFormatASTC_8x8_LDR;
-            case TextureFormat::RGBA_ASTC_10x5: return MTLPixelFormatASTC_10x5_LDR;
-            case TextureFormat::RGBA_ASTC_10x6: return MTLPixelFormatASTC_10x6_LDR;
-            case TextureFormat::RGBA_ASTC_10x8: return MTLPixelFormatASTC_10x8_LDR;
-            case TextureFormat::RGBA_ASTC_10x10: return MTLPixelFormatASTC_10x10_LDR;
-            case TextureFormat::RGBA_ASTC_12x10: return MTLPixelFormatASTC_12x10_LDR;
-            case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_LDR;
-            default: break;
-        }
-    }
-#endif
-
-    switch (format) {
-        // 8-bits per element
-        case TextureFormat::R8: return MTLPixelFormatR8Unorm;
-        case TextureFormat::R8_SNORM: return MTLPixelFormatR8Snorm;
-        case TextureFormat::R8UI: return MTLPixelFormatR8Uint;
-        case TextureFormat::R8I: return MTLPixelFormatR8Sint;
-        case TextureFormat::STENCIL8: return MTLPixelFormatStencil8;
-
-        // 16-bits per element
-        case TextureFormat::R16F: return MTLPixelFormatR16Float;
-        case TextureFormat::R16UI: return MTLPixelFormatR16Uint;
-        case TextureFormat::R16I: return MTLPixelFormatR16Sint;
-        case TextureFormat::RG8: return MTLPixelFormatRG8Unorm;
-        case TextureFormat::RG8_SNORM: return MTLPixelFormatRG8Snorm;
-        case TextureFormat::RG8UI: return MTLPixelFormatRG8Uint;
-        case TextureFormat::RG8I: return MTLPixelFormatRG8Sint;
-
-#if defined(IOS)
-        // iOS does not support 16 bit or 24 bit depth textures.
-        case TextureFormat::DEPTH16:
-        case TextureFormat::DEPTH24:
-            return MTLPixelFormatDepth32Float;
-#else
-        case TextureFormat::DEPTH16: return MTLPixelFormatDepth16Unorm;
-        // MacOS only supports 24 bit depth + 8 bits Stencil
-        case TextureFormat::DEPTH24: return MTLPixelFormatDepth24Unorm_Stencil8;
-#endif
-
-        // TODO: Add packed 16 bit formats- only available on iOS
-        case TextureFormat::RGB565:
-        case TextureFormat::RGB5_A1:
-        case TextureFormat::RGBA4:
-            return MTLPixelFormatInvalid;
-
-        // 24-bits per element, not supported by Metal.
-        case TextureFormat::RGB8:
-        case TextureFormat::SRGB8:
-        case TextureFormat::RGB8_SNORM:
-        case TextureFormat::RGB8UI:
-        case TextureFormat::RGB8I:
-            return MTLPixelFormatInvalid;
-
-        // 32-bits per element
-        case TextureFormat::R32F: return MTLPixelFormatR32Float;
-        case TextureFormat::R32UI: return MTLPixelFormatR32Uint;
-        case TextureFormat::R32I: return MTLPixelFormatR32Sint;
-        case TextureFormat::RG16F: return MTLPixelFormatRG16Float;
-        case TextureFormat::RG16UI: return MTLPixelFormatRG16Uint;
-        case TextureFormat::RG16I: return MTLPixelFormatRG16Sint;
-        case TextureFormat::R11F_G11F_B10F: return MTLPixelFormatRG11B10Float;
-        case TextureFormat::RGB9_E5: return MTLPixelFormatRGB9E5Float;
-        case TextureFormat::RGBA8: return MTLPixelFormatRGBA8Unorm;
-        case TextureFormat::SRGB8_A8: return MTLPixelFormatRGBA8Unorm_sRGB;
-        case TextureFormat::RGBA8_SNORM: return MTLPixelFormatRGBA8Snorm;
-        case TextureFormat::RGB10_A2: return MTLPixelFormatRGB10A2Unorm;
-        case TextureFormat::RGBA8UI: return MTLPixelFormatRGBA8Uint;
-        case TextureFormat::RGBA8I: return MTLPixelFormatRGBA8Sint;
-        case TextureFormat::DEPTH32F: return MTLPixelFormatDepth32Float;
-#if !defined(IOS)
-        case TextureFormat::DEPTH24_STENCIL8: return MTLPixelFormatDepth24Unorm_Stencil8;
-#else
-        case TextureFormat::DEPTH24_STENCIL8: return MTLPixelFormatDepth32Float_Stencil8;
-#endif
-        case TextureFormat::DEPTH32F_STENCIL8: return MTLPixelFormatDepth32Float_Stencil8;
-
-        // 48-bits per element
-        case TextureFormat::RGB16F:
-        case TextureFormat::RGB16UI:
-        case TextureFormat::RGB16I:
-            return MTLPixelFormatInvalid;
-
-        // 64-bits per element
-        case TextureFormat::RG32F: return MTLPixelFormatRG32Float;
-        case TextureFormat::RG32UI: return MTLPixelFormatRG32Uint;
-        case TextureFormat::RG32I: return MTLPixelFormatRG32Sint;
-        case TextureFormat::RGBA16F: return MTLPixelFormatRGBA16Float;
-        case TextureFormat::RGBA16UI: return MTLPixelFormatRGBA16Uint;
-        case TextureFormat::RGBA16I: return MTLPixelFormatRGBA16Sint;
-
-        // 96-bits per element
-        case TextureFormat::RGB32F:
-        case TextureFormat::RGB32UI:
-        case TextureFormat::RGB32I:
-            return MTLPixelFormatInvalid;
-
-        // 128-bits per element
-        case TextureFormat::RGBA32F: return MTLPixelFormatRGBA32Float;
-        case TextureFormat::RGBA32UI: return MTLPixelFormatRGBA32Uint;
-        case TextureFormat::RGBA32I: return MTLPixelFormatRGBA32Sint;
-
-#if defined(IOS)
-        // EAC / ETC2 formats are only available on iPhone.
-        case TextureFormat::EAC_R11: return MTLPixelFormatEAC_R11Unorm;
-        case TextureFormat::EAC_R11_SIGNED: return MTLPixelFormatEAC_R11Snorm;
-        case TextureFormat::EAC_RG11: return MTLPixelFormatEAC_RG11Unorm;
-        case TextureFormat::EAC_RG11_SIGNED: return MTLPixelFormatEAC_RG11Snorm;
-        case TextureFormat::ETC2_RGB8: return MTLPixelFormatETC2_RGB8;
-        case TextureFormat::ETC2_SRGB8: return MTLPixelFormatETC2_RGB8_sRGB;
-        case TextureFormat::ETC2_RGB8_A1: return MTLPixelFormatETC2_RGB8A1;
-        case TextureFormat::ETC2_SRGB8_A1: return MTLPixelFormatETC2_RGB8A1_sRGB;
-        case TextureFormat::ETC2_EAC_RGBA8: return MTLPixelFormatEAC_RGBA8;
-        case TextureFormat::ETC2_EAC_SRGBA8: return MTLPixelFormatEAC_RGBA8_sRGB;
-#endif
-
-#if !defined(IOS)
-        // DXT (BC) formats are only available on macOS desktop.
-        // See https://en.wikipedia.org/wiki/S3_Texture_Compression#S3TC_format_comparison
-        case TextureFormat::DXT1_RGBA: return MTLPixelFormatBC1_RGBA;
-        case TextureFormat::DXT1_SRGBA: return MTLPixelFormatBC1_RGBA_sRGB;
-        case TextureFormat::DXT3_RGBA: return MTLPixelFormatBC2_RGBA;
-        case TextureFormat::DXT3_SRGBA: return MTLPixelFormatBC2_RGBA_sRGB;
-        case TextureFormat::DXT5_RGBA: return MTLPixelFormatBC3_RGBA;
-        case TextureFormat::DXT5_SRGBA: return MTLPixelFormatBC3_RGBA_sRGB;
-
-        case TextureFormat::DXT1_RGB: return MTLPixelFormatInvalid;
-        case TextureFormat::DXT1_SRGB: return MTLPixelFormatInvalid;
-#endif
-
-        default:
-        case TextureFormat::UNUSED:
-            return MTLPixelFormatInvalid;
-    }
-}
+MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexcept;
 
 // Converts PixelBufferDescriptor format + type pair into a MTLPixelFormat.
 inline MTLPixelFormat getMetalFormat(PixelDataFormat format, PixelDataType type) {
@@ -537,6 +375,7 @@ inline MTLTextureSwizzleChannels getSwizzleChannels(TextureSwizzle r, TextureSwi
             getSwizzle(a));
 }
 
+} // namespace metal
 } // namespace backend
 } // namespace filament
 

--- a/filament/backend/src/metal/MetalEnums.mm
+++ b/filament/backend/src/metal/MetalEnums.mm
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MetalEnums.h"
+
+#include "MetalContext.h"
+
+namespace filament {
+namespace backend {
+namespace metal {
+
+MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexcept {
+    switch (format) {
+        // 8-bits per element
+        case TextureFormat::R8: return MTLPixelFormatR8Unorm;
+        case TextureFormat::R8_SNORM: return MTLPixelFormatR8Snorm;
+        case TextureFormat::R8UI: return MTLPixelFormatR8Uint;
+        case TextureFormat::R8I: return MTLPixelFormatR8Sint;
+        case TextureFormat::STENCIL8: return MTLPixelFormatStencil8;
+
+        // 16-bits per element
+        case TextureFormat::R16F: return MTLPixelFormatR16Float;
+        case TextureFormat::R16UI: return MTLPixelFormatR16Uint;
+        case TextureFormat::R16I: return MTLPixelFormatR16Sint;
+        case TextureFormat::RG8: return MTLPixelFormatRG8Unorm;
+        case TextureFormat::RG8_SNORM: return MTLPixelFormatRG8Snorm;
+        case TextureFormat::RG8UI: return MTLPixelFormatRG8Uint;
+        case TextureFormat::RG8I: return MTLPixelFormatRG8Sint;
+
+        // 24-bits per element, not supported by Metal.
+        case TextureFormat::RGB8:
+        case TextureFormat::SRGB8:
+        case TextureFormat::RGB8_SNORM:
+        case TextureFormat::RGB8UI:
+        case TextureFormat::RGB8I:
+            return MTLPixelFormatInvalid;
+
+        // 32-bits per element
+        case TextureFormat::R32F: return MTLPixelFormatR32Float;
+        case TextureFormat::R32UI: return MTLPixelFormatR32Uint;
+        case TextureFormat::R32I: return MTLPixelFormatR32Sint;
+        case TextureFormat::RG16F: return MTLPixelFormatRG16Float;
+        case TextureFormat::RG16UI: return MTLPixelFormatRG16Uint;
+        case TextureFormat::RG16I: return MTLPixelFormatRG16Sint;
+        case TextureFormat::R11F_G11F_B10F: return MTLPixelFormatRG11B10Float;
+        case TextureFormat::RGB9_E5: return MTLPixelFormatRGB9E5Float;
+        case TextureFormat::RGBA8: return MTLPixelFormatRGBA8Unorm;
+        case TextureFormat::SRGB8_A8: return MTLPixelFormatRGBA8Unorm_sRGB;
+        case TextureFormat::RGBA8_SNORM: return MTLPixelFormatRGBA8Snorm;
+        case TextureFormat::RGB10_A2: return MTLPixelFormatRGB10A2Unorm;
+        case TextureFormat::RGBA8UI: return MTLPixelFormatRGBA8Uint;
+        case TextureFormat::RGBA8I: return MTLPixelFormatRGBA8Sint;
+        case TextureFormat::DEPTH32F: return MTLPixelFormatDepth32Float;
+        case TextureFormat::DEPTH32F_STENCIL8: return MTLPixelFormatDepth32Float_Stencil8;
+
+        // 48-bits per element
+        case TextureFormat::RGB16F:
+        case TextureFormat::RGB16UI:
+        case TextureFormat::RGB16I:
+            return MTLPixelFormatInvalid;
+
+        // 64-bits per element
+        case TextureFormat::RG32F: return MTLPixelFormatRG32Float;
+        case TextureFormat::RG32UI: return MTLPixelFormatRG32Uint;
+        case TextureFormat::RG32I: return MTLPixelFormatRG32Sint;
+        case TextureFormat::RGBA16F: return MTLPixelFormatRGBA16Float;
+        case TextureFormat::RGBA16UI: return MTLPixelFormatRGBA16Uint;
+        case TextureFormat::RGBA16I: return MTLPixelFormatRGBA16Sint;
+
+        // 96-bits per element
+        case TextureFormat::RGB32F:
+        case TextureFormat::RGB32UI:
+        case TextureFormat::RGB32I:
+            return MTLPixelFormatInvalid;
+
+        // 128-bits per element
+        case TextureFormat::RGBA32F: return MTLPixelFormatRGBA32Float;
+        case TextureFormat::RGBA32UI: return MTLPixelFormatRGBA32Uint;
+        case TextureFormat::RGBA32I: return MTLPixelFormatRGBA32Sint;
+
+        case TextureFormat::UNUSED:
+            return MTLPixelFormatInvalid;
+
+        default: break;
+    }
+
+    // Packed 16 bit formats are only available on Apple GPUs.
+    if (context->highestSupportedGpuFamily.apple >= 1) {
+        if (@available(macOS 11.0, *)) {
+            switch (format) {
+                case TextureFormat::RGB565: return MTLPixelFormatB5G6R5Unorm;
+                case TextureFormat::RGB5_A1: return MTLPixelFormatA1BGR5Unorm;
+                case TextureFormat::RGBA4: return MTLPixelFormatABGR4Unorm;
+                default: break;
+            }
+        }
+    }
+
+    if (@available(iOS 13.0, *)) {
+        if (format == TextureFormat::DEPTH16) return MTLPixelFormatDepth16Unorm;
+    }
+
+#if TARGET_OS_OSX
+    if (context->highestSupportedGpuFamily.mac >= 1 &&
+            context->device.depth24Stencil8PixelFormatSupported) {
+        if (@available(macOS 11.0, *)) {
+            if (format == TextureFormat::DEPTH24_STENCIL8) {
+                return MTLPixelFormatDepth24Unorm_Stencil8;
+            }
+        }
+    }
+#endif
+
+    // Only iOS 13.0 and Apple Silicon support the ASTC HDR profile. Older OS versions fallback to
+    // LDR. The HDR profile is a superset of the LDR profile.
+    if (context->highestSupportedGpuFamily.apple >= 2) {
+        if (@available(iOS 13, macOS 11.0, *)) {
+            switch (format) {
+                case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_HDR;
+                case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_HDR;
+                case TextureFormat::RGBA_ASTC_5x5: return MTLPixelFormatASTC_5x5_HDR;
+                case TextureFormat::RGBA_ASTC_6x5: return MTLPixelFormatASTC_6x5_HDR;
+                case TextureFormat::RGBA_ASTC_6x6: return MTLPixelFormatASTC_6x6_HDR;
+                case TextureFormat::RGBA_ASTC_8x5: return MTLPixelFormatASTC_8x5_HDR;
+                case TextureFormat::RGBA_ASTC_8x6: return MTLPixelFormatASTC_8x6_HDR;
+                case TextureFormat::RGBA_ASTC_8x8: return MTLPixelFormatASTC_8x8_HDR;
+                case TextureFormat::RGBA_ASTC_10x5: return MTLPixelFormatASTC_10x5_HDR;
+                case TextureFormat::RGBA_ASTC_10x6: return MTLPixelFormatASTC_10x6_HDR;
+                case TextureFormat::RGBA_ASTC_10x8: return MTLPixelFormatASTC_10x8_HDR;
+                case TextureFormat::RGBA_ASTC_10x10: return MTLPixelFormatASTC_10x10_HDR;
+                case TextureFormat::RGBA_ASTC_12x10: return MTLPixelFormatASTC_12x10_HDR;
+                case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_HDR;
+                default: break;
+            }
+        } else if (@available(macOS 11.0, *)) {
+            switch (format) {
+                case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_LDR;
+                case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_LDR;
+                case TextureFormat::RGBA_ASTC_5x5: return MTLPixelFormatASTC_5x5_LDR;
+                case TextureFormat::RGBA_ASTC_6x5: return MTLPixelFormatASTC_6x5_LDR;
+                case TextureFormat::RGBA_ASTC_6x6: return MTLPixelFormatASTC_6x6_LDR;
+                case TextureFormat::RGBA_ASTC_8x5: return MTLPixelFormatASTC_8x5_LDR;
+                case TextureFormat::RGBA_ASTC_8x6: return MTLPixelFormatASTC_8x6_LDR;
+                case TextureFormat::RGBA_ASTC_8x8: return MTLPixelFormatASTC_8x8_LDR;
+                case TextureFormat::RGBA_ASTC_10x5: return MTLPixelFormatASTC_10x5_LDR;
+                case TextureFormat::RGBA_ASTC_10x6: return MTLPixelFormatASTC_10x6_LDR;
+                case TextureFormat::RGBA_ASTC_10x8: return MTLPixelFormatASTC_10x8_LDR;
+                case TextureFormat::RGBA_ASTC_10x10: return MTLPixelFormatASTC_10x10_LDR;
+                case TextureFormat::RGBA_ASTC_12x10: return MTLPixelFormatASTC_12x10_LDR;
+                case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_LDR;
+                default: break;
+            }
+        }
+    }
+
+    // EAC / ETC2 formats are only available on Apple GPUs.
+    if (context->highestSupportedGpuFamily.apple >= 1) {
+        if (@available(macOS 11.0, *)) {
+            switch (format) {
+                case TextureFormat::EAC_R11: return MTLPixelFormatEAC_R11Unorm;
+                case TextureFormat::EAC_R11_SIGNED: return MTLPixelFormatEAC_R11Snorm;
+                case TextureFormat::EAC_RG11: return MTLPixelFormatEAC_RG11Unorm;
+                case TextureFormat::EAC_RG11_SIGNED: return MTLPixelFormatEAC_RG11Snorm;
+                case TextureFormat::ETC2_RGB8: return MTLPixelFormatETC2_RGB8;
+                case TextureFormat::ETC2_SRGB8: return MTLPixelFormatETC2_RGB8_sRGB;
+                case TextureFormat::ETC2_RGB8_A1: return MTLPixelFormatETC2_RGB8A1;
+                case TextureFormat::ETC2_SRGB8_A1: return MTLPixelFormatETC2_RGB8A1_sRGB;
+                case TextureFormat::ETC2_EAC_RGBA8: return MTLPixelFormatEAC_RGBA8;
+                case TextureFormat::ETC2_EAC_SRGBA8: return MTLPixelFormatEAC_RGBA8_sRGB;
+                default: break;
+            }
+        }
+    }
+
+    // DXT (BC) formats are only available on macOS desktop.
+    // See https://en.wikipedia.org/wiki/S3_Texture_Compression#S3TC_format_comparison
+#if TARGET_OS_OSX
+    if (context->highestSupportedGpuFamily.mac >= 1) {
+        switch (format) {
+            case TextureFormat::DXT1_RGBA: return MTLPixelFormatBC1_RGBA;
+            case TextureFormat::DXT1_SRGBA: return MTLPixelFormatBC1_RGBA_sRGB;
+            case TextureFormat::DXT3_RGBA: return MTLPixelFormatBC2_RGBA;
+            case TextureFormat::DXT3_SRGBA: return MTLPixelFormatBC2_RGBA_sRGB;
+            case TextureFormat::DXT5_RGBA: return MTLPixelFormatBC3_RGBA;
+            case TextureFormat::DXT5_SRGBA: return MTLPixelFormatBC3_RGBA_sRGB;
+
+            case TextureFormat::DXT1_RGB: return MTLPixelFormatInvalid;
+            case TextureFormat::DXT1_SRGB: return MTLPixelFormatInvalid;
+            default: break;
+        }
+    }
+#endif
+
+    return MTLPixelFormatInvalid;
+}
+
+} // namespace metal
+} // namespace backend
+} // namespace filament

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -194,7 +194,7 @@ struct MetalTexture : public HwTexture {
             const PixelBufferShape& shape);
     void updateLodRange(uint32_t level);
 
-    static MTLPixelFormat decidePixelFormat(id<MTLDevice> device, TextureFormat format);
+    static MTLPixelFormat decidePixelFormat(MetalContext* context, TextureFormat format);
 
     MetalContext& context;
     MetalExternalImage externalImage;


### PR DESCRIPTION
This removes a bunch of assumptions that only iOS devices have Apple GPUs. For example, M1 Macs should now also support compressed texture formats like ASTC and ETC.