### PR TITLE
extend `blendOrder` functionality

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - gltfio: support skinning with bones that do not belong to any scene
 - gltfio: add attachSkin / detachSkin method to FilamentAsset
+- engine: add a "global" mode for render primitive's `blendOrder`
 
 ## v1.23.0
 

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -120,6 +120,14 @@ Java_com_google_android_filament_RenderableManager_nBuilderBlendOrder(JNIEnv*, j
     builder->blendOrder((size_t) index, (uint16_t) blendOrder);
 }
 
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderGlobalBlendOrderEnabled(JNIEnv*, jclass,
+        jlong nativeBuilder, jint index, jboolean enabled) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->globalBlendOrderEnabled((size_t) index, (bool) enabled);
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_RenderableManager_nBuilderBoundingBox(JNIEnv*, jclass,
         jlong nativeBuilder, jfloat cx, jfloat cy, jfloat cz, jfloat ex, jfloat ey, jfloat ez) {
@@ -437,6 +445,14 @@ Java_com_google_android_filament_RenderableManager_nSetBlendOrderAt(JNIEnv*, jcl
     RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
     rm->setBlendOrderAt((RenderableManager::Instance) i, (size_t) primitiveIndex,
             (uint16_t) blendOrder);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSetGlobalBlendOrderEnabledAt(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jint primitiveIndex, jboolean enabled) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    rm->setGlobalBlendOrderEnabledAt((RenderableManager::Instance) i, (size_t) primitiveIndex,
+            (bool) enabled);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -191,7 +191,9 @@ public class RenderableManager {
         }
 
         /**
-         * Sets an ordering index for blended primitives that all live at the same Z value.
+         * Sets the drawing order for blended primitives. The drawing order is either global or
+         * local (default) to this Renderable. In either case, the Renderable priority takes
+         * precedence.
          *
          * @param index the primitive of interest
          * @param blendOrder draw order number (0 by default). Only the lowest 15 bits are used.
@@ -200,6 +202,18 @@ public class RenderableManager {
         public Builder blendOrder(@IntRange(from = 0) int index,
                 @IntRange(from = 0, to = 32767) int blendOrder) {
             nBuilderBlendOrder(mNativeBuilder, index, blendOrder);
+            return this;
+        }
+
+       /**
+         * Sets whether the blend order is global or local to this Renderable (by default).
+         *
+         * @param index the primitive of interest
+         * @param enabled true for global, false for local blend ordering.
+         */
+        @NonNull
+        public Builder globalBlendOrderEnabled(@IntRange(from = 0) int index, boolean enabled) {
+            nBuilderGlobalBlendOrderEnabled(mNativeBuilder, index, enabled);
             return this;
         }
 
@@ -803,7 +817,8 @@ public class RenderableManager {
     }
 
     /**
-     * Changes the ordering index for blended primitives that all live at the same Z value.
+     * Changes the drawing order for blended primitives. The drawing order is either global or
+     * local (default) to this Renderable. In either case, the Renderable priority takes precedence.
      *
      * @see Builder#blendOrder
      *
@@ -814,6 +829,20 @@ public class RenderableManager {
     public void setBlendOrderAt(@EntityInstance int instance, @IntRange(from = 0) int primitiveIndex,
             @IntRange(from = 0, to = 65535) int blendOrder) {
         nSetBlendOrderAt(mNativeObject, instance, primitiveIndex, blendOrder);
+    }
+
+    /**
+     * Changes whether the blend order is global or local to this Renderable (by default).
+     *
+     * @see Builder#globalBlendOrderEnabled
+     *
+     * @param instance the renderable of interest
+     * @param primitiveIndex the primitive of interest
+     * @param enabled true for global, false for local blend ordering.
+     */
+    public void setGlobalBlendOrderEnabledAt(@EntityInstance int instance, @IntRange(from = 0) int primitiveIndex,
+            boolean enabled) {
+        nSetGlobalBlendOrderEnabledAt(mNativeObject, instance, primitiveIndex, enabled);
     }
 
     /**
@@ -853,6 +882,7 @@ public class RenderableManager {
     private static native void nBuilderGeometry(long nativeBuilder, int index, int value, long nativeVertexBuffer, long nativeIndexBuffer, int offset, int minIndex, int maxIndex, int count);
     private static native void nBuilderMaterial(long nativeBuilder, int index, long nativeMaterialInstance);
     private static native void nBuilderBlendOrder(long nativeBuilder, int index, int blendOrder);
+    private static native void nBuilderGlobalBlendOrderEnabled(long nativeBuilder, int index, boolean enabled);
     private static native void nBuilderBoundingBox(long nativeBuilder, float cx, float cy, float cz, float ex, float ey, float ez);
     private static native void nBuilderLayerMask(long nativeBuilder, int select, int value);
     private static native void nBuilderPriority(long nativeBuilder, int priority);
@@ -893,5 +923,6 @@ public class RenderableManager {
     private static native void nSetGeometryAt(long nativeRenderableManager, int i, int primitiveIndex, int primitiveType, long nativeVertexBuffer, long nativeIndexBuffer, int offset, int count);
     private static native void nSetGeometryAt(long nativeRenderableManager, int i, int primitiveIndex, int primitiveType, int offset, int count);
     private static native void nSetBlendOrderAt(long nativeRenderableManager, int i, int primitiveIndex, int blendOrder);
+    private static native void nSetGlobalBlendOrderEnabledAt(long nativeRenderableManager, int i, int primitiveIndex, boolean enabled);
     private static native int nGetEnabledAttributesAt(long nativeRenderableManager, int i, int primitiveIndex);
 }

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -205,10 +205,12 @@ public:
          * avoid using a separate View for the HUD. Note that priority is completely orthogonal to
          * Builder::layerMask, which merely controls visibility.
          *
-         * \see Builder::blendOrder()
+         * @param priority clamped to the range [0..7], defaults to 4; 7 is lowest priority
+         *                 (rendered last).
          *
-         * The priority is clamped to the range [0..7], defaults to 4; 7 is lowest priority
-         * (rendered last).
+         * @return Builder reference for chaining calls.
+         *
+         * @see Builder::blendOrder(), RenderableManager::setBlendOrderAt()
          */
         Builder& priority(uint8_t priority) noexcept;
 
@@ -337,16 +339,36 @@ public:
          */
         Builder& morphing(uint8_t level, size_t primitiveIndex,
                 MorphTargetBuffer* morphTargetBuffer, size_t offset, size_t count) noexcept;
+
         inline Builder& morphing(uint8_t level, size_t primitiveIndex,
                 MorphTargetBuffer* morphTargetBuffer) noexcept;
 
         /**
-         * Sets an ordering index for blended primitives that all live at the same Z value.
+         * Sets the drawing order for blended primitives. The drawing order is either global or
+         * local (default) to this Renderable. In either case, the Renderable priority takes
+         * precedence.
          *
          * @param primitiveIndex the primitive of interest
          * @param order draw order number (0 by default). Only the lowest 15 bits are used.
+         *
+         * @return Builder reference for chaining calls.
+         *
+         * @see globalBlendOrderEnabled
          */
         Builder& blendOrder(size_t primitiveIndex, uint16_t order) noexcept;
+
+        /**
+         * Sets whether the blend order is global or local to this Renderable (by default).
+         *
+         * @param primitiveIndex the primitive of interest
+         * @param enabled true for global, false for local blend ordering.
+         *
+         * @return Builder reference for chaining calls.
+         *
+         * @see blendOrder
+         */
+        Builder& globalBlendOrderEnabled(size_t primitiveIndex, bool enabled) noexcept;
+
 
         /**
          * Specifies the number of draw instance of this renderable. The default is 1 instance and
@@ -394,6 +416,7 @@ public:
             MaterialInstance const* materialInstance = nullptr;
             PrimitiveType type = PrimitiveType::TRIANGLES;
             uint16_t blendOrder = 0;
+            bool globalBlendOrderEnabled = false;
             struct {
                 MorphTargetBuffer* buffer = nullptr;
                 size_t offset = 0;
@@ -586,15 +609,27 @@ public:
             PrimitiveType type, size_t offset, size_t count) noexcept;
 
     /**
-     * Changes the ordering index for blended primitives that all live at the same Z value.
-     *
-     * \see Builder::blendOrder()
+     * Changes the drawing order for blended primitives. The drawing order is either global or
+     * local (default) to this Renderable. In either case, the Renderable priority takes precedence.
      *
      * @param instance the renderable of interest
      * @param primitiveIndex the primitive of interest
      * @param order draw order number (0 by default). Only the lowest 15 bits are used.
+     *
+     * @see Builder::blendOrder(), setGlobalBlendOrderEnabledAt()
      */
     void setBlendOrderAt(Instance instance, size_t primitiveIndex, uint16_t order) noexcept;
+
+    /**
+     * Changes whether the blend order is global or local to this Renderable (by default).
+     *
+     * @param instance the renderable of interest
+     * @param primitiveIndex the primitive of interest
+     * @param enabled true for global, false for local blend ordering.
+     *
+     * @see Builder::globalBlendOrderEnabled(), setBlendOrderAt()
+     */
+    void setGlobalBlendOrderEnabledAt(Instance instance, size_t primitiveIndex, bool enabled) noexcept;
 
     /**
      * Retrieves the set of enabled attribute slots in the given primitive's VertexBuffer.

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -424,15 +424,23 @@ void RenderPass::generateCommandsImpl(uint32_t extraFlags,
                 const bool blendPass = Pass(cmdColor.key & PASS_MASK) == Pass::BLENDED;
                 if (blendPass) {
                     // TODO: at least for transparent objects, AABB should be per primitive
+                    //       but that would break the "local" blend-order, which relies on
+                    //       all primitives having the same Z
                     // blend pass:
-                    // this will sort back-to-front for blended, and honor explicit ordering
-                    // for a given Z value
+                    //   This will sort back-to-front for blended, and honor explicit ordering
+                    //   for a given Z value, or globally.
                     cmdColor.key &= ~BLEND_ORDER_MASK;
                     cmdColor.key &= ~BLEND_DISTANCE_MASK;
+                    // write the distance
                     cmdColor.key |= makeField(~distanceBits,
                             BLEND_DISTANCE_MASK, BLEND_DISTANCE_SHIFT);
+                    // clear the distance if global ordering is enabled
+                    cmdColor.key &= ~select(primitive.isGlobalBlendOrderEnabled(),
+                            BLEND_DISTANCE_MASK);
+                    // write blend order
                     cmdColor.key |= makeField(primitive.getBlendOrder(),
                             BLEND_ORDER_MASK, BLEND_ORDER_SHIFT);
+
 
                     const TransparencyMode mode = mi->getTransparencyMode();
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -213,6 +213,11 @@ public:
         return boolish ? std::numeric_limits<uint64_t>::max() : uint64_t(0);
     }
 
+    template<typename T>
+    static CommandKey select(T boolish, uint64_t value) noexcept {
+        return boolish ? value : uint64_t(0);
+    }
+
     struct PrimitiveInfo { // 48 bytes
         union {
             FMaterialInstance const* mi;

--- a/filament/src/RenderPrimitive.h
+++ b/filament/src/RenderPrimitive.h
@@ -53,18 +53,26 @@ public:
     backend::PrimitiveType getPrimitiveType() const noexcept { return mPrimitiveType; }
     AttributeBitset getEnabledAttributes() const noexcept { return mEnabledAttributes; }
     uint16_t getBlendOrder() const noexcept { return mBlendOrder; }
+    bool isGlobalBlendOrderEnabled() const noexcept { return mGlobalBlendOrderEnabled; }
 
     void setMaterialInstance(FMaterialInstance const* mi) noexcept { mMaterialInstance = mi; }
+
     void setBlendOrder(uint16_t order) noexcept {
         mBlendOrder = static_cast<uint16_t>(order & 0x7FFF);
     }
 
+    void setGlobalBlendOrderEnabled(bool enabled) noexcept {
+        mGlobalBlendOrderEnabled = enabled;
+    }
+
 private:
     FMaterialInstance const* mMaterialInstance = nullptr;
-    backend::Handle<backend::HwRenderPrimitive> mHandle;
-    backend::PrimitiveType mPrimitiveType = backend::PrimitiveType::NONE;
-    AttributeBitset mEnabledAttributes;
+    backend::Handle<backend::HwRenderPrimitive> mHandle = {};
+    AttributeBitset mEnabledAttributes = {};
     uint16_t mBlendOrder = 0;
+    bool mGlobalBlendOrderEnabled = false;
+    backend::PrimitiveType mPrimitiveType = backend::PrimitiveType::NONE;
+    UTILS_UNUSED uint8_t reserved[4] = {};
 };
 
 } // namespace filament

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -102,6 +102,11 @@ void RenderableManager::setBlendOrderAt(Instance instance, size_t primitiveIndex
     upcast(this)->setBlendOrderAt(instance, 0, primitiveIndex, order);
 }
 
+void RenderableManager::setGlobalBlendOrderEnabledAt(RenderableManager::Instance instance,
+        size_t primitiveIndex, bool enabled) noexcept {
+    upcast(this)->setGlobalBlendOrderEnabledAt(instance, 0, primitiveIndex, enabled);
+}
+
 AttributeBitset RenderableManager::getEnabledAttributesAt(Instance instance, size_t primitiveIndex) const noexcept {
     return upcast(this)->getEnabledAttributesAt(instance, 0, primitiveIndex);
 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -27,6 +27,8 @@
 #include "details/Material.h"
 
 #include "private/filament/SibGenerator.h"
+#include "filament/RenderableManager.h"
+
 
 #include <backend/DriverEnums.h>
 
@@ -210,9 +212,18 @@ RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level, 
     return *this;
 }
 
-RenderableManager::Builder& RenderableManager::Builder::blendOrder(size_t index, uint16_t blendOrder) noexcept {
+RenderableManager::Builder& RenderableManager::Builder::blendOrder(
+        size_t index, uint16_t blendOrder) noexcept {
     if (index < mImpl->mEntries.size()) {
         mImpl->mEntries[index].blendOrder = blendOrder;
+    }
+    return *this;
+}
+
+RenderableManager::Builder& RenderableManager::Builder::globalBlendOrderEnabled(
+        size_t index, bool enabled) noexcept {
+    if (index < mImpl->mEntries.size()) {
+        mImpl->mEntries[index].globalBlendOrderEnabled = enabled;
     }
     return *this;
 }
@@ -531,6 +542,16 @@ void FRenderableManager::setBlendOrderAt(Instance instance, uint8_t level,
         Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
         if (primitiveIndex < primitives.size()) {
             primitives[primitiveIndex].setBlendOrder(order);
+        }
+    }
+}
+
+void FRenderableManager::setGlobalBlendOrderEnabledAt(Instance instance, uint8_t level,
+        size_t primitiveIndex, bool enabled) noexcept {
+    if (instance) {
+        Slice<FRenderPrimitive>& primitives = getRenderPrimitives(instance, level);
+        if (primitiveIndex < primitives.size()) {
+            primitives[primitiveIndex].setGlobalBlendOrderEnabled(enabled);
         }
     }
 }

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -168,6 +168,7 @@ public:
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
             PrimitiveType type, size_t offset, size_t count) noexcept;
     void setBlendOrderAt(Instance instance, uint8_t level, size_t primitiveIndex, uint16_t blendOrder) noexcept;
+    void setGlobalBlendOrderEnabledAt(Instance instance, uint8_t level, size_t primitiveIndex, bool enabled) noexcept;
     AttributeBitset getEnabledAttributesAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
     inline utils::Slice<FRenderPrimitive> const& getRenderPrimitives(Instance instance, uint8_t level) const noexcept;
     inline utils::Slice<FRenderPrimitive>& getRenderPrimitives(Instance instance, uint8_t level) noexcept;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -919,6 +919,10 @@ class_<RenderableBuilder>("RenderableManager$Builder")
             (RenderableBuilder* builder, size_t index, uint16_t order), {
         return &builder->blendOrder(index, order); })
 
+    .BUILDER_FUNCTION("globalBlendOrderEnabled", RenderableBuilder,
+            (RenderableBuilder* builder, size_t index, bool enabled), {
+        return &builder->globalBlendOrderEnabled(index, enabled); })
+
     .BUILDER_FUNCTION("lightChannel", RenderableBuilder,
             (RenderableBuilder* builder, unsigned int channel, bool enable), {
         return &builder->lightChannel(channel, enable); })
@@ -1003,6 +1007,8 @@ class_<RenderableManager>("RenderableManager")
     }), allow_raw_pointers())
 
     .function("setBlendOrderAt", &RenderableManager::setBlendOrderAt)
+
+    .function("setGlobalBlendOrderEnabledAt", &RenderableManager::setGlobalBlendOrderEnabledAt)
 
     .function("getEnabledAttributesAt", EMBIND_LAMBDA(uint32_t, (RenderableManager* self,
             RenderableManager::Instance instance, size_t primitiveIndex), {


### PR DESCRIPTION
blendOrder was used to control the draw order of blended render
primitive within a Renderable. We now have an option to make the
blend order global, in this case those primitives with a global blend
order are always sorted solely using the blend order value (i.e. the 
distance from the camera is not take into account).