### PR TITLE
New behavior for BlendingMode::MASKED.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.20.4 (currently main branch)
 
+- New behavior for MASKED to work with translucent views. [⚠️ **Recompile Materials** to get the fix]
+
 ## v1.20.3
 
 ## v1.20.2

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1280,7 +1280,8 @@ Description
       render target is brightened.
     - **Masked**: blending is disabled. This blending mode enables alpha masking. The alpha channel
       of the material's output defines whether a fragment is discarded or not. Additionally,
-      ALPHA_TO_COVERAGE is enabled. See the maskThreshold section for more information.
+      ALPHA_TO_COVERAGE is enabled for non-translucent views. See the maskThreshold section for more
+      information.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1279,8 +1279,8 @@ Description
     - **Screen**: blending is enabled. Effectively the opposite of the `multiply`, the content of the
       render target is brightened.
     - **Masked**: blending is disabled. This blending mode enables alpha masking. The alpha channel
-      of the material's output defines whether a fragment is discarded or not. See the maskThreshold
-      section for more information.
+      of the material's output defines whether a fragment is discarded or not. Additionally,
+      ALPHA_TO_COVERAGE is enabled. See the maskThreshold section for more information.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {
@@ -1364,8 +1364,9 @@ Value
 
 Description
 :     Sets the minimum alpha value a fragment must have to not be discarded when the `blending` mode
-      is set to `masked`. When the blending mode is not `masked`, this value is ignored. This value
-      can be used to controlled the appearance of alpha-masked objects.
+      is set to `masked`. If the fragment is not discarded, its source alpha is set to 1. When the
+      blending mode is not `masked`, this value is ignored. This value can be used to controlled the
+      appearance of alpha-masked objects.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
 material {

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -168,6 +168,10 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOption
     s.aoBentNormals = options.enabled && options.bentNormals ? 1.0f : 0.0f;
 }
 
+void PerViewUniforms::prepareBlending(bool needsAlphaChannel) noexcept {
+    mPerViewUb.edit().needsAlphaChannel = needsAlphaChannel ? 1.0f : 0.0f;
+}
+
 void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
         float refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -72,6 +72,7 @@ public:
     void prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept;
     void prepareStructure(TextureHandle structure) noexcept;
     void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
+    void prepareBlending(bool needsAlphaChannel) noexcept;
 
     // screen-space reflection and/or refraction (SSR)
     void prepareSSR(TextureHandle ssr,

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -213,22 +213,15 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     using BlendFunction = RasterState::BlendFunction;
     using DepthFunc = RasterState::DepthFunc;
     switch (mBlendingMode) {
+        // Do not change the MASKED behavior without checking for regressions with
+        // AlphaBlendModeTest and TextureLinearInterpolationTest, with and without
+        // View::BlendMode::TRANSLUCENT.
+        case BlendingMode::MASKED:
         case BlendingMode::OPAQUE:
             mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
             mRasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
             mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
             mRasterState.blendFunctionDstAlpha = BlendFunction::ZERO;
-            mRasterState.depthWrite = true;
-            break;
-        case BlendingMode::MASKED:
-            // MASKED mode now leaves destination alpha intact.
-            // This prevents strange behavior with semi-transparent render targets, which the
-            // model viewer team discovered when testing against the Khronos alpha test
-            // conformance model.
-            mRasterState.blendFunctionSrcRGB   = BlendFunction::ONE;
-            mRasterState.blendFunctionSrcAlpha = BlendFunction::ZERO;
-            mRasterState.blendFunctionDstRGB   = BlendFunction::ZERO;
-            mRasterState.blendFunctionDstAlpha = BlendFunction::ONE;
             mRasterState.depthWrite = true;
             break;
         case BlendingMode::TRANSPARENT:

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -260,7 +260,11 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         return;
     }
 
-    view.prepare(engine, driver, arena, svp, getShaderUserTime());
+    const bool blendModeTranslucent = view.getBlendMode() == BlendMode::TRANSLUCENT;
+    // If the swapchain is transparent or if we blend into it, we need to allocate our intermediate
+    // buffers with an alpha channel.
+    const bool needsAlphaChannel = (mSwapChain && mSwapChain->isTransparent()) || blendModeTranslucent;
+    view.prepare(engine, driver, arena, svp, getShaderUserTime(), needsAlphaChannel);
 
     view.prepareUpscaler(scale);
 
@@ -367,11 +371,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                     .keepOverrideEnd = keepOverrideEndFlags
             }, viewRenderTarget);
 
-    const bool blendModeTranslucent = view.getBlendMode() == BlendMode::TRANSLUCENT;
     const bool blending = blendModeTranslucent;
-    // If the swapchain is transparent or if we blend into it, we need to allocate our intermediate
-    // buffers with an alpha channel.
-    const bool needsAlphaChannel = (mSwapChain && mSwapChain->isTransparent()) || blendModeTranslucent;
     const TextureFormat hdrFormat = getHdrFormat(view, needsAlphaChannel);
 
     ColorPassConfig config{

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -407,7 +407,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 }
 
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
-        filament::Viewport const& viewport, float4 const& userTime) noexcept {
+        filament::Viewport const& viewport, float4 const& userTime, bool needsAlphaChannel) noexcept {
     JobSystem& js = engine.getJobSystem();
 
     /*
@@ -576,6 +576,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
     mPerViewUniforms.prepareTime(userTime);
     mPerViewUniforms.prepareFog(mViewingCameraInfo, mFogOptions);
     mPerViewUniforms.prepareTemporalNoise(mTemporalAntiAliasingOptions);
+    mPerViewUniforms.prepareBlending(needsAlphaChannel);
 
     // set uniforms and samplers
     bindPerViewUniformsAndSamplers(driver);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -119,7 +119,7 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& arena,
-            Viewport const& viewport, math::float4 const& userTime) noexcept;
+            Viewport const& viewport, math::float4 const& userTime, bool needsAlphaChannel) noexcept;
 
     void setScene(FScene* scene) { mScene = scene; }
     FScene const* getScene() const noexcept { return mScene; }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -65,7 +65,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
     math::float2 lightFarAttenuationParams;     // a, a/far (a=1/pct-of-far)
-    float padding0;
+    float needsAlphaChannel;
     uint32_t lightChannels;
 
     math::float3 lightDirection;

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -52,7 +52,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("lightFarAttenuationParams",1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
+            .add("needsAlphaChannel",       1, UniformInterfaceBlock::Type::FLOAT)
             .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
             .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -2,29 +2,39 @@
 // Lighting
 //------------------------------------------------------------------------------
 
+#if defined(BLEND_MODE_MASKED)
+float computeMaskedAlpha(float a) {
+    // Use derivatives to smooth alpha tested edges
+    return (a - getMaskThreshold()) / max(fwidth(a), 1e-3) + 0.5;
+}
+
 float computeDiffuseAlpha(float a) {
-#if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE) || defined(BLEND_MODE_MASKED)
+    // If we reach this point in the code, we already know that the fragment is not discarded due
+    // to the threshold factor. Therefore we can just output 1.0, which prevents a "punch thru"
+    // effect from occuring.
+    return 1.0;
+}
+
+void applyAlphaMask(inout vec4 baseColor) {
+    baseColor.a = computeMaskedAlpha(baseColor.a);
+    if (baseColor.a <= 0.0) {
+        discard;
+    }
+}
+
+#else // not masked
+
+float computeDiffuseAlpha(float a) {
+#if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)
     return a;
 #else
     return 1.0;
 #endif
 }
 
-#if defined(BLEND_MODE_MASKED)
-float computeMaskedAlpha(float a) {
-    // Use derivatives to smooth alpha tested edges
-    return (a - getMaskThreshold()) / max(fwidth(a), 1e-3) + 0.5;
-}
-#endif
+void applyAlphaMask(inout vec4 baseColor) {}
 
-void applyAlphaMask(inout vec4 baseColor) {
-#if defined(BLEND_MODE_MASKED)
-    baseColor.a = computeMaskedAlpha(baseColor.a);
-    if (baseColor.a <= 0.0) {
-        discard;
-    }
 #endif
-}
 
 #if defined(GEOMETRIC_SPECULAR_AA)
 float normalFiltering(float perceptualRoughness, const vec3 worldNormal) {

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -10,9 +10,10 @@ float computeMaskedAlpha(float a) {
 
 float computeDiffuseAlpha(float a) {
     // If we reach this point in the code, we already know that the fragment is not discarded due
-    // to the threshold factor. Therefore we can just output 1.0, which prevents a "punch thru"
-    // effect from occuring.
-    return 1.0;
+    // to the threshold factor. Therefore we can just output 1.0, which prevents a "punch through"
+    // effect from occuring. We do this only for TRANSLUCENT views in order to prevent breakage
+    // of ALPHA_TO_COVERAGE.
+    return (frameUniforms.needsAlphaChannel == 1.0) ? 1.0 : a;
 }
 
 void applyAlphaMask(inout vec4 baseColor) {

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -34,7 +34,11 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     color.a = computeMaskedAlpha(color.a);
     if (color.a <= 0.0) {
         discard;
-    } else {
+    }
+
+    // Output 1.0 for translucent view to prevent "punch through" artifacts. We do not do this
+    // for opaque views to enable proper usage of ALPHA_TO_COVERAGE.
+    if (frameUniforms.needsAlphaChannel == 1.0) {
         color.a = 1.0;
     }
 #endif

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -34,6 +34,8 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     color.a = computeMaskedAlpha(color.a);
     if (color.a <= 0.0) {
         discard;
+    } else {
+        color.a = 1.0;
     }
 #endif
 


### PR DESCRIPTION
The existing behavior was surprising for users who draw opaque objects
into a semitransparent views, and this was especially evident with
the labels in `TextureLinearInterpolationTest`.

We now disable blending for MASKED, which is what our existing materials
documentation already says. We also now set the fragment alpha to 1 when
the fragment is not discarded, which prevents the "punch through"
effect. This is consistent with ThreeJS.

Fixes #4576.