### PR TITLE
Fix material compilation error with device vertex domain

### DIFF
--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -16,11 +16,10 @@ void main() {
     // Run initMaterialVertex to compute material.worldPosition.
     MaterialVertexInputs material;
     initMaterialVertex(material);
-#endif
-
     // materialVertex() is guaranteed to be empty here, but we keep it to workaround some problem
     // in NVIDA drivers related to depth invariance.
     materialVertex(material);
+#endif
 
 #else // defined(USE_OPTIMIZED_DEPTH_VERTEX_SHADER)
 


### PR DESCRIPTION
A recent refactor was causing the following error when the vertex domain was set to `device`:

```
ERROR: main.vs:23: 'material' : undeclared identifier
ERROR: main.vs:23: 'materialVertex' : no matching overloaded function found
```