### PR TITLE
don't run the component manager gc in a job each

### DIFF
--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -396,17 +396,11 @@ void FEngine::prepare() {
 
 void FEngine::gc() {
     // Note: this runs in a Job
-
-    JobSystem& js = mJobSystem;
-    auto *parent = js.createJob();
-    auto em = std::ref(mEntityManager);
-
-    js.run(jobs::createJob(js, parent, &FRenderableManager::gc, &mRenderableManager, em));
-    js.run(jobs::createJob(js, parent, &FLightManager::gc, &mLightManager, em));
-    js.run(jobs::createJob(js, parent, &FTransformManager::gc, &mTransformManager, em));
-    js.run(jobs::createJob(js, parent, &FCameraManager::gc, &mCameraManager, em));
-
-    js.runAndWait(parent);
+    auto& em = mEntityManager;
+    mRenderableManager.gc(em);
+    mLightManager.gc(em);
+    mTransformManager.gc(em);
+    mCameraManager.gc(em);
 }
 
 void FEngine::flush() {


### PR DESCRIPTION
the gc usually runs for a very short amount of time, so the jobsystem
overhead is very significant compared to the actual work.

additionally this works around a scheduling issue that happens sometimes
on some devices where a thread could be "runnable but not running" for
many milliseconds.