### PR TITLE
A few screen space reflections improvements

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -187,7 +187,7 @@ void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
     s.ssrProjectToPixelMatrix = projectToPixelMatrix;
     s.ssrThickness = ssrOptions.thickness;
     s.ssrBias = ssrOptions.bias;
-    s.ssrDistance = ssrOptions.maxDistance;
+    s.ssrDistance = ssrOptions.enabled ? ssrOptions.maxDistance : 0.0f;
     s.ssrStride = ssrOptions.stride;
 }
 


### PR DESCRIPTION
- Make sure to disabled SSR when it's... disabled.

- Fade the reflection when the ray direction is towards de camera,
  where it will likely hit a back face

- Simplify the fading code, for near identical results.