### PR TITLE
cleanup attributes/varyings generation

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -235,10 +235,13 @@ io::sstream& CodeGenerator::generateShaderInputs(io::sstream& out, ShaderType ty
             }
         }
 
-        out << SHADERS_INPUTS_VS_DATA;
+        out << SHADERS_ATTRIBUTES_VS_DATA;
+
+        generateDefine(out, "VARYING", "out");
     } else if (type == ShaderType::FRAGMENT) {
-        out << SHADERS_INPUTS_FS_DATA;
+        generateDefine(out, "VARYING", "in");
     }
+    out << SHADERS_VARYINGS_GLSL_DATA;
     return out;
 }
 

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 # ==================================================================================================
 set(SHADERS
         src/ambient_occlusion.fs
+        src/attributes.vs
         src/brdf.fs
         src/common_getters.fs
         src/common_graphics.fs
@@ -25,8 +26,6 @@ set(SHADERS
         src/fog.fs
         src/getters.fs
         src/getters.vs
-        src/inputs.fs
-        src/inputs.vs
         src/light_directional.fs
         src/light_indirect.fs
         src/light_reflections.fs
@@ -49,6 +48,7 @@ set(SHADERS
         src/shading_reflections.fs
         src/shading_unlit.fs
         src/shadowing.fs
+        src/varyings.glsl
         src/vignette.fs
 )
 

--- a/shaders/src/attributes.vs
+++ b/shaders/src/attributes.vs
@@ -1,3 +1,7 @@
+//------------------------------------------------------------------------------
+// Attributes
+//------------------------------------------------------------------------------
+
 layout(location = LOCATION_POSITION) in vec4 mesh_position;
 
 #if defined(HAS_ATTRIBUTE_TANGENTS)
@@ -54,29 +58,4 @@ layout(location = LOCATION_CUSTOM6) in vec4 mesh_custom6;
 
 #if defined(HAS_ATTRIBUTE_CUSTOM7)
 layout(location = LOCATION_CUSTOM7) in vec4 mesh_custom7;
-#endif
-
-LAYOUT_LOCATION(4) out highp vec4 vertex_worldPosition;
-
-#if defined(HAS_ATTRIBUTE_TANGENTS)
-LAYOUT_LOCATION(5) SHADING_INTERPOLATION out mediump vec3 vertex_worldNormal;
-#if defined(MATERIAL_NEEDS_TBN)
-LAYOUT_LOCATION(6) SHADING_INTERPOLATION out mediump vec4 vertex_worldTangent;
-#endif
-#endif
-
-LAYOUT_LOCATION(7) out highp vec4 vertex_position;
-
-#if defined(HAS_ATTRIBUTE_COLOR)
-LAYOUT_LOCATION(9) out mediump vec4 vertex_color;
-#endif
-
-#if defined(HAS_ATTRIBUTE_UV0) && !defined(HAS_ATTRIBUTE_UV1)
-LAYOUT_LOCATION(10) out highp vec2 vertex_uv01;
-#elif defined(HAS_ATTRIBUTE_UV1)
-LAYOUT_LOCATION(10) out highp vec4 vertex_uv01;
-#endif
-
-#if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
-LAYOUT_LOCATION(11) out highp vec4 vertex_lightSpacePosition;
 #endif

--- a/shaders/src/varyings.glsl
+++ b/shaders/src/varyings.glsl
@@ -1,30 +1,30 @@
 //------------------------------------------------------------------------------
-// Attributes and uniforms
+// Varyings
 //------------------------------------------------------------------------------
 
-LAYOUT_LOCATION(4) in highp vec4 vertex_worldPosition;
+LAYOUT_LOCATION(4) VARYING highp vec4 vertex_worldPosition;
 
 #if defined(HAS_ATTRIBUTE_TANGENTS)
-LAYOUT_LOCATION(5) SHADING_INTERPOLATION in mediump vec3 vertex_worldNormal;
+LAYOUT_LOCATION(5) SHADING_INTERPOLATION VARYING mediump vec3 vertex_worldNormal;
 #if defined(MATERIAL_NEEDS_TBN)
-LAYOUT_LOCATION(6) SHADING_INTERPOLATION in mediump vec4 vertex_worldTangent;
+LAYOUT_LOCATION(6) SHADING_INTERPOLATION VARYING mediump vec4 vertex_worldTangent;
 #endif
 #endif
 
-LAYOUT_LOCATION(7) in highp vec4 vertex_position;
+LAYOUT_LOCATION(7) VARYING highp vec4 vertex_position;
 
 #if defined(HAS_ATTRIBUTE_COLOR)
-LAYOUT_LOCATION(9) in mediump vec4 vertex_color;
+LAYOUT_LOCATION(9) VARYING mediump vec4 vertex_color;
 #endif
 
 #if defined(HAS_ATTRIBUTE_UV0) && !defined(HAS_ATTRIBUTE_UV1)
-LAYOUT_LOCATION(10) in highp vec2 vertex_uv01;
+LAYOUT_LOCATION(10) VARYING highp vec2 vertex_uv01;
 #elif defined(HAS_ATTRIBUTE_UV1)
-LAYOUT_LOCATION(10) in highp vec4 vertex_uv01;
+LAYOUT_LOCATION(10) VARYING highp vec4 vertex_uv01;
 #endif
 
 #if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
-LAYOUT_LOCATION(11) in highp vec4 vertex_lightSpacePosition;
+LAYOUT_LOCATION(11) VARYING highp vec4 vertex_lightSpacePosition;
 #endif
 
 // Note that fragColor is an output and is not declared here; see main.fs and depth_main.fs


### PR DESCRIPTION
We now have a single varyings.glsl containing our varyings for both
the vertex and fragment shader. This file is included with the right
definition of VARYING as `in` or `out`.

inputs.vs is now renamed attributes.vs