### PR TITLE
fix VariantList type

### DIFF
--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -151,8 +151,6 @@ public:
     static void onEditCallback(void* userdata, const utils::CString& name, const void* packageData,
             size_t packageSize);
 
-    using VariantList = utils::bitset<uint64_t, VARIANT_COUNT>;
-
     /**
      * Returns a list of "active" variants.
      *

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -23,9 +23,10 @@
 #include <utils/bitset.h>
 
 namespace filament {
-    static constexpr size_t VARIANT_COUNT = 128;
+    static constexpr size_t VARIANT_BITS = 7;
+    static constexpr size_t VARIANT_COUNT = 1 << VARIANT_BITS;
 
-    using VariantList = utils::bitset<uint64_t, VARIANT_COUNT>;
+    using VariantList = utils::bitset<uint64_t, VARIANT_COUNT / 64>;
 
     // IMPORTANT: update filterVariant() when adding more variants
     // Also be sure to update formatVariantString inside CommonWriter.cpp

--- a/libs/utils/include/utils/bitset.h
+++ b/libs/utils/include/utils/bitset.h
@@ -19,6 +19,7 @@
 
 #include <utils/algorithm.h>
 #include <utils/compiler.h>
+#include <utils/debug.h>
 
 #include <assert.h>
 #include <stddef.h>
@@ -59,10 +60,12 @@ public:
     }
 
     T getBitsAt(size_t n) const noexcept {
+        assert_invariant(n<N);
         return storage[n];
     }
 
     T& getBitsAt(size_t n) noexcept {
+        assert_invariant(n<N);
         return storage[n];
     }
 
@@ -93,19 +96,23 @@ public:
     bool test(size_t bit) const noexcept { return operator[](bit); }
 
     void set(size_t b) noexcept {
+        assert_invariant(b / BITS_PER_WORD < N);
         storage[b / BITS_PER_WORD] |= T(1) << (b % BITS_PER_WORD);
     }
 
     void set(size_t b, bool value) noexcept {
+        assert_invariant(b / BITS_PER_WORD < N);
         storage[b / BITS_PER_WORD] &= ~(T(1) << (b % BITS_PER_WORD));
         storage[b / BITS_PER_WORD] |= T(value) << (b % BITS_PER_WORD);
     }
 
     void unset(size_t b) noexcept {
+        assert_invariant(b / BITS_PER_WORD < N);
         storage[b / BITS_PER_WORD] &= ~(T(1) << (b % BITS_PER_WORD));
     }
 
     void flip(size_t b) noexcept {
+        assert_invariant(b / BITS_PER_WORD < N);
         storage[b / BITS_PER_WORD] ^= T(1) << (b % BITS_PER_WORD);
     }
 
@@ -115,6 +122,7 @@ public:
     }
 
     bool operator[](size_t b) const noexcept {
+        assert_invariant(b / BITS_PER_WORD < N);
         return bool(storage[b / BITS_PER_WORD] & (T(1) << (b % BITS_PER_WORD)));
     }
 


### PR DESCRIPTION
There was a confusion on utils::bitset<> API, it specifies the number
of words to use, not then number of bits in the set.
VariantList was sized to store 8192 bits instead of 128.