### PR TITLE
Fix not calculating the normal while morphing in the legacy path

### DIFF
--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -70,9 +70,26 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal);
 
         #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
-            if ((objectUniforms.flags & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
-                skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
-            }
+        if ((objectUniforms.flags & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
+            #if defined(LEGACY_MORPHING)
+            vec3 normal0, normal1, normal2, normal3;
+            toTangentFrame(mesh_custom4, normal0);
+            toTangentFrame(mesh_custom5, normal1);
+            toTangentFrame(mesh_custom6, normal2);
+            toTangentFrame(mesh_custom7, normal3);
+            material.worldNormal += morphingUniforms.weights[0].xyz * normal0;
+            material.worldNormal += morphingUniforms.weights[1].xyz * normal1;
+            material.worldNormal += morphingUniforms.weights[2].xyz * normal2;
+            material.worldNormal += morphingUniforms.weights[3].xyz * normal3;
+            #else
+            morphNormal(material.worldNormal);
+            material.worldNormal = normalize(material.worldNormal);
+            #endif
+        }
+
+        if ((objectUniforms.flags & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
+            skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
+        }
         #endif
 
         material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;


### PR DESCRIPTION
When the material doesn't need TBN, Filament doesn't calculate morph target's normal. As a result, the geometry is changed but the geometry's normal is not changed while morphing. This PR fixes this issue and now calculating normals while morphing.