### PR TITLE
Add read-only mask to RenderPassParams.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -953,7 +953,14 @@ struct RenderPassParams {
      * For now only 2 subpasses are supported, so only the lower 8 bits are used, one for each color
      * attachment (see MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT).
      */
-    uint32_t subpassMask = 0;
+    uint16_t subpassMask = 0;
+
+    /**
+     * This mask makes a promise to the backend about read-only usage of the depth attachment (bit
+     * 0) and the stencil attachment (bit 1). Some backends need to know if writes are disabled in
+     * order to allow sampling from the depth attachment.
+     */
+    uint16_t readOnlyDepthStencil = 0;
 };
 
 struct PolygonOffset {

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -961,6 +961,9 @@ struct RenderPassParams {
      * order to allow sampling from the depth attachment.
      */
     uint16_t readOnlyDepthStencil = 0;
+
+    static constexpr uint16_t READONLY_DEPTH = 1 << 0;
+    static constexpr uint16_t READONLY_STENCIL = 1 << 1;
 };
 
 struct PolygonOffset {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1025,7 +1025,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     //
     // https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-vkCmdDrawIndexed-None-04584)
     //
-    if (params.readOnlyDepthStencil & 1) {
+    if (params.readOnlyDepthStencil & RenderPassParams::READONLY_DEPTH) {
         depthFeedback = depth.texture;
         renderPassDepthLayout = VulkanDepthLayout::READ_ONLY;
     }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1013,9 +1013,8 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
             fromVkImageLayout(getDefaultImageLayout(TextureUsage::DEPTH_ATTACHMENT));
     VulkanDepthLayout finalDepthLayout = renderPassDepthLayout;
 
-    // If an uncleared depth buffer is attached but discarded at the end of the pass, then we should
-    // permit the shader to sample from it by transitioning the layout of all its subresources to a
-    // read-only layout. This is especially crucial for SSAO.
+    // Sometimes we need to permit the shader to sample the depth attachment by transitioning the
+    // layout of all its subresources to a read-only layout. This is especially crucial for SSAO.
     //
     // We do not use GENERAL here due to the following validation message:
     //
@@ -1026,8 +1025,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     //
     // https://vulkan.lunarg.com/doc/view/1.2.182.0/mac/1.2-extensions/vkspec.html#VUID-vkCmdDrawIndexed-None-04584)
     //
-    if (depth.texture && any(params.flags.discardEnd & TargetBufferFlags::DEPTH) &&
-            !any(params.flags.clear & TargetBufferFlags::DEPTH)) {
+    if (params.readOnlyDepthStencil & 1) {
         depthFeedback = depth.texture;
         renderPassDepthLayout = VulkanDepthLayout::READ_ONLY;
     }

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -760,6 +760,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
 
                 PipelineState pipeline(material.getPipelineState());
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::L;
+                ssao.params.readOnlyDepthStencil = 1; // TODO: make this automatic
                 render(ssao, pipeline, driver);
             });
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -760,7 +760,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
 
                 PipelineState pipeline(material.getPipelineState());
                 pipeline.rasterState.depthFunc = RasterState::DepthFunc::L;
-                ssao.params.readOnlyDepthStencil = 1; // TODO: make this automatic
+                ssao.params.readOnlyDepthStencil = RenderPassParams::READONLY_DEPTH; // TODO: make this automatic
                 render(ssao, pipeline, driver);
             });
 

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -542,7 +542,7 @@ void RenderPass::Executor::execute(const char* name,
     engine.flush();
 
     driver.beginRenderPass(renderTarget, params);
-    recordDriverCommands(engine, driver, mBegin, mEnd, mRenderableSoa, params);
+    recordDriverCommands(engine, driver, mBegin, mEnd, mRenderableSoa, params.readOnlyDepthStencil);
     driver.endRenderPass();
 }
 
@@ -550,7 +550,7 @@ UTILS_NOINLINE // no need to be inlined
 void RenderPass::Executor::recordDriverCommands(FEngine& engine,
         backend::DriverApi& driver,
         const Command* first, const Command* last,
-        FScene::RenderableSoa const& soa, backend::RenderPassParams params) const noexcept {
+        FScene::RenderableSoa const& soa, uint16_t readOnlyDepthStencil) const noexcept {
     SYSTRACE_CALL();
 
     if (first != last) {
@@ -585,7 +585,7 @@ void RenderPass::Executor::recordDriverCommands(FEngine& engine,
             pipeline.rasterState = info.rasterState;
 
 #ifndef NDEBUG
-            const bool readOnlyDepthGuaranteed = params.readOnlyDepthStencil & 1;
+            const bool readOnlyDepthGuaranteed = readOnlyDepthStencil & RenderPassParams::READONLY_DEPTH;
             assert_invariant(!readOnlyDepthGuaranteed || !pipeline.rasterState.depthWrite);
 #endif
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -337,7 +337,7 @@ public:
 
         void recordDriverCommands(FEngine& engine, backend::DriverApi& driver,
                 const Command* first, const Command* last,
-                FScene::RenderableSoa const& soa, backend::RenderPassParams params) const noexcept;
+                FScene::RenderableSoa const& soa, uint16_t readOnlyDepthStencil) const noexcept;
 
     public:
         void execute(const char* name,

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -337,7 +337,7 @@ public:
 
         void recordDriverCommands(FEngine& engine, backend::DriverApi& driver,
                 const Command* first, const Command* last,
-                FScene::RenderableSoa const& soa) const noexcept;
+                FScene::RenderableSoa const& soa, backend::RenderPassParams params) const noexcept;
 
     public:
         void execute(const char* name,


### PR DESCRIPTION
Previously, the Vulkan backend made an educated guess about the depth
write state during the start of the render pass. The logic for this
did not make any sense, so now we're replacing it with an explicit
hint that PostProcessManager sets up. In a sense this gives backends
a sneak peek into the raster state.