### PR TITLE
Fix compatibility with libstdc++

### DIFF
--- a/filament/backend/include/backend/Handle.h
+++ b/filament/backend/include/backend/Handle.h
@@ -21,6 +21,8 @@
 #include <utils/Log.h>
 #include <utils/debug.h>
 
+#include <limits>
+
 namespace filament {
 namespace backend {
 

--- a/libs/imageio/src/HDRDecoder.cpp
+++ b/libs/imageio/src/HDRDecoder.cpp
@@ -22,6 +22,7 @@
 
 #include <utils/Log.h>
 
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <sstream>

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -21,6 +21,7 @@
 #include <utils/Panic.h>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <type_traits>
 #include <utility>

--- a/libs/viewer/src/RemoteServer.cpp
+++ b/libs/viewer/src/RemoteServer.cpp
@@ -20,6 +20,7 @@
 
 #include <utils/Log.h>
 
+#include <cstring>
 #include <vector>
 
 using namespace utils;


### PR DESCRIPTION
The codebase needs only a few additional standard #includes to compile
against libstdc++ on Linux; presumably those headers are implicitly
included with MSVC's and Clang's standard C++ library, but even if
libstdc++ compatibility is not a goal, it is advisable to have them
included directly.