### PR TITLE
enable both screen-space refraction and reflection

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1284,20 +1284,22 @@ PostProcessManager::ScreenSpaceRefConfig PostProcessManager::prepareMipmapSSR(Fr
     };
 
     struct PrepareMipmapSSRPassData {
+        FrameGraphId<FrameGraphTexture> ssr;
         FrameGraphId<FrameGraphTexture> refraction;
         FrameGraphId<FrameGraphTexture> reflection;
     };
     auto& pass = fg.addPass<PrepareMipmapSSRPassData>("Prepare MipmapSSR Pass",
             [&](FrameGraph::Builder& builder, auto& data){
                 // create the SSR 2D array
-                auto ssr = builder.createTexture("ssr", outDesc);
+                data.ssr = builder.createTexture("ssr", outDesc);
                 // create the refraction subresource at layer 0
-                data.refraction = builder.createSubresource(ssr, "refraction", {.layer = 0 });
+                data.refraction = builder.createSubresource(data.ssr, "refraction", {.layer = 0 });
                 // create the reflection subresource at layer 1
-                data.reflection = builder.createSubresource(ssr, "reflection", {.layer = 1 });
+                data.reflection = builder.createSubresource(data.ssr, "reflection", {.layer = 1 });
             });
 
     return {
+            .ssr = pass->ssr,
             .refraction = pass->refraction,
             .reflection = pass->reflection,
             .lodOffset = refractionLodOffset,

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -103,6 +103,8 @@ public:
             size_t kernelWidth, float sigma) noexcept;
 
     struct ScreenSpaceRefConfig {
+        // The SSR texture (i.e. the 2d Array)
+        FrameGraphId<FrameGraphTexture> ssr;
         // handle to subresource to receive the refraction
         FrameGraphId<FrameGraphTexture> refraction;
         // handle to subresource to receive the reflections

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -161,8 +161,6 @@ private:
         float ssrLodOffset;
         // Contact shadow enabled?
         bool hasContactShadows;
-        // Screen-space reflections enabled?
-        bool hasScreenSpaceReflections;
     };
 
     FrameGraphId<FrameGraphTexture> colorPass(FrameGraph& fg, const char* name,

--- a/filament/src/fg/ResourceNode.cpp
+++ b/filament/src/fg/ResourceNode.cpp
@@ -44,8 +44,13 @@ ResourceNode* ResourceNode::getParentNode() noexcept {
     return parentNode;
 }
 
-FrameGraphHandle ResourceNode::getParentHandle() noexcept {
-    return mParentHandle;
+ResourceNode* ResourceNode::getAncestorNode(ResourceNode* node) noexcept {
+    ResourceNode* ancestor = node;
+    do {
+        node = node->getParentNode();
+        ancestor = node ? node : ancestor;
+    } while (node);
+    return ancestor;
 }
 
 char const* ResourceNode::getName() const noexcept {

--- a/filament/src/fg/details/ResourceNode.h
+++ b/filament/src/fg/details/ResourceNode.h
@@ -71,9 +71,16 @@ public:
 
     void resolveResourceUsage(DependencyGraph& graph) noexcept;
 
+    // return the parent's handle
+    FrameGraphHandle getParentHandle() noexcept {
+        return mParentHandle;
+    }
+
+    // return the parent's node
     ResourceNode* getParentNode() noexcept;
 
-    FrameGraphHandle getParentHandle() noexcept;
+    // return the oldest ancestor node
+    static ResourceNode* getAncestorNode(ResourceNode* node) noexcept;
 
     // this is the parent resource we're reading from, as a propagating effect of
     // us being read from.

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -565,10 +565,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
             const float invLog2sqrt5 = 0.8614;
             float d = -mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).z;
             float lod = max(0.0, (log2(pixel.roughness / d) + frameUniforms.refractionLodOffset) * invLog2sqrt5);
-#if !defined(MATERIAL_HAS_REFRACTION)
-            // this is temporary, until we can access the SSR buffer when we have refraction
             ssrFr = textureLod(light_ssr, vec3(interpolationCache.uv, 1.0), lod);
-#endif
         }
     }
 #else // BLEND_MODE_OPAQUE


### PR DESCRIPTION
Both "SSR" can now be used on the same material. This is made possible
by using a 2D array to store both buffers
![ssr](https://user-images.githubusercontent.com/1240896/161328713-42085da2-6681-42ec-9a39-070b8daff183.png)
.