### PR TITLE
fix readPixels vertical offset in vk backend

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1487,7 +1487,7 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
         },
         .srcOffset = {
             .x = (int32_t) x,
-            .y = (int32_t) y,
+            .y = (int32_t) (srcTarget->getExtent(mContext.currentSurface).height - (height + y)),
         },
         .dstSubresource = {
             .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,


### PR DESCRIPTION
vulkan expected a vertical offset from the top, but the api is in
gl convention with the offset from the bottom.