### PR TITLE
fix trailing zero when setting shader sources

### DIFF
--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -67,6 +67,8 @@ public:
             utils::Invocable<utils::io::ostream&(utils::io::ostream& out)>&& logger);
 
     // sets one of the program's shader (e.g. vertex, fragment)
+    // string-based shaders are null terminated, consequently the size parameter must include the
+    // null terminating character.
     Program& shader(Shader shader, void const* data, size_t size) noexcept;
 
     // sets the 'bindingPoint' uniform block's name for this program.
@@ -84,10 +86,14 @@ public:
     Program& setSamplerGroup(size_t bindingPoint, ShaderStageFlags stageFlags,
             Sampler const* samplers, size_t count) noexcept;
 
+    // string-based shaders are null terminated, consequently the size parameter must include the
+    // null terminating character.
     Program& withVertexShader(void const* data, size_t size) {
         return shader(Shader::VERTEX, data, size);
     }
 
+    // string-based shaders are null terminated, consequently the size parameter must include the
+    // null terminating character.
     Program& withFragmentShader(void const* data, size_t size) {
         return shader(Shader::FRAGMENT, data, size);
     }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -346,8 +346,11 @@ MetalProgram::MetalProgram(id<MTLDevice> device, const Program& program) noexcep
             continue;
         }
 
+        assert_invariant( source[source.size() - 1] == '\0' );
+
+        // the shader string is null terminated and the length includes the null character
         NSString* objcSource = [[NSString alloc] initWithBytes:source.data()
-                                                        length:source.size()
+                                                        length:source.size() - 1
                                                       encoding:NSUTF8StringEncoding];
         NSError* error = nil;
         // When options is nil, Metal uses the most recent language version available.

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -186,7 +186,11 @@ highp uint packHalf2x16(vec2 v) {
             GLuint shaderId = glCreateShader(glShaderType);
             { // scope for source/length (we don't want them to leak out)
                 const char* const source = shaderView.data();
-                const GLint length = (GLint)shaderView.length();
+
+                // the shader string is null terminated and the length includes the null character
+                const GLint length = (GLint)shaderView.length() - 1;
+                assert_invariant( source[length] == '\0' );
+
                 glShaderSource(shaderId, 1, &source, &length);
                 glCompileShader(shaderId);
 #ifndef NDEBUG


### PR DESCRIPTION
the shader source blob's size included the null terminating character,
which ended up being passed to the opengl/metal API.