### PR TITLE
Quick repair to matdbg for alignment padding.

### DIFF
--- a/libs/matdbg/README.md
+++ b/libs/matdbg/README.md
@@ -333,6 +333,7 @@ These chunks have the following layout.
     [u32] Compression
     [u32] Blob count
     for each blob:
+        [u8 ...] Alignment padding
         [u64] Byte count
         [u8 u8 u8 ...]
 


### PR DESCRIPTION
This needs to be refactored for a proper fix that shares code
with the flattener / unflattener pipeline.