### PR TITLE
Fix HwRenderPrimitiveFactory with NoopDriver

### DIFF
--- a/filament/src/HwRenderPrimitiveFactory.cpp
+++ b/filament/src/HwRenderPrimitiveFactory.cpp
@@ -89,6 +89,17 @@ RenderPrimitiveHandle HwRenderPrimitiveFactory::create(DriverApi& driver,
         // create the backend object
         auto handle = driver.createRenderPrimitive(vbh, ibh,
                 type, offset, minIndex, maxIndex, count);
+
+        // First, check if the handle is already in our set. This shouldn't normally happen, except
+        // when the driver always returns the same handle for render primitives (such as the
+        // NoopDriver).
+        auto pos = mMap.find(handle.getId());
+        if (UTILS_UNLIKELY(pos != mMap.end())) {
+            auto ipos = pos->second;
+            ipos->refs++;
+            return ipos->handle;
+        }
+
         // insert key/handle in our set with a refcount of 1
         // IMPORTANT: std::set<> doesn't invalidate iterators in insert/erase
         auto [ipos, _] = mSet.insert({ key, handle, 1 });


### PR DESCRIPTION
Problem: the `NoopDriver` always returns the same handle for RenderPrimitives (even if the buffers are different). This break's `HwRenderPrimitiveFactory`'s assumption that `createRenderPrimitive` will always be unique. What ends up happening is multiple `RenderPrimitive`s map to the same `HwRenderPrimitive`, which causes an assertion to fail upon a Google3 test termination.