### PR TITLE
matc: add --template option.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - Vulkan: smol-v blobs are now 8-byte aligned within the filamat archive. [⚠️ **Recompile Materials**]
 - backend: added support for EGL on linux (headless)
 - uberz tool: add --append and --template arguments.
+- matc tool: add --template argument.
 
 ## v1.23.3
 

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -64,21 +64,26 @@ set(UBERZ_OUTPUT_PATH "${RESOURCE_DIR}/default.uberz")
 
 function(build_ubershader NAME SRC SHADINGMODEL BLENDING)
     set(DEST "${RESOURCE_DIR}/${NAME}")
-    configure_file(materials/${SRC}.mat.in "${DEST}.mat")
+    configure_file(materials/${SRC}.mat.in "${DEST}.mat" COPYONLY)
     configure_file(materials/${SRC}.spec.in "${DEST}.spec" COPYONLY)
-    add_custom_command(
-            OUTPUT "${NAME}.filamat"
-            COMMAND matc ${MATC_BASE_FLAGS} -o "${NAME}.filamat" "${NAME}.mat"
-            DEPENDS matc "${DEST}.mat"
-            WORKING_DIRECTORY ${RESOURCE_DIR}
-            COMMENT "Compiling material ${NAME}")
 
-    set(UBERZ_ARGS
-        -o ${UBERZ_OUTPUT_PATH}
+    set(TEMPLATE_ARGS
+        -TCUSTOM_PARAMS="// no custom params"
+        -TCUSTOM_VERTEX="// no custom vertex"
+        -TCUSTOM_FRAGMENT="// no custom fragment"
         -TDOUBLESIDED=false
         -TTRANSPARENCY=default
         -TSHADINGMODEL=${SHADINGMODEL}
         -TBLENDING=${BLENDING})
+
+    add_custom_command(
+        OUTPUT "${NAME}.filamat"
+        COMMAND matc ${MATC_BASE_FLAGS} ${TEMPLATE_ARGS} -o "${NAME}.filamat" "${NAME}.mat"
+        DEPENDS matc "${DEST}.mat"
+        WORKING_DIRECTORY ${RESOURCE_DIR}
+        COMMENT "Compiling material ${NAME}")
+
+    set(UBERZ_ARGS -o ${UBERZ_OUTPUT_PATH} ${TEMPLATE_ARGS})
 
     # Invoke uberz to consume foo.spec + foo.filamat and produce default.uberz
     # The first time this is invoked, it omits the --append argument.

--- a/tools/matc/src/matc/CommandlineConfig.h
+++ b/tools/matc/src/matc/CommandlineConfig.h
@@ -74,12 +74,12 @@ public:
     }
 
     std::unique_ptr<const char[]> read() noexcept override {
-        auto mMaterialBuffer = std::unique_ptr<const char[]>(new char[mFilesize]);
-        if (!mFile.read(const_cast<char*>(mMaterialBuffer.get()), mFilesize)) {
+        auto buffer = std::make_unique<char[]>(mFilesize);
+        if (!mFile.read(buffer.get(), mFilesize)) {
             std::cerr << "Unable to read material source file '" << mPath << "'" << std::endl;
             return nullptr;
         }
-         return mMaterialBuffer;
+        return std::unique_ptr<const char[]>(buffer.release());
     }
 
     bool close() noexcept override {

--- a/tools/matc/src/matc/Config.h
+++ b/tools/matc/src/matc/Config.h
@@ -22,8 +22,8 @@
 
 #include <filamat/MaterialBuilder.h>
 
+#include <map>
 #include <memory>
-#include <unordered_map>
 #include <ostream>
 
 #include <utils/compiler.h>
@@ -40,6 +40,11 @@ public:
     using Platform = filamat::MaterialBuilder::Platform;
     using TargetApi = filamat::MaterialBuilder::TargetApi;
     using Optimization = filamat::MaterialBuilder::Optimization;
+
+    // For defines and template args, we use an ordered map with a transparent comparator.
+    // Even though the key is stored using std::string, this allows you to make lookups using
+    // std::string_view. There is no need to construct a std::string object just to make a lookup.
+    using StringReplacementMap = std::map<std::string, std::string, std::less<>>;
 
     enum class Metadata {
         NONE,
@@ -114,8 +119,12 @@ public:
         return mVariantFilter;
     }
 
-    const std::unordered_map<std::string, std::string>& getDefines() const noexcept {
+    const StringReplacementMap& getDefines() const noexcept {
         return mDefines;
+    }
+
+    const StringReplacementMap& getTemplateMap() const noexcept {
+        return mTemplateMap;
     }
 
 protected:
@@ -128,7 +137,8 @@ protected:
     Platform mPlatform = Platform::ALL;
     OutputFormat mOutputFormat = OutputFormat::BLOB;
     TargetApi mTargetApi = (TargetApi) 0;
-    std::unordered_map<std::string, std::string> mDefines;
+    StringReplacementMap mDefines;
+    StringReplacementMap mTemplateMap;
     filament::UserVariantFilterMask mVariantFilter = 0;
 };
 

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -264,7 +264,67 @@ bool MaterialCompiler::run(const Config& config) {
         std::cerr << "Input file is empty" << std::endl;
         return false;
     }
-    auto buffer = input->read();
+    std::unique_ptr<const char[]> buffer = input->read();
+
+    // Perform template substitutions in two passes: the first pass determines the size of the
+    // modified buffer and checks for errors. The second pass rebuilds the buffer.
+    const auto& templateMap = config.getTemplateMap();
+    ssize_t modifiedSize = size;
+    bool modified = false;
+    if (!templateMap.empty()) {
+        for (ssize_t cursor = 0, n = size - 1; cursor < n; ++cursor) {
+            if (UTILS_LIKELY(buffer[cursor] != '$' || buffer[cursor + 1] != '{')) {
+                continue;
+            }
+            cursor += 2;
+            ssize_t endCursor = cursor;
+            while (true) {
+                if (endCursor == size) {
+                    std::cerr << "Unexpected end of file" << std::endl;
+                    return false;
+                }
+                if (buffer[endCursor] == '}') {
+                    break;
+                }
+                ++endCursor;
+            }
+            // At this point, cursor points to the F in ${FOO} and endCursor points to the }.
+            std::string_view macro(&buffer[cursor], endCursor - cursor);
+            if (auto iter = templateMap.find(macro); iter != templateMap.end()) {
+                modifiedSize -= macro.size() + 3;
+                modifiedSize += iter->second.size();
+            } else {
+                std::cerr << "Undefined template macro:" << macro << std::endl;
+                return false;
+            }
+            modified = true;
+        }
+    }
+
+    // Second pass of template substitution allocates a new buffer and performs the actual
+    // substitutions. Since the first pass did not return early, we can safely assume no errors.
+    if (modified) {
+        auto modifiedBuffer = std::make_unique<char[]>(modifiedSize);
+        for (ssize_t cursor = 0, dstCursor = 0; cursor < size; ++cursor) {
+            const ssize_t next = cursor + 1;
+            if (UTILS_LIKELY(buffer[cursor] != '$' || next >= size || buffer[next] != '{')) {
+                modifiedBuffer[dstCursor++] = buffer[cursor];
+                continue;
+            }
+            cursor += 2;
+            ssize_t endCursor = cursor;
+            while (buffer[endCursor] != '}') ++endCursor;
+            // At this point, cursor points to the F in ${FOO} and endCursor points to the }.
+            std::string_view macro(&buffer[cursor], endCursor - cursor);
+            const std::string& val = templateMap.find(macro)->second;
+            for (size_t i = 0, n = val.size(); i < n; ++i, ++dstCursor) {
+                modifiedBuffer[dstCursor] = val[i];
+            }
+            cursor = endCursor;
+        }
+        buffer.reset(modifiedBuffer.release());
+        size = modifiedSize;
+    }
 
     utils::Path materialFilePath = utils::Path(input->getName()).getAbsolutePath();
     assert(materialFilePath.isFile());


### PR DESCRIPTION
This makes it easier to generate ubershaders without the fancy CMake machinery available in its `configure_file` command.