### PR TITLE
Fix suzanne and redball live web demos.

### DIFF
--- a/docs/webgl/demo_redball.html
+++ b/docs/webgl/demo_redball.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <canvas></canvas>
-    <script src="//unpkg.com/filament@1.15.0/filament.js"></script>
+    <script src="filament.js"></script>
     <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="//unpkg.com/gltumble"></script>
     <script src="tutorial_redball.js"></script>

--- a/docs/webgl/demo_suzanne.html
+++ b/docs/webgl/demo_suzanne.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <canvas></canvas>
-    <script src="//unpkg.com/filament@1.15.0/filament.js"></script>
+    <script src="filament.js"></script>
     <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="//unpkg.com/gltumble"></script>
     <script src="tutorial_suzanne.js"></script>

--- a/docs/webgl/demo_triangle.html
+++ b/docs/webgl/demo_triangle.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <canvas></canvas>
-    <script src="//unpkg.com/filament@1.15.0/filament.js"></script>
+    <script src="filament.js"></script>
     <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="//unpkg.com/gltumble"></script>
     <script src="tutorial_triangle.js"></script>

--- a/web/docs/demo_template.html
+++ b/web/docs/demo_template.html
@@ -12,7 +12,7 @@
 </head>
 <body>
     <canvas></canvas>
-    <script src="//unpkg.com/filament@1.15.0/filament.js"></script>
+    <script src="filament.js"></script>
     <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="//unpkg.com/gltumble"></script>
     <script src="$SCRIPT"></script>

--- a/web/docs/tutorial_triangle.md
+++ b/web/docs/tutorial_triangle.md
@@ -17,7 +17,7 @@ a mobile-friendly page with a full-screen canvas.
 </head>
 <body>
     <canvas></canvas>
-    <script src="//unpkg.com/filament@1.15.0/filament.js"></script>
+    <script src="filament.js"></script>
     <script src="//unpkg.com/gl-matrix@2.8.1"></script>
     <script src="triangle.js"></script>
 </body>


### PR DESCRIPTION
Some of our web samples were using unpkg to refer to the Filament build rather than using the local copy, which was inconsistent with the other web samples.

We now use the local copy of Filament for everything except the drag-and-drop viewer, which always uses the latest version of Filament.