### PR TITLE
code health: cleanup FrameInfo and FrameSkipper a bit

### DIFF
--- a/filament/src/FrameInfo.cpp
+++ b/filament/src/FrameInfo.cpp
@@ -24,7 +24,9 @@
 #include <cmath>
 
 namespace filament {
+
 using namespace utils;
+using namespace backend;
 
 // this is to avoid a call to memmove
 template<class InputIterator, class OutputIterator>
@@ -35,8 +37,7 @@ void move_backward(InputIterator first, InputIterator last, OutputIterator resul
     }
 }
 
-FrameInfoManager::FrameInfoManager(FEngine& engine) : mEngine(engine) {
-    backend::DriverApi& driver = mEngine.getDriverApi();
+FrameInfoManager::FrameInfoManager(DriverApi& driver) noexcept {
     for (auto& query : mQueries) {
         query = driver.createTimerQuery();
     }
@@ -44,15 +45,13 @@ FrameInfoManager::FrameInfoManager(FEngine& engine) : mEngine(engine) {
 
 FrameInfoManager::~FrameInfoManager() noexcept = default;
 
-void FrameInfoManager::terminate() {
-    backend::DriverApi& driver = mEngine.getDriverApi();
+void FrameInfoManager::terminate(DriverApi& driver) noexcept {
     for (auto& query : mQueries) {
         driver.destroyTimerQuery(query);
     }
 }
 
-void FrameInfoManager::beginFrame(Config const& config, uint32_t frameId) {
-    backend::DriverApi& driver = mEngine.getDriverApi();
+void FrameInfoManager::beginFrame(DriverApi& driver,Config const& config, uint32_t frameId) noexcept {
     driver.beginTimerQuery(mQueries[mIndex]);
     uint64_t elapsed = 0;
     if (driver.getTimerQueryValue(mQueries[mLast], &elapsed)) {
@@ -63,13 +62,12 @@ void FrameInfoManager::beginFrame(Config const& config, uint32_t frameId) {
     update(config, mFrameTime);
 }
 
-void FrameInfoManager::endFrame() {
-    backend::DriverApi& driver = mEngine.getDriverApi();
+void FrameInfoManager::endFrame(DriverApi& driver) noexcept {
     driver.endTimerQuery(mQueries[mIndex]);
     mIndex = (mIndex + 1) % POOL_COUNT;
 }
 
-void FrameInfoManager::update(Config const& config, FrameInfoManager::duration lastFrameTime) {
+void FrameInfoManager::update(Config const& config, FrameInfoManager::duration lastFrameTime) noexcept {
     // keep an history of frame times
     auto& history = mFrameTimeHistory;
 

--- a/filament/src/FrameInfo.h
+++ b/filament/src/FrameInfo.h
@@ -17,9 +17,8 @@
 #ifndef TNT_FILAMENT_FRAMEINFO_H
 #define TNT_FILAMENT_FRAMEINFO_H
 
-#include "details/Engine.h"
-
 #include "backend/Handle.h"
+#include <private/backend/DriverApi.h>
 
 #include <array>
 #include <chrono>
@@ -47,13 +46,18 @@ public:
         uint32_t historySize;
     };
 
-    explicit FrameInfoManager(FEngine& engine);
-    ~FrameInfoManager() noexcept;
-    void terminate();
-    void beginFrame(Config const& config, uint32_t frameId);  // call this immediately after "make current"
-    void endFrame(); // call this immediately before "swap buffers"
+    explicit FrameInfoManager(backend::DriverApi& driver) noexcept;
 
-    FrameInfo const& getLastFrameInfo() const {
+    ~FrameInfoManager() noexcept;
+    void terminate(backend::DriverApi& driver) noexcept;
+
+    // call this immediately after "make current"
+    void beginFrame(backend::DriverApi& driver, Config const& config, uint32_t frameId) noexcept;
+
+    // call this immediately before "swap buffers"
+    void endFrame(backend::DriverApi& driver) noexcept;
+
+    FrameInfo const& getLastFrameInfo() const noexcept {
         return mFrameTimeHistory[0];
     }
 
@@ -61,10 +65,8 @@ public:
         return getLastFrameInfo().frameTime;
     }
 
-
 private:
-    void update(Config const& config, duration lastFrameTime);
-    FEngine& mEngine;
+    void update(Config const& config, duration lastFrameTime) noexcept;
     backend::Handle<backend::HwTimerQuery> mQueries[POOL_COUNT];
     duration mFrameTime{};
     uint32_t mIndex = 0;

--- a/filament/src/FrameSkipper.cpp
+++ b/filament/src/FrameSkipper.cpp
@@ -26,13 +26,14 @@ namespace filament {
 using namespace utils;
 using namespace backend;
 
-FrameSkipper::FrameSkipper(FEngine& engine, size_t latency) noexcept
-        : mEngine(engine), mLast(latency) {
+FrameSkipper::FrameSkipper(size_t latency) noexcept
+        : mLast(latency) {
     assert_invariant(latency <= MAX_FRAME_LATENCY);
 }
 
-FrameSkipper::~FrameSkipper() noexcept {
-    auto& driver = mEngine.getDriverApi();
+FrameSkipper::~FrameSkipper() noexcept = default;
+
+void FrameSkipper::terminate(DriverApi& driver) noexcept {
     for (auto sync : mDelayedSyncs) {
         if (sync) {
             driver.destroySync(sync);
@@ -40,8 +41,7 @@ FrameSkipper::~FrameSkipper() noexcept {
     }
 }
 
-bool FrameSkipper::beginFrame() noexcept {
-    auto& driver = mEngine.getDriverApi();
+bool FrameSkipper::beginFrame(DriverApi& driver) noexcept {
     auto& syncs = mDelayedSyncs;
     auto sync = syncs.front();
     if (sync) {
@@ -58,11 +58,10 @@ bool FrameSkipper::beginFrame() noexcept {
     return true;
 }
 
-void FrameSkipper::endFrame() noexcept {
+void FrameSkipper::endFrame(DriverApi& driver) noexcept {
     // if the user produced a new frame despite the fact that the previous one wasn't finished
     // (i.e. FrameSkipper::beginFrame() returned false), we need to make sure to replace
     // a fence that might be here already)
-    auto& driver = mEngine.getDriverApi();
     auto& sync = mDelayedSyncs[mLast];
     if (sync) {
         driver.destroySync(sync);

--- a/filament/src/FrameSkipper.h
+++ b/filament/src/FrameSkipper.h
@@ -18,28 +18,28 @@
 #define TNT_FILAMENT_DETAILS_FRAMESKIPPER_H
 
 #include <backend/Handle.h>
+#include <private/backend/DriverApi.h>
 
 #include <array>
 
 namespace filament {
 
-class FEngine;
-
 class FrameSkipper {
     static constexpr size_t MAX_FRAME_LATENCY = 4;
 public:
-    explicit FrameSkipper(FEngine& engine, size_t latency = 2) noexcept;
+    explicit FrameSkipper(size_t latency = 2) noexcept;
     ~FrameSkipper() noexcept;
+
+    void terminate(backend::DriverApi& driver) noexcept;
 
     // returns false if we need to skip this frame, because the gpu is running behind the cpu.
     // in that case, don't call endFrame().
     // returns true if rendering can proceed. Always call endFrame() when done.
-    bool beginFrame() noexcept;
+    bool beginFrame(backend::DriverApi& driver) noexcept;
 
-    void endFrame() noexcept;
+    void endFrame(backend::DriverApi& driver) noexcept;
 
 private:
-    FEngine& mEngine;
     using Container = std::array<backend::Handle<backend::HwSync>, MAX_FRAME_LATENCY>;
     mutable Container mDelayedSyncs{};
     size_t mLast;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -22,6 +22,7 @@
 #include "Allocators.h"
 #include "FrameInfo.h"
 #include "FrameSkipper.h"
+#include "PostProcessManager.h"
 #include "RenderPass.h"
 
 #include "details/SwapChain.h"
@@ -29,9 +30,11 @@
 #include "private/backend/DriverApiForward.h"
 
 #include <fg2/FrameGraphId.h>
+#include <fg2/FrameGraphTexture.h>
 
 #include <filament/Renderer.h>
 #include <filament/View.h>
+#include <filament/Viewport.h>
 
 #include <backend/DriverEnums.h>
 #include <backend/Handle.h>


### PR DESCRIPTION
in particular add a terminate() method to FrameSkipper instead of
destroying driver objects in the destructor -- this matches all other
objects.

also remove dependency on FEngine which wasn't needed.