### PR TITLE
ASTC texture enums missing in JNI interface

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -216,7 +216,38 @@ public class Texture {
         ETC2_EAC_RGBA8, ETC2_EAC_SRGBA8,
 
         // Available everywhere except Android/iOS
-        DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA
+        DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA,
+        DXT1_SRGB, DXT1_SRGBA, DXT3_SRGBA, DXT5_SRGBA,
+
+        // ASTC formats are available with a GLES extension
+        RGBA_ASTC_4x4,
+        RGBA_ASTC_5x4,
+        RGBA_ASTC_5x5,
+        RGBA_ASTC_6x5,
+        RGBA_ASTC_6x6,
+        RGBA_ASTC_8x5,
+        RGBA_ASTC_8x6,
+        RGBA_ASTC_8x8,
+        RGBA_ASTC_10x5,
+        RGBA_ASTC_10x6,
+        RGBA_ASTC_10x8,
+        RGBA_ASTC_10x10,
+        RGBA_ASTC_12x10,
+        RGBA_ASTC_12x12,
+        SRGB8_ALPHA8_ASTC_4x4,
+        SRGB8_ALPHA8_ASTC_5x4,
+        SRGB8_ALPHA8_ASTC_5x5,
+        SRGB8_ALPHA8_ASTC_6x5,
+        SRGB8_ALPHA8_ASTC_6x6,
+        SRGB8_ALPHA8_ASTC_8x5,
+        SRGB8_ALPHA8_ASTC_8x6,
+        SRGB8_ALPHA8_ASTC_8x8,
+        SRGB8_ALPHA8_ASTC_10x5,
+        SRGB8_ALPHA8_ASTC_10x6,
+        SRGB8_ALPHA8_ASTC_10x8,
+        SRGB8_ALPHA8_ASTC_10x10,
+        SRGB8_ALPHA8_ASTC_12x10,
+        SRGB8_ALPHA8_ASTC_12x12
     }
 
     /**
@@ -231,7 +262,38 @@ public class Texture {
         ETC2_EAC_RGBA8, ETC2_EAC_SRGBA8,
 
         // Available everywhere except Android/iOS
-        DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA
+        DXT1_RGB, DXT1_RGBA, DXT3_RGBA, DXT5_RGBA,
+        DXT1_SRGB, DXT1_SRGBA, DXT3_SRGBA, DXT5_SRGBA,
+
+        // ASTC formats are available with a GLES extension
+        RGBA_ASTC_4x4,
+        RGBA_ASTC_5x4,
+        RGBA_ASTC_5x5,
+        RGBA_ASTC_6x5,
+        RGBA_ASTC_6x6,
+        RGBA_ASTC_8x5,
+        RGBA_ASTC_8x6,
+        RGBA_ASTC_8x8,
+        RGBA_ASTC_10x5,
+        RGBA_ASTC_10x6,
+        RGBA_ASTC_10x8,
+        RGBA_ASTC_10x10,
+        RGBA_ASTC_12x10,
+        RGBA_ASTC_12x12,
+        SRGB8_ALPHA8_ASTC_4x4,
+        SRGB8_ALPHA8_ASTC_5x4,
+        SRGB8_ALPHA8_ASTC_5x5,
+        SRGB8_ALPHA8_ASTC_6x5,
+        SRGB8_ALPHA8_ASTC_6x6,
+        SRGB8_ALPHA8_ASTC_8x5,
+        SRGB8_ALPHA8_ASTC_8x6,
+        SRGB8_ALPHA8_ASTC_8x8,
+        SRGB8_ALPHA8_ASTC_10x5,
+        SRGB8_ALPHA8_ASTC_10x6,
+        SRGB8_ALPHA8_ASTC_10x8,
+        SRGB8_ALPHA8_ASTC_10x10,
+        SRGB8_ALPHA8_ASTC_12x10,
+        SRGB8_ALPHA8_ASTC_12x12
     }
 
     /**


### PR DESCRIPTION
I needed ASTC support in Android on the Java side and it looks like it's as easy as adding the missing enums, but I may be missing a trick.