### PR TITLE
gltfio: Clear texture caches before loading resources

### DIFF
--- a/ios/samples/README.md
+++ b/ios/samples/README.md
@@ -99,3 +99,17 @@ $ xcodegen
 
 within a sample folder to re-generate the Xcode project. You may need to close and re-open the
 project in Xcode to see changes take effect.
+
+## Building iOS Samples with ASan / UBSan
+
+1. Turn on ASan / UBSan in Filament's top-level CMakeLists.txt by uncommenting the following line:
+
+```
+set(EXTRA_SANITIZE_OPTIONS "-fsanitize=undefined -fsanitize=address")
+```
+
+2. In the Xcode project, navigate to Product -> Scheme -> Edit Scheme... Under the Diagnostics tab,
+   check the box next for Address Sanitizer and Undefined Behavior.
+
+3. Build Filament and run the iOS sample as usual. Any errors will cause an exception to raise and
+   diagnostics to print in the console.

--- a/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILViewController.mm
@@ -56,6 +56,8 @@ using namespace ktxreader;
     Texture* _iblTexture;
     IndirectLight* _indirectLight;
     Entity _sun;
+
+    UITapGestureRecognizer* _doubleTapRecognizer;
 }
 
 #pragma mark UIViewController methods
@@ -91,6 +93,10 @@ using namespace ktxreader;
 
     _server = new viewer::RemoteServer();
     _automation = viewer::AutomationEngine::createDefault();
+
+    _doubleTapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(reloadModel)];
+    _doubleTapRecognizer.numberOfTapsRequired = 2;
+    [self.modelView addGestureRecognizer:_doubleTapRecognizer];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -100,6 +106,8 @@ using namespace ktxreader;
 - (void)viewWillDisappear:(BOOL)animated {
     [self stopDisplayLink];
 }
+
+#pragma mark Private
 
 - (void)startDisplayLink {
     [self stopDisplayLink];
@@ -115,8 +123,6 @@ using namespace ktxreader;
     [_displayLink invalidate];
     _displayLink = nil;
 }
-
-#pragma mark Private
 
 - (void)createRenderablesFromPath:(NSString*)model {
     // Retrieve the full path to the model in the documents directory.
@@ -255,6 +261,11 @@ using namespace ktxreader;
     }
 
     [self.modelView render];
+}
+
+- (void)reloadModel {
+    [self.modelView destroyModel];
+    [self createDefaultRenderables];
 }
 
 - (void)dealloc {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -342,6 +342,11 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     SYSTRACE_CONTEXT();
     SYSTRACE_ASYNC_END("addResourceData", 1);
 
+    // Clear our texture caches. Previous calls to loadResources may have populated these, but the
+    // Texture objects could have since been destroyed.
+    pImpl->mBufferTextureCache.clear();
+    pImpl->mFilepathTextureCache.clear();
+
     if (asset->mResourcesLoaded) {
         return false;
     }


### PR DESCRIPTION
Some textures would persist in the cache between calls to `loadResources`, but had since been destroyed. This caused a crash in the iOS gltf-viewer sample when reloading the model.

Fixes #5527