### PR TITLE
Metal: don't call createTextureViewWithSwizzle directly

### DIFF
--- a/filament/backend/src/metal/MetalExternalImage.h
+++ b/filament/backend/src/metal/MetalExternalImage.h
@@ -100,6 +100,7 @@ private:
     CVMetalTextureRef createTextureFromImage(CVPixelBufferRef image, MTLPixelFormat format,
             size_t plane);
     id<MTLTexture> createRgbTexture(size_t width, size_t height);
+    id<MTLTexture> createSwizzledTextureView(id<MTLTexture> texture) const;
     id<MTLTexture> createSwizzledTextureView(CVMetalTextureRef texture) const;
     void ensureComputePipelineState();
     id<MTLCommandBuffer> encodeColorConversionPass(id<MTLTexture> inYPlane, id<MTLTexture>
@@ -125,7 +126,7 @@ private:
 
     struct {
         TextureSwizzle r, g, b, a;
-    } swizzle;
+    } mSwizzle;
 };
 
 } // namespace metal


### PR DESCRIPTION
`createTextureViewWithSwizzle` should not be called directly, as it's only available on newer systems. This was causing a build warning and potentially a crash with older (< iOS 13.0) devices.