### PR TITLE
Use a clip space that matches our screen space for the z axis

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -667,8 +667,10 @@ bool MetalDriver::isFrameTimeSupported() {
 }
 
 math::float2 MetalDriver::getClipSpaceParams() {
-    // z-coordinate of clip-space is in [0,w]
-    return math::float2{ -0.5f, 0.5f };
+    // virtual and physical z-coordinate of clip-space is in [-w, 0]
+    // Note: this is actually never used (see: main.vs), but it's a backend API so we implement it
+    // properly.
+    return math::float2{ 1.0f, 0.0f };
 }
 
 uint8_t MetalDriver::getMaxDrawBuffers() {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -165,7 +165,7 @@ bool NoopDriver::isFrameTimeSupported() {
 }
 
 math::float2 NoopDriver::getClipSpaceParams() {
-    return math::float2{ -1.0f, 0.0f };
+    return math::float2{ 1.0f, 0.0f };
 }
 
 uint8_t NoopDriver::getMaxDrawBuffers() {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1565,7 +1565,10 @@ bool OpenGLDriver::isFrameTimeSupported() {
 
 math::float2 OpenGLDriver::getClipSpaceParams() {
     return mContext.ext.EXT_clip_control ?
-            math::float2{ -0.5f, 0.5f } : math::float2{ -1.0f, 0.0f };
+           // z-coordinate of virtual and physical clip-space is in [-w, 0]
+           math::float2{ 1.0f, 0.0f } :
+           // z-coordinate of virtual clip-space is in [-w,0], physical is in [-w, w]
+           math::float2{ 2.0f, -1.0f };
 }
 
 uint8_t OpenGLDriver::getMaxDrawBuffers() {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -821,8 +821,10 @@ bool VulkanDriver::isFrameTimeSupported() {
 }
 
 math::float2 VulkanDriver::getClipSpaceParams() {
-    // z-coordinate of clip-space is in [0,w]
-    return math::float2{ -0.5f, 0.5f };
+    // virtual and physical z-coordinate of clip-space is in [-w, 0]
+    // Note: this is actually never used (see: main.vs), but it's a backend API so we implement it
+    // properly.
+    return math::float2{ 1.0f, 0.0f };
 }
 
 uint8_t VulkanDriver::getMaxDrawBuffers() {

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -168,10 +168,14 @@ void UTILS_NOINLINE FCamera::setProjection(Camera::Projection projection,
 }
 
 math::mat4 FCamera::getProjectionMatrix() const noexcept {
+    // This is where we transform the user clip-space (GL convention) to our virtual clip-space
+    // (inverted DX convention)
+    // Note that this math, ends up setting the projection matrix' p33 to 0, which is where we're
+    // getting back a lot of precision in the depth buffer.
     const mat4 m{ mat4::row_major_init{
             mScaling.x, 0.0, 0.0, mShiftCS.x,
             0.0, mScaling.y, 0.0, mShiftCS.y,
-            0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, -0.5, 0.5,    // GL to inverted DX convention
             0.0, 0.0, 0.0, 1.0
     }};
     return m * mProjection;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -566,7 +566,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                 mi->setParameter("projectionScaleRadius",
                         projectionScale * options.radius);
                 mi->setParameter("depthParams",
-                        cameraInfo.projection[3][2] * 0.5f);
+                        -cameraInfo.projection[3][2]);  // z_v = -near / z_s
                 mi->setParameter("positionParams", float2{
                         invProjection[0][0], invProjection[1][1] } * 2.0f);
                 mi->setParameter("peak2", peak * peak);
@@ -935,12 +935,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
      *  -------------------------------
      *
      *  1/d is computed from the depth buffer value as:
-     *  (note: our z-buffer is encoded as reversed-z, so we use 1-z below)
+     *  (note: our Z clip space is 1 to 0 (inverted DirectX NDC))
      *
-     *          screen-space -> clip-space -> view-space -> distance (x-1)
+     *          screen-space -> clip-space -> view-space -> distance (*-1)
      *
-     *   v_s = { x, y, 1 - z, 1 }                 // screen space (reversed-z)
-     *   v_c = 2 * v_s - 1                        // clip space
+     *   v_s = { x, y, z, 1 }                     // screen space (reversed-z)
+     *   v_c = v_s                                // clip space (matches screen space)
      *   v   = inverse(projection) * v_c          // view space
      *   d   = -v.z / v.w                         // view space distance to camera
      *   1/d = -v.w / v.z
@@ -954,23 +954,23 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
      *
      * It comes that:
      *
-     *          -2C         C - A
-     *    1/d = --- . z  + -------
-     *           B            B
+     *           C          A
+     *    1/d = --- . z  - ---
+     *           B          B
      *
      * note: Here the result doesn't depend on {x, y}. This wouldn't be the case with a
      *       tilt-shift lens.
      *
      * Mathematica code:
      *      p = {{a, 0, b, 0}, {0, c, d, 0}, {0, 0, m22, m32}, {0, 0, m23, 0}};
-     *      v = {x, y, (1 - z)*2 - 1, 1};
+     *      v = {x, y, z, 1};
      *      f = Inverse[p].v;
      *      Simplify[f[[4]]/f[[3]]]
      *
      * Plugging this back into the expression of: coc(z) = Kc . Ks . (1 - S / d)
      * We get that:  coc(z) = C0 * z + C1
-     * With: C0 = - Kc * Ks * S * 2 * C / B
-     *       C1 =   Kc * Ks * (1 - S * (C - A) / B)
+     * With: C0 = - Kc * Ks * S * -C / B
+     *       C1 =   Kc * Ks * (1 + S * A / B)
      *
      * It's just a madd!
      */
@@ -982,8 +982,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
 
     auto const& p = cameraInfo.projection;
     const float2 cocParams = {
-              -K * focusDistance * 2.0 * p[2][3] / p[3][2],
-               K * (1.0 - focusDistance * (p[2][3] - p[2][2]) / p[3][2])
+              K * focusDistance * p[2][3] / p[3][2],
+              K * (1.0 + focusDistance * p[2][2] / p[3][2])
     };
 
     Blackboard& blackboard = fg.getBlackboard();

--- a/filament/src/details/ShadowMap.h
+++ b/filament/src/details/ShadowMap.h
@@ -215,7 +215,7 @@ private:
 
     static math::mat4f directionalLightFrustum(float n, float f) noexcept;
 
-    math::mat4f getTextureCoordsMapping() const noexcept;
+    math::mat4 getTextureCoordsMapping() const noexcept;
 
     static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpace,
             const math::mat4f& Mv, float zfar) noexcept;

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -18,6 +18,8 @@ void main() {
 
 #if defined(VERTEX_DOMAIN_DEVICE)
     gl_Position = getPosition();
+    // GL convention to inverted DX convention
+    gl_Position.z = gl_Position.z * -0.5 + 0.5;
 #else
     gl_Position = getClipFromWorldMatrix() * getWorldPosition(material);
 #endif
@@ -31,5 +33,8 @@ void main() {
     gl_Position.y = -gl_Position.y;
 #endif
 
-    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
+#if !defined(TARGET_VULKAN_ENVIRONMENT) && !defined(TARGET_METAL_ENVIRONMENT)
+    // This is not needed in Vulkan or Metal because clipControl is always (1, 0)
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl);
+#endif
 }

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -150,6 +150,6 @@ vec4 computeWorldPosition() {
     }
     return position * (1.0 / position.w);
 #else
-#error "Unknown Vertex Domain"
+#error Unknown Vertex Domain
 #endif
 }

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -142,12 +142,14 @@ vec4 computeWorldPosition() {
     mat4 transform = getWorldFromViewMatrix();
     vec3 position = getPosition().xyz;
     return mulMat4x4Float3(transform, position);
-#else
+#elif defined(VERTEX_DOMAIN_DEVICE)
     mat4 transform = getWorldFromClipMatrix();
     vec4 position = transform * getPosition();
     if (abs(position.w) < MEDIUMP_FLT_MIN) {
         position.w = position.w < 0.0 ? -MEDIUMP_FLT_MIN : MEDIUMP_FLT_MIN;
     }
     return position * (1.0 / position.w);
+#else
+#error "Unknown Vertex Domain"
 #endif
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -95,6 +95,8 @@ void main() {
 #if defined(VERTEX_DOMAIN_DEVICE)
     // The other vertex domains are handled in initMaterialVertex()->computeWorldPosition()
     gl_Position = getPosition();
+    // GL convention to inverted DX convention
+    gl_Position.z = gl_Position.z * -0.5 + 0.5;
 #else
     gl_Position = getClipFromWorldMatrix() * getWorldPosition(material);
 #endif
@@ -111,5 +113,8 @@ void main() {
     gl_Position.y = -gl_Position.y;
 #endif
 
-    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
+#if !defined(TARGET_VULKAN_ENVIRONMENT) && !defined(TARGET_METAL_ENVIRONMENT)
+    // This is not needed in Vulkan or Metal because clipControl is always (1, 0)
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl);
+#endif
 }

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -13,9 +13,14 @@ void main() {
 #endif
 
     gl_Position = getPosition();
+    // GL convention to inverted DX convention
+    gl_Position.z = gl_Position.z * -0.5 + 0.5;
 
     // Adjust clip-space
-    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl.xy);
+#if !defined(TARGET_VULKAN_ENVIRONMENT) && !defined(TARGET_METAL_ENVIRONMENT)
+    // This is not needed in Vulkan or Metal because clipControl is always (1, 0)
+    gl_Position.z = dot(gl_Position.zw, frameUniforms.clipControl);
+#endif
 
     // Invoke user code
     postProcessVertex(inputs);


### PR DESCRIPTION
We now set the projection matrix so that the clip space for the z
axis follows the inverted DX convention, i.e.: z_clip between 1 (near)
and 0 (far), which matches our screen space.

Note that the actual clip space in the GPU can revert to the "inverted
GL convention", i.e.: z_clip between -1 and 1, if the clip_control
extension is not present. In that case the precision benefits are 
mostly lost.

Also note that there shouldn't be any user facing changes. 
The projection matrix at the API level, still follows the GL convention.

Also, currently, the VERTEX_DOMAIN_DEVICE for materials also keeps
the GL convention (this is corrected in the vertex shader).


The gist of this change is to move the "reversed DX" mapping from the
vertex shader to the projection matrix.