### PR TITLE
Slight tweak to the generic tone mapper

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -123,15 +123,15 @@ public class ToneMapper {
          * the {@link ACESLegacy} tone mapper. The default values are:
          *
          * <ul>
-         * <li>contrast = 1.4f</li>
+         * <li>contrast = 1.585f</li>
          * <li>shoulder = 0.5f</li>
          * <li>midGrayIn = 0.18f</li>
-         * <li>midGrayOut = 0.266f</li>
+         * <li>midGrayOut = 0.268f</li>
          * <li>hdrMax = 10.0f</li>
          * </ul>
          */
         public Generic() {
-            this(1.4f, 0.5f, 0.18f, 0.266f, 10.0f);
+            this(1.585f, 0.5f, 0.18f, 0.268f, 10.0f);
         }
 
         /**

--- a/filament/include/filament/ToneMapper.h
+++ b/filament/include/filament/ToneMapper.h
@@ -146,10 +146,10 @@ struct UTILS_PUBLIC GenericToneMapper final : public ToneMapper {
      *                output white. Must be >= 1.0.
      */
     GenericToneMapper(
-            float contrast = 1.4f,
+            float contrast = 1.585f,
             float shoulder = 0.5f,
             float midGrayIn = 0.18f,
-            float midGrayOut = 0.266f,
+            float midGrayOut = 0.268f,
             float hdrMax = 10.0f
     ) noexcept;
     ~GenericToneMapper() noexcept final;

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -103,10 +103,10 @@ private:
 };
 
 struct GenericToneMapperSettings {
-    float contrast = 1.4f;
+    float contrast = 1.585f;
     float shoulder = 0.5f;
     float midGrayIn = 0.18f;
-    float midGrayOut = 0.266f;
+    float midGrayOut = 0.268f;
     float hdrMax = 10.0f;
     bool operator!=(const GenericToneMapperSettings &rhs) const { return !(rhs == *this); }
     bool operator==(const GenericToneMapperSettings &rhs) const;


### PR DESCRIPTION
The new default values match almost exactly the filmic tone mapper which
is itself a close approximation of ACES. This result in a slightly more
contrasty and pleasing image out of the box.