### PR TITLE
Vk: set ENUMERATE_PORTABILITY_BIT for MoltenVK.

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -116,20 +116,15 @@ void VulkanContext::selectPhysicalDevice() {
         for (uint32_t k = 0; k < extensionCount; ++k) {
             if (!strcmp(extensions[k].extensionName, VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
                 supportsSwapchain = true;
-            }
-            if (!strcmp(extensions[k].extensionName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
+            } else if (!strcmp(extensions[k].extensionName, VK_EXT_DEBUG_MARKER_EXTENSION_NAME)) {
                 debugMarkersSupported = true;
-            }
-            if (!strcmp(extensions[k].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+            } else if (!strcmp(extensions[k].extensionName, VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
                 portabilitySubsetSupported = true;
-            }
-            if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME)) {
+            } else if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME)) {
                 maintenanceSupported[0] = true;
-            }
-            if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE2_EXTENSION_NAME)) {
+            } else if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE2_EXTENSION_NAME)) {
                 maintenanceSupported[1] = true;
-            }
-            if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE3_EXTENSION_NAME)) {
+            } else if (!strcmp(extensions[k].extensionName, VK_KHR_MAINTENANCE3_EXTENSION_NAME)) {
                 maintenanceSupported[2] = true;
             }
         }
@@ -240,8 +235,7 @@ void VulkanContext::createLogicalDevice() {
         deviceCreateInfo.pNext = &portability;
     }
 
-    VkResult result = vkCreateDevice(physicalDevice, &deviceCreateInfo, VKALLOC,
-            &device);
+    VkResult result = vkCreateDevice(physicalDevice, &deviceCreateInfo, VKALLOC, &device);
     ASSERT_POSTCONDITION(result == VK_SUCCESS, "vkCreateDevice error.");
     vkGetDeviceQueue(device, graphicsQueueFamilyIndex, 0,
             &graphicsQueue);

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -82,6 +82,7 @@ struct VulkanContext {
     bool debugMarkersSupported = false;
     bool debugUtilsSupported = false;
     bool portabilitySubsetSupported = false;
+    bool portabilityEnumerationSupported = false;
     bool maintenanceSupported[3] = {};
     VulkanPipelineCache::RasterState rasterState;
     VulkanSwapChain* currentSwapChain;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -118,7 +118,8 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
     for  (const auto& extProps : availableExts) {
         if (!strcmp(extProps.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
             mContext.debugUtilsSupported = true;
-            break;
+        } else if (!strcmp(extProps.extensionName, VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+            mContext.portabilityEnumerationSupported = true;
         }
     }
 
@@ -187,18 +188,21 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
     uint32_t enabledExtensionCount = 0;
 
     // Request all cross-platform extensions.
-    ppEnabledExtensions[enabledExtensionCount++] = "VK_KHR_surface";
-    ppEnabledExtensions[enabledExtensionCount++] = "VK_KHR_get_physical_device_properties2";
+    ppEnabledExtensions[enabledExtensionCount++] = VK_KHR_SURFACE_EXTENSION_NAME;
+    ppEnabledExtensions[enabledExtensionCount++] = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME;
 #if VK_ENABLE_VALIDATION
 #if defined(__ANDROID__)
-    ppEnabledExtensions[enabledExtensionCount++] = "VK_EXT_debug_report";
+    ppEnabledExtensions[enabledExtensionCount++] = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 #endif
     if (validationFeaturesSupported) {
-        ppEnabledExtensions[enabledExtensionCount++] = "VK_EXT_validation_features";
+        ppEnabledExtensions[enabledExtensionCount++] = VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME;
     }
 #endif
     if (mContext.debugUtilsSupported) {
-        ppEnabledExtensions[enabledExtensionCount++] = "VK_EXT_debug_utils";
+        ppEnabledExtensions[enabledExtensionCount++] = VK_EXT_DEBUG_UTILS_EXTENSION_NAME;
+    }
+    if (mContext.portabilityEnumerationSupported) {
+        ppEnabledExtensions[enabledExtensionCount++] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
     }
 
     // Request platform-specific extensions.
@@ -215,6 +219,9 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
     instanceCreateInfo.pApplicationInfo = &appInfo;
     instanceCreateInfo.enabledExtensionCount = enabledExtensionCount;
     instanceCreateInfo.ppEnabledExtensionNames = ppEnabledExtensions;
+    if (mContext.portabilityEnumerationSupported) {
+        instanceCreateInfo.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    }
 
     VkValidationFeaturesEXT features = {};
     VkValidationFeatureEnableEXT enables[] = {


### PR DESCRIPTION
This lets us avoid the following validation error.

    Attempting to create a VkDevice from a VkPhysicalDevice which is
    from a portability driver without the
    VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR bit in the
    VkInstanceCreateInfo flags being set...