### PR TITLE
Fix web apps that have multiple Filament viewers.

### DIFF
--- a/web/filament-js/filament-viewer.js
+++ b/web/filament-js/filament-viewer.js
@@ -17,20 +17,15 @@
 // If you are bundling this with rollup, webpack, or esbuild, the following URL should be trimmed.
 import { LitElement, html, css } from "https://unpkg.com/lit-element?module";
 
-// To allow the DOM to render before the Filament WASM module is ready, we maintain a little
-// queue of tasks that get invoked as soon as the module is done loading.
+// This little utility checks if the Filament module is ready for action.
+// If so, it immediately calls the given function. If not, it asks the Filament
+// loader to call it as soon as the module becomes ready.
 class FilamentTasks {
-    constructor() {
-        this.tasks = []
-        if (!Filament.Engine) {
-            Filament.init([], () => { for (const task of this.tasks) task(); });
-        }
-    }
     add(callback) {
-        if (!Filament.Engine) {
-            this.tasks.push(callback);
-        } else {
+        if (Filament.isReady) {
             callback();
+        } else {
+            Filament.init([], callback);
         }
     }
 }

--- a/web/filament-js/wasmloader.js
+++ b/web/filament-js/wasmloader.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+Filament.onReadyListeners = [];
+
+Filament.isReady = false;
+
 /// init ::function:: Downloads assets, loads the Filament module, and invokes a callback when done.
 ///
 /// All JavaScript clients must call the init function, passing in a list of asset URL's and a
@@ -28,7 +32,15 @@
 /// onready ::argument:: callback that gets invoked after all assets have been downloaded and the \
 /// Filament WebAssembly module has been loaded.
 Filament.init = (assets, onready) => {
-    onready = onready || (() => {});
+    if (onready) {
+        Filament.onReadyListeners.push(onready);
+    }
+    if (Filament.initialized) {
+        console.assert(!assets || assets.length == 0, "Assets can be specified only with the first call to init.");
+        return;
+    };
+    Filament.initialized = true;
+
     Filament.assets = {};
 
     // Usage of glmatrix is optional. If it exists, then go ahead and augment it with some
@@ -41,7 +53,10 @@ Filament.init = (assets, onready) => {
     let remainingTasks = 1 + assets.length;
     const taskFinished = () => {
         if (--remainingTasks == 0) {
-            onready();
+            for (const callback of Filament.onReadyListeners) {
+                callback();
+            }
+            Filament.isReady = true;
         }
     };
 


### PR DESCRIPTION
This fixes the emscripten binding errors that we've been seeing
with the <filament-viewer> test page, which prevented us from
including web in the last few Filament releases.

The binding errors were caused by double-initializing the emscripten
module.

I fixed this by allowing clients (e.g. FilamentViewer) to call
Filament.init() more than once. We now accumulate a list of "on ready"
callbacks that get triggered after the emscripten module becomes ready.

As far as I can tell, multiple canvases were actually always broken, and
the viewer test page worked in the past only because we got lucky.