### PR TITLE
backend: remove STREAM buffers and add Unsynchronized buffer update API

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -128,7 +128,6 @@ inline constexpr TargetBufferFlags getTargetBufferFlagsAt(size_t index) noexcept
 enum class BufferUsage : uint8_t {
     STATIC,      //!< content modified once, used many times
     DYNAMIC,     //!< content modified frequently, used many times
-    STREAM,      //!< content invalidated and modified frequently, used many times
 };
 
 /**

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -325,6 +325,14 @@ DECL_DRIVER_API_N(updateBufferObject,
         backend::BufferDescriptor&&, data,
         uint32_t, byteOffset)
 
+DECL_DRIVER_API_N(updateBufferObjectUnsynchronized,
+        backend::BufferObjectHandle, ibh,
+        backend::BufferDescriptor&&, data,
+        uint32_t, byteOffset)
+
+DECL_DRIVER_API_N(resetBufferObject,
+        backend::BufferObjectHandle, ibh)
+
 DECL_DRIVER_API_N(updateSamplerGroup,
         backend::SamplerGroupHandle, ubh,
         backend::SamplerGroup&&, samplerGroup)

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -42,7 +42,8 @@ public:
      * Update the buffer with data inside src. Potentially allocates a new buffer allocation to hold
      * the bytes which will be released when the current frame is finished.
      */
-    void copyIntoBuffer(void* src, size_t size, size_t byteOffset = 0);
+    void copyIntoBuffer(void* src, size_t size, size_t byteOffset);
+    void copyIntoBufferUnsynchronized(void* src, size_t size, size_t byteOffset);
 
     /**
      * Denotes that this buffer is used for a draw call ensuring that its allocation remains valid
@@ -56,12 +57,6 @@ public:
      *
      */
     id<MTLBuffer> getGpuBufferForDraw(id<MTLCommandBuffer> cmdBuffer) noexcept;
-
-    /**
-     * Returns the offset into the buffer returned by getGpuBufferForDraw. This is always 0 for
-     * non-STREAM buffers.
-     */
-    size_t getGpuBufferStreamOffset() noexcept { return mCurrentStreamStart; }
 
     void* getCpuBuffer() const noexcept { return mCpuBuffer; }
 
@@ -84,13 +79,9 @@ private:
 
     BufferUsage mUsage;
     size_t mBufferSize = 0;
-    size_t mCurrentStreamStart = 0;
-    size_t mCurrentStreamEnd = 0;
     const MetalBufferPoolEntry* mBufferPoolEntry = nullptr;
     void* mCpuBuffer = nullptr;
     MetalContext& mContext;
-
-    void copyIntoStreamBuffer(void* src, size_t size);
 };
 
 } // namespace backend

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -708,6 +708,22 @@ void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescripto
     scheduleDestroy(std::move(data));
 }
 
+void MetalDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> boh,
+        BufferDescriptor&& data, uint32_t byteOffset) {
+    auto* bo = handle_cast<MetalBufferObject>(boh);
+    bo->updateBufferUnsynchronized(data.buffer, data.size, byteOffset);
+    scheduleDestroy(std::move(data));
+}
+
+void MetalDriver::resetBufferObject(Handle<HwBufferObject> boh) {
+    // TODO: implement resetBufferObject(). This is equivalent to calling
+    // destroyBufferObject() followed by createBufferObject() keeping the same handle.
+    // It is actually okay to keep a no-op implementation, the intention here is to "orphan" the
+    // buffer (and possibly return it to a pool) and allocate a new one (or get it from a pool),
+    // so that no further synchronization with the GPU is needed.
+    // This is only useful if updateBufferObjectUnsynchronized() is implemented unsynchronizedly.
+}
+
 void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
     auto* vertexBuffer = handle_cast<MetalVertexBuffer>(vbh);
@@ -1377,12 +1393,11 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
 
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
     id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer.getGpuBufferForDraw(cmdBuffer);
-    size_t offset = indexBuffer->buffer.getGpuBufferStreamOffset();
     [mContext->currentRenderPassEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)
                                                    indexCount:primitive->count
                                                     indexType:getIndexType(indexBuffer->elementSize)
                                                   indexBuffer:metalIndexBuffer
-                                            indexBufferOffset:primitive->offset + offset
+                                            indexBufferOffset:primitive->offset
                                                 instanceCount:instanceCount];
 }
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -117,6 +117,7 @@ public:
     MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
+    void updateBufferUnsynchronized(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }
 
     // Tracks which uniform buffers this buffer object is bound into.

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -273,6 +273,10 @@ void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffse
     buffer.copyIntoBuffer(data, size, byteOffset);
 }
 
+void MetalBufferObject::updateBufferUnsynchronized(void* data, size_t size, uint32_t byteOffset) {
+    buffer.copyIntoBufferUnsynchronized(data, size, byteOffset);
+}
+
 MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
             uint8_t attributeCount, uint32_t vertexCount, AttributeArray const& attributes)
     : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes), buffers(bufferCount, nullptr) {}

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -195,6 +195,14 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
     scheduleDestroy(std::move(p));
 }
 
+void NoopDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> ibh, BufferDescriptor&& p,
+        uint32_t byteOffset) {
+    scheduleDestroy(std::move(p));
+}
+
+void NoopDriver::resetBufferObject(Handle<HwBufferObject> boh) {
+}
+
 void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
 }

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -108,8 +108,7 @@ constexpr inline GLenum getBufferUsage(BufferUsage usage) noexcept {
     switch (usage) {
         case BufferUsage::STATIC:
             return GL_STATIC_DRAW;
-        case BufferUsage::DYNAMIC:
-        case BufferUsage::STREAM:
+        default:
             return GL_DYNAMIC_DRAW;
     }
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1647,22 +1647,17 @@ void OpenGLDriver::updateBufferObject(
 
     assert_invariant(bd.size + byteOffset <= bo->byteCount);
 
-    if (bo->gl.binding == GL_UNIFORM_BUFFER) {
-        // TODO: use updateBuffer() for all types of buffer? Make sure GL supports that.
-        updateBuffer(bo, bd, byteOffset, (uint32_t)gl.gets.uniform_buffer_offset_alignment);
+    if (bo->gl.binding == GL_ARRAY_BUFFER) {
+        gl.bindVertexArray(nullptr);
+    }
+    gl.bindBuffer(bo->gl.binding, bo->gl.id);
+    if (byteOffset == 0 && bd.size == bo->byteCount) {
+        // it looks like it's generally faster (or not worse) to use glBufferData()
+        glBufferData(bo->gl.binding, bd.size, bd.buffer, getBufferUsage(bo->usage));
     } else {
-        if (bo->gl.binding == GL_ARRAY_BUFFER) {
-            gl.bindVertexArray(nullptr);
-        }
-        gl.bindBuffer(bo->gl.binding, bo->gl.id);
-        if (byteOffset == 0 && bd.size == bo->byteCount) {
-            // it looks like it's generally faster (or not worse) to use glBufferData()
-            glBufferData(bo->gl.binding, bd.size, bd.buffer, getBufferUsage(bo->usage));
-        } else {
-            // glBufferSubData() could be catastrophically inefficient if several are
-            // issued during the same frame. Currently, we're not doing that though.
-            glBufferSubData(bo->gl.binding, byteOffset, bd.size, bd.buffer);
-        }
+        // glBufferSubData() could be catastrophically inefficient if several are
+        // issued during the same frame. Currently, we're not doing that though.
+        glBufferSubData(bo->gl.binding, byteOffset, bd.size, bd.buffer);
     }
 
     scheduleDestroy(std::move(bd));
@@ -1670,73 +1665,58 @@ void OpenGLDriver::updateBufferObject(
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::updateBuffer(GLBufferObject* buffer, BufferDescriptor const& p,
-        uint32_t byteOffset, uint32_t alignment) noexcept {
-    assert_invariant(buffer->byteCount >= p.size);
-    assert_invariant(buffer->gl.id);
+void OpenGLDriver::updateBufferObjectUnsynchronized(
+        Handle<HwBufferObject> boh, BufferDescriptor&& bd, uint32_t byteOffset) {
+    DEBUG_MARKER()
 
-    auto& gl = mContext;
-    gl.bindBuffer(buffer->gl.binding, buffer->gl.id);
-    if (buffer->usage == BufferUsage::STREAM) {
+    if constexpr (!HAS_MAPBUFFERS) {
+        updateBufferObject(boh, std::move(bd), byteOffset);
+    } else {
+        GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
 
-        // in streaming mode it's meaningless to have an offset specified
-        assert_invariant(byteOffset == 0);
+        assert_invariant(bo->gl.id);
+        assert_invariant(bd.size + byteOffset <= bo->byteCount);
 
-        buffer->size = (uint32_t)p.size;
-
-        // If MapBufferRange is supported, then attempt to use that instead of BufferSubData, which
-        // can be quite inefficient on some platforms. Note that WebGL does not support
-        // MapBufferRange, but we still allow STREAM semantics for the web platform.
-        if (HAS_MAPBUFFERS) {
-            uint32_t offset = buffer->base + buffer->size;
-            offset = (offset + (alignment - 1u)) & ~(alignment - 1u);
-
-            if (offset + p.size > buffer->byteCount) {
-                // if we've reached the end of the buffer, we orphan it and allocate a new one.
-                // this is assuming the driver actually does that as opposed to stalling. This is
-                // the case for Mali and Adreno -- we could use fences instead.
-                offset = 0;
-                glBufferData(buffer->gl.binding, buffer->byteCount, nullptr, getBufferUsage(buffer->usage));
-            }
-    retry:
-            void* vaddr = glMapBufferRange(buffer->gl.binding, offset, p.size,
+        if (bo->gl.binding != GL_UNIFORM_BUFFER) {
+            // TODO: use updateBuffer() for all types of buffer? Make sure GL supports that.
+            updateBufferObject(boh, std::move(bd), byteOffset);
+        } else {
+            auto& gl = mContext;
+            gl.bindBuffer(bo->gl.binding, bo->gl.id);
+retry:
+            void* const vaddr = glMapBufferRange(bo->gl.binding, byteOffset, bd.size,
                     GL_MAP_WRITE_BIT |
                     GL_MAP_INVALIDATE_RANGE_BIT |
                     GL_MAP_UNSYNCHRONIZED_BIT);
-            if (vaddr) {
-                memcpy(vaddr, p.buffer, p.size);
-                if (glUnmapBuffer(buffer->gl.binding) == GL_FALSE) {
+            if (UTILS_LIKELY(vaddr)) {
+                memcpy(vaddr, bd.buffer, bd.size);
+                if (UTILS_UNLIKELY(glUnmapBuffer(bo->gl.binding) == GL_FALSE)) {
                     // According to the spec, UnmapBuffer can return FALSE in rare conditions (e.g.
-                    // during a screen mode change). Note that is not a GL error, and we can handle
+                    // during a screen mode change). Note that this is not a GL error, and we can handle
                     // it by simply making a second attempt.
                     goto retry; // NOLINT(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
                 }
             } else {
                 // handle mapping error, revert to glBufferSubData()
-                glBufferSubData(buffer->gl.binding, offset, p.size, p.buffer);
+                glBufferSubData(bo->gl.binding, byteOffset, bd.size, bd.buffer);
             }
-            buffer->base = offset;
+        }
 
-            CHECK_GL_ERROR(utils::slog.e)
-        } else {
-            // In stream mode we're allowed to allocate a whole new buffer
-            glBufferData(buffer->gl.binding, p.size, p.buffer, getBufferUsage(buffer->usage));
-        }
-    } else {
-        if (byteOffset == 0 && p.size == buffer->byteCount) {
-            // it looks like it's generally faster (or not worse) to use glBufferData()
-            glBufferData(buffer->gl.binding, buffer->byteCount, p.buffer,
-                    getBufferUsage(buffer->usage));
-        } else {
-            // glBufferSubData() could be catastrophically inefficient if several are
-            // issued during the same frame. Currently, we're not doing that though.
-            glBufferSubData(buffer->gl.binding, byteOffset, p.size, p.buffer);
-        }
+        scheduleDestroy(std::move(bd));
     }
-
     CHECK_GL_ERROR(utils::slog.e)
 }
 
+void OpenGLDriver::resetBufferObject(Handle<HwBufferObject> boh) {
+    DEBUG_MARKER()
+
+    auto& gl = mContext;
+    GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
+    assert_invariant(bo->gl.id);
+
+    gl.bindBuffer(bo->gl.binding, bo->gl.id);
+    glBufferData(bo->gl.binding, bo->byteCount, nullptr, getBufferUsage(bo->usage));
+}
 
 void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
@@ -2467,7 +2447,6 @@ void OpenGLDriver::bindUniformBuffer(uint32_t index, Handle<HwBufferObject> ubh)
     auto& gl = mContext;
     GLBufferObject* ub = handle_cast<GLBufferObject *>(ubh);
     assert_invariant(ub->gl.binding == GL_UNIFORM_BUFFER);
-    assert_invariant(ub->base == 0);
     gl.bindBufferRange(ub->gl.binding, GLuint(index), ub->gl.id, 0, ub->byteCount);
     CHECK_GL_ERROR(utils::slog.e)
 }
@@ -2479,8 +2458,8 @@ void OpenGLDriver::bindUniformBufferRange(uint32_t index, Handle<HwBufferObject>
 
     GLBufferObject* ub = handle_cast<GLBufferObject *>(ubh);
     assert_invariant(ub->gl.binding == GL_UNIFORM_BUFFER);
-    assert_invariant(ub->base + offset + size <= ub->byteCount);
-    gl.bindBufferRange(ub->gl.binding, GLuint(index), ub->gl.id, ub->base + offset, size);
+    assert_invariant(offset + size <= ub->byteCount);
+    gl.bindBufferRange(ub->gl.binding, GLuint(index), ub->gl.id, offset, size);
     CHECK_GL_ERROR(utils::slog.e)
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -79,8 +79,6 @@ public:
             GLuint id = 0;
             GLenum binding = 0;
         } gl;
-        uint32_t base = 0;
-        uint32_t size = 0;
         BufferUsage usage = {};
     };
 
@@ -357,8 +355,6 @@ private:
     OpenGLPlatform& mPlatform;
 
     void updateStreamAcquired(GLTexture* t, DriverApi* driver) noexcept;
-    void updateBuffer(GLBufferObject* buffer, BufferDescriptor const& p,
-            uint32_t byteOffset, uint32_t alignment = 16) noexcept;
     void updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept;
 
     void setExternalTexture(GLTexture* t, void* image);

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -96,7 +96,6 @@ io::ostream& operator<<(io::ostream& out, BufferUsage usage) {
     switch (usage) {
         CASE(BufferUsage, STATIC)
         CASE(BufferUsage, DYNAMIC)
-        CASE(BufferUsage, STREAM)
     }
     return out;
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -889,6 +889,24 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
     scheduleDestroy(std::move(bd));
 }
 
+void VulkanDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> boh,
+        BufferDescriptor&& bd, uint32_t byteOffset) {
+    auto bo = handle_cast<VulkanBufferObject*>(boh);
+    // TODO: implement unsynchronized version
+    bo->buffer.loadFromCpu(mContext, mStagePool, bd.buffer, byteOffset, bd.size);
+    mDisposer.acquire(bo);
+    scheduleDestroy(std::move(bd));
+}
+
+void VulkanDriver::resetBufferObject(Handle<HwBufferObject> boh) {
+    // TODO: implement resetBufferObject(). This is equivalent to calling
+    // destroyBufferObject() followed by createBufferObject() keeping the same handle.
+    // It is actually okay to keep a no-op implementation, the intention here is to "orphan" the
+    // buffer (and possibly return it to a pool) and allocate a new one (or get it from a pool),
+    // so that no further synchronization with the GPU is needed.
+    // This is only useful if updateBufferObjectUnsynchronized() is implemented unsynchronizedly.
+}
+
 void VulkanDriver::update2DImage(Handle<HwTexture> th,
         uint32_t level, uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         PixelBufferDescriptor&& data) {

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -282,7 +282,8 @@ void FScene::updateUBOs(
     }
 
     // update the UBO
-    driver.updateBufferObject(renderableUbh, {
+    driver.resetBufferObject(renderableUbh);
+    driver.updateBufferObjectUnsynchronized(renderableUbh, {
             buffer, count * sizeof(PerRenderableData),
             +[](void* p, size_t s, void* user) {
                 if (s >= MAX_STREAM_ALLOCATION_COUNT * sizeof(PerRenderableData)) {

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -558,7 +558,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
                 mRenderableUBOSize = uint32_t(count * sizeof(PerRenderableData));
                 driver.destroyBufferObject(mRenderableUbh);
                 mRenderableUbh = driver.createBufferObject(mRenderableUBOSize,
-                        BufferObjectBinding::UNIFORM, BufferUsage::STREAM);
+                        BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
             } else {
                 // TODO: should we shrink the underlying UBO at some point?
             }


### PR DESCRIPTION
Unsynchronized update just means that the buffer is updated regardless
if what the gpu is doing, the synchronization is the responsibility of
the caller.


Also added resetBufferObject(), which essentially destroys and reallocate
a buffer for the same handle.


With this change, per-renderable UBO updates are no longer using the
unsynchronized algorithm. We will reinstate this later.