### PR TITLE
fix a bug of rendering transparent object when using GLTFIO_LITE/gltfresources_lite.bin

### DIFF
--- a/libs/gltfio/src/UbershaderLoader.cpp
+++ b/libs/gltfio/src/UbershaderLoader.cpp
@@ -131,7 +131,7 @@ Material* UbershaderLoader::getMaterial(const MaterialKey& config) const {
         case MATINDEX(LIT, AlphaMode::OPAQUE, false, false, false): mMaterials[matindex] = CREATE_MATERIAL(LIT_OPAQUE); break;
         #endif
 
-        #if !GLTFIO_LITE || defined(GLTFRESOURCES_LITE_LIT_BLEND_DATA)
+        #if !GLTFIO_LITE || defined(GLTFRESOURCES_LITE_LIT_FADE_DATA)
         case MATINDEX(LIT, AlphaMode::BLEND, false, false, false): mMaterials[matindex] = CREATE_MATERIAL(LIT_FADE); break;
         #endif
 


### PR DESCRIPTION
The macro GLTFRESOURCES_LITE_LIT_BLEND_DATA is not defined anywhere, it should be GLTFRESOURCES_LITE_LIT_FADE_DATA. This solves the issue of rendering transparent objects using GLTFIO_LITE macro, i.e. using gltfresources_lite.bin. If we don't change this macro, the transparent objects will be rended using lit_opaque material instead of lit_fade material.
I think [this issue](https://github.com/google/filament/issues/4164) recorded is also caused by this bug. It should be fixed after this macro change.