### PR TITLE
Vulkan: shrink PipelineKey from 608 bytes to 304 bytes, et al.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -332,33 +332,24 @@ void VulkanBlitter::blitSlowDepth(VkImageAspectFlags aspect, VkFilter filter,
     mPipelineCache.bindProgram(*mDepthResolveProgram);
     mPipelineCache.bindPrimitiveTopology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
 
-    mContext.rasterState.depthStencil = {
-        .depthTestEnable = VK_TRUE,
-        .depthWriteEnable = true,
-        .depthCompareOp = VK_COMPARE_OP_ALWAYS,
-        .depthBoundsTestEnable = VK_FALSE,
-        .stencilTestEnable = VK_FALSE,
-    };
-    mContext.rasterState.multisampling = {
-        .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
-        .alphaToCoverageEnable = false,
-    };
-    mContext.rasterState.blending = {
-        .blendEnable = VK_FALSE,
-        .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
-        .dstColorBlendFactor = VK_BLEND_FACTOR_ZERO,
-        .colorBlendOp = VK_BLEND_OP_ADD,
-        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
-        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
-        .alphaBlendOp = VK_BLEND_OP_ADD,
-        .colorWriteMask = (VkColorComponentFlags) 0,
-    };
-    auto& vkraster = mContext.rasterState.rasterization;
+    auto& vkraster = mContext.rasterState;
+    vkraster.depthWriteEnable = true;
+    vkraster.depthCompareOp = SamplerCompareFunc::A;
+    vkraster.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+    vkraster.alphaToCoverageEnable = false,
+    vkraster.blendEnable = VK_FALSE,
+    vkraster.srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+    vkraster.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+    vkraster.colorBlendOp = BlendEquation::ADD,
+    vkraster.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+    vkraster.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+    vkraster.alphaBlendOp = BlendEquation::ADD,
+    vkraster.colorWriteMask = (VkColorComponentFlags) 0,
     vkraster.cullMode = VK_CULL_MODE_NONE;
     vkraster.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
     vkraster.depthBiasEnable = VK_FALSE;
-    mContext.rasterState.colorTargetCount = 0;
-    mPipelineCache.bindRasterState(mContext.rasterState);
+    vkraster.colorTargetCount = 0;
+    mPipelineCache.bindRasterState(vkraster);
 
     VulkanPipelineCache::VertexArray varray = {};
     VkBuffer buffers[1] = {};

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1386,7 +1386,6 @@ void VulkanDriver::commit(Handle<HwSwapChain> sch) {
 
 void VulkanDriver::bindUniformBuffer(uint32_t index, Handle<HwBufferObject> boh) {
     auto* bo = handle_cast<VulkanBufferObject*>(boh);
-    // The driver API does not currently expose offset / range, but it will do so in the future.
     const VkDeviceSize offset = 0;
     const VkDeviceSize size = VK_WHOLE_SIZE;
     mPipelineCache.bindUniformBuffer((uint32_t) index, bo->buffer.getGpuBuffer(), offset, size);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1690,38 +1690,25 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
 
     const VulkanRenderTarget* rt = mCurrentRenderTarget;
 
-    mContext.rasterState.depthStencil = {
-        .depthTestEnable = VK_TRUE,
-        .depthWriteEnable = (VkBool32) rasterState.depthWrite,
-        .depthCompareOp = getCompareOp(rasterState.depthFunc),
-        .depthBoundsTestEnable = VK_FALSE,
-        .stencilTestEnable = VK_FALSE,
-    };
-
-    mContext.rasterState.multisampling = {
-        .rasterizationSamples = (VkSampleCountFlagBits) rt->getSamples(),
-        .alphaToCoverageEnable = rasterState.alphaToCoverage,
-    };
-
-    mContext.rasterState.blending = {
-        .blendEnable = (VkBool32) rasterState.hasBlending(),
-        .srcColorBlendFactor = getBlendFactor(rasterState.blendFunctionSrcRGB),
-        .dstColorBlendFactor = getBlendFactor(rasterState.blendFunctionDstRGB),
-        .colorBlendOp = (VkBlendOp) rasterState.blendEquationRGB,
-        .srcAlphaBlendFactor = getBlendFactor(rasterState.blendFunctionSrcAlpha),
-        .dstAlphaBlendFactor = getBlendFactor(rasterState.blendFunctionDstAlpha),
-        .alphaBlendOp =  (VkBlendOp) rasterState.blendEquationAlpha,
-        .colorWriteMask = (VkColorComponentFlags) (rasterState.colorWrite ? 0xf : 0x0),
-    };
-
-    auto& vkraster = mContext.rasterState.rasterization;
+    auto& vkraster = mContext.rasterState;
     vkraster.cullMode = getCullMode(rasterState.culling);
     vkraster.frontFace = getFrontFace(rasterState.inverseFrontFaces);
-    vkraster.depthBiasEnable = (depthOffset.constant || depthOffset.slope) ? VK_TRUE : VK_FALSE;
+    vkraster.depthBiasEnable = (depthOffset.constant || depthOffset.slope) ? true : false;
     vkraster.depthBiasConstantFactor = depthOffset.constant;
     vkraster.depthBiasSlopeFactor = depthOffset.slope;
-
-    mContext.rasterState.colorTargetCount = rt->getColorTargetCount(mContext.currentRenderPass);
+    vkraster.blendEnable = rasterState.hasBlending();
+    vkraster.srcColorBlendFactor = getBlendFactor(rasterState.blendFunctionSrcRGB);
+    vkraster.dstColorBlendFactor = getBlendFactor(rasterState.blendFunctionDstRGB);
+    vkraster.colorBlendOp = rasterState.blendEquationRGB;
+    vkraster.srcAlphaBlendFactor = getBlendFactor(rasterState.blendFunctionSrcAlpha);
+    vkraster.dstAlphaBlendFactor = getBlendFactor(rasterState.blendFunctionDstAlpha);
+    vkraster.alphaBlendOp =  rasterState.blendEquationAlpha;
+    vkraster.colorWriteMask = (VkColorComponentFlags) (rasterState.colorWrite ? 0xf : 0x0);
+    vkraster.depthWriteEnable = rasterState.depthWrite;
+    vkraster.depthCompareOp = rasterState.depthFunc;
+    vkraster.rasterizationSamples = rt->getSamples();
+    vkraster.alphaToCoverageEnable = rasterState.alphaToCoverage;
+    vkraster.colorTargetCount = rt->getColorTargetCount(mContext.currentRenderPass);
 
     // Declare fixed-size arrays that get passed to the pipeCache and to vkCmdBindVertexBuffers.
     VulkanPipelineCache::VertexArray varray = {};

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1361,13 +1361,14 @@ void VulkanDriver::commit(Handle<HwSwapChain> sch) {
 
     // Present the backbuffer after the most recent command buffer submission has finished.
     VkSemaphore renderingFinished = mContext.commands->acquireFinishedSignal();
+    uint32_t currentSwapIndex = surface.getSwapIndex();
     VkPresentInfoKHR presentInfo {
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
         .waitSemaphoreCount = 1,
         .pWaitSemaphores = &renderingFinished,
         .swapchainCount = 1,
         .pSwapchains = &surface.swapchain,
-        .pImageIndices = &surface.currentSwapIndex,
+        .pImageIndices = &currentSwapIndex,
     };
     VkResult result = vkQueuePresentKHR(surface.presentQueue, &presentInfo);
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -101,8 +101,8 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(
 
 void VulkanRenderTarget::bindToSwapChain(VulkanSwapChain& swapChain) {
     assert_invariant(!mOffscreen);
-    mColor[0] = swapChain.getColorAttachment();
-    mDepth = swapChain.getDepthAttachment();
+    mColor[0] = { .texture = &swapChain.getColorTexture() };
+    mDepth = { .texture = &swapChain.getDepthTexture() };
     width = swapChain.clientSize.width;
     height = swapChain.clientSize.height;
 }

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -202,12 +202,12 @@ VulkanAttachment VulkanRenderTarget::getMsaaDepth() const {
     return mMsaaDepthAttachment;
 }
 
-int VulkanRenderTarget::getColorTargetCount(const VulkanRenderPass& pass) const {
+uint8_t VulkanRenderTarget::getColorTargetCount(const VulkanRenderPass& pass) const {
     if (!mOffscreen) {
         return 1;
     }
-    int count = 0;
-    for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         if (!mColor[i].texture) {
             continue;
         }

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -60,7 +60,7 @@ struct VulkanRenderTarget : private HwRenderTarget {
     VulkanAttachment getMsaaColor(int target) const;
     VulkanAttachment getDepth() const;
     VulkanAttachment getMsaaDepth() const;
-    int getColorTargetCount(const VulkanRenderPass& pass) const;
+    uint8_t getColorTargetCount(const VulkanRenderPass& pass) const;
     uint8_t getSamples() const { return mSamples; }
     bool hasDepth() const { return mDepth.texture; }
     bool isSwapChain() const { return !mOffscreen; }

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -269,6 +269,12 @@ VulkanPipelineCache::DescriptorCacheEntry* VulkanPipelineCache::createDescriptor
             bufferInfo.buffer = mDescriptorRequirements.uniformBuffers[binding];
             bufferInfo.offset = mDescriptorRequirements.uniformBufferOffsets[binding];
             bufferInfo.range = mDescriptorRequirements.uniformBufferSizes[binding];
+
+            // We store size with 32 bits, so our "WHOLE" sentinel is different from Vk.
+            if (bufferInfo.range == WHOLE_SIZE) {
+                bufferInfo.range = VK_WHOLE_SIZE;
+            }
+
             writeInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             writeInfo.pNext = nullptr;
             writeInfo.dstArrayElement = 0;
@@ -629,6 +635,14 @@ void VulkanPipelineCache::bindUniformBuffer(uint32_t bindingIndex, VkBuffer unif
             bindingIndex, UBUFFER_BINDING_COUNT);
     auto& key = mDescriptorRequirements;
     key.uniformBuffers[bindingIndex] = uniformBuffer;
+
+    if (size == VK_WHOLE_SIZE) {
+        size = WHOLE_SIZE;
+    }
+
+    assert_invariant(offset <= 0xffffffffu);
+    assert_invariant(size <= 0xffffffffu);
+
     key.uniformBufferOffsets[bindingIndex] = offset;
     key.uniformBufferSizes[bindingIndex] = size;
 }

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -347,11 +347,11 @@ bool VulkanSwapChain::hasResized() const {
     return !equivalent(clientSize, surfaceCapabilities.currentExtent);
 }
 
-VulkanTexture& VulkanSwapChain::getColorTexture() const {
+VulkanTexture& VulkanSwapChain::getColorTexture() {
     return *mColor[mCurrentSwapIndex];
 }
 
-VulkanTexture& VulkanSwapChain::getDepthTexture() const {
+VulkanTexture& VulkanSwapChain::getDepthTexture() {
     return *mDepth;
 }
 

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -39,8 +39,8 @@ struct VulkanSwapChain : public HwSwapChain {
     void makePresentable();
     bool hasResized() const;
 
-    VulkanTexture& getColorTexture() const;
-    VulkanTexture& getDepthTexture() const;
+    VulkanTexture& getColorTexture();
+    VulkanTexture& getDepthTexture();
     uint32_t getSwapIndex() const { return mCurrentSwapIndex; }
 
     VkSurfaceKHR surface = {};

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -38,11 +38,10 @@ struct VulkanSwapChain : public HwSwapChain {
     void destroy();
     void makePresentable();
     bool hasResized() const;
-    VulkanAttachment getColorAttachment() const; // TODO: remove
-    VulkanAttachment getDepthAttachment() const; // TODO: remove
-    VulkanTexture& getColorTexture() const;
 
-    // TODO: privatize more fields
+    VulkanTexture& getColorTexture() const;
+    VulkanTexture& getDepthTexture() const;
+    uint32_t getSwapIndex() const { return mCurrentSwapIndex; }
 
     VkSurfaceKHR surface = {};
     VkSwapchainKHR swapchain = {};
@@ -50,7 +49,6 @@ struct VulkanSwapChain : public HwSwapChain {
     VkExtent2D clientSize = {};
     VkQueue presentQueue = {};
     VkQueue headlessQueue = {};
-    uint32_t currentSwapIndex = {};
 
     // This is signaled when vkAcquireNextImageKHR succeeds, and is waited on by the first
     // submission.
@@ -64,6 +62,7 @@ struct VulkanSwapChain : public HwSwapChain {
 
 private:
     VulkanContext& mContext;
+    uint32_t mCurrentSwapIndex = 0u;
 
     // Color attachments are swapped, but depth is not. Typically there are 2 or 3 color attachments
     // in a swap chain.


### PR DESCRIPTION
This optimizes our memory footprint and does some cleanup. 
 There are no behavioral changes.

This PR is composed of 3 commits that should stay separate.