### PR TITLE
gltfio ubershader mode: set sheen to OPAQUE.

### DIFF
--- a/libs/gltfio/materials/sheen.mat.in
+++ b/libs/gltfio/materials/sheen.mat.in
@@ -2,7 +2,7 @@ material {
     name : sheen_${SHADINGMODEL}_${BLENDING},
     requires : [ uv0, uv1, color ],
     shadingModel : ${SHADINGMODEL},
-    blending : fade,
+    blending : opaque,
     depthWrite : true,
     doubleSided : ${DOUBLESIDED},
     transparency : ${TRANSPARENCY},


### PR DESCRIPTION
This makes ubershader mode more consistent with jit mode.

SheenChair and ToyCar in the samples repo both have opaque cloth.