### PR TITLE
Crucial refactoring of VulkanFboCache and VulkanSwapChain.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -265,10 +265,14 @@ void VulkanBlitter::blitSlowDepth(VkImageAspectFlags aspect, VkFilter filter,
     // BEGIN RENDER PASS
     // -----------------
 
-    const VkImageLayout layout = getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT);
+    const VulkanDepthLayout layout =
+            fromVkImageLayout(getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT));
 
     const VulkanFboCache::RenderPassKey rpkey = {
-        .depthLayout = layout,
+        .initialColorLayoutMask = 0,
+        .initialDepthLayout = VulkanDepthLayout::UNDEFINED,
+        .renderPassDepthLayout = layout,
+        .finalDepthLayout = layout,
         .depthFormat = dst.format,
         .clear = {},
         .discardStart = TargetBufferFlags::DEPTH,
@@ -376,7 +380,7 @@ void VulkanBlitter::blitSlowDepth(VkImageAspectFlags aspect, VkFilter filter,
     samplers[0] = {
         .sampler = vksampler,
         .imageView = src.view,
-        .imageLayout = layout
+        .imageLayout = getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT)
     };
 
     mPipelineCache.bindSamplers(samplers);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1041,7 +1041,6 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         .discardEnd = params.flags.discardEnd,
         .samples = rt->getSamples(),
         .subpassMask = uint8_t(params.subpassMask),
-        .isSwapChain = rt->isSwapChain(),
     };
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         const VulkanAttachment& info = rt->getColor(sc, i);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -575,13 +575,13 @@ void VulkanDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow,
     const VkInstance instance = mContext.instance;
     auto vksurface = (VkSurfaceKHR) mContextManager.createVkSurfaceKHR(nativeWindow, instance,
             flags);
-    construct<VulkanSwapChain>(sch, mContext, vksurface);
+    construct<VulkanSwapChain>(sch, mContext, mStagePool, vksurface);
 }
 
 void VulkanDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
         uint32_t width, uint32_t height, uint64_t flags) {
     assert_invariant(width > 0 && height > 0 && "Vulkan requires non-zero swap chain dimensions.");
-    construct<VulkanSwapChain>(sch, mContext, width, height);
+    construct<VulkanSwapChain>(sch, mContext, mStagePool, width, height);
 }
 
 void VulkanDriver::createStreamFromTextureIdR(Handle<HwStream> sh, intptr_t externalTextureId,
@@ -1005,44 +1005,56 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     VulkanAttachment depth = rt->getSamples() == 1 ? rt->getDepth(sc) : rt->getMsaaDepth();
     VulkanTexture* depthFeedback = nullptr;
 
+    VulkanDepthLayout initialDepthLayout = fromVkImageLayout(depth.layout);
+    VulkanDepthLayout renderPassDepthLayout =
+            fromVkImageLayout(getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT));
+    VulkanDepthLayout finalDepthLayout = renderPassDepthLayout;
+
     // If an uncleared depth buffer is attached but discarded at the end of the pass, then we should
     // permit the shader to sample from it by transitioning the layout of all its subresources to a
     // read-only layout. This is especially crucial for SSAO.
+    //
+    // We do not use GENERAL here due to the following validation message:
+    //
+    //   The Vulkan spec states: Image subresources used as attachments in the current render pass
+    //   must not be accessed in any way other than as an attachment by this command, except for
+    //   cases involving read-only access to depth/stencil attachments as described in the Render
+    //   Pass chapter.
+    //
+    // https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-vkCmdDrawIndexed-None-04584)
+    //
     if (depth.texture && any(params.flags.discardEnd & TargetBufferFlags::DEPTH) &&
             !any(params.flags.clear & TargetBufferFlags::DEPTH)) {
         depthFeedback = depth.texture;
-        const VulkanLayoutTransition transition = {
-            .image = depth.image,
-            .oldLayout = depth.layout,
-            .newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-            .subresources = {
-                .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
-                .levelCount = depth.texture->levels,
-                .layerCount = depth.texture->depth,
-            },
-            .srcStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-            .dstStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT
-        };
-        transitionImageLayout(cmdbuffer, transition);
-        depth.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+        renderPassDepthLayout = VulkanDepthLayout::READ_ONLY;
     }
 
     // Create the VkRenderPass or fetch it from cache.
     VulkanFboCache::RenderPassKey rpkey = {
-        .depthLayout = depth.layout,
+        .initialColorLayoutMask = 0,
+        .initialDepthLayout = initialDepthLayout,
+        .renderPassDepthLayout = renderPassDepthLayout,
+        .finalDepthLayout = finalDepthLayout,
         .depthFormat = depth.format,
         .clear = params.flags.clear,
         .discardStart = discardStart,
         .discardEnd = params.flags.discardEnd,
         .samples = rt->getSamples(),
-        .subpassMask = uint8_t(params.subpassMask)
+        .subpassMask = uint8_t(params.subpassMask),
+        .isSwapChain = rt->isSwapChain(),
     };
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-        rpkey.colorLayout[i] = rt->getColor(sc, i).layout;
-        rpkey.colorFormat[i] = rt->getColor(sc, i).format;
-        VulkanTexture* texture = rt->getColor(sc, i).texture;
+        const VulkanAttachment& info = rt->getColor(sc, i);
+        if (info.layout != VK_IMAGE_LAYOUT_UNDEFINED) {
+            rpkey.initialColorLayoutMask |= 1 << i;
+        }
+        rpkey.colorFormat[i] = info.format;
+        VulkanTexture* texture = info.texture;
         if (rpkey.samples > 1 && texture && texture->samples == 1) {
             rpkey.needsResolveMask |= (1 << i);
+        }
+        if (texture) {
+            texture->trackLayout(info.level, info.layer, getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT));
         }
     }
 
@@ -1166,23 +1178,6 @@ void VulkanDriver::endRenderPass(int) {
     vkCmdEndRenderPass(cmdbuffer);
 
     assert_invariant(mCurrentRenderTarget);
-
-    VulkanTexture* depthFeedback = mContext.currentRenderPass.depthFeedback;
-    if (depthFeedback) {
-        const VulkanLayoutTransition transition = {
-            .image = depthFeedback->getVkImage(),
-            .oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-            .newLayout = VK_IMAGE_LAYOUT_GENERAL,
-            .subresources = {
-                .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
-                .levelCount = depthFeedback->levels,
-                .layerCount = depthFeedback->depth,
-            },
-            .srcStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-            .dstStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT
-        };
-        transitionImageLayout(cmdbuffer, transition);
-    }
 
     // Since we might soon be sampling from the render target that we just wrote to, we need a
     // pipeline barrier between framebuffer writes and shader reads. This is a memory barrier rather
@@ -1760,7 +1755,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
         SamplerGroup* sb = vksb->sb.get();
         assert_invariant(sb->getSize() == samplers.size());
         size_t samplerIdx = 0;
-        for (const auto& sampler : samplers) {
+        for (auto& sampler : samplers) {
             size_t bindingPoint = sampler.binding;
             const SamplerGroup::Sampler* boundSampler = sb->getSamplers() + samplerIdx;
             samplerIdx++;
@@ -1769,7 +1764,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
             // appropriate. The fallback improves robustness but does not guarantee 100% success.
             // It can be argued that clients are being malfeasant here anyway, since Vulkan does
             // not allow sampling from a non-bound texture.
-            const VulkanTexture* texture;
+            VulkanTexture* texture;
             if (UTILS_UNLIKELY(!boundSampler->t)) {
                 if (!sampler.strict) {
                     continue;
@@ -1781,7 +1776,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 utils::slog.w << " at binding point " << +bindingPoint << utils::io::endl;
                 texture = mContext.emptyTexture;
             } else {
-                texture = handle_cast<const VulkanTexture*>(boundSampler->t);
+                texture = handle_cast<VulkanTexture*>(boundSampler->t);
                 mDisposer.acquire(texture);
             }
 
@@ -1794,8 +1789,18 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 .imageLayout = getDefaultImageLayout(texture->usage)
             };
 
+            // TODO: it should not be necessary to use a custom image view here, an actual fix might
+            // be necessary in a higher layer (e.g. adding a call setMinMaxLevels in the SSAO path).
             if (mContext.currentRenderPass.depthFeedback == texture) {
                 iInfo[bindingPoint].imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+                VkImageSubresourceRange range = {
+                    .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
+                    .baseMipLevel = 0,
+                    .levelCount = 1,
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+                };
+                iInfo[bindingPoint].imageView = texture->getImageView(range);
             }
         }
     }
@@ -1872,7 +1877,7 @@ void VulkanDriver::refreshSwapChain() {
 
     assert_invariant(!surface.headlessQueue && "Resizing headless swap chains is not supported.");
     surface.destroy();
-    surface.create();
+    surface.create(mStagePool);
 
     mFramebufferCache.reset();
 }

--- a/filament/backend/src/vulkan/VulkanFboCache.cpp
+++ b/filament/backend/src/vulkan/VulkanFboCache.cpp
@@ -19,6 +19,7 @@
 #include <utils/Panic.h>
 
 #include "VulkanConstants.h"
+#include "VulkanUtility.h"
 
 // If any VkRenderPass or VkFramebuffer is unused for more than TIME_BEFORE_EVICTION frames, it
 // is evicted from the cache.
@@ -31,18 +32,20 @@ namespace backend {
 
 bool VulkanFboCache::RenderPassEq::operator()(const RenderPassKey& k1,
         const RenderPassKey& k2) const {
+    if (k1.initialColorLayoutMask != k2.initialColorLayoutMask) return false;
+    if (k1.initialDepthLayout != k2.initialDepthLayout) return false;
+    if (k1.renderPassDepthLayout != k2.renderPassDepthLayout) return false;
+    if (k1.finalDepthLayout != k2.finalDepthLayout) return false;
+    for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
+        if (k1.colorFormat[i] != k2.colorFormat[i]) return false;
+    }
+    if (k1.depthFormat != k2.depthFormat) return false;
     if (k1.clear != k2.clear) return false;
     if (k1.discardStart != k2.discardStart) return false;
     if (k1.discardEnd != k2.discardEnd) return false;
     if (k1.samples != k2.samples) return false;
     if (k1.needsResolveMask != k2.needsResolveMask) return false;
     if (k1.subpassMask != k2.subpassMask) return false;
-    if (k1.depthLayout != k2.depthLayout) return false;
-    if (k1.depthFormat != k2.depthFormat) return false;
-    for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-        if (k1.colorLayout[i] != k2.colorLayout[i]) return false;
-        if (k1.colorFormat[i] != k2.colorFormat[i]) return false;
-    }
     return true;
 }
 
@@ -125,7 +128,6 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         iter.value().timestamp = mCurrentTime;
         return iter->second.handle;
     }
-    const bool isSwapChain = config.colorLayout[0] == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     const bool hasSubpasses = config.subpassMask != 0;
 
     // Set up some const aliases for terseness.
@@ -137,25 +139,6 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
 
     // In Vulkan, the subpass desc specifies the layout to transition to at the start of the render
     // pass, and the attachment description specifies the layout to transition to at the end.
-    // However we use render passes to cause layout transitions only when drawing directly into the
-    // swap chain.
-    const bool discard = any(config.discardStart & TargetBufferFlags::COLOR);
-    struct { VkImageLayout subpass, initial, final; } colorLayouts[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
-    if (isSwapChain) {
-        colorLayouts[0].subpass = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-        // Specifying UNDEFINED for "initial" can discard the existing data.
-        colorLayouts[0].initial = discard ? VK_IMAGE_LAYOUT_UNDEFINED :
-                VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-        colorLayouts[0].final = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    } else {
-        for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
-            colorLayouts[i].subpass = config.colorLayout[i];
-            colorLayouts[i].initial = config.colorLayout[i];
-            colorLayouts[i].final = config.colorLayout[i];
-        }
-    }
 
     VkAttachmentReference inputAttachmentRef[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};
     VkAttachmentReference colorAttachmentRefs[2][MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};
@@ -212,7 +195,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         if (config.colorFormat[i] == VK_FORMAT_UNDEFINED) {
             continue;
         }
-        const VkImageLayout subpassLayout = colorLayouts[i].subpass;
+        const VkImageLayout subpassLayout = getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT);
         uint32_t index;
 
         if (!hasSubpasses) {
@@ -257,8 +240,9 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .storeOp = config.samples == 1 ? kEnableStore : kDisableStore,
             .stencilLoadOp = kDontCare,
             .stencilStoreOp = kDisableStore,
-            .initialLayout = colorLayouts[i].initial,
-            .finalLayout = colorLayouts[i].final
+            .initialLayout = (!discard && config.initialColorLayoutMask & (1 << i)) ?
+                VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_UNDEFINED,
+            .finalLayout = getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT)
         };
     }
 
@@ -295,7 +279,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .stencilLoadOp = kDontCare,
             .stencilStoreOp = kDisableStore,
             .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-            .finalLayout = colorLayouts[i].final
+            .finalLayout = getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT)
         };
     }
 
@@ -304,7 +288,7 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
         const bool clear = any(config.clear & TargetBufferFlags::DEPTH);
         const bool discardStart = any(config.discardStart & TargetBufferFlags::DEPTH);
         const bool discardEnd = any(config.discardEnd & TargetBufferFlags::DEPTH);
-        depthAttachmentRef.layout = config.depthLayout;
+        depthAttachmentRef.layout = toVkImageLayout(config.renderPassDepthLayout);
         depthAttachmentRef.attachment = attachmentIndex;
         attachments[attachmentIndex++] = {
             .format = config.depthFormat,
@@ -313,8 +297,8 @@ VkRenderPass VulkanFboCache::getRenderPass(RenderPassKey config) noexcept {
             .storeOp = discardEnd ? kDisableStore : kEnableStore,
             .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
             .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
-            .initialLayout = config.depthLayout,
-            .finalLayout = config.depthLayout
+            .initialLayout = toVkImageLayout(config.initialDepthLayout),
+            .finalLayout = toVkImageLayout(config.finalDepthLayout),
         };
     }
     renderPassInfo.attachmentCount = attachmentIndex;

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -28,6 +28,13 @@
 namespace filament {
 namespace backend {
 
+// Avoid using VkImageLayout since it requires 4 bytes.
+enum class VulkanDepthLayout : uint8_t {
+    UNDEFINED, // VK_IMAGE_LAYOUT_UNDEFINED
+    GENERAL,   // VK_IMAGE_LAYOUT_GENERAL
+    READ_ONLY, // VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL.
+};
+
 // Simple manager for VkFramebuffer and VkRenderPass objects.
 //
 // Note that a VkFramebuffer is just a binding between a render pass and a set of image views. So,
@@ -39,25 +46,36 @@ public:
     // RenderPassKey is a small POD representing the immutable state that is used to construct
     // a VkRenderPass. It is hashed and used as a lookup key.
     struct alignas(8) RenderPassKey {
-        VkImageLayout colorLayout[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];  // 32 bytes
+        // For each target, we need to know three image layouts: the layout BEFORE the pass, the
+        // layout DURING the pass, and the layout AFTER the pass. Here are the rules:
+        // - For depth, we explicitly specify all three layouts.
+        // - Color targets have their initial image layout specified with a bitmask.
+        // - For each color target, the pre-existing layout is either UNDEFINED (0) or GENERAL (1).
+        // - The render pass and final images layout for color buffers is always GENERAL.
+        uint8_t initialColorLayoutMask;          // 1 byte
+        VulkanDepthLayout initialDepthLayout;    // 1 byte
+        VulkanDepthLayout renderPassDepthLayout; // 1 byte
+        VulkanDepthLayout finalDepthLayout;      // 1 byte (for now this is always GENERAL)
+
         VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
-        VkImageLayout depthLayout;  // 4 bytes
         VkFormat depthFormat; // 4 bytes
         TargetBufferFlags clear; // 4 bytes
         TargetBufferFlags discardStart; // 4 bytes
         TargetBufferFlags discardEnd; // 4 bytes
         uint8_t samples; // 1 byte
         uint8_t needsResolveMask; // 1 byte
-        uint8_t subpassMask; // 1 bytes
-        uint8_t padding; // 1 bytes
+        uint8_t subpassMask; // 1 byte
+        bool isSwapChain; // 1 byte
     };
     struct RenderPassVal {
         VkRenderPass handle;
         uint32_t timestamp;
     };
+    static_assert(0 == MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT % 8);
+    static_assert(sizeof(RenderPassKey::initialColorLayoutMask) == MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT / 8);
     static_assert(sizeof(TargetBufferFlags) == 4, "TargetBufferFlags has unexpected size.");
     static_assert(sizeof(VkFormat) == 4, "VkFormat has unexpected size.");
-    static_assert(sizeof(RenderPassKey) == 88, "RenderPassKey has unexpected size.");
+    static_assert(sizeof(RenderPassKey) == 56, "RenderPassKey has unexpected size.");
     using RenderPassHash = utils::hash::MurmurHashFn<RenderPassKey>;
     struct RenderPassEq {
         bool operator()(const RenderPassKey& k1, const RenderPassKey& k2) const;
@@ -110,6 +128,22 @@ private:
     tsl::robin_map<VkRenderPass, uint32_t> mRenderPassRefCount;
     uint32_t mCurrentTime = 0;
 };
+
+inline VulkanDepthLayout fromVkImageLayout(VkImageLayout layout) {
+    switch (layout) {
+        case VK_IMAGE_LAYOUT_GENERAL: return VulkanDepthLayout::GENERAL;
+        case VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL: return VulkanDepthLayout::READ_ONLY;
+        default: return VulkanDepthLayout::UNDEFINED;
+    }
+}
+
+inline VkImageLayout toVkImageLayout(VulkanDepthLayout layout) {
+    switch (layout) {
+        case VulkanDepthLayout::GENERAL: return VK_IMAGE_LAYOUT_GENERAL;
+        case VulkanDepthLayout::READ_ONLY: return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+        default: return VK_IMAGE_LAYOUT_UNDEFINED;
+    }
+}
 
 } // namespace filament
 } // namespace backend

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -45,6 +45,8 @@ class VulkanFboCache {
 public:
     // RenderPassKey is a small POD representing the immutable state that is used to construct
     // a VkRenderPass. It is hashed and used as a lookup key.
+    // TODO: This struct can be reduced in size by using a subset of formats instead of VkFormat
+    //       and removing the "finalDepthLayout" field.
     struct alignas(8) RenderPassKey {
         // For each target, we need to know three image layouts: the layout BEFORE the pass, the
         // layout DURING the pass, and the layout AFTER the pass. Here are the rules:
@@ -52,10 +54,12 @@ public:
         // - Color targets have their initial image layout specified with a bitmask.
         // - For each color target, the pre-existing layout is either UNDEFINED (0) or GENERAL (1).
         // - The render pass and final images layout for color buffers is always GENERAL.
-        uint8_t initialColorLayoutMask;          // 1 byte
-        VulkanDepthLayout initialDepthLayout;    // 1 byte
-        VulkanDepthLayout renderPassDepthLayout; // 1 byte
-        VulkanDepthLayout finalDepthLayout;      // 1 byte (for now this is always GENERAL)
+        uint8_t initialColorLayoutMask;
+        VulkanDepthLayout initialDepthLayout : 2;
+        VulkanDepthLayout renderPassDepthLayout : 2;
+        VulkanDepthLayout finalDepthLayout : 2;      // for now this is always GENERAL
+        uint8_t padding0 : 2;
+        uint8_t padding1[2];
 
         VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
         VkFormat depthFormat; // 4 bytes
@@ -65,7 +69,7 @@ public:
         uint8_t samples; // 1 byte
         uint8_t needsResolveMask; // 1 byte
         uint8_t subpassMask; // 1 byte
-        bool isSwapChain; // 1 byte
+        bool padding2; // 1 byte
     };
     struct RenderPassVal {
         VkRenderPass handle;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -78,7 +78,7 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
 #if FILAMENT_VULKAN_VERBOSE
     utils::slog.d << "Created VulkanProgram " << builder.getName().c_str()
                 << ", variant = (" << utils::io::hex
-                << (int) builder.getVariant() << utils::io::dec << "), "
+                << (int) builder.getVariant().key() << utils::io::dec << "), "
                 << "shaders = (" << bundle.vertex << ", " << bundle.fragment << ")"
                 << utils::io::endl;
 #endif

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -20,27 +20,29 @@
 #include "VulkanContext.h"
 #include "VulkanDriver.h"
 
+#include <memory>
+
 #include <utils/FixedCapacityVector.h>
 
 namespace filament {
 namespace backend {
 
 struct VulkanSwapChain : public HwSwapChain {
-    VulkanSwapChain(VulkanContext& context, VkSurfaceKHR vksurface);
-    VulkanSwapChain(VulkanContext& context, uint32_t width, uint32_t height);
+    VulkanSwapChain(VulkanContext& context, VulkanStagePool& stagePool, VkSurfaceKHR vksurface);
+
+    // Headless constructor.
+    VulkanSwapChain(VulkanContext& context, VulkanStagePool& stagePool, uint32_t width, uint32_t height);
 
     bool acquire();
-    void create();
+    void create(VulkanStagePool& stagePool);
     void destroy();
     void makePresentable();
     bool hasResized() const;
+    VulkanAttachment getColorAttachment() const; // TODO: remove
+    VulkanAttachment getDepthAttachment() const; // TODO: remove
+    VulkanTexture& getColorTexture() const;
 
-    // TODO: remove the "attachment" structs from here and instead return a VulkanTexture reference.
-    // Leveraging VulkanTexture will simplify this class by providing management and tracking
-    // for VkImageView and VkImageLayout. More importantly, it will allow us to remove many
-    // "is this a swap chain?" conditionals that are sprinkled throughout the Vulkan backend.
-    const VulkanAttachment& getColorAttachment() { return mColor[currentSwapIndex]; }
-    const VulkanAttachment& getDepthAttachment() { return mDepth; }
+    // TODO: privatize more fields
 
     VkSurfaceKHR surface = {};
     VkSwapchainKHR swapchain = {};
@@ -52,7 +54,7 @@ struct VulkanSwapChain : public HwSwapChain {
 
     // This is signaled when vkAcquireNextImageKHR succeeds, and is waited on by the first
     // submission.
-    VkSemaphore imageAvailable = {};
+    VkSemaphore imageAvailable = VK_NULL_HANDLE;
 
     // This is true after the swap chain image has been acquired, but before it has been presented.
     bool acquired = false;
@@ -65,13 +67,11 @@ private:
 
     // Color attachments are swapped, but depth is not. Typically there are 2 or 3 color attachments
     // in a swap chain.
-    utils::FixedCapacityVector<VulkanAttachment> mColor;
-    VulkanAttachment mDepth = {};
-
-    void createFinalDepthBuffer(VkFormat depthFormat, VkExtent2D size);
+    utils::FixedCapacityVector<std::unique_ptr<VulkanTexture>> mColor;
+    std::unique_ptr<VulkanTexture> mDepth;
 };
 
 } // namespace filament
 } // namespace backend
 
-#endif // TNT_FILAMENT_DRIVER_VULKANTEXTURE_H
+#endif // TNT_FILAMENT_DRIVER_VULKANSWAPCHAIN_H

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -29,6 +29,18 @@ using namespace bluevk;
 namespace filament {
 namespace backend {
 
+VulkanTexture::VulkanTexture(VulkanContext& context, VkImage image, VkFormat format, uint8_t samples,
+        uint32_t width, uint32_t height, TextureUsage tusage, VulkanStagePool& stagePool) :
+        HwTexture(SamplerType::SAMPLER_2D, 1, samples, width, height, 1, TextureFormat::UNUSED, tusage),
+        mVkFormat(format),
+        mAspect(any(usage & TextureUsage::DEPTH_ATTACHMENT) ? VK_IMAGE_ASPECT_DEPTH_BIT :
+            VK_IMAGE_ASPECT_COLOR_BIT),
+        mViewType(getImageViewType(target)),
+        mSwizzle({}),
+        mTextureImage(image),
+        mContext(context),
+        mStagePool(stagePool) {}
+
 VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t levels,
         TextureFormat tformat, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
         TextureUsage tusage, VulkanStagePool& stagePool, VkComponentMapping swizzle) :
@@ -188,8 +200,10 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
 
 VulkanTexture::~VulkanTexture() {
     delete mSidecarMSAA;
-    vkDestroyImage(mContext.device, mTextureImage, VKALLOC);
-    vkFreeMemory(mContext.device, mTextureImageMemory, VKALLOC);
+    if (mTextureImageMemory != VK_NULL_HANDLE) {
+        vkDestroyImage(mContext.device, mTextureImage, VKALLOC);
+        vkFreeMemory(mContext.device, mTextureImageMemory, VKALLOC);
+    }
     for (auto entry : mCachedImageViews) {
         vkDestroyImageView(mContext.device, entry.second, VKALLOC);
     }
@@ -355,6 +369,19 @@ void VulkanTexture::setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel) 
     getImageView(mPrimaryViewRange);
 }
 
+bool VulkanTexture::validatePrimaryImageView() const {
+    const auto& sr = mPrimaryViewRange;
+    for (uint32_t layer = 0; layer < sr.layerCount; ++layer) {
+        for (uint32_t level = 0; level < sr.levelCount; ++level) {
+            VkImageLayout layout = getVkLayout(layer + sr.baseArrayLayer, level + sr.baseMipLevel);
+            if (layout == VK_IMAGE_LAYOUT_UNDEFINED) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 VkImageView VulkanTexture::getAttachmentView(int singleLevel, int singleLayer,
         VkImageAspectFlags aspect) {
     VkImageSubresourceRange range = {
@@ -444,6 +471,17 @@ void VulkanTexture::transitionLayout(VkCommandBuffer commands, const VkImageSubr
             const uint32_t last = (layer << 16) | last_level;
             mSubresourceLayouts.add(first, last, newLayout);
         }
+    }
+}
+
+// Notifies the texture that a particular subresource's layout has changed.
+void VulkanTexture::trackLayout(uint32_t miplevel, uint32_t layer, VkImageLayout layout) {
+    const uint32_t first = (layer << 16) | miplevel;
+    const uint32_t last = (layer << 16) | (miplevel + 1);
+    if (UTILS_UNLIKELY(layout == VK_IMAGE_LAYOUT_UNDEFINED)) {
+        mSubresourceLayouts.clear(first, last);
+    } else {
+        mSubresourceLayouts.add(first, last, layout);
     }
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -459,6 +459,10 @@ void VulkanTexture::transitionLayout(VkCommandBuffer commands, const VkImageSubr
     const uint32_t last_layer = first_layer + range.layerCount;
     const uint32_t first_level = range.baseMipLevel;
     const uint32_t last_level = first_level + range.levelCount;
+
+    assert_invariant(first_level <= 0xffff && last_level <= 0xffff);
+    assert_invariant(first_layer <= 0xffff && last_layer <= 0xffff);
+
     if (newLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
         for (uint32_t layer = first_layer; layer < last_layer; ++layer) {
             const uint32_t first = (layer << 16) | first_level;
@@ -476,6 +480,7 @@ void VulkanTexture::transitionLayout(VkCommandBuffer commands, const VkImageSubr
 
 // Notifies the texture that a particular subresource's layout has changed.
 void VulkanTexture::trackLayout(uint32_t miplevel, uint32_t layer, VkImageLayout layout) {
+    assert_invariant((miplevel + 1) <= 0xffff && layer <= 0xffff);
     const uint32_t first = (layer << 16) | miplevel;
     const uint32_t last = (layer << 16) | (miplevel + 1);
     if (UTILS_UNLIKELY(layout == VK_IMAGE_LAYOUT_UNDEFINED)) {
@@ -486,6 +491,7 @@ void VulkanTexture::trackLayout(uint32_t miplevel, uint32_t layer, VkImageLayout
 }
 
 VkImageLayout VulkanTexture::getVkLayout(uint32_t layer, uint32_t level) const {
+    assert_invariant(level <= 0xffff && layer <= 0xffff);
     const uint32_t key = (layer << 16) | level;
     if (!mSubresourceLayouts.has(key)) {
         return VK_IMAGE_LAYOUT_UNDEFINED;

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -27,9 +27,17 @@ namespace filament {
 namespace backend {
 
 struct VulkanTexture : public HwTexture {
+
+    // Standard constructor for user-facing textures.
     VulkanTexture(VulkanContext& context, SamplerType target, uint8_t levels,
             TextureFormat format, uint8_t samples, uint32_t w, uint32_t h, uint32_t depth,
             TextureUsage usage, VulkanStagePool& stagePool, VkComponentMapping swizzle = {});
+
+    // Specialized constructor for internally created textures (e.g. from a swap chain)
+    // The texture will never destroy the given VkImage, but it does manages its subresources.
+    VulkanTexture(VulkanContext& context, VkImage image, VkFormat format, uint8_t samples,
+            uint32_t w, uint32_t h, TextureUsage usage, VulkanStagePool& stagePool);
+
     ~VulkanTexture();
 
     // Uploads data into a subregion of a 2D or 3D texture.
@@ -46,6 +54,9 @@ struct VulkanTexture : public HwTexture {
     // Sets the min/max range of miplevels in the primary image view.
     void setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel);
 
+    // If any primary views have UNDEFINED layout, this returns false. For diagnostic purposes only.
+    bool validatePrimaryImageView() const;
+
     // Gets or creates a cached VkImageView for a single subresource that can be used as a render
     // target attachment.  Unlike the primary image view, this always has type VK_IMAGE_VIEW_TYPE_2D
     // and the identity swizzle.
@@ -61,9 +72,13 @@ struct VulkanTexture : public HwTexture {
     void transitionLayout(VkCommandBuffer commands, const VkImageSubresourceRange& range,
             VkImageLayout newLayout);
 
-private:
+    // Notifies the texture that a particular subresource's layout has changed.
+    void trackLayout(uint32_t miplevel, uint32_t layer, VkImageLayout layout);
+
     // Gets or creates a cached VkImageView for a range of miplevels and array layers.
     VkImageView getImageView(VkImageSubresourceRange range);
+
+private:
 
     void updateImageWithBlit(const PixelBufferDescriptor& hostData, uint32_t width,
         uint32_t height, uint32_t depth, uint32_t miplevel);


### PR DESCRIPTION
Two big changes to simplify and fix layout transitions:

(1) The RenderPassKey struct has been reduced from 88 bytes to 56 bytes
by using custom enum types and bitmasks. It also now has separate fields
for "final" and "initial" image layouts.

(2) VulkanSwapChain now leverages VulkanTexture, which enables it to
share tracking functionality, avoid duplicated state, and have less code
overall.

In a future PR we will clean up the ReadPixels and Blit paths, and also
remove some hacks that appease Vulkan when SSAO is enabled.