### PR TITLE
Ktx2Reader: Fix error in enum translation table.

### DIFF
--- a/libs/ktxreader/src/Ktx2Reader.cpp
+++ b/libs/ktxreader/src/Ktx2Reader.cpp
@@ -86,8 +86,8 @@ static FinalFormatInfo getFinalFormatInfo(Texture::InternalFormat fmt) {
         case tif::ETC2_EAC_RGBA8:  return {"ETC2_EAC_RGBA8", true, true, LINEAR, ttf::cTFETC2_RGBA, tct::ETC2_EAC_SRGBA8};
         case tif::DXT1_SRGB: return {"DXT1_SRGB", true, true, sRGB, ttf::cTFBC1_RGB, tct::DXT1_RGB};
         case tif::DXT1_RGB: return {"DXT1_RGB", true, true, LINEAR, ttf::cTFBC1_RGB, tct::DXT1_SRGB};
-        case tif::DXT3_SRGBA: return {"DXT3_SRGBA", true, true, sRGB, ttf::cTFBC3_RGBA, tct::DXT3_RGBA};
-        case tif::DXT3_RGBA: return {"DXT3_RGBA", true, true, LINEAR, ttf::cTFBC3_RGBA, tct::DXT3_SRGBA};
+        case tif::DXT5_SRGBA: return {"DXT5_SRGBA", true, true, sRGB, ttf::cTFBC3_RGBA, tct::DXT5_RGBA};
+        case tif::DXT5_RGBA: return {"DXT5_RGBA", true, true, LINEAR, ttf::cTFBC3_RGBA, tct::DXT5_SRGBA};
         case tif::SRGB8_ALPHA8_ASTC_4x4: return {"SRGB8_ALPHA8_ASTC_4x4", true, true, sRGB, ttf::cTFASTC_4x4_RGBA, tct::RGBA_ASTC_4x4};
         case tif::RGBA_ASTC_4x4: return {"RGBA_ASTC_4x4", true, true, LINEAR, ttf::cTFASTC_4x4_RGBA, tct::SRGB8_ALPHA8_ASTC_4x4};
         case tif::EAC_R11: return {"EAC_R11", true, true, LINEAR, ttf::cTFETC2_EAC_R11, tct::EAC_R11};

--- a/third_party/basisu/tnt/CMakeLists.txt
+++ b/third_party/basisu/tnt/CMakeLists.txt
@@ -44,7 +44,7 @@ set (BASIS_CONFIG
 # even for debug builds, since it is quite verbose.
 # set (BASIS_CONFIG ${BASIS_CONFIG} $<$<CONFIG:Debug>:BASISU_FORCE_DEVEL_MESSAGES=1>)
 
-# DXT5A and DXT1 are both required for cTFBC3_RGBA aka DXT3_RGBA.
+# DXT5A and DXT1 are both required for cTFBC3_RGBA aka DXT5_RGBA.
 if (NOT IS_MOBILE_TARGET)
     set (BASIS_CONFIG ${BASIS_CONFIG} BASISD_SUPPORT_DXT5A=1 BASISD_SUPPORT_DXT1=1)
 else()


### PR DESCRIPTION
This caused DXT5 content to be interpreted as DXT3 by the GPU,
which seemed to manifest as visual artifacts in the alpha channel.