### PR TITLE
Fix, assertion with shadowReceiver = false and VSM

### DIFF
--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -185,6 +185,10 @@ namespace filament {
             if (isValidDepthVariant(variantKey)) {
                 return variantKey;
             }
+            // if shadow receiver is disabled, turn off VSM
+            if (!(variantKey & SHADOW_RECEIVER)) {
+                return variantKey & ~(VSM);
+            }
             // when the shading mode is unlit, remove all the lighting variants
             return isLit ? variantKey : (variantKey & UNLIT_MASK);
         }

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -187,7 +187,7 @@ namespace filament {
             }
             // if shadow receiver is disabled, turn off VSM
             if (!(variantKey & SHADOW_RECEIVER)) {
-                return variantKey & ~(VSM);
+                return variantKey & ~VSM;
             }
             // when the shading mode is unlit, remove all the lighting variants
             return isLit ? variantKey : (variantKey & UNLIT_MASK);

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -186,7 +186,7 @@ namespace filament {
                 return variantKey;
             }
             // if shadow receiver is disabled, turn off VSM
-            if (!(variantKey & SHADOW_RECEIVER)) {
+            if (isLit && !(variantKey & SHADOW_RECEIVER)) {
                 return variantKey & ~VSM;
             }
             // when the shading mode is unlit, remove all the lighting variants

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -586,8 +586,11 @@ void SimpleViewer::updateUserInterface() {
         }
         auto instance = rm.getInstance(entity);
         bool scaster = rm.isShadowCaster(instance);
+        bool sreceiver = rm.isShadowReceiver(instance);
         ImGui::Checkbox("casts shadows", &scaster);
         rm.setCastShadows(instance, scaster);
+        ImGui::Checkbox("receives shadows", &sreceiver);
+        rm.setReceiveShadows(instance, sreceiver);
         size_t numPrims = rm.getPrimitiveCount(instance);
         for (size_t prim = 0; prim < numPrims; ++prim) {
             const char* mname = rm.getMaterialInstanceAt(instance, prim)->getName();


### PR DESCRIPTION
When VSM is turned on but shadow receiver is turned off for a renderable, we're hitting an assertion:

```
reason: ../../filament/src/Material.cpp:366: failed assertion `!Variant::isReserved(variantKey)'
```

The variant in question is 0x41, which is a reserved variant:

```
//                      +-----+-----+-----+-----+-----+-----+-----+-----+
// Variant              |  0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |   128
//                      +-----+-----+-----+-----+-----+-----+-----+-----+
//  0x41                   0     1     0     0     0     0     0     1
```

It's reserved because it doesn't make sense to have shadows if the shadow receiver bit is off.

This variant should get filtered to 0x01. We were checking for this in `isValidStandardVariant`, but not accounting for it in `filterVariant`.

Fixes #5053
