### PR TITLE
Fix timer queries in Vulkan backend

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -54,8 +54,8 @@ void VulkanContext::selectPhysicalDevice() {
         }
 
         // Does the device have any command queues that support graphics?
-        // In theory we should also ensure that the device supports presentation of our
-        // particular VkSurface, but we don't have a VkSurface yet so we'll skip this requirement.
+        // In theory, we should also ensure that the device supports presentation of our
+        // particular VkSurface, but we don't have a VkSurface yet, so we'll skip this requirement.
         uint32_t queueFamiliesCount;
         vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueFamiliesCount, nullptr);
         if (queueFamiliesCount == 0) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -939,7 +939,8 @@ bool VulkanDriver::getTimerQueryValue(Handle<HwTimerQuery> tqh, uint64_t* elapse
     // However there are plans for implementing this properly. See the following GitHub ticket.
     // https://github.com/KhronosGroup/MoltenVK/issues/773
 
-    uint64_t delta = timestamp1 - timestamp0;
+    float period = mContext.physicalDeviceProperties.limits.timestampPeriod;
+    uint64_t delta = uint64_t(float(timestamp1 - timestamp0) * period);
     *elapsedTime = delta;
     return true;
 }


### PR DESCRIPTION
The timestamps are given in "ticks", not in nanoseconds, like our API expects.

Fixes #4588