### PR TITLE
filamat: dictionaries now store each blob once, not twice. 

### DIFF
--- a/libs/filamat/src/eiff/BlobDictionary.cpp
+++ b/libs/filamat/src/eiff/BlobDictionary.cpp
@@ -28,7 +28,6 @@ size_t BlobDictionary::addBlob(const std::vector<uint32_t>& vblob) noexcept {
     }
     mBlobIndices.emplace(blob, mBlobs.size());
     mBlobs.emplace_back(blob);
-    mStorageSize += blob.size();
     return mBlobs.size() - 1;
 }
 

--- a/libs/filamat/src/eiff/BlobDictionary.cpp
+++ b/libs/filamat/src/eiff/BlobDictionary.cpp
@@ -26,8 +26,8 @@ size_t BlobDictionary::addBlob(const std::vector<uint32_t>& vblob) noexcept {
     if (iter != mBlobIndices.end()) {
         return iter->second;
     }
-    mBlobIndices.emplace(blob, mBlobs.size());
-    mBlobs.emplace_back(blob);
+    mBlobs.emplace_back(std::make_unique<std::string>(blob));
+    mBlobIndices.emplace(*mBlobs.back(), mBlobs.size() - 1);
     return mBlobs.size() - 1;
 }
 

--- a/libs/filamat/src/eiff/BlobDictionary.h
+++ b/libs/filamat/src/eiff/BlobDictionary.h
@@ -17,9 +17,11 @@
 #ifndef TNT_FILAMAT_BLOBDICTIONARY_H
 #define TNT_FILAMAT_BLOBDICTIONARY_H
 
-#include <cassert>
+#include <memory>
 #include <string>
-#include <map>
+#include <string_view>
+#include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace filamat {
@@ -27,6 +29,12 @@ namespace filamat {
 // Establish a blob <-> id mapping. Note that std::string may have binary data with null characters.
 class BlobDictionary {
 public:
+    BlobDictionary() = default;
+
+    // Due to the presence of unique_ptr, disallow copy construction but allow move construction.
+    BlobDictionary(BlobDictionary const&) = delete;
+    BlobDictionary(BlobDictionary&&) = default;
+
     // Adds a blob if it's not already a duplicate and returns its index.
     size_t addBlob(const std::vector<uint32_t>& blob) noexcept;
 
@@ -38,17 +46,13 @@ public:
         return mBlobs.size() == 0;
     }
 
-    const std::string& getBlob(size_t index) const noexcept {
-        assert(index < mBlobs.size());
-        return mBlobs[index];
+    std::string_view getBlob(size_t index) const noexcept {
+        return *mBlobs[index];
     }
 
 private:
-
-    // Use an ordered map with a transparent comparator to allow lookups using
-    // std::string_view without need for construction of a std::string object.
-    std::map<std::string, size_t, std::less<>> mBlobIndices;
-    std::vector<std::string> mBlobs;
+    std::unordered_map<std::string_view, size_t> mBlobIndices;
+    std::vector<std::unique_ptr<std::string>> mBlobs;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/BlobDictionary.h
+++ b/libs/filamat/src/eiff/BlobDictionary.h
@@ -24,24 +24,14 @@
 
 namespace filamat {
 
-// Establish a blob <-> id mapping. Note that std::string may binary data with null characters.
+// Establish a blob <-> id mapping. Note that std::string may have binary data with null characters.
 class BlobDictionary {
 public:
-    BlobDictionary() : mStorageSize(0) {
-    }
-
-    ~BlobDictionary() = default;
-
     // Adds a blob if it's not already a duplicate and returns its index.
     size_t addBlob(const std::vector<uint32_t>& blob) noexcept;
 
     size_t getBlobCount() const noexcept {
         return mBlobs.size();
-    }
-
-    // Returns the total storage size, assuming that each blob is prefixed with a 64-bit size.
-    size_t getSize() const noexcept {
-        return mStorageSize + 8 * getBlobCount();
     }
 
     bool isEmpty() const noexcept {
@@ -59,7 +49,6 @@ private:
     // std::string_view without need for construction of a std::string object.
     std::map<std::string, size_t, std::less<>> mBlobIndices;
     std::vector<std::string> mBlobs;
-    size_t mStorageSize;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/DictionarySpirvChunk.cpp
+++ b/libs/filamat/src/eiff/DictionarySpirvChunk.cpp
@@ -21,7 +21,7 @@
 namespace filamat {
 
 DictionarySpirvChunk::DictionarySpirvChunk(BlobDictionary&& dictionary, bool stripDebugInfo) :
-        Chunk(ChunkType::DictionarySpirv), mDictionary(dictionary), mStripDebugInfo(stripDebugInfo) {
+        Chunk(ChunkType::DictionarySpirv), mDictionary(std::move(dictionary)), mStripDebugInfo(stripDebugInfo) {
 }
 
 void DictionarySpirvChunk::flatten(Flattener& f) {
@@ -36,7 +36,7 @@ void DictionarySpirvChunk::flatten(Flattener& f) {
 
     f.writeUint32(mDictionary.getBlobCount());
     for (size_t i = 0 ; i < mDictionary.getBlobCount() ; i++) {
-        const std::string& spirv = mDictionary.getBlob(i);
+        std::string_view spirv = mDictionary.getBlob(i);
         smolv::ByteArray compressed;
         if (!smolv::Encode(spirv.data(), spirv.size(), compressed, flags)) {
             utils::slog.e << "Error with SPIRV compression" << utils::io::endl;

--- a/libs/filamat/src/eiff/DictionaryTextChunk.cpp
+++ b/libs/filamat/src/eiff/DictionaryTextChunk.cpp
@@ -19,7 +19,7 @@
 namespace filamat {
 
 DictionaryTextChunk::DictionaryTextChunk(LineDictionary&& dictionary, ChunkType chunkType) :
-        Chunk(chunkType), mDictionary(dictionary) {
+        Chunk(chunkType), mDictionary(std::move(dictionary)) {
 }
 
 void DictionaryTextChunk::flatten(Flattener& f) {
@@ -28,7 +28,7 @@ void DictionaryTextChunk::flatten(Flattener& f) {
 
     // Strings
     for (size_t i = 0 ; i < mDictionary.getLineCount() ; i++) {
-        f.writeString(mDictionary.getString(i).c_str());
+        f.writeString(mDictionary.getString(i).data());
     }
 }
 

--- a/libs/filamat/src/eiff/LineDictionary.cpp
+++ b/libs/filamat/src/eiff/LineDictionary.cpp
@@ -20,9 +20,6 @@
 
 namespace filamat {
 
-    LineDictionary::LineDictionary() : mStorageSize(0){
-}
-
 const std::string& LineDictionary::getString(size_t index) const noexcept {
     assert(index < mStrings.size());
     return mStrings[index];
@@ -70,7 +67,6 @@ void LineDictionary::addLine(const std::string&& line) noexcept {
     mLineIndices[line] = mStrings.size();
     size_t size = line.size();
     mStrings.push_back(std::move(line));
-    mStorageSize += size + 1;
 }
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/LineDictionary.cpp
+++ b/libs/filamat/src/eiff/LineDictionary.cpp
@@ -16,30 +16,25 @@
 
 #include "LineDictionary.h"
 
-#include <assert.h>
-
 namespace filamat {
 
-const std::string& LineDictionary::getString(size_t index) const noexcept {
-    assert(index < mStrings.size());
-    return mStrings[index];
+std::string_view LineDictionary::getString(size_t index) const noexcept {
+    return *mStrings[index];
 }
 
 size_t LineDictionary::getLineCount() const {
     return mStrings.size();
 }
 
-size_t LineDictionary::getIndex(const std::string& s) const noexcept {
-    if (mLineIndices.find(s) == mLineIndices.end()) {
-        return SIZE_MAX;
+size_t LineDictionary::getIndex(std::string_view s) const noexcept {
+    if (auto iter = mLineIndices.find(s); iter != mLineIndices.end()) {
+        return iter->second;
     }
-    return mLineIndices.at(s);
+    return SIZE_MAX;
 }
 
 void LineDictionary::addText(const std::string& line) noexcept {
     const char* s = line.c_str();
-
-    assert(s != nullptr);
 
     size_t cur = 0;
     size_t pos = 0;
@@ -63,10 +58,8 @@ void LineDictionary::addLine(const std::string&& line) noexcept {
     if (mLineIndices.find(line) != mLineIndices.end()) {
         return;
     }
-
-    mLineIndices[line] = mStrings.size();
-    size_t size = line.size();
-    mStrings.push_back(std::move(line));
+    mStrings.emplace_back(std::make_unique<std::string>(line));
+    mLineIndices.emplace(*mStrings.back(), mStrings.size() - 1);
 }
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/LineDictionary.h
+++ b/libs/filamat/src/eiff/LineDictionary.h
@@ -27,15 +27,8 @@ namespace filamat {
 // and each line encoded into a 16 bit id.
 class LineDictionary {
 public:
-    LineDictionary();
-    ~LineDictionary() = default;
-
     void addText(const std::string& text) noexcept;
     size_t getLineCount() const;
-
-    constexpr size_t getSize() const noexcept {
-        return mStorageSize;
-    }
 
     bool isEmpty() const noexcept {
         return mStrings.empty();
@@ -49,7 +42,6 @@ private:
 
     std::unordered_map<std::string, size_t> mLineIndices;
     std::vector<std::string> mStrings;
-    size_t mStorageSize = 0;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/LineDictionary.h
+++ b/libs/filamat/src/eiff/LineDictionary.h
@@ -17,7 +17,9 @@
 #ifndef TNT_FILAMAT_LINEDICTIONARY_H
 #define TNT_FILAMAT_LINEDICTIONARY_H
 
+#include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -27,6 +29,12 @@ namespace filamat {
 // and each line encoded into a 16 bit id.
 class LineDictionary {
 public:
+    LineDictionary() = default;
+
+    // Due to the presence of unique_ptr, disallow copy construction but allow move construction.
+    LineDictionary(LineDictionary const&) = delete;
+    LineDictionary(LineDictionary&&) = default;
+
     void addText(const std::string& text) noexcept;
     size_t getLineCount() const;
 
@@ -34,14 +42,14 @@ public:
         return mStrings.empty();
     }
 
-    const std::string& getString(size_t index) const noexcept;
-    size_t getIndex(const std::string& s) const noexcept;
+    std::string_view getString(size_t index) const noexcept;
+    size_t getIndex(std::string_view s) const noexcept;
 
 private:
     void addLine(const std::string&& line) noexcept;
 
-    std::unordered_map<std::string, size_t> mLineIndices;
-    std::vector<std::string> mStrings;
+    std::unordered_map<std::string_view, size_t> mLineIndices;
+    std::vector<std::unique_ptr<std::string>> mStrings;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/MaterialTextChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialTextChunk.cpp
@@ -43,7 +43,7 @@ void compressShader(std::string_view src, Flattener &f, const LineDictionary& di
             len++;
         }
 
-        std::string newLine(s + pos, len);
+        std::string_view newLine(s + pos, len);
 
         size_t index = dictionary.getIndex(newLine);
         if (index > UINT16_MAX) {

--- a/libs/filamat/src/eiff/MaterialTextChunk.h
+++ b/libs/filamat/src/eiff/MaterialTextChunk.h
@@ -35,15 +35,14 @@ public:
 private:
     void flatten(Flattener& f) override;
 
-    const char* getShaderText(size_t entryIndex) const noexcept;
     void writeEntryAttributes(size_t entryIndex, Flattener& f) const noexcept;
 
     // Structure to keep track of duplicates.
-    struct ShaderAttribute{
+    struct ShaderMapping {
         bool isDup = false;
         size_t dupOfIndex = 0;
     };
-    std::vector<ShaderAttribute> mDuplicateMap;
+    std::vector<ShaderMapping> mDuplicateMap;
 
     const std::vector<TextEntry> mEntries;
     const LineDictionary& mDictionary;


### PR DESCRIPTION
BlobDictionary and LineDictionary were storing blobs as map keys to achieve simple compression, but they also stored duplicates in a vector for index-based lookup.

Now, the vector is storage and the map has keys that are string_view.