### PR TITLE
gltf_viewer: fix bad ReadPixels size in headless mode

### DIFF
--- a/libs/filamentapp/include/filamentapp/FilamentApp.h
+++ b/libs/filamentapp/include/filamentapp/FilamentApp.h
@@ -180,8 +180,10 @@ private:
         void configureCamerasForWindow();
         void fixupMouseCoordinatesForHdpi(ssize_t& x, ssize_t& y) const;
 
+        FilamentApp* const mFilamentApp = nullptr;
+        const bool mIsHeadless;
+
         SDL_Window* mWindow = nullptr;
-        FilamentApp* mFilamentApp = nullptr;
         filament::Renderer* mRenderer = nullptr;
         filament::Engine::Backend mBackend;
 

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -521,7 +521,7 @@ void FilamentApp::initSDL() {
 
 FilamentApp::Window::Window(FilamentApp* filamentApp,
         const Config& config, std::string title, size_t w, size_t h)
-        : mFilamentApp(filamentApp) {
+        : mFilamentApp(filamentApp), mIsHeadless(config.headless) {
     const int x = SDL_WINDOWPOS_CENTERED;
     const int y = SDL_WINDOWPOS_CENTERED;
     uint32_t windowFlags = SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI;
@@ -788,7 +788,7 @@ void FilamentApp::Window::configureCamerasForWindow() {
     float dpiScaleY = 1.0f;
 
     // If the app is not headless, query the window for its physical & virtual sizes.
-    if (mWindow) {
+    if (!mIsHeadless) {
         uint32_t width, height;
         SDL_GL_GetDrawableSize(mWindow, (int*) &width, (int*) &height);
         mWidth = (size_t) width;


### PR DESCRIPTION
This fixes the gltf_viewer automated testing mode, invoked via
`--batch=default --headless`.

ReadPixels was being issued with an out-of-bounds size on high DPI
platforms, which caused weird backend errors.

Since we create an invisible SDL window while in headless mode, the
presence of the SDL window does *not* indicate headless vs non-headless.

Partial fix for #5111