### PR TITLE
Cache calls to Enum.values()

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Engine.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Engine.java
@@ -106,7 +106,10 @@ import com.google.android.filament.proguard.UsedByReflection;
  * @see Renderer
  */
 public class Engine {
+    private static final Backend[] sBackendValues = Backend.values();
+
     private long mNativeObject;
+
     @NonNull private final TransformManager mTransformManager;
     @NonNull private final LightManager mLightManager;
     @NonNull private final RenderableManager mRenderableManager;
@@ -252,7 +255,7 @@ public class Engine {
      */
     @NonNull
     public Backend getBackend() {
-        return Backend.values()[(int) nGetBackend(getNativeObject())];
+        return sBackendValues[(int) nGetBackend(getNativeObject())];
     }
 
     // SwapChain

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -117,6 +117,8 @@ import androidx.annotation.Size;
  * </ul>
  */
 public class LightManager {
+    private static final Type[] sTypeValues = Type.values();
+
     private long mNativeObject;
 
     LightManager(long nativeLightManager) {
@@ -781,7 +783,7 @@ public class LightManager {
 
     @NonNull
     public Type getType(@EntityInstance int i) {
-        return Type.values()[nGetType(mNativeObject, i)];
+        return sTypeValues[nGetType(mNativeObject, i)];
     }
 
     /**

--- a/android/filament-android/src/main/java/com/google/android/filament/Material.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Material.java
@@ -37,6 +37,20 @@ import java.util.Set;
  * @see <a href="https://google.github.io/filament/Materials.html">Filament Materials Guide</a>
  */
 public class Material {
+    static final class EnumCache {
+        private EnumCache() { }
+
+        static final Shading[] sShadingValues = Shading.values();
+        static final Interpolation[] sInterpolationValues = Interpolation.values();
+        static final BlendingMode[] sBlendingModeValues = BlendingMode.values();
+        static final RefractionMode[] sRefractionModeValues = RefractionMode.values();
+        static final RefractionType[] sRefractionTypeValues = RefractionType.values();
+        static final VertexDomain[] sVertexDomainValues = VertexDomain.values();
+        static final CullingMode[] sCullingModeValues = CullingMode.values();
+        static final VertexBuffer.VertexAttribute[] sVertexAttributeValues =
+                VertexBuffer.VertexAttribute.values();
+    }
+
     private long mNativeObject;
     private final MaterialInstance mDefaultInstance;
 
@@ -210,6 +224,8 @@ public class Material {
 
     @UsedByNative("Material.cpp")
     public static class Parameter {
+        private static final Type[] sTypeValues = Type.values();
+
         public enum Type {
             BOOL,
             BOOL2,
@@ -275,7 +291,7 @@ public class Material {
                 @IntRange(from = 0) int type, @IntRange(from = 0) int precision,
                 @IntRange(from = 1) int count) {
             parameters.add(
-                    new Parameter(name, Type.values()[type], Precision.values()[precision], count));
+                    new Parameter(name, sTypeValues[type], Precision.values()[precision], count));
         }
     }
 
@@ -373,7 +389,7 @@ public class Material {
      * Material Models</a>
      */
     public Shading getShading() {
-        return Shading.values()[nGetShading(getNativeObject())];
+        return EnumCache.sShadingValues[nGetShading(getNativeObject())];
     }
 
     /**
@@ -384,7 +400,7 @@ public class Material {
      * Vertex and attributes: interpolation</a>
      */
     public Interpolation getInterpolation() {
-        return Interpolation.values()[nGetInterpolation(getNativeObject())];
+        return EnumCache.sInterpolationValues[nGetInterpolation(getNativeObject())];
     }
 
     /**
@@ -395,7 +411,7 @@ public class Material {
      * Blending and transparency: blending</a>
      */
     public BlendingMode getBlendingMode() {
-        return BlendingMode.values()[nGetBlendingMode(getNativeObject())];
+        return EnumCache.sBlendingModeValues[nGetBlendingMode(getNativeObject())];
     }
 
     /**
@@ -406,7 +422,7 @@ public class Material {
      * Blending and transparency: refraction</a>
      */
     public RefractionMode getRefractionMode() {
-        return RefractionMode.values()[nGetRefractionMode(getNativeObject())];
+        return EnumCache.sRefractionModeValues[nGetRefractionMode(getNativeObject())];
     }
 
     /**
@@ -417,9 +433,8 @@ public class Material {
      * Blending and transparency: refractionType</a>
      */
     public RefractionType getRefractionType() {
-        return RefractionType.values()[nGetRefractionType(getNativeObject())];
+        return EnumCache.sRefractionTypeValues[nGetRefractionType(getNativeObject())];
     }
-
 
     /**
      * Returns the vertex domain of this material.
@@ -429,7 +444,7 @@ public class Material {
      * Vertex and attributes: vertexDomain</a>
      */
     public VertexDomain getVertexDomain() {
-        return VertexDomain.values()[nGetVertexDomain(getNativeObject())];
+        return EnumCache.sVertexDomainValues[nGetVertexDomain(getNativeObject())];
     }
 
     /**
@@ -440,7 +455,7 @@ public class Material {
      * Rasterization: culling</a>
      */
     public CullingMode getCullingMode() {
-        return CullingMode.values()[nGetCullingMode(getNativeObject())];
+        return EnumCache.sCullingModeValues[nGetCullingMode(getNativeObject())];
     }
 
     /**
@@ -531,7 +546,7 @@ public class Material {
         if (mRequiredAttributes == null) {
             int bitSet = nGetRequiredAttributes(getNativeObject());
             mRequiredAttributes = EnumSet.noneOf(VertexBuffer.VertexAttribute.class);
-            VertexBuffer.VertexAttribute[] values = VertexBuffer.VertexAttribute.values();
+            VertexBuffer.VertexAttribute[] values = EnumCache.sVertexAttributeValues;
             for (int i = 0; i < values.length; i++) {
                 if ((bitSet & (1 << i)) != 0) {
                     mRequiredAttributes.add(values[i]);

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderTarget.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderTarget.java
@@ -31,8 +31,10 @@ import androidx.annotation.Nullable;
  * @see View
  */
 public class RenderTarget {
-    private long mNativeObject;
     private static final int ATTACHMENT_COUNT = AttachmentPoint.values().length;
+    private static final Texture.CubemapFace[] sCubemapFaceValues = Texture.CubemapFace.values();
+
+    private long mNativeObject;
     private final Texture[] mTextures = new Texture[ATTACHMENT_COUNT];
 
     private RenderTarget(long nativeRenderTarget, Builder builder) {
@@ -194,7 +196,7 @@ public class RenderTarget {
      * a cubemap.
      */
     public Texture.CubemapFace getFace(AttachmentPoint attachment) {
-        return Texture.CubemapFace.values()[nGetFace(getNativeObject(), attachment.ordinal())];
+        return sCubemapFaceValues[nGetFace(getNativeObject(), attachment.ordinal())];
     }
 
     /**

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -58,6 +58,10 @@ import java.util.Set;
  */
 public class RenderableManager {
     private static final String LOG_TAG = "Filament";
+
+    private static final VertexBuffer.VertexAttribute[] sVertexAttributeValues =
+            VertexBuffer.VertexAttribute.values();
+
     private long mNativeObject;
 
     RenderableManager(long nativeRenderableManager) {
@@ -712,15 +716,19 @@ public class RenderableManager {
     /**
      * Retrieves the set of enabled attribute slots in the given primitive's VertexBuffer.
      */
-    public Set<VertexBuffer.VertexAttribute> getEnabledAttributesAt(@EntityInstance int i, @IntRange(from = 0) int primitiveIndex) {
+    public Set<VertexBuffer.VertexAttribute> getEnabledAttributesAt(
+            @EntityInstance int i, @IntRange(from = 0) int primitiveIndex) {
         int bitSet = nGetEnabledAttributesAt(mNativeObject, i, primitiveIndex);
-        Set<VertexBuffer.VertexAttribute> requiredAttributes = EnumSet.noneOf(VertexBuffer.VertexAttribute.class);
-        VertexBuffer.VertexAttribute[] values = VertexBuffer.VertexAttribute.values();
+        Set<VertexBuffer.VertexAttribute> requiredAttributes =
+                EnumSet.noneOf(VertexBuffer.VertexAttribute.class);
+        VertexBuffer.VertexAttribute[] values = sVertexAttributeValues;
+
         for (int j = 0; j < values.length; j++) {
             if ((bitSet & (1 << j)) != 0) {
                 requiredAttributes.add(values[j]);
             }
         }
+
         requiredAttributes = Collections.unmodifiableSet(requiredAttributes);
         return requiredAttributes;
     }

--- a/android/filament-android/src/main/java/com/google/android/filament/Stream.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Stream.java
@@ -91,6 +91,8 @@ import java.nio.ReadOnlyBufferException;
  * @see Engine#destroyStream
  */
 public class Stream {
+    private static final StreamType[] sStreamTypeValues = StreamType.values();
+
     private long mNativeObject;
     private long mNativeEngine;
 
@@ -236,7 +238,7 @@ public class Stream {
      * Indicates whether this <code>Stream</code> is NATIVE, TEXTURE_ID, or ACQUIRED.
      */
     public StreamType getStreamType() {
-        return StreamType.values()[nGetStreamType(getNativeObject())];
+        return sStreamTypeValues[nGetStreamType(getNativeObject())];
     }
 
     /**

--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -71,6 +71,9 @@ import static com.google.android.filament.Texture.Type.COMPRESSED;
  * @see MaterialInstance#setParameter(String, Texture, TextureSampler)
  */
 public class Texture {
+    private static final Sampler[] sSamplerValues = Sampler.values();
+    private static final InternalFormat[] sInternalFormatValues = InternalFormat.values();
+
     private long mNativeObject;
 
     public Texture(long nativeTexture) {
@@ -867,7 +870,7 @@ public class Texture {
      */
     @NonNull
     public Sampler getTarget() {
-        return Sampler.values()[nGetTarget(getNativeObject())];
+        return sSamplerValues[nGetTarget(getNativeObject())];
     }
 
     /**
@@ -875,7 +878,7 @@ public class Texture {
      */
     @NonNull
     public InternalFormat getFormat() {
-        return InternalFormat.values()[nGetInternalFormat(getNativeObject())];
+        return sInternalFormatValues[nGetInternalFormat(getNativeObject())];
     }
 
     // TODO: add a setImage() version that takes an android Bitmap

--- a/android/filament-android/src/main/java/com/google/android/filament/TextureSampler.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/TextureSampler.java
@@ -22,6 +22,14 @@ import androidx.annotation.NonNull;
  * <code>TextureSampler</code> defines how a texture is accessed.
  */
 public class TextureSampler {
+    static final class EnumCache {
+        static final MinFilter[] sMinFilterValues = MinFilter.values();
+        static final MagFilter[] sMagFilterValues = MagFilter.values();
+        static final WrapMode[] sWrapModeValues = WrapMode.values();
+        static final CompareMode[] sCompareModeValues = CompareMode.values();
+        static final CompareFunction[] sCompareFunctionValues = CompareFunction.values();
+    }
+
     public enum WrapMode {
         /**
          * The edge of the texture extends to infinity.
@@ -202,7 +210,7 @@ public class TextureSampler {
      * @return the minification filter
      */
     public MinFilter getMinFilter() {
-        return MinFilter.values()[nGetMinFilter(mSampler)];
+        return EnumCache.sMinFilterValues[nGetMinFilter(mSampler)];
     }
 
     /**
@@ -218,7 +226,7 @@ public class TextureSampler {
      * @return the magnification filter
      */
     public MagFilter getMagFilter() {
-        return MagFilter.values()[nGetMagFilter(mSampler)];
+        return EnumCache.sMagFilterValues[nGetMagFilter(mSampler)];
     }
 
     /**
@@ -234,7 +242,7 @@ public class TextureSampler {
      * @return the wrapping mode in the s (horizontal) direction
      */
     public WrapMode getWrapModeS() {
-        return WrapMode.values()[nGetWrapModeS(mSampler)];
+        return EnumCache.sWrapModeValues[nGetWrapModeS(mSampler)];
     }
 
     /**
@@ -249,7 +257,7 @@ public class TextureSampler {
      * @return the wrapping mode in the t (vertical) direction
      */
     public WrapMode getWrapModeT() {
-        return WrapMode.values()[nGetWrapModeT(mSampler)];
+        return EnumCache.sWrapModeValues[nGetWrapModeT(mSampler)];
     }
 
     /**
@@ -264,7 +272,7 @@ public class TextureSampler {
      * @return the wrapping mode in the r (depth) direction
      */
     public WrapMode getWrapModeR() {
-        return WrapMode.values()[nGetWrapModeR(mSampler)];
+        return EnumCache.sWrapModeValues[nGetWrapModeR(mSampler)];
     }
 
     /**
@@ -297,7 +305,7 @@ public class TextureSampler {
      * @return the comparison mode
      */
     public CompareMode getCompareMode() {
-        return CompareMode.values()[nGetCompareMode(mSampler)];
+        return EnumCache.sCompareModeValues[nGetCompareMode(mSampler)];
     }
 
     /**
@@ -313,7 +321,7 @@ public class TextureSampler {
      * @return the comparison function
      */
     public CompareFunction getCompareFunction() {
-        return CompareFunction.values()[nGetCompareFunction(mSampler)];
+        return EnumCache.sCompareFunctionValues[nGetCompareFunction(mSampler)];
     }
 
     /**

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -59,6 +59,10 @@ import static com.google.android.filament.Colors.LinearColor;
  * @see RenderTarget
  */
 public class View {
+    private static final AntiAliasing[] sAntiAliasingValues = AntiAliasing.values();
+    private static final Dithering[] sDitheringValues = Dithering.values();
+    private static final AmbientOcclusion[] sAmbientOcclusionValues = AmbientOcclusion.values();
+
     private long mNativeObject;
     private String mName;
     private Scene mScene;
@@ -1116,7 +1120,7 @@ public class View {
      */
     @NonNull
     public AntiAliasing getAntiAliasing() {
-        return AntiAliasing.values()[nGetAntiAliasing(getNativeObject())];
+        return sAntiAliasingValues[nGetAntiAliasing(getNativeObject())];
     }
 
     /**
@@ -1229,7 +1233,7 @@ public class View {
      */
     @NonNull
     public Dithering getDithering() {
-        return Dithering.values()[nGetDithering(getNativeObject())];
+        return sDitheringValues[nGetDithering(getNativeObject())];
     }
 
     /**
@@ -1449,7 +1453,7 @@ public class View {
     @Deprecated
     @NonNull
     public AmbientOcclusion getAmbientOcclusion() {
-        return AmbientOcclusion.values()[nGetAmbientOcclusion(getNativeObject())];
+        return sAmbientOcclusionValues[nGetAmbientOcclusion(getNativeObject())];
     }
 
     /**

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Manipulator.java
@@ -32,7 +32,9 @@ import androidx.annotation.Size;
  * @see Bookmark
  */
 public class Manipulator {
-    private long mNativeObject;
+    private static final Mode[] sModeValues = Mode.values();
+
+    private final long mNativeObject;
 
     private Manipulator(long nativeIndexBuffer) {
         mNativeObject = nativeIndexBuffer;
@@ -320,7 +322,7 @@ public class Manipulator {
     /**
      * Gets the immutable mode of the manipulator.
      */
-    public Mode getMode() { return Mode.values()[nGetMode(mNativeObject)]; }
+    public Mode getMode() { return sModeValues[nGetMode(mNativeObject)]; }
 
     /**
      * Sets the viewport dimensions in terms of pixels.

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderLoader.java
@@ -32,6 +32,9 @@ import androidx.annotation.Size;
  * Client applications do not need to call methods on it.</p>
  */
 public class UbershaderLoader implements MaterialProvider {
+    private static final VertexBuffer.VertexAttribute[] sVertexAttributesValues =
+            VertexBuffer.VertexAttribute.values();
+
     private long mNativeObject;
 
     /**
@@ -70,7 +73,7 @@ public class UbershaderLoader implements MaterialProvider {
     }
 
     public boolean needsDummyData(int attrib) {
-        VertexBuffer.VertexAttribute vattrib = VertexBuffer.VertexAttribute.values()[attrib];
+        VertexBuffer.VertexAttribute vattrib = sVertexAttributesValues[attrib];
         switch (vattrib) {
             case UV0:
             case UV1:
@@ -92,7 +95,8 @@ public class UbershaderLoader implements MaterialProvider {
     private static native long nCreateUbershaderLoader(long nativeEngine);
     private static native void nDestroyUbershaderLoader(long nativeProvider);
     private static native void nDestroyMaterials(long nativeProvider);
-    private static native long nCreateMaterialInstance(long nativeProvider, MaterialKey config, int[] uvmap, String label);
+    private static native long nCreateMaterialInstance(long nativeProvider,
+            MaterialKey config, int[] uvmap, String label);
     private static native int nGetMaterialCount(long nativeProvider);
     private static native void nGetMaterials(long nativeProvider, long[] result);
 }


### PR DESCRIPTION
Each call to .values() allocates a new array. Let's cache them once
and for all to avoid unncessary allocations.