### PR TITLE
Vulkan now supports offsets when uploading texture data.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -340,7 +340,7 @@ void VulkanContext::createEmptyTexture(VulkanStagePool& stagePool) {
             TextureUsage::SUBPASS_INPUT, stagePool);
     uint32_t black = 0;
     PixelBufferDescriptor pbd(&black, 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
-    emptyTexture->update2DImage(pbd, 1, 1, 0);
+    emptyTexture->updateImage(pbd, 1, 1, 1, 0, 0, 0, 0);
 }
 
 } // namespace filament

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -865,8 +865,8 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
 void VulkanDriver::update2DImage(Handle<HwTexture> th,
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& data) {
-    assert_invariant(xoffset == 0 && yoffset == 0 && "Offsets not yet supported.");
-    handle_cast<VulkanTexture*>(th)->update2DImage(data, width, height, level);
+    handle_cast<VulkanTexture*>(th)->updateImage(data, width, height, 1,
+            xoffset, yoffset, 0, level);
     scheduleDestroy(std::move(data));
 }
 
@@ -879,8 +879,8 @@ void VulkanDriver::update3DImage(
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
         uint32_t width, uint32_t height, uint32_t depth,
         PixelBufferDescriptor&& data) {
-    assert_invariant(xoffset == 0 && yoffset == 0 && zoffset == 0 && "Offsets not yet supported.");
-    handle_cast<VulkanTexture*>(th)->update3DImage(data, width, height, depth, level);
+    handle_cast<VulkanTexture*>(th)->updateImage(data, width, height, depth,
+            xoffset, yoffset, zoffset, level);
     scheduleDestroy(std::move(data));
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -31,10 +31,12 @@ struct VulkanTexture : public HwTexture {
             TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
             TextureUsage usage, VulkanStagePool& stagePool, VkComponentMapping swizzle = {});
     ~VulkanTexture();
-    void update2DImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
-            int miplevel);
-    void update3DImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
-            uint32_t depth, int miplevel);
+
+    // Uploads data into a subregion of a 2D or 3D texture.
+    void updateImage(const PixelBufferDescriptor& data, uint32_t width, uint32_t height,
+            uint32_t depth, uint32_t xoffset, uint32_t yoffset, uint32_t zoffset, uint32_t miplevel);
+
+    // Uploads data into all 6 faces of a cubemap for a given miplevel.
     void updateCubeImage(const PixelBufferDescriptor& data, const FaceOffsets& faceOffsets,
             uint32_t miplevel);
 
@@ -63,16 +65,7 @@ private:
     // Gets or creates a cached VkImageView for a range of miplevels and array layers.
     VkImageView getImageView(VkImageSubresourceRange range);
 
-    // Issues a copy from a VkBuffer to a specified miplevel in a VkImage. The given width and
-    // height define a subregion within the miplevel.
-    void copyBufferToImage(VkCommandBuffer cmdbuffer, VkBuffer buffer, VkImage image,
-            uint32_t width, uint32_t height, uint32_t depth,
-            FaceOffsets const* faceOffsets, uint32_t miplevel);
-
-    void updateWithCopyBuffer(const PixelBufferDescriptor& hostData, uint32_t width,
-        uint32_t height, uint32_t depth, uint32_t miplevel);
-
-    void updateWithBlitImage(const PixelBufferDescriptor& hostData, uint32_t width,
+    void updateImageWithBlit(const PixelBufferDescriptor& hostData, uint32_t width,
         uint32_t height, uint32_t depth, uint32_t miplevel);
 
     VulkanTexture* mSidecarMSAA = nullptr;


### PR DESCRIPTION
This allows `MorphStressTest` to work on Vulkan.

However, `Horse` is still broken because it provides positions but not
tangents.  Separate fix for that is coming.

Partial fix for #5109.