### PR TITLE
Fix precondition for RenderableManager::setMorphWeights.

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -644,7 +644,7 @@ static void updateMorphWeights(FEngine& engine, backend::Handle<backend::HwBuffe
 void FRenderableManager::setMorphWeights(Instance instance, float const* weights,
         size_t count, size_t offset) {
     if (instance) {
-        ASSERT_PRECONDITION(count + offset < CONFIG_MAX_MORPH_TARGET_COUNT,
+        ASSERT_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT,
                 "Only %d morph targets are supported (count=%d, offset=%d)",
                 CONFIG_MAX_MORPH_TARGET_COUNT, count, offset);
 


### PR DESCRIPTION
Was checking for `MAX - 1` instead of `MAX`.

@dsternfeld7 since he had the original change in a prototype CL.
@daemyung and @pixelflinger for review.