### PR TITLE
remove the CameraInfo state from FView

### DIFF
--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -120,7 +120,7 @@ public:
     float getLightFar() const noexcept { return mZLightFar; }
 
     // update Records and Froxels texture with lights data. this is thread-safe.
-    void froxelizeLights(FEngine& engine, CameraInfo const& camera,
+    void froxelizeLights(FEngine& engine, math::mat4f const& viewMatrix,
             const FScene::LightSoa& lightData) noexcept;
 
     void updateUniforms(PerViewUib& s) {
@@ -194,7 +194,7 @@ private:
     bool update() noexcept;
 
     void froxelizeLoop(FEngine& engine,
-            const CameraInfo& camera, const FScene::LightSoa& lightData) noexcept;
+            math::mat4f const& viewMatrix, const FScene::LightSoa& lightData) noexcept;
 
     void froxelizeAssignRecordsCompress() noexcept;
 

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -127,7 +127,7 @@ void PerViewUniforms::prepareTemporalNoise(TemporalAntiAliasingOptions const& op
     s.temporalNoise = options.enabled ? temporalNoise : 0.0f;
 }
 
-void PerViewUniforms::prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept {
+void PerViewUniforms::prepareFog(float3 const& cameraPosition, FogOptions const& options) noexcept {
     // this can't be too high because we need density / heightFalloff to produce something
     // close to fogOptions.density in the fragment shader which use 16-bits floats.
     constexpr float epsilon = 0.001f;
@@ -135,7 +135,7 @@ void PerViewUniforms::prepareFog(const CameraInfo& camera, FogOptions const& opt
 
     // precalculate the constant part of density  integral and correct for exp2() in the shader
     const float density = ((options.density / heightFalloff) *
-            std::exp(-heightFalloff * (camera.getPosition().y - options.height)))
+            std::exp(-heightFalloff * (cameraPosition.y - options.height)))
                     * float(1.0f / F_LN2);
 
     auto& s = mUniforms.edit();

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -69,7 +69,7 @@ public:
     void prepareTime(math::float4 const& userTime) noexcept;
     void prepareTemporalNoise(TemporalAntiAliasingOptions const& options) noexcept;
     void prepareExposure(float ev100) noexcept;
-    void prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept;
+    void prepareFog(math::float3 const& cameraPosition, FogOptions const& options) noexcept;
     void prepareStructure(TextureHandle structure) noexcept;
     void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
     void prepareBlending(bool needsAlphaChannel) noexcept;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -74,6 +74,11 @@ void RenderPass::setGeometry(FScene::RenderableSoa const& soa, Range<uint32_t> v
     mUboHandle = uboHandle;
 }
 
+void RenderPass::setCamera(const CameraInfo& camera) noexcept {
+    mCameraPosition = camera.getPosition();
+    mCameraForwardVector = camera.getForwardVector();
+}
+
 void RenderPass::overridePolygonOffset(backend::PolygonOffset* polygonOffset) noexcept {
     if ((mPolygonOffsetOverride = (polygonOffset != nullptr))) {
         mPolygonOffset = *polygonOffset;
@@ -97,7 +102,6 @@ void RenderPass::appendCommands(CommandTypeFlags const commandTypeFlags) noexcep
     const RenderFlags renderFlags = mFlags;
     const Variant variant = mVariant;
     const FScene::VisibleMaskType visibilityMask = mVisibilityMask;
-    CameraInfo const& camera = mCamera;
 
     // up-to-date summed primitive counts needed for generateCommands()
     FScene::RenderableSoa const& soa = *mRenderableSoa;
@@ -112,9 +116,8 @@ void RenderPass::appendCommands(CommandTypeFlags const commandTypeFlags) noexcep
     commandCount += 1; // for the sentinel
     Command* const curr = append(commandCount);
 
-    // we extract camera position/forward outside of the loop, because these are not cheap.
-    const float3 cameraPosition(camera.getPosition());
-    const float3 cameraForwardVector(camera.getForwardVector());
+    const float3 cameraPosition(mCameraPosition);
+    const float3 cameraForwardVector(mCameraForwardVector);
     auto work = [commandTypeFlags, curr, &soa, variant, renderFlags, visibilityMask, cameraPosition,
                  cameraForwardVector]
             (uint32_t startIndex, uint32_t indexCount) {

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -272,7 +272,7 @@ public:
             backend::Handle<backend::HwBufferObject> uboHandle) noexcept;
 
     // specifies camera information (e.g. used for sorting commands)
-    void setCamera(const CameraInfo& camera) noexcept { mCamera = camera; }
+    void setCamera(const CameraInfo& camera) noexcept;
 
     //  flags controlling how commands are generated
     void setRenderFlags(RenderFlags flags) noexcept { mFlags = flags; }
@@ -406,7 +406,8 @@ private:
     backend::Handle<backend::HwBufferObject> mUboHandle;
 
     // info about the camera
-    CameraInfo mCamera;
+    math::float3 mCameraPosition{};
+    math::float3 mCameraForwardVector{};
 
     // info about the scene features (e.g.: has shadows, lighting, etc...)
     RenderFlags mFlags{};

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -72,7 +72,7 @@ ShadowMap::~ShadowMap() {
 void ShadowMap::render(FScene const& scene, utils::Range<uint32_t> range,
         FScene::VisibleMaskType visibilityMask, filament::CameraInfo const& cameraInfo,
         RenderPass* const pass) noexcept {
-    pass->setCamera(cameraInfo);
+//    pass->setCamera(cameraInfo);
     pass->setVisibilityMask(visibilityMask);
     pass->setGeometry(scene.getRenderableData(), range, scene.getRenderableUBO());
     pass->overridePolygonOffset(&mShadowMapInfo.polygonOffset);
@@ -1048,13 +1048,12 @@ void ShadowMap::visitScene(const FScene& scene, uint32_t visibleLayers,
     }
 }
 
-void ShadowMap::initSceneInfo(FScene const& scene, filament::CameraInfo const& camera,
+void ShadowMap::initSceneInfo(FScene const& scene, mat4f const& viewMatrix,
         ShadowMap::SceneInfo& sceneInfo) {
     sceneInfo.vsNearFar = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max() };
 
     // We assume the light is at the origin to compute the SceneInfo. This is consumed later by
     // computeShadowCameraDirectional() which takes this into account.
-    const mat4f V = camera.view;
 
     // Compute scene bounds in world space, as well as the light-space and view-space near/far planes
     sceneInfo.wsShadowCastersVolume = {};
@@ -1071,7 +1070,7 @@ void ShadowMap::initSceneInfo(FScene const& scene, filament::CameraInfo const& c
                         min(sceneInfo.wsShadowReceiversVolume.min, receiver.min);
                 sceneInfo.wsShadowReceiversVolume.max =
                         max(sceneInfo.wsShadowReceiversVolume.max, receiver.max);
-                float2 nf = ShadowMap::computeNearFar(V, receiver);
+                float2 nf = ShadowMap::computeNearFar(viewMatrix, receiver);
                 sceneInfo.vsNearFar.x = std::max(sceneInfo.vsNearFar.x, nf.x);
                 sceneInfo.vsNearFar.y = std::min(sceneInfo.vsNearFar.y, nf.y);
             }

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -129,7 +129,7 @@ public:
 
     // Call once per frame to populate the SceneInfo struct, then pass to update().
     // This computes values constant across all shadow maps.
-    static void initSceneInfo(FScene const& scene, filament::CameraInfo const& camera,
+    static void initSceneInfo(FScene const& scene, math::mat4f const& viewMatrix,
             ShadowMap::SceneInfo& sceneInfo);
 
     // Update SceneInfo struct for a given light

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -55,10 +55,9 @@ ShadowMapManager::~ShadowMapManager() {
     }
 }
 
-ShadowMapManager::ShadowTechnique ShadowMapManager::update(
-        FEngine& engine, FView& view,
-        TypedUniformBuffer<ShadowUib>& shadowUb, FScene::RenderableSoa& renderableData,
-        FScene::LightSoa& lightData) noexcept {
+ShadowMapManager::ShadowTechnique ShadowMapManager::update(FEngine& engine, FView& view,
+        CameraInfo const& cameraInfo, TypedUniformBuffer<ShadowUib>& shadowUb,
+        FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept {
     ShadowTechnique shadowTechnique = {};
 
     calculateTextureRequirements(engine, view, lightData);
@@ -66,15 +65,13 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::update(
     ShadowMap::SceneInfo sceneInfo(view.getVisibleLayers());
 
     // Compute scene-dependent values shared across all shadow maps
-    ShadowMap::initSceneInfo(
-            *view.getScene(), view.getCameraInfo(),
-            sceneInfo);
+    ShadowMap::initSceneInfo(*view.getScene(), cameraInfo.view, sceneInfo);
 
     shadowTechnique |= updateCascadeShadowMaps(
-            engine, view, renderableData, lightData, sceneInfo);
+            engine, view, cameraInfo, renderableData, lightData, sceneInfo);
 
     shadowTechnique |= updateSpotShadowMaps(
-            engine, view, renderableData, lightData, sceneInfo, shadowUb);
+            engine, view, cameraInfo, renderableData, lightData, sceneInfo, shadowUb);
 
     return shadowTechnique;
 }
@@ -338,10 +335,9 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FrameGraph& fg,
 }
 
 ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEngine& engine,
-        FView& view, FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
-        ShadowMap::SceneInfo& sceneInfo) noexcept {
+        FView& view, CameraInfo const& cameraInfo, FScene::RenderableSoa& renderableData,
+        FScene::LightSoa& lightData, ShadowMap::SceneInfo& sceneInfo) noexcept {
     FScene* scene = view.getScene();
-    const CameraInfo& viewingCameraInfo = view.getCameraInfo();
     auto& lcm = engine.getLightManager();
 
     FLightManager::Instance directionalLight = lightData.elementAt<FScene::LIGHT_INSTANCE>(0);
@@ -365,7 +361,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         ShadowMapEntry& entry = mCascadeShadowMaps[0];
         ShadowMap& shadowMap = entry.getShadowMap();
 
-        shadowMap.updateDirectional(lightData, 0, viewingCameraInfo, shadowMapInfo, *scene, sceneInfo);
+        shadowMap.updateDirectional(lightData, 0, cameraInfo, shadowMapInfo, *scene, sceneInfo);
 
         Frustum const& frustum = shadowMap.getCamera().getCullingFrustum();
         FView::cullRenderables(engine.getJobSystem(), renderableData, frustum,
@@ -384,8 +380,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     }
 
     // Adjust the near and far planes to tightly bound the scene.
-    float vsNear = -viewingCameraInfo.zn;
-    float vsFar = -viewingCameraInfo.zf;
+    float vsNear = -cameraInfo.zn;
+    float vsFar = -cameraInfo.zf;
     if (engine.debug.shadowmap.tightly_bound_scene) {
         vsNear = std::min(vsNear, sceneInfo.vsNearFar.x);
         vsFar = std::max(vsFar, sceneInfo.vsNearFar.y);
@@ -402,7 +398,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     }
 
     const CascadeSplits::Params p {
-        .proj = viewingCameraInfo.cullingProjection,
+        .proj = cameraInfo.cullingProjection,
         .near = vsNear,
         .far = vsFar,
         .cascadeCount = cascadeCount,
@@ -440,7 +436,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         sceneInfo.csNearFar = { csSplitPosition[i], csSplitPosition[i + 1] };
 
         shadowMap.updateDirectional(lightData, 0,
-                viewingCameraInfo, shadowMapInfo,
+                cameraInfo, shadowMapInfo,
                 *scene, sceneInfo);
 
         if (shadowMap.hasVisibleShadows()) {
@@ -479,11 +475,11 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
 }
 
 ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine& engine,
-        FView& view, FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
-        ShadowMap::SceneInfo& sceneInfo, TypedUniformBuffer<ShadowUib>& shadowUb) noexcept {
+        FView& view, CameraInfo const& cameraInfo, FScene::RenderableSoa& renderableData,
+        FScene::LightSoa& lightData, ShadowMap::SceneInfo& sceneInfo,
+        TypedUniformBuffer<ShadowUib>& shadowUb) noexcept {
 
     auto& lcm = engine.getLightManager();
-    const CameraInfo& viewingCameraInfo = view.getCameraInfo();
 
     // shadow-map shadows for point/spotlights
     ShadowTechnique shadowTechnique{};
@@ -529,7 +525,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateSpotShadowMaps(FEngine
                 VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(i));
 
         shadowMap.updateSpot(lightData, lightIndex,
-                viewingCameraInfo, shadowMapInfo,
+                cameraInfo, shadowMapInfo,
                 *view.getScene(), sceneInfo);
 
         if (shadowMap.hasVisibleShadows()) {

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -82,8 +82,8 @@ public:
 
     // Updates all of the shadow maps and performs culling.
     // Returns true if any of the shadow maps have visible shadows.
-    ShadowTechnique update(FEngine& engine, FView& view,
-            TypedUniformBuffer<ShadowUib>& shadowUb,
+    ShadowMapManager::ShadowTechnique update(FEngine& engine, FView& view,
+            CameraInfo const& cameraInfo, TypedUniformBuffer<ShadowUib>& shadowUb,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
 
     // Renders all the shadow maps.
@@ -101,7 +101,8 @@ public:
 
     ShadowMap* getSpotShadowMap(size_t spot) noexcept {
         assert_invariant(spot < CONFIG_MAX_SHADOW_CASTING_SPOTS);
-        return std::launder(reinterpret_cast<ShadowMap*>(&mShadowMapCache[CONFIG_MAX_SHADOW_CASCADES + spot]));
+        return std::launder(reinterpret_cast<ShadowMap*>(
+                &mShadowMapCache[CONFIG_MAX_SHADOW_CASCADES + spot]));
     }
 
     ShadowMap const* getSpotShadowMap(size_t spot) const noexcept {
@@ -114,13 +115,14 @@ public:
     }
 
 private:
-    ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
-            FView& view, FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
-            ShadowMap::SceneInfo& sceneInfo) noexcept;
+    ShadowMapManager::ShadowTechnique updateCascadeShadowMaps(FEngine& engine,
+            FView& view, CameraInfo const& cameraInfo, FScene::RenderableSoa& renderableData,
+            FScene::LightSoa& lightData, ShadowMap::SceneInfo& sceneInfo) noexcept;
 
-    ShadowTechnique updateSpotShadowMaps(FEngine& engine,
-            FView& view, FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
-            ShadowMap::SceneInfo& sceneInfo, TypedUniformBuffer<ShadowUib>& shadowUb) noexcept;
+    ShadowMapManager::ShadowTechnique updateSpotShadowMaps(FEngine& engine,
+            FView& view, CameraInfo const& cameraInfo, FScene::RenderableSoa& renderableData,
+            FScene::LightSoa& lightData, ShadowMap::SceneInfo& sceneInfo,
+            TypedUniformBuffer<ShadowUib>& shadowUb) noexcept;
 
     void calculateTextureRequirements(FEngine& engine, FView& view, FScene::LightSoa& lightData) noexcept;
 

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -293,7 +293,7 @@ CameraInfo::CameraInfo(FCamera const& camera, const math::mat4& worldOriginCamer
     A                  = f / camera.getAperture();
     d                  = std::max(zn, camera.getFocusDistance());
     worldOffset        = camera.getPosition();
-    worldOrigin        = mat4f{ worldOriginCamera };
+    worldOrigin        = worldOriginCamera;
 }
 
 } // namespace filament

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -217,11 +217,10 @@ struct CameraInfo {
     float A{};                      // f-number or f / aperture diameter [m]
     float d{};                      // focus distance [m]
     math::float3 worldOffset{};     // world offset, API-level camera position
+    math::mat4 worldOrigin;         // this is already applied to model and view
     math::float3 const& getPosition() const noexcept { return model[3].xyz; }
     math::float3 getForwardVector() const noexcept { return normalize(-model[2].xyz); }
 
-    // for debugging:
-    math::mat4f worldOrigin; // this is already applied to model and view
 };
 
 FILAMENT_UPCAST(Camera)

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -51,6 +51,7 @@
 #include <utils/Slice.h>
 
 #include <math/scalar.h>
+#include <math/mat4.h>
 
 namespace utils {
 class JobSystem;
@@ -118,8 +119,11 @@ public:
 
     void terminate(FEngine& engine);
 
+    CameraInfo computeCameraInfo(FEngine& engine) noexcept;
+
     void prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& arena,
-            Viewport const& viewport, math::float4 const& userTime, bool needsAlphaChannel) noexcept;
+            filament::Viewport const& viewport, CameraInfo const& cameraInfo,
+            math::float4 const& userTime, bool needsAlphaChannel) noexcept;
 
     void setScene(FScene* scene) { mScene = scene; }
     FScene const* getScene() const noexcept { return mScene; }
@@ -127,8 +131,6 @@ public:
 
     void setCullingCamera(FCamera* camera) noexcept { mCullingCamera = camera; }
     void setViewingCamera(FCamera* camera) noexcept { mViewingCamera = camera; }
-
-    CameraInfo const& getCameraInfo() const noexcept { return mViewingCameraInfo; }
 
     void setViewport(Viewport const& viewport) noexcept;
     Viewport const& getViewport() const noexcept {
@@ -166,9 +168,10 @@ public:
     void prepareCamera(const CameraInfo& camera) const noexcept;
     void prepareViewport(const Viewport& viewport) const noexcept;
     void prepareShadowing(FEngine& engine, backend::DriverApi& driver,
-            FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData) noexcept;
-    void prepareLighting(FEngine& engine, FEngine::DriverApi& driver,
-            ArenaScope& arena, Viewport const& viewport) noexcept;
+            FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
+            CameraInfo const& cameraInfo) noexcept;
+    void prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaScope& arena,
+            filament::Viewport const& viewport, CameraInfo const &cameraInfo) noexcept;
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
     void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset,
@@ -181,7 +184,7 @@ public:
     void prepareShadowMap() const noexcept;
 
     void cleanupRenderPasses() const noexcept;
-    void froxelize(FEngine& engine) const noexcept;
+    void froxelize(FEngine& engine, math::mat4f const& viewMatrix) const noexcept;
     void commitUniforms(backend::DriverApi& driver) const noexcept;
     void commitFroxels(backend::DriverApi& driverApi) const noexcept;
 
@@ -461,11 +464,11 @@ private:
             Frustum const& frustum, FScene::RenderableSoa& renderableData) const noexcept;
 
     static void prepareVisibleLights(FLightManager const& lcm, ArenaScope& rootArena,
-            const CameraInfo& camera, Frustum const& frustum,
+            math::mat4f const& viewMatrix, Frustum const& frustum,
             FScene::LightSoa& lightData) noexcept;
 
     static inline void computeLightCameraDistances(float* distances,
-            const CameraInfo& camera, const math::float4* spheres, size_t count) noexcept;
+            math::mat4f const& viewMatrix, const math::float4* spheres, size_t count) noexcept;
 
     static void computeVisibilityMasks(
             uint8_t visibleLayers, uint8_t const* layers,
@@ -500,7 +503,6 @@ private:
     FCamera* mCullingCamera = nullptr;
     FCamera* mViewingCamera = nullptr;
 
-    CameraInfo mViewingCameraInfo;
     Frustum mCullingFrustum{};
 
     mutable Froxelizer mFroxelizer;


### PR DESCRIPTION
this state only exists during Renderer::render(), having it outside
of view is more flexible as it give us an opportunity to adjust
camera parameter globally before drawing.

Also greatly reduced the size of RenderPass (which is a Value object).