### PR TITLE
Vulkan: be graceful when apps use uninitialized textures.

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1800,6 +1800,15 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 mDisposer.acquire(texture);
             }
 
+            if (UTILS_UNLIKELY(texture->getPrimaryImageLayout() == VK_IMAGE_LAYOUT_UNDEFINED)) {
+#ifndef NDEBUG
+                utils::slog.w << "Uninitialized texture bound to '" << sampler.name.c_str() << "'";
+                utils::slog.w << " in material '" << program->name.c_str() << "'";
+                utils::slog.w << " at binding point " << +bindingPoint << utils::io::endl;
+#endif
+                texture = mContext.emptyTexture;
+            }
+
             const SamplerParams& samplerParams = boundSampler->s;
             VkSampler vksampler = mSamplerCache.getSampler(samplerParams);
 

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -476,10 +476,10 @@ VulkanPipelineCache::PipelineCacheEntry* VulkanPipelineCache::createPipeline() n
     PipelineCacheEntry& bundle = mPipelines.emplace(
             std::make_pair(mPipelineRequirements, PipelineCacheEntry {})).first.value();
 
-    #if FILAMENT_VULKAN_VERBOSE
-    utils::slog.d << "vkCreateGraphicsPipelines with shaders = ("
-            << shaderStages[0].module << ", " << shaderStages[1].module << ")" << utils::io::endl;
-    #endif
+    if constexpr (FILAMENT_VULKAN_VERBOSE) {
+        utils::slog.d << "vkCreateGraphicsPipelines with shaders = ("
+                << shaderStages[0].module << ", " << shaderStages[1].module << ")" << utils::io::endl;
+    }
     VkResult error = vkCreateGraphicsPipelines(mDevice, VK_NULL_HANDLE, 1, &pipelineCreateInfo,
             VKALLOC, &bundle.handle);
     assert_invariant(error == VK_SUCCESS);


### PR DESCRIPTION
This makes it so that we emit a nice error message instead of triggering
a hairy validation error due to UNDEFINED image layout.