### PR TITLE
one more step towards reflection+refraction support

### DIFF
--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -102,16 +102,37 @@ public:
             FrameGraphId<FrameGraphTexture> input, size_t levels, bool reinhard,
             size_t kernelWidth, float sigma) noexcept;
 
-    // Helper to generate gaussian mipmaps for SSR (refraction and reflections).
-    // This performs the following tasks:
-    // - resolves input if needed
-    // - optionally duplicates the input
-    // - rescale input, so it has a homogenous scale
-    // - generate a new texture with gaussian mips
+    struct ScreenSpaceRefConfig {
+        // handle to subresource to receive the refraction
+        FrameGraphId<FrameGraphTexture> refraction;
+        // handle to subresource to receive the reflections
+        FrameGraphId<FrameGraphTexture> reflection;
+        float lodOffset;            // LOD offset
+        uint8_t roughnessLodCount;  // LOD count
+        uint8_t kernelSize;         // Kernel size
+        float sigma0;               // sigma0
+    };
+
+    /*
+     * Create the 2D array that will receive the reflection and refraction buffers
+     */
+    static ScreenSpaceRefConfig prepareMipmapSSR(FrameGraph& fg,
+            uint32_t width, uint32_t height, backend::TextureFormat format,
+            float verticalFieldOfView, math::float2 scale) noexcept;
+
+    /*
+     * Helper to generate gaussian mipmaps for SSR (refraction and reflections).
+     * This performs the following tasks:
+     *  - resolves input if needed
+     *  - optionally duplicates the input
+     *  - rescale input, so it has a homogenous scale
+     *  - generate a new texture with gaussian mips
+     */
     static FrameGraphId<FrameGraphTexture> generateMipmapSSR(
-            PostProcessManager& ppm, FrameGraph& fg, FrameGraphId<FrameGraphTexture> input,
-            bool needInputDuplication, float verticalFieldOfView, math::float2 scale,
-            backend::TextureFormat format, float* pLodOffset) noexcept;
+            PostProcessManager& ppm, FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> output,
+            bool needInputDuplication, ScreenSpaceRefConfig const& config) noexcept;
 
     // Depth-of-field
     FrameGraphId<FrameGraphTexture> dof(FrameGraph& fg,

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -173,6 +173,7 @@ private:
 
     FrameGraphId<FrameGraphTexture> refractionPass(FrameGraph& fg,
             ColorPassConfig config,
+            PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,
             PostProcessManager::ColorGradingConfig colorGradingConfig,
             RenderPass const& pass, FView const& view) const noexcept;
 
@@ -197,8 +198,6 @@ private:
     duration getUserTime() const noexcept {
         return clock::now() - getUserEpoch();
     }
-
-    math::mat4f getClipSpaceToTextureSpaceMatrix() const noexcept;
 
     // keep a reference to our engine
     FEngine& mEngine;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -220,7 +220,7 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
     driver.popGroupMarker();
 }
 
-void FrameGraph::addPresentPass(std::function<void(FrameGraph::Builder&)> setup) noexcept {
+void FrameGraph::addPresentPass(const std::function<void(FrameGraph::Builder&)>& setup) noexcept {
     PresentPassNode* node = mArena.make<PresentPassNode>(*this);
     mPassNodes.push_back(node);
     Builder builder(*this, node);

--- a/filament/src/fg/FrameGraphPass.h
+++ b/filament/src/fg/FrameGraphPass.h
@@ -50,10 +50,10 @@ class FrameGraphPassBase : protected FrameGraphPassExecutor {
 
 public:
     using FrameGraphPassExecutor::FrameGraphPassExecutor;
-    virtual ~FrameGraphPassBase() noexcept;
+    ~FrameGraphPassBase() noexcept override;
 };
 
-template<typename Data, typename Execute>
+template<typename Data>
 class FrameGraphPass : public FrameGraphPassBase {
     friend class FrameGraph;
 
@@ -61,20 +61,34 @@ class FrameGraphPass : public FrameGraphPassBase {
     template<typename, typename, typename, typename>
     friend class utils::Arena;
 
-    explicit FrameGraphPass(Execute&& execute) noexcept
-            : FrameGraphPassBase(), mExecute(std::move(execute)) {
-    }
+    void execute(FrameGraphResources const&, backend::DriverApi&) noexcept override {}
 
-    void execute(FrameGraphResources const& resources, backend::DriverApi& driver) noexcept final {
-        mExecute(resources, mData, driver);
-    }
-
-    Execute mExecute;
+protected:
+    FrameGraphPass() = default;
     Data mData;
 
 public:
     Data const& getData() const noexcept { return mData; }
-    Data const* operator->() const { return &getData(); }
+    Data const* operator->() const { return &mData; }
+};
+
+template<typename Data, typename Execute>
+class FrameGraphPassConcrete : public FrameGraphPass<Data> {
+    friend class FrameGraph;
+
+    // allow our allocators to instantiate us
+    template<typename, typename, typename, typename>
+    friend class utils::Arena;
+
+    explicit FrameGraphPassConcrete(Execute&& execute) noexcept
+            : mExecute(std::move(execute)) {
+    }
+
+    void execute(FrameGraphResources const& resources, backend::DriverApi& driver) noexcept final {
+        mExecute(resources, this->mData, driver);
+    }
+
+    Execute mExecute;
 };
 
 } // namespace filament

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -567,7 +567,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
             float lod = max(0.0, (log2(pixel.roughness / d) + frameUniforms.refractionLodOffset) * invLog2sqrt5);
 #if !defined(MATERIAL_HAS_REFRACTION)
             // this is temporary, until we can access the SSR buffer when we have refraction
-            ssrFr = textureLod(light_ssr, vec3(interpolationCache.uv, 0.0), lod);
+            ssrFr = textureLod(light_ssr, vec3(interpolationCache.uv, 1.0), lod);
 #endif
         }
     }


### PR DESCRIPTION
With this change we are now generating refraction and reflections
buffer into their own layer of a 2D array -- so they can coexist.

This change doesn't actually enable both at the same time yet.

There are downsides to this approach:
- a 2d array of 2 layers is created even if only one of reflection or
  refraction is active. This could be fixed at the cost of more
  complexity.
- if reflections are active then refraction must use a RGBA16F texture
  instead of RGB_11_11_10, because they share the texture