### PR TITLE
Remove NSOpenGLPFANoRecovery requirement when creating the NSOpenGLContext

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/platforms/PlatformCocoaGL.mm
@@ -145,7 +145,6 @@ Driver* PlatformCocoaGL::createDriver(void* sharedContext) noexcept {
             NSOpenGLPFADepthSize,    (NSOpenGLPixelFormatAttribute) 24,
             NSOpenGLPFADoubleBuffer, (NSOpenGLPixelFormatAttribute) true,
             NSOpenGLPFAAccelerated,  (NSOpenGLPixelFormatAttribute) true,
-            NSOpenGLPFANoRecovery,   (NSOpenGLPixelFormatAttribute) true,
             0, 0,
     };
 


### PR DESCRIPTION
As discussed in #5624 