### PR TITLE
fix an out-of-bound access when setting morphing buffer

### DIFF
--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -88,7 +88,8 @@ public:
      * @param count number of position elements in positions
      * @see setTangentsAt
      */
-    void setPositionsAt(Engine& engine, size_t targetIndex, math::float3 const* positions, size_t count);
+    void setPositionsAt(Engine& engine, size_t targetIndex,
+            math::float3 const* positions, size_t count, size_t offset = 0);
 
     /**
      * Updates the position of morph target at the index.
@@ -101,7 +102,8 @@ public:
      * @param count number of position elements in positions
      * @see setPositionsAt
      */
-    void setPositionsAt(Engine& engine, size_t targetIndex, math::float4 const* positions, size_t count);
+    void setPositionsAt(Engine& engine, size_t targetIndex,
+            math::float4 const* positions, size_t count, size_t offset = 0);
 
     /**
      * Updates the position of morph target at the index.
@@ -114,7 +116,8 @@ public:
      * @param count number of tangent elements in tangents
      * @see setTangentsAt
      */
-    void setTangentsAt(Engine& engine, size_t targetIndex, math::short4 const* tangents, size_t count);
+    void setTangentsAt(Engine& engine, size_t targetIndex,
+            math::short4 const* tangents, size_t count, size_t offset = 0);
 
     /**
      * Returns the vertex count of this MorphTargetBuffer.

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -484,6 +484,7 @@ public:
      */
     void setMorphTargetBufferAt(Instance instance, uint8_t level, size_t primitiveIndex,
             MorphTargetBuffer* morphTargetBuffer, size_t offset, size_t count);
+
     void setMorphTargetBufferAt(Instance instance, uint8_t level, size_t primitiveIndex,
             MorphTargetBuffer* morphTargetBuffer, size_t count); //!< \overload
 

--- a/filament/src/details/MorphTargetBuffer.h
+++ b/filament/src/details/MorphTargetBuffer.h
@@ -42,9 +42,15 @@ public:
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    void setPositionsAt(FEngine& engine, size_t targetIndex, math::float3 const* positions, size_t count);
-    void setPositionsAt(FEngine& engine, size_t targetIndex, math::float4 const* positions, size_t count);
-    void setTangentsAt(FEngine& engine, size_t targetIndex, math::short4 const* tangents, size_t count);
+    void setPositionsAt(FEngine& engine, size_t targetIndex,
+            math::float3 const* positions, size_t count, size_t offset);
+
+    void setPositionsAt(FEngine& engine, size_t targetIndex,
+            math::float4 const* positions, size_t count, size_t offset);
+
+    void setTangentsAt(FEngine& engine, size_t targetIndex,
+            math::short4 const* tangents, size_t count, size_t offset);
+
     inline size_t getVertexCount() const noexcept { return mVertexCount; }
     inline size_t getCount() const noexcept { return mCount; }
 
@@ -54,7 +60,10 @@ private:
     friend class FView;
     friend class RenderPass;
 
-    void updatePositionsAt(FEngine& engine, size_t targetIndex, void* data, size_t size);
+    void updateDataAt(backend::DriverApi& driver, backend::Handle <backend::HwTexture> handle,
+            backend::PixelDataFormat format, backend::PixelDataType type, const char* out,
+            size_t elementSize, size_t targetIndex, size_t count, size_t offset);
+
     inline backend::Handle<backend::HwSamplerGroup> getHwHandle() const noexcept { return mSbHandle; }
 
     backend::Handle<backend::HwSamplerGroup> mSbHandle;


### PR DESCRIPTION
Because the morphing buffer is actually a texture, it's possible that
the last line is not a full-width line when updating the buffer.

Because textures are updated via a rectangle, it was possible to read
past the malloc'ed buffer during the update.

Moreover, because the count can be specified, we can't just blindly send
more "dummy" data. 

Finally, added an offset to match the skinning API, and in that case, 
the first line can also be incomplete.

We fix this by issuing up to 3 texture update calls if needed.

The java/js API update will come later.