### PR TITLE
improve structure pass performance when not used

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -317,7 +317,8 @@ void PostProcessManager::commitAndRender(FrameGraphResources::RenderPassInfo con
 // ------------------------------------------------------------------------------------------------
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
-        RenderPass const& pass, uint32_t width, uint32_t height,
+        RenderPass const& pass, uint8_t structureRenderFlags,
+        uint32_t width, uint32_t height,
         StructurePassConfig const& config) noexcept {
 
     const float scale = config.scale;
@@ -367,10 +368,13 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::structure(FrameGraph& fg,
                         .clearFlags = TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH
                 });
             },
-            [=](FrameGraphResources const& resources,
+            [=, renderPass = pass](FrameGraphResources const& resources,
                     auto const& data, DriverApi& driver) mutable {
                 auto out = resources.getRenderPassInfo();
-                pass.execute(resources.getPassName(), out.target, out.params);
+                renderPass.setRenderFlags(structureRenderFlags);
+                renderPass.appendCommands(RenderPass::CommandTypeFlags::SSAO);
+                renderPass.sortCommands();
+                renderPass.execute(resources.getPassName(), out.target, out.params);
             });
 
     auto depth = structurePass->depth;

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -70,7 +70,8 @@ public:
     // methods below are ordered relative to their position in the pipeline (as much as possible)
 
     // structure (depth) pass
-    FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg, RenderPass const& pass,
+    FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg,
+            RenderPass const& pass, uint8_t structureRenderFlags,
             uint32_t width, uint32_t height, StructurePassConfig const& config) noexcept;
 
     // SSAO

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -438,14 +438,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // Currently it consists of a simple depth pass.
     // This is normally used by SSAO and contact-shadows
 
-    // TODO: ideally this should be a FrameGraph pass to participate to automatic culling
-    RenderPass structurePass(pass);
-    structurePass.setRenderFlags(structureRenderFlags);
-    structurePass.appendCommands(RenderPass::CommandTypeFlags::SSAO);
-    structurePass.sortCommands();
-
     // TODO: the scaling should depends on all passes that need the structure pass
-    ppm.structure(fg, structurePass, svp.width, svp.height, {
+    ppm.structure(fg, pass, structureRenderFlags, svp.width, svp.height, {
             .scale = aoOptions.resolution,
             .picking = view.hasPicking()
     });
@@ -510,7 +504,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // --------------------------------------------------------------------------------------------
     // Color passes
 
-    // TODO: ideally this should be a FrameGraph pass to participate to automatic culling
+    // This one doesn't need to be a FrameGraph pass because it always happens by construction
+    // (i.e. it won't be culled, unless everything is culled), so no need to complexify things.
     pass.setRenderFlags(colorRenderFlags);
     pass.appendCommands(RenderPass::COLOR);
     pass.sortCommands();
@@ -549,7 +544,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     colorGradingConfigForColor.asSubpass = colorGradingConfigForColor.asSubpass && !taaOptions.enabled;
 
     if (colorGradingConfigForColor.asSubpass) {
-        // append colorgrading subpass after all other passes
+        // append color grading subpass after all other passes
         pass.appendCustomCommand(
                 RenderPass::Pass::BLENDED,
                 RenderPass::CustomCommand::EPILOG,


### PR DESCRIPTION
Move the command generation of the structure pass into its execute 
block, meaning that if the structure pass is culled, the command 
generation is now skipped too.