### PR TITLE
double-precision accurate translation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,8 +5,10 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.12.1 (currently main branch)
 
-- engine: `double` precision model (and view) matrix on `Camera`. This is only an
-  API change, internal precision is still `float` [⚠️ **API Change**].
+- engine: `double` precision translation support in TransformManager. Disabled by default. 
+  Augment model (and view) matrix on `Camera` to accept double precision matrices. When enabled,
+  double precision translations allow filament to handle a very large world space.
+  [**New API**].
 
 ## v1.12.0
 

--- a/android/filament-android/src/main/cpp/TransformManager.cpp
+++ b/android/filament-android/src/main/cpp/TransformManager.cpp
@@ -70,6 +70,23 @@ Java_com_google_android_filament_TransformManager_nCreateArray(JNIEnv* env,
     return tm->getInstance(entity);
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_TransformManager_nCreateArrayFp64(JNIEnv* env,
+        jclass, jlong nativeTransformManager, jint entity_, jint parent,
+        jdoubleArray localTransform_) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    Entity& entity = *reinterpret_cast<Entity*>(&entity_);
+    if (localTransform_) {
+        jdouble *localTransform = env->GetDoubleArrayElements(localTransform_, NULL);
+        tm->create(entity, (TransformManager::Instance) parent,
+                *reinterpret_cast<const filament::math::mat4 *>(localTransform));
+        env->ReleaseDoubleArrayElements(localTransform_, localTransform, JNI_ABORT);
+    } else {
+        tm->create(entity, (TransformManager::Instance) parent);
+    }
+    return tm->getInstance(entity);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_TransformManager_nDestroy(JNIEnv*, jclass,
         jlong nativeTransformManager, jint entity_) {
@@ -105,6 +122,17 @@ Java_com_google_android_filament_TransformManager_nSetTransform(JNIEnv* env,
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_TransformManager_nSetTransformFp64(JNIEnv* env,
+        jclass, jlong nativeTransformManager, jint i,
+        jdoubleArray localTransform_) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    jdouble *localTransform = env->GetDoubleArrayElements(localTransform_, NULL);
+    tm->setTransform((TransformManager::Instance) i,
+            *reinterpret_cast<const filament::math::mat4 *>(localTransform));
+    env->ReleaseDoubleArrayElements(localTransform_, localTransform, JNI_ABORT);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_TransformManager_nGetTransform(JNIEnv* env,
         jclass, jlong nativeTransformManager, jint i,
         jfloatArray outLocalTransform_) {
@@ -113,6 +141,17 @@ Java_com_google_android_filament_TransformManager_nGetTransform(JNIEnv* env,
     *reinterpret_cast<filament::math::mat4f *>(outLocalTransform) = tm->getTransform(
             (TransformManager::Instance) i);
     env->ReleaseFloatArrayElements(outLocalTransform_, outLocalTransform, 0);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_TransformManager_nGetTransformFp64(JNIEnv* env,
+        jclass, jlong nativeTransformManager, jint i,
+        jdoubleArray outLocalTransform_) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    jdouble *outLocalTransform = env->GetDoubleArrayElements(outLocalTransform_, NULL);
+    *reinterpret_cast<filament::math::mat4 *>(outLocalTransform) = tm->getTransformAccurate(
+            (TransformManager::Instance) i);
+    env->ReleaseDoubleArrayElements(outLocalTransform_, outLocalTransform, 0);
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -127,6 +166,17 @@ Java_com_google_android_filament_TransformManager_nGetWorldTransform(JNIEnv* env
 }
 
 extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_TransformManager_nGetWorldTransformFp64(JNIEnv* env,
+        jclass, jlong nativeTransformManager, jint i,
+        jdoubleArray outWorldTransform_) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    jdouble *outWorldTransform = env->GetDoubleArrayElements(outWorldTransform_, NULL);
+    *reinterpret_cast<filament::math::mat4 *>(outWorldTransform) = tm->getWorldTransformAccurate(
+            (TransformManager::Instance) i);
+    env->ReleaseDoubleArrayElements(outWorldTransform_, outWorldTransform, 0);
+}
+
+extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_TransformManager_nOpenLocalTransformTransaction(
         JNIEnv*, jclass, jlong nativeTransformManager) {
     TransformManager* tm = (TransformManager*) nativeTransformManager;
@@ -138,4 +188,20 @@ Java_com_google_android_filament_TransformManager_nCommitLocalTransformTransacti
         JNIEnv*, jclass, jlong nativeTransformManager) {
     TransformManager* tm = (TransformManager*) nativeTransformManager;
     tm->commitLocalTransformTransaction();
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_TransformManager_nSetAccurateTranslationsEnabled(JNIEnv*,
+        jclass, jlong nativeTransformManager, jboolean enable) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    tm->setAccurateTranslationsEnabled((bool)enable);
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_TransformManager_nIsAccurateTranslationsEnabled(JNIEnv*,
+        jclass, jlong nativeTransformManager) {
+    TransformManager* tm = (TransformManager*) nativeTransformManager;
+    return (jboolean)tm->isAccurateTranslationsEnabled();
 }

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -325,6 +325,15 @@ public:
     TransformManager& getTransformManager() noexcept;
 
     /**
+     * Helper to enable accurate translations.
+     * If you need this Engine to handle a very large world space, one way to achieve this
+     * automatically is to enable accurate translations in the TransformManager. This helper
+     * provides a convenient way of doing that.
+     * This is typically called once just after creating the Engine.
+     */
+    void enableAccurateTranslations() noexcept;
+
+    /**
      * Creates a SwapChain from the given Operating System's native window handle.
      *
      * @param nativeWindow An opaque native window handle. e.g.: on Android this is an

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -113,6 +113,30 @@ public:
     Instance getInstance(utils::Entity e) const noexcept;
 
     /**
+     * Enables or disable the accurate translation mode. Disabled by default.
+     *
+     * When accurate translation mode is active, the translation component of all transforms is
+     * maintained at double precision. This is only useful if the mat4 version of setTransform()
+     * is used, as well as getTransformAccurate().
+     *
+     * @param enable true to enable the accurate translation mode, false to disable.
+     *
+     * @see isAccurateTranslationsEnabled
+     * @see create(utils::Entity, Instance, const math::mat4&);
+     * @see setTransform(Instance, const math::mat4&)
+     * @see getTransformAccurate
+     * @see getWorldTransformAccurate
+     */
+    void setAccurateTranslationsEnabled(bool enable) noexcept;
+
+    /**
+     * Returns whether the high precision translation mode is active.
+     * @return true if accurate translations mode is active, false otherwise
+     * @see setAccurateTranslationsEnabled
+     */
+    bool isAccurateTranslationsEnabled() const noexcept;
+
+    /**
      * Creates a transform component and associate it with the given entity.
      * @param entity            An Entity to associate a transform component to.
      * @param parent            The Instance of the parent transform, or Instance{} if no parent.
@@ -125,7 +149,8 @@ public:
      * @see destroy()
      */
     void create(utils::Entity entity, Instance parent, const math::mat4f& localTransform);
-    void create(utils::Entity entity, Instance parent = {});
+    void create(utils::Entity entity, Instance parent, const math::mat4& localTransform); //!< \overload
+    void create(utils::Entity entity, Instance parent = {}); //!< \overload
 
     /**
      * Destroys this component from the given entity, children are orphaned.
@@ -203,6 +228,18 @@ public:
     void setTransform(Instance ci, const math::mat4f& localTransform) noexcept;
 
     /**
+     * Sets a local transform of a transform component and keeps double precision translation.
+     * All other values of the transform are stored at single precision.
+     * @param ci              The instance of the transform component to set the local transform to.
+     * @param localTransform  The local transform (i.e. relative to the parent).
+     * @see getTransform()
+     * @attention This operation can be slow if the hierarchy of transform is too deep, and this
+     *            will be particularly bad when updating a lot of transforms. In that case,
+     *            consider using openLocalTransformTransaction() / commitLocalTransformTransaction().
+     */
+    void setTransform(Instance ci, const math::mat4& localTransform) noexcept;
+
+    /**
      * Returns the local transform of a transform component.
      * @param ci The instance of the transform component to query the local transform from.
      * @return The local transform of the component (i.e. relative to the parent). This always
@@ -212,6 +249,15 @@ public:
     const math::mat4f& getTransform(Instance ci) const noexcept;
 
     /**
+     * Returns the local transform of a transform component.
+     * @param ci The instance of the transform component to query the local transform from.
+     * @return The local transform of the component (i.e. relative to the parent). This always
+     *         returns the value set by setTransform().
+     * @see setTransform()
+     */
+    const math::mat4 getTransformAccurate(Instance ci) const noexcept;
+
+    /**
      * Return the world transform of a transform component.
      * @param ci The instance of the transform component to query the world transform from.
      * @return The world transform of the component (i.e. relative to the root). This is the
@@ -219,6 +265,15 @@ public:
      * @see setTransform()
      */
     const math::mat4f& getWorldTransform(Instance ci) const noexcept;
+
+    /**
+     * Return the world transform of a transform component.
+     * @param ci The instance of the transform component to query the world transform from.
+     * @return The world transform of the component (i.e. relative to the root). This is the
+     *         composition of this component's local transform with its parent's world transform.
+     * @see setTransform()
+     */
+    const math::mat4 getWorldTransformAccurate(Instance ci) const noexcept;
 
     /**
      * Opens a local transform transaction. During a transaction, getWorldTransform() can

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -198,21 +198,18 @@ void UTILS_NOINLINE FCamera::setModelMatrix(const mat4f& modelMatrix) noexcept {
 
 void UTILS_NOINLINE FCamera::setModelMatrix(const mat4& modelMatrix) noexcept {
     FTransformManager& transformManager = mEngine.getTransformManager();
-    // TODO: eventually setTransform() will accept mat4 directly
-    transformManager.setTransform(transformManager.getInstance(mEntity), mat4f(modelMatrix));
+    transformManager.setTransform(transformManager.getInstance(mEntity), modelMatrix);
 }
 
 void FCamera::lookAt(const float3& eye, const float3& center, const float3& up) noexcept {
     FTransformManager& transformManager = mEngine.getTransformManager();
-    // TODO: eventually setTransform() will accept mat4
     transformManager.setTransform(transformManager.getInstance(mEntity),
-            mat4f::lookAt(eye, center, up));
+            mat4::lookAt(eye, center, up));
 }
 
 mat4 FCamera::getModelMatrix() const noexcept {
     FTransformManager const& transformManager = mEngine.getTransformManager();
-    // TODO: eventually getWorldTransform() will return mat4 directly
-    return (mat4)transformManager.getWorldTransform(transformManager.getInstance(mEntity));
+    return transformManager.getWorldTransformAccurate(transformManager.getInstance(mEntity));
 }
 
 mat4 UTILS_NOINLINE FCamera::getViewMatrix() const noexcept {

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -1046,6 +1046,10 @@ TransformManager& Engine::getTransformManager() noexcept {
     return upcast(this)->getTransformManager();
 }
 
+void Engine::enableAccurateTranslations() noexcept  {
+    getTransformManager().setAccurateTranslationsEnabled(true);
+}
+
 void* Engine::streamAlloc(size_t size, size_t alignment) noexcept {
     return upcast(this)->streamAlloc(size, alignment);
 }

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -111,8 +111,7 @@ void FScene::prepare(const mat4& worldOriginTransform, bool shadowReceiversAreCa
         // get the world transform
         auto ti = tcm.getInstance(e);
         // this is where we go from double to float for our transforms
-        // (in the future, getWorldTransform() will have a double version)
-        const mat4f worldTransform{ worldOriginTransform * tcm.getWorldTransform(ti) };
+        const mat4f worldTransform{ worldOriginTransform * tcm.getWorldTransformAccurate(ti) };
         const bool reversedWindingOrder = det(worldTransform.upperLeft()) < 0;
 
         // don't even draw this object if it doesn't have a transform (which shouldn't happen

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -53,9 +53,17 @@ public:
         return Instance(mManager.getInstance(e));
     }
 
+    void setAccurateTranslationsEnabled(bool enable) noexcept;
+
+    bool isAccurateTranslationsEnabled() const noexcept {
+        return mAccurateTranslations;
+    }
+
     void create(utils::Entity entity);
 
     void create(utils::Entity entity, Instance parent, const math::mat4f& localTransform);
+
+    void create(utils::Entity entity, Instance parent, const math::mat4& localTransform);
 
     void destroy(utils::Entity e) noexcept;
 
@@ -83,12 +91,30 @@ public:
 
     void setTransform(Instance ci, const math::mat4f& model) noexcept;
 
+    void setTransform(Instance ci, const math::mat4& model) noexcept;
+
     const math::mat4f& getTransform(Instance ci) const noexcept {
         return mManager[ci].local;
     }
 
     const math::mat4f& getWorldTransform(Instance ci) const noexcept {
         return mManager[ci].world;
+    }
+
+    math::mat4 getTransformAccurate(Instance ci) const noexcept {
+        math::mat4f const& local = mManager[ci].local;
+        math::float3 localTranslationLo = mManager[ci].localTranslationLo;
+        math::mat4 r(local);
+        r[3].xyz += localTranslationLo;
+        return r;
+    }
+
+    math::mat4 getWorldTransformAccurate(Instance ci) const noexcept {
+        math::mat4f const& world = mManager[ci].world;
+        math::float3 worldTranslationLo = mManager[ci].worldTranslationLo;
+        math::mat4 r(world);
+        r[3].xyz += worldTranslationLo;
+        return r;
     }
 
 private:
@@ -100,13 +126,22 @@ private:
     void updateNodeTransform(Instance i) noexcept;
     void insertNode(Instance i, Instance p) noexcept;
     void swapNode(Instance i, Instance j) noexcept;
-    static void transformChildren(Sim& manager, Instance firstChild) noexcept;
+    void transformChildren(Sim& manager, Instance firstChild) noexcept;
+
+    void computeAllWorldTransforms() noexcept;
+
+    void computeWorldTransform(math::mat4f& outWorld, math::float3& inoutWorldTranslationLo,
+            math::mat4f const& pt, math::mat4f const& local,
+            math::float3 const& ptTranslationLo, math::float3 const& localTranslationLo,
+            bool accurate);
 
     friend class TransformManager::children_iterator;
 
     enum {
         LOCAL,          // local transform (relative to parent), world if no parent
         WORLD,          // world transform
+        LOCAL_LO,       // accurate local translation
+        WORLD_LO,       // accurate world translation
         PARENT,         // instance to the parent
         FIRST_CHILD,    // instance to our first child
         NEXT,           // instance to our next sibling
@@ -114,12 +149,14 @@ private:
     };
 
     using Base = utils::SingleInstanceComponentManager<
-            math::mat4f,
-            math::mat4f,
-            Instance,
-            Instance,
-            Instance,
-            Instance
+            math::mat4f,    // local
+            math::mat4f,    // world
+            math::float3,   // accurate local translation
+            math::float3,   // accurate world translation
+            Instance,       // parent
+            Instance,       // firstChild
+            Instance,       // next
+            Instance        // prev
     >;
 
     struct Sim : public Base {
@@ -138,6 +175,8 @@ private:
                 // this specific usage of union is permitted. All fields are identical
                 Field<LOCAL>        local;
                 Field<WORLD>        world;
+                Field<LOCAL_LO>     localTranslationLo;
+                Field<WORLD_LO>     worldTranslationLo;
                 Field<PARENT>       parent;
                 Field<FIRST_CHILD>  firstChild;
                 Field<NEXT>         next;
@@ -155,6 +194,7 @@ private:
 
     Sim mManager;
     bool mLocalTransformTransactionOpen = false;
+    bool mAccurateTranslations = false;
 };
 
 FILAMENT_UPCAST(TransformManager)

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -337,7 +337,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
                     .falloff(20.0f)
                     .build(*engine, g_lights.back());
 
-            tcm.create(g_lights.back(), parent, {});
+            tcm.create(g_lights.back(), parent);
 
             scene->addEntity(g_lights.back());
         }


### PR DESCRIPTION
Augment the TransformManager so it can maintain the 4th column as
double precision; we accomplish this by storing an extra float3 per matrix.
It's calculated as `doubleTranslation - float3{doubleTranslation}`.

We also add methods to set and get a transform as mat4, internally only
the 4th column is kept as double precision.

Finally when we calculate the worldTransform, we take this extra data into
account, but only for calculating the new 4th column, so the extra work
is small.

model/view matrices on Camera now store their translation as double
double precision. This allows filament to handle a very large world
space (thousands of kilometers).