### PR TITLE
Avoid calling std::string(nullptr) in MockConfig.cpp

### DIFF
--- a/tools/matc/tests/MockConfig.cpp
+++ b/tools/matc/tests/MockConfig.cpp
@@ -61,5 +61,5 @@ matc::Config::Input* MockConfig::getInput() const noexcept {
 }
 
 std::string MockConfig::toString() const noexcept {
-    return nullptr;
+    return {};
 }


### PR DESCRIPTION
This is in preparation for a new version of MSVC. See #5006