### PR TITLE
avoid an extra copy during the screen-space reflection pass

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -105,11 +105,12 @@ public:
     // Helper to generate gaussian mipmaps for SSR (refraction and reflections).
     // This performs the following tasks:
     // - resolves input if needed
-    // - rescale input so it has a homogenous scale
+    // - optionally duplicates the input
+    // - rescale input, so it has a homogenous scale
     // - generate a new texture with gaussian mips
-    static FrameGraphId<FrameGraphTexture> generateMipmapSSR(PostProcessManager& ppm,
-            FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, float verticalFieldOfView, math::float2 scale,
+    static FrameGraphId<FrameGraphTexture> generateMipmapSSR(
+            PostProcessManager& ppm, FrameGraph& fg, FrameGraphId<FrameGraphTexture> input,
+            bool needInputDuplication, float verticalFieldOfView, math::float2 scale,
             backend::TextureFormat format, float* pLodOffset) noexcept;
 
     // Depth-of-field

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -501,7 +501,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 { .width = svp.width, .height = svp.height });
 
         // generate the mipchain
-        reflections = PostProcessManager::generateMipmapSSR(ppm, fg, reflections,
+        reflections = PostProcessManager::generateMipmapSSR(ppm, fg, reflections, false,
                 view.getCameraUser().getFieldOfView(Camera::Fov::VERTICAL), config.scale,
                 TextureFormat::RGBA16F,
                 &config.ssrLodOffset);
@@ -781,7 +781,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
                 view);
 
         // generate the mipmap chain
-        input = PostProcessManager::generateMipmapSSR(ppm, fg, input,
+        input = PostProcessManager::generateMipmapSSR(ppm, fg, input, true,
                 view.getCameraUser().getFieldOfView(Camera::Fov::VERTICAL), config.scale,
                 TextureFormat::R11F_G11F_B10F,
                 &refractionLodOffset);

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -304,6 +304,42 @@ public:
             FrameGraphId<RESOURCE> replacedResource);
 
     /**
+     * Create a new resource from the descriptor and forwards it to a specified resource that
+     * gets replaced.
+     * The replaced resource's handle becomes forever invalid.
+     *
+     * @tparam RESOURCE             Type of the resources
+     * @param name                  A name for the new resource
+     * @param desc                  Descriptor to create the new resource
+     * @param replacedResource      Handle of the subresource being replaced
+     *                              This handle becomes invalid after this call
+     * @return                      Handle to a new version of the forwarded resource
+     */
+    template<typename RESOURCE>
+    FrameGraphId<RESOURCE> forwardResource(char const* name,
+            typename RESOURCE::Descriptor const& desc,
+            FrameGraphId<RESOURCE> replacedResource);
+
+    /**
+     * Create a new subresource from the descriptors and forwards it to a specified resource that
+     * gets replaced.
+     * The replaced resource's handle becomes forever invalid.
+     *
+     * @tparam RESOURCE             Type of the resources
+     * @param name                  A name for the new subresource
+     * @param desc                  Descriptor to create the new subresource
+     * @param subdesc               Descriptor to create the new subresource
+     * @param replacedResource      Handle of the subresource being replaced
+     *                              This handle becomes invalid after this call
+     * @return                      Handle to a new version of the forwarded resource
+     */
+    template<typename RESOURCE>
+    FrameGraphId<RESOURCE> forwardResource(char const* name,
+            typename RESOURCE::Descriptor const& desc,
+            typename RESOURCE::SubResourceDescriptor const& subdesc,
+            FrameGraphId<RESOURCE> replacedResource);
+
+    /**
      * Adds a reference to 'input', preventing it from being culled
      *
      * @param input a resource handle
@@ -564,6 +600,24 @@ template<typename RESOURCE>
 FrameGraphId<RESOURCE> FrameGraph::forwardResource(FrameGraphId<RESOURCE> resource,
         FrameGraphId<RESOURCE> replacedResource) {
     return FrameGraphId<RESOURCE>(forwardResourceInternal(resource, replacedResource));
+}
+
+template<typename RESOURCE>
+FrameGraphId<RESOURCE> FrameGraph::forwardResource(char const* name,
+        typename RESOURCE::Descriptor const& desc,
+        FrameGraphId<RESOURCE> replacedResource) {
+    FrameGraphId<RESOURCE> handle = create<RESOURCE>(name, desc);
+    return forwardResource(handle, replacedResource);
+}
+
+template<typename RESOURCE>
+FrameGraphId<RESOURCE> FrameGraph::forwardResource(char const* name,
+        typename RESOURCE::Descriptor const& desc,
+        typename RESOURCE::SubResourceDescriptor const& subdesc,
+        FrameGraphId<RESOURCE> replacedResource) {
+    FrameGraphId<RESOURCE> handle = create<RESOURCE>(name, desc);
+    handle = createSubresource<RESOURCE>(handle, name, subdesc);
+    return forwardResource(handle, replacedResource);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -410,7 +410,7 @@ private:
     void reset() noexcept;
     void addPresentPass(std::function<void(Builder&)> setup) noexcept;
     Builder addPassInternal(const char* name, FrameGraphPassBase* base) noexcept;
-    FrameGraphHandle createNewVersion(FrameGraphHandle handle, FrameGraphHandle parent = {}) noexcept;
+    FrameGraphHandle createNewVersion(FrameGraphHandle handle) noexcept;
     ResourceNode* createNewVersionForSubresourceIfNeeded(ResourceNode* node) noexcept;
     FrameGraphHandle addResourceInternal(VirtualResource* resource) noexcept;
     FrameGraphHandle addSubResourceInternal(FrameGraphHandle parent, VirtualResource* resource) noexcept;
@@ -431,7 +431,7 @@ private:
     FrameGraphId<RESOURCE> createSubresource(FrameGraphId<RESOURCE> parent,
             char const* name, typename RESOURCE::SubResourceDescriptor const& desc) noexcept;
 
-        template<typename RESOURCE>
+    template<typename RESOURCE>
     FrameGraphId<RESOURCE> read(PassNode* passNode,
             FrameGraphId<RESOURCE> input, typename RESOURCE::Usage usage);
 
@@ -458,6 +458,7 @@ private:
     }
 
     ResourceNode* getActiveResourceNode(FrameGraphHandle handle) noexcept {
+        assert_invariant(handle);
         ResourceSlot const& slot = getResourceSlot(handle);
         assert_invariant((size_t)slot.nid < mResourceNodes.size());
         return mResourceNodes[slot.nid];

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -38,8 +38,14 @@ ResourceNode::~ResourceNode() noexcept {
 }
 
 ResourceNode* ResourceNode::getParentNode() noexcept {
-    return mParentHandle.isInitialized() ?
-           mFrameGraph.getActiveResourceNode(mParentHandle) : nullptr;
+    ResourceNode* const parentNode = mParentHandle ?
+            mFrameGraph.getActiveResourceNode(mParentHandle) : nullptr;
+    assert_invariant(mParentHandle == ResourceNode::getHandle(parentNode));
+    return parentNode;
+}
+
+FrameGraphHandle ResourceNode::getParentHandle() noexcept {
+    return mParentHandle;
 }
 
 char const* ResourceNode::getName() const noexcept {

--- a/filament/src/fg/details/ResourceNode.h
+++ b/filament/src/fg/details/ResourceNode.h
@@ -73,6 +73,8 @@ public:
 
     ResourceNode* getParentNode() noexcept;
 
+    FrameGraphHandle getParentHandle() noexcept;
+
     // this is the parent resource we're reading from, as a propagating effect of
     // us being read from.
     void setParentReadDependency(ResourceNode* parent) noexcept;
@@ -85,6 +87,10 @@ public:
 
     // virtuals from DependencyGraph::Node
     char const* getName() const noexcept override;
+
+    static FrameGraphHandle getHandle(ResourceNode const* node) noexcept {
+        return node ? node->resourceHandle : FrameGraphHandle{};
+    }
 
 private:
     FrameGraph& mFrameGraph;


### PR DESCRIPTION
unlike for refraction, the reflection buffer is distinct from "the"
color buffer, this allows an optimization (compared to ssr) when we
generate the mipmap chain -- we can allocate the mipmaped texture
and render the SSR pass directly into its level 0. This achieved
use the framegraph's forward resource feature.