### PR TITLE
Metal: fix blitting when render target is smaller than texture

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - gltfio: support skinning with bones that do not belong to any scene
 - gltfio: add attachSkin / detachSkin method to FilamentAsset
+- Metal: fix issues seen with dynamic resolution on M1 Macs
 
 ## v1.23.0
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1068,33 +1068,13 @@ void MetalDriver::blit(TargetBufferFlags buffers,
                         dstRect.left >= 0 && dstRect.bottom >= 0,
             "Source and destination rects must be positive.");
 
-    // Metal's texture coordinates have (0, 0) at the top-left of the texture, but Filament's
-    // coordinates have (0, 0) at bottom-left.
-    const NSInteger srcHeight =
-            srcTarget->isDefaultRenderTarget() ?
-            mContext->currentReadSwapChain->getSurfaceHeight() : srcTarget->height;
-    MTLRegion srcRegion = MTLRegionMake2D(
-            (NSUInteger) srcRect.left,
-            srcHeight - (NSUInteger) srcRect.bottom - srcRect.height,
-            srcRect.width, srcRect.height);
-
-    const NSInteger dstHeight =
-            dstTarget->isDefaultRenderTarget() ?
-            mContext->currentDrawSwapChain->getSurfaceHeight() : dstTarget->height;
-    MTLRegion dstRegion = MTLRegionMake2D(
-            (NSUInteger) dstRect.left,
-            dstHeight - (NSUInteger) dstRect.bottom - dstRect.height,
-            dstRect.width, dstRect.height);
-
     auto isBlitableTextureType = [](MTLTextureType t) {
         return t == MTLTextureType2D || t == MTLTextureType2DMultisample ||
                t == MTLTextureType2DArray;
     };
 
-    MetalBlitter::BlitArgs args;
-    args.filter = filter;
-    args.source.region = srcRegion;
-    args.destination.region = dstRegion;
+    // MetalBlitter supports blitting color and depth simultaneously, but for simplicitly we'll blit
+    // them separately. In practice, Filament only ever blits a single buffer at a time anyway.
 
     if (any(buffers & TargetBufferFlags::COLOR_ALL)) {
         // We always blit from/to the COLOR0 attachment.
@@ -1106,12 +1086,17 @@ void MetalDriver::blit(TargetBufferFlags buffers,
                                 isBlitableTextureType(dstColorAttachment.getTexture().textureType),
                                "Metal does not support blitting to/from non-2D textures.");
 
+            MetalBlitter::BlitArgs args;
+            args.filter = filter;
+            args.source.region = srcColorAttachment.getRegionFromClientRect(srcRect);
+            args.destination.region = dstColorAttachment.getRegionFromClientRect(dstRect);
             args.source.color = srcColorAttachment.getTexture();
             args.destination.color = dstColorAttachment.getTexture();
             args.source.level = srcColorAttachment.level;
             args.destination.level = dstColorAttachment.level;
             args.source.slice = srcColorAttachment.layer;
             args.destination.slice = dstColorAttachment.layer;
+            mContext->blitter->blit(getPendingCommandBuffer(mContext), args);
         }
     }
 
@@ -1124,34 +1109,19 @@ void MetalDriver::blit(TargetBufferFlags buffers,
                                 isBlitableTextureType(dstDepthAttachment.getTexture().textureType),
                                "Metal does not support blitting to/from non-2D textures.");
 
+            MetalBlitter::BlitArgs args;
+            args.filter = filter;
+            args.source.region = srcDepthAttachment.getRegionFromClientRect(srcRect);
+            args.destination.region = dstDepthAttachment.getRegionFromClientRect(dstRect);
             args.source.depth = srcDepthAttachment.getTexture();
             args.destination.depth = dstDepthAttachment.getTexture();
-
-            if (args.blitColor()) {
-                // If blitting color, we've already set the source and destination levels and slices.
-                // Check that they match the requested depth levels/slices.
-                ASSERT_PRECONDITION(args.source.level == srcDepthAttachment.level,
-                                   "Color and depth source LOD must match. (%d != %d)",
-                                   args.source.level, srcDepthAttachment.level);
-                ASSERT_PRECONDITION(args.destination.level == dstDepthAttachment.level,
-                                   "Color and depth destination LOD must match. (%d != %d)",
-                                   args.destination.level, dstDepthAttachment.level);
-                ASSERT_PRECONDITION(args.source.slice == srcDepthAttachment.layer,
-                        "Color and depth source layer must match. (%d != %d)",
-                        args.source.slice, srcDepthAttachment.layer);
-                ASSERT_PRECONDITION(args.destination.slice == dstDepthAttachment.layer,
-                        "Color and depth destination layer must match. (%d != %d)",
-                        args.destination.slice, dstDepthAttachment.layer);
-            }
-
             args.source.level = srcDepthAttachment.level;
             args.destination.level = dstDepthAttachment.level;
             args.source.slice = srcDepthAttachment.layer;
             args.destination.slice = dstDepthAttachment.layer;
+            mContext->blitter->blit(getPendingCommandBuffer(mContext), args);
         }
     }
-
-    mContext->blitter->blit(getPendingCommandBuffer(mContext), args);
 }
 
 void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t instanceCount) {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -257,6 +257,16 @@ public:
             return texture ? texture.pixelFormat : MTLPixelFormatInvalid;
         }
 
+        MTLRegion getRegionFromClientRect(Viewport rect) {
+            // Convert the Filament rect into Metal texture coordinates, taking into account Metal's
+            // inverted texture space and the mip level. Note that the underlying Texture could be
+            // larger than the RenderTarget. Metal's texture coordinates have (0, 0) at the top-left
+            // of the texture, but Filament's coordinates have (0, 0) at bottom-left.
+            const auto mipheight = texture.height >> level;
+            return MTLRegionMake2D((NSUInteger)rect.left,
+                    mipheight - (NSUInteger)rect.bottom - rect.height, rect.width, rect.height);
+        }
+
         explicit operator bool() const {
             return texture != nil;
         }


### PR DESCRIPTION
The Metal backend wasn't correctly handling the case where Filament would blit from a RenderTarget whose width & height were smaller than the backing Texture.

To test on non-M1 MacBooks, make the following change to Renderer.cpp:

```
-                input = ppm.colorGrading(fg, input, xvp,
+                input = ppm.colorGrading(fg, input, svp,
                         bloom, flare,
                         colorGrading, colorGradingConfig,
                         bloomOptions, vignetteOptions);
                 // the padded buffer is resolved now
-                xvp.left = xvp.bottom = 0;
-                svp = xvp;
```

then, disable all post-processing effects (but keep post-processing turned on), disable MSAA & SSAO, turn on dynamic resolution, and adjust the max scale slider.