### PR TITLE
fix build android aar on Linux because of case sensitive

### DIFF
--- a/libs/utils/src/android/ThermalManager.cpp
+++ b/libs/utils/src/android/ThermalManager.cpp
@@ -16,7 +16,7 @@
 
 #include <utils/android/ThermalManager.h>
 
-#include <android/Thermal.h>
+#include <android/thermal.h>
 
 #include <utility>
 


### PR DESCRIPTION
"#include <android/Thermal.h>" will cause some errors when building aar on Linux,
the corrret answer is "#include <android/thermal.h>"
