### PR TITLE
Fix shadow frustum computation wrt projection matrix

### DIFF
--- a/filament/include/filament/Frustum.h
+++ b/filament/include/filament/Frustum.h
@@ -59,30 +59,6 @@ public:
     explicit Frustum(const math::mat4f& pv);
 
     /**
-     * Creates a frustum from 8 corner coordinates.
-     * @param corners the corners of the frustum
-     *
-     * The corners should be specified in this order:
-     * 0. far bottom left
-     * 1. far bottom right
-     * 2. far top left
-     * 3. far top right
-     * 4. near bottom left
-     * 5. near bottom right
-     * 6. near top left
-     * 7. near top right
-     *
-     *     2----3
-     *    /|   /|
-     *   6----7 |
-     *   | 0--|-1      far
-     *   |/   |/       /
-     *   4----5      near
-     *
-     */
-    explicit Frustum(const math::float3 corners[8]);
-
-    /**
      * Sets the frustum from the given projection matrix
      * @param pv a 4x4 projection matrix
      */

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -28,38 +28,6 @@ Frustum::Frustum(const mat4f& pv) {
     Frustum::setProjection(pv);
 }
 
-Frustum::Frustum(const float3 corners[8]) {
-    float3 a = corners[0];
-    float3 b = corners[1];
-    float3 c = corners[2];
-    float3 d = corners[3];
-    float3 e = corners[4];
-    float3 f = corners[5];
-    float3 g = corners[6];
-    float3 h = corners[7];
-
-    //     c----d
-    //    /|   /|
-    //   g----h |
-    //   | a--|-b
-    //   |/   |/
-    //   e----f
-
-    auto plane = [](float3 p1, float3 p2, float3 p3) {
-        auto v12 = p2 - p1;
-        auto v23 = p3 - p2;
-        auto n = normalize(cross(v12, v23));
-        return float4{n, -dot(n, p1)};
-    };
-
-    mPlanes[0] = plane(a, e, g);   // left
-    mPlanes[1] = plane(f, b, d);   // right
-    mPlanes[2] = plane(a, b, f);   // bottom
-    mPlanes[3] = plane(g, h, d);   // top
-    mPlanes[4] = plane(a, c, d);   // far
-    mPlanes[5] = plane(e, f, h);   // near
-}
-
 // NOTE: if we don't specify noinline here, LLVM inlines this huge function into
 // two (?!) version of the Frustum(const mat4f& pv) constructor!
 

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -202,7 +202,8 @@ private:
 
     static size_t intersectFrustumWithBox(
             FrustumBoxIntersection& outVertices,
-            const math::float3* wsFrustumCorners,
+            Frustum const& wsFrustum,
+            math::float3 const* wsFrustumCorners,
             Aabb const& wsBox);
 
     static math::mat4f warpFrustum(float n, float f) noexcept;


### PR DESCRIPTION
Instead of recomputing the Frustum from its 8 vertices, we compute it
from the projection matrix directly. This ensures this works with any
projection matrix.  Building a Frustum object from 8 vertices required
these vertices to be given in a certain order which wasn't correct if
the projection was flipped for instance.

Removed the API to construct a Frustum from vertices.

fixes b/225975881