### PR TITLE
remove getUV() from post-process materials

### DIFF
--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -98,9 +98,7 @@ float starburst(const vec2 uv) {
     return saturate(mask + (1.0 - smoothstep(0.0, 0.3, d)));
 }
 
-vec3 bloom(const vec3 color) {
-    highp vec2 uv = variable_vertex.xy;
-
+vec3 bloom(highp vec2 uv, const vec3 color) {
     vec3 result = vec3(0.0);
 
     if (materialParams.bloom.x > 0.0) {
@@ -124,27 +122,28 @@ vec3 bloom(const vec3 color) {
     return result;
 }
 
-vec4 resolveFragment(const ivec2 uv) {
+vec4 resolveFragment(const highp vec2 uv) {
 #if POST_PROCESS_OPAQUE
-    return vec4(texelFetch(materialParams_colorBuffer, uv, 0).rgb, 1.0);
+    return vec4(textureLod(materialParams_colorBuffer, uv, 0.0).rgb, 1.0);
 #else
-    vec4 color = texelFetch(materialParams_colorBuffer, uv, 0);
+    vec4 color = textureLod(materialParams_colorBuffer, uv, 0.0);
     color.rgb *= 1.0 / (color.a + FLT_EPS);
     return color;
 #endif
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
-    vec4 color = resolveFragment(ivec2(getUV()));
+    highp vec2 uv = variable_vertex.xy;
+
+    vec4 color = resolveFragment(uv);
 
     // Bloom
     if (materialParams.bloom.x > 0.0) {
-        color.rgb = bloom(color.rgb);
+        color.rgb = bloom(uv, color.rgb);
     }
 
     // Vignette
     if (materialParams.vignette.x < MEDIUMP_FLT_MAX) {
-        highp vec2 uv = getUV() * frameUniforms.resolution.zw;
         color.rgb = vignette(color.rgb, uv, materialParams.vignette, materialParams.vignetteColor);
     }
 

--- a/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
+++ b/filament/src/materials/colorGrading/colorGradingAsSubpass.mat
@@ -86,11 +86,12 @@ vec4 resolveFragment() {
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
+    highp vec2 uv = variable_vertex.xy;
+
     vec4 color = resolveFragment();
 
     // Vignette
     if (materialParams.vignette.x < MEDIUMP_FLT_MAX) {
-        highp vec2 uv = getUV() * frameUniforms.resolution.zw;
         color.rgb = vignette(color.rgb, uv, materialParams.vignette, materialParams.vignetteColor);
     }
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -537,9 +537,6 @@ std::string ShaderGenerator::createPostProcessVertexProgram(
 
     CodeGenerator::generateDefine(vs, "LOCATION_POSITION", uint32_t(VertexAttribute::POSITION));
 
-    // The UVs are at the location immediately following the custom variables.
-    CodeGenerator::generateDefine(vs, "LOCATION_UVS", uint32_t(MaterialBuilder::MATERIAL_VARIABLES_COUNT));
-
     // custom material variables
     size_t variableIndex = 0;
     for (const auto& variable : mVariables) {
@@ -578,9 +575,6 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(
     cg.generateProlog(fs, ShaderType::FRAGMENT, false);
 
     cg.generateQualityDefine(fs, material.quality);
-
-    // The UVs are at the location immediately following the custom variables.
-    CodeGenerator::generateDefine(fs, "LOCATION_UVS", uint32_t(MaterialBuilder::MATERIAL_VARIABLES_COUNT));
 
     generatePostProcessMaterialVariantDefines(fs, PostProcessVariant(variant));
 

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -4,11 +4,9 @@ void main() {
     initPostProcessMaterialVertex(inputs);
 
     inputs.normalizedUV = position.xy * 0.5 + 0.5;
-    inputs.texelCoords = inputs.normalizedUV * frameUniforms.resolution.xy;
 
 // In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
 #if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    inputs.texelCoords.y = frameUniforms.resolution.y - inputs.texelCoords.y;
     inputs.normalizedUV.y = 1.0 - inputs.normalizedUV.y;
 #endif
 
@@ -24,8 +22,6 @@ void main() {
 
     // Invoke user code
     postProcessVertex(inputs);
-
-    vertex_uv = inputs.texelCoords;
 
     // Handle user-defined interpolated attributes
 #if defined(VARIABLE_CUSTOM0)

--- a/shaders/src/post_process_inputs.fs
+++ b/shaders/src/post_process_inputs.fs
@@ -1,9 +1,3 @@
-LAYOUT_LOCATION(LOCATION_UVS) in highp vec2 vertex_uv;
-
-/** @public-api */
-highp vec2 getUV() {
-    return vertex_uv;
-}
 
 struct PostProcessInputs {
 #if defined(FRAG_OUTPUT0)

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -1,13 +1,9 @@
 LAYOUT_LOCATION(LOCATION_POSITION) in vec4 position;
 
-LAYOUT_LOCATION(LOCATION_UVS) out vec2 vertex_uv;
-
 struct PostProcessVertexInputs {
 
-    // We provide normalized and non-normalized texture coordinates to custom vertex shaders.
-    // By default the non-normalized coordinates are passed through to the fragment shader.
+    // We provide normalized texture coordinates to custom vertex shaders.
     vec2 normalizedUV;
-    vec2 texelCoords;
 
 #ifdef VARIABLE_CUSTOM0
     vec4 VARIABLE_CUSTOM0;


### PR DESCRIPTION
it made it actually more confusing to have two version of the uv
(normalized and not). Also the unnormalized version was computed from
frameUniforms which is not great in the case of post-processing
(it just happened to work).