### PR TITLE
fix FSR upscaling offset on metal/vulkan

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2705,11 +2705,12 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::upscale(FrameGraph& fg, bool
                     auto const& data, DriverApi& driver) {
 
                 // helper to set the EASU uniforms
-                auto setEasuUniforms = [vp](FMaterialInstance* mi,
+                auto setEasuUniforms = [vp, backend = mEngine.getBackend()](FMaterialInstance* mi,
                         FrameGraphTexture::Descriptor const& inputDesc,
                         FrameGraphTexture::Descriptor const& outputDesc) {
                     FSRUniforms uniforms{};
                     FSR_ScalingSetup(&uniforms, {
+                            .backend = backend,
                             .input = vp,
                             .inputWidth = inputDesc.width,
                             .inputHeight = inputDesc.height,

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2652,51 +2652,28 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::opaqueBlit(FrameGraph& fg,
     return ppBlit->output;
 }
 
-FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
-        FrameGraph& fg, bool translucent, DynamicResolutionOptions dsrOptions,
-        FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
-        FrameGraphTexture::Descriptor const& outDesc) noexcept {
+FrameGraphId<FrameGraphTexture> PostProcessManager::upscale(FrameGraph& fg, bool translucent,
+        DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
+        filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+        backend::SamplerMagFilter filter) noexcept {
 
-    Handle<HwRenderPrimitive> fullScreenRenderPrimitive = mEngine.getFullScreenRenderPrimitive();
+    if (UTILS_LIKELY(!translucent && dsrOptions.quality == QualityLevel::LOW)) {
+        return opaqueBlit(fg, input, vp, outDesc, filter);
+    }
 
-    bool lowQualityFallback = false;
-    if (translucent && dsrOptions.quality != QualityLevel::LOW) {
+    // The code below cannot handle sub-resources
+    assert_invariant(fg.getSubResourceDescriptor(input).layer == 0);
+    assert_invariant(fg.getSubResourceDescriptor(input).level == 0);
+
+    const bool lowQualityFallback = translucent && dsrOptions.quality != QualityLevel::LOW;
+    if (lowQualityFallback) {
         // FidelityFX-FSR doesn't support the alpha channel currently
         dsrOptions.quality = QualityLevel::LOW;
-        lowQualityFallback = true;
     }
 
     const bool twoPassesEASU = mWorkaroundSplitEasu &&
             (dsrOptions.quality == QualityLevel::MEDIUM
                 || dsrOptions.quality == QualityLevel::HIGH);
-
-    // helper to set the EASU uniforms
-    auto setEasuUniforms = [vp](FMaterialInstance* mi,
-            FrameGraphTexture::Descriptor const& inputDesc,
-            FrameGraphTexture::Descriptor const& outputDesc) {
-        FSRUniforms uniforms{};
-        FSR_ScalingSetup(&uniforms, {
-                .input = vp,
-                .inputWidth = inputDesc.width,
-                .inputHeight = inputDesc.height,
-                .outputWidth = outputDesc.width,
-                .outputHeight = outputDesc.height,
-        });
-        mi->setParameter("EasuCon0", uniforms.EasuCon0);
-        mi->setParameter("EasuCon1", uniforms.EasuCon1);
-        mi->setParameter("EasuCon2", uniforms.EasuCon2);
-        mi->setParameter("EasuCon3", uniforms.EasuCon3);
-        mi->setParameter("textureSize",
-                float2{ inputDesc.width, inputDesc.height });
-    };
-
-    // helper to enable blending
-    auto enableTranslucentBlending = [](PipelineState& pipeline) {
-        pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
-        pipeline.rasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
-        pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE_MINUS_SRC_ALPHA;
-        pipeline.rasterState.blendFunctionDstAlpha = BlendFunction::ONE_MINUS_SRC_ALPHA;
-    };
 
     struct QuadBlitData {
         FrameGraphId<FrameGraphTexture> input;
@@ -2704,14 +2681,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
         FrameGraphId<FrameGraphTexture> depth;
     };
 
-    auto& ppQuadBlit = fg.addPass<QuadBlitData>(dsrOptions.enabled ? "quad scaling" : "blendBlit",
+    auto& ppQuadBlit = fg.addPass<QuadBlitData>(dsrOptions.enabled ? "upscaling" : "compositing",
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.input = builder.sample(input);
-                data.output = builder.createTexture("scaled output", outDesc);
+                data.output = builder.createTexture("upscaled output", outDesc);
 
                 if (twoPassesEASU) {
-                    // FIXME: it would be better to use the stencil buffer in this case
-                    data.depth = builder.createTexture("scaled output depth", {
+                    // FIXME: it would be better to use the stencil buffer in this case (less bandwidth)
+                    data.depth = builder.createTexture("upscaled output depth", {
                         .width = outDesc.width,
                         .height = outDesc.height,
                         .format = TextureFormat::DEPTH16
@@ -2724,8 +2701,36 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
                         .attachments = { .color = { data.output }, .depth = { data.depth }},
                         .clearFlags = TargetBufferFlags::DEPTH });
             },
-            [=](FrameGraphResources const& resources,
+            [this, twoPassesEASU, dsrOptions, vp, translucent, filter](FrameGraphResources const& resources,
                     auto const& data, DriverApi& driver) {
+
+                // helper to set the EASU uniforms
+                auto setEasuUniforms = [vp](FMaterialInstance* mi,
+                        FrameGraphTexture::Descriptor const& inputDesc,
+                        FrameGraphTexture::Descriptor const& outputDesc) {
+                    FSRUniforms uniforms{};
+                    FSR_ScalingSetup(&uniforms, {
+                            .input = vp,
+                            .inputWidth = inputDesc.width,
+                            .inputHeight = inputDesc.height,
+                            .outputWidth = outputDesc.width,
+                            .outputHeight = outputDesc.height,
+                    });
+                    mi->setParameter("EasuCon0", uniforms.EasuCon0);
+                    mi->setParameter("EasuCon1", uniforms.EasuCon1);
+                    mi->setParameter("EasuCon2", uniforms.EasuCon2);
+                    mi->setParameter("EasuCon3", uniforms.EasuCon3);
+                    mi->setParameter("textureSize",
+                            float2{ inputDesc.width, inputDesc.height });
+                };
+
+                // helper to enable blending
+                auto enableTranslucentBlending = [](PipelineState& pipeline) {
+                    pipeline.rasterState.blendFunctionSrcRGB = BlendFunction::ONE;
+                    pipeline.rasterState.blendFunctionSrcAlpha = BlendFunction::ONE;
+                    pipeline.rasterState.blendFunctionDstRGB = BlendFunction::ONE_MINUS_SRC_ALPHA;
+                    pipeline.rasterState.blendFunctionDstAlpha = BlendFunction::ONE_MINUS_SRC_ALPHA;
+                };
 
                 auto color = resources.getTexture(data.input);
                 auto const& inputDesc = resources.getDescriptor(data.input);
@@ -2742,8 +2747,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
                     auto* mi = splitEasuMaterial->getMaterialInstance(mEngine);
                     setEasuUniforms(mi, inputDesc, outputDesc);
                     mi->setParameter("color", color, {
-                        .filterMag = SamplerMagFilter::LINEAR,
-                        .filterMin = SamplerMinFilter::LINEAR
+                        .filterMag = SamplerMagFilter::LINEAR
                     });
                     mi->setParameter("resolution",
                             float4{ outputDesc.width, outputDesc.height,
@@ -2762,8 +2766,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
                         setEasuUniforms(mi, inputDesc, outputDesc);
                     }
                     mi->setParameter("color", color, {
-                        .filterMag = SamplerMagFilter::LINEAR,
-                        .filterMin = SamplerMinFilter::LINEAR
+                        .filterMag = (dsrOptions.quality == QualityLevel::LOW) ?
+                                filter : SamplerMagFilter::LINEAR
                     });
                     mi->setParameter("resolution",
                             float4{ outputDesc.width, outputDesc.height,
@@ -2780,6 +2784,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
 
                 // --------------------------------------------------------------------------------
                 // render pass with draw calls
+
+                auto fullScreenRenderPrimitive = mEngine.getFullScreenRenderPrimitive();
 
                 auto out = resources.getRenderPassInfo();
 
@@ -2848,6 +2854,14 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::blendBlit(
 
     // we rely on automatic culling of unused render passes
     return output;
+}
+
+FrameGraphId<FrameGraphTexture> PostProcessManager::blit(FrameGraph& fg, bool translucent,
+        FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
+        FrameGraphTexture::Descriptor const& outDesc,
+        backend::SamplerMagFilter filter) noexcept {
+    // for now, we implement this by calling upscale() with the low-quality setting.
+    return upscale(fg, translucent, { .quality = QualityLevel::LOW }, input, vp, outDesc, filter);
 }
 
 FrameGraphId<FrameGraphTexture> PostProcessManager::resolveBaseLevel(FrameGraph& fg,

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -211,10 +211,15 @@ public:
             FrameGraphTexture::Descriptor const& outDesc,
             backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
 
-    FrameGraphId<FrameGraphTexture> blendBlit(
-            FrameGraph& fg, bool translucent, DynamicResolutionOptions dsrOptions,
+    FrameGraphId<FrameGraphTexture> upscale(FrameGraph& fg, bool translucent,
+            DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
+            filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+            backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
+
+    FrameGraphId<FrameGraphTexture> blit(FrameGraph& fg, bool translucent,
             FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
-            FrameGraphTexture::Descriptor const& outDesc) noexcept;
+            FrameGraphTexture::Descriptor const& outDesc,
+            backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
 
     // resolve base level of input and outputs a 1-level texture
     FrameGraphId<FrameGraphTexture> resolveBaseLevel(FrameGraph& fg,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1011,15 +1011,9 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (scaled) {
             mightNeedFinalBlit = false;
             auto viewport = DEBUG_DYNAMIC_SCALING ? xvp : vp;
-            if (UTILS_LIKELY(!blending && dsrOptions.quality == QualityLevel::LOW)) {
-                input = ppm.opaqueBlit(fg, input, xvp, {
-                        .width = viewport.width, .height = viewport.height,
-                        .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::LINEAR);
-            } else {
-                input = ppm.blendBlit(fg, blending, dsrOptions, input, xvp, {
-                        .width = viewport.width, .height = viewport.height,
-                        .format = colorGradingConfig.ldrFormat });
-            }
+            input = ppm.upscale(fg, blending, dsrOptions, input, xvp, {
+                    .width = viewport.width, .height = viewport.height,
+                    .format = colorGradingConfig.ldrFormat });
             xvp.left = xvp.bottom = 0;
             svp = xvp;
         }
@@ -1047,21 +1041,13 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             (outputIsSwapChain &&
                     (msaaSampleCount > 1 ||
                     colorGradingConfig.asSubpass ||
-                    ssReflectionsOptions.enabled)))
-        {
+                    ssReflectionsOptions.enabled))) {
             assert_invariant(!scaled);
-            if (UTILS_LIKELY(!blending)) {
-                input = ppm.opaqueBlit(fg, input, xvp, {
-                        .width = vp.width, .height = vp.height,
-                        .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::NEAREST);
-            } else {
-                input = ppm.blendBlit(fg, blending, { .quality = QualityLevel::LOW }, input, xvp, {
-                        .width = vp.width, .height = vp.height,
-                        .format = colorGradingConfig.ldrFormat});
-            }
+            input = ppm.blit(fg, blending, input, xvp, {
+                    .width = vp.width, .height = vp.height,
+                    .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::NEAREST);
         }
     }
-
 
 //    auto debug = structure
 //    fg.forwardResource(fgViewRenderTarget, debug ? debug : input);

--- a/filament/src/fsr.cpp
+++ b/filament/src/fsr.cpp
@@ -39,6 +39,15 @@ using namespace math;
 #pragma clang diagnostic pop
 
 void FSR_ScalingSetup(FSRUniforms* outUniforms, FSRScalingConfig config) noexcept {
+    // FsrEasu API claims it needs the left-top offset, however that's not true with OpenGL,
+    // in which case it uses the left-bottom offset.
+
+    auto yoffset = config.input.bottom;
+    if (config.backend == backend::Backend::METAL ||
+        config.backend == backend::Backend::VULKAN) {
+        yoffset = config.inputHeight - (config.input.bottom + config.input.height);
+    }
+
     FsrEasuConOffset( outUniforms->EasuCon0.v, outUniforms->EasuCon1.v,
                 outUniforms->EasuCon2.v, outUniforms->EasuCon3.v,
             // Viewport size (top left aligned) in the input image which is to be scaled.
@@ -48,10 +57,7 @@ void FSR_ScalingSetup(FSRUniforms* outUniforms, FSRScalingConfig config) noexcep
             // The output resolution.
             config.outputWidth, config.outputHeight,
             // Input image offset
-            config.input.left, config.input.bottom);
-    // FIXME: FsrEasu api claims it needs the top,left offset, but when using that we get
-    //        some bad artifacts. To investigate. For reference:
-    //           top = config.inputHeight - (config.input.bottom + config.input.height)
+            config.input.left, yoffset);
 }
 
 void FSR_SharpeningSetup(FSRUniforms* outUniforms, FSRSharpeningConfig config) noexcept {

--- a/filament/src/fsr.h
+++ b/filament/src/fsr.h
@@ -26,6 +26,7 @@
 namespace filament {
 
 struct FSRScalingConfig {
+    filament::backend::Backend backend;
     filament::Viewport input;   // region of source to be scaled
     uint32_t inputWidth;        // width of source
     uint32_t inputHeight;       // height of source


### PR DESCRIPTION
The FSR API documentation is a bit misleading, it expects offsets
with different origin depending on the backend API.

Also cleanup blitting passes:
We now have 3 public APIS:

- opaqueBlit() which is used for basic blitting and scaling and
  supports sub-resources.

- blit() which is used for blitting + composition
  - can optionally perform basic scaling
  - doesn't support sub-resources

- upscale() which is used for high quality upscaling
  - can do composition (blending)
  - doesn't support sub-resources