### PR TITLE
[GL backend] fix sampler binding bug

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -273,6 +273,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
         BlockInfo blockInfo = blockInfos[i];
         HwSamplerGroup const * const UTILS_RESTRICT hwsb = samplerBindings[blockInfo.binding];
         if (UTILS_UNLIKELY(!hwsb)) {
+            tmu += blockInfo.count + 1;
             continue;
         }
         SamplerGroup const& UTILS_RESTRICT sb = *(hwsb->sb);


### PR DESCRIPTION
When a program had an unused SamplerInterfaceBlock, other samplers
could be bound to the wrong TMU

Fixes #5088 which was exposed by #4999.