### PR TITLE
Rewrite VulkanPipelineCache (without changing its API).

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -50,6 +50,7 @@ struct VulkanCommandBuffer {
     uint32_t index = 0;
 };
 
+// Allows classes to be notified after a new command buffer has been activated.
 class CommandBufferObserver {
 public:
     virtual void onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) = 0;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1826,7 +1826,11 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     mPipelineCache.bindScissor(cmdbuffer, scissor);
 
     // Bind a new pipeline if the pipeline state changed.
-    mPipelineCache.bindPipeline(cmdbuffer);
+    // If allocation failed, skip the draw call and bail. We do not emit an error since the
+    // validation layer will already do so.
+    if (!mPipelineCache.bindPipeline(cmdbuffer)) {
+        return;
+    }
 
     // Next bind the vertex buffers and index buffer. One potential performance improvement is to
     // avoid rebinding these if they are already bound, but since we do not (yet) support subranges

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 
 #include <utils/Log.h>
 #include <utils/Panic.h>
-#include <utils/trap.h>
 
 #include "VulkanConstants.h"
 #include "VulkanHandles.h"
@@ -66,11 +65,6 @@ static getPipelineLayoutKey(const Program::SamplerGroupInfo& samplerGroupInfo) n
 }
 
 VulkanPipelineCache::VulkanPipelineCache() : mDefaultRasterState(createDefaultRasterState()) {
-    markDirtyDescriptor();
-    markDirtyPipeline();
-    mDescriptorKey = {};
-    mPipelineKey = {};
-
     mDummyBufferWriteInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     mDummyBufferWriteInfo.pNext = nullptr;
     mDummyBufferWriteInfo.dstArrayElement = 0;
@@ -110,11 +104,10 @@ void VulkanPipelineCache::setDevice(VkDevice device, VmaAllocator allocator) {
     mAllocator = allocator;
     mDescriptorPool = createDescriptorPool(mDescriptorPoolSize);
 
-    // Next, create a small dummy UBO. Filament's fixed-sized binding arrays are nice because they
-    // allow us to track only 1 VkPipelineLayout object. However, we occasionally need to clear
-    // out an unused descriptor set slot. Since Vulkan does not allow specifying VK_NULL_HANDLE
-    // without the robustness2 extension, we are forced to clear out unused UBO slots using a dummy
-    // resource.
+    // Formulate some dummy objects and dummy descriptor info used only for clearing out unused
+    // bindings. This is especially crucial after a texture has been destroyed. Since core Vulkan
+    // does not allow specifying VK_NULL_HANDLE without the robustness2 extension, we are forced to
+    // bind dummy objects.
 
     VkBufferCreateInfo bufferInfo {
         .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
@@ -126,11 +119,6 @@ void VulkanPipelineCache::setDevice(VkDevice device, VmaAllocator allocator) {
 
     mDummyBufferInfo.buffer = mDummyBuffer;
     mDummyBufferInfo.range = bufferInfo.size;
-
-    // Formulate some dummy descriptor info used solely for clearing out unused bindings. This is
-    // especially crucial after a texture has been destroyed. Since core Vulkan does not allow
-    // specifying VK_NULL_HANDLE without the robustness2 extension, we are forced to use dummy
-    // resources for this.
     mDummySamplerInfo.imageLayout = mDummyTargetInfo.imageLayout;
 
     VkSamplerCreateInfo samplerInfo {
@@ -154,108 +142,106 @@ void VulkanPipelineCache::setDevice(VkDevice device, VmaAllocator allocator) {
 }
 
 bool VulkanPipelineCache::bindDescriptors(VkCommandBuffer cmdbuffer) noexcept {
-    VkDescriptorSet descriptors[VulkanPipelineCache::DESCRIPTOR_TYPE_COUNT];
-    bool bind = false, overflow = false;
-    getOrCreateDescriptors(descriptors, &bind, &overflow);
+    DescriptorMap::iterator descriptorIter = mDescriptorSets.find(mDescriptorRequirements);
 
-    if (overflow) {
+    // Check if the required descriptors are already bound.
+    if (DescEqual equals; UTILS_LIKELY(equals(mBoundDescriptor, mDescriptorRequirements))) {
+        assert_invariant(descriptorIter != mDescriptorSets.end());
+        descriptorIter.value().lastUsed = mCurrentTime;
+        return true;
+    }
+
+    // If a cached object exists, re-use it, otherwise create a new one.
+    DescriptorCacheEntry* cacheEntry = UTILS_LIKELY(descriptorIter != mDescriptorSets.end()) ?
+            &descriptorIter.value() : createDescriptorSets();
+
+    // If a descriptor set overflow occurred, allow higher levels to handle it gracefully.
+    assert_invariant(cacheEntry != nullptr);
+    if (UTILS_UNLIKELY(cacheEntry == nullptr)) {
         return false;
     }
-    if (bind) {
-        LayoutBundle* layout = getOrCreatePipelineLayout();
-        vkCmdBindDescriptorSets(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                layout->pipelineLayout, 0, VulkanPipelineCache::DESCRIPTOR_TYPE_COUNT,
-                descriptors, 0, nullptr);
-    }
+
+    cacheEntry->lastUsed = mCurrentTime;
+    mBoundDescriptor = mDescriptorRequirements;
+
+    vkCmdBindDescriptorSets(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
+            getOrCreatePipelineLayout()->handle, 0, VulkanPipelineCache::DESCRIPTOR_TYPE_COUNT,
+            cacheEntry->handles.data(), 0, nullptr);
+
     return true;
 }
 
-void VulkanPipelineCache::bindPipeline(VkCommandBuffer cmdbuffer) noexcept {
-    VkPipeline pipeline;
-    if (getOrCreatePipeline(&pipeline)) {
-        vkCmdBindPipeline(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+bool VulkanPipelineCache::bindPipeline(VkCommandBuffer cmdbuffer) noexcept {
+    PipelineMap::iterator pipelineIter = mPipelines.find(mPipelineRequirements);
+
+    // Check if the required pipeline is already bound.
+    if (PipelineEqual equals; UTILS_LIKELY(equals(mBoundPipeline, mPipelineRequirements))) {
+        assert_invariant(pipelineIter != mPipelines.end());
+        pipelineIter.value().lastUsed = mCurrentTime;
+        return true;
     }
+
+    // If a cached object exists, re-use it, otherwise create a new one.
+    PipelineCacheEntry* cacheEntry = UTILS_LIKELY(pipelineIter != mPipelines.end()) ?
+            &pipelineIter.value() : createPipeline();
+
+    // If an error occurred, allow higher levels to handle it gracefully.
+    assert_invariant(cacheEntry != nullptr);
+    if (UTILS_UNLIKELY(cacheEntry == nullptr)) {
+        return false;
+    }
+
+    cacheEntry->lastUsed = mCurrentTime;
+    getOrCreatePipelineLayout()->lastUsed = mCurrentTime;
+
+    mBoundPipeline = mPipelineRequirements;
+    mBoundLayout = mLayoutRequirements;
+
+    vkCmdBindPipeline(cmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, cacheEntry->handle);
+    return true;
 }
 
 void VulkanPipelineCache::bindScissor(VkCommandBuffer cmdbuffer, VkRect2D scissor) noexcept {
-    VkRect2D& currentScissor = mCmdBufferState[mCmdBufferIndex].scissor;
-    if (UTILS_UNLIKELY(!equivalent(currentScissor, scissor))) {
-        currentScissor = scissor;
+    if (UTILS_UNLIKELY(!equivalent(mCurrentScissor, scissor))) {
+        mCurrentScissor = scissor;
         vkCmdSetScissor(cmdbuffer, 0, 1, &scissor);
     }
 }
 
-void VulkanPipelineCache::getOrCreateDescriptors(
-        VkDescriptorSet descriptorSets[DESCRIPTOR_TYPE_COUNT],
-        bool* bind, bool* overflow) noexcept {
-    DescriptorBundle*& descriptorBundle = mCmdBufferState[mCmdBufferIndex].currentDescriptorBundle;
+VulkanPipelineCache::DescriptorCacheEntry* VulkanPipelineCache::createDescriptorSets() noexcept {
+    PipelineLayoutCacheEntry* layoutCacheEntry = getOrCreatePipelineLayout();
 
-    // Leave early if no bindings have been dirtied.
-    if (!mDirtyDescriptor[mCmdBufferIndex]) {
-        assert_invariant(descriptorBundle);
-        for (uint32_t i = 0; i < DESCRIPTOR_TYPE_COUNT; ++i) {
-            descriptorSets[i] = descriptorBundle->handles[i];
-        }
-        descriptorBundle->commandBuffers.set(mCmdBufferIndex);
-        return;
-    }
+    DescriptorCacheEntry& descriptorCacheEntry = mDescriptorSets.emplace(
+            std::make_pair(mDescriptorRequirements, DescriptorCacheEntry {})).first.value();
 
-    // If a cached object exists, re-use it.
-    auto iter = mDescriptorBundles.find(mDescriptorKey);
-    if (UTILS_LIKELY(iter != mDescriptorBundles.end())) {
-        descriptorBundle = &iter.value();
-        for (uint32_t i = 0; i < DESCRIPTOR_TYPE_COUNT; ++i) {
-            descriptorSets[i] = descriptorBundle->handles[i];
-        }
-        descriptorBundle->commandBuffers.set(mCmdBufferIndex);
-        mDirtyDescriptor.unset(mCmdBufferIndex);
-        *bind = true;
-        return;
-    }
+    descriptorCacheEntry.pipelineLayout = mLayoutRequirements;
 
-    // Create a new pipeline layout or fetch one from the cache.
-    LayoutBundle* layoutBundle = getOrCreatePipelineLayout();
-
-    // If there are no available descriptor sets that can be re-used, then create brand new ones
-    // (one for each type). Otherwise, grab a descriptor set from each of the arenas.
-    auto& descriptorSetArenas = layoutBundle->setArenas;
+    // Each of the arenas for this particular layout are guaranteed to have the same size. Check
+    // the first arena to see if any descriptor sets are available that can be re-claimed. If not,
+    // create brand new ones (one for each type). They will be added to the arena later, after they
+    // are no longer used. This occurs during the cleanup phase during command buffer submission.
+    auto& descriptorSetArenas = layoutCacheEntry->descriptorSetArenas;
     if (descriptorSetArenas[0].empty()) {
-        if (mDescriptorBundles.size() >= mDescriptorPoolSize) {
+        if (mDescriptorSets.size() >= mDescriptorPoolSize) {
             growDescriptorPool();
         }
         VkDescriptorSetAllocateInfo allocInfo = {};
         allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         allocInfo.descriptorPool = mDescriptorPool;
         allocInfo.descriptorSetCount = DESCRIPTOR_TYPE_COUNT;
-        allocInfo.pSetLayouts = layoutBundle->setLayouts.data();
-        VkResult err = vkAllocateDescriptorSets(mDevice, &allocInfo, descriptorSets);
-        assert_invariant(err == VK_SUCCESS);
-        if (err != VK_SUCCESS) {
-            *overflow = true;
-            return;
+        allocInfo.pSetLayouts = layoutCacheEntry->descriptorSetLayouts.data();
+        VkResult error = vkAllocateDescriptorSets(mDevice, &allocInfo,
+                descriptorCacheEntry.handles.data());
+        assert_invariant(error == VK_SUCCESS);
+        if (error != VK_SUCCESS) {
+            return nullptr;
         }
     } else {
         for (uint32_t i = 0; i < DESCRIPTOR_TYPE_COUNT; ++i) {
-            descriptorSets[i] = descriptorSetArenas[i].back();
+            descriptorCacheEntry.handles[i] = descriptorSetArenas[i].back();
             descriptorSetArenas[i].pop_back();
         }
     }
-
-    // Construct a cache entry in place, then stash its pointer to allow fast subsequent calls to
-    // getOrCreateDescriptor when nothing has been dirtied. Note that the robin_map iterator type
-    // proffers a "value" method, which returns a stable reference.
-    auto& bundle = mDescriptorBundles.emplace(std::make_pair(mDescriptorKey, DescriptorBundle {}))
-            .first.value();
-
-    descriptorBundle = &bundle;
-    for (uint32_t i = 0; i < DESCRIPTOR_TYPE_COUNT; ++i) {
-        descriptorBundle->handles[i] = descriptorSets[i];
-    }
-    descriptorBundle->pipelineLayout = mLayoutKey;
-    descriptorBundle->commandBuffers.setValue(1 << mCmdBufferIndex);
-
-    // Clear the dirty flag for this command buffer.
-    mDirtyDescriptor.unset(mCmdBufferIndex);
 
     // Rewrite every binding in the new descriptor sets.
     VkDescriptorBufferInfo descriptorBuffers[UBUFFER_BINDING_COUNT];
@@ -268,11 +254,11 @@ void VulkanPipelineCache::getOrCreateDescriptors(
     nwrites = 0;
     for (uint32_t binding = 0; binding < UBUFFER_BINDING_COUNT; binding++) {
         VkWriteDescriptorSet& writeInfo = writes[nwrites++];
-        if (mDescriptorKey.uniformBuffers[binding]) {
+        if (mDescriptorRequirements.uniformBuffers[binding]) {
             VkDescriptorBufferInfo& bufferInfo = descriptorBuffers[binding];
-            bufferInfo.buffer = mDescriptorKey.uniformBuffers[binding];
-            bufferInfo.offset = mDescriptorKey.uniformBufferOffsets[binding];
-            bufferInfo.range = mDescriptorKey.uniformBufferSizes[binding];
+            bufferInfo.buffer = mDescriptorRequirements.uniformBuffers[binding];
+            bufferInfo.offset = mDescriptorRequirements.uniformBufferOffsets[binding];
+            bufferInfo.range = mDescriptorRequirements.uniformBufferSizes[binding];
             writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writeInfo.pNext = nullptr;
             writeInfo.dstArrayElement = 0;
@@ -286,14 +272,14 @@ void VulkanPipelineCache::getOrCreateDescriptors(
             assert_invariant(mDummyBufferWriteInfo.pBufferInfo->buffer);
         }
         assert_invariant(writeInfo.pBufferInfo->buffer);
-        writeInfo.dstSet = descriptorBundle->handles[0];
+        writeInfo.dstSet = descriptorCacheEntry.handles[0];
         writeInfo.dstBinding = binding;
     }
     for (uint32_t binding = 0; binding < SAMPLER_BINDING_COUNT; binding++) {
         VkWriteDescriptorSet& writeInfo = writes[nwrites++];
-        if (mDescriptorKey.samplers[binding].sampler) {
+        if (mDescriptorRequirements.samplers[binding].sampler) {
             VkDescriptorImageInfo& imageInfo = descriptorSamplers[binding];
-            imageInfo = mDescriptorKey.samplers[binding];
+            imageInfo = mDescriptorRequirements.samplers[binding];
             writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writeInfo.pNext = nullptr;
             writeInfo.dstArrayElement = 0;
@@ -308,14 +294,14 @@ void VulkanPipelineCache::getOrCreateDescriptors(
             assert_invariant(mDummySamplerInfo.imageView);
 
         }
-        writeInfo.dstSet = descriptorBundle->handles[1];
+        writeInfo.dstSet = descriptorCacheEntry.handles[1];
         writeInfo.dstBinding = binding;
     }
     for (uint32_t binding = 0; binding < TARGET_BINDING_COUNT; binding++) {
         VkWriteDescriptorSet& writeInfo = writes[nwrites++];
-        if (mDescriptorKey.inputAttachments[binding].imageView) {
+        if (mDescriptorRequirements.inputAttachments[binding].imageView) {
             VkDescriptorImageInfo& imageInfo = descriptorInputAttachments[binding];
-            imageInfo = mDescriptorKey.inputAttachments[binding];
+            imageInfo = mDescriptorRequirements.inputAttachments[binding];
             writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writeInfo.pNext = nullptr;
             writeInfo.dstArrayElement = 0;
@@ -328,99 +314,18 @@ void VulkanPipelineCache::getOrCreateDescriptors(
             writeInfo = mDummyTargetWriteInfo;
             assert_invariant(mDummyTargetInfo.imageView);
         }
-        writeInfo.dstSet = descriptorBundle->handles[2];
+        writeInfo.dstSet = descriptorCacheEntry.handles[2];
         writeInfo.dstBinding = binding;
     }
     vkUpdateDescriptorSets(mDevice, nwrites, writes, 0, nullptr);
-    *bind = true;
+    return &descriptorCacheEntry;
 }
 
-VulkanPipelineCache::LayoutBundle* VulkanPipelineCache::getOrCreatePipelineLayout() noexcept {
-    auto iter = mLayouts.find(mLayoutKey);
-    if (UTILS_LIKELY(iter != mLayouts.end())) {
-        return &iter.value();
-    }
+VulkanPipelineCache::PipelineCacheEntry* VulkanPipelineCache::createPipeline() noexcept {
+    assert_invariant(mPipelineRequirements.shaders[0] && "Vertex shader is not bound.");
 
-    std::array<VkDescriptorSetLayout, DESCRIPTOR_TYPE_COUNT> setLayouts;
-    VkPipelineLayout pipelineLayout;
-
-    VkDescriptorSetLayoutBinding binding = {};
-    binding.descriptorCount = 1; // NOTE: We never use arrays-of-blocks.
-    binding.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS; // NOTE: This is potentially non-optimal.
-
-    // First create the descriptor set layout for UBO's.
-    VkDescriptorSetLayoutBinding ubindings[UBUFFER_BINDING_COUNT];
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    for (uint32_t i = 0; i < UBUFFER_BINDING_COUNT; i++) {
-        binding.binding = i;
-        ubindings[i] = binding;
-    }
-    VkDescriptorSetLayoutCreateInfo dlinfo = {};
-    dlinfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    dlinfo.bindingCount = UBUFFER_BINDING_COUNT;
-    dlinfo.pBindings = ubindings;
-    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &setLayouts[0]);
-
-    // Next create the descriptor set layout for samplers.
-    VkDescriptorSetLayoutBinding sbindings[SAMPLER_BINDING_COUNT];
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    for (uint32_t i = 0; i < SAMPLER_BINDING_COUNT; i++) {
-        binding.stageFlags = getShaderStageFlags(mLayoutKey, i);
-        binding.binding = i;
-        sbindings[i] = binding;
-    }
-    dlinfo.bindingCount = SAMPLER_BINDING_COUNT;
-    dlinfo.pBindings = sbindings;
-    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &setLayouts[1]);
-
-    // Next create the descriptor set layout for input attachments.
-    VkDescriptorSetLayoutBinding tbindings[TARGET_BINDING_COUNT];
-    binding.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-    binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    for (uint32_t i = 0; i < TARGET_BINDING_COUNT; i++) {
-        binding.binding = i;
-        tbindings[i] = binding;
-    }
-    dlinfo.bindingCount = TARGET_BINDING_COUNT;
-    dlinfo.pBindings = tbindings;
-    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &setLayouts[2]);
-
-    // Create VkPipelineLayout based on how to resources are bounded.
-    VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {};
-    pPipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    pPipelineLayoutCreateInfo.setLayoutCount = setLayouts.size();
-    pPipelineLayoutCreateInfo.pSetLayouts = setLayouts.data();
-    VkResult err = vkCreatePipelineLayout(mDevice, &pPipelineLayoutCreateInfo, VKALLOC,
-            &pipelineLayout);
-    ASSERT_POSTCONDITION(!err, "Unable to create pipeline layout.");
-
-    auto result = mLayouts.emplace(mLayoutKey, LayoutBundle{ setLayouts, {}, pipelineLayout });
-    return &result.first.value();
-}
-
-bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
-    LayoutBundle* layout = getOrCreatePipelineLayout();
+    PipelineLayoutCacheEntry* layout = getOrCreatePipelineLayout();
     assert_invariant(layout);
-    PipelineVal*& currentPipeline = mCmdBufferState[mCmdBufferIndex].currentPipeline;
-
-    // If no bindings have been dirtied, return false to indicate there's no need to re-bind.
-    if (!mDirtyPipeline[mCmdBufferIndex]) {
-        assert_invariant(currentPipeline);
-        currentPipeline->age = 0;
-        *pipeline = currentPipeline->handle;
-        return false;
-    }
-    assert_invariant(mPipelineKey.shaders[0] && "Vertex shader is not bound.");
-
-    // If a cached object exists, return true to indicate that the caller should call vmCmdBind.
-    auto iter = mPipelines.find(mPipelineKey);
-    if (UTILS_LIKELY(iter != mPipelines.end())) {
-        currentPipeline = &iter.value();
-        currentPipeline->age = 0;
-        *pipeline = currentPipeline->handle;
-        mDirtyPipeline.unset(mCmdBufferIndex);
-        return true;
-    }
 
     VkPipelineShaderStageCreateInfo shaderStages[SHADER_MODULE_COUNT];
     shaderStages[0] = VkPipelineShaderStageCreateInfo{};
@@ -441,18 +346,18 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     colorBlendState.pAttachments = colorBlendAttachments;
 
     // If we reach this point, we need to create and stash a brand new pipeline object.
-    shaderStages[0].module = mPipelineKey.shaders[0];
-    shaderStages[1].module = mPipelineKey.shaders[1];
+    shaderStages[0].module = mPipelineRequirements.shaders[0];
+    shaderStages[1].module = mPipelineRequirements.shaders[1];
 
     // We don't store array sizes to save space, but it's quick to count all non-zero
     // entries because these arrays have a small fixed-size capacity.
     uint32_t numVertexAttribs = 0;
     uint32_t numVertexBuffers = 0;
     for (uint32_t i = 0; i < VERTEX_ATTRIBUTE_COUNT; i++) {
-        if (mPipelineKey.vertexAttributes[i].format > 0) {
+        if (mPipelineRequirements.vertexAttributes[i].format > 0) {
             numVertexAttribs++;
         }
-        if (mPipelineKey.vertexBuffers[i].stride > 0) {
+        if (mPipelineRequirements.vertexBuffers[i].stride > 0) {
             numVertexBuffers++;
         }
     }
@@ -460,13 +365,13 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     VkPipelineVertexInputStateCreateInfo vertexInputState = {};
     vertexInputState.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
     vertexInputState.vertexBindingDescriptionCount = numVertexBuffers;
-    vertexInputState.pVertexBindingDescriptions = mPipelineKey.vertexBuffers;
+    vertexInputState.pVertexBindingDescriptions = mPipelineRequirements.vertexBuffers;
     vertexInputState.vertexAttributeDescriptionCount = numVertexAttribs;
-    vertexInputState.pVertexAttributeDescriptions = mPipelineKey.vertexAttributes;
+    vertexInputState.pVertexAttributeDescriptions = mPipelineRequirements.vertexAttributes;
 
     VkPipelineInputAssemblyStateCreateInfo inputAssemblyState = {};
     inputAssemblyState.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    inputAssemblyState.topology = mPipelineKey.topology;
+    inputAssemblyState.topology = mPipelineRequirements.topology;
 
     VkPipelineViewportStateCreateInfo viewportState = {};
     viewportState.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
@@ -486,9 +391,9 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
 
     VkGraphicsPipelineCreateInfo pipelineCreateInfo = {};
     pipelineCreateInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pipelineCreateInfo.layout = layout->pipelineLayout;
-    pipelineCreateInfo.renderPass = mPipelineKey.renderPass;
-    pipelineCreateInfo.subpass = mPipelineKey.subpassIndex;
+    pipelineCreateInfo.layout = layout->handle;
+    pipelineCreateInfo.renderPass = mPipelineRequirements.renderPass;
+    pipelineCreateInfo.subpass = mPipelineRequirements.subpassIndex;
     pipelineCreateInfo.stageCount = hasFragmentShader ? SHADER_MODULE_COUNT : 1;
     pipelineCreateInfo.pStages = shaderStages;
     pipelineCreateInfo.pVertexInputState = &vertexInputState;
@@ -515,7 +420,7 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     };
     pipelineCreateInfo.pDepthStencilState = &vkDs;
 
-    const auto& raster = mPipelineKey.rasterState;
+    const auto& raster = mPipelineRequirements.rasterState;
 
     vkRaster.depthClampEnable = raster.rasterization.depthClampEnable;
     vkRaster.rasterizerDiscardEnable = raster.rasterization.rasterizerDiscardEnable;
@@ -547,9 +452,9 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
     pipelineCreateInfo.pDynamicState = &dynamicState;
 
     // Filament assumes consistent blend state across all color attachments.
-    colorBlendState.attachmentCount = mPipelineKey.rasterState.colorTargetCount;
+    colorBlendState.attachmentCount = mPipelineRequirements.rasterState.colorTargetCount;
     for (auto& target : colorBlendAttachments) {
-        target = mPipelineKey.rasterState.blending;
+        target = mPipelineRequirements.rasterState.blending;
     }
 
     // There are no color attachments if there is no bound fragment shader.  (e.g. shadow map gen)
@@ -558,135 +463,115 @@ bool VulkanPipelineCache::getOrCreatePipeline(VkPipeline* pipeline) noexcept {
         colorBlendState.attachmentCount = 0;
     }
 
+    PipelineCacheEntry& bundle = mPipelines.emplace(
+            std::make_pair(mPipelineRequirements, PipelineCacheEntry {})).first.value();
+
     #if FILAMENT_VULKAN_VERBOSE
     utils::slog.d << "vkCreateGraphicsPipelines with shaders = ("
             << shaderStages[0].module << ", " << shaderStages[1].module << ")" << utils::io::endl;
     #endif
-    VkResult err = vkCreateGraphicsPipelines(mDevice, VK_NULL_HANDLE, 1, &pipelineCreateInfo,
-            VKALLOC, pipeline);
-    if (err) {
-        utils::slog.e << "vkCreateGraphicsPipelines error " << err << utils::io::endl;
-        utils::debug_trap();
+    VkResult error = vkCreateGraphicsPipelines(mDevice, VK_NULL_HANDLE, 1, &pipelineCreateInfo,
+            VKALLOC, &bundle.handle);
+    assert_invariant(error == VK_SUCCESS);
+    if (error != VK_SUCCESS) {
+        utils::slog.e << "vkCreateGraphicsPipelines error " << error << utils::io::endl;
+        return nullptr;
     }
-    ++layout->referenceCount;
 
-    // Stash a stable pointer to the stored cache entry to allow fast subsequent calls to
-    // getOrCreatePipeline when nothing has been dirtied.
-    const PipelineVal cacheEntry = { *pipeline, mLayoutKey, 0u };
-    currentPipeline = &mPipelines.emplace(std::make_pair(mPipelineKey, cacheEntry)).first.value();
-    mDirtyPipeline.unset(mCmdBufferIndex);
+    return &bundle;
+}
 
-    return true;
+VulkanPipelineCache::PipelineLayoutCacheEntry* VulkanPipelineCache::getOrCreatePipelineLayout() noexcept {
+    auto iter = mPipelineLayouts.find(mLayoutRequirements);
+    if (UTILS_LIKELY(iter != mPipelineLayouts.end())) {
+        return &iter.value();
+    }
+
+    PipelineLayoutCacheEntry& cacheEntry = mPipelineLayouts.emplace(
+            mLayoutRequirements, PipelineLayoutCacheEntry{}).first.value();
+
+    VkDescriptorSetLayoutBinding binding = {};
+    binding.descriptorCount = 1; // NOTE: We never use arrays-of-blocks.
+    binding.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS; // NOTE: This is potentially non-optimal.
+
+    // First create the descriptor set layout for UBO's.
+    VkDescriptorSetLayoutBinding ubindings[UBUFFER_BINDING_COUNT];
+    binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    for (uint32_t i = 0; i < UBUFFER_BINDING_COUNT; i++) {
+        binding.binding = i;
+        ubindings[i] = binding;
+    }
+    VkDescriptorSetLayoutCreateInfo dlinfo = {};
+    dlinfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    dlinfo.bindingCount = UBUFFER_BINDING_COUNT;
+    dlinfo.pBindings = ubindings;
+    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &cacheEntry.descriptorSetLayouts[0]);
+
+    // Next create the descriptor set layout for samplers.
+    VkDescriptorSetLayoutBinding sbindings[SAMPLER_BINDING_COUNT];
+    binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    for (uint32_t i = 0; i < SAMPLER_BINDING_COUNT; i++) {
+        binding.stageFlags = getShaderStageFlags(mLayoutRequirements, i);
+        binding.binding = i;
+        sbindings[i] = binding;
+    }
+    dlinfo.bindingCount = SAMPLER_BINDING_COUNT;
+    dlinfo.pBindings = sbindings;
+    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &cacheEntry.descriptorSetLayouts[1]);
+
+    // Next create the descriptor set layout for input attachments.
+    VkDescriptorSetLayoutBinding tbindings[TARGET_BINDING_COUNT];
+    binding.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    for (uint32_t i = 0; i < TARGET_BINDING_COUNT; i++) {
+        binding.binding = i;
+        tbindings[i] = binding;
+    }
+    dlinfo.bindingCount = TARGET_BINDING_COUNT;
+    dlinfo.pBindings = tbindings;
+    vkCreateDescriptorSetLayout(mDevice, &dlinfo, VKALLOC, &cacheEntry.descriptorSetLayouts[2]);
+
+    // Create VkPipelineLayout based on how to resources are bounded.
+    VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {};
+    pPipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pPipelineLayoutCreateInfo.setLayoutCount = cacheEntry.descriptorSetLayouts.size();
+    pPipelineLayoutCreateInfo.pSetLayouts = cacheEntry.descriptorSetLayouts.data();
+    VkResult error = vkCreatePipelineLayout(mDevice, &pPipelineLayoutCreateInfo, VKALLOC,
+            &cacheEntry.handle);
+    assert_invariant(error == VK_SUCCESS);
+    return error == VK_SUCCESS ? &cacheEntry : nullptr;
 }
 
 void VulkanPipelineCache::bindProgram(const VulkanProgram& program) noexcept {
     const VkShaderModule shaders[2] = { program.bundle.vertex, program.bundle.fragment };
     for (uint32_t ssi = 0; ssi < SHADER_MODULE_COUNT; ssi++) {
-        if (mPipelineKey.shaders[ssi] != shaders[ssi]) {
-            markDirtyPipeline();
-            mPipelineKey.shaders[ssi] = shaders[ssi];
-        }
+        mPipelineRequirements.shaders[ssi] = shaders[ssi];
     }
-    PipelineLayoutKey key = getPipelineLayoutKey(program.samplerGroupInfo);
-    if (key != mLayoutKey) {
-        markDirtyPipeline();
-        markDirtyDescriptor();
-        mLayoutKey = key;
-    }
+    mLayoutRequirements = getPipelineLayoutKey(program.samplerGroupInfo);
 }
 
 void VulkanPipelineCache::bindRasterState(const RasterState& rasterState) noexcept {
-    auto& raster0 = mPipelineKey.rasterState.rasterization;
-    const auto& raster1 = rasterState.rasterization;
-    auto& blend0 = mPipelineKey.rasterState.blending;
-    const auto& blend1 = rasterState.blending;
-    auto& ds0 = mPipelineKey.rasterState.depthStencil;
-    const auto& ds1 = rasterState.depthStencil;
-    auto& ms0 = mPipelineKey.rasterState.multisampling;
-    const auto& ms1 = rasterState.multisampling;
-    if (UTILS_UNLIKELY(
-        raster0.depthClampEnable != raster1.depthClampEnable ||
-        raster0.rasterizerDiscardEnable != raster1.rasterizerDiscardEnable ||
-        raster0.polygonMode != raster1.polygonMode ||
-        raster0.cullMode != raster1.cullMode ||
-        raster0.frontFace != raster1.frontFace ||
-        raster0.depthBiasEnable != raster1.depthBiasEnable ||
-        raster0.depthBiasConstantFactor != raster1.depthBiasConstantFactor ||
-        raster0.depthBiasClamp != raster1.depthBiasClamp ||
-        raster0.depthBiasSlopeFactor != raster1.depthBiasSlopeFactor ||
-        raster0.lineWidth != raster1.lineWidth ||
-
-        blend0.blendEnable != blend1.blendEnable ||
-        blend0.srcColorBlendFactor != blend1.srcColorBlendFactor ||
-        blend0.dstColorBlendFactor != blend1.dstColorBlendFactor ||
-        blend0.colorBlendOp != blend1.colorBlendOp ||
-        blend0.srcAlphaBlendFactor != blend1.srcAlphaBlendFactor ||
-        blend0.dstAlphaBlendFactor != blend1.dstAlphaBlendFactor ||
-        blend0.alphaBlendOp != blend1.alphaBlendOp ||
-        blend0.colorWriteMask != blend1.colorWriteMask ||
-
-        ds0.depthTestEnable != ds1.depthTestEnable ||
-        ds0.depthWriteEnable != ds1.depthWriteEnable ||
-        ds0.depthCompareOp != ds1.depthCompareOp ||
-        ds0.depthBoundsTestEnable != ds1.depthBoundsTestEnable ||
-        ds0.stencilTestEnable != ds1.stencilTestEnable ||
-        ds0.minDepthBounds != ds1.minDepthBounds ||
-        ds0.maxDepthBounds != ds1.maxDepthBounds ||
-
-        ms0.rasterizationSamples != ms1.rasterizationSamples ||
-        ms0.sampleShadingEnable != ms1.sampleShadingEnable ||
-        ms0.minSampleShading != ms1.minSampleShading ||
-        ms0.alphaToCoverageEnable != ms1.alphaToCoverageEnable ||
-        ms0.alphaToOneEnable != ms1.alphaToOneEnable ||
-
-        mPipelineKey.rasterState.colorTargetCount != rasterState.colorTargetCount
-    )) {
-        markDirtyPipeline();
-        mPipelineKey.rasterState = rasterState;
-    }
+    mPipelineRequirements.rasterState = rasterState;
 }
 
 void VulkanPipelineCache::bindRenderPass(VkRenderPass renderPass, int subpassIndex) noexcept {
-    if (mPipelineKey.renderPass != renderPass || mPipelineKey.subpassIndex != subpassIndex) {
-        markDirtyPipeline();
-        mPipelineKey.renderPass = renderPass;
-        mPipelineKey.subpassIndex = subpassIndex;
-    }
+    mPipelineRequirements.renderPass = renderPass;
+    mPipelineRequirements.subpassIndex = subpassIndex;
 }
 
 void VulkanPipelineCache::bindPrimitiveTopology(VkPrimitiveTopology topology) noexcept {
-    if (mPipelineKey.topology != topology) {
-        markDirtyPipeline();
-        mPipelineKey.topology = topology;
-    }
+    mPipelineRequirements.topology = topology;
 }
 
 void VulkanPipelineCache::bindVertexArray(const VertexArray& varray) noexcept {
     for (size_t i = 0; i < VERTEX_ATTRIBUTE_COUNT; i++) {
-        VkVertexInputAttributeDescription& attrib0 = mPipelineKey.vertexAttributes[i];
-        const VkVertexInputAttributeDescription& attrib1 = varray.attributes[i];
-        if (attrib1.location != attrib0.location || attrib1.binding != attrib0.binding ||
-                attrib1.format != attrib0.format || attrib1.offset != attrib0.offset) {
-            attrib0.format = attrib1.format;
-            attrib0.binding = attrib1.binding;
-            attrib0.location = attrib1.location;
-            attrib0.offset = attrib1.offset;
-            markDirtyPipeline();
-        }
-        VkVertexInputBindingDescription& buffer0 = mPipelineKey.vertexBuffers[i];
-        const VkVertexInputBindingDescription& buffer1 = varray.buffers[i];
-        if (buffer0.binding != buffer1.binding || buffer0.stride != buffer1.stride) {
-            buffer0.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-            buffer0.binding = buffer1.binding;
-            buffer0.stride = buffer1.stride;
-            markDirtyPipeline();
-        }
+        mPipelineRequirements.vertexAttributes[i] = varray.attributes[i];
+        mPipelineRequirements.vertexBuffers[i] = varray.buffers[i];
     }
 }
 
-VulkanPipelineCache::UniformBufferBinding VulkanPipelineCache::getUniformBufferBinding(
-            uint32_t bindingIndex) const noexcept {
-    auto& key = mDescriptorKey;
+VulkanPipelineCache::UniformBufferBinding VulkanPipelineCache::getUniformBufferBinding(uint32_t bindingIndex) const noexcept {
+    auto& key = mDescriptorRequirements;
     return {
         key.uniformBuffers[bindingIndex],
         key.uniformBufferOffsets[bindingIndex],
@@ -695,28 +580,25 @@ VulkanPipelineCache::UniformBufferBinding VulkanPipelineCache::getUniformBufferB
 }
 
 void VulkanPipelineCache::unbindUniformBuffer(VkBuffer uniformBuffer) noexcept {
-    auto& key = mDescriptorKey;
+    auto& key = mDescriptorRequirements;
     for (uint32_t bindingIndex = 0u; bindingIndex < UBUFFER_BINDING_COUNT; ++bindingIndex) {
         if (key.uniformBuffers[bindingIndex] == uniformBuffer) {
             key.uniformBuffers[bindingIndex] = {};
             key.uniformBufferSizes[bindingIndex] = {};
             key.uniformBufferOffsets[bindingIndex] = {};
-            markDirtyDescriptor();
         }
     }
 }
 
 void VulkanPipelineCache::unbindImageView(VkImageView imageView) noexcept {
-    for (auto& sampler : mDescriptorKey.samplers) {
+    for (auto& sampler : mDescriptorRequirements.samplers) {
         if (sampler.imageView == imageView) {
             sampler = {};
-            markDirtyDescriptor();
         }
     }
-    for (auto& target : mDescriptorKey.inputAttachments) {
+    for (auto& target : mDescriptorRequirements.inputAttachments) {
         if (target.imageView == imageView) {
             target = {};
-            markDirtyDescriptor();
         }
     }
 }
@@ -726,27 +608,15 @@ void VulkanPipelineCache::bindUniformBuffer(uint32_t bindingIndex, VkBuffer unif
     ASSERT_POSTCONDITION(bindingIndex < UBUFFER_BINDING_COUNT,
             "Uniform bindings overflow: index = %d, capacity = %d.",
             bindingIndex, UBUFFER_BINDING_COUNT);
-    auto& key = mDescriptorKey;
-    if (key.uniformBuffers[bindingIndex] != uniformBuffer ||
-        key.uniformBufferOffsets[bindingIndex] != offset ||
-        key.uniformBufferSizes[bindingIndex] != size) {
-        key.uniformBuffers[bindingIndex] = uniformBuffer;
-        key.uniformBufferOffsets[bindingIndex] = offset;
-        key.uniformBufferSizes[bindingIndex] = size;
-        markDirtyDescriptor();
-    }
+    auto& key = mDescriptorRequirements;
+    key.uniformBuffers[bindingIndex] = uniformBuffer;
+    key.uniformBufferOffsets[bindingIndex] = offset;
+    key.uniformBufferSizes[bindingIndex] = size;
 }
 
 void VulkanPipelineCache::bindSamplers(VkDescriptorImageInfo samplers[SAMPLER_BINDING_COUNT]) noexcept {
     for (uint32_t bindingIndex = 0; bindingIndex < SAMPLER_BINDING_COUNT; bindingIndex++) {
-        const VkDescriptorImageInfo& requested = samplers[bindingIndex];
-        VkDescriptorImageInfo& existing = mDescriptorKey.samplers[bindingIndex];
-        if (existing.sampler != requested.sampler ||
-            existing.imageView != requested.imageView ||
-            existing.imageLayout != requested.imageLayout) {
-            existing = requested;
-            markDirtyDescriptor();
-        }
+        mDescriptorRequirements.samplers[bindingIndex] = samplers[bindingIndex];
     }
 }
 
@@ -755,12 +625,7 @@ void VulkanPipelineCache::bindInputAttachment(uint32_t bindingIndex,
     ASSERT_POSTCONDITION(bindingIndex < TARGET_BINDING_COUNT,
             "Input attachment bindings overflow: index = %d, capacity = %d.",
             bindingIndex, TARGET_BINDING_COUNT);
-    VkDescriptorImageInfo& imageInfo = mDescriptorKey.inputAttachments[bindingIndex];
-    if (imageInfo.imageView != targetInfo.imageView ||
-            imageInfo.imageLayout != targetInfo.imageLayout) {
-        imageInfo = targetInfo;
-        markDirtyDescriptor();
-    }
+    mDescriptorRequirements.inputAttachments[bindingIndex] = targetInfo;
 }
 
 void VulkanPipelineCache::destroyCache() noexcept {
@@ -770,10 +635,7 @@ void VulkanPipelineCache::destroyCache() noexcept {
         vkDestroyPipeline(mDevice, iter.second.handle, VKALLOC);
     }
     mPipelines.clear();
-    for (int i = 0; i < VK_MAX_COMMAND_BUFFERS; i++) {
-        mCmdBufferState[i].currentPipeline = nullptr;
-    }
-    markDirtyPipeline();
+    mBoundPipeline = {};
     if (mDummySamplerInfo.sampler) {
         vkDestroySampler(mDevice, mDummySamplerInfo.sampler, VKALLOC);
         mDummySamplerInfo.sampler = VK_NULL_HANDLE;
@@ -784,47 +646,43 @@ void VulkanPipelineCache::destroyCache() noexcept {
 }
 
 void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) {
-    // This method is called each time a command buffer is flushed and a new command buffer is
-    // ready to be written into. Stash the index of this command buffer for state-tracking purposes.
-    mCmdBufferIndex = cmdbuffer.index;
+    // The timestamp associated with a given cache entry represents "time" as a count of flush
+    // events since the cache was constructed. If any cache entry was most recently used over
+    // VK_MAX_PIPELINE_AGE flush events in the past, then we can be sure that it is no longer
+    // being used by the GPU, and is therefore safe to destroy or reclaim.
+    ++mCurrentTime;
 
-    // Mark everything as dirty, as per the Vulkan spec, which says: "When a command buffer begins
-    // recording, all state in that command buffer is undefined."
-    mDirtyPipeline.set(mCmdBufferIndex);
-    mDirtyDescriptor.set(mCmdBufferIndex);
-    mCmdBufferState[mCmdBufferIndex].scissor = {};
+    // The Vulkan spec says: "When a command buffer begins recording, all state in that command
+    // buffer is undefined." Therefore we need to clear all bindings at this time.
+    mBoundPipeline = {};
+    mBoundLayout = {};
+    mBoundDescriptor = {};
+    mCurrentScissor = {};
 
     // NOTE: Due to robin_map restrictions, we cannot use auto or range-based loops.
 
     // Check if any bundles in the cache are no longer in use by any command buffer. Descriptors
     // from unused bundles are moved back to their respective arenas.
-    using ConstDescIterator = decltype(mDescriptorBundles)::const_iterator;
-    for (ConstDescIterator iter = mDescriptorBundles.begin(); iter != mDescriptorBundles.end();) {
-        const DescriptorBundle& cacheEntry = iter.value();
-        if (cacheEntry.commandBuffers.getValue() == 0) {
-            auto& descriptorSetArenas = mLayouts[cacheEntry.pipelineLayout].setArenas;
+    using ConstDescIterator = decltype(mDescriptorSets)::const_iterator;
+    for (ConstDescIterator iter = mDescriptorSets.begin(); iter != mDescriptorSets.end();) {
+        const DescriptorCacheEntry& cacheEntry = iter.value();
+        if (cacheEntry.lastUsed + VK_MAX_PIPELINE_AGE < mCurrentTime) {
+            auto& arenas = mPipelineLayouts[cacheEntry.pipelineLayout].descriptorSetArenas;
             for (uint32_t i = 0; i < DESCRIPTOR_TYPE_COUNT; ++i) {
-                descriptorSetArenas[i].push_back(cacheEntry.handles[i]);
+                arenas[i].push_back(cacheEntry.handles[i]);
             }
-            iter = mDescriptorBundles.erase(iter);
+            iter = mDescriptorSets.erase(iter);
         } else {
             ++iter;
         }
-    }
-
-    // Increment the "age" of all cached pipelines. If the age of any pipeline is 0, then it is
-    // being used by the command buffer that was just flushed.
-    using PipeIterator = decltype(mPipelines)::iterator;
-    for (PipeIterator iter = mPipelines.begin(); iter != mPipelines.end(); ++iter) {
-        ++iter.value().age;
     }
 
     // Evict any pipelines that have not been used in a while.
     // Any pipeline older than VK_MAX_COMMAND_BUFFERS can be safely destroyed.
     using ConstPipeIterator = decltype(mPipelines)::const_iterator;
     for (ConstPipeIterator iter = mPipelines.begin(); iter != mPipelines.end();) {
-        if (iter.value().age > VK_MAX_PIPELINE_AGE) {
-            --mLayouts[iter->second.pipelineLayout].referenceCount;
+        const PipelineCacheEntry& cacheEntry = iter.value();
+        if (cacheEntry.lastUsed + VK_MAX_PIPELINE_AGE < mCurrentTime) {
             vkDestroyPipeline(mDevice, iter->second.handle, VKALLOC);
             iter = mPipelines.erase(iter);
         } else {
@@ -833,38 +691,35 @@ void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) 
     }
 
     // Evict any layouts that have not been used in a while.
-    using ConstLayoutIterator = decltype(mLayouts)::const_iterator;
-    for (ConstLayoutIterator iter = mLayouts.begin(); iter != mLayouts.end();) {
-        if (iter->second.referenceCount <= 0) {
-            vkDestroyPipelineLayout(mDevice, iter->second.pipelineLayout, VKALLOC);
-            for (auto setLayout : iter->second.setLayouts) {
+    using ConstLayoutIterator = decltype(mPipelineLayouts)::const_iterator;
+    for (ConstLayoutIterator iter = mPipelineLayouts.begin(); iter != mPipelineLayouts.end();) {
+        const PipelineLayoutCacheEntry& cacheEntry = iter.value();
+        if (cacheEntry.lastUsed + VK_MAX_PIPELINE_AGE < mCurrentTime) {
+            vkDestroyPipelineLayout(mDevice, iter->second.handle, VKALLOC);
+            for (auto setLayout : iter->second.descriptorSetLayouts) {
+#ifndef NDEBUG
+                PipelineLayoutKey key = iter.key();
+                for (auto& pair : mDescriptorSets) {
+                    assert_invariant(pair.second.pipelineLayout != key);
+                }
+#endif
                 vkDestroyDescriptorSetLayout(mDevice, setLayout, VKALLOC);
             }
-            iter = mLayouts.erase(iter);
+            iter = mPipelineLayouts.erase(iter);
         } else {
             ++iter;
         }
     }
 
-    // We know that the new command buffer is not being processed by the GPU, so we can clear
-    // its "in use" bit from all descriptors in the cache.
-    using DescIterator = decltype(mDescriptorBundles)::iterator;
-    for (DescIterator iter = mDescriptorBundles.begin(); iter != mDescriptorBundles.end(); ++iter) {
-        iter.value().commandBuffers.unset(mCmdBufferIndex);
-    }
-
-    // Descriptor sets that arose from an old pool (i.e. before the most recent growth event)
-    // also need to have their "in use" bit cleared for this command buffer.
-    bool canPurgeExtinctPools = true;
-    for (auto& bundle : mExtinctDescriptorBundles) {
-        bundle.commandBuffers.unset(mCmdBufferIndex);
-        if (bundle.commandBuffers.getValue() != 0) {
-            canPurgeExtinctPools = false;
-        }
-    }
-
     // If there are no descriptors from any extinct pool that are still in use, we can safely
     // destroy the extinct pools, which implicitly frees their associated descriptor sets.
+    bool canPurgeExtinctPools = true;
+    for (auto& bundle : mExtinctDescriptorBundles) {
+        if (bundle.lastUsed + VK_MAX_PIPELINE_AGE >= mCurrentTime) {
+            canPurgeExtinctPools = false;
+            break;
+        }
+    }
     if (canPurgeExtinctPools) {
         for (VkDescriptorPool pool : mExtinctDescriptorPools) {
             vkDestroyDescriptorPool(mDevice, pool, VKALLOC);
@@ -898,40 +753,37 @@ VkDescriptorPool VulkanPipelineCache::createDescriptorPool(uint32_t size) const 
 }
 
 void VulkanPipelineCache::destroyLayoutsAndDescriptors() noexcept {
-    if (mLayouts.empty()) {
+    if (mPipelineLayouts.empty()) {
         return;
     }
 
     // Our current descriptor set strategy can cause the # of descriptor sets to explode in certain
     // situations, so it's interesting to report the number that get stuffed into the cache.
     #ifndef NDEBUG
-    utils::slog.d << "Destroying " << mDescriptorBundles.size() << " bundles of descriptor sets."
+    utils::slog.d << "Destroying " << mDescriptorSets.size() << " bundles of descriptor sets."
             << utils::io::endl;
     #endif
 
-    mDescriptorBundles.clear();
+    mDescriptorSets.clear();
 
     // Our current layout bundle strategy can cause the # of layout bundles to explode in certain
     // situations, so it's interesting to report the number that get stuffed into the cache.
     #ifndef NDEBUG
-    utils::slog.d << "Destroying " << mLayouts.size() << " bundles of layouts."
+    utils::slog.d << "Destroying " << mPipelineLayouts.size() << " pipeline layouts."
                   << utils::io::endl;
     #endif
 
-    for (auto& iter : mLayouts) {
-        vkDestroyPipelineLayout(mDevice, iter.second.pipelineLayout, VKALLOC);
-        for (auto setLayout : iter.second.setLayouts) {
+    for (auto& iter : mPipelineLayouts) {
+        vkDestroyPipelineLayout(mDevice, iter.second.handle, VKALLOC);
+        for (auto setLayout : iter.second.descriptorSetLayouts) {
             vkDestroyDescriptorSetLayout(mDevice, setLayout, VKALLOC);
         }
         // There is no need to free descriptor sets individually since destroying the VkDescriptorPool
         // implicitly frees them.
     }
-    mLayouts.clear();
+    mPipelineLayouts.clear();
     vkDestroyDescriptorPool(mDevice, mDescriptorPool, VKALLOC);
     mDescriptorPool = VK_NULL_HANDLE;
-    for (int i = 0; i < VK_MAX_COMMAND_BUFFERS; i++) {
-        mCmdBufferState[i].currentDescriptorBundle = nullptr;
-    }
 
     for (VkDescriptorPool pool : mExtinctDescriptorPools) {
         vkDestroyDescriptorPool(mDevice, pool, VKALLOC);
@@ -939,7 +791,7 @@ void VulkanPipelineCache::destroyLayoutsAndDescriptors() noexcept {
     mExtinctDescriptorPools.clear();
     mExtinctDescriptorBundles.clear();
 
-    markDirtyDescriptor();
+    mBoundDescriptor = {};
 }
 
 void VulkanPipelineCache::growDescriptorPool() noexcept {
@@ -953,27 +805,26 @@ void VulkanPipelineCache::growDescriptorPool() noexcept {
 
     // Clear out all unused descriptor sets in the arena so they don't get reclaimed. There is no
     // need to free them individually since the old VkDescriptorPool will be destroyed.
-    for (auto iter = mLayouts.begin(); iter != mLayouts.end(); ++iter) {
-        auto& setArenas = iter.value().setArenas;
-        for (auto& arena : setArenas) {
+    for (auto iter = mPipelineLayouts.begin(); iter != mPipelineLayouts.end(); ++iter) {
+        for (auto& arena : iter.value().descriptorSetArenas) {
             arena.clear();
         }
     }
 
     // Move all in-use descriptors from the primary cache into an "extinct" list, so that they will
     // later be destroyed rather than reclaimed.
-    using DescIterator = decltype(mDescriptorBundles)::iterator;
-    for (DescIterator iter = mDescriptorBundles.begin(); iter != mDescriptorBundles.end(); ++iter) {
+    using DescIterator = decltype(mDescriptorSets)::iterator;
+    for (DescIterator iter = mDescriptorSets.begin(); iter != mDescriptorSets.end(); ++iter) {
         mExtinctDescriptorBundles.push_back(iter.value());
     }
-    mDescriptorBundles.clear();
+    mDescriptorSets.clear();
 }
 
-size_t VulkanPipelineCache::LayoutKeyHashFn::operator()(const PipelineLayoutKey& key) const {
+size_t VulkanPipelineCache::PipelineLayoutKeyHashFn::operator()(const PipelineLayoutKey& key) const {
     return key.getValue();
 }
 
-bool VulkanPipelineCache::LayoutKeyEqual::operator()(const PipelineLayoutKey& k1,
+bool VulkanPipelineCache::PipelineLayoutKeyEqual::operator()(const PipelineLayoutKey& k1,
         const PipelineLayoutKey& k2) const {
     return k1 == k2;
 }


### PR DESCRIPTION
All three types of internal caches (descriptor sets, pipelines, and pipeline
layouts) are now managed in exactly the same way. They all use an LRU
eviction scheme that is based on a count of command buffer flush
events.

Vulkan objects can only be destroyed if there are no in-flight command
buffers that reference them, so an easy way to know when it is safe to
evict a given entry is to wait for "N" flushes after its last use, where
"N" is the number of command buffers in the command buffer ring.

Another big simplification is that there are no more dirty flags,
instead we store two sets of state vectors for each type of cache: the
"currently bound" state, and the "current requirements" state.