### PR TITLE
Tighten spotlights near/far further

### DIFF
--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -114,11 +114,13 @@ public:
 
 private:
 
-    struct TextureRequirements {
+    // Atlas requirements, updated in ShadowMapManager::update(),
+    // consumed in ShadowMapManager::render()
+    struct TextureAtlasRequirements {
         uint16_t size = 0;
         uint8_t layers = 0;
         uint8_t levels = 0;
-    } mTextureRequirements;
+    } mTextureAtlasRequirements;
 
     ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
             FView& view, FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
@@ -200,7 +202,6 @@ private:
     // TODO: make it an option.
     // TODO: iOS does not support the DEPTH16 texture format.
     backend::TextureFormat mTextureFormat = backend::TextureFormat::DEPTH16;
-    float mTextureZResolution = 1.0f / (1u << 16u);
 
     ShadowMappingUniforms mShadowMappingUniforms;
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -316,21 +316,21 @@ void FView::prepareShadowing(FEngine& engine, DriverApi& driver,
         // when we get here all the lights should be visible
         assert_invariant(lightData.elementAt<FScene::VISIBILITY>(l));
 
-        FLightManager::Instance light = lightData.elementAt<FScene::LIGHT_INSTANCE>(l);
+        FLightManager::Instance li = lightData.elementAt<FScene::LIGHT_INSTANCE>(l);
 
-        if (UTILS_LIKELY(!light)) {
+        if (UTILS_LIKELY(!li)) {
             continue; // invalid instance
         }
 
-        if (UTILS_LIKELY(!lcm.isShadowCaster(light))) {
+        if (UTILS_LIKELY(!lcm.isShadowCaster(li))) {
             continue; // doesn't cast shadows
         }
 
-        if (UTILS_LIKELY(!lcm.isSpotLight(light))) {
-            continue; // is not a spot-light (we're not supporting point-lights yet)
+        if (UTILS_LIKELY(!lcm.isSpotLight(li))) {
+            continue; // is not a spot-li (we're not supporting point-lights yet)
         }
 
-        const auto& shadowOptions = lcm.getShadowOptions(light);
+        const auto& shadowOptions = lcm.getShadowOptions(li);
         mShadowMapManager.addSpotShadowMap(l, &shadowOptions);
         ++shadowCastingSpotCount;
         if (shadowCastingSpotCount > CONFIG_MAX_SHADOW_CASTING_SPOTS - 1) {

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -106,7 +106,7 @@ public:
         VISIBILITY_STATE,       //  1 | visibility data of the component
         SKINNING_BUFFER,        //  8 | bones uniform buffer handle, count, offset
         WORLD_AABB_CENTER,      // 12 | world-space bounding box center of the renderable
-        VISIBLE_MASK,           //  1 | each bit represents a visibility in a pass
+        VISIBLE_MASK,           //  2 | each bit represents a visibility in a pass
         MORPH_WEIGHTS,          //  4 | floats for morphing
         CHANNELS,               //  1 | currently light channels only
 


### PR DESCRIPTION
We now cull the shadow casters before computing the near/far plane
for spotlights -- we can do that because we know the light's frustum.
So only these casters that contribute to the shadow are accounted for
when calculating the near/far plane.

This PR also include more cleanup and simplifications.