### PR TITLE
Add a MAX_LEGACY_MORPH_TARGETS definition

### DIFF
--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -150,6 +150,7 @@ enum VertexAttribute : uint8_t {
     // this is limited by driver::MAX_VERTEX_ATTRIBUTE_COUNT
 };
 
+static constexpr size_t MAX_LEGACY_MORPH_TARGETS = 4;
 static constexpr size_t MAX_MORPH_TARGETS = 128; // this is limited by filament::CONFIG_MAX_MORPH_TARGET_COUNT
 static constexpr size_t MAX_CUSTOM_ATTRIBUTES = 8;
 


### PR DESCRIPTION
This is useful for clients who previously relied on `MAX_MORPH_TARGETS` being 4.