### PR TITLE
move BuilderBase to libutils and rename to PrivateImplementation

### DIFF
--- a/filament/include/filament/FilamentAPI.h
+++ b/filament/include/filament/FilamentAPI.h
@@ -18,6 +18,7 @@
 #define TNT_FILAMENT_FILAMENTAPI_H
 
 #include <utils/compiler.h>
+#include <utils/PrivateImplementation.h>
 
 #include <stddef.h>
 
@@ -52,39 +53,8 @@ public:
     static void  operator delete[](void*)  = delete;
 };
 
-
-/**
- * \privatesection
- * BuilderBase is used to hide the implementation details of builders and ensure a higher
- * level of backward binary compatibility.
- * The actual implementation is in src/FilamentAPI-impl.h"
- */
-template <typename T>
-class BuilderBase {
-public:
-    // none of these methods must be implemented inline because it's important that their
-    // implementation be hidden from the public headers.
-    template<typename ... ARGS>
-    explicit BuilderBase(ARGS&& ...) noexcept;
-    BuilderBase() noexcept;
-    ~BuilderBase() noexcept;
-    BuilderBase(BuilderBase const& rhs) noexcept;
-    BuilderBase& operator = (BuilderBase const& rhs) noexcept;
-
-    // move ctor and copy operator can be implemented inline and don't need to be exported
-    BuilderBase(BuilderBase&& rhs) noexcept : mImpl(rhs.mImpl) { rhs.mImpl = nullptr; }
-    BuilderBase& operator = (BuilderBase&& rhs) noexcept {
-        auto temp = mImpl;
-        mImpl = rhs.mImpl;
-        rhs.mImpl = temp;
-        return *this;
-    }
-
-protected:
-    T* mImpl = nullptr;
-    inline T* operator->() noexcept { return mImpl; }
-    inline T const* operator->() const noexcept { return mImpl; }
-};
+template<typename T>
+using BuilderBase = utils::PrivateImplementation<T>;
 
 } // namespace filament
 

--- a/filament/src/FilamentAPI-impl.h
+++ b/filament/src/FilamentAPI-impl.h
@@ -24,37 +24,6 @@
 
 #include <filament/FilamentAPI.h>
 
-#include <utility>
-
-namespace filament {
-
-template<typename T>
-BuilderBase<T>::BuilderBase() noexcept
-        : mImpl(new T) {
-}
-
-template<typename T>
-template<typename ... ARGS>
-BuilderBase<T>::BuilderBase(ARGS&& ... args) noexcept
-        : mImpl(new T(std::forward<ARGS>(args)...)) {
-}
-
-template<typename T>
-BuilderBase<T>::~BuilderBase() noexcept {
-    delete mImpl;
-}
-
-template<typename T>
-BuilderBase<T>::BuilderBase(BuilderBase const& rhs) noexcept
-        : mImpl(new T(*rhs.mImpl)) {
-}
-
-template<typename T>
-BuilderBase<T>& BuilderBase<T>::operator=(BuilderBase<T> const& rhs) noexcept {
-    *mImpl = *rhs.mImpl;
-    return *this;
-}
-
-} // namespace filament
+#include <utils/PrivateImplementation-impl.h>
 
 #endif // TNT_FILAMENT_FILAMENTAPI_IMPL_H

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -33,6 +33,8 @@ set(DIST_HDRS
         ${PUBLIC_HDR_DIR}/${TARGET}/ostream.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Panic.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Path.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation.h
+        ${PUBLIC_HDR_DIR}/${TARGET}/PrivateImplementation-impl.h
         ${PUBLIC_HDR_DIR}/${TARGET}/SingleInstanceComponentManager.h
         ${PUBLIC_HDR_DIR}/${TARGET}/Slice.h
         ${PUBLIC_HDR_DIR}/${TARGET}/SpinLock.h

--- a/libs/utils/include/utils/PrivateImplementation-impl.h
+++ b/libs/utils/include/utils/PrivateImplementation-impl.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTILS_PRIVATEIMPLEMENTATION_IMPL_H
+#define UTILS_PRIVATEIMPLEMENTATION_IMPL_H
+
+/*
+ * This looks like a header file, but really it acts as a .cpp, because it's used to
+ * explicitly instantiate the methods of PrivateImplementation<>
+ */
+
+#include <utils/PrivateImplementation.h>
+
+#include <utility>
+
+namespace utils {
+
+template<typename T>
+PrivateImplementation<T>::PrivateImplementation() noexcept
+        : mImpl(new T) {
+}
+
+template<typename T>
+template<typename ... ARGS>
+PrivateImplementation<T>::PrivateImplementation(ARGS&& ... args) noexcept
+        : mImpl(new T(std::forward<ARGS>(args)...)) {
+}
+
+template<typename T>
+PrivateImplementation<T>::~PrivateImplementation() noexcept {
+    delete mImpl;
+}
+
+#ifndef UTILS_PRIVATE_IMPLEMENTATION_NON_COPYABLE
+
+template<typename T>
+PrivateImplementation<T>::PrivateImplementation(PrivateImplementation const& rhs) noexcept
+        : mImpl(new T(*rhs.mImpl)) {
+}
+
+template<typename T>
+PrivateImplementation<T>& PrivateImplementation<T>::operator=(PrivateImplementation<T> const& rhs) noexcept {
+    if (this != &rhs) {
+        *mImpl = *rhs.mImpl;
+    }
+    return *this;
+}
+
+#endif
+
+} // namespace utils
+
+#endif // UTILS_PRIVATEIMPLEMENTATION_IMPL_H

--- a/libs/utils/include/utils/PrivateImplementation.h
+++ b/libs/utils/include/utils/PrivateImplementation.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UTILS_PRIVATEIMPLEMENTATION_H
+#define UTILS_PRIVATEIMPLEMENTATION_H
+
+#include <utils/compiler.h>
+
+#include <stddef.h>
+
+namespace utils {
+
+/**
+ * \privatesection
+ * PrivateImplementation is used to hide the implementation details of a class and ensure a higher
+ * level of backward binary compatibility.
+ * The actual implementation is in src/PrivateImplementation-impl.h"
+ */
+template<typename T>
+class PrivateImplementation {
+public:
+    // none of these methods must be implemented inline because it's important that their
+    // implementation be hidden from the public headers.
+    template<typename ... ARGS>
+    explicit PrivateImplementation(ARGS&& ...) noexcept;
+    PrivateImplementation() noexcept;
+    ~PrivateImplementation() noexcept;
+    PrivateImplementation(PrivateImplementation const& rhs) noexcept;
+    PrivateImplementation& operator = (PrivateImplementation const& rhs) noexcept;
+
+    // move ctor and copy operator can be implemented inline and don't need to be exported
+    PrivateImplementation(PrivateImplementation&& rhs) noexcept : mImpl(rhs.mImpl) { rhs.mImpl = nullptr; }
+    PrivateImplementation& operator = (PrivateImplementation&& rhs) noexcept {
+        auto temp = mImpl;
+        mImpl = rhs.mImpl;
+        rhs.mImpl = temp;
+        return *this;
+    }
+
+protected:
+    T* mImpl = nullptr;
+    inline T* operator->() noexcept { return mImpl; }
+    inline T const* operator->() const noexcept { return mImpl; }
+};
+
+} // namespace utils
+
+#endif // UTILS_PRIVATEIMPLEMENTATION_H

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -17,18 +17,21 @@
 #ifndef TNT_UTILS_OSTREAM_H
 #define TNT_UTILS_OSTREAM_H
 
-#include <mutex>
 #include <string>
 #include <utility>
 
 #include <utils/bitset.h>
-#include <utils/compiler.h> // ssize_t is a POSIX type.
+#include <utils/compiler.h>
+#include <utils/PrivateImplementation.h>
 
 namespace utils::io {
 
-class UTILS_PUBLIC  ostream {
-public:
+struct ostream_;
 
+class UTILS_PUBLIC  ostream : protected utils::PrivateImplementation<ostream_> {
+    friend struct ostream_;
+
+public:
     virtual ~ostream();
 
     ostream& operator<<(short value) noexcept;
@@ -63,6 +66,8 @@ public:
     ostream& hex() noexcept;
 
 protected:
+    ostream& print(const char* format, ...) noexcept;
+
     class Buffer {
     public:
         Buffer() noexcept;
@@ -86,11 +91,8 @@ protected:
         size_t capacity = 0;        // total capacity of the buffer
     };
 
-    std::mutex mLock;
-    Buffer mData;
-    Buffer& getBuffer() noexcept { return mData; }
-
-    ostream& print(const char* format, ...) noexcept;
+    Buffer& getBuffer() noexcept;
+    Buffer const& getBuffer() const noexcept;
 
 private:
     virtual ostream& flush() noexcept = 0;
@@ -105,9 +107,7 @@ private:
         LONG_DOUBLE
     };
 
-    inline const char* getFormat(type t) const noexcept;
-
-    bool mShowHex = false;
+    const char* getFormat(type t) const noexcept;
 };
 
 // handles std::string

--- a/libs/utils/include/utils/sstream.h
+++ b/libs/utils/include/utils/sstream.h
@@ -19,19 +19,14 @@
 
 #include <utils/ostream.h>
 
-namespace utils {
-namespace io {
+namespace utils::io {
 
 class sstream : public ostream {
 public:
-
-    ostream &flush() noexcept override;
-
+    ostream& flush() noexcept override;
     const char* c_str() const noexcept;
-
 };
 
-} // namespace io
-} // namespace utils
+} // namespace utils::io
 
 #endif // TNT_UTILS_SSTREAM_H

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -16,7 +16,8 @@
 
 #include <utils/Log.h>
 
-#include <string>
+#include "ostream_.h"
+
 #include <utils/compiler.h>
 
 #ifdef __ANDROID__
@@ -27,7 +28,6 @@
 #endif
 
 namespace utils {
-
 namespace io {
 
 class LogStream : public ostream {
@@ -46,7 +46,7 @@ private:
 };
 
 ostream& LogStream::flush() noexcept {
-    std::lock_guard lock(mLock);
+    std::lock_guard lock(mImpl->mLock);
     Buffer& buf = getBuffer();
 #ifdef __ANDROID__
     switch (mPriority) {

--- a/libs/utils/src/ostream_.h
+++ b/libs/utils/src/ostream_.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The Android Open Source Project
+ * Copyright (C) 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-#include <utils/sstream.h>
+#ifndef TNT_UTILS_OSTREAM__H
+#define TNT_UTILS_OSTREAM__H
+
+#include <utils/ostream.h>
+#include <mutex>
 
 namespace utils::io {
 
-utils::io::ostream& sstream::flush() noexcept {
-    // no-op.
-    return *this;
-}
+struct ostream_ {
+    std::mutex mLock;
+    ostream::Buffer mData;
+    bool mShowHex = false;
+};
 
-const char* sstream::c_str() const noexcept {
-    char const* buffer = getBuffer().get();
-    return buffer ? buffer : "";
-}
+} // utils::io
 
-} // namespace utils::io
+#endif // TNT_UTILS_OSTREAM__H


### PR DESCRIPTION
- move BuilderBase to libutils and rename to PrivateImplementation
- hide ostream implementation details into ostream.cpp

Fixes #5343
