### PR TITLE
WebGL: Support compile filament.wasm on Linux platform.

### DIFF
--- a/build/web/ci-common.sh
+++ b/build/web/ci-common.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
+if [ `uname` == "Linux" ];then
+    curl -OL https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-linux.zip
+    unzip -q ninja-linux.zip
+elif [ `uname` == "Darwin" ];then
+    curl -OL https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
+    unzip -q ninja-mac.zip
+else
+    echo "Unsupported OS"
+    exit 1
+fi
 
-curl -OL https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-mac.zip
-unzip -q ninja-mac.zip
 chmod +x ninja
 export PATH="$PWD:$PATH"
 


### PR DESCRIPTION
Now， Filament WebGL could  be compiled on MacOS. I add somethings in webgl/common-ci.sh scripts to support linux platform compile.