### PR TITLE
Fix missing bookkeeping in bindUniformBufferRange

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -903,6 +903,7 @@ void MetalDriver::bindUniformBufferRange(uint32_t index, Handle<HwBufferObject> 
     if (currentBo) {
         currentBo->boundUniformBuffers.unset(index);
     }
+    bo->boundUniformBuffers.set(index);
     mContext->uniformState[index] = UniformBufferState{
             .buffer = bo,
             .offset = offset,


### PR DESCRIPTION
Fixes #4534

This should also be cherry-picked to rc/1.12.2