### PR TITLE
Morphing API docstring fixups.

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/MorphTargetBuffer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MorphTargetBuffer.java
@@ -104,12 +104,12 @@ public class MorphTargetBuffer {
     }
 
     /**
-     * Updates positions of morph target at the index.
+     * Updates float4 positions for the given morph target.
      *
      * @param engine {@link Engine} instance
      * @param targetIndex The index of morph target to be updated
-     * @param positions Pointer to at least count positions
-     * @param count Number of position elements in positions
+     * @param positions An array with at least count*4 floats
+     * @param count Number of float4 vectors in positions to be consumed
      */
     public void setPositionsAt(@NonNull Engine engine,
             @IntRange(from = 0) int targetIndex,
@@ -122,12 +122,15 @@ public class MorphTargetBuffer {
     }
 
     /**
-     * Updates tangents of morph target at the index.
+     * Updates tangents for the given morph target.
+     *
+     * These quaternions must be represented as signed shorts, where real numbers in the [-1,+1]
+     * range multiplied by 32767.
      *
      * @param engine {@link Engine} instance
      * @param targetIndex The index of morph target to be updated
-     * @param tangents Pointer to at least count tangents
-     * @param count Number of tangent elements in tangents
+     * @param tangents An array with at least "count*4" shorts
+     * @param count number of short4 quaternions in tangents
      */
     public void setTangentsAt(@NonNull Engine engine,
             @IntRange(from = 0) int targetIndex,
@@ -140,14 +143,14 @@ public class MorphTargetBuffer {
     }
 
     /**
-     * @return number of vertex count in this {@link MorphTargetBuffer}
+     * @return number of vertices in this {@link MorphTargetBuffer}
      */
     public int getVertexCount() {
         return nGetVertexCount(mNativeObject);
     }
 
     /**
-     * @return number of target count in this {@link MorphTargetBuffer}
+     * @return number of morph targets in this {@link MorphTargetBuffer}
      */
     public int getCount() {
         return nGetCount(mNativeObject);

--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -78,43 +78,49 @@ public:
     };
 
     /**
-     * Updates the position of morph target at the index.
+     * Updates positions for the given morph target.
+     *
+     * This is equivalent to the float4 method, but uses 1.0 for the 4th component.
      *
      * Both positions and tangents must be provided.
      *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
-     * @param weights pointer to at least count positions
-     * @param count number of position elements in positions
+     * @param positions pointer to at least "count" positions
+     * @param count number of float3 vectors in positions
+     * @param offset offset into the target buffer, expressed as a number of float4 vectors
      * @see setTangentsAt
      */
     void setPositionsAt(Engine& engine, size_t targetIndex,
             math::float3 const* positions, size_t count, size_t offset = 0);
 
     /**
-     * Updates the position of morph target at the index.
+     * Updates positions for the given morph target.
      *
      * Both positions and tangents must be provided.
      *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
-     * @param weights pointer to at least count positions
-     * @param count number of position elements in positions
-     * @see setPositionsAt
+     * @param positions pointer to at least "count" positions
+     * @param count number of float4 vectors in positions
+     * @param offset offset into the target buffer, expressed as a number of float4 vectors
+     * @see setTangentsAt
      */
     void setPositionsAt(Engine& engine, size_t targetIndex,
             math::float4 const* positions, size_t count, size_t offset = 0);
 
     /**
-     * Updates the position of morph target at the index.
+     * Updates tangents for the given morph target.
      *
-     * Both positions and tangents must be provided.
+     * These quaternions must be represented as signed shorts, where real numbers in the [-1,+1]
+     * range multiplied by 32767.
      *
      * @param engine Reference to the filament::Engine associated with this MorphTargetBuffer.
      * @param targetIndex the index of morph target to be updated.
-     * @param tangents pointer to at least count tangents
-     * @param count number of tangent elements in tangents
-     * @see setTangentsAt
+     * @param tangents pointer to at least "count" tangents
+     * @param count number of short4 quaternions in tangents
+     * @param offset offset into the target buffer, expressed as a number of short4 vectors
+     * @see setPositionsAt
      */
     void setTangentsAt(Engine& engine, size_t targetIndex,
             math::short4 const* tangents, size_t count, size_t offset = 0);


### PR DESCRIPTION
I think the most important thing here is that we now let users know that
"offset" is not a byte count.  This also fixes some small typos, e.g.
"weights" was used in the docstring instead of "positions".

To avoid making API changes, this does not fix a few weird things I
noticed in the Java API. For example, there is a redundant "count"
argument in methods that take an array.  Also some methods do not
provide an "offset" argument, which is not consistent with C++.