### PR TITLE
Simplify and optimize morphing

### DIFF
--- a/filament/src/MorphTargetBuffer.cpp
+++ b/filament/src/MorphTargetBuffer.cpp
@@ -95,20 +95,23 @@ static inline size_t getTangentIndex(size_t targetIndex) noexcept {
 }
 
 FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
-        : mSBuffer(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT),
-          mVertexCount(builder->mVertexCount),
+        : mVertexCount(builder->mVertexCount),
           mCount(builder->mCount) {
     FEngine::DriverApi& driver = engine.getDriverApi();
 
-    mSbHandle = driver.createSamplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
-    mTbHandle = driver.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1, TextureFormat::RGBA32F, 1,
-            getWidth(mVertexCount), getHeight(mVertexCount), getDepth(mCount),
+    // create buffer (here a texture) to store the morphing vertex data
+    mTbHandle = driver.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
+            TextureFormat::RGBA32F, 1,
+            getWidth(mVertexCount),
+            getHeight(mVertexCount),
+            getDepth(mCount),
             TextureUsage::DEFAULT);
 
-    SamplerParams samplerParams{};
-    samplerParams.filterMin = SamplerMinFilter::NEAREST;
-    samplerParams.filterMag = SamplerMagFilter::NEAREST;
-    mSBuffer.setSampler(PerRenderPrimitiveMorphingSib::TARGETS, mTbHandle, samplerParams);
+    // create and update sampler group
+    mSbHandle = driver.createSamplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
+    SamplerGroup samplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
+    samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::TARGETS, mTbHandle, {});
+    driver.updateSamplerGroup(mSbHandle, std::move(samplerGroup.toCommandStream()));
 }
 
 void FMorphTargetBuffer::terminate(FEngine& engine) {
@@ -184,13 +187,6 @@ void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex, math
     driver.update3DImage(mTbHandle, 0, 0, 0, getTangentIndex(targetIndex),
             getWidth(mVertexCount), getHeight(mVertexCount), 1,
             std::move(buffer));
-}
-
-void FMorphTargetBuffer::commit(FEngine& engine) const noexcept {
-    if (mSBuffer.isDirty()) {
-        FEngine::DriverApi& driver = engine.getDriverApi();
-        driver.updateSamplerGroup(mSbHandle, std::move(mSBuffer.toCommandStream()));
-    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -418,9 +418,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // of RenderPass::setCamera / RenderPass::setGeometry calls.
     view.updatePrimitivesLod(engine, cameraInfo,
             scene.getRenderableData(), view.getVisibleRenderables());
-    // updatePrimitivesMorphTargetBuffer must be run after updatePrimitivesLod.
-    view.updatePrimitivesMorphTargetBuffer(engine, cameraInfo,
-            scene.getRenderableData(), view.getVisibleRenderables());
 
     pass.setCamera(cameraInfo);
     pass.setGeometry(scene.getRenderableData(), view.getVisibleRenderables(), scene.getRenderableUBO());

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -264,8 +264,6 @@ void ShadowMapManager::render(FrameGraph& fg, FEngine& engine, backend::DriverAp
 
                     // updatePrimitivesLod must be run before RenderPass::appendCommands.
                     view.updatePrimitivesLod(engine, cameraInfo, scene->getRenderableData(), entry.range);
-                    // updatePrimitivesMorphTargetBuffer must be run after updatePrimitivesLod.
-                    view.updatePrimitivesMorphTargetBuffer(engine, cameraInfo, scene->getRenderableData(), entry.range);
 
                     // generate and sort the commands for rendering the shadow map
                     RenderPass entryPass(pass);

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -872,19 +872,6 @@ void FView::updatePrimitivesLod(FEngine& engine, const CameraInfo&,
     }
 }
 
-void FView::updatePrimitivesMorphTargetBuffer(FEngine& engine, const CameraInfo&,
-        FScene::RenderableSoa& renderableData, Range visible) noexcept {
-    for (uint32_t index : visible) {
-        Slice<FRenderPrimitive> primitives = renderableData.elementAt<FScene::PRIMITIVES>(index);
-        for (auto& primitive : primitives) {
-            auto morphTargetBuffer = primitive.getMorphTargetBuffer();
-            if (morphTargetBuffer) {
-                morphTargetBuffer->commit(engine);
-            }
-        }
-    }
-}
-
 void FView::renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi& driver,
         RenderPass const& pass) noexcept {
     mShadowMapManager.render(fg, engine, driver, pass, *this);

--- a/filament/src/details/MorphTargetBuffer.h
+++ b/filament/src/details/MorphTargetBuffer.h
@@ -52,13 +52,10 @@ private:
     friend class FView;
     friend class RenderPass;
 
-    void commit(FEngine& engine) const noexcept;
-
     inline backend::Handle<backend::HwSamplerGroup> getHwHandle() const noexcept { return mSbHandle; }
 
     backend::Handle<backend::HwSamplerGroup> mSbHandle;
     backend::Handle<backend::HwTexture> mTbHandle;
-    backend::SamplerGroup mSBuffer;
     size_t mVertexCount;
     size_t mCount;
 };

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -200,10 +200,6 @@ public:
             FEngine& engine, const CameraInfo& camera,
             FScene::RenderableSoa& renderableData, Range visible) noexcept;
 
-    void updatePrimitivesMorphTargetBuffer(
-            FEngine& engine, const CameraInfo&,
-            FScene::RenderableSoa& renderableData, Range visible) noexcept;
-
     void setShadowingEnabled(bool enabled) noexcept { mShadowingEnabled = enabled; }
 
     bool isShadowingEnabled() const noexcept { return mShadowingEnabled; }


### PR DESCRIPTION
There is no need to go through all primitive and call updateSamplerGroup,
because the SamplerGroup never changes -- it just hold the texture that
holds the data.