### PR TITLE
Add presentation time to Renderer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## v1.22.1 (currently main branch)
 
 - Metal: Shaders now use `half` floating-point arithmetic when possible for improved performance. [⚠️ **Recompile Materials**]
+- engine: add support for presentation time in `Renderer`
 
 ## v1.22.0
 

--- a/android/filament-android/src/main/cpp/Renderer.cpp
+++ b/android/filament-android/src/main/cpp/Renderer.cpp
@@ -156,12 +156,9 @@ Java_com_google_android_filament_Renderer_nResetUserTime(JNIEnv*, jclass, jlong 
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_Renderer_nSetDisplayInfo(JNIEnv*, jclass, jlong nativeRenderer,
-        jfloat refreshRate, jlong presentationDeadlineNanos, jlong vsyncOffsetNanos) {
+Java_com_google_android_filament_Renderer_nSetDisplayInfo(JNIEnv*, jclass, jlong nativeRenderer, jfloat refreshRate) {
     Renderer *renderer = (Renderer *) nativeRenderer;
-    renderer->setDisplayInfo({ .refreshRate = refreshRate,
-                               .presentationDeadlineNanos = (uint64_t)presentationDeadlineNanos,
-                               .vsyncOffsetNanos = (uint64_t)vsyncOffsetNanos });
+    renderer->setDisplayInfo({ .refreshRate = refreshRate });
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -182,4 +179,11 @@ Java_com_google_android_filament_Renderer_nSetClearOptions(JNIEnv *, jclass ,
     renderer->setClearOptions({ .clearColor = {r, g, b, a},
                                 .clear = (bool) clear,
                                 .discard = (bool) discard});
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_Renderer_nSetPresentationTime(JNIEnv *, jclass ,
+    jlong nativeRenderer, jlong monotonicClockNanos) {
+    Renderer *renderer = (Renderer *) nativeRenderer;
+    renderer->setPresentationTime(monotonicClockNanos);
 }

--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -61,13 +61,17 @@ public class Renderer {
         /**
          * How far in advance a buffer must be queued for presentation at a given time in ns
          * On Android you can use {@link android.view.Display#getPresentationDeadlineNanos()}.
+         * @deprecated this value is ignored
          */
+        @Deprecated
         public long presentationDeadlineNanos = 0;
 
         /**
          * Offset by which vsyncSteadyClockTimeNano provided in beginFrame() is offset in ns
          * On Android you can use {@link android.view.Display#getAppVsyncOffsetNanos()}.
+         * @deprecated this value is ignored
          */
+        @Deprecated
         public long vsyncOffsetNanos = 0;
     };
 
@@ -175,8 +179,7 @@ public class Renderer {
      */
     public void setDisplayInfo(@NonNull DisplayInfo info) {
         mDisplayInfo = info;
-        nSetDisplayInfo(getNativeObject(),
-                info.refreshRate, info.presentationDeadlineNanos, info.vsyncOffsetNanos);
+        nSetDisplayInfo(getNativeObject(), info.refreshRate);
     }
 
     /**
@@ -245,6 +248,23 @@ public class Renderer {
     @NonNull
     public Engine getEngine() {
         return mEngine;
+    }
+
+    /**
+     * Set the time at which the frame must be presented to the display.
+     * <p>
+     * This must be called between {@link #beginFrame} and {@link #endFrame}.
+     * </p>
+     *
+     * @param monotonicClockNanos  The time in nanoseconds corresponding to the system monotonic
+     *                             up-time clock. The presentation time is typically set in the
+     *                             middle of the period of interest and cannot be too far in the
+     *                             future as it is limited by how many buffers are available in
+     *                             the display sub-system. Typically it is set to 1 or 2 vsync
+     *                             periods away.
+     */
+    public void setPresentationTime(long monotonicClockNanos) {
+        nSetPresentationTime(getNativeObject(), monotonicClockNanos);
     }
 
     /**
@@ -664,6 +684,7 @@ public class Renderer {
         mNativeObject = 0;
     }
 
+    private static native void nSetPresentationTime(long nativeObject, long monotonicClockNanos);
     private static native boolean nBeginFrame(long nativeRenderer, long nativeSwapChain, long frameTimeNanos);
     private static native void nEndFrame(long nativeRenderer);
     private static native void nRender(long nativeRenderer, long nativeView);
@@ -685,8 +706,7 @@ public class Renderer {
             Object handler, Runnable callback);
     private static native double nGetUserTime(long nativeRenderer);
     private static native void nResetUserTime(long nativeRenderer);
-    private static native void nSetDisplayInfo(long nativeRenderer,
-            float refreshRate, long presentationDeadlineNanos, long vsyncOffsetNanos);
+    private static native void nSetDisplayInfo(long nativeRenderer, float refreshRate);
     private static native void nSetFrameRateOptions(long nativeRenderer,
             float interval, float headRoomRatio, float scaleRate, int history);
     private static native void nSetClearOptions(long nativeRenderer,

--- a/android/filament-android/src/main/java/com/google/android/filament/android/DisplayHelper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/android/DisplayHelper.java
@@ -157,8 +157,6 @@ public class DisplayHelper {
             info = new Renderer.DisplayInfo();
         }
         info.refreshRate = DisplayHelper.getRefreshRate(display);
-        info.presentationDeadlineNanos = DisplayHelper.getPresentationDeadlineNanos(display);
-        info.vsyncOffsetNanos = DisplayHelper.getAppVsyncOffsetNanos(display);
         return info;
     }
 

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -80,11 +80,8 @@ public:
         // refresh-rate of the display in Hz. set to 0 for offscreen or turn off frame-pacing.
         float refreshRate = 60.0f;
 
-        // how far in advance a buffer must be queued for presentation at a given time in ns
-        uint64_t presentationDeadlineNanos = 0;
-
-        // offset by which vsyncSteadyClockTimeNano provided in beginFrame() is offset in ns
-        uint64_t vsyncOffsetNanos = 0;
+        [[deprecated]] uint64_t presentationDeadlineNanos = 0;
+        [[deprecated]] uint64_t vsyncOffsetNanos = 0;
     };
 
     /**
@@ -242,6 +239,20 @@ public:
      */
     bool beginFrame(SwapChain* swapChain,
             uint64_t vsyncSteadyClockTimeNano = 0u);
+
+    /**
+     * Set the time at which the frame must be presented to the display.
+     *
+     * This must be called between beginFrame() and endFrame().
+     *
+     * @param monotonic_clock_ns  the time in nanoseconds corresponding to the system monotonic up-time clock.
+     *                            the presentation time is typically set in the middle of the period
+     *                            of interest. The presentation time cannot be too far in the
+     *                            future because it is limited by how many buffers are available in
+     *                            the display sub-system. Typically it is set to 1 or 2 vsync periods
+     *                            away.
+     */
+    void setPresentationTime(int64_t monotonic_clock_ns);
 
     /**
      * Render a View into this renderer's window.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -32,6 +32,10 @@ void Renderer::render(View const* view) {
     upcast(this)->render(upcast(view));
 }
 
+void Renderer::setPresentationTime(int64_t monotonic_clock_ns) {
+    upcast(this)->setPresentationTime(monotonic_clock_ns);
+}
+
 bool Renderer::beginFrame(SwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano) {
     return upcast(this)->beginFrame(upcast(swapChain), vsyncSteadyClockTimeNano);
 }

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -75,6 +75,9 @@ public:
     // renders a single standalone view. The view must have a a custom rendertarget.
     void renderStandaloneView(FView const* view);
 
+
+    void setPresentationTime(int64_t monotonic_clock_ns);
+
     // start a frame
     bool beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeNano);
 
@@ -99,7 +102,7 @@ public:
 
 
     void setDisplayInfo(DisplayInfo const& info) noexcept {
-        mDisplayInfo = info;
+        mDisplayInfo.refreshRate = info.refreshRate;
     }
 
     void setFrameRateOptions(FrameRateOptions const& options) noexcept {


### PR DESCRIPTION
Also deprecate some fields of DisplayInfo this shouldn't be a problem
because they were not actually used.


This change should allow an external-to-filament code to manage 
frame pacing (e.g. something like swappy).