### PR TITLE
Fix Metal depth comparison initialization

### DIFF
--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -259,7 +259,7 @@ using PipelineStateCache = StateCache<PipelineState, id<MTLRenderPipelineState>,
 // Depth-stencil State
 
 struct DepthStencilState {
-    MTLCompareFunction compareFunction = MTLCompareFunctionNever;       // 8 bytes
+    MTLCompareFunction compareFunction = MTLCompareFunctionAlways;      // 8 bytes
     bool depthWriteEnabled = false;                                     // 1 byte
     char padding[7] = { 0 };                                            // 7 bytes
 


### PR DESCRIPTION
#4860 introduced a bug caused by default-initializing the Metal depth stencil state. `MTLCompareFunctionAlways` should be the default comparison function, which turns off depth testing.