### PR TITLE
Various glTF-related cleanup and enhancements.

### DIFF
--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -120,10 +120,34 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetLightEntities(JNIEnv* env, jclass,
         jlong nativeAsset, jintArray result) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    jsize available = env->GetArrayLength(result);
+    const jsize available = env->GetArrayLength(result);
+    const size_t minCount = std::min(available, (jsize) asset->getLightEntityCount());
+    if (minCount == 0) {
+        return;
+    }
     Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
-    std::copy_n(asset->getLightEntities(),
-            std::min(available, (jsize) asset->getLightEntityCount()), entities);
+    std::copy_n(asset->getLightEntities(), minCount, entities);
+    env->ReleaseIntArrayElements(result, (jint*) entities, 0);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetRenderableEntityCount(JNIEnv*, jclass,
+        jlong nativeAsset) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    return asset->getRenderableEntityCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetRenderableEntities(JNIEnv* env, jclass,
+        jlong nativeAsset, jintArray result) {
+    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
+    const jsize available = env->GetArrayLength(result);
+    const size_t minCount = std::min(available, (jsize) asset->getRenderableEntityCount());
+    if (minCount == 0) {
+        return;
+    }
+    Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
+    std::copy_n(asset->getRenderableEntities(), minCount, entities);
     env->ReleaseIntArrayElements(result, (jint*) entities, 0);
 }
 
@@ -131,10 +155,13 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetCameraEntities(JNIEnv* env, jclass,
         jlong nativeAsset, jintArray result) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    jsize available = env->GetArrayLength(result);
+    const jsize available = env->GetArrayLength(result);
+    const size_t minCount = std::min(available, (jsize) asset->getCameraEntityCount());
+    if (minCount == 0) {
+        return;
+    }
     Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
-    std::copy_n(asset->getCameraEntities(),
-            std::min(available, (jsize) asset->getCameraEntityCount()), entities);
+    std::copy_n(asset->getCameraEntities(), minCount, entities);
     env->ReleaseIntArrayElements(result, (jint*) entities, 0);
 }
 

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -114,6 +114,15 @@ public class FilamentAsset {
     }
 
     /**
+     * Gets only the entities that have renderable components.
+     */
+    public @NonNull @Entity int[] getRenderableEntities() {
+        int[] result = new int[nGetRenderableEntityCount(mNativeObject)];
+        nGetRenderableEntities(mNativeObject, result);
+        return result;
+    }
+
+    /**
      * Gets only the entities that have camera components.
      *
      * <p>
@@ -320,6 +329,9 @@ public class FilamentAsset {
 
     private static native int nGetLightEntityCount(long nativeAsset);
     private static native void nGetLightEntities(long nativeAsset, int[] result);
+
+    private static native int nGetRenderableEntityCount(long nativeAsset);
+    private static native void nGetRenderableEntities(long nativeAsset, int[] result);
 
     private static native int nGetCameraEntityCount(long nativeAsset);
     private static native void nGetCameraEntities(long nativeAsset, int[] result);

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -78,6 +78,16 @@ public:
     size_t getLightEntityCount() const noexcept;
 
     /**
+     * Gets the list of entities in the asset that have renderable components.
+     */
+    const utils::Entity* getRenderableEntities() const noexcept;
+
+    /**
+     * Gets the number of entities returned by getRenderableEntities().
+     */
+    size_t getRenderableEntityCount() const noexcept;
+
+    /**
      * Gets the list of entities in the scene representing cameras. All of these have a \c Camera
      * component.
      *

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -139,6 +139,14 @@ struct FFilamentAsset : public FilamentAsset {
         return mLightEntities.size();
     }
 
+    const utils::Entity* getRenderableEntities() const noexcept {
+        return (mRenderableCount == 0) ? nullptr : mEntities.data();
+    }
+
+    size_t getRenderableEntityCount() const noexcept {
+        return mRenderableCount;
+    }
+
     const utils::Entity* getCameraEntities() const noexcept {
         return mCameraEntities.empty() ? nullptr : mCameraEntities.data();
     }
@@ -250,9 +258,10 @@ struct FFilamentAsset : public FilamentAsset {
     filament::Engine* mEngine;
     utils::NameComponentManager* mNameManager;
     utils::EntityManager* mEntityManager;
-    std::vector<utils::Entity> mEntities;
+    std::vector<utils::Entity> mEntities; // sorted such that renderables come first
     std::vector<utils::Entity> mLightEntities;
     std::vector<utils::Entity> mCameraEntities;
+    size_t mRenderableCount = 0;
     std::vector<filament::MaterialInstance*> mMaterialInstances;
     std::vector<filament::VertexBuffer*> mVertexBuffers;
     std::vector<filament::BufferObject*> mBufferObjects;

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -280,6 +280,14 @@ size_t FilamentAsset::getLightEntityCount() const noexcept {
     return upcast(this)->getLightEntityCount();
 }
 
+const Entity* FilamentAsset::getRenderableEntities() const noexcept {
+    return upcast(this)->getRenderableEntities();
+}
+
+size_t FilamentAsset::getRenderableEntityCount() const noexcept {
+    return upcast(this)->getRenderableEntityCount();
+}
+
 const utils::Entity* FilamentAsset::getCameraEntities() const noexcept {
     return upcast(this)->getCameraEntities();
 }

--- a/libs/viewer/include/viewer/ViewerGui.h
+++ b/libs/viewer/include/viewer/ViewerGui.h
@@ -76,15 +76,25 @@ public:
     ~ViewerGui();
 
     /**
-     * Adds the asset's ready-to-render entities into the scene.
+     * Sets the viewer's current asset.
      *
      * The viewer does not claim ownership over the asset or its entities. Clients should use
      * AssetLoader and ResourceLoader to load an asset before passing it in.
      *
+     * This method does not add renderables to the scene; see populateScene().
+     *
      * @param asset The asset to view.
      * @param instanceToAnimate Optional instance from which to get the animator.
      */
-    void populateScene(FilamentAsset* asset, FilamentInstance* instanceToAnimate = nullptr);
+    void setAsset(FilamentAsset* asset,  FilamentInstance* instanceToAnimate = nullptr);
+
+    /**
+     * Adds the asset's ready-to-render entities into the scene.
+     *
+     * This is used for asychronous loading. It can be called once per frame to gradually add
+     * entities into the scene as their textures are loaded.
+     */
+    void populateScene();
 
     /**
      * Removes the current asset from the viewer.

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -394,7 +394,7 @@ ViewerGui::~ViewerGui() {
     delete mImGuiHelper;
 }
 
-void ViewerGui::populateScene(FilamentAsset* asset,  FilamentInstance* instanceToAnimate) {
+void ViewerGui::setAsset(FilamentAsset* asset,  FilamentInstance* instanceToAnimate) {
     if (mAsset != asset) {
         removeAsset();
         mAsset = asset;
@@ -407,7 +407,9 @@ void ViewerGui::populateScene(FilamentAsset* asset,  FilamentInstance* instanceT
         updateRootTransform();
         mScene->addEntities(asset->getLightEntities(), asset->getLightEntityCount());
     }
+}
 
+void ViewerGui::populateScene() {
     auto& tcm = mEngine->getRenderableManager();
 
     static constexpr int kNumAvailable = 128;
@@ -847,8 +849,9 @@ void ViewerGui::updateUserInterface() {
     if (ImGui::CollapsingHeader("Scene")) {
         ImGui::Indent();
 
-        ImGui::Checkbox("Scale to unit cube", &mSettings.viewer.autoScaleEnabled);
-        updateRootTransform();
+        if (ImGui::Checkbox("Scale to unit cube", &mSettings.viewer.autoScaleEnabled)) {
+            updateRootTransform();
+        }
 
         ImGui::Checkbox("Show skybox", &mSettings.viewer.skyboxEnabled);
         ImGui::ColorEdit3("Background color", &mSettings.viewer.backgroundColor.r);

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -254,6 +254,10 @@ int main(int argc, char** argv) {
             loadAsset(filename);
         }
 
+        FilamentInstance* const instance = app.instanceToAnimate > -1 ?
+                app.instances[app.instanceToAnimate] : nullptr;
+        app.viewer->setAsset(app.asset, instance);
+
         arrangeIntoCircle();
         loadResources(filename);
     };
@@ -271,12 +275,8 @@ int main(int argc, char** argv) {
 
     auto animate = [&app, arrangeIntoCircle](Engine* engine, View* view, double now) {
         app.resourceLoader->asyncUpdateLoad();
-        FilamentInstance* instance = nullptr;
-        if (app.instanceToAnimate > -1) {
-            instance = app.instances[app.instanceToAnimate];
-        }
         app.viewer->updateRootTransform();
-        app.viewer->populateScene(app.asset, instance);
+        app.viewer->populateScene();
         app.viewer->applyAnimation(now);
 
         // Add a new instance every second until reaching 100 instances.

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -505,6 +505,7 @@ int main(int argc, char** argv) {
         } else {
             loadAsset(filename);
         }
+        app.viewer->setAsset(app.asset);
 
         loadResources(filename);
 
@@ -665,8 +666,8 @@ int main(int argc, char** argv) {
         // Optionally fit the model into a unit cube at the origin.
         app.viewer->updateRootTransform();
 
-        // Add renderables to the scene as they become ready.
-        app.viewer->populateScene(app.asset);
+        // Gradually add renderables to the scene as their textures become ready.
+        app.viewer->populateScene();
 
         app.viewer->applyAnimation(now);
     };

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -702,6 +702,10 @@ Filament.loadClassExtensions = function() {
         return Filament.vectorToArray(this._getLightEntities());
     };
 
+    Filament.gltfio$FilamentAsset.prototype.getRenderableEntities = function() {
+        return Filament.vectorToArray(this._getRenderableEntities());
+    };
+
     Filament.gltfio$FilamentAsset.prototype.getCameraEntities = function() {
         return Filament.vectorToArray(this._getCameraEntities());
     };

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -629,6 +629,7 @@ export class gltfio$FilamentAsset {
     public getEntityByName(name: string): Entity;
     public getEntitiesByPrefix(name: string): Entity[];
     public getLightEntities(): Entity[];
+    public getRenderableEntities(): Entity[];
     public getCameraEntities(): Entity[];
     public getRoot(): Entity;
     public popRenderable(): Entity;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1826,6 +1826,11 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         return EntityVector(ptr, ptr + self->getLightEntityCount());
     }), allow_raw_pointers())
 
+    .function("_getRenderableEntities", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self), {
+        const utils::Entity* ptr = self->getRenderableEntities();
+        return EntityVector(ptr, ptr + self->getRenderableEntityCount());
+    }), allow_raw_pointers())
+
     .function("_getCameraEntities", EMBIND_LAMBDA(EntityVector, (FilamentAsset* self), {
         const utils::Entity* ptr = self->getCameraEntities();
         return EntityVector(ptr, ptr + self->getCameraEntityCount());

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -87,15 +87,6 @@ class App {
         const onDone = () => {
             this.allowRefresh = true;
 
-            // Enable shadows on every renderable.
-            const entities = asset.getEntities();
-            const rm = engine.getRenderableManager();
-            for (const entity of entities) {
-                const instance = rm.getInstance(entity);
-                rm.setCastShadows(instance, true);
-                instance.delete();
-            }
-
             // Hide the HUD.
             messages.remove();
         };
@@ -149,7 +140,7 @@ class App {
         tcm.setTransform(inst, this.trackball.getMatrix());
         inst.delete();
 
-        // Add renderable entities to the scene as they become ready.
+        // Gradually add renderables to the scene as their textures become ready.
         let entity;
         const popRenderable = () => {
             entity = this.asset.popRenderable();


### PR DESCRIPTION
- For completion, FilamentAsset now has getRenderableEntities(). This is
  similar to sister methods getLightEntities() and getCameraEntities()
  except there is no need to store a separate array.

- The web helmet demo does not need to enable shadows, they are already
  enabled.

- The ViewerGui populateAsset() method was doing two things that are
  now decoupled for clarity: setAsset() and populateAsset().

- The updateRootTransform() method is now called only when the autoscale
  checkbox is toggled, instead of every frame.

- The getFooEntities() methods in Java now skip doing work for empty
  lists. Actually these should not return arrays at all, but let's fix
  that later, since it will break backwards compatibility.