### PR TITLE
fix depth precision with VSM

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -84,6 +84,8 @@ void PerViewUniforms::prepareCamera(const CameraInfo& camera) noexcept {
     s.cameraPosition = float3{ camera.getPosition() };
     s.worldOffset = camera.worldOffset;
     s.cameraFar = camera.zf;
+    s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);
+    s.nearOverFarMinusNear = camera.zn / (camera.zf - camera.zn);
     s.clipControl = mClipControl;
 }
 

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -213,8 +213,8 @@ private:
 
     math::mat4 getTextureCoordsMapping() const noexcept;
 
-    static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpace,
-            const math::mat4f& Mv, float zfar) noexcept;
+    static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpacePcf,
+            const math::mat4f& Mv, float znear, float zfar) noexcept;
 
     float texelSizeWorldSpace(const math::mat3f& worldToShadowTexture) const noexcept;
     float texelSizeWorldSpace(const math::mat4f& W, const math::mat4f& MbMtF) const noexcept;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -88,7 +88,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::float4 userTime;  // time(s), (double)time - (float)time, 0, 0
 
     float iblRoughnessOneLevel;       // level for roughness == 1
-    float cameraFar;                  // camera *culling* far-plane distance (projection far is at +inf)
+    float cameraFar;                  // camera *culling* far-plane distance, always positive (projection far is at +inf)
     float refractionLodOffset;
 
     // bit 0: directional (sun) shadow enabled
@@ -129,8 +129,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float vsmReserved0;
 
     float lodBias;
-    float reserved1;
-    float reserved2;
+    float oneOverFarMinusNear;          // 1 / (f-n), always positive
+    float nearOverFarMinusNear;         // n / (f-n), always positive
     float reserved3;
 
     // bring PerViewUib to 2 KiB

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -110,8 +110,8 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("vsmReserved0",            1, UniformInterfaceBlock::Type::FLOAT)
 
             .add("lodBias",                 1, UniformInterfaceBlock::Type::FLOAT)
-            .add("reserved1",               1, UniformInterfaceBlock::Type::FLOAT)
-            .add("reserved2",               1, UniformInterfaceBlock::Type::FLOAT)
+            .add("oneOverFarMinusNear",     1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
+            .add("nearOverFarMinusNear",    1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
             .add("reserved3",               1, UniformInterfaceBlock::Type::FLOAT)
 
             // bring PerViewUib to 2 KiB

--- a/shaders/src/depth_main.vs
+++ b/shaders/src/depth_main.vs
@@ -25,16 +25,21 @@ void main() {
 #endif
 
 #if defined(HAS_VSM)
-    // For VSM, we use the linear-light space Z coordinate as the depth metric, which works for both
+    // For VSM, we use the linear light-space Z coordinate as the depth metric, which works for both
     // directional and spot lights and can be safely interpolated.
-    // The value is guaranteed to be between [0, -zfar] by construction of viewFromWorldMatrix,
+    // The value is guaranteed to be between [-znear, -zfar] by construction of viewFromWorldMatrix,
     // (see ShadowMap.cpp).
     // Use vertex_worldPosition.w which is otherwise not used to store the interpolated
     // light-space depth.
     highp float z = (frameUniforms.viewFromWorldMatrix * vec4(material.worldPosition.xyz, 1.0)).z;
-    highp float depth = -z / abs(frameUniforms.cameraFar); // rescale the depth between [0, 1]
-    depth = depth * 2.0 - 1.0;
-    vertex_worldPosition.w = frameUniforms.vsmExponent * depth;
+
+    // rescale [near, far] to [0, 1]
+    highp float depth = -z * frameUniforms.oneOverFarMinusNear - frameUniforms.nearOverFarMinusNear;
+
+    // EVSM pre-mapping
+    depth = frameUniforms.vsmExponent * (depth * 2.0 - 1.0);
+
+    vertex_worldPosition.w = depth;
 #endif
 
     // this must happen before we compensate for vulkan below

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -110,16 +110,21 @@ void main() {
 #endif
 
 #if defined(HAS_VSM)
-    // For VSM, we use the linear-light space Z coordinate as the depth metric, which works for both
+    // For VSM, we use the linear light-space Z coordinate as the depth metric, which works for both
     // directional and spot lights and can be safely interpolated.
-    // The value is guaranteed to be between [0, -zfar] by construction of viewFromWorldMatrix,
+    // The value is guaranteed to be between [-znear, -zfar] by construction of viewFromWorldMatrix,
     // (see ShadowMap.cpp).
     // Use vertex_worldPosition.w which is otherwise not used to store the interpolated
     // light-space depth.
     highp float z = (frameUniforms.viewFromWorldMatrix * vec4(material.worldPosition.xyz, 1.0)).z;
-    highp float depth = -z / abs(frameUniforms.cameraFar); // rescale the depth between [0, 1]
-    depth = depth * 2.0 - 1.0;
-    vertex_worldPosition.w = frameUniforms.vsmExponent * depth;
+
+    // rescale [near, far] to [0, 1]
+    highp float depth = -z * frameUniforms.oneOverFarMinusNear - frameUniforms.nearOverFarMinusNear;
+
+    // EVSM pre-mapping
+    depth = frameUniforms.vsmExponent * (depth * 2.0 - 1.0);
+
+    vertex_worldPosition.w = depth;
 #endif
 
     // this must happen before we compensate for vulkan below


### PR DESCRIPTION
When calculating the linear depth for VSM, we were using the whole
range between 0 and the far plane, the near plane wasn't taken into
account.

This can be a problem is the light is very far, but it's near plane is
closer to the camera/scene, in this case the depth precision wasn't
used optimally.

Note that we don't hit this problem currently, because the directional
light is constructed such that its origin is at the near plane, and the
spotlights have a fixed near plane (which is a problem and will be 
fixed at a later time).