### PR TITLE
Reduce cascade of run-time warnings.

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1388,8 +1388,8 @@ void MetalDriver::enumerateSamplerGroups(
         }
         const auto* metalSamplerGroup = mContext->samplerBindings[samplerGroupIdx];
         if (!metalSamplerGroup) {
-            utils::slog.w << "Program has non-empty samplerGroup (index " << samplerGroupIdx <<
-                    ") but has not bound any samplers." << utils::io::endl;
+            // Do not emit warning here. For example this can arise when skinning is enabled
+            // and the morphing texture is unused.
             continue;
         }
         SamplerGroup* sb = metalSamplerGroup->sb.get();


### PR DESCRIPTION
The `uint8_t` here needs to be cast to an integer to be printed
correctly. Also these warnings seem to be quite common so we should
hide them in Release builds.

These warnings probably indicate an actual problem that I do not fully
understand yet.