### PR TITLE
Fix, use zero texture array when SSR is off

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -318,6 +318,10 @@ backend::Handle<backend::HwTexture> PostProcessManager::getOneTextureArray() con
     return mEngine.getOneTextureArray();
 }
 
+backend::Handle<backend::HwTexture> PostProcessManager::getZeroTextureArray() const {
+    return mEngine.getZeroTextureArray();
+}
+
 UTILS_NOINLINE
 void PostProcessManager::render(FrameGraphResources::RenderPassInfo const& out,
         backend::PipelineState const& pipeline,
@@ -542,7 +546,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::ssr(FrameGraph& fg,
                 mat4f reprojection = uvFromClipMatrix * historyProjection
                                      * inverse(cameraInfo.view * cameraInfo.worldOrigin);
                 TextureHandle history = data.history ?
-                        resources.getTexture(data.history) : getZeroTexture();
+                        resources.getTexture(data.history) : getZeroTextureArray();
                 uniforms.prepareHistorySSR(history,reprojection, uvFromViewMatrix,options);
 
                 uniforms.commit(driver);

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -191,6 +191,7 @@ public:
     backend::Handle<backend::HwTexture> getOneTexture() const;
     backend::Handle<backend::HwTexture> getZeroTexture() const;
     backend::Handle<backend::HwTexture> getOneTextureArray() const;
+    backend::Handle<backend::HwTexture> getZeroTextureArray() const;
 
     math::float2 halton(size_t index) const noexcept {
         return mHaltonSamples[index & 0xFu];

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -291,11 +291,15 @@ void FEngine::init() {
     mDummyOneTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
+    mDummyZeroTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
+            TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
     mDummyOneIntegerTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
             TextureFormat::RGBA8I, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     mDummyZeroTexture = driverApi.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
 
     // initialize the dummy textures so that their contents are not undefined
 
@@ -318,6 +322,9 @@ void FEngine::init() {
             PixelBufferDescriptor(&signedOnes, 4, Texture::Format::RGBA_INTEGER, Texture::Type::BYTE));
 
     driverApi.update3DImage(mDummyZeroTexture, 0, 0, 0, 0, 1, 1, 1,
+            PixelBufferDescriptor(&zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE));
+
+    driverApi.update3DImage(mDummyZeroTextureArray, 0, 0, 0, 0, 1, 1, 1,
             PixelBufferDescriptor(&zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE));
 
     mDefaultRenderTarget = driverApi.createDefaultRenderTarget();
@@ -410,6 +417,7 @@ void FEngine::shutdown() {
     driver.destroyTexture(mDummyOneTextureArray);
     driver.destroyTexture(mDummyOneIntegerTextureArray);
     driver.destroyTexture(mDummyZeroTexture);
+    driver.destroyTexture(mDummyZeroTextureArray);
 
     driver.destroyRenderTarget(mDefaultRenderTarget);
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -348,6 +348,7 @@ public:
     backend::Handle<backend::HwTexture> getOneTexture() const { return mDummyOneTexture; }
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
     backend::Handle<backend::HwTexture> getOneTextureArray() const { return mDummyOneTextureArray; }
+    backend::Handle<backend::HwTexture> getZeroTextureArray() const { return mDummyZeroTextureArray; }
     backend::Handle<backend::HwTexture> getOneIntegerTextureArray() const { return mDummyOneIntegerTextureArray; }
 
 private:
@@ -452,6 +453,7 @@ private:
 
     backend::Handle<backend::HwTexture> mDummyOneTexture;
     backend::Handle<backend::HwTexture> mDummyOneTextureArray;
+    backend::Handle<backend::HwTexture> mDummyZeroTextureArray;
     backend::Handle<backend::HwTexture> mDummyOneIntegerTextureArray;
     backend::Handle<backend::HwTexture> mDummyZeroTexture;
 

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -926,7 +926,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
 
                 // set screen-space reflections and screen-space refractions
                 TextureHandle ssr = data.ssr ?
-                        resources.getTexture(data.ssr) : ppm.getOneTexture();
+                        resources.getTexture(data.ssr) : ppm.getOneTextureArray();
 
                 view.prepareSSR(ssr, config.ssrLodOffset,
                         view.getScreenSpaceReflectionsOptions());


### PR DESCRIPTION
This partially fixes the Metal crashes with SSR.