### PR TITLE
Fix a java global reference leak

### DIFF
--- a/android/common/CallbackUtils.cpp
+++ b/android/common/CallbackUtils.cpp
@@ -86,7 +86,6 @@ JniBufferCallback::JniBufferCallback(JNIEnv* env, jobject handler, jobject callb
         AutoBuffer&& buffer)
         : JniCallback(env, handler, callback),
         mBuffer(std::move(buffer)) {
-    acquireCallbackJni(env, mCallbackUtils);
 }
 
 JniBufferCallback::~JniBufferCallback() = default;
@@ -109,7 +108,6 @@ JniImageCallback* JniImageCallback::make(filament::Engine*,
 JniImageCallback::JniImageCallback(JNIEnv* env, jobject handler, jobject callback, long image)
         : JniCallback(env, handler, callback),
         mImage(image) {
-    acquireCallbackJni(env, mCallbackUtils);
 }
 
 JniImageCallback::~JniImageCallback() = default;


### PR DESCRIPTION
We were acquiring a reference twice by accident.

Fix #4957