### PR TITLE
Expose Engine::destroy(SkinningBuffer*)

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -35,6 +35,7 @@ class ColorGrading;
 class DebugRegistry;
 class Fence;
 class IndexBuffer;
+class SkinningBuffer;
 class IndirectLight;
 class Material;
 class MaterialInstance;
@@ -419,6 +420,7 @@ public:
     bool destroy(const VertexBuffer* p);        //!< Destroys an VertexBuffer object.
     bool destroy(const Fence* p);               //!< Destroys a Fence object.
     bool destroy(const IndexBuffer* p);         //!< Destroys an IndexBuffer object.
+    bool destroy(const SkinningBuffer* p);      //!< Destroys a SkinningBuffer object.
     bool destroy(const IndirectLight* p);       //!< Destroys an IndirectLight object.
 
     /**

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -962,6 +962,10 @@ bool Engine::destroy(const IndexBuffer* p) {
     return upcast(this)->destroy(upcast(p));
 }
 
+bool Engine::destroy(const SkinningBuffer* p) {
+    return upcast(this)->destroy(upcast(p));
+}
+
 bool Engine::destroy(const IndirectLight* p) {
     return upcast(this)->destroy(upcast(p));
 }


### PR DESCRIPTION
This commit enables Engine::destroy(SkinningBuffer*), which is already implemented internally in FEngine.

I implement a shared animator class for multiple renderables utilizing SkinningBuffer instances. I found FEngine already has destroy function for FSkinningBuffer, but there is no trampoline somehow.