### PR TITLE
Added config object to engine initialization (#2057) (#5470)

### DIFF
--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -37,6 +37,20 @@ public:
         uintptr_t image = 0;
     };
 
+    class DriverConfig {
+    private:
+        size_t mHandleArenaSize;    // size of handle arena in bytes
+
+    public:
+        DriverConfig(const DriverConfig* srcConfig);
+        DriverConfig(uint32_t handleArenaSizeInMB = 0);
+
+        const size_t getHandleArenaSize() const noexcept { return mHandleArenaSize; }
+
+    private:
+        void init(uint32_t handleArenaSizeInMB);
+    };
+
     virtual ~Platform() noexcept;
 
     /**
@@ -56,7 +70,7 @@ public:
      *
      * @return nullptr on failure, or a pointer to the newly created driver.
      */
-    virtual backend::Driver* createDriver(void* sharedContext) noexcept = 0;
+    virtual backend::Driver* createDriver(void* sharedContext, const DriverConfig& driverConfig) noexcept = 0;
 
     /**
      * Processes the platform's event queue when called from its primary event-handling thread.

--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -37,18 +37,8 @@ public:
         uintptr_t image = 0;
     };
 
-    class DriverConfig {
-    private:
-        size_t mHandleArenaSize;    // size of handle arena in bytes
-
-    public:
-        DriverConfig(const DriverConfig* srcConfig);
-        DriverConfig(uint32_t handleArenaSizeInMB = 0);
-
-        const size_t getHandleArenaSize() const noexcept { return mHandleArenaSize; }
-
-    private:
-        void init(uint32_t handleArenaSizeInMB);
+    struct DriverConfig {
+        size_t handleArenaSize = 0; // size of handle arena in bytes
     };
 
     virtual ~Platform() noexcept;
@@ -70,7 +60,7 @@ public:
      *
      * @return nullptr on failure, or a pointer to the newly created driver.
      */
-    virtual backend::Driver* createDriver(void* sharedContext, const DriverConfig& driverConfig) noexcept = 0;
+    virtual backend::Driver* createDriver(void* sharedContext, DriverConfig& driverConfig) noexcept = 0;
 
     /**
      * Processes the platform's event queue when called from its primary event-handling thread.

--- a/filament/backend/include/private/backend/BackendUtils.h
+++ b/filament/backend/include/private/backend/BackendUtils.h
@@ -23,10 +23,6 @@
 
 #include <stddef.h>
 
-#ifndef FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB
-#    define FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB 1
-#endif
-
 namespace filament {
 namespace backend {
 

--- a/filament/backend/include/private/backend/MetalPlatform.h
+++ b/filament/backend/include/private/backend/MetalPlatform.h
@@ -29,7 +29,7 @@ class MetalPlatform : public DefaultPlatform {
 public:
     ~MetalPlatform() override;
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 
     /**

--- a/filament/backend/include/private/backend/MetalPlatform.h
+++ b/filament/backend/include/private/backend/MetalPlatform.h
@@ -29,7 +29,7 @@ class MetalPlatform : public DefaultPlatform {
 public:
     ~MetalPlatform() override;
 
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 
     /**

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -33,7 +33,7 @@ protected:
      * Derived classes can use this to instantiate the default OpenGLDriver backend.
      * This is typically called from your implementation of createDriver()
      */
-    static Driver* createDefaultDriver(OpenGLPlatform* platform, void* sharedContext);
+    static Driver* createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, const DriverConfig& driverConfig);
 
 public:
     ~OpenGLPlatform() noexcept override;

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -33,7 +33,7 @@ protected:
      * Derived classes can use this to instantiate the default OpenGLDriver backend.
      * This is typically called from your implementation of createDriver()
      */
-    static Driver* createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, const DriverConfig& driverConfig);
+    static Driver* createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, DriverConfig& driverConfig);
 
 public:
     ~OpenGLPlatform() noexcept override;

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -84,26 +84,6 @@ namespace backend {
 // this generates the vtable in this translation unit
 Platform::~Platform() noexcept = default;
 
-Platform::DriverConfig::DriverConfig(const DriverConfig* srcConfig) {
-    if (srcConfig != nullptr) {
-        *this = *srcConfig;
-    }
-    else {
-        init(0);
-    }
-}
-
-Platform::DriverConfig::DriverConfig(uint32_t handleArenaSizeInMB)
-{
-    init(handleArenaSizeInMB);
-}
-
-void Platform::DriverConfig::init(uint32_t handleArenaSizeInMB) {
-    constexpr size_t MB = 1024 * 1024;
-
-    mHandleArenaSize = handleArenaSizeInMB * MB;
-}
-
 // Creates the platform-specific Platform object. The caller takes ownership and is
 // responsible for destroying it. Initialization of the backend API is deferred until
 // createDriver(). The passed-in backend hint is replaced with the resolved backend.

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -78,10 +78,31 @@ filament::backend::DefaultPlatform* createDefaultMetalPlatform();
 #include "noop/PlatformNoop.h"
 
 namespace filament {
+
 namespace backend {
 
 // this generates the vtable in this translation unit
 Platform::~Platform() noexcept = default;
+
+Platform::DriverConfig::DriverConfig(const DriverConfig* srcConfig) {
+    if (srcConfig != nullptr) {
+        *this = *srcConfig;
+    }
+    else {
+        init(0);
+    }
+}
+
+Platform::DriverConfig::DriverConfig(uint32_t handleArenaSizeInMB)
+{
+    init(handleArenaSizeInMB);
+}
+
+void Platform::DriverConfig::init(uint32_t handleArenaSizeInMB) {
+    constexpr size_t MB = 1024 * 1024;
+
+    mHandleArenaSize = handleArenaSizeInMB * MB;
+}
 
 // Creates the platform-specific Platform object. The caller takes ownership and is
 // responsible for destroying it. Initialization of the backend API is deferred until

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -42,12 +42,13 @@ struct UniformBufferState;
 #endif
 
 class MetalDriver final : public DriverBase {
-    explicit MetalDriver(MetalPlatform* platform) noexcept;
+    explicit MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept;
     ~MetalDriver() noexcept override;
     Dispatcher getDispatcher() const noexcept final;
 
 public:
-    static Driver* create(MetalPlatform* platform);
+    static Driver* create(MetalPlatform* platform, const Platform::DriverConfig& driverConfig);
+    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
 
 private:
 

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -42,13 +42,12 @@ struct UniformBufferState;
 #endif
 
 class MetalDriver final : public DriverBase {
-    explicit MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept;
+    explicit MetalDriver(MetalPlatform* platform, Platform::DriverConfig& driverConfig) noexcept;
     ~MetalDriver() noexcept override;
     Dispatcher getDispatcher() const noexcept final;
 
 public:
-    static Driver* create(MetalPlatform* platform, const Platform::DriverConfig& driverConfig);
-    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
+    static Driver* create(MetalPlatform* platform, Platform::DriverConfig& driverConfig);
 
 private:
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -40,20 +40,16 @@
 namespace filament {
 namespace backend {
 
-Driver* MetalDriverFactory::create(MetalPlatform* const platform, const Platform::DriverConfig& driverConfig) {
+Driver* MetalDriverFactory::create(MetalPlatform* const platform, Platform::DriverConfig& driverConfig) {
     return MetalDriver::create(platform, driverConfig);
 }
 
 UTILS_NOINLINE
-Driver* MetalDriver::create(MetalPlatform* const platform, const Platform::DriverConfig& driverConfig) {
+Driver* MetalDriver::create(MetalPlatform* const platform, Platform::DriverConfig& driverConfig) {
     assert_invariant(platform);
-    return new MetalDriver(platform, driverConfig);
-}
-
-size_t MetalDriver::getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept {
-    size_t configSize = driverConfig.getHandleArenaSize();
     size_t defaultSize = FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
-    return configSize > defaultSize ? configSize : defaultSize;
+    driverConfig.handleArenaSize = std::max(driverConfig.handleArenaSize, defaultSize);
+    return new MetalDriver(platform, driverConfig);
 }
 
 Dispatcher MetalDriver::getDispatcher() const noexcept {
@@ -63,7 +59,7 @@ Dispatcher MetalDriver::getDispatcher() const noexcept {
 MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
         : mPlatform(*platform),
           mContext(new MetalContext),
-          mHandleAllocator("Handles", getHandleArenaSize(driverConfig)) {
+          mHandleAllocator("Handles", driverConfig.handleArenaSize) {
     mContext->driver = this;
 
     mContext->device = mPlatform.createDevice();

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -40,24 +40,30 @@
 namespace filament {
 namespace backend {
 
-Driver* MetalDriverFactory::create(MetalPlatform* const platform) {
-    return MetalDriver::create(platform);
+Driver* MetalDriverFactory::create(MetalPlatform* const platform, const Platform::DriverConfig& driverConfig) {
+    return MetalDriver::create(platform, driverConfig);
 }
 
 UTILS_NOINLINE
-Driver* MetalDriver::create(MetalPlatform* const platform) {
+Driver* MetalDriver::create(MetalPlatform* const platform, const Platform::DriverConfig& driverConfig) {
     assert_invariant(platform);
-    return new MetalDriver(platform);
+    return new MetalDriver(platform, driverConfig);
+}
+
+size_t MetalDriver::getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept {
+    size_t configSize = driverConfig.getHandleArenaSize();
+    size_t defaultSize = FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
+    return configSize > defaultSize ? configSize : defaultSize;
 }
 
 Dispatcher MetalDriver::getDispatcher() const noexcept {
     return ConcreteDispatcher<MetalDriver>::make();
 }
 
-MetalDriver::MetalDriver(MetalPlatform* platform) noexcept
+MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
         : mPlatform(*platform),
           mContext(new MetalContext),
-          mHandleAllocator("Handles", FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U) {
+          mHandleAllocator("Handles", getHandleArenaSize(driverConfig)) {
     mContext->driver = this;
 
     mContext->device = mPlatform.createDevice();

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -56,7 +56,7 @@ Dispatcher MetalDriver::getDispatcher() const noexcept {
     return ConcreteDispatcher<MetalDriver>::make();
 }
 
-MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
+MetalDriver::MetalDriver(MetalPlatform* platform, Platform::DriverConfig& driverConfig) noexcept
         : mPlatform(*platform),
           mContext(new MetalContext),
           mHandleAllocator("Handles", driverConfig.handleArenaSize) {

--- a/filament/backend/src/metal/MetalDriverFactory.h
+++ b/filament/backend/src/metal/MetalDriverFactory.h
@@ -24,7 +24,7 @@ class Driver;
 
 class MetalDriverFactory {
 public:
-    static Driver* create(MetalPlatform* platform);
+    static Driver* create(MetalPlatform* platform, const Platform::DriverConfig& driverConfig);
 };
 
 } // namespace backend

--- a/filament/backend/src/metal/MetalDriverFactory.h
+++ b/filament/backend/src/metal/MetalDriverFactory.h
@@ -24,7 +24,7 @@ class Driver;
 
 class MetalDriverFactory {
 public:
-    static Driver* create(MetalPlatform* platform, const Platform::DriverConfig& driverConfig);
+    static Driver* create(MetalPlatform* platform, Platform::DriverConfig& driverConfig);
 };
 
 } // namespace backend

--- a/filament/backend/src/metal/MetalPlatform.mm
+++ b/filament/backend/src/metal/MetalPlatform.mm
@@ -31,8 +31,8 @@ DefaultPlatform* createDefaultMetalPlatform() {
 
 MetalPlatform::~MetalPlatform() = default;
 
-Driver* MetalPlatform::createDriver(void* sharedContext) noexcept {
-    return MetalDriverFactory::create(this);
+Driver* MetalPlatform::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+    return MetalDriverFactory::create(this, driverConfig);
 }
 
 id<MTLDevice> MetalPlatform::createDevice() noexcept {

--- a/filament/backend/src/metal/MetalPlatform.mm
+++ b/filament/backend/src/metal/MetalPlatform.mm
@@ -31,7 +31,7 @@ DefaultPlatform* createDefaultMetalPlatform() {
 
 MetalPlatform::~MetalPlatform() = default;
 
-Driver* MetalPlatform::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* MetalPlatform::createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     return MetalDriverFactory::create(this, driverConfig);
 }
 

--- a/filament/backend/src/noop/PlatformNoop.cpp
+++ b/filament/backend/src/noop/PlatformNoop.cpp
@@ -20,7 +20,7 @@
 
 namespace filament::backend {
 
-Driver* PlatformNoop::createDriver(void* const sharedGLContext) noexcept {
+Driver* PlatformNoop::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     return NoopDriver::create();
 }
 

--- a/filament/backend/src/noop/PlatformNoop.cpp
+++ b/filament/backend/src/noop/PlatformNoop.cpp
@@ -20,7 +20,7 @@
 
 namespace filament::backend {
 
-Driver* PlatformNoop::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformNoop::createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     return NoopDriver::create();
 }
 

--- a/filament/backend/src/noop/PlatformNoop.h
+++ b/filament/backend/src/noop/PlatformNoop.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
 };
 
 } // namespace filament

--- a/filament/backend/src/noop/PlatformNoop.h
+++ b/filament/backend/src/noop/PlatformNoop.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
 };
 
 } // namespace filament

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -63,7 +63,7 @@ using namespace utils;
 namespace filament::backend {
 
 Driver* OpenGLDriverFactory::create(
-        OpenGLPlatform* const platform, void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+        OpenGLPlatform* const platform, void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     return OpenGLDriver::create(platform, sharedGLContext, driverConfig);
 }
 
@@ -73,7 +73,7 @@ using namespace GLUtils;
 
 UTILS_NOINLINE
 Driver* OpenGLDriver::create(
-        OpenGLPlatform* const platform, void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+        OpenGLPlatform* const platform, void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     assert_invariant(platform);
     OpenGLPlatform* const ec = platform;
 
@@ -136,16 +136,11 @@ Driver* OpenGLDriver::create(
         }
     }
 
+    size_t defaultSize = FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
+    driverConfig.handleArenaSize = std::max(driverConfig.handleArenaSize, defaultSize);
     OpenGLDriver* const driver = new OpenGLDriver(ec, driverConfig);
     return driver;
 }
-
-size_t OpenGLDriver::getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept {
-    size_t configSize = driverConfig.getHandleArenaSize();
-    size_t defaultSize = FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
-    return configSize > defaultSize ? configSize : defaultSize;
-}
-
 
 // ------------------------------------------------------------------------------------------------
 
@@ -160,8 +155,8 @@ OpenGLDriver::DebugMarker::~DebugMarker() noexcept {
 
 // ------------------------------------------------------------------------------------------------
 
-OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
-        : mHandleAllocator("Handles", getHandleArenaSize(driverConfig)),
+OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, Platform::DriverConfig& driverConfig) noexcept
+        : mHandleAllocator("Handles", driverConfig.handleArenaSize),
           mSamplerMap(32),
           mPlatform(*platform) {
   

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -63,8 +63,8 @@ using namespace utils;
 namespace filament::backend {
 
 Driver* OpenGLDriverFactory::create(
-        OpenGLPlatform* const platform, void* const sharedGLContext) noexcept {
-    return OpenGLDriver::create(platform, sharedGLContext);
+        OpenGLPlatform* const platform, void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+    return OpenGLDriver::create(platform, sharedGLContext, driverConfig);
 }
 
 using namespace GLUtils;
@@ -73,7 +73,7 @@ using namespace GLUtils;
 
 UTILS_NOINLINE
 Driver* OpenGLDriver::create(
-        OpenGLPlatform* const platform, void* const sharedGLContext) noexcept {
+        OpenGLPlatform* const platform, void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     assert_invariant(platform);
     OpenGLPlatform* const ec = platform;
 
@@ -136,9 +136,16 @@ Driver* OpenGLDriver::create(
         }
     }
 
-    OpenGLDriver* const driver = new OpenGLDriver(ec);
+    OpenGLDriver* const driver = new OpenGLDriver(ec, driverConfig);
     return driver;
 }
+
+size_t OpenGLDriver::getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept {
+    size_t configSize = driverConfig.getHandleArenaSize();
+    size_t defaultSize = FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U;
+    return configSize > defaultSize ? configSize : defaultSize;
+}
+
 
 // ------------------------------------------------------------------------------------------------
 
@@ -153,8 +160,8 @@ OpenGLDriver::DebugMarker::~DebugMarker() noexcept {
 
 // ------------------------------------------------------------------------------------------------
 
-OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
-        : mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U), // TODO: set the amount in configuration
+OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
+        : mHandleAllocator("Handles", getHandleArenaSize(driverConfig)),
           mSamplerMap(32),
           mPlatform(*platform) {
   

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -52,12 +52,13 @@ class OpenGLBlitter;
 class OpenGLTimerQueryInterface;
 
 class OpenGLDriver final : public DriverBase {
-    inline explicit OpenGLDriver(OpenGLPlatform* platform) noexcept;
+    inline explicit OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept;
     ~OpenGLDriver() noexcept final;
     Dispatcher getDispatcher() const noexcept final;
 
 public:
-    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext) noexcept;
+    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept;
+    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
 
     class DebugMarker {
         OpenGLDriver& driver;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -52,13 +52,12 @@ class OpenGLBlitter;
 class OpenGLTimerQueryInterface;
 
 class OpenGLDriver final : public DriverBase {
-    inline explicit OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept;
+    inline explicit OpenGLDriver(OpenGLPlatform* platform, Platform::DriverConfig& driverConfig) noexcept;
     ~OpenGLDriver() noexcept final;
     Dispatcher getDispatcher() const noexcept final;
 
 public:
-    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept;
-    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
+    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, Platform::DriverConfig& driverConfig) noexcept;
 
     class DebugMarker {
         OpenGLDriver& driver;

--- a/filament/backend/src/opengl/OpenGLDriverFactory.h
+++ b/filament/backend/src/opengl/OpenGLDriverFactory.h
@@ -24,7 +24,7 @@ class Driver;
 
 class OpenGLDriverFactory {
 public:
-    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext) noexcept;
+    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/OpenGLDriverFactory.h
+++ b/filament/backend/src/opengl/OpenGLDriverFactory.h
@@ -24,7 +24,7 @@ class Driver;
 
 class OpenGLDriverFactory {
 public:
-    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept;
+    static Driver* create(OpenGLPlatform* platform, void* sharedGLContext, Platform::DriverConfig& driverConfig) noexcept;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -22,8 +22,8 @@ namespace filament::backend {
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
 
-Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform, void* sharedContext) {
-    return OpenGLDriverFactory::create(platform, sharedContext);
+Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, const Platform::DriverConfig& driverConfig) {
+    return OpenGLDriverFactory::create(platform, sharedContext, driverConfig);
 }
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -22,7 +22,7 @@ namespace filament::backend {
 
 OpenGLPlatform::~OpenGLPlatform() noexcept = default;
 
-Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, const Platform::DriverConfig& driverConfig) {
+Driver* OpenGLPlatform::createDefaultDriver(OpenGLPlatform* platform, void* sharedContext, Platform::DriverConfig& driverConfig) {
     return OpenGLDriverFactory::create(platform, sharedContext, driverConfig);
 }
 

--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.h
@@ -32,7 +32,7 @@ public:
     PlatformCocoaGL();
     ~PlatformCocoaGL() noexcept final;
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.h
@@ -32,7 +32,7 @@ public:
     PlatformCocoaGL();
     ~PlatformCocoaGL() noexcept final;
 
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
@@ -138,7 +138,7 @@ PlatformCocoaGL::~PlatformCocoaGL() noexcept {
     delete pImpl;
 }
 
-Driver* PlatformCocoaGL::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformCocoaGL::createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     // NSOpenGLPFAColorSize: when unspecified, a format that matches the screen is preferred
     NSOpenGLPixelFormatAttribute pixelFormatAttributes[] = {
             NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,

--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
@@ -138,7 +138,7 @@ PlatformCocoaGL::~PlatformCocoaGL() noexcept {
     delete pImpl;
 }
 
-Driver* PlatformCocoaGL::createDriver(void* sharedContext) noexcept {
+Driver* PlatformCocoaGL::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     // NSOpenGLPFAColorSize: when unspecified, a format that matches the screen is preferred
     NSOpenGLPixelFormatAttribute pixelFormatAttributes[] = {
             NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
@@ -161,7 +161,7 @@ Driver* PlatformCocoaGL::createDriver(void* sharedContext) noexcept {
 
     int result = bluegl::bind();
     ASSERT_POSTCONDITION(!result, "Unable to load OpenGL entry points.");
-    return OpenGLDriverFactory::create(this, sharedContext);
+    return OpenGLDriverFactory::create(this, sharedContext, driverConfig);
 }
 
 void PlatformCocoaGL::terminate() noexcept {

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.h
@@ -32,7 +32,7 @@ public:
     PlatformCocoaTouchGL();
     ~PlatformCocoaTouchGL() noexcept final;
 
-    Driver* createDriver(void* sharedGLContext) noexcept override;
+    Driver* createDriver(void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.h
@@ -32,7 +32,7 @@ public:
     PlatformCocoaTouchGL();
     ~PlatformCocoaTouchGL() noexcept final;
 
-    Driver* createDriver(void* sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedGLContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept final;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final;

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
@@ -59,7 +59,7 @@ PlatformCocoaTouchGL::~PlatformCocoaTouchGL() noexcept {
     delete pImpl;
 }
 
-Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext) noexcept {
+Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     EAGLSharegroup* sharegroup = (__bridge EAGLSharegroup*) sharedGLContext;
 
     EAGLContext *context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3 sharegroup:sharegroup];
@@ -93,7 +93,7 @@ Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext) noexcept
 
     pImpl->mExternalImageSharedGl = new CocoaTouchExternalImage::SharedGl();
 
-    return OpenGLDriverFactory::create(this, sharedGLContext);
+    return OpenGLDriverFactory::create(this, sharedGLContext, driverConfig);
 }
 
 void PlatformCocoaTouchGL::terminate() noexcept {

--- a/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaTouchGL.mm
@@ -59,7 +59,7 @@ PlatformCocoaTouchGL::~PlatformCocoaTouchGL() noexcept {
     delete pImpl;
 }
 
-Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformCocoaTouchGL::createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     EAGLSharegroup* sharegroup = (__bridge EAGLSharegroup*) sharedGLContext;
 
     EAGLContext *context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3 sharegroup:sharegroup];

--- a/filament/backend/src/opengl/platforms/PlatformDummyGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformDummyGL.cpp
@@ -18,7 +18,7 @@
 
 namespace filament::backend {
 
-Driver* PlatformDummyGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformDummyGL::createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     return nullptr;
 }
 

--- a/filament/backend/src/opengl/platforms/PlatformDummyGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformDummyGL.cpp
@@ -18,7 +18,7 @@
 
 namespace filament::backend {
 
-Driver* PlatformDummyGL::createDriver(void* const sharedGLContext) noexcept {
+Driver* PlatformDummyGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     return nullptr;
 }
 

--- a/filament/backend/src/opengl/platforms/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformDummyGL.h
@@ -28,7 +28,7 @@ namespace filament::backend {
 class PlatformDummyGL final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override { }
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override {

--- a/filament/backend/src/opengl/platforms/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformDummyGL.h
@@ -28,7 +28,7 @@ namespace filament::backend {
 class PlatformDummyGL final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override { }
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override {

--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -80,7 +80,7 @@ static void clearGlError() noexcept {
 
 PlatformEGL::PlatformEGL() noexcept = default;
 
-Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
+Driver* PlatformEGL::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
 
@@ -219,7 +219,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     clearGlError();
 
     // success!!
-    return OpenGLDriverFactory::create(this, sharedContext);
+    return OpenGLDriverFactory::create(this, sharedContext, driverConfig);
 
 error:
     // if we're here, we've failed

--- a/filament/backend/src/opengl/platforms/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.cpp
@@ -80,7 +80,7 @@ static void clearGlError() noexcept {
 
 PlatformEGL::PlatformEGL() noexcept = default;
 
-Driver* PlatformEGL::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformEGL::createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
 

--- a/filament/backend/src/opengl/platforms/PlatformEGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.h
@@ -33,7 +33,7 @@ public:
 
     PlatformEGL() noexcept;
 
-    Driver* createDriver(void* sharedContext) noexcept override;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;

--- a/filament/backend/src/opengl/platforms/PlatformEGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformEGL.h
@@ -33,7 +33,7 @@ public:
 
     PlatformEGL() noexcept;
 
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -105,7 +105,7 @@ void PlatformEGLAndroid::terminate() noexcept {
     PlatformEGL::terminate();
 }
 
-Driver* PlatformEGLAndroid::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformEGLAndroid::createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     Driver* driver = PlatformEGL::createDriver(sharedContext, driverConfig);
     auto extensions = GLUtils::split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
 

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.cpp
@@ -105,8 +105,8 @@ void PlatformEGLAndroid::terminate() noexcept {
     PlatformEGL::terminate();
 }
 
-Driver* PlatformEGLAndroid::createDriver(void* sharedContext) noexcept {
-    Driver* driver = PlatformEGL::createDriver(sharedContext);
+Driver* PlatformEGLAndroid::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+    Driver* driver = PlatformEGL::createDriver(sharedContext, driverConfig);
     auto extensions = GLUtils::split(eglQueryString(mEGLDisplay, EGL_EXTENSIONS));
 
     eglGetNativeClientBufferANDROID = (PFNEGLGETNATIVECLIENTBUFFERANDROIDPROC) eglGetProcAddress(

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.h
@@ -31,7 +31,7 @@ public:
 
     void terminate() noexcept override;
 
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept final;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept final;
 
     int getOSVersion() const noexcept final;
 

--- a/filament/backend/src/opengl/platforms/PlatformEGLAndroid.h
+++ b/filament/backend/src/opengl/platforms/PlatformEGLAndroid.h
@@ -31,7 +31,7 @@ public:
 
     void terminate() noexcept override;
 
-    Driver* createDriver(void* sharedContext) noexcept final;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept final;
 
     int getOSVersion() const noexcept final;
 

--- a/filament/backend/src/opengl/platforms/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformGLX.cpp
@@ -130,7 +130,7 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformGLX::createDriver(void* const sharedGLContext, const DriverConfig& driverConfig) noexcept {
+Driver* PlatformGLX::createDriver(void* const sharedGLContext, DriverConfig& driverConfig) noexcept {
     loadLibraries();
     // Get the display device
     mGLXDisplay = g_x11.openDisplay(NULL);

--- a/filament/backend/src/opengl/platforms/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformGLX.cpp
@@ -130,7 +130,7 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
+Driver* PlatformGLX::createDriver(void* const sharedGLContext, const DriverConfig& driverConfig) noexcept {
     loadLibraries();
     // Get the display device
     mGLXDisplay = g_x11.openDisplay(NULL);
@@ -229,7 +229,7 @@ Driver* PlatformGLX::createDriver(void* const sharedGLContext) noexcept {
     int result = bluegl::bind();
     ASSERT_POSTCONDITION(!result, "Unable to load OpenGL entry points.");
 
-    return OpenGLDriverFactory::create(this, sharedGLContext);
+    return OpenGLDriverFactory::create(this, sharedGLContext, driverConfig);
 }
 
 void PlatformGLX::terminate() noexcept {

--- a/filament/backend/src/opengl/platforms/PlatformGLX.h
+++ b/filament/backend/src/opengl/platforms/PlatformGLX.h
@@ -33,7 +33,7 @@ namespace filament::backend {
 class PlatformGLX final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, const DriverConfig& driverConfig) noexcept override;
 
     void terminate() noexcept override;
 

--- a/filament/backend/src/opengl/platforms/PlatformGLX.h
+++ b/filament/backend/src/opengl/platforms/PlatformGLX.h
@@ -33,7 +33,7 @@ namespace filament::backend {
 class PlatformGLX final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext, const DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, DriverConfig& driverConfig) noexcept override;
 
     void terminate() noexcept override;
 

--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -76,7 +76,7 @@ struct WGLSwapChain {
     bool isHeadless = false;
 };
 
-Driver* PlatformWGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformWGL::createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     int result = 0;
     PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribs = nullptr;
     int pixelFormat = 0;

--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -76,7 +76,7 @@ struct WGLSwapChain {
     bool isHeadless = false;
 };
 
-Driver* PlatformWGL::createDriver(void* const sharedGLContext) noexcept {
+Driver* PlatformWGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
     int result = 0;
     PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribs = nullptr;
     int pixelFormat = 0;
@@ -147,7 +147,7 @@ Driver* PlatformWGL::createDriver(void* const sharedGLContext) noexcept {
 
     result = bluegl::bind();
     ASSERT_POSTCONDITION(!result, "Unable to load OpenGL entry points.");
-    return OpenGLDriverFactory::create(this, sharedGLContext);
+    return OpenGLDriverFactory::create(this, sharedGLContext, driverConfig);
 
 error:
     if (tempContext) {

--- a/filament/backend/src/opengl/platforms/PlatformWGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.h
@@ -30,7 +30,7 @@ namespace filament::backend {
 
 class PlatformWGL final : public OpenGLPlatform {
 public:
-    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;

--- a/filament/backend/src/opengl/platforms/PlatformWGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.h
@@ -30,7 +30,7 @@ namespace filament::backend {
 
 class PlatformWGL final : public OpenGLPlatform {
 public:
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept override;

--- a/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
@@ -21,8 +21,8 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformWebGL::createDriver(void* const sharedGLContext) noexcept {
-    return OpenGLDriverFactory::create(this, sharedGLContext);
+Driver* PlatformWebGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+    return OpenGLDriverFactory::create(this, sharedGLContext, driverConfig);
 }
 
 void PlatformWebGL::terminate() noexcept {

--- a/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWebGL.cpp
@@ -21,7 +21,7 @@ namespace filament::backend {
 
 using namespace backend;
 
-Driver* PlatformWebGL::createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformWebGL::createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept {
     return OpenGLDriverFactory::create(this, sharedGLContext, driverConfig);
 }
 

--- a/filament/backend/src/opengl/platforms/PlatformWebGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformWebGL.h
@@ -31,7 +31,7 @@ namespace filament::backend {
 class PlatformWebGL final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override;

--- a/filament/backend/src/opengl/platforms/PlatformWebGL.h
+++ b/filament/backend/src/opengl/platforms/PlatformWebGL.h
@@ -31,7 +31,7 @@ namespace filament::backend {
 class PlatformWebGL final : public OpenGLPlatform {
 public:
 
-    Driver* createDriver(void* const sharedGLContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedGLContext, Platform::DriverConfig& driverConfig) noexcept override;
     void terminate() noexcept override;
 
     SwapChain* createSwapChain(void* nativewindow, uint64_t& flags) noexcept final override;

--- a/filament/backend/src/vulkan/PlatformVkAndroid.cpp
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.cpp
@@ -29,7 +29,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkAndroid::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkAndroid::createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requiredInstanceExtensions[] = { "VK_KHR_android_surface" };
     return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1, driverConfig);

--- a/filament/backend/src/vulkan/PlatformVkAndroid.cpp
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.cpp
@@ -29,10 +29,10 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkAndroid::createDriver(void* const sharedContext) noexcept {
+Driver* PlatformVkAndroid::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requiredInstanceExtensions[] = { "VK_KHR_android_surface" };
-    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1);
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1, driverConfig);
 }
 
 void* PlatformVkAndroid::createVkSurfaceKHR(void* nativeWindow, void* vkinstance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkAndroid.h
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.h
@@ -27,7 +27,7 @@ namespace filament::backend {
 class PlatformVkAndroid final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkAndroid.h
+++ b/filament/backend/src/vulkan/PlatformVkAndroid.h
@@ -27,7 +27,7 @@ namespace filament::backend {
 class PlatformVkAndroid final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkCocoa.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.h
@@ -26,7 +26,7 @@ namespace filament::backend {
 
 class PlatformVkCocoa final : public VulkanPlatform {
 public:
-    Driver* createDriver(void* sharedContext) noexcept override;
+    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };

--- a/filament/backend/src/vulkan/PlatformVkCocoa.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.h
@@ -26,7 +26,7 @@ namespace filament::backend {
 
 class PlatformVkCocoa final : public VulkanPlatform {
 public:
-    Driver* createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };

--- a/filament/backend/src/vulkan/PlatformVkCocoa.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.mm
@@ -34,7 +34,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkCocoa::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkCocoa::createDriver(void* sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requiredInstanceExtensions[] = {
         "VK_MVK_macos_surface", // TODO: replace with VK_EXT_metal_surface

--- a/filament/backend/src/vulkan/PlatformVkCocoa.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoa.mm
@@ -34,12 +34,12 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkCocoa::createDriver(void* sharedContext) noexcept {
+Driver* PlatformVkCocoa::createDriver(void* sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requiredInstanceExtensions[] = {
         "VK_MVK_macos_surface", // TODO: replace with VK_EXT_metal_surface
     };
-    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1);
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1, driverConfig);
 }
 
 void* PlatformVkCocoa::createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
@@ -26,7 +26,7 @@ namespace filament::backend {
 
 class PlatformVkCocoaTouch final : public VulkanPlatform {
 public:
-    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.h
@@ -26,7 +26,7 @@ namespace filament::backend {
 
 class PlatformVkCocoaTouch final : public VulkanPlatform {
 public:
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
     int getOSVersion() const noexcept override { return 0; }
 };

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
@@ -39,10 +39,10 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkCocoaTouch::createDriver(void* const sharedContext) noexcept {
+Driver* PlatformVkCocoaTouch::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requestedExtensions[] = {"VK_MVK_ios_surface"};
-    return VulkanDriverFactory::create(this, requestedExtensions, 1);
+    return VulkanDriverFactory::create(this, requestedExtensions, 1, driverConfig);
 }
 
 void* PlatformVkCocoaTouch::createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
+++ b/filament/backend/src/vulkan/PlatformVkCocoaTouch.mm
@@ -39,7 +39,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkCocoaTouch::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkCocoaTouch::createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     static const char* requestedExtensions[] = {"VK_MVK_ios_surface"};
     return VulkanDriverFactory::create(this, requestedExtensions, 1, driverConfig);

--- a/filament/backend/src/vulkan/PlatformVkLinuxWayland.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinuxWayland.cpp
@@ -29,7 +29,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkLinuxWayland::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkLinuxWayland::createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = {
         "VK_KHR_wayland_surface",

--- a/filament/backend/src/vulkan/PlatformVkLinuxWayland.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinuxWayland.cpp
@@ -29,13 +29,13 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkLinuxWayland::createDriver(void* const sharedContext) noexcept {
+Driver* PlatformVkLinuxWayland::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = {
         "VK_KHR_wayland_surface",
     };
     return VulkanDriverFactory::create(this, requiredInstanceExtensions,
-            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
+            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]), driverConfig);
 }
 
 void* PlatformVkLinuxWayland::createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkLinuxWayland.h
+++ b/filament/backend/src/vulkan/PlatformVkLinuxWayland.h
@@ -28,7 +28,7 @@ namespace filament::backend {
 class PlatformVkLinuxWayland final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkLinuxWayland.h
+++ b/filament/backend/src/vulkan/PlatformVkLinuxWayland.h
@@ -28,7 +28,7 @@ namespace filament::backend {
 class PlatformVkLinuxWayland final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkLinuxX11.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinuxX11.cpp
@@ -50,7 +50,7 @@ struct X11Functions {
     void* library = nullptr;
 } g_x11;
 
-Driver* PlatformVkLinuxX11::createDriver(void* const sharedContext) noexcept {
+Driver* PlatformVkLinuxX11::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = {
 #ifdef FILAMENT_SUPPORTS_XCB
@@ -61,7 +61,7 @@ Driver* PlatformVkLinuxX11::createDriver(void* const sharedContext) noexcept {
 #endif
     };
     return VulkanDriverFactory::create(this, requiredInstanceExtensions,
-            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]));
+            sizeof(requiredInstanceExtensions) / sizeof(requiredInstanceExtensions[0]), driverConfig);
 }
 
 void* PlatformVkLinuxX11::createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkLinuxX11.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinuxX11.cpp
@@ -50,7 +50,7 @@ struct X11Functions {
     void* library = nullptr;
 } g_x11;
 
-Driver* PlatformVkLinuxX11::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkLinuxX11::createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = {
 #ifdef FILAMENT_SUPPORTS_XCB

--- a/filament/backend/src/vulkan/PlatformVkLinuxX11.h
+++ b/filament/backend/src/vulkan/PlatformVkLinuxX11.h
@@ -35,7 +35,7 @@ namespace filament::backend {
 class PlatformVkLinuxX11 final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkLinuxX11.h
+++ b/filament/backend/src/vulkan/PlatformVkLinuxX11.h
@@ -35,7 +35,7 @@ namespace filament::backend {
 class PlatformVkLinuxX11 final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkWindows.cpp
+++ b/filament/backend/src/vulkan/PlatformVkWindows.cpp
@@ -27,10 +27,10 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkWindows::createDriver(void* const sharedContext) noexcept {
+Driver* PlatformVkWindows::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = { "VK_KHR_win32_surface" };
-    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1);
+    return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1, driverConfig);
 }
 
 void* PlatformVkWindows::createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept {

--- a/filament/backend/src/vulkan/PlatformVkWindows.cpp
+++ b/filament/backend/src/vulkan/PlatformVkWindows.cpp
@@ -27,7 +27,7 @@ using namespace bluevk;
 
 namespace filament::backend {
 
-Driver* PlatformVkWindows::createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept {
+Driver* PlatformVkWindows::createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept {
     ASSERT_PRECONDITION(sharedContext == nullptr, "Vulkan does not support shared contexts.");
     const char* requiredInstanceExtensions[] = { "VK_KHR_win32_surface" };
     return VulkanDriverFactory::create(this, requiredInstanceExtensions, 1, driverConfig);

--- a/filament/backend/src/vulkan/PlatformVkWindows.h
+++ b/filament/backend/src/vulkan/PlatformVkWindows.h
@@ -27,7 +27,7 @@ namespace filament::backend {
 class PlatformVkWindows final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
+    Driver* createDriver(void* const sharedContext, Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/PlatformVkWindows.h
+++ b/filament/backend/src/vulkan/PlatformVkWindows.h
@@ -27,7 +27,7 @@ namespace filament::backend {
 class PlatformVkWindows final : public VulkanPlatform {
 public:
 
-    Driver* createDriver(void* const sharedContext) noexcept override;
+    Driver* createDriver(void* const sharedContext, const Platform::DriverConfig& driverConfig) noexcept override;
 
     void* createVkSurfaceKHR(void* nativeWindow, void* instance, uint64_t flags) noexcept override;
 

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -50,7 +50,7 @@ private:
     void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
 
     inline VulkanDriver(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount,
             const Platform::DriverConfig& driverConfig) noexcept;
 
     ~VulkanDriver() noexcept override;

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -42,8 +42,7 @@ struct VulkanSamplerGroup;
 class VulkanDriver final : public DriverBase {
 public:
     static Driver* create(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, const Platform::DriverConfig& driverConfig) noexcept;
-    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, Platform::DriverConfig& driverConfig) noexcept;
 
 private:
 
@@ -51,7 +50,7 @@ private:
 
     inline VulkanDriver(VulkanPlatform* platform,
             const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount,
-            const Platform::DriverConfig& driverConfig) noexcept;
+            Platform::DriverConfig& driverConfig) noexcept;
 
     ~VulkanDriver() noexcept override;
 

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -42,14 +42,16 @@ struct VulkanSamplerGroup;
 class VulkanDriver final : public DriverBase {
 public:
     static Driver* create(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount) noexcept;
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, const Platform::DriverConfig& driverConfig) noexcept;
+    static size_t getHandleArenaSize(const Platform::DriverConfig& driverConfig) noexcept;
 
 private:
 
     void debugCommandBegin(CommandStream* cmds, bool synchronous, const char* methodName) noexcept override;
 
     inline VulkanDriver(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount) noexcept;
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount
+            const Platform::DriverConfig& driverConfig) noexcept;
 
     ~VulkanDriver() noexcept override;
 

--- a/filament/backend/src/vulkan/VulkanDriverFactory.h
+++ b/filament/backend/src/vulkan/VulkanDriverFactory.h
@@ -27,7 +27,7 @@ class Driver;
 class VulkanDriverFactory {
 public:
     static Driver* create(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, const Platform::DriverConfig& driverConfig) noexcept;
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, Platform::DriverConfig& driverConfig) noexcept;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanDriverFactory.h
+++ b/filament/backend/src/vulkan/VulkanDriverFactory.h
@@ -27,7 +27,7 @@ class Driver;
 class VulkanDriverFactory {
 public:
     static Driver* create(VulkanPlatform* platform,
-            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount) noexcept;
+            const char* const* ppEnabledExtensions, uint32_t enabledExtensionCount, const Platform::DriverConfig& driverConfig) noexcept;
 };
 
 } // namespace filament::backend

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -54,6 +54,22 @@ class LightManager;
 class RenderableManager;
 class TransformManager;
 
+#ifndef FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB
+// Froxelization needs about 1 MiB. Command buffer needs about 1 MiB.
+#    define FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB 3
+#endif
+
+#ifndef FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB
+// size of the high-level draw commands buffer (comes from the per-render pass allocator)
+#    define FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB 2
+#endif
+
+#ifndef FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB
+// size of a command-stream buffer (comes from mmap -- not the per-engine arena)
+#    define FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB 1
+#endif
+
+
 /**
  * Engine is filament's main entry-point.
  *
@@ -151,6 +167,70 @@ class UTILS_PUBLIC Engine {
 public:
     using Platform = backend::Platform;
     using Backend = backend::Backend;
+    using DriverConfig = backend::Platform::DriverConfig;
+
+    /**
+    * ConfigParams are used to define the memory footprint used by the engine, such as the
+    * command buffer size. ConfigParams can be used to customize engine requirements based 
+    * on the applications needs.
+    */
+    class ConfigParams {
+    private:
+        static constexpr uint32_t DEFAULT_COMMAND_BUFFER_SIZE_IN_MB = FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB * 3;
+
+        size_t mMinCommandBufferSize;           // minimum size of command buffer
+        size_t mCommandBufferSize;              // size of command buffer
+        size_t mPerFrameCommandsSize;           // size of the high-level draw commands buffer
+        size_t mPerRenderPassArenaSize;         // size of the per-pass arena buffer
+        DriverConfig mDriverConfig;             // parameters for driver initialization
+
+    public:
+        /**
+        * ConfigParams constructor
+        * 
+        * @param srcConfig      A pointer to a ConfigParams object containing values to be duplicated.
+        */
+        ConfigParams(const ConfigParams* srcConfig);
+
+        /**
+        * ConfigParams constructor. Parameters may be ignored and default values used if
+        * they are deemed too small or invalid by the engine.
+        *
+        * @param commandBufferMB            Memory size (in MB) to allocate for Engine command buffer.
+        * 
+        *                                   Should always be 3 * perFrameCommandsMB so up to 3 frames can
+        *                                   be overlapping at once.
+        * 
+        *                                   Defaults to FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB.
+        * 
+        * @param perFrameCommandsMB         Memory size (in MB) to allocate for per-frame commands.
+        * 
+        *                                   This size dictates the maximum number of visible objects in
+        *                                   the scene.
+        * 
+        * @param perRenderPassArenaMB       Memory size (in MB) to allocate for per-render-pass arena.
+        * 
+        *                                   Rule of thumb: perRenderPassArenaMB must be roughly 
+        *                                   1 MB larger than perFrameCommandsMB
+        * 
+        * @param driverHandleArenaSizeMB    Memory size (in MB) to allocate to the driver handle arena.
+        * 
+        *                                   If 0, then the default value for the given platform is used.
+        */
+        ConfigParams(uint32_t commandBufferMB = DEFAULT_COMMAND_BUFFER_SIZE_IN_MB,
+            uint32_t perFrameCommandsMB = FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB,
+            uint32_t perRenderPassArenaMB = FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB,
+            uint32_t driverHandleArenaSizeMB = 0);      
+
+        const size_t CommandBufferSize() const noexcept { return mCommandBufferSize; }
+        const size_t MinCommandBufferSize() const noexcept { return mMinCommandBufferSize; }
+        const size_t PerFrameCommandsSize() const noexcept { return mPerFrameCommandsSize; }
+        const size_t PerRenderPassArenaSize() const noexcept { return mPerRenderPassArenaSize; }
+        const DriverConfig& DriverParams() const noexcept { return mDriverConfig; }
+
+    private:
+        void init(uint32_t commandBufferMB, uint32_t perFrameCommandsMB, uint32_t perRenderPassArenaMB);
+    };
 
     /**
      * Creates an instance of Engine
@@ -175,6 +255,8 @@ public:
      *                          Setting this parameter will force filament to use the OpenGL
      *                          implementation (instead of Vulkan for instance).
      *
+     * @param configParams      A pointer to optional parameters to specify memory size
+     *                          configuration options.  If nullptr, then defaults used.
      *
      * @return A pointer to the newly created Engine, or nullptr if the Engine couldn't be created.
      *
@@ -189,7 +271,8 @@ public:
      * This method is thread-safe.
      */
     static Engine* create(Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Platform* platform = nullptr, void* sharedGLContext = nullptr,
+            const ConfigParams* configParams = nullptr);
 
 #if UTILS_HAS_THREADING
     /**
@@ -231,10 +314,14 @@ public:
      *                          when creating filament's internal context.
      *                          Setting this parameter will force filament to use the OpenGL
      *                          implementation (instead of Vulkan for instance).
+     * 
+     * @param configParams      A pointer to optional parameters to specify memory size
+     *                          configuration options
      */
     static void createAsync(CreateCallback callback, void* user,
             Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Platform* platform = nullptr, void* sharedGLContext = nullptr,
+            const ConfigParams* configParams = nullptr);
 
     /**
      * Retrieve an Engine* from createAsync(). This must be called from the same thread than

--- a/filament/src/Allocators.h
+++ b/filament/src/Allocators.h
@@ -21,26 +21,7 @@
 
 #include "private/backend/BackendUtils.h"
 
-#ifndef FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB
-#    define FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB 3
-#endif
-
-#ifndef FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB
-#    define FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB 2
-#endif
-
 namespace filament {
-
-// per render pass allocations
-// Froxelization needs about 1 MiB. Command buffer needs about 1 MiB.
-static constexpr size_t CONFIG_PER_RENDER_PASS_ARENA_SIZE  = FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB * 1024 * 1024;
-
-// size of the high-level draw commands buffer (comes from the per-render pass allocator)
-static constexpr size_t CONFIG_PER_FRAME_COMMANDS_SIZE     = FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB * 1024 * 1024;
-
-// size of a command-stream buffer (comes from mmap -- not the per-engine arena)
-static constexpr size_t CONFIG_MIN_COMMAND_BUFFERS_SIZE    = FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB * 1024 * 1024;
-static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE        = 3 * CONFIG_MIN_COMMAND_BUFFERS_SIZE;
 
 #ifndef NDEBUG
 

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -44,7 +44,7 @@ namespace filament {
 using namespace math;
 using namespace backend;
 
-Engine* Engine::create(Backend backend, Platform* platform, void* sharedGLContext, const ConfigParams* configParams) {
+Engine* Engine::create(Backend backend, Platform* platform, void* sharedGLContext, const Config* configParams) {
     return FEngine::create(backend, platform, sharedGLContext, configParams);
 }
 
@@ -54,7 +54,7 @@ void Engine::destroy(Engine* engine) {
 
 #if UTILS_HAS_THREADING
 void Engine::createAsync(Engine::CreateCallback callback, void* user, Backend backend,
-        Platform* platform, void* sharedGLContext, const ConfigParams* configParams) {
+        Platform* platform, void* sharedGLContext, const Config* configParams) {
     FEngine::createAsync(callback, user, backend, platform, sharedGLContext, configParams);
 }
 
@@ -250,41 +250,5 @@ DebugRegistry& Engine::getDebugRegistry() noexcept {
 void Engine::pumpMessageQueues() {
     upcast(this)->pumpMessageQueues();
 }
-
-Engine::ConfigParams::ConfigParams(const ConfigParams* srcConfig) :
-    mDriverConfig(srcConfig == nullptr ? nullptr : &srcConfig->DriverParams())
-{
-    if (srcConfig != nullptr) {
-        *this = *srcConfig;
-    }
-    else {
-        init(DEFAULT_COMMAND_BUFFER_SIZE_IN_MB, FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB);
-    }
-}
-
-Engine::ConfigParams::ConfigParams(uint32_t commandBufferMB, uint32_t perFrameCommandsMB, uint32_t perRenderPassArenaMB, uint32_t driverHandleArenaSizeMB) :
-    mDriverConfig(driverHandleArenaSizeMB) 
-{
-    init(commandBufferMB, perFrameCommandsMB, perRenderPassArenaMB);
-}
-
-void Engine::ConfigParams::init(uint32_t commandBufferMB, uint32_t perFrameCommandsMB, uint32_t perRenderPassArenaMB) {
-    constexpr size_t MB = 1024 * 1024;
-    constexpr uint32_t ARENA_COMMANDS_DELTA = 1;    // Rule of thumb: perRenderPassArenaMB must be roughly 1 MB larger than perFrameCommandsMB
-    constexpr uint32_t NUM_FRAMES_OVERLAP = 3;      // Number of potential concurrent frames in flight
-
-    uint32_t minCommandBuffersSizeMB = max((uint32_t)FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB, perFrameCommandsMB);  // As a rule of thumb use the same value as perFrameCommandsMB
-    commandBufferMB = max(commandBufferMB, minCommandBuffersSizeMB * NUM_FRAMES_OVERLAP);
-    perFrameCommandsMB = max((uint32_t)FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, minCommandBuffersSizeMB);
-    perRenderPassArenaMB = max((uint32_t)FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, perRenderPassArenaMB);
-    perRenderPassArenaMB = max(perRenderPassArenaMB, perFrameCommandsMB + ARENA_COMMANDS_DELTA);        // Enforce pre-render-pass arena rule-of-thumb
-
-    mMinCommandBufferSize = minCommandBuffersSizeMB * MB;
-    mCommandBufferSize = commandBufferMB * MB;
-    mPerFrameCommandsSize = perFrameCommandsMB * MB;
-    mPerRenderPassArenaSize = perRenderPassArenaMB * MB;
-}
-
-
 
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -126,16 +126,25 @@ public:
     static constexpr size_t CONFIG_FROXEL_SLICE_COUNT      = 16;
     static constexpr bool   CONFIG_IBL_USE_IRRADIANCE_MAP  = false;
 
+    // Creation parameters
+    size_t mMinCommandBufferSize;           // minimum size of command buffer (in bytes)
+    size_t mCommandBufferSize;              // size of command buffer (in bytes)
+    size_t mPerFrameCommandsSize;           // size of the high-level draw commands buffer (in bytes)
+    size_t mPerRenderPassArenaSize;         // size of the per-pass arena buffer (in bytes)
+    size_t mDriverHandleArenaSize;          // size of driver handle arena (in bytes)
+
 public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
             Platform* platform = nullptr, void* sharedGLContext = nullptr,
-            const ConfigParams* configParams = nullptr);
+            const Config* config = nullptr);
+
+    static void validateConfig(const Config* srcConfig, Config& validConfig) noexcept;
 
 #if UTILS_HAS_THREADING
     static void createAsync(CreateCallback callback, void* user,
             Backend backend = Backend::DEFAULT,
             Platform* platform = nullptr, void* sharedGLContext = nullptr,
-            const ConfigParams* configParams = nullptr);
+            const Config* config = nullptr);
 
     static FEngine* getEngine(void* token);
 #endif
@@ -143,8 +152,6 @@ public:
     static void destroy(FEngine* engine);
 
     ~FEngine() noexcept;
-
-    const ConfigParams& GetConfig() const noexcept { return mConfigParams; }
 
     backend::Driver& getDriver() const noexcept { return *mDriver; }
 
@@ -356,7 +363,7 @@ public:
     backend::Handle<backend::HwTexture> getOneIntegerTextureArray() const { return mDummyOneIntegerTextureArray; }
 
 private:
-    FEngine(Backend backend, Platform* platform, void* sharedGLContext, const ConfigParams& configParams);
+    FEngine(Backend backend, Platform* platform, void* sharedGLContext, const Config& config);
     void init();
     void shutdown();
 
@@ -378,7 +385,6 @@ private:
     backend::Driver* mDriver = nullptr;
     backend::Handle<backend::HwRenderTarget> mDefaultRenderTarget;
 
-    ConfigParams mConfigParams;
     Backend mBackend;
     Platform* mPlatform = nullptr;
     bool mOwnPlatform = false;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -126,19 +126,16 @@ public:
     static constexpr size_t CONFIG_FROXEL_SLICE_COUNT      = 16;
     static constexpr bool   CONFIG_IBL_USE_IRRADIANCE_MAP  = false;
 
-    static constexpr size_t CONFIG_PER_RENDER_PASS_ARENA_SIZE   = filament::CONFIG_PER_RENDER_PASS_ARENA_SIZE;
-    static constexpr size_t CONFIG_PER_FRAME_COMMANDS_SIZE      = filament::CONFIG_PER_FRAME_COMMANDS_SIZE;
-    static constexpr size_t CONFIG_MIN_COMMAND_BUFFERS_SIZE     = filament::CONFIG_MIN_COMMAND_BUFFERS_SIZE;
-    static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE         = filament::CONFIG_COMMAND_BUFFERS_SIZE;
-
 public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Platform* platform = nullptr, void* sharedGLContext = nullptr,
+            const ConfigParams* configParams = nullptr);
 
 #if UTILS_HAS_THREADING
     static void createAsync(CreateCallback callback, void* user,
             Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Platform* platform = nullptr, void* sharedGLContext = nullptr,
+            const ConfigParams* configParams = nullptr);
 
     static FEngine* getEngine(void* token);
 #endif
@@ -146,6 +143,8 @@ public:
     static void destroy(FEngine* engine);
 
     ~FEngine() noexcept;
+
+    const ConfigParams& GetConfig() const noexcept { return mConfigParams; }
 
     backend::Driver& getDriver() const noexcept { return *mDriver; }
 
@@ -357,7 +356,7 @@ public:
     backend::Handle<backend::HwTexture> getOneIntegerTextureArray() const { return mDummyOneIntegerTextureArray; }
 
 private:
-    FEngine(Backend backend, Platform* platform, void* sharedGLContext);
+    FEngine(Backend backend, Platform* platform, void* sharedGLContext, const ConfigParams& configParams);
     void init();
     void shutdown();
 
@@ -379,6 +378,7 @@ private:
     backend::Driver* mDriver = nullptr;
     backend::Handle<backend::HwRenderTarget> mDefaultRenderTarget;
 
+    ConfigParams mConfigParams;
     Backend mBackend;
     Platform* mPlatform = nullptr;
     bool mOwnPlatform = false;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -104,7 +104,7 @@ FRenderer::~FRenderer() noexcept {
     // to free what we can (it would probably mean something when wrong).
 #ifndef NDEBUG
     size_t wm = getCommandsHighWatermark();
-    size_t wmpct = wm / (CONFIG_PER_FRAME_COMMANDS_SIZE / 100);
+    size_t wmpct = wm / (mEngine.GetConfig().PerFrameCommandsSize() / 100);
     slog.d << "Renderer: Commands High watermark "
     << wm / 1024 << " KiB (" << wmpct << "%), "
     << wm / sizeof(Command) << " commands, " << sizeof(Command) << " bytes/command"
@@ -619,8 +619,9 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     // Allocate some space for our commands in the per-frame Arena, and use that space as
     // an Arena for commands. All this space is released when we exit this method.
-    void* const arenaBegin = arena.allocate(FEngine::CONFIG_PER_FRAME_COMMANDS_SIZE, CACHELINE_SIZE);
-    void* const arenaEnd = pointermath::add(arenaBegin, FEngine::CONFIG_PER_FRAME_COMMANDS_SIZE);
+    size_t perFrameCommandsSize = engine.GetConfig().PerFrameCommandsSize();
+    void* const arenaBegin = arena.allocate(perFrameCommandsSize, CACHELINE_SIZE);
+    void* const arenaEnd = pointermath::add(arenaBegin, perFrameCommandsSize);
     RenderPass::Arena commandArena("Command Arena", { arenaBegin, arenaEnd });
 
     RenderPass::RenderFlags renderFlags = 0;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -104,7 +104,7 @@ FRenderer::~FRenderer() noexcept {
     // to free what we can (it would probably mean something when wrong).
 #ifndef NDEBUG
     size_t wm = getCommandsHighWatermark();
-    size_t wmpct = wm / (mEngine.GetConfig().PerFrameCommandsSize() / 100);
+    size_t wmpct = wm / (mEngine.mPerFrameCommandsSize / 100);
     slog.d << "Renderer: Commands High watermark "
     << wm / 1024 << " KiB (" << wmpct << "%), "
     << wm / sizeof(Command) << " commands, " << sizeof(Command) << " bytes/command"
@@ -619,7 +619,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     // Allocate some space for our commands in the per-frame Arena, and use that space as
     // an Arena for commands. All this space is released when we exit this method.
-    size_t perFrameCommandsSize = engine.GetConfig().PerFrameCommandsSize();
+    size_t perFrameCommandsSize = engine.mPerFrameCommandsSize;
     void* const arenaBegin = arena.allocate(perFrameCommandsSize, CACHELINE_SIZE);
     void* const arenaEnd = pointermath::add(arenaBegin, perFrameCommandsSize);
     RenderPass::Arena commandArena("Command Arena", { arenaBegin, arenaEnd });


### PR DESCRIPTION
This code adds a config object, "ConfigParams," to Engine creation parameters for setting memory buffer sizes for command buffers and driver handle arena sizes.  It will use #define values (FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, etc.) as defaults (and as minimum acceptable values) if the user does not provide values.  It attempts to validate the values given to prevent the user from creating a unusable state.

**NOTE:** I have tried to be very careful in making changes that affect all platforms, but I am not set up to build, run, and test anything other than PC desktop at the moment.  All other platforms should build and run correctly, but they've not been directly tested.