### PR TITLE
Vulkan: support multiple renderers

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -89,7 +89,7 @@ struct VulkanContext {
     bool portabilitySubsetSupported = false;
     bool maintenanceSupported[3] = {};
     VulkanPipelineCache::RasterState rasterState;
-    VulkanSwapChain* currentSurface;
+    VulkanSwapChain* currentSwapChain;
     tsl::robin_set<VulkanRenderTarget*> defaultRenderTargets;
     VulkanRenderPass currentRenderPass;
     VkViewport viewport;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -59,6 +59,7 @@ struct VulkanTimestamps {
 };
 
 struct VulkanRenderPass {
+    VulkanRenderTarget* renderTarget;
     VkRenderPass renderPass;
     RenderPassParams params;
     int currentSubpass;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -28,6 +28,8 @@
 #include <utils/Slice.h>
 #include <utils/Mutex.h>
 
+#include <tsl/robin_set.h>
+
 VK_DEFINE_HANDLE(VmaAllocator)
 VK_DEFINE_HANDLE(VmaPool)
 
@@ -88,7 +90,7 @@ struct VulkanContext {
     bool maintenanceSupported[3] = {};
     VulkanPipelineCache::RasterState rasterState;
     VulkanSwapChain* currentSurface;
-    Handle<HwRenderTarget> defaultRenderTarget;
+    tsl::robin_set<VulkanRenderTarget*> defaultRenderTargets;
     VulkanRenderPass currentRenderPass;
     VkViewport viewport;
     VkFormat finalDepthFormat;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -38,7 +38,6 @@ namespace filament {
 namespace backend {
 
 class VulkanPlatform;
-struct VulkanRenderTarget;
 struct VulkanSamplerGroup;
 
 class VulkanDriver final : public DriverBase {
@@ -143,7 +142,6 @@ private:
     VulkanFboCache mFramebufferCache;
     VulkanSamplerCache mSamplerCache;
     VulkanBlitter mBlitter;
-    VulkanRenderTarget* mCurrentRenderTarget = nullptr;
     VulkanSamplerGroup* mSamplerBindings[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
     VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -96,8 +96,7 @@ VulkanProgram::~VulkanProgram() {
 }
 
 // Creates a special "default" render target (i.e. associated with the swap chain)
-VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0),
-        mOffscreen(false), mSamples(1) {}
+VulkanRenderTarget::VulkanRenderTarget() : HwRenderTarget(0, 0), mOffscreen(false), mSamples(1) {}
 
 void VulkanRenderTarget::bindToSwapChain(VulkanSwapChain& swapChain) {
     assert_invariant(!mOffscreen);

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -50,8 +50,8 @@ struct VulkanRenderTarget : private HwRenderTarget {
             VulkanAttachment color[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT], VulkanAttachment depthStencil[2],
             VulkanStagePool& stagePool);
 
-    // Creates a special "default" render target (i.e. associated with the swap chain)
-    explicit VulkanRenderTarget(VulkanContext& context);
+    // Creates a special "default" render target (i.e. associated with a swap chain)
+    explicit VulkanRenderTarget();
 
     void transformClientRectToPlatform(VkRect2D* bounds) const;
     void transformClientRectToPlatform(VkViewport* bounds) const;

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "VulkanHandles.h"
 #include "VulkanSwapChain.h"
 #include "VulkanTexture.h"
 
@@ -354,6 +355,13 @@ VulkanTexture& VulkanSwapChain::getColorTexture() {
 VulkanTexture& VulkanSwapChain::getDepthTexture() {
     return *mDepth;
 }
+
+void VulkanSwapChain::bindToDefaultRenderTargets() {
+    for (VulkanRenderTarget* rt : mContext.defaultRenderTargets) {
+        rt->bindToSwapChain(*this);
+    }
+}
+
 
 } // namespace filament
 } // namespace backend

--- a/filament/backend/src/vulkan/VulkanSwapChain.h
+++ b/filament/backend/src/vulkan/VulkanSwapChain.h
@@ -43,6 +43,8 @@ struct VulkanSwapChain : public HwSwapChain {
     VulkanTexture& getDepthTexture();
     uint32_t getSwapIndex() const { return mCurrentSwapIndex; }
 
+    void bindToDefaultRenderTargets();
+
     VkSurfaceKHR surface = {};
     VkSwapchainKHR swapchain = {};
     VkSurfaceFormatKHR surfaceFormat = {};


### PR DESCRIPTION
The first commit is the important one, it fixes #5291.  The other two commits are cleanup.

I tested this with our `multiple_windows` sample.