### PR TITLE
matdbg: repair invalid JSON and display of active variants.

### DIFF
--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -79,6 +79,7 @@ public:
 
     backend::Handle<backend::HwProgram> getProgram(Variant variant) const noexcept {
 #if FILAMENT_ENABLE_MATDBG
+        assert_invariant(variant.key < VARIANT_COUNT);
         mActivePrograms.set(variant.key);
         if (UTILS_UNLIKELY(mPendingEdits.load())) {
             const_cast<FMaterial*>(this)->applyPendingEdits();
@@ -89,8 +90,6 @@ public:
     }
     backend::Program getProgramBuilderWithVariants(Variant variant, Variant vertexVariant,
             Variant fragmentVariant) const noexcept;
-    backend::Handle<backend::HwProgram> createAndCacheProgram(backend::Program&& p,
-            Variant variant) const noexcept;
 
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 
@@ -168,10 +167,14 @@ private:
     backend::Handle<backend::HwProgram> getSurfaceProgramSlow(Variant variant) const noexcept;
     backend::Handle<backend::HwProgram> getPostProcessProgramSlow(Variant variant) const noexcept;
 
+    backend::Handle<backend::HwProgram> createAndCacheProgram(backend::Program&& p,
+            Variant variant) const noexcept;
+
     // try to order by frequency of use
     mutable std::array<backend::Handle<backend::HwProgram>, VARIANT_COUNT> mCachedPrograms;
 
 #if FILAMENT_ENABLE_MATDBG
+    // TODO: this should be protected with a mutex
     mutable VariantList mActivePrograms;
 #endif
 

--- a/libs/matdbg/README.md
+++ b/libs/matdbg/README.md
@@ -167,8 +167,8 @@ Returns an array with all information (except shader source) for all known mater
     "shading": { "model": "unlit", "vertex_domain": "object", ... },
     "raster":  { "blending": "transparent", "color_write": "true", ... },
     "opengl": [
-        { "index": " 0", "shaderModel": "gl41", "pipelineStage": "vertex  ", "variantString": "", "variant": "0" },
-        { "index": " 1", "shaderModel": "gl41", "pipelineStage": "fragment", "variantString": "", "variant": "0" },
+        { "index": " 0", "shaderModel": "gl41", "pipelineStage": "vertex  ", "variantString": "", "variant": 0 },
+        { "index": " 1", "shaderModel": "gl41", "pipelineStage": "fragment", "variantString": "", "variant": 0 },
     ],
     "vulkan": [],
     "metal": [],
@@ -183,6 +183,8 @@ Returns an array with all information (except shader source) for all known mater
 Some of the returned data may seem redundant (e.g. the `index` and `variantString` fields) but
 these allow the client to be very simple by passing the raw JSON into [mustache][4] templates.
 Moreover it helps prevent duplication of knowledge between C++ and JavaScript.
+
+This format of this message is also used for the in-browser "database" of materials.
 
 ---
 

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -128,7 +128,7 @@ static void printShaderInfo(ostream& json, const vector<ShaderInfo>& info, const
                 << "\"shaderModel\": \"" << toString(item.shaderModel) << "\", "
                 << "\"pipelineStage\": \"" << ps << "\", "
                 << "\"variantString\": \"" << variantString << "\", "
-                << "\"variant\": \"" << std::hex << +item.variant.key << std::dec << "\" }"
+                << "\"variant\": " << +item.variant.key << " }"
             << ((i == info.size() - 1) ? "\n" : ",\n");
     }
 }
@@ -241,13 +241,11 @@ bool JsonWriter::writeActiveInfo(const filaflat::ChunkContainer& package,
             return false;
     }
     json << "\"";
-    json << std::hex;
     for (size_t variant = 0; variant < activeVariants.size(); variant++) {
         if (activeVariants[variant]) {
             json << ", " << variant;
         }
     }
-    json << std::dec;
     json << "]";
     mJsonString = CString(json.str().c_str());
     return true;


### PR DESCRIPTION
The JSON response to /api/active became malformed after #4465 because
raw hex strings need to be enclosed by quotes.

This commit changes the variant format in the /api/materials response
to be consistent with one used for /api/active. By using integers
instead of strings, we're avoiding the need to parse integers at run
time.

The JSON error did not appear in the Chrome console because it was being
silenced as a hack to appease "matinfo --web-server". I fix this by
removing the hack and simply emitting a valid response when there's
no live backend.

Also fixed the display of materials, which were always being marked
as active even when they had no active variants.