### PR TITLE
fix overallocation by about 17MB

### DIFF
--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -107,8 +107,8 @@ class ResourceAllocator;
 class FEngine : public Engine {
 public:
 
-    inline void* operator new(std::size_t count) noexcept {
-        return utils::aligned_alloc(count * sizeof(FEngine), alignof(FEngine));
+    inline void* operator new(std::size_t size) noexcept {
+        return utils::aligned_alloc(size, alignof(FEngine));
     }
 
     inline void operator delete(void* p) noexcept {


### PR DESCRIPTION
In practice on most systems this would only consume address space,
since most of those pages won't be accessed.

fixes #5608