### PR TITLE
ImGuiHelper: add support for Y flip.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 
 ## v1.23.3
 
+- ImGuiHelper: add support for Y flip.
 - materials: add a new `instanced` material parameter that is now mandatory in order to call `getInstanceIndex()`
 - gltfio: UbershaderProvider now takes the ubershader archive in its constructor [⚠️ **API Change**]
 - gltfio: Fix morphing with sparse accessors.

--- a/libs/filagui/include/filagui/ImGuiHelper.h
+++ b/libs/filagui/include/filagui/ImGuiHelper.h
@@ -53,7 +53,8 @@ public:
     ~ImGuiHelper();
 
     // Informs ImGui of the current display size, as well as a scaling factor when scissoring.
-    void setDisplaySize(int width, int height, float scaleX = 1.0f, float scaleY = 1.0f);
+    void setDisplaySize(int width, int height, float scaleX = 1.0f,
+            float scaleY = 1.0f, bool flipVertical = false);
 
     // High-level utility method that takes a callback for creating all ImGui windows and widgets.
     // Clients are responsible for rendering the View. This should be called on every frame,
@@ -93,6 +94,7 @@ public:
       bool mHasSynced = false;
       ImGuiContext* mImGuiContext;
       filament::TextureSampler mSampler;
+      bool mFlipVertical = false;
 };
 
 } // namespace filagui


### PR DESCRIPTION
Reflects a change from Betty and should be cherry picked to v1.23.3

Users could customize the ImGuiHelper camera, but they had no control
over the scissor coordinates. This allows them to use vertically flipped
coordinates, which, unfortunately, is required for MediaPipe
integration.