### PR TITLE
Vulkan: simplify management of "default" render target.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -39,8 +39,8 @@ struct BlitterUniforms {
 };
 
 void VulkanBlitter::blitColor(BlitArgs args) {
-    const VulkanAttachment src = args.srcTarget->getColor(mContext.currentSurface, args.targetIndex);
-    const VulkanAttachment dst = args.dstTarget->getColor(mContext.currentSurface, 0);
+    const VulkanAttachment src = args.srcTarget->getColor(args.targetIndex);
+    const VulkanAttachment dst = args.dstTarget->getColor(0);
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT;
 
 #if FILAMENT_VULKAN_CHECK_BLIT_FORMAT
@@ -58,14 +58,13 @@ void VulkanBlitter::blitColor(BlitArgs args) {
     }
 #endif
 
-    blitFast(aspect, args.filter, args.srcTarget->getExtent(mContext.currentSurface), src, dst,
+    blitFast(aspect, args.filter, args.srcTarget->getExtent(), src, dst,
             args.srcRectPair, args.dstRectPair);
 }
 
 void VulkanBlitter::blitDepth(BlitArgs args) {
-    VulkanSwapChain* const sc = mContext.currentSurface;
-    const VulkanAttachment src = args.srcTarget->getDepth(sc);
-    const VulkanAttachment dst = args.dstTarget->getDepth(sc);
+    const VulkanAttachment src = args.srcTarget->getDepth();
+    const VulkanAttachment dst = args.dstTarget->getDepth();
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 
 #if FILAMENT_VULKAN_CHECK_BLIT_FORMAT
@@ -86,12 +85,12 @@ void VulkanBlitter::blitDepth(BlitArgs args) {
     assert_invariant(src.texture && dst.texture);
 
     if (src.texture->samples > 1 && dst.texture->samples == 1) {
-        blitSlowDepth(aspect, args.filter, args.srcTarget->getExtent(sc), src, dst, args.srcRectPair,
+        blitSlowDepth(aspect, args.filter, args.srcTarget->getExtent(), src, dst, args.srcRectPair,
                 args.dstRectPair);
         return;
     }
 
-    blitFast(aspect, args.filter, args.srcTarget->getExtent(sc), src, dst, args.srcRectPair,
+    blitFast(aspect, args.filter, args.srcTarget->getExtent(), src, dst, args.srcRectPair,
             args.dstRectPair);
 }
 

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -17,6 +17,7 @@
 #include "VulkanContext.h"
 #include "VulkanHandles.h"
 #include "VulkanMemory.h"
+#include "VulkanTexture.h"
 #include "VulkanUtility.h"
 
 #include <utils/Panic.h>
@@ -28,6 +29,10 @@ using utils::FixedCapacityVector;
 
 namespace filament {
 namespace backend {
+
+VkImageLayout VulkanAttachment::getLayout() const {
+    return texture ? texture->getVkLayout(layer, level) : VK_IMAGE_LAYOUT_UNDEFINED;
+}
 
 void VulkanContext::selectPhysicalDevice() {
     uint32_t physicalDeviceCount = 0;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -46,9 +46,9 @@ struct VulkanAttachment {
     VkImageView view;
     VkDeviceMemory memory;
     VulkanTexture* texture = nullptr;
-    VkImageLayout layout; // TODO remove
     uint8_t level;
     uint16_t layer;
+    VkImageLayout getLayout() const;
 };
 
 struct VulkanTimestamps {

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -46,7 +46,7 @@ struct VulkanAttachment {
     VkImageView view;
     VkDeviceMemory memory;
     VulkanTexture* texture = nullptr;
-    VkImageLayout layout;
+    VkImageLayout layout; // TODO remove
     uint8_t level;
     uint16_t layer;
 };
@@ -90,6 +90,7 @@ struct VulkanContext {
     bool maintenanceSupported[3] = {};
     VulkanPipelineCache::RasterState rasterState;
     VulkanSwapChain* currentSurface;
+    Handle<HwRenderTarget> defaultRenderTarget;
     VulkanRenderPass currentRenderPass;
     VkViewport viewport;
     VkFormat finalDepthFormat;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -105,7 +105,6 @@ static VulkanAttachment createAttachment(VulkanContext& context, VulkanAttachmen
         .view = {},
         .memory = {},
         .texture = spec.texture,
-        .layout = spec.texture->getVkLayout(spec.layer, spec.level),
         .level = spec.level,
         .layer = spec.layer
     };
@@ -208,7 +207,6 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
         .view = {},
         .memory = {},
         .texture = msTexture,
-        .layout = {},
         .level = depthSpec.level,
         .layer = depthSpec.layer,
     });

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -53,17 +53,18 @@ struct VulkanRenderTarget : private HwRenderTarget {
     // Creates a special "default" render target (i.e. associated with the swap chain)
     explicit VulkanRenderTarget(VulkanContext& context);
 
-    void transformClientRectToPlatform(VulkanSwapChain* currentSurface, VkRect2D* bounds) const;
-    void transformClientRectToPlatform(VulkanSwapChain* currentSurface, VkViewport* bounds) const;
-    VkExtent2D getExtent(VulkanSwapChain* currentSurface) const;
-    VulkanAttachment getColor(VulkanSwapChain* currentSurface, int target) const;
+    void transformClientRectToPlatform(VkRect2D* bounds) const;
+    void transformClientRectToPlatform(VkViewport* bounds) const;
+    VkExtent2D getExtent() const;
+    VulkanAttachment getColor(int target) const;
     VulkanAttachment getMsaaColor(int target) const;
-    VulkanAttachment getDepth(VulkanSwapChain* currentSurface) const;
+    VulkanAttachment getDepth() const;
     VulkanAttachment getMsaaDepth() const;
     int getColorTargetCount(const VulkanRenderPass& pass) const;
     uint8_t getSamples() const { return mSamples; }
     bool hasDepth() const { return mDepth.format != VK_FORMAT_UNDEFINED; }
     bool isSwapChain() const { return !mOffscreen; }
+    void bindToSwapChain(VulkanSwapChain& surf);
 
 private:
     VulkanAttachment mColor[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -34,8 +34,8 @@ bool VulkanSwapChain::acquire() {
         // catch errors here than with validation. If this is the first time a particular image has
         // been acquired, it should be in an UNDEFINED state. If this is not the first time, then it
         // should be in the normal layout that we use for color attachments.
-        assert_invariant(this->getColorAttachment().layout == VK_IMAGE_LAYOUT_UNDEFINED ||
-                this->getColorAttachment().layout == getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT));
+        assert_invariant(this->getColorAttachment().getLayout() == VK_IMAGE_LAYOUT_UNDEFINED ||
+                this->getColorAttachment().getLayout() == getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT));
 
         return true;
     }
@@ -54,8 +54,8 @@ bool VulkanSwapChain::acquire() {
 
     // Next perform a quick sanity check on the image layout. Similar to attachable textures, we
     // immediately transition the swap chain image layout during the first render pass of the frame.
-    assert_invariant(this->getColorAttachment().layout == VK_IMAGE_LAYOUT_UNDEFINED ||
-            this->getColorAttachment().layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    assert_invariant(this->getColorAttachment().getLayout() == VK_IMAGE_LAYOUT_UNDEFINED ||
+            this->getColorAttachment().getLayout() == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     // To ensure that the next command buffer submission does not write into the image before
     // it has been acquired, push the image available semaphore into the command buffer manager.
@@ -334,7 +334,6 @@ VulkanAttachment VulkanSwapChain::getColorAttachment() const {
         .view = tex.getAttachmentView(0, 0, VK_IMAGE_ASPECT_COLOR_BIT),
         .memory = VK_NULL_HANDLE,
         .texture = &tex,
-        .layout = tex.getVkLayout(0, 0),
         .level = 0,
         .layer = 0,
     };
@@ -348,7 +347,6 @@ VulkanAttachment VulkanSwapChain::getDepthAttachment() const {
         .view = tex.getAttachmentView(0, 0, VK_IMAGE_ASPECT_DEPTH_BIT),
         .memory = VK_NULL_HANDLE,
         .texture = &tex,
-        .layout = tex.getVkLayout(0, 0),
         .level = 0,
         .layer = 0,
     };

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -369,19 +369,6 @@ void VulkanTexture::setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel) 
     getImageView(mPrimaryViewRange);
 }
 
-bool VulkanTexture::validatePrimaryImageView() const {
-    const auto& sr = mPrimaryViewRange;
-    for (uint32_t layer = 0; layer < sr.layerCount; ++layer) {
-        for (uint32_t level = 0; level < sr.levelCount; ++level) {
-            VkImageLayout layout = getVkLayout(layer + sr.baseArrayLayer, level + sr.baseMipLevel);
-            if (layout == VK_IMAGE_LAYOUT_UNDEFINED) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
 VkImageView VulkanTexture::getAttachmentView(int singleLevel, int singleLayer,
         VkImageAspectFlags aspect) {
     VkImageSubresourceRange range = {

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -54,8 +54,11 @@ struct VulkanTexture : public HwTexture {
     // Sets the min/max range of miplevels in the primary image view.
     void setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel);
 
-    // If any primary views have UNDEFINED layout, this returns false. For diagnostic purposes only.
-    bool validatePrimaryImageView() const;
+    VkImageSubresourceRange getPrimaryRange() const { return mPrimaryViewRange; }
+
+    VkImageLayout getPrimaryImageLayout() const {
+        return getVkLayout(mPrimaryViewRange.baseArrayLayer, mPrimaryViewRange.baseMipLevel);
+    }
 
     // Gets or creates a cached VkImageView for a single subresource that can be used as a render
     // target attachment.  Unlike the primary image view, this always has type VK_IMAGE_VIEW_TYPE_2D


### PR DESCRIPTION
Do not squash, these are actually 3 separate refactorings.