### PR TITLE
Fixed vulkan blit crash / validation issue

### DIFF
--- a/filament/backend/include/backend/TargetBufferInfo.h
+++ b/filament/backend/include/backend/TargetBufferInfo.h
@@ -34,12 +34,18 @@ public:
             : handle(h), level(level) { }
     // ctor for cubemaps
     TargetBufferInfo(Handle<HwTexture> h, uint8_t level, TextureCubemapFace face) noexcept
-            : handle(h), level(level), face(face) { }
+            : handle(h), level(level) {
+		//cannot initialize in the initializer list because this would cause the layer member to stop being zeroed and vulkan code depends on this
+	    this->face = face;
+    }
     // ctor for 3D textures
     TargetBufferInfo(Handle<HwTexture> h, uint8_t level, uint16_t layer) noexcept
             : handle(h), level(level), layer(layer) { }
 
-    explicit TargetBufferInfo(TextureCubemapFace face) noexcept : face(face) {}
+    explicit TargetBufferInfo(TextureCubemapFace face) noexcept {
+		//cannot initialize in the initializer list because this would cause the layer member to stop being zeroed and vulkan code depends on this
+	    this->face = face;
+    }
 
     explicit TargetBufferInfo(uint16_t layer) noexcept : layer(layer) {}
 


### PR DESCRIPTION
The TargetBufferInfo uses an union for the face (uint8_t) and layer (uint16_t), and the vulkan driver relies on this fact and always uses the layer, even for cubemaps.
However, the constructor of TargetBufferInfo for cubemaps sets the face in the initializer list, and this causes the layer to not be initialized anymore, resulting in the face-layer union to have the lower 8 bits set with the proper value (the face) but the upper 8 bits random (or 0xCC in MSVC Debug).

There are 2 solutions - fix the behavior in the vulkan driver to stop depending on this union and use either the face or the layer depending on the texture type OR always initialize the layer with 0 and then set the face member (the solution in this PR).

This fixes a lot of validation issues and crashes on Windows 10 & 11, Visual Studio 2019/2022 Debug and Release. The validation errors are 100% reproductible in debug due to the pattern 0xCC in the uninitialized byte, but the crash has lower repro usually and needs a View resize or two to trigger.