### PR TITLE
IBLPrefilter relied on finalizer which could cause crashes

### DIFF
--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -196,6 +196,10 @@ class MainActivity : Activity() {
 
                 val sky = Skybox.Builder().environment(skyboxTexture).build(engine)
 
+                specularFilter.destroy();
+                equirectToCubemap.destroy();
+                context.destroy();
+
                 modelViewer.scene.skybox = sky
                 modelViewer.scene.indirectLight = ibl
             }

--- a/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
+++ b/libs/iblprefilter/include/filament-iblprefilter/IBLPrefilterContext.h
@@ -62,7 +62,7 @@ public:
      * Creates an IBLPrefilter context.
      * @param engine filament engine to use
      */
-    IBLPrefilterContext(filament::Engine& engine);
+    explicit IBLPrefilterContext(filament::Engine& engine);
 
     /**
      * Destroys all GPU resources created during initialization.
@@ -75,7 +75,7 @@ public:
 
     // movable
     IBLPrefilterContext(IBLPrefilterContext&& rhs) noexcept;
-    IBLPrefilterContext& operator=(IBLPrefilterContext&& rhs);
+    IBLPrefilterContext& operator=(IBLPrefilterContext&& rhs) noexcept;
 
     // -------------------------------------------------------------------------------------------
 
@@ -98,7 +98,7 @@ public:
         EquirectangularToCubemap(EquirectangularToCubemap const&) = delete;
         EquirectangularToCubemap& operator=(EquirectangularToCubemap const&) = delete;
         EquirectangularToCubemap(EquirectangularToCubemap&& rhs) noexcept;
-        EquirectangularToCubemap& operator=(EquirectangularToCubemap&& rhs);
+        EquirectangularToCubemap& operator=(EquirectangularToCubemap&& rhs) noexcept;
 
         /**
          * Converts an equirectangular image to a cubemap.
@@ -175,7 +175,7 @@ public:
         SpecularFilter(SpecularFilter const&) = delete;
         SpecularFilter& operator=(SpecularFilter const&) = delete;
         SpecularFilter(SpecularFilter&& rhs) noexcept;
-        SpecularFilter& operator=(SpecularFilter&& rhs);
+        SpecularFilter& operator=(SpecularFilter&& rhs) noexcept;
 
         /**
          * Generates a prefiltered cubemap.

--- a/libs/iblprefilter/src/IBLPrefilterContext.cpp
+++ b/libs/iblprefilter/src/IBLPrefilterContext.cpp
@@ -142,7 +142,7 @@ IBLPrefilterContext::IBLPrefilterContext(IBLPrefilterContext&& rhs) noexcept
     this->operator=(std::move(rhs));
 }
 
-IBLPrefilterContext& IBLPrefilterContext::operator=(IBLPrefilterContext&& rhs) {
+IBLPrefilterContext& IBLPrefilterContext::operator=(IBLPrefilterContext&& rhs) noexcept {
     using std::swap;
     if (this != & rhs) {
         swap(mRenderer, rhs.mRenderer);
@@ -182,7 +182,7 @@ IBLPrefilterContext::EquirectangularToCubemap::EquirectangularToCubemap(
 
 IBLPrefilterContext::EquirectangularToCubemap&
 IBLPrefilterContext::EquirectangularToCubemap::operator=(
-        IBLPrefilterContext::EquirectangularToCubemap&& rhs) {
+        IBLPrefilterContext::EquirectangularToCubemap&& rhs) noexcept {
     using std::swap;
     if (this != &rhs) {
         swap(mEquirectMaterial, rhs.mEquirectMaterial);
@@ -332,7 +332,8 @@ IBLPrefilterContext::SpecularFilter::SpecularFilter(SpecularFilter&& rhs) noexce
     this->operator=(std::move(rhs));
 }
 
-IBLPrefilterContext::SpecularFilter& IBLPrefilterContext::SpecularFilter::operator=(SpecularFilter&& rhs) {
+IBLPrefilterContext::SpecularFilter&
+IBLPrefilterContext::SpecularFilter::operator=(SpecularFilter&& rhs) noexcept {
     using std::swap;
     if (this != & rhs) {
         swap(mKernelMaterial, rhs.mKernelMaterial);


### PR DESCRIPTION
The finalizer can't be used to dispose of filament resource, because
it runs on its own thread.

Added a destroy() method to all IBLPrefilter related classes that must
be called once the object is no longer needed.

note: Resources will be freed eventually anyways when the Engine itself is
destroyed.


fixes #4633