### PR TITLE
Ensure we always have 4 "safe" mip levels

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## v1.22.0 (currently main branch)
 
 - engine: Changed UBOs layout [⚠️ **Material breakage**].
+- engine: Improve effects relying on mipmapping
 
 ## v1.21.3
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2169,7 +2169,7 @@ type aliases:
 
                  Name               |   Type   |            Description
 :-----------------------------------|:--------:|:------------------------------------
-**getResolution()**                 | float4   |  Resolution of the view in pixels: `width`, `height`, `1 / width`, `1 / height`
+**getResolution()**                 | float4   |  Dimensions of the view's effective viewport in pixels: `width`, `height`, `1 / width`, `1 / height`. This might be different from `View::getViewport()` for instance because of added rendering guard-bands. This can be used in conjunction with `getNormalizedViewportCoord()` to generate pixel coordinates.
 **getWorldCameraPosition()**        | float3   |  Position of the camera/eye in world space
 **getWorldOffset()**                | float3   |  The shift required to obtain API-level world space
 **getTime()**                       | float    |  Current time as a remainder of 1 second. Yields a value between 0 and 1

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -162,7 +162,7 @@ public:
 
         // Color grading, tone mapping, dithering and bloom
     FrameGraphId<FrameGraphTexture> colorGrading(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
             FrameGraphId<FrameGraphTexture> bloom,
             FrameGraphId<FrameGraphTexture> flare,
             const FColorGrading* colorGrading,
@@ -187,8 +187,8 @@ public:
 
     // Anti-aliasing
     FrameGraphId<FrameGraphTexture> fxaa(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, backend::TextureFormat outFormat,
-            bool translucent) noexcept;
+            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
+            backend::TextureFormat outFormat, bool translucent) noexcept;
 
     // Temporal Anti-aliasing
     void prepareTaa(FrameGraph& fg, filament::Viewport const& svp,
@@ -207,12 +207,13 @@ public:
 
     // Blit/rescaling/resolves
     FrameGraphId<FrameGraphTexture> opaqueBlit(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, FrameGraphTexture::Descriptor const& outDesc,
+            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
+            FrameGraphTexture::Descriptor const& outDesc,
             backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
 
     FrameGraphId<FrameGraphTexture> blendBlit(
             FrameGraph& fg, bool translucent, DynamicResolutionOptions dsrOptions,
-            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
             FrameGraphTexture::Descriptor const& outDesc) noexcept;
 
     // resolve base level of input and outputs a 1-level texture

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -233,7 +233,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // DEBUG: driver commands must all happen from the same thread. Enforce that on debug builds.
     driver.debugThreading();
 
-    filament::Viewport const& vp = view.getViewport();
     const bool hasPostProcess = view.hasPostProcessPass();
     bool hasColorGrading = hasPostProcess;
     bool hasDithering = view.getDithering() == Dithering::TEMPORAL;
@@ -248,6 +247,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     auto vignetteOptions = view.getVignetteOptions();
     auto colorGrading = view.getColorGrading();
     auto ssReflectionsOptions = view.getScreenSpaceReflectionsOptions();
+    const uint8_t msaaSampleCount = msaaOptions.enabled ? msaaOptions.sampleCount : 1u;
     if (!hasPostProcess) {
         // disable all effects that are part of post-processing
         dofOptions.enabled = false;
@@ -260,30 +260,107 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         scale = 1.0f;
     }
 
-    const uint8_t msaaSampleCount = msaaOptions.enabled ? msaaOptions.sampleCount : 1u;
+    const bool blendModeTranslucent = view.getBlendMode() == BlendMode::TRANSLUCENT;
+    // If the swap-chain is transparent or if we blend into it, we need to allocate our intermediate
+    // buffers with an alpha channel.
+    const bool needsAlphaChannel =
+            (mSwapChain && mSwapChain->isTransparent()) || blendModeTranslucent;
+
+    // asSubpass is disabled with TAA (although it's supported) because performance was degraded
+    // on qualcomm hardware -- we might need a backend dependent toggle at some point
+    const PostProcessManager::ColorGradingConfig colorGradingConfig{
+            .asSubpass =
+                    hasColorGrading &&
+                    msaaSampleCount <= 1 &&
+                    !bloomOptions.enabled && !dofOptions.enabled && !taaOptions.enabled &&
+                    driver.isFrameBufferFetchSupported(),
+            .customResolve =
+                    msaaOptions.customResolve &&
+                    msaaSampleCount > 1 &&
+                    hasColorGrading &&
+                    driver.isFrameBufferFetchMultiSampleSupported(),
+            .translucent = needsAlphaChannel,
+            .fxaa = hasFXAA,
+            .dithering = hasDithering,
+            .ldrFormat = (hasColorGrading && hasFXAA) ?
+                    TextureFormat::RGBA8 : getLdrFormat(needsAlphaChannel)
+    };
 
     // whether we're scaled at all
     const bool scaled = any(notEqual(scale, float2(1.0f)));
 
-    // The scale factor guarantees that the width and height are integers (multiple of 8, in fact),
-    // and all the code below ignores entirely svp's origin -- because we want to render the view
-    // at the origin of the buffer, so we set it to zero here to make that fact clear.
-    const filament::Viewport svp = {
+    // vp is the user defined viewport within the View
+    filament::Viewport const& vp = view.getViewport();
+
+    // svp is the "rendering" viewport. That is the viewport after dynamic-resolution is applied
+    // as well as other adjustment, such as the guard band.
+    filament::Viewport svp = {
             0, 0, // this is ignored
             uint32_t(float(vp.width ) * scale.x),
             uint32_t(float(vp.height) * scale.y)
     };
-
     if (svp.empty()) {
         return;
     }
 
-    const bool blendModeTranslucent = view.getBlendMode() == BlendMode::TRANSLUCENT;
-    // If the swap-chain is transparent or if we blend into it, we need to allocate our intermediate
-    // buffers with an alpha channel.
-    const bool needsAlphaChannel = (mSwapChain && mSwapChain->isTransparent()) || blendModeTranslucent;
+    // xvp is the viewport relative to svp containing the "interesting" rendering
+    filament::Viewport xvp = svp;
 
     CameraInfo cameraInfo = view.computeCameraInfo(engine);
+
+    // when colorgrading-as-subpass is active, we know that many other effects are disabled
+    // such as dof, bloom. Moreover if fxaa and scaling are not enabled, we're essentially in
+    // a very fast rendering path -- in this case, we would need an extra blit to "resolve" the
+    // buffer padding (because there are no other pass that can do it as a side effect).
+    // In this case, it is better to skip the padding, which won't be helping much.
+    const bool noBufferPadding = colorGradingConfig.asSubpass && !hasFXAA && !scaled;
+
+    if (hasPostProcess && !noBufferPadding) {
+        // We always pad the rendering viewport to dimensions multiple of 16, this guarantees
+        // that up to 4 mipmap levels are possible with an exact 1:2 scale. This also helps
+        // with memory allocations and quad-shading when dynamic-resolution is enabled.
+        // There is a small performance cost for dimensions that are not already multiple of 16.
+        // But, this a no-op in common resolutions, in particular in 720p.
+        // The origin of rendering is not modified, the padding is added to the right/top.
+        //
+        // TODO: use this feature to implement guard-bands
+        //
+        // TODO: Should we enable when we don't have post-processing?
+        //       Without post-processing, we usually draw directly into
+        //       the SwapChain, and we might want to keep it this way.
+
+        // compute the new rendering width and height, multiple of 16.
+        constexpr uint32_t rounding = 16u;
+        const float width  = float( (svp.width  + (rounding - 1u)) & ~(rounding - 1u) );
+        const float height = float( (svp.height + (rounding - 1u)) & ~(rounding - 1u) );
+
+        // scale the field-of-view up, so it covers exactly the extra pixels
+        const float3 clipSpaceScaling{
+                float(svp.width)  / width,
+                float(svp.height) / height,
+                1.0f };
+
+        // add the extra-pixels on the right/top of the viewport
+        // the translation comes from (same for height): 2*((width - svp.width)/2) / width
+        // i.e. we offset by half the width/height delta and the 2* comes from the fact that
+        // clip-space has width/height of 2.
+        // note: this creates an asymmetric frustum -- but we eventually copy only the
+        // left/bottom part, which is a symmetric region.
+        const float2 clipSpaceTranslation{
+                1.0f - clipSpaceScaling.x,
+                1.0f - clipSpaceScaling.y
+        };
+
+        mat4f ts = mat4f::scaling(clipSpaceScaling);
+        ts[3].xy = -clipSpaceTranslation;
+
+        // update the camera projection
+        cameraInfo.projection = highPrecisionMultiply(ts, cameraInfo.projection);
+
+        // adjust svp to the new, larger, rendering dimensions
+        svp.width  = uint32_t(width);
+        svp.height = uint32_t(height);
+    }
 
     view.prepare(engine, driver, arena, svp, cameraInfo, getShaderUserTime(), needsAlphaChannel);
 
@@ -391,7 +468,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     const TextureFormat hdrFormat = getHdrFormat(view, needsAlphaChannel);
 
     ColorPassConfig config{
-            .svp = svp,
+            .width = svp.width,
+            .height = svp.height,
+            .xoffset = (uint32_t)xvp.left,
+            .yoffset = (uint32_t)xvp.bottom,
             .scale = scale,
             .hdrFormat = hdrFormat,
             .msaa = msaaSampleCount,
@@ -399,25 +479,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             .clearColor = clearColor,
             .ssrLodOffset = 0.0f,
             .hasContactShadows = scene.hasContactShadows()
-    };
-
-    // asSubpass is disabled with TAA (although it's supported) because performance was degraded
-    // on qualcomm hardware -- we might need a backend dependent toggle at some point
-    const PostProcessManager::ColorGradingConfig colorGradingConfig{
-            .asSubpass =
-                    hasColorGrading &&
-                    msaaSampleCount <= 1 &&
-                    !bloomOptions.enabled && !dofOptions.enabled && !taaOptions.enabled &&
-                    driver.isFrameBufferFetchSupported(),
-            .customResolve =
-                    msaaOptions.customResolve &&
-                    msaaSampleCount > 1 &&
-                    hasColorGrading &&
-                    driver.isFrameBufferFetchMultiSampleSupported(),
-            .translucent = needsAlphaChannel,
-            .fxaa = hasFXAA,
-            .dithering = hasDithering,
-            .ldrFormat = (hasColorGrading && hasFXAA) ? TextureFormat::RGBA8 : getLdrFormat(needsAlphaChannel)
     };
 
     /*
@@ -436,7 +497,29 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     fg.addTrivialSideEffectPass("Prepare View Uniforms",
             [=, &uniforms = view.getPerViewUniforms()](DriverApi& driver) {
                 uniforms.prepareCamera(cameraInfo);
-                uniforms.prepareViewport(svp, 0, 0);
+
+                // The code here is a little fragile. In theory, we need to call prepareViewport()
+                // for each render pass, because the viewport parameters depend on the resolution.
+                // However, in practice, we only have two resolutions: the color pass resolution,
+                // and the structure pass which is governed by aoOptions.resolution (this could
+                // change in the future).
+                // So here we set the parameters for the structure pass and SSAO passes which
+                // are always done first. The SSR pass will also use these parameters which
+                // is wrong if it doesn't run at the same resolution as SSAO.
+                // preapreViewport() is called again during the color pass, which resets the
+                // values correctly for the Color pass, however, this will be again wrong
+                // for passes that come after the Color pass, such as DoF.
+                //
+                // The solution is to call prepareViewport() for each pass, really (so we should
+                // move it to its own UBO).
+                //
+                // The reason why this bug is acceptable is that the viewport parameters are
+                // currently only used for generating noise, so it's not too bad.
+
+                uniforms.prepareViewport(svp,
+                        xvp.left   * aoOptions.resolution,
+                        xvp.bottom * aoOptions.resolution);
+
                 uniforms.commit(driver);
             });
 
@@ -526,8 +609,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     pass.sortCommands();
 
     FrameGraphTexture::Descriptor desc = {
-            .width = config.svp.width,
-            .height = config.svp.height,
+            .width = config.width,
+            .height = config.height,
             .format = config.hdrFormat
     };
 
@@ -538,7 +621,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 if (colorGradingConfig.asSubpass) {
                     ppm.colorGradingPrepareSubpass(driver,
                             colorGrading, colorGradingConfig, vignetteOptions,
-                            config.svp.width, config.svp.height);
+                            config.width, config.height);
                 } else if (colorGradingConfig.customResolve) {
                     ppm.customResolvePrepareSubpass(driver,
                             PostProcessManager::CustomResolveOp::COMPRESS);
@@ -645,6 +728,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // --------------------------------------------------------------------------------------------
     // Post Processing...
 
+    auto const& inputDesc = fg.getDescriptor(input);
+    assert_invariant(inputDesc.width == svp.width);
+    assert_invariant(inputDesc.height == svp.height);
+
     bool mightNeedFinalBlit = true;
     if (hasPostProcess) {
         if (dofOptions.enabled) {
@@ -667,24 +754,30 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
         if (hasColorGrading) {
             if (!colorGradingConfig.asSubpass) {
-                input = ppm.colorGrading(fg, input, bloom, flare,
+                input = ppm.colorGrading(fg, input, xvp,
+                        bloom, flare,
                         colorGrading, colorGradingConfig,
                         bloomOptions, vignetteOptions);
+                // the padded buffer is resolved now
+                xvp.left = xvp.bottom = 0;
             }
         }
+
         if (hasFXAA) {
-            input = ppm.fxaa(fg, input, colorGradingConfig.ldrFormat,
+            input = ppm.fxaa(fg, input, xvp, colorGradingConfig.ldrFormat,
                     !hasColorGrading || needsAlphaChannel);
+            // the padded buffer is resolved now
+            xvp.left = xvp.bottom = 0;
         }
         if (scaled) {
             mightNeedFinalBlit = false;
-            auto viewport = DEBUG_DYNAMIC_SCALING ? svp : vp;
+            auto viewport = DEBUG_DYNAMIC_SCALING ? xvp : vp;
             if (UTILS_LIKELY(!blending && dsrOptions.quality == QualityLevel::LOW)) {
-                input = ppm.opaqueBlit(fg, input, {
+                input = ppm.opaqueBlit(fg, input, xvp, {
                         .width = viewport.width, .height = viewport.height,
                         .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::LINEAR);
             } else {
-                input = ppm.blendBlit(fg, blending, dsrOptions, input, {
+                input = ppm.blendBlit(fg, blending, dsrOptions, input, xvp, {
                         .width = viewport.width, .height = viewport.height,
                         .format = colorGradingConfig.ldrFormat });
             }
@@ -702,11 +795,14 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     //   as a subpass)
     // * And we also can't use the default rendertarget if frame history is needed (e.g. with
     //   screen-space reflections)
+    // * We also need an extra blit if we haven't yet handled "xvp"
+    //   TODO: in that specific scenario it would be better to just not use xvp
     // The intermediate buffer is accomplished with a "fake" opaqueBlit (i.e. blit) operation.
 
     const bool outputIsSwapChain = (input == colorPassOutput) && (viewRenderTarget == mRenderTarget);
     if (mightNeedFinalBlit) {
         if (blending ||
+            xvp != svp ||
             (outputIsSwapChain &&
                     (msaaSampleCount > 1 ||
                     colorGradingConfig.asSubpass ||
@@ -714,11 +810,11 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         {
             assert_invariant(!scaled);
             if (UTILS_LIKELY(!blending)) {
-                input = ppm.opaqueBlit(fg, input, {
+                input = ppm.opaqueBlit(fg, input, xvp, {
                         .width = vp.width, .height = vp.height,
                         .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::NEAREST);
             } else {
-                input = ppm.blendBlit(fg, blending, { .quality = QualityLevel::LOW }, input, {
+                input = ppm.blendBlit(fg, blending, { .quality = QualityLevel::LOW }, input, xvp, {
                         .width = vp.width, .height = vp.height,
                         .format = colorGradingConfig.ldrFormat});
             }
@@ -778,8 +874,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
                 {
                         // When rendering the opaques, we need to conserve the sample buffer,
                         // so create config that specifies the sample count.
-                        .width = config.svp.width,
-                        .height = config.svp.height,
+                        .width = config.width,
+                        .height = config.height,
                         .samples = config.msaa,
                         .format = config.hdrFormat
                 },
@@ -800,8 +896,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
         config.clearFlags = TargetBufferFlags::NONE;
         output = colorPass(fg, "Color Pass (transparent)",
                 {
-                        .width = config.svp.width,
-                        .height = config.svp.height
+                        .width = config.width,
+                        .height = config.height
                 },
                 config,
                 colorGradingConfig,
@@ -976,7 +1072,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 assert_invariant(
                         out.params.viewport.height == resources.getDescriptor(data.color).height);
 
-                view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport), 0u, 0u);
+                view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport),
+                        config.xoffset, config.yoffset);
                 view.commitUniforms(driver);
 
                 out.params.clearColor = data.clearColor;

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -143,8 +143,14 @@ private:
     void renderInternal(FView const* view);
 
     struct ColorPassConfig {
-        // Scaled (down) viewport from dynamic resolution
-        Viewport svp;
+        // Rendering viewport width (e.g. scaled down viewport from dynamic resolution)
+        uint32_t width;
+        // Rendering viewport height (e.g. scaled down viewport from dynamic resolution)
+        uint32_t height;
+        // Rendering offset within the viewport (e.g. non-zero when we have guard bands)
+        uint32_t xoffset;
+        // Rendering offset within the viewport (e.g. non-zero when we have guard bands)
+        uint32_t yoffset;
         // dynamic resolution scale
         math::float2 scale;
         // HDR format

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -160,10 +160,6 @@ float2 FView::updateScale(FEngine& engine,
         Renderer::FrameRateOptions const& frameRateOptions,
         Renderer::DisplayInfo const& displayInfo) noexcept {
 
-    // scale factor returned to the caller is modified so the scaled viewport is rounded to
-    // 8 pixels. The internal scale factor, mScale, doesn't have this rounding.
-    float2 roundedScale = mScale;
-
     DynamicResolutionOptions const& options = mDynamicResolution;
     if (options.enabled) {
         if (!UTILS_UNLIKELY(info.valid)) {
@@ -241,14 +237,8 @@ float2 FView::updateScale(FEngine& engine,
         // (i.e. we clamped). This help not to have to wait too long for the Integral term
         // to kick in after a clamping event.
         mPidController.setIntegralInhibitionEnabled(mScale != s);
-
-        // now tweak the scaling factor to get multiples of 8 (to help quad-shading)
-        // i.e. 8x8=64 fragments, to try to help with warp sizes.
-        roundedScale.x = mScale.x == 1.0f ? 1.0f : (std::floor(mScale.x * float{ w } / 8) * 8) / float{ w };
-        roundedScale.y = mScale.y == 1.0f ? 1.0f : (std::floor(mScale.y * float{ h } / 8) * 8) / float{ h };
     } else {
         mScale = 1.0f;
-        roundedScale = 1.0f;
     }
 
 #ifndef NDEBUG
@@ -270,7 +260,7 @@ float2 FView::updateScale(FEngine& engine,
     };
 #endif
 
-    return roundedScale;
+    return mScale;
 }
 
 void FView::setVisibleLayers(uint8_t select, uint8_t values) noexcept {

--- a/filament/src/fsr.cpp
+++ b/filament/src/fsr.cpp
@@ -39,14 +39,19 @@ using namespace math;
 #pragma clang diagnostic pop
 
 void FSR_ScalingSetup(FSRUniforms* outUniforms, FSRScalingConfig config) noexcept {
-    FsrEasuCon( outUniforms->EasuCon0.v, outUniforms->EasuCon1.v,
+    FsrEasuConOffset( outUniforms->EasuCon0.v, outUniforms->EasuCon1.v,
                 outUniforms->EasuCon2.v, outUniforms->EasuCon3.v,
             // Viewport size (top left aligned) in the input image which is to be scaled.
-            config.viewportWidth, config.viewportHeight,
+            config.input.width, config.input.height,
             // The size of the input image.
             config.inputWidth, config.inputHeight,
             // The output resolution.
-            config.outputWidth, config.outputHeight);
+            config.outputWidth, config.outputHeight,
+            // Input image offset
+            config.input.left, config.input.bottom);
+    // FIXME: FsrEasu api claims it needs the top,left offset, but when using that we get
+    //        some bad artifacts. To investigate. For reference:
+    //           top = config.inputHeight - (config.input.bottom + config.input.height)
 }
 
 void FSR_SharpeningSetup(FSRUniforms* outUniforms, FSRSharpeningConfig config) noexcept {

--- a/filament/src/fsr.h
+++ b/filament/src/fsr.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_FSR_H
 #define TNT_FILAMENT_FSR_H
 
+#include <filament/Viewport.h>
+
 #include <math/vec4.h>
 
 #include <stdint.h>
@@ -24,12 +26,11 @@
 namespace filament {
 
 struct FSRScalingConfig {
-    uint32_t viewportWidth;
-    uint32_t viewportHeight;
-    uint32_t inputWidth;
-    uint32_t inputHeight;
-    uint32_t outputWidth;
-    uint32_t outputHeight;
+    filament::Viewport input;   // region of source to be scaled
+    uint32_t inputWidth;        // width of source
+    uint32_t inputHeight;       // height of source
+    uint32_t outputWidth;       // width of destination
+    uint32_t outputHeight;      // height of destination
 };
 
 struct FSRSharpeningConfig {

--- a/filament/src/materials/antiAliasing/fxaa.mat
+++ b/filament/src/materials/antiAliasing/fxaa.mat
@@ -7,6 +7,11 @@ material {
             precision : medium
         },
         {
+            type : float4,
+            name : viewport,
+            precision : high
+        },
+        {
             type : float2,
             name : texelSize,
             precision : high
@@ -23,7 +28,7 @@ material {
 vertex {
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
     }
 
 }

--- a/filament/src/materials/blitLow.mat
+++ b/filament/src/materials/blitLow.mat
@@ -10,6 +10,11 @@ material {
             type : float4,
             name : resolution,
             precision: high
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision: high
         }
     ],
     variables : [
@@ -22,7 +27,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
     }
 }
 

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -59,6 +59,11 @@ material {
         {
             type : float4,
             name : vignetteColor
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision : high
         }
     ],
     variables : [
@@ -71,7 +76,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
     }
 }
 

--- a/filament/src/materials/fsr/fsr_easu.mat
+++ b/filament/src/materials/fsr/fsr_easu.mat
@@ -35,6 +35,11 @@ material {
             type : float4,
             name : EasuCon3,
             precision: high
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision: high
         }
     ],
     variables : [

--- a/filament/src/materials/fsr/fsr_easu_mobile.mat
+++ b/filament/src/materials/fsr/fsr_easu_mobile.mat
@@ -35,6 +35,11 @@ material {
             type : float4,
             name : EasuCon3,
             precision: high
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision: high
         }
     ],
     variables : [

--- a/filament/src/materials/fsr/fsr_easu_mobileF.mat
+++ b/filament/src/materials/fsr/fsr_easu_mobileF.mat
@@ -35,6 +35,11 @@ material {
             type : float4,
             name : EasuCon3,
             precision: high
+        },
+        {
+            type : float4,
+            name : viewport,
+            precision: high
         }
     ],
     variables : [


### PR DESCRIPTION
A "safe" mip-level is one that has exactly half the dimensions of
the current level. In other words, we guarantee that we can halve the
dimensions 4 times without loss (i.e. odd dimension).

This is achieved by effectively padding the viewport (i.e. making the
viewport's dimensions multiple of 16). The post-processing passes
eventually take care of cropping the extra padding so the final
image is unchanged.

This is a more generic solution to dynamic resolution padding, helps
with memory allocations and helps all the algorithms that depend on
mipmaping (e.g. DoF, SSAO, Bloom).


One important improvement brought by this change is that all "final"
post-processing effects are now able to handle a sub-region of the
source, including: color-gradding, fxaa and upscaling.