### PR TITLE
Temporary workaround for WebGL builds on macOS.

### DIFF
--- a/third_party/etc2comp/EtcLib/EtcCodec/EtcBlock4x4Encoding_RGB8.cpp
+++ b/third_party/etc2comp/EtcLib/EtcCodec/EtcBlock4x4Encoding_RGB8.cpp
@@ -24,6 +24,13 @@ Block4x4Encoding_ETC1 encodes the ETC1 subset of RGB8.
 
 */
 
+#if defined(__clang__)
+// Workaround for relying on undefined behavior (casting nan to unsigned int) which can cause hang
+// behavior when the resulting int is used as a loop upper bound. Ideally this pragma would go in
+// EtcConfig.h, but moving it there triggers asserts.
+#pragma float_control(precise, off)
+#endif
+
 #include "EtcConfig.h"
 #include "EtcBlock4x4Encoding_RGB8.h"
 

--- a/third_party/etc2comp/tnt/README
+++ b/third_party/etc2comp/tnt/README
@@ -25,3 +25,15 @@ alternative to the existing lines:
 See:
 
     https://cliutils.gitlab.io/modern-cmake/chapters/intro/dodonot.html
+
+(4)
+
+Add the following to the top of EtcBlock4x4Encoding_RGB8.cpp to prevent potential unbounded upper
+loops due to reliance on undefined nan behavior.
+
+#if defined(__clang__)
+// Workaround for relying on undefined behavior (casting nan to unsigned int) which can cause hang
+// behavior when the resulting int is used as a loop upper bound. Ideally this pragma would go in
+// EtcConfig.h, but moving it there triggers asserts.
+#pragma float_control(precise, off)
+#endif


### PR DESCRIPTION
Better fix is to replace etc2comp and astcenc with basis.