### PR TITLE
Always apply bone matrices, even for non-animated models.

### DIFF
--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -42,10 +42,9 @@ using namespace filament::math;
 namespace filament {
 namespace viewer {
 
-filament::math::mat4f fitIntoUnitCube(const filament::Aabb& bounds, float zoffset) {
-    using namespace filament::math;
-    auto minpt = bounds.min;
-    auto maxpt = bounds.max;
+mat4f fitIntoUnitCube(const Aabb& bounds, float zoffset) {
+    float3 minpt = bounds.min;
+    float3 maxpt = bounds.max;
     float maxExtent;
     maxExtent = std::max(maxpt.x - minpt.x, maxpt.y - minpt.y);
     maxExtent = std::max(maxExtent, maxpt.z - minpt.z);
@@ -469,9 +468,6 @@ void SimpleViewer::updateIndirectLight() {
 }
 
 void SimpleViewer::applyAnimation(double currentTime) {
-    if (!mAnimator) {
-        return;
-    }
     static double startTime = 0;
     const size_t numAnimations = mAnimator->getAnimationCount();
     if (mResetAnimation) {

--- a/web/filament-js/filament-viewer.js
+++ b/web/filament-js/filament-viewer.js
@@ -378,9 +378,11 @@ class FilamentViewer extends LitElement {
 
     _updateAsset() {
         // Invoke the first glTF animation if it exists.
-        if (this.animator && this.animator.getAnimationCount() > 0) {
-            const ms = Date.now() - this.animationStartTime;
-            this.animator.applyAnimation(0, ms / 1000);
+        if (this.animator) {
+            if (this.animator.getAnimationCount() > 0) {
+                const ms = Date.now() - this.animationStartTime;
+                this.animator.applyAnimation(0, ms / 1000);
+            }
             this.animator.updateBoneMatrices();
         }
 


### PR DESCRIPTION
This changes the WebGL and desktop glTF viewers so that they always
call `updateBoneMatrices`, even when there are 0 animations. Note
that our Android sample was already doing this correctly.

When combined with #5301, this fixes #5299, although users would need to
use the `recomputeBoundingBoxes` feature in gltfio (`-r` in the desktop
viewer) for this model to be scaled to fill the viewport, since its
embedded bounds are quite large.

<img width="1136" alt="Screen Shot 2022-03-09 at 3 27 50 PM" src="https://user-images.githubusercontent.com/1288904/157557321-47bb9851-200d-407c-9791-24487c7913f5.png">