### PR TITLE
Metal: support integer formats with readPixels

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -320,7 +320,7 @@ enum class PixelDataType : uint8_t {
     BYTE,                 //!< signed byte
     USHORT,               //!< unsigned short (16-bit)
     SHORT,                //!< signed short (16-bit)
-    UINT,                 //!< unsigned int (16-bit)
+    UINT,                 //!< unsigned int (32-bit)
     INT,                  //!< signed int (32-bit)
     HALF,                 //!< half-float (16-bit float)
     FLOAT,                //!< float (32-bits float)
@@ -558,6 +558,48 @@ static constexpr bool isDepthFormat(TextureFormat format) noexcept {
         case TextureFormat::DEPTH32F_STENCIL8:
         case TextureFormat::DEPTH24_STENCIL8:
             return true;
+        default:
+            return false;
+    }
+}
+
+static constexpr bool isUnsignedIntFormat(TextureFormat format) {
+    switch (format) {
+        case TextureFormat::R8UI:
+        case TextureFormat::R16UI:
+        case TextureFormat::R32UI:
+        case TextureFormat::RG8UI:
+        case TextureFormat::RG16UI:
+        case TextureFormat::RG32UI:
+        case TextureFormat::RGB8UI:
+        case TextureFormat::RGB16UI:
+        case TextureFormat::RGB32UI:
+        case TextureFormat::RGBA8UI:
+        case TextureFormat::RGBA16UI:
+        case TextureFormat::RGBA32UI:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+static constexpr bool isSignedIntFormat(TextureFormat format) {
+    switch (format) {
+        case TextureFormat::R8I:
+        case TextureFormat::R16I:
+        case TextureFormat::R32I:
+        case TextureFormat::RG8I:
+        case TextureFormat::RG16I:
+        case TextureFormat::RG32I:
+        case TextureFormat::RGB8I:
+        case TextureFormat::RGB16I:
+        case TextureFormat::RGB32I:
+        case TextureFormat::RGBA8I:
+        case TextureFormat::RGBA16I:
+        case TextureFormat::RGBA32I:
+            return true;
+
         default:
             return false;
     }

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -222,6 +222,34 @@ inline MTLPixelFormat getMetalFormatLinear(MTLPixelFormat format) {
     return format;
 }
 
+constexpr inline bool isMetalFormatInteger(MTLPixelFormat format) {
+    switch (format) {
+        case MTLPixelFormatR8Uint:
+        case MTLPixelFormatR8Sint:
+        case MTLPixelFormatR16Uint:
+        case MTLPixelFormatR16Sint:
+        case MTLPixelFormatRG8Uint:
+        case MTLPixelFormatRG8Sint:
+        case MTLPixelFormatR32Uint:
+        case MTLPixelFormatR32Sint:
+        case MTLPixelFormatRG16Uint:
+        case MTLPixelFormatRG16Sint:
+        case MTLPixelFormatRGBA8Uint:
+        case MTLPixelFormatRGBA8Sint:
+        case MTLPixelFormatRGB10A2Uint:
+        case MTLPixelFormatRG32Uint:
+        case MTLPixelFormatRG32Sint:
+        case MTLPixelFormatRGBA16Uint:
+        case MTLPixelFormatRGBA16Sint:
+        case MTLPixelFormatRGBA32Uint:
+        case MTLPixelFormatRGBA32Sint:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 constexpr inline MTLTextureType getMetalType(SamplerType target) {
     switch (target) {
         case SamplerType::SAMPLER_2D:

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -178,5 +178,65 @@ int runTests() {
     return RUN_ALL_TESTS();
 }
 
+void getPixelInfo(PixelDataFormat format, PixelDataType type, size_t& outComponents, int& outBpp) {
+    switch (format) {
+        case PixelDataFormat::UNUSED:
+        case PixelDataFormat::R:
+        case PixelDataFormat::R_INTEGER:
+        case PixelDataFormat::DEPTH_COMPONENT:
+        case PixelDataFormat::ALPHA:
+            outComponents = 1;
+            break;
+        case PixelDataFormat::RG:
+        case PixelDataFormat::RG_INTEGER:
+        case PixelDataFormat::DEPTH_STENCIL:
+            outComponents = 2;
+            break;
+        case PixelDataFormat::RGB:
+        case PixelDataFormat::RGB_INTEGER:
+            outComponents = 3;
+            break;
+        case PixelDataFormat::RGBA:
+        case PixelDataFormat::RGBA_INTEGER:
+            outComponents = 4;
+            break;
+    }
+
+    outBpp = outComponents;
+    switch (type) {
+        case PixelDataType::COMPRESSED:
+        case PixelDataType::UBYTE:
+        case PixelDataType::BYTE:
+            // nothing to do
+            break;
+        case PixelDataType::USHORT:
+        case PixelDataType::SHORT:
+        case PixelDataType::HALF:
+            outBpp *= 2;
+            break;
+        case PixelDataType::UINT:
+        case PixelDataType::INT:
+        case PixelDataType::FLOAT:
+            outBpp *= 4;
+            break;
+        case PixelDataType::UINT_10F_11F_11F_REV:
+            // Special case, format must be RGB and uses 4 bytes
+            assert_invariant(format == PixelDataFormat::RGB);
+            outBpp = 4;
+            break;
+        case PixelDataType::UINT_2_10_10_10_REV:
+            // Special case, format must be RGBA and uses 4 bytes
+            assert_invariant(format == PixelDataFormat::RGBA);
+            outBpp = 4;
+            break;
+        case PixelDataType::USHORT_565:
+            // Special case, format must be RGB and uses 2 bytes
+            assert_invariant(format == PixelDataFormat::RGB);
+            outBpp = 2;
+            break;
+    }
+}
+
+
 } // namespace test
 

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -72,6 +72,12 @@ private:
     filament::backend::Handle<filament::backend::HwBufferObject> uniform;
 };
 
+
+// Utilities
+
+void getPixelInfo(filament::backend::PixelDataFormat format, filament::backend::PixelDataType type,
+        size_t& outComponents, int& outBpp);
+
 } // namespace test
 
 #endif

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -159,65 +159,6 @@ static PixelBufferDescriptor compressedCheckerboardPixelBuffer(size_t size) {
 }
 #endif
 
-static void getPixelInfo(PixelDataFormat format, PixelDataType type, size_t& outComponents, int& outBpp) {
-    switch (format) {
-        case PixelDataFormat::UNUSED:
-        case PixelDataFormat::R:
-        case PixelDataFormat::R_INTEGER:
-        case PixelDataFormat::DEPTH_COMPONENT:
-        case PixelDataFormat::ALPHA:
-            outComponents = 1;
-            break;
-        case PixelDataFormat::RG:
-        case PixelDataFormat::RG_INTEGER:
-        case PixelDataFormat::DEPTH_STENCIL:
-            outComponents = 2;
-            break;
-        case PixelDataFormat::RGB:
-        case PixelDataFormat::RGB_INTEGER:
-            outComponents = 3;
-            break;
-        case PixelDataFormat::RGBA:
-        case PixelDataFormat::RGBA_INTEGER:
-            outComponents = 4;
-            break;
-    }
-
-    outBpp = outComponents;
-    switch (type) {
-        case PixelDataType::COMPRESSED:
-        case PixelDataType::UBYTE:
-        case PixelDataType::BYTE:
-            // nothing to do
-            break;
-        case PixelDataType::USHORT:
-        case PixelDataType::SHORT:
-        case PixelDataType::HALF:
-            outBpp *= 2;
-            break;
-        case PixelDataType::UINT:
-        case PixelDataType::INT:
-        case PixelDataType::FLOAT:
-            outBpp *= 4;
-            break;
-        case PixelDataType::UINT_10F_11F_11F_REV:
-            // Special case, format must be RGB and uses 4 bytes
-            assert_invariant(format == PixelDataFormat::RGB);
-            outBpp = 4;
-            break;
-        case PixelDataType::UINT_2_10_10_10_REV:
-            // Special case, format must be RGBA and uses 4 bytes
-            assert_invariant(format == PixelDataFormat::RGBA);
-            outBpp = 4;
-            break;
-        case PixelDataType::USHORT_565:
-            // Special case, format must be RGB and uses 2 bytes
-            assert_invariant(format == PixelDataFormat::RGB);
-            outBpp = 2;
-            break;
-    }
-}
-
 static PixelBufferDescriptor checkerboardPixelBuffer(PixelDataFormat format, PixelDataType type,
         size_t size, size_t bufferPadding = 0) {
     size_t components; int bpp;

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -48,12 +48,22 @@ void main() {
 }
 )");
 
-std::string fragment (R"(#version 450 core
+std::string fragmentFloat (R"(#version 450 core
 
 layout(location = 0) out vec4 fragColor;
 
 void main() {
     fragColor = vec4(1.0);
+}
+
+)");
+
+std::string fragmentUint (R"(#version 450 core
+
+layout(location = 0) out uvec4 fragColor;
+
+void main() {
+    fragColor = uvec4(1);
 }
 
 )");
@@ -104,22 +114,10 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         size_t bufferDimension = getRenderTargetSize();
 
         size_t getBufferSizeBytes() const {
-            auto getPixelSize = [] (PixelDataType type) {
-                switch(type) {
-                    case PixelDataType::FLOAT:
-                        return sizeof(float);
-
-                    case PixelDataType::UBYTE:
-                        return sizeof(uint8_t);
-
-                    case PixelDataType::UINT:
-                        return sizeof(uint32_t);
-
-                    default:
-                        return 0ul;
-                }
-            };
-            return bufferDimension * bufferDimension * 4 * getPixelSize(type);
+            size_t components;
+            int bpp;
+            getPixelInfo(format, type, components, bpp);
+            return bufferDimension * bufferDimension * bpp;
         }
 
         // The offset and stride set on the pixel buffer.
@@ -146,8 +144,19 @@ TEST_F(ReadPixelsTest, ReadPixels) {
             #endif
         }
 
+        void exportRawBytes(void* pixelData) const {
+            std::string out = std::string(testName) + ".raw";
+            std::ofstream outputStream(out.c_str(), std::ios::binary | std::ios::trunc);
+            outputStream.write((char*) pixelData, getBufferSizeBytes());
+            outputStream.close();
+        }
+
+        // The format and type for the readPixels call.
         PixelDataFormat format = PixelDataFormat::RGBA;
         PixelDataType type = PixelDataType::UBYTE;
+
+        // The texture format of the render target.
+        TextureFormat textureFormat = TextureFormat::RGBA8;
     };
 
     // The normative read pixels test case. Render a white triangle over a blue background and read
@@ -194,7 +203,36 @@ TEST_F(ReadPixelsTest, ReadPixels) {
     t5.top = 64;
     t5.hash = 0xbaefdb54;
 
-    TestCase testCases[] = { t, t2, t3, t4, t5 };
+    // Check that readPixels works with integer formats.
+    TestCase t6;
+    t6.testName = "readPixels_UINT";
+    t6.format = PixelDataFormat::R_INTEGER;
+    t6.type = PixelDataType::UINT;
+    t6.textureFormat = TextureFormat::R32UI;
+    t6.hash = 0x9d91227;
+
+    // Check that readPixels works with half formats.
+    TestCase t7;
+    t7.testName = "readPixels_half";
+    t7.format = PixelDataFormat::RG;
+    t7.type = PixelDataType::HALF;
+    t7.textureFormat = TextureFormat::RG16F;
+    t7.hash = 3726805703;
+
+    TestCase testCases[] = { t, t2, t3, t4, t5, t6, t7 };
+
+    // Create programs.
+    Handle<HwProgram> programFloat, programUint;
+    {
+        ShaderGenerator shaderGen(vertex, fragmentFloat, sBackend, sIsMobilePlatform);
+        Program p = shaderGen.getProgram();
+        programFloat = getDriverApi().createProgram(std::move(p));
+    }
+    {
+        ShaderGenerator shaderGen(vertex, fragmentUint, sBackend, sIsMobilePlatform);
+        Program p = shaderGen.getProgram();
+        programUint = getDriverApi().createProgram(std::move(p));
+    }
 
     for (const auto& t : testCases)
     {
@@ -203,33 +241,18 @@ TEST_F(ReadPixelsTest, ReadPixels) {
                 t.getRenderTargetSize(), 0);
         getDriverApi().makeCurrent(swapChain, swapChain);
 
-        // Create a program.
-        ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
-        auto program = getDriverApi().createProgram(std::move(p));
-
         // Create a Texture and RenderTarget to render into.
         auto usage = TextureUsage::COLOR_ATTACHMENT | TextureUsage::SAMPLEABLE;
-        Handle<HwTexture> texture = getDriverApi().createTexture(
-                    SamplerType::SAMPLER_2D,            // target
-                    t.mipLevels,                        // levels
-                    TextureFormat::RGBA8,               // format
-                    1,                                  // samples
-                    renderTargetBaseSize,               // width
-                    renderTargetBaseSize,               // height
-                    1,                                  // depth
-                    usage);                             // usage
+        Handle<HwTexture> texture = getDriverApi().createTexture(SamplerType::SAMPLER_2D,
+                t.mipLevels, t.textureFormat, 1, renderTargetBaseSize, renderTargetBaseSize, 1,
+                usage);
 
+        // The width and height must match the width and height of the respective mip
+        // level (at least for OpenGL).
         Handle<HwRenderTarget> renderTarget = getDriverApi().createRenderTarget(
-                TargetBufferFlags::COLOR,
-                // The width and height must match the width and height of the respective mip
-                // level (at least for OpenGL).
-                t.getRenderTargetSize(),                   // width
-                t.getRenderTargetSize(),                   // height
-                t.samples,                                 // samples
-                TargetBufferInfo(texture, t.mipLevel),     // color
-                {},                                        // depth
-                {});                                       // stencil
+                TargetBufferFlags::COLOR, t.getRenderTargetSize(),
+                t.getRenderTargetSize(), t.samples, TargetBufferInfo(texture, t.mipLevel), {},
+                {});
 
         TrianglePrimitive triangle(getDriverApi());
 
@@ -249,7 +272,10 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         getDriverApi().beginRenderPass(renderTarget, params);
 
         PipelineState state;
-        state.program = program;
+        state.program = programFloat;
+        if (isUnsignedIntFormat(t.textureFormat)) {
+            state.program = programUint;
+        }
         state.rasterState.colorWrite = true;
         state.rasterState.depthWrite = false;
         state.rasterState.depthFunc = RasterState::DepthFunc::A;
@@ -263,13 +289,9 @@ TEST_F(ReadPixelsTest, ReadPixels) {
             // correct mip.
             RenderPassParams p = params;
             Handle<HwRenderTarget> mipLevelOneRT = getDriverApi().createRenderTarget(
-                    TargetBufferFlags::COLOR,
-                    renderTargetBaseSize,                      // width
-                    renderTargetBaseSize,                      // height
-                    1,                                         // samples
-                    TargetBufferInfo(texture, 0),              // color
-                    {},                                        // depth
-                    {});                                       // stencil
+                    TargetBufferFlags::COLOR, renderTargetBaseSize, renderTargetBaseSize, 1,
+                    TargetBufferInfo(texture, 0), {},
+                    {});
             p.clearColor = {1.f, 0.f, 0.f, 1.f};
             getDriverApi().beginRenderPass(mipLevelOneRT, p);
             getDriverApi().endRenderPass();
@@ -282,10 +304,11 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         PixelBufferDescriptor descriptor(buffer, t.getBufferSizeBytes(), t.format, t.type,
                 t.alignment, t.left, t.top, t.getPixelBufferStride(), [](void* buffer, size_t size,
                     void* user) {
-                    const TestCase* test = (const TestCase*) user;
+                    const auto* test = (const TestCase*) user;
                     assert_invariant(test);
 
                     test->exportScreenshot(buffer);
+                    //test->exportRawBytes(buffer);
 
                     // Hash the contents of the buffer and check that they match.
                     uint32_t hash = utils::hash::murmur3((const uint32_t*) buffer, size / 4, 0);
@@ -309,11 +332,13 @@ TEST_F(ReadPixelsTest, ReadPixels) {
         getDriverApi().commit(swapChain);
         getDriverApi().endFrame(0);
 
-        getDriverApi().destroyProgram(program);
         getDriverApi().destroySwapChain(swapChain);
         getDriverApi().destroyRenderTarget(renderTarget);
         getDriverApi().destroyTexture(texture);
     }
+
+    getDriverApi().destroyProgram(programFloat);
+    getDriverApi().destroyProgram(programUint);
 
     // This ensures all driver commands have finished before exiting the test.
     getDriverApi().finish();
@@ -332,7 +357,7 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
     getDriverApi().makeCurrent(swapChain, swapChain);
 
     // Create a program.
-    ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
+    ShaderGenerator shaderGen(vertex, fragmentFloat, sBackend, sIsMobilePlatform);
     Program p = shaderGen.getProgram();
     auto program = getDriverApi().createProgram(std::move(p));
 


### PR DESCRIPTION
This change enables more formats for readPixels, notably `UINT`/`R_INTEGER` for picking. Formats that require a conversion to an integer type are not yet supported, due to current limitations of `MetalBlitter`.