### PR TITLE
allow a scene to have both transmission and reflection

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -168,38 +168,27 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOption
     s.aoBentNormals = options.enabled && options.bentNormals ? 1.0f : 0.0f;
 }
 
-void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset) noexcept {
+void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
+        float refractionLodOffset,
+        math::mat4f const& historyProjection,
+        math::mat4f const& projectToPixelMatrix,
+        ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
+
     mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
         .filterMag = SamplerMagFilter::LINEAR,
         .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
     });
-    auto& s = mPerViewUb.edit();
-    s.refractionLodOffset = refractionLodOffset;
-}
 
-void PerViewUniforms::prepareSSReflections(TextureHandle ssr, math::mat4f const& historyProjection,
-        math::mat4f const& projectToPixelMatrix,
-        ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
-    mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
-            .filterMag = SamplerMagFilter::LINEAR,
-            .filterMin = SamplerMinFilter::LINEAR
-    });
     auto& s = mPerViewUb.edit();
+
+    s.refractionLodOffset = refractionLodOffset;
+
     s.ssrReprojection = historyProjection;
     s.ssrProjectToPixelMatrix = projectToPixelMatrix;
     s.ssrThickness = ssrOptions.thickness;
     s.ssrBias = ssrOptions.bias;
     s.ssrDistance = ssrOptions.maxDistance;
     s.ssrStride = ssrOptions.stride;
-}
-
-void PerViewUniforms::disableSSReflections() noexcept {
-    // We must bind a placeholder texture, even if reflections are disabled, to avoid a
-    // "no texture unit bound" warning.
-    Handle<backend::HwTexture> placeholder = mEngine.getPostProcessManager().getOneTexture();
-    auto& s = mPerViewUb.edit();
-    mPerViewSb.setSampler(PerViewSib::SSR, placeholder, {});
-    s.ssrDistance = 0.0f;
 }
 
 void PerViewUniforms::prepareStructure(Handle<HwTexture> structure) noexcept {

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -72,11 +72,14 @@ public:
     void prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept;
     void prepareStructure(TextureHandle structure) noexcept;
     void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
-    void prepareSSR(TextureHandle ssr, float refractionLodOffset) noexcept;
-    void prepareSSReflections(TextureHandle ssr, math::mat4f const& historyProjection,
+
+    // screen-space reflection and/or refraction (SSR)
+    void prepareSSR(TextureHandle ssr,
+            float refractionLodOffset,
+            math::mat4f const& historyProjection,
             math::mat4f const& projectToPixelMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
-    void disableSSReflections() noexcept;
+
     void prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,
             VsmShadowOptions const& options) noexcept;
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -813,6 +813,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
 
         config.refractionLodOffset = refractionLodOffset;
         config.clearFlags = TargetBufferFlags::NONE;
+        config.hasScreenSpaceReflections = false;
         output = colorPass(fg, "Color Pass (transparent)",
                 desc, config, colorGradingConfig, translucentPass, view);
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -657,22 +657,11 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
     mPerViewUniforms.prepareSSAO(ssao, mAmbientOcclusionOptions);
 }
 
-void FView::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset) const noexcept {
-    // If screen-space refractions are enabled, make sure to disable screen-space reflections.
-    // disableSSReflections binds a dummy texture to light_ssr, but this is overridden by prepareSSR.
-    // TODO: support simultaneous screen-space refractions and reflections.
-    mPerViewUniforms.disableSSReflections();
-    mPerViewUniforms.prepareSSR(ssr, refractionLodOffset);
-}
-
-void FView::disableSSReflections() const noexcept {
-    mPerViewUniforms.disableSSReflections();
-}
-
-void FView::prepareSSReflections(backend::Handle<backend::HwTexture> ssr,
-        math::mat4f historyProjection, math::mat4f projectToPixelMatrix,
+void FView::prepareSSR(Handle <HwTexture> ssr, float refractionLodOffset,
+        mat4f const& historyProjection, mat4f const& projectToPixelMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
-    mPerViewUniforms.prepareSSReflections(ssr, historyProjection, projectToPixelMatrix, ssrOptions);
+    mPerViewUniforms.prepareSSR(ssr, refractionLodOffset,
+            historyProjection, projectToPixelMatrix, ssrOptions);
 }
 
 void FView::prepareStructure(Handle<HwTexture> structure) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -171,10 +171,8 @@ public:
             ArenaScope& arena, Viewport const& viewport) noexcept;
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
-    void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset) const noexcept;
-    void disableSSReflections() const noexcept;
-    void prepareSSReflections(backend::Handle<backend::HwTexture> ssr,
-            math::mat4f historyProjection, math::mat4f projectToPixelMatrix,
+    void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset,
+            math::mat4f const& historyProjection, math::mat4f const& projectToPixelMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
     void prepareShadow(backend::Handle<backend::HwTexture> structure) const noexcept;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -308,10 +308,9 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     auto specularAO = material.specularAOSet ? material.specularAO : defaultSpecularAO;
     CodeGenerator::generateDefine(fs, "SPECULAR_AMBIENT_OCCLUSION", uint32_t(specularAO));
 
-    // Currently, we only support either screen-space refractions or reflections.
-    // The HAS_REFRACTION/HAS_REFLECTIONS defines signify if refraction/reflections are supported by
-    // the material, yet only one technique will be selected at runtime.
-    // TODO: support simultaneous screen-space refractions and reflections.
+    // We only support both screen-space refractions and reflections at the same time.
+    // And the HAS_REFRACTION/HAS_REFLECTIONS defines signify if refraction/reflections are supported by
+    // the material.
 
     CodeGenerator::generateDefine(fs, "HAS_REFRACTION", material.refractionMode != RefractionMode::NONE);
     if (material.refractionMode != RefractionMode::NONE) {

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -540,29 +540,21 @@ void applyRefraction(
     vec3 Ft = prefilteredRadiance(ray.direction, perceptualRoughness) * frameUniforms.iblLuminance;
 #else
     vec3 Ft;
-#if defined(HAS_REFLECTIONS) && REFLECTION_MODE == REFLECTION_MODE_SCREEN_SPACE
-    if (frameUniforms.ssrDistance > 0.0f) {
-        // if screen-space reflections is enabled, we can't read from the screen-space buffer, so
-        // fall back to cubemap refractions
-        Ft = prefilteredRadiance(ray.direction, perceptualRoughness) * frameUniforms.iblLuminance;
-    } else
-#endif
-    {
-        // compute the point where the ray exits the medium, if needed
-        vec4 p = vec4(frameUniforms.clipFromWorldMatrix * vec4(ray.position, 1.0));
-        p.xy = uvToRenderTargetUV(p.xy * (0.5 / p.w) + 0.5);
 
-        // perceptualRoughness to LOD
-        // Empirical factor to compensate for the gaussian approximation of Dggx, chosen so
-        // cubemap and screen-space modes match at perceptualRoughness 0.125
-        // TODO: Remove this factor temporarily until we find a better solution
-        //       This overblurs many scenes and needs a more principled approach
-        // float tweakedPerceptualRoughness = perceptualRoughness * 1.74;
-        float tweakedPerceptualRoughness = perceptualRoughness;
-        float lod = max(0.0, 2.0 * log2(tweakedPerceptualRoughness) + frameUniforms.refractionLodOffset);
+    // compute the point where the ray exits the medium, if needed
+    vec4 p = vec4(frameUniforms.clipFromWorldMatrix * vec4(ray.position, 1.0));
+    p.xy = uvToRenderTargetUV(p.xy * (0.5 / p.w) + 0.5);
 
-        Ft = textureLod(light_ssr, p.xy, lod).rgb;
-    }
+    // perceptualRoughness to LOD
+    // Empirical factor to compensate for the gaussian approximation of Dggx, chosen so
+    // cubemap and screen-space modes match at perceptualRoughness 0.125
+    // TODO: Remove this factor temporarily until we find a better solution
+    //       This overblurs many scenes and needs a more principled approach
+    // float tweakedPerceptualRoughness = perceptualRoughness * 1.74;
+    float tweakedPerceptualRoughness = perceptualRoughness;
+    float lod = max(0.0, 2.0 * log2(tweakedPerceptualRoughness) + frameUniforms.refractionLodOffset);
+
+    Ft = textureLod(light_ssr, p.xy, lod).rgb;
 #endif
 
     // base color changes the amount of light passing through the boundary


### PR DESCRIPTION
what's not allowed at this point is an object which has both screen
space refraction and reflection.

this is accomplished by just always disabling screen-space reflections
for the translucent step of the refraction pass
![Screen Shot 2022-01-18 at 2 44 41 PM](https://user-images.githubusercontent.com/1240896/150030776-bba19770-fb9b-44f5-b8e5-084e97e49dc3.png)
.