### PR TITLE
don't issue a flush systematically after framegraph's execute

### DIFF
--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -204,6 +204,7 @@ private:
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;
+    uint32_t mViewRenderedCount = 0;
     FrameInfoManager mFrameInfoManager;
     backend::TextureFormat mHdrTranslucent{};
     backend::TextureFormat mHdrQualityMedium{};

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -215,8 +215,6 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
 
         driver.popGroupMarker();
     }
-    // this is a good place to kick the GPU, since we've just done a bunch of work
-    driver.flush();
     driver.popGroupMarker();
 }
 


### PR DESCRIPTION
This is only a good place for a flush *if* we're going to draw another
view (so the GPU can start working). Otherwise, it can be costly
on some drivers and unnecessary since swapbuffers will do the same.