### PR TITLE
Vulkan: misc SwapChain-related cleanup. 

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -57,6 +57,7 @@ struct VulkanTimestamps {
 };
 
 struct VulkanRenderPass {
+    VulkanRenderTarget* renderTarget;
     VkRenderPass renderPass;
     RenderPassParams params;
     int currentSubpass;

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -20,11 +20,8 @@
 #include "VulkanPipelineCache.h"
 #include "VulkanCommands.h"
 #include "VulkanConstants.h"
-#include "VulkanDisposer.h"
 
-#include <backend/DriverEnums.h>
-
-#include <utils/Condition.h>
+#include <utils/bitset.h>
 #include <utils/Slice.h>
 #include <utils/Mutex.h>
 
@@ -88,8 +85,8 @@ struct VulkanContext {
     bool portabilitySubsetSupported = false;
     bool maintenanceSupported[3] = {};
     VulkanPipelineCache::RasterState rasterState;
-    VulkanSwapChain* currentSurface;
-    Handle<HwRenderTarget> defaultRenderTarget;
+    VulkanSwapChain* currentSwapChain;
+    VulkanRenderTarget* defaultRenderTarget;
     VulkanRenderPass currentRenderPass;
     VkViewport viewport;
     VkFormat finalDepthFormat;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -324,10 +324,6 @@ void VulkanDriver::terminate() {
     delete mContext.commands;
     delete mContext.emptyTexture;
 
-    if (mContext.defaultRenderTarget) {
-        destruct<VulkanRenderTarget>(mContext.defaultRenderTarget);
-    }
-
     mBlitter.shutdown();
 
     // Allow the stage pool and disposer to clean up.
@@ -525,9 +521,12 @@ void VulkanDriver::destroyProgram(Handle<HwProgram> ph) {
 }
 
 void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
-    assert_invariant(!mContext.defaultRenderTarget);
-    mContext.defaultRenderTarget = rth;
-    construct<VulkanRenderTarget>(rth, mContext);
+    assert_invariant(mContext.defaultRenderTarget == nullptr);
+    VulkanRenderTarget* renderTarget = construct<VulkanRenderTarget>(rth);
+    mContext.defaultRenderTarget = renderTarget;
+    mDisposer.createDisposable(renderTarget, [this, rth] () {
+        destruct<VulkanRenderTarget>(rth);
+    });
 }
 
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
@@ -576,10 +575,11 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
 
 void VulkanDriver::destroyRenderTarget(Handle<HwRenderTarget> rth) {
     if (rth) {
-        if (UTILS_LIKELY(mContext.defaultRenderTarget != rth)) {
-            VulkanRenderTarget* rt = handle_cast<VulkanRenderTarget*>(rth);
-            mDisposer.removeReference(rt);
+        VulkanRenderTarget* rt = handle_cast<VulkanRenderTarget*>(rth);
+        if (UTILS_UNLIKELY(rt == mContext.defaultRenderTarget)) {
+            mContext.defaultRenderTarget = nullptr;
         }
+        mDisposer.removeReference(rt);
     }
 }
 
@@ -709,12 +709,12 @@ void VulkanDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
 
 void VulkanDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     if (sch) {
-        VulkanSwapChain& surfaceContext = *handle_cast<VulkanSwapChain*>(sch);
-        surfaceContext.destroy();
+        VulkanSwapChain& swapChain = *handle_cast<VulkanSwapChain*>(sch);
+        swapChain.destroy();
 
-        vkDestroySurfaceKHR(mContext.instance, surfaceContext.surface, VKALLOC);
-        if (mContext.currentSurface == &surfaceContext) {
-            mContext.currentSurface = nullptr;
+        vkDestroySurfaceKHR(mContext.instance, swapChain.surface, VKALLOC);
+        if (mContext.currentSwapChain == &swapChain) {
+            mContext.currentSwapChain = nullptr;
         }
 
         destruct<VulkanSwapChain>(sch);
@@ -1019,7 +1019,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     // passes, due to multiple views.
     TargetBufferFlags discardStart = params.flags.discardStart;
     if (rt->isSwapChain()) {
-        VulkanSwapChain* const sc = mContext.currentSurface;
+        VulkanSwapChain* const sc = mContext.currentSwapChain;
         assert_invariant(sc);
         if (sc->firstRenderPass) {
             discardStart |= TargetBufferFlags::COLOR;
@@ -1327,71 +1327,69 @@ void VulkanDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
 void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
     ASSERT_PRECONDITION_NON_FATAL(drawSch == readSch,
                                   "Vulkan driver does not support distinct draw/read swap chains.");
-    VulkanSwapChain& surf = *handle_cast<VulkanSwapChain*>(drawSch);
-    mContext.currentSurface = &surf;
+    VulkanSwapChain& swapChain = *handle_cast<VulkanSwapChain*>(drawSch);
+    mContext.currentSwapChain = &swapChain;
 
     // Leave early if the swap chain image has already been acquired but not yet presented.
-    if (surf.acquired) {
+    if (swapChain.acquired) {
         if (UTILS_LIKELY(mContext.defaultRenderTarget)) {
-            VulkanRenderTarget* rt = handle_cast<VulkanRenderTarget*>(mContext.defaultRenderTarget);
-            rt->bindToSwapChain(surf);
+            mContext.defaultRenderTarget->bindToSwapChain(swapChain);
         }
         return;
     }
 
     // Query the surface caps to see if it has been resized.  This handles not just resized windows,
     // but also screen rotation on Android and dragging between low DPI and high DPI monitors.
-    if (surf.hasResized()) {
+    if (swapChain.hasResized()) {
         refreshSwapChain();
     }
 
     // Call vkAcquireNextImageKHR and insert its signal semaphore into the command manager's
     // dependency chain.
-    surf.acquire();
+    swapChain.acquire();
 
     if (UTILS_LIKELY(mContext.defaultRenderTarget)) {
-        VulkanRenderTarget* rt = handle_cast<VulkanRenderTarget*>(mContext.defaultRenderTarget);
-        rt->bindToSwapChain(surf);
+        mContext.defaultRenderTarget->bindToSwapChain(swapChain);
     }
 }
 
 void VulkanDriver::commit(Handle<HwSwapChain> sch) {
-    VulkanSwapChain& surface = *handle_cast<VulkanSwapChain*>(sch);
+    VulkanSwapChain& swapChain = *handle_cast<VulkanSwapChain*>(sch);
 
     // Before swapping, transition the current swap chain image to the PRESENT layout. This cannot
     // be done as part of the render pass because it does not know if it is last pass in the frame.
-    surface.makePresentable();
+    swapChain.makePresentable();
 
     if (mContext.commands->flush()) {
         collectGarbage();
     }
 
-    surface.firstRenderPass = true;
+    swapChain.firstRenderPass = true;
 
-    if (surface.headlessQueue) {
+    if (swapChain.headlessQueue) {
         return;
     }
 
-    surface.acquired = false;
+    swapChain.acquired = false;
 
     // Present the backbuffer after the most recent command buffer submission has finished.
     VkSemaphore renderingFinished = mContext.commands->acquireFinishedSignal();
-    uint32_t currentSwapIndex = surface.getSwapIndex();
+    uint32_t currentSwapIndex = swapChain.getSwapIndex();
     VkPresentInfoKHR presentInfo {
         .sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR,
         .waitSemaphoreCount = 1,
         .pWaitSemaphores = &renderingFinished,
         .swapchainCount = 1,
-        .pSwapchains = &surface.swapchain,
+        .pSwapchains = &swapChain.swapchain,
         .pImageIndices = &currentSwapIndex,
     };
-    VkResult result = vkQueuePresentKHR(surface.presentQueue, &presentInfo);
+    VkResult result = vkQueuePresentKHR(swapChain.presentQueue, &presentInfo);
 
     // On Android Q and above, a suboptimal surface is always reported after screen rotation:
     // https://android-developers.googleblog.com/2020/02/handling-device-orientation-efficiently.html
-    if (result == VK_SUBOPTIMAL_KHR && !surface.suboptimal) {
+    if (result == VK_SUBOPTIMAL_KHR && !swapChain.suboptimal) {
         utils::slog.w << "Vulkan Driver: Suboptimal swap chain." << utils::io::endl;
-        surface.suboptimal = true;
+        swapChain.suboptimal = true;
     }
 
     // The surface can be "out of date" when it has been resized, which is not an error.
@@ -1907,11 +1905,11 @@ void VulkanDriver::endTimerQuery(Handle<HwTimerQuery> tqh) {
 }
 
 void VulkanDriver::refreshSwapChain() {
-    VulkanSwapChain& surface = *mContext.currentSurface;
+    VulkanSwapChain& swapChain = *mContext.currentSwapChain;
 
-    assert_invariant(!surface.headlessQueue && "Resizing headless swap chains is not supported.");
-    surface.destroy();
-    surface.create(mStagePool);
+    assert_invariant(!swapChain.headlessQueue && "Resizing headless swap chains is not supported.");
+    swapChain.destroy();
+    swapChain.create(mStagePool);
 
     mFramebufferCache.reset();
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1009,8 +1009,7 @@ void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 }
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {
-    mCurrentRenderTarget = handle_cast<VulkanRenderTarget*>(rth);
-    VulkanRenderTarget* const rt = mCurrentRenderTarget;
+    VulkanRenderTarget* const rt = handle_cast<VulkanRenderTarget*>(rth);
 
     const VkExtent2D extent = rt->getExtent();
     assert_invariant(extent.width > 0 && extent.height > 0);
@@ -1211,10 +1210,11 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         .maxDepth = params.depthRange.far
     };
 
-    mCurrentRenderTarget->transformClientRectToPlatform(&viewport);
+    rt->transformClientRectToPlatform(&viewport);
     vkCmdSetViewport(cmdbuffer, 0, 1, &viewport);
 
     mContext.currentRenderPass = {
+        .renderTarget = rt,
         .renderPass = renderPassInfo.renderPass,
         .params = params,
         .currentSubpass = 0,
@@ -1225,12 +1225,13 @@ void VulkanDriver::endRenderPass(int) {
     VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     vkCmdEndRenderPass(cmdbuffer);
 
-    assert_invariant(mCurrentRenderTarget);
+    VulkanRenderTarget* rt = mContext.currentRenderPass.renderTarget;
+    assert_invariant(rt);
 
     // In some cases, depth needs to be transitioned from DEPTH_STENCIL_READ_ONLY_OPTIMAL back to
     // GENERAL. We did not do this using the render pass because we need to change multiple mips.
     if (mContext.currentRenderPass.params.readOnlyDepthStencil & RenderPassParams::READONLY_DEPTH) {
-        const VulkanAttachment& depth = mCurrentRenderTarget->getDepth();
+        const VulkanAttachment& depth = rt->getDepth();
         VkImageSubresourceRange range = {
             .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
             .baseMipLevel = 0,
@@ -1253,14 +1254,14 @@ void VulkanDriver::endRenderPass(int) {
     // seems to be insufficient on Mali devices. To work around this we are adding a more aggressive
     // TOP_OF_PIPE barrier.
 
-    if (!mCurrentRenderTarget->isSwapChain()) {
+    if (!rt->isSwapChain()) {
         VkMemoryBarrier barrier {
             .sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
             .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             .dstAccessMask = VK_ACCESS_SHADER_READ_BIT,
         };
         VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-        if (mCurrentRenderTarget->hasDepth()) {
+        if (rt->hasDepth()) {
             barrier.srcAccessMask |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
             srcStageMask |= VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
         }
@@ -1270,13 +1271,13 @@ void VulkanDriver::endRenderPass(int) {
                 0, 1, &barrier, 0, nullptr, 0, nullptr);
     }
 
-    mCurrentRenderTarget = VK_NULL_HANDLE;
     if (mContext.currentRenderPass.currentSubpass > 0) {
         for (uint32_t i = 0; i < VulkanPipelineCache::TARGET_BINDING_COUNT; i++) {
             mPipelineCache.bindInputAttachment(i, {});
         }
         mContext.currentRenderPass.currentSubpass = 0;
     }
+    mContext.currentRenderPass.renderTarget = nullptr;
     mContext.currentRenderPass.renderPass = VK_NULL_HANDLE;
 }
 
@@ -1284,7 +1285,8 @@ void VulkanDriver::nextSubpass(int) {
     ASSERT_PRECONDITION(mContext.currentRenderPass.currentSubpass == 0,
             "Only two subpasses are currently supported.");
 
-    assert_invariant(mCurrentRenderTarget);
+    VulkanRenderTarget* renderTarget = mContext.currentRenderPass.renderTarget;
+    assert_invariant(renderTarget);
     assert_invariant(mContext.currentRenderPass.params.subpassMask);
 
     vkCmdNextSubpass(mContext.commands->get().cmdbuffer, VK_SUBPASS_CONTENTS_INLINE);
@@ -1294,7 +1296,7 @@ void VulkanDriver::nextSubpass(int) {
 
     for (uint32_t i = 0; i < VulkanPipelineCache::TARGET_BINDING_COUNT; i++) {
         if ((1 << i) & mContext.currentRenderPass.params.subpassMask) {
-            VulkanAttachment subpassInput = mCurrentRenderTarget->getColor(i);
+            VulkanAttachment subpassInput = renderTarget->getColor(i);
             VkDescriptorImageInfo info = {
                 .imageView = subpassInput.getImageView(VK_IMAGE_ASPECT_COLOR_BIT),
                 .imageLayout = subpassInput.getLayout(),
@@ -1700,7 +1702,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
 
     // Update the VK raster state.
 
-    const VulkanRenderTarget* rt = mCurrentRenderTarget;
+    const VulkanRenderTarget* rt = mContext.currentRenderPass.renderTarget;
 
     auto& vkraster = mContext.rasterState;
     vkraster.cullMode = getCullMode(rasterState.culling);

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -38,7 +38,6 @@ namespace filament {
 namespace backend {
 
 class VulkanPlatform;
-struct VulkanRenderTarget;
 struct VulkanSamplerGroup;
 
 class VulkanDriver final : public DriverBase {
@@ -143,7 +142,6 @@ private:
     VulkanFboCache mFramebufferCache;
     VulkanSamplerCache mSamplerCache;
     VulkanBlitter mBlitter;
-    VulkanRenderTarget* mCurrentRenderTarget = nullptr;
     VulkanSamplerGroup* mSamplerBindings[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
     VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -96,8 +96,7 @@ VulkanProgram::~VulkanProgram() {
 }
 
 // Creates a special "default" render target (i.e. associated with the swap chain)
-VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context) : HwRenderTarget(0, 0),
-        mOffscreen(false), mSamples(1) {}
+VulkanRenderTarget::VulkanRenderTarget() : HwRenderTarget(0, 0), mOffscreen(false), mSamples(1) {}
 
 void VulkanRenderTarget::bindToSwapChain(VulkanSwapChain& swapChain) {
     assert_invariant(!mOffscreen);

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -51,7 +51,7 @@ struct VulkanRenderTarget : private HwRenderTarget {
             VulkanStagePool& stagePool);
 
     // Creates a special "default" render target (i.e. associated with the swap chain)
-    explicit VulkanRenderTarget(VulkanContext& context);
+    explicit VulkanRenderTarget();
 
     void transformClientRectToPlatform(VkRect2D* bounds) const;
     void transformClientRectToPlatform(VkViewport* bounds) const;


### PR DESCRIPTION
- Remove some special handling of the default render target lifetime that is no longer needed
- Rename "surface" to "swapChain" where it is appropriate to do so
- Remove some state from the VulkanDriver class
