### PR TITLE
Workaround: partially revert "don't issue a flush..."

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -192,7 +192,6 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     const time_point<steady_clock> appVsync(vsyncSteadyClockTimeNano ? userVsync : now);
 
     mFrameId++;
-    mViewRenderedCount = 0;
 
     { // scope for frame id trace
         char buf[64];
@@ -421,13 +420,9 @@ void FRenderer::render(FView const* view) {
     }
 
     if (UTILS_LIKELY(view && view->getScene())) {
-        if (mViewRenderedCount) {
-            // this is a good place to kick the GPU, since we've rendered a View before
-            // and we're about to render another one.
-            mEngine.getDriverApi().flush();
-        }
+        // NOTE: in the past we tried to kick the GPU here with a flush (b2cdf9f), but this
+        // was problematic on certain devices. b/232224942
         renderInternal(view);
-        mViewRenderedCount++;
     }
 }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -164,7 +164,6 @@ private:
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;
-    uint32_t mViewRenderedCount = 0;
     FrameInfoManager mFrameInfoManager;
     backend::TextureFormat mHdrTranslucent;
     backend::TextureFormat mHdrQualityMedium;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -215,6 +215,11 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
 
         driver.popGroupMarker();
     }
+
+    // NOTE: in the past we tried to make this flush conditional (b2cdf9f), but this
+    // was problematic on certain devices. b/232224942
+    driver.flush();
+
     driver.popGroupMarker();
 }
 


### PR DESCRIPTION
This is a temporary workaround for a memory corruption issue observed on
some devices from a specific vendor. We will likely make this workaround
more targeted in the future.

Partial revert for b2cdf9f2b41ec732abd7bd56639b2c3c9316acc0.