### PR TITLE
Added line/triangle strip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ steps:
   - [x] Points
   - [x] Lines
   - [ ] Line Loop
-  - [ ] Line Strip
+  - [x] Line Strip
   - [x] Triangles
-  - [ ] Triangle Strip
+  - [x] Triangle Strip
   - [ ] Triangle Fan
 
 - Animation

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -96,7 +96,9 @@ public class RenderableManager {
     public enum PrimitiveType {
         POINTS(0),
         LINES(1),
-        TRIANGLES(4);
+        LINE_STRIP(3),
+        TRIANGLES(4),
+        TRIANGLE_STRIP(5);
 
         private final int mType;
         PrimitiveType(int value) { mType = value; }

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -197,7 +197,7 @@ enum class PrimitiveType : uint8_t {
     LINES          = 1,    //!< lines
     LINE_STRIP     = 3,    //!< line strip
     TRIANGLES      = 4,    //!< triangles
-    TRIANGLE_STRIP = 5, //!< triangle strip
+    TRIANGLE_STRIP = 5,    //!< triangle strip
     NONE           = 0xFF
 };
 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -193,10 +193,12 @@ static constexpr size_t SHADER_MODEL_COUNT = 3;
  */
 enum class PrimitiveType : uint8_t {
     // don't change the enums values (made to match GL)
-    POINTS      = 0,    //!< points
-    LINES       = 1,    //!< lines
-    TRIANGLES   = 4,    //!< triangles
-    NONE        = 0xFF
+    POINTS         = 0,    //!< points
+    LINES          = 1,    //!< lines
+    LINE_STRIP     = 3,    //!< line strip
+    TRIANGLES      = 4,    //!< triangles
+    TRIANGLE_STRIP = 5, //!< triangle strip
+    NONE           = 0xFF
 };
 
 /**

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -304,7 +304,9 @@ constexpr inline MTLPrimitiveType getMetalPrimitiveType(PrimitiveType type) noex
     switch (type) {
         case PrimitiveType::POINTS: return MTLPrimitiveTypePoint;
         case PrimitiveType::LINES: return MTLPrimitiveTypeLine;
+        case PrimitiveType::LINE_STRIP: return MTLPrimitiveTypeLineStrip;
         case PrimitiveType::TRIANGLES: return MTLPrimitiveTypeTriangle;
+        case PrimitiveType::TRIANGLE_STRIP: return MTLPrimitiveTypeTriangleStrip;
         case PrimitiveType::NONE:
             ASSERT_POSTCONDITION(false, "NONE is not a valid primitive type.");
     }

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -51,7 +51,9 @@ io::ostream& operator<<(io::ostream& out, ShaderModel model) {
 io::ostream& operator<<(io::ostream& out, PrimitiveType type) {
     switch (type) {
         CASE(PrimitiveType, TRIANGLES)
+        CASE(PrimitiveType, TRIANGLE_STRIP)
         CASE(PrimitiveType, LINES)
+        CASE(PrimitiveType, LINE_STRIP)
         CASE(PrimitiveType, POINTS)
         CASE(PrimitiveType, NONE)
     }

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -283,8 +283,14 @@ void VulkanRenderPrimitive::setPrimitiveType(backend::PrimitiveType pt) {
         case backend::PrimitiveType::LINES:
             primitiveTopology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
             break;
+        case backend::PrimitiveType::LINE_STRIP:
+            primitiveTopology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
+            break;
         case backend::PrimitiveType::TRIANGLES:
             primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+            break;
+        case backend::PrimitiveType::TRIANGLE_STRIP:
+            primitiveTopology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
             break;
     }
 }

--- a/libs/gltfio/src/GltfEnums.h
+++ b/libs/gltfio/src/GltfEnums.h
@@ -122,12 +122,16 @@ inline bool getPrimitiveType(cgltf_primitive_type in,
         case cgltf_primitive_type_lines:
             *out = filament::RenderableManager::PrimitiveType::LINES;
             return true;
+        case cgltf_primitive_type_line_strip:
+            *out = filament::RenderableManager::PrimitiveType::LINE_STRIP;
+            return true;
         case cgltf_primitive_type_triangles:
             *out = filament::RenderableManager::PrimitiveType::TRIANGLES;
             return true;
-        case cgltf_primitive_type_line_loop:
-        case cgltf_primitive_type_line_strip:
         case cgltf_primitive_type_triangle_strip:
+            *out = filament::RenderableManager::PrimitiveType::TRIANGLE_STRIP;
+            return true;
+        case cgltf_primitive_type_line_loop:
         case cgltf_primitive_type_triangle_fan:
             return false;
     }

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -824,7 +824,9 @@ export enum PixelDataType {
 export enum RenderableManager$PrimitiveType {
     POINTS,
     LINES,
+    LINE_STRIP,
     TRIANGLES,
+    TRIANGLE_STRIP,
     NONE,
 }
 

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -116,7 +116,9 @@ enum_<LightManager::Type>("LightManager$Type")
 enum_<RenderableManager::PrimitiveType>("RenderableManager$PrimitiveType")
     .value("POINTS", RenderableManager::PrimitiveType::POINTS)
     .value("LINES", RenderableManager::PrimitiveType::LINES)
+    .value("LINE_STRIP", RenderableManager::PrimitiveType::LINE_STRIP)
     .value("TRIANGLES", RenderableManager::PrimitiveType::TRIANGLES)
+    .value("TRIANGLE_STRIP", RenderableManager::PrimitiveType::TRIANGLE_STRIP)
     .value("NONE", RenderableManager::PrimitiveType::NONE);
 
 enum_<View::QualityLevel>("View$QualityLevel")


### PR DESCRIPTION
Initially discussed [here](https://github.com/google/filament/issues/4508l)
Strips are supported on all current backends and can be useful in some cases.
The changes are minimal.