### PR TITLE
Metal: add support for scissor

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -116,6 +116,9 @@ struct MetalContext {
 
     std::stack<const char*> groupMarkers;
 
+    int32_t currentRenderTargetHeight;
+    MTLViewport currentViewport;
+
 #if defined(FILAMENT_METAL_PROFILING)
     // Logging and profiling.
     os_log_t log;


### PR DESCRIPTION
This patch enables user scissor in Metal backend; There was no implementation for it.
While the absence of the feature in Metal does not incur serious problem, many rendering glitches were found in apps using ImGui due to it.