### PR TITLE
string improvements

### DIFF
--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -44,11 +44,8 @@ void assertFramebufferStatus(utils::io::ostream& out, GLenum target, const char*
 #   define CHECK_GL_ERROR(out)
 #   define CHECK_GL_FRAMEBUFFER_STATUS(out, target)
 #else
-#   ifdef _MSC_VER
-#       define __PRETTY_FUNCTION__ __FUNCSIG__
-#   endif
-#   define CHECK_GL_ERROR(out) { GLUtils::assertGLError(out, __PRETTY_FUNCTION__, __LINE__); }
-#   define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __PRETTY_FUNCTION__, __LINE__); }
+#   define CHECK_GL_ERROR(out) { GLUtils::assertGLError(out, __func__, __LINE__); }
+#   define CHECK_GL_FRAMEBUFFER_STATUS(out, target) { GLUtils::checkFramebufferStatus(out, target, __func__, __LINE__); }
 #endif
 
 constexpr inline GLuint getComponentCount(ElementType type) noexcept {

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -278,7 +278,7 @@ void OpenGLContext::initExtensionsGLES() noexcept {
     GLUtils::unordered_string_set exts = GLUtils::split(extensions);
     if constexpr (DEBUG_PRINT_EXTENSIONS) {
         for (auto extension: exts) {
-            slog.d << "\"" << std::string(extension) << "\"\n";
+            slog.d << "\"" << std::string_view(extension) << "\"\n";
         }
         flush(slog.d);
     }
@@ -320,7 +320,7 @@ void OpenGLContext::initExtensionsGL() noexcept {
     }
     if constexpr (DEBUG_PRINT_EXTENSIONS) {
         for (auto extension: exts) {
-            slog.d << "\"" << std::string(extension) << "\"\n";
+            slog.d << "\"" << std::string_view(extension) << "\"\n";
         }
         flush(slog.d);
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -53,7 +53,7 @@
 
 #if DEBUG_MARKER_LEVEL == DEBUG_MARKER_OPENGL
 #   define DEBUG_MARKER() \
-        DebugMarker _debug_marker(*this, __PRETTY_FUNCTION__);
+        DebugMarker _debug_marker(*this, __func__);
 #else
 #   define DEBUG_MARKER()
 #endif
@@ -145,10 +145,7 @@ Driver* OpenGLDriver::create(
 
 OpenGLDriver::DebugMarker::DebugMarker(OpenGLDriver& driver, const char* string) noexcept
         : driver(driver) {
-    // FIXME: this is not safe nor portable
-    const char* const begin = string + sizeof("virtual void filament::backend::OpenGLDriver::") - 1;
-    const char* const end = strchr(begin, '(');
-    driver.pushGroupMarker(begin, end - begin);
+    driver.pushGroupMarker(string, strlen(string));
 }
 
 OpenGLDriver::DebugMarker::~DebugMarker() noexcept {

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -17,12 +17,13 @@
 #ifndef TNT_UTILS_OSTREAM_H
 #define TNT_UTILS_OSTREAM_H
 
-#include <string>
-#include <utility>
-
 #include <utils/bitset.h>
 #include <utils/compiler.h>
 #include <utils/PrivateImplementation.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
 
 namespace utils::io {
 
@@ -59,6 +60,9 @@ public:
 
     ostream& operator<<(const char* string) noexcept;
     ostream& operator<<(const unsigned char* string) noexcept;
+
+    ostream& operator<<(std::string const& s) noexcept;
+    ostream& operator<<(std::string_view const& s) noexcept;
 
     ostream& operator<<(ostream& (* f)(ostream&)) noexcept { return f(*this); }
 
@@ -110,9 +114,6 @@ private:
     const char* getFormat(type t) const noexcept;
 };
 
-// handles std::string
-inline ostream& operator << (ostream& o, std::string const& s) noexcept { return o << s.c_str(); }
-
 // handles utils::bitset
 inline ostream& operator << (ostream& o, utils::bitset32 const& s) noexcept {
     return o << (void*)uintptr_t(s.getValue());
@@ -131,7 +132,7 @@ inline ostream& operator<<(ostream& stream, const VECTOR<T>& v) {
 
 inline ostream& hex(ostream& s) noexcept { return s.hex(); }
 inline ostream& dec(ostream& s) noexcept { return s.dec(); }
-inline ostream& endl(ostream& s) noexcept { s << "\n"; return s.flush(); }
+inline ostream& endl(ostream& s) noexcept { s << '\n'; return s.flush(); }
 inline ostream& flush(ostream& s) noexcept { return s.flush(); }
 
 } // namespace utils::io

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -24,6 +24,9 @@
 #include <utils/PrivateImplementation-impl.h>
 
 #include <algorithm>
+#include <string>
+#include <string_view>
+
 #include <stdarg.h>
 
 template class utils::PrivateImplementation<utils::io::ostream_>;
@@ -167,6 +170,14 @@ ostream& ostream::operator<<(const unsigned char* string) noexcept {
 
 ostream& ostream::operator<<(const void* value) noexcept {
     return print("%p", value);
+}
+
+ostream& ostream::operator<<(std::string const& s) noexcept {
+    return print("%s", s.c_str());
+}
+
+ostream& ostream::operator<<(std::string_view const& s) noexcept {
+    return print("%.*s", s.length(), s.data());
 }
 
 ostream& ostream::hex() noexcept {


### PR DESCRIPTION
- don't use __PRETTY_FUNCTION__ and try to parse it, __func__ is
standardized and in most case returns what we want (the function name).

- add native support for string_view in our ostream.

- uninline string support from ostream