### PR TITLE
Export Metal Device to public.

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -66,6 +66,8 @@ public:
      * thread, or if the platform does not need to perform any special processing.
      */
     virtual bool pumpEvents() noexcept { return false; }
+    
+    virtual void* getMTLDevice() noexcept { return nullptr; }
 };
 
 

--- a/filament/backend/include/private/backend/MetalPlatform.h
+++ b/filament/backend/include/private/backend/MetalPlatform.h
@@ -32,7 +32,7 @@ public:
     Driver* createDriver(void* sharedContext) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
     
-    void* getMTLDevice() noexcept override;
+    void* getMTLDevice() noexcept override { return mDevice; }
 
     /**
      * Obtain the preferred Metal device object for the backend to use.
@@ -59,6 +59,7 @@ public:
 
 private:
     id<MTLCommandQueue> mCommandQueue = nil;
+    id<MTLDevice> mDevice = nil;
 
 };
 

--- a/filament/backend/include/private/backend/MetalPlatform.h
+++ b/filament/backend/include/private/backend/MetalPlatform.h
@@ -31,6 +31,8 @@ public:
 
     Driver* createDriver(void* sharedContext) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
+    
+    void* getMTLDevice() noexcept override;
 
     /**
      * Obtain the preferred Metal device object for the backend to use.

--- a/filament/backend/include/private/backend/MetalPlatform.h
+++ b/filament/backend/include/private/backend/MetalPlatform.h
@@ -32,7 +32,7 @@ public:
     Driver* createDriver(void* sharedContext) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
     
-    void* getMTLDevice() noexcept override { return mDevice; }
+    void* getMTLDevice() noexcept override { return (__bridge void *)mDevice; }
 
     /**
      * Obtain the preferred Metal device object for the backend to use.

--- a/filament/backend/src/metal/MetalPlatform.mm
+++ b/filament/backend/src/metal/MetalPlatform.mm
@@ -55,6 +55,8 @@ id<MTLDevice> MetalPlatform::createDevice() noexcept {
     {
         result = MTLCreateSystemDefaultDevice();
     }
+    
+    mDevice = result;
 
     utils::slog.i << "Selected physical device '"
                   << [result.name cStringUsingEncoding:NSUTF8StringEncoding] << "'"


### PR DESCRIPTION
It's necessary to share the same Metal Device for the rendering pipeline when using filament as a part of offscreen rendering frameworks in a video processing app.