### PR TITLE
Properly address the color grading LUT

### DIFF
--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -470,6 +470,8 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
         c.adaptationTransform = adaptationTransform(builder->whiteBalance);
     }
 
+    mDimension = c.lutDimension;
+
     size_t lutElementCount = c.lutDimension * c.lutDimension * c.lutDimension;
     size_t elementSize = sizeof(half4);
     void* data = malloc(lutElementCount * elementSize);

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1850,6 +1850,7 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
 
     auto const& material = getPostProcessMaterial("colorGradingAsSubpass");
     FMaterialInstance* mi = material.getMaterialInstance();
+
     mi->setParameter("lut", colorGrading->getHwHandle(), {
             .filterMag = SamplerMagFilter::LINEAR,
             .filterMin = SamplerMinFilter::LINEAR,
@@ -1857,6 +1858,10 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
             .wrapT = SamplerWrapMode::CLAMP_TO_EDGE,
             .wrapR = SamplerWrapMode::CLAMP_TO_EDGE,
             .anisotropyLog2 = 0
+    });
+    mi->setParameter("lutSize", float2{
+        float(colorGrading->getDimension()) - 1.0f,
+        1.0f / float(colorGrading->getDimension()),
     });
 
     const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
@@ -1970,9 +1975,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
 
                 auto const& material = getPostProcessMaterial("colorGrading");
                 FMaterialInstance* mi = material.getMaterialInstance();
+
                 mi->setParameter("lut", colorGrading->getHwHandle(), {
                         .filterMag = SamplerMagFilter::LINEAR,
                         .filterMin = SamplerMinFilter::LINEAR
+                });
+                mi->setParameter("lutSize", float2{
+                    float(colorGrading->getDimension()) - 1.0f,
+                    1.0f / float(colorGrading->getDimension()),
                 });
                 mi->setParameter("colorBuffer", colorTexture, { /* shader uses texelFetch */ });
                 mi->setParameter("bloomBuffer", bloomTexture, {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1859,9 +1859,9 @@ void PostProcessManager::colorGradingPrepareSubpass(DriverApi& driver,
             .wrapR = SamplerWrapMode::CLAMP_TO_EDGE,
             .anisotropyLog2 = 0
     });
+    const float lutDimension = float(colorGrading->getDimension());
     mi->setParameter("lutSize", float2{
-        float(colorGrading->getDimension()) - 1.0f,
-        1.0f / float(colorGrading->getDimension()),
+        0.5f / lutDimension, (lutDimension - 1.0f) / lutDimension,
     });
 
     const float temporalNoise = mUniformDistribution(mEngine.getRandomEngine());
@@ -1980,9 +1980,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                         .filterMag = SamplerMagFilter::LINEAR,
                         .filterMin = SamplerMinFilter::LINEAR
                 });
+                const float lutDimension = float(colorGrading->getDimension());
                 mi->setParameter("lutSize", float2{
-                    float(colorGrading->getDimension()) - 1.0f,
-                    1.0f / float(colorGrading->getDimension()),
+                    0.5f / lutDimension, (lutDimension - 1.0f) / lutDimension,
                 });
                 mi->setParameter("colorBuffer", colorTexture, { /* shader uses texelFetch */ });
                 mi->setParameter("bloomBuffer", bloomTexture, {

--- a/filament/src/details/ColorGrading.h
+++ b/filament/src/details/ColorGrading.h
@@ -43,8 +43,11 @@ public:
 
     backend::TextureHandle getHwHandle() const noexcept { return mLutHandle; }
 
+    uint32_t getDimension() const noexcept { return mDimension; }
+
 private:
     backend::TextureHandle mLutHandle;
+    uint32_t mDimension;
 };
 
 FILAMENT_UPCAST(ColorGrading)

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -12,6 +12,10 @@ material {
             precision: medium
         },
         {
+            type : float2,
+            name : lutSize
+        },
+        {
             type : sampler2d,
             name : bloomBuffer,
             precision: medium
@@ -126,6 +130,10 @@ vec3 colorGrade(mediump sampler3D lut, const vec3 x) {
     const float c = 0.244161 / log2(10.0);
     const float d = 0.386036;
     vec3 logc = c * log2(a * x + b) + d;
+
+    // Remap to sample pixel centers
+    logc = (0.5 + logc * materialParams.lutSize.x) * materialParams.lutSize.y;
+
     return textureLod(lut, logc, 0.0).rgb;
 }
 

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -132,7 +132,7 @@ vec3 colorGrade(mediump sampler3D lut, const vec3 x) {
     vec3 logc = c * log2(a * x + b) + d;
 
     // Remap to sample pixel centers
-    logc = (0.5 + logc * materialParams.lutSize.x) * materialParams.lutSize.y;
+    logc = materialParams.lutSize.x + logc * materialParams.lutSize.y;
 
     return textureLod(lut, logc, 0.0).rgb;
 }

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -81,7 +81,7 @@ fragment {
         vec3 logc = c * log2(a * x + b) + d;
 
         // Remap to sample pixel centers
-        logc = (0.5 + logc * materialParams.lutSize.x) * materialParams.lutSize.y;
+        logc = materialParams.lutSize.x + logc * materialParams.lutSize.y;
 
         return textureLod(lut, logc, 0.0).rgb;
     }

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -7,6 +7,10 @@ material {
             precision: medium
         },
         {
+            type : float2,
+            name : lutSize
+        },
+        {
             type : int,
             name : dithering
         },
@@ -75,6 +79,10 @@ fragment {
         const float c = 0.244161 / log2(10.0);
         const float d = 0.386036;
         vec3 logc = c * log2(a * x + b) + d;
+
+        // Remap to sample pixel centers
+        logc = (0.5 + logc * materialParams.lutSize.x) * materialParams.lutSize.y;
+
         return textureLod(lut, logc, 0.0).rgb;
     }
 


### PR DESCRIPTION
With this change we properly sample from the texel centers when we should, thus avoiding a bias toward the low values. This was particularly problematic in the darks, resulting in darker results than they should have been.

Before:
<img width="1136" alt="Screen Shot 2021-08-03 at 2 32 47 PM" src="https://user-images.githubusercontent.com/869684/128091479-8b09aa7b-72ef-4c3a-ae75-3aba2b2c1033.png">

After:
<img width="1136" alt="Screen Shot 2021-08-03 at 2 32 31 PM" src="https://user-images.githubusercontent.com/869684/128091486-25959e5b-02e9-4172-af0d-a717bda43318.png">

