### PR TITLE
Metal: fix invalid MSL generated due to missing optimization pass

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - engine: improve ResourceAllocator performance a bit by reserving 128 cache entries
 - utils: remove `std::hash<T>` definitions for `libutils` types. Use `T::Hasher` explicitly instead. [⚠️ **API Change**]
 - backend: fix WGL context attributes
+- Metal: Fix potential invalid shaders when using gltfio in Ubershader mode. [⚠️ **Recompile Materials to get the fix**]
 
 ## v1.23.1
 

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -469,8 +469,10 @@ void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config c
             .RegisterPass(CreateWrapOpKillPass())
             .RegisterPass(CreateDeadBranchElimPass());
 
-    if (config.shaderModel != ShaderModel::GL_CORE_41) {
-        // this triggers a segfault with AMD drivers on MacOS
+    if (config.shaderModel != ShaderModel::GL_CORE_41 ||
+            config.targetApi != MaterialBuilder::TargetApi::OPENGL) {
+        // this triggers a segfault with AMD OpenGL drivers on MacOS
+        // note that Metal also requires this pass in order to correctly generate half-precision MSL
         optimizer.RegisterPass(CreateMergeReturnPass());
     }
 


### PR DESCRIPTION
Fixes #5614

This fixes the issue, though I still think this is a bug with spirv-cross / spirv-opt. We should be good to enable the "merge return pass" for Metal though.