### PR TITLE
don't rely on frameUniform.resolution for froxelization

### DIFF
--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -127,8 +127,8 @@ public:
         s.zParams = mParamsZ;
         s.fParams = mParamsF.yz;
         s.fParamsX = mParamsF.x;
-        s.oneOverFroxelDimensionX = mOneOverDimension.x;
-        s.oneOverFroxelDimensionY = mOneOverDimension.y;
+        s.widthOverFroxelDimensionX  = float(mViewport.width ) * mOneOverDimension.x;
+        s.heightOverFroxelDimensionY = float(mViewport.height) * mOneOverDimension.y;
     }
 
     // send froxel data to GPU

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -74,14 +74,14 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float shadowBulbRadiusLs;       // light radius in light-space
     float shadowBias;               // normal bias
     float shadowPenumbraRatioScale; // For DPCF or PCSS, scale penumbra ratio for artistic use
-    float oneOverFroxelDimensionY;
+    float heightOverFroxelDimensionY;
 
     math::float4 zParams; // froxel Z parameters
 
     math::uint2 fParams; // stride-y, stride-z
     math::float2 origin; // viewport left, viewport bottom
 
-    float oneOverFroxelDimensionX;
+    float widthOverFroxelDimensionX;
     float iblLuminance;
     float exposure;
     float ev100;

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -60,13 +60,13 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("shadowBulbRadiusLs",      1, UniformInterfaceBlock::Type::FLOAT)
             .add("shadowBias",              1, UniformInterfaceBlock::Type::FLOAT)
             .add("shadowPenumbraRatioScale",1, UniformInterfaceBlock::Type::FLOAT)
-            .add("oneOverFroxelDimensionY", 1, UniformInterfaceBlock::Type::FLOAT)
+            .add("heightOverFroxelDimensionY", 1, UniformInterfaceBlock::Type::FLOAT)
             // froxels
             .add("zParams",                 1, UniformInterfaceBlock::Type::FLOAT4)
             .add("fParams",                 1, UniformInterfaceBlock::Type::UINT2)
             .add("origin",                  1, UniformInterfaceBlock::Type::FLOAT2)
             // froxels (again, for alignment purposes)
-            .add("oneOverFroxelDimension",  1, UniformInterfaceBlock::Type::FLOAT)
+            .add("widthOverFroxelDimension",  1, UniformInterfaceBlock::Type::FLOAT)
             // ibl
             .add("iblLuminance",            1, UniformInterfaceBlock::Type::FLOAT)
             // camera

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -27,8 +27,8 @@ struct FroxelParams {
 uvec3 getFroxelCoords(const highp vec3 fragCoords) {
     uvec3 froxelCoord;
 
-    froxelCoord.xy = uvec2(fragCoords.xy * frameUniforms.resolution.xy *
-            vec2(frameUniforms.oneOverFroxelDimension, frameUniforms.oneOverFroxelDimensionY));
+    froxelCoord.xy = uvec2(fragCoords.xy *
+            vec2(frameUniforms.widthOverFroxelDimension, frameUniforms.heightOverFroxelDimensionY));
 
     // go from screen-space to reciprocal of normalized view-space Z (i.e. scaled by 1/zLightFar)
     // we get away with the reciprocal because 1/z is handled by the log2() below.


### PR DESCRIPTION
this is because this uniform is not well defined -- it's unclear if
it is set to the viewport or the buffer size.

also, it's not needed, and removes a couple multiplies from the shader.