### PR TITLE
Use locale-independent string->float conversion

### DIFF
--- a/libs/image/src/KtxBundle.cpp
+++ b/libs/image/src/KtxBundle.cpp
@@ -17,10 +17,11 @@
 #include <image/KtxBundle.h>
 
 #include <utils/Panic.h>
+#include <utils/string.h>
 
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace {
 
@@ -295,7 +296,7 @@ bool KtxBundle::getSphericalHarmonics(filament::math::float3* result) {
     // 3 bands, 9 RGB coefficients for a total of 27 floats.
     for (int i = 0; i < 9 * 3; i++) {
         char* next;
-        *flat++ = std::strtof(src, &next);
+        *flat++ = utils::strtof_c(src, &next);
         if (next == src) {
             return false;
         }

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRCS
         src/Path.cpp
         src/Profiler.cpp
         src/sstream.cpp
+        src/string.cpp
         src/Systrace.cpp
 )
 
@@ -136,6 +137,7 @@ set(TEST_SRCS
         test/test_JobSystem.cpp
         test/test_StructureOfArrays.cpp
         test/test_sstream.cpp
+        test/test_string.cpp
         test/test_utils_main.cpp
         test/test_Zip2Iterator.cpp
         test/test_BinaryTreeArray.cpp

--- a/libs/utils/include/utils/string.h
+++ b/libs/utils/include/utils/string.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_UTILS_STRING_H
+#define TNT_UTILS_STRING_H
+
+#include <utils/ostream.h>
+
+namespace utils {
+
+float strtof_c(const char* start, char** end);
+
+} // namespace utils
+
+#endif // TNT_UTILS_STRING_H

--- a/libs/utils/src/string.cpp
+++ b/libs/utils/src/string.cpp
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #if defined(WIN32)
 #    include <locale.h>
+#elif defined(__linux__)
+#    include <locale.h>
 #else
 #    include <xlocale.h>
 #endif

--- a/libs/utils/src/string.cpp
+++ b/libs/utils/src/string.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <utils/string.h>
+
+#include <stdlib.h>
+#if defined(WIN32)
+#    include <locale.h>
+#else
+#    include <xlocale.h>
+#endif
+
+#include <mutex>
+
+namespace utils {
+
+#if defined(WIN32)
+
+_locale_t sLocaleC;
+std::once_flag sLocaleCOnceFlag;
+
+_locale_t get_c_locale() {
+    std::call_once(sLocaleCOnceFlag, []() {
+        sLocaleC = _create_locale(LC_ALL, "C");
+    });
+    return sLocaleC;
+}
+
+float strtof_c(const char* start, char** end) {
+    return _strtof_l(start, end, get_c_locale());
+}
+
+#else // if defined(WIN32)
+
+locale_t sLocaleC;
+std::once_flag sLocaleCOnceFlag;
+
+locale_t get_c_locale() {
+    std::call_once(sLocaleCOnceFlag, []() {
+        sLocaleC = newlocale(LC_ALL_MASK, "C", nullptr);
+    });
+    return sLocaleC;
+}
+
+float strtof_c(const char* start, char** end) {
+    return strtof_l(start, end, get_c_locale());
+}
+
+#endif
+
+} // namespace utils

--- a/libs/utils/test/test_string.cpp
+++ b/libs/utils/test/test_string.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <utils/string.h>
+
+using namespace utils;
+
+TEST(strtof_c, EmptyString) {
+    char* end = nullptr;
+    const char* start = "";
+    float r = strtof_c(start, &end);
+    EXPECT_EQ(start, end);
+    EXPECT_EQ(0.0f, r);
+}
+
+TEST(strtof_c, ValidString) {
+    char* end = nullptr;
+    const char* start = "42.24, independent of the locale";
+    float r = strtof_c(start, &end);
+    EXPECT_TRUE(end > start);
+    EXPECT_FLOAT_EQ(42.24f, r);
+}

--- a/tools/matc/src/matc/JsonishParser.cpp
+++ b/tools/matc/src/matc/JsonishParser.cpp
@@ -22,6 +22,8 @@
 
 #include <string.h>
 
+#include <utils/string.h>
+
 namespace matc {
 
 static std::string resolveEscapes(const std::string&& s) {
@@ -269,7 +271,7 @@ JsonishValue* JsonishParser::parseValue() noexcept {
             return parseString();
         case NUMBER:
             consumeLexeme(NUMBER);
-            return new JsonishNumber(strtof(next->getStart(), nullptr));
+            return new JsonishNumber(utils::strtof_c(next->getStart(), nullptr));
         case BLOCK_START:
             return parseObject();
         case ARRAY_START:

--- a/tools/specular-color/src/main.cpp
+++ b/tools/specular-color/src/main.cpp
@@ -26,6 +26,7 @@
 #include <getopt/getopt.h>
 
 #include <utils/Path.h>
+#include <utils/string.h>
 
 #include <math/mat3.h>
 #include <math/scalar.h>
@@ -826,7 +827,7 @@ static bool parseSpectralData(std::ifstream& in, std::vector<Sample>& samples) {
         }
 
         Sample sample = { 0 };
-        sample.w = std::strtof(value.c_str(), nullptr) * 1000.0f; // um to nm
+        sample.w = utils::strtof_c(value.c_str(), nullptr) * 1000.0f; // um to nm
 
         float n;
         in >> n;


### PR DESCRIPTION
strtof and friends are locale aware and won't parse decimal numbers
with a period ("12.6" for instance) in locales that use another
character for the decimal period ("," in French for instance).

This change introduces a new function called strtof_c that forces
the use of a specific locale (called "C") to make sure we always
parse floats in the desired "C" format ("12.6").

With C++17 we should be able to use std::from_chars but this API
is not implemented in clang for floats at the moment.

Fixes #4883.