### PR TITLE
Always use homogeneous attachment sizes

### DIFF
--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -28,6 +28,9 @@
 #include <utils/trap.h>
 #include <utils/debug.h>
 
+#include <math/vec2.h>
+#include <math/scalar.h>
+
 #include <math.h>
 
 namespace filament {
@@ -806,6 +809,10 @@ void MetalTexture::updateLodRange(uint32_t level) {
 MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint32_t height,
         uint8_t samples, Attachment colorAttachments[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT], Attachment depthAttachment) :
         HwRenderTarget(width, height), context(context), samples(samples) {
+    UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmin = {std::numeric_limits<size_t>::max()};
+    UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmax = {0};
+    UTILS_UNUSED_IN_RELEASE size_t attachmentCount = 0;
+
     for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         if (!colorAttachments[i]) {
             continue;
@@ -815,6 +822,13 @@ MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint
         ASSERT_PRECONDITION(color[i].getSampleCount() <= samples,
                 "MetalRenderTarget was initialized with a MSAA COLOR%d texture, but sample count is %d.",
                 i, samples);
+
+        auto t = color[i].metalTexture;
+        const auto twidth = std::max(1u, t->width >> color[i].level);
+        const auto theight = std::max(1u, t->height >> color[i].level);
+        tmin = { std::min(tmin.x, twidth), std::min(tmin.y, theight) };
+        tmax = { std::max(tmax.x, twidth), std::max(tmax.y, theight) };
+        attachmentCount++;
 
         // If we were given a single-sampled texture but the samples parameter is > 1, we create
         // a multisampled sidecar texture and do a resolve automatically.
@@ -834,6 +848,13 @@ MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint
                 "MetalRenderTarget was initialized with a MSAA DEPTH texture, but sample count is %d.",
                 samples);
 
+        auto t = depth.metalTexture;
+        const auto twidth = std::max(1u, t->width >> depth.level);
+        const auto theight = std::max(1u, t->height >> depth.level);
+        tmin = { math::min(tmin.x, twidth), math::min(tmin.y, theight) };
+        tmax = { math::max(tmax.x, twidth), math::max(tmax.y, theight) };
+        attachmentCount++;
+
         // If we were given a single-sampled texture but the samples parameter is > 1, we create
         // a multisampled sidecar texture and do a resolve automatically.
         if (samples > 1 && depth.getSampleCount() == 1) {
@@ -844,6 +865,10 @@ MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint
             }
         }
     }
+
+    // Verify that all attachments have the same dimensions.
+    assert_invariant(attachmentCount > 0);
+    assert_invariant(tmin == tmax);
 }
 
 void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* descriptor,

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -539,6 +539,10 @@ void VulkanDriver::createDefaultRenderTargetR(Handle<HwRenderTarget> rth, int) {
 void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targets, uint32_t width, uint32_t height, uint8_t samples,
         MRT color, TargetBufferInfo depth, TargetBufferInfo stencil) {
+    UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmin = {std::numeric_limits<uint32_t>::max()};
+    UTILS_UNUSED_IN_RELEASE math::vec2<uint32_t> tmax = {0};
+    UTILS_UNUSED_IN_RELEASE size_t attachmentCount = 0;
+
     VulkanAttachment colorTargets[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};
     for (int i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         if (color[i].handle) {
@@ -548,7 +552,9 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
                 .layer = color[i].layer,
             };
             UTILS_UNUSED_IN_RELEASE VkExtent2D extent = colorTargets[i].getExtent2D();
-            assert_invariant(extent.width >= width && extent.height >= height);
+            tmin = { std::min(tmin.x, extent.width), std::min(tmin.y, extent.height) };
+            tmax = { std::max(tmax.x, extent.width), std::max(tmax.y, extent.height) };
+            attachmentCount++;
         }
     }
 
@@ -560,7 +566,9 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             .layer = depth.layer,
         };
         UTILS_UNUSED_IN_RELEASE VkExtent2D extent = depthStencil[0].getExtent2D();
-        assert_invariant(extent.width >= width && extent.height >= height);
+        tmin = { std::min(tmin.x, extent.width), std::min(tmin.y, extent.height) };
+        tmax = { std::max(tmax.x, extent.width), std::max(tmax.y, extent.height) };
+        attachmentCount++;
     }
 
     if (stencil.handle) {
@@ -570,8 +578,16 @@ void VulkanDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             .layer = stencil.layer,
         };
         UTILS_UNUSED_IN_RELEASE VkExtent2D extent = depthStencil[1].getExtent2D();
-        assert_invariant(extent.width >= width && extent.height >= height);
+        tmin = { std::min(tmin.x, extent.width), std::min(tmin.y, extent.height) };
+        tmax = { std::max(tmax.x, extent.width), std::max(tmax.y, extent.height) };
+        attachmentCount++;
     }
+
+    // All attachments must have the same dimensions, which must be greater than or equal to the
+    // render target dimensions.
+    assert_invariant(attachmentCount > 0);
+    assert_invariant(tmin == tmax);
+    assert_invariant(tmin.x >= width && tmin.y >= height);
 
     auto renderTarget = construct<VulkanRenderTarget>(rth, mContext,
             width, height, samples, colorTargets, depthStencil, mStagePool);

--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -129,19 +129,6 @@ backend::TextureHandle ResourceAllocator::createTexture(const char* name,
         uint32_t width, uint32_t height, uint32_t depth,
         std::array<backend::TextureSwizzle, 4> swizzle,
         backend::TextureUsage usage) noexcept {
-
-    // Some WebGL implementations complain about an incomplete framebuffer when the attachment sizes
-    // are heterogeneous. This merits further investigation.
-#if !defined(__EMSCRIPTEN__)
-    if (!(usage & TextureUsage::SAMPLEABLE)) {
-        // If this texture is not going to be sampled, we can round its size up
-        // this helps prevent many reallocations for small size changes.
-        // We round to 16 pixels, which works for 720p btw.
-        width  = (width  + 15u) & ~15u;
-        height = (height + 15u) & ~15u;
-    }
-#endif
-
     // The frame graph descriptor uses "0" to mean "auto" but the sample count that is passed to the
     // backend should always be 1 or greater.
     samples = samples ? samples : uint8_t(1);

--- a/filament/src/fg/PassNode.cpp
+++ b/filament/src/fg/PassNode.cpp
@@ -190,6 +190,8 @@ void RenderPassNode::resolve() noexcept {
                     rt.descriptor.clearFlags & rt.targetBufferFlags);
         }
 
+        assert_invariant(minWidth == maxWidth);
+        assert_invariant(minHeight == maxHeight);
         assert_invariant(any(rt.targetBufferFlags));
 
         // of all attachments size matches there are no ambiguity about the RT size.


### PR DESCRIPTION
Homogeneous attachments are a requirement for Metal (and possibly Vulkan) correctness. If rendering to a RenderTarget that has a smaller height than the underlying Texture, the Metal backend must set the Viewport to be the bottom-left of the texture, to match OGL. However, it can only do this correctly if all attachments have the same size.