### PR TITLE
Clean up BasisU CMake targets, add zstd target.

### DIFF
--- a/third_party/basisu/tnt/CMakeLists.txt
+++ b/third_party/basisu/tnt/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.19)
 
 set(TRANSCODER_SRC
     ../transcoder/basisu_transcoder.cpp
-    ../zstd/zstd.c
 )
 
 set(ENCODER_SRC
@@ -51,9 +50,14 @@ else()
     set (BASIS_CONFIG ${BASIS_CONFIG} BASISD_SUPPORT_DXT5A=0 BASISD_SUPPORT_DXT1=0)
 endif()
 
-add_library(basis_encoder ${ENCODER_SRC} ${TRANSCODER_SRC})
+add_library(zstd ../zstd/zstd.c)
+add_library(basis_encoder ${ENCODER_SRC})
 add_library(basis_transcoder ${TRANSCODER_SRC})
 
+target_link_libraries(basis_transcoder zstd)
+target_link_libraries(basis_encoder basis_transcoder)
+
+target_include_directories(zstd PUBLIC ../zstd)
 target_include_directories(basis_encoder PUBLIC ../encoder)
 target_include_directories(basis_transcoder PUBLIC ../transcoder)
 
@@ -61,7 +65,8 @@ target_compile_definitions(basis_encoder PRIVATE ${BASIS_CONFIG})
 target_compile_definitions(basis_transcoder PRIVATE ${BASIS_CONFIG})
 
 if (IS_HOST_PLATFORM)
-    add_executable(basisu ${ENCODER_SRC} ${TRANSCODER_SRC} ../basisu_tool.cpp)
+    add_executable(basisu ../basisu_tool.cpp)
+    target_link_libraries(basisu basis_encoder)
     target_compile_definitions(basisu PRIVATE ${BASIS_CONFIG})
     install(TARGETS basisu DESTINATION bin)
 


### PR DESCRIPTION
We were re-building various C++ files in three different targets
(basis_encoder, basis_transcoder, basisu executable), it's probably
better just to set up proper dependencies between the libraries.  Note
that I'm not sure if this actually improves build times.

More importantly, this creates a CMake target for the zstd library
because we want to use zstd in other places.