### PR TITLE
update binding points from 8 to 12.

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -42,22 +42,22 @@
  */
 namespace filament::backend {
 
-static constexpr uint64_t SWAP_CHAIN_CONFIG_TRANSPARENT = 0x1;
-static constexpr uint64_t SWAP_CHAIN_CONFIG_READABLE = 0x2;
-static constexpr uint64_t SWAP_CHAIN_CONFIG_ENABLE_XCB = 0x4;
+static constexpr uint64_t SWAP_CHAIN_CONFIG_TRANSPARENT         = 0x1;
+static constexpr uint64_t SWAP_CHAIN_CONFIG_READABLE            = 0x2;
+static constexpr uint64_t SWAP_CHAIN_CONFIG_ENABLE_XCB          = 0x4;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER = 0x8;
 
-static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 16; // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_VERTEX_SAMPLER_COUNT = 16;   // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_FRAGMENT_SAMPLER_COUNT = 16; // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_SAMPLER_COUNT = 32;          // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_VERTEX_BUFFER_COUNT = 16;    // Max number of bound buffer objects.
+static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT  = 16;   // This is guaranteed by OpenGL ES.
+static constexpr size_t MAX_VERTEX_SAMPLER_COUNT    = 16;   // This is guaranteed by OpenGL ES.
+static constexpr size_t MAX_FRAGMENT_SAMPLER_COUNT  = 16;   // This is guaranteed by OpenGL ES.
+static constexpr size_t MAX_SAMPLER_COUNT           = 32;   // This is guaranteed by OpenGL ES.
+static constexpr size_t MAX_VERTEX_BUFFER_COUNT     = 16;   // Max number of bound buffer objects.
 
 static_assert(MAX_VERTEX_BUFFER_COUNT <= MAX_VERTEX_ATTRIBUTE_COUNT,
         "The number of buffer objects that can be attached to a VertexBuffer must be "
         "less than or equal to the maximum number of vertex attributes.");
 
-static constexpr size_t CONFIG_BINDING_COUNT = 8;
+static constexpr size_t CONFIG_BINDING_COUNT = 12;  // This is guaranteed by OpenGL ES.
 
 /**
  * Selects which driver a particular Engine should use.

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -345,7 +345,7 @@ private:
     void setViewportScissor(Viewport const& viewportScissor) noexcept;
 
     // sampler buffer binding points (nullptr if not used)
-    std::array<HwSamplerGroup*, Program::BINDING_COUNT> mSamplerBindings = {};   // 8 pointers
+    std::array<HwSamplerGroup*, Program::BINDING_COUNT> mSamplerBindings = {};   // 12 pointers
 
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
     mutable std::vector<GLTexture*> mExternalStreams;

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -113,7 +113,7 @@ private:
     union {
         // when mInitialized == true:
         // information about each USED sampler buffer per binding (no gaps)
-        std::array<uint8_t, Program::BINDING_COUNT> mUsedBindingPoints;   // 8 bytes
+        std::array<uint8_t, Program::BINDING_COUNT> mUsedBindingPoints;   // 12 bytes
         // when mInitialized == false:
         // lazy initialization data pointer
         LazyInitializationData* mLazyInitializationData;

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -289,18 +289,17 @@ private:
 
     // Represents all the Vulkan state that comprises a bound descriptor set.
     struct DescriptorKey {
-        VkBuffer uniformBuffers[UBUFFER_BINDING_COUNT];             // 0
-        DescriptorImageInfo samplers[SAMPLER_BINDING_COUNT];        // 64
-        DescriptorImageInfo inputAttachments[TARGET_BINDING_COUNT]; // 832
-        uint32_t uniformBufferOffsets[UBUFFER_BINDING_COUNT];       // 1024
-        uint32_t uniformBufferSizes[UBUFFER_BINDING_COUNT];         // 1056
+        VkBuffer uniformBuffers[UBUFFER_BINDING_COUNT];             //   96     0
+        DescriptorImageInfo samplers[SAMPLER_BINDING_COUNT];        //  768    96
+        DescriptorImageInfo inputAttachments[TARGET_BINDING_COUNT]; //  192   864
+        uint32_t uniformBufferOffsets[UBUFFER_BINDING_COUNT];       //   48  1056
+        uint32_t uniformBufferSizes[UBUFFER_BINDING_COUNT];         //   48  1104
     };
-
-    static_assert(offsetof(DescriptorKey, samplers)              == 64);
-    static_assert(offsetof(DescriptorKey, inputAttachments)      == 832);
-    static_assert(offsetof(DescriptorKey, uniformBufferOffsets)  == 1024);
-    static_assert(offsetof(DescriptorKey, uniformBufferSizes)    == 1056);
-    static_assert(sizeof(DescriptorKey) == 1088, "DescriptorKey must not have implicit padding.");
+    static_assert(offsetof(DescriptorKey, samplers)              == 96);
+    static_assert(offsetof(DescriptorKey, inputAttachments)      == 864);
+    static_assert(offsetof(DescriptorKey, uniformBufferOffsets)  == 1056);
+    static_assert(offsetof(DescriptorKey, uniformBufferSizes)    == 1104);
+    static_assert(sizeof(DescriptorKey) == 1152, "DescriptorKey must not have implicit padding.");
 
     using DescHashFn = utils::hash::MurmurHashFn<DescriptorKey>;
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -42,7 +42,7 @@ namespace BindingPoints {
     constexpr uint8_t FROXEL_RECORDS             = 6;
     constexpr uint8_t PER_MATERIAL_INSTANCE      = 7;    // uniforms/samplers updates per material
     constexpr uint8_t COUNT                      = 8;
-    // These are limited by Program::UNIFORM_BINDING_COUNT (currently 8)
+    // These are limited by CONFIG_BINDING_COUNT (currently 12)
 }
 
 static_assert(BindingPoints::COUNT <= backend::CONFIG_BINDING_COUNT);


### PR DESCRIPTION
12 UBOs is the minspec in GLES3.0.  This in preparation of an upcoming change.