### PR TITLE
Fixed cubemap update

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1807,10 +1807,12 @@ void OpenGLDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
     DEBUG_MARKER()
 
     GLTexture* t = handle_cast<GLTexture *>(th);
+    auto width = std::max(1u, t->width >> level);
+    auto height = std::max(1u, t->height >> level);
     if (data.type == PixelDataType::COMPRESSED) {
-        setCompressedTextureData(t, level, 0, 0, 0, std::max(1u, t->width >> level), std::max(1u, t->height >> level), 0, std::move(data), &faceOffsets);
+        setCompressedTextureData(t, level, 0, 0, 0, width, height, 0, std::move(data), &faceOffsets);
     } else {
-        setTextureData(t, level, 0, 0, 0, std::max(1u, t->width >> level), std::max(1u, t->height >> level), 0, std::move(data), &faceOffsets);
+        setTextureData(t, level, 0, 0, 0, width, height, 0, std::move(data), &faceOffsets);
     }
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1808,9 +1808,9 @@ void OpenGLDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
 
     GLTexture* t = handle_cast<GLTexture *>(th);
     if (data.type == PixelDataType::COMPRESSED) {
-        setCompressedTextureData(t, level, 0, 0, 0, t->width >> level, t->height >> level, 0, std::move(data), &faceOffsets);
+        setCompressedTextureData(t, level, 0, 0, 0, std::max(1u, t->width >> level), std::max(1u, t->height >> level), 0, std::move(data), &faceOffsets);
     } else {
-        setTextureData(t, level, 0, 0, 0, t->width >> level, t->height >> level, 0, std::move(data), &faceOffsets);
+        setTextureData(t, level, 0, 0, 0, std::max(1u, t->width >> level), std::max(1u, t->height >> level), 0, std::move(data), &faceOffsets);
     }
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1808,9 +1808,9 @@ void OpenGLDriver::updateCubeImage(Handle<HwTexture> th, uint32_t level,
 
     GLTexture* t = handle_cast<GLTexture *>(th);
     if (data.type == PixelDataType::COMPRESSED) {
-        setCompressedTextureData(t, level, 0, 0, 0, 0, 0, 0, std::move(data), &faceOffsets);
+        setCompressedTextureData(t, level, 0, 0, 0, t->width >> level, t->height >> level, 0, std::move(data), &faceOffsets);
     } else {
-        setTextureData(t, level, 0, 0, 0, 0, 0, 0, std::move(data), &faceOffsets);
+        setTextureData(t, level, 0, 0, 0, t->width >> level, t->height >> level, 0, std::move(data), &faceOffsets);
     }
 }
 


### PR DESCRIPTION
Cubemap update was broken by this commit: [6fa82ea73d7263931d6c96d56a42b5cca20a07a0](https://github.com/google/filament/commit/6fa82ea73d7263931d6c96d56a42b5cca20a07a0)
Cubemap update call setcompressedTextureData/setTextureData with 0, 0 as width and height as this was relying on those methods to just use the t->width, t->height instead of the function arguments.
Not sure if that is legal, maybe an assert should check for that case or it should be handled in the function (width = width ? width : t->width)

