### PR TITLE
`Renderer::getUserTime()` now returns seconds as documented

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## main branch
 
 - Metal: implement scissor support.
+- engine: `Renderer::getUserTime()` now returns seconds as documented (#5722) [⚠️ **API Fix**]
 
 ## v1.25.1
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -62,7 +62,7 @@ void Renderer::endFrame() {
 }
 
 double Renderer::getUserTime() const {
-    return upcast(this)->getUserTime().count();
+    return upcast(this)->getUserTime();
 }
 
 void Renderer::resetUserTime() {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -140,7 +140,11 @@ private:
     backend::TextureFormat getLdrFormat(bool translucent) const noexcept;
 
     Epoch getUserEpoch() const { return mUserEpoch; }
-    duration getUserTime() const noexcept { return clock::now() - getUserEpoch(); }
+    double getUserTime() const noexcept {
+        duration d = clock::now() - getUserEpoch();
+        // convert the duration (whatever it is) to a duration in seconds encoded as double
+        return std::chrono::duration<double>(d).count();
+    }
 
     void getRenderTarget(FView const& view,
             backend::TargetBufferFlags& outAttachementMask,


### PR DESCRIPTION
Fixes #5722