### PR TITLE
Add missing include to Range.h

### DIFF
--- a/libs/utils/include/utils/Range.h
+++ b/libs/utils/include/utils/Range.h
@@ -19,6 +19,8 @@
 
 #include <stddef.h>
 
+#include <iterator>
+
 namespace utils {
 
 template<typename T>


### PR DESCRIPTION
Needed for `std::random_access_iterator_tag`.