### PR TITLE
create only a single "default render target"

### DIFF
--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -320,6 +320,8 @@ void FEngine::init() {
     driverApi.update3DImage(mDummyZeroTexture, 0, 0, 0, 0, 1, 1, 1,
             PixelBufferDescriptor(&zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE));
 
+    mDefaultRenderTarget = driverApi.createDefaultRenderTarget();
+
     mPostProcessManager.init();
     mLightManager.init(*this);
     mDFG = std::make_unique<DFG>(*this);
@@ -408,6 +410,8 @@ void FEngine::shutdown() {
     driver.destroyTexture(mDummyOneTextureArray);
     driver.destroyTexture(mDummyOneIntegerTextureArray);
     driver.destroyTexture(mDummyZeroTexture);
+
+    driver.destroyRenderTarget(mDefaultRenderTarget);
 
     /*
      * Shutdown the backend...

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -233,6 +233,10 @@ public:
         return clock::now() - getEngineEpoch();
     }
 
+    backend::Handle<backend::HwRenderTarget> getDefaultRenderTarget() const noexcept {
+        return mDefaultRenderTarget;
+    }
+
     template <typename T>
     T* create(ResourceList<T>& list, typename T::Builder const& builder) noexcept;
 
@@ -367,6 +371,7 @@ private:
     void cleanupResourceListLocked(Lock& lock, ResourceList<T>&& list);
 
     backend::Driver* mDriver = nullptr;
+    backend::Handle<backend::HwRenderTarget> mDefaultRenderTarget;
 
     Backend mBackend;
     Platform* mPlatform = nullptr;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -69,7 +69,7 @@ FRenderer::FRenderer(FEngine& engine) :
 void FRenderer::init() noexcept {
     DriverApi& driver = mEngine.getDriverApi();
     mUserEpoch = mEngine.getEngineEpoch();
-    mRenderTarget = driver.createDefaultRenderTarget();
+    mRenderTarget = mEngine.getDefaultRenderTarget();
     mIsRGB8Supported = driver.isRenderTargetFormatSupported(TextureFormat::RGB8);
 
     // our default HDR translucent format, fallback to LDR if not supported by the backend
@@ -118,7 +118,6 @@ void FRenderer::terminate(FEngine& engine) {
     // Here we would cleanly free resources we've allocated or we own, in particular we would
     // shut down threads if we created any.
     DriverApi& driver = engine.getDriverApi();
-    driver.destroyRenderTarget(mRenderTarget);
 
     // before we can destroy this Renderer's resources, we must make sure
     // that all pending commands have been executed (as they could reference data in this


### PR DESCRIPTION
we didn't need one per Renderer, and doing so created complexity in the
backends.

fixes #5291