### PR TITLE
more cleanup: remove unused code, hardcoded types...

### DIFF
--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -22,7 +22,16 @@
 
 using namespace filament::math;
 
+// We use a vectorize width of 8 because, on ARMv8 it allows the compiler to write eight
+// 8-bits results in one go. Without this it has to do 4 separate byte writes, which
+// ends-up being slower.
+
+#define FILAMENT_CULLER_VECTORIZE_HINT 8
+
 namespace filament {
+
+static_assert(Culler::MODULO % FILAMENT_CULLER_VECTORIZE_HINT == 0,
+        "MODULO m=must be a multiple of FILAMENT_CULLER_VECTORIZE_HINT");
 
 void Culler::intersects(
         result_type* UTILS_RESTRICT results,
@@ -32,11 +41,8 @@ void Culler::intersects(
 
     float4 const * const UTILS_RESTRICT planes = frustum.mPlanes;
 
-    // we use a vectorize width of 8 because, on ARMv8 it allow the compiler to write 8
-    // 8-bits results in one go. Without this it has to do 4 separate byte writes, which
-    // ends-up being slower.
-    count = round(count); // capacity guaranteed to be multiple of 8
-    #pragma clang loop vectorize_width(8)
+    count = round(count);
+    #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
     for (size_t i = 0; i < count; i++) {
         int visible = ~0;
         float4 const sphere(b[i]);
@@ -64,11 +70,8 @@ void Culler::intersects(
 
     float4 const * UTILS_RESTRICT const planes = frustum.mPlanes;
 
-    // we use a vectorize width of 8 because, on ARMv8 it allows the compiler to write eight
-    // 8-bits results in one go. Without this it has to do 4 separate byte writes, which
-    // ends-up being slower.
-    count = round(count); // capacity guaranteed to be multiple of 8
-    #pragma clang loop vectorize_width(8)
+    count = round(count);
+    #pragma clang loop vectorize_width(FILAMENT_CULLER_VECTORIZE_HINT)
     for (size_t i = 0; i < count; i++) {
         int visible = ~0;
 

--- a/filament/src/Culler.h
+++ b/filament/src/Culler.h
@@ -37,13 +37,10 @@ namespace filament {
 class Culler {
 public:
     // Culler can only process buffers with a size multiple of MODULO
-    static constexpr size_t MODULO = 8;
+    static constexpr size_t MODULO = 8u;
     static inline size_t round(size_t count) noexcept {
         return (count + (MODULO - 1)) & ~(MODULO - 1);
     }
-
-    // A good loop value to use to amortize the loop overhead
-    static constexpr size_t MIN_LOOP_COUNT_HINT = 8;
 
     using result_type = uint8_t;
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -275,7 +275,6 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
     const bool depthFilterAlphaMaskedObjects = bool(extraFlags & CommandTypeFlags::DEPTH_FILTER_ALPHA_MASKED_OBJECTS);
 
     auto const* const UTILS_RESTRICT soaWorldAABBCenter = soa.data<FScene::WORLD_AABB_CENTER>();
-    auto const* const UTILS_RESTRICT soaReversedWinding = soa.data<FScene::REVERSED_WINDING_ORDER>();
     auto const* const UTILS_RESTRICT soaVisibility      = soa.data<FScene::VISIBILITY_STATE>();
     auto const* const UTILS_RESTRICT soaPrimitives      = soa.data<FScene::PRIMITIVES>();
     auto const* const UTILS_RESTRICT soaVisibilityMask  = soa.data<FScene::VISIBLE_MASK>();
@@ -347,7 +346,7 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
         const uint32_t distanceBits = reinterpret_cast<uint32_t&>(distance);
 
         // calculate the per-primitive face winding order inversion
-        const bool inverseFrontFaces = viewInverseFrontFaces ^ soaReversedWinding[i];
+        const bool inverseFrontFaces = viewInverseFrontFaces ^ soaVisibility[i].reversedWindingOrder;
 
         cmdColor.key = makeField(soaVisibility[i].priority, PRIORITY_MASK, PRIORITY_SHIFT);
         cmdColor.primitive.index = (uint16_t)i;

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -57,6 +57,7 @@ public:
         bool skinning                   : 1;
         bool morphing                   : 1;
         bool screenSpaceContactShadows  : 1;
+        bool reversedWindingOrder       : 1;
     };
 
     static_assert(sizeof(Visibility) == sizeof(uint16_t), "Visibility should be 16 bits");

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -103,7 +103,6 @@ public:
     enum {
         RENDERABLE_INSTANCE,    //  4 | instance of the Renderable component
         WORLD_TRANSFORM,        // 16 | instance of the Transform component
-        REVERSED_WINDING_ORDER, //  1 | det(WORLD_TRANSFORM)<0
         VISIBILITY_STATE,       //  1 | visibility data of the component
         SKINNING_BUFFER,        //  8 | bones uniform buffer handle, count, offset
         WORLD_AABB_CENTER,      // 12 | world-space bounding box center of the renderable
@@ -126,7 +125,6 @@ public:
     using RenderableSoa = utils::StructureOfArrays<
             utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
             math::mat4f,                                // WORLD_TRANSFORM
-            bool,                                       // REVERSED_WINDING_ORDER
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             FRenderableManager::SkinningBindingInfo,    // SKINNING_BUFFER
             math::float3,                               // WORLD_AABB_CENTER

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -88,19 +88,19 @@ static constexpr size_t VISIBLE_RENDERABLE_BIT = 0u;
 static constexpr size_t VISIBLE_DIR_SHADOW_RENDERABLE_BIT = 1u;
 static constexpr size_t VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(size_t n) { return n + 2; }
 
-static constexpr uint8_t VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
-static constexpr uint8_t VISIBLE_DIR_SHADOW_RENDERABLE = 1u << VISIBLE_DIR_SHADOW_RENDERABLE_BIT;
-static constexpr uint8_t VISIBLE_SPOT_SHADOW_RENDERABLE_N(size_t n) {
+static constexpr Culler::result_type VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
+static constexpr Culler::result_type VISIBLE_DIR_SHADOW_RENDERABLE = 1u << VISIBLE_DIR_SHADOW_RENDERABLE_BIT;
+static constexpr Culler::result_type VISIBLE_SPOT_SHADOW_RENDERABLE_N(size_t n) {
     return 1u << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(n);
 }
 
 // ORing of all the VISIBLE_SPOT_SHADOW_RENDERABLE bits
-static constexpr uint8_t VISIBLE_SPOT_SHADOW_RENDERABLE =
-        (0xFFu >> (sizeof(uint8_t) * 8u - CONFIG_MAX_SHADOW_CASTING_SPOTS)) << 2u;
+static constexpr Culler::result_type VISIBLE_SPOT_SHADOW_RENDERABLE =
+        (0xFFu >> (sizeof(Culler::result_type) * 8u - CONFIG_MAX_SHADOW_CASTING_SPOTS)) << 2u;
 
 // Because we're using a uint8_t for the visibility mask, we're limited to 6 spot light shadows.
 // (2 of the bits are used for visible renderables + directional light shadow casters).
-static_assert(CONFIG_MAX_SHADOW_CASTING_SPOTS <= 6,
+static_assert(CONFIG_MAX_SHADOW_CASTING_SPOTS <= sizeof(Culler::result_type) * 8 - 2,
         "CONFIG_MAX_SHADOW_CASTING_SPOTS cannot be higher than 6.");
 
 // ------------------------------------------------------------------------------------------------
@@ -441,8 +441,9 @@ private:
 
     static void computeVisibilityMasks(
             uint8_t visibleLayers, uint8_t const* layers,
-            FRenderableManager::Visibility const* visibility, uint8_t* visibleMask,
-            size_t count, bool hasVsm);
+            FRenderableManager::Visibility const* visibility,
+            Culler::result_type* visibleMask,
+            size_t count);
 
     void bindPerViewUniformsAndSamplers(FEngine::DriverApi& driver) const noexcept {
         mPerViewUniforms.bind(driver);

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -19,6 +19,7 @@
 
 
 #include <utils/compiler.h>
+#include <utils/debug.h>
 #include <utils/memalign.h>
 #include <utils/Mutex.h>
 #include <utils/SpinLock.h>
@@ -793,7 +794,9 @@ public:
     explicit STLAllocator(STLAllocator<U, ARENA> const& rhs) : mArena(rhs.mArena) { }
 
     TYPE* allocate(std::size_t n) {
-        return static_cast<TYPE *>(mArena.alloc(n * sizeof(TYPE), alignof(TYPE)));
+        auto p = static_cast<TYPE *>(mArena.alloc(n * sizeof(TYPE), alignof(TYPE)));
+        assert_invariant(p);
+        return p;
     }
 
     void deallocate(TYPE* p, std::size_t n) {


### PR DESCRIPTION
- don't use a separate array for "reversedWindingOrder"
  it's just one bit of data and we had 7 bits left in the Visibility structure.

- use Culler::result_type instead of hardcoded value everywhere

- other minor cleanups