### PR TITLE
Enable rough screen-space reflections

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -342,7 +342,7 @@ public class View {
      */
     public static class ScreenSpaceReflectionsOptions {
         /** ray thickness, in world units */
-        public float thickness = 0.5f;
+        public float thickness = 0.1f;
 
         /** bias, in world units, to prevent self-intersections */
         public float bias = 0.01f;
@@ -351,7 +351,7 @@ public class View {
         public float maxDistance = 3.0f;
 
         /** stride, in texels, for samples along the ray. */
-        public float stride = 1.0f;
+        public float stride = 2.0f;
 
         /** enables or disables screen-space reflections */
         public boolean enabled = false;

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1050,7 +1050,7 @@ Type
 :    array of `string`
 
 Value
-:     Each entry must be any of `dynamicLighting`, `directionalLighting`, `shadowReceiver` or `skinning`.
+:     Each entry must be any of `dynamicLighting`, `directionalLighting`, `shadowReceiver`,`skinning` or `ssr`.
 
 Description
 :     Used to specify a list of shader variants that the application guarantees will never be
@@ -1068,6 +1068,7 @@ Description of the variants:
 - `skinning`, used when an object is animated using GPU skinning
 - `fog`, used when global fog is applied to the scene
 - `vsm`, used when VSM shadows are enabled and the object is a shadow receiver
+- `ssr`, used when screen-space reflections are enabled in the View
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {
@@ -2337,6 +2338,7 @@ variants:
 - `skinning`, used when an object is animated using GPU skinning or vertex morphing
 - `fog`, used when global fog is applied to the scene
 - `vsm`, used when VSM shadows are enabled and the object is a shadow receiver
+- `ssr`, used when screen-space reflections are enabled in the View
 
 Example:
 ```

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -321,10 +321,10 @@ struct TemporalAntiAliasingOptions {
  * @see setScreenSpaceReflectionsOptions()
  */
 struct ScreenSpaceReflectionsOptions {
-    float thickness = 0.5f;     //!< ray thickness, in world units
+    float thickness = 0.1f;     //!< ray thickness, in world units
     float bias = 0.01f;         //!< bias, in world units, to prevent self-intersections
     float maxDistance = 3.0f;   //!< maximum distance, in world units, to raycast
-    float stride = 1.0f;        //!< stride, in texels, for samples along the ray.
+    float stride = 2.0f;        //!< stride, in texels, for samples along the ray.
     bool enabled = false;
 };
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -235,6 +235,25 @@ void FEngine::init() {
     driverApi.setRenderPrimitiveRange(mFullScreenTriangleRph, PrimitiveType::TRIANGLES,
             0, 0, 2, (uint32_t)mFullScreenTriangleIb->getIndexCount());
 
+    // Compute a clip-space [-1 to 1] to texture space [0 to 1] matrix, taking into account
+    // backend differences.
+    const bool textureSpaceYFlipped = mBackend == Backend::METAL || mBackend == Backend::VULKAN;
+    if (textureSpaceYFlipped) {
+        mUvFromClipMatrix = mat4f(mat4f::row_major_init{
+                0.5f,  0.0f,   0.0f, 0.5f,
+                0.0f, -0.5f,   0.0f, 0.5f,
+                0.0f,  0.0f,   1.0f, 0.0f,
+                0.0f,  0.0f,   0.0f, 1.0f
+        });
+    } else {
+        mUvFromClipMatrix = mat4f(mat4f::row_major_init{
+                0.5f,  0.0f,   0.0f, 0.5f,
+                0.0f,  0.5f,   0.0f, 0.5f,
+                0.0f,  0.0f,   1.0f, 0.0f,
+                0.0f,  0.0f,   0.0f, 1.0f
+        });
+    }
+
     mDefaultIblTexture = upcast(Texture::Builder()
             .width(1).height(1).levels(1)
             .format(Texture::InternalFormat::RGBA8)

--- a/filament/src/FrameHistory.h
+++ b/filament/src/FrameHistory.h
@@ -25,13 +25,21 @@
 namespace filament {
 
 // This is where we store all the history of a frame
+// when adding things here, please update:
+//      FView::commitFrameHistory()
 struct FrameHistoryEntry {
-    FrameGraphTexture color;
-    FrameGraphTexture::Descriptor colorDesc;
-    math::mat4f projection;     // world space to clip space
-    math::float2 jitter{};
+    struct {
+        FrameGraphTexture color;
+        FrameGraphTexture::Descriptor desc;
+        math::mat4f projection;     // world space to clip space
+        math::float2 jitter{};
+    } taa;
+    struct {
+        FrameGraphTexture color;
+        FrameGraphTexture::Descriptor desc;
+        math::mat4f projection;
+    } ssr;
     uint32_t frameId = 0;
-
 };
 
 /*

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -221,6 +221,10 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
             mRasterState.depthWrite = true;
             break;
         case BlendingMode::MASKED:
+            // MASKED mode now leaves destination alpha intact.
+            // This prevents strange behavior with semi-transparent render targets, which the
+            // model viewer team discovered when testing against the Khronos alpha test
+            // conformance model.
             mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
             mRasterState.blendFunctionSrcAlpha = BlendFunction::ZERO;
             mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -170,8 +170,6 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOption
 
 void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
         float refractionLodOffset,
-        math::mat4f const& historyProjection,
-        math::mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
     mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
@@ -180,9 +178,21 @@ void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
     });
 
     auto& s = mPerViewUb.edit();
-
     s.refractionLodOffset = refractionLodOffset;
+    s.ssrDistance = ssrOptions.enabled ? ssrOptions.maxDistance : 0.0f;
+}
 
+void PerViewUniforms::prepareHistorySSR(Handle<HwTexture> ssr,
+        math::mat4f const& historyProjection,
+        math::mat4f const& uvFromViewMatrix,
+        ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
+
+    mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
+        .filterMag = SamplerMagFilter::LINEAR,
+        .filterMin = SamplerMinFilter::LINEAR
+    });
+
+    auto& s = mPerViewUb.edit();
     s.ssrReprojection = historyProjection;
     s.ssrUvFromViewMatrix = uvFromViewMatrix;
     s.ssrThickness = ssrOptions.thickness;

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -76,6 +76,9 @@ public:
     // screen-space reflection and/or refraction (SSR)
     void prepareSSR(TextureHandle ssr,
             float refractionLodOffset,
+            ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
+
+    void prepareHistorySSR(TextureHandle ssr,
             math::mat4f const& historyProjection,
             math::mat4f const& uvFromViewMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -881,9 +881,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bilateralBlurPass(
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::generateGaussianMipmap(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> input, size_t levels,
-        bool reinhard, size_t kernelWidth, float sigmaRatio) noexcept {
+        bool reinhard, size_t kernelWidth, float sigma) noexcept {
     for (size_t i = 1; i < levels; i++) {
-        input = gaussianBlurPass(fg, input, i - 1, input, i, 0, reinhard, kernelWidth, sigmaRatio);
+        input = gaussianBlurPass(fg, input, i - 1, input, i, 0, reinhard, kernelWidth, sigma);
         reinhard = false; // only do the reinhard filtering on the first level
     }
     return input;
@@ -892,9 +892,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::generateGaussianMipmap(Frame
 FrameGraphId<FrameGraphTexture> PostProcessManager::gaussianBlurPass(FrameGraph& fg,
         FrameGraphId<FrameGraphTexture> input, uint8_t srcLevel,
         FrameGraphId<FrameGraphTexture> output, uint8_t dstLevel, uint8_t layer,
-        bool reinhard, size_t kernelWidth, float sigmaRatio) noexcept {
-
-    const float sigma = (float(kernelWidth) + 1.0f) / sigmaRatio;
+        bool reinhard, size_t kernelWidth, const float sigma) noexcept {
 
     Handle<HwRenderPrimitive> fullScreenRenderPrimitive = mEngine.getFullScreenRenderPrimitive();
 
@@ -1054,8 +1052,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::generateMipmapSSR(FrameGraph
 
     auto const& desc = fg.getDescriptor(input);
 
-    // scale factor for the gaussian so it matches our resolution / FOV
-    const float s = verticalFieldOfView / float(desc.height);
+    // texel size of the reflection buffer in world units at 1 meter
+    constexpr float d = 1.0f; // 1m
+    const float texelSizeAtOneMeter = d * std::tan(verticalFieldOfView) / float(desc.height);
 
     // The kernel-size was determined empirically so that we don't get too many artifacts
     // due to the down-sampling with a box filter (which happens implicitly).
@@ -1067,29 +1066,99 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::generateMipmapSSR(FrameGraph
     static_assert(kernelSize & 1u, "kernel size must be odd");
     static_assert((((kernelSize - 1u) / 2u) & 1u) == 0, "kernel positive side size must be even");
 
-    // The relation between n and sigma (variance) is 6*sigma - 1 = N
+    // The relation between the kernel size N and sigma (standard deviation) is 6*sigma - 1 = N
+    // and is designed so the filter keeps its "gaussian-ness".
+    // The standard deviation sigma0 is expressed in texels.
     constexpr float sigma0 = (kernelSize + 1) / 6.0f;
 
-    // The variance doubles each time we go one mip down:
-    //      sigma = sigma0 * 2^lod
-    //      lod = log2(sigma) - log2(sigma0) = log2(sigma / sigma0).
-    //
-    // sigma is deduced from the roughness:
-    //      roughness = sqrt(2) * s * sigma
-    //
-    // In the end we get: lod = 2 * log2(perceptualRoughness) - log2(sigma0 * s * sqrt2)
+    /*
+     * 1. Relation between standard deviation and LOD
+     * ----------------------------------------------
+     *
+     * The standard deviation doubles at each level (i.e. variance quadruples), however,
+     * the mip-chain is constructed by successively blurring each level, which causes the
+     * variance of a given level to increase by the variance of the previous level (i.e. variances
+     * add under convolution). This results in a scaling of 2.23 (instead of 2) of the standard
+     * deviation for each level: sqrt( 1^2 + 2^2 ) = sqrt(5) = 2.23;
+     *
+     *  The standard deviation is scaled by 2.23 each time we go one mip down,
+     *  and our mipmap chain is built such that lod 0 is not blurred and lod 1 is blurred with
+     *  sigma0 * 2 (because of the smaller resolution of lod 1). To simplify things a bit, we
+     *  replace this factor by 2.23 (i.e. we pretend that lod 0 is blurred by sigma0).
+     *  We then get:
+     *      sigma = sigma0 * 2.23^lod
+     *      lod   = log2(sigma / sigma0) / log2(2.23)
+     *
+     *      +------------------------------------------------+
+     *      |  lod = [ log2(sigma) - log2(sigma0) ] * 0.8614 |
+     *      +------------------------------------------------+
+     *
+     * 2. Relation between standard deviation and roughness
+     * ----------------------------------------------------
+     *
+     *  The spherical gaussian approximation of the GGX distribution is given by:
+     *
+     *           1         2(cos(theta)-1)
+     *         ------ exp(  --------------- )
+     *         pi*a^2           a^2
+     *
+     *
+     *  Which is equivalent to:
+     *
+     *      sqrt(2)
+     *      ------- Gaussian(2 * sqrt(1 - cos(theta)), a)
+     *       pi*a
+     *
+     *  But when we filter a frame, we're actually calculating:
+     *
+     *      Gaussian(d * tan(theta), sigma)
+     *
+     *  With d the distance from the eye to the center sample, theta the angle, and it turns out
+     *  that sqrt(2) * tan(theta) is very close to 2 * sqrt(1 - cos(theta)) for small angles, we
+     *  can make that assumption because our filter is not wide.
+     *  The above can be rewritten as:
+     *
+     *      Gaussian(d * tan(theta), a * d / sqrt(2))
+     *    = Gaussian(    tan(theta), a     / sqrt(2))
+     *
+     *  Which now matches the SG approximation (we don't mind the scale factor because it's
+     *  calculated automatically in the shader).
+     *
+     *  We finally get that:
+     *
+     *      +---------------------+
+     *      | sigma = a / sqrt(2) |
+     *      +---------------------+
+     *
+     *
+     * 3. Taking the resolution into account
+     * -------------------------------------
+     *
+     *  sigma0 above is expressed in texels, but we're interested in world units. The texel
+     *  size in world unit is given by:
+     *
+     *      +--------------------------------+
+     *      |  s = d * tan(fov) / resolution |      with d distance to camera plane
+     *      +--------------------------------+
+     *
+     * 4. Roughness to lod mapping
+     * ---------------------------
+     *
+     *  Putting it all together we get:
+     *
+     *      lod   = [ log2(sigma)       - log2(           sigma0 * s ) ] * 0.8614
+     *      lod   = [ log2(a / sqrt(2)) - log2(           sigma0 * s ) ] * 0.8614
+     *      lod   = [ log2(a)           - log2( sqrt(2) * sigma0 * s ) ] * 0.8614
+     *
+     *   +-------------------------------------------------------------------------------------+
+     *   | lod   = [ log2(a / d) - log2(sqrt(2) * sigma0 * (tan(fov) / resolution)) ] * 0.8614 |
+     *   +-------------------------------------------------------------------------------------+
+     */
 
-    // FIXME: revisit the formula above. Not sure where the 2* comes from.
-
-    const float refractionLodOffset = -std::log2(sigma0 * s * f::SQRT2);
-    const float maxPerceptualRoughness = 0.5f;
-    const uint8_t maxLod = std::ceil(2.0f * std::log2(maxPerceptualRoughness) + refractionLodOffset);
-
-    // Number of roughness levels we want.
-    // TODO: If we want to limit the number of mip levels, we must reduce the initial
-    //       resolution (if we want to keep the same filter, and still match the IBL somewhat).
-    const uint8_t roughnessLodCount =
-            std::min(maxLod, FTexture::maxLevelCount(desc.width, desc.height));
+    const float refractionLodOffset = -std::log2(f::SQRT2 * sigma0 * texelSizeAtOneMeter);
+    uint8_t roughnessLodCount = FTexture::maxLevelCount(desc.width, desc.height);
+    // we don't go lower than 16 texel in one dimension
+    roughnessLodCount = std::max(std::min(4, +roughnessLodCount), +roughnessLodCount - 4);
 
     // Then copy the color buffer into a texture, making sure that we keep the original
     // buffer aspect-ratio (this is because dynamic-resolution is not necessarily homogenous).
@@ -1141,7 +1210,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::generateMipmapSSR(FrameGraph
      */
 
     *pLodOffset = refractionLodOffset;
-    input = ppm.generateGaussianMipmap(fg, input, roughnessLodCount, true, kernelSize);
+    input = ppm.generateGaussianMipmap(fg, input, roughnessLodCount, true, kernelSize, sigma0);
     return input;
 }
 
@@ -1859,10 +1928,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::bloomPass(FrameGraph& fg,
                     commitAndRender(out, material, driver);
                 });
 
+        constexpr float kernelWidth = 9;
+        constexpr float sigma = (kernelWidth + 1.0f) / 6.0f;
         auto flare = gaussianBlurPass(fg,
                 flarePass->out, 0,
                 {}, 0, 0,
-                false, 9);
+                false, kernelWidth, sigma);
 
         fg.getBlackboard().put("flare", flare);
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -93,7 +93,7 @@ public:
     // Gaussian mipmap
     FrameGraphId<FrameGraphTexture> generateGaussianMipmap(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, size_t levels, bool reinhard,
-            size_t kernelWidth, float sigmaRatio = 6.0f) noexcept;
+            size_t kernelWidth, float sigma) noexcept;
 
     FrameGraphId<FrameGraphTexture> generateMipmapSSR(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, float verticalFieldOfView,
@@ -176,7 +176,7 @@ public:
     FrameGraphId<FrameGraphTexture> gaussianBlurPass(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, uint8_t srcLevel,
             FrameGraphId<FrameGraphTexture> output, uint8_t dstLevel, uint8_t layer,
-            bool reinhard, size_t kernelWidth, float sigma = 6.0f) noexcept;
+            bool reinhard, size_t kernelWidth, float sigma) noexcept;
 
     backend::Handle<backend::HwTexture> getOneTexture() const;
     backend::Handle<backend::HwTexture> getZeroTexture() const;

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -44,7 +44,7 @@ class FEngine;
 class FMaterial;
 class FMaterialInstance;
 class FrameGraph;
-class FView;
+class PerViewUniforms;
 class RenderPass;
 struct CameraInfo;
 
@@ -75,6 +75,15 @@ public:
     FrameGraphId<FrameGraphTexture> structure(FrameGraph& fg,
             RenderPass const& pass, uint8_t structureRenderFlags,
             uint32_t width, uint32_t height, StructurePassConfig const& config) noexcept;
+
+    // reflections pass
+    FrameGraphId<FrameGraphTexture> ssr(FrameGraph& fg,
+            RenderPass const& pass,
+            FrameHistory const& frameHistory,
+            CameraInfo const& cameraInfo,
+            PerViewUniforms& uniforms,
+            ScreenSpaceReflectionsOptions const& options,
+            FrameGraphTexture::Descriptor const& desc) noexcept;
 
     // SSAO
     FrameGraphId<FrameGraphTexture> screenSpaceAmbientOcclusion(FrameGraph& fg,
@@ -135,7 +144,6 @@ public:
 
     FrameGraphId<FrameGraphTexture> taa(FrameGraph& fg,
             FrameGraphId<FrameGraphTexture> input, FrameHistory& frameHistory,
-            FrameGraphId<FrameGraphTexture> colorHistory,
             TemporalAntiAliasingOptions const& taaOptions,
             ColorGradingConfig colorGradingConfig) noexcept;
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -171,15 +171,18 @@ public:
 
         // shadow-casters are rendered in the depth buffer, regardless of blending (or alpha masking)
         DEPTH_CONTAINS_SHADOW_CASTERS = 0x4,
-        // alpha-blended objects are not rendered in the depth buffer
-        DEPTH_FILTER_TRANSLUCENT_OBJECTS = 0x8,
         // alpha-tested objects are not rendered in the depth buffer
-        DEPTH_FILTER_ALPHA_MASKED_OBJECTS = 0x10,
+        DEPTH_FILTER_ALPHA_MASKED_OBJECTS = 0x08,
+
+        // alpha-blended objects are not rendered in the depth buffer
+        FILTER_TRANSLUCENT_OBJECTS = 0x10,
 
         // generate commands for shadow map
         SHADOW = DEPTH | DEPTH_CONTAINS_SHADOW_CASTERS,
         // generate commands for SSAO
-        SSAO = DEPTH | DEPTH_FILTER_TRANSLUCENT_OBJECTS,
+        SSAO = DEPTH | FILTER_TRANSLUCENT_OBJECTS,
+        // generate commands for screen-space reflections
+        SCREEN_SPACE_REFLECTIONS = COLOR | FILTER_TRANSLUCENT_OBJECTS
     };
 
 
@@ -272,6 +275,7 @@ public:
 
     //  flags controlling how commands are generated
     void setRenderFlags(RenderFlags flags) noexcept { mFlags = flags; }
+    RenderFlags getRenderFlags() const noexcept { return mFlags; }
 
     // variant to use
     void setVariant(Variant variant) noexcept { mVariant = variant; }

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -657,10 +657,15 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
     mPerViewUniforms.prepareSSAO(ssao, mAmbientOcclusionOptions);
 }
 
-void FView::prepareSSR(Handle <HwTexture> ssr, float refractionLodOffset,
+void FView::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset,
+        ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
+    mPerViewUniforms.prepareSSR(ssr, refractionLodOffset, ssrOptions);
+}
+
+void FView::prepareHistorySSR(Handle<HwTexture> ssr,
         mat4f const& historyProjection, mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
-    mPerViewUniforms.prepareSSR(ssr, refractionLodOffset,
+    mPerViewUniforms.prepareHistorySSR(ssr,
             historyProjection, uvFromViewMatrix, ssrOptions);
 }
 
@@ -880,8 +885,10 @@ void FView::renderShadowMaps(FrameGraph& fg, FEngine& engine, FEngine::DriverApi
 void FView::commitFrameHistory(FEngine& engine) noexcept {
     // Here we need to destroy resources in mFrameHistory.back()
     auto& frameHistory = mFrameHistory;
+
     FrameHistoryEntry& last = frameHistory.back();
-    last.color.destroy(engine.getResourceAllocator());
+    last.taa.color.destroy(engine.getResourceAllocator());
+    last.ssr.color.destroy(engine.getResourceAllocator());
 
     // and then push the new history entry to the history stack
     frameHistory.commit();

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -130,7 +130,7 @@ public:
     }
 
     float getFieldOfView(Camera::Fov direction) const noexcept {
-        // note: this is meaning less for an orthographic projection
+        // note: this is meaningless for an orthographic projection
         auto const& p = getProjectionMatrix();
         switch (direction) {
             case Fov::VERTICAL:

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -176,6 +176,10 @@ public:
         return mFullScreenTriangleIb;
     }
 
+    math::mat4f getUvFromClipMatrix() const noexcept {
+        return mUvFromClipMatrix;
+    }
+
     PostProcessManager const& getPostProcessManager() const noexcept {
         return mPostProcessManager;
     }
@@ -366,6 +370,7 @@ private:
     backend::Handle<backend::HwRenderPrimitive> mFullScreenTriangleRph;
     FVertexBuffer* mFullScreenTriangleVb = nullptr;
     FIndexBuffer* mFullScreenTriangleIb = nullptr;
+    math::mat4f mUvFromClipMatrix;
 
     PostProcessManager mPostProcessManager;
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -157,8 +157,8 @@ private:
         backend::TargetBufferFlags clearFlags;
         // Clear color
         math::float4 clearColor = {};
-        // Lod offset for the SSR pass
-        float refractionLodOffset;
+        // Lod offset for the SSR passes
+        float ssrLodOffset;
         // Contact shadow enabled?
         bool hasContactShadows;
         // Screen-space reflections enabled?
@@ -199,11 +199,6 @@ private:
     }
 
     math::mat4f getClipSpaceToTextureSpaceMatrix() const noexcept;
-
-    void setHistoryProjection(FView& view, math::mat4f const& projection);
-
-    static FrameGraphId<FrameGraphTexture> getColorHistory(FrameGraph& fg,
-            FrameHistory const& frameHistory) noexcept;
 
     // keep a reference to our engine
     FEngine& mEngine;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -172,6 +172,8 @@ public:
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset,
+            ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
+    void prepareHistorySSR(backend::Handle<backend::HwTexture> ssr,
             math::mat4f const& historyProjection, math::mat4f const& uvFromViewMatrix,
             ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
@@ -465,6 +467,9 @@ public:
             Frustum const& frustum, size_t bit) noexcept;
 
     auto& getShadowUniforms() const { return mShadowUb; }
+
+    PerViewUniforms const& getPerViewUniforms() const noexcept { return mPerViewUniforms; }
+    PerViewUniforms& getPerViewUniforms() noexcept { return mPerViewUniforms; }
 
     // Returns the frame history FIFO. This is typically used by the FrameGraph to access
     // previous frame data.

--- a/libs/filabridge/CMakeLists.txt
+++ b/libs/filabridge/CMakeLists.txt
@@ -12,8 +12,9 @@ file(GLOB_RECURSE PUBLIC_HDRS ${PUBLIC_HDR_DIR}/**/*.h)
 set(SRCS
         src/SamplerBindingMap.cpp
         src/SamplerInterfaceBlock.cpp
-        src/UniformInterfaceBlock.cpp
         src/SibGenerator.cpp
+        src/UniformInterfaceBlock.cpp
+        src/Variant.cpp
 )
 
 # ==================================================================================================

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -238,6 +238,7 @@ enum class UserVariantFilterBit : uint32_t {
     SKINNING                    = 0x08,
     FOG                         = 0x10,
     VSM                         = 0x20,
+    SSR                         = 0x40,
 };
 
 using UserVariantFilterMask = uint32_t;

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -231,6 +231,17 @@ enum class Property : uint8_t {
     // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
 };
 
+enum class UserVariantFilterBit : uint32_t {
+    DIRECTIONAL_LIGHTING        = 0x01,
+    DYNAMIC_LIGHTING            = 0x02,
+    SHADOW_RECEIVER             = 0x04,
+    SKINNING                    = 0x08,
+    FOG                         = 0x10,
+    VSM                         = 0x20,
+};
+
+using UserVariantFilterMask = uint32_t;
+
 } // namespace filament
 
 #endif

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -51,7 +51,7 @@ struct Variant {
     // VSM: Variance shadow maps
     //
     //   X: either 1 or 0
-    //
+    //                               1     0    0      0     1     0     1
     //                      +-----+-----+-----+-----+-----+-----+-----+-----+
     // Variant              |  0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |   128
     //                      +-----+-----+-----+-----+-----+-----+-----+-----+
@@ -59,11 +59,13 @@ struct Variant {
     //
     // Standard variants:
     //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-    //                      |  0  | VSM | FOG |  0  | SKN | SRE | DYN | DIR |    64 - 24 = 40
+    //                      |  0  | VSM | FOG |  0  | SKN | SRE | DYN | DIR |    64 - 22 = 42
     //                      +-----+-----+-----+-----+-----+-----+-----+-----+
     //      Vertex shader            0     0     0     X     X     X     X
     //    Fragment shader            X     X     0     0     X     X     X
-    //           Reserved            X     X     0     X     1     0     0      [ -8]
+    //       Fragment SSR            1     0     0     0     1     0     0
+    //           Reserved            1     1     0     X     1     0     0      [ -2]
+    //           Reserved            0     X     0     X     1     0     0      [ -4]
     //           Reserved            1     X     0     X     0     X     X      [-16]
     //
     // Depth variants:
@@ -74,7 +76,7 @@ struct Variant {
     //     Fragment depth            X     X     1     0     0     0     0
     //           Reserved            1     1     1     X     0     0     0     [ -2]
     //
-    // 46 variants used, 82 reserved (128 - 46)
+    // 48 variants used, 80 reserved (128 - 46)
     //
     // note: a valid variant can be neither a valid vertex nor a valid fragment variant
     //       (e.g.: FOG|SKN variants), the proper bits are filtered appropriately,
@@ -93,6 +95,9 @@ struct Variant {
     static constexpr type_t PCK   = 0x20; // picking (depth)
     static constexpr type_t VSM   = 0x40; // variance shadow maps
 
+    // special variants (variants that use the reserved space)
+    static constexpr type_t SPECIAL_SSR   = VSM | SRE; // screen-space reflections variant
+
     static constexpr type_t STANDARD_MASK      = DEP;
     static constexpr type_t STANDARD_VARIANT   = 0u;
 
@@ -107,12 +112,7 @@ struct Variant {
     // returns raw variant bits
     inline bool hasDirectionalLighting() const noexcept { return key & DIR; }
     inline bool hasDynamicLighting() const noexcept     { return key & DYN; }
-    inline bool hasShadowReceiver() const noexcept      { return key & SRE; }
     inline bool hasSkinningOrMorphing() const noexcept  { return key & SKN; }
-    inline bool hasDepth() const noexcept               { return key & DEP; }
-    inline bool hasFog() const noexcept                 { return key & FOG; }
-    inline bool hasPicking() const noexcept             { return key & PCK; }
-    inline bool hasVsm() const noexcept                 { return key & VSM; }
 
     inline void setDirectionalLighting(bool v) noexcept { set(v, DIR); }
     inline void setDynamicLighting(bool v) noexcept     { set(v, DYN); }
@@ -132,14 +132,21 @@ struct Variant {
 
     inline static constexpr bool isValidStandardVariant(Variant variant) noexcept {
         // can't have shadow receiver if we don't have any lighting
-        constexpr type_t RESERVED0_MASK  = SRE | DYN | DIR;
-        constexpr type_t RESERVED0_VALUE = SRE;
+        constexpr type_t RESERVED0_MASK  = VSM | FOG | SRE | DYN | DIR;
+        constexpr type_t RESERVED0_VALUE = VSM | FOG | SRE;
+
+        // can't have shadow receiver if we don't have any lighting
+        constexpr type_t RESERVED1_MASK  = VSM | SRE | DYN | DIR;
+        constexpr type_t RESERVED1_VALUE = SRE;
+
         // can't have VSM without shadow receiver
-        constexpr type_t RESERVED1_MASK  = VSM | SRE;
-        constexpr type_t RESERVED1_VALUE = VSM;
+        constexpr type_t RESERVED2_MASK  = VSM | SRE;
+        constexpr type_t RESERVED2_VALUE = VSM;
+
         return ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) &&
                ((variant.key & RESERVED0_MASK) != RESERVED0_VALUE) &&
-               ((variant.key & RESERVED1_MASK) != RESERVED1_VALUE);
+               ((variant.key & RESERVED1_MASK) != RESERVED1_VALUE) &&
+               ((variant.key & RESERVED2_MASK) != RESERVED2_VALUE);
     }
 
     inline static constexpr bool isVertexVariant(Variant variant) noexcept {
@@ -151,17 +158,40 @@ struct Variant {
     }
 
     static constexpr bool isReserved(Variant variant) noexcept {
-        return !isValidStandardVariant(variant) && !isValidDepthVariant(variant);
+        return !isValid(variant);
     }
 
     static constexpr bool isValid(Variant variant) noexcept {
         return isValidStandardVariant(variant) || isValidDepthVariant(variant);
     }
 
+    inline static constexpr bool isSSRVariant(Variant variant) noexcept {
+        return (variant.key & (VSM | DEP | SRE | DYN | DIR)) == (VSM | SRE);
+    }
+
+    inline static constexpr bool isVSMVariant(Variant variant) noexcept {
+        return !isSSRVariant(variant) && ((variant.key & VSM) == VSM);
+    }
+
+    inline static constexpr bool isShadowReceiverVariant(Variant variant) noexcept {
+        return !isSSRVariant(variant) && ((variant.key & SRE) == SRE);
+    }
+
+    inline static constexpr bool isFogVariant(Variant variant) noexcept {
+        return (variant.key & (FOG | DEP)) == FOG;
+    }
+
+    inline static constexpr bool isPickingVariant(Variant variant) noexcept {
+        return (variant.key & (PCK | DEP)) == (PCK | DEP);
+    }
+
     static constexpr Variant filterVariantVertex(Variant variant) noexcept {
         // filter out vertex variants that are not needed. For e.g. fog doesn't affect the
         // vertex shader.
         if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
+            if (isSSRVariant(variant)) {
+                variant.key &= ~(VSM | SRE);
+            }
             return variant & (SKN | SRE | DYN | DIR);
         }
         if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
@@ -187,6 +217,9 @@ struct Variant {
     static constexpr Variant filterVariant(Variant variant, bool isLit) noexcept {
         // special case for depth variant
         if (isValidDepthVariant(variant)) {
+            return variant;
+        }
+        if (isSSRVariant(variant)) {
             return variant;
         }
         if (!isLit) {

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -23,194 +23,194 @@
 #include <utils/bitset.h>
 
 namespace filament {
-    static constexpr size_t VARIANT_BITS = 7;
-    static constexpr size_t VARIANT_COUNT = 1 << VARIANT_BITS;
+static constexpr size_t VARIANT_BITS = 7;
+static constexpr size_t VARIANT_COUNT = 1 << VARIANT_BITS;
 
-    using VariantList = utils::bitset<uint64_t, VARIANT_COUNT / 64>;
+using VariantList = utils::bitset<uint64_t, VARIANT_COUNT / 64>;
 
-    // IMPORTANT: update filterVariant() when adding more variants
-    // Also be sure to update formatVariantString inside CommonWriter.cpp
-    struct Variant {
-        using type_t = uint8_t;
+// IMPORTANT: update filterVariant() when adding more variants
+// Also be sure to update formatVariantString inside CommonWriter.cpp
+struct Variant {
+    using type_t = uint8_t;
 
-        Variant() noexcept = default;
-        Variant(Variant const& rhs) noexcept = default;
-        Variant& operator=(Variant const& rhs) noexcept = default;
-        constexpr explicit Variant(type_t key) noexcept : key(key) { }
+    Variant() noexcept = default;
+    Variant(Variant const& rhs) noexcept = default;
+    Variant& operator=(Variant const& rhs) noexcept = default;
+    constexpr explicit Variant(type_t key) noexcept : key(key) { }
 
 
-        // DIR: Directional Lighting
-        // DYN: Dynamic Lighting
-        // SRE: Shadow Receiver
-        // SKN: Skinning
-        // DEP: Depth only
-        // FOG: Fog
-        // PCK: Picking (depth variant only)
-        // VSM: Variance shadow maps
-        //
-        //   X: either 1 or 0
-        //
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        // Variant              |  0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |   128
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        //                                    PCK
-        //
-        // Standard variants:
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        //                      |  0  | VSM | FOG |  0  | SKN | SRE | DYN | DIR |    64 - 24 = 40
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        //      Vertex shader            0     0     0     X     X     X     X
-        //    Fragment shader            X     X     0     0     X     X     X
-        //           Reserved            X     X     0     X     1     0     0      [ -8]
-        //           Reserved            1     X     0     X     0     X     X      [-16]
-        //
-        // Depth variants:
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        //                      |  0  | VSM | PCK |  1  | SKN |  0  |  0  |  0  |   8 - 2 = 6
-        //                      +-----+-----+-----+-----+-----+-----+-----+-----+
-        //       Vertex depth            X     0     1     X     0     0     0
-        //     Fragment depth            X     X     1     0     0     0     0
-        //           Reserved            1     1     1     X     0     0     0     [ -2]
-        //
-        // 46 variants used, 82 reserved (128 - 46)
-        //
-        // note: a valid variant can be neither a valid vertex nor a valid fragment variant
-        //       (e.g.: FOG|SKN variants), the proper bits are filtered appropriately,
-        //       see filterVariantVertex(), filterVariantFragment().
+    // DIR: Directional Lighting
+    // DYN: Dynamic Lighting
+    // SRE: Shadow Receiver
+    // SKN: Skinning
+    // DEP: Depth only
+    // FOG: Fog
+    // PCK: Picking (depth variant only)
+    // VSM: Variance shadow maps
+    //
+    //   X: either 1 or 0
+    //
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    // Variant              |  0  | VSM | FOG | DEP | SKN | SRE | DYN | DIR |   128
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    //                                    PCK
+    //
+    // Standard variants:
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    //                      |  0  | VSM | FOG |  0  | SKN | SRE | DYN | DIR |    64 - 24 = 40
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    //      Vertex shader            0     0     0     X     X     X     X
+    //    Fragment shader            X     X     0     0     X     X     X
+    //           Reserved            X     X     0     X     1     0     0      [ -8]
+    //           Reserved            1     X     0     X     0     X     X      [-16]
+    //
+    // Depth variants:
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    //                      |  0  | VSM | PCK |  1  | SKN |  0  |  0  |  0  |   8 - 2 = 6
+    //                      +-----+-----+-----+-----+-----+-----+-----+-----+
+    //       Vertex depth            X     0     1     X     0     0     0
+    //     Fragment depth            X     X     1     0     0     0     0
+    //           Reserved            1     1     1     X     0     0     0     [ -2]
+    //
+    // 46 variants used, 82 reserved (128 - 46)
+    //
+    // note: a valid variant can be neither a valid vertex nor a valid fragment variant
+    //       (e.g.: FOG|SKN variants), the proper bits are filtered appropriately,
+    //       see filterVariantVertex(), filterVariantFragment().
 
-        type_t key = 0u;
+    type_t key = 0u;
 
-        // when adding more bits, update FRenderer::CommandKey::draw::materialVariant as needed
-        // when adding more bits, update VARIANT_COUNT
-        static constexpr type_t DIR   = 0x01; // directional light present, per frame/world position
-        static constexpr type_t DYN   = 0x02; // point, spot or area present, per frame/world position
-        static constexpr type_t SRE   = 0x04; // receives shadows, per renderable
-        static constexpr type_t SKN   = 0x08; // GPU skinning and/or morphing
-        static constexpr type_t DEP   = 0x10; // depth only variants
-        static constexpr type_t FOG   = 0x20; // fog (standard)
-        static constexpr type_t PCK   = 0x20; // picking (depth)
-        static constexpr type_t VSM   = 0x40; // variance shadow maps
+    // when adding more bits, update FRenderer::CommandKey::draw::materialVariant as needed
+    // when adding more bits, update VARIANT_COUNT
+    static constexpr type_t DIR   = 0x01; // directional light present, per frame/world position
+    static constexpr type_t DYN   = 0x02; // point, spot or area present, per frame/world position
+    static constexpr type_t SRE   = 0x04; // receives shadows, per renderable
+    static constexpr type_t SKN   = 0x08; // GPU skinning and/or morphing
+    static constexpr type_t DEP   = 0x10; // depth only variants
+    static constexpr type_t FOG   = 0x20; // fog (standard)
+    static constexpr type_t PCK   = 0x20; // picking (depth)
+    static constexpr type_t VSM   = 0x40; // variance shadow maps
 
-        static constexpr type_t STANDARD_MASK      = DEP;
-        static constexpr type_t STANDARD_VARIANT   = 0u;
+    static constexpr type_t STANDARD_MASK      = DEP;
+    static constexpr type_t STANDARD_VARIANT   = 0u;
 
-        // the depth variant deactivates all variants that make no sense when writing the depth
-        // only -- essentially, all fragment-only variants.
-        static constexpr type_t DEPTH_MASK         = DEP | SRE | DYN | DIR;
-        static constexpr type_t DEPTH_VARIANT      = DEP;
+    // the depth variant deactivates all variants that make no sense when writing the depth
+    // only -- essentially, all fragment-only variants.
+    static constexpr type_t DEPTH_MASK         = DEP | SRE | DYN | DIR;
+    static constexpr type_t DEPTH_VARIANT      = DEP;
 
-        // this mask filters out the lighting variants
-        static constexpr type_t UNLIT_MASK         = SKN | FOG;
+    // this mask filters out the lighting variants
+    static constexpr type_t UNLIT_MASK         = SKN | FOG;
 
-        // returns raw variant bits
-        inline bool hasDirectionalLighting() const noexcept { return key & DIR; }
-        inline bool hasDynamicLighting() const noexcept     { return key & DYN; }
-        inline bool hasShadowReceiver() const noexcept      { return key & SRE; }
-        inline bool hasSkinningOrMorphing() const noexcept  { return key & SKN; }
-        inline bool hasDepth() const noexcept               { return key & DEP; }
-        inline bool hasFog() const noexcept                 { return key & FOG; }
-        inline bool hasPicking() const noexcept             { return key & PCK; }
-        inline bool hasVsm() const noexcept                 { return key & VSM; }
+    // returns raw variant bits
+    inline bool hasDirectionalLighting() const noexcept { return key & DIR; }
+    inline bool hasDynamicLighting() const noexcept     { return key & DYN; }
+    inline bool hasShadowReceiver() const noexcept      { return key & SRE; }
+    inline bool hasSkinningOrMorphing() const noexcept  { return key & SKN; }
+    inline bool hasDepth() const noexcept               { return key & DEP; }
+    inline bool hasFog() const noexcept                 { return key & FOG; }
+    inline bool hasPicking() const noexcept             { return key & PCK; }
+    inline bool hasVsm() const noexcept                 { return key & VSM; }
 
-        inline void setDirectionalLighting(bool v) noexcept { set(v, DIR); }
-        inline void setDynamicLighting(bool v) noexcept     { set(v, DYN); }
-        inline void setShadowReceiver(bool v) noexcept      { set(v, SRE); }
-        inline void setSkinning(bool v) noexcept            { set(v, SKN); }
-        inline void setFog(bool v) noexcept                 { set(v, FOG); }
-        inline void setPicking(bool v) noexcept             { set(v, PCK); }
-        inline void setVsm(bool v) noexcept                 { set(v, VSM); }
+    inline void setDirectionalLighting(bool v) noexcept { set(v, DIR); }
+    inline void setDynamicLighting(bool v) noexcept     { set(v, DYN); }
+    inline void setShadowReceiver(bool v) noexcept      { set(v, SRE); }
+    inline void setSkinning(bool v) noexcept            { set(v, SKN); }
+    inline void setFog(bool v) noexcept                 { set(v, FOG); }
+    inline void setPicking(bool v) noexcept             { set(v, PCK); }
+    inline void setVsm(bool v) noexcept                 { set(v, VSM); }
 
-        inline static constexpr bool isValidDepthVariant(Variant variant) noexcept {
-            // Can't have VSM and PICKING together with DEPTH variants
-            constexpr type_t RESERVED_MASK  = VSM | PCK | DEP | SRE | DYN | DIR;
-            constexpr type_t RESERVED_VALUE = VSM | PCK | DEP;
-            return ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) &&
-                   ((variant.key & RESERVED_MASK) != RESERVED_VALUE);
-       }
+    inline static constexpr bool isValidDepthVariant(Variant variant) noexcept {
+        // Can't have VSM and PICKING together with DEPTH variants
+        constexpr type_t RESERVED_MASK  = VSM | PCK | DEP | SRE | DYN | DIR;
+        constexpr type_t RESERVED_VALUE = VSM | PCK | DEP;
+        return ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) &&
+               ((variant.key & RESERVED_MASK) != RESERVED_VALUE);
+   }
 
-        inline static constexpr bool isValidStandardVariant(Variant variant) noexcept {
-            // can't have shadow receiver if we don't have any lighting
-            constexpr type_t RESERVED0_MASK  = SRE | DYN | DIR;
-            constexpr type_t RESERVED0_VALUE = SRE;
-            // can't have VSM without shadow receiver
-            constexpr type_t RESERVED1_MASK  = VSM | SRE;
-            constexpr type_t RESERVED1_VALUE = VSM;
-            return ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) &&
-                   ((variant.key & RESERVED0_MASK) != RESERVED0_VALUE) &&
-                   ((variant.key & RESERVED1_MASK) != RESERVED1_VALUE);
+    inline static constexpr bool isValidStandardVariant(Variant variant) noexcept {
+        // can't have shadow receiver if we don't have any lighting
+        constexpr type_t RESERVED0_MASK  = SRE | DYN | DIR;
+        constexpr type_t RESERVED0_VALUE = SRE;
+        // can't have VSM without shadow receiver
+        constexpr type_t RESERVED1_MASK  = VSM | SRE;
+        constexpr type_t RESERVED1_VALUE = VSM;
+        return ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) &&
+               ((variant.key & RESERVED0_MASK) != RESERVED0_VALUE) &&
+               ((variant.key & RESERVED1_MASK) != RESERVED1_VALUE);
+    }
+
+    inline static constexpr bool isVertexVariant(Variant variant) noexcept {
+        return filterVariantVertex(variant) == variant;
+    }
+
+    inline static constexpr bool isFragmentVariant(Variant variant) noexcept {
+        return filterVariantFragment(variant) == variant;
+    }
+
+    static constexpr bool isReserved(Variant variant) noexcept {
+        return !isValidStandardVariant(variant) && !isValidDepthVariant(variant);
+    }
+
+    static constexpr Variant filterVariantVertex(Variant variant) noexcept {
+        // filter out vertex variants that are not needed. For e.g. fog doesn't affect the
+        // vertex shader.
+        if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
+            return variant & (SKN | SRE | DYN | DIR);
         }
-
-        inline static constexpr bool isVertexVariant(Variant variant) noexcept {
-            return filterVariantVertex(variant) == variant;
+        if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
+            // Only VSM and skinning affects the vertex shader's DEPTH variant
+            return variant & (VSM | SKN | DEP);
         }
+        return {};
+    }
 
-        inline static constexpr bool isFragmentVariant(Variant variant) noexcept {
-            return filterVariantFragment(variant) == variant;
+    static constexpr Variant filterVariantFragment(Variant variant) noexcept {
+        // filter out fragment variants that are not needed. For e.g. skinning doesn't
+        // affect the fragment shader.
+        if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
+            return variant & (VSM | FOG | SRE | DYN | DIR);
         }
-
-        static constexpr bool isReserved(Variant variant) noexcept {
-            return !isValidStandardVariant(variant) && !isValidDepthVariant(variant);
+        if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
+            // Only VSM & PICKING affects the fragment shader's DEPTH variant
+            return variant & (VSM | PCK | DEP);
         }
+        return {};
+    }
 
-        static constexpr Variant filterVariantVertex(Variant variant) noexcept {
-            // filter out vertex variants that are not needed. For e.g. fog doesn't affect the
-            // vertex shader.
-            if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
-                return variant & (SKN | SRE | DYN | DIR);
-            }
-            if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
-                // Only VSM and skinning affects the vertex shader's DEPTH variant
-                return variant & (VSM | SKN | DEP);
-            }
-            return {};
-        }
-
-        static constexpr Variant filterVariantFragment(Variant variant) noexcept {
-            // filter out fragment variants that are not needed. For e.g. skinning doesn't
-            // affect the fragment shader.
-            if ((variant.key & STANDARD_MASK) == STANDARD_VARIANT) {
-                return variant & (VSM | FOG | SRE | DYN | DIR);
-            }
-            if ((variant.key & DEPTH_MASK) == DEPTH_VARIANT) {
-                // Only VSM & PICKING affects the fragment shader's DEPTH variant
-                return variant & (VSM | PCK | DEP);
-            }
-            return {};
-        }
-
-        static constexpr Variant filterVariant(Variant variant, bool isLit) noexcept {
-            // special case for depth variant
-            if (isValidDepthVariant(variant)) {
-                return variant;
-            }
-            if (!isLit) {
-                // when the shading mode is unlit, remove all the lighting variants
-                return variant & UNLIT_MASK;
-            }
-            // if shadow receiver is disabled, turn off VSM
-            if (!(variant.key & SRE)) {
-                return variant & ~VSM;
-            }
+    static constexpr Variant filterVariant(Variant variant, bool isLit) noexcept {
+        // special case for depth variant
+        if (isValidDepthVariant(variant)) {
             return variant;
         }
-
-        constexpr bool operator==(Variant rhs) const noexcept {
-            return key == rhs.key;
+        if (!isLit) {
+            // when the shading mode is unlit, remove all the lighting variants
+            return variant & UNLIT_MASK;
         }
-
-        constexpr bool operator!=(Variant rhs) const noexcept {
-            return key != rhs.key;
+        // if shadow receiver is disabled, turn off VSM
+        if (!(variant.key & SRE)) {
+            return variant & ~VSM;
         }
+        return variant;
+    }
 
-        constexpr Variant operator & (type_t rhs) const noexcept {
-            return Variant(key & rhs);
-        }
+    constexpr bool operator==(Variant rhs) const noexcept {
+        return key == rhs.key;
+    }
 
-    private:
-        void set(bool v, type_t mask) noexcept {
-            key = (key & ~mask) | (v ? mask : type_t(0));
-        }
-    };
+    constexpr bool operator!=(Variant rhs) const noexcept {
+        return key != rhs.key;
+    }
+
+    constexpr Variant operator & (type_t rhs) const noexcept {
+        return Variant(key & rhs);
+    }
+
+private:
+    void set(bool v, type_t mask) noexcept {
+        key = (key & ~mask) | (v ? mask : type_t(0));
+    }
+};
 
 namespace details {
 

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -62,9 +62,7 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib(Variant variant) noexce
     assert(sibPcf.getSize() == PerViewSib::SAMPLER_COUNT);
     assert(sibVsm.getSize() == PerViewSib::SAMPLER_COUNT);
 
-    Variant v(variant);
-
-    return v.hasVsm() ? sibVsm : sibPcf;
+    return Variant::isVSMVariant(variant) ? sibVsm : sibPcf;
 }
 
 SamplerInterfaceBlock const& SibGenerator::getPerRenderPrimitiveMorphingSib(Variant variant) noexcept {

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <private/filament/Variant.h>
+
+namespace filament {
+
+Variant Variant::filterUserVariant(
+        Variant variant, UserVariantFilterMask filterMask) noexcept {
+    // these are easy to filter by just removing the corresponding bit
+    if (filterMask & (uint32_t)UserVariantFilterBit::DIRECTIONAL_LIGHTING) {
+        variant.key &= ~(filterMask & DIR);
+    }
+    if (filterMask & (uint32_t)UserVariantFilterBit::DYNAMIC_LIGHTING) {
+        variant.key &= ~(filterMask & DYN);
+    }
+    if (filterMask & (uint32_t)UserVariantFilterBit::SKINNING) {
+        variant.key &= ~(filterMask & SKN);
+    }
+    if (!isValidDepthVariant(variant)) {
+        // we can't remove FOG from depth variants, this would, in fact, remove picking
+        if (filterMask & (uint32_t)UserVariantFilterBit::FOG) {
+            variant.key &= ~(filterMask & FOG);
+        }
+    }
+    if (filterMask & (uint32_t)UserVariantFilterBit::SHADOW_RECEIVER) {
+        variant.key &= ~(filterMask & SRE);
+    }
+    if (filterMask & (uint32_t)UserVariantFilterBit::VSM) {
+        variant.key &= ~(filterMask & VSM);
+    }
+    return variant;
+}
+
+
+
+namespace details {
+
+// compile time sanity-check tests
+
+constexpr inline bool reserved_is_not_valid() noexcept {
+    for (Variant::type_t i = 0; i < VARIANT_COUNT; i++) {
+        const Variant variant(i);
+        bool is_valid = Variant::isValid(variant);
+        bool is_reserved = Variant::isReserved(variant);
+        if (is_valid == is_reserved) {
+            return false;
+        }
+    }
+    return true;
+}
+
+constexpr inline size_t reserved_variant_count() noexcept {
+    size_t count = 0;
+    for (Variant::type_t i = 0; i < VARIANT_COUNT; i++) {
+        const Variant variant(i);
+        if (Variant::isReserved(variant)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+constexpr inline size_t valid_variant_count() noexcept {
+    size_t count = 0;
+    for (Variant::type_t i = 0; i < VARIANT_COUNT; i++) {
+        const Variant variant(i);
+        if (Variant::isValid(variant)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+constexpr inline size_t vertex_variant_count() noexcept {
+    size_t count = 0;
+    for (Variant::type_t i = 0; i < VARIANT_COUNT; i++) {
+        const Variant variant(i);
+        if (Variant::isValid(variant)) {
+            if (Variant::isVertexVariant(variant)) {
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+constexpr inline size_t fragment_variant_count() noexcept {
+    size_t count = 0;
+    for (Variant::type_t i = 0; i < VARIANT_COUNT; i++) {
+        const Variant variant(i);
+        if (Variant::isValid(variant)) {
+            if (Variant::isFragmentVariant(variant)) {
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+static_assert(reserved_is_not_valid());
+static_assert(reserved_variant_count() == 82);
+static_assert(valid_variant_count()    == 46);
+static_assert(vertex_variant_count()   == 16 - (2 + 0) + 4 - 0);    // 18
+static_assert(fragment_variant_count() == 32 - (4 + 8) + 4 - 1);    // 25
+
+} // namespace details
+
+} // namespace filament

--- a/libs/filabridge/src/Variant.cpp
+++ b/libs/filabridge/src/Variant.cpp
@@ -36,11 +36,19 @@ Variant Variant::filterUserVariant(
             variant.key &= ~(filterMask & FOG);
         }
     }
-    if (filterMask & (uint32_t)UserVariantFilterBit::SHADOW_RECEIVER) {
-        variant.key &= ~(filterMask & SRE);
-    }
-    if (filterMask & (uint32_t)UserVariantFilterBit::VSM) {
-        variant.key &= ~(filterMask & VSM);
+    if (!isSSRVariant(variant)) {
+        // SSR variant needs to be handled separately
+        if (filterMask & (uint32_t)UserVariantFilterBit::SHADOW_RECEIVER) {
+            variant.key &= ~(filterMask & SRE);
+        }
+        if (filterMask & (uint32_t)UserVariantFilterBit::VSM) {
+            variant.key &= ~(filterMask & VSM);
+        }
+    } else {
+        // see if we need to filter out the SSR variants
+        if (filterMask & (uint32_t)UserVariantFilterBit::SSR) {
+            variant.key &= ~SPECIAL_SSR;
+        }
     }
     return variant;
 }
@@ -112,10 +120,10 @@ constexpr inline size_t fragment_variant_count() noexcept {
 }
 
 static_assert(reserved_is_not_valid());
-static_assert(reserved_variant_count() == 82);
-static_assert(valid_variant_count()    == 46);
-static_assert(vertex_variant_count()   == 16 - (2 + 0) + 4 - 0);    // 18
-static_assert(fragment_variant_count() == 32 - (4 + 8) + 4 - 1);    // 25
+static_assert(reserved_variant_count() == 80);
+static_assert(valid_variant_count() == 48);
+static_assert(vertex_variant_count() == 16 - (2 + 0) + 4 - 0);        // 18
+static_assert(fragment_variant_count() == 33 - (2 + 2 + 8) + 4 - 1);    // 24
 
 } // namespace details
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -118,7 +118,6 @@ protected:
         .targetApi = TargetApi::OPENGL,
         .targetLanguage = TargetLanguage::SPIRV
     };
-    uint8_t mVariantFilter = 0;
 
     // Keeps track of how many times MaterialBuilder::init() has been called without a call to
     // MaterialBuilder::shutdown(). Internally, glslang does something similar. We keep track for
@@ -518,7 +517,7 @@ public:
     MaterialBuilder& generateDebugInfo(bool generateDebugInfo) noexcept;
 
     //! Specifies a list of variants that should be filtered out during code generation.
-    MaterialBuilder& variantFilter(uint8_t variantFilter) noexcept;
+    MaterialBuilder& variantFilter(filament::UserVariantFilterMask variantFilter) noexcept;
 
     //! Adds a new preprocessor macro definition to the shader code. Can be called repeatedly.
     MaterialBuilder& shaderDefine(const char* name, const char* value) noexcept;
@@ -635,7 +634,7 @@ public:
     // returns a list of at least getParameterCount() parameters
     const ParameterList& getParameters() const noexcept { return mParameters; }
 
-    uint8_t getVariantFilter() const { return mVariantFilter; }
+    filament::UserVariantFilterMask getVariantFilter() const { return mVariantFilter; }
 
     /// @endcond
 
@@ -753,6 +752,8 @@ private:
     bool mUseLegacyMorphing = false;
 
     PreprocessorDefineList mDefines;
+
+    filament::UserVariantFilterMask mVariantFilter = {};
 };
 
 } // namespace filamat

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -404,7 +404,7 @@ MaterialBuilder& MaterialBuilder::generateDebugInfo(bool generateDebugInfo) noex
     return *this;
 }
 
-MaterialBuilder& MaterialBuilder::variantFilter(uint8_t variantFilter) noexcept {
+MaterialBuilder& MaterialBuilder::variantFilter(filament::UserVariantFilterMask variantFilter) noexcept {
     mVariantFilter = variantFilter;
     return *this;
 }

--- a/libs/filamat/src/MaterialVariants.cpp
+++ b/libs/filamat/src/MaterialVariants.cpp
@@ -21,24 +21,26 @@
 namespace filamat {
 
 std::vector<Variant> determineSurfaceVariants(
-        filament::Variant::type_t variantFilter, bool isLit, bool shadowMultiplier) {
+        filament::UserVariantFilterMask userVariantFilter, bool isLit, bool shadowMultiplier) {
     std::vector<Variant> variants;
-    filament::Variant::type_t variantMask = ~variantFilter;
     for (filament::Variant::type_t k = 0; k < filament::VARIANT_COUNT; k++) {
         filament::Variant variant(k);
         if (filament::Variant::isReserved(variant)) {
             continue;
         }
 
-        // Remove variants for unlit materials
-        filament::Variant v = filament::Variant::filterVariant(
-                variant & variantMask, isLit || shadowMultiplier);
+        filament::Variant filteredVariant =
+                filament::Variant::filterUserVariant(variant, userVariantFilter);
 
-        if (filament::Variant::filterVariantVertex(v) == variant) {
+        // Remove variants for unlit materials
+        filteredVariant = filament::Variant::filterVariant(
+                filteredVariant, isLit || shadowMultiplier);
+
+        if (filament::Variant::filterVariantVertex(filteredVariant) == variant) {
             variants.emplace_back(variant, filament::backend::ShaderType::VERTEX);
         }
 
-        if (filament::Variant::filterVariantFragment(v) == variant) {
+        if (filament::Variant::filterVariantFragment(filteredVariant) == variant) {
             variants.emplace_back(variant, filament::backend::ShaderType::FRAGMENT);
         }
     }

--- a/libs/filamat/src/MaterialVariants.h
+++ b/libs/filamat/src/MaterialVariants.h
@@ -33,7 +33,7 @@ struct Variant {
 };
 
 std::vector<Variant> determineSurfaceVariants(
-        filament::Variant::type_t variantFilter, bool isLit, bool shadowMultiplier);
+        filament::UserVariantFilterMask, bool isLit, bool shadowMultiplier);
 
 std::vector<Variant> determinePostProcessVariants();
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -81,6 +81,10 @@ public:
     static utils::io::sstream& generateShaderUnlit(utils::io::sstream& out, ShaderType type,
             filament::Variant variant, bool hasShadowMultiplier) ;
 
+    // generate the shader's code for the screen-space reflections
+    static utils::io::sstream& generateShaderReflections(utils::io::sstream& out, ShaderType type,
+            filament::Variant variant);
+
     // generate declarations for custom interpolants
     static utils::io::sstream& generateVariable(utils::io::sstream& out, ShaderType type,
             const utils::CString& name, size_t index) ;

--- a/libs/viewer/src/AutomationSpec.cpp
+++ b/libs/viewer/src/AutomationSpec.cpp
@@ -61,6 +61,7 @@ static const char* DEFAULT_AUTOMATION = R"TXT([
             "view.taa.enabled": [false, true],
             "view.antiAliasing": ["NONE", "FXAA"],
             "view.ssao.enabled": [false, true],
+            "view.screenSpaceReflections.enabled": [false, true]
             "view.bloom.enabled": [false, true],
             "view.dof.enabled": [false, true]
         }

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SHADERS
         src/shading_model_standard.fs
         src/shading_model_subsurface.fs
         src/shading_parameters.fs
+        src/shading_reflections.fs
         src/shading_unlit.fs
         src/shadowing.fs
         src/vignette.fs

--- a/shaders/src/ambient_occlusion.fs
+++ b/shaders/src/ambient_occlusion.fs
@@ -18,7 +18,7 @@ float unpack(vec2 depth) {
 
 struct SSAOInterpolationCache {
     highp vec4 weights;
-#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
+#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED) || defined(MATERIAL_HAS_REFLECTIONS)
     highp vec2 uv;
 #endif
 };

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -94,3 +94,12 @@ vec3 getReflectedVector(const PixelParams pixel, const vec3 v, const vec3 n) {
 #endif
     return r;
 }
+
+void getAnisotropyPixelParams(const MaterialInputs material, inout PixelParams pixel) {
+#if defined(MATERIAL_HAS_ANISOTROPY)
+    vec3 direction = material.anisotropyDirection;
+    pixel.anisotropy = material.anisotropy;
+    pixel.anisotropicT = normalize(shading_tangentToWorld * direction);
+    pixel.anisotropicB = normalize(cross(getWorldGeometricNormalVector(), pixel.anisotropicT));
+#endif
+}

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -127,30 +127,6 @@ vec3 specularDFG(const PixelParams pixel) {
 #endif
 }
 
-/**
- * Returns the reflected vector at the current shading point. The reflected vector
- * return by this function might be different from shading_reflected:
- * - For anisotropic material, we bend the reflection vector to simulate
- *   anisotropic indirect lighting
- * - The reflected vector may be modified to point towards the dominant specular
- *   direction to match reference renderings when the roughness increases
- */
-
-vec3 getReflectedVector(const PixelParams pixel, const vec3 v, const vec3 n) {
-#if defined(MATERIAL_HAS_ANISOTROPY)
-    vec3  anisotropyDirection = pixel.anisotropy >= 0.0 ? pixel.anisotropicB : pixel.anisotropicT;
-    vec3  anisotropicTangent  = cross(anisotropyDirection, v);
-    vec3  anisotropicNormal   = cross(anisotropicTangent, anisotropyDirection);
-    float bendFactor          = abs(pixel.anisotropy) * saturate(5.0 * pixel.perceptualRoughness);
-    vec3  bentNormal          = normalize(mix(n, anisotropicNormal, bendFactor));
-
-    vec3 r = reflect(-v, bentNormal);
-#else
-    vec3 r = reflect(-v, n);
-#endif
-    return r;
-}
-
 vec3 getReflectedVector(const PixelParams pixel, const vec3 n) {
 #if defined(MATERIAL_HAS_ANISOTROPY)
     vec3 r = getReflectedVector(pixel, shading_view, n);
@@ -575,17 +551,34 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     // specular layer
     vec3 Fr = vec3(0.0f);
 
+    SSAOInterpolationCache interpolationCache;
+#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED) || defined(MATERIAL_HAS_REFLECTIONS)
+    interpolationCache.uv = uvToRenderTargetUV(getNormalizedViewportCoord().xy);
+#endif
+
     // screen-space reflections
-#if defined(MATERIAL_HAS_REFLECTIONS) && REFLECTION_MODE == REFLECTION_MODE_SCREEN_SPACE
-    vec4 Fssr = vec4(0.0f);
-    // evaluateScreenSpaceReflections will set the value of ssr if there's a hit.
-    // ssr.a contains the reflection's contribution.
-    if (pixel.roughness <= 0.1f && frameUniforms.ssrDistance > 0.0f) {
-        vec3 r = getReflectedVector(pixel, shading_view, shading_normal);
-        Fssr = evaluateScreenSpaceReflections(pixel, r);
+#if defined(MATERIAL_HAS_REFLECTIONS)
+    vec4 ssrFr = vec4(0.0f);
+#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
+    // do the uniform based test first
+    if (frameUniforms.ssrDistance > 0.0f) {
+        // There is no point doing SSR for very high roughness because we're limited by the fov
+        // of the screen, in addition it doesn't really add much to the final image.
+        // TODO: maybe make this a parameter
+        const float maxPerceptualRoughness = sqrt(0.5);
+        if (pixel.perceptualRoughness < maxPerceptualRoughness) {
+            float lod = max(0.0, 2.0 * log2(pixel.perceptualRoughness) + frameUniforms.refractionLodOffset);
+#if !defined(MATERIAL_HAS_REFRACTION)
+            // this is temporary, until we can access the SSR buffer when we have refraction
+            ssrFr = textureLod(light_ssr, interpolationCache.uv, lod);
+#endif
+        }
     }
-#else
-    const vec4 Fssr = vec4(0.0f);
+#else // BLEND_MODE_OPAQUE
+    // TODO: for blended transparency, we have to ray-march here (limited to mirror reflections)
+#endif
+#else // MATERIAL_HAS_REFLECTIONS
+    const vec4 ssrFr = vec4(0.0f);
 #endif
 
     // If screen-space reflections are turned on and have full contribution (ssr.a == 1.0f), then we
@@ -593,27 +586,18 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
 
 #if IBL_INTEGRATION == IBL_INTEGRATION_PREFILTERED_CUBEMAP
     vec3 E = specularDFG(pixel);
-    if (Fssr.a < 1.0f) { // prevent reading the IBL if possible
+    if (ssrFr.a < 1.0f) { // prevent reading the IBL if possible
         vec3 r = getReflectedVector(pixel, shading_normal);
         Fr = E * prefilteredRadiance(r, pixel.perceptualRoughness);
     }
 #elif IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING
     vec3 E = vec3(0.0); // TODO: fix for importance sampling
-    if (Fssr.a < 1.0f) { // prevent evaluating the IBL if possible
+    if (ssrFr.a < 1.0f) { // prevent evaluating the IBL if possible
         Fr = isEvaluateSpecularIBL(pixel, shading_normal, shading_view, shading_NoV);
     }
 #endif
 
-#if defined(MATERIAL_HAS_REFLECTIONS)
-    Fssr.rgb *= E;
-#endif
-
-    // Ambiant occlusion
-    SSAOInterpolationCache interpolationCache;
-#if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
-    interpolationCache.uv = uvToRenderTargetUV(getNormalizedViewportCoord().xy);
-#endif
-
+    // Ambient occlusion
     float ssao = evaluateSSAO(interpolationCache);
     float diffuseAO = min(material.ambientOcclusion, ssao);
     float specularAO = specularAO(shading_NoV, diffuseAO, pixel.roughness, interpolationCache);
@@ -621,7 +605,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     vec3 specularSingleBounceAO = singleBounceAO(specularAO) * pixel.energyCompensation;
     Fr *= specularSingleBounceAO;
 #if defined(MATERIAL_HAS_REFLECTIONS)
-    Fssr.rgb *= specularSingleBounceAO;
+    ssrFr.rgb *= specularSingleBounceAO;
 #endif
 
     // diffuse layer
@@ -654,27 +638,24 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     // clear coat layer
     evaluateClearCoatIBL(pixel, diffuseAO, interpolationCache, Fd, Fr);
 
+    Fr *= frameUniforms.iblLuminance;
+    Fd *= frameUniforms.iblLuminance;
+
 #if defined(MATERIAL_HAS_REFRACTION)
     vec3 Ft = evaluateRefraction(pixel, shading_normal, E);
+    Ft *= pixel.transmission;
+    Fd *= (1.0 - pixel.transmission);
+#endif
+
+#if defined(MATERIAL_HAS_REFLECTIONS)
+    Fr = Fr * (1.0 - ssrFr.a) + (E * ssrFr.rgb);
 #endif
 
     // Combine all terms
     // Note: iblLuminance is already premultiplied by the exposure
-#if defined(MATERIAL_HAS_REFRACTION) && defined(MATERIAL_HAS_REFLECTIONS)
-    color.rgb +=
-            Fr * (frameUniforms.iblLuminance * (1.0 - Fssr.a)) + Fssr.rgb * Fssr.a +
-            Fd * (frameUniforms.iblLuminance * (1.0 - pixel.transmission)) +
-            Ft * pixel.transmission;
-#elif defined(MATERIAL_HAS_REFRACTION)
-    color.rgb +=
-            Fr *  frameUniforms.iblLuminance +
-            Fd * (frameUniforms.iblLuminance * (1.0 - pixel.transmission)) +
-            Ft * pixel.transmission;
-#elif defined(MATERIAL_HAS_REFLECTIONS)
-    color.rgb +=
-            Fr * (frameUniforms.iblLuminance * (1.0 - Fssr.a)) + Fssr.rgb * Fssr.a +
-            Fd * frameUniforms.iblLuminance;
-#else
-    color.rgb += (Fd + Fr) * frameUniforms.iblLuminance;
+
+    color.rgb += Fr + Fd;
+#if defined(MATERIAL_HAS_REFRACTION)
+    color.rgb += Ft;
 #endif
 }

--- a/shaders/src/light_reflections.fs
+++ b/shaders/src/light_reflections.fs
@@ -2,7 +2,7 @@
 // Screen-space reflections
 //------------------------------------------------------------------------------
 
-#if defined(MATERIAL_HAS_REFLECTIONS) && REFLECTION_MODE == REFLECTION_MODE_SCREEN_SPACE
+#if defined(MATERIAL_HAS_REFLECTIONS)
 
 // Copied from depthUtils.fs
 highp float linearizeDepth(highp float depth) {
@@ -200,7 +200,7 @@ highp mat4 scaleMatrix(const highp float x, const highp float y) {
  *
  * If there is no hit, the return value is vec4(0).
  */
-vec4 evaluateScreenSpaceReflections(const PixelParams pixel, const vec3 wsRayDirection) {
+vec4 evaluateScreenSpaceReflections(const vec3 wsRayDirection) {
     vec4 Fr = vec4(0.0f);
     highp vec3 wsRayStart = shading_position + frameUniforms.ssrBias * wsRayDirection;
 
@@ -254,9 +254,10 @@ vec4 evaluateScreenSpaceReflections(const PixelParams pixel, const vec3 wsRayDir
         // note: vsDirection.z is the cos(vsDirection, view)
         fade *= (1.0 - max(0.0, vsDirection.z));
 
-        Fr = vec4(textureLod(light_ssr, reprojected.xy, 0.0f).rgb, fade);
+        // we output a premultiplied alpha color because this is going to be mipmapped
+        Fr = vec4(textureLod(light_ssr, reprojected.xy, 0.0).rgb * fade, fade);
     }
     return Fr;
 }
 
-#endif // screen-space reflections
+#endif // MATERIAL_HAS_REFLECTIONS

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -44,7 +44,7 @@ void main() {
     fragColor = fog(fragColor, view);
 #endif
 
-#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
+#if defined(MATERIAL_HAS_POST_LIGHTING_COLOR) && !defined(MATERIAL_HAS_REFLECTIONS)
     blendPostLightingColor(inputs, fragColor);
 #endif
 }

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -206,15 +206,6 @@ void getSubsurfacePixelParams(const MaterialInputs material, inout PixelParams p
 #endif
 }
 
-void getAnisotropyPixelParams(const MaterialInputs material, inout PixelParams pixel) {
-#if defined(MATERIAL_HAS_ANISOTROPY)
-    vec3 direction = material.anisotropyDirection;
-    pixel.anisotropy = material.anisotropy;
-    pixel.anisotropicT = normalize(shading_tangentToWorld * direction);
-    pixel.anisotropicB = normalize(cross(getWorldGeometricNormalVector(), pixel.anisotropicT));
-#endif
-}
-
 void getEnergyCompensationPixelParams(inout PixelParams pixel) {
     // Pre-filtered DFG term used for image-based lighting
     pixel.dfg = prefilteredDFG(pixel.perceptualRoughness, shading_NoV);

--- a/shaders/src/shading_reflections.fs
+++ b/shaders/src/shading_reflections.fs
@@ -1,0 +1,23 @@
+/*
+ * screen-space reflection shading
+ */
+vec4 evaluateMaterial(const MaterialInputs material) {
+
+#if defined(MATERIAL_HAS_REFLECTIONS)
+    PixelParams pixel;
+    //getAnisotropyPixelParams(inputs, pixel);
+    vec4 color = vec4(0.0);
+    if (frameUniforms.ssrDistance > 0.0) {
+        vec3 r = getReflectedVector(pixel, shading_view, shading_normal);
+        // evaluateScreenSpaceReflections will set the value of color if there's a hit.
+        // color.a contains the reflection's contribution.
+        color = evaluateScreenSpaceReflections(r);
+    }
+#else
+    // objects without reflections just erase the framebuffer, they need to be drawn in the
+    // reflection buffer because they could be partially occluding other objects with reflections.
+    const vec4 color = vec4(0.0);
+#endif
+
+    return color;
+}

--- a/shaders/src/shading_reflections.fs
+++ b/shaders/src/shading_reflections.fs
@@ -5,7 +5,7 @@ vec4 evaluateMaterial(const MaterialInputs material) {
 
 #if defined(MATERIAL_HAS_REFLECTIONS)
     PixelParams pixel;
-    //getAnisotropyPixelParams(inputs, pixel);
+    getAnisotropyPixelParams(material, pixel);
     vec4 color = vec4(0.0);
     if (frameUniforms.ssrDistance > 0.0) {
         vec3 r = getReflectedVector(pixel, shading_view, shading_normal);

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -706,6 +706,7 @@ static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& v
         strToEnum["skinning"]               = filament::UserVariantFilterBit::SKINNING;
         strToEnum["vsm"]                    = filament::UserVariantFilterBit::VSM;
         strToEnum["fog"]                    = filament::UserVariantFilterBit::FOG;
+        strToEnum["ssr"]                    = filament::UserVariantFilterBit::SSR;
         return strToEnum;
     }();
 

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -697,17 +697,19 @@ static bool processRefractionType(MaterialBuilder& builder, const JsonishValue& 
 static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& value) {
     // We avoid using an initializer list for this particular map to avoid build errors that are
     // due to static initialization ordering.
-    static const std::unordered_map<std::string, uint8_t> strToEnum  = [] {
-        std::unordered_map<std::string, uint8_t> strToEnum;
-        strToEnum["directionalLighting"] = filament::Variant::DIR;
-        strToEnum["dynamicLighting"] = filament::Variant::DYN;
-        strToEnum["shadowReceiver"] = filament::Variant::SRE;
-        strToEnum["skinning"] = filament::Variant::SKN;
-        strToEnum["vsm"] = filament::Variant::VSM;
-        strToEnum["fog"] = filament::Variant::FOG;
+    using filament::Variant;
+    static const std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum  = [] {
+        std::unordered_map<std::string, filament::UserVariantFilterBit> strToEnum;
+        strToEnum["directionalLighting"]    = filament::UserVariantFilterBit::DIRECTIONAL_LIGHTING;
+        strToEnum["dynamicLighting"]        = filament::UserVariantFilterBit::DYNAMIC_LIGHTING;
+        strToEnum["shadowReceiver"]         = filament::UserVariantFilterBit::SHADOW_RECEIVER;
+        strToEnum["skinning"]               = filament::UserVariantFilterBit::SKINNING;
+        strToEnum["vsm"]                    = filament::UserVariantFilterBit::VSM;
+        strToEnum["fog"]                    = filament::UserVariantFilterBit::FOG;
         return strToEnum;
     }();
-    uint8_t variantFilter = 0;
+
+    filament::UserVariantFilterMask variantFilter = {};
     const JsonishArray* jsonArray = value.toJsonArray();
     const auto& elements = jsonArray->getElements();
 
@@ -726,7 +728,7 @@ static bool processVariantFilter(MaterialBuilder& builder, const JsonishValue& v
                       " is not a valid variant" << std::endl;
         }
 
-        variantFilter |= strToEnum.at(s);
+        variantFilter |= (uint32_t)strToEnum.at(s);
     }
 
     builder.variantFilter(variantFilter);


### PR DESCRIPTION
This works by first generating a reflection buffer which gets blurred,
then the color pass samples from this buffer according to the roughness
of the surface being rendered.

A lot of the changes here involve utilizing "reserved" variants for
the new "SSR" pass and all the fallout from that.