### PR TITLE
Use morph target's normal stored in glTF

### DIFF
--- a/android/filament-android/src/main/cpp/MorphTargetBuffer.cpp
+++ b/android/filament-android/src/main/cpp/MorphTargetBuffer.cpp
@@ -85,15 +85,15 @@ Java_com_google_android_filament_MorphTargetBuffer_nSetPositionsAt(JNIEnv* env, 
 
 extern "C"
 JNIEXPORT jint JNICALL
-Java_com_google_android_filament_MorphTargetBuffer_nSetTangentsAt(JNIEnv* env, jclass,
+Java_com_google_android_filament_MorphTargetBuffer_nSetNormalssAt(JNIEnv* env, jclass,
         jlong nativeObject, jlong nativeEngine,
-        jint targetIndex, jshortArray tangents, jint count) {
+        jint targetIndex, jshortArray normals, jint count) {
     MorphTargetBuffer *morphTargetBuffer = (MorphTargetBuffer *) nativeObject;
     Engine *engine = (Engine *) nativeEngine;
-    jshort* data = env->GetShortArrayElements(tangents, NULL);
-    morphTargetBuffer->setTangentsAt(*engine, targetIndex,
-            (math::short4*) data, size_t(count));
-    env->ReleaseShortArrayElements(tangents, data, JNI_ABORT);
+    jshort* data = env->GetShortArrayElements(normals, NULL);
+    morphTargetBuffer->setNormalsAt(*engine, targetIndex,
+            (math::short4*) normals, size_t(count));
+    env->ReleaseShortArrayElements(normals, data, JNI_ABORT);
     return 0;
 }
 

--- a/android/filament-android/src/main/java/com/google/android/filament/MorphTargetBuffer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MorphTargetBuffer.java
@@ -129,11 +129,11 @@ public class MorphTargetBuffer {
      * @param tangents Pointer to at least count tangents
      * @param count Number of tangent elements in tangents
      */
-    public void setTangentsAt(@NonNull Engine engine,
+    public void setNormalsAt(@NonNull Engine engine,
             @IntRange(from = 0) int targetIndex,
-            @NonNull short[] tangents, @IntRange(from = 0, to = 125) int count) {
-        int result = nSetTangentsAt(mNativeObject, engine.getNativeObject(), targetIndex,
-                tangents, count);
+            @NonNull short[] normals, @IntRange(from = 0, to = 125) int count) {
+        int result = nSetNormalsAt(mNativeObject, engine.getNativeObject(), targetIndex,
+                normals, count);
         if (result < 0) {
             throw new BufferOverflowException();
         }
@@ -171,7 +171,7 @@ public class MorphTargetBuffer {
     private static native long nBuilderBuild(long nativeBuilder, long nativeEngine);
 
     private static native int nSetPositionsAt(long nativeObject, long nativeEngine, int targetIndex, float[] positions, int count);
-    private static native int nSetTangentsAt(long nativeObject, long nativeEngine, int targetIndex, short[] tangents, int count);
+    private static native int nSetNormalsAt(long nativeObject, long nativeEngine, int targetIndex, short[] normals, int count);
     private static native int nGetVertexCount(long nativeObject);
     private static native int nGetCount(long nativeObject);
 }

--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -86,7 +86,7 @@ public:
      * @param targetIndex the index of morph target to be updated.
      * @param weights pointer to at least count positions
      * @param count number of position elements in positions
-     * @see setTangentsAt
+     * @see setNormalsAt
      */
     void setPositionsAt(Engine& engine, size_t targetIndex,
             math::float3 const* positions, size_t count, size_t offset = 0);
@@ -112,12 +112,11 @@ public:
      *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
-     * @param tangents pointer to at least count tangents
-     * @param count number of tangent elements in tangents
-     * @see setTangentsAt
+     * @param normals pointer to at least count normals
+     * @param count number of tangent elements in normals
      */
-    void setTangentsAt(Engine& engine, size_t targetIndex,
-            math::short4 const* tangents, size_t count, size_t offset = 0);
+    void setNormalsAt(Engine& engine, size_t targetIndex,
+            math::short4 const* normals, size_t count, size_t offset = 0);
 
     /**
      * Returns the vertex count of this MorphTargetBuffer.

--- a/filament/src/MorphTargetBuffer.cpp
+++ b/filament/src/MorphTargetBuffer.cpp
@@ -30,9 +30,9 @@ void MorphTargetBuffer::setPositionsAt(Engine& engine, size_t targetIndex,
     upcast(this)->setPositionsAt(upcast(engine), targetIndex, positions, count, offset);
 }
 
-void MorphTargetBuffer::setTangentsAt(Engine& engine, size_t targetIndex,
-        math::short4 const* tangents, size_t count, size_t offset) {
-    upcast(this)->setTangentsAt(upcast(engine), targetIndex, tangents, count, offset);
+void MorphTargetBuffer::setNormalsAt(Engine& engine, size_t targetIndex,
+        math::short4 const* normals, size_t count, size_t offset) {
+    upcast(this)->setNormalsAt(upcast(engine), targetIndex, normals, count, offset);
 }
 
 size_t MorphTargetBuffer::getVertexCount() const noexcept {

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -284,7 +284,7 @@ void FEngine::init() {
     float3 dummyPositions[1] = {};
     short4 dummyTangents[1] = {};
     mDummyMorphTargetBuffer->setPositionsAt(*this, 0, dummyPositions, 1, 0);
-    mDummyMorphTargetBuffer->setTangentsAt(*this, 0, dummyTangents, 1, 0);
+    mDummyMorphTargetBuffer->setNormalsAt(*this, 0, dummyTangents, 1, 0);
 
     // create dummy textures we need throughout the engine
 

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -182,8 +182,8 @@ void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,
             count, offset);
 }
 
-void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
-        math::short4 const* tangents, size_t count, size_t offset) {
+void FMorphTargetBuffer::setNormalsAt(FEngine& engine, size_t targetIndex,
+        math::short4 const* normals, size_t count, size_t offset) {
 
     ASSERT_PRECONDITION(offset + count <= mVertexCount,
             "MorphTargetBuffer (size=%lu) overflow (count=%u, offset=%u)",
@@ -196,7 +196,7 @@ void FMorphTargetBuffer::setTangentsAt(FEngine& engine, size_t targetIndex,
 
     // We could use a pool instead of malloc() directly.
     auto* out = (short4*) malloc(size);
-    memcpy(out, tangents, sizeof(short4) * count);
+    memcpy(out, normals, sizeof(short4) * count);
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     updateDataAt(driver, mTbHandle,

--- a/filament/src/details/MorphTargetBuffer.h
+++ b/filament/src/details/MorphTargetBuffer.h
@@ -53,8 +53,8 @@ public:
     void setPositionsAt(FEngine& engine, size_t targetIndex,
             math::float4 const* positions, size_t count, size_t offset);
 
-    void setTangentsAt(FEngine& engine, size_t targetIndex,
-            math::short4 const* tangents, size_t count, size_t offset);
+    void setNormalsAt(FEngine& engine, size_t targetIndex,
+            math::short4 const* normals, size_t count, size_t offset);
 
     inline size_t getVertexCount() const noexcept { return mVertexCount; }
     inline size_t getCount() const noexcept { return mCount; }

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -91,7 +91,7 @@ SamplerInterfaceBlock const& SibGenerator::getPerRenderPrimitiveMorphingSib(Vari
             .name("MorphTargetBuffer")
             .stageFlags({ .vertex = true })
             .add({  { "positions", Type::SAMPLER_2D_ARRAY, Format::FLOAT, Precision::HIGH },
-                    { "tangents",  Type::SAMPLER_2D_ARRAY, Format::INT,   Precision::HIGH }})
+                    { "normals",   Type::SAMPLER_2D_ARRAY, Format::INT,   Precision::HIGH }})
             .build();
 
     return sib;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -911,11 +911,15 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive* inPrim, Primitive* out
                     assert_invariant(!previous || previous->component_type == accessor->component_type);
                     assert_invariant(!previous || previous->type == accessor->type);
                     previous = accessor;
-                    BufferSlot slot = { accessor };
+                    BufferSlot slot = { accessor, atype };
                     slot.morphTargetBuffer = targets;
                     slot.bufferIndex = tindex;
                     addBufferSlot(slot);
-                    break;
+                } else if (atype == cgltf_attribute_type_normal) {
+                    BufferSlot slot = { accessor, atype };
+                    slot.morphTargetBuffer = targets;
+                    slot.bufferIndex = tindex;
+                    addBufferSlot(slot);
                 }
             }
         }

--- a/libs/gltfio/src/TangentsJob.h
+++ b/libs/gltfio/src/TangentsJob.h
@@ -33,20 +33,16 @@ namespace gltfio {
  * required to do so.
  */
 struct TangentsJob {
-    static constexpr int kMorphTargetUnused = -1;
-
     // The inputs to the procedure. The prim is owned by the client, which should ensure that it
     // stays alive for the duration of the procedure.
     struct InputParams {
         const cgltf_primitive* prim;
-        const int morphTargetIndex = kMorphTargetUnused;
     };
 
     // The context of the procedure. These fields are not used by the procedure but are provided as
     // a convenience to clients. You can think of this as a scratch space for clients.
     struct Context {
         filament::VertexBuffer* const vb;
-        filament::MorphTargetBuffer* const tb;
         const uint8_t slot;
     };
 

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -101,10 +101,8 @@ void morphNormal(inout vec3 n) {
         float w = morphingUniforms.weights[i][0];
         if (w != 0.0) {
             texcoord.z = int(i);
-            ivec4 tangent = texelFetch(morphTargetBuffer_tangents, texcoord, 0);
-            vec3 normal;
-            toTangentFrame(float4(tangent) * (1.0 / 32767.0), normal);
-            n += w * normal;
+            ivec4 normal = texelFetch(morphTargetBuffer_normals, texcoord, 0);
+            n += w * (float4(normal) * (1.0 / 32767.0)).xyz;
         }
     }
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -37,18 +37,16 @@ void main() {
         #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
         if ((objectUniforms.flags & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
             #if defined(LEGACY_MORPHING)
-            vec3 normal0, normal1, normal2, normal3;
-            toTangentFrame(mesh_custom4, normal0);
-            toTangentFrame(mesh_custom5, normal1);
-            toTangentFrame(mesh_custom6, normal2);
-            toTangentFrame(mesh_custom7, normal3);
+            vec3 normal0 = mesh_custom4.xyz;
+            vec3 normal1 = mesh_custom5.xyz;
+            vec3 normal2 = mesh_custom6.xyz;
+            vec3 normal3 = mesh_custom7.xyz;
             material.worldNormal += morphingUniforms.weights[0].xyz * normal0;
             material.worldNormal += morphingUniforms.weights[1].xyz * normal1;
             material.worldNormal += morphingUniforms.weights[2].xyz * normal2;
             material.worldNormal += morphingUniforms.weights[3].xyz * normal3;
             #else
             morphNormal(material.worldNormal);
-            material.worldNormal = normalize(material.worldNormal);
             #endif
         }
 
@@ -72,18 +70,16 @@ void main() {
         #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
         if ((objectUniforms.flags & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
             #if defined(LEGACY_MORPHING)
-            vec3 normal0, normal1, normal2, normal3;
-            toTangentFrame(mesh_custom4, normal0);
-            toTangentFrame(mesh_custom5, normal1);
-            toTangentFrame(mesh_custom6, normal2);
-            toTangentFrame(mesh_custom7, normal3);
+            vec3 normal0 = mesh_custom4.xyz;
+            vec3 normal1 = mesh_custom5.xyz;
+            vec3 normal2 = mesh_custom6.xyz;
+            vec3 normal3 = mesh_custom7.xyz;
             material.worldNormal += morphingUniforms.weights[0].xyz * normal0;
             material.worldNormal += morphingUniforms.weights[1].xyz * normal1;
             material.worldNormal += morphingUniforms.weights[2].xyz * normal2;
             material.worldNormal += morphingUniforms.weights[3].xyz * normal3;
             #else
             morphNormal(material.worldNormal);
-            material.worldNormal = normalize(material.worldNormal);
             #endif
         }
 


### PR DESCRIPTION
Don't calculate morph target's normal. Read morph target's normal from glTF and use it.

Fix #5584