### PR TITLE
Use the more common EOTF/OETF acronyms

### DIFF
--- a/filament/src/Color.cpp
+++ b/filament/src/Color.cpp
@@ -26,11 +26,11 @@ namespace filament {
 using namespace math;
 
 float3 Color::sRGBToLinear(float3 color) noexcept {
-    return EOCF_sRGB(color);
+    return EOTF_sRGB(color);
 }
 
 float3 Color::linearToSRGB(float3 color) noexcept {
-    return OECF_sRGB(color);
+    return OETF_sRGB(color);
 }
 
 LinearColor Color::cct(float K) {

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -746,8 +746,8 @@ FColorGrading::FColorGrading(FEngine& engine, const Builder& builder) {
                     // We need to clamp for the output transfer function
                     v = saturate(v);
 
-                    // Apply OECF
-                    v = OECF_sRGB(v);
+                    // Apply OETF
+                    v = OETF_sRGB(v);
 
                     *p++ = half4{v, 0.0f};
                 }

--- a/filament/src/ColorSpace.h
+++ b/filament/src/ColorSpace.h
@@ -272,7 +272,7 @@ inline float3 linearAP1_to_ACEScct(float3 x) noexcept {
     return x;
 }
 
-inline float3 OECF_sRGB(float3 x) noexcept {
+inline float3 OETF_sRGB(float3 x) noexcept {
     constexpr float a  = 0.055f;
     constexpr float a1 = 1.055f;
     constexpr float b  = 12.92f;
@@ -283,7 +283,7 @@ inline float3 OECF_sRGB(float3 x) noexcept {
     return x;
 }
 
-inline float3 EOCF_sRGB(float3 x) noexcept {
+inline float3 EOTF_sRGB(float3 x) noexcept {
     constexpr float a  = 0.055f;
     constexpr float a1 = 1.055f;
     constexpr float b  = 1.0f / 12.92f;
@@ -294,7 +294,7 @@ inline float3 EOCF_sRGB(float3 x) noexcept {
     return x;
 }
 
-inline float3 OECF_PQ(float3 x, float maxPqValue) {
+inline float3 OETF_PQ(float3 x, float maxPqValue) {
     constexpr float PQ_constant_N  = 2610.0f / 4096.0f /   4.0f;
     constexpr float PQ_constant_M  = 2523.0f / 4096.0f * 128.0f;
     constexpr float PQ_constant_C1 = 3424.0f / 4096.0f;
@@ -309,7 +309,7 @@ inline float3 OECF_PQ(float3 x, float maxPqValue) {
     return pow(numerator / denominator, PQ_constant_M);
 }
 
-inline float3 EOCF_PQ(float3 x, float maxPqValue) {
+inline float3 EOTF_PQ(float3 x, float maxPqValue) {
     constexpr float PQ_constant_N  = 2610.0f / 4096.0f /   4.0f;
     constexpr float PQ_constant_M  = 2523.0f / 4096.0f * 128.0f;
     constexpr float PQ_constant_C1 = 3424.0f / 4096.0f;

--- a/shaders/src/dithering.fs
+++ b/shaders/src/dithering.fs
@@ -93,7 +93,7 @@ vec4 Dither_TriangleNoiseRGB(vec4 rgba, const highp float temporalNoise01) {
 
 /**
  * Dithers the specified RGBA color based on the current time and fragment
- * coordinates the input must be in the final color space (including OECF).
+ * coordinates the input must be in the final color space (including OETF).
  * This dithering function assumes we are dithering to an 8-bit target.
  * This function dithers the alpha channel assuming premultiplied output
  */


### PR DESCRIPTION
Nothing wrong with EOCF/OECF but the "T" version is more common and readers will
therefore be more likely to be more familiar with it.