### PR TITLE
Shrink BasisU transcoder.

### DIFF
--- a/third_party/basisu/tnt/CMakeLists.txt
+++ b/third_party/basisu/tnt/CMakeLists.txt
@@ -2,6 +2,11 @@ project(basisu)
 
 cmake_minimum_required(VERSION 3.19)
 
+set(TRANSCODER_SRC
+    ../transcoder/basisu_transcoder.cpp
+    ../zstd/zstd.c
+)
+
 set(ENCODER_SRC
     ../encoder/basisu_backend.cpp
     ../encoder/basisu_basis_file.cpp
@@ -20,23 +25,41 @@ set(ENCODER_SRC
     ../encoder/basisu_kernels_sse.cpp
     ../encoder/basisu_opencl.cpp
     ../encoder/pvpngreader.cpp
-    ../transcoder/basisu_transcoder.cpp
-    ../zstd/zstd.c
 )
 
-add_executable(basisu ${ENCODER_SRC} ../basisu_tool.cpp)
-add_library(basis_encoder ${ENCODER_SRC})
-add_library(basis_transcoder ../transcoder/basisu_transcoder.cpp)
+# Filament does not support certain compressed formats that BasisU can transcode
+# to, so we disable them in the build to save space. Some of these mappings are
+# confusing. (e.g., DXT5A corresponds to transcoder_texture_format::cTFBC4_R).
+set (BASIS_CONFIG
+    BASISD_SUPPORT_KTX2=1
+    BASISD_SUPPORT_KTX2_ZSTD=1
+    BASISD_SUPPORT_ATC=0
+    BASISD_SUPPORT_BC7=0
+    BASISD_SUPPORT_PVRTC1=0
+    BASISD_SUPPORT_PVRTC2=0
+    BASISD_SUPPORT_FXT1=0
+)
+
+# DXT5A and DXT1 are both required for cTFBC3_RGBA aka DXT3_RGBA.
+if (NOT IS_MOBILE_TARGET)
+    set (BASIS_CONFIG ${BASIS_CONFIG} BASISD_SUPPORT_DXT5A=1 BASISD_SUPPORT_DXT1=1)
+else()
+    set (BASIS_CONFIG ${BASIS_CONFIG} BASISD_SUPPORT_DXT5A=0 BASISD_SUPPORT_DXT1=0)
+endif()
+
+add_executable(basisu ${ENCODER_SRC} ${TRANSCODER_SRC} ../basisu_tool.cpp)
+add_library(basis_encoder ${ENCODER_SRC} ${TRANSCODER_SRC})
+add_library(basis_transcoder ${TRANSCODER_SRC})
 
 target_include_directories(basis_encoder PUBLIC ../encoder)
 target_include_directories(basis_transcoder PUBLIC ../transcoder)
 
-target_compile_definitions(basisu PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
-target_compile_definitions(basis_encoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
-target_compile_definitions(basis_transcoder PRIVATE BASISD_SUPPORT_KTX2_ZSTD=1)
+target_compile_definitions(basisu PRIVATE ${BASIS_CONFIG})
+target_compile_definitions(basis_encoder PRIVATE ${BASIS_CONFIG})
+target_compile_definitions(basis_transcoder PRIVATE ${BASIS_CONFIG})
 
 if (NOT MSVC)
-   target_link_libraries(basisu m pthread ${BASISU_EXTRA_LIBS})
+   target_link_libraries(basisu m pthread)
 endif()
 
 install(TARGETS basisu DESTINATION bin)

--- a/third_party/basisu/tnt/README.md
+++ b/third_party/basisu/tnt/README.md
@@ -13,7 +13,7 @@ Our CMakeLists differs from the one in basisu as follows.
 
 (1)
 
-Disable some warnings: "-Wno-unused-but-set-variable -Wno-unused-lambda-capture"
+Disable support for various texture formats that we don't need.
 
 (2)
 


### PR DESCRIPTION
We do not support these formats and they add bloat to the basis tables.
In a release x86 build, this reduces the transcoder size from 774 KiB to
475 KiB.

(This library is not yet used, stay tuned.)