### PR TITLE
Vk: remove slow allocations workaround.

### DIFF
--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -37,7 +37,7 @@ VulkanBuffer::VulkanBuffer(VulkanContext& context, VulkanStagePool& stagePool,
         .usage = usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT
     };
 
-    VmaAllocationCreateInfo allocInfo { .pool = context.vmaPoolGPU };
+    VmaAllocationCreateInfo allocInfo { .usage = VMA_MEMORY_USAGE_GPU_ONLY };
     vmaCreateBuffer(context.allocator, &bufferInfo, &allocInfo, &mGpuBuffer, &mGpuMemory, nullptr);
 }
 

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -271,38 +271,6 @@ void VulkanContext::createLogicalDevice() {
         .instance = instance
     };
     vmaCreateAllocator(&allocatorInfo, &allocator);
-
-    const uint32_t memTypeBits = UINT32_MAX;
-
-    // Create a GPU memory pool for VkBuffer objects that ignores the bufferImageGranularity field
-    // in VkPhysicalDeviceLimits. We have observed that honoring bufferImageGranularity can cause
-    // the allocator to slow to a crawl.
-    uint32_t memTypeIndex = UINT32_MAX;
-    const VmaAllocationCreateInfo gpuInfo = { .usage = VMA_MEMORY_USAGE_GPU_ONLY };
-    UTILS_UNUSED_IN_RELEASE VkResult res = vmaFindMemoryTypeIndex(allocator, memTypeBits, &gpuInfo,
-            &memTypeIndex);
-    assert_invariant(res == VK_SUCCESS && memTypeIndex != UINT32_MAX);
-    const VmaPoolCreateInfo gpuPoolInfo {
-        .memoryTypeIndex = memTypeIndex,
-        .flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT,
-        .blockSize = VMA_BUFFER_POOL_BLOCK_SIZE_IN_MB * 1024 * 1024,
-    };
-    res = vmaCreatePool(allocator, &gpuPoolInfo, &vmaPoolGPU);
-    assert_invariant(res == VK_SUCCESS);
-
-    // Next, create a similar pool but for CPU mappable memory (typically used as a staging area).
-    memTypeIndex = UINT32_MAX;
-    const VmaAllocationCreateInfo cpuInfo = { .usage = VMA_MEMORY_USAGE_CPU_ONLY };
-    res = vmaFindMemoryTypeIndex(allocator, memTypeBits, &cpuInfo, &memTypeIndex);
-    assert_invariant(res == VK_SUCCESS && memTypeIndex != UINT32_MAX);
-    const VmaPoolCreateInfo cpuPoolInfo {
-        .memoryTypeIndex = memTypeIndex,
-        .flags = VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT,
-        .blockSize = VMA_BUFFER_POOL_BLOCK_SIZE_IN_MB * 1024 * 1024,
-    };
-    res = vmaCreatePool(allocator, &cpuPoolInfo, &vmaPoolCPU);
-    assert_invariant(res == VK_SUCCESS);
-
     commands = new VulkanCommands(device, graphicsQueueFamilyIndex);
 }
 

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -91,8 +91,6 @@ struct VulkanContext {
     VkViewport viewport;
     VkFormat finalDepthFormat;
     VmaAllocator allocator;
-    VmaPool vmaPoolGPU;
-    VmaPool vmaPoolCPU;
     VulkanTexture* emptyTexture = nullptr;
     VulkanCommands* commands = nullptr;
     std::string currentDebugMarker;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -347,8 +347,6 @@ void VulkanDriver::terminate() {
     mFramebufferCache.reset();
     mSamplerCache.reset();
 
-    vmaDestroyPool(mContext.allocator, mContext.vmaPoolGPU);
-    vmaDestroyPool(mContext.allocator, mContext.vmaPoolCPU);
     vmaDestroyAllocator(mContext.allocator);
 
     vkDestroyQueryPool(mContext.device, mContext.timestamps.pool, VKALLOC);

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -50,7 +50,7 @@ VulkanStage const* VulkanStagePool::acquireStage(uint32_t numBytes) {
         .size = numBytes,
         .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
     };
-    VmaAllocationCreateInfo allocInfo { .pool = mContext.vmaPoolCPU };
+    VmaAllocationCreateInfo allocInfo { .usage = VMA_MEMORY_USAGE_CPU_ONLY };
     UTILS_UNUSED_IN_RELEASE VkResult result = vmaCreateBuffer(mContext.allocator, &bufferInfo,
             &allocInfo, &stage->buffer, &stage->memory, nullptr);
 


### PR DESCRIPTION
Now that we've updated vkmemalloc, the "poor allocator performance" workaround (#4128) is no longer necessary. Removing this fixes #5432.