### PR TITLE
Fix texture coordinate calculations in post-process materials

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -457,6 +457,34 @@ add_custom_command(
 )
 
 add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/separableGaussianBlur1L.filamat"
+        DEPENDS src/materials/separableGaussianBlur.vs
+        DEPENDS src/materials/separableGaussianBlur.fs
+        APPEND
+)
+
+add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/separableGaussianBlur2L.filamat"
+        DEPENDS src/materials/separableGaussianBlur.vs
+        DEPENDS src/materials/separableGaussianBlur.fs
+        APPEND
+)
+
+add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/separableGaussianBlur3L.filamat"
+        DEPENDS src/materials/separableGaussianBlur.vs
+        DEPENDS src/materials/separableGaussianBlur.fs
+        APPEND
+)
+
+add_custom_command(
+        OUTPUT "${MATERIAL_DIR}/separableGaussianBlur4L.filamat"
+        DEPENDS src/materials/separableGaussianBlur.vs
+        DEPENDS src/materials/separableGaussianBlur.fs
+        APPEND
+)
+
+add_custom_command(
         OUTPUT ${RESGEN_OUTPUTS}
         COMMAND resgen ${RESGEN_FLAGS} ${MATERIAL_BINS}
         DEPENDS resgen ${MATERIAL_BINS}

--- a/filament/src/materials/antiAliasing/fxaa.mat
+++ b/filament/src/materials/antiAliasing/fxaa.mat
@@ -29,6 +29,7 @@ vertex {
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
         postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.vertex.xy);
     }
 
 }

--- a/filament/src/materials/antiAliasing/taa.mat
+++ b/filament/src/materials/antiAliasing/taa.mat
@@ -38,7 +38,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 
@@ -204,22 +204,15 @@ void postProcess(inout PostProcessInputs postProcess) {
     float depth = textureLod(materialParams_depth, uv.xy, 0.0).r;
 
 #if HISTORY_REPROJECTION
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    // on metal/vulkan postProcess.normalizedUV has its origin at the left-top, but
-    // our projection matrix screen-space's origin is left-bottom
-    uv.w = 1.0 - uv.w;
-#endif
+    uv.zw = uvToRenderTargetUV(uv.zw);
     // reproject history to current frame
     highp vec4 q = materialParams.reprojection * vec4(uv.zw, depth, 1.0);
     uv.zw = (q.xy * (1.0 / q.w)) * 0.5 + 0.5;
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    // on metal/vulkan after we applied the reprojection, we need to correct our uv back
-    uv.w = 1.0 - uv.w;
-#endif
+    uv.zw = uvToRenderTargetUV(uv.zw);
 #endif
 
     // read center color and history samples
-    vec4 color = textureLodOffset(materialParams_color, uv.xy, 0.0, ivec2( 0,  0));
+    vec4 color = textureLod(materialParams_color, uv.xy, 0.0);
 #if FILTER_HISTORY
     vec4 history = sampleTextureCatmullRom(materialParams_history, uv.zw,
             vec2(textureSize(materialParams_history, 0)));

--- a/filament/src/materials/blitLow.mat
+++ b/filament/src/materials/blitLow.mat
@@ -28,6 +28,7 @@ material {
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
         postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.vertex.xy);
     }
 }
 

--- a/filament/src/materials/bloom/bloomDownsample.mat
+++ b/filament/src/materials/bloom/bloomDownsample.mat
@@ -29,7 +29,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/bloom/bloomUpsample.mat
+++ b/filament/src/materials/bloom/bloomUpsample.mat
@@ -26,7 +26,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -77,6 +77,7 @@ material {
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
         postProcess.vertex.xy = materialParams.viewport.xy + postProcess.normalizedUV * materialParams.viewport.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.vertex.xy);
     }
 }
 

--- a/filament/src/materials/colorGrading/customResolveAsSubpass.mat
+++ b/filament/src/materials/colorGrading/customResolveAsSubpass.mat
@@ -32,12 +32,6 @@ material {
     framebufferFetch: true
 }
 
-vertex {
-    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
-    }
-}
-
 fragment {
 
     void dummy(){}

--- a/filament/src/materials/dof/dof.mat
+++ b/filament/src/materials/dof/dof.mat
@@ -37,11 +37,6 @@ material {
         },
         {
            type : float4,
-           name : uvscale,
-           precision: high
-        },
-        {
-           type : float4,
            name : ringCounts,
            precision: medium
         }
@@ -68,7 +63,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex = postProcess.normalizedUV.xyxy * materialParams.uvscale;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 
@@ -578,7 +573,7 @@ void backgroundTile(inout vec4 background, inout float bgOpacity,
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
-    vec2 tiles = textureLod(materialParams_tiles, variable_vertex.zw, 0.0).rg;
+    vec2 tiles = textureLod(materialParams_tiles, variable_vertex.xy, 0.0).rg;
 
     /*
      * Tiles that are neither foreground or background (in focus) can be skipped

--- a/filament/src/materials/dof/dofCoc.mat
+++ b/filament/src/materials/dof/dofCoc.mat
@@ -20,8 +20,8 @@ material {
             name : cocClamp
         },
         {
-            type : float4,
-            name : uvscale,
+            type : float2,
+            name : texelSize,
             precision: high
         }
     ],
@@ -50,7 +50,7 @@ vertex {
     void dummy(){}
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = (postProcess.normalizedUV * materialParams.uvscale.xy) * materialParams.uvscale.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/dof/dofCombine.mat
+++ b/filament/src/materials/dof/dofCombine.mat
@@ -20,11 +20,6 @@ material {
             type : sampler2d,
             name : alpha,
             precision: medium
-        },
-        {
-            type : float4,
-            name : uvscale,
-            precision: high
         }
     ],
     variables : [
@@ -37,8 +32,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
-        postProcess.vertex.zw = postProcess.normalizedUV * materialParams.uvscale.zw;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 
@@ -49,23 +43,19 @@ fragment {
 void dummy(){}
 
 void postProcess(inout PostProcessInputs postProcess) {
-    highp vec2 uv2 = variable_vertex.zw;
-    vec2 tiles = textureLod(materialParams_tiles, uv2, 0.0).rg;
+    highp vec2 uv = variable_vertex.xy;
+    vec2 tiles = textureLod(materialParams_tiles, uv, 0.0).rg;
 
     vec4 color;
     if (isTrivialTile(tiles)) {
-        highp vec2 uv0 = variable_vertex.xy;
-        color = textureLod(materialParams_color, uv0, 0.0);
+        color = textureLod(materialParams_color, uv, 0.0);
     } else if (isFastTile(tiles) && (abs(tiles.r) >= MAX_IN_FOCUS_COC + 1.0)) {
         // we can only handle fast tiles that don't have an alpha channel here
-        highp vec2 uv1 = variable_vertex.xy * materialParams.uvscale.xy;
-        color = textureLod(materialParams_dof, uv1, 0.0);
+        color = textureLod(materialParams_dof, uv, 0.0);
     } else {
-        highp vec2 uv0 = variable_vertex.xy;
-        highp vec2 uv1 = variable_vertex.xy * materialParams.uvscale.xy;
-        float alpha = textureLod(materialParams_alpha, uv1, 0.0).r;
-        vec4 dof = textureLod(materialParams_dof, uv1, 0.0);
-        color = textureLod(materialParams_color, uv0, 0.0);
+        float alpha = textureLod(materialParams_alpha, uv, 0.0).r;
+        vec4 dof = textureLod(materialParams_dof, uv, 0.0);
+        color = textureLod(materialParams_color, uv, 0.0);
         color = dof + (1.0 - alpha) * color;
     }
 

--- a/filament/src/materials/dof/dofDilate.mat
+++ b/filament/src/materials/dof/dofDilate.mat
@@ -17,7 +17,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/dof/dofDownsample.mat
+++ b/filament/src/materials/dof/dofDownsample.mat
@@ -20,8 +20,8 @@ material {
             name : cocClamp
         },
         {
-            type : float4,
-            name : uvscale,
+            type : float2,
+            name : texelSize,
             precision: high
         }
     ],
@@ -50,7 +50,21 @@ vertex {
     void dummy(){}
 
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = (postProcess.normalizedUV * materialParams.uvscale.xy * 2.0 - 0.5) * materialParams.uvscale.zw;
+        // It works to fix-up the UV *before* applying the offsets because materialParams.texelSize
+        // corresponds to one texel.
+        // on GL:           v0 = v - 0.5 * texel                                                (1)
+        //                  v1 = v - 0.5 * texel + 1 * texel
+        //                     = v + 0.5 * texel                                                (2)
+        // on MTL/VK:       v0 = 1 - ((1 - v) - 0.5 * texel)
+        //                     = v + 0.5 * texel                                                (3)
+        //                  v1 = 1 - ((1 - v) - 0.5 * texel + 1 * texel)
+        //                     = v - 0.5 * texel                                                (4)
+        // Because the all the operations on the 4 texels in the fragment shader don't depend on
+        // the order they're fetched, it all works out.
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
+
+        // offset UVs by -0.5 texel because we use textureLodOffset() in the fragment shader
+        postProcess.vertex.xy = postProcess.normalizedUV - 0.5 * materialParams.texelSize;
     }
 }
 

--- a/filament/src/materials/dof/dofMedian.mat
+++ b/filament/src/materials/dof/dofMedian.mat
@@ -15,11 +15,6 @@ material {
             type : sampler2d,
             name : tiles,
             precision: medium
-        },
-        {
-            type : float2,
-            name : uvscale,
-            precision: high
         }
     ],
     variables : [
@@ -32,8 +27,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
-        postProcess.vertex.zw = postProcess.vertex.xy * materialParams.uvscale;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 
@@ -121,7 +115,7 @@ vec4 median(ivec2 ij) {
 }
 
 void postProcess(inout PostProcessInputs postProcess) {
-    vec2 tiles = textureLod(materialParams_tiles, variable_vertex.zw, 0.0).rg;
+    vec2 tiles = textureLod(materialParams_tiles, variable_vertex.xy, 0.0).rg;
     vec4 dof = vec4(0.0);
 
     if (!isTrivialTile(tiles)) {

--- a/filament/src/materials/dof/dofMipmap.mat
+++ b/filament/src/materials/dof/dofMipmap.mat
@@ -21,7 +21,7 @@ material {
         },
         {
             type : float2,
-            name : pixelSize
+            name : texelSize
         }
     ],
     variables : [
@@ -46,7 +46,9 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV - materialParams.pixelSize * 0.5;
+        // see explanation in dofDownSample.mat
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
+        postProcess.vertex.xy = postProcess.normalizedUV - 0.5 * materialParams.texelSize;
     }
 }
 

--- a/filament/src/materials/dof/dofTiles.mat
+++ b/filament/src/materials/dof/dofTiles.mat
@@ -7,8 +7,8 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : uvscale,
+            type : float2,
+            name : texelSize,
             precision: high
         }
     ],
@@ -22,7 +22,9 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = (postProcess.normalizedUV * materialParams.uvscale.xy * 2.0 - 0.5) * materialParams.uvscale.zw;
+        // see explanation in dofDownSample.mat
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
+        postProcess.vertex.xy = postProcess.normalizedUV - 0.5 * materialParams.texelSize;
     }
 }
 

--- a/filament/src/materials/dof/dofTilesSwizzle.mat
+++ b/filament/src/materials/dof/dofTilesSwizzle.mat
@@ -7,8 +7,8 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : uvscale,
+            type : float2,
+            name : texelSize,
             precision: high
         }
     ],
@@ -22,7 +22,9 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = (postProcess.normalizedUV * materialParams.uvscale.xy * 2.0 - 0.5) * materialParams.uvscale.zw;
+        // see explanation in dofDownSample.mat
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
+        postProcess.vertex.xy = postProcess.normalizedUV - 0.5 * materialParams.texelSize;
     }
 }
 

--- a/filament/src/materials/flare/flare.mat
+++ b/filament/src/materials/flare/flare.mat
@@ -68,13 +68,7 @@ vertex {
 void dummy(){ }
 
 void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-    postProcess.vertex.xy = postProcess.normalizedUV;
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    // On metal/vulkan postProcess.normalizedUV has its origin at the left-top, but we need a
-    // uniform coordinate space. So, we flip the y coordinate so we have bottom-left UV
-    // coordinates across all backends.
-    postProcess.vertex.y = 1.0 - postProcess.vertex.y;
-#endif
+    postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
 }
 
 }

--- a/filament/src/materials/fsr/fsr_easu.mat
+++ b/filament/src/materials/fsr/fsr_easu.mat
@@ -52,6 +52,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
         postProcess.vertex.xy = postProcess.normalizedUV * materialParams.resolution.xy;
     }
 }

--- a/filament/src/materials/fsr/fsr_easu_mobile.mat
+++ b/filament/src/materials/fsr/fsr_easu_mobile.mat
@@ -52,6 +52,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
         postProcess.vertex.xy = postProcess.normalizedUV * materialParams.resolution.xy;
     }
 }

--- a/filament/src/materials/fsr/fsr_easu_mobileF.mat
+++ b/filament/src/materials/fsr/fsr_easu_mobileF.mat
@@ -52,6 +52,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
         postProcess.vertex.xy = postProcess.normalizedUV * materialParams.resolution.xy;
     }
 }

--- a/filament/src/materials/fsr/fsr_rcas.mat
+++ b/filament/src/materials/fsr/fsr_rcas.mat
@@ -27,6 +27,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.normalizedUV = uvToRenderTargetUV(postProcess.normalizedUV);
         postProcess.vertex.xy = postProcess.normalizedUV * materialParams.resolution.xy;
     }
 }

--- a/filament/src/materials/separableGaussianBlur.vs
+++ b/filament/src/materials/separableGaussianBlur.vs
@@ -1,6 +1,3 @@
 void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-    // in the fragment shader, this is interpolated to pixel centers, but since we use
-    // texel-fetch, it's not what we want. Convert from screen uv to texture uv.
-    vec2 size = vec2(textureSize(materialParams_source, int(materialParams.level)));
-    postProcess.vertex.xy = (postProcess.normalizedUV - 0.5 * materialParams.resolution.zw) + 0.5 / size;
+    postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
 }

--- a/filament/src/materials/separableGaussianBlur1.mat
+++ b/filament/src/materials/separableGaussianBlur1.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur1L.mat
+++ b/filament/src/materials/separableGaussianBlur1L.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur2.mat
+++ b/filament/src/materials/separableGaussianBlur2.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur2L.mat
+++ b/filament/src/materials/separableGaussianBlur2L.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur3.mat
+++ b/filament/src/materials/separableGaussianBlur3.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur3L.mat
+++ b/filament/src/materials/separableGaussianBlur3L.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur4.mat
+++ b/filament/src/materials/separableGaussianBlur4.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/separableGaussianBlur4L.mat
+++ b/filament/src/materials/separableGaussianBlur4L.mat
@@ -7,11 +7,6 @@ material {
             precision: medium
         },
         {
-            type : float4,
-            name : resolution,
-            precision: high
-        },
-        {
             type : float2,
             name : axis
         },

--- a/filament/src/materials/ssao/bilateralBlur.mat
+++ b/filament/src/materials/ssao/bilateralBlur.mat
@@ -34,7 +34,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/ssao/bilateralBlurBentNormals.mat
+++ b/filament/src/materials/ssao/bilateralBlurBentNormals.mat
@@ -46,7 +46,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/filament/src/materials/ssao/depthUtils.fs
+++ b/filament/src/materials/ssao/depthUtils.fs
@@ -29,13 +29,7 @@ highp float linearizeDepth(highp float depth) {
 }
 
 highp float sampleDepth(const highp sampler2D depthTexture, const highp vec2 uv, float lod) {
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    // On metal/vulkan, texture space is flipped vertically and we need to adjust the uv
-    // coordinates.
-    return textureLod(depthTexture, vec2(uv.x, 1.0 - uv.y), lod).r;
-#else
-    return textureLod(depthTexture, uv, lod).r;
-#endif
+    return textureLod(depthTexture, uvToRenderTargetUV(uv), lod).r;
 }
 
 highp float sampleDepthLinear(const highp sampler2D depthTexture,

--- a/filament/src/materials/ssao/sao.mat
+++ b/filament/src/materials/ssao/sao.mat
@@ -119,13 +119,9 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        // we don't use use uvToRenderTargetUV() here to compensate for metal/vulkan texture
+        // coordinates differences because this is done in sampleDepth()
         postProcess.vertex.xy = postProcess.normalizedUV;
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-        // On metal/vulkan postProcess.normalizedUV has its origin at the left-top, but we need a
-        // uniform coordinate space for SAO. So, we flip the y coordinate so we have bottom-left UV
-        // coordinates across all backends.
-        postProcess.vertex.y = 1.0 - postProcess.vertex.y;
-#endif
     }
 }
 

--- a/filament/src/materials/ssao/saoBentNormals.mat
+++ b/filament/src/materials/ssao/saoBentNormals.mat
@@ -131,13 +131,9 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        // we don't use use uvToRenderTargetUV() here to compensate for metal/vulkan texture
+        // coordinates differences because this is done in sampleDepth()
         postProcess.vertex.xy = postProcess.normalizedUV;
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-        // On metal/vulkan postProcess.normalizedUV has its origin at the left-top, but we need a
-        // uniform coordinate space for SAO. So, we flip the y coordinate so we have bottom-left UV
-        // coordinates across all backends.
-        postProcess.vertex.y = 1.0 - postProcess.vertex.y;
-#endif
     }
 }
 

--- a/libs/iblprefilter/src/materials/equirectToCube.mat
+++ b/libs/iblprefilter/src/materials/equirectToCube.mat
@@ -39,7 +39,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/libs/iblprefilter/src/materials/generateKernel.mat
+++ b/libs/iblprefilter/src/materials/generateKernel.mat
@@ -32,7 +32,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV * vec2(materialParams.size);
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV) * vec2(materialParams.size);
     }
 }
 

--- a/libs/iblprefilter/src/materials/iblprefilter.mat
+++ b/libs/iblprefilter/src/materials/iblprefilter.mat
@@ -64,7 +64,7 @@ material {
 
 vertex {
     void postProcessVertex(inout PostProcessVertexInputs postProcess) {
-        postProcess.vertex.xy = postProcess.normalizedUV;
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
     }
 }
 

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -47,6 +47,26 @@ highp float getUserTimeMod(float m) {
     return mod(mod(frameUniforms.userTime.x, m) + mod(frameUniforms.userTime.y, m), m);
 }
 
+/**
+ * Transforms a texture UV to make it suitable for a render target attachment.
+ *
+ * In Vulkan and Metal, texture coords are Y-down but in OpenGL they are Y-up. This wrapper function
+ * accounts for these differences. When sampling from non-render targets (i.e. uploaded textures)
+ * these differences do not matter because OpenGL has a second piece of backwardness, which is that
+ * the first row of texels in glTexImage2D is interpreted as the bottom row.
+ *
+ * To protect users from these differences, we recommend that materials in the SURFACE domain
+ * leverage this wrapper function when sampling from offscreen render targets.
+ *
+ * @public-api
+ */
+highp vec2 uvToRenderTargetUV(highp vec2 uv) {
+#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+    uv.y = 1.0 - uv.y;
+#endif
+    return uv;
+}
+
 // TODO: below shouldn't be accessible from post-process materials
 
 #define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x1u

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -62,26 +62,6 @@ float getNdotV() {
 }
 
 /**
- * Transforms a texture UV to make it suitable for a render target attachment.
- *
- * In Vulkan and Metal, texture coords are Y-down but in OpenGL they are Y-up. This wrapper function
- * accounts for these differences. When sampling from non-render targets (i.e. uploaded textures)
- * these differences do not matter because OpenGL has a second piece of backwardness, which is that
- * the first row of texels in glTexImage2D is interpreted as the bottom row.
- *
- * To protect users from these differences, we recommend that materials in the SURFACE domain
- * leverage this wrapper function when sampling from offscreen render targets.
- *
- * @public-api
- */
-highp vec2 uvToRenderTargetUV(highp vec2 uv) {
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    uv.y = 1.0 - uv.y;
-#endif
-    return uv;
-}
-
-/**
  * Returns the normalized [0, 1] viewport coordinates with the origin at the viewport's bottom-left.
  * Z coordinate is in the [0, 1] range as well.
  *

--- a/shaders/src/post_process.vs
+++ b/shaders/src/post_process.vs
@@ -5,11 +5,6 @@ void main() {
 
     inputs.normalizedUV = position.xy * 0.5 + 0.5;
 
-// In Vulkan and Metal, texture coords are Y-down. In OpenGL, texture coords are Y-up.
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    inputs.normalizedUV.y = 1.0 - inputs.normalizedUV.y;
-#endif
-
     gl_Position = getPosition();
     // GL convention to inverted DX convention
     gl_Position.z = gl_Position.z * -0.5 + 0.5;


### PR DESCRIPTION
The most important change here is that we no longer apply the
backend (e.g. Metal/Vulkan) UV transformation before calling the
user's vertex shader. This is an API change for post-process materials
(but they're not public).
Now the user is responsible for using uvToRenderTargetUV() in their
shaders (either in the fragment or vertex as appropriate).

This makes it easier to handle offsets/transforms with all APIs.

Conceptually, the only thing that is needed is to call 
uvToRenderTargetUV() just before making a texture call.


This fixes a couple of issues:
- some image shifting in metal/vk
- flare in metal/vk was upside down

We also simplify the DoF code quite a bit now that we can rely on the
rendertargets begin multiple of 16.

We also "fix" SSAO that was working by accident on  metal/vk. The UV
correction was applied 3 times 2 of which were canceling each other.