### PR TITLE
VulkanRenderTarget: remove duplicated state tracking.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -30,8 +30,21 @@ using utils::FixedCapacityVector;
 namespace filament {
 namespace backend {
 
+VkImage VulkanAttachment::getImage() const {
+    return texture ? texture->getVkImage() : VK_NULL_HANDLE;
+}
+
+VkFormat VulkanAttachment::getFormat() const {
+    return texture ? texture->getVkFormat() : VK_FORMAT_UNDEFINED;
+}
+
 VkImageLayout VulkanAttachment::getLayout() const {
     return texture ? texture->getVkLayout(layer, level) : VK_IMAGE_LAYOUT_UNDEFINED;
+}
+
+VkImageView VulkanAttachment::getImageView(VkImageAspectFlags aspect) {
+    assert_invariant(texture);
+    return texture->getAttachmentView(level, layer, aspect);
 }
 
 void VulkanContext::selectPhysicalDevice() {

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -39,16 +39,14 @@ struct VulkanSwapChain;
 struct VulkanTexture;
 class VulkanStagePool;
 
-// TODO: make this as lean as possible, it makes VulkanRenderTarget very big (currently 880 bytes).
 struct VulkanAttachment {
-    VkFormat format;
-    VkImage image;
-    VkImageView view;
-    VkDeviceMemory memory;
     VulkanTexture* texture = nullptr;
-    uint8_t level;
-    uint16_t layer;
+    uint8_t level = 0;
+    uint16_t layer = 0;
+    VkImage getImage() const;
+    VkFormat getFormat() const;
     VkImageLayout getLayout() const;
+    VkImageView getImageView(VkImageAspectFlags aspect);
 };
 
 struct VulkanTimestamps {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -62,7 +62,7 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getMsaaDepth() const;
     int getColorTargetCount(const VulkanRenderPass& pass) const;
     uint8_t getSamples() const { return mSamples; }
-    bool hasDepth() const { return mDepth.format != VK_FORMAT_UNDEFINED; }
+    bool hasDepth() const { return mDepth.texture; }
     bool isSwapChain() const { return !mOffscreen; }
     void bindToSwapChain(VulkanSwapChain& surf);
 

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -328,28 +328,12 @@ bool VulkanSwapChain::hasResized() const {
 
 VulkanAttachment VulkanSwapChain::getColorAttachment() const {
     VulkanTexture& tex = getColorTexture();
-    return VulkanAttachment {
-        .format = tex.getVkFormat(),
-        .image = tex.getVkImage(),
-        .view = tex.getAttachmentView(0, 0, VK_IMAGE_ASPECT_COLOR_BIT),
-        .memory = VK_NULL_HANDLE,
-        .texture = &tex,
-        .level = 0,
-        .layer = 0,
-    };
+    return VulkanAttachment { .texture = &tex, .level = 0, .layer = 0 };
 }
 
 VulkanAttachment VulkanSwapChain::getDepthAttachment() const {
     VulkanTexture& tex = *this->mDepth.get();
-    return VulkanAttachment {
-        .format = tex.getVkFormat(),
-        .image = tex.getVkImage(),
-        .view = tex.getAttachmentView(0, 0, VK_IMAGE_ASPECT_DEPTH_BIT),
-        .memory = VK_NULL_HANDLE,
-        .texture = &tex,
-        .level = 0,
-        .layer = 0,
-    };
+    return VulkanAttachment { .texture = &tex, .level = 0, .layer = 0 };
 }
 
 VulkanTexture& VulkanSwapChain::getColorTexture() const {


### PR DESCRIPTION
Now that VulkanRenderTarget is always backed by textures, it no longer
needs to track state that is already tracked by VulkanTexture.