### PR TITLE
beamsplitter: progress with Java codegen.

### DIFF
--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -72,8 +72,8 @@ enum class BlendMode : uint8_t {
  *
  */
 struct DynamicResolutionOptions {
-    math::float2 minScale = {0.5f, 0.5f};           //!< minimum scale factors in x and y
-    math::float2 maxScale = {1.0f, 1.0f};           //!< maximum scale factors in x and y
+    math::float2 minScale = {0.5f, 0.5f};           //!< minimum scale factors in x and y %codegen_java_float%
+    math::float2 maxScale = {1.0f, 1.0f};           //!< maximum scale factors in x and y %codegen_java_float%
     float sharpness = 0.9f;                         //!< sharpness when QualityLevel::MEDIUM or higher is used [0 (disabled), 1 (sharpest)]
     bool enabled = false;                           //!< enable or disable dynamic resolution
     bool homogeneousScaling = false;                //!< set to true to force homogeneous scaling
@@ -285,7 +285,7 @@ struct AmbientOcclusionOptions {
         uint8_t sampleCount = 4;        //!< tracing sample count, between 1 and 255
         uint8_t rayCount = 1;           //!< # of rays to trace, between 1 and 255
         bool enabled = false;           //!< enables or disables SSCT
-    } ssct;                             // %codegen_skip_javascript%
+    } ssct;                             // %codegen_skip_javascript% %codegen_java_flatten%
 };
 
 /**

--- a/tools/beamsplitter/README.md
+++ b/tools/beamsplitter/README.md
@@ -3,7 +3,7 @@
 - [Description](#description)
 - [Instructions](#instructions)
 - [Input Limitations](#input-limitations)
-- [Magic Strings](#magic-strings)
+- [Emitter Flags](#emitter-flags)
 - [Input Files](#input-files)
 - [Output Files](#output-files)
 
@@ -34,13 +34,17 @@ The source files must have very simple C++ syntax. Some of the limitations inclu
 - If the default value of a field is a vector, it must be in the form: `{ x, y, z }`.
 - There must be no string literals that contain keywords.
 
-### Magic Strings
+### Emitter Flags
 
-If the comment for a struct field contains the string `%codegen_skip_json%`, then the field is
-skipped when generating JSON serialization code.
+Special directives in the form `%codegen_foo%` are called *emitter flags*. They are typically
+embedded in a comment associated with a particular struct field.
 
-If the comment for a struct field contains the string `%codegen_skip_javascript%`, then the field is
-skipped when generating JavaScript and TypeScript bindings.
+flag                        | description
+--------------------------- | ----
+**codegen_skip_json**       | Field is skipped when generating JSON serialization code.
+**codegen_skip_javascript** | Field is skipped when generating JavaScript and TypeScript bindings.
+**codegen_java_flatten**    | Field is replaced with constituent sub-fields. (TBD)
+**codegen_java_float**      | Field will be forced to have a `float` representation in Java.
 
 ### Input Files
 

--- a/tools/beamsplitter/java.template
+++ b/tools/beamsplitter/java.template
@@ -1,7 +1,10 @@
 {{ define "Struct" }}
     {{ docblock .  1 }}public static class {{ .BaseName }} {
+    {{- nested_type_declarations . }}
     {{- range $index, $field := .Fields}}
-        {{ docblock . 2 }}public {{ java_type $field.Type }} {{ $field.Name }} = {{ java_value $field.DefaultValue}};
+        {{ docblock . 2 }}{{ annotation $field 2 }}public
+        {{- java_type $field }} {{ $field.Name }} =
+        {{- java_value $field}};
     {{- end }}
     };
 {{ end }}

--- a/tools/beamsplitter/javascript.go
+++ b/tools/beamsplitter/javascript.go
@@ -50,6 +50,10 @@ func createJsCodeGenerator(namespace string) func(*os.File, string, parse.TypeDe
 			typename = strings.ReplaceAll(typename, "::", "$")
 			return typename
 		},
+		"flag": func(field *parse.StructField, flag string) bool {
+			_, exists := field.EmitterFlags[flag]
+			return exists
+		},
 		"qualifiedvalue": func(name string) string {
 			count := strings.Count(name, "::")
 			if count > 0 {

--- a/tools/beamsplitter/javascript.template
+++ b/tools/beamsplitter/javascript.template
@@ -15,7 +15,7 @@ EMSCRIPTEN_BINDINGS(jsbindings_generated) {
 {{- $struct_name := .QualifiedName }}
 value_object<{{ cprefix }}{{ $struct_name }}>("{{ jsprefix }}{{ qualifiedtype .QualifiedName }}")
 {{- range $index, $field := .Fields}}
-{{- if $field.SkipJavaScript}}
+{{- if flag $field "skip_javascript" }}
     // JavaScript binding for {{$field.Name}} is not yet supported, must use default value.
 {{- else }}
     .field("{{ $field.Name }}", &{{ cprefix }}{{ $struct_name }}::{{ $field.Name }})
@@ -67,7 +67,7 @@ Filament.loadGeneratedExtensions = function() {
     Filament.{{ classprefix}}set{{ .BaseName }}Defaults = function(overrides) {
         const options = {
 {{- range $index, $field := .Fields}}
-{{- if $field.SkipJavaScript}}
+{{- if flag $field "skip_javascript" }}
             // JavaScript binding for {{$field.Name}} is not yet supported, must use default value.
 {{- else }}
             {{$field.Name}}: {{qualifiedvalue $field.DefaultValue}},
@@ -88,10 +88,10 @@ Filament.loadGeneratedExtensions = function() {
 {{- $struct_name := .QualifiedName }}
 {{.Description}}export interface {{ jsprefix }}{{ qualifiedtype .QualifiedName }} {
 {{- range $index, $field := .Fields}}
-{{- if $field.SkipJavaScript}}
+{{- if flag $field "skip_javascript" }}
     // JavaScript binding for {{$field.Name}} is not yet supported, must use default value.
 {{- else }}
-    {{ $field.Name }}?: {{ tstype $field.Type }};
+    {{ $field.Name }}?: {{ tstype $field.TypeString }};
     {{- if $field.Description}} // {{ $field.Description }}{{end}}
 {{- end }}
 {{- end }}

--- a/tools/beamsplitter/main.go
+++ b/tools/beamsplitter/main.go
@@ -53,7 +53,7 @@ func main() {
 			case *parse.StructDefinition:
 				fmt.Println("STRUCT:", concrete.QualifiedName())
 				for _, field := range concrete.Fields {
-					fmt.Println("\t", field.Type, "...", field.Name, "...", field.DefaultValue)
+					fmt.Println("\t", field.TypeString, "...", field.Name, "...", field.DefaultValue)
 				}
 			case *parse.EnumDefinition:
 				fmt.Println("  ENUM:", concrete.QualifiedName())

--- a/tools/beamsplitter/parse/parse.go
+++ b/tools/beamsplitter/parse/parse.go
@@ -52,27 +52,30 @@ func Parse(sourcePath string) []TypeDefinition {
 type TypeDefinition interface {
 	BaseName() string
 	QualifiedName() string
+	Parent() TypeDefinition
 }
 
 type StructField struct {
-	Type           string
-	Name           string
-	DefaultValue   string
-	Description    string
-	SkipJson       bool
-	SkipJavaScript bool
-	LineNumber     int
+	TypeString   string
+	Name         string
+	DefaultValue string
+	Description  string
+	LineNumber   int
+	EmitterFlags map[string]struct{}
+	CustomType   TypeDefinition
 }
 
 type StructDefinition struct {
-	StructName  string
-	Qualifier   string
+	name        string
+	qualifier   string
 	Fields      []StructField
 	Description string
+	parent      TypeDefinition
 }
 
-func (defn StructDefinition) BaseName() string      { return defn.StructName }
-func (defn StructDefinition) QualifiedName() string { return defn.Qualifier + defn.StructName }
+func (defn StructDefinition) BaseName() string       { return defn.name }
+func (defn StructDefinition) QualifiedName() string  { return defn.qualifier + defn.name }
+func (defn StructDefinition) Parent() TypeDefinition { return defn.parent }
 
 type EnumValue struct {
 	Description string
@@ -80,14 +83,16 @@ type EnumValue struct {
 }
 
 type EnumDefinition struct {
-	EnumName    string
-	Qualifier   string
+	name        string
+	qualifier   string
 	Values      []EnumValue
 	Description string
+	parent      TypeDefinition
 }
 
-func (defn EnumDefinition) BaseName() string      { return defn.EnumName }
-func (defn EnumDefinition) QualifiedName() string { return defn.Qualifier + defn.EnumName }
+func (defn EnumDefinition) BaseName() string       { return defn.name }
+func (defn EnumDefinition) QualifiedName() string  { return defn.qualifier + defn.name }
+func (defn EnumDefinition) Parent() TypeDefinition { return defn.parent }
 
 type Documented interface{ GetDoc() string }
 
@@ -101,21 +106,41 @@ type generalScope struct{}
 type scope interface {
 	BaseName() string
 	QualifiedName() string
+	Parent() TypeDefinition
 }
 
-func (defn generalScope) BaseName() string      { return "" }
-func (defn generalScope) QualifiedName() string { return "" }
+func (defn generalScope) BaseName() string       { return "" }
+func (defn generalScope) QualifiedName() string  { return "" }
+func (defn generalScope) Parent() TypeDefinition { return nil }
 
 type parserContext struct {
-	definitions     []TypeDefinition
-	stack           []scope
-	insideComment   bool
-	commentBlocks   map[int]string
-	cppTokenizer    *regexp.Regexp
-	floatMatcher    *regexp.Regexp
-	vectorMatcher   *regexp.Regexp
-	fieldParser     *regexp.Regexp
-	fieldDescParser *regexp.Regexp
+	definitions      []TypeDefinition
+	stack            []scope
+	insideComment    bool
+	commentBlocks    map[int]string
+	cppTokenizer     *regexp.Regexp
+	floatMatcher     *regexp.Regexp
+	vectorMatcher    *regexp.Regexp
+	fieldParser      *regexp.Regexp
+	fieldDescParser  *regexp.Regexp
+	customFlagFinder *regexp.Regexp
+}
+
+// https://github.com/google/re2/wiki/Syntax
+func (context *parserContext) compileRegexps() {
+	context.cppTokenizer = regexp.MustCompile(`((?:/\*)|(?:\*/)|(?:;)|(?://)|(?:\})|(?:\{))`)
+	context.floatMatcher = regexp.MustCompile(`(\-?[0-9]+\.[0-9]*)f?`)
+	context.vectorMatcher = regexp.MustCompile(`\{(\s*\-?[0-9\.]+\s*(,\s*\-?[0-9\.]+\s*){1,})\}`)
+	context.customFlagFinder = regexp.MustCompile(`\s*\%codegen_([a-zA-Z0-9_]+)\%\s*`)
+
+	const kFieldType = `(?P<type>.*)`
+	const kFieldName = `(?P<name>[A-Za-z0-9_]+)`
+	const kFieldValue = `(?P<value>(.*?))`
+	const kFieldDesc = `(?://\s*\!\<\s*(?P<description>.*))?`
+	context.fieldParser = regexp.MustCompile(
+		`^\s*` + kFieldType + `\s+` + kFieldName + `\s*=\s*` + kFieldValue + `\s*;\s*` + kFieldDesc)
+
+	context.fieldDescParser = regexp.MustCompile(`(?://\s*\!\<\s*(.*))`)
 }
 
 // Creates a mapping from line numbers to strings, where the strings are entire block comments
@@ -149,22 +174,6 @@ func gatherCommentBlocks(sourceFile *os.File) map[int]string {
 	return comments
 }
 
-// https://github.com/google/re2/wiki/Syntax
-func (context *parserContext) compileRegexps() {
-	context.cppTokenizer = regexp.MustCompile(`((?:/\*)|(?:\*/)|(?:;)|(?://)|(?:\})|(?:\{))`)
-	context.floatMatcher = regexp.MustCompile(`(\-?[0-9]+\.[0-9]*)f?`)
-	context.vectorMatcher = regexp.MustCompile(`\{(\s*\-?[0-9\.]+\s*(,\s*\-?[0-9\.]+\s*){1,})\}`)
-
-	const kFieldType = `(?P<type>.*)`
-	const kFieldName = `(?P<name>[A-Za-z0-9_]+)`
-	const kFieldValue = `(?P<value>(.*?))`
-	const kFieldDesc = `(?://\s*\!\<\s*(?P<description>.*))?`
-	context.fieldParser = regexp.MustCompile(
-		`^\s*` + kFieldType + `\s+` + kFieldName + `\s*=\s*` + kFieldValue + `\s*;\s*` + kFieldDesc)
-
-	context.fieldDescParser = regexp.MustCompile(`(?://\s*\!\<\s*(.*))`)
-}
-
 func (context parserContext) generateQualifier() string {
 	qualifier := ""
 	for _, defn := range context.stack {
@@ -175,36 +184,73 @@ func (context parserContext) generateQualifier() string {
 	return qualifier
 }
 
+func (context parserContext) findParent() TypeDefinition {
+	for i := len(context.stack) - 1; i >= 0; i-- {
+		switch defn := context.stack[i].(type) {
+		case *StructDefinition, *EnumDefinition:
+			var result TypeDefinition = defn
+			return result
+		}
+	}
+	return nil
+}
+
+// Annotates struct fields that have custom types (i.e. enums or structs).
 func (context parserContext) addTypeQualifiers() {
-	typeMap := make(map[string]scope)
+	typeMap := make(map[string]TypeDefinition)
 	for _, defn := range context.definitions {
-		typeMap[defn.BaseName()] = defn
+		typeMap[defn.QualifiedName()] = defn
 	}
 	for _, defn := range context.definitions {
-		switch structDefn := defn.(type) {
-		case *StructDefinition:
-			for fieldIndex, field := range structDefn.Fields {
-				if typeDefn, found := typeMap[field.Type]; found {
-					mutable := &structDefn.Fields[fieldIndex]
+		structDefn, isStruct := defn.(*StructDefinition)
+		if !isStruct {
+			continue
+		}
+		for fieldIndex, field := range structDefn.Fields {
+			// Extract the namespace prefix (if any) explicitly specified for this field type.
+			var namespace string
+			localTypeName := field.TypeString
+			if index := strings.LastIndex(field.TypeString, "::"); index > -1 {
+				namespace = field.TypeString[:index]
+				localTypeName = field.TypeString[index+2:]
+			}
 
-					// If this is an enum, add qualifier to the RHS of the assignment.
-					// Remember that all enums must be class enums.
-					if end := strings.LastIndex(field.DefaultValue, "::"); end != -1 {
-						enumValue := field.DefaultValue[end+2:]
-						mutable.DefaultValue = typeDefn.QualifiedName() + "::" + enumValue
+			// Prepend additional qualifiers to the type string by searching upward through
+			// the current namespace hierarchy, and looking for a match.
+			mutable := &structDefn.Fields[fieldIndex]
+			for ancestor := defn; ; ancestor = ancestor.Parent() {
+				var qualified string
+				if namespace != "" && strings.HasSuffix(ancestor.QualifiedName(), namespace) {
+					qualified = ancestor.QualifiedName() + "::" + localTypeName
+				} else {
+					qualified = ancestor.QualifiedName() + "::" + field.TypeString
+				}
+				if fieldType, found := typeMap[qualified]; found {
+					mutable.TypeString = qualified
+					mutable.CustomType = fieldType
+					break
+				}
+				if ancestor.Parent() == nil {
+					if fieldType, found := typeMap[field.TypeString]; found {
+						mutable.CustomType = fieldType
 					}
+					break
+				}
+			}
 
-					mutable.Type = typeDefn.QualifiedName()
-					continue
+			if mutable.CustomType == nil {
+				continue
+			}
+
+			// Prepend additional qualifiers to the value string if it is a known enum.
+			var fieldType TypeDefinition = structDefn.Fields[fieldIndex].CustomType
+			enumDefn, isEnum := fieldType.(*EnumDefinition)
+			if isEnum {
+				selectedEnum := field.DefaultValue
+				if index := strings.LastIndex(field.DefaultValue, "::"); index > -1 {
+					selectedEnum = field.DefaultValue[index+2:]
 				}
-				if isSimpleType(field.Type) {
-					continue
-				}
-				// If this field is neither a simple type nor a type that was defined in the source
-				// file, then emit a warning.  Unknown custom types are error prone because it is
-				// difficult to know if additional scoping qualifiers are required, or how they are
-				// bound in the target language.
-				log.Printf("%d: WARNING: %v is an unrecognized type", field.LineNumber, field.Type)
+				mutable.DefaultValue = enumDefn.QualifiedName() + "::" + selectedEnum
 			}
 		}
 	}
@@ -254,10 +300,18 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 
 	scanStructField := func(defn *StructDefinition, firstWord string) {
 		var field = StructField{
-			SkipJson:       strings.Contains(codeline, `%codegen_skip_json%`),
-			SkipJavaScript: strings.Contains(codeline, `%codegen_skip_javascript%`),
-			LineNumber:     lineNumber,
+			LineNumber: lineNumber,
 		}
+
+		// Extract all custom flags into a string set. These are special backend-specific directives
+		// delimited by percent signs, e.g. %codegen_skip_javascript%
+		if matches := context.customFlagFinder.FindAllStringSubmatch(codeline, -1); matches != nil {
+			field.EmitterFlags = make(map[string]struct{}, len(matches))
+			for _, flag := range matches {
+				field.EmitterFlags[flag[1]] = struct{}{}
+			}
+		}
+		codeline = context.customFlagFinder.ReplaceAllString(codeline, "")
 
 		// Normally when we're inside a struct, the first word on each codeline is the field type,
 		// and the second word is the field name. However if a nested struct is defined, then the
@@ -273,7 +327,7 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 		//     };
 		// In the above example, inPlaceDefinition == Baz.
 		if inPlaceDefinition != "" {
-			field.Type = inPlaceDefinition
+			field.TypeString = inPlaceDefinition
 			field.Name = firstWord
 			defn.Fields = append(defn.Fields, field)
 			return
@@ -293,10 +347,11 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 			}
 		}
 
-		field.Type = subexpMap["type"]
+		field.TypeString = subexpMap["type"]
 		field.Name = subexpMap["name"]
 		field.Description = subexpMap["description"]
 		field.DefaultValue = context.distillValue(subexpMap["value"], lineNumber)
+
 		defn.Fields = append(defn.Fields, field)
 	}
 
@@ -337,9 +392,10 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 				log.Fatalf("%d: bad formatting", lineNumber)
 			}
 			stackEntry := StructDefinition{
-				StructName:  scanner.Text(),
-				Qualifier:   context.generateQualifier(),
+				name:        scanner.Text(),
+				qualifier:   context.generateQualifier(),
 				Description: context.commentBlocks[lineNumber-1],
+				parent:      context.findParent(),
 			}
 			context.stack = append(context.stack, &stackEntry)
 			return
@@ -351,9 +407,10 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 				log.Fatalf("%d: bad formatting", lineNumber)
 			}
 			stackEntry := EnumDefinition{
-				EnumName:    scanner.Text(),
-				Qualifier:   context.generateQualifier(),
+				name:        scanner.Text(),
+				qualifier:   context.generateQualifier(),
 				Description: context.commentBlocks[lineNumber-1],
+				parent:      context.findParent(),
 			}
 			context.stack = append(context.stack, &stackEntry)
 			return
@@ -380,19 +437,4 @@ func (context *parserContext) scanCppCodeline(codeline string, lineNumber int) {
 	if err := scanner.Err(); err != nil {
 		log.Fatalf("%d: %s", lineNumber, err)
 	}
-}
-
-func isSimpleType(cpptype string) bool {
-	if strings.HasPrefix(cpptype, "math::") {
-		return true
-	}
-	switch cpptype {
-	case "bool", "int", "uint8_t", "uint16_t", "uint32_t", "uint64_t":
-		return true
-	case "float", "double":
-		return true
-	case "LinearColor", "LinearColorA":
-		return true
-	}
-	return false
 }

--- a/tools/beamsplitter/serializer.go
+++ b/tools/beamsplitter/serializer.go
@@ -35,6 +35,10 @@ func emitSerializer(definitions []parse.TypeDefinition, outputFolder string) {
 			}
 			return ","
 		},
+		"flag": func(field *parse.StructField, flag string) bool {
+			_, exists := field.EmitterFlags[flag]
+			return exists
+		},
 		"elseif": func(index int) string {
 			if index == 0 {
 				return "if"

--- a/tools/beamsplitter/serializer.template
+++ b/tools/beamsplitter/serializer.template
@@ -164,7 +164,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, {{.QualifiedNam
         const jsmntok_t tok = tokens[i];
         CHECK_KEY(tok);
         {{- range $index, $field := .Fields}}
-        {{- if $field.SkipJson}}
+        {{- if flag $field "skip_json" }}
         {{braceif $index}} (compare(tok, jsonChunk, "{{$field.Name}}") == 0) {
             // JSON serialization for {{$field.Name}} is not supported.
             int unused;
@@ -194,10 +194,10 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, {{.QualifiedNam
 std::ostream& operator<<(std::ostream& out, const {{.QualifiedName}}& in) {
     return out << "{\n"
     {{- range $index, $field := .Fields}}
-        {{- if $field.SkipJson }}
+        {{- if flag $field "skip_json" }}
         // JSON serialization for {{$field.Name}} is not supported.
         {{- else }}
-        << "\"{{$field.Name}}\": " << {{ cast $field.Type }}(in.{{$field.Name}}) << "
+        << "\"{{$field.Name}}\": " << {{ cast $field.TypeString }}(in.{{$field.Name}}) << "
         {{- trailingcomma $index $length}}\n"
         {{- end}}
     {{- end}}


### PR DESCRIPTION
Unlike our JavaScript bindings, our Java bindings (usually) reflect the nested nature of the C++ types that they expose.  This change makes beamsplitter more robust at handling namespace hierarchy.

e.g. the entries in the type database that it creates now has "parent" pointers.
