### PR TITLE
PlatformCocoaGL: If a share context is specified, use its pixel format

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
@@ -150,7 +150,13 @@ Driver* PlatformCocoaGL::createDriver(void* sharedContext) noexcept {
     };
 
     NSOpenGLContext* shareContext = (__bridge NSOpenGLContext*) sharedContext;
-    NSOpenGLPixelFormat* pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:pixelFormatAttributes];
+    NSOpenGLPixelFormat* pixelFormat;
+    // If a share context is specified, use its pixel format
+    if (shareContext) {
+        pixelFormat = shareContext.pixelFormat;
+    } else {
+        pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:pixelFormatAttributes];
+    }
     NSOpenGLContext* nsOpenGLContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:shareContext];
 
     GLint interval = 0;


### PR DESCRIPTION
This is the CocoaGL equivalent to https://github.com/google/filament/pull/1456

I was unable to figure out the right settings to make a GLFW shared context work without this, despite, as far as I can tell, the pixel format attributes ending up identical.

There's a demo/test of this at https://github.com/jfaust/filament-glfw-share-context. It will crash on a NULL context without this change.