### PR TITLE
shrink post-process materials a bit

### DIFF
--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -40,20 +40,24 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("viewFromClipMatrix",      1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("clipFromWorldMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromClipMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("lightFromWorldMatrix",    4, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+
+            .add("clipControl",             1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("time",                    1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
+            .add("temporalNoise",           1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
+            .add("userTime",                1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
+
+            // ------------------------------------------------------------------------------------
+            // values below should only be accessed in surface materials
+            // ------------------------------------------------------------------------------------
 
             .add("origin",                  1, UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH)
             .add("offset",                  1, UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH)
             .add("resolution",              1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
 
-            .add("clipControl",             1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("padding2",                1, UniformInterfaceBlock::Type::FLOAT2)
-
-            .add("userTime",                1, UniformInterfaceBlock::Type::FLOAT4)
-            .add("time",                    1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
-            .add("temporalNoise",           1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
             .add("lodBias",                 1, UniformInterfaceBlock::Type::FLOAT)
             .add("refractionLodOffset",     1, UniformInterfaceBlock::Type::FLOAT)
+            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT)
+            .add("padding2",                1, UniformInterfaceBlock::Type::FLOAT)
 
             .add("cameraPosition",          1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
             .add("oneOverFarMinusNear",     1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
@@ -64,23 +68,36 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("ev100",                   1, UniformInterfaceBlock::Type::FLOAT)
             .add("needsAlphaChannel",       1, UniformInterfaceBlock::Type::FLOAT)
 
+            // AO
+            .add("aoSamplingQualityAndEdgeDistance", 1, UniformInterfaceBlock::Type::FLOAT)
+            .add("aoBentNormals",           1, UniformInterfaceBlock::Type::FLOAT)
+            .add("aoReserved0",             1, UniformInterfaceBlock::Type::FLOAT)
+            .add("aoReserved1",             1, UniformInterfaceBlock::Type::FLOAT)
+
+            // ------------------------------------------------------------------------------------
+            // Dynamic Lighting [variant: DYN]
+            // ------------------------------------------------------------------------------------
             .add("zParams",                 1, UniformInterfaceBlock::Type::FLOAT4)
             .add("fParams",                 1, UniformInterfaceBlock::Type::UINT3)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
+            .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
             .add("froxelCountXY",           1, UniformInterfaceBlock::Type::FLOAT2)
 
             .add("iblLuminance",            1, UniformInterfaceBlock::Type::FLOAT)
             .add("iblRoughnessOneLevel",    1, UniformInterfaceBlock::Type::FLOAT)
             .add("iblSH",                   9, UniformInterfaceBlock::Type::FLOAT3)
 
-            // Direct Lighting
+            // ------------------------------------------------------------------------------------
+            // Directional Lighting [variant: DIR]
+            // ------------------------------------------------------------------------------------
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
-            .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("lightFarAttenuationParams",1, UniformInterfaceBlock::Type::FLOAT2)
 
-            // Shadows
+            // ------------------------------------------------------------------------------------
+            // Directional light shadowing [variant: SRE | DIR]
+            // ------------------------------------------------------------------------------------
             .add("directionalShadows",      1, UniformInterfaceBlock::Type::UINT)
             .add("ssContactShadowDistance", 1, UniformInterfaceBlock::Type::FLOAT)
 
@@ -89,8 +106,19 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("shadowBulbRadiusLs",      1, UniformInterfaceBlock::Type::FLOAT)
             .add("shadowBias",              1, UniformInterfaceBlock::Type::FLOAT)
             .add("shadowPenumbraRatioScale",1, UniformInterfaceBlock::Type::FLOAT)
+            .add("lightFromWorldMatrix",    4, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
 
-            // Fog
+            // ------------------------------------------------------------------------------------
+            // VSM shadows [variant: VSM]
+            // ------------------------------------------------------------------------------------
+            .add("vsmExponent",             1, UniformInterfaceBlock::Type::FLOAT)
+            .add("vsmDepthScale",           1, UniformInterfaceBlock::Type::FLOAT)
+            .add("vsmLightBleedReduction",  1, UniformInterfaceBlock::Type::FLOAT)
+            .add("shadowSamplingType",      1, UniformInterfaceBlock::Type::UINT)
+
+            // ------------------------------------------------------------------------------------
+            // Fog [variant: FOG]
+            // ------------------------------------------------------------------------------------
             .add("fogStart",                1, UniformInterfaceBlock::Type::FLOAT)
             .add("fogMaxOpacity",           1, UniformInterfaceBlock::Type::FLOAT)
             .add("fogHeight",               1, UniformInterfaceBlock::Type::FLOAT)
@@ -102,19 +130,9 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("fogColorFromIbl",         1, UniformInterfaceBlock::Type::FLOAT)
             .add("fogReserved0",            1, UniformInterfaceBlock::Type::FLOAT)
 
-            // AO
-            .add("aoSamplingQualityAndEdgeDistance", 1, UniformInterfaceBlock::Type::FLOAT)
-            .add("aoBentNormals",           1, UniformInterfaceBlock::Type::FLOAT)
-            .add("aoReserved0",             1, UniformInterfaceBlock::Type::FLOAT)
-            .add("aoReserved1",             1, UniformInterfaceBlock::Type::FLOAT)
-
-            // VSM
-            .add("vsmExponent",             1, UniformInterfaceBlock::Type::FLOAT)
-            .add("vsmDepthScale",           1, UniformInterfaceBlock::Type::FLOAT)
-            .add("vsmLightBleedReduction",  1, UniformInterfaceBlock::Type::FLOAT)
-            .add("shadowSamplingType",      1, UniformInterfaceBlock::Type::UINT)
-
-            // Screen-space reflections
+            // ------------------------------------------------------------------------------------
+            // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]
+            // ------------------------------------------------------------------------------------
             .add("ssrReprojection",         1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("ssrUvFromViewMatrix",     1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("ssrThickness",            1, UniformInterfaceBlock::Type::FLOAT)

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -570,15 +570,16 @@ io::sstream& CodeGenerator::generatePostProcessInputs(io::sstream& out, ShaderTy
 
 io::sstream& CodeGenerator::generatePostProcessGetters(io::sstream& out,
         ShaderType type) {
-    out << SHADERS_COMMON_GETTERS_FS_DATA;
+    out << SHADERS_COMMON_GETTERS_GLSL_DATA;
     if (type == ShaderType::VERTEX) {
         out << SHADERS_POST_PROCESS_GETTERS_VS_DATA;
+    } else if (type == ShaderType::FRAGMENT) {
     }
     return out;
 }
 
 io::sstream& CodeGenerator::generateGetters(io::sstream& out, ShaderType type) {
-    out << SHADERS_COMMON_GETTERS_FS_DATA;
+    out << SHADERS_COMMON_GETTERS_GLSL_DATA;
     if (type == ShaderType::VERTEX) {
         out << SHADERS_GETTERS_VS_DATA;
     } else if (type == ShaderType::FRAGMENT) {

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -391,8 +391,7 @@ io::sstream& CodeGenerator::generateSamplers(
     return out;
 }
 
-io::sstream& CodeGenerator::generateSubpass(io::sstream& out,
-        SubpassInfo subpass) {
+io::sstream& CodeGenerator::generateSubpass(io::sstream& out, SubpassInfo subpass) {
     if (!subpass.isValid) {
         return out;
     }
@@ -529,6 +528,16 @@ io::sstream& CodeGenerator::generateCommon(io::sstream& out, ShaderType type) {
         out << SHADERS_COMMON_SHADING_FS_DATA;
         out << SHADERS_COMMON_GRAPHICS_FS_DATA;
         out << SHADERS_COMMON_MATERIAL_FS_DATA;
+    }
+    return out;
+}
+
+io::sstream& CodeGenerator::generatePostProcessCommon(io::sstream& out, ShaderType type) {
+    out << SHADERS_COMMON_MATH_GLSL_DATA;
+    if (type == ShaderType::VERTEX) {
+    } else if (type == ShaderType::FRAGMENT) {
+        out << SHADERS_COMMON_SHADING_FS_DATA;
+        out << SHADERS_COMMON_GRAPHICS_FS_DATA;
     }
     return out;
 }

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -65,6 +65,7 @@ public:
 
     // generate common functions for the given shader
     static utils::io::sstream& generateCommon(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generatePostProcessCommon(utils::io::sstream& out, ShaderType type) ;
     static utils::io::sstream& generateCommonMaterial(utils::io::sstream& out, ShaderType type) ;
 
     static utils::io::sstream& generateFog(utils::io::sstream& out, ShaderType type) ;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -555,7 +555,7 @@ std::string ShaderGenerator::createPostProcessVertexProgram(
             material.samplerBindings.getBlockOffset(BindingPoints::PER_MATERIAL_INSTANCE),
             material.sib);
 
-    CodeGenerator::generateCommon(vs, ShaderType::VERTEX);
+    CodeGenerator::generatePostProcessCommon(vs, ShaderType::VERTEX);
     CodeGenerator::generatePostProcessGetters(vs, ShaderType::VERTEX);
 
     appendShader(vs, mMaterialVertexCode, mMaterialVertexLineOffset);
@@ -596,7 +596,7 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(
     // subpass
     CodeGenerator::generateSubpass(fs, material.subpass);
 
-    CodeGenerator::generateCommon(fs, ShaderType::FRAGMENT);
+    CodeGenerator::generatePostProcessCommon(fs, ShaderType::FRAGMENT);
     CodeGenerator::generatePostProcessGetters(fs, ShaderType::FRAGMENT);
 
     // Generate post-process outputs.

--- a/libs/iblprefilter/src/materials/generateKernel.mat
+++ b/libs/iblprefilter/src/materials/generateKernel.mat
@@ -40,6 +40,12 @@ fragment {
 
 void dummy() {}
 
+#if defined(TARGET_MOBILE)
+#   define MIN_ROUGHNESS            0.007921
+#else
+#   define MIN_ROUGHNESS            0.002025
+#endif
+
 // we default to highp in this shader
 precision highp float;
 precision highp int;

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SHADERS
         src/ambient_occlusion.fs
         src/attributes.vs
         src/brdf.fs
-        src/common_getters.fs
+        src/common_getters.glsl
         src/common_graphics.fs
         src/common_lighting.fs
         src/common_material.fs

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -2,10 +2,6 @@
 // Uniforms access
 //------------------------------------------------------------------------------
 
-#define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x1u
-#define FILAMENT_OBJECT_MORPHING_ENABLED_BIT   0x2u
-#define FILAMENT_OBJECT_CONTACT_SHADOWS_BIT    0x4u
-
 /** @public-api */
 highp mat4 getViewFromWorldMatrix() {
     return frameUniforms.viewFromWorldMatrix;
@@ -37,21 +33,6 @@ highp mat4 getWorldFromClipMatrix() {
 }
 
 /** @public-api */
-highp vec4 getResolution() {
-    return frameUniforms.resolution;
-}
-
-/** @public-api */
-highp vec3 getWorldCameraPosition() {
-    return frameUniforms.cameraPosition;
-}
-
-/** @public-api */
-highp vec3 getWorldOffset() {
-    return frameUniforms.worldOffset;
-}
-
-/** @public-api */
 float getTime() {
     return frameUniforms.time;
 }
@@ -64,6 +45,27 @@ highp vec4 getUserTime() {
 /** @public-api **/
 highp float getUserTimeMod(float m) {
     return mod(mod(frameUniforms.userTime.x, m) + mod(frameUniforms.userTime.y, m), m);
+}
+
+// TODO: below shouldn't be accessible from post-process materials
+
+#define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x1u
+#define FILAMENT_OBJECT_MORPHING_ENABLED_BIT   0x2u
+#define FILAMENT_OBJECT_CONTACT_SHADOWS_BIT    0x4u
+
+/** @public-api */
+highp vec4 getResolution() {
+    return frameUniforms.resolution;
+}
+
+/** @public-api */
+highp vec3 getWorldCameraPosition() {
+    return frameUniforms.cameraPosition;
+}
+
+/** @public-api */
+highp vec3 getWorldOffset() {
+    return frameUniforms.worldOffset;
 }
 
 /** @public-api */


### PR DESCRIPTION
post-process materials don't need common_shadowing nor common_shading.

also don't rely on MIN_ROUGHNESS in .mat files, because it's not public.