### PR TITLE
Minor cleanups

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -171,7 +171,7 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOption
 void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
         float refractionLodOffset,
         math::mat4f const& historyProjection,
-        math::mat4f const& projectToPixelMatrix,
+        math::mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
     mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
@@ -184,7 +184,7 @@ void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
     s.refractionLodOffset = refractionLodOffset;
 
     s.ssrReprojection = historyProjection;
-    s.ssrProjectToPixelMatrix = projectToPixelMatrix;
+    s.ssrUvFromViewMatrix = uvFromViewMatrix;
     s.ssrThickness = ssrOptions.thickness;
     s.ssrBias = ssrOptions.bias;
     s.ssrDistance = ssrOptions.enabled ? ssrOptions.maxDistance : 0.0f;

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -77,7 +77,7 @@ public:
     void prepareSSR(TextureHandle ssr,
             float refractionLodOffset,
             math::mat4f const& historyProjection,
-            math::mat4f const& projectToPixelMatrix,
+            math::mat4f const& uvFromViewMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
 
     void prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -971,10 +971,10 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
 
                 // set screen-space reflections and screen-space refractions
                 mat4f reprojection;
-                mat4f projectToPixelMatrix;
+                mat4f uvFromViewMatrix;
                 if (config.hasScreenSpaceReflections) {
                     const auto& cameraInfo = view.getCameraInfo();
-                    projectToPixelMatrix =
+                    uvFromViewMatrix =
                             getClipSpaceToTextureSpaceMatrix() *
                             cameraInfo.projection;
                     reprojection =
@@ -985,7 +985,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 TextureHandle ssrHandle = data.ssr ?
                         resources.getTexture(data.ssr) : ppm.getOneTexture();
                 view.prepareSSR(ssrHandle, config.refractionLodOffset,
-                        reprojection, projectToPixelMatrix,
+                        reprojection, uvFromViewMatrix,
                         view.getScreenSpaceReflectionsOptions());
 
                 view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport));

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -658,10 +658,10 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
 }
 
 void FView::prepareSSR(Handle <HwTexture> ssr, float refractionLodOffset,
-        mat4f const& historyProjection, mat4f const& projectToPixelMatrix,
+        mat4f const& historyProjection, mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
     mPerViewUniforms.prepareSSR(ssr, refractionLodOffset,
-            historyProjection, projectToPixelMatrix, ssrOptions);
+            historyProjection, uvFromViewMatrix, ssrOptions);
 }
 
 void FView::prepareStructure(Handle<HwTexture> structure) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -172,7 +172,7 @@ public:
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset,
-            math::mat4f const& historyProjection, math::mat4f const& projectToPixelMatrix,
+            math::mat4f const& historyProjection, math::mat4f const& uvFromViewMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
     void prepareShadow(backend::Handle<backend::HwTexture> structure) const noexcept;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -138,7 +138,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     // Screen-space reflections
     math::mat4f ssrReprojection;
-    math::mat4f ssrProjectToPixelMatrix;
+    math::mat4f ssrUvFromViewMatrix;
     float ssrThickness;                 // ssr thickness, in world units
     float ssrBias;                      // ssr bias, in world units
     float ssrDistance;                  // ssr world raycast distance, 0 when ssr is off

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -119,7 +119,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 
             // Screen-space reflection parameters
             .add("ssrReprojection",         1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("ssrProjectToPixelMatrix", 1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add("ssrUvFromViewMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("ssrThickness",            1, UniformInterfaceBlock::Type::FLOAT)
             .add("ssrBias",                 1, UniformInterfaceBlock::Type::FLOAT)
             .add("ssrDistance",             1, UniformInterfaceBlock::Type::FLOAT)

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -541,7 +541,7 @@ vec3 evaluateRefraction(
     vec3 Ft;
 
     // compute the point where the ray exits the medium, if needed
-    vec4 p = vec4(frameUniforms.clipFromWorldMatrix * vec4(ray.position, 1.0));
+    vec4 p = vec4(getClipFromWorldMatrix() * vec4(ray.position, 1.0));
     p.xy = uvToRenderTargetUV(p.xy * (0.5 / p.w) + 0.5);
 
     // perceptualRoughness to LOD
@@ -580,7 +580,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     vec4 Fssr = vec4(0.0f);
     // evaluateScreenSpaceReflections will set the value of ssr if there's a hit.
     // ssr.a contains the reflection's contribution.
-    if (pixel.roughness <= 0.01f && frameUniforms.ssrDistance > 0.0f) {
+    if (pixel.roughness <= 0.1f && frameUniforms.ssrDistance > 0.0f) {
         vec3 r = getReflectedVector(pixel, shading_view, shading_normal);
         Fssr = evaluateScreenSpaceReflections(pixel, r);
     }

--- a/shaders/src/light_reflections.fs
+++ b/shaders/src/light_reflections.fs
@@ -58,7 +58,7 @@ highp float distanceSquared(highp vec2 a, highp vec2 b) {
 // Note: McGuire and Mara use the "cs" prefix to stand for "camera space", equivalent to Filament's
 // "view space". "cs" has been replaced with "vs" to avoid confusion.
 bool traceScreenSpaceRay(const highp vec3 vsOrigin, const highp vec3 vsDirection,
-        const highp mat4 projectToPixelMatrix, const highp sampler2D vsZBuffer,
+        const highp mat4 uvFromViewMatrix, const highp sampler2D vsZBuffer,
         const float vsZThickness, const highp float nearPlaneZ, const float stride,
         const float jitterFraction, const highp float maxSteps, const float maxRayTraceDistance,
         out highp vec2 hitPixel, out highp vec3 vsHitPoint) {
@@ -69,8 +69,8 @@ bool traceScreenSpaceRay(const highp vec3 vsOrigin, const highp vec3 vsDirection
     highp vec3 vsEndPoint = vsDirection * rayLength + vsOrigin;
 
     // Project into screen space
-    highp vec4 H0 = mulMat4x4Float3(projectToPixelMatrix, vsOrigin);
-    highp vec4 H1 = mulMat4x4Float3(projectToPixelMatrix, vsEndPoint);
+    highp vec4 H0 = mulMat4x4Float3(uvFromViewMatrix, vsOrigin);
+    highp vec4 H1 = mulMat4x4Float3(uvFromViewMatrix, vsEndPoint);
 
     // There are a lot of divisions by w that can be turned into multiplications at some minor
     // precision loss...and we need to interpolate these 1/w values anyway.
@@ -205,11 +205,10 @@ vec4 evaluateScreenSpaceReflections(const PixelParams pixel, const vec3 wsRayDir
     highp vec3 wsRayStart = shading_position + frameUniforms.ssrBias * wsRayDirection;
 
     // ray start/end in view space
-    highp vec4 vsRayStart = mulMat4x4Float3(getViewFromWorldMatrix(), wsRayStart);
-    highp vec4 vsRayDirection = getViewFromWorldMatrix() * vec4(wsRayDirection, 0.0);
+    highp vec3 vsOrigin = mulMat4x4Float3(getViewFromWorldMatrix(), wsRayStart).xyz;
+    // the view matrix is guaranteed to be a rigid transform
+    highp vec3 vsDirection = mulMat3x3Float3(getViewFromWorldMatrix(), wsRayDirection);
 
-    highp vec3 vsOrigin = vsRayStart.xyz;
-    highp vec3 vsDirection = vsRayDirection.xyz;
     float vsZThickness = frameUniforms.ssrThickness;
     highp float nearPlaneZ = -frameUniforms.nearOverFarMinusNear / frameUniforms.oneOverFarMinusNear;
     float stride = frameUniforms.ssrStride;
@@ -221,9 +220,9 @@ vec4 evaluateScreenSpaceReflections(const PixelParams pixel, const vec3 wsRayDir
     float maxRayTraceDistance = frameUniforms.ssrDistance;
 
     highp vec2 res = vec2(textureSize(light_structure, 0).xy);
-    highp mat4 projectToPixelMatrix =
+    highp mat4 uvFromViewMatrix =
         scaleMatrix(res.x, res.y) *
-        frameUniforms.ssrProjectToPixelMatrix;
+        frameUniforms.ssrUvFromViewMatrix;
 
     highp float maxSteps = float(max(res.x, res.y));
 
@@ -231,7 +230,7 @@ vec4 evaluateScreenSpaceReflections(const PixelParams pixel, const vec3 wsRayDir
     highp vec2 hitPixel;  // not currently used
     highp vec3 vsHitPoint;
 
-    if (traceScreenSpaceRay(vsOrigin, vsDirection, projectToPixelMatrix, light_structure,
+    if (traceScreenSpaceRay(vsOrigin, vsDirection, uvFromViewMatrix, light_structure,
             vsZThickness, nearPlaneZ, stride, jitterFraction, maxSteps,
             maxRayTraceDistance, hitPixel, vsHitPoint)) {
         highp vec4 reprojected = frameUniforms.ssrReprojection * vec4(vsHitPoint, 1.0f);


### PR DESCRIPTION
- Rename projectToPixelMatrix to uvFromViewMatrix, this match our 
existing style better.

- slightly more efficient direction transform

- limit roughness to 0.1 instead of 0.01, because in a lot of cases, 
the roughness increases with the LOD, for instance if it comes from
a texture (to combat aliasing).