### PR TITLE
Simplify OpenGLProgram sampler bindings

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -92,8 +92,8 @@ Driver* OpenGLDriver::create(
     //    GLBufferObject            :  24       many
     //    GLSync                    :  24       few
     //    GLTimerQuery              :  32       few
+    //    OpenGLProgram             :  32       moderate
     //    GLRenderPrimitive         :  48       many
-    //    OpenGLProgram             :  64       moderate
     // -- less than or equal 64 bytes
     //    GLTexture                 :  72       moderate
     //    GLRenderTarget            : 112       few

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -95,27 +95,12 @@ private:
 
     void updateSamplers(OpenGLDriver* gld) noexcept;
 
-    struct BlockInfo {
-        uint8_t binding : 3;    // binding (i.e.: index in mSamplerBindings)
-        uint8_t count   : 5;    // number of TMUs actually used minus 1
-
-        // if TEXTURE_UNIT_COUNT > 32, the count bitfield must be increased accordingly
-        static_assert(TEXTURE_UNIT_COUNT <= 32, "TEXTURE_UNIT_COUNT must be <= 32");
-
-        // if SAMPLER_BINDING_COUNT > 8, the binding bitfield must be increased accordingly
-        static_assert(backend::Program::BINDING_COUNT <= 8, "BINDING_COUNT must be <= 8");
-    };
-
-    // keep these sway from of other class attributes
+    // keep these away from of other class attributes
     struct LazyInitializationData {
         backend::Program::UniformBlockInfo uniformBlockInfo;
         backend::Program::SamplerGroupInfo samplerGroupInfo;
         std::array<utils::CString, backend::Program::SHADER_TYPE_COUNT> shaderSourceCode;
     };
-
-    // This assert checks that the struct is the size we expect without any "hidden" padding bytes
-    // inserted by the compiler.
-    static_assert(sizeof(BlockInfo) == sizeof(uint8_t), "BlockInfo must be 8 bits");
 
     // number of bindings actually used by this program
     uint8_t mUsedBindingsCount = 0u;
@@ -125,14 +110,10 @@ private:
     bool mValid : 1;
     UTILS_UNUSED uint8_t padding[2] = {};
 
-    // information about each USED sampler buffer per binding (no gaps)
-    std::array<BlockInfo, backend::Program::BINDING_COUNT> mBlockInfos;   // 8 bytes
-
     union {
         // when mInitialized == true:
-        // runs of indices into SamplerGroup -- run start index and size given by BlockInfo
-        std::array<uint8_t, TEXTURE_UNIT_COUNT> mIndicesRuns;    // 32 bytes
-
+        // information about each USED sampler buffer per binding (no gaps)
+        std::array<uint8_t, backend::Program::BINDING_COUNT> mUsedBindingPoints;   // 8 bytes
         // when mInitialized == false:
         // lazy initialization data pointer
         LazyInitializationData* mLazyInitializationData;


### PR DESCRIPTION
This reduces the size of OpenGLProgram from 64 to 32 bytes and
improves the code that sets new samplers.

The main simplification is that we're not trying to "pack" the 
texture units used in the program. For e.g. we could be using
units 0,3,4, where before it would be 0,1,2.
This allows us to do less tracking.

Another optimization is that we're discarding entirely a SamplerGroup 
if the program doesn't use any of its samplers. This helps remove
a test in updateSampler which in turn remove somem tracking data.