### PR TITLE
Make ios/samples support source code debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -727,6 +727,12 @@ if (IS_HOST_PLATFORM)
     add_subdirectory(${TOOLS}/specular-color)
 endif()
 
+if (IOS AND IOS_DEBUG_SAMPLES)
+    add_subdirectory(${FILAMENT}/ios/samples/hello-triangle)
+    add_subdirectory(${FILAMENT}/ios/samples/hello-pbr)
+    add_subdirectory(${FILAMENT}/ios/samples/hello-gltf)
+endif()
+
 # Generate exported executables for cross-compiled builds (Android, WebGL, and iOS)
 if (NOT CMAKE_CROSSCOMPILING)
     export(TARGETS matc cmgen filamesh mipgen resgen glslminifier FILE ${IMPORT_EXECUTABLES})

--- a/ios/samples/README.md
+++ b/ios/samples/README.md
@@ -99,3 +99,26 @@ $ xcodegen
 
 within a sample folder to re-generate the Xcode project. You may need to close and re-open the
 project in Xcode to see changes take effect.
+
+## Sources Debug
+If you want to source debug filament on the iOS platform, the following command can be run at the
+root of the Filament source tree:
+
+```
+$ ./build.sh -p desktop -i release         # build required desktop tools (matc, resgen, etc)
+$ cmake . \
+-B out-ios \
+-G Xcode \
+-DCMAKE_TOOLCHAIN_FILE=third_party/clang/iOS.cmake \
+-DPLATFORM=OS64COMBINED \
+-DIMPORT_EXECUTABLES_DIR=build-ios \
+-DCMAKE_BUILD_TYPE=Debug \
+-DIOS=1 \
+-DPLATFORM_NAME=iphoneos \
+-DIOS_ARCH=arm64 \
+-DIMPORT_EXECUTABLES_DIR=out \
+-DCMAKE_XCODE_GENERATE_SCHEME=ON \
+-DIOS_DEBUG_SAMPLES=1
+```
+You can open `out-ios/TNT.xcodeproj` with xcode for source debugging, and here are the three 
+corresponding demos, `hello-triangle`, `hello-pbr` and `hello-gltf`.

--- a/ios/samples/hello-gltf/CMakelists.txt
+++ b/ios/samples/hello-gltf/CMakelists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(APP_NAME hello_gltf)
+
+project(${APP_NAME})
+
+# resources
+set(RESOURCE_DIR ${hello_gltf_SOURCE_DIR}/hello-gltf/SupportFiles/Base.lproj)
+file(GLOB_RECURSE RESOURCES
+    "${RESOURCE_DIR}/*.storyboard"
+)
+list(APPEND RESOURCES ${CMAKE_SOURCE_DIR}/third_party/models/DamagedHelmet/DamagedHelmet.glb)
+
+# sources
+file(GLOB_RECURSE SOURCES
+    "${hello_gltf_SOURCE_DIR}/hello-gltf/*.h"
+    "${hello_gltf_SOURCE_DIR}/hello-gltf/*.m"
+    "${hello_gltf_SOURCE_DIR}/hello-gltf/*.cpp"
+    "${hello_gltf_SOURCE_DIR}/hello-gltf/*.mm"
+)
+list(APPEND SOURCES ${hello_gltf_SOURCE_DIR}/hello-gltf/SupportFiles/Resources.S)
+
+
+set(BUILD_RESOURCE_NAME "build_resource")
+add_custom_command(
+    OUTPUT
+        ${BUILD_RESOURCE_NAME}
+    COMMAND cd ${hello_gltf_SOURCE_DIR}
+    COMMAND export PROJECT_DIR=${hello_gltf_SOURCE_DIR}
+    COMMAND sh build-resources.sh
+)
+
+add_executable(${APP_NAME} MACOSX_BUNDLE
+    ${SOURCES} ${BUILD_RESOURCE_NAME}
+    ${RESOURCES}
+)
+
+set_target_properties(${APP_NAME} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${hello_gltf_SOURCE_DIR}/hello-gltf/SupportFiles/Info.plist
+    RESOURCE "${RESOURCES}"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "google.filament.hello-gltf"
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+    XCODE_ATTRIBUTE_COPY_PHASE_STRIP NO
+    XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY ON
+    XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY ON
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES  
+)
+
+target_link_libraries(${APP_NAME} PRIVATE filament image gltfio_core)
+target_include_directories(${APP_NAME} PRIVATE "generated")
+target_include_directories(${APP_NAME} PRIVATE "hello-gltf")
+target_compile_definitions(${APP_NAME} PRIVATE FILAMENT_APP_USE_METAL=1)
+target_link_libraries(${APP_NAME} PUBLIC
+    "-framework UIKit"
+    "-framework CoreGraphics"
+    "-framework QuartzCore"
+    "-framework OpenGLES"
+    "-framework Metal"
+)

--- a/ios/samples/hello-pbr/CMakelists.txt
+++ b/ios/samples/hello-pbr/CMakelists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(APP_NAME hello_pbr)
+
+# Set your deployment target version of iOS
+set(DEPLOYMENT_TARGET 11.0)
+
+project(${APP_NAME})
+
+# resources
+set(RESOURCE_DIR ${hello_pbr_SOURCE_DIR}/hello-pbr/Base.lproj)
+file(GLOB_RECURSE RESOURCES
+    "${RESOURCE_DIR}/*.storyboard"
+)
+
+# sources
+file(GLOB_RECURSE SOURCES
+    "${hello_pbr_SOURCE_DIR}/hello-pbr/*.h"
+    "${hello_pbr_SOURCE_DIR}/hello-pbr/*.m"
+    "${hello_pbr_SOURCE_DIR}/hello-pbr/*.cpp"
+    "${hello_pbr_SOURCE_DIR}/hello-pbr/*.mm"
+)
+list(APPEND SOURCES ${hello_pbr_SOURCE_DIR}/hello-pbr/Resources.S)
+
+
+set(BUILD_RESOURCE_NAME "build_resource")
+add_custom_command(
+    OUTPUT
+        ${BUILD_RESOURCE_NAME}
+    COMMAND cd ${hello_pbr_SOURCE_DIR}
+    COMMAND export PROJECT_DIR=${hello_pbr_SOURCE_DIR}
+    COMMAND sh build-resources.sh
+)
+
+add_executable(${APP_NAME} MACOSX_BUNDLE
+    ${SOURCES} ${BUILD_RESOURCE_NAME}
+    ${RESOURCES}
+)
+
+set_target_properties(${APP_NAME} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${hello_pbr_SOURCE_DIR}/hello-pbr/Info.plist
+    RESOURCE "${RESOURCES}"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "google.filament.hello-pbr"
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+    XCODE_ATTRIBUTE_COPY_PHASE_STRIP NO
+    XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY ON
+    XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY ON
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES  
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET}
+)
+
+set_target_properties(meshoptimizer PROPERTIES
+    XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET}
+)
+target_link_libraries(${APP_NAME} PRIVATE filament filameshio image)
+target_include_directories(${APP_NAME} PRIVATE "generated")
+target_compile_definitions(${APP_NAME} PRIVATE FILAMENT_APP_USE_METAL=1)
+target_link_libraries(${APP_NAME} PUBLIC
+    "-framework UIKit"
+    "-framework CoreGraphics"
+    "-framework QuartzCore"
+    "-framework OpenGLES"
+    "-framework Metal"
+)

--- a/ios/samples/hello-triangle/CMakelists.txt
+++ b/ios/samples/hello-triangle/CMakelists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.12)
+
+set(APP_NAME hello_triangle)
+
+project(${APP_NAME})
+
+# resources
+set(RESOURCE_DIR ${hello_triangle_SOURCE_DIR}/hello-triangle/Base.lproj)
+file(GLOB_RECURSE RESOURCES
+    "${RESOURCE_DIR}/*.storyboard"
+)
+
+# sources
+file(GLOB_RECURSE SOURCES
+    "${hello_triangle_SOURCE_DIR}/hello-triangle/*.h"
+    "${hello_triangle_SOURCE_DIR}/hello-triangle/*.m"
+    "${hello_triangle_SOURCE_DIR}/hello-triangle/*.mm"
+)
+
+set(BUILD_RESOURCE_NAME "build_resource")
+add_custom_command(
+    OUTPUT
+        ${BUILD_RESOURCE_NAME}
+    COMMAND cd ${hello_triangle_SOURCE_DIR}
+    COMMAND export PROJECT_DIR=${hello_triangle_SOURCE_DIR}
+    COMMAND sh build-materials.sh
+)
+
+add_executable(${APP_NAME} MACOSX_BUNDLE
+    ${SOURCES} ${BUILD_RESOURCE_NAME}
+    ${RESOURCES}
+)
+
+set_target_properties(${APP_NAME} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${hello_triangle_SOURCE_DIR}/hello-triangle/Info.plist
+    RESOURCE "${RESOURCES}"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "google.filament.hello-triangle"
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"
+    XCODE_ATTRIBUTE_COPY_PHASE_STRIP NO
+    XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY ON
+    XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY ON
+    XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES  
+)
+
+target_link_libraries(${APP_NAME} PRIVATE filament)
+target_include_directories(${APP_NAME} PRIVATE "generated")
+target_compile_definitions(${APP_NAME} PRIVATE FILAMENT_APP_USE_METAL=1)
+target_link_libraries(${APP_NAME} PUBLIC
+    "-framework UIKit"
+    "-framework CoreGraphics"
+    "-framework QuartzCore"
+    "-framework OpenGLES"
+    "-framework Metal"
+)


### PR DESCRIPTION
Current `ios/samples` do not allow easy debugging of filament source code, because filament is relied on by the demo as a compilation product and not in source form.
I added three CMakelists.txt to facilitate source debugging of `ios/samples` against samples, which I think will be more friendly to iOS developers and make it easier for them to debug filament.