### PR TITLE
Rework color history in preparation for SSR

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2177,19 +2177,17 @@ void PostProcessManager::prepareTaa(FrameHistory& frameHistory,
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> input, FrameHistory& frameHistory,
+        FrameGraphId<FrameGraphTexture> colorHistory,
         TemporalAntiAliasingOptions const& taaOptions,
         ColorGradingConfig colorGradingConfig) noexcept {
 
     FrameHistoryEntry const& entry = frameHistory[0];
-    FrameGraphId<FrameGraphTexture> colorHistory;
     mat4f const* historyProjection = nullptr;
-    if (UTILS_UNLIKELY(!entry.color.handle)) {
+    if (UTILS_UNLIKELY(!colorHistory)) {
         // if we don't have a history yet, just use the current color buffer as history
         colorHistory = input;
         historyProjection = &frameHistory.getCurrent().projection;
     } else {
-        colorHistory = fg.import("TAA history", entry.colorDesc,
-                FrameGraphTexture::Usage::SAMPLEABLE, entry.color);
         historyProjection = &entry.projection;
     }
 
@@ -2296,9 +2294,6 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
                     colorGradingSubpass(driver, colorGradingConfig);
                 }
                 driver.endRenderPass();
-
-                // perform TAA here using colorHistory + input -> output
-                resources.detach(data.output, &current.color, &current.colorDesc);
             });
     return colorGradingConfig.asSubpass ? taa->tonemappedOutput : taa->output;
 }

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -126,6 +126,7 @@ public:
 
     FrameGraphId<FrameGraphTexture> taa(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, FrameHistory& frameHistory,
+            FrameGraphId<FrameGraphTexture> colorHistory,
             TemporalAntiAliasingOptions const& taaOptions,
             ColorGradingConfig colorGradingConfig) noexcept;
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -187,7 +187,8 @@ private:
         return clock::now() - getUserEpoch();
     }
 
-    static FrameGraphId<FrameGraphTexture> getColorHistory(FrameGraph& fg, FView& view) noexcept;
+    static FrameGraphId<FrameGraphTexture> getColorHistory(FrameGraph& fg,
+            FrameHistory const& frameHistory) noexcept;
 
     // keep a reference to our engine
     FEngine& mEngine;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -187,6 +187,8 @@ private:
         return clock::now() - getUserEpoch();
     }
 
+    static FrameGraphId<FrameGraphTexture> getColorHistory(FrameGraph& fg, FView& view) noexcept;
+
     // keep a reference to our engine
     FEngine& mEngine;
     FrameSkipper mFrameSkipper;


### PR DESCRIPTION
Call `import` and `detach` outside of TAA, since SSR will also need color history.