### PR TITLE
Revert "Workaround: partially revert "don't issue a flush..." (#5557)"

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ A new header is inserted each time a *tag* is created.
 - utils: remove `std::hash<T>` definitions for `libutils` types. Use `T::Hasher` explicitly instead. [⚠️ **API Change**]
 - backend: fix WGL context attributes
 - backend: workaround broken GLES timer query on some Mali-Gxx old drivers
+- backend: revert c049a1 & reenable b2cdf9 ("don't issue a flush systematically after framegraph's execute")
 - Metal: Fix potential invalid shaders when using gltfio in Ubershader mode. [⚠️ **Recompile Materials to get the fix**]
 
 ## v1.23.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@ A new header is inserted each time a *tag* is created.
 - engine: improve ResourceAllocator performance a bit by reserving 128 cache entries
 - utils: remove `std::hash<T>` definitions for `libutils` types. Use `T::Hasher` explicitly instead. [⚠️ **API Change**]
 - backend: fix WGL context attributes
+- backend: workaround broken GLES timer query on some Mali-Gxx old drivers
 - Metal: Fix potential invalid shaders when using gltfio in Ubershader mode. [⚠️ **Recompile Materials to get the fix**]
 
 ## v1.23.1

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -192,6 +192,7 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     const time_point<steady_clock> appVsync(vsyncSteadyClockTimeNano ? userVsync : now);
 
     mFrameId++;
+    mViewRenderedCount = 0;
 
     { // scope for frame id trace
         char buf[64];
@@ -420,9 +421,13 @@ void FRenderer::render(FView const* view) {
     }
 
     if (UTILS_LIKELY(view && view->getScene())) {
-        // NOTE: in the past we tried to kick the GPU here with a flush (b2cdf9f), but this
-        // was problematic on certain devices. b/232224942
+        if (mViewRenderedCount) {
+            // this is a good place to kick the GPU, since we've rendered a View before
+            // and we're about to render another one.
+            mEngine.getDriverApi().flush();
+        }
         renderInternal(view);
+        mViewRenderedCount++;
     }
 }
 

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -164,6 +164,7 @@ private:
     FSwapChain* mSwapChain = nullptr;
     size_t mCommandsHighWatermark = 0;
     uint32_t mFrameId = 0;
+    uint32_t mViewRenderedCount = 0;
     FrameInfoManager mFrameInfoManager;
     backend::TextureFormat mHdrTranslucent;
     backend::TextureFormat mHdrQualityMedium;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -215,11 +215,6 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
 
         driver.popGroupMarker();
     }
-
-    // NOTE: in the past we tried to make this flush conditional (b2cdf9f), but this
-    // was problematic on certain devices. b/232224942
-    driver.flush();
-
     driver.popGroupMarker();
 }
 


### PR DESCRIPTION
This reverts commit c049a1 and reenables commit b2cdf9:
    
    "don't issue a flush systematically after framegraph's execute"