### PR TITLE
Camera::get*ProjectionMatrix should return the value set by the user

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Camera.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Camera.java
@@ -254,6 +254,9 @@ public class Camera {
     /**
      * Sets a custom projection matrix.
      *
+     * <p>The projection matrix must define an NDC system that must match the OpenGL convention,
+     * that is all 3 axis are mapped to [-1, 1].</p>
+     *
      * @param inProjection  custom projection matrix for rendering and culling
      *
      * @param near          distance in world units from the camera to the near plane.
@@ -278,6 +281,9 @@ public class Camera {
 
     /**
      * Sets a custom projection matrix.
+     *
+     * <p>The projection matrices must define an NDC system that must match the OpenGL convention,
+     * that is all 3 axis are mapped to [-1, 1].</p>
      *
      * @param inProjection              custom projection matrix for rendering.
      *

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -207,6 +207,9 @@ public:
      *       0 0 tz c              0 0 c tz
      *       0 0 -1 0              0 0 0 1
      *
+     * The projection matrix must define an NDC system that must match the OpenGL convention,
+     * that is all 3 axis are mapped to [-1, 1].
+     *
      * @param projection  custom projection matrix used for rendering and culling
      * @param near        distance in world units from the camera to the near plane. \p near > 0.
      * @param far         distance in world units from the camera to the far plane. \p far > \p near.
@@ -220,6 +223,9 @@ public:
      *       0 b ty 0              0 b 0 ty
      *       0 0 tz c              0 0 c tz
      *       0 0 -1 0              0 0 0 1
+     *
+     * The projection matrices must define an NDC system that must match the OpenGL convention,
+     * that is all 3 axis are mapped to [-1, 1].
      *
      * @param projection  custom projection matrix used for rendering
      * @param projectionForCulling  custom projection matrix used for culling

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -356,11 +356,11 @@ void Camera::setShift(math::double2 shift) noexcept {
 }
 
 mat4 Camera::getProjectionMatrix() const noexcept {
-    return upcast(this)->getProjectionMatrix();
+    return upcast(this)->getUserProjectionMatrix();
 }
 
 mat4 Camera::getCullingProjectionMatrix() const noexcept {
-    return upcast(this)->getCullingProjectionMatrix();
+    return upcast(this)->getUserCullingProjectionMatrix();
 }
 
 math::double4 Camera::getScaling() const noexcept {

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -71,10 +71,18 @@ public:
 
     const math::double2 getShift() const noexcept { return mShiftCS * 0.5; }
 
-    // returns the projection matrix
+    // viewing the projection matrix to be used for rendering, contains scaling/shift and possibly
+    // other transforms needed by the shaders
     math::mat4 getProjectionMatrix() const noexcept;
 
+    // culling the projection matrix to be used for culling, contains scaling/shift
     math::mat4 getCullingProjectionMatrix() const noexcept;
+
+    // viewing projection matrix set by the user
+    math::mat4 getUserProjectionMatrix() const noexcept { return mProjection; }
+
+    // culling projection matrix set by the user
+    math::mat4 getUserCullingProjectionMatrix() const noexcept { return mProjectionForCulling; }
 
     float getNear() const noexcept { return mNear; }
 


### PR DESCRIPTION
Camera::getProjectionMatrix and Camera::getCullingProjectionMatrix used
to return the projection matrix modified by scaling and shift, instead
they should return the value set by the user, especially when
setCustomProjection() is used.