### PR TITLE
Remove all "Shadow Receiver Plane Depth Bias" related code

### DIFF
--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -1,75 +1,25 @@
 //------------------------------------------------------------------------------
-// Shadowing configuration
+// PCF Shadow Sampling
 //------------------------------------------------------------------------------
-
-#define SHADOW_SAMPLING_ERROR_DISABLED              0
-#define SHADOW_SAMPLING_ERROR_ENABLED               1
-
-#define SHADOW_RECEIVER_PLANE_DEPTH_BIAS_DISABLED   0
-#define SHADOW_RECEIVER_PLANE_DEPTH_BIAS_ENABLED    1
-
-#define SHADOW_SAMPLING_ERROR             SHADOW_SAMPLING_ERROR_DISABLED
-#define SHADOW_RECEIVER_PLANE_DEPTH_BIAS  SHADOW_RECEIVER_PLANE_DEPTH_BIAS_DISABLED
-
-//------------------------------------------------------------------------------
-// Shadow sampling methods
-//------------------------------------------------------------------------------
-
-vec2 computeReceiverPlaneDepthBias(const highp vec3 position) {
-    // see: GDC '06: Shadow Mapping: GPU-based Tips and Techniques
-    vec2 bias;
-#if SHADOW_RECEIVER_PLANE_DEPTH_BIAS == SHADOW_RECEIVER_PLANE_DEPTH_BIAS_ENABLED
-    highp vec3 du = dFdx(position);
-    highp vec3 dv = dFdy(position);
-
-    // Chain rule we use:
-    //     | du.x   du.y |^-T      |  dv.y  -du.y |T    |  dv.y  -dv.x |
-    // D * | dv.x   dv.y |     =   | -dv.x   du.x |  =  | -du.y   du.x |
-
-    bias = inverse(mat2(du.xy, dv.xy)) * vec2(du.z, dv.z);
-#else
-    bias = vec2(0.0);
-#endif
-    return bias;
-}
-
-float samplingBias(float depth, const vec2 rpdb, const highp vec2 texelSize) {
-#if SHADOW_SAMPLING_ERROR == SHADOW_SAMPLING_ERROR_ENABLED
-    // note: if filtering is set to NEAREST, the 2.0 factor below can be changed to 1.0
-    float samplingError = min(2.0 * dot(texelSize, abs(rpdb)), 0.01);
-    depth += samplingError;
-#endif
-    return depth;
-}
 
 float sampleDepth(const mediump sampler2DArrayShadow map, const uint layer,
-        const highp vec2 base, const highp vec2 dudv, float depth, vec2 rpdb) {
-#if SHADOW_RECEIVER_PLANE_DEPTH_BIAS == SHADOW_RECEIVER_PLANE_DEPTH_BIAS_ENABLED
-    depth += dot(dudv, rpdb);
-#endif
+        const highp vec2 uv, float depth) {
     // depth must be clamped to support floating-point depth formats. This is to avoid comparing a
     // value from the depth texture (which is never greater than 1.0) with a greater-than-one
     // comparison value (which is possible with floating-point formats).
-    return texture(map, vec4(base + dudv, layer, saturate(depth)));
+    return texture(map, vec4(uv, layer, saturate(depth)));
 }
 
+// use hardware assisted PCF
 float ShadowSample_PCF(const mediump sampler2DArrayShadow map,
         const uint layer, const highp vec3 position) {
-    highp vec2 size = vec2(textureSize(map, 0));
-    highp vec2 texelSize = vec2(1.0) / size;
-    vec2 rpdb = computeReceiverPlaneDepthBias(position);
-    float depth = samplingBias(position.z, rpdb, texelSize);
-    // use hardware assisted PCF
-    return sampleDepth(map,layer, position.xy, vec2(0.0f), depth, rpdb);
+    return sampleDepth(map, layer, position.xy, position.z);
 }
 
+// use manual PCF
 float ShadowSample_PCF(const mediump sampler2DArray shadowMap,
         const uint layer, const highp vec3 position) {
     highp vec2 size = vec2(textureSize(shadowMap, 0));
-    highp vec2 texelSize = vec2(1.0) / size;
-    vec2 rpdb = computeReceiverPlaneDepthBias(position);
-    float depth = samplingBias(position.z, rpdb, texelSize);
-    // use manual PCF
     highp vec2 st = position.xy * size - 0.5;
     vec4 d;
 #if defined(FILAMENT_HAS_FEATURE_TEXTURE_GATHER)
@@ -81,7 +31,7 @@ float ShadowSample_PCF(const mediump sampler2DArray shadowMap,
     d[2] = texelFetchOffset(shadowMap, tc, 0, ivec2(1, 0)).r;
     d[3] = texelFetchOffset(shadowMap, tc, 0, ivec2(0, 0)).r;
 #endif
-    vec4 pcf = step(0.0, d - vec4(depth));
+    vec4 pcf = step(0.0, d - position.zzzz);
     highp vec2 grad = fract(st);
     return mix(mix(pcf.w, pcf.z, grad.x), mix(pcf.x, pcf.y, grad.x), grad.y);
 }


### PR DESCRIPTION
Shadow Receiver Plane Depth Bias is only needed when using large PCF
filters, which we are no longer doing. Large filter kernels are now 
supported through VSM sampling.