### PR TITLE
Fix swallowed errors in MaterialParser.

### DIFF
--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -96,16 +96,19 @@ ChunkContainer const& MaterialParser::getChunkContainer() const noexcept {
 
 MaterialParser::ParseResult MaterialParser::parse() noexcept {
     ChunkContainer& cc = getChunkContainer();
-    if (cc.parse()) {
-        if (!cc.hasChunk(mImpl.mMaterialTag) || !cc.hasChunk(mImpl.mDictionaryTag)) {
-            return ParseResult::ERROR_MISSING_BACKEND;
-        }
-        if (!DictionaryReader::unflatten(cc, mImpl.mDictionaryTag, mImpl.mBlobDictionary)) {
-            return ParseResult::ERROR_OTHER;
-        }
-        if (!mImpl.mMaterialChunk.initialize(mImpl.mMaterialTag)) {
-            return ParseResult::ERROR_OTHER;
-        }
+    if (UTILS_UNLIKELY(!cc.parse())) {
+        return ParseResult::ERROR_OTHER;
+    }
+    const ChunkType matTag = mImpl.mMaterialTag;
+    const ChunkType dictTag = mImpl.mDictionaryTag;
+    if (UTILS_UNLIKELY(!cc.hasChunk(matTag) || !cc.hasChunk(dictTag))) {
+        return ParseResult::ERROR_MISSING_BACKEND;
+    }
+    if (UTILS_UNLIKELY(!DictionaryReader::unflatten(cc, dictTag, mImpl.mBlobDictionary))) {
+        return ParseResult::ERROR_OTHER;
+    }
+    if (UTILS_UNLIKELY(!mImpl.mMaterialChunk.initialize(matTag))) {
+        return ParseResult::ERROR_OTHER;
     }
     return ParseResult::SUCCESS;
 }


### PR DESCRIPTION
If `ChunkContainer::parse` failed, then `MaterialParser::parse` was returning SUCCESS.