### PR TITLE
gltfio: decouple MaterialProvider lifetime from AssetLoader.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.20.4 (currently main branch)
 
+- gltfio: Java clients must now destroy the MaterialProvider [⚠️ **API Change**].
+
 ## v1.20.3
 
 ## v1.20.2

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -98,6 +98,7 @@ class ModelViewer(
 
     private var swapChain: SwapChain? = null
     private var assetLoader: AssetLoader
+    private var materialProvider: MaterialProvider
     private var resourceLoader: ResourceLoader
     private val readyRenderables = IntArray(128) // add up to 128 entities at a time
 
@@ -113,7 +114,8 @@ class ModelViewer(
         view.scene = scene
         view.camera = camera
 
-        assetLoader = AssetLoader(engine, UbershaderLoader(engine), EntityManager.get())
+        materialProvider = UbershaderLoader(engine)
+        assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights, recomputeBoundingBoxes, ignoreBindTransform)
 
         // Always add a direct light source since it is required for shadowing.
@@ -316,6 +318,8 @@ class ModelViewer(
 
                 destroyModel()
                 assetLoader.destroy()
+                materialProvider.destroyMaterials()
+                materialProvider.destroy()
                 resourceLoader.destroy()
 
                 engine.destroyEntity(light)

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -201,7 +201,6 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_AssetLoader_nDestroyAssetLoader(JNIEnv*, jclass,
         jlong nativeLoader) {
     AssetLoader* loader = (AssetLoader*) nativeLoader;
-    delete loader->getMaterialProvider();
     NameComponentManager* names = loader->getNames();
     AssetLoader::destroy(&loader);
     delete names;

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -45,7 +45,8 @@ import java.nio.Buffer;
  *
  *     ...
  *
- *     assetLoader = AssetLoader(engine, UbershaderLoader(engine), EntityManager.get())
+ *     materialProvider = UbershaderLoader(engine)
+ *     assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
  *
  *     filamentAsset = assets.open("models/lucy.gltf").use { input -&gt;
  *         val bytes = ByteArray(input.available())
@@ -104,10 +105,12 @@ public class AssetLoader {
     }
 
     /**
-     * Frees all memory consumed by the native <code>AssetLoader</code> and its material cache.
+     * Frees all memory consumed by the native <code>AssetLoader</code>
+     *
+     * This does not not automatically free the cache of materials, nor
+     * does it free the entities for created assets (see destroyAsset).
      */
     public void destroy() {
-        mMaterialCache.destroyMaterials();
         nDestroyAssetLoader(mNativeObject);
         mNativeObject = 0;
     }

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/MaterialProvider.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/MaterialProvider.java
@@ -127,4 +127,10 @@ public interface MaterialProvider {
      * clients to take ownership of the cache if desired.
      */
     public void destroyMaterials();
+
+    /**
+     * Frees memory consumed by the native <code>MaterialProvider</code>, but does not destroy
+     * cached materials.
+     */
+    public void destroy();
 }


### PR DESCRIPTION
This is a Java-only gltfio API change (!)

Jave clients now need to call destroy on MaterialProvider.

Previously, the Java AssetLoader took ownership of the native
material provider upon construction, but this was neither documented
nor consistent with the C++ layer. (This is historical; in the past we
did not expose MaterialProvider to Java.)

One motivation for this (aside from API consistency) is that users may
wish to preserve the material cache from one run to another.

Fixes #5132.