### PR TITLE
views with custom render target should be blendable

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -352,9 +352,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             }, viewRenderTarget);
 
     const bool blendModeTranslucent = view.getBlendMode() == View::BlendMode::TRANSLUCENT;
-    const bool hasCustomRenderTarget = viewRenderTarget != mRenderTarget;
-    // "blending" is meaningless when the view has a custom rendertarget because it's not composited
-    const bool blending = !hasCustomRenderTarget && blendModeTranslucent;
+    const bool blending = blendModeTranslucent;
     // If the swapchain is transparent or if we blend into it, we need to allocate our intermediate
     // buffers with an alpha channel.
     const bool needsAlphaChannel = (mSwapChain ? mSwapChain->isTransparent() : false) || blendModeTranslucent;


### PR DESCRIPTION
We made this wrong assumption that views with a custom rendertarget
are never blended, but it's not true -- e.g. two views can use the
same rendertarget.

Fixes #4430
May impact #2802