### PR TITLE
Optimize custom rendertargets use in Renderer

### DIFF
--- a/filament/src/details/RenderTarget.h
+++ b/filament/src/details/RenderTarget.h
@@ -55,6 +55,10 @@ public:
         return mAttachmentMask;
     }
 
+    backend::TargetBufferFlags getSampleableAttachmentsMask() const noexcept {
+        return mSampleableAttachmentsMask;
+    }
+
     uint8_t getSupportedColorAttachmentsCount() const noexcept {
         return mSupportedColorAttachmentsCount;
     }
@@ -67,6 +71,7 @@ private:
     Attachment mAttachments[ATTACHMENT_COUNT];
     HwHandle mHandle{};
     backend::TargetBufferFlags mAttachmentMask = {};
+    backend::TargetBufferFlags mSampleableAttachmentsMask = {};
     const uint8_t mSupportedColorAttachmentsCount;
 };
 


### PR DESCRIPTION
we just store the "sampleable" attachments as a bitmask in 
RenderTarget instead of computing it each time.