### PR TITLE
beamsplitter: use generated code for View.java

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- Java View has several minor changes due to generated code, such as field ordering.
+
 ## v1.22.2
 
 - Java minor API change: rename ssctStartTraceDistance to ssctShadowDistance

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1152,64 +1152,71 @@ public class View {
         LOW,
         MEDIUM,
         HIGH,
-        ULTRA
+        ULTRA,
     }
 
     public enum BlendMode {
         OPAQUE,
-        TRANSLUCENT
+        TRANSLUCENT,
     }
 
     /**
-     * Dynamic resolution can be used to either reach a desired target frame rate by lowering the
-     * resolution of a <code>View</code>, or to increase the quality when the rendering is faster
-     * than the target frame rate.
+     * Dynamic resolution can be used to either reach a desired target frame rate
+     * by lowering the resolution of a View, or to increase the quality when the
+     * rendering is faster than the target frame rate.
      *
-     * <p>
-     * This structure can be used to specify the minimum scale factor used when lowering the
-     * resolution of a <code>View</code>, and the maximum scale factor used when increasing the
-     * resolution for higher quality rendering. The scale factors can be controlled on each X and Y
-     * axis independently. By default, all scale factors are set to 1.0.
-     * </p>
+     * This structure can be used to specify the minimum scale factor used when
+     * lowering the resolution of a View, and the maximum scale factor used when
+     * increasing the resolution for higher quality rendering. The scale factors
+     * can be controlled on each X and Y axis independently. By default, all scale
+     * factors are set to 1.0.
      *
-     * <p>
-     * Dynamic resolution is only supported on platforms where the time to render a frame can be
-     * measured accurately. Dynamic resolution is currently only supported on Android.
-     * </p>
+     * enabled:   enable or disables dynamic resolution on a View
+     *
+     * homogeneousScaling: by default the system scales the major axis first. Set this to true
+     *                     to force homogeneous scaling.
+     *
+     * minScale:  the minimum scale in X and Y this View should use
+     *
+     * maxScale:  the maximum scale in X and Y this View should use
+     *
+     * quality:   upscaling quality.
+     *            LOW: 1 bilinear tap, Medium: 4 bilinear taps, High: 9 bilinear taps (tent)
+     *
+     * \note
+     * Dynamic resolution is only supported on platforms where the time to render
+     * a frame can be measured accurately. Dynamic resolution is currently only
+     * supported on Android.
+     *
+     * @see Renderer::FrameRateOptions
+     *
      */
     public static class DynamicResolutionOptions {
         /**
-         * Enables or disables dynamic resolution on a View.
-         */
-        public boolean enabled = false;
-
-        /**
-         * If false, the system scales the major axis first.
-         */
-        public boolean homogeneousScaling = false;
-
-        /**
-         * The minimum scale in X and Y this View should use.
+         * minimum scale factors in x and y
          */
         public float minScale = 0.5f;
-
         /**
-         * The maximum scale in X and Y this View should use.
+         * maximum scale factors in x and y
          */
         public float maxScale = 1.0f;
-
         /**
-         * Sharpness when QualityLevel.MEDIUM or higher is used [0, 1].
-         * 0 is disabled, 1 is the sharpest setting.
-         * The default is set to 0.9
+         * sharpness when QualityLevel::MEDIUM or higher is used [0 (disabled), 1 (sharpest)]
          */
         public float sharpness = 0.9f;
-
+        /**
+         * enable or disable dynamic resolution
+         */
+        public boolean enabled = false;
+        /**
+         * set to true to force homogeneous scaling
+         */
+        public boolean homogeneousScaling = false;
         /**
          * Upscaling quality
-         * LOW: bilinear filtered blit. Fastest, poor quality
-         * MEDIUM: AMD FidelityFX FSR1 w/ mobile optimizations no RCAS sharpening pass
-         * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations + RCAS
+         * LOW:    bilinear filtered blit. Fastest, poor quality
+         * MEDIUM: AMD FidelityFX FSR1 w/ mobile optimizations
+         * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations
          * ULTRA:  AMD FidelityFX FSR1
          *      FSR1 require a well anti-aliased (MSAA or TAA), noise free scene.
          *
@@ -1220,131 +1227,123 @@ public class View {
     }
 
     /**
-     * Options for controlling the Bloom effect
+     * Options to control the bloom effect
      *
      * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
+     *
      * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
-     *              maximum is 11. This value together with resolution influences the spread of the
+     *              maximum is 12. This value together with resolution influences the spread of the
      *              blur effect. This value can be silently reduced to accommodate the original
      *              image size.
-     * resolution:  Resolution of bloom's vertical axis. The minimum value is 2^levels and the
-     *              the maximum is lower of the original resolution and 2048. This parameter is
+     *
+     * resolution:  Resolution of bloom's minor axis. The minimum value is 2^levels and the
+     *              the maximum is lower of the original resolution and 4096. This parameter is
      *              silently clamped to the minimum and maximum.
      *              It is highly recommended that this value be smaller than the target resolution
      *              after dynamic resolution is applied (horizontally and vertically).
+     *
      * strength:    how much of the bloom is added to the original image. Between 0 and 1.
+     *
      * blendMode:   Whether the bloom effect is purely additive (false) or mixed with the original
      *              image (true).
+     *
      * anamorphism: Bloom's aspect ratio (x/y), for artistic purposes.
+     *
      * threshold:   When enabled, a threshold at 1.0 is applied on the source image, this is
      *              useful for artistic reasons and is usually needed when a dirt texture is used.
+     *
      * dirt:        A dirt/scratch/smudges texture (that can be RGB), which gets added to the
      *              bloom effect. Smudges are visible where bloom occurs. Threshold must be
      *              enabled for the dirt effect to work properly.
-     * dirtStrength: Strength of the dirt texture.
      *
-     * @see View#setBloomOptions
+     * dirtStrength: Strength of the dirt texture.
      */
     public static class BloomOptions {
-
-        public enum BlendingMode {
+        public enum BlendMode {
+            /**
+             * Bloom is modulated by the strength parameter and added to the scene
+             */
             ADD,
-            INTERPOLATE
+            /**
+             * Bloom is interpolated with the scene using the strength parameter
+             */
+            INTERPOLATE,
         }
 
         /**
-         * User provided dirt texture
+         * user provided dirt texture
          */
         @Nullable
         public Texture dirt = null;
-
         /**
          * strength of the dirt texture
          */
         public float dirtStrength = 0.2f;
-
         /**
-         * Strength of the bloom effect, between 0.0 and 1.0
+         * bloom's strength between 0.0 and 1.0
          */
         public float strength = 0.10f;
-
         /**
-         * Resolution of minor axis (2^levels to 2048)
+         * resolution of vertical axis (2^levels to 2048)
          */
         public int resolution = 360;
-
         /**
-         * Bloom x/y aspect-ratio (1/32 to 32)
+         * bloom x/y aspect-ratio (1/32 to 32)
          */
         public float anamorphism = 1.0f;
-
         /**
-         * Number of blur levels (3 to 11)
+         * number of blur levels (3 to 11)
          */
         public int levels = 6;
-
         /**
-         * How the bloom effect is applied
+         * how the bloom effect is applied
          */
-        public BlendingMode blendMode = BlendingMode.ADD;
-
+        @NonNull
+        public BloomOptions.BlendMode blendMode = BloomOptions.BlendMode.ADD;
         /**
-         * Whether to threshold the source
+         * whether to threshold the source
          */
         public boolean threshold = true;
-
         /**
          * enable or disable bloom
          */
         public boolean enabled = false;
-
         /**
-         * limit highlights to this value before bloom. Use +inf for no limiting.
-         * minimum value is 10.0.
+         * limit highlights to this value before bloom [10, +inf]
          */
         public float highlight = 1000.0f;
-
-
         /**
          * enable screen-space lens flare
          */
         public boolean lensFlare = false;
-
         /**
          * enable starburst effect on lens flare
          */
         public boolean starburst = true;
-
         /**
          * amount of chromatic aberration
          */
         public float chromaticAberration = 0.005f;
-
         /**
          * number of flare "ghosts"
          */
         public int ghostCount = 4;
-
         /**
          * spacing of the ghost in screen units [0, 1[
          */
         public float ghostSpacing = 0.6f;
-
         /**
          * hdr threshold for the ghosts
          */
         public float ghostThreshold = 10.0f;
-
         /**
          * thickness of halo in vertical screen units, 0 to disable
          */
         public float haloThickness = 0.1f;
-
         /**
          * radius of halo in vertical screen units [0, 0.5]
          */
         public float haloRadius = 0.4f;
-
         /**
          * hdr threshold for the halo
          */
@@ -1353,57 +1352,45 @@ public class View {
 
     /**
      * Options to control fog in the scene
-     *
-     * @see View#setFogOptions
      */
     public static class FogOptions {
         /**
          * distance in world units from the camera where the fog starts ( >= 0.0 )
          */
         public float distance = 0.0f;
-
         /**
          * fog's maximum opacity between 0 and 1
          */
         public float maximumOpacity = 1.0f;
-
         /**
          * fog's floor in world units
          */
         public float height = 0.0f;
-
         /**
          * how fast fog dissipates with altitude
          */
         public float heightFalloff = 1.0f;
-
         /**
-         * Fog's color as a linear RGB color.
+         * fog's color (linear), see fogColorFromIbl
          */
-        @NonNull
-        @Size(min = 3)
-        public float[] color = { 0.5f, 0.5f, 0.5f };
-
+        @NonNull @Size(min = 3)
+        public float[] color = {0.5f, 0.5f, 0.5f};
         /**
          * fog's density at altitude given by 'height'
          */
         public float density = 0.1f;
-
         /**
          * distance in world units from the camera where in-scattering starts
          */
         public float inScatteringStart = 0.0f;
-
         /**
-         * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100)
+         * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
          */
         public float inScatteringSize = -1.0f;
-
         /**
-         * fog color will be modulated by the IBL color in the view direction
+         * Fog color will be modulated by the IBL color in the view direction.
          */
         public boolean fogColorFromIbl = false;
-
         /**
          * enable or disable fog
          */
@@ -1411,456 +1398,398 @@ public class View {
     }
 
     /**
-     * Options to control Depth of Field (DoF) effect in the scene
+     * Options to control Depth of Field (DoF) effect in the scene.
      *
-     * @see View#setDepthOfFieldOptions
+     * cocScale can be used to set the depth of field blur independently from the camera
+     * aperture, e.g. for artistic reasons. This can be achieved by setting:
+     *      cocScale = cameraAperture / desiredDoFAperture
+     *
+     * @see Camera
      */
     public static class DepthOfFieldOptions {
-
         public enum Filter {
             NONE,
             UNUSED,
-            MEDIAN
+            MEDIAN,
         }
 
         /**
          * circle of confusion scale factor (amount of blur)
-         *
-         * <p>cocScale can be used to set the depth of field blur independently from the camera
-         * aperture, e.g. for artistic reasons. This can be achieved by setting:</p>
-         * <code>
-         *      cocScale = cameraAperture / desiredDoFAperture
-         * </code>
-         *
          */
         public float cocScale = 1.0f;
-
-        /** maximum aperture diameter in meters (zero to disable bokeh rotation) */
-        public float maxApertureDiameter = 0.01f;
-
-        /** enable or disable Depth of field effect */
-        public boolean enabled = false;
-
-        /** filter to use for filling gaps in the kernel */
-        @NonNull
-        public Filter filter = Filter.MEDIAN;
-
-        /** perform DoF processing at native resolution */
-        public boolean nativeResolution = false;
-
         /**
-         * <p>Number of of rings used by the foreground kernel. The number of rings affects quality
+         * maximum aperture diameter in meters (zero to disable rotation)
+         */
+        public float maxApertureDiameter = 0.01f;
+        /**
+         * enable or disable depth of field effect
+         */
+        public boolean enabled = false;
+        /**
+         * filter to use for filling gaps in the kernel
+         */
+        @NonNull
+        public DepthOfFieldOptions.Filter filter = DepthOfFieldOptions.Filter.MEDIAN;
+        /**
+         * perform DoF processing at native resolution
+         */
+        public boolean nativeResolution = false;
+        /**
+         * Number of of rings used by the gather kernels. The number of rings affects quality
          * and performance. The actual number of sample per pixel is defined
-         * as (ringCount * 2 - 1)^2. Here are a few commonly used values:</p>
+         * as (ringCount * 2 - 1)^2. Here are a few commonly used values:
          *       3 rings :   25 ( 5x 5 grid)
          *       4 rings :   49 ( 7x 7 grid)
          *       5 rings :   81 ( 9x 9 grid)
          *      17 rings : 1089 (33x33 grid)
          *
-         * <p>With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.</p>
+         * With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.
          *
-         * <p>Usually all three settings below are set to the same value, however, it is often
+         * Usually all three settings below are set to the same value, however, it is often
          * acceptable to use a lower ring count for the "fast tiles", which improves performance.
          * Fast tiles are regions of the screen where every pixels have a similar
-         * circle-of-confusion radius.</p>
+         * circle-of-confusion radius.
          *
-         * <p>A value of 0 means default, which is 5 on desktop and 3 on mobile.</p>
+         * A value of 0 means default, which is 5 on desktop and 3 on mobile.
+         *
+         * @{
          */
         public int foregroundRingCount = 0;
-
         /**
-         * Number of of rings used by the background kernel. The number of rings affects quality
-         * and performance.
-         * @see #foregroundRingCount
+         * number of kernel rings for background tiles
          */
         public int backgroundRingCount = 0;
-
         /**
-         * Number of of rings used by the fast gather kernel. The number of rings affects quality
-         * and performance.
-         * @see #foregroundRingCount
+         * number of kernel rings for fast tiles
          */
         public int fastGatherRingCount = 0;
-
         /**
          * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
          * A value of 0 means default, which is 32 on desktop and 24 on mobile.
          */
         public int maxForegroundCOC = 0;
-
         /**
          * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
          * A value of 0 means default, which is 32 on desktop and 24 on mobile.
          */
         public int maxBackgroundCOC = 0;
-    };
+    }
 
     /**
      * Options to control the vignetting effect.
      */
     public static class VignetteOptions {
         /**
-         * High values restrict the vignette closer to the corners, between 0 and 1.
+         * high values restrict the vignette closer to the corners, between 0 and 1
          */
         public float midPoint = 0.5f;
-
         /**
-         * Controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5),
-         * to a circle (1.0). The value must be between 0 and 1.
+         * controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5), to a circle (1.0)
          */
         public float roundness = 0.5f;
-
         /**
-         * Softening amount of the vignette effect, between 0 and 1.
+         * softening amount of the vignette effect, between 0 and 1
          */
         public float feather = 0.5f;
-
         /**
-         * Color of the vignette effect as a linear RGBA color. The alpha channel is currently
-         * ignored.
+         * color of the vignette effect, alpha is currently ignored
          */
-        @NonNull
-        @Size(min = 4)
-        public float[] color = { 0.0f, 0.0f, 0.0f, 1.0f };
-
+        @NonNull @Size(min = 4)
+        public float[] color = {0.0f, 0.0f, 0.0f, 1.0f};
         /**
-         * Enables or disables the vignette effect.
+         * enables or disables the vignette effect
          */
         public boolean enabled = false;
     }
 
     /**
-     * Structure used to set the color precision for the rendering of a <code>View</code>.
+     * Structure used to set the precision of the color buffer and related quality settings.
      *
-     * <p>
-     * This structure offers separate quality settings for different parts of the rendering
-     * pipeline.
-     * </p>
-     *
-     * @see #setRenderQuality
-     * @see #getRenderQuality
+     * @see setRenderQuality, getRenderQuality
      */
     public static class RenderQuality {
         /**
-          * <p>
-          * A quality of <code>HIGH</code> or <code>ULTRA</code> means using an RGB16F or RGBA16F color
-          * buffer. This means colors in the LDR range (0..1) have 10 bit precision. A quality of
-          * <code>LOW</code> or <code>MEDIUM</code> means using an R11G11B10F opaque color buffer or an
-          * RGBA16F transparent color buffer. With R11G11B10F colors in the LDR range have a precision of
-          * either 6 bits (red and green channels) or 5 bits (blue channel).
-          * </p>
-          */
+         * Sets the quality of the HDR color buffer.
+         *
+         * A quality of HIGH or ULTRA means using an RGB16F or RGBA16F color buffer. This means
+         * colors in the LDR range (0..1) have a 10 bit precision. A quality of LOW or MEDIUM means
+         * using an R11G11B10F opaque color buffer or an RGBA16F transparent color buffer. With
+         * R11G11B10F colors in the LDR range have a precision of either 6 bits (red and green
+         * channels) or 5 bits (blue channel).
+         */
+        @NonNull
         public QualityLevel hdrColorBuffer = QualityLevel.HIGH;
     }
 
     /**
-     * Options for screen space Ambient Occlusion
+     * Options for screen space Ambient Occlusion (SSAO) and Screen Space Cone Tracing (SSCT)
+     * @see setAmbientOcclusionOptions()
      */
     public static class AmbientOcclusionOptions {
         /**
          * Ambient Occlusion radius in meters, between 0 and ~10.
          */
         public float radius = 0.3f;
-
+        /**
+         * Controls ambient occlusion's contrast. Must be positive.
+         */
+        public float power = 1.0f;
         /**
          * Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
          */
         public float bias = 0.0005f;
-
-        /**
-         * Controls ambient occlusion's contrast. Must be positive. Default is 1.
-         * Good values are between 0.5 and 3.
-         */
-        public float power = 1.0f;
-
         /**
          * How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
          */
         public float resolution = 0.5f;
-
         /**
-         * Strength of the Ambient Occlusion effect. Must be positive.
+         * Strength of the Ambient Occlusion effect.
          */
         public float intensity = 1.0f;
-
         /**
-         * Depth distance that constitute an edge for filtering. Must be positive.
-         * Default is 5cm.
-         * This must be adjusted with the scene's scale and/or units.
-         * A value too low will result in high frequency noise, while a value too high will
-         * result in the loss of geometry edges. For AO, it is generally better to be too
-         * blurry than not enough.
+         * depth distance that constitute an edge for filtering
          */
         public float bilateralThreshold = 0.05f;
-
         /**
-         * The quality setting controls the number of samples used for evaluating Ambient
-         * occlusion. The default is QualityLevel.LOW which is sufficient for most mobile
-         * applications.
+         * affects # of samples used for AO.
          */
         @NonNull
         public QualityLevel quality = QualityLevel.LOW;
-
         /**
-         * The lowPassFilter setting controls the quality of the low pass filter applied to
-         * AO estimation. The default is QualityLevel.MEDIUM which is sufficient for most mobile
-         * applications. QualityLevel.LOW disables the filter entirely.
+         * affects AO smoothness
          */
         @NonNull
         public QualityLevel lowPassFilter = QualityLevel.MEDIUM;
-
         /**
-         * The upsampling setting controls the quality of the ambient occlusion buffer upsampling.
-         * The default is QualityLevel.LOW and uses bilinear filtering, a value of
-         * QualityLevel.HIGH or more enables a better bilateral filter.
+         * affects AO buffer upsampling quality
          */
         @NonNull
         public QualityLevel upsampling = QualityLevel.LOW;
-
         /**
-         * enable or disable screen space ambient occlusion
+         * enables or disables screen-space ambient occlusion
          */
         public boolean enabled = false;
-
         /**
          * enables bent normals computation from AO, and specular AO
          */
         public boolean bentNormals = false;
-
         /**
-         * Minimal angle to consider in radian. This is used to reduce the creases that can
-         * appear due to insufficiently tessellated geometry.
-         * For e.g. a good values to try could be around 0.2.
+         * min angle in radian to consider
          */
         public float minHorizonAngleRad = 0.0f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctLightConeRad = 1.0f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctShadowDistance = 0.3f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctContactDistanceMax = 1.0f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctIntensity = 0.8f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        @NonNull @Size(min = 3)
+        public float[] ssctLightDirection = {0f, -1f, 0f};
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctDepthBias = 0.01f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public float ssctDepthSlopeBias = 0.01f;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public int ssctSampleCount = 4;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public int ssctRayCount = 1;
+        /**
+         * Screen Space Cone Tracing (SSCT) options
+         * Ambient shadows from dominant light
+         */
+        public boolean ssctEnabled = false;
 
-
-       /**
-        * Full cone angle in radian, between 0 and pi/2. This affects the softness of the shadows,
-        * as well as how far they are cast. A smaller angle yields to sharper and shorter shadows.
-        * The default angle is about 60 degrees.
-        */
-       public float ssctLightConeRad = 1.0f;
-
-       /**
-        * Distance from where tracing starts.
-        * This affects how far shadows are cast.
-        */
-       public float ssctShadowDistance = 0.01f;
-
-       /**
-        * Maximum contact distance with the cone. Intersections between the traced cone and
-        * geometry samller than this distance are ignored.
-        */
-       public float ssctContactDistanceMax = 1.0f;
-
-       /**
-        * Intensity of the shadows.
-        */
-       public float ssctIntensity = 0.8f;
-
-       /**
-        * Light direction.
-        */
-       @NonNull @Size(min = 3)
-       public float[] ssctLightDirection = { 0, -1, 0 };
-
-       /**
-        * Depth bias in world units (mitigate self shadowing)
-        */
-       public float ssctDepthBias = 0.01f;
-
-       /**
-        * Depth slope bias (mitigate self shadowing)
-        */
-       public float ssctDepthSlopeBias = 0.01f;
-
-       /**
-        * Tracing sample count, between 1 and 255. This affects the quality as well as the
-        * distance of the shadows.
-        */
-       public int ssctSampleCount = 4;
-
-       /**
-        * Numbers of rays to trace, between 1 and 255. This affects the noise of the shadows.
-        * Performance degrades quickly with this value.
-        */
-       public int ssctRayCount = 1;
-
-       /**
-        * Enables or disables SSCT.
-        */
-       public boolean ssctEnabled = false;
     }
 
     /**
-     * Options for Multi-sample Anti-aliasing (MSAA)
-     * @see View#setMultiSampleAntiAliasingOptions
+     * Options for Temporal Multi-Sample Anti-aliasing (MSAA)
+     * @see setMultiSampleAntiAliasingOptions()
      */
     public static class MultiSampleAntiAliasingOptions {
-        /** enables or disables temporal anti-aliasing */
-        public boolean enabled = false;
-
         /**
-         * number of samples to use for multi-sampled anti-aliasing.\n
-         *      0: treated as 1
-         *      1: no anti-aliasing
-         *      n: sample count. Effective sample could be different depending on the
-         *         GPU capabilities.
+         * enables or disables msaa
+         */
+        public boolean enabled = false;
+        /**
+         * sampleCount number of samples to use for multi-sampled anti-aliasing.\n
+         *              0: treated as 1
+         *              1: no anti-aliasing
+         *              n: sample count. Effective sample could be different depending on the
+         *                 GPU capabilities.
          */
         public int sampleCount = 4;
-
         /**
          * custom resolve improves quality for HDR scenes, but may impact performance.
          */
         public boolean customResolve = false;
-    };
+    }
 
     /**
      * Options for Temporal Anti-aliasing (TAA)
-     * @see View#setTemporalAntiAliasingOptions
+     * @see setTemporalAntiAliasingOptions()
      */
     public static class TemporalAntiAliasingOptions {
-        /** reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother) */
+        /**
+         * reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
+         */
         public float filterWidth = 1.0f;
-
-        /** history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA). */
+        /**
+         * history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
+         */
         public float feedback = 0.04f;
-
-        /** enables or disables temporal anti-aliasing */
+        /**
+         * enables or disables temporal anti-aliasing
+         */
         public boolean enabled = false;
-    };
+    }
 
     /**
      * Options for Screen-space Reflections.
-     * @see View#setScreenSpaceReflectionOptions
+     * @see setScreenSpaceReflectionsOptions()
      */
     public static class ScreenSpaceReflectionsOptions {
-        /** ray thickness, in world units */
+        /**
+         * ray thickness, in world units
+         */
         public float thickness = 0.1f;
-
-        /** bias, in world units, to prevent self-intersections */
+        /**
+         * bias, in world units, to prevent self-intersections
+         */
         public float bias = 0.01f;
-
-        /** maximum distance, in world units, to raycast */
+        /**
+         * maximum distance, in world units, to raycast
+         */
         public float maxDistance = 3.0f;
-
-        /** stride, in texels, for samples along the ray. */
+        /**
+         * stride, in texels, for samples along the ray.
+         */
         public float stride = 2.0f;
-
-        /** enables or disables screen-space reflections */
         public boolean enabled = false;
-    };
+    }
 
     /**
      * Options for the  screen-space guard band.
      * A guard band can be enabled to avoid some artifacts towards the edge of the screen when
-     * using screen-space effects such as SSAO.
-     * Enabling the guard band reduces performance slightly.
+     * using screen-space effects such as SSAO. Enabling the guard band reduces performance slightly.
      * Currently the guard band can only be enabled or disabled.
-     *
-     * @see View#setGuardBandOptions
      */
     public static class GuardBandOptions {
-        /** enables or disables the guard band */
         public boolean enabled = false;
-    };
+    }
 
     /**
      * List of available post-processing anti-aliasing techniques.
-     *
-     * @see #setAntiAliasing
-     * @see #getAntiAliasing
+     * @see setAntiAliasing, getAntiAliasing, setSampleCount
      */
     public enum AntiAliasing {
         /**
-         * No anti aliasing performed as part of post-processing.
+         * no anti aliasing performed as part of post-processing
          */
         NONE,
-
         /**
          * FXAA is a low-quality but very efficient type of anti-aliasing. (default).
          */
-        FXAA
+        FXAA,
     }
 
     /**
      * List of available post-processing dithering techniques.
      */
     public enum Dithering {
+        /**
+         * No dithering
+         */
         NONE,
-        TEMPORAL
+        /**
+         * Temporal dithering (default)
+         */
+        TEMPORAL,
     }
 
     /**
      * List of available shadow mapping techniques.
-     *
-     * @see #setShadowType
+     * @see setShadowType
      */
     public enum ShadowType {
         /**
-         * Percentage-closer filtered shadows (default).
+         * percentage-closer filtered shadows (default)
          */
         PCF,
-
         /**
-         * Variance shadows.
+         * variance shadows
          */
         VSM,
-
         /**
-         * Percentage-closer filtered shadows, with contact hardening simulation.
+         * PCF with contact hardening simulation
          */
         DPCF,
-
         /**
-         * Percentage-closer soft shadows
+         * PCF with soft shadows and contact hardening
          */
-        PCSS
+        PCSS,
     }
 
     /**
-     * View-level options for VSM shadowing.
-     *
-     * <strong>Warning: This API is still experimental and subject to change.</strong>
-     *
-     * @see View#setVsmShadowOptions
+     * View-level options for VSM Shadowing.
+     * @see setVsmShadowOptions()
+     * @warning This API is still experimental and subject to change.
      */
     public static class VsmShadowOptions {
         /**
          * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
          * than 0, mipmaps will automatically be generated each frame for all lights.
-         * This implies mipmapping below.
          *
-         * <p>
          * The number of anisotropic samples = 2 ^ vsmAnisotropy.
-         * </p>
-         *
          */
         public int anisotropy = 0;
-
         /**
          * Whether to generate mipmaps for all VSM shadow maps.
          */
         public boolean mipmapping = false;
-
         /**
          * VSM minimum variance scale, must be positive.
          */
-        public float minVarianceScale = 1.0f;
-
+        public float minVarianceScale = 0.5f;
         /**
          * VSM light bleeding reduction amount, between 0 and 1.
          */
-        public float lightBleedReduction = 0.2f;
+        public float lightBleedReduction = 0.15f;
     }
 
     /**
      * View-level options for DPCF and PCSS Shadowing.
-     *
-     * <strong>Warning: This API is still experimental and subject to change.</strong>
-     *
-     * @see View#setSoftShadowOptions
+     * @see setSoftShadowOptions()
+     * @warning This API is still experimental and subject to change.
      */
     public static class SoftShadowOptions {
         /**
@@ -1868,7 +1797,6 @@ public class View {
          * Acceptable values are greater than 0
          */
         public float penumbraScale = 1.0f;
-
         /**
          * Globally scales the computed penumbra ratio of all DPCF and PCSS shadows.
          * This effectively controls the strength of contact hardening effect and is useful for

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -86,656 +86,6 @@ public class View {
     private GuardBandOptions mGuardBandOptions;
 
     /**
-     * Generic quality level.
-     */
-    public enum QualityLevel {
-        LOW,
-        MEDIUM,
-        HIGH,
-        ULTRA
-    }
-
-    public enum BlendMode {
-        OPAQUE,
-        TRANSLUCENT
-    }
-
-    /**
-     * Dynamic resolution can be used to either reach a desired target frame rate by lowering the
-     * resolution of a <code>View</code>, or to increase the quality when the rendering is faster
-     * than the target frame rate.
-     *
-     * <p>
-     * This structure can be used to specify the minimum scale factor used when lowering the
-     * resolution of a <code>View</code>, and the maximum scale factor used when increasing the
-     * resolution for higher quality rendering. The scale factors can be controlled on each X and Y
-     * axis independently. By default, all scale factors are set to 1.0.
-     * </p>
-     *
-     * <p>
-     * Dynamic resolution is only supported on platforms where the time to render a frame can be
-     * measured accurately. Dynamic resolution is currently only supported on Android.
-     * </p>
-     */
-    public static class DynamicResolutionOptions {
-        /**
-         * Enables or disables dynamic resolution on a View.
-         */
-        public boolean enabled = false;
-
-        /**
-         * If false, the system scales the major axis first.
-         */
-        public boolean homogeneousScaling = false;
-
-        /**
-         * The minimum scale in X and Y this View should use.
-         */
-        public float minScale = 0.5f;
-
-        /**
-         * The maximum scale in X and Y this View should use.
-         */
-        public float maxScale = 1.0f;
-
-        /**
-         * Sharpness when QualityLevel.MEDIUM or higher is used [0, 1].
-         * 0 is disabled, 1 is the sharpest setting.
-         * The default is set to 0.9
-         */
-        public float sharpness = 0.9f;
-
-        /**
-         * Upscaling quality
-         * LOW: bilinear filtered blit. Fastest, poor quality
-         * MEDIUM: AMD FidelityFX FSR1 w/ mobile optimizations no RCAS sharpening pass
-         * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations + RCAS
-         * ULTRA:  AMD FidelityFX FSR1
-         *      FSR1 require a well anti-aliased (MSAA or TAA), noise free scene.
-         *
-         * The default upscaling quality is set to LOW.
-         */
-        @NonNull
-        public QualityLevel quality = QualityLevel.LOW;
-    }
-
-    /**
-     * Options for screen space Ambient Occlusion
-     */
-    public static class AmbientOcclusionOptions {
-        /**
-         * Ambient Occlusion radius in meters, between 0 and ~10.
-         */
-        public float radius = 0.3f;
-
-        /**
-         * Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
-         */
-        public float bias = 0.0005f;
-
-        /**
-         * Controls ambient occlusion's contrast. Must be positive. Default is 1.
-         * Good values are between 0.5 and 3.
-         */
-        public float power = 1.0f;
-
-        /**
-         * How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
-         */
-        public float resolution = 0.5f;
-
-        /**
-         * Strength of the Ambient Occlusion effect. Must be positive.
-         */
-        public float intensity = 1.0f;
-
-        /**
-         * Depth distance that constitute an edge for filtering. Must be positive.
-         * Default is 5cm.
-         * This must be adjusted with the scene's scale and/or units.
-         * A value too low will result in high frequency noise, while a value too high will
-         * result in the loss of geometry edges. For AO, it is generally better to be too
-         * blurry than not enough.
-         */
-        public float bilateralThreshold = 0.05f;
-
-        /**
-         * The quality setting controls the number of samples used for evaluating Ambient
-         * occlusion. The default is QualityLevel.LOW which is sufficient for most mobile
-         * applications.
-         */
-        @NonNull
-        public QualityLevel quality = QualityLevel.LOW;
-
-        /**
-         * The lowPassFilter setting controls the quality of the low pass filter applied to
-         * AO estimation. The default is QualityLevel.MEDIUM which is sufficient for most mobile
-         * applications. QualityLevel.LOW disables the filter entirely.
-         */
-        @NonNull
-        public QualityLevel lowPassFilter = QualityLevel.MEDIUM;
-
-        /**
-         * The upsampling setting controls the quality of the ambient occlusion buffer upsampling.
-         * The default is QualityLevel.LOW and uses bilinear filtering, a value of
-         * QualityLevel.HIGH or more enables a better bilateral filter.
-         */
-        @NonNull
-        public QualityLevel upsampling = QualityLevel.LOW;
-
-        /**
-         * enable or disable screen space ambient occlusion
-         */
-        public boolean enabled = false;
-
-        /**
-         * enables bent normals computation from AO, and specular AO
-         */
-        public boolean bentNormals = false;
-
-        /**
-         * Minimal angle to consider in radian. This is used to reduce the creases that can
-         * appear due to insufficiently tessellated geometry.
-         * For e.g. a good values to try could be around 0.2.
-         */
-        public float minHorizonAngleRad = 0.0f;
-
-
-       /**
-        * Full cone angle in radian, between 0 and pi/2. This affects the softness of the shadows,
-        * as well as how far they are cast. A smaller angle yields to sharper and shorter shadows.
-        * The default angle is about 60 degrees.
-        */
-       public float ssctLightConeRad = 1.0f;
-
-       /**
-        * Distance from where tracing starts.
-        * This affects how far shadows are cast.
-        */
-       public float ssctShadowDistance = 0.01f;
-
-       /**
-        * Maximum contact distance with the cone. Intersections between the traced cone and
-        * geometry samller than this distance are ignored.
-        */
-       public float ssctContactDistanceMax = 1.0f;
-
-       /**
-        * Intensity of the shadows.
-        */
-       public float ssctIntensity = 0.8f;
-
-       /**
-        * Light direction.
-        */
-       @NonNull @Size(min = 3)
-       public float[] ssctLightDirection = { 0, -1, 0 };
-
-       /**
-        * Depth bias in world units (mitigate self shadowing)
-        */
-       public float ssctDepthBias = 0.01f;
-
-       /**
-        * Depth slope bias (mitigate self shadowing)
-        */
-       public float ssctDepthSlopeBias = 0.01f;
-
-       /**
-        * Tracing sample count, between 1 and 255. This affects the quality as well as the
-        * distance of the shadows.
-        */
-       public int ssctSampleCount = 4;
-
-       /**
-        * Numbers of rays to trace, between 1 and 255. This affects the noise of the shadows.
-        * Performance degrades quickly with this value.
-        */
-       public int ssctRayCount = 1;
-
-       /**
-        * Enables or disables SSCT.
-        */
-       public boolean ssctEnabled = false;
-    }
-
-    /**
-     * Options for Multi-sample Anti-aliasing (MSAA)
-     * @see View#setMultiSampleAntiAliasingOptions
-     */
-    public static class MultiSampleAntiAliasingOptions {
-        /** enables or disables temporal anti-aliasing */
-        public boolean enabled = false;
-
-        /**
-         * number of samples to use for multi-sampled anti-aliasing.\n
-         *      0: treated as 1
-         *      1: no anti-aliasing
-         *      n: sample count. Effective sample could be different depending on the
-         *         GPU capabilities.
-         */
-        public int sampleCount = 4;
-
-        /**
-         * custom resolve improves quality for HDR scenes, but may impact performance.
-         */
-        public boolean customResolve = false;
-    };
-
-    /**
-     * Options for Temporal Anti-aliasing (TAA)
-     * @see View#setTemporalAntiAliasingOptions
-     */
-    public static class TemporalAntiAliasingOptions {
-        /** reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother) */
-        public float filterWidth = 1.0f;
-
-        /** history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA). */
-        public float feedback = 0.04f;
-
-        /** enables or disables temporal anti-aliasing */
-        public boolean enabled = false;
-    };
-
-    /**
-     * Options for Screen-space Reflections.
-     * @see View#setScreenSpaceReflectionOptions
-     */
-    public static class ScreenSpaceReflectionsOptions {
-        /** ray thickness, in world units */
-        public float thickness = 0.1f;
-
-        /** bias, in world units, to prevent self-intersections */
-        public float bias = 0.01f;
-
-        /** maximum distance, in world units, to raycast */
-        public float maxDistance = 3.0f;
-
-        /** stride, in texels, for samples along the ray. */
-        public float stride = 2.0f;
-
-        /** enables or disables screen-space reflections */
-        public boolean enabled = false;
-    };
-
-    /**
-     * Options for the  screen-space guard band.
-     * A guard band can be enabled to avoid some artifacts towards the edge of the screen when
-     * using screen-space effects such as SSAO.
-     * Enabling the guard band reduces performance slightly.
-     * Currently the guard band can only be enabled or disabled.
-     *
-     * @see View#setGuardBandOptions
-     */
-    public static class GuardBandOptions {
-        /** enables or disables the guard band */
-        public boolean enabled = false;
-    };
-
-    /**
-     * Options for controlling the Bloom effect
-     *
-     * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
-     * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
-     *              maximum is 11. This value together with resolution influences the spread of the
-     *              blur effect. This value can be silently reduced to accommodate the original
-     *              image size.
-     * resolution:  Resolution of bloom's vertical axis. The minimum value is 2^levels and the
-     *              the maximum is lower of the original resolution and 2048. This parameter is
-     *              silently clamped to the minimum and maximum.
-     *              It is highly recommended that this value be smaller than the target resolution
-     *              after dynamic resolution is applied (horizontally and vertically).
-     * strength:    how much of the bloom is added to the original image. Between 0 and 1.
-     * blendMode:   Whether the bloom effect is purely additive (false) or mixed with the original
-     *              image (true).
-     * anamorphism: Bloom's aspect ratio (x/y), for artistic purposes.
-     * threshold:   When enabled, a threshold at 1.0 is applied on the source image, this is
-     *              useful for artistic reasons and is usually needed when a dirt texture is used.
-     * dirt:        A dirt/scratch/smudges texture (that can be RGB), which gets added to the
-     *              bloom effect. Smudges are visible where bloom occurs. Threshold must be
-     *              enabled for the dirt effect to work properly.
-     * dirtStrength: Strength of the dirt texture.
-     *
-     * @see View#setBloomOptions
-     */
-    public static class BloomOptions {
-
-        public enum BlendingMode {
-            ADD,
-            INTERPOLATE
-        }
-
-        /**
-         * User provided dirt texture
-         */
-        @Nullable
-        public Texture dirt = null;
-
-        /**
-         * strength of the dirt texture
-         */
-        public float dirtStrength = 0.2f;
-
-        /**
-         * Strength of the bloom effect, between 0.0 and 1.0
-         */
-        public float strength = 0.10f;
-
-        /**
-         * Resolution of minor axis (2^levels to 2048)
-         */
-        public int resolution = 360;
-
-        /**
-         * Bloom x/y aspect-ratio (1/32 to 32)
-         */
-        public float anamorphism = 1.0f;
-
-        /**
-         * Number of blur levels (3 to 11)
-         */
-        public int levels = 6;
-
-        /**
-         * How the bloom effect is applied
-         */
-        public BlendingMode blendMode = BlendingMode.ADD;
-
-        /**
-         * Whether to threshold the source
-         */
-        public boolean threshold = true;
-
-        /**
-         * enable or disable bloom
-         */
-        public boolean enabled = false;
-
-        /**
-         * limit highlights to this value before bloom. Use +inf for no limiting.
-         * minimum value is 10.0.
-         */
-        public float highlight = 1000.0f;
-
-
-        /**
-         * enable screen-space lens flare
-         */
-        public boolean lensFlare = false;
-
-        /**
-         * enable starburst effect on lens flare
-         */
-        public boolean starburst = true;
-
-        /**
-         * amount of chromatic aberration
-         */
-        public float chromaticAberration = 0.005f;
-
-        /**
-         * number of flare "ghosts"
-         */
-        public int ghostCount = 4;
-
-        /**
-         * spacing of the ghost in screen units [0, 1[
-         */
-        public float ghostSpacing = 0.6f;
-
-        /**
-         * hdr threshold for the ghosts
-         */
-        public float ghostThreshold = 10.0f;
-
-        /**
-         * thickness of halo in vertical screen units, 0 to disable
-         */
-        public float haloThickness = 0.1f;
-
-        /**
-         * radius of halo in vertical screen units [0, 0.5]
-         */
-        public float haloRadius = 0.4f;
-
-        /**
-         * hdr threshold for the halo
-         */
-        public float haloThreshold = 10.0f;
-    }
-
-    /**
-     * Options to control fog in the scene
-     *
-     * @see View#setFogOptions
-     */
-    public static class FogOptions {
-        /**
-         * distance in world units from the camera where the fog starts ( >= 0.0 )
-         */
-        public float distance = 0.0f;
-
-        /**
-         * fog's maximum opacity between 0 and 1
-         */
-        public float maximumOpacity = 1.0f;
-
-        /**
-         * fog's floor in world units
-         */
-        public float height = 0.0f;
-
-        /**
-         * how fast fog dissipates with altitude
-         */
-        public float heightFalloff = 1.0f;
-
-        /**
-         * Fog's color as a linear RGB color.
-         */
-        @NonNull
-        @Size(min = 3)
-        public float[] color = { 0.5f, 0.5f, 0.5f };
-
-        /**
-         * fog's density at altitude given by 'height'
-         */
-        public float density = 0.1f;
-
-        /**
-         * distance in world units from the camera where in-scattering starts
-         */
-        public float inScatteringStart = 0.0f;
-
-        /**
-         * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100)
-         */
-        public float inScatteringSize = -1.0f;
-
-        /**
-         * fog color will be modulated by the IBL color in the view direction
-         */
-        public boolean fogColorFromIbl = false;
-
-        /**
-         * enable or disable fog
-         */
-        public boolean enabled = false;
-    }
-
-    /**
-     * Options to control Depth of Field (DoF) effect in the scene
-     *
-     * @see View#setDepthOfFieldOptions
-     */
-    public static class DepthOfFieldOptions {
-
-        public enum Filter {
-            NONE,
-            UNUSED,
-            MEDIAN
-        }
-
-        /**
-         * circle of confusion scale factor (amount of blur)
-         *
-         * <p>cocScale can be used to set the depth of field blur independently from the camera
-         * aperture, e.g. for artistic reasons. This can be achieved by setting:</p>
-         * <code>
-         *      cocScale = cameraAperture / desiredDoFAperture
-         * </code>
-         *
-         */
-        public float cocScale = 1.0f;
-
-        /** maximum aperture diameter in meters (zero to disable bokeh rotation) */
-        public float maxApertureDiameter = 0.01f;
-
-        /** enable or disable Depth of field effect */
-        public boolean enabled = false;
-
-        /** filter to use for filling gaps in the kernel */
-        @NonNull
-        public Filter filter = Filter.MEDIAN;
-
-        /** perform DoF processing at native resolution */
-        public boolean nativeResolution = false;
-
-        /**
-         * <p>Number of of rings used by the foreground kernel. The number of rings affects quality
-         * and performance. The actual number of sample per pixel is defined
-         * as (ringCount * 2 - 1)^2. Here are a few commonly used values:</p>
-         *       3 rings :   25 ( 5x 5 grid)
-         *       4 rings :   49 ( 7x 7 grid)
-         *       5 rings :   81 ( 9x 9 grid)
-         *      17 rings : 1089 (33x33 grid)
-         *
-         * <p>With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.</p>
-         *
-         * <p>Usually all three settings below are set to the same value, however, it is often
-         * acceptable to use a lower ring count for the "fast tiles", which improves performance.
-         * Fast tiles are regions of the screen where every pixels have a similar
-         * circle-of-confusion radius.</p>
-         *
-         * <p>A value of 0 means default, which is 5 on desktop and 3 on mobile.</p>
-         */
-        public int foregroundRingCount = 0;
-
-        /**
-         * Number of of rings used by the background kernel. The number of rings affects quality
-         * and performance.
-         * @see #foregroundRingCount
-         */
-        public int backgroundRingCount = 0;
-
-        /**
-         * Number of of rings used by the fast gather kernel. The number of rings affects quality
-         * and performance.
-         * @see #foregroundRingCount
-         */
-        public int fastGatherRingCount = 0;
-
-        /**
-         * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
-         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
-         */
-        public int maxForegroundCOC = 0;
-
-        /**
-         * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
-         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
-         */
-        public int maxBackgroundCOC = 0;
-    };
-
-    /**
-     * Options to control the vignetting effect.
-     */
-    public static class VignetteOptions {
-        /**
-         * High values restrict the vignette closer to the corners, between 0 and 1.
-         */
-        public float midPoint = 0.5f;
-
-        /**
-         * Controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5),
-         * to a circle (1.0). The value must be between 0 and 1.
-         */
-        public float roundness = 0.5f;
-
-        /**
-         * Softening amount of the vignette effect, between 0 and 1.
-         */
-        public float feather = 0.5f;
-
-        /**
-         * Color of the vignette effect as a linear RGBA color. The alpha channel is currently
-         * ignored.
-         */
-        @NonNull
-        @Size(min = 4)
-        public float[] color = { 0.0f, 0.0f, 0.0f, 1.0f };
-
-        /**
-         * Enables or disables the vignette effect.
-         */
-        public boolean enabled = false;
-    }
-
-    /**
-     * Structure used to set the color precision for the rendering of a <code>View</code>.
-     *
-     * <p>
-     * This structure offers separate quality settings for different parts of the rendering
-     * pipeline.
-     * </p>
-     *
-     * @see #setRenderQuality
-     * @see #getRenderQuality
-     */
-    public static class RenderQuality {
-        /**
-          * <p>
-          * A quality of <code>HIGH</code> or <code>ULTRA</code> means using an RGB16F or RGBA16F color
-          * buffer. This means colors in the LDR range (0..1) have 10 bit precision. A quality of
-          * <code>LOW</code> or <code>MEDIUM</code> means using an R11G11B10F opaque color buffer or an
-          * RGBA16F transparent color buffer. With R11G11B10F colors in the LDR range have a precision of
-          * either 6 bits (red and green channels) or 5 bits (blue channel).
-          * </p>
-          */
-        public QualityLevel hdrColorBuffer = QualityLevel.HIGH;
-    }
-
-    /**
-     * List of available ambient occlusion techniques.
-     * @deprecated use setAmbientOcclusionOptions instead
-     * @see #setAmbientOcclusion
-     */
-    @Deprecated
-    public enum AmbientOcclusion {
-        NONE,
-        SSAO
-    }
-
-    /**
-     * List of available post-processing anti-aliasing techniques.
-     *
-     * @see #setAntiAliasing
-     * @see #getAntiAliasing
-     */
-    public enum AntiAliasing {
-        /**
-         * No anti aliasing performed as part of post-processing.
-         */
-        NONE,
-
-        /**
-         * FXAA is a low-quality but very efficient type of anti-aliasing. (default).
-         */
-        FXAA
-    }
-
-    /**
      * List of available tone-mapping operators
      *
      * @deprecated Use ColorGrading instead
@@ -751,100 +101,6 @@ public class View {
          * The Academy Color Encoding System (ACES).
          */
         ACES
-    }
-
-    /**
-     * List of available post-processing dithering techniques.
-     */
-    public enum Dithering {
-        NONE,
-        TEMPORAL
-    }
-
-    /**
-     * List of available shadow mapping techniques.
-     *
-     * @see #setShadowType
-     */
-    public enum ShadowType {
-        /**
-         * Percentage-closer filtered shadows (default).
-         */
-        PCF,
-
-        /**
-         * Variance shadows.
-         */
-        VSM,
-
-        /**
-         * Percentage-closer filtered shadows, with contact hardening simulation.
-         */
-        DPCF,
-
-        /**
-         * Percentage-closer soft shadows
-         */
-        PCSS
-    }
-
-    /**
-     * View-level options for VSM shadowing.
-     *
-     * <strong>Warning: This API is still experimental and subject to change.</strong>
-     *
-     * @see View#setVsmShadowOptions
-     */
-    public static class VsmShadowOptions {
-        /**
-         * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
-         * than 0, mipmaps will automatically be generated each frame for all lights.
-         * This implies mipmapping below.
-         *
-         * <p>
-         * The number of anisotropic samples = 2 ^ vsmAnisotropy.
-         * </p>
-         *
-         */
-        public int anisotropy = 0;
-
-        /**
-         * Whether to generate mipmaps for all VSM shadow maps.
-         */
-        public boolean mipmapping = false;
-
-        /**
-         * VSM minimum variance scale, must be positive.
-         */
-        public float minVarianceScale = 1.0f;
-
-        /**
-         * VSM light bleeding reduction amount, between 0 and 1.
-         */
-        public float lightBleedReduction = 0.2f;
-    }
-
-    /**
-     * View-level options for DPCF and PCSS Shadowing.
-     *
-     * <strong>Warning: This API is still experimental and subject to change.</strong>
-     *
-     * @see View#setSoftShadowOptions
-     */
-    public static class SoftShadowOptions {
-        /**
-         * Globally scales the penumbra of all DPCF and PCSS shadows
-         * Acceptable values are greater than 0
-         */
-        public float penumbraScale = 1.0f;
-
-        /**
-         * Globally scales the computed penumbra ratio of all DPCF and PCSS shadows.
-         * This effectively controls the strength of contact hardening effect and is useful for
-         * artistic purposes. Higher values make the shadows become softer faster.
-         * Acceptable values are equal to or greater than 1.
-         */
-        public float penumbraRatioScale = 1.0f;
     }
 
     /**
@@ -1876,5 +1132,749 @@ public class View {
     private static native boolean nIsScreenSpaceRefractionEnabled(long nativeView);
     private static native void nPick(long nativeView, int x, int y, Object handler, InternalOnPickCallback internalCallback);
 
+    /**
+     * List of available ambient occlusion techniques.
+     * @deprecated use setAmbientOcclusionOptions instead
+     * @see #setAmbientOcclusion
+     */
+    @Deprecated
+    public enum AmbientOcclusion {
+        NONE,
+        SSAO
+    }
+
     // The remainder of this file is generated by beamsplitter
+
+    /**
+     * Generic quality level.
+     */
+    public enum QualityLevel {
+        LOW,
+        MEDIUM,
+        HIGH,
+        ULTRA
+    }
+
+    public enum BlendMode {
+        OPAQUE,
+        TRANSLUCENT
+    }
+
+    /**
+     * Dynamic resolution can be used to either reach a desired target frame rate by lowering the
+     * resolution of a <code>View</code>, or to increase the quality when the rendering is faster
+     * than the target frame rate.
+     *
+     * <p>
+     * This structure can be used to specify the minimum scale factor used when lowering the
+     * resolution of a <code>View</code>, and the maximum scale factor used when increasing the
+     * resolution for higher quality rendering. The scale factors can be controlled on each X and Y
+     * axis independently. By default, all scale factors are set to 1.0.
+     * </p>
+     *
+     * <p>
+     * Dynamic resolution is only supported on platforms where the time to render a frame can be
+     * measured accurately. Dynamic resolution is currently only supported on Android.
+     * </p>
+     */
+    public static class DynamicResolutionOptions {
+        /**
+         * Enables or disables dynamic resolution on a View.
+         */
+        public boolean enabled = false;
+
+        /**
+         * If false, the system scales the major axis first.
+         */
+        public boolean homogeneousScaling = false;
+
+        /**
+         * The minimum scale in X and Y this View should use.
+         */
+        public float minScale = 0.5f;
+
+        /**
+         * The maximum scale in X and Y this View should use.
+         */
+        public float maxScale = 1.0f;
+
+        /**
+         * Sharpness when QualityLevel.MEDIUM or higher is used [0, 1].
+         * 0 is disabled, 1 is the sharpest setting.
+         * The default is set to 0.9
+         */
+        public float sharpness = 0.9f;
+
+        /**
+         * Upscaling quality
+         * LOW: bilinear filtered blit. Fastest, poor quality
+         * MEDIUM: AMD FidelityFX FSR1 w/ mobile optimizations no RCAS sharpening pass
+         * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations + RCAS
+         * ULTRA:  AMD FidelityFX FSR1
+         *      FSR1 require a well anti-aliased (MSAA or TAA), noise free scene.
+         *
+         * The default upscaling quality is set to LOW.
+         */
+        @NonNull
+        public QualityLevel quality = QualityLevel.LOW;
+    }
+
+    /**
+     * Options for controlling the Bloom effect
+     *
+     * enabled:     Enable or disable the bloom post-processing effect. Disabled by default.
+     * levels:      Number of successive blurs to achieve the blur effect, the minimum is 3 and the
+     *              maximum is 11. This value together with resolution influences the spread of the
+     *              blur effect. This value can be silently reduced to accommodate the original
+     *              image size.
+     * resolution:  Resolution of bloom's vertical axis. The minimum value is 2^levels and the
+     *              the maximum is lower of the original resolution and 2048. This parameter is
+     *              silently clamped to the minimum and maximum.
+     *              It is highly recommended that this value be smaller than the target resolution
+     *              after dynamic resolution is applied (horizontally and vertically).
+     * strength:    how much of the bloom is added to the original image. Between 0 and 1.
+     * blendMode:   Whether the bloom effect is purely additive (false) or mixed with the original
+     *              image (true).
+     * anamorphism: Bloom's aspect ratio (x/y), for artistic purposes.
+     * threshold:   When enabled, a threshold at 1.0 is applied on the source image, this is
+     *              useful for artistic reasons and is usually needed when a dirt texture is used.
+     * dirt:        A dirt/scratch/smudges texture (that can be RGB), which gets added to the
+     *              bloom effect. Smudges are visible where bloom occurs. Threshold must be
+     *              enabled for the dirt effect to work properly.
+     * dirtStrength: Strength of the dirt texture.
+     *
+     * @see View#setBloomOptions
+     */
+    public static class BloomOptions {
+
+        public enum BlendingMode {
+            ADD,
+            INTERPOLATE
+        }
+
+        /**
+         * User provided dirt texture
+         */
+        @Nullable
+        public Texture dirt = null;
+
+        /**
+         * strength of the dirt texture
+         */
+        public float dirtStrength = 0.2f;
+
+        /**
+         * Strength of the bloom effect, between 0.0 and 1.0
+         */
+        public float strength = 0.10f;
+
+        /**
+         * Resolution of minor axis (2^levels to 2048)
+         */
+        public int resolution = 360;
+
+        /**
+         * Bloom x/y aspect-ratio (1/32 to 32)
+         */
+        public float anamorphism = 1.0f;
+
+        /**
+         * Number of blur levels (3 to 11)
+         */
+        public int levels = 6;
+
+        /**
+         * How the bloom effect is applied
+         */
+        public BlendingMode blendMode = BlendingMode.ADD;
+
+        /**
+         * Whether to threshold the source
+         */
+        public boolean threshold = true;
+
+        /**
+         * enable or disable bloom
+         */
+        public boolean enabled = false;
+
+        /**
+         * limit highlights to this value before bloom. Use +inf for no limiting.
+         * minimum value is 10.0.
+         */
+        public float highlight = 1000.0f;
+
+
+        /**
+         * enable screen-space lens flare
+         */
+        public boolean lensFlare = false;
+
+        /**
+         * enable starburst effect on lens flare
+         */
+        public boolean starburst = true;
+
+        /**
+         * amount of chromatic aberration
+         */
+        public float chromaticAberration = 0.005f;
+
+        /**
+         * number of flare "ghosts"
+         */
+        public int ghostCount = 4;
+
+        /**
+         * spacing of the ghost in screen units [0, 1[
+         */
+        public float ghostSpacing = 0.6f;
+
+        /**
+         * hdr threshold for the ghosts
+         */
+        public float ghostThreshold = 10.0f;
+
+        /**
+         * thickness of halo in vertical screen units, 0 to disable
+         */
+        public float haloThickness = 0.1f;
+
+        /**
+         * radius of halo in vertical screen units [0, 0.5]
+         */
+        public float haloRadius = 0.4f;
+
+        /**
+         * hdr threshold for the halo
+         */
+        public float haloThreshold = 10.0f;
+    }
+
+    /**
+     * Options to control fog in the scene
+     *
+     * @see View#setFogOptions
+     */
+    public static class FogOptions {
+        /**
+         * distance in world units from the camera where the fog starts ( >= 0.0 )
+         */
+        public float distance = 0.0f;
+
+        /**
+         * fog's maximum opacity between 0 and 1
+         */
+        public float maximumOpacity = 1.0f;
+
+        /**
+         * fog's floor in world units
+         */
+        public float height = 0.0f;
+
+        /**
+         * how fast fog dissipates with altitude
+         */
+        public float heightFalloff = 1.0f;
+
+        /**
+         * Fog's color as a linear RGB color.
+         */
+        @NonNull
+        @Size(min = 3)
+        public float[] color = { 0.5f, 0.5f, 0.5f };
+
+        /**
+         * fog's density at altitude given by 'height'
+         */
+        public float density = 0.1f;
+
+        /**
+         * distance in world units from the camera where in-scattering starts
+         */
+        public float inScatteringStart = 0.0f;
+
+        /**
+         * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100)
+         */
+        public float inScatteringSize = -1.0f;
+
+        /**
+         * fog color will be modulated by the IBL color in the view direction
+         */
+        public boolean fogColorFromIbl = false;
+
+        /**
+         * enable or disable fog
+         */
+        public boolean enabled = false;
+    }
+
+    /**
+     * Options to control Depth of Field (DoF) effect in the scene
+     *
+     * @see View#setDepthOfFieldOptions
+     */
+    public static class DepthOfFieldOptions {
+
+        public enum Filter {
+            NONE,
+            UNUSED,
+            MEDIAN
+        }
+
+        /**
+         * circle of confusion scale factor (amount of blur)
+         *
+         * <p>cocScale can be used to set the depth of field blur independently from the camera
+         * aperture, e.g. for artistic reasons. This can be achieved by setting:</p>
+         * <code>
+         *      cocScale = cameraAperture / desiredDoFAperture
+         * </code>
+         *
+         */
+        public float cocScale = 1.0f;
+
+        /** maximum aperture diameter in meters (zero to disable bokeh rotation) */
+        public float maxApertureDiameter = 0.01f;
+
+        /** enable or disable Depth of field effect */
+        public boolean enabled = false;
+
+        /** filter to use for filling gaps in the kernel */
+        @NonNull
+        public Filter filter = Filter.MEDIAN;
+
+        /** perform DoF processing at native resolution */
+        public boolean nativeResolution = false;
+
+        /**
+         * <p>Number of of rings used by the foreground kernel. The number of rings affects quality
+         * and performance. The actual number of sample per pixel is defined
+         * as (ringCount * 2 - 1)^2. Here are a few commonly used values:</p>
+         *       3 rings :   25 ( 5x 5 grid)
+         *       4 rings :   49 ( 7x 7 grid)
+         *       5 rings :   81 ( 9x 9 grid)
+         *      17 rings : 1089 (33x33 grid)
+         *
+         * <p>With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.</p>
+         *
+         * <p>Usually all three settings below are set to the same value, however, it is often
+         * acceptable to use a lower ring count for the "fast tiles", which improves performance.
+         * Fast tiles are regions of the screen where every pixels have a similar
+         * circle-of-confusion radius.</p>
+         *
+         * <p>A value of 0 means default, which is 5 on desktop and 3 on mobile.</p>
+         */
+        public int foregroundRingCount = 0;
+
+        /**
+         * Number of of rings used by the background kernel. The number of rings affects quality
+         * and performance.
+         * @see #foregroundRingCount
+         */
+        public int backgroundRingCount = 0;
+
+        /**
+         * Number of of rings used by the fast gather kernel. The number of rings affects quality
+         * and performance.
+         * @see #foregroundRingCount
+         */
+        public int fastGatherRingCount = 0;
+
+        /**
+         * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
+         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+         */
+        public int maxForegroundCOC = 0;
+
+        /**
+         * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
+         * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+         */
+        public int maxBackgroundCOC = 0;
+    };
+
+    /**
+     * Options to control the vignetting effect.
+     */
+    public static class VignetteOptions {
+        /**
+         * High values restrict the vignette closer to the corners, between 0 and 1.
+         */
+        public float midPoint = 0.5f;
+
+        /**
+         * Controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5),
+         * to a circle (1.0). The value must be between 0 and 1.
+         */
+        public float roundness = 0.5f;
+
+        /**
+         * Softening amount of the vignette effect, between 0 and 1.
+         */
+        public float feather = 0.5f;
+
+        /**
+         * Color of the vignette effect as a linear RGBA color. The alpha channel is currently
+         * ignored.
+         */
+        @NonNull
+        @Size(min = 4)
+        public float[] color = { 0.0f, 0.0f, 0.0f, 1.0f };
+
+        /**
+         * Enables or disables the vignette effect.
+         */
+        public boolean enabled = false;
+    }
+
+    /**
+     * Structure used to set the color precision for the rendering of a <code>View</code>.
+     *
+     * <p>
+     * This structure offers separate quality settings for different parts of the rendering
+     * pipeline.
+     * </p>
+     *
+     * @see #setRenderQuality
+     * @see #getRenderQuality
+     */
+    public static class RenderQuality {
+        /**
+          * <p>
+          * A quality of <code>HIGH</code> or <code>ULTRA</code> means using an RGB16F or RGBA16F color
+          * buffer. This means colors in the LDR range (0..1) have 10 bit precision. A quality of
+          * <code>LOW</code> or <code>MEDIUM</code> means using an R11G11B10F opaque color buffer or an
+          * RGBA16F transparent color buffer. With R11G11B10F colors in the LDR range have a precision of
+          * either 6 bits (red and green channels) or 5 bits (blue channel).
+          * </p>
+          */
+        public QualityLevel hdrColorBuffer = QualityLevel.HIGH;
+    }
+
+    /**
+     * Options for screen space Ambient Occlusion
+     */
+    public static class AmbientOcclusionOptions {
+        /**
+         * Ambient Occlusion radius in meters, between 0 and ~10.
+         */
+        public float radius = 0.3f;
+
+        /**
+         * Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
+         */
+        public float bias = 0.0005f;
+
+        /**
+         * Controls ambient occlusion's contrast. Must be positive. Default is 1.
+         * Good values are between 0.5 and 3.
+         */
+        public float power = 1.0f;
+
+        /**
+         * How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
+         */
+        public float resolution = 0.5f;
+
+        /**
+         * Strength of the Ambient Occlusion effect. Must be positive.
+         */
+        public float intensity = 1.0f;
+
+        /**
+         * Depth distance that constitute an edge for filtering. Must be positive.
+         * Default is 5cm.
+         * This must be adjusted with the scene's scale and/or units.
+         * A value too low will result in high frequency noise, while a value too high will
+         * result in the loss of geometry edges. For AO, it is generally better to be too
+         * blurry than not enough.
+         */
+        public float bilateralThreshold = 0.05f;
+
+        /**
+         * The quality setting controls the number of samples used for evaluating Ambient
+         * occlusion. The default is QualityLevel.LOW which is sufficient for most mobile
+         * applications.
+         */
+        @NonNull
+        public QualityLevel quality = QualityLevel.LOW;
+
+        /**
+         * The lowPassFilter setting controls the quality of the low pass filter applied to
+         * AO estimation. The default is QualityLevel.MEDIUM which is sufficient for most mobile
+         * applications. QualityLevel.LOW disables the filter entirely.
+         */
+        @NonNull
+        public QualityLevel lowPassFilter = QualityLevel.MEDIUM;
+
+        /**
+         * The upsampling setting controls the quality of the ambient occlusion buffer upsampling.
+         * The default is QualityLevel.LOW and uses bilinear filtering, a value of
+         * QualityLevel.HIGH or more enables a better bilateral filter.
+         */
+        @NonNull
+        public QualityLevel upsampling = QualityLevel.LOW;
+
+        /**
+         * enable or disable screen space ambient occlusion
+         */
+        public boolean enabled = false;
+
+        /**
+         * enables bent normals computation from AO, and specular AO
+         */
+        public boolean bentNormals = false;
+
+        /**
+         * Minimal angle to consider in radian. This is used to reduce the creases that can
+         * appear due to insufficiently tessellated geometry.
+         * For e.g. a good values to try could be around 0.2.
+         */
+        public float minHorizonAngleRad = 0.0f;
+
+
+       /**
+        * Full cone angle in radian, between 0 and pi/2. This affects the softness of the shadows,
+        * as well as how far they are cast. A smaller angle yields to sharper and shorter shadows.
+        * The default angle is about 60 degrees.
+        */
+       public float ssctLightConeRad = 1.0f;
+
+       /**
+        * Distance from where tracing starts.
+        * This affects how far shadows are cast.
+        */
+       public float ssctShadowDistance = 0.01f;
+
+       /**
+        * Maximum contact distance with the cone. Intersections between the traced cone and
+        * geometry samller than this distance are ignored.
+        */
+       public float ssctContactDistanceMax = 1.0f;
+
+       /**
+        * Intensity of the shadows.
+        */
+       public float ssctIntensity = 0.8f;
+
+       /**
+        * Light direction.
+        */
+       @NonNull @Size(min = 3)
+       public float[] ssctLightDirection = { 0, -1, 0 };
+
+       /**
+        * Depth bias in world units (mitigate self shadowing)
+        */
+       public float ssctDepthBias = 0.01f;
+
+       /**
+        * Depth slope bias (mitigate self shadowing)
+        */
+       public float ssctDepthSlopeBias = 0.01f;
+
+       /**
+        * Tracing sample count, between 1 and 255. This affects the quality as well as the
+        * distance of the shadows.
+        */
+       public int ssctSampleCount = 4;
+
+       /**
+        * Numbers of rays to trace, between 1 and 255. This affects the noise of the shadows.
+        * Performance degrades quickly with this value.
+        */
+       public int ssctRayCount = 1;
+
+       /**
+        * Enables or disables SSCT.
+        */
+       public boolean ssctEnabled = false;
+    }
+
+    /**
+     * Options for Multi-sample Anti-aliasing (MSAA)
+     * @see View#setMultiSampleAntiAliasingOptions
+     */
+    public static class MultiSampleAntiAliasingOptions {
+        /** enables or disables temporal anti-aliasing */
+        public boolean enabled = false;
+
+        /**
+         * number of samples to use for multi-sampled anti-aliasing.\n
+         *      0: treated as 1
+         *      1: no anti-aliasing
+         *      n: sample count. Effective sample could be different depending on the
+         *         GPU capabilities.
+         */
+        public int sampleCount = 4;
+
+        /**
+         * custom resolve improves quality for HDR scenes, but may impact performance.
+         */
+        public boolean customResolve = false;
+    };
+
+    /**
+     * Options for Temporal Anti-aliasing (TAA)
+     * @see View#setTemporalAntiAliasingOptions
+     */
+    public static class TemporalAntiAliasingOptions {
+        /** reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother) */
+        public float filterWidth = 1.0f;
+
+        /** history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA). */
+        public float feedback = 0.04f;
+
+        /** enables or disables temporal anti-aliasing */
+        public boolean enabled = false;
+    };
+
+    /**
+     * Options for Screen-space Reflections.
+     * @see View#setScreenSpaceReflectionOptions
+     */
+    public static class ScreenSpaceReflectionsOptions {
+        /** ray thickness, in world units */
+        public float thickness = 0.1f;
+
+        /** bias, in world units, to prevent self-intersections */
+        public float bias = 0.01f;
+
+        /** maximum distance, in world units, to raycast */
+        public float maxDistance = 3.0f;
+
+        /** stride, in texels, for samples along the ray. */
+        public float stride = 2.0f;
+
+        /** enables or disables screen-space reflections */
+        public boolean enabled = false;
+    };
+
+    /**
+     * Options for the  screen-space guard band.
+     * A guard band can be enabled to avoid some artifacts towards the edge of the screen when
+     * using screen-space effects such as SSAO.
+     * Enabling the guard band reduces performance slightly.
+     * Currently the guard band can only be enabled or disabled.
+     *
+     * @see View#setGuardBandOptions
+     */
+    public static class GuardBandOptions {
+        /** enables or disables the guard band */
+        public boolean enabled = false;
+    };
+
+    /**
+     * List of available post-processing anti-aliasing techniques.
+     *
+     * @see #setAntiAliasing
+     * @see #getAntiAliasing
+     */
+    public enum AntiAliasing {
+        /**
+         * No anti aliasing performed as part of post-processing.
+         */
+        NONE,
+
+        /**
+         * FXAA is a low-quality but very efficient type of anti-aliasing. (default).
+         */
+        FXAA
+    }
+
+    /**
+     * List of available post-processing dithering techniques.
+     */
+    public enum Dithering {
+        NONE,
+        TEMPORAL
+    }
+
+    /**
+     * List of available shadow mapping techniques.
+     *
+     * @see #setShadowType
+     */
+    public enum ShadowType {
+        /**
+         * Percentage-closer filtered shadows (default).
+         */
+        PCF,
+
+        /**
+         * Variance shadows.
+         */
+        VSM,
+
+        /**
+         * Percentage-closer filtered shadows, with contact hardening simulation.
+         */
+        DPCF,
+
+        /**
+         * Percentage-closer soft shadows
+         */
+        PCSS
+    }
+
+    /**
+     * View-level options for VSM shadowing.
+     *
+     * <strong>Warning: This API is still experimental and subject to change.</strong>
+     *
+     * @see View#setVsmShadowOptions
+     */
+    public static class VsmShadowOptions {
+        /**
+         * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
+         * than 0, mipmaps will automatically be generated each frame for all lights.
+         * This implies mipmapping below.
+         *
+         * <p>
+         * The number of anisotropic samples = 2 ^ vsmAnisotropy.
+         * </p>
+         *
+         */
+        public int anisotropy = 0;
+
+        /**
+         * Whether to generate mipmaps for all VSM shadow maps.
+         */
+        public boolean mipmapping = false;
+
+        /**
+         * VSM minimum variance scale, must be positive.
+         */
+        public float minVarianceScale = 1.0f;
+
+        /**
+         * VSM light bleeding reduction amount, between 0 and 1.
+         */
+        public float lightBleedReduction = 0.2f;
+    }
+
+    /**
+     * View-level options for DPCF and PCSS Shadowing.
+     *
+     * <strong>Warning: This API is still experimental and subject to change.</strong>
+     *
+     * @see View#setSoftShadowOptions
+     */
+    public static class SoftShadowOptions {
+        /**
+         * Globally scales the penumbra of all DPCF and PCSS shadows
+         * Acceptable values are greater than 0
+         */
+        public float penumbraScale = 1.0f;
+
+        /**
+         * Globally scales the computed penumbra ratio of all DPCF and PCSS shadows.
+         * This effectively controls the strength of contact hardening effect and is useful for
+         * artistic purposes. Higher values make the shadows become softer faster.
+         * Acceptable values are equal to or greater than 1.
+         */
+        public float penumbraRatioScale = 1.0f;
+    }
 }

--- a/tools/beamsplitter/README.md
+++ b/tools/beamsplitter/README.md
@@ -59,9 +59,8 @@ flag                        | description
 - `web/filament-js/jsbindings_generated.cpp`
 - `web/filament-js/jsenums_generated.cpp`
 - `web/filament-js/extensions_generated.js`
-- `android/filament-android/src/main/cpp/View_generated.cpp` (TBD)
 
 Additionally, in-place edits are made to the following files:
 
 - `web/filament-js/filament.d.ts`
-- `android/filament-android/src/main/java/.../View.java` (TBD)
+- `android/filament-android/src/main/java/.../View.java`

--- a/tools/beamsplitter/java.template
+++ b/tools/beamsplitter/java.template
@@ -2,11 +2,16 @@
     {{ docblock .  1 }}public static class {{ .BaseName }} {
     {{- nested_type_declarations . }}
     {{- range $index, $field := .Fields}}
-        {{ docblock . 2 }}{{ annotation $field 2 }}public
+        {{ docblock . 2 }}
+        {{- if flag $field "java_flatten" }}
+        {{- flatten $field }}
+        {{- else}}
+        {{- annotation $field 2 }}public
         {{- java_type $field }} {{ $field.Name }} =
         {{- java_value $field}};
+        {{- end }}
     {{- end }}
-    };
+    }
 {{ end }}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -16,5 +21,5 @@
     {{- range .Values}}
         {{ docblock . 2 }}{{ .Name }},
     {{- end }}
-    };
+    }
 {{ end }}

--- a/tools/beamsplitter/javascript.go
+++ b/tools/beamsplitter/javascript.go
@@ -82,6 +82,17 @@ func createJsCodeGenerator(namespace string) func(*os.File, string, parse.TypeDe
 		"jsprefix":    func() string { return jsPrefix },
 		"cprefix":     func() string { return cppPrefix },
 		"classprefix": func() string { return classPrefix },
+		"docblock": func(defn parse.Documented, depth int) string {
+			doc := defn.GetDoc()
+			if doc == "" {
+				return ""
+			}
+			indent := strings.Repeat("    ", depth)
+			if strings.Count(doc, "\n") > 0 {
+				return strings.ReplaceAll(doc, "\n", "\n"+indent)
+			}
+			return "/**\n" + indent + " * " + doc + "\n" + indent + " */\n" + indent
+		},
 	}
 
 	templ := template.New("beamsplitter").Funcs(customExtensions)

--- a/tools/beamsplitter/javascript.template
+++ b/tools/beamsplitter/javascript.template
@@ -91,8 +91,8 @@ Filament.loadGeneratedExtensions = function() {
 {{- if flag $field "skip_javascript" }}
     // JavaScript binding for {{$field.Name}} is not yet supported, must use default value.
 {{- else }}
-    {{ $field.Name }}?: {{ tstype $field.TypeString }};
-    {{- if $field.Description}} // {{ $field.Description }}{{end}}
+    {{ docblock $field 1 }}
+    {{- $field.Name }}?: {{ tstype $field.TypeString }};
 {{- end }}
 {{- end }}
 }

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1088,11 +1088,36 @@ export enum View$BlendMode {
  *
  */
 export interface View$DynamicResolutionOptions {
-    minScale?: float2; // minimum scale factors in x and y
-    maxScale?: float2; // maximum scale factors in x and y
-    sharpness?: number; // sharpness when QualityLevel::MEDIUM or higher is used [0 (disabled), 1 (sharpest)]
-    enabled?: boolean; // enable or disable dynamic resolution
-    homogeneousScaling?: boolean; // set to true to force homogeneous scaling
+    /**
+     * minimum scale factors in x and y
+     */
+    minScale?: float2;
+    /**
+     * maximum scale factors in x and y
+     */
+    maxScale?: float2;
+    /**
+     * sharpness when QualityLevel::MEDIUM or higher is used [0 (disabled), 1 (sharpest)]
+     */
+    sharpness?: number;
+    /**
+     * enable or disable dynamic resolution
+     */
+    enabled?: boolean;
+    /**
+     * set to true to force homogeneous scaling
+     */
+    homogeneousScaling?: boolean;
+    /**
+     * Upscaling quality
+     * LOW:    bilinear filtered blit. Fastest, poor quality
+     * MEDIUM: AMD FidelityFX FSR1 w/ mobile optimizations
+     * HIGH:   AMD FidelityFX FSR1 w/ mobile optimizations
+     * ULTRA:  AMD FidelityFX FSR1
+     *      FSR1 require a well anti-aliased (MSAA or TAA), noise free scene.
+     *
+     * The default upscaling quality is set to LOW.
+     */
     quality?: View$QualityLevel;
 }
 
@@ -1136,39 +1161,120 @@ export enum View$BloomOptions$BlendMode {
 export interface View$BloomOptions {
     // JavaScript binding for dirt is not yet supported, must use default value.
     // JavaScript binding for dirtStrength is not yet supported, must use default value.
-    strength?: number; // bloom's strength between 0.0 and 1.0
-    resolution?: number; // resolution of vertical axis (2^levels to 2048)
-    anamorphism?: number; // bloom x/y aspect-ratio (1/32 to 32)
-    levels?: number; // number of blur levels (3 to 11)
-    blendMode?: View$BloomOptions$BlendMode; // how the bloom effect is applied
-    threshold?: boolean; // whether to threshold the source
-    enabled?: boolean; // enable or disable bloom
-    highlight?: number; // limit highlights to this value before bloom [10, +inf]
-    lensFlare?: boolean; // enable screen-space lens flare
-    starburst?: boolean; // enable starburst effect on lens flare
-    chromaticAberration?: number; // amount of chromatic aberration
-    ghostCount?: number; // number of flare "ghosts"
-    ghostSpacing?: number; // spacing of the ghost in screen units [0, 1[
-    ghostThreshold?: number; // hdr threshold for the ghosts
-    haloThickness?: number; // thickness of halo in vertical screen units, 0 to disable
-    haloRadius?: number; // radius of halo in vertical screen units [0, 0.5]
-    haloThreshold?: number; // hdr threshold for the halo
+    /**
+     * bloom's strength between 0.0 and 1.0
+     */
+    strength?: number;
+    /**
+     * resolution of vertical axis (2^levels to 2048)
+     */
+    resolution?: number;
+    /**
+     * bloom x/y aspect-ratio (1/32 to 32)
+     */
+    anamorphism?: number;
+    /**
+     * number of blur levels (3 to 11)
+     */
+    levels?: number;
+    /**
+     * how the bloom effect is applied
+     */
+    blendMode?: View$BloomOptions$BlendMode;
+    /**
+     * whether to threshold the source
+     */
+    threshold?: boolean;
+    /**
+     * enable or disable bloom
+     */
+    enabled?: boolean;
+    /**
+     * limit highlights to this value before bloom [10, +inf]
+     */
+    highlight?: number;
+    /**
+     * enable screen-space lens flare
+     */
+    lensFlare?: boolean;
+    /**
+     * enable starburst effect on lens flare
+     */
+    starburst?: boolean;
+    /**
+     * amount of chromatic aberration
+     */
+    chromaticAberration?: number;
+    /**
+     * number of flare "ghosts"
+     */
+    ghostCount?: number;
+    /**
+     * spacing of the ghost in screen units [0, 1[
+     */
+    ghostSpacing?: number;
+    /**
+     * hdr threshold for the ghosts
+     */
+    ghostThreshold?: number;
+    /**
+     * thickness of halo in vertical screen units, 0 to disable
+     */
+    haloThickness?: number;
+    /**
+     * radius of halo in vertical screen units [0, 0.5]
+     */
+    haloRadius?: number;
+    /**
+     * hdr threshold for the halo
+     */
+    haloThreshold?: number;
 }
 
 /**
  * Options to control fog in the scene
  */
 export interface View$FogOptions {
-    distance?: number; // distance in world units from the camera where the fog starts ( >= 0.0 )
-    maximumOpacity?: number; // fog's maximum opacity between 0 and 1
-    height?: number; // fog's floor in world units
-    heightFalloff?: number; // how fast fog dissipates with altitude
-    color?: float3; // fog's color (linear), see fogColorFromIbl
-    density?: number; // fog's density at altitude given by 'height'
-    inScatteringStart?: number; // distance in world units from the camera where in-scattering starts
-    inScatteringSize?: number; // size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
-    fogColorFromIbl?: boolean; // Fog color will be modulated by the IBL color in the view direction.
-    enabled?: boolean; // enable or disable fog
+    /**
+     * distance in world units from the camera where the fog starts ( >= 0.0 )
+     */
+    distance?: number;
+    /**
+     * fog's maximum opacity between 0 and 1
+     */
+    maximumOpacity?: number;
+    /**
+     * fog's floor in world units
+     */
+    height?: number;
+    /**
+     * how fast fog dissipates with altitude
+     */
+    heightFalloff?: number;
+    /**
+     * fog's color (linear), see fogColorFromIbl
+     */
+    color?: float3;
+    /**
+     * fog's density at altitude given by 'height'
+     */
+    density?: number;
+    /**
+     * distance in world units from the camera where in-scattering starts
+     */
+    inScatteringStart?: number;
+    /**
+     * size of in-scattering (>0 to activate). Good values are >> 1 (e.g. ~10 - 100).
+     */
+    inScatteringSize?: number;
+    /**
+     * Fog color will be modulated by the IBL color in the view direction.
+     */
+    fogColorFromIbl?: boolean;
+    /**
+     * enable or disable fog
+     */
+    enabled?: boolean;
 }
 
 export enum View$DepthOfFieldOptions$Filter {
@@ -1187,15 +1293,64 @@ export enum View$DepthOfFieldOptions$Filter {
  * @see Camera
  */
 export interface View$DepthOfFieldOptions {
-    cocScale?: number; // circle of confusion scale factor (amount of blur)
-    maxApertureDiameter?: number; // maximum aperture diameter in meters (zero to disable rotation)
-    enabled?: boolean; // enable or disable depth of field effect
-    filter?: View$DepthOfFieldOptions$Filter; // filter to use for filling gaps in the kernel
-    nativeResolution?: boolean; // perform DoF processing at native resolution
-    foregroundRingCount?: number; // number of kernel rings for foreground tiles
-    backgroundRingCount?: number; // number of kernel rings for background tiles
-    fastGatherRingCount?: number; // number of kernel rings for fast tiles
+    /**
+     * circle of confusion scale factor (amount of blur)
+     */
+    cocScale?: number;
+    /**
+     * maximum aperture diameter in meters (zero to disable rotation)
+     */
+    maxApertureDiameter?: number;
+    /**
+     * enable or disable depth of field effect
+     */
+    enabled?: boolean;
+    /**
+     * filter to use for filling gaps in the kernel
+     */
+    filter?: View$DepthOfFieldOptions$Filter;
+    /**
+     * perform DoF processing at native resolution
+     */
+    nativeResolution?: boolean;
+    /**
+     * Number of of rings used by the gather kernels. The number of rings affects quality
+     * and performance. The actual number of sample per pixel is defined
+     * as (ringCount * 2 - 1)^2. Here are a few commonly used values:
+     *       3 rings :   25 ( 5x 5 grid)
+     *       4 rings :   49 ( 7x 7 grid)
+     *       5 rings :   81 ( 9x 9 grid)
+     *      17 rings : 1089 (33x33 grid)
+     *
+     * With a maximum circle-of-confusion of 32, it is never necessary to use more than 17 rings.
+     *
+     * Usually all three settings below are set to the same value, however, it is often
+     * acceptable to use a lower ring count for the "fast tiles", which improves performance.
+     * Fast tiles are regions of the screen where every pixels have a similar
+     * circle-of-confusion radius.
+     *
+     * A value of 0 means default, which is 5 on desktop and 3 on mobile.
+     *
+     * @{
+     */
+    foregroundRingCount?: number;
+    /**
+     * number of kernel rings for background tiles
+     */
+    backgroundRingCount?: number;
+    /**
+     * number of kernel rings for fast tiles
+     */
+    fastGatherRingCount?: number;
+    /**
+     * maximum circle-of-confusion in pixels for the foreground, must be in [0, 32] range.
+     * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+     */
     maxForegroundCOC?: number;
+    /**
+     * maximum circle-of-confusion in pixels for the background, must be in [0, 32] range.
+     * A value of 0 means default, which is 32 on desktop and 24 on mobile.
+     */
     maxBackgroundCOC?: number;
 }
 
@@ -1203,11 +1358,26 @@ export interface View$DepthOfFieldOptions {
  * Options to control the vignetting effect.
  */
 export interface View$VignetteOptions {
-    midPoint?: number; // high values restrict the vignette closer to the corners, between 0 and 1
-    roundness?: number; // controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5), to a circle (1.0)
-    feather?: number; // softening amount of the vignette effect, between 0 and 1
-    color?: float4; // color of the vignette effect, alpha is currently ignored
-    enabled?: boolean; // enables or disables the vignette effect
+    /**
+     * high values restrict the vignette closer to the corners, between 0 and 1
+     */
+    midPoint?: number;
+    /**
+     * controls the shape of the vignette, from a rounded rectangle (0.0), to an oval (0.5), to a circle (1.0)
+     */
+    roundness?: number;
+    /**
+     * softening amount of the vignette effect, between 0 and 1
+     */
+    feather?: number;
+    /**
+     * color of the vignette effect, alpha is currently ignored
+     */
+    color?: float4;
+    /**
+     * enables or disables the vignette effect
+     */
+    enabled?: boolean;
 }
 
 /**
@@ -1216,6 +1386,15 @@ export interface View$VignetteOptions {
  * @see setRenderQuality, getRenderQuality
  */
 export interface View$RenderQuality {
+    /**
+     * Sets the quality of the HDR color buffer.
+     *
+     * A quality of HIGH or ULTRA means using an RGB16F or RGBA16F color buffer. This means
+     * colors in the LDR range (0..1) have a 10 bit precision. A quality of LOW or MEDIUM means
+     * using an R11G11B10F opaque color buffer or an RGBA16F transparent color buffer. With
+     * R11G11B10F colors in the LDR range have a precision of either 6 bits (red and green
+     * channels) or 5 bits (blue channel).
+     */
     hdrColorBuffer?: View$QualityLevel;
 }
 
@@ -1224,16 +1403,46 @@ export interface View$RenderQuality {
  * Ambient shadows from dominant light
  */
 export interface View$AmbientOcclusionOptions$Ssct {
-    lightConeRad?: number; // full cone angle in radian, between 0 and pi/2
-    shadowDistance?: number; // how far shadows can be cast
-    contactDistanceMax?: number; // max distance for contact
-    intensity?: number; // intensity
-    lightDirection?: float3; // light direction
-    depthBias?: number; // depth bias in world units (mitigate self shadowing)
-    depthSlopeBias?: number; // depth slope bias (mitigate self shadowing)
-    sampleCount?: number; // tracing sample count, between 1 and 255
-    rayCount?: number; // # of rays to trace, between 1 and 255
-    enabled?: boolean; // enables or disables SSCT
+    /**
+     * full cone angle in radian, between 0 and pi/2
+     */
+    lightConeRad?: number;
+    /**
+     * how far shadows can be cast
+     */
+    shadowDistance?: number;
+    /**
+     * max distance for contact
+     */
+    contactDistanceMax?: number;
+    /**
+     * intensity
+     */
+    intensity?: number;
+    /**
+     * light direction
+     */
+    lightDirection?: float3;
+    /**
+     * depth bias in world units (mitigate self shadowing)
+     */
+    depthBias?: number;
+    /**
+     * depth slope bias (mitigate self shadowing)
+     */
+    depthSlopeBias?: number;
+    /**
+     * tracing sample count, between 1 and 255
+     */
+    sampleCount?: number;
+    /**
+     * # of rays to trace, between 1 and 255
+     */
+    rayCount?: number;
+    /**
+     * enables or disables SSCT
+     */
+    enabled?: boolean;
 }
 
 /**
@@ -1241,18 +1450,54 @@ export interface View$AmbientOcclusionOptions$Ssct {
  * @see setAmbientOcclusionOptions()
  */
 export interface View$AmbientOcclusionOptions {
-    radius?: number; // Ambient Occlusion radius in meters, between 0 and ~10.
-    power?: number; // Controls ambient occlusion's contrast. Must be positive.
-    bias?: number; // Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
-    resolution?: number; // How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
-    intensity?: number; // Strength of the Ambient Occlusion effect.
-    bilateralThreshold?: number; // depth distance that constitute an edge for filtering
-    quality?: View$QualityLevel; // affects # of samples used for AO.
-    lowPassFilter?: View$QualityLevel; // affects AO smoothness
-    upsampling?: View$QualityLevel; // affects AO buffer upsampling quality
-    enabled?: boolean; // enables or disables screen-space ambient occlusion
-    bentNormals?: boolean; // enables bent normals computation from AO, and specular AO
-    minHorizonAngleRad?: number; // min angle in radian to consider
+    /**
+     * Ambient Occlusion radius in meters, between 0 and ~10.
+     */
+    radius?: number;
+    /**
+     * Controls ambient occlusion's contrast. Must be positive.
+     */
+    power?: number;
+    /**
+     * Self-occlusion bias in meters. Use to avoid self-occlusion. Between 0 and a few mm.
+     */
+    bias?: number;
+    /**
+     * How each dimension of the AO buffer is scaled. Must be either 0.5 or 1.0.
+     */
+    resolution?: number;
+    /**
+     * Strength of the Ambient Occlusion effect.
+     */
+    intensity?: number;
+    /**
+     * depth distance that constitute an edge for filtering
+     */
+    bilateralThreshold?: number;
+    /**
+     * affects # of samples used for AO.
+     */
+    quality?: View$QualityLevel;
+    /**
+     * affects AO smoothness
+     */
+    lowPassFilter?: View$QualityLevel;
+    /**
+     * affects AO buffer upsampling quality
+     */
+    upsampling?: View$QualityLevel;
+    /**
+     * enables or disables screen-space ambient occlusion
+     */
+    enabled?: boolean;
+    /**
+     * enables bent normals computation from AO, and specular AO
+     */
+    bentNormals?: boolean;
+    /**
+     * min angle in radian to consider
+     */
+    minHorizonAngleRad?: number;
     // JavaScript binding for ssct is not yet supported, must use default value.
 }
 
@@ -1261,8 +1506,21 @@ export interface View$AmbientOcclusionOptions {
  * @see setMultiSampleAntiAliasingOptions()
  */
 export interface View$MultiSampleAntiAliasingOptions {
-    enabled?: boolean; // enables or disables msaa
+    /**
+     * enables or disables msaa
+     */
+    enabled?: boolean;
+    /**
+     * sampleCount number of samples to use for multi-sampled anti-aliasing.\n
+     *              0: treated as 1
+     *              1: no anti-aliasing
+     *              n: sample count. Effective sample could be different depending on the
+     *                 GPU capabilities.
+     */
     sampleCount?: number;
+    /**
+     * custom resolve improves quality for HDR scenes, but may impact performance.
+     */
     customResolve?: boolean;
 }
 
@@ -1271,9 +1529,18 @@ export interface View$MultiSampleAntiAliasingOptions {
  * @see setTemporalAntiAliasingOptions()
  */
 export interface View$TemporalAntiAliasingOptions {
-    filterWidth?: number; // reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
-    feedback?: number; // history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
-    enabled?: boolean; // enables or disables temporal anti-aliasing
+    /**
+     * reconstruction filter width typically between 0 (sharper, aliased) and 1 (smoother)
+     */
+    filterWidth?: number;
+    /**
+     * history feedback, between 0 (maximum temporal AA) and 1 (no temporal AA).
+     */
+    feedback?: number;
+    /**
+     * enables or disables temporal anti-aliasing
+     */
+    enabled?: boolean;
 }
 
 /**
@@ -1281,10 +1548,22 @@ export interface View$TemporalAntiAliasingOptions {
  * @see setScreenSpaceReflectionsOptions()
  */
 export interface View$ScreenSpaceReflectionsOptions {
-    thickness?: number; // ray thickness, in world units
-    bias?: number; // bias, in world units, to prevent self-intersections
-    maxDistance?: number; // maximum distance, in world units, to raycast
-    stride?: number; // stride, in texels, for samples along the ray.
+    /**
+     * ray thickness, in world units
+     */
+    thickness?: number;
+    /**
+     * bias, in world units, to prevent self-intersections
+     */
+    bias?: number;
+    /**
+     * maximum distance, in world units, to raycast
+     */
+    maxDistance?: number;
+    /**
+     * stride, in texels, for samples along the ray.
+     */
+    stride?: number;
     enabled?: boolean;
 }
 
@@ -1332,9 +1611,24 @@ export enum View$ShadowType {
  * @warning This API is still experimental and subject to change.
  */
 export interface View$VsmShadowOptions {
+    /**
+     * Sets the number of anisotropic samples to use when sampling a VSM shadow map. If greater
+     * than 0, mipmaps will automatically be generated each frame for all lights.
+     *
+     * The number of anisotropic samples = 2 ^ vsmAnisotropy.
+     */
     anisotropy?: number;
+    /**
+     * Whether to generate mipmaps for all VSM shadow maps.
+     */
     mipmapping?: boolean;
+    /**
+     * VSM minimum variance scale, must be positive.
+     */
     minVarianceScale?: number;
+    /**
+     * VSM light bleeding reduction amount, between 0 and 1.
+     */
     lightBleedReduction?: number;
 }
 
@@ -1344,6 +1638,16 @@ export interface View$VsmShadowOptions {
  * @warning This API is still experimental and subject to change.
  */
 export interface View$SoftShadowOptions {
+    /**
+     * Globally scales the penumbra of all DPCF and PCSS shadows
+     * Acceptable values are greater than 0
+     */
     penumbraScale?: number;
+    /**
+     * Globally scales the computed penumbra ratio of all DPCF and PCSS shadows.
+     * This effectively controls the strength of contact hardening effect and is useful for
+     * artistic purposes. Higher values make the shadows become softer faster.
+     * Acceptable values are equal to or greater than 1.
+     */
     penumbraRatioScale?: number;
 }


### PR DESCRIPTION
Note that JNI c++ functions still need to be manually maintained, as well as the setter / getter
methods.

Everything before the following codeline must be manually maintained:

```
// The remainder of this file is generated by beamsplitter
```