### PR TITLE
Update blending equation for MASKED (core Filament change)

### DIFF
--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -220,15 +220,13 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
             mRasterState.blendFunctionDstAlpha = BlendFunction::ZERO;
             mRasterState.depthWrite = true;
             break;
+        // Do not change this behavior without checking for regressions with AlphaBlendModeTest
+        // and TextureLinearInterpolationTest, with and without View::BlendMode::TRANSLUCENT.
         case BlendingMode::MASKED:
-            // This leaves destination alpha intact if it is already opaque, but makes it opaque if
-            // it is already semi-transparent. This is usually what you want when drawing a scene.
-            // Do not change this behavior without checking for regressions with AlphaBlendModeTest
-            // and TextureLinearInterpolationTest, with and without View::BlendMode::TRANSLUCENT.
             mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
-            mRasterState.blendFunctionSrcAlpha = BlendFunction::SRC_ALPHA;
-            mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
-            mRasterState.blendFunctionDstAlpha = BlendFunction::ONE;
+            mRasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
+            mRasterState.blendFunctionDstRGB   = BlendFunction::ONE_MINUS_SRC_ALPHA;
+            mRasterState.blendFunctionDstAlpha = BlendFunction::ONE_MINUS_SRC_ALPHA;
             mRasterState.depthWrite = true;
             break;
         case BlendingMode::TRANSPARENT:

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -221,12 +221,12 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
             mRasterState.depthWrite = true;
             break;
         case BlendingMode::MASKED:
-            // MASKED mode now leaves destination alpha intact.
-            // This prevents strange behavior with semi-transparent render targets, which the
-            // model viewer team discovered when testing against the Khronos alpha test
-            // conformance model.
+            // This leaves destination alpha intact if it is already opaque, but makes it opaque if
+            // it is already semi-transparent. This is usually what you want when drawing a scene.
+            // Do not change this behavior without checking for regressions with AlphaBlendModeTest
+            // and TextureLinearInterpolationTest, with and without View::BlendMode::TRANSLUCENT.
             mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
-            mRasterState.blendFunctionSrcAlpha = BlendFunction::ZERO;
+            mRasterState.blendFunctionSrcAlpha = BlendFunction::SRC_ALPHA;
             mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
             mRasterState.blendFunctionDstAlpha = BlendFunction::ONE;
             mRasterState.depthWrite = true;


### PR DESCRIPTION
Our existing behavior was surprising for users who draw opaque objects
into a semitransparent views, and this was especially evident with
the labels in `TextureLinearInterpolationTest`.

Yes, once again the labels in a glTF test turned out to be more useful
than the test itself. :)

After discussion with Romain we realized that you don't always want to
leave destination alpha intact.

I also made sure that this does not regress `AlphaBlendModeTest`.

Fixes #4576.