### PR TITLE
fix an issue where we'd use the FSR scaling instead of a dumb blit

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2342,7 +2342,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
         FrameGraphId<FrameGraphTexture> depth;
     };
 
-    auto& ppQuadBlit = fg.addPass<QuadBlitData>("quad scaling",
+    auto& ppQuadBlit = fg.addPass<QuadBlitData>(dsrOptions.enabled ? "quad scaling" : "blendBlit",
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.input = builder.sample(input);
                 data.output = builder.createTexture("scaled output", outDesc);

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -612,12 +612,15 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     if (mightNeedFinalBlit &&
             ((outputIsSwapChain && (msaaSampleCount > 1 || colorGradingConfig.asSubpass)) ||
              blending)) {
-        if (UTILS_LIKELY(!blending && dsrOptions.quality == QualityLevel::LOW)) {
+        assert_invariant(!scaled);
+        if (UTILS_LIKELY(!blending)) {
             input = ppm.opaqueBlit(fg, input, {
                     .width = vp.width, .height = vp.height,
                     .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::LINEAR);
         } else {
-            input = ppm.blendBlit(fg, blending, dsrOptions, input, {
+            input = ppm.blendBlit(fg, blending, {
+                    .quality = QualityLevel::LOW
+            }, input, {
                     .width = vp.width, .height = vp.height,
                     .format = colorGradingConfig.ldrFormat });
         }


### PR DESCRIPTION
The DSR options were carried all the way to the final blit that is 
sometimes needed to impedence-match our rendering features with the
swapchain. This blit is never a scaling blit, but we were using the
FSR option, which would sometimes trigger the FSR scaling code.