### PR TITLE
Renamings: gltfio => filament::gltfio, UbershaderLoader => UbershaderProvider.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,9 @@ A new header is inserted each time a *tag* is created.
 
 - gltfio: fix morphing for un-packed accessors
 - gltfio: ubershaders are now packaged into flexible archives [⚠️ **API Change**]
+- gltfio: namespace now lives under Filament [⚠️ **API Change**]
+- gltfio: UbershaderLoader renamed to UbershaderProvider [⚠️ **API Change**]
+- gltfio: MaterialGenerator renamed to JitShaderProvider [⚠️ **API Change**]
 - gltfio: remove poorly maintained lite flavor
 - engine: disable user scissor while rendering the Shadow Maps (#5607)
 - engine: merge identical backend RenderPrimitives together

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -114,7 +114,7 @@ class ModelViewer(
         view.scene = scene
         view.camera = camera
 
-        materialProvider = UbershaderLoader(engine)
+        materialProvider = UbershaderProvider(engine)
         assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
         resourceLoader = ResourceLoader(engine, normalizeSkinningWeights, recomputeBoundingBoxes, ignoreBindTransform)
 

--- a/android/gltfio-android/CMakeLists.txt
+++ b/android/gltfio-android/CMakeLists.txt
@@ -71,7 +71,7 @@ set(GLTFIO_SRCS
         ${GLTFIO_DIR}/src/StbProvider.cpp
         ${GLTFIO_DIR}/src/TangentsJob.cpp
         ${GLTFIO_DIR}/src/TangentsJob.h
-        ${GLTFIO_DIR}/src/UbershaderLoader.cpp
+        ${GLTFIO_DIR}/src/UbershaderProvider.cpp
         ${GLTFIO_DIR}/src/Wireframe.cpp
         ${GLTFIO_DIR}/src/Wireframe.h
         ${GLTFIO_DIR}/src/upcast.h
@@ -82,7 +82,7 @@ set(GLTFIO_SRCS
         src/main/cpp/FilamentInstance.cpp
         src/main/cpp/MaterialKey.cpp
         src/main/cpp/MaterialKey.h
-        src/main/cpp/UbershaderLoader.cpp
+        src/main/cpp/UbershaderProvider.cpp
         src/main/cpp/ResourceLoader.cpp
 
         ${FILAMENT_DIR}/include/gltfio/resources/gltfresources.h

--- a/android/gltfio-android/src/main/cpp/Animator.cpp
+++ b/android/gltfio-android/src/main/cpp/Animator.cpp
@@ -20,7 +20,7 @@
 
 using namespace filament;
 using namespace filament::math;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -30,7 +30,7 @@
 #include "MaterialKey.h"
 
 using namespace filament;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 class JavaMaterialProvider : public MaterialProvider {

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -20,7 +20,7 @@
 
 using namespace filament;
 using namespace filament::math;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
@@ -20,7 +20,7 @@
 
 #include <algorithm>
 
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 extern "C" JNIEXPORT jint JNICALL

--- a/android/gltfio-android/src/main/cpp/MaterialKey.cpp
+++ b/android/gltfio-android/src/main/cpp/MaterialKey.cpp
@@ -20,7 +20,7 @@
 
 #include "MaterialKey.h"
 
-using namespace gltfio;
+using namespace filament::gltfio;
 
 MaterialKeyHelper& MaterialKeyHelper::get() {
     static MaterialKeyHelper helper;

--- a/android/gltfio-android/src/main/cpp/MaterialKey.h
+++ b/android/gltfio-android/src/main/cpp/MaterialKey.h
@@ -22,10 +22,12 @@
 
 class MaterialKeyHelper {
 public:
+    using MaterialKey = filament::gltfio::MaterialKey;
+
     static MaterialKeyHelper& get();
 
-    void copy(JNIEnv* env, gltfio::MaterialKey& dst, jobject src);
-    void copy(JNIEnv* env, jobject dst, const gltfio::MaterialKey& src);
+    void copy(JNIEnv* env, MaterialKey& dst, jobject src);
+    void copy(JNIEnv* env, jobject dst, const MaterialKey& src);
 
     void init(JNIEnv* env); // called only from the Java static class constructor
 

--- a/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/ResourceLoader.cpp
@@ -26,7 +26,7 @@
 #include "common/NioUtils.h"
 
 using namespace filament;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 static void destroy(void*, size_t, void *userData) {

--- a/android/gltfio-android/src/main/cpp/UbershaderProvider.cpp
+++ b/android/gltfio-android/src/main/cpp/UbershaderProvider.cpp
@@ -26,28 +26,28 @@ using namespace filament;
 using namespace gltfio;
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nCreateUbershaderLoader(JNIEnv*, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nCreateUbershaderProvider(JNIEnv*, jclass,
         jlong nativeEngine) {
     Engine* engine = (Engine*) nativeEngine;
-    return (jlong) createUbershaderLoader(engine);
+    return (jlong) createUbershaderProvider(engine);
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nDestroyUbershaderLoader(JNIEnv*, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nDestroyUbershaderProvider(JNIEnv*, jclass,
         jlong nativeProvider) {
     auto provider = (MaterialProvider*) nativeProvider;
     delete provider;
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nDestroyMaterials(JNIEnv*, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nDestroyMaterials(JNIEnv*, jclass,
         jlong nativeProvider) {
     auto provider = (MaterialProvider*) nativeProvider;
     provider->destroyMaterials();
 }
 
 extern "C" JNIEXPORT long JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nCreateMaterialInstance(JNIEnv* env, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nCreateMaterialInstance(JNIEnv* env, jclass,
         jlong nativeProvider, jobject materialKey, jintArray uvmap, jstring label) {
     MaterialKey nativeKey = {};
 
@@ -80,14 +80,14 @@ Java_com_google_android_filament_gltfio_UbershaderLoader_nCreateMaterialInstance
 }
 
 extern "C" JNIEXPORT int JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nGetMaterialCount(JNIEnv*, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nGetMaterialCount(JNIEnv*, jclass,
         jlong nativeProvider) {
     auto provider = (MaterialProvider*) nativeProvider;
     return provider->getMaterialsCount();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_UbershaderLoader_nGetMaterials(JNIEnv* env, jclass,
+Java_com_google_android_filament_gltfio_UbershaderProvider_nGetMaterials(JNIEnv* env, jclass,
         jlong nativeProvider, jlongArray result) {
     auto provider = (MaterialProvider *) nativeProvider;
     auto materials = provider->getMaterials();

--- a/android/gltfio-android/src/main/cpp/UbershaderProvider.cpp
+++ b/android/gltfio-android/src/main/cpp/UbershaderProvider.cpp
@@ -23,7 +23,7 @@
 #include "MaterialKey.h"
 
 using namespace filament;
-using namespace gltfio;
+using namespace filament::gltfio;
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_UbershaderProvider_nCreateUbershaderProvider(JNIEnv*, jclass,

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -45,7 +45,7 @@ import java.nio.Buffer;
  *
  *     ...
  *
- *     materialProvider = UbershaderLoader(engine)
+ *     materialProvider = UbershaderProvider(engine)
  *     assetLoader = AssetLoader(engine, materialProvider, EntityManager.get())
  *
  *     filamentAsset = assets.open("models/lucy.gltf").use { input -&gt;

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
@@ -31,7 +31,7 @@ import androidx.annotation.Size;
  * <p>This class is used by {@link AssetLoader} to create Filament materials.
  * Client applications do not need to call methods on it.</p>
  */
-public class UbershaderLoader implements MaterialProvider {
+public class UbershaderProvider implements MaterialProvider {
     private static final VertexBuffer.VertexAttribute[] sVertexAttributesValues =
             VertexBuffer.VertexAttribute.values();
 
@@ -42,16 +42,16 @@ public class UbershaderLoader implements MaterialProvider {
      *
      * @param engine the engine used to create materials
      */
-    public UbershaderLoader(Engine engine) {
+    public UbershaderProvider(Engine engine) {
         long nativeEngine = engine.getNativeObject();
-        mNativeObject = nCreateUbershaderLoader(nativeEngine);
+        mNativeObject = nCreateUbershaderProvider(nativeEngine);
     }
 
     /**
      * Frees memory associated with the native material provider.
      * */
     public void destroy() {
-        nDestroyUbershaderLoader(mNativeObject);
+        nDestroyUbershaderProvider(mNativeObject);
         mNativeObject = 0;
     }
 
@@ -92,8 +92,8 @@ public class UbershaderLoader implements MaterialProvider {
         return mNativeObject;
     }
 
-    private static native long nCreateUbershaderLoader(long nativeEngine);
-    private static native void nDestroyUbershaderLoader(long nativeProvider);
+    private static native long nCreateUbershaderProvider(long nativeEngine);
+    private static native void nDestroyUbershaderProvider(long nativeProvider);
     private static native void nDestroyMaterials(long nativeProvider);
     private static native long nCreateMaterialInstance(long nativeProvider,
             MaterialKey config, int[] uvmap, String label);

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.h
@@ -23,7 +23,7 @@ class View;
 class Renderer;
 };
 
-namespace gltfio {
+namespace filament::gltfio {
 class Animator;
 class FilamentAsset;
 };
@@ -56,8 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) filament::View* view;
 @property(nonatomic, readonly) filament::Renderer* renderer;
 
-@property(nonatomic, readonly) gltfio::FilamentAsset* _Nullable asset;
-@property(nonatomic, readonly) gltfio::Animator* _Nullable animator;
+@property(nonatomic, readonly) filament::gltfio::FilamentAsset* _Nullable asset;
+@property(nonatomic, readonly) filament::gltfio::Animator* _Nullable animator;
 
 @property(nonatomic, readwrite) float cameraFocalLength;
 

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -47,7 +47,7 @@
 
 using namespace filament;
 using namespace utils;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace camutils;
 
 const double kNearPlane = 0.05;   // 5 cm

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -126,7 +126,7 @@ const float kSensitivity = 100.0f;
 
     _swapChain = _engine->createSwapChain((__bridge void*)self.layer);
 
-    _materialProvider = createUbershaderLoader(_engine);
+    _materialProvider = createUbershaderProvider(_engine);
     EntityManager& em = EntityManager::get();
     NameComponentManager* ncm = new NameComponentManager(em);
     _assetLoader = AssetLoader::create({_engine, _materialProvider, ncm, &em});

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
@@ -61,7 +61,7 @@ App::~App() {
     app.assetLoader->destroyAsset(app.asset);
     app.materialProvider->destroyMaterials();
     delete app.materialProvider;
-    gltfio::AssetLoader::destroy(&app.assetLoader);
+    filament::gltfio::AssetLoader::destroy(&app.assetLoader);
 
     engine->destroy(renderer);
     engine->destroy(scene);
@@ -122,8 +122,8 @@ void App::setupIbl() {
 }
 
 void App::setupMesh() {
-    app.materialProvider = gltfio::createUbershaderProvider(engine);
-    app.assetLoader = gltfio::AssetLoader::create({engine, app.materialProvider, nullptr});
+    app.materialProvider = filament::gltfio::createUbershaderProvider(engine);
+    app.assetLoader = filament::gltfio::AssetLoader::create({engine, app.materialProvider, nullptr});
 
     // Load the glTF file.
     std::ifstream in(resourcePath.concat(utils::Path("DamagedHelmet.glb")), std::ifstream::in);
@@ -137,7 +137,7 @@ void App::setupMesh() {
     }
     app.asset = app.assetLoader->createAssetFromBinary(buffer.data(), static_cast<uint32_t>(size));
 
-    gltfio::ResourceLoader({
+    filament::gltfio::ResourceLoader({
         .engine = engine,
         .normalizeSkinningWeights = true,
         .recomputeBoundingBoxes = false

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
@@ -122,7 +122,7 @@ void App::setupIbl() {
 }
 
 void App::setupMesh() {
-    app.materialProvider = gltfio::createUbershaderLoader(engine);
+    app.materialProvider = gltfio::createUbershaderProvider(engine);
     app.assetLoader = gltfio::AssetLoader::create({engine, app.materialProvider, nullptr});
 
     // Load the glTF file.

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
@@ -36,7 +36,7 @@ using namespace filament::math;
 using utils::Entity;
 using utils::EntityManager;
 
-namespace gltfio {
+namespace filament::gltfio {
     class AssetLoader;
     class MaterialProvider;
     class FilamentAsset;
@@ -80,9 +80,9 @@ private:
         Skybox* skybox = nullptr;
         Entity sun;
 
-        gltfio::AssetLoader* assetLoader;
-        gltfio::MaterialProvider* materialProvider;
-        gltfio::FilamentAsset* asset;
+        filament::gltfio::AssetLoader* assetLoader;
+        filament::gltfio::MaterialProvider* materialProvider;
+        filament::gltfio::FilamentAsset* asset;
     } app;
 
     CameraManipulator cameraManipulator;

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SRCS
         src/StbProvider.cpp
         src/TangentsJob.cpp
         src/TangentsJob.h
-        src/UbershaderLoader.cpp
+        src/UbershaderProvider.cpp
         src/Wireframe.cpp
         src/Wireframe.h
         src/upcast.h
@@ -157,7 +157,7 @@ if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
     # ==================================================================================================
     # Link the core library with additional dependencies to create the "full" library
     # ==================================================================================================
-    add_library(${TARGET} STATIC ${PUBLIC_HDRS} src/MaterialGenerator.cpp)
+    add_library(${TARGET} STATIC ${PUBLIC_HDRS} src/JitShaderProvider.cpp)
     target_link_libraries(${TARGET} PUBLIC filamat gltfio_core)
     target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 

--- a/libs/gltfio/README.md
+++ b/libs/gltfio/README.md
@@ -7,15 +7,15 @@ gltfio has two plug-in interfaces, `TextureProvider` and `MaterialProvider`.  Fi
 several ready-to-go implementations described below.
 
 - `MaterialProvider` creates Filament materials in response to certain glTF requirements.
-    - [UbershaderLoader](#ubershaderloader) loads pre-built materials.
-    - `MaterialGenerator` builds materials at run time using the `filamat` library.
+    - [UbershaderProvider](#ubershaderloader) loads pre-built materials.
+    - `JitShaderProvider` builds materials at run time using the `filamat` library.
 - `TextureProvider` creates and populates Filament `Texture` objects.
     - `StbProvider` uses the STB library to read PNG and JPEG files.
     - `Ktx2Provider` uses the BasisU library to read KTX2 files.
 
-# UbershaderLoader
+# UbershaderProvider
 
-`UbershaderLoader` is a ready-to-go implementation of the `MaterialProvider` interface that should
+`UbershaderProvider` is a ready-to-go implementation of the `MaterialProvider` interface that should
 be used in applications that need fast startup times. There is no material compilation that
 occurs at run time, but the shaders might be relatively large and complex.
 

--- a/libs/gltfio/include/gltfio/Animator.h
+++ b/libs/gltfio/include/gltfio/Animator.h
@@ -20,7 +20,7 @@
 #include <gltfio/FilamentAsset.h>
 #include <gltfio/FilamentInstance.h>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 struct FFilamentAsset;
 struct FFilamentInstance;
@@ -114,6 +114,6 @@ private:
     AnimatorImpl* mImpl;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_ANIMATOR_H

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -49,7 +49,7 @@ struct AssetConfiguration {
 
     //! Controls whether the loader uses filamat to generate materials on the fly, or loads a small
     //! set of precompiled ubershader materials. Deleting the MaterialProvider is the client's
-    //! responsibility. See createMaterialGenerator() and createUbershaderLoader().
+    //! responsibility. See createJitShaderProvider() and createUbershaderProvider().
     MaterialProvider* materials;
 
     //! Optional manager for associating string names with entities in the transform hierarchy.
@@ -86,7 +86,7 @@ struct AssetConfiguration {
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * auto engine = Engine::create();
- * auto materials = createMaterialGenerator(engine);
+ * auto materials = createJitShaderProvider(engine);
  * auto decoder = createStbProvider(engine);
  * auto loader = AssetLoader::create({engine, materials});
  *

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -34,7 +34,7 @@ namespace utils {
 /**
  * Loader and pipeline for glTF 2.0 assets.
  */
-namespace gltfio {
+namespace filament::gltfio {
 
 class NodeManager;
 
@@ -246,6 +246,6 @@ public:
     /*! \endcond */
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_ASSETLOADER_H

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -32,7 +32,7 @@ namespace filament {
     class Scene;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class Animator;
 class FilamentInstance;
@@ -351,6 +351,6 @@ public:
     /*! \endcond */
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_FILAMENTASSET_H

--- a/libs/gltfio/include/gltfio/FilamentInstance.h
+++ b/libs/gltfio/include/gltfio/FilamentInstance.h
@@ -20,7 +20,7 @@
 #include <utils/compiler.h>
 #include <utils/Entity.h>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class Animator;
 class FilamentAsset;
@@ -76,6 +76,6 @@ public:
     Animator* getAnimator() noexcept;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_FILAMENTINSTANCE_H

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -26,7 +26,7 @@
 #include <array>
 #include <string>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 enum class AlphaMode : uint8_t {
     OPAQUE,
@@ -203,6 +203,6 @@ MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimiz
 UTILS_PUBLIC
 MaterialProvider* createUbershaderProvider(filament::Engine* engine);
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_MATERIALPROVIDER_H

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -118,12 +118,12 @@ inline uint8_t getNumUvSets(const UvMap& uvmap) {
  * \class MaterialProvider MaterialProvider.h gltfio/MaterialProvider.h
  * \brief Interface to a provider of glTF materials (has two implementations).
  *
- * - The \c MaterialGenerator implementation generates materials at run time (which can be slow) and
- *   requires the filamat library, but produces streamlined shaders. See createMaterialGenerator().
+ * - The \c JitShaderProvider implementation generates materials at run time (which can be slow) and
+ *   requires the filamat library, but produces streamlined shaders. See createJitShaderProvider().
  *
- * - The \c UbershaderLoader implementation uses a small number of pre-built materials with complex
+ * - The \c UbershaderProvider implementation uses a small number of pre-built materials with complex
  *   fragment shaders, but does not require any run time work or usage of filamat. See
- *   createUbershaderLoader().
+ *   createUbershaderProvider().
  *
  * Both implementations of MaterialProvider maintain a small cache of materials which must be
  * explicitly freed using destroyMaterials(). These materials are not freed automatically when the
@@ -186,10 +186,10 @@ void processShaderString(std::string* shader, const UvMap& uvmap,
  *
  * Requires \c libfilamat to be linked in. Not available in \c libgltfio_core.
  *
- * @see createUbershaderLoader
+ * @see createUbershaderProvider
  */
 UTILS_PUBLIC
-MaterialProvider* createMaterialGenerator(filament::Engine* engine, bool optimizeShaders = false);
+MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimizeShaders = false);
 
 /**
  * Creates a material provider that loads a small set of pre-built materials.
@@ -198,10 +198,10 @@ MaterialProvider* createMaterialGenerator(filament::Engine* engine, bool optimiz
  *
  * Requires \c libgltfio_resources to be linked in.
  *
- * @see createMaterialGenerator
+ * @see createJitShaderProvider
  */
 UTILS_PUBLIC
-MaterialProvider* createUbershaderLoader(filament::Engine* engine);
+MaterialProvider* createUbershaderProvider(filament::Engine* engine);
 
 } // namespace gltfio
 

--- a/libs/gltfio/include/gltfio/NodeManager.h
+++ b/libs/gltfio/include/gltfio/NodeManager.h
@@ -29,7 +29,7 @@ namespace utils {
 class Entity;
 } // namespace utils
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class FNodeManager;
 
@@ -104,7 +104,7 @@ public:
     NodeManager& operator=(NodeManager&&) = delete;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 
 #endif // GLTFIO_NODEMANAGER_H

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -27,7 +27,7 @@ namespace filament {
     class Engine;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 struct FFilamentAsset;
 class AssetPool;
@@ -169,7 +169,7 @@ private:
     Impl* pImpl;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_RESOURCELOADER_H
 

--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -27,7 +27,7 @@ namespace filament {
     class Texture;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 /**
  * TextureProvider is an interface that allows clients to implement their own texture decoding
@@ -175,6 +175,6 @@ TextureProvider* createStbProvider(filament::Engine* engine);
  */
 TextureProvider* createKtx2Provider(filament::Engine* engine);
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_TEXTUREPROVIDER_H

--- a/libs/gltfio/include/gltfio/math.h
+++ b/libs/gltfio/include/gltfio/math.h
@@ -23,7 +23,7 @@
 #include <math/mat4.h>
 #include <math/TVecHelpers.h>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 template <typename T>
 UTILS_PUBLIC T cubicSpline(const T& vert0, const T& tang0, const T& vert1, const T& tang1, float t) {
@@ -121,6 +121,6 @@ inline filament::math::mat3f matrixFromUvTransform(const float offset[2], float 
     return filament::math::mat3f(sx * c, sx * s, tx, -sy * s, sy * c, ty, 0.0f, 0.0f, 1.0f);
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_MATH_H

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -42,7 +42,7 @@ using namespace filament::math;
 using namespace std;
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 using TimeValues = map<float, size_t>;
 using SourceValues = vector<float>;
@@ -558,4 +558,4 @@ void AnimatorImpl::applyAnimation(const Channel& channel, float t, size_t prevIn
     transformManager->setTransform(node, xform);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -59,7 +59,7 @@ using namespace filament;
 using namespace filament::math;
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 using SceneMask = NodeManager::SceneMask;
 
@@ -1456,4 +1456,4 @@ MaterialProvider& AssetLoader::getMaterialProvider() noexcept {
     return upcast(this)->mMaterials;
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/DependencyGraph.cpp
+++ b/libs/gltfio/src/DependencyGraph.cpp
@@ -19,7 +19,7 @@
 using namespace filament;
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 size_t DependencyGraph::popRenderables(Entity* result, size_t count) noexcept {
     if (result == nullptr) {
@@ -136,4 +136,4 @@ DependencyGraph::TextureNode* DependencyGraph::getStatus(Texture* texture) {
     return iter->second.get();
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/DependencyGraph.h
+++ b/libs/gltfio/src/DependencyGraph.h
@@ -30,7 +30,7 @@ namespace filament {
     class Texture;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 /**
  * Internal graph that enables FilamentAsset to discover "ready-to-render" entities by tracking
@@ -132,6 +132,6 @@ private:
     bool mFinalized = false;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_DEPENDENCY_GRAPH_H

--- a/libs/gltfio/src/DracoCache.cpp
+++ b/libs/gltfio/src/DracoCache.cpp
@@ -30,7 +30,7 @@ using std::vector;
 
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 DracoMesh* DracoCache::findOrCreateMesh(const cgltf_buffer_view* key) {
     auto iter = mCache.find(key);
@@ -222,4 +222,4 @@ bool DracoMesh::getVertexAttributes(uint32_t attributeId, cgltf_accessor* target
 
 #endif
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/DracoCache.h
+++ b/libs/gltfio/src/DracoCache.h
@@ -27,7 +27,7 @@
 #define GLTFIO_DRACO_SUPPORTED 0
 #endif
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class DracoMesh;
 
@@ -66,6 +66,6 @@ private:
     std::unique_ptr<struct DracoMeshDetails> mDetails;
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_DRACO_CACHE_H

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -62,7 +62,7 @@ namespace utils {
     class EntityManager;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class Animator;
 class Wireframe;
@@ -331,6 +331,6 @@ struct FFilamentAsset : public FilamentAsset {
 
 FILAMENT_UPCAST(FilamentAsset)
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_FFILAMENTASSET_H

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -38,7 +38,7 @@ namespace filament {
     class MaterialInstance;
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 struct FFilamentAsset;
 class Animator;
@@ -91,6 +91,6 @@ struct FFilamentInstance : public FilamentInstance {
 
 FILAMENT_UPCAST(FilamentInstance)
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_FFILAMENTINSTANCE_H

--- a/libs/gltfio/src/FNodeManager.h
+++ b/libs/gltfio/src/FNodeManager.h
@@ -26,7 +26,7 @@
 #include <utils/Entity.h>
 #include <utils/Slice.h>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class UTILS_PRIVATE FNodeManager : public NodeManager {
 public:
@@ -134,6 +134,6 @@ private:
 
 FILAMENT_UPCAST(NodeManager)
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 #endif // GLTFIO_FNODEMANAGER_H

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -30,7 +30,7 @@
 using namespace filament;
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 FFilamentAsset::~FFilamentAsset() {
     releaseSourceData();
@@ -461,4 +461,4 @@ void FilamentAsset::addEntitiesToScene(Scene& targetScene, const Entity* entitie
     upcast(this)->addEntitiesToScene(targetScene, entities, count, sceneFilter);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -24,7 +24,7 @@
 using namespace filament;
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 Animator* FFilamentInstance::getAnimator() const noexcept {
     assert_invariant(animator);
@@ -98,4 +98,4 @@ Animator* FilamentInstance::getAnimator() noexcept {
     return upcast(this)->getAnimator();
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -31,10 +31,10 @@ using namespace utils;
 
 namespace {
 
-class MaterialGenerator : public MaterialProvider {
+class JitShaderProvider : public MaterialProvider {
 public:
-    explicit MaterialGenerator(Engine* engine, bool optimizeShaders);
-    ~MaterialGenerator() override;
+    explicit JitShaderProvider(Engine* engine, bool optimizeShaders);
+    ~JitShaderProvider() override;
 
     MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label, const char* extras) override;
@@ -54,24 +54,24 @@ public:
     const bool mOptimizeShaders;
 };
 
-MaterialGenerator::MaterialGenerator(Engine* engine, bool optimizeShaders) : mEngine(engine),
+JitShaderProvider::JitShaderProvider(Engine* engine, bool optimizeShaders) : mEngine(engine),
         mOptimizeShaders(optimizeShaders) {
     MaterialBuilder::init();
 }
 
-MaterialGenerator::~MaterialGenerator() {
+JitShaderProvider::~JitShaderProvider() {
     MaterialBuilder::shutdown();
 }
 
-size_t MaterialGenerator::getMaterialsCount() const noexcept {
+size_t JitShaderProvider::getMaterialsCount() const noexcept {
     return mMaterials.size();
 }
 
-const Material* const* MaterialGenerator::getMaterials() const noexcept {
+const Material* const* JitShaderProvider::getMaterials() const noexcept {
     return mMaterials.data();
 }
 
-void MaterialGenerator::destroyMaterials() {
+void JitShaderProvider::destroyMaterials() {
     for (auto& iter : mCache) {
         mEngine->destroy(iter.second);
     }
@@ -536,7 +536,7 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
     return Material::Builder().package(pkg.getData(), pkg.getSize()).build(*engine);
 }
 
-MaterialInstance* MaterialGenerator::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+MaterialInstance* JitShaderProvider::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
         const char* label, const char* extras) {
     constrainMaterial(config, uvmap);
     auto iter = mCache.find(*config);
@@ -559,8 +559,8 @@ MaterialInstance* MaterialGenerator::createMaterialInstance(MaterialKey* config,
 
 namespace gltfio {
 
-MaterialProvider* createMaterialGenerator(filament::Engine* engine, bool optimizeShaders) {
-    return new MaterialGenerator(engine, optimizeShaders);
+MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimizeShaders) {
+    return new JitShaderProvider(engine, optimizeShaders);
 }
 
 } // namespace gltfio

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -26,7 +26,7 @@
 
 using namespace filamat;
 using namespace filament;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 namespace {
@@ -557,10 +557,10 @@ MaterialInstance* JitShaderProvider::createMaterialInstance(MaterialKey* config,
 
 } // anonymous namespace
 
-namespace gltfio {
+namespace filament::gltfio {
 
 MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimizeShaders) {
     return new JitShaderProvider(engine, optimizeShaders);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/Ktx2Provider.cpp
+++ b/libs/gltfio/src/Ktx2Provider.cpp
@@ -33,7 +33,7 @@ using std::atomic;
 using std::vector;
 using std::unique_ptr;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class Ktx2Provider final : public TextureProvider {
 public:
@@ -250,4 +250,4 @@ TextureProvider* createKtx2Provider(Engine* engine) {
     return new Ktx2Provider(engine);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/MaterialProvider.cpp
+++ b/libs/gltfio/src/MaterialProvider.cpp
@@ -18,7 +18,7 @@
 
 #include <string>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 bool operator==(const MaterialKey& k1, const MaterialKey& k2) {
     return
@@ -182,4 +182,4 @@ void processShaderString(std::string* shader, const UvMap& uvmap, const Material
     replaceAll("${volumeThickness}", volumeThicknessUV);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/NodeManager.cpp
+++ b/libs/gltfio/src/NodeManager.cpp
@@ -22,7 +22,7 @@
 
 using namespace utils;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 using Instance = NodeManager::Instance;
 
@@ -80,4 +80,4 @@ bitset32 NodeManager::getSceneMembership(Instance ci) const noexcept {
     return upcast(this)->getSceneMembership(ci);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -63,7 +63,7 @@ using filament::geometry::ComponentType;
 
 static const auto FREE_CALLBACK = [](void* mem, size_t, void*) { free(mem); };
 
-namespace gltfio {
+namespace filament::gltfio {
 
 using BufferTextureCache = tsl::robin_map<const void*, Texture*>;
 using FilepathTextureCache = tsl::robin_map<std::string, Texture*>;
@@ -1075,4 +1075,4 @@ void ResourceLoader::updateBoundingBoxes(FFilamentAsset* asset) const {
     asset->mBoundingBox = assetBounds;
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/StbProvider.cpp
+++ b/libs/gltfio/src/StbProvider.cpp
@@ -33,7 +33,7 @@ using std::atomic;
 using std::vector;
 using std::unique_ptr;
 
-namespace gltfio {
+namespace filament::gltfio {
 
 class StbProvider final : public TextureProvider {
 public:
@@ -258,4 +258,4 @@ TextureProvider* createStbProvider(Engine* engine) {
     return new StbProvider(engine);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/TangentsJob.cpp
+++ b/libs/gltfio/src/TangentsJob.cpp
@@ -20,7 +20,7 @@
 
 #include <geometry/SurfaceOrientation.h>
 
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace filament;
 using namespace filament::math;
 

--- a/libs/gltfio/src/TangentsJob.h
+++ b/libs/gltfio/src/TangentsJob.h
@@ -25,7 +25,7 @@ class MorphTargetBuffer;
 
 }
 
-namespace gltfio {
+namespace filament::gltfio {
 
 /**
  * Internal helper that examines a cgltf primitive and generates data suitable for Filament's
@@ -69,4 +69,4 @@ struct TangentsJob {
     static void run(Params* params);
 };
 
-} // namespace gltfio
+} // namespace filament::gltfio

--- a/libs/gltfio/src/UbershaderProvider.cpp
+++ b/libs/gltfio/src/UbershaderProvider.cpp
@@ -42,10 +42,10 @@ namespace {
 
 using CullingMode = MaterialInstance::CullingMode;
 
-class UbershaderLoader : public MaterialProvider {
+class UbershaderProvider : public MaterialProvider {
 public:
-    UbershaderLoader(filament::Engine* engine);
-    ~UbershaderLoader() {}
+    UbershaderProvider(filament::Engine* engine);
+    ~UbershaderProvider() {}
 
     MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label, const char* extras) override;
@@ -73,7 +73,7 @@ public:
     Engine* mEngine;
 };
 
-UbershaderLoader::UbershaderLoader(Engine* engine) : mEngine(engine), mMaterials(*engine) {
+UbershaderProvider::UbershaderProvider(Engine* engine) : mEngine(engine), mMaterials(*engine) {
     unsigned char texels[4] = {};
     mDummyTexture = Texture::Builder()
             .width(1).height(1)
@@ -85,20 +85,20 @@ UbershaderLoader::UbershaderLoader(Engine* engine) : mEngine(engine), mMaterials
     mMaterials.load((void*) GLTFRESOURCES_FULL_DATA, GLTFRESOURCES_FULL_SIZE);
 }
 
-size_t UbershaderLoader::getMaterialsCount() const noexcept {
+size_t UbershaderProvider::getMaterialsCount() const noexcept {
     return mMaterials.getMaterialsCount();
 }
 
-const Material* const* UbershaderLoader::getMaterials() const noexcept {
+const Material* const* UbershaderProvider::getMaterials() const noexcept {
     return mMaterials.getMaterials();
 }
 
-void UbershaderLoader::destroyMaterials() {
+void UbershaderProvider::destroyMaterials() {
     mMaterials.destroyMaterials();
     mEngine->destroy(mDummyTexture);
 }
 
-Material* UbershaderLoader::getMaterial(const MaterialKey& config) const {
+Material* UbershaderProvider::getMaterial(const MaterialKey& config) const {
     const Shading shading = config.unlit ? Shading::UNLIT :
             (config.useSpecularGlossiness ? Shading::SPECULAR_GLOSSINESS : Shading::LIT);
 
@@ -141,7 +141,7 @@ Material* UbershaderLoader::getMaterial(const MaterialKey& config) const {
     return nullptr;
 }
 
-MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+MaterialInstance* UbershaderProvider::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
         const char* label, const char* extras) {
     // Diagnostics are not supported with LOAD_UBERSHADERS, please use GENERATE_SHADERS instead.
     if (config->enableDiagnostics) {
@@ -286,8 +286,8 @@ MaterialInstance* UbershaderLoader::createMaterialInstance(MaterialKey* config, 
 
 namespace gltfio {
 
-MaterialProvider* createUbershaderLoader(filament::Engine* engine) {
-    return new UbershaderLoader(engine);
+MaterialProvider* createUbershaderProvider(filament::Engine* engine) {
+    return new UbershaderProvider(engine);
 }
 
 } // namespace gltfio

--- a/libs/gltfio/src/UbershaderProvider.cpp
+++ b/libs/gltfio/src/UbershaderProvider.cpp
@@ -31,7 +31,7 @@
 using namespace filament;
 using namespace filament::math;
 using namespace filament::uberz;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 #if !defined(NDEBUG)
@@ -284,13 +284,13 @@ MaterialInstance* UbershaderProvider::createMaterialInstance(MaterialKey* config
 
 } // anonymous namespace
 
-namespace gltfio {
+namespace filament::gltfio {
 
 MaterialProvider* createUbershaderProvider(filament::Engine* engine) {
     return new UbershaderProvider(engine);
 }
 
-} // namespace gltfio
+} // namespace filament::gltfio
 
 
 #if !defined(NDEBUG)

--- a/libs/gltfio/src/Wireframe.cpp
+++ b/libs/gltfio/src/Wireframe.cpp
@@ -37,7 +37,7 @@ using namespace utils;
 
 static const auto FREE_CALLBACK = [](void* mem, size_t, void*) { free(mem); };
 
-namespace gltfio {
+namespace filament::gltfio {
 
 struct FFilamentAsset;
 

--- a/libs/gltfio/src/Wireframe.h
+++ b/libs/gltfio/src/Wireframe.h
@@ -22,7 +22,7 @@
 
 #include <utils/Entity.h>
 
-namespace gltfio {
+namespace filament::gltfio {
 
 struct FFilamentAsset;
 

--- a/libs/uberz/README.md
+++ b/libs/uberz/README.md
@@ -77,7 +77,7 @@ blending mode in certain ubershader materials (e.g. materials that support `KHR_
 These materials should simply omit the `BlendingMode` line from the spec.
 
 If any feature flag is missing from the spec, it implicitly has the value of `unsupported`. For an
-up-to-date list of recognized feature flags, look at the source for `UbershaderLoader::getMaterial`.
+up-to-date list of recognized feature flags, look at the source for `UbershaderProvider::getMaterial`.
 
 If a particular feature flag is set to `required` for a particular material, then the glTF loader
 will bind that material to a given glTF mesh only if that feature is enabled in the mesh.

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -252,7 +252,7 @@ int main(int argc, char** argv) {
         app.names = new NameComponentManager(EntityManager::get());
         app.viewer = new ViewerGui(engine, scene, view, app.instanceToAnimate);
         app.materials = (app.materialSource == GENERATE_SHADERS) ?
-                createMaterialGenerator(engine) : createUbershaderLoader(engine);
+                createJitShaderProvider(engine) : createUbershaderProvider(engine);
         app.loader = AssetLoader::create({engine, app.materials, app.names });
         if (filename.isEmpty()) {
             app.asset = app.loader->createInstancedAsset(

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -49,7 +49,7 @@ using namespace filament;
 using namespace filament::math;
 using namespace filament::viewer;
 
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 enum MaterialSource {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -63,7 +63,7 @@ using namespace filament;
 using namespace filament::math;
 using namespace filament::viewer;
 
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace utils;
 
 enum MaterialSource {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -495,7 +495,7 @@ int main(int argc, char** argv) {
         }
 
         app.materials = (app.materialSource == GENERATE_SHADERS) ?
-                createMaterialGenerator(engine) : createUbershaderLoader(engine);
+                createJitShaderProvider(engine) : createUbershaderProvider(engine);
         app.assetLoader = AssetLoader::create({engine, app.materials, app.names });
         app.mainCamera = &view->getCamera();
         if (filename.isEmpty()) {

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -220,7 +220,7 @@ Filament.loadClassExtensions = function() {
     /// Clients should create only one asset loader for the lifetime of their app, this prevents
     /// memory leaks and duplication of Material objects.
     Filament.Engine.prototype.createAssetLoader = function() {
-        const materials = new Filament.gltfio$UbershaderLoader(this);
+        const materials = new Filament.gltfio$UbershaderProvider(this);
         return new Filament.gltfio$AssetLoader(this, materials);
     };
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1838,7 +1838,7 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
 
 // These little wrappers exist to get around RTTI requirements in embind.
 
-struct UbershaderLoader {
+struct UbershaderProvider {
     MaterialProvider* provider;
     void destroyMaterials() { provider->destroyMaterials(); }
 };
@@ -1846,11 +1846,11 @@ struct UbershaderLoader {
 struct StbProvider { TextureProvider* provider; };
 struct Ktx2Provider { TextureProvider* provider; };
 
-class_<UbershaderLoader>("gltfio$UbershaderLoader")
-    .constructor(EMBIND_LAMBDA(UbershaderLoader, (Engine* engine), {
-        return UbershaderLoader { createUbershaderLoader(engine) };
+class_<UbershaderProvider>("gltfio$UbershaderProvider")
+    .constructor(EMBIND_LAMBDA(UbershaderProvider, (Engine* engine), {
+        return UbershaderProvider { createUbershaderProvider(engine) };
     }))
-    .function("destroyMaterials", &UbershaderLoader::destroyMaterials);
+    .function("destroyMaterials", &UbershaderProvider::destroyMaterials);
 
 class_<StbProvider>("gltfio$StbProvider")
     .constructor(EMBIND_LAMBDA(StbProvider, (Engine* engine), {
@@ -1864,7 +1864,7 @@ class_<Ktx2Provider>("gltfio$Ktx2Provider")
 
 class_<AssetLoader>("gltfio$AssetLoader")
 
-    .constructor(EMBIND_LAMBDA(AssetLoader*, (Engine* engine, UbershaderLoader materials), {
+    .constructor(EMBIND_LAMBDA(AssetLoader*, (Engine* engine, UbershaderProvider materials), {
         auto names = new utils::NameComponentManager(utils::EntityManager::get());
         return AssetLoader::create({ engine, materials.provider, names });
     }), allow_raw_pointers())

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -93,7 +93,7 @@ using namespace emscripten;
 using namespace filament;
 using namespace filamesh;
 using namespace geometry;
-using namespace gltfio;
+using namespace filament::gltfio;
 using namespace image;
 using namespace ktxreader;
 


### PR DESCRIPTION
We ship with two TextureProvider plugins (StbProvider and Ktx2Provider) and two MaterialProvider plugins (UbershaderLoader and MaterialGenerator) so this brings clarity and consistency.