### PR TITLE
Vulkan: clean up image layout management.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -129,11 +129,9 @@ void VulkanBlitter::blitFast(VkImageAspectFlags aspect, VkFilter filter,
 
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
 
-
-    VkImageLayout srcLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    if (src.texture) {
-        srcLayout = mContext.getTextureLayout(src.texture->usage);
-    }
+    const VkImageLayout srcLayout = src.texture ?
+        getDefaultImageLayout(src.texture->usage) :
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     transitionImageLayout(cmdbuffer, {
         src.image,
@@ -172,7 +170,7 @@ void VulkanBlitter::blitFast(VkImageAspectFlags aspect, VkFilter filter,
     // Determine the desired texture layout for the destination while ensuring that the default
     // render target is supported, which has no associated texture.
     const VkImageLayout desiredLayout = dst.texture ?
-            mContext.getTextureLayout(dst.texture->usage) :
+            getDefaultImageLayout(dst.texture->usage) :
             mContext.currentSurface->getColor().layout;
 
     transitionImageLayout(cmdbuffer, blitterTransitionHelper({
@@ -267,7 +265,7 @@ void VulkanBlitter::blitSlowDepth(VkImageAspectFlags aspect, VkFilter filter,
     // BEGIN RENDER PASS
     // -----------------
 
-    const VkImageLayout layout = mContext.getTextureLayout(TextureUsage::DEPTH_ATTACHMENT);
+    const VkImageLayout layout = getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT);
 
     const VulkanFboCache::RenderPassKey rpkey = {
         .depthLayout = layout,

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -333,25 +333,6 @@ VkFormat VulkanContext::findSupportedFormat(utils::Slice<VkFormat> candidates,
     return VK_FORMAT_UNDEFINED;
 }
 
-VkImageLayout VulkanContext::getTextureLayout(TextureUsage usage) const {
-    // Filament sometimes samples from depth while it is bound to the current render target, (e.g.
-    // SSAO does this while depth writes are disabled) so let's keep it simple and use GENERAL for
-    // all depth textures.
-    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
-        return VK_IMAGE_LAYOUT_GENERAL;
-    }
-
-    // Filament sometimes samples from one miplevel while writing to another level in the same
-    // texture (e.g. bloom does this). Moreover we'd like to avoid lots of expensive layout
-    // transitions. So, keep it simple and use GENERAL for all color-attachable textures.
-    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
-        return VK_IMAGE_LAYOUT_GENERAL;
-    }
-
-    // Finally, the layout for an immutable texture is optimal read-only.
-    return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-}
-
 void VulkanContext::createEmptyTexture(VulkanStagePool& stagePool) {
     emptyTexture = new VulkanTexture(*this, SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1,

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -72,7 +72,6 @@ struct VulkanContext {
     uint32_t selectMemoryType(uint32_t flags, VkFlags reqs);
     VkFormat findSupportedFormat(utils::Slice<VkFormat> candidates, VkImageTiling tiling,
             VkFormatFeatureFlags features);
-    VkImageLayout getTextureLayout(TextureUsage usage) const;
     void createEmptyTexture(VulkanStagePool& stagePool);
 
     VkInstance instance;

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -138,16 +138,13 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
     // In Vulkan, the subpass desc specifies the layout to transition to at the start of the render
     // pass, and the attachment description specifies the layout to transition to at the end.
     // However we use render passes to cause layout transitions only when drawing directly into the
-    // swap chain. We keep our offscreen images in GENERAL layout, which is simple and prevents
-    // thrashing the layout. Note that pipeline barriers are more powerful than render passes for
-    // performing layout transitions, because they allow for per-miplevel transitions.
+    // swap chain.
     const bool discard = any(config.discardStart & TargetBufferFlags::COLOR);
     struct { VkImageLayout subpass, initial, final; } colorLayouts[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
     if (isSwapChain) {
         colorLayouts[0].subpass = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-        // It is legal to always use UNDEFINED for "initial", but we wish to avoid warnings
-        // when the load op is LOAD.
+        // Specifying UNDEFINED for "initial" can discard the existing data.
         colorLayouts[0].initial = discard ? VK_IMAGE_LAYOUT_UNDEFINED :
                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -105,7 +105,7 @@ static VulkanAttachment createAttachment(VulkanContext& context, VulkanAttachmen
         .view = {},
         .memory = {},
         .texture = spec.texture,
-        .layout = context.getTextureLayout(spec.texture->usage),
+        .layout = spec.texture->getVkLayout(spec.layer, spec.level),
         .level = spec.level,
         .layer = spec.layer
     };

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -289,6 +289,7 @@ void VulkanSwapChain::makePresentable() {
         return;
     }
     VulkanAttachment& swapContext = color[currentSwapIndex];
+    assert_invariant(swapContext.layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
     VkImageMemoryBarrier barrier {
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -311,7 +312,7 @@ void VulkanSwapChain::makePresentable() {
         .oldLayout = firstRenderPass ? VK_IMAGE_LAYOUT_UNDEFINED : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
 #endif
 
-        .newLayout = swapContext.layout,
+        .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
         .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
         .image = swapContext.image,

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -501,6 +501,38 @@ VkComponentMapping getSwizzleMap(TextureSwizzle swizzle[4]) {
     return map;
 }
 
+VkImageViewType getImageViewType(SamplerType target) {
+    switch (target) {
+        case SamplerType::SAMPLER_CUBEMAP:
+            return VK_IMAGE_VIEW_TYPE_CUBE;
+        case SamplerType::SAMPLER_2D_ARRAY:
+            return VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        case  SamplerType::SAMPLER_3D:
+            return VK_IMAGE_VIEW_TYPE_3D;
+        default:
+            return VK_IMAGE_VIEW_TYPE_2D;
+    }
+}
+
+VkImageLayout getDefaultImageLayout(TextureUsage usage) {
+    // Filament sometimes samples from depth while it is bound to the current render target, (e.g.
+    // SSAO does this while depth writes are disabled) so let's keep it simple and use GENERAL for
+    // all depth textures.
+    if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
+        return VK_IMAGE_LAYOUT_GENERAL;
+    }
+
+    // Filament sometimes samples from one miplevel while writing to another level in the same
+    // texture (e.g. bloom does this). Moreover we'd like to avoid lots of expensive layout
+    // transitions. So, keep it simple and use GENERAL for all color-attachable textures.
+    if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
+        return VK_IMAGE_LAYOUT_GENERAL;
+    }
+
+    // Finally, the layout for an immutable texture is optimal read-only.
+    return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+}
+
 void transitionImageLayout(VkCommandBuffer cmdbuffer, VulkanLayoutTransition transition) {
     if (transition.oldLayout == transition.newLayout) {
         return;
@@ -564,7 +596,7 @@ VulkanLayoutTransition textureTransitionHelper(VulkanLayoutTransition transition
             break;
 
             // We support PRESENT as a target layout to allow blitting from the swap chain.
-            // See also makeSwapChainPresentable().
+            // See also SwapChain::makePresentable().
         case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
         case VK_IMAGE_LAYOUT_PRESENT_SRC_KHR:
             transition.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -47,6 +47,9 @@ VkCullModeFlags getCullMode(CullingMode mode);
 VkFrontFace getFrontFace(bool inverseFrontFaces);
 PixelDataType getComponentType(VkFormat format);
 VkComponentMapping getSwizzleMap(TextureSwizzle swizzle[4]);
+VkImageViewType getImageViewType(SamplerType target);
+VkImageLayout getDefaultImageLayout(TextureUsage usage);
+
 void transitionImageLayout(VkCommandBuffer cmdbuffer, VulkanLayoutTransition transition);
 
 // Helper function for populating barrier fields based on the desired image layout.


### PR DESCRIPTION
This fixes validation errors and makes a first pass at simplification.
VulkanTexture now tracks image layout using RangeMap, which paves the
way for further simplification.