### PR TITLE
Minor optimizations and documentation cleanup

### DIFF
--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -28,6 +28,9 @@ namespace filament {
 
 /**
  * MorphTargetBuffer is used to hold morphing data (positions and tangents).
+ *
+ * Both positions and tangents are required.
+ *
  */
 class UTILS_PUBLIC MorphTargetBuffer : public FilamentAPI {
     struct BuilderDetails;
@@ -76,28 +79,40 @@ public:
 
     /**
      * Updates the position of morph target at the index.
+     *
+     * Both positions and tangents must be provided.
+     *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
      * @param weights pointer to at least count positions
      * @param count number of position elements in positions
+     * @see setTangentsAt
      */
     void setPositionsAt(Engine& engine, size_t targetIndex, math::float3 const* positions, size_t count);
 
     /**
      * Updates the position of morph target at the index.
+     *
+     * Both positions and tangents must be provided.
+     *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
      * @param weights pointer to at least count positions
      * @param count number of position elements in positions
+     * @see setPositionsAt
      */
     void setPositionsAt(Engine& engine, size_t targetIndex, math::float4 const* positions, size_t count);
 
     /**
      * Updates the position of morph target at the index.
+     *
+     * Both positions and tangents must be provided.
+     *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
      * @param tangents pointer to at least count tangents
      * @param count number of tangent elements in tangents
+     * @see setTangentsAt
      */
     void setTangentsAt(Engine& engine, size_t targetIndex, math::short4 const* tangents, size_t count);
 

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -589,10 +589,9 @@ static void updateMorphWeights(FEngine& engine, backend::Handle<backend::HwBuffe
         float const* weights, size_t count) noexcept {
     auto& driver = engine.getDriverApi();
     auto size = sizeof(PerRenderableMorphingUib);
-    auto* UTILS_RESTRICT out = (PerRenderableMorphingUib*)driver.allocate(size);
-    memset(out, 0, size);
+    auto* UTILS_RESTRICT out = driver.allocatePod<PerRenderableMorphingUib>(1);
     std::transform(weights, weights + count, out->weights,
-            [](float value) { return float4(value); });
+            [](float value) { return float4(value, 0, 0, 0); });
     driver.updateBufferObject(handle, { out, size }, 0);
 }
 

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -79,7 +79,7 @@ void morphPosition(inout vec4 p) {
     ivec3 texcoord = ivec3(getVertexIndex() % MAX_MORPH_TARGET_BUFFER_WIDTH, getVertexIndex() / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
     for (uint i = 0u; i < objectUniforms.morphTargetCount; ++i) {
         texcoord.z = int(i) * 2 + 0;
-        p += morphingUniforms.weights[i] * texelFetch(morphing_targets, texcoord, 0);
+        p += morphingUniforms.weights[i][0] * texelFetch(morphing_targets, texcoord, 0);
     }
 }
 
@@ -89,7 +89,7 @@ void morphNormal(inout vec3 n) {
         texcoord.z = int(i) * 2 + 1;
         vec3 normal;
         toTangentFrame(texelFetch(morphing_targets, texcoord, 0), normal);
-        n += morphingUniforms.weights[i].xyz * normal;
+        n += morphingUniforms.weights[i][0] * normal;
     }
 }
 #endif


### PR DESCRIPTION
- Document that both positions and tangents must be provided.
- Don't memset buffer before filling it
- Don't read 4 identical weights in shader