### PR TITLE
Fix specular AO for the sheen and clear coat layers

### DIFF
--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -18,11 +18,11 @@ float unpack(vec2 depth) {
 
 struct SSAOInterpolationCache {
     highp vec4 weights;
+    highp vec2 uv;
 };
 
-float evaluateSSAO(const highp vec2 uv, out SSAOInterpolationCache cache) {
+float evaluateSSAO(inout SSAOInterpolationCache cache) {
 #if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
-
     // Upscale the SSAO buffer in real-time, in high quality mode we use a custom bilinear
     // filter. This adds about 2.0ms @ 250MHz on Pixel 4.
 
@@ -31,14 +31,14 @@ float evaluateSSAO(const highp vec2 uv, out SSAOInterpolationCache cache) {
 
         // Read four AO samples and their depths values
 #if defined(FILAMENT_HAS_FEATURE_TEXTURE_GATHER)
-        vec4 ao = textureGather(light_ssao, vec3(uv, 0.0), 0);
-        vec4 dg = textureGather(light_ssao, vec3(uv, 0.0), 1);
-        vec4 db = textureGather(light_ssao, vec3(uv, 0.0), 2);
+        vec4 ao = textureGather(light_ssao, vec3(cache.uv, 0.0), 0);
+        vec4 dg = textureGather(light_ssao, vec3(cache.uv, 0.0), 1);
+        vec4 db = textureGather(light_ssao, vec3(cache.uv, 0.0), 2);
 #else
-        vec3 s01 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(0, 1)).rgb;
-        vec3 s11 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(1, 1)).rgb;
-        vec3 s10 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(1, 0)).rgb;
-        vec3 s00 = textureLodOffset(light_ssao, vec3(uv, 0.0), 0.0, ivec2(0, 0)).rgb;
+        vec3 s01 = textureLodOffset(light_ssao, vec3(cache.uv, 0.0), 0.0, ivec2(0, 1)).rgb;
+        vec3 s11 = textureLodOffset(light_ssao, vec3(cache.uv, 0.0), 0.0, ivec2(1, 1)).rgb;
+        vec3 s10 = textureLodOffset(light_ssao, vec3(cache.uv, 0.0), 0.0, ivec2(1, 0)).rgb;
+        vec3 s00 = textureLodOffset(light_ssao, vec3(cache.uv, 0.0), 0.0, ivec2(0, 0)).rgb;
         vec4 ao = vec4(s01.r, s11.r, s10.r, s00.r);
         vec4 dg = vec4(s01.g, s11.g, s10.g, s00.g);
         vec4 db = vec4(s01.b, s11.b, s10.b, s00.b);
@@ -52,7 +52,7 @@ float evaluateSSAO(const highp vec2 uv, out SSAOInterpolationCache cache) {
         depths *= -frameUniforms.cameraFar;
 
         // bilinear weights
-        vec2 f = fract(uv * size - 0.5);
+        vec2 f = fract(cache.uv * size - 0.5);
         vec4 b;
         b.x = (1.0 - f.x) * f.y;
         b.y = f.x * f.y;
@@ -66,7 +66,7 @@ float evaluateSSAO(const highp vec2 uv, out SSAOInterpolationCache cache) {
         cache.weights = w / (w.x + w.y + w.z + w.w);
         return dot(ao, cache.weights);
     } else {
-        return textureLod(light_ssao, vec3(uv, 0.0), 0.0).r;
+        return textureLod(light_ssao, vec3(cache.uv, 0.0), 0.0).r;
     }
 #else
     // SSAO is not applied when blending is enabled
@@ -131,9 +131,7 @@ vec3 unpackBentNormal(vec3 bn) {
     return bn * 2.0 - 1.0;
 }
 
-float computeSpecularAO(const highp vec2 uv, float NoV, float visibility, float roughness,
-        const in SSAOInterpolationCache cache) {
-
+float specularAO(float NoV, float visibility, float roughness, const in SSAOInterpolationCache cache) {
     float specularAO = 1.0;
 
 // SSAO is not applied when blending is enabled
@@ -154,14 +152,14 @@ float computeSpecularAO(const highp vec2 uv, float NoV, float visibility, float 
         vec3 bn;
         if (frameUniforms.aoSamplingQualityAndEdgeDistance > 0.0) {
 #if defined(FILAMENT_HAS_FEATURE_TEXTURE_GATHER)
-            vec4 bnr = textureGather(light_ssao, vec3(uv, 1.0), 0);
-            vec4 bng = textureGather(light_ssao, vec3(uv, 1.0), 1);
-            vec4 bnb = textureGather(light_ssao, vec3(uv, 1.0), 2);
+            vec4 bnr = textureGather(light_ssao, vec3(cache.uv, 1.0), 0);
+            vec4 bng = textureGather(light_ssao, vec3(cache.uv, 1.0), 1);
+            vec4 bnb = textureGather(light_ssao, vec3(cache.uv, 1.0), 2);
 #else
-            vec3 s01 = textureLodOffset(light_ssao, vec3(uv, 1.0), 0.0, ivec2(0, 1)).rgb;
-            vec3 s11 = textureLodOffset(light_ssao, vec3(uv, 1.0), 0.0, ivec2(1, 1)).rgb;
-            vec3 s10 = textureLodOffset(light_ssao, vec3(uv, 1.0), 0.0, ivec2(1, 0)).rgb;
-            vec3 s00 = textureLodOffset(light_ssao, vec3(uv, 1.0), 0.0, ivec2(0, 0)).rgb;
+            vec3 s01 = textureLodOffset(light_ssao, vec3(cache.uv, 1.0), 0.0, ivec2(0, 1)).rgb;
+            vec3 s11 = textureLodOffset(light_ssao, vec3(cache.uv, 1.0), 0.0, ivec2(1, 1)).rgb;
+            vec3 s10 = textureLodOffset(light_ssao, vec3(cache.uv, 1.0), 0.0, ivec2(1, 0)).rgb;
+            vec3 s00 = textureLodOffset(light_ssao, vec3(cache.uv, 1.0), 0.0, ivec2(0, 0)).rgb;
             vec4 bnr = vec4(s01.r, s11.r, s10.r, s00.r);
             vec4 bng = vec4(s01.g, s11.g, s10.g, s00.g);
             vec4 bnb = vec4(s01.b, s11.b, s10.b, s00.b);
@@ -170,21 +168,16 @@ float computeSpecularAO(const highp vec2 uv, float NoV, float visibility, float 
             bn.g = dot(bng, cache.weights);
             bn.b = dot(bnb, cache.weights);
         } else {
-            bn = textureLod(light_ssao, vec3(uv, 1.0), 0.0).xyz;
+            bn = textureLod(light_ssao, vec3(cache.uv, 1.0), 0.0).xyz;
         }
 
         bn = unpackBentNormal(bn);
         bn = normalize(bn);
 
-        // Since our screen space specular AO uses normals reconstructed from the depth buffer,
-        // too much occlusion may be computed at grazing angles. This is an artistic hack to
-        // reduce the occlusion at grazing viewing angles.
         float ssSpecularAO = SpecularAO_Cones(bn, visibility, roughness);
-        // TODO: Revisit this artistic choice after we find a better way to compute bent normals
-        ssSpecularAO = mix(1.0, ssSpecularAO, smoothstep(0.0, 0.2, NoV));
-
         // Combine the specular AO from the texture with screen space specular AO
         specularAO = min(specularAO, ssSpecularAO);
+
         // For now we don't use the screen space AO bent normal for the diffuse because the
         // AO bent normal is currently a face normal.
     }

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -18,7 +18,9 @@ float unpack(vec2 depth) {
 
 struct SSAOInterpolationCache {
     highp vec4 weights;
+#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
     highp vec2 uv;
+#endif
 };
 
 float evaluateSSAO(inout SSAOInterpolationCache cache) {


### PR DESCRIPTION
We used a single specular AO term for the sheen and clear coat layers,
computed for the base layer. This was creating occlusion that was way
too strong when the roughness from the top layers was very different from
the roughness of the base layer. The effect was particularly obvious
on clear coat materials (car paint for instance).

With this change we can also remove the "grazing angle fade" artistic
hack that was previously introduced to combat this effect.

Ambient occlusion:
<img width="1482" alt="Screen Shot 2021-07-30 at 4 33 37 PM" src="https://user-images.githubusercontent.com/869684/127721190-d13f29f3-7150-4490-b0fa-80b3645174e6.png">

Specular ambient occlusion from screen-space bent normals with this fix:
<img width="1482" alt="Screen Shot 2021-07-30 at 4 33 34 PM" src="https://user-images.githubusercontent.com/869684/127721203-99dfaa81-7377-4350-bae1-460f0c85ee84.png">

