### PR TITLE
Fix morphed normals.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- Normals on morphed models have been fixed (core Filament change)
 - Java View has several minor changes due to generated code, such as field ordering.
 
 ## v1.22.2

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -96,6 +96,7 @@ void morphPosition(inout vec4 p) {
 }
 
 void morphNormal(inout vec3 n) {
+    vec3 baseNormal = n;
     ivec3 texcoord = ivec3(getVertexIndex() % MAX_MORPH_TARGET_BUFFER_WIDTH, getVertexIndex() / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
     for (uint i = 0u; i < objectUniforms.morphTargetCount; ++i) {
         float w = morphingUniforms.weights[i][0];
@@ -104,7 +105,7 @@ void morphNormal(inout vec3 n) {
             ivec4 tangent = texelFetch(morphTargetBuffer_tangents, texcoord, 0);
             vec3 normal;
             toTangentFrame(float4(tangent) * (1.0 / 32767.0), normal);
-            n += w * normal;
+            n += w * (normal - baseNormal);
         }
     }
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -42,10 +42,11 @@ void main() {
             toTangentFrame(mesh_custom5, normal1);
             toTangentFrame(mesh_custom6, normal2);
             toTangentFrame(mesh_custom7, normal3);
-            material.worldNormal += morphingUniforms.weights[0].xyz * normal0;
-            material.worldNormal += morphingUniforms.weights[1].xyz * normal1;
-            material.worldNormal += morphingUniforms.weights[2].xyz * normal2;
-            material.worldNormal += morphingUniforms.weights[3].xyz * normal3;
+            vec3 baseNormal = material.worldNormal;
+            material.worldNormal += morphingUniforms.weights[0].xyz * (normal0 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[1].xyz * (normal1 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[2].xyz * (normal2 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[3].xyz * (normal3 - baseNormal);
             #else
             morphNormal(material.worldNormal);
             material.worldNormal = normalize(material.worldNormal);
@@ -77,10 +78,11 @@ void main() {
             toTangentFrame(mesh_custom5, normal1);
             toTangentFrame(mesh_custom6, normal2);
             toTangentFrame(mesh_custom7, normal3);
-            material.worldNormal += morphingUniforms.weights[0].xyz * normal0;
-            material.worldNormal += morphingUniforms.weights[1].xyz * normal1;
-            material.worldNormal += morphingUniforms.weights[2].xyz * normal2;
-            material.worldNormal += morphingUniforms.weights[3].xyz * normal3;
+            vec3 baseNormal = material.worldNormal;
+            material.worldNormal += morphingUniforms.weights[0].xyz * (normal0 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[1].xyz * (normal1 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[2].xyz * (normal2 - baseNormal);
+            material.worldNormal += morphingUniforms.weights[3].xyz * (normal3 - baseNormal);
             #else
             morphNormal(material.worldNormal);
             material.worldNormal = normalize(material.worldNormal);


### PR DESCRIPTION
Our `morphNormal` GLSL function treats each normal target as a displacement from the base normal. However the normal that is extracted from the tangent frame is actually an absolute normal, not a displacement vector.

In other words, if _b_ is the base normal, we were doing:

    b = b + w0 * n0 + w1 * n1 + ...

This is obviously wrong, since the base normal has an overpowering influence.

The fixed math looks like this:

    b = b + w0 * (n0 - b) + w1 * (n1 - b) + ...

Fixes #5584.