### PR TITLE
Minor updates to how we include vk_mem_alloc.

### DIFF
--- a/filament/backend/src/vulkan/VulkanMemory.cpp
+++ b/filament/backend/src/vulkan/VulkanMemory.cpp
@@ -17,20 +17,17 @@
 #include <bluevk/BlueVK.h> // must be included before vk_mem_alloc
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
 #pragma clang diagnostic ignored "-Wundef"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wtautological-compare"
-#pragma clang diagnostic ignored "-Wnullability-completeness"
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #pragma clang diagnostic ignored "-Wimplicit-fallthrough"
+#pragma clang diagnostic ignored "-Wunused-private-field"
 
 static const PFN_vkGetInstanceProcAddr& vkGetInstanceProcAddr = bluevk::vkGetInstanceProcAddr;
 static const PFN_vkGetDeviceProcAddr& vkGetDeviceProcAddr = bluevk::vkGetDeviceProcAddr;
 
-#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_IMPLEMENTATION
-#include <cstdio>
 #include "vk_mem_alloc.h"
 #pragma clang diagnostic pop

--- a/filament/backend/src/vulkan/VulkanMemory.h
+++ b/filament/backend/src/vulkan/VulkanMemory.h
@@ -19,9 +19,6 @@
 
 #include <bluevk/BlueVK.h> // must be included before vk_mem_alloc
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundef"
 #include "vk_mem_alloc.h"
-#pragma clang diagnostic pop
 
 #endif // TNT_FILAMENT_DRIVER_VULKANMEMORY_H


### PR DESCRIPTION
In the current version of the library, it looks like the DYNAMIC config macro has been replaced with a STATIC config macro.

Also disabled the "unused-private-field" warning when building this library.