### PR TITLE
Fixed VulkanTexture::copyBufferToImage for 2D texture arrays

### DIFF
--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -428,6 +428,10 @@ void VulkanTexture::copyBufferToImage(VkCommandBuffer cmd, VkBuffer buffer, VkIm
     region.imageSubresource.mipLevel = miplevel;
     region.imageSubresource.layerCount = 1;
     region.imageExtent = extent;
+    if (target == SamplerType::SAMPLER_2D_ARRAY) {      
+        region.imageExtent.depth = 1;      
+        region.imageSubresource.layerCount = depth;
+    }
     vkCmdCopyBufferToImage(cmd, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 }
 


### PR DESCRIPTION
2D array textures are initialized with .depth = 1 and layerCount = depth (see line 58 in VulkanTexture.cpp). By setting layerCount = 1 only the first layer was copied over, leaving the other layers uninitialized.