### PR TITLE
fix a framegraph crash when forwarding a subresource

### DIFF
--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -410,7 +410,7 @@ private:
     void reset() noexcept;
     void addPresentPass(std::function<void(Builder&)> setup) noexcept;
     Builder addPassInternal(const char* name, FrameGraphPassBase* base) noexcept;
-    FrameGraphHandle createNewVersion(FrameGraphHandle handle, FrameGraphHandle parent = {}) noexcept;
+    FrameGraphHandle createNewVersion(FrameGraphHandle handle) noexcept;
     ResourceNode* createNewVersionForSubresourceIfNeeded(ResourceNode* node) noexcept;
     FrameGraphHandle addResourceInternal(VirtualResource* resource) noexcept;
     FrameGraphHandle addSubResourceInternal(FrameGraphHandle parent, VirtualResource* resource) noexcept;
@@ -431,7 +431,7 @@ private:
     FrameGraphId<RESOURCE> createSubresource(FrameGraphId<RESOURCE> parent,
             char const* name, typename RESOURCE::SubResourceDescriptor const& desc) noexcept;
 
-        template<typename RESOURCE>
+    template<typename RESOURCE>
     FrameGraphId<RESOURCE> read(PassNode* passNode,
             FrameGraphId<RESOURCE> input, typename RESOURCE::Usage usage);
 
@@ -458,6 +458,7 @@ private:
     }
 
     ResourceNode* getActiveResourceNode(FrameGraphHandle handle) noexcept {
+        assert_invariant(handle);
         ResourceSlot const& slot = getResourceSlot(handle);
         assert_invariant((size_t)slot.nid < mResourceNodes.size());
         return mResourceNodes[slot.nid];

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -38,8 +38,14 @@ ResourceNode::~ResourceNode() noexcept {
 }
 
 ResourceNode* ResourceNode::getParentNode() noexcept {
-    return mParentHandle.isInitialized() ?
-           mFrameGraph.getActiveResourceNode(mParentHandle) : nullptr;
+    ResourceNode* const parentNode = mParentHandle ?
+            mFrameGraph.getActiveResourceNode(mParentHandle) : nullptr;
+    assert_invariant(mParentHandle == ResourceNode::getHandle(parentNode));
+    return parentNode;
+}
+
+FrameGraphHandle ResourceNode::getParentHandle() noexcept {
+    return mParentHandle;
 }
 
 char const* ResourceNode::getName() const noexcept {

--- a/filament/src/fg/details/ResourceNode.h
+++ b/filament/src/fg/details/ResourceNode.h
@@ -73,6 +73,8 @@ public:
 
     ResourceNode* getParentNode() noexcept;
 
+    FrameGraphHandle getParentHandle() noexcept;
+
     // this is the parent resource we're reading from, as a propagating effect of
     // us being read from.
     void setParentReadDependency(ResourceNode* parent) noexcept;
@@ -85,6 +87,10 @@ public:
 
     // virtuals from DependencyGraph::Node
     char const* getName() const noexcept override;
+
+    static FrameGraphHandle getHandle(ResourceNode const* node) noexcept {
+        return node ? node->resourceHandle : FrameGraphHandle{};
+    }
 
 private:
     FrameGraph& mFrameGraph;


### PR DESCRIPTION
the crash would happen when forwarding a subresource of a subresource,
because in this case the parent's handle would be reset to the null
handle.