### PR TITLE
Implement picking functionality

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.12.8 (currently main branch)
 
+- engine: Added picking API to `View`  [⚠️ **Materials need to be rebuilt to access this new feature**].
+
 ## v1.12.7
 
 ## v1.12.6

--- a/android/common/CallbackUtils.h
+++ b/android/common/CallbackUtils.h
@@ -78,6 +78,9 @@ struct JniCallback {
 
     static void invoke(void* user);
 
+    jobject getCallbackObject() { return mCallback; }
+    JNIEnv* getJniEnv() { return mEnv; }
+
 private:
     JniCallback(JNIEnv* env, jobject handler, jobject runnable);
     JniCallback(JniCallback const &) = delete;

--- a/filament/backend/src/DataReshaper.h
+++ b/filament/backend/src/DataReshaper.h
@@ -83,7 +83,13 @@ public:
             dstComponentType* out = (dstComponentType*) dest;
             for (size_t column = 0; column < width; ++column) {
                 for (size_t channel = 0; channel < minChannelCount; ++channel) {
-                    out[channel] = in[inds[channel]] * dstMaxValue / srcMaxValue;
+                    if constexpr (std::is_same_v<dstComponentType, srcComponentType>) {
+                        out[channel] = in[inds[channel]];
+                    } else {
+                        // TODO: beware of overflows in the multiply
+                        // TODO: probably not correct for _INTEGER src/dst
+                        out[channel] = in[inds[channel]] * dstMaxValue / srcMaxValue;
+                    }
                 }
                 for (size_t channel = srcChannelCount; channel < dstChannelCount; ++channel) {
                     out[channel] = dstMaxValue;
@@ -102,6 +108,12 @@ public:
             bool flip) {
         size_t dstChannelCount;
         switch (dst->format) {
+            case PixelDataFormat::R_INTEGER: dstChannelCount = 1; break;
+            case PixelDataFormat::RG_INTEGER: dstChannelCount = 2; break;
+            case PixelDataFormat::RGB_INTEGER: dstChannelCount = 3; break;
+            case PixelDataFormat::RGBA_INTEGER: dstChannelCount = 4; break;
+            case PixelDataFormat::R: dstChannelCount = 1; break;
+            case PixelDataFormat::RG: dstChannelCount = 2; break;
             case PixelDataFormat::RGB: dstChannelCount = 3; break;
             case PixelDataFormat::RGBA: dstChannelCount = 4; break;
             default: return false;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2834,6 +2834,7 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
     glBufferData(GL_PIXEL_PACK_BUFFER, p.size, nullptr, GL_STATIC_DRAW);
     glReadPixels(GLint(x), GLint(y), GLint(width), GLint(height), glFormat, glType, nullptr);
     gl.bindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+    CHECK_GL_ERROR(utils::slog.e)
 
     // we're forced to make a copy on the heap because otherwise it deletes std::function<> copy
     // constructor.
@@ -2865,8 +2866,6 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         delete pUserBuffer;
         CHECK_GL_ERROR(utils::slog.e)
     });
-
-    CHECK_GL_ERROR(utils::slog.e)
 }
 
 void OpenGLDriver::whenGpuCommandsComplete(std::function<void()> fn) noexcept {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1452,6 +1452,8 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     vkAllocateMemory(device, &allocInfo, nullptr, &stagingMemory);
     vkBindImageMemory(device, stagingImage, stagingMemory, 0);
 
+    // TODO: don't flush/wait here, this should be asynchronous
+
     mContext.commands->flush();
     mContext.commands->wait();
 
@@ -1577,6 +1579,8 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
 
     vkCmdPipelineBarrier(cmdbuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    // TODO: don't flush/wait here -- we should do this asynchronously
 
     // Flush and wait.
     mContext.commands->flush();

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -288,7 +288,7 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     if (UTILS_UNLIKELY(!mIsDefaultMaterial && !mHasCustomDepthShader)) {
         auto& cachedPrograms = mCachedPrograms;
         for (uint8_t i = 0, n = cachedPrograms.size(); i < n; ++i) {
-            if (Variant(i).isDepthPass()) {
+            if (Variant::isValidDepthVariant(i)) {
                 cachedPrograms[i] = engine.getDefaultMaterial()->getProgram(i);
             }
         }
@@ -430,7 +430,7 @@ Program FMaterial::getProgramBuilderWithVariants(
 
     ASSERT_POSTCONDITION(isNoop || (fsOK && fsBuilder.size() > 0),
             "The material '%s' has not been compiled to include the required "
-            "GLSL or SPIR-V chunks for the fragment shader (variant=0x%x, filterer=0x%x).",
+            "GLSL or SPIR-V chunks for the fragment shader (variant=0x%x, filtered=0x%x).",
             mName.c_str(), variantKey, fragmentVariantKey);
 
     Program pb;
@@ -543,7 +543,7 @@ void FMaterial::destroyPrograms(FEngine& engine) {
         if (!mIsDefaultMaterial) {
             // The depth variants may be shared with the default material, in which case
             // we should not free it now.
-            bool isSharedVariant = Variant(i).isDepthPass() && !mHasCustomDepthShader;
+            bool isSharedVariant = Variant::isValidDepthVariant(i) && !mHasCustomDepthShader;
             if (isSharedVariant) {
                 // we don't own this variant, skip.
                 continue;

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -49,11 +49,16 @@ struct CameraInfo;
 class PostProcessManager {
 public:
     struct ColorGradingConfig {
-        bool asSubpass = false;
+        bool asSubpass{};
         bool translucent{};
         bool fxaa{};
         bool dithering{};
         backend::TextureFormat ldrFormat{};
+    };
+
+    struct StructurePassConfig {
+        float scale = 0.5f;
+        bool picking{};
     };
 
     explicit PostProcessManager(FEngine& engine) noexcept;
@@ -65,7 +70,7 @@ public:
 
     // structure (depth) pass
     FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg, RenderPass const& pass,
-            uint32_t width, uint32_t height, float scale) noexcept;
+            uint32_t width, uint32_t height, StructurePassConfig const& config) noexcept;
 
     // SSAO
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOcclusion(FrameGraph& fg,

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -239,6 +239,7 @@ public:
     static constexpr RenderFlags HAS_INVERSE_FRONT_FACES = 0x08;
     static constexpr RenderFlags HAS_FOG                 = 0x10;
     static constexpr RenderFlags HAS_VSM                 = 0x20;
+    static constexpr RenderFlags HAS_PICKING             = 0x40;
 
     // Arena used for commands
     using Arena = utils::Arena<
@@ -270,7 +271,7 @@ public:
     // specifies camera information (e.g. used for sorting commands)
     void setCamera(const CameraInfo& camera) noexcept { mCamera = camera; }
 
-    //  flags controling how commands are generated
+    //  flags controlling how commands are generated
     void setRenderFlags(RenderFlags flags) noexcept { mFlags = flags; }
 
     // Sets the visibility mask, which is AND-ed against each Renderable's VISIBLE_MASK to determine

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -194,7 +194,6 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, backend::DriverAp
                         auto depth = builder.createTexture("Temporary VSM Depth Texture", {
                                 .width = textureRequirements.size, .height = textureRequirements.size,
                                 .samples = options->vsm.msaaSamples,
-                                .type = SamplerType::SAMPLER_2D,
                                 .format = mTextureFormat,
                         });
 
@@ -202,7 +201,6 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, backend::DriverAp
                         // is needed -- it'll be used as the source of the blur.
                         data.tempBlurSrc = builder.createTexture("Temporary Shadowmap", {
                                 .width = textureRequirements.size, .height = textureRequirements.size,
-                                .type = SamplerType::SAMPLER_2D,
                                 .format = vsmTextureFormat
                         });
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -135,6 +135,10 @@ public:
     inline uint32_t getBoneCount(Instance instance) const noexcept;
 
 
+    utils::Entity getEntity(Instance instance) const noexcept {
+        return mManager.getEntity(instance);
+    }
+
     inline size_t getLevelCount(Instance instance) const noexcept { return 1; }
     inline size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;
     void setMaterialInstanceAt(Instance instance, uint8_t level,

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -147,9 +147,9 @@ struct alignas(256) PerRenderableUib {
     math::mat4f worldFromModelMatrix;
     math::mat3f worldFromModelNormalMatrix;   // this gets expanded to 48 bytes during the copy to the UBO
     alignas(16) math::float4 morphWeights;    // morph weights (we could easily have 8 using half)
-    uint32_t flags;                                     // see packFlags() below
-    uint32_t channels;                                  // 0x000000ll
-    uint32_t reserved1;                                 // 0
+    uint32_t flags;                           // see packFlags() below
+    uint32_t channels;                        // 0x000000ll
+    uint32_t objectId;                        // used for picking
     // TODO: We need a better solution, this currently holds the average local scale for the renderable
     float userData;
 

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -41,23 +41,38 @@ namespace filament {
         // SKN: Skinning
         // DEP: Depth only
         // FOG: Fog
+        // PCK: Picking (depth variant only)
         // VSM: Variance shadow maps
         //
         //   X: either 1 or 0
         //
-        //                    ...-----+-----+-----+-----+-----+-----+-----+-----+
-        // Variant                 0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |
-        //                    ...-----+-----+-----+-----+-----+-----+-----+-----+
-        // Reserved variants:
-        //       Vertex depth            X     0     1     X     0     0     0
-        //     Fragment depth            X     0     1     0     0     0     0
-        //           Reserved            X     X     1     X     X     X     X
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        // Variant              |  0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |   128
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        //                                    PCK
+        //
+        // Standard variants:
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        //                      |  0  | VSM | FOG |  0  | SKN | SRE | DYN | DIR |    64 (-24)
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        //      Vertex shader            0     0     0     X     X     X     X
+        //    Fragment shader            X     X     0     0     X     X     X
         //           Reserved            X     X     0     X     1     0     0
         //           Reserved            1     X     0     X     0     X     X
         //
-        // Standard variants:
-        //      Vertex shader            0     0     0     X     X     X     X
-        //    Fragment shader            X     X     0     0     X     X     X
+        // Depth variants:
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        //                      |  0  | VSM | PCK |  1  | SKN |  0  |  0  |  0  |     8 (-58)
+        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+        //       Vertex depth            X     0     1     X     0     0     0
+        //     Fragment depth            X     X     1     0     0     0     0
+        //           Reserved            1     1     1     X     0     0     0
+        //           Reserved            X     X     1     X     X     X     1
+        //           Reserved            X     X     1     X     X     1     X
+        //           Reserved            X     X     1     X     1     X     X
+        //
+        // 46 variants used, 82 reserved
+        //
 
         uint8_t key = 0;
 
@@ -68,27 +83,14 @@ namespace filament {
         static constexpr uint8_t SHADOW_RECEIVER        = 0x04; // receives shadows, per renderable
         static constexpr uint8_t SKINNING_OR_MORPHING   = 0x08; // GPU skinning and/or morphing
         static constexpr uint8_t DEPTH                  = 0x10; // depth only variants
-        static constexpr uint8_t FOG                    = 0x20; // fog
+        static constexpr uint8_t FOG                    = 0x20; // fog (standard)
+        static constexpr uint8_t PICKING                = 0x20; // picking (depth)
         static constexpr uint8_t VSM                    = 0x40; // variance shadow maps
-
-        static constexpr uint8_t VERTEX_MASK = DIRECTIONAL_LIGHTING |
-                                               DYNAMIC_LIGHTING |
-                                               SHADOW_RECEIVER |
-                                               SKINNING_OR_MORPHING |
-                                               DEPTH;
-
-        static constexpr uint8_t FRAGMENT_MASK = DIRECTIONAL_LIGHTING |
-                                                 DYNAMIC_LIGHTING |
-                                                 SHADOW_RECEIVER |
-                                                 FOG |
-                                                 DEPTH |
-                                                 VSM;
 
         static constexpr uint8_t DEPTH_MASK = DIRECTIONAL_LIGHTING |
                                               DYNAMIC_LIGHTING |
                                               SHADOW_RECEIVER |
-                                              DEPTH |
-                                              FOG;
+                                              DEPTH;
 
         // the depth variant deactivates all variants that make no sense when writing the depth
         // only -- essentially, all fragment-only variants.
@@ -97,28 +99,29 @@ namespace filament {
         // this mask filters out the lighting variants
         static constexpr uint8_t UNLIT_MASK    = SKINNING_OR_MORPHING | FOG;
 
-        inline bool hasSkinningOrMorphing() const noexcept { return key & SKINNING_OR_MORPHING; }
+        // returns raw variant bits
         inline bool hasDirectionalLighting() const noexcept { return key & DIRECTIONAL_LIGHTING; }
         inline bool hasDynamicLighting() const noexcept { return key & DYNAMIC_LIGHTING; }
         inline bool hasShadowReceiver() const noexcept { return key & SHADOW_RECEIVER; }
+        inline bool hasSkinningOrMorphing() const noexcept { return key & SKINNING_OR_MORPHING; }
+        inline bool hasDepth() const noexcept { return key & DEPTH; }
         inline bool hasFog() const noexcept { return key & FOG; }
+        inline bool hasPicking() const noexcept { return key & PICKING; }
         inline bool hasVsm() const noexcept { return key & VSM; }
 
-        inline void setSkinning(bool v) noexcept { set(v, SKINNING_OR_MORPHING); }
         inline void setDirectionalLighting(bool v) noexcept { set(v, DIRECTIONAL_LIGHTING); }
         inline void setDynamicLighting(bool v) noexcept { set(v, DYNAMIC_LIGHTING); }
         inline void setShadowReceiver(bool v) noexcept { set(v, SHADOW_RECEIVER); }
+        inline void setSkinning(bool v) noexcept { set(v, SKINNING_OR_MORPHING); }
         inline void setFog(bool v) noexcept { set(v, FOG); }
+        inline void setPicking(bool v) noexcept { set(v, PICKING); }
         inline void setVsm(bool v) noexcept { set(v, VSM); }
 
-        inline constexpr bool isDepthPass() const noexcept {
-            return isValidDepthVariant(key);
-        }
-
         inline static constexpr bool isValidDepthVariant(uint8_t variantKey) noexcept {
-            // For a variant to be a valid depth variant, all of the bits in DEPTH_MASK must be 0,
-            // except for DEPTH.
-            return (variantKey & DEPTH_MASK) == DEPTH_VARIANT;
+            // VSM and PICKING are mutually exclusive for DEPTH variants
+            return (variantKey & DEPTH_MASK) == DEPTH_VARIANT &&
+                    variantKey != 0b1110000u &&
+                    variantKey != 0b1111000u;
         }
 
         static constexpr bool isReserved(uint8_t variantKey) noexcept {
@@ -128,26 +131,38 @@ namespace filament {
             // 2. If SRE is set, either DYN or DIR must also be set (it makes no sense to have
             // shadows without lights).
             // 3. If VSM is set, then SRE must be set.
-            return
-                ((variantKey & DEPTH) && !isValidDepthVariant(variantKey)) ||
-                (variantKey & 0b0010111u) == 0b0000100u ||
-                (variantKey & 0b1010100u) == 0b1000000u;
+            return ((variantKey & DEPTH) && !isValidDepthVariant(variantKey)) ||
+                    (variantKey & 0b0010111u) == 0b0000100u ||
+                    (variantKey & 0b1010100u) == 0b1000000u;
         }
 
         static constexpr uint8_t filterVariantVertex(uint8_t variantKey) noexcept {
             // filter out vertex variants that are not needed. For e.g. fog doesn't affect the
             // vertex shader.
             if (variantKey & DEPTH) {
-                // VSM affects the vertex shader, but only for DEPTH variants.
-                return variantKey & (VERTEX_MASK | VSM);
+                // Only VSM and skinning affects the vertex shader's DEPTH variant
+                return variantKey & (DEPTH | SKINNING_OR_MORPHING | VSM);
             }
-            return variantKey & VERTEX_MASK;
+            return variantKey & (
+                    DIRECTIONAL_LIGHTING |
+                    DYNAMIC_LIGHTING |
+                    SHADOW_RECEIVER |
+                    SKINNING_OR_MORPHING);
         }
 
         static constexpr uint8_t filterVariantFragment(uint8_t variantKey) noexcept {
             // filter out fragment variants that are not needed. For e.g. skinning doesn't
             // affect the fragment shader.
-            return variantKey & FRAGMENT_MASK;
+            if (variantKey & DEPTH) {
+                // Only VSM & PICKING affects the fragment shader's DEPTH variant
+                return variantKey & (DEPTH | VSM | PICKING);
+            }
+            return variantKey & (
+                    DIRECTIONAL_LIGHTING |
+                    DYNAMIC_LIGHTING |
+                    SHADOW_RECEIVER |
+                    FOG |
+                    VSM);
         }
 
         static constexpr uint8_t filterVariant(uint8_t variantKey, bool isLit) noexcept {
@@ -164,5 +179,19 @@ namespace filament {
             key = (key & ~mask) | (v ? mask : uint8_t(0));
         }
     };
+
+namespace details {
+// this ensures at compile time that we are correctly triaging the reserved variants
+constexpr inline size_t valid_variant_count() noexcept {
+    size_t count = 0;
+    for (uint8_t i = 0; i < VARIANT_COUNT; i++) {
+        if (!Variant::isReserved(i)) { count++; }
+    }
+    return count;
 }
+static_assert(valid_variant_count() == 46);
+} // namespace details
+
+} // namespace filament
+
 #endif

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -128,7 +128,7 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
             .add("morphWeights", 1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             .add("flags", 1, UniformInterfaceBlock::Type::UINT)
             .add("channels", 1, UniformInterfaceBlock::Type::UINT)
-            .add("reserved1", 1, UniformInterfaceBlock::Type::UINT)
+            .add("objectId", 1, UniformInterfaceBlock::Type::UINT)
             .add("userData", 1, UniformInterfaceBlock::Type::FLOAT)
             .build();
     return uib;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -244,7 +244,7 @@ std::string ShaderGenerator::createVertexProgram(filament::backend::ShaderModel 
     cg.generateGetters(vs, ShaderType::VERTEX);
     cg.generateCommonMaterial(vs, ShaderType::VERTEX);
 
-    if (variant.isDepthPass() &&
+    if (filament::Variant::isValidDepthVariant(variantKey) &&
             material.blendingMode != BlendingMode::MASKED &&
             !material.hasTransparentShadow &&
             !hasCustomDepthShader()) {
@@ -347,10 +347,11 @@ std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderMode
     cg.generateDefine(fs, "HAS_DIRECTIONAL_LIGHTING", litVariants && variant.hasDirectionalLighting());
     cg.generateDefine(fs, "HAS_DYNAMIC_LIGHTING", litVariants && variant.hasDynamicLighting());
     cg.generateDefine(fs, "HAS_SHADOWING", litVariants && variant.hasShadowReceiver());
+    cg.generateDefine(fs, "HAS_FOG", variant.hasFog() && !variant.hasDepth());
+    cg.generateDefine(fs, "HAS_PICKING", variant.hasPicking() && variant.hasDepth());
+    cg.generateDefine(fs, "HAS_VSM", variant.hasVsm());
     cg.generateDefine(fs, "HAS_SHADOW_MULTIPLIER", material.hasShadowMultiplier);
     cg.generateDefine(fs, "HAS_TRANSPARENT_SHADOW", material.hasTransparentShadow);
-    cg.generateDefine(fs, "HAS_FOG", variant.hasFog());
-    cg.generateDefine(fs, "HAS_VSM", variant.hasVsm());
 
     // material defines
     cg.generateDefine(fs, "MATERIAL_HAS_DOUBLE_SIDED_CAPABILITY", material.hasDoubleSidedCapability);
@@ -444,7 +445,7 @@ std::string ShaderGenerator::createFragmentProgram(filament::backend::ShaderMode
     cg.generateFog(fs, ShaderType::FRAGMENT);
 
     // shading model
-    if (variant.isDepthPass()) {
+    if (filament::Variant::isValidDepthVariant(variantKey)) {
         if (material.blendingMode == BlendingMode::MASKED || material.hasTransparentShadow) {
             appendShader(fs, mMaterialCode, mMaterialLineOffset);
         }

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -1,9 +1,15 @@
 #if defined(HAS_VSM)
 layout(location = 0) out vec4 fragColor;
+#elif defined(HAS_PICKING)
+layout(location = 0) out highp uint2 outPicking;
+#else
+// not color output
 #endif
 
 //------------------------------------------------------------------------------
 // Depth
+//
+// note: HAS_VSM and HAS_PICKING are mutually exclusive
 //------------------------------------------------------------------------------
 
 void main() {
@@ -58,5 +64,10 @@ void main() {
     moments.y = depth * depth + 0.25 * (dx * dx + dy * dy);
 
     fragColor = vec4(moments, 0.0, 0.0);
+#elif defined(HAS_PICKING)
+    outPicking.x = objectUniforms.objectId;
+    outPicking.y = floatBitsToUint(vertex_position.z / vertex_position.w);
+#else
+    // that's it
 #endif
 }

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -28,6 +28,9 @@ void main() {
     vertex_worldPosition = material.worldPosition.xyz;
 #endif
 
+    // this must happen before we compensate for vulkan below
+    vertex_position = gl_Position;
+
 #if defined(TARGET_VULKAN_ENVIRONMENT)
     // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
     gl_Position.y = -gl_Position.y;


### PR DESCRIPTION
This is a pixel accurate implementation of picking. Picking queries
can be created on view, and upon completion a user provided callback
is called with the Entity of the renderable at the queried coordinates
in the viewport.


Picking queries typically have 1 or 2 frame of latency and may impact
performance on some drivers.

It is mostly intended for use by editors, or when latency is not a major
concern. This api should not be used for dragging/moving objects, it is
intended for initial picking only.


Picking is implemented in the structure pass.