### PR TITLE
cached sidecar renderbuffer must honor MS count

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -514,7 +514,7 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    samples = std::min(samples, uint8_t(gl.gets.max_samples));
+    samples = std::clamp(samples, uint8_t(1u), uint8_t(gl.gets.max_samples));
     GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
     if (UTILS_LIKELY(usage & TextureUsage::SAMPLEABLE)) {
         if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
@@ -590,7 +590,7 @@ void OpenGLDriver::createTextureSwizzledR(Handle<HwTexture> th,
 
     // WebGL does not support swizzling. We assert for this in the Texture builder,
     // so it is probably fine to silently ignore the swizzle state here.
-    #if !defined(__EMSCRIPTEN__)
+#if !defined(__EMSCRIPTEN__)
 
     // the texture is still bound and active from createTextureR
     GLTexture* t = handle_cast<GLTexture *>(th);
@@ -600,7 +600,7 @@ void OpenGLDriver::createTextureSwizzledR(Handle<HwTexture> th,
     glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_B, getSwizzleChannel(b));
     glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_A, getSwizzleChannel(a));
 
-    #endif
+#endif
 
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -611,6 +611,7 @@ void OpenGLDriver::importTextureR(Handle<HwTexture> th, intptr_t id,
     DEBUG_MARKER()
 
     auto& gl = mContext;
+    samples = std::clamp(samples, uint8_t(1u), uint8_t(gl.gets.max_samples));
     GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
 
     t->gl.id = (GLuint)id;
@@ -906,10 +907,14 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
 
         gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
 
-        if (UTILS_UNLIKELY(pAttachmentTexture->gl.sidecarRenderBufferMS == 0)) {
-            glGenRenderbuffers(1, &pAttachmentTexture->gl.sidecarRenderBufferMS);
+        if (UTILS_UNLIKELY(pAttachmentTexture->gl.sidecarRenderBufferMS == 0 ||
+                rt->gl.samples != pAttachmentTexture->gl.sidecarSamples)) {
+            if (pAttachmentTexture->gl.sidecarRenderBufferMS == 0) {
+                glGenRenderbuffers(1, &pAttachmentTexture->gl.sidecarRenderBufferMS);
+            }
             renderBufferStorage(pAttachmentTexture->gl.sidecarRenderBufferMS,
                     t->gl.internalFormat, rt->width, rt->height, rt->gl.samples);
+            pAttachmentTexture->gl.sidecarSamples = rt->gl.samples;
         }
 
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER,
@@ -1055,7 +1060,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
      *  undefined after execution of a rendering command.
      */
 
-    samples = std::min(samples, uint8_t(mContext.gets.max_samples));
+    samples = std::clamp(samples, uint8_t(1u), uint8_t(mContext.gets.max_samples));
 
     rt->gl.samples = samples;
     rt->targets = targets;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -109,7 +109,8 @@ public:
 
     struct GLTexture : public backend::HwTexture {
         using HwTexture::HwTexture;
-        struct {
+        struct GL {
+            GL() noexcept : imported(false), sidecarSamples(1), reserved(0) {}
             GLuint id = 0;          // texture or renderbuffer id
             GLenum target = 0;
             GLenum internalFormat = 0;
@@ -121,7 +122,9 @@ public:
             int8_t baseLevel = 127;
             int8_t maxLevel = -1;
             uint8_t targetIndex = 0;    // optimization: index corresponding to target
-            bool imported = false;
+            bool imported           : 1;
+            uint8_t sidecarSamples  : 4;
+            uint8_t reserved        : 3;
         } gl;
 
         void* platformPImpl = nullptr;
@@ -181,7 +184,7 @@ public:
 
     struct GLRenderTarget : public backend::HwRenderTarget {
         using HwRenderTarget::HwRenderTarget;
-        struct GL {
+        struct {
             // field ordering to optimize size on 64-bits
             GLTexture* color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
             GLTexture* depth;
@@ -189,7 +192,7 @@ public:
             GLuint fbo = 0;
             mutable GLuint fbo_read = 0;
             mutable backend::TargetBufferFlags resolve = backend::TargetBufferFlags::NONE; // attachments in fbo_draw to resolve
-            uint8_t samples : 4;
+            uint8_t samples = 1;
         } gl;
         backend::TargetBufferFlags targets = {};
     };


### PR DESCRIPTION
When we associate a sidecar renderbuffer (for MSRTT emulation) to a 
texture, the msaa count comes from the rendertarget -- if this texture
is later used with a rendertarget with a different MS count, it should
still work -- in this case we have to reallocate the sidecar buffer.