### PR TITLE
Android: re-enable VSM cascade fix

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -90,7 +90,7 @@ OpenGLContext::OpenGLContext() noexcept {
 
         // Blits to texture arrays are failing
         //   This bug continues to reproduce, though at times we've seen it appear to "go away". The
-        //   standalone sample app that was written to show this problem still reprdocues.
+        //   standalone sample app that was written to show this problem still reproduces.
         //   The working hypthesis is that some other state affects this behavior.
         bugs.disable_sidecar_blit_into_texture_array = true;
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -89,11 +89,10 @@ OpenGLContext::OpenGLContext() noexcept {
         bugs.dont_use_timer_query = true;
 
         // Blits to texture arrays are failing
-        //   This bug doesn't happen anymore, but we don't know why. The standalone sample
-        //   app that was written to show this problem still does. We have tested this on
-        //   several V@0490.0 on several devices and the problem appears to have gone away.
+        //   This bug continues to reproduce, though at times we've seen it appear to "go away". The
+        //   standalone sample app that was written to show this problem still reprdocues.
         //   The working hypthesis is that some other state affects this behavior.
-        bugs.disable_sidecar_blit_into_texture_array = false;
+        bugs.disable_sidecar_blit_into_texture_array = true;
 
         // early exit condition is flattened in EASU code
         bugs.split_easu = true;


### PR DESCRIPTION
I don't understand why, but I'm able to reproduce the VSM/cascade issue on Android again. I want to bisect recent commits and see if I can track down where this started reproducing again, but for now I'm going to re-enable the fix.