### PR TITLE
View refactoring & cleanup

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -28,6 +28,7 @@ set(PUBLIC_HDRS
         include/filament/LightManager.h
         include/filament/Material.h
         include/filament/MaterialInstance.h
+        include/filament/Options.h
         include/filament/RenderTarget.h
         include/filament/RenderableManager.h
         include/filament/Renderer.h

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SRCS
         src/Material.cpp
         src/MaterialInstance.cpp
         src/MaterialParser.cpp
+        src/PerViewUniforms.cpp
         src/PostProcessManager.cpp
         src/RenderPass.cpp
         src/RenderPrimitive.cpp
@@ -108,6 +109,7 @@ set(PRIVATE_HDRS
         src/FrameInfo.h
         src/Intersections.h
         src/MaterialParser.h
+        src/PerViewUniforms.h
         src/PostProcessManager.h
         src/RenderPass.h
         src/ResourceAllocator.h

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_OPTIONS_H
+#define TNT_FILAMENT_OPTIONS_H
+
+#include <filament/Color.h>
+
+#include <stdint.h>
+
+namespace filament {
+
+class Texture;
+
+enum class QualityLevel : uint8_t {
+    LOW,
+    MEDIUM,
+    HIGH,
+    ULTRA
+};
+
+enum class BlendMode : uint8_t {
+    OPAQUE,
+    TRANSLUCENT
+};
+
+/**
+ * Dynamic resolution can be used to either reach a desired target frame rate
+ * by lowering the resolution of a View, or to increase the quality when the
+ * rendering is faster than the target frame rate.
+ *
+ * This structure can be used to specify the minimum scale factor used when
+ * lowering the resolution of a View, and the maximum scale factor used when
+ * increasing the resolution for higher quality rendering. The scale factors
+ * can be controlled on each X and Y axis independently. By default, all scale
+ * factors are set to 1.0.
+ *
+ * enabled:   enable or disables dynamic resolution on a View
+ *
+ * homogeneousScaling: by default the system scales the major axis first. Set this to true
+ *                     to force homogeneous scaling.
+ *
+ * minScale:  the minimum scale in X and Y this View should use
+ *
+ * maxScale:  the maximum scale in X and Y this View should use
+ *
+ * quality:   upscaling quality.
+ *            LOW: 1 bilinear tap, Medium: 4 bilinear taps, High: 9 bilinear taps (tent)
+ *
+ * \note
+ * Dynamic resolution is only supported on platforms where the time to render
+ * a frame can be measured accurately. Dynamic resolution is currently only
+ * supported on Android.
+ *
+ * @see Renderer::FrameRateOptions
+ *
+ */
+struct DynamicResolutionOptions {
+    math::float2 minScale = math::float2(0.5f);     //!< minimum scale factors in x and y
+    math::float2 maxScale = math::float2(1.0f);     //!< maximum scale factors in x and y
+    bool enabled = false;                           //!< enable or disable dynamic resolution
+    bool homogeneousScaling = false;                //!< set to true to force homogeneous scaling
+    QualityLevel quality = QualityLevel::LOW;       //!< Upscaling quality
+};
+
+/**
+ * Options to control the bloom effect
+ *
+ * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
+ *
+ * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
+ *              maximum is 12. This value together with resolution influences the spread of the
+ *              blur effect. This value can be silently reduced to accommodate the original
+ *              image size.
+ *
+ * resolution:  Resolution of bloom's minor axis. The minimum value is 2^levels and the
+ *              the maximum is lower of the original resolution and 4096. This parameter is
+ *              silently clamped to the minimum and maximum.
+ *              It is highly recommended that this value be smaller than the target resolution
+ *              after dynamic resolution is applied (horizontally and vertically).
+ *
+ * strength:    how much of the bloom is added to the original image. Between 0 and 1.
+ *
+ * blendMode:   Whether the bloom effect is purely additive (false) or mixed with the original
+ *              image (true).
+ *
+ * anamorphism: Bloom's aspect ratio (x/y), for artistic purposes.
+ *
+ * threshold:   When enabled, a threshold at 1.0 is applied on the source image, this is
+ *              useful for artistic reasons and is usually needed when a dirt texture is used.
+ *
+ * dirt:        A dirt/scratch/smudges texture (that can be RGB), which gets added to the
+ *              bloom effect. Smudges are visible where bloom occurs. Threshold must be
+ *              enabled for the dirt effect to work properly.
+ *
+ * dirtStrength: Strength of the dirt texture.
+ */
+struct BloomOptions {
+    enum class BlendMode : uint8_t {
+        ADD,           //!< Bloom is modulated by the strength parameter and added to the scene
+        INTERPOLATE    //!< Bloom is interpolated with the scene using the strength parameter
+    };
+    Texture* dirt = nullptr;                //!< user provided dirt texture
+    float dirtStrength = 0.2f;              //!< strength of the dirt texture
+    float strength = 0.10f;                 //!< bloom's strength between 0.0 and 1.0
+    uint32_t resolution = 360;              //!< resolution of vertical axis (2^levels to 2048)
+    float anamorphism = 1.0f;               //!< bloom x/y aspect-ratio (1/32 to 32)
+    uint8_t levels = 6;                     //!< number of blur levels (3 to 11)
+    BlendMode blendMode = BlendMode::ADD;   //!< how the bloom effect is applied
+    bool threshold = true;                  //!< whether to threshold the source
+    bool enabled = false;                   //!< enable or disable bloom
+    float highlight = 1000.0f;              //!< limit highlights to this value before bloom [10, +inf]
+
+    bool lensFlare = false;                 //!< enable screen-space lens flare
+    bool starburst = true;                  //!< enable starburst effect on lens flare
+    float chromaticAberration = 0.005f;     //!< amount of chromatic aberration
+    uint8_t ghostCount = 4;                 //!< number of flare "ghosts"
+    float ghostSpacing = 0.6f;              //!< spacing of the ghost in screen units [0, 1[
+    float ghostThreshold = 10.0f;           //!< hdr threshold for the ghosts
+    float haloThickness = 0.1f;             //!< thickness of halo in vertical screen units, 0 to disable
+    float haloRadius = 0.4f;                //!< radius of halo in vertical screen units [0, 0.5]
+    float haloThreshold = 10.0f;            //!< hdr threshold for the halo
+};
+
+/**
+ * Options to control fog in the scene
+ */
+struct FogOptions {
+    float distance = 0.0f;              //!< distance in world units from the camera where the fog starts ( >= 0.0 )
+    float maximumOpacity = 1.0f;        //!< fog's maximum opacity between 0 and 1
+    float height = 0.0f;                //!< fog's floor in world units
+    float heightFalloff = 1.0f;         //!< how fast fog dissipates with altitude
+    LinearColor color{0.5f};            //!< fog's color (linear), see fogColorFromIbl
+    float density = 0.1f;               //!< fog's density at altitude given by 'height'
+    float inScatteringStart = 0.0f;     //!< distance in world units from the camera where in-scattering starts
+    float inScatteringSize = -1.0f;     //!< size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
+    bool fogColorFromIbl = false;       //!< Fog color will be modulated by the IBL color in the view direction.
+    bool enabled = false;               //!< enable or disable fog
+};
+
+/**
+ * Options to control Depth of Field (DoF) effect in the scene.
+ *
+ * cocScale can be used to set the depth of field blur independently from the camera
+ * aperture, e.g. for artistic reasons. This can be achieved by setting:
+ *      cocScale = cameraAperture / desiredDoFAperture
+ *
+ * @see Camera
+ */
+struct DepthOfFieldOptions {
+    enum class Filter : uint8_t {
+        NONE = 0,
+        MEDIAN = 2
+    };
+    float cocScale = 1.0f;              //!< circle of confusion scale factor (amount of blur)
+    float maxApertureDiameter = 0.01f;  //!< maximum aperture diameter in meters (zero to disable rotation)
+    bool enabled = false;               //!< enable or disable depth of field effect
+    Filter filter = Filter::MEDIAN;     //!< filter to use for filling gaps in the kernel
+    bool nativeResolution = false;      //!< perform DoF processing at native resolution
+    /**
+     * Number of of rings used by the gather kernels. The number of rings affects quality
+     * and performance. The actual number of sample per pixel is defined
+     * as (ringCount * 2 - 1)^2. Here are a few commonly used values:
+     *       3 rings :   25 ( 5x 5 grid)
+     *       4 rings :   49 ( 7x 7 grid)
+     *       5 rings :   81 ( 9x 9 grid)
+     *      17 rings : 1089 (33x33 grid)
+     *
+     * With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.
+     *
+     * Usually all three settings below are set to the same value, however, it is often
+     * acceptable to use a lower ring count for the "fast tiles", which improves performance.
+     * Fast tiles are regions of the screen where every pixels have a similar
+     * circle-of-confusion radius.
+     *
+     * A value of 0 means default, which is 5 on desktop and 3 on mobile.
+     *
+     * @{
+     */
+    uint8_t foregroundRingCount = 0; //!< number of kernel rings for foreground tiles
+    uint8_t backgroundRingCount = 0; //!< number of kernel rings for background tiles
+    uint8_t fastGatherRingCount = 0; //!< number of kernel rings for fast tiles
+    /** @}*/
+
+    /**
+     * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
+     * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+     */
+    uint16_t maxForegroundCOC = 0;
+
+    /**
+     * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
+     * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+     */
+    uint16_t maxBackgroundCOC = 0;
+};
+
+/**
+ * Options to control the vignetting effect.
+ */
+struct VignetteOptions {
+    float midPoint = 0.5f;                      //!< high values restrict the vignette closer to the corners, between 0 and 1
+    float roundness = 0.5f;                     //!< controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5), to a circle (1.0)
+    float feather = 0.5f;                       //!< softening amount of the vignette effect, between 0 and 1
+    LinearColorA color{0.0f, 0.0f, 0.0f, 1.0f}; //!< color of the vignette effect, alpha is currently ignored
+    bool enabled = false;                       //!< enables or disables the vignette effect
+};
+
+/**
+ * Structure used to set the precision of the color buffer and related quality settings.
+ *
+ * @see setRenderQuality, getRenderQuality
+ */
+struct RenderQuality {
+    /**
+     * Sets the quality of the HDR color buffer.
+     *
+     * A quality of HIGH or ULTRA means using an RGB16F or RGBA16F color buffer. This means
+     * colors in the LDR range (0..1) have a 10 bit precision. A quality of LOW or MEDIUM means
+     * using an R11G11B10F opaque color buffer or an RGBA16F transparent color buffer. With
+     * R11G11B10F colors in the LDR range have a precision of either 6 bits (red and green
+     * channels) or 5 bits (blue channel).
+     */
+    QualityLevel hdrColorBuffer = QualityLevel::HIGH;
+};
+
+/**
+ * Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+ * @see setAmbientOcclusionOptions()
+ */
+struct AmbientOcclusionOptions {
+    float radius = 0.3f;    //!< Ambient Occlusion radius in meters, between 0 and ~10.
+    float power = 1.0f;     //!< Controls ambient occlusion's contrast. Must be positive.
+    float bias = 0.0005f;   //!< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
+    float resolution = 0.5f;//!< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
+    float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
+    float bilateralThreshold = 0.05f; //!< depth distance that constitute an edge for filtering
+    QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
+    QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
+    QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality
+    bool enabled = false;    //!< enables or disables screen-space ambient occlusion
+    bool bentNormals = false; //!< enables bent normals computation from AO, and specular AO
+    float minHorizonAngleRad = 0.0f;  //!< min angle in radian to consider
+    /**
+     * Screen Space Cone Tracing (SSCT) options
+     * Ambient shadows from dominant light
+     */
+    struct Ssct {
+        float lightConeRad = 1.0f;          //!< full cone angle in radian, between 0 and pi/2
+        float shadowDistance = 0.3f;        //!< how far shadows can be cast
+        float contactDistanceMax = 1.0f;    //!< max distance for contact
+        float intensity = 0.8f;             //!< intensity
+        math::float3 lightDirection{ 0, -1, 0 };    //!< light direction
+        float depthBias = 0.01f;        //!< depth bias in world units (mitigate self shadowing)
+        float depthSlopeBias = 0.01f;   //!< depth slope bias (mitigate self shadowing)
+        uint8_t sampleCount = 4;        //!< tracing sample count, between 1 and 255
+        uint8_t rayCount = 1;           //!< # of rays to trace, between 1 and 255
+        bool enabled = false;           //!< enables or disables SSCT
+    } ssct;
+};
+
+/**
+ * Options for Temporal Anti-aliasing (TAA)
+ * @see setTemporalAntiAliasingOptions()
+ */
+struct TemporalAntiAliasingOptions {
+    float filterWidth = 1.0f;   //!< reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
+    float feedback = 0.04f;     //!< history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
+    bool enabled = false;       //!< enables or disables temporal anti-aliasing
+};
+
+/**
+ * List of available post-processing anti-aliasing techniques.
+ * @see setAntiAliasing, getAntiAliasing, setSampleCount
+ */
+enum class AntiAliasing : uint8_t {
+    NONE = 0,   //!< no anti aliasing performed as part of post-processing
+    FXAA = 1    //!< FXAA is a low-quality but very efficient type of anti-aliasing. (default).
+};
+
+/**
+ * List of available post-processing dithering techniques.
+ */
+enum class Dithering : uint8_t {
+    NONE = 0,       //!< No dithering
+    TEMPORAL = 1    //!< Temporal dithering (default)
+};
+
+/**
+ * List of available shadow mapping techniques.
+ * @see setShadowType
+ */
+enum class ShadowType : uint8_t {
+    PCF,        //!< percentage-closer filtered shadows (default)
+    VSM         //!< variance shadows
+};
+
+/**
+ * View-level options for VSM Shadowing.
+ * @see setVsmShadowOptions()
+ * @warning This API is still experimental and subject to change.
+ */
+struct VsmShadowOptions {
+    /**
+     * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
+     * than 0, mipmaps will automatically be generated each frame for all lights.
+     *
+     * The number of anisotropic samples = 2 ^ vsmAnisotropy.
+     */
+    uint8_t anisotropy = 0;
+
+    /**
+     * Whether to generate mipmaps for all VSM shadow maps.
+     */
+    bool mipmapping = false;
+
+    /**
+     * EVSM exponent.
+     * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
+     * shadow map in fp32. Currently the shadow map bit depth is always fp16.
+     */
+    float exponent = 5.54f;
+
+    /**
+     * VSM minimum variance scale, must be positive.
+     */
+    float minVarianceScale = 0.5f;
+
+    /**
+     * VSM light bleeding reduction amount, between 0 and 1.
+     */
+    float lightBleedReduction = 0.15f;
+};
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_OPTIONS_H

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -21,6 +21,7 @@
 
 #include <filament/Color.h>
 #include <filament/FilamentAPI.h>
+#include <filament/Options.h>
 
 #include <backend/DriverEnums.h>
 
@@ -35,7 +36,6 @@ class ColorGrading;
 class MaterialInstance;
 class RenderTarget;
 class Scene;
-class Texture;
 class Viewport;
 
 /**
@@ -61,325 +61,21 @@ class Viewport;
  */
 class UTILS_PUBLIC View : public FilamentAPI {
 public:
-    enum class QualityLevel : uint8_t {
-        LOW,
-        MEDIUM,
-        HIGH,
-        ULTRA
-    };
+    using QualityLevel = QualityLevel;
+    using BlendMode = BlendMode;
+    using AntiAliasing = AntiAliasing;
+    using Dithering = Dithering;
+    using ShadowType = ShadowType;
 
-    enum class BlendMode : uint8_t {
-        OPAQUE,
-        TRANSLUCENT
-    };
-
-    /**
-     * Dynamic resolution can be used to either reach a desired target frame rate
-     * by lowering the resolution of a View, or to increase the quality when the
-     * rendering is faster than the target frame rate.
-     *
-     * This structure can be used to specify the minimum scale factor used when
-     * lowering the resolution of a View, and the maximum scale factor used when
-     * increasing the resolution for higher quality rendering. The scale factors
-     * can be controlled on each X and Y axis independently. By default, all scale
-     * factors are set to 1.0.
-     *
-     * enabled:   enable or disables dynamic resolution on a View
-     *
-     * homogeneousScaling: by default the system scales the major axis first. Set this to true
-     *                     to force homogeneous scaling.
-     *
-     * minScale:  the minimum scale in X and Y this View should use
-     *
-     * maxScale:  the maximum scale in X and Y this View should use
-     *
-     * quality:   upscaling quality.
-     *            LOW: 1 bilinear tap, Medium: 4 bilinear taps, High: 9 bilinear taps (tent)
-     *
-     * \note
-     * Dynamic resolution is only supported on platforms where the time to render
-     * a frame can be measured accurately. Dynamic resolution is currently only
-     * supported on Android.
-     *
-     * @see Renderer::FrameRateOptions
-     *
-     */
-    struct DynamicResolutionOptions {
-        math::float2 minScale = math::float2(0.5f);     //!< minimum scale factors in x and y
-        math::float2 maxScale = math::float2(1.0f);     //!< maximum scale factors in x and y
-        bool enabled = false;                           //!< enable or disable dynamic resolution
-        bool homogeneousScaling = false;                //!< set to true to force homogeneous scaling
-        QualityLevel quality = QualityLevel::LOW;       //!< Upscaling quality
-    };
-
-    /**
-     * Options to control the bloom effect
-     *
-     * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
-     *
-     * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
-     *              maximum is 12. This value together with resolution influences the spread of the
-     *              blur effect. This value can be silently reduced to accommodate the original
-     *              image size.
-     *
-     * resolution:  Resolution of bloom's minor axis. The minimum value is 2^levels and the
-     *              the maximum is lower of the original resolution and 4096. This parameter is
-     *              silently clamped to the minimum and maximum.
-     *              It is highly recommended that this value be smaller than the target resolution
-     *              after dynamic resolution is applied (horizontally and vertically).
-     *
-     * strength:    how much of the bloom is added to the original image. Between 0 and 1.
-     *
-     * blendMode:   Whether the bloom effect is purely additive (false) or mixed with the original
-     *              image (true).
-     *
-     * anamorphism: Bloom's aspect ratio (x/y), for artistic purposes.
-     *
-     * threshold:   When enabled, a threshold at 1.0 is applied on the source image, this is
-     *              useful for artistic reasons and is usually needed when a dirt texture is used.
-     *
-     * dirt:        A dirt/scratch/smudges texture (that can be RGB), which gets added to the
-     *              bloom effect. Smudges are visible where bloom occurs. Threshold must be
-     *              enabled for the dirt effect to work properly.
-     *
-     * dirtStrength: Strength of the dirt texture.
-     */
-    struct BloomOptions {
-        enum class BlendMode : uint8_t {
-            ADD,           //!< Bloom is modulated by the strength parameter and added to the scene
-            INTERPOLATE    //!< Bloom is interpolated with the scene using the strength parameter
-        };
-        Texture* dirt = nullptr;                //!< user provided dirt texture
-        float dirtStrength = 0.2f;              //!< strength of the dirt texture
-        float strength = 0.10f;                 //!< bloom's strength between 0.0 and 1.0
-        uint32_t resolution = 360;              //!< resolution of vertical axis (2^levels to 2048)
-        float anamorphism = 1.0f;               //!< bloom x/y aspect-ratio (1/32 to 32)
-        uint8_t levels = 6;                     //!< number of blur levels (3 to 11)
-        BlendMode blendMode = BlendMode::ADD;   //!< how the bloom effect is applied
-        bool threshold = true;                  //!< whether to threshold the source
-        bool enabled = false;                   //!< enable or disable bloom
-        float highlight = 1000.0f;              //!< limit highlights to this value before bloom [10, +inf]
-
-        bool lensFlare = false;                 //!< enable screen-space lens flare
-        bool starburst = true;                  //!< enable starburst effect on lens flare
-        float chromaticAberration = 0.005f;     //!< amount of chromatic aberration
-        uint8_t ghostCount = 4;                 //!< number of flare "ghosts"
-        float ghostSpacing = 0.6f;              //!< spacing of the ghost in screen units [0, 1[
-        float ghostThreshold = 10.0f;           //!< hdr threshold for the ghosts
-        float haloThickness = 0.1f;             //!< thickness of halo in vertical screen units, 0 to disable
-        float haloRadius = 0.4f;                //!< radius of halo in vertical screen units [0, 0.5]
-        float haloThreshold = 10.0f;            //!< hdr threshold for the halo
-    };
-
-    /**
-     * Options to control fog in the scene
-     */
-    struct FogOptions {
-        float distance = 0.0f;              //!< distance in world units from the camera where the fog starts ( >= 0.0 )
-        float maximumOpacity = 1.0f;        //!< fog's maximum opacity between 0 and 1
-        float height = 0.0f;                //!< fog's floor in world units
-        float heightFalloff = 1.0f;         //!< how fast fog dissipates with altitude
-        LinearColor color{0.5f};            //!< fog's color (linear), see fogColorFromIbl
-        float density = 0.1f;               //!< fog's density at altitude given by 'height'
-        float inScatteringStart = 0.0f;     //!< distance in world units from the camera where in-scattering starts
-        float inScatteringSize = -1.0f;     //!< size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
-        bool fogColorFromIbl = false;       //!< Fog color will be modulated by the IBL color in the view direction.
-        bool enabled = false;               //!< enable or disable fog
-    };
-
-    /**
-     * Options to control Depth of Field (DoF) effect in the scene.
-     *
-     * cocScale can be used to set the depth of field blur independently from the camera
-     * aperture, e.g. for artistic reasons. This can be achieved by setting:
-     *      cocScale = cameraAperture / desiredDoFAperture
-     *
-     * @see Camera
-     */
-    struct DepthOfFieldOptions {
-        enum class Filter : uint8_t {
-            NONE = 0,
-            MEDIAN = 2
-        };
-        float cocScale = 1.0f;              //!< circle of confusion scale factor (amount of blur)
-        float maxApertureDiameter = 0.01f;  //!< maximum aperture diameter in meters (zero to disable rotation)
-        bool enabled = false;               //!< enable or disable depth of field effect
-        Filter filter = Filter::MEDIAN;     //!< filter to use for filling gaps in the kernel
-        bool nativeResolution = false;      //!< perform DoF processing at native resolution
-        /**
-         * Number of of rings used by the gather kernels. The number of rings affects quality
-         * and performance. The actual number of sample per pixel is defined
-         * as (ringCount * 2 - 1)^2. Here are a few commonly used values:
-         *       3 rings :   25 ( 5x 5 grid)
-         *       4 rings :   49 ( 7x 7 grid)
-         *       5 rings :   81 ( 9x 9 grid)
-         *      17 rings : 1089 (33x33 grid)
-         *
-         * With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.
-         *
-         * Usually all three settings below are set to the same value, however, it is often
-         * acceptable to use a lower ring count for the "fast tiles", which improves performance.
-         * Fast tiles are regions of the screen where every pixels have a similar
-         * circle-of-confusion radius.
-         *
-         * A value of 0 means default, which is 5 on desktop and 3 on mobile.
-         *
-         * @{
-         */
-        uint8_t foregroundRingCount = 0; //!< number of kernel rings for foreground tiles
-        uint8_t backgroundRingCount = 0; //!< number of kernel rings for background tiles
-        uint8_t fastGatherRingCount = 0; //!< number of kernel rings for fast tiles
-        /** @}*/
-
-        /**
-         * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
-         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
-         */
-        uint16_t maxForegroundCOC = 0;
-
-        /**
-         * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
-         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
-         */
-        uint16_t maxBackgroundCOC = 0;
-    };
-
-    /**
-     * Options to control the vignetting effect.
-     */
-    struct VignetteOptions {
-        float midPoint = 0.5f;                      //!< high values restrict the vignette closer to the corners, between 0 and 1
-        float roundness = 0.5f;                     //!< controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5), to a circle (1.0)
-        float feather = 0.5f;                       //!< softening amount of the vignette effect, between 0 and 1
-        LinearColorA color{0.0f, 0.0f, 0.0f, 1.0f}; //!< color of the vignette effect, alpha is currently ignored
-        bool enabled = false;                       //!< enables or disables the vignette effect
-    };
-
-    /**
-     * Structure used to set the precision of the color buffer and related quality settings.
-     *
-     * @see setRenderQuality, getRenderQuality
-     */
-    struct RenderQuality {
-        /**
-         * Sets the quality of the HDR color buffer.
-         *
-         * A quality of HIGH or ULTRA means using an RGB16F or RGBA16F color buffer. This means
-         * colors in the LDR range (0..1) have a 10 bit precision. A quality of LOW or MEDIUM means
-         * using an R11G11B10F opaque color buffer or an RGBA16F transparent color buffer. With
-         * R11G11B10F colors in the LDR range have a precision of either 6 bits (red and green
-         * channels) or 5 bits (blue channel).
-         */
-        QualityLevel hdrColorBuffer = QualityLevel::HIGH;
-    };
-
-    /**
-     * Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
-     * @see setAmbientOcclusionOptions()
-     */
-    struct AmbientOcclusionOptions {
-        float radius = 0.3f;    //!< Ambient Occlusion radius in meters, between 0 and ~10.
-        float power = 1.0f;     //!< Controls ambient occlusion's contrast. Must be positive.
-        float bias = 0.0005f;   //!< Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
-        float resolution = 0.5f;//!< How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
-        float intensity = 1.0f; //!< Strength of the Ambient Occlusion effect.
-        float bilateralThreshold = 0.05f; //!< depth distance that constitute an edge for filtering
-        QualityLevel quality = QualityLevel::LOW; //!< affects # of samples used for AO.
-        QualityLevel lowPassFilter = QualityLevel::MEDIUM; //!< affects AO smoothness
-        QualityLevel upsampling = QualityLevel::LOW; //!< affects AO buffer upsampling quality
-        bool enabled = false;    //!< enables or disables screen-space ambient occlusion
-        bool bentNormals = false; //!< enables bent normals computation from AO, and specular AO
-        float minHorizonAngleRad = 0.0f;  //!< min angle in radian to consider
-        /**
-         * Screen Space Cone Tracing (SSCT) options
-         * Ambient shadows from dominant light
-         */
-        struct Ssct {
-            float lightConeRad = 1.0f;          //!< full cone angle in radian, between 0 and pi/2
-            float shadowDistance = 0.3f;        //!< how far shadows can be cast
-            float contactDistanceMax = 1.0f;    //!< max distance for contact
-            float intensity = 0.8f;             //!< intensity
-            math::float3 lightDirection{ 0, -1, 0 };    //!< light direction
-            float depthBias = 0.01f;        //!< depth bias in world units (mitigate self shadowing)
-            float depthSlopeBias = 0.01f;   //!< depth slope bias (mitigate self shadowing)
-            uint8_t sampleCount = 4;        //!< tracing sample count, between 1 and 255
-            uint8_t rayCount = 1;           //!< # of rays to trace, between 1 and 255
-            bool enabled = false;           //!< enables or disables SSCT
-        } ssct;
-    };
-
-    /**
-     * Options for Temporal Anti-aliasing (TAA)
-     * @see setTemporalAntiAliasingOptions()
-     */
-    struct TemporalAntiAliasingOptions {
-        float filterWidth = 1.0f;   //!< reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
-        float feedback = 0.04f;     //!< history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
-        bool enabled = false;       //!< enables or disables temporal anti-aliasing
-    };
-
-    /**
-     * List of available post-processing anti-aliasing techniques.
-     * @see setAntiAliasing, getAntiAliasing, setSampleCount
-     */
-    enum class AntiAliasing : uint8_t {
-        NONE = 0,   //!< no anti aliasing performed as part of post-processing
-        FXAA = 1    //!< FXAA is a low-quality but very efficient type of anti-aliasing. (default).
-    };
-
-    /**
-     * List of available post-processing dithering techniques.
-     */
-    enum class Dithering : uint8_t {
-        NONE = 0,       //!< No dithering
-        TEMPORAL = 1    //!< Temporal dithering (default)
-    };
-
-    /**
-     * List of available shadow mapping techniques.
-     * @see setShadowType
-     */
-    enum class ShadowType : uint8_t {
-        PCF,        //!< percentage-closer filtered shadows (default)
-        VSM         //!< variance shadows
-    };
-
-    /**
-     * View-level options for VSM Shadowing.
-     * @see setVsmShadowOptions()
-     * @warning This API is still experimental and subject to change.
-     */
-    struct VsmShadowOptions {
-        /**
-         * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
-         * than 0, mipmaps will automatically be generated each frame for all lights.
-         *
-         * The number of anisotropic samples = 2 ^ vsmAnisotropy.
-         */
-        uint8_t anisotropy = 0;
-
-        /**
-         * Whether to generate mipmaps for all VSM shadow maps.
-         */
-        bool mipmapping = false;
-
-        /**
-         * EVSM exponent.
-         * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
-         * shadow map in fp32. Currently the shadow map bit depth is always fp16.
-         */
-        float exponent = 5.54f;
-
-        /**
-         * VSM minimum variance scale, must be positive.
-         */
-        float minVarianceScale = 0.5f;
-
-        /**
-         * VSM light bleeding reduction amount, between 0 and 1.
-         */
-         float lightBleedReduction = 0.15f;
-    };
+    using DynamicResolutionOptions = DynamicResolutionOptions;
+    using BloomOptions = BloomOptions;
+    using FogOptions = FogOptions;
+    using DepthOfFieldOptions = DepthOfFieldOptions;
+    using VignetteOptions = VignetteOptions;
+    using RenderQuality = RenderQuality;
+    using AmbientOcclusionOptions = AmbientOcclusionOptions;
+    using TemporalAntiAliasingOptions = TemporalAntiAliasingOptions;
+    using VsmShadowOptions = VsmShadowOptions;
 
     /**
      * Sets the View's name. Only useful for debugging.

--- a/filament/src/Exposure.cpp
+++ b/filament/src/Exposure.cpp
@@ -132,7 +132,7 @@ float exposure(float ev100) noexcept {
     // with the maximum luminance Lmax
     //
     // Reference: https://en.wikipedia.org/wiki/Film_speed
-    return static_cast<float>(1.0 / (1.2 * std::pow(2.0, ev100)));
+    return 1.0f / (1.2f * std::pow(2.0f, ev100));
 }
 
 float luminance(const Camera& c) noexcept {

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PerViewUniforms.h"
+
+#include <filament/Exposure.h>
+#include <filament/Options.h>
+#include <filament/TextureSampler.h>
+
+#include <private/filament/SibGenerator.h>
+
+#include "details/Camera.h"
+#include "details/DFG.h"
+#include "details/Engine.h"
+#include "details/Froxelizer.h"
+#include "details/IndirectLight.h"
+#include "details/ShadowMapManager.h"
+#include "details/Texture.h"
+
+#include <math/mat4.h>
+
+namespace filament {
+
+using namespace backend;
+using namespace math;
+
+PerViewUniforms::PerViewUniforms(FEngine& engine) noexcept
+        : mEngine(engine),
+          mPerViewSb(PerViewSib::SAMPLER_COUNT) {
+    DriverApi& driver = engine.getDriverApi();
+
+    mPerViewSbh = driver.createSamplerGroup(mPerViewSb.getSize());
+
+    mPerViewUbh = driver.createBufferObject(mPerViewUb.getSize(),
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
+
+    // with a clip-space of [-w, w] ==> z' = -z
+    // with a clip-space of [0,  w] ==> z' = (w - z)/2
+    mClipControl = driver.getClipSpaceParams();
+
+    if (engine.getDFG()->isValid()) {
+        TextureSampler sampler(TextureSampler::MagFilter::LINEAR);
+        mPerViewSb.setSampler(PerViewSib::IBL_DFG_LUT,
+                engine.getDFG()->getTexture(), sampler.getSamplerParams());
+    }
+}
+
+void PerViewUniforms::terminate(FEngine& engine) {
+    DriverApi& driver = engine.getDriverApi();
+    driver.destroyBufferObject(mPerViewUbh);
+    driver.destroySamplerGroup(mPerViewSbh);
+}
+
+void PerViewUniforms::prepareCamera(const CameraInfo& camera) noexcept {
+    mat4f const& viewFromWorld = camera.view;
+    mat4f const& worldFromView = camera.model;
+    mat4f const& clipFromView  = camera.projection;
+
+    const mat4f viewFromClip{ inverse((mat4)camera.projection) };
+    const mat4f clipFromWorld{ highPrecisionMultiply(clipFromView, viewFromWorld) };
+    const mat4f worldFromClip{ highPrecisionMultiply(worldFromView, viewFromClip) };
+
+    auto& s = mPerViewUb.edit();
+    s.viewFromWorldMatrix = viewFromWorld;    // view
+    s.worldFromViewMatrix = worldFromView;    // model
+    s.clipFromViewMatrix  = clipFromView;     // projection
+    s.viewFromClipMatrix  = viewFromClip;     // 1/projection
+    s.clipFromWorldMatrix = clipFromWorld;    // projection * view
+    s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+    s.cameraPosition = float3{ camera.getPosition() };
+    s.worldOffset = camera.worldOffset;
+    s.cameraFar = camera.zf;
+    s.clipControl = mClipControl;
+}
+
+void PerViewUniforms::prepareExposure(float ev100) noexcept {
+    const float exposure = Exposure::exposure(ev100);
+    auto& s = mPerViewUb.edit();
+    s.exposure = exposure;
+    s.ev100 = ev100;
+}
+
+void PerViewUniforms::prepareViewport(const filament::Viewport &viewport) noexcept {
+    const float w = viewport.width;
+    const float h = viewport.height;
+    auto& s = mPerViewUb.edit();
+    s.resolution = float4{ w, h, 1.0f / w, 1.0f / h };
+    s.origin = float2{ viewport.left, viewport.bottom };
+}
+
+void PerViewUniforms::prepareTime(FEngine& engine, float4 const& userTime) noexcept {
+    auto& s = mPerViewUb.edit();
+    const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
+    const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
+    s.time = fraction;
+    s.userTime = userTime;
+}
+
+void PerViewUniforms::prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept {
+    // this can't be too high because we need density / heightFalloff to produce something
+    // close to fogOptions.density in the fragment shader which use 16-bits floats.
+    constexpr float epsilon = 0.001f;
+    const float heightFalloff = std::max(epsilon, options.heightFalloff);
+
+    // precalculate the constant part of density  integral and correct for exp2() in the shader
+    const float density = ((options.density / heightFalloff) *
+            std::exp(-heightFalloff * (camera.getPosition().y - options.height)))
+                    * float(1.0f / F_LN2);
+
+    auto& s = mPerViewUb.edit();
+    s.fogStart             = options.distance;
+    s.fogMaxOpacity        = options.maximumOpacity;
+    s.fogHeight            = options.height;
+    s.fogHeightFalloff     = heightFalloff;
+    s.fogColor             = options.color;
+    s.fogDensity           = density;
+    s.fogInscatteringStart = options.inScatteringStart;
+    s.fogInscatteringSize  = options.inScatteringSize;
+    s.fogColorFromIbl      = options.fogColorFromIbl ? 1.0f : 0.0f;
+}
+
+void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOptions const& options) noexcept {
+    // High quality sampling is enabled only if AO itself is enabled and upsampling quality is at
+    // least set to high and of course only if upsampling is needed.
+    const bool highQualitySampling = options.upsampling >= QualityLevel::HIGH
+            && options.resolution < 1.0f;
+
+    // LINEAR filtering is only needed when AO is enabled and low-quality upsampling is used.
+    mPerViewSb.setSampler(PerViewSib::SSAO, ssao, {
+        .filterMag = options.enabled && !highQualitySampling ?
+                SamplerMagFilter::LINEAR : SamplerMagFilter::NEAREST
+    });
+
+    const float edgeDistance = 1.0f / options.bilateralThreshold;
+    auto& s = mPerViewUb.edit();
+    s.aoSamplingQualityAndEdgeDistance = options.enabled && highQualitySampling ? edgeDistance : 0.0f;
+    s.aoBentNormals = options.enabled && options.bentNormals ? 1.0f : 0.0f;
+}
+
+void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset) noexcept {
+    mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
+        .filterMag = SamplerMagFilter::LINEAR,
+        .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
+    });
+    auto& s = mPerViewUb.edit();
+    s.refractionLodOffset = refractionLodOffset;
+}
+
+void PerViewUniforms::prepareStructure(Handle<HwTexture> structure) noexcept {
+    // sampler must be NEAREST
+    mPerViewSb.setSampler(PerViewSib::STRUCTURE, structure, {});
+}
+
+void PerViewUniforms::prepareDirectionalLight(
+        float exposure,
+        float3 const& sceneSpaceDirection,
+        PerViewUniforms::LightManagerInstance directionalLight) noexcept {
+    FLightManager& lcm = mEngine.getLightManager();
+    auto& s = mPerViewUb.edit();
+
+    const float3 l = -sceneSpaceDirection; // guaranteed normalized
+
+    if (directionalLight.isValid()) {
+        const float4 colorIntensity = {
+                lcm.getColor(directionalLight), lcm.getIntensity(directionalLight) * exposure };
+
+        s.lightDirection = l;
+        s.lightColorIntensity = colorIntensity;
+        s.lightChannels = lcm.getLightChannels(directionalLight);
+
+        const bool isSun = lcm.isSunLight(directionalLight);
+        // The last parameter must be < 0.0f for regular directional lights
+        float4 sun{ 0.0f, 0.0f, 0.0f, -1.0f };
+        if (UTILS_UNLIKELY(isSun && colorIntensity.w > 0.0f)) {
+            // currently we have only a single directional light, so it's probably likely that it's
+            // also the Sun. However, conceptually, most directional lights won't be sun lights.
+            float radius = lcm.getSunAngularRadius(directionalLight);
+            float haloSize = lcm.getSunHaloSize(directionalLight);
+            float haloFalloff = lcm.getSunHaloFalloff(directionalLight);
+            sun.x = std::cos(radius);
+            sun.y = std::sin(radius);
+            sun.z = 1.0f / (std::cos(radius * haloSize) - sun.x);
+            sun.w = haloFalloff;
+        }
+        s.sun = sun;
+    } else {
+        // Disable the sun if there's no directional light
+        s.sun = float4{ 0.0f, 0.0f, 0.0f, -1.0f };
+    }
+}
+
+void PerViewUniforms::prepareAmbientLight(FIndirectLight const& ibl,
+        float intensity, float exposure) noexcept {
+    auto& engine = mEngine;
+    auto& s = mPerViewUb.edit();
+
+    // Set up uniforms and sampler for the IBL, guaranteed to be non-null at this point.
+    float iblRoughnessOneLevel = ibl.getLevelCount() - 1.0f;
+    s.iblRoughnessOneLevel = iblRoughnessOneLevel;
+    s.iblLuminance = intensity * exposure;
+    std::transform(ibl.getSH(), ibl.getSH() + 9, s.iblSH, [](float3 v) {
+        return float4(v, 0.0f);
+    });
+
+    // We always sample from the reflection texture, so provide a dummy texture if necessary.
+    Handle<HwTexture> reflection = ibl.getReflectionHwHandle();
+    if (!reflection) {
+        reflection = engine.getDummyCubemap()->getHwHandle();
+    }
+    mPerViewSb.setSampler(PerViewSib::IBL_SPECULAR, {
+            reflection, {
+                    .filterMag = SamplerMagFilter::LINEAR,
+                    .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
+            }});
+}
+
+void PerViewUniforms::prepareDynamicLights(Froxelizer& froxelizer) noexcept {
+    auto& s = mPerViewUb.edit();
+    froxelizer.updateUniforms(s);
+    mPerViewSb.setSampler(PerViewSib::FROXELS, { froxelizer.getFroxelTexture() });
+}
+
+void PerViewUniforms::prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,
+        VsmShadowOptions const& options) noexcept {
+    auto& s = mPerViewUb.edit();
+    s.vsmExponent = options.exponent;  // fp16: max 5.54f, fp32: max 42.0
+    s.vsmDepthScale = options.minVarianceScale * 0.01f * options.exponent;
+    s.vsmLightBleedReduction = options.lightBleedReduction;
+
+    s.lightFromWorldMatrix = shadowMappingUniforms.lightFromWorldMatrix;
+    s.cascadeSplits = shadowMappingUniforms.cascadeSplits;
+    s.shadowBias = shadowMappingUniforms.shadowBias;
+    s.ssContactShadowDistance = shadowMappingUniforms.ssContactShadowDistance;
+    s.directionalShadows = shadowMappingUniforms.directionalShadows;
+    s.cascades = shadowMappingUniforms.cascades;
+}
+
+void PerViewUniforms::prepareShadowVSM(Handle<HwTexture> texture, VsmShadowOptions const& options) noexcept {
+    SamplerMinFilter filterMin = SamplerMinFilter::LINEAR;
+    if (options.anisotropy > 0 || options.mipmapping) {
+        filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR;
+    }
+    mPerViewSb.setSampler(PerViewSib::SHADOW_MAP, {
+            texture, {
+                    .filterMag = SamplerMagFilter::LINEAR,
+                    .filterMin = filterMin,
+                    .anisotropyLog2 = options.anisotropy,
+            }});
+}
+
+void PerViewUniforms::prepareShadowPCF(Handle<HwTexture> texture) noexcept {
+    mPerViewSb.setSampler(PerViewSib::SHADOW_MAP, {
+            texture, {
+                    .filterMag = SamplerMagFilter::LINEAR,
+                    .filterMin = SamplerMinFilter::LINEAR,
+                    .compareMode = SamplerCompareMode::COMPARE_TO_TEXTURE, // ignored for VSM
+                    .compareFunc = SamplerCompareFunc::GE                  // ignored for VSM
+            }});
+}
+
+void PerViewUniforms::commit(backend::DriverApi& driver) noexcept {
+    if (mPerViewUb.isDirty()) {
+        driver.updateBufferObject(mPerViewUbh, mPerViewUb.toBufferDescriptor(driver), 0);
+    }
+    if (mPerViewSb.isDirty()) {
+        driver.updateSamplerGroup(mPerViewSbh, std::move(mPerViewSb.toCommandStream()));
+    }
+}
+
+void PerViewUniforms::bind(backend::DriverApi& driver) noexcept {
+    driver.bindUniformBuffer(BindingPoints::PER_VIEW, mPerViewUbh);
+    driver.bindSamplers(BindingPoints::PER_VIEW, mPerViewSbh);
+}
+
+void PerViewUniforms::unbindSamplers() noexcept {
+    auto& samplerGroup = mPerViewSb;
+    samplerGroup.clearSampler(PerViewSib::SSAO);
+    samplerGroup.clearSampler(PerViewSib::SSR);
+    samplerGroup.clearSampler(PerViewSib::STRUCTURE);
+    samplerGroup.clearSampler(PerViewSib::SHADOW_MAP);
+}
+
+} // namespace filament
+

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_PERVIEWUNIFORMS_H
+#define TNT_FILAMENT_PERVIEWUNIFORMS_H
+
+#include <filament/Viewport.h>
+
+#include <private/filament/UibStructs.h>
+#include <private/backend/SamplerGroup.h>
+
+#include "TypedUniformBuffer.h"
+
+#include <backend/Handle.h>
+
+#include <utils/EntityInstance.h>
+
+namespace filament {
+
+struct FogOptions;
+struct AmbientOcclusionOptions;
+struct VsmShadowOptions;
+
+struct CameraInfo;
+struct ShadowMappingUniforms;
+
+class FEngine;
+class FIndirectLight;
+class Froxelizer;
+class LightManager;
+
+class PerViewUniforms {
+
+    using LightManagerInstance = utils::EntityInstance<LightManager>;
+    using TextureHandle = backend::Handle<backend::HwTexture>;
+
+public:
+    PerViewUniforms(FEngine& engine) noexcept;
+
+    void terminate(FEngine& engine);
+
+    void prepareCamera(const CameraInfo& camera) noexcept;
+    void prepareViewport(const filament::Viewport& viewport) noexcept;
+    void prepareTime(FEngine& engine, math::float4 const& userTime) noexcept;
+    void prepareExposure(float ev100) noexcept;
+    void prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept;
+    void prepareStructure(TextureHandle structure) noexcept;
+    void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
+    void prepareSSR(TextureHandle ssr, float refractionLodOffset) noexcept;
+    void prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,
+            VsmShadowOptions const& options) noexcept;
+
+    void prepareDirectionalLight(float exposure,
+            math::float3 const& sceneSpaceDirection, LightManagerInstance instance) noexcept;
+
+    void prepareAmbientLight(FIndirectLight const& ibl, float intensity, float exposure) noexcept;
+
+    void prepareDynamicLights(Froxelizer& froxelizer) noexcept;
+
+    // maybe these should have their own UBO, they're needed only when GENERATING the shadowmaps
+    void prepareShadowVSM(TextureHandle texture, VsmShadowOptions const& options) noexcept;
+    void prepareShadowPCF(TextureHandle texture) noexcept;
+
+    // update local data into GPU UBO
+    void commit(backend::DriverApi& driver) noexcept;
+
+    // bind this UBO
+    void bind(backend::DriverApi& driver) noexcept;
+
+    void unbindSamplers() noexcept;
+
+private:
+    FEngine& mEngine;
+    math::float2 mClipControl{};
+    TypedUniformBuffer<PerViewUib> mPerViewUb;
+    backend::SamplerGroup mPerViewSb;
+    backend::Handle<backend::HwSamplerGroup> mPerViewSbh;
+    backend::Handle<backend::HwBufferObject> mPerViewUbh;
+};
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_PERVIEWUNIFORMS_H

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -40,52 +40,52 @@ namespace filament {
 
 struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     static constexpr utils::StaticString _name{ "FrameUniforms" };
-    filament::math::mat4f viewFromWorldMatrix;
-    filament::math::mat4f worldFromViewMatrix;
-    filament::math::mat4f clipFromViewMatrix;
-    filament::math::mat4f viewFromClipMatrix;
-    filament::math::mat4f clipFromWorldMatrix;
-    filament::math::mat4f worldFromClipMatrix;
-    filament::math::mat4f lightFromWorldMatrix[CONFIG_MAX_SHADOW_CASCADES];
+    math::mat4f viewFromWorldMatrix;
+    math::mat4f worldFromViewMatrix;
+    math::mat4f clipFromViewMatrix;
+    math::mat4f viewFromClipMatrix;
+    math::mat4f clipFromWorldMatrix;
+    math::mat4f worldFromClipMatrix;
+    std::array<math::mat4f, CONFIG_MAX_SHADOW_CASCADES> lightFromWorldMatrix;
 
     // position of cascade splits, in world space (not including the near plane)
     // -Inf stored in unused components
-    filament::math::float4 cascadeSplits;
+    math::float4 cascadeSplits;
 
-    filament::math::float4 resolution; // viewport width, height, 1/width, 1/height
+    math::float4 resolution; // viewport width, height, 1/width, 1/height
 
     // camera position in view space (when camera_at_origin is enabled), i.e. it's (0,0,0).
     // Always add worldOffset in the shader to get the true world-space position of the camera.
-    filament::math::float3 cameraPosition;
+    math::float3 cameraPosition;
 
     float time; // time in seconds, with a 1 second period
 
-    filament::math::float4 lightColorIntensity; // directional light
+    math::float4 lightColorIntensity; // directional light
 
-    filament::math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
+    math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
-    filament::math::float3 padding0;
+    math::float3 padding0;
     uint32_t lightChannels;
 
-    filament::math::float3 lightDirection;
+    math::float3 lightDirection;
     uint32_t fParamsX; // stride-x
 
-    filament::math::float3 shadowBias; // unused, normal bias, unused
+    math::float3 shadowBias; // unused, normal bias, unused
     float oneOverFroxelDimensionY;
 
-    filament::math::float4 zParams; // froxel Z parameters
+    math::float4 zParams; // froxel Z parameters
 
-    filament::math::uint2 fParams; // stride-y, stride-z
-    filament::math::float2 origin; // viewport left, viewport bottom
+    math::uint2 fParams; // stride-y, stride-z
+    math::float2 origin; // viewport left, viewport bottom
 
     float oneOverFroxelDimensionX;
     float iblLuminance;
     float exposure;
     float ev100;
 
-    alignas(16) filament::math::float4 iblSH[9]; // actually float3 entries (std140 requires float4 alignment)
+    alignas(16) math::float4 iblSH[9]; // actually float3 entries (std140 requires float4 alignment)
 
-    filament::math::float4 userTime;  // time(s), (double)time - (float)time, 0, 0
+    math::float4 userTime;  // time(s), (double)time - (float)time, 0, 0
 
     float iblRoughnessOneLevel;       // level for roughness == 1
     float cameraFar;                  // camera *culling* far-plane distance (projection far is at +inf)
@@ -96,7 +96,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // bit 8-15: screen-space contact shadows ray casting steps
     uint32_t directionalShadows;
 
-    filament::math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
+    math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
     float ssContactShadowDistance;
 
     // fog
@@ -129,19 +129,19 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float vsmReserved0;
 
     // bring PerViewUib to 2 KiB
-    filament::math::float4 padding2[59];
+    math::float4 padding2[59];
 };
 
 // 2 KiB == 128 float4s
-static_assert(sizeof(PerViewUib) == sizeof(filament::math::float4) * 128,
+static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 128,
         "PerViewUib should be exactly 2KiB");
 
 // PerRenderableUib must have an alignment of 256 to be compatible with all versions of GLES.
 struct alignas(256) PerRenderableUib {
     static constexpr utils::StaticString _name{ "ObjectUniforms" };
-    filament::math::mat4f worldFromModelMatrix;
-    filament::math::mat3f worldFromModelNormalMatrix;   // this gets expanded to 48 bytes during the copy to the UBO
-    alignas(16) filament::math::float4 morphWeights;    // morph weights (we could easily have 8 using half)
+    math::mat4f worldFromModelMatrix;
+    math::mat3f worldFromModelNormalMatrix;   // this gets expanded to 48 bytes during the copy to the UBO
+    alignas(16) math::float4 morphWeights;    // morph weights (we could easily have 8 using half)
     uint32_t flags;                                     // see packFlags() below
     uint32_t channels;                                  // 0x000000ll
     uint32_t reserved1;                                 // 0
@@ -158,14 +158,14 @@ static_assert(sizeof(PerRenderableUib) % 256 == 0, "sizeof(Transform) should be 
 
 struct LightsUib {
     static constexpr utils::StaticString _name{ "LightsUniforms" };
-    filament::math::float4 positionFalloff;     // { float3(pos), 1/falloff^2 }
-    filament::math::half4 color;                // { half3(col),  0           }
-    filament::math::half4 directionIES;         // { half3(dir),  IES index   }
-    filament::math::half2 spotScaleOffset;      // { scale, offset }
+    math::float4 positionFalloff;     // { float3(pos), 1/falloff^2 }
+    math::half4 color;                // { half3(col),  0           }
+    math::half4 directionIES;         // { half3(dir),  IES index   }
+    math::half2 spotScaleOffset;      // { scale, offset }
     float intensity;                            // float
     uint32_t typeShadow;                        // 0x00.ll.ii.ct (t: 0=point, 1=spot, c:contact, ii: index, ll: layer)
     uint32_t channels;                          // 0x000c00ll (ll: light channels, c: caster)
-    filament::math::float4 reserved;            // 0
+    math::float4 reserved;            // 0
 
     static uint32_t packTypeShadow(uint8_t type, bool contactShadow, uint8_t index, uint8_t layer) noexcept {
         return (type & 0xF) | (contactShadow ? 0x10 : 0x00) | (index << 8) | (layer << 16);
@@ -179,23 +179,23 @@ static_assert(sizeof(LightsUib) == 64, "the actual UBO is an array of 256 mat4")
 // UBO for punctual (spot light) shadows.
 struct ShadowUib {
     static constexpr utils::StaticString _name{ "ShadowUniforms" };
-    filament::math::mat4f spotLightFromWorldMatrix[CONFIG_MAX_SHADOW_CASTING_SPOTS];
-    filament::math::float4 directionShadowBias[CONFIG_MAX_SHADOW_CASTING_SPOTS]; // light direction, normal bias
+    math::mat4f spotLightFromWorldMatrix[CONFIG_MAX_SHADOW_CASTING_SPOTS];
+    math::float4 directionShadowBias[CONFIG_MAX_SHADOW_CASTING_SPOTS]; // light direction, normal bias
 };
 
 // UBO froxel record buffer.
 struct FroxelRecordUib {
     static constexpr utils::StaticString _name{ "FroxelRecordUniforms" };
-    filament::math::uint4 records[1024];
+    math::uint4 records[1024];
 };
 
 // This is not the UBO proper, but just an element of a bone array.
 struct PerRenderableUibBone {
     static constexpr utils::StaticString _name{ "BonesUniforms" };
-    filament::math::quatf q = { 1, 0, 0, 0 };
-    filament::math::float4 t = {};
-    filament::math::float4 s = { 1, 1, 1, 0 };
-    filament::math::float4 ns = { 1, 1, 1, 0 };
+    math::quatf q = { 1, 0, 0, 0 };
+    math::float4 t = {};
+    math::float4 s = { 1, 1, 1, 0 };
+    math::float4 ns = { 1, 1, 1, 0 };
 };
 
 static_assert(CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone) <= 16384,


### PR DESCRIPTION
- move all `View` options to a new public header `Options.h`. This decouples these simple C-structs from `View`. These are more about rendering settings than `View` (which is about the camera and scene really).
- move all code managing the "per-view" uniforms to its own class. This is because in the future this won't be necessarily "per view", anymore (e.g. shadow maps should probably have their own).
