### PR TITLE
Vulkan: fix hack by allowing SSAO to read from all mips.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -57,9 +57,8 @@ struct VulkanTimestamps {
 
 struct VulkanRenderPass {
     VkRenderPass renderPass;
-    uint32_t subpassMask;
+    RenderPassParams params;
     int currentSubpass;
-    VulkanTexture* depthFeedback;
 };
 
 // For now we only support a single-device, single-instance scenario. Our concept of "context" is a

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -214,7 +214,7 @@ int VulkanRenderTarget::getColorTargetCount(const VulkanRenderPass& pass) const 
             continue;
         }
         // NOTE: This must be consistent with VkRenderPass construction (see VulkanFboCache).
-        if (!(pass.subpassMask & (1 << i)) || pass.currentSubpass == 1) {
+        if (!(pass.params.subpassMask & (1 << i)) || pass.currentSubpass == 1) {
             count++;
         }
     }

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -601,6 +601,7 @@ VulkanLayoutTransition textureTransitionHelper(VulkanLayoutTransition transition
             break;
         case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
         case VK_IMAGE_LAYOUT_GENERAL:
+        case VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL:
             transition.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
             transition.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
             transition.srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;


### PR DESCRIPTION
When we overhauled image layout transitions, we moved as many
transitions as possible into the render pass. However the transition
that we perform for "depth read only" layout still needs to be applied to
multiple miplevels, so we cannot use the render pass for that.