### PR TITLE
Java gltfio: fix use-after-free error in shutdown.

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -107,8 +107,8 @@ public class AssetLoader {
      * Frees all memory consumed by the native <code>AssetLoader</code> and its material cache.
      */
     public void destroy() {
-        nDestroyAssetLoader(mNativeObject);
         mMaterialCache.destroyMaterials();
+        nDestroyAssetLoader(mNativeObject);
         mNativeObject = 0;
     }
 


### PR DESCRIPTION
Fixes #4517.