### PR TITLE
ModelViewer move UiHelper to constructor 

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -58,7 +58,10 @@ private const val kSensitivity = 100f
  *
  * See `sample-gltf-viewer` for a usage example.
  */
-class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
+class ModelViewer(
+        val engine: Engine,
+        private val uiHelper: UiHelper
+) : android.view.View.OnTouchListener {
     var asset: FilamentAsset? = null
         private set
 
@@ -84,7 +87,6 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     val renderer: Renderer
     @Entity val light: Int
 
-    private val uiHelper: UiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK)
     private lateinit var displayHelper: DisplayHelper
     private lateinit var cameraManipulator: Manipulator
     private lateinit var gestureDetector: GestureDetector
@@ -129,7 +131,12 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
         scene.addEntity(light)
     }
 
-    constructor(surfaceView: SurfaceView, engine: Engine = Engine.create(), manipulator: Manipulator? = null) : this(engine) {
+    constructor(
+            surfaceView: SurfaceView,
+            engine: Engine = Engine.create(),
+            uiHelper: UiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK),
+            manipulator: Manipulator? = null
+    ) : this(engine, uiHelper) {
         cameraManipulator = manipulator ?: Manipulator.Builder()
                 .targetPosition(kDefaultObjectPosition.x, kDefaultObjectPosition.y, kDefaultObjectPosition.z)
                 .viewport(surfaceView.width, surfaceView.height)
@@ -144,7 +151,12 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     }
 
     @Suppress("unused")
-    constructor(textureView: TextureView, engine: Engine = Engine.create(), manipulator: Manipulator? = null) : this(engine) {
+    constructor(
+            textureView: TextureView,
+            engine: Engine = Engine.create(),
+            uiHelper: UiHelper = UiHelper(UiHelper.ContextErrorPolicy.DONT_CHECK),
+            manipulator: Manipulator? = null
+    ) : this(engine, uiHelper) {
         cameraManipulator = manipulator ?: Manipulator.Builder()
                 .targetPosition(kDefaultObjectPosition.x, kDefaultObjectPosition.y, kDefaultObjectPosition.z)
                 .viewport(textureView.width, textureView.height)
@@ -215,8 +227,8 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     fun transformToUnitCube(centerPoint: Float3 = kDefaultObjectPosition) {
         asset?.let { asset ->
             val tm = engine.transformManager
-            var center = asset.boundingBox.center.let { v-> Float3(v[0], v[1], v[2]) }
-            val halfExtent = asset.boundingBox.halfExtent.let { v-> Float3(v[0], v[1], v[2]) }
+            var center = asset.boundingBox.center.let { v -> Float3(v[0], v[1], v[2]) }
+            val halfExtent = asset.boundingBox.halfExtent.let { v -> Float3(v[0], v[1], v[2]) }
             val maxExtent = 2.0f * max(halfExtent)
             val scaleFactor = 2.0f / maxExtent
             center -= centerPoint / scaleFactor
@@ -284,9 +296,9 @@ class ModelViewer(val engine: Engine) : android.view.View.OnTouchListener {
     private fun populateScene(asset: FilamentAsset) {
         val rcm = engine.renderableManager
         var count = 0
-        val popRenderables = {count = asset.popRenderables(readyRenderables); count != 0}
+        val popRenderables = { count = asset.popRenderables(readyRenderables); count != 0 }
         while (popRenderables()) {
-            for (i in 0..count-1) {
+            for (i in 0..count - 1) {
                 val ri = rcm.getInstance(readyRenderables[i])
                 rcm.setScreenSpaceContactShadows(ri, true)
             }


### PR DESCRIPTION
Moving `UiHelper` to the constructor which allows for more composable control of the underlying views & surface.

More specifically, I needed to set the opacity of the underlying views within `ModelViewer`.
