### PR TITLE
Moved reference to std::mutex out of public include header ostream.h …

### DIFF
--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -17,7 +17,6 @@
 #ifndef TNT_UTILS_OSTREAM_H
 #define TNT_UTILS_OSTREAM_H
 
-#include <mutex>
 #include <string>
 #include <utility>
 
@@ -86,7 +85,6 @@ protected:
         size_t capacity = 0;        // total capacity of the buffer
     };
 
-    std::mutex mLock;
     Buffer mData;
     Buffer& getBuffer() noexcept { return mData; }
 

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <utils/compiler.h>
+#include <mutex>
 
 #ifdef __ANDROID__
 #   include <android/log.h>
@@ -29,6 +30,8 @@
 namespace utils {
 
 namespace io {
+
+extern std::mutex mLock;        // defined in ostream.cpp
 
 class LogStream : public ostream {
 public:

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -20,8 +20,11 @@
 #include <algorithm>
 #include <stdarg.h>
 #include <string>
+#include <mutex>
 
 namespace utils::io {
+
+std::mutex mLock;
 
 ostream::~ostream() = default;
 


### PR DESCRIPTION
I chose the simplest solution and moved the reference to **std::mutex** out of **ostream.h** and created a global in **ostream.cpp**.
Fixes #5331