### PR TITLE
Fix, call VirtualMachineEnv::JNI_OnLoad for non-Android Java builds

### DIFF
--- a/android/filament-android/src/main/cpp/Filament.cpp
+++ b/android/filament-android/src/main/cpp/Filament.cpp
@@ -16,6 +16,8 @@
 
 #include <jni.h>
 
+#include "private/backend/VirtualMachineEnv.h"
+
 namespace filament {
     extern jint JNI_OnLoad(JavaVM* vm, void* reserved);
 };
@@ -28,6 +30,8 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
 #if ANDROID
     ::filament::JNI_OnLoad(vm, reserved);
+#else
+    ::filament::VirtualMachineEnv::JNI_OnLoad(vm);
 #endif
 
     return JNI_VERSION_1_6;


### PR DESCRIPTION
We need to make sure that `VirtualMachineEnv` is initialized now for non-Android builds.