### PR TITLE
Replace generic tonemap curve with a simpler one

### DIFF
--- a/android/filament-android/src/main/cpp/ToneMapper.cpp
+++ b/android/filament-android/src/main/cpp/ToneMapper.cpp
@@ -49,18 +49,13 @@ Java_com_google_android_filament_ToneMapper_nCreateFilmicToneMapper(JNIEnv*, jcl
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_ToneMapper_nCreateGenericToneMapper(JNIEnv*, jclass,
-        jfloat contrast, jfloat shoulder, jfloat midGrayIn, jfloat midGrayOut, jfloat hdrMax) {
-    return (jlong) new GenericToneMapper(contrast, shoulder, midGrayIn, midGrayOut, hdrMax);
+        jfloat contrast, jfloat midGrayIn, jfloat midGrayOut, jfloat hdrMax) {
+    return (jlong) new GenericToneMapper(contrast, midGrayIn, midGrayOut, hdrMax);
 }
 
 extern "C" JNIEXPORT jfloat JNICALL
 Java_com_google_android_filament_ToneMapper_nGenericGetContrast(JNIEnv*, jclass, jlong nativeObject) {
     return ((GenericToneMapper*) nativeObject)->getContrast();
-}
-
-extern "C" JNIEXPORT jfloat JNICALL
-Java_com_google_android_filament_ToneMapper_nGenericGetShoulder(JNIEnv*, jclass, jlong nativeObject) {
-    return ((GenericToneMapper*) nativeObject)->getShoulder();
 }
 
 extern "C" JNIEXPORT jfloat JNICALL
@@ -82,12 +77,6 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_ToneMapper_nGenericSetContrast(JNIEnv*, jclass,
         jlong nativeObject, jfloat contrast) {
     ((GenericToneMapper*) nativeObject)->setContrast(contrast);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_ToneMapper_nGenericSetShoulder(JNIEnv*, jclass,
-        jlong nativeObject, jfloat shoulder) {
-    ((GenericToneMapper*) nativeObject)->setShoulder(shoulder);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -129,7 +129,7 @@ public class ToneMapper {
          * </ul>
          */
         public Generic() {
-            this(1.585f, 0.5f, 0.18f, 0.268f, 10.0f);
+            this(1.55f, 0.18f, 0.215f, 10.0f);
         }
 
         /**

--- a/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/ToneMapper.java
@@ -109,7 +109,6 @@ public class ToneMapper {
      * The tone mapping curve is defined by 5 parameters:
      * <ul>
      * <li>contrast: controls the contrast of the curve</li>
-     * <li>shoulder: controls the shoulder of the curve, i.e. how quickly scene
      * referred values map to output white</li>
      * <li>midGrayIn: sets the input middle gray</li>
      * <li>midGrayOut: sets the output middle gray</li>
@@ -123,10 +122,9 @@ public class ToneMapper {
          * the {@link ACESLegacy} tone mapper. The default values are:
          *
          * <ul>
-         * <li>contrast = 1.585f</li>
-         * <li>shoulder = 0.5f</li>
+         * <li>contrast = 1.55f</li>
          * <li>midGrayIn = 0.18f</li>
-         * <li>midGrayOut = 0.268f</li>
+         * <li>midGrayOut = 0.215f</li>
          * <li>hdrMax = 10.0f</li>
          * </ul>
          */
@@ -139,16 +137,14 @@ public class ToneMapper {
          *
          * @param contrast: controls the contrast of the curve, must be > 0.0, values
          *                  in the range 0.5..2.0 are recommended.
-         * @param shoulder: controls the shoulder of the curve, i.e. how quickly scene
-         *                  referred values map to output white, between 0.0 and 1.0.
          * @param midGrayIn: sets the input middle gray, between 0.0 and 1.0.
          * @param midGrayOut: sets the output middle gray, between 0.0 and 1.0.
          * @param hdrMax: defines the maximum input value that will be mapped to
          *                output white. Must be >= 1.0.
          */
         public Generic(
-                float contrast, float shoulder, float midGrayIn, float midGrayOut, float hdrMax) {
-            super(nCreateGenericToneMapper(contrast, shoulder, midGrayIn, midGrayOut, hdrMax));
+                float contrast, float midGrayIn, float midGrayOut, float hdrMax) {
+            super(nCreateGenericToneMapper(contrast, midGrayIn, midGrayOut, hdrMax));
         }
 
         /** Returns the contrast of the curve as a strictly positive value. */
@@ -159,16 +155,6 @@ public class ToneMapper {
         /** Sets the contrast of the curve, must be > 0.0, values in the range 0.5..2.0 are recommended. */
         public void setContrast(float contrast) {
             nGenericSetContrast(getNativeObject(), contrast);
-        }
-
-        /** Returns how fast scene referred values map to output white as a value between 0.0 and 1.0. */
-        public float getShoulder() {
-            return nGenericGetShoulder(getNativeObject());
-        }
-
-        /** Sets how quickly scene referred values map to output white, between 0.0 and 1.0. */
-        public void setShoulder(float shoulder) {
-            nGenericSetShoulder(getNativeObject(), shoulder);
         }
 
         /** Returns the middle gray point for input values as a value between 0.0 and 1.0. */
@@ -209,17 +195,15 @@ public class ToneMapper {
     private static native long nCreateACESLegacyToneMapper();
     private static native long nCreateFilmicToneMapper();
     private static native long nCreateGenericToneMapper(
-            float contrast, float shoulder, float midGrayIn, float midGrayOut, float hdrMax);
+            float contrast, float midGrayIn, float midGrayOut, float hdrMax);
 
     // Generic tone mappper
     private static native float nGenericGetContrast(long nativeObject);
-    private static native float nGenericGetShoulder(long nativeObject);
     private static native float nGenericGetMidGrayIn(long nativeObject);
     private static native float nGenericGetMidGrayOut(long nativeObject);
     private static native float nGenericGetHdrMax(long nativeObject);
 
     private static native void nGenericSetContrast(long nativeObject, float contrast);
-    private static native void nGenericSetShoulder(long nativeObject, float shoulder);
     private static native void nGenericSetMidGrayIn(long nativeObject, float midGrayIn);
     private static native void nGenericSetMidGrayOut(long nativeObject, float midGrayOut);
     private static native void nGenericSetHdrMax(long nativeObject, float hdrMax);

--- a/filament/include/filament/ToneMapper.h
+++ b/filament/include/filament/ToneMapper.h
@@ -123,8 +123,6 @@ struct UTILS_PUBLIC FilmicToneMapper final : public ToneMapper {
  *
  * The tone mapping curve is defined by 5 parameters:
  * - contrast: controls the contrast of the curve
- * - shoulder: controls the shoulder of the curve, i.e. how quickly scene
- *             referred values map to output white
  * - midGrayIn: sets the input middle gray
  * - midGrayOut: sets the output middle gray
  * - hdrMax: defines the maximum input value that will be mapped to
@@ -138,18 +136,15 @@ struct UTILS_PUBLIC GenericToneMapper final : public ToneMapper {
      *
      * @param contrast: controls the contrast of the curve, must be > 0.0, values
      *                  in the range 0.5..2.0 are recommended.
-     * @param shoulder: controls the shoulder of the curve, i.e. how quickly scene
-     *                  referred values map to output white, between 0.0 and 1.0.
      * @param midGrayIn: sets the input middle gray, between 0.0 and 1.0.
      * @param midGrayOut: sets the output middle gray, between 0.0 and 1.0.
      * @param hdrMax: defines the maximum input value that will be mapped to
      *                output white. Must be >= 1.0.
      */
     explicit GenericToneMapper(
-            float contrast = 1.585f,
-            float shoulder = 0.5f,
+            float contrast = 1.55f,
             float midGrayIn = 0.18f,
-            float midGrayOut = 0.268f,
+            float midGrayOut = 0.215f,
             float hdrMax = 10.0f
     ) noexcept;
     ~GenericToneMapper() noexcept final;
@@ -178,9 +173,6 @@ struct UTILS_PUBLIC GenericToneMapper final : public ToneMapper {
 
     /** Sets the contrast of the curve, must be > 0.0, values in the range 0.5..2.0 are recommended. */
     void setContrast(float contrast) noexcept;
-
-    /** Sets how quickly scene referred values map to output white, between 0.0 and 1.0. */
-    void setShoulder(float shoulder) noexcept;
 
     /** Sets the input middle gray, between 0.0 and 1.0. */
     void setMidGrayIn(float midGrayIn) noexcept;

--- a/filament/src/ColorGrading.cpp
+++ b/filament/src/ColorGrading.cpp
@@ -400,7 +400,7 @@ constexpr mat3f adaptationTransform(float2 whiteBalance) noexcept {
     float y = chromaticityCoordinateIlluminantD(x) + t * 0.066f;
 
     float3 lms = XYZ_to_CIECAT16 * xyY_to_XYZ({x, y, 1.0f});
-    return LMS_CAT16_to_REC2020 * mat3f{ILLUMINANT_D65_LMS_CAT16 / lms} * REC2020_to_LMS_CAT16;
+    return LMS_CAT16_to_Rec2020 * mat3f{ILLUMINANT_D65_LMS_CAT16 / lms} * Rec2020_to_LMS_CAT16;
 }
 
 UTILS_ALWAYS_INLINE
@@ -575,21 +575,21 @@ static mat3f selectColorGradingTransformIn(ColorGrading::ToneMapping toneMapping
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
         return mat3f{};
     }
-    return sRGB_to_REC2020;
+    return sRGB_to_Rec2020;
 }
 
 static mat3f selectColorGradingTransformOut(ColorGrading::ToneMapping toneMapping) noexcept {
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
         return mat3f{};
     }
-    return REC2020_to_sRGB;
+    return Rec2020_to_sRGB;
 }
 
 static float3 selectColorGradingLuminance(ColorGrading::ToneMapping toneMapping) noexcept {
     if (toneMapping == ColorGrading::ToneMapping::FILMIC) {
-        return LUMINANCE_REC709;
+        return LUMINANCE_Rec709;
     }
-    return LUMINANCE_REC2020;
+    return LUMINANCE_Rec2020;
 }
 #pragma clang diagnostic pop
 

--- a/filament/src/ColorSpace.h
+++ b/filament/src/ColorSpace.h
@@ -52,13 +52,13 @@ constexpr mat3f sRGB_to_XYZ{
      0.1804380f,  0.0721750f,  0.9503040f
 };
 
-constexpr mat3f REC2020_to_XYZ{
+constexpr mat3f Rec2020_to_XYZ{
      0.6369530f,  0.2626983f,  0.0000000f,
      0.1446169f,  0.6780088f,  0.0280731f,
      0.1688558f,  0.0592929f,  1.0608272f
 };
 
-constexpr mat3f XYZ_to_REC2020{
+constexpr mat3f XYZ_to_Rec2020{
     1.7166634f,  -0.6666738f,  0.0176425f,
     -0.3556733f,  1.6164557f, -0.0427770f,
     -0.2533681f,  0.0157683f,  0.9422433f
@@ -130,6 +130,18 @@ constexpr mat3f sRGB_to_OkLab_LMS{
      0.0514459929f, 0.1073969566f, 0.6299787005f
 };
 
+constexpr mat3f XYZ_to_OkLab_LMS{
+     0.8189330101f, 0.3618667424f, -0.1288597137f,
+     0.0329845436f, 0.9293118715f,  0.0361456387f,
+     0.0482003018f, 0.2643662691f,  0.6338517070f
+};
+
+constexpr mat3f OkLab_LMS_to_XYZ{
+     1.227014f, -0.557800f,  0.281256f,
+    -0.040580f,  1.112257f, -0.071677f,
+    -0.076381f, -0.421482f,  1.586163f
+};
+
 constexpr mat3f OkLab_LMS_to_OkLab{
      0.2104542553f,  1.9779984951f,  0.0259040371f,
      0.7936177850f, -2.4285922050f,  0.7827717662f,
@@ -148,21 +160,25 @@ constexpr mat3f OkLab_LMS_to_sRGB{
      0.2309699292f, -0.3413193965f,  1.7076147010f
 };
 
-constexpr mat3f sRGB_to_REC2020 = XYZ_to_REC2020 * sRGB_to_XYZ;
+constexpr mat3f sRGB_to_Rec2020 = XYZ_to_Rec2020 * sRGB_to_XYZ;
 
-constexpr mat3f REC2020_to_sRGB = XYZ_to_sRGB * REC2020_to_XYZ;
+constexpr mat3f Rec2020_to_sRGB = XYZ_to_sRGB * Rec2020_to_XYZ;
 
 constexpr mat3f sRGB_to_LMS_CAT16 = XYZ_to_CIECAT16 * sRGB_to_XYZ;
 
 constexpr mat3f LMS_CAT16_to_sRGB = XYZ_to_sRGB * CIECAT16_to_XYZ;
 
-constexpr mat3f REC2020_to_LMS_CAT16 = XYZ_to_CIECAT16 * REC2020_to_XYZ;
+constexpr mat3f Rec2020_to_LMS_CAT16 = XYZ_to_CIECAT16 * Rec2020_to_XYZ;
 
-constexpr mat3f LMS_CAT16_to_REC2020 = XYZ_to_REC2020 * CIECAT16_to_XYZ;
+constexpr mat3f LMS_CAT16_to_Rec2020 = XYZ_to_Rec2020 * CIECAT16_to_XYZ;
 
-constexpr mat3f REC2020_to_AP0 = AP1_to_AP0 * XYZ_to_AP1 * REC2020_to_XYZ;
+constexpr mat3f Rec2020_to_AP0 = AP1_to_AP0 * XYZ_to_AP1 * Rec2020_to_XYZ;
 
-constexpr mat3f AP1_to_REC2020 = XYZ_to_REC2020 * AP1_to_XYZ;
+constexpr mat3f AP1_to_Rec2020 = XYZ_to_Rec2020 * AP1_to_XYZ;
+
+constexpr mat3f Rec2020_to_OkLab_LMS = XYZ_to_OkLab_LMS * Rec2020_to_XYZ;
+
+constexpr mat3f OkLab_LMS_to_Rec2020 = XYZ_to_Rec2020 * OkLab_LMS_to_XYZ;
 
 //------------------------------------------------------------------------------
 // Constants
@@ -175,17 +191,17 @@ constexpr float3 ILLUMINANT_D65_xyY{0.31271f, 0.32902f, 1.0f};
 // Result of: XYZ_to_CIECAT16 * xyY_to_XYZ(ILLUMINANT_D65_xyY);
 constexpr float3 ILLUMINANT_D65_LMS_CAT16{0.975533f, 1.016483f, 1.084837f};
 
-// RGB to luminance coefficients for Rec.2020, from REC2020_to_XYZ
-constexpr float3 LUMINANCE_REC2020{0.2627002f, 0.6779981f, 0.0593017f};
+// RGB to luminance coefficients for Rec.2020, from Rec2020_to_XYZ
+constexpr float3 LUMINANCE_Rec2020{0.2627002f, 0.6779981f, 0.0593017f};
 
 // RGB to luminance coefficients for ACEScg (AP1), from AP1_to_XYZ
 constexpr float3 LUMINANCE_AP1{0.272229f, 0.674082f, 0.0536895f};
 
 // RGB to luminance coefficients for Rec.709, from sRGB_to_XYZ
-constexpr float3 LUMINANCE_REC709{0.2126730f, 0.7151520f, 0.0721750f};
+constexpr float3 LUMINANCE_Rec709{0.2126730f, 0.7151520f, 0.0721750f};
 
 // RGB to luminance coefficients for Rec.709 with HK-like weighting
-constexpr float3 LUMINANCE_HK_REC709{0.13913043f, 0.73043478f, 0.13043478f};
+constexpr float3 LUMINANCE_HK_Rec709{0.13913043f, 0.73043478f, 0.13043478f};
 
 constexpr float MIDDLE_GRAY_ACEScg = 0.18f;
 
@@ -212,19 +228,27 @@ inline constexpr XYZ xyY_to_XYZ(xyY v) noexcept {
 }
 
 inline constexpr xyY XYZ_to_xyY(XYZ v) noexcept {
-    return float3(v.xy / max(v.x + v.y + v.z, 1e-5f), v.y);
-}
-
-inline float3 sRGB_to_OkLab(float3 x) noexcept {
-    return OkLab_LMS_to_OkLab * cbrt(sRGB_to_OkLab_LMS * x);
+    return {v.xy / max(v.x + v.y + v.z, 1e-5f), v.y};
 }
 
 inline constexpr float3 pow3(float3 x) noexcept {
     return x * x * x;
 }
 
+inline float3 sRGB_to_OkLab(float3 x) noexcept {
+    return OkLab_LMS_to_OkLab * cbrt(sRGB_to_OkLab_LMS * x);
+}
+
+inline float3 Rec2020_to_OkLab(float3 x) noexcept {
+    return OkLab_LMS_to_OkLab * cbrt(Rec2020_to_OkLab_LMS * x);
+}
+
 inline float3 OkLab_to_sRGB(float3 x) noexcept {
     return OkLab_LMS_to_sRGB * pow3(OkLab_to_OkLab_LMS * x);
+}
+
+inline float3 OkLab_to_Rec2020(float3 x) noexcept {
+    return OkLab_LMS_to_Rec2020 * pow3(OkLab_to_OkLab_LMS * x);
 }
 
 //------------------------------------------------------------------------------

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -477,6 +477,13 @@ private:
         return v;
     }
 
+    friend inline VECTOR<T> MATH_PURE sign(VECTOR<T> v) {
+        for (size_t i = 0; i < v.size(); i++) {
+            v[i] = std::copysign(T(1), v[i]);
+        }
+        return v;
+    }
+
     friend inline VECTOR<T> MATH_PURE pow(VECTOR<T> v, T p) {
         for (size_t i = 0; i < v.size(); i++) {
             v[i] = std::pow(v[i], p);

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -105,10 +105,9 @@ private:
 };
 
 struct GenericToneMapperSettings {
-    float contrast = 1.585f;
-    float shoulder = 0.5f;
+    float contrast = 1.55f;
     float midGrayIn = 0.18f;
-    float midGrayOut = 0.268f;
+    float midGrayOut = 0.215f;
     float hdrMax = 10.0f;
     bool operator!=(const GenericToneMapperSettings &rhs) const { return !(rhs == *this); }
     bool operator==(const GenericToneMapperSettings &rhs) const;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -336,8 +336,6 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, GenericT
         CHECK_KEY(tok);
         if (compare(tok, jsonChunk, "contrast") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->contrast);
-        } else if (compare(tok, jsonChunk, "shoulder") == 0) {
-            i = parse(tokens, i + 1, jsonChunk, &out->shoulder);
         } else if (compare(tok, jsonChunk, "midGrayIn") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->midGrayIn);
         } else if (compare(tok, jsonChunk, "midGrayOut") == 0) {
@@ -1101,7 +1099,6 @@ constexpr ToneMapper* createToneMapper(const ColorGradingSettings& settings) noe
         case ToneMapping::FILMIC: return new FilmicToneMapper;
         case ToneMapping::GENERIC: return new GenericToneMapper(
                     settings.genericToneMapper.contrast,
-                    settings.genericToneMapper.shoulder,
                     settings.genericToneMapper.midGrayIn,
                     settings.genericToneMapper.midGrayOut,
                     settings.genericToneMapper.hdrMax
@@ -1265,7 +1262,6 @@ static std::ostream& operator<<(std::ostream& out, const TemporalAntiAliasingOpt
 static std::ostream& operator<<(std::ostream& out, const GenericToneMapperSettings& in) {
     return out << "{\n"
        << "\"contrast\": " << (in.contrast) << ",\n"
-       << "\"shoulder\": " << (in.shoulder) << ",\n"
        << "\"midGrayIn\": " << (in.midGrayIn) << ",\n"
        << "\"midGrayOut\": " << (in.midGrayOut) << ",\n"
        << "\"hdrMax\": " << (in.hdrMax) << "\n"
@@ -1544,9 +1540,8 @@ static std::ostream& operator<<(std::ostream& out, const Settings& in) {
 }
 
 bool GenericToneMapperSettings::operator==(const GenericToneMapperSettings &rhs) const {
-    static_assert(sizeof(GenericToneMapperSettings) == 20, "Please update Settings.cpp");
+    static_assert(sizeof(GenericToneMapperSettings) == 16, "Please update Settings.cpp");
     return contrast == rhs.contrast &&
-           shoulder == rhs.shoulder &&
            midGrayIn == rhs.midGrayIn &&
            midGrayOut == rhs.midGrayOut &&
            hdrMax == rhs.hdrMax;
@@ -1555,7 +1550,7 @@ bool GenericToneMapperSettings::operator==(const GenericToneMapperSettings &rhs)
 bool ColorGradingSettings::operator==(const ColorGradingSettings &rhs) const {
     // If you had to fix the following codeline, then you likely also need to update the
     // implementation of operator==.
-    static_assert(sizeof(ColorGradingSettings) == 232, "Please update Settings.cpp");
+    static_assert(sizeof(ColorGradingSettings) == 228, "Please update Settings.cpp");
     return enabled == rhs.enabled &&
             quality == rhs.quality &&
             toneMapping == rhs.toneMapping &&

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -137,7 +137,6 @@ static void computeToneMapPlot(ColorGradingSettings& settings, float* plot) {
         case ToneMapping::GENERIC:
             mapper = new GenericToneMapper(
                     settings.genericToneMapper.contrast,
-                    settings.genericToneMapper.shoulder,
                     settings.genericToneMapper.midGrayIn,
                     settings.genericToneMapper.midGrayOut,
                     settings.genericToneMapper.hdrMax
@@ -196,8 +195,7 @@ static void colorGradingUI(Settings& settings, float* rangePlot, float* curvePlo
         if (colorGrading.toneMapping == ToneMapping::GENERIC) {
             if (ImGui::CollapsingHeader("Tonemap parameters")) {
                 GenericToneMapperSettings& generic = colorGrading.genericToneMapper;
-                ImGui::SliderFloat("Contrast##genericToneMapper", &generic.contrast, 1e-5f, 3.0f);
-                ImGui::SliderFloat("Shoulder##genericToneMapper", &generic.shoulder, 0.0f, 1.0f);
+                ImGui::SliderFloat("Contrast##genericToneMapper", &generic.contrast, 1e-5f, 8.0f);
                 ImGui::SliderFloat("Mid-gray in##genericToneMapper", &generic.midGrayIn, 0.0f, 1.0f);
                 ImGui::SliderFloat("Mid-gray out##genericToneMapper", &generic.midGrayOut, 0.0f, 1.0f);
                 ImGui::SliderFloat("HDR max", &generic.hdrMax, 1.0f, 64.0f);

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -195,7 +195,7 @@ static void colorGradingUI(Settings& settings, float* rangePlot, float* curvePlo
         if (colorGrading.toneMapping == ToneMapping::GENERIC) {
             if (ImGui::CollapsingHeader("Tonemap parameters")) {
                 GenericToneMapperSettings& generic = colorGrading.genericToneMapper;
-                ImGui::SliderFloat("Contrast##genericToneMapper", &generic.contrast, 1e-5f, 8.0f);
+                ImGui::SliderFloat("Contrast##genericToneMapper", &generic.contrast, 1e-5f, 3.0f);
                 ImGui::SliderFloat("Mid-gray in##genericToneMapper", &generic.midGrayIn, 0.0f, 1.0f);
                 ImGui::SliderFloat("Mid-gray out##genericToneMapper", &generic.midGrayOut, 0.0f, 1.0f);
                 ImGui::SliderFloat("HDR max", &generic.hdrMax, 1.0f, 64.0f);

--- a/libs/viewer/tests/test_settings.cpp
+++ b/libs/viewer/tests/test_settings.cpp
@@ -52,7 +52,6 @@ static const char* JSON_TEST_DEFAULTS = R"TXT(
             "toneMapping": "ACES_LEGACY",
             "genericToneMapper": {
                 "contrast": 1.0,
-                "shoulder": 1.0,
                 "midGrayIn": 1.0,
                 "midGrayOut": 1.0,
                 "hdrMax": 16.0


### PR DESCRIPTION
This change removes the shoulder parameter which had inconsistent
behaviors. The new curve is simpler and designed to still match
by default the gray point and the contrast of ACES in a bright
surround.