### PR TITLE
more Engine configuration cleanup

### DIFF
--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -227,6 +227,7 @@ public:
          */
         uint32_t minCommandBufferSizeMB = FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB;
 
+
         /**
          * Size in MiB of the per-frame high level command buffer.
          *

--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -248,8 +248,8 @@ private:
     math::float4 mParamsZ = {};
     math::uint3 mParamsF = {};
     float mNear = 0.0f;        // camera near
-    float mZLightFar = FEngine::CONFIG_Z_LIGHT_FAR;
-    float mZLightNear = FEngine::CONFIG_Z_LIGHT_NEAR;  // light near (first slice)
+    float mZLightNear;
+    float mZLightFar;
 
     // track if we need to update our internal state before froxelizing
     uint8_t mDirtyFlags = 0;

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -118,16 +118,10 @@ public:
     using Epoch = clock::time_point;
     using duration = clock::duration;
 
-    // TODO: these should come from a configuration object
-    static constexpr float  CONFIG_Z_LIGHT_NEAR            = 5;
-    static constexpr float  CONFIG_Z_LIGHT_FAR             = 100;
-    static constexpr size_t CONFIG_FROXEL_SLICE_COUNT      = 16;
-    static constexpr bool   CONFIG_IBL_USE_IRRADIANCE_MAP  = false;
-
 public:
     static FEngine* create(Backend backend = Backend::DEFAULT,
             Platform* platform = nullptr, void* sharedGLContext = nullptr,
-            const Config* config = nullptr);
+            const Config* pConfig = nullptr);
 
 #if UTILS_HAS_THREADING
     static void createAsync(CreateCallback callback, void* user,
@@ -361,11 +355,13 @@ public:
     backend::Handle<backend::HwTexture> getZeroTextureArray() const { return mDummyZeroTextureArray; }
     backend::Handle<backend::HwTexture> getOneIntegerTextureArray() const { return mDummyOneIntegerTextureArray; }
 
-    size_t getMinCommandBufferSize() const noexcept     { return mMinCommandBufferSize; }
-    size_t getCommandBufferSize() const noexcept        { return mCommandBufferSize; }
-    size_t getPerFrameCommandsSize() const noexcept     { return mPerFrameCommandsSize; }
-    size_t getPerRenderPassArenaSize() const noexcept   { return mPerRenderPassArenaSize; }
-    size_t getRequestedDriverHandleArenaSize() const noexcept   { return mRequestedDriverHandleArenaSize; }
+    static constexpr const size_t MiB = 1024u * 1024u;
+    size_t getMinCommandBufferSize() const noexcept { return mConfig.minCommandBufferSizeMB * MiB; }
+    size_t getCommandBufferSize() const noexcept { return mConfig.commandBufferSizeMB * MiB; }
+    size_t getPerFrameCommandsSize() const noexcept { return mConfig.perFrameCommandsSizeMB * MiB; }
+    size_t getPerRenderPassArenaSize() const noexcept { return mConfig.perRenderPassArenaSizeMB * MiB; }
+    size_t getRequestedDriverHandleArenaSize() const noexcept { return mConfig.driverHandleArenaSizeMB * MiB; }
+    Config const& getConfig() const noexcept { return mConfig; }
 
 private:
     static Config validateConfig(const Config* pConfig) noexcept;
@@ -480,11 +476,7 @@ private:
     std::thread::id mMainThreadId{};
 
     // Creation parameters
-    size_t mMinCommandBufferSize;           // minimum size of command buffer (in bytes)
-    size_t mCommandBufferSize;              // size of command buffer (in bytes)
-    size_t mPerFrameCommandsSize;           // size of the high-level draw commands buffer (in bytes)
-    size_t mPerRenderPassArenaSize;         // size of the per-pass arena buffer (in bytes)
-    size_t mRequestedDriverHandleArenaSize; // requested size of driver handle arena (in bytes). Driver will validate and clam
+    Config mConfig;
 
 public:
     // these are the debug properties used by FDebug. They're accessed directly by modules who need them.

--- a/filament/src/details/IndirectLight.cpp
+++ b/filament/src/details/IndirectLight.cpp
@@ -36,6 +36,9 @@ using namespace filament::math;
 
 namespace filament {
 
+// TODO: This should be a quality setting on View or LightManager
+static constexpr bool CONFIG_IBL_USE_IRRADIANCE_MAP = false;
+
 // ------------------------------------------------------------------------------------------------
 
 struct IndirectLight::BuilderDetails {
@@ -188,13 +191,13 @@ FIndirectLight::FIndirectLight(FEngine& engine, const Builder& builder) noexcept
         mIrradianceTexture = upcast(builder->mIrradianceMap);
     } else {
         // TODO: if needed, generate the irradiance map, this is an engine config
-        if (FEngine::CONFIG_IBL_USE_IRRADIANCE_MAP) {
+        if (CONFIG_IBL_USE_IRRADIANCE_MAP) {
         }
     }
 }
 
 void FIndirectLight::terminate(FEngine& engine) {
-    if (FEngine::CONFIG_IBL_USE_IRRADIANCE_MAP) {
+    if (CONFIG_IBL_USE_IRRADIANCE_MAP) {
         FEngine::DriverApi& driver = engine.getDriverApi();
         driver.destroyTexture(getIrradianceHwHandle());
     }


### PR DESCRIPTION
- add configuration for irradiance map to Config
  (currently, still unused)

- move all froxel configuration constants out of Engine.h, unlike
  the previous todo/comment, these shouldn't be part of Engine::Config.