### PR TITLE
Complete the OGL backend's stencil support and add test case

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -389,6 +389,7 @@ if (APPLE)
         test/test_MRT.cpp
         test/test_LoadImage.cpp
         test/test_RenderExternalImage.cpp
+        test/test_StencilBuffer.cpp
         )
 
     target_link_libraries(backend_test PRIVATE

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -843,7 +843,9 @@ struct RasterState {
         blendFunctionDstRGB = BlendFunction::ZERO;
         blendFunctionDstAlpha = BlendFunction::ZERO;
         stencilFunc = StencilFunction::A;
-        stencilOp = StencilOperation::KEEP;
+        stencilOpSFail = StencilOperation::KEEP;
+        stencilOpDpFail = StencilOperation::KEEP;
+        stencilOpDpPass = StencilOperation::KEEP;
     }
 
     bool operator == (RasterState rhs) const noexcept { return u == rhs.u; }
@@ -908,10 +910,18 @@ struct RasterState {
             uint8_t stencilRef                  : 8;        // 40
             //! Stencil test function
             StencilFunction stencilFunc         : 3;        // 43
-            //! Stencil operation (when stencil and depth pass)
-            StencilOperation stencilOp          : 3;        // 46
+            //! Stencil operation when stencil test fails
+            StencilOperation stencilOpSFail     : 3;        // 46
             //! padding, must be 0
-            uint32_t padding                    : 18;       // 64
+            uint8_t padding0                    : 2;        // 48
+            //! Stencil operation when stencil test passes but depth test fails
+            StencilOperation stencilOpDpFail    : 3;        // 51
+            //! Stencil operation when both stencil and depth test pass
+            StencilOperation stencilOpDpPass    : 3;        // 54
+            //! padding, must be 0
+            uint8_t padding1                    : 2;        // 56
+            //! padding, must be 0
+            uint8_t padding2                    : 8;        // 64
         };
         uint64_t u = 0;
     };

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -843,9 +843,9 @@ struct RasterState {
         blendFunctionDstRGB = BlendFunction::ZERO;
         blendFunctionDstAlpha = BlendFunction::ZERO;
         stencilFunc = StencilFunction::A;
-        stencilOpSFail = StencilOperation::KEEP;
-        stencilOpDpFail = StencilOperation::KEEP;
-        stencilOpDpPass = StencilOperation::KEEP;
+        stencilOpStencilFail = StencilOperation::KEEP;
+        stencilOpDepthFail = StencilOperation::KEEP;
+        stencilOpDepthStencilPass = StencilOperation::KEEP;
     }
 
     bool operator == (RasterState rhs) const noexcept { return u == rhs.u; }
@@ -874,54 +874,54 @@ struct RasterState {
     union {
         struct {
             //! culling mode
-            CullingMode culling                 : 2;        //  2
+            CullingMode culling                         : 2;        //  2
 
             //! blend equation for the red, green and blue components
-            BlendEquation blendEquationRGB      : 3;        //  5
+            BlendEquation blendEquationRGB              : 3;        //  5
             //! blend equation for the alpha component
-            BlendEquation blendEquationAlpha    : 3;        //  8
+            BlendEquation blendEquationAlpha            : 3;        //  8
 
             //! blending function for the source color
-            BlendFunction blendFunctionSrcRGB   : 4;        // 12
+            BlendFunction blendFunctionSrcRGB           : 4;        // 12
             //! blending function for the source alpha
-            BlendFunction blendFunctionSrcAlpha : 4;        // 16
+            BlendFunction blendFunctionSrcAlpha         : 4;        // 16
             //! blending function for the destination color
-            BlendFunction blendFunctionDstRGB   : 4;        // 20
+            BlendFunction blendFunctionDstRGB           : 4;        // 20
             //! blending function for the destination alpha
-            BlendFunction blendFunctionDstAlpha : 4;        // 24
+            BlendFunction blendFunctionDstAlpha         : 4;        // 24
 
             //! Whether depth-buffer writes are enabled
-            bool depthWrite                     : 1;        // 25
+            bool depthWrite                             : 1;        // 25
             //! Depth test function
-            DepthFunc depthFunc                 : 3;        // 28
+            DepthFunc depthFunc                         : 3;        // 28
 
             //! Whether color-buffer writes are enabled
-            bool colorWrite                     : 1;        // 29
+            bool colorWrite                             : 1;        // 29
 
             //! use alpha-channel as coverage mask for anti-aliasing
-            bool alphaToCoverage                : 1;        // 30
+            bool alphaToCoverage                        : 1;        // 30
 
             //! whether front face winding direction must be inverted
-            bool inverseFrontFaces              : 1;        // 31
+            bool inverseFrontFaces                      : 1;        // 31
 
             //! Whether stencil-buffer writes are enabled
-            bool stencilWrite                   : 1;        // 32
+            bool stencilWrite                           : 1;        // 32
             //! Stencil reference value
-            uint8_t stencilRef                  : 8;        // 40
+            uint8_t stencilRef                          : 8;        // 40
             //! Stencil test function
-            StencilFunction stencilFunc         : 3;        // 43
+            StencilFunction stencilFunc                 : 3;        // 43
             //! Stencil operation when stencil test fails
-            StencilOperation stencilOpSFail     : 3;        // 46
+            StencilOperation stencilOpStencilFail       : 3;        // 46
             //! padding, must be 0
-            uint8_t padding0                    : 2;        // 48
+            uint8_t padding0                            : 2;        // 48
             //! Stencil operation when stencil test passes but depth test fails
-            StencilOperation stencilOpDpFail    : 3;        // 51
+            StencilOperation stencilOpDepthFail         : 3;        // 51
             //! Stencil operation when both stencil and depth test pass
-            StencilOperation stencilOpDpPass    : 3;        // 54
+            StencilOperation stencilOpDepthStencilPass  : 3;        // 54
             //! padding, must be 0
-            uint8_t padding1                    : 2;        // 56
+            uint8_t padding1                            : 2;        // 56
             //! padding, must be 0
-            uint8_t padding2                    : 8;        // 64
+            uint8_t padding2                            : 8;        // 64
         };
         uint64_t u = 0;
     };

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -255,6 +255,23 @@ constexpr inline GLenum getDepthFunc(SamplerCompareFunc func) noexcept {
     return getTextureCompareFunc(func);
 }
 
+constexpr inline GLenum getStencilFunc(SamplerCompareFunc func) noexcept {
+    return getTextureCompareFunc(func);
+}
+
+constexpr inline GLenum getStencilOp(StencilOperation op) noexcept {
+    switch (op) {
+        case StencilOperation::KEEP:        return GL_KEEP;
+        case StencilOperation::ZERO:        return GL_ZERO;
+        case StencilOperation::REPLACE:     return GL_REPLACE;
+        case StencilOperation::INCR:        return GL_INCR;
+        case StencilOperation::INCR_WRAP:   return GL_INCR_WRAP;
+        case StencilOperation::DECR:        return GL_DECR;
+        case StencilOperation::DECR_WRAP:   return GL_DECR_WRAP;
+        case StencilOperation::INVERT:      return GL_INVERT;
+    }
+}
+
 constexpr inline GLenum getFormat(PixelDataFormat format) noexcept {
     using PixelDataFormat = PixelDataFormat;
     switch (format) {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -102,7 +102,7 @@ public:
     inline void depthMask(GLboolean flag) noexcept;
     inline void depthFunc(GLenum func) noexcept;
     inline void stencilFunc(GLenum func, GLint ref, GLuint mask) noexcept;
-    inline void stencilOp(GLenum op) noexcept;
+    inline void stencilOp(GLenum sfail, GLenum dpfail, GLenum dppass) noexcept;
     inline void stencilMask(GLuint mask) noexcept;
     inline void polygonOffset(GLfloat factor, GLfloat units) noexcept;
     inline void beginQuery(GLenum target, GLuint query) noexcept;
@@ -300,7 +300,14 @@ private:
                     return func != rhs.func || ref != rhs.ref || mask != rhs.mask;
                 }
             } stencilFunc;
-            GLenum stencilOp            = GL_KEEP;
+            struct StencilOp {
+                GLenum sfail            = GL_KEEP;
+                GLenum dpfail           = GL_KEEP;
+                GLenum dppass           = GL_KEEP;
+                bool operator != (StencilOp const& rhs) const noexcept {
+                    return sfail != rhs.sfail || dpfail != rhs.dpfail || dppass != rhs.dppass;
+                }
+            } stencilOp;
             GLuint stencilMask          = ~GLuint(0);
         } raster;
 
@@ -654,10 +661,10 @@ void OpenGLContext::stencilFunc(GLenum func, GLint ref, GLuint mask) noexcept {
     });
 }
 
-void OpenGLContext::stencilOp(GLenum op) noexcept {
+void OpenGLContext::stencilOp(GLenum sfail, GLenum dpfail, GLenum dppass) noexcept {
     // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.stencilOp, op, [&]() {
-        glStencilOp(GL_KEEP, GL_KEEP, op);
+    update_state(state.raster.stencilOp, {sfail, dpfail, dppass}, [&]() {
+        glStencilOp(sfail, dpfail, dppass);
     });
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -101,6 +101,9 @@ public:
     inline void colorMask(GLboolean flag) noexcept;
     inline void depthMask(GLboolean flag) noexcept;
     inline void depthFunc(GLenum func) noexcept;
+    inline void stencilFunc(GLenum func, GLint ref, GLuint mask) noexcept;
+    inline void stencilOp(GLenum op) noexcept;
+    inline void stencilMask(GLuint mask) noexcept;
     inline void polygonOffset(GLfloat factor, GLfloat units) noexcept;
     inline void beginQuery(GLenum target, GLuint query) noexcept;
     inline void endQuery(GLenum target) noexcept;
@@ -289,6 +292,16 @@ private:
             GLboolean colorMask         = GL_TRUE;
             GLboolean depthMask         = GL_TRUE;
             GLenum depthFunc            = GL_LESS;
+            struct StencilFunc {
+                GLenum func             = GL_ALWAYS;
+                GLint ref               = 0;
+                GLuint mask             = ~GLuint(0);
+                bool operator != (StencilFunc const& rhs) const noexcept {
+                    return func != rhs.func || ref != rhs.ref || mask != rhs.mask;
+                }
+            } stencilFunc;
+            GLenum stencilOp            = GL_KEEP;
+            GLuint stencilMask          = ~GLuint(0);
         } raster;
 
         struct PolygonOffset {
@@ -631,6 +644,27 @@ void OpenGLContext::depthFunc(GLenum func) noexcept {
     // WARNING: don't call this without updating mRasterState
     update_state(state.raster.depthFunc, func, [&]() {
         glDepthFunc(func);
+    });
+}
+
+void OpenGLContext::stencilFunc(GLenum func, GLint ref, GLuint mask) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.stencilFunc, {func, ref, mask}, [&]() {
+        glStencilFunc(func, ref, mask);
+    });
+}
+
+void OpenGLContext::stencilOp(GLenum op) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.stencilOp, op, [&]() {
+        glStencilOp(GL_KEEP, GL_KEEP, op);
+    });
+}
+
+void OpenGLContext::stencilMask(GLuint mask) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.stencilMask, mask, [&]() {
+        glStencilMask(mask);
     });
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -300,7 +300,8 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
     } else {
         gl.enable(GL_STENCIL_TEST);
         gl.stencilFunc(getStencilFunc(rs.stencilFunc), rs.stencilRef, ~GLuint(0));
-        gl.stencilOp(getStencilOp(rs.stencilOp));
+        gl.stencilOp(getStencilOp(rs.stencilOpSFail), getStencilOp(rs.stencilOpDpFail),
+                getStencilOp(rs.stencilOpDpPass));
         GLuint stencilMask = rs.stencilWrite ? ~GLuint(0) : 0x00;
         gl.stencilMask(stencilMask);
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -300,8 +300,9 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
     } else {
         gl.enable(GL_STENCIL_TEST);
         gl.stencilFunc(getStencilFunc(rs.stencilFunc), rs.stencilRef, ~GLuint(0));
-        gl.stencilOp(getStencilOp(rs.stencilOpSFail), getStencilOp(rs.stencilOpDpFail),
-                getStencilOp(rs.stencilOpDpPass));
+        gl.stencilOp(getStencilOp(rs.stencilOpStencilFail),
+                getStencilOp(rs.stencilOpDepthFail),
+                getStencilOp(rs.stencilOpDepthStencilPass));
         GLuint stencilMask = rs.stencilWrite ? ~GLuint(0) : 0x00;
         gl.stencilMask(stencilMask);
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -294,6 +294,17 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
         gl.depthMask(GLboolean(rs.depthWrite));
     }
 
+    // stencil test / operation
+    if (rs.stencilFunc == RasterState::StencilFunction::A && !rs.stencilWrite) {
+        gl.disable(GL_STENCIL_TEST);
+    } else {
+        gl.enable(GL_STENCIL_TEST);
+        gl.stencilFunc(getStencilFunc(rs.stencilFunc), rs.stencilRef, ~GLuint(0));
+        gl.stencilOp(getStencilOp(rs.stencilOp));
+        GLuint stencilMask = rs.stencilWrite ? ~GLuint(0) : 0x00;
+        gl.stencilMask(stencilMask);
+    }
+
     // write masks
     gl.colorMask(GLboolean(rs.colorWrite));
 

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -149,7 +149,7 @@ void BackendTest::readPixelsAndAssertHash(const char* testName, size_t width, si
         bool exportScreenshot;
         size_t width, height;
     };
-    Capture* c = new Capture();
+    auto* c = new Capture();
     c->expectedHash = expectedHash;
     c->name = strdup(testName);
     c->exportScreenshot = exportScreenshot;
@@ -158,24 +158,18 @@ void BackendTest::readPixelsAndAssertHash(const char* testName, size_t width, si
 
     PixelBufferDescriptor pbd(buffer, width * height * 4, PixelDataFormat::RGBA, PixelDataType::UBYTE,
             1, 0, 0, width, [](void* buffer, size_t size, void* user) {
-                Capture* c = (Capture*)user;
+                auto* c = (Capture*)user;
 
                 // Export a screenshot, if requested.
                 if (c->exportScreenshot) {
 #ifndef IOS
                     LinearImage image(c->width, c->height, 4);
-                    // TODO:
-                    //if (format == PixelDataFormat::RGBA && type == PixelDataType::UBYTE) {
                     image = toLinearWithAlpha<uint8_t>(c->width, c->height, c->width * 4,
                             (uint8_t*) buffer);
-                    //}
-                    //if (format == PixelDataFormat::RGBA && type == PixelDataType::FLOAT) {
-                    //memcpy(image.getPixelRef(), pixelData, width * height * sizeof(math::float4));
-                    //}
-                    std::string png = std::string(c->name) + ".png";
+                    const std::string png = std::string(c->name) + ".png";
                     std::ofstream outputStream(png.c_str(), std::ios::binary | std::ios::trunc);
                     ImageEncoder::encode(outputStream, ImageEncoder::Format::PNG, image, "",
-                            png.c_str());
+                            png);
 #endif
                 }
 

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -56,7 +56,8 @@ protected:
             filament::backend::Handle<filament::backend::HwProgram> program);
 
     void readPixelsAndAssertHash(const char* testName, size_t width, size_t height,
-            filament::backend::Handle<filament::backend::HwRenderTarget> rt, uint32_t expectedHash);
+            filament::backend::Handle<filament::backend::HwRenderTarget> rt, uint32_t expectedHash,
+            bool exportScreenshot = false);
 
     filament::backend::DriverApi& getDriverApi() { return *commandStream; }
     filament::backend::Driver& getDriver() { return *driver; }

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTest.h"
+
+#include "ShaderGenerator.h"
+#include "TrianglePrimitive.h"
+
+using namespace filament;
+using namespace filament::backend;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Shaders
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+std::string vertex (R"(#version 450 core
+
+layout(location = 0) in vec4 mesh_position;
+
+void main() {
+    gl_Position = vec4(mesh_position.xy, 0.0, 1.0);
+#if defined(TARGET_VULKAN_ENVIRONMENT)
+    // In Vulkan, clip space is Y-down. In OpenGL and Metal, clip space is Y-up.
+    gl_Position.y = -gl_Position.y;
+#endif
+}
+)");
+
+std::string fragment (R"(#version 450 core
+
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0);
+}
+
+)");
+
+}
+
+namespace test {
+
+// 1. Clear the stencil buffer to all zeroes.
+// 2. Render a small triangle only to the stencil buffer and set the operation to write ones.
+// 3. Enable a "== 0" stencil test and enable color writes.
+// 4. Render a larger triangle to the SwapChain.
+// 5. The larger triangle should have a "hole" in the middle.
+TEST_F(BackendTest, StencilBuffer) {
+    auto& api = getDriverApi();
+
+    // The test is executed within this block scope to force destructors to run before
+    // executeCommands().
+    {
+        // Create a platform-specific SwapChain and make it current.
+        auto swapChain = createSwapChain();
+        api.makeCurrent(swapChain, swapChain);
+
+        // Create a program.
+        ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
+        Program p = shaderGen.getProgram();
+        ProgramHandle program = api.createProgram(std::move(p));
+
+        // We'll be using a triangle as geometry.
+        TrianglePrimitive smallTriangle(api);
+        static filament::math::float2 vertices[3] = {
+                { -0.5, -0.5 },
+                {  0.5, -0.5 },
+                { -0.5,  0.5 }
+        };
+        smallTriangle.updateVertices(vertices);
+        TrianglePrimitive triangle(api);
+
+        // Create two textures: a color and a stencil, and an associated RenderTarget.
+        auto colorTexture = getDriverApi().createTexture(SamplerType::SAMPLER_2D, 1,
+                TextureFormat::RGBA8, 1, 512, 512, 1, TextureUsage::COLOR_ATTACHMENT);
+        auto stencilTexture = getDriverApi().createTexture(SamplerType::SAMPLER_2D, 1,
+                TextureFormat::STENCIL8, 1, 512, 512, 1, TextureUsage::STENCIL_ATTACHMENT);
+        auto renderTarget = getDriverApi().createRenderTarget(
+                TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL, 512, 512, 1,
+                {{colorTexture}}, {}, {{stencilTexture}});
+
+        // Step 1: Clear the stencil buffer to all zeroes and the color buffer to blue.
+        // Render a small triangle only to the stencil buffer, increasing the stencil buffer to 1.
+        RenderPassParams params = {};
+        params.flags.clear = TargetBufferFlags::COLOR0 | TargetBufferFlags::STENCIL;
+        params.viewport = {0, 0, 512, 512};
+        params.clearColor = math::float4(0.0f, 0.0f, 1.0f, 1.0f);
+        params.clearStencil = 0u;
+        params.flags.discardStart = TargetBufferFlags::ALL;
+        params.flags.discardEnd = TargetBufferFlags::NONE;
+
+        PipelineState ps = {};
+        ps.program = program;
+        ps.rasterState.colorWrite = false;
+        ps.rasterState.depthWrite = false;
+        ps.rasterState.stencilWrite = true;
+        ps.rasterState.stencilOp = StencilOperation::INCR;
+
+        api.makeCurrent(swapChain, swapChain);
+        api.beginFrame(0, 0);
+
+        api.beginRenderPass(renderTarget, params);
+        api.draw(ps, smallTriangle.getRenderPrimitive(), 1);
+        api.endRenderPass();
+
+        // Step 2: Render a larger triangle with the stencil test enabled.
+        params.flags.clear = TargetBufferFlags::NONE;
+        params.flags.discardStart = TargetBufferFlags::NONE;
+        ps.rasterState.colorWrite = true;
+        ps.rasterState.stencilWrite = false;
+        ps.rasterState.stencilOp = StencilOperation::KEEP;
+        ps.rasterState.stencilFunc = RasterState::StencilFunction::E;
+        ps.rasterState.stencilRef = 0u;
+
+        api.beginRenderPass(renderTarget, params);
+        api.draw(ps, triangle.getRenderPrimitive(), 1);
+        api.endRenderPass();
+
+        readPixelsAndAssertHash("StencilBuffer", 512, 512, renderTarget, 0x3B1AEF0F, true);
+
+        api.commit(swapChain);
+        api.endFrame(0);
+
+        api.destroyProgram(program);
+        api.destroySwapChain(swapChain);
+        api.destroyTexture(colorTexture);
+        api.destroyTexture(stencilTexture);
+        api.destroyRenderTarget(renderTarget);
+    }
+
+    flushAndWait();
+    getDriver().purge();
+}
+
+} // namespace test

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -109,7 +109,7 @@ TEST_F(BackendTest, StencilBuffer) {
         ps.rasterState.colorWrite = false;
         ps.rasterState.depthWrite = false;
         ps.rasterState.stencilWrite = true;
-        ps.rasterState.stencilOp = StencilOperation::INCR;
+        ps.rasterState.stencilOpDpPass = StencilOperation::INCR;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
@@ -123,7 +123,7 @@ TEST_F(BackendTest, StencilBuffer) {
         params.flags.discardStart = TargetBufferFlags::NONE;
         ps.rasterState.colorWrite = true;
         ps.rasterState.stencilWrite = false;
-        ps.rasterState.stencilOp = StencilOperation::KEEP;
+        ps.rasterState.stencilOpDpPass = StencilOperation::KEEP;
         ps.rasterState.stencilFunc = RasterState::StencilFunction::E;
         ps.rasterState.stencilRef = 0u;
 

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -109,7 +109,7 @@ TEST_F(BackendTest, StencilBuffer) {
         ps.rasterState.colorWrite = false;
         ps.rasterState.depthWrite = false;
         ps.rasterState.stencilWrite = true;
-        ps.rasterState.stencilOpDpPass = StencilOperation::INCR;
+        ps.rasterState.stencilOpDepthStencilPass = StencilOperation::INCR;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
@@ -123,7 +123,7 @@ TEST_F(BackendTest, StencilBuffer) {
         params.flags.discardStart = TargetBufferFlags::NONE;
         ps.rasterState.colorWrite = true;
         ps.rasterState.stencilWrite = false;
-        ps.rasterState.stencilOpDpPass = StencilOperation::KEEP;
+        ps.rasterState.stencilOpDepthStencilPass = StencilOperation::KEEP;
         ps.rasterState.stencilFunc = RasterState::StencilFunction::E;
         ps.rasterState.stencilRef = 0u;
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -213,22 +213,22 @@ public:
         return boolish ? std::numeric_limits<uint64_t>::max() : uint64_t(0);
     }
 
-    struct PrimitiveInfo { // 32 bytes
+    struct PrimitiveInfo { // 40 bytes
         FMaterialInstance const* mi = nullptr;                          // 8 bytes (4)
         backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
         backend::Handle<backend::HwBufferObject> morphWeightBuffer;     // 4 bytes
         backend::Handle<backend::HwSamplerGroup> morphTargetBuffer;     // 4 bytes
-        backend::RasterState rasterState;                               // 4 bytes
         uint16_t index = 0;                                             // 2 bytes
         uint16_t instanceCount;                                         // 2 bytes
+        backend::RasterState rasterState;                               // 8 bytes
         Variant materialVariant;                                        // 1 byte
-        uint8_t reserved[11 - sizeof(void*)] = {};                      // 3 bytes (7)
+        uint8_t reserved[15 - sizeof(void*)] = {};                      // 7 bytes (11)
     };
-    static_assert(sizeof(PrimitiveInfo) == 32);
+    static_assert(sizeof(PrimitiveInfo) == 40);
 
     struct alignas(8) Command {     // 40 bytes
         CommandKey key = 0;         //  8 bytes
-        PrimitiveInfo primitive;    // 32 bytes
+        PrimitiveInfo primitive;    // 40 bytes
         bool operator < (Command const& rhs) const noexcept { return key < rhs.key; }
         // placement new declared as "throw" to avoid the compiler's null-check
         inline void* operator new (std::size_t, void* ptr) {
@@ -236,7 +236,7 @@ public:
             return ptr;
         }
     };
-    static_assert(sizeof(Command) == 40);
+    static_assert(sizeof(Command) == 48);
     static_assert(std::is_trivially_destructible_v<Command>,
             "Command isn't trivially destructible");
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -214,8 +214,10 @@ public:
     }
 
     struct PrimitiveInfo { // 40 bytes
-        FMaterialInstance const* mi = nullptr;                          // 8 bytes (4)
-        uint8_t reserved0[8 - sizeof(void*)] = {};                      // 0 bytes (4)
+        union {
+            FMaterialInstance const* mi;
+            uint64_t reserved0 = {}; // ensures mi is 8 bytes on all archs
+        };                                                              // 8 bytes
         backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
         backend::Handle<backend::HwBufferObject> morphWeightBuffer;     // 4 bytes
         backend::Handle<backend::HwSamplerGroup> morphTargetBuffer;     // 4 bytes

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -215,6 +215,7 @@ public:
 
     struct PrimitiveInfo { // 40 bytes
         FMaterialInstance const* mi = nullptr;                          // 8 bytes (4)
+        uint8_t reserved0[8 - sizeof(void*)] = {};                      // 0 bytes (4)
         backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
         backend::Handle<backend::HwBufferObject> morphWeightBuffer;     // 4 bytes
         backend::Handle<backend::HwSamplerGroup> morphTargetBuffer;     // 4 bytes
@@ -222,7 +223,7 @@ public:
         uint16_t instanceCount;                                         // 2 bytes
         backend::RasterState rasterState;                               // 8 bytes
         Variant materialVariant;                                        // 1 byte
-        uint8_t reserved[15 - sizeof(void*)] = {};                      // 7 bytes (11)
+        uint8_t reserved1[7] = {};                                      // 7 bytes
     };
     static_assert(sizeof(PrimitiveInfo) == 40);
 


### PR DESCRIPTION
A first pass at implementing complete stencil buffer support. We still need to support other backends and a user-facing API.