### PR TITLE
Fix release distribution

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -94,20 +94,20 @@ set(CMGEN_ARGS --quiet --format=ktx --size=256 --extract-blur=0.1)
 function(add_envmap SOURCE TARGET)
     set(source_envmap "${ROOT_DIR}/${SOURCE}")
 
-    set(target_skybox   "${PROJECT_BINARY_DIR}/${TARGET}/${TARGET}_skybox.ktx")
-    set(target_envmap   "${PROJECT_BINARY_DIR}/${TARGET}/${TARGET}_ibl.ktx")
+    set(target_skybox "${PROJECT_BINARY_DIR}/assets/ibl/${TARGET}/${TARGET}_skybox.ktx")
+    set(target_envmap "${PROJECT_BINARY_DIR}/assets/ibl/${TARGET}/${TARGET}_ibl.ktx")
 
     set(target_envmaps ${target_envmaps} ${target_skybox} PARENT_SCOPE)
     set(target_envmaps ${target_envmaps} ${target_envmap} PARENT_SCOPE)
 
     add_custom_command(OUTPUT ${target_skybox} ${target_envmap}
-        COMMAND cmgen -x ${TARGET} ${CMGEN_ARGS} ${source_envmap}
+        COMMAND cmgen -x assets/ibl/${TARGET} ${CMGEN_ARGS} ${source_envmap}
         MAIN_DEPENDENCY ${source_envmap}
         DEPENDS cmgen
         COMMENT "Generating environment map ${target_envmap}")
 endfunction()
 
-add_envmap("third_party/environments/lightroom_14b.hdr" "default_env")
+add_envmap("third_party/environments/lightroom_14b.hdr" "lightroom_14b")
 
 # ==================================================================================================
 # Build suzanne resources
@@ -263,6 +263,10 @@ if (NOT ANDROID)
     # ==============================================================================================
     install(TARGETS gltf_viewer RUNTIME DESTINATION bin)
     install(TARGETS material_sandbox RUNTIME DESTINATION bin)
+
+    # Install resources
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/assets/fonts DESTINATION bin/assets)
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/assets/ibl/ DESTINATION bin/assets)
 endif()
 
 # ==================================================================================================

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -70,7 +70,7 @@ struct App {
     std::vector<FilamentInstance*> instances;
 };
 
-static const char* DEFAULT_IBL = "default_env";
+static const char* DEFAULT_IBL = "assets/ibl/lightroom_14b";
 
 static void printUsage(char* name) {
     std::string exec_name(Path(name).getName());

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -108,7 +108,7 @@ struct App {
     AutomationEngine* automationEngine = nullptr;
 };
 
-static const char* DEFAULT_IBL = "default_env";
+static const char* DEFAULT_IBL = "assets/ibl/lightroom_14b";
 
 static void printUsage(char* name) {
     std::string exec_name(Path(name).getName());

--- a/samples/hellopbr.cpp
+++ b/samples/hellopbr.cpp
@@ -46,7 +46,7 @@ struct App {
     mat4f transform;
 };
 
-static const char* IBL_FOLDER = "default_env";
+static const char* IBL_FOLDER = "assets/ibl/lightroom_14b";
 
 int main(int argc, char** argv) {
     Config config;

--- a/samples/multiple_windows.cpp
+++ b/samples/multiple_windows.cpp
@@ -51,7 +51,7 @@ namespace {
     static constexpr double kFieldOfViewDeg = 60.0;
     static constexpr double kNearPlane = 0.1;
     static constexpr double kFarPlane = 50.0;
-    static constexpr const char* kIBLFolder = "default_env";
+    static constexpr const char* kIBLFolder = "assets/ibl/lightroom_14b";
     static constexpr double kRotationDegPerSec = 36.0;
     static constexpr math::float3 kCameraCenter = {0.0f, 0.0f, 0.0f};
     static constexpr math::float3 kCameraUp = {0.0f, 1.0f, 0.0f};

--- a/samples/shadowtest.cpp
+++ b/samples/shadowtest.cpp
@@ -55,7 +55,7 @@ struct App {
 };
 
 static const char* MODEL_FILE = "assets/models/monkey/monkey.obj";
-static const char* IBL_FOLDER = "default_env";
+static const char* IBL_FOLDER = "assets/ibl/lightroom_14b";
 
 static constexpr bool ENABLE_SHADOWS = true;
 

--- a/samples/suzanne.cpp
+++ b/samples/suzanne.cpp
@@ -62,7 +62,7 @@ struct App {
     Texture* ao;
 };
 
-static const char* IBL_FOLDER = "default_env";
+static const char* IBL_FOLDER = "assets/ibl/lightroom_14b";
 
 static void printUsage(char* name) {
     std::string exec_name(utils::Path(name).getName());

--- a/third_party/libsdl2/tnt/CMakeLists.txt
+++ b/third_party/libsdl2/tnt/CMakeLists.txt
@@ -142,7 +142,7 @@ include_directories(
 add_definitions(-D_THREAD_SAFE)
 
 # we're building a library
-add_library(${TARGET} SHARED ${SRCS})
+add_library(${TARGET} STATIC ${SRCS})
 
 # libraries we're linking against
 target_link_libraries(${TARGET} ${EXTRA_LIBS})
@@ -172,7 +172,8 @@ if (WIN32)
 else()
     target_compile_options(${TARGET} PRIVATE -fvisibility=hidden)
 
-    # FIXME: the way SDL does atomics is insane, just disable all atomics because there are no implementation for
-    #        aarch64 on certain targets. ideally, we would just std::atomic
+    # FIXME: the way SDL does atomics is insane, just disable all atomics because there are no
+    #        implementation for aarch64 on certain targets. ideally, we would just std::atomic
     target_compile_definitions(${TARGET} PRIVATE SDL_ATOMIC_DISABLED=1)
 endif()
+


### PR DESCRIPTION
Statically link SDL2 to make our samples (glTF Viewer, etc.) completely
standalone, and include missing resources (fonts and default environment
map for the IBL).

Fixes #4712.