### PR TITLE
batch all program linking at begin renderpass time

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -393,6 +393,11 @@ private:
     void executeEveryNowAndThenOps() noexcept;
     std::vector<std::function<bool()>> mEveryNowAndThenOps;
 
+    void runAtNextRenderPass(void* token, std::function<void()> fn) noexcept;
+    void executeRenderPassOps() noexcept;
+    void cancelRunAtNextPassOp(void* token) noexcept;
+    tsl::robin_map<void*, std::function<void()>> mRunAtNextRenderPassOps;
+
     // timer query implementation
     TimerQueryInterface* mTimerQueryImpl = nullptr;
     bool mFrameTimeSupported = false;


### PR DESCRIPTION
With this change, shaders are compiled at program creation, programs
are linked at the start of the next render pass and queries are
deferred until first use.

This should improve overall performance on some drivers.