### PR TITLE
Implement an optional guard band for screen-space effects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - Metal: Shaders now use `half` floating-point arithmetic when possible for improved performance. [⚠️ **Recompile Materials**]
 - engine: add support for presentation time in `Renderer`
+- engine: added guard bands support for screen-space effects
 
 ## v1.22.0
 

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -461,3 +461,11 @@ Java_com_google_android_filament_View_nPick(JNIEnv* env, jclass,
         JniCallback::postToJavaAndDestroy(callback);
     }, callback->getHandler());
 }
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nSetGuardBandOptions(JNIEnv *, jclass,
+        jlong nativeView, jboolean enabled) {
+    View* view = (View*) nativeView;
+    view->setGuardBandOptions({ .enabled = (bool)enabled });
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -83,6 +83,7 @@ public class View {
     private MultiSampleAntiAliasingOptions mMultiSampleAntiAliasingOptions;
     private VsmShadowOptions mVsmShadowOptions;
     private SoftShadowOptions mSoftShadowOptions;
+    private GuardBandOptions mGuardBandOptions;
 
     /**
      * Generic quality level.
@@ -357,6 +358,19 @@ public class View {
         public boolean enabled = false;
     };
 
+    /**
+     * Options for the  screen-space guard band.
+     * A guard band can be enabled to avoid some artifacts towards the edge of the screen when
+     * using screen-space effects such as SSAO.
+     * Enabling the guard band reduces performance slightly.
+     * Currently the guard band can only be enabled or disabled.
+     *
+     * @see View#setGuardBandOptions
+     */
+    public static class GuardBandOptions {
+        /** enables or disables the guard band */
+        public boolean enabled = false;
+    };
 
     /**
      * Options for controlling the Bloom effect
@@ -1209,17 +1223,6 @@ public class View {
     }
 
     /**
-     * Enables or disable screen-space reflections. Disabled by default.
-     *
-     * @param options screen-space reflections options
-     */
-    public void setScreenSpaceReflectionsOptions(@NonNull ScreenSpaceReflectionsOptions options) {
-        mScreenSpaceReflectionsOptions = options;
-        nSetScreenSpaceReflectionsOptions(getNativeObject(), options.thickness, options.bias,
-                options.maxDistance, options.stride, options.enabled);
-    }
-
-    /**
      * Returns temporal anti-aliasing options.
      *
      * @return temporal anti-aliasing options
@@ -1230,6 +1233,17 @@ public class View {
             mTemporalAntiAliasingOptions = new TemporalAntiAliasingOptions();
         }
         return mTemporalAntiAliasingOptions;
+    }
+
+    /**
+     * Enables or disable screen-space reflections. Disabled by default.
+     *
+     * @param options screen-space reflections options
+     */
+    public void setScreenSpaceReflectionsOptions(@NonNull ScreenSpaceReflectionsOptions options) {
+        mScreenSpaceReflectionsOptions = options;
+        nSetScreenSpaceReflectionsOptions(getNativeObject(), options.thickness, options.bias,
+                options.maxDistance, options.stride, options.enabled);
     }
 
     /**
@@ -1244,6 +1258,30 @@ public class View {
         }
         return mScreenSpaceReflectionsOptions;
     }
+
+    /**
+     * Enables or disable screen-space guard band. Disabled by default.
+     *
+     * @param options guard band options
+     */
+    public void setGuardBandOptions(@NonNull GuardBandOptions options) {
+        mGuardBandOptions = options;
+        nSetGuardBandOptions(getNativeObject(), options.enabled);
+    }
+
+    /**
+     * Returns screen-space guard band options.
+     *
+     * @return guard band options
+     */
+    @NonNull
+    public GuardBandOptions getGuardBandOptions() {
+        if (mGuardBandOptions == null) {
+            mGuardBandOptions = new GuardBandOptions();
+        }
+        return mGuardBandOptions;
+    }
+
 
     /**
      * Enables or disables tone-mapping in the post-processing stage. Enabled by default.
@@ -1833,6 +1871,7 @@ public class View {
     private static native void nSetMultiSampleAntiAliasingOptions(long nativeView, boolean enabled, int sampleCount, boolean customResolve);
     private static native boolean nIsShadowingEnabled(long nativeView);
     private static native void nSetScreenSpaceRefractionEnabled(long nativeView, boolean enabled);
+    private static native void nSetGuardBandOptions(long nativeView, boolean enabled);
     private static native boolean nIsScreenSpaceRefractionEnabled(long nativeView);
     private static native void nPick(long nativeView, int x, int y, Object handler, InternalOnPickCallback internalCallback);
 }

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -329,6 +329,16 @@ struct ScreenSpaceReflectionsOptions {
 };
 
 /**
+ * Options for the  screen-space guard band.
+ * A guard band can be enabled to avoid some artifacts towards the edge of the screen when
+ * using screen-space effects such as SSAO. Enabling the guard band reduces performance slightly.
+ * Currently the guard band can only be enabled or disabled.
+ */
+struct GuardBandOptions {
+    bool enabled = false;
+};
+
+/**
  * List of available post-processing anti-aliasing techniques.
  * @see setAntiAliasing, getAntiAliasing, setSampleCount
  */

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -84,6 +84,7 @@ public:
     using VsmShadowOptions = VsmShadowOptions;
     using SoftShadowOptions = SoftShadowOptions;
     using ScreenSpaceReflectionsOptions = ScreenSpaceReflectionsOptions;
+    using GuardBandOptions = GuardBandOptions;
 
     /**
      * Sets the View's name. Only useful for debugging.
@@ -344,6 +345,20 @@ public:
      * @return screen-space reflections options
      */
     ScreenSpaceReflectionsOptions const& getScreenSpaceReflectionsOptions() const noexcept;
+
+    /**
+     * Enables or disable screen-space guard band. Disabled by default.
+     *
+     * @param options guard band options
+     */
+    void setGuardBandOptions(GuardBandOptions options) noexcept;
+
+    /**
+     * Returns screen-space guard band options.
+     *
+     * @return guard band options
+     */
+    GuardBandOptions const& getGuardBandOptions() const noexcept;
 
     /**
      * Enables or disable multi-sample anti-aliasing (MSAA). Disabled by default.

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -123,6 +123,14 @@ const View::ScreenSpaceReflectionsOptions& View::getScreenSpaceReflectionsOption
     return upcast(this)->getScreenSpaceReflectionsOptions();
 }
 
+void View::setGuardBandOptions(GuardBandOptions options) noexcept {
+    upcast(this)->setGuardBandOptions(options);
+}
+
+GuardBandOptions const& View::getGuardBandOptions() const noexcept {
+    return upcast(this)->getGuardBandOptions();
+}
+
 void View::setColorGrading(ColorGrading* colorGrading) noexcept {
     return upcast(this)->setColorGrading(upcast(colorGrading));
 }

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -478,13 +478,6 @@ public:
             float dzf =  1.0f;
         } shadowmap;
         struct {
-            bool enabled = true;
-            int sampleCount = 7;
-            int spiralTurns = 1;
-            int kernelSize = 23;
-            float stddev = 8.0f;
-        } ssao;
-        struct {
             bool camera_at_origin = true;
             struct {
                 float kp = 0.0f;

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -953,6 +953,10 @@ void FView::setScreenSpaceReflectionsOptions(ScreenSpaceReflectionsOptions optio
     mScreenSpaceReflectionsOptions = options;
 }
 
+void FView::setGuardBandOptions(GuardBandOptions options) noexcept {
+    mGuardBandOptions = options;
+}
+
 void FView::setAmbientOcclusionOptions(AmbientOcclusionOptions options) noexcept {
     options.radius = math::max(0.0f, options.radius);
     options.power = std::max(0.0f, options.power);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -232,6 +232,12 @@ public:
         return mScreenSpaceReflectionsOptions;
     }
 
+    void setGuardBandOptions(GuardBandOptions options) noexcept;
+
+    GuardBandOptions const& getGuardBandOptions() const noexcept {
+        return mGuardBandOptions;
+    }
+
     void setColorGrading(FColorGrading* colorGrading) noexcept {
         mColorGrading = colorGrading == nullptr ? mDefaultColorGrading : colorGrading;
     }
@@ -494,6 +500,7 @@ private:
     TemporalAntiAliasingOptions mTemporalAntiAliasingOptions;
     MultiSampleAntiAliasingOptions mMultiSampleAntiAliasingOptions;
     ScreenSpaceReflectionsOptions mScreenSpaceReflectionsOptions;
+    GuardBandOptions mGuardBandOptions;
     BlendMode mBlendMode = BlendMode::OPAQUE;
     const FColorGrading* mColorGrading = nullptr;
     const FColorGrading* mDefaultColorGrading = nullptr;

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -72,6 +72,7 @@ using MultiSampleAntiAliasingOptions = filament::View::MultiSampleAntiAliasingOp
 using TemporalAntiAliasingOptions = filament::View::TemporalAntiAliasingOptions;
 using VignetteOptions = filament::View::VignetteOptions;
 using VsmShadowOptions = filament::View::VsmShadowOptions;
+using GuardBandOptions = filament::View::GuardBandOptions;
 using LightManager = filament::LightManager;
 
 // These functions push all editable property values to their respective Filament objects.
@@ -171,6 +172,7 @@ struct ViewSettings {
     TemporalAntiAliasingOptions taa;
     VignetteOptions vignette;
     VsmShadowOptions vsmShadowOptions;
+    GuardBandOptions guardBand;
 
     // Custom View Options
     ColorGradingSettings colorGrading;

--- a/libs/viewer/src/AutomationSpec.cpp
+++ b/libs/viewer/src/AutomationSpec.cpp
@@ -35,10 +35,8 @@ using std::vector;
 
 static const bool VERBOSE = false;
 
-namespace filament {
-namespace viewer {
+namespace filament::viewer {
 
-// The default spec generates 66 test cases.
 static const char* DEFAULT_AUTOMATION = R"TXT([
     {
         "name": "ppoff",
@@ -63,7 +61,8 @@ static const char* DEFAULT_AUTOMATION = R"TXT([
             "view.ssao.enabled": [false, true],
             "view.screenSpaceReflections.enabled": [false, true]
             "view.bloom.enabled": [false, true],
-            "view.dof.enabled": [false, true]
+            "view.dof.enabled": [false, true],
+            "view.guardBand.enabled": [false, true]
         }
     }
 ]
@@ -335,5 +334,4 @@ size_t AutomationSpec::size() const { return mImpl->cases.size(); }
 AutomationSpec::AutomationSpec(Impl* impl) : mImpl(impl) {}
 AutomationSpec::~AutomationSpec() { delete mImpl; }
 
-} // namespace viewer
-} // namespace filament
+} // namespace filament::viewer

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -757,6 +757,8 @@ void ViewerGui::updateUserInterface() {
             ImGui::SliderFloat("Stride", &ssrefl.stride, 1.0, 10.0f);
         }
         ImGui::Unindent();
+
+        ImGui::Checkbox("Screen-space Guard Band", &mSettings.view.guardBand.enabled);
     }
 
     if (ImGui::CollapsingHeader("Dynamic Resolution")) {

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -403,6 +403,17 @@ Filament.loadClassExtensions = function() {
         this._setVignetteOptions(options);
     };
 
+    /// setGuardBandOptions ::method::
+    /// overrides ::argument:: Dictionary with one or more of the following properties: \
+    /// enabled.
+    Filament.View.prototype.setGuardBandOptions = function(overrides) {
+        const options = {
+            enabled: false
+        };
+        Object.assign(options, overrides);
+        this._setGuardBandOptions(options);
+    };
+
     /// BufferObject ::core class::
 
     /// setBuffer ::method::

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -152,6 +152,10 @@ export interface View$VignetteOptions {
     enabled?: boolean;
 }
 
+export interface View$GuardBandOptions {
+    enabled?: boolean;
+}
+
 export function fitIntoUnitCube(box: Aabb): mat4;
 export function multiplyMatrices(a: mat4, b: mat4): mat4;
 
@@ -532,6 +536,7 @@ export class View {
     public setScreenSpaceReflectionsOptions(options: View$ScreenSpaceReflectionsOptions): void;
     public setFogOptions(options: View$FogOptions): void;
     public setVignetteOptions(options: View$VignetteOptions): void;
+    public setGuardBandOptions(options: View$GuardBandOptions): void;
     public setAmbientOcclusion(ambientOcclusion: View$AmbientOcclusion): void;
     public getAmbientOcclusion(): View$AmbientOcclusion;
     public setBlendMode(mode: View$BlendMode): void;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -447,6 +447,9 @@ value_object<filament::View::VignetteOptions>("View$VignetteOptions")
     .field("color", &filament::View::VignetteOptions::color)
     .field("enabled", &filament::View::VignetteOptions::enabled);
 
+value_object<filament::View::GuardBandOptions>("View$GuardBandOptions")
+    .field("enabled", &filament::View::GuardBandOptions::enabled);
+
 value_object<LightManager::ShadowOptions>("LightManager$ShadowOptions")
     .field("mapSize", &LightManager::ShadowOptions::mapSize)
     .field("shadowCascades", &LightManager::ShadowOptions::shadowCascades)
@@ -707,6 +710,7 @@ class_<View>("View")
     .function("_setBloomOptions", &View::setBloomOptions)
     .function("_setFogOptions", &View::setFogOptions)
     .function("_setVignetteOptions", &View::setVignetteOptions)
+    .function("_setGuardBandOptions", &View::setGuardBandOptions)
     .function("setAmbientOcclusion", &View::setAmbientOcclusion)
     .function("getAmbientOcclusion", &View::getAmbientOcclusion)
     .function("setAntiAliasing", &View::setAntiAliasing)


### PR DESCRIPTION
When the guard band is enabled, the effective rendering area is
increased by a certain amount (currently 16 pixels on each side) so
that screen-space effects (e.g. SSAO, SSR, DoF) behave better around
the edges of the screen. Of course, this comes at a performance and
memory cost.

Currently the guard band is not configurable other than being optional.

Added c++, java and js bindings.