### PR TITLE
Fix spotlight direction and falloff

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 This file contains one line summaries of commits that are worthy of mentioning in release notes.
 A new header is inserted each time a *tag* is created.
 
-## v1.12.12 (currently main branch)
+## v1.13.0 (currently main branch)
 
 - Android: Gradle configuration caching is now enabled
 - Android: Filament's Gradle properties have all been renamed to `com.google.android.filament.xxx`
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - Android: The Gradle property `filament_tools_dir` (now called
   `com.google.android.filament.tools-dir`) does not have a default value anymore. Please specify
   one in your `gradle.properties` if you reuse the Gradle plugin in your projects  [⚠️]
+- Engine: Fix spotlights direction and falloff.  [⚠️ **Material breakage**].
 
 ## v1.12.11
 

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -316,9 +316,11 @@ void FScene::prepareDynamicLights(const CameraInfo& camera, ArenaScope& rootAren
         const size_t gpuIndex = i - DIRECTIONAL_LIGHTS_COUNT;
         auto li = instances[i];
         lp[gpuIndex].positionFalloff      = { spheres[i].xyz, lcm.getSquaredFalloffInv(li) };
-        lp[gpuIndex].color                = { lcm.getColor(li), 0.0f };
-        lp[gpuIndex].directionIES         = { directions[i], 0.0f };
+        lp[gpuIndex].direction            = directions[i];
+        lp[gpuIndex].reserved1            = {};
+        lp[gpuIndex].colorIES             = { lcm.getColor(li), 0.0f };
         lp[gpuIndex].spotScaleOffset      = lcm.getSpotParams(li).scaleOffset;
+        lp[gpuIndex].reserved3            = {};
         lp[gpuIndex].intensity            = lcm.getIntensity(li);
         lp[gpuIndex].typeShadow           = LightsUib::packTypeShadow(
                 lcm.isPointLight(li) ? 0u : 1u,
@@ -326,7 +328,6 @@ void FScene::prepareDynamicLights(const CameraInfo& camera, ArenaScope& rootAren
                 shadowInfo[i].index,
                 shadowInfo[i].layer);
         lp[gpuIndex].channels             = LightsUib::packChannels(lcm.getLightChannels(li), shadowInfo[i].castsShadows);
-        lp[gpuIndex].reserved             = {};
     }
 
     driver.updateBufferObject(lightUbh, { lp, positionalLightCount * sizeof(LightsUib) }, 0);

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 12;
+static constexpr size_t MATERIAL_VERSION = 13;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -164,13 +164,14 @@ static_assert(sizeof(PerRenderableUib) % 256 == 0, "sizeof(Transform) should be 
 struct LightsUib {
     static constexpr utils::StaticString _name{ "LightsUniforms" };
     math::float4 positionFalloff;     // { float3(pos), 1/falloff^2 }
-    math::half4 color;                // { half3(col),  0           }
-    math::half4 directionIES;         // { half3(dir),  IES index   }
-    math::half2 spotScaleOffset;      // { scale, offset }
-    float intensity;                            // float
-    uint32_t typeShadow;                        // 0x00.ll.ii.ct (t: 0=point, 1=spot, c:contact, ii: index, ll: layer)
-    uint32_t channels;                          // 0x000c00ll (ll: light channels, c: caster)
-    math::float4 reserved;            // 0
+    math::float3 direction;           // dir
+    float reserved1;                  // 0
+    math::half4 colorIES;             // { half3(col),  IES index   }
+    math::float2 spotScaleOffset;     // { scale, offset }
+    float reserved3;                  // 0
+    float intensity;                  // float
+    uint32_t typeShadow;              // 0x00.ll.ii.ct (t: 0=point, 1=spot, c:contact, ii: index, ll: layer)
+    uint32_t channels;                // 0x000c00ll (ll: light channels, c: caster)
 
     static uint32_t packTypeShadow(uint8_t type, bool contactShadow, uint8_t index, uint8_t layer) noexcept {
         return (type & 0xF) | (contactShadow ? 0x10 : 0x00) | (index << 8) | (layer << 16);


### PR DESCRIPTION
Direction and falloff were recently changed to fp16 int the shader,
which is not enough (far from it) when a spotlight is over 100m away.