### PR TITLE
fix aabb misalignment for skinned gltf model

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -71,6 +71,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
 
     var normalizeSkinningWeights = true
     var recomputeBoundingBoxes = false
+    var ignoreBindTransform = false
 
     var cameraFocalLength = 28f
         set(value) {
@@ -111,7 +112,7 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
         view.camera = camera
 
         assetLoader = AssetLoader(engine, UbershaderLoader(engine), EntityManager.get())
-        resourceLoader = ResourceLoader(engine, normalizeSkinningWeights, recomputeBoundingBoxes)
+        resourceLoader = ResourceLoader(engine, normalizeSkinningWeights, recomputeBoundingBoxes, ignoreBindTransform)
 
         // Always add a direct light source since it is required for shadowing.
         // We highly recommend adding an indirect light as well.

--- a/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
@@ -35,10 +35,11 @@ static void destroy(void*, size_t, void *userData) {
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_ResourceLoader_nCreateResourceLoader(JNIEnv*, jclass,
-        jlong nativeEngine, jboolean normalizeSkinningWeights, jboolean recomputeBoundingBoxes) {
+        jlong nativeEngine, jboolean normalizeSkinningWeights, jboolean recomputeBoundingBoxes,
+        jboolean ignoreBindTransform) {
     Engine* engine = (Engine*) nativeEngine;
     return (jlong) new ResourceLoader({ engine, {}, (bool) normalizeSkinningWeights,
-            (bool) recomputeBoundingBoxes });
+            (bool) recomputeBoundingBoxes, (bool) ignoreBindTransform});
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/ResourceLoader.java
@@ -45,7 +45,7 @@ public class ResourceLoader {
      */
     public ResourceLoader(@NonNull Engine engine) {
         long nativeEngine = engine.getNativeObject();
-        mNativeObject = nCreateResourceLoader(nativeEngine, false, false);
+        mNativeObject = nCreateResourceLoader(nativeEngine, false, false, false);
     }
 
     /**
@@ -54,14 +54,15 @@ public class ResourceLoader {
      * @param engine the engine that gets passed to all builder methods
      * @param normalizeSkinningWeights scale non-conformant skinning weights so they sum to 1
      * @param recomputeBoundingBoxes use computed bounding boxes rather than the ones in the asset
+     * @param ignoreBindTransform ignore skinned primitives bind transform when compute bounding boxes
      * @throws IllegalAccessException
      * @throws InvocationTargetException
      */
     public ResourceLoader(@NonNull Engine engine, boolean normalizeSkinningWeights,
-            boolean recomputeBoundingBoxes) {
+            boolean recomputeBoundingBoxes, boolean ignoreBindTransform) {
         long nativeEngine = engine.getNativeObject();
         mNativeObject = nCreateResourceLoader(nativeEngine, normalizeSkinningWeights,
-                recomputeBoundingBoxes);
+                recomputeBoundingBoxes, ignoreBindTransform);
     }
 
     /**
@@ -166,7 +167,7 @@ public class ResourceLoader {
     }
 
     private static native long nCreateResourceLoader(long nativeEngine,
-            boolean normalizeSkinningWeights, boolean recomputeBoundingBoxes);
+            boolean normalizeSkinningWeights, boolean recomputeBoundingBoxes, boolean ignoreBindTransform);
     private static native void nDestroyResourceLoader(long nativeLoader);
     private static native void nAddResourceData(long nativeLoader, String url, Buffer buffer,
             int remaining);

--- a/docs/remote/filament.js
+++ b/docs/remote/filament.js
@@ -713,7 +713,8 @@ Filament.loadClassExtensions = function() {
         const interval = asyncInterval || 30;
         const defaults = {
             normalizeSkinningWeights: true,
-            recomputeBoundingBoxes: false
+            recomputeBoundingBoxes: false,
+            ignoreBindTransform: false
         };
         config = Object.assign(defaults, config || {});
 
@@ -736,7 +737,8 @@ Filament.loadClassExtensions = function() {
         // Construct a resource loader and start decoding after all textures are fetched.
         const resourceLoader = new Filament.gltfio$ResourceLoader(engine,
                 config.normalizeSkinningWeights,
-                config.recomputeBoundingBoxes);
+                config.recomputeBoundingBoxes,
+                config.ignoreBindTransform);
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);
 

--- a/docs/viewer/filament-viewer.js
+++ b/docs/viewer/filament-viewer.js
@@ -307,6 +307,7 @@ class FilamentViewer extends LitElement {
             const config = {
                 normalizeSkinningWeights: true,
                 recomputeBoundingBoxes: false,
+                ignoreBindTransform: false,
                 asyncInterval: 30
             };
 
@@ -333,7 +334,8 @@ class FilamentViewer extends LitElement {
 
                 const resourceLoader = new Filament.gltfio$ResourceLoader(this.engine,
                     config.normalizeSkinningWeights,
-                    config.recomputeBoundingBoxes);
+                    config.recomputeBoundingBoxes,
+                    config.ignoreBindTransform);
 
                 let remaining = Object.keys(this.srcBlobResources).length;
                 for (const name in this.srcBlobResources) {

--- a/docs/webgl/filament.js
+++ b/docs/webgl/filament.js
@@ -713,7 +713,8 @@ Filament.loadClassExtensions = function() {
         const interval = asyncInterval || 30;
         const defaults = {
             normalizeSkinningWeights: true,
-            recomputeBoundingBoxes: false
+            recomputeBoundingBoxes: false,
+            ignoreBindTransform: false
         };
         config = Object.assign(defaults, config || {});
 
@@ -736,7 +737,8 @@ Filament.loadClassExtensions = function() {
         // Construct a resource loader and start decoding after all textures are fetched.
         const resourceLoader = new Filament.gltfio$ResourceLoader(engine,
                 config.normalizeSkinningWeights,
-                config.recomputeBoundingBoxes);
+                config.recomputeBoundingBoxes,
+                config.ignoreBindTransform);
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);
 

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -53,8 +53,8 @@ struct ResourceConfiguration {
     //! do not need this, but it is useful for robustness.
     bool recomputeBoundingBoxes;
 
-    //! If true, ignore bind transform for skinned primitives when compute bounding box. Only 
-    //! applicable when recomputeBoundingBoxes is set to true
+    //! If true, ignore bind transform for skinned primitives when compute bounding box. Implicitly true 
+    //! for instanced asset. Only applicable when recomputeBoundingBoxes is set to true
     bool ignoreBindTransform;
 };
 

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -151,7 +151,7 @@ private:
     bool loadResources(FFilamentAsset* asset, bool async);
     void applySparseData(FFilamentAsset* asset) const;
     void normalizeSkinningWeights(FFilamentAsset* asset) const;
-    void updateBoundingBoxes(FFilamentAsset* asset) const;
+    void updateBoundingBoxes(FFilamentAsset* asset, void* cgltfSkinBaseAddress) const;
     AssetPool* mPool;
     struct Impl;
     Impl* pImpl;

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -53,7 +53,7 @@ struct ResourceConfiguration {
     //! do not need this, but it is useful for robustness.
     bool recomputeBoundingBoxes;
 
-    //! If true, ignore bind transform for skinned primitives when compute bounding box. Implicitly true 
+    //! If true, ignore skinned primitives bind transform when compute bounding box. Implicitly true 
     //! for instanced asset. Only applicable when recomputeBoundingBoxes is set to true
     bool ignoreBindTransform;
 };

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -52,6 +52,10 @@ struct ResourceConfiguration {
     //! If true, computes the bounding boxes of all \c POSITION attibutes. Well formed glTF files
     //! do not need this, but it is useful for robustness.
     bool recomputeBoundingBoxes;
+
+    //! If true, ignore bind transform for skinned primitives when compute bounding box. Only 
+    //! applicable when recomputeBoundingBoxes is set to true
+    bool ignoreBindTransform;
 };
 
 /**
@@ -151,7 +155,7 @@ private:
     bool loadResources(FFilamentAsset* asset, bool async);
     void applySparseData(FFilamentAsset* asset) const;
     void normalizeSkinningWeights(FFilamentAsset* asset) const;
-    void updateBoundingBoxes(FFilamentAsset* asset, void* cgltfSkinBaseAddress) const;
+    void updateBoundingBoxes(FFilamentAsset* asset) const;
     AssetPool* mPool;
     struct Impl;
     Impl* pImpl;

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -1020,8 +1020,7 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
     const size_t skinningAttrSize = cgltf_num_components(cgltf_type_vec4);
     auto computeBoundingBoxSkinned = [&](const cgltf_primitive* prim, const Skin* skin, Aabb* result) {
         Aabb aabb;
-        std::vector<mat4f> inverseGlobalTransforms;
-        inverseGlobalTransforms.resize(skin->targets.size());
+        std::vector<mat4f> inverseGlobalTransforms(skin->targets.size());
         for (size_t i = 0; i < skin->targets.size(); i++) {
             auto xformable = tm.getInstance(skin->targets[i]);
             if (xformable) {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -465,7 +465,9 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
 
     if (pImpl->mRecomputeBoundingBoxes) {
         // asset->mSkins is unused for instanced assets
-        pImpl->mIgnoreBindTransform = asset->isInstanced();
+        if (!pImpl->mIgnoreBindTransform) {
+            pImpl->mIgnoreBindTransform = asset->isInstanced();
+        }
         if (!pImpl->mIgnoreBindTransform) {
            pImpl->cgltfSkinBaseAddress = &gltf->skins[0];
         }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -464,6 +464,8 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     }
 
     if (pImpl->mRecomputeBoundingBoxes) {
+        // asset->mSkins is unused for instanced assets
+        pImpl->mIgnoreBindTransform = asset->isInstanced();
         if (!pImpl->mIgnoreBindTransform) {
            pImpl->cgltfSkinBaseAddress = &gltf->skins[0];
         }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -1064,7 +1064,7 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
                     if (normalizeWeight) {
                         skinMatrix /= skinMatrix[3].w;
                     }
-                    auto skinnedPoint = (point.x * skinMatrix[0] + point.y * skinMatrix[1] + point.z * skinMatrix[2] + skinMatrix[3]).xyz;
+                    float3 skinnedPoint = (point.x * skinMatrix[0] + point.y * skinMatrix[1] + point.z * skinMatrix[2] + skinMatrix[3]).xyz;
                     aabb.min = min(aabb.min, skinnedPoint);
                     aabb.max = max(aabb.max, skinnedPoint);
                 }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -1000,10 +1000,10 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
     const size_t skinningAttrSize = cgltf_num_components(cgltf_type_vec4);
     const bool normalizeWeight = !pImpl->mNormalizeSkinningWeights;
     const bool ignoreBindTransform = pImpl->mIgnoreBindTransform;
-    auto computeBoundingBox = [&](const SkinnedPrimitive skinnedPrim, Aabb* result) {
+    auto computeBoundingBox = [&](const SkinnedPrimitive skinnedPrimitive, Aabb* result) {
         Aabb aabb;
-        auto prim = skinnedPrim.first;
-        auto skin = skinnedPrim.second;
+        auto prim = skinnedPrimitive.first;
+        auto skin = skinnedPrimitive.second;
         std::vector<mat4f> inverseGlobalTransforms;
         if (skin) {
             inverseGlobalTransforms.resize(skin->targets.size());
@@ -1097,10 +1097,10 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
     JobSystem* js = &pImpl->mEngine->getJobSystem();
     JobSystem::Job* parent = js->createJob();
     for (size_t i = 0; i < skinnedPrimitives.size(); ++i) {
-        SkinnedPrimitive skinnedPrim = skinnedPrimitives[i];
+        SkinnedPrimitive skinnedPrimitive = skinnedPrimitives[i];
         Aabb* result = &bounds[i];
-        js->run(jobs::createJob(*js, parent, [skinnedPrim, result, computeBoundingBox] {
-            computeBoundingBox(skinnedPrim, result);
+        js->run(jobs::createJob(*js, parent, [skinnedPrimitive, result, computeBoundingBox] {
+            computeBoundingBox(skinnedPrimitive, result);
         }));
     }
     js->runAndWait(parent);

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -1018,17 +1018,14 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
 
     const size_t posAttrSize = cgltf_num_components(cgltf_type_vec3);
     const size_t skinningAttrSize = cgltf_num_components(cgltf_type_vec4);
-    const bool weightNormalized = pImpl->mNormalizeSkinningWeights;
     auto computeBoundingBoxSkinned = [&](const cgltf_primitive* prim, const Skin* skin, Aabb* result) {
         Aabb aabb;
         std::vector<mat4f> inverseGlobalTransforms;
         inverseGlobalTransforms.resize(skin->targets.size());
         for (size_t i = 0; i < skin->targets.size(); i++) {
             auto xformable = tm.getInstance(skin->targets[i]);
-            if (!skin->targets.empty()) {
+            if (xformable) {
                 inverseGlobalTransforms[i] = inverse(tm.getWorldTransform(xformable));
-            } else {
-                inverseGlobalTransforms[i] = mat4f();
             }
         }
         std::vector<float> verts;
@@ -1065,7 +1062,7 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
             }
             for (const auto& inverseGlobalTransform: inverseGlobalTransforms) {
                 mat4f skinMatrix = inverseGlobalTransform * tmp;
-                if (!weightNormalized) {
+                if (!pImpl->mNormalizeSkinningWeights) {
                     skinMatrix /= skinMatrix[3].w;
                 }
                 float3 skinnedPoint = (point.x * skinMatrix[0] + point.y * skinMatrix[1] + point.z * skinMatrix[2] + skinMatrix[3]).xyz;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -135,7 +135,7 @@ static void printUsage(char* name) {
         "   --recompute-aabb, -r\n"
         "       Ignore the min/max attributes in the glTF file\n\n"
         "   --ignore-bind-transform, -g\n"
-        "       Ignore bind transform when recompute aabb\n\n"
+        "       Ignore bind transform when recomputing aabb\n\n"
         "   --settings=<path to JSON file>, -t\n"
         "       Apply the settings in the given JSON file\n\n"
         "   --ubershader, -u\n"

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -85,6 +85,7 @@ struct App {
 
     gltfio::ResourceLoader* resourceLoader = nullptr;
     bool recomputeAabb = false;
+    bool ignoreBindTransform = false;
 
     bool actualSize = false;
 
@@ -133,6 +134,8 @@ static void printUsage(char* name) {
         "       Do not scale the model to fit into a unit cube\n\n"
         "   --recompute-aabb, -r\n"
         "       Ignore the min/max attributes in the glTF file\n\n"
+        "   --ignore-bind-transform, -g\n"
+        "       Ignore bind transform when recompute aabb\n\n"
         "   --settings=<path to JSON file>, -t\n"
         "       Apply the settings in the given JSON file\n\n"
         "   --ubershader, -u\n"
@@ -161,19 +164,20 @@ static std::ifstream::pos_type getFileSize(const char* filename) {
 }
 
 static int handleCommandLineArguments(int argc, char* argv[], App* app) {
-    static constexpr const char* OPTSTR = "ha:i:usc:rt:b:ev";
+    static constexpr const char* OPTSTR = "ha:i:usc:rgt:b:ev";
     static const struct option OPTIONS[] = {
-        { "help",         no_argument,       nullptr, 'h' },
-        { "api",          required_argument, nullptr, 'a' },
-        { "batch",        required_argument, nullptr, 'b' },
-        { "headless",     no_argument,       nullptr, 'e' },
-        { "ibl",          required_argument, nullptr, 'i' },
-        { "ubershader",   no_argument,       nullptr, 'u' },
-        { "actual-size",  no_argument,       nullptr, 's' },
-        { "camera",       required_argument, nullptr, 'c' },
-        { "recompute-aabb", no_argument,     nullptr, 'r' },
-        { "settings",     required_argument, nullptr, 't' },
-        { "split-view",   no_argument,       nullptr, 'v' },
+        { "help",         no_argument,          nullptr, 'h' },
+        { "api",          required_argument,    nullptr, 'a' },
+        { "batch",        required_argument,    nullptr, 'b' },
+        { "headless",     no_argument,          nullptr, 'e' },
+        { "ibl",          required_argument,    nullptr, 'i' },
+        { "ubershader",   no_argument,          nullptr, 'u' },
+        { "actual-size",  no_argument,          nullptr, 's' },
+        { "camera",       required_argument,    nullptr, 'c' },
+        { "recompute-aabb", no_argument,        nullptr, 'r' },
+        { "ignore-bind-transform", no_argument, nullptr, 'g' },
+        { "settings",     required_argument,    nullptr, 't' },
+        { "split-view",   no_argument,          nullptr, 'v' },
         { nullptr, 0, nullptr, 0 }
     };
     int opt;
@@ -219,6 +223,9 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 break;
             case 'r':
                 app->recomputeAabb = true;
+                break;
+            case 'g':
+                app->ignoreBindTransform = true;
                 break;
             case 't':
                 app->settingsFile = arg;
@@ -412,6 +419,7 @@ int main(int argc, char** argv) {
         configuration.engine = app.engine;
         configuration.gltfPath = gltfPath.c_str();
         configuration.recomputeBoundingBoxes = app.recomputeAabb;
+        configuration.ignoreBindTransform = app.ignoreBindTransform;
         configuration.normalizeSkinningWeights = true;
         if (!app.resourceLoader) {
             app.resourceLoader = new gltfio::ResourceLoader(configuration);

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -578,7 +578,8 @@ Filament.loadClassExtensions = function() {
         const interval = asyncInterval || 30;
         const defaults = {
             normalizeSkinningWeights: true,
-            recomputeBoundingBoxes: false
+            recomputeBoundingBoxes: false,
+            ignoreBindTransform: false
         };
         config = Object.assign(defaults, config || {});
 
@@ -601,7 +602,8 @@ Filament.loadClassExtensions = function() {
         // Construct a resource loader and start decoding after all textures are fetched.
         const resourceLoader = new Filament.gltfio$ResourceLoader(engine,
                 config.normalizeSkinningWeights,
-                config.recomputeBoundingBoxes);
+                config.recomputeBoundingBoxes,
+                config.ignoreBindTransform);
         const onComplete = () => {
             resourceLoader.asyncBeginLoad(asset);
 

--- a/web/filament-js/filament-viewer.js
+++ b/web/filament-js/filament-viewer.js
@@ -307,6 +307,7 @@ class FilamentViewer extends LitElement {
             const config = {
                 normalizeSkinningWeights: true,
                 recomputeBoundingBoxes: false,
+                ignoreBindTransform: false,
                 asyncInterval: 30
             };
 
@@ -333,7 +334,8 @@ class FilamentViewer extends LitElement {
 
                 const resourceLoader = new Filament.gltfio$ResourceLoader(this.engine,
                     config.normalizeSkinningWeights,
-                    config.recomputeBoundingBoxes);
+                    config.recomputeBoundingBoxes,
+                    config.ignoreBindTransform);
 
                 let remaining = Object.keys(this.srcBlobResources).length;
                 for (const name in this.srcBlobResources) {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1910,12 +1910,13 @@ class_<AssetLoader>("gltfio$AssetLoader")
 
 class_<ResourceLoader>("gltfio$ResourceLoader")
     .constructor(EMBIND_LAMBDA(ResourceLoader*, (Engine* engine, bool normalizeSkinningWeights,
-            bool recomputeBoundingBoxes), {
+            bool recomputeBoundingBoxes, bool ignoreBindTransform), {
         return new ResourceLoader({
             .engine = engine,
             .gltfPath = nullptr,
             .normalizeSkinningWeights = normalizeSkinningWeights,
-            .recomputeBoundingBoxes = recomputeBoundingBoxes
+            .recomputeBoundingBoxes = recomputeBoundingBoxes,
+            .ignoreBindTransform = ignoreBindTransform
         });
     }), allow_raw_pointers())
 


### PR DESCRIPTION
For a skinned gltf model, its mesh primitives world transform may not be the same as its bind transform. This pr aims to recompute aabb based on bind transform to fix misalignment issue.

| | Suzanne     | torus | 
|----------|-----------|----------|
| Before | ![Suzanne_skinning_before](https://user-images.githubusercontent.com/21233675/146144254-fedd3fb3-de75-40b2-994a-7a4c5da5d982.png)   | ![torus_before](https://user-images.githubusercontent.com/21233675/146144424-2fb56624-462f-4f37-a047-99bee3fdf0cb.png) |
| After | ![Suzanne_skinning_after](https://user-images.githubusercontent.com/21233675/146144352-4ac69261-315a-4f66-b08d-cdd0aee793d0.png)  | ![torus_after](https://user-images.githubusercontent.com/21233675/146144380-e6316cdd-a5ca-45c6-8fc3-7d08f5f206d8.png) |

Test models: [test_models_glb.zip](https://github.com/google/filament/files/7717362/test_models_glb.zip)



