### PR TITLE
Fix very narrow spotlight lighting and other minor issues

### DIFF
--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -558,10 +558,11 @@ public:
          * and are defined by the angle from the center axis to where the falloff begins (i.e.
          * cones are defined by their half-angle).
          *
-         * @param inner inner cone angle in *radians* between 0 and @f$ \pi/2 @f$
+         * Both inner and outer are silently clamped to a minimum value of 0.5 degrees
+         * (~0.00873 radians) to avoid floating-point precision issues during rendering.
          *
-         * @param outer outer cone angle in *radians* between \p inner and @f$ \pi/2 @f$
-         *
+         * @param inner inner cone angle in *radians* between 0.00873 and \p outer
+         * @param outer outer cone angle in *radians* between 0.00873 inner and @f$ \pi/2 @f$
          * @return This Builder, for chaining calls.
          *
          * @note
@@ -812,8 +813,8 @@ public:
      * Dynamically updates a spot light's cone as angles
      *
      * @param i     Instance of the component obtained from getInstance().
-     * @param inner inner cone angle in *radians* between 0 and pi/2
-     * @param outer outer cone angle in *radians* between inner and pi/2
+     * @param inner inner cone angle in *radians* between 0.00873 and outer
+     * @param outer outer cone angle in *radians* between 0.00873 and pi/2
      *
      * @see Builder.spotLightCone()
      */

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -352,23 +352,23 @@ void FLightManager::setFalloff(Instance i, float falloff) noexcept {
 void FLightManager::setSpotLightCone(Instance i, float inner, float outer) noexcept {
     auto& manager = mManager;
     if (i && isSpotLight(i)) {
-        // clamp the inner/outer angles to pi
-        float innerClamped = std::min(std::abs(inner), f::PI_2);
-        float outerClamped = std::min(std::abs(outer), f::PI_2);
+        // clamp the inner/outer angles to [0.5 degrees, 90 degrees]
+        float innerClamped = std::clamp(std::abs(inner), 0.5f * f::DEG_TO_RAD, f::PI_2);
+        float outerClamped = std::clamp(std::abs(outer), 0.5f * f::DEG_TO_RAD, f::PI_2);
 
-        // outer must always be bigger than inner
-        outerClamped = std::max(innerClamped, outerClamped);
+        // inner must always be smaller than outer
+        innerClamped = std::min(innerClamped, outerClamped);
 
         float cosOuter = fast::cos(outerClamped);
         float cosInner = fast::cos(innerClamped);
         float cosOuterSquared = cosOuter * cosOuter;
-        float scale = 1 / std::max(1.0f / 1024.0f, cosInner - cosOuter);
+        float scale = 1.0f / std::max(1.0f / 1024.0f, cosInner - cosOuter);
         float offset = -cosOuter * scale;
 
         SpotParams& spotParams = manager[i].spotParams;
         spotParams.outerClamped = outerClamped;
         spotParams.cosOuterSquared = cosOuterSquared;
-        spotParams.sinInverse = 1 / std::sqrt(1 - cosOuterSquared);
+        spotParams.sinInverse = 1.0f / std::sin(outerClamped);
         spotParams.scaleOffset = { scale, offset };
 
         // we need to recompute the luminous intensity


### PR DESCRIPTION
The froxel code was failing when a spotlight cone was too narrow. This
is fixed here by never using a cone smaller than 0.5 degrees during
forxelization. 

Additionally we now silently clamp the cone angles to 0.5 degrees at
the API level because, the falloff was also failing due to floating
point precision in the shader.

Finally, we clamp the inner cone upper value to the outer cone's
instead of the other way around. i.e. the outer cone defines the 
spotlight while the inner cone just controls the falloff.