### PR TITLE
Vulkan: fix lifetime issue with sidecar depth.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1114,8 +1114,9 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     }
 
     // The current command buffer now owns a reference to the render target and its attachments.
+    // Note that we must acquire parent textures, not sidecars.
     mDisposer.acquire(rt);
-    mDisposer.acquire(depth.texture);
+    mDisposer.acquire(rt->getDepth().texture);
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         mDisposer.acquire(rt->getColor(i).texture);
     }


### PR DESCRIPTION
We were passing the wrong texture object to VulkanDisposer::acquire().
MSAA depth sidecar textures are not managed by VulkanDisposer, but their
parent textures are.

Fixes #5217.