### PR TITLE
mipgen: fixups / clarification regarding sRGB.

### DIFF
--- a/libs/image/include/image/ColorTransform.h
+++ b/libs/image/include/image/ColorTransform.h
@@ -158,8 +158,8 @@ inline filament::math::float3 linearToSRGB(const filament::math::float3& color) 
     return sRGBColor;
 }
 
-// Creates a n-channel sRGB image from a linear floating-point image.
-// The source image can have more than N channels, but only the first N are converted to sRGB.
+// Creates a N-channel sRGB image from a linear floating-point image.
+// The source image can have more than N channels, but only the first 3 are converted to sRGB.
 template<typename T, int N = 3>
 std::unique_ptr<uint8_t[]> fromLinearTosRGB(const LinearImage& image) {
     const size_t w = image.getWidth();

--- a/libs/imageio/include/imageio/BlockCompression.h
+++ b/libs/imageio/include/imageio/BlockCompression.h
@@ -116,7 +116,7 @@ enum class AstcSemantic {
 struct AstcConfig {
     AstcPreset quality;
     AstcSemantic semantic;
-     filament::math::ushort2 blocksize;
+    filament::math::ushort2 blocksize;
     bool srgb;
 };
 
@@ -182,6 +182,37 @@ struct CompressionConfig {
     AstcConfig astc;
     S3tcConfig s3tc;
     EtcConfig etc;
+    bool isLinear() const {
+        if (type == ASTC) {
+            return !astc.srgb;
+        }
+        switch (type == S3TC ? s3tc.format : etc.format) {
+            case CompressedFormat::R11_EAC:
+            case CompressedFormat::SIGNED_R11_EAC:
+            case CompressedFormat::RG11_EAC:
+            case CompressedFormat::SIGNED_RG11_EAC:
+            case CompressedFormat::RGB8_ETC2:
+            case CompressedFormat::RGB8_ALPHA1_ETC2:
+            case CompressedFormat::RGBA8_ETC2_EAC:
+            case CompressedFormat::RGB_S3TC_DXT1:
+            case CompressedFormat::RGBA_S3TC_DXT1:
+            case CompressedFormat::RGBA_S3TC_DXT3:
+            case CompressedFormat::RGBA_S3TC_DXT5:
+                return true;
+            case CompressedFormat::SRGB8_ETC2:
+            case CompressedFormat::SRGB8_ALPHA1_ETC:
+            case CompressedFormat::SRGB8_ALPHA8_ETC2_EAC:
+            case CompressedFormat::SRGB_S3TC_DXT1:
+            case CompressedFormat::SRGB_ALPHA_S3TC_DXT1:
+            case CompressedFormat::SRGB_ALPHA_S3TC_DXT3:
+            case CompressedFormat::SRGB_ALPHA_S3TC_DXT5:
+                return false;
+            default:
+                // This should be unreachable.
+                assert(false && "ASTC formats are already handled");
+                return false;
+        }
+    }
 };
 
 bool parseOptionString(const std::string& options, CompressionConfig* config);

--- a/libs/imageio/src/BlockCompression.cpp
+++ b/libs/imageio/src/BlockCompression.cpp
@@ -381,7 +381,7 @@ static void extract4x4RGBA(uint8_t* dst, const LinearImage& source, uint32_t x0,
 //  - DXT1 with no alpha (16 input pixels in 64 bits of output, 6:1)
 //  - DXT5 with alpha (16 input pixels into 128 bits of output, 4:1)
 //
-// TODO: investigate using something more capable than STB (eg AMD Compressenator, bimg, libsquish)
+// TODO: remove this in favor of basisu
 CompressedTexture s3tcCompress(const LinearImage& original, S3tcConfig config) {
     const bool dxt5 = config.format == CompressedFormat::RGBA_S3TC_DXT5;
     LinearImage source = extendToFourChannels(original);

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -151,9 +151,9 @@ add_mesh("assets/models/monkey/monkey.obj" "suzanne.filamesh")
 # Use a RGBA compression format for Metal and Vulkan support.
 set (COMPRESSION "--compression=s3tc_rgba_dxt5")
 add_ktxfiles("assets/models/monkey/albedo.png" "albedo_s3tc.ktx" "${COMPRESSION}")
-add_ktxfiles("assets/models/monkey/roughness.png" "roughness.ktx" "${COMPRESSION};--grayscale")
-add_ktxfiles("assets/models/monkey/metallic.png" "metallic.ktx" "${COMPRESSION};--grayscale")
-add_ktxfiles("assets/models/monkey/ao.png" "ao.ktx" "${COMPRESSION};--grayscale")
+add_ktxfiles("assets/models/monkey/roughness.png" "roughness.ktx" "${COMPRESSION};--grayscale;--linear")
+add_ktxfiles("assets/models/monkey/metallic.png" "metallic.ktx" "${COMPRESSION};--grayscale;--linear")
+add_ktxfiles("assets/models/monkey/ao.png" "ao.ktx" "${COMPRESSION};--grayscale;--linear")
 
 add_pngfile("assets/models/monkey/normal.png" "normal.png")
 


### PR DESCRIPTION
The `g_linearized` variable was being used for two purposes: to denote
the linearity of the source format AND the linearity of the destination
format. This was confusing and is now split is `sourceIsLinear` and
`destIsLinear`.

This change has no effect on the the look of the suzanne demo.