### PR TITLE
cleanup and fixes regarding skinning UBO

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - materials: add a new `instanced` material parameter that is now mandatory in order to call `getInstanceIndex()`
 - gltfio: UbershaderProvider now takes the ubershader archive in its constructor [⚠️ **API Change**]
 - gltfio: Fix morphing with sparse accessors.
+- engine: Documentation improvements regarding SkinningBuffer and fix an off-by-one assert when setting a SkinningBuffer.
 
 ## v1.23.2
 

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -521,7 +521,15 @@ public:
     void setBones(Instance instance, math::mat4f const* transforms, size_t boneCount = 1, size_t offset = 0); //!< \overload
 
     /**
-     * Associates a SkinningBuffer to a renderable instance
+     * Associates a region of a SkinningBuffer to a renderable instance
+     *
+     * Note: due to hardware limitations offset + 256 must be smaller or equal to
+     *       skinningBuffer->getBoneCount()
+     *
+     * @param instance          Instance of the component obtained from getInstance().
+     * @param skinningBuffer    skinning buffer to associate to the instance
+     * @param count             Size of the region in bones, must be smaller or equal to 256.
+     * @param offset            Start offset of the region in bones
      */
     void setSkinningBuffer(Instance instance, SkinningBuffer* skinningBuffer,
             size_t count, size_t offset);
@@ -535,7 +543,7 @@ public:
      * @param instance Instance of the component obtained from getInstance().
      * @param weights Pointer to morph target weights to be update.
      * @param count Number of morph target weights.
-     * @param offset Index of the first first morph target weight to set at instance.
+     * @param offset Index of the first morph target weight to set at instance.
      */
     void setMorphWeights(Instance instance,
             float const* weights, size_t count, size_t offset = 0);

--- a/filament/include/filament/SkinningBuffer.h
+++ b/filament/include/filament/SkinningBuffer.h
@@ -33,6 +33,7 @@ namespace filament {
 /**
  * SkinningBuffer is used to hold skinning data (bones). It is a simple wraper around
  * a structured UBO.
+ * @see RenderableManager::setSkinningBuffer
  */
 class UTILS_PUBLIC SkinningBuffer : public FilamentAPI {
     struct BuilderDetails;
@@ -93,6 +94,7 @@ public:
      * @param transforms pointer to at least count Bone
      * @param count number of Bone elements in transforms
      * @param offset offset in elements (not bytes) in the SkinningBuffer (not in transforms)
+     * @see RenderableManager::setSkinningBuffer
      */
     void setBones(Engine& engine, RenderableManager::Bone const* transforms,
             size_t count, size_t offset = 0);
@@ -103,6 +105,7 @@ public:
      * @param transforms pointer to at least count mat4f
      * @param count number of mat4f elements in transforms
      * @param offset offset in elements (not bytes) in the SkinningBuffer (not in transforms)
+     * @see RenderableManager::setSkinningBuffer
      */
     void setBones(Engine& engine, math::mat4f const* transforms,
             size_t count, size_t offset = 0);

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -642,11 +642,11 @@ void RenderPass::Executor::recordDriverCommands(FEngine& engine, backend::Driver
                     uboHandle, offset, sizeof(PerRenderableUib));
 
             if (UTILS_UNLIKELY(info.skinningHandle)) {
-                // note: we can't bind less than CONFIG_MAX_BONE_COUNT due to glsl limitations
+                // note: we can't bind less than sizeof(PerRenderableBoneUib) due to glsl limitations
                 driver.bindUniformBufferRange(BindingPoints::PER_RENDERABLE_BONES,
                         info.skinningHandle,
-                        info.skinningOffset * sizeof(PerRenderableUibBone),
-                        CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone));
+                        info.skinningOffset * sizeof(PerRenderableBoneUib::BoneData),
+                        sizeof(PerRenderableBoneUib));
                 // note: even if only skinning is enabled, binding morphTargetBuffer is needed.
                 driver.bindSamplers(BindingPoints::PER_RENDERABLE_MORPHING,
                         info.morphTargetBuffer);

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -378,7 +378,7 @@ void FMaterial::getSurfaceProgramSlow(Variant variant) const noexcept {
         .setUniformBlock(BindingPoints::PER_MATERIAL_INSTANCE, mUniformInterfaceBlock.getName());
 
     if (Variant(variant).hasSkinningOrMorphing()) {
-        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES, PerRenderableUibBone::_name);
+        pb.setUniformBlock(BindingPoints::PER_RENDERABLE_BONES, PerRenderableBoneUib::_name);
         pb.setUniformBlock(BindingPoints::PER_RENDERABLE_MORPHING, PerRenderableMorphingUib::_name);
     }
 

--- a/filament/src/details/SkinningBuffer.h
+++ b/filament/src/details/SkinningBuffer.h
@@ -18,10 +18,10 @@
 #define TNT_FILAMENT_DETAILS_SKINNINGBUFFER_H
 
 #include "upcast.h"
-
 #include <filament/SkinningBuffer.h>
 
 #include "private/filament/EngineEnums.h"
+#include "private/filament/UibStructs.h"
 
 #include <backend/Handle.h>
 
@@ -31,8 +31,6 @@
 class FilamentTest_Bones_Test;
 
 namespace filament {
-
-struct PerRenderableUibBone;
 
 class FEngine;
 class FRenderableManager;
@@ -48,7 +46,9 @@ public:
     void setBones(FEngine& engine, math::mat4f const* transforms, size_t count, size_t offset);
     size_t getBoneCount() const noexcept { return mBoneCount; }
 
+    // round count to the size of the UBO in the shader
     static size_t getPhysicalBoneCount(size_t count) noexcept {
+        static_assert((CONFIG_MAX_BONE_COUNT & (CONFIG_MAX_BONE_COUNT - 1)) == 0);
         return (count + CONFIG_MAX_BONE_COUNT - 1) & ~(CONFIG_MAX_BONE_COUNT - 1);
     }
 
@@ -63,7 +63,7 @@ private:
     static void setBones(FEngine& engine, backend::Handle<backend::HwBufferObject> handle,
             math::mat4f const* transforms, size_t boneCount, size_t offset) noexcept;
 
-    static PerRenderableUibBone makeBone(math::mat4f transform) noexcept;
+    static PerRenderableBoneUib::BoneData makeBone(math::mat4f transform) noexcept;
 
     backend::Handle<backend::HwBufferObject> getHwHandle() const noexcept {
         return mHandle;

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -64,7 +64,7 @@ constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 14;
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
 
 // This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
-// We store 64 bytes per bone.
+// We store 64 bytes per bone. Must be a power-of-two.
 constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 
 // The maximum number of morph target count.

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -278,7 +278,7 @@ static_assert(sizeof(FroxelRecordUib) == 16384,
 // MARK: -
 
 // This is not the UBO proper, but just an element of a bone array.
-struct PerRenderableUibBone { // NOLINT(cppcoreguidelines-pro-type-member-init)
+struct PerRenderableBoneUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     static constexpr utils::StaticString _name{ "BonesUniforms" };
     struct alignas(16) BoneData {
         // bone transform, last row assumed [0,0,0,1]
@@ -286,9 +286,9 @@ struct PerRenderableUibBone { // NOLINT(cppcoreguidelines-pro-type-member-init)
         // 8 first cofactor matrix of transform's upper left
         math::uint4 cof;
     };
-    BoneData bone;
+    BoneData bones[CONFIG_MAX_BONE_COUNT];
 };
-static_assert(CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone) <= 16384,
+static_assert(sizeof(PerRenderableBoneUib) <= 16384,
         "PerRenderableUibBone exceed max UBO size");
 
 // ------------------------------------------------------------------------------------------------

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -172,8 +172,8 @@ UniformInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
 
 UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
-            .name(PerRenderableUibBone::_name)
-            .add("bones", CONFIG_MAX_BONE_COUNT, "BoneData", sizeof(PerRenderableUibBone::BoneData))
+            .name(PerRenderableBoneUib::_name)
+            .add("bones", CONFIG_MAX_BONE_COUNT, "BoneData", sizeof(PerRenderableBoneUib::BoneData))
             .build();
     return uib;
 }


### PR DESCRIPTION
- rename PerRenderableUibBones to PerRenderableBonesUib to be more
  consistant with other interface block naming.

- make sure the C++ struct and the UBO definition match. 
  PerRenderableBonesUib is a UBO with one bones[256] field, but the
  C++ struct has a single bone and treated the UBO as an array.
  This makes things less confusing.
  We can now use sizeof(PerRenderableBonesUib) in many places which
  better expresse what we are doing.

- Fix an off-by-one assert when setting a skinning buffer to a renderable

- Asserts that no more than 256 bones are associated to a renderable

- improve documentation and fix some typos