### PR TITLE
Tag SDL2 windows as sRGB

### DIFF
--- a/libs/filamentapp/include/filamentapp/NativeWindowHelper.h
+++ b/libs/filamentapp/include/filamentapp/NativeWindowHelper.h
@@ -24,6 +24,8 @@ extern "C" void* getNativeWindow(SDL_Window* sdlWindow);
 #if defined(__APPLE__)
 // Add a backing CAMetalLayer to the NSView and return the layer.
 extern "C" void* setUpMetalLayer(void* nativeWindow);
+// Setup the window the way Filament expects (color space, etc.).
+extern "C" void prepareNativeWindow(SDL_Window* sdlWindow);
 // Resize the backing CAMetalLayer's drawable to match the new view's size. Returns the layer.
 extern "C" void* resizeMetalLayer(void* nativeView);
 #endif

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -544,6 +544,7 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
         void* nativeSwapChain = nativeWindow;
 
 #if defined(__APPLE__)
+        ::prepareNativeWindow(mWindow);
 
         void* metalLayer = nullptr;
         if (config.backend == filament::Engine::Backend::METAL) {

--- a/libs/filamentapp/src/NativeWindowHelperCocoa.mm
+++ b/libs/filamentapp/src/NativeWindowHelperCocoa.mm
@@ -32,6 +32,14 @@ void* getNativeWindow(SDL_Window* sdlWindow) {
     return view;
 }
 
+void prepareNativeWindow(SDL_Window* sdlWindow) {
+    SDL_SysWMinfo wmi;
+    SDL_VERSION(&wmi.version);
+    ASSERT_POSTCONDITION(SDL_GetWindowWMInfo(sdlWindow, &wmi), "SDL version unsupported!");
+    NSWindow* win = wmi.info.cocoa.window;
+    [win setColorSpace:[NSColorSpace sRGBColorSpace]];
+}
+
 void* setUpMetalLayer(void* nativeView) {
     NSView* view = (NSView*) nativeView;
     [view setWantsLayer:YES];


### PR DESCRIPTION
By default windows on macOS are tagged with the display's color profile. This is fine if the app performs its own conversion from its working color space to the display profile's color space. However, Filament expects to output sRGB in sRGB windows and does not attempt to match the display profile, leaving this to the underlying operating system.

As a result, sRGB content output by Filament was stretched to the gamut volume of the display, which are commonly P3-ish nowadays. This resulted in over-saturated colors. With this change, our windows are properly tagged as sRGB and preserve the colors as expected.