### PR TITLE
remove 'exponent' from VsmShadowOptions

### DIFF
--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -149,13 +149,12 @@ Java_com_google_android_filament_View_nSetShadowType(JNIEnv*, jclass, jlong nati
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetVsmShadowOptions(JNIEnv*, jclass, jlong nativeView,
-        jint anisotropy, jboolean mipmapping, jfloat exponent, jfloat minVarianceScale,
+        jint anisotropy, jboolean mipmapping, jfloat minVarianceScale,
         jfloat lightBleedReduction) {
     View* view = (View*) nativeView;
     View::VsmShadowOptions options;
     options.anisotropy = (uint8_t)anisotropy;
     options.mipmapping = (bool)mipmapping;
-    options.exponent = exponent;
     options.minVarianceScale = minVarianceScale;
     options.lightBleedReduction = lightBleedReduction;
     view->setVsmShadowOptions(options);

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -770,13 +770,6 @@ public class View {
         public boolean mipmapping = false;
 
         /**
-         * EVSM exponent
-         * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
-         * shadow map in fp32. Currently the shadow map bit depth is always fp16.
-         */
-        public float exponent = 5.54f;
-
-        /**
          * VSM minimum variance scale, must be positive.
          */
         public float minVarianceScale = 1.0f;
@@ -1424,7 +1417,7 @@ public class View {
     public void setVsmShadowOptions(@NonNull VsmShadowOptions options) {
         mVsmShadowOptions = options;
         nSetVsmShadowOptions(getNativeObject(), options.anisotropy, options.mipmapping,
-                options.exponent, options.minVarianceScale, options.lightBleedReduction);
+                options.minVarianceScale, options.lightBleedReduction);
     }
 
     /**
@@ -1705,7 +1698,7 @@ public class View {
     private static native void nSetRenderQuality(long nativeView, int hdrColorBufferQuality);
     private static native void nSetDynamicLightingOptions(long nativeView, float zLightNear, float zLightFar);
     private static native void nSetShadowType(long nativeView, int type);
-    private static native void nSetVsmShadowOptions(long nativeView, int anisotropy, boolean mipmapping, float exponent, float minVarianceScale, float lightBleedReduction);
+    private static native void nSetVsmShadowOptions(long nativeView, int anisotropy, boolean mipmapping, float minVarianceScale, float lightBleedReduction);
     private static native void nSetColorGrading(long nativeView, long nativeColorGrading);
     private static native void nSetPostProcessingEnabled(long nativeView, boolean enabled);
     private static native boolean nIsPostProcessingEnabled(long nativeView);

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -363,13 +363,6 @@ struct VsmShadowOptions {
     bool mipmapping = false;
 
     /**
-     * EVSM exponent.
-     * The maximum value permissible is 5.54 for a shadow map in fp16, or 42.0 for a
-     * shadow map in fp32. Currently the shadow map bit depth is always fp16.
-     */
-    float exponent = 5.54f;
-
-    /**
      * VSM minimum variance scale, must be positive.
      */
     float minVarianceScale = 0.5f;

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -254,8 +254,8 @@ void PerViewUniforms::prepareDynamicLights(Froxelizer& froxelizer) noexcept {
 void PerViewUniforms::prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,
         VsmShadowOptions const& options) noexcept {
     auto& s = mPerViewUb.edit();
-    s.vsmExponent = options.exponent;  // fp16: max 5.54f, fp32: max 42.0
-    s.vsmDepthScale = options.minVarianceScale * 0.01f * options.exponent;
+    s.vsmExponent = 5.54f;  // fp16: max 5.54f, fp32: max 42.0
+    s.vsmDepthScale = options.minVarianceScale * 0.01f * s.vsmExponent;
     s.vsmLightBleedReduction = options.lightBleedReduction;
 
     s.lightFromWorldMatrix = shadowMappingUniforms.lightFromWorldMatrix;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -230,8 +230,6 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk,
             i = parse(tokens, i + 1, jsonChunk, &out->anisotropy);
         } else if (0 == compare(tok, jsonChunk, "mipmapping")) {
             i = parse(tokens, i + 1, jsonChunk, &out->mipmapping);
-        } else if (0 == compare(tok, jsonChunk, "exponent")) {
-            i = parse(tokens, i + 1, jsonChunk, &out->exponent);
         } else if (0 == compare(tok, jsonChunk, "minVarianceScale")) {
             i = parse(tokens, i + 1, jsonChunk, &out->minVarianceScale);
         } else if (0 == compare(tok, jsonChunk, "lightBleedReduction")) {
@@ -1472,7 +1470,6 @@ static std::ostream& operator<<(std::ostream& out, const VsmShadowOptions& in) {
     return out << "{\n"
         << "\"anisotropy\": " << int(in.anisotropy) << ",\n"
         << "\"mipmapping\": " << to_string(in.mipmapping) << ",\n"
-        << "\"exponent\": " << in.exponent << ",\n"
         << "\"minVarianceScale\": " << in.minVarianceScale << ",\n"
         << "\"lightBleedReduction\": " << in.lightBleedReduction << "\n"
         << "}";


### PR DESCRIPTION
this is an internal parameter and has no reason to be user settable.