### PR TITLE
Use NDK29 new (and experimental) way to access NDK functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,10 @@ if (ANDROID OR WEBGL OR IOS OR FILAMENT_LINUX_IS_MOBILE)
     set(IS_MOBILE_TARGET TRUE)
 endif()
 
+if (ANDROID)
+    add_definitions(-D__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__)
+endif()
+
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS AND NOT FILAMENT_LINUX_IS_MOBILE)
     set(IS_HOST_PLATFORM TRUE)
 endif()
@@ -295,7 +299,7 @@ if (LINUX)
 endif()
 
 if (ANDROID)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Werror=unguarded-availability")
 endif()
 
 if (CYGWIN)

--- a/filament/backend/src/android/ExternalTextureManagerAndroid.h
+++ b/filament/backend/src/android/ExternalTextureManagerAndroid.h
@@ -25,10 +25,6 @@
 #include <android/api-level.h>
 #include <android/hardware_buffer.h>
 
-#if __ANDROID_API__ >= 26
-#   define PLATFORM_HAS_HARDWAREBUFFER
-#endif
-
 namespace filament {
 
 /*
@@ -78,16 +74,9 @@ private:
 
     VirtualMachineEnv& mVm;
 
-#ifndef PLATFORM_HAS_HARDWAREBUFFER
-    // if we compile for API 26 (Oreo) and above, we're guaranteed to have AHardwareBuffer
-    // in all other cases, we need to get them at runtime.
-    int (*AHardwareBuffer_allocate)(const AHardwareBuffer_Desc*, AHardwareBuffer**) = nullptr;
-    void (*AHardwareBuffer_release)(AHardwareBuffer*) = nullptr;
-
     jclass mGraphicBufferClass = nullptr;
     jmethodID mGraphicBuffer_nCreateGraphicBuffer = nullptr;
     jmethodID mGraphicBuffer_nDestroyGraphicBuffer = nullptr;
-#endif
 };
 
 

--- a/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
+++ b/filament/backend/src/opengl/platforms/ExternalStreamManagerAndroid.h
@@ -84,13 +84,6 @@ private:
     jmethodID mSurfaceTextureClass_getTimestamp{};
     jmethodID mSurfaceTextureClass_attachToGLContext{};
     jmethodID mSurfaceTextureClass_detachFromGLContext{};
-
-    ASurfaceTexture* (*ASurfaceTexture_fromSurfaceTexture)(JNIEnv*, jobject){};
-    void (*ASurfaceTexture_release)(ASurfaceTexture*){};
-    int  (*ASurfaceTexture_attachToGLContext)(ASurfaceTexture*, uint32_t){};
-    int  (*ASurfaceTexture_detachFromGLContext)(ASurfaceTexture*){};
-    int  (*ASurfaceTexture_updateTexImage)(ASurfaceTexture*){};
-    int64_t (*ASurfaceTexture_getTimestamp)(ASurfaceTexture*){};   // available since api 28
 };
 
 } // namespace filament

--- a/third_party/spirv-cross/spirv_glsl.cpp
+++ b/third_party/spirv-cross/spirv_glsl.cpp
@@ -176,11 +176,23 @@ void CompilerGLSL::init()
 	const struct lconv *conv = localeconv();
 	if (conv && conv->decimal_point)
 		current_locale_radix_character = *conv->decimal_point;
-#elif defined(__ANDROID__) && __ANDROID_API__ < 26
-	// nl_langinfo is not supported on this platform, fall back to the worse alternative.
-	const struct lconv *conv = localeconv();
-	if (conv && conv->decimal_point)
-		current_locale_radix_character = *conv->decimal_point;
+#elif defined(__ANDROID__)
+    #if __ANDROID_API__ >= 26
+    // nl_langinfo is not even defined if __ANDROID_API__ is not at least 26!
+    if (__builtin_available(android 26, *)) {
+        // localeconv, the portable function is not MT safe ...
+        const char *decimal_point = nl_langinfo(RADIXCHAR);
+        if (decimal_point && *decimal_point != '\0')
+            current_locale_radix_character = *decimal_point;
+    } else
+    #endif
+    if (__builtin_available(android 21, *)) {
+        const struct lconv *conv = localeconv();
+        if (conv && conv->decimal_point)
+            current_locale_radix_character = *conv->decimal_point;
+    } else {
+        // we do nothing
+    }
 #else
 	// localeconv, the portable function is not MT safe ...
 	const char *decimal_point = nl_langinfo(RADIXCHAR);


### PR DESCRIPTION
This uses compile time guarded calls to weak symbols, and allows us to
call NDK APIs without having to dlsym() them.