### PR TITLE
Small ShadowMapManager refactoring 

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -22,7 +22,6 @@
 
 #include "details/Engine.h"
 #include "details/Scene.h"
-#include "details/View.h"
 
 #include <backend/DriverEnums.h>
 
@@ -69,20 +68,11 @@ ShadowMap::~ShadowMap() {
     engine.getEntityManager().destroy(sizeof(entities) / sizeof(Entity), entities);
 }
 
-void ShadowMap::render(DriverApi& driver, utils::Range<uint32_t> range,
-        RenderPass* const pass, FView& view) noexcept {
-    FEngine& engine = mEngine;
-
+void ShadowMap::render(FScene const& scene, utils::Range<uint32_t> range,
+        RenderPass* const pass) noexcept {
     filament::CameraInfo cameraInfo(getCamera());
-
-    FScene& scene = *view.getScene();
-    FScene::RenderableSoa& renderableData = scene.getRenderableData();
-
     pass->setCamera(cameraInfo);
-    pass->setGeometry(renderableData, range, scene.getRenderableUBO());
-    // updatePrimitivesLod must be run before appendCommands.
-    view.updatePrimitivesLod(engine, cameraInfo, renderableData, range);
-
+    pass->setGeometry(scene.getRenderableData(), range, scene.getRenderableUBO());
     pass->overridePolygonOffset(&mPolygonOffset);
     pass->appendCommands(RenderPass::SHADOW);
     pass->sortCommands();

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -98,7 +98,9 @@ public:
             filament::CameraInfo const& camera,
             const ShadowMapInfo& shadowMapInfo, const SceneInfo& cascadeParams) noexcept;
 
-    void render(FScene const& scene, utils::Range<uint32_t> range, RenderPass* pass) noexcept;
+    void render(FScene const& scene, utils::Range<uint32_t> range,
+            FScene::VisibleMaskType visibilityMask, filament::CameraInfo const& cameraInfo,
+            RenderPass* pass) noexcept;
 
     // Do we have visible shadows. Valid after calling update().
     bool hasVisibleShadows() const noexcept { return mHasVisibleShadows; }
@@ -119,16 +121,13 @@ public:
     backend::PolygonOffset getPolygonOffset() const noexcept { return mPolygonOffset; }
 
 private:
-    struct CameraInfo {
+    struct ShadowCameraInfo {
         math::mat4f projection;
         math::mat4f model;
         math::mat4f view;
         math::mat4f worldOrigin;
         float zn = 0;
         float zf = 0;
-        Frustum frustum;
-        float getNear() const noexcept { return zn; }
-        float getFar() const noexcept { return zf; }
         math::float3 const& getPosition() const noexcept { return model[3].xyz; }
         math::float3 getForwardVector() const noexcept {
             return -normalize(model[2].xyz);   // the camera looks towards -z
@@ -148,14 +147,14 @@ private:
 
     void computeShadowCameraDirectional(
             math::float3 const& direction,
-            CameraInfo const& camera, FLightManager::ShadowParams const& params,
+            ShadowCameraInfo const& camera, FLightManager::ShadowParams const& params,
             SceneInfo cascadeParams) noexcept;
     void computeShadowCameraSpot(math::float3 const& position, math::float3 const& dir,
-            float outerConeAngle, float radius, CameraInfo const& camera,
+            float outerConeAngle, float radius, ShadowCameraInfo const& camera,
             FLightManager::ShadowParams const& params) noexcept;
 
     static math::mat4f applyLISPSM(math::mat4f& Wp,
-            CameraInfo const& camera, FLightManager::ShadowParams const& params,
+            ShadowCameraInfo const& camera, FLightManager::ShadowParams const& params,
             const math::mat4f& LMpMv,
             FrustumBoxIntersection const& wsShadowReceiverVolume, size_t vertexCount,
             const math::float3& dir);

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -98,8 +98,7 @@ public:
             filament::CameraInfo const& camera,
             const ShadowMapInfo& shadowMapInfo, const SceneInfo& cascadeParams) noexcept;
 
-    void render(backend::DriverApi& driver, utils::Range<uint32_t> range,
-            RenderPass* pass, FView& view) noexcept;
+    void render(FScene const& scene, utils::Range<uint32_t> range, RenderPass* pass) noexcept;
 
     // Do we have visible shadows. Valid after calling update().
     bool hasVisibleShadows() const noexcept { return mHasVisibleShadows; }

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -85,19 +85,31 @@ public:
             TypedUniformBuffer<ShadowUib>& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
 
-    // valid after calling update() above
-    ShadowMappingUniforms getShadowMappingUniforms() const noexcept {
-        return mShadowMappingUniforms;
-    }
-
     // Renders all of the shadow maps.
     void render(FrameGraph& fg, FEngine& engine, backend::DriverApi& driver,
             RenderPass const& pass, FView& view) noexcept;
 
-    const ShadowMap* getCascadeShadowMap(size_t cascade) const noexcept {
+    ShadowMap* getCascadeShadowMap(size_t cascade) noexcept {
         assert_invariant(cascade < CONFIG_MAX_SHADOW_CASCADES);
-        auto shadowMap = std::launder(reinterpret_cast<ShadowMap const*>(&mShadowMapCache[cascade]));
-        return shadowMap;
+        return std::launder(reinterpret_cast<ShadowMap*>(&mShadowMapCache[cascade]));
+    }
+
+    ShadowMap const* getCascadeShadowMap(size_t cascade) const noexcept {
+        return const_cast<ShadowMapManager*>(this)->getCascadeShadowMap(cascade);
+    }
+
+    ShadowMap* getSpotShadowMap(size_t spot) noexcept {
+        assert_invariant(spot < CONFIG_MAX_SHADOW_CASTING_SPOTS);
+        return std::launder(reinterpret_cast<ShadowMap*>(&mShadowMapCache[CONFIG_MAX_SHADOW_CASCADES + spot]));
+    }
+
+    ShadowMap const* getSpotShadowMap(size_t spot) const noexcept {
+        return const_cast<ShadowMapManager*>(this)->getSpotShadowMap(spot);
+    }
+
+    // valid after calling update() above
+    ShadowMappingUniforms getShadowMappingUniforms() const noexcept {
+        return mShadowMappingUniforms;
     }
 
 private:


### PR DESCRIPTION
The main changes are:
- Break dependency of ShadowMap over View
- shadowmap command generation is now done in the framegraph pass 
  itself, which allows it to be culled should the pass be culled.
- CameraInfo is created only once instead of twice / shadowmap. 
  It's not super heavy but also not cheap, as several matrices are 
  computed.
- simplified code.