### PR TITLE
new feature level API for backends

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- engine: new feature level APIs, see `Engine::getSupportedFeatureLevel()`
+
 ## v1.25.6
 
 - Add CONFIG_MINSPEC_UBO_SIZE as a nicer way to allow exceeding the ES3.0 minspec.

--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -328,3 +328,24 @@ Java_com_google_android_filament_Engine_nIsAutomaticInstancingEnabled(JNIEnv*, j
     Engine* engine = (Engine*) nativeEngine;
     return (jboolean)engine->isAutomaticInstancingEnabled();
 }
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Engine_nGetSupportedFeatureLevel(JNIEnv *, jclass,
+        jlong nativeEngine) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jint)engine->getSupportedFeatureLevel();
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Engine_nSetActiveFeatureLevel(JNIEnv *, jclass,
+        jlong nativeEngine, jint ordinal) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jint)engine->setActiveFeatureLevel((Engine::FeatureLevel)ordinal);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Engine_nGetActiveFeatureLevel(JNIEnv *, jclass,
+        jlong nativeEngine) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jint)engine->getActiveFeatureLevel();
+}

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -932,6 +932,36 @@ material {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+### General: featureLevel
+
+Type
+:    `number`
+
+Value
+:     An integer value, either 1 or 2. Defaults to 1.
+
+      Feature Level    |        Guaranteed features
+:----------------------|:---------------------------------
+1                      | 9 textures per material
+2                      | 12 textures per material, cubemap arrays, ESSL 3.10
+[Table [featureLevels]: Feature levels]
+
+Description
+:     Sets the feature level of the material. Each feature level defines a set of features the
+      material can use. If the material uses a feature not supported by the selected level, `matc`
+      will generate an error during compilation. A given feature level is guaranteed to support
+      all features of lower feature levels.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
+material {
+    featureLevel : 2
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bugs
+:     `matc` doesn't verify that a material is not using features above its selected feature level.
+
+
 ### General: shadingModel
 
 Type

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -64,7 +64,7 @@ static constexpr size_t CONFIG_BINDING_COUNT = 12;  // This is guaranteed by Ope
  */
 enum class FeatureLevel : uint8_t {
     FEATURE_LEVEL_1 = 1,  //!< OpenGL ES 3.0 features (default)
-    FEATURE_LEVEL_2       //!< OpenGL ES 3.1 features + 31 textures units minimum + cubemap arrays
+    FEATURE_LEVEL_2       //!< OpenGL ES 3.1 features + 31 textures units + cubemap arrays
 };
 
 /**

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -60,6 +60,14 @@ static_assert(MAX_VERTEX_BUFFER_COUNT <= MAX_VERTEX_ATTRIBUTE_COUNT,
 static constexpr size_t CONFIG_BINDING_COUNT = 12;  // This is guaranteed by OpenGL ES.
 
 /**
+ * Defines the backend's feature levels.
+ */
+enum class FeatureLevel : uint8_t {
+    FEATURE_LEVEL_1 = 1,  //!< OpenGL ES 3.0 features (default)
+    FEATURE_LEVEL_2       //!< OpenGL ES 3.1 features + 31 textures units minimum + cubemap arrays
+};
+
+/**
  * Selects which driver a particular Engine should use.
  */
 enum class Backend : uint8_t {

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -304,6 +304,7 @@ DECL_DRIVER_API_SYNCHRONOUS_N(void, cancelExternalImage, void*, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, getTimerQueryValue, backend::TimerQueryHandle, query, uint64_t*, elapsedTime)
 DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncHandle, sh)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isWorkaroundNeeded, backend::Workaround, workaround)
+DECL_DRIVER_API_SYNCHRONOUS_0(backend::FeatureLevel, getFeatureLevel)
 
 /*
  * Updating driver objects

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -688,6 +688,13 @@ bool MetalDriver::isWorkaroundNeeded(Workaround workaround) {
     return false;
 }
 
+FeatureLevel MetalDriver::getFeatureLevel() {
+    // TODO: before we can return FEATURE_LEVEL_2 we need to decouple the samplers from
+    //       the textures. Metal only supports 16 samplers, but at least 31 textures on all
+    //       hardware.
+    return FeatureLevel::FEATURE_LEVEL_1;
+}
+
 math::float2 MetalDriver::getClipSpaceParams() {
     // virtual and physical z-coordinate of clip-space is in [-w, 0]
     // Note: this is actually never used (see: main.vs), but it's a backend API so we implement it

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -177,6 +177,10 @@ bool NoopDriver::isWorkaroundNeeded(Workaround workaround) {
     return false;
 }
 
+FeatureLevel NoopDriver::getFeatureLevel() {
+    return FeatureLevel::FEATURE_LEVEL_1;
+}
+
 math::float2 NoopDriver::getClipSpaceParams() {
     return math::float2{ 1.0f, 0.0f };
 }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -125,6 +125,7 @@ public:
         GLint max_renderbuffer_size;
         GLint max_samples;
         GLint max_uniform_block_size;
+        GLint max_texture_image_units;
         GLint uniform_buffer_offset_alignment;
     } gets = {};
 
@@ -150,6 +151,7 @@ public:
         bool EXT_texture_compression_etc2 = false;
         bool EXT_texture_compression_s3tc = false;
         bool EXT_texture_compression_s3tc_srgb = false;
+        bool EXT_texture_cube_map_array = false;
         bool EXT_texture_filter_anisotropic = false;
         bool EXT_texture_sRGB = false;
         bool GOOGLE_cpp_style_line_directive = false;
@@ -210,7 +212,8 @@ public:
         // GL and Vulkan and probably Metal.
         bool allow_read_only_ancillary_feedback_loop = false;
 
-        // Some Adreno drivers would crash gl draw when there's uninitialized uniform array exists, even when the code using that uniform array is not called. it's needed to do an initialization to avoid it.
+        // Some Adreno drivers crash in glDrawXXX() when there's an uninitialized uniform block,
+        // even when the shader doesn't access it.
         bool enable_initialize_non_used_uniform_array = false;
     } bugs;
 
@@ -223,6 +226,8 @@ public:
         state.textures.units[state.textures.active].targets[index].texture_id = id;
     }
     void resetProgram() noexcept { state.program.use = 0; }
+
+    FeatureLevel getFeatureLevel() const noexcept { return mFeatureLevel; }
 
     // Try to keep the State structure sorted by data-access patterns
     struct State {
@@ -343,6 +348,7 @@ public:
 
 private:
     ShaderModel mShaderModel = ShaderModel::MOBILE;
+    FeatureLevel mFeatureLevel = FeatureLevel::FEATURE_LEVEL_1;
 
     const std::array<std::tuple<bool const&, char const*, char const*>, sizeof(bugs)> mBugDatabase{{
             {   bugs.disable_glFlush,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1633,6 +1633,10 @@ bool OpenGLDriver::isWorkaroundNeeded(Workaround workaround) {
     return false;
 }
 
+FeatureLevel OpenGLDriver::getFeatureLevel() {
+    return mContext.getFeatureLevel();
+}
+
 math::float2 OpenGLDriver::getClipSpaceParams() {
     return mContext.ext.EXT_clip_control ?
            // z-coordinate of virtual and physical clip-space is in [-w, 0]

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -884,9 +884,21 @@ bool VulkanDriver::isWorkaroundNeeded(Workaround workaround) {
     return false;
 }
 
+FeatureLevel VulkanDriver::getFeatureLevel() {
+    const auto supportedSamplerCount = std::min(
+            mContext.physicalDeviceProperties.limits.maxDescriptorSetSamplers,
+            mContext.physicalDeviceProperties.limits.maxDescriptorSetSampledImages);
+
+    const bool imageCubeArray = (bool)mContext.physicalDeviceFeatures.imageCubeArray;
+
+    return (supportedSamplerCount >= 31 && imageCubeArray) ?
+            FeatureLevel::FEATURE_LEVEL_2 :
+            FeatureLevel::FEATURE_LEVEL_1;
+}
+
 math::float2 VulkanDriver::getClipSpaceParams() {
     // virtual and physical z-coordinate of clip-space is in [-w, 0]
-    // Note: this is actually never used (see: main.vs), but it's a backend API so we implement it
+    // Note: this is actually never used (see: main.vs), but it's a backend API, so we implement it
     // properly.
     return math::float2{ 1.0f, 0.0f };
 }

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -695,7 +695,7 @@ void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) 
     ++mCurrentTime;
 
     // The Vulkan spec says: "When a command buffer begins recording, all state in that command
-    // buffer is undefined." Therefore we need to clear all bindings at this time.
+    // buffer is undefined." Therefore, we need to clear all bindings at this time.
     mBoundPipeline = {};
     mBoundLayout = {};
     mBoundDescriptor = {};

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -403,6 +403,45 @@ public:
      */
     static void destroy(Engine* engine);
 
+    using FeatureLevel = backend::FeatureLevel;
+
+
+    /**
+     * Query the feature level supported by the selected backend.
+     *
+     * A specific feature level needs to be set before the corresponding features can be used.
+     *
+     * @return FeatureLevel supported the selected backend.
+     * @see setActiveFeatureLevel
+     */
+    FeatureLevel getSupportedFeatureLevel() const noexcept;
+
+    /**
+     * Activate all features of a given feature level. By default FeatureLevel::FEATURE_LEVEL_1 is
+     * active. The selected feature level must not be higher than the value returned by
+     * getActiveFeatureLevel() and it's not possible lower the active feature level.
+     *
+     * @param featureLevel the feature level to activate. If featureLevel is lower than
+     *                     getActiveFeatureLevel(), the current (higher) feature level is kept.
+     *                     If featureLevel is higher than getSupportedFeatureLevel(), an exception
+     *                     is thrown, or the program is terminated if exceptions are disabled.
+     *
+     * @return the active feature level.
+     *
+     * @see getSupportedFeatureLevel
+     * @see getActiveFeatureLevel
+     */
+    FeatureLevel setActiveFeatureLevel(FeatureLevel featureLevel);
+
+    /**
+     * Returns the currently active feature level.
+     * @return currently active feature level
+     * @see getSupportedFeatureLevel
+     * @see setActiveFeatureLevel
+     */
+    FeatureLevel getActiveFeatureLevel() const noexcept;
+
+
     /**
      * @return EntityManager used by filament
      */

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -40,7 +40,6 @@ namespace filament {
 class BufferObject;
 class Engine;
 class IndexBuffer;
-class Material;
 class MaterialInstance;
 class Renderer;
 class SkinningBuffer;
@@ -161,10 +160,17 @@ public:
         /**
          * Binds a material instance to the specified primitive.
          *
-         * If no material is specified for a given primitive, Filament will fall back to a basic default material.
+         * If no material is specified for a given primitive, Filament will fall back to a basic
+         * default material.
          *
-         * @param index zero-based index of the primitive, must be less than the count passed to Builder constructor
+         * The MaterialInstance's material must have a feature level equal or lower to the engine's
+         * selected feature level.
+         *
+         * @param index zero-based index of the primitive, must be less than the count passed to
+         * Builder constructor
          * @param materialInstance the material to bind
+         *
+         * @see Engine::setActiveFeatureLevel
          */
         Builder& material(size_t index, MaterialInstance const* materialInstance) noexcept;
 
@@ -590,10 +596,17 @@ public:
     /**
      * Changes the material instance binding for the given primitive.
      *
-     * \see Builder::material()
+     * The MaterialInstance's material must have a feature level equal or lower to the engine's
+     * selected feature level.
+     *
+     * @exception utils::PreConditionPanic if the engine doesn't support the material's
+     *                                     feature level.
+     *
+     * @see Builder::material()
+     * @see Engine::setActiveFeatureLevel
      */
     void setMaterialInstanceAt(Instance instance,
-            size_t primitiveIndex, MaterialInstance const* materialInstance) noexcept;
+            size_t primitiveIndex, MaterialInstance const* materialInstance);
 
     /**
      * Retrieves the material instance that is bound to the given primitive.

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -261,4 +261,16 @@ bool Engine::isAutomaticInstancingEnabled() const noexcept {
     return upcast(this)->isAutomaticInstancingEnabled();
 }
 
+FeatureLevel Engine::getSupportedFeatureLevel() const noexcept {
+    return upcast(this)->getSupportedFeatureLevel();
+}
+
+FeatureLevel Engine::setActiveFeatureLevel(FeatureLevel featureLevel) {
+    return upcast(this)->setActiveFeatureLevel(featureLevel);
+}
+
+FeatureLevel Engine::getActiveFeatureLevel() const noexcept {
+    return upcast(this)->getActiveFeatureLevel();
+}
+
 } // namespace filament

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -118,6 +118,10 @@ bool MaterialParser::getMaterialVersion(uint32_t* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialVersion, value);
 }
 
+bool MaterialParser::getFeatureLevel(uint8_t* value) const noexcept {
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialFeatureLevel, value);
+}
+
 bool MaterialParser::getName(utils::CString* cstring) const noexcept {
    ChunkType type = ChunkType::MaterialName;
    const uint8_t* start = mImpl.mChunkContainer.getChunkStart(type);

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -58,6 +58,7 @@ public:
 
     // Accessors
     bool getMaterialVersion(uint32_t* value) const noexcept;
+    bool getFeatureLevel(uint8_t* value) const noexcept;
     bool getName(utils::CString*) const noexcept;
     bool getUIB(UniformInterfaceBlock* uib) const noexcept;
     bool getSIB(SamplerInterfaceBlock* sib) const noexcept;

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -89,7 +89,7 @@ size_t RenderableManager::getPrimitiveCount(Instance instance) const noexcept {
 }
 
 void RenderableManager::setMaterialInstanceAt(Instance instance,
-        size_t primitiveIndex, MaterialInstance const* materialInstance) noexcept {
+        size_t primitiveIndex, MaterialInstance const* materialInstance) {
     upcast(this)->setMaterialInstanceAt(instance, 0, primitiveIndex, upcast(materialInstance));
 }
 

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -161,7 +161,7 @@ public:
     inline size_t getLevelCount(Instance) const noexcept { return 1; }
     inline size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;
     void setMaterialInstanceAt(Instance instance, uint8_t level,
-            size_t primitiveIndex, FMaterialInstance const* materialInstance) noexcept;
+            size_t primitiveIndex, FMaterialInstance const* materialInstance);
     MaterialInstance* getMaterialInstanceAt(Instance instance, uint8_t level, size_t primitiveIndex) const noexcept;
     void setGeometryAt(Instance instance, uint8_t level, size_t primitiveIndex,
             PrimitiveType type, FVertexBuffer* vertices, FIndexBuffer* indices,

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -264,6 +264,8 @@ void FEngine::init() {
 
     DriverApi& driverApi = getDriverApi();
 
+    slog.i << "FEngine feature level: " << int(driverApi.getFeatureLevel()) << io::endl;
+
     mResourceAllocator = new ResourceAllocator(driverApi);
 
     mFullScreenTriangleVb = upcast(VertexBuffer::Builder()
@@ -588,7 +590,7 @@ int FEngine::loop() {
         mPlatform = DefaultPlatform::create(&mBackend);
         mOwnPlatform = true;
         const char* const backend = backendToString(mBackend);
-        slog.d << "FEngine resolved backend: " << backend << io::endl;
+        slog.i << "FEngine resolved backend: " << backend << io::endl;
         if (mPlatform == nullptr) {
             slog.e << "Selected backend not supported in this build." << io::endl;
             mDriverBarrier.latch();

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -1061,4 +1061,15 @@ void FEngine::destroy(FEngine* engine) {
     }
 }
 
+Engine::FeatureLevel FEngine::getSupportedFeatureLevel() const noexcept {
+    FEngine::DriverApi& driver = const_cast<FEngine*>(this)->getDriverApi();
+    return driver.getFeatureLevel();
+}
+
+Engine::FeatureLevel FEngine::setActiveFeatureLevel(FeatureLevel featureLevel) {
+    ASSERT_PRECONDITION(featureLevel <= getSupportedFeatureLevel(),
+            "Feature level %u not supported", (unsigned)featureLevel);
+    return (mActiveFeatureLevel = std::max(mActiveFeatureLevel, featureLevel));
+}
+
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -175,6 +175,14 @@ public:
         return mUvFromClipMatrix;
     }
 
+    FeatureLevel getSupportedFeatureLevel() const noexcept;
+
+    FeatureLevel setActiveFeatureLevel(FeatureLevel featureLevel);
+
+    FeatureLevel getActiveFeatureLevel() const noexcept {
+        return mActiveFeatureLevel;
+    }
+
     PostProcessManager const& getPostProcessManager() const noexcept {
         return mPostProcessManager;
     }
@@ -362,6 +370,10 @@ public:
     size_t getRequestedDriverHandleArenaSize() const noexcept { return mConfig.driverHandleArenaSizeMB * MiB; }
     Config const& getConfig() const noexcept { return mConfig; }
 
+    bool hasFeatureLevel(backend::FeatureLevel featureLevel) const noexcept {
+        return featureLevel <= mActiveFeatureLevel;
+    }
+
 private:
     static Config validateConfig(const Config* pConfig) noexcept;
 
@@ -388,6 +400,7 @@ private:
     backend::Handle<backend::HwRenderTarget> mDefaultRenderTarget;
 
     Backend mBackend;
+    FeatureLevel mActiveFeatureLevel = FeatureLevel::FEATURE_LEVEL_1;
     Platform* mPlatform = nullptr;
     bool mOwnPlatform = false;
     bool mAutomaticInstancingEnabled = false;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -105,6 +105,7 @@ public:
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 
     const utils::CString& getName() const noexcept { return mName; }
+    backend::FeatureLevel getFeatureLevel() const noexcept { return mFeatureLevel; }
     backend::RasterState getRasterState() const noexcept  { return mRasterState; }
     uint32_t getId() const noexcept { return mMaterialId; }
 
@@ -196,6 +197,7 @@ private:
     BlendingMode mRenderBlendingMode = BlendingMode::OPAQUE;
     TransparencyMode mTransparencyMode = TransparencyMode::DEFAULT;
     bool mIsVariantLit = false;
+    backend::FeatureLevel mFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1;
     Shading mShading = Shading::UNLIT;
 
     BlendingMode mBlendingMode = BlendingMode::OPAQUE;

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -50,6 +50,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
 
     MaterialName = charTo64bitNum("MAT_NAME"),
     MaterialVersion = charTo64bitNum("MAT_VERS"),
+    MaterialFeatureLevel = charTo64bitNum("MAT_FEAT"),
     MaterialShading = charTo64bitNum("MAT_SHAD"),
     MaterialBlendingMode = charTo64bitNum("MAT_BLEN"),
     MaterialTransparencyMode = charTo64bitNum("MAT_TRMD"),

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -206,6 +206,7 @@ public:
     using SamplerFormat = filament::backend::SamplerFormat;
     using ParameterPrecision = filament::backend::Precision;
     using CullingMode = filament::backend::CullingMode;
+    using FeatureLevel = filament::backend::FeatureLevel;
 
     enum class VariableQualifier : uint8_t {
         OUT
@@ -359,6 +360,8 @@ public:
 
 
     MaterialBuilder& quality(ShaderQuality quality) noexcept;
+
+    MaterialBuilder& featureLevel(FeatureLevel featureLevel) noexcept;
 
     //! Set the blending mode for this material.
     MaterialBuilder& blending(BlendingMode blending) noexcept;
@@ -654,7 +657,7 @@ private:
     // and vertex shaders in mProperties.
     bool findProperties(filament::backend::ShaderType type,
             MaterialBuilder::PropertyList& p) noexcept;
-    bool runSemanticAnalysis() noexcept;
+    bool runSemanticAnalysis(MaterialInfo const& info) noexcept;
 
     bool checkLiteRequirements() noexcept;
 
@@ -709,6 +712,7 @@ private:
     OutputList mOutputs;
 
     ShaderQuality mShaderQuality = ShaderQuality::DEFAULT;
+    FeatureLevel mFeatureLevel = FeatureLevel::FEATURE_LEVEL_1;
     BlendingMode mBlendingMode = BlendingMode::OPAQUE;
     BlendingMode mPostLightingBlendingMode = BlendingMode::TRANSPARENT;
     CullingMode mCullingMode = CullingMode::BACK;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1045,6 +1045,7 @@ std::string MaterialBuilder::peek(filament::backend::ShaderType type,
 
 void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo& info) const noexcept {
     container.addSimpleChild<uint32_t>(ChunkType::MaterialVersion, filament::MATERIAL_VERSION);
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialFeatureLevel, (uint8_t)mFeatureLevel);
     container.addSimpleChild<const char*>(ChunkType::MaterialName, mMaterialName.c_str_safe());
     container.addSimpleChild<uint32_t>(ChunkType::MaterialShaderModels, mShaderModels.getValue());
     container.addSimpleChild<uint8_t>(ChunkType::MaterialDomain, static_cast<uint8_t>(mMaterialDomain));

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -271,6 +271,11 @@ MaterialBuilder& MaterialBuilder::quality(ShaderQuality quality) noexcept {
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::featureLevel(FeatureLevel featureLevel) noexcept {
+    mFeatureLevel = featureLevel;
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::blending(BlendingMode blending) noexcept {
     mBlendingMode = blending;
     return *this;
@@ -499,6 +504,7 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.useLegacyMorphing = mUseLegacyMorphing;
     info.instanced = mInstanced;
     info.vertexDomainDeviceJittered = mVertexDomainDeviceJittered;
+    info.featureLevel = mFeatureLevel;
 }
 
 bool MaterialBuilder::findProperties(filament::backend::ShaderType type,
@@ -546,7 +552,7 @@ bool MaterialBuilder::findAllProperties() noexcept {
 #endif
 }
 
-bool MaterialBuilder::runSemanticAnalysis() noexcept {
+bool MaterialBuilder::runSemanticAnalysis(MaterialInfo const& info) noexcept {
 #ifndef FILAMAT_LITE
     using namespace filament::backend;
     GLSLTools glslTools;
@@ -561,12 +567,12 @@ bool MaterialBuilder::runSemanticAnalysis() noexcept {
 
     ShaderModel model = static_cast<ShaderModel>(mSemanticCodeGenParams.shaderModel);
     std::string shaderCode = peek(ShaderType::VERTEX, mSemanticCodeGenParams, mProperties);
-    bool result = glslTools.analyzeVertexShader(shaderCode, model, mMaterialDomain, targetApi);
+    bool result = glslTools.analyzeVertexShader(shaderCode, model, mMaterialDomain, targetApi, info);
     if (!result) return false;
 
     shaderCode = peek(ShaderType::FRAGMENT, mSemanticCodeGenParams, mProperties);
     result = glslTools.analyzeFragmentShader(shaderCode, model, mMaterialDomain, targetApi,
-            mCustomSurfaceShading);
+            mCustomSurfaceShading, info);
     return result;
 #else
     return true;
@@ -953,12 +959,12 @@ Package MaterialBuilder::build(JobSystem& jobSystem) noexcept {
     }
 
     // prepareToBuild must be called first, to populate mCodeGenPermutations.
-    MaterialInfo info {};
+    MaterialInfo info{};
     prepareToBuild(info);
 
     // Run checks, in order.
     // The call to findProperties populates mProperties and must come before runSemanticAnalysis.
-    if (!checkLiteRequirements() || !findAllProperties() || !runSemanticAnalysis()) {
+    if (!checkLiteRequirements() || !findAllProperties() || !runSemanticAnalysis(info)) {
         // Return an empty package to signal a failure to build the material.
         return Package::invalidPackage();
     }

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -22,6 +22,7 @@
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>
 #include <filamat/MaterialBuilder.h>
+#include "../shaders/MaterialInfo.h"
 
 #include <utils/Log.h>
 
@@ -53,7 +54,8 @@ GLSLangCleaner::~GLSLangCleaner() {
 
 bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel model,
         MaterialBuilder::MaterialDomain materialDomain,
-        MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading) const noexcept {
+        MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading,
+        MaterialInfo const& info) const noexcept {
 
     // Parse to check syntax and semantic.
     const char* shaderCString = shaderCode.c_str();
@@ -88,6 +90,18 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
         utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find " << materialFunctionName << "() function" << utils::io::endl;
         return false;
+    }
+
+    switch (info.featureLevel) {
+        case FeatureLevel::FEATURE_LEVEL_1:
+            // TODO: feature level checks
+            //  - check no more than 9 samplers are used by the user and 16 total
+            //  - check cubemap arrays are not used
+            break;
+        case FeatureLevel::FEATURE_LEVEL_2:
+            // TODO: feature level checks
+            //  - check no more than 12 samplers are used by the user and 31 total
+            break;
     }
 
     // If this is a post-process material, at this point we've successfully met all the
@@ -129,7 +143,8 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
 
 bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel model,
         MaterialBuilder::MaterialDomain materialDomain,
-        MaterialBuilder::TargetApi targetApi) const noexcept {
+        MaterialBuilder::TargetApi targetApi,
+        MaterialInfo const& info) const noexcept {
 
     // TODO: After implementing post-process vertex shaders, properly analyze them here.
     if (materialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
@@ -159,6 +174,18 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel m
         utils::slog.e << "ERROR: Invalid vertex shader" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find materialVertex() function" << utils::io::endl;
         return false;
+    }
+
+    switch (info.featureLevel) {
+        case FeatureLevel::FEATURE_LEVEL_1:
+            // TODO: feature level checks
+            //  - check no more than 9 samplers are used by the user and 16 total
+            //  - check cubemap arrays are not used
+            break;
+        case FeatureLevel::FEATURE_LEVEL_2:
+            // TODO: feature level checks
+            //  - check no more than 12 samplers are used by the user and 31 total
+            break;
     }
 
     return true;

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -124,12 +124,14 @@ public:
     bool analyzeFragmentShader(const std::string& shaderCode,
             filament::backend::ShaderModel model,
             MaterialBuilder::MaterialDomain materialDomain,
-            MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading) const noexcept;
+            MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading,
+            MaterialInfo const& info) const noexcept;
 
     bool analyzeVertexShader(const std::string& shaderCode,
             filament::backend::ShaderModel model,
             MaterialBuilder::MaterialDomain materialDomain,
-            MaterialBuilder::TargetApi targetApi) const noexcept;
+            MaterialBuilder::TargetApi targetApi,
+            MaterialInfo const& info) const noexcept;
 
     // Public for unit tests.
     using Property = MaterialBuilder::Property;

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -56,31 +56,32 @@ public:
     filament::backend::ShaderModel getShaderModel() const noexcept { return mShaderModel; }
 
     // insert a separator (can be a new line)
-    static utils::io::sstream& generateSeparator(utils::io::sstream& out) ;
+    static utils::io::sstream& generateSeparator(utils::io::sstream& out);
 
     // generate prolog for the given shader
-    utils::io::sstream& generateProlog(utils::io::sstream& out, ShaderType type, bool hasExternalSamplers) const;
+    utils::io::sstream& generateProlog(utils::io::sstream& out, ShaderType type,
+            MaterialInfo const& info) const;
 
-    static utils::io::sstream& generateEpilog(utils::io::sstream& out) ;
+    static utils::io::sstream& generateEpilog(utils::io::sstream& out);
 
     // generate common functions for the given shader
-    static utils::io::sstream& generateCommon(utils::io::sstream& out, ShaderType type) ;
-    static utils::io::sstream& generatePostProcessCommon(utils::io::sstream& out, ShaderType type) ;
-    static utils::io::sstream& generateCommonMaterial(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generateCommon(utils::io::sstream& out, ShaderType type);
+    static utils::io::sstream& generatePostProcessCommon(utils::io::sstream& out, ShaderType type);
+    static utils::io::sstream& generateCommonMaterial(utils::io::sstream& out, ShaderType type);
 
-    static utils::io::sstream& generateFog(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generateFog(utils::io::sstream& out, ShaderType type);
 
     // generate the shader's main()
-    static utils::io::sstream& generateShaderMain(utils::io::sstream& out, ShaderType type) ;
-    static utils::io::sstream& generatePostProcessMain(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generateShaderMain(utils::io::sstream& out, ShaderType type);
+    static utils::io::sstream& generatePostProcessMain(utils::io::sstream& out, ShaderType type);
 
     // generate the shader's code for the lit shading model
     static utils::io::sstream& generateShaderLit(utils::io::sstream& out, ShaderType type,
-            filament::Variant variant, filament::Shading shading, bool customSurfaceShading) ;
+            filament::Variant variant, filament::Shading shading, bool customSurfaceShading);
 
     // generate the shader's code for the unlit shading model
     static utils::io::sstream& generateShaderUnlit(utils::io::sstream& out, ShaderType type,
-            filament::Variant variant, bool hasShadowMultiplier) ;
+            filament::Variant variant, bool hasShadowMultiplier);
 
     // generate the shader's code for the screen-space reflections
     static utils::io::sstream& generateShaderReflections(utils::io::sstream& out, ShaderType type,
@@ -88,12 +89,12 @@ public:
 
     // generate declarations for custom interpolants
     static utils::io::sstream& generateVariable(utils::io::sstream& out, ShaderType type,
-            const utils::CString& name, size_t index) ;
+            const utils::CString& name, size_t index);
 
     // generate declarations for non-custom "in" variables
     static utils::io::sstream& generateShaderInputs(utils::io::sstream& out, ShaderType type,
-        const filament::AttributeBitset& attributes, filament::Interpolation interpolation) ;
-    static utils::io::sstream& generatePostProcessInputs(utils::io::sstream& out, ShaderType type) ;
+        const filament::AttributeBitset& attributes, filament::Interpolation interpolation);
+    static utils::io::sstream& generatePostProcessInputs(utils::io::sstream& out, ShaderType type);
 
     // generate declarations for custom output variables
     utils::io::sstream& generateOutput(utils::io::sstream& out, ShaderType type,
@@ -102,7 +103,7 @@ public:
             MaterialBuilder::OutputType outputType) const;
 
     // generate no-op shader for depth prepass
-    static utils::io::sstream& generateDepthShaderMain(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generateDepthShaderMain(utils::io::sstream& out, ShaderType type);
 
     // generate uniforms
     utils::io::sstream& generateUniforms(utils::io::sstream& out, ShaderType type, uint8_t binding,
@@ -114,23 +115,23 @@ public:
 
     // generate subpass
     static utils::io::sstream& generateSubpass(utils::io::sstream& out,
-            filament::SubpassInfo subpass) ;
+            filament::SubpassInfo subpass);
 
     // generate material properties getters
     static utils::io::sstream& generateMaterialProperty(utils::io::sstream& out,
-            MaterialBuilder::Property property, bool isSet) ;
+            MaterialBuilder::Property property, bool isSet);
 
     utils::io::sstream& generateQualityDefine(utils::io::sstream& out, ShaderQuality quality) const;
 
-    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, bool value) ;
-    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, uint32_t value) ;
-    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, const char* string) ;
+    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, bool value);
+    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, uint32_t value);
+    static utils::io::sstream& generateDefine(utils::io::sstream& out, const char* name, const char* string);
     static utils::io::sstream& generateIndexedDefine(utils::io::sstream& out, const char* name,
-            uint32_t index, uint32_t value) ;
+            uint32_t index, uint32_t value);
 
-    static utils::io::sstream& generatePostProcessGetters(utils::io::sstream& out, ShaderType type) ;
-    static utils::io::sstream& generateGetters(utils::io::sstream& out, ShaderType type) ;
-    static utils::io::sstream& generateParameters(utils::io::sstream& out, ShaderType type) ;
+    static utils::io::sstream& generatePostProcessGetters(utils::io::sstream& out, ShaderType type);
+    static utils::io::sstream& generateGetters(utils::io::sstream& out, ShaderType type);
+    static utils::io::sstream& generateParameters(utils::io::sstream& out, ShaderType type);
 
     static void fixupExternalSamplers(
             std::string& shader, filament::SamplerInterfaceBlock const& sib) noexcept;

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -61,6 +61,7 @@ struct UTILS_PUBLIC MaterialInfo {
     filament::SubpassInfo subpass;
     filament::SamplerBindingMap samplerBindings;
     filament::ShaderQuality quality;
+    filament::backend::FeatureLevel featureLevel;
 };
 
 }

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -181,7 +181,7 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage);
     const bool lit = material.isLit;
 
-    cg.generateProlog(vs, ShaderType::VERTEX, material.hasExternalSamplers);
+    cg.generateProlog(vs, ShaderType::VERTEX, material);
 
     cg.generateQualityDefine(vs, material.quality);
 
@@ -306,7 +306,7 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     const bool lit = material.isLit;
 
     io::sstream fs;
-    cg.generateProlog(fs, ShaderType::FRAGMENT, material.hasExternalSamplers);
+    cg.generateProlog(fs, ShaderType::FRAGMENT, material);
 
     cg.generateQualityDefine(fs, material.quality);
 
@@ -525,7 +525,7 @@ std::string ShaderGenerator::createPostProcessVertexProgram(
         const filament::Variant::type_t variantKey, SamplerBindingMap const& samplerBindingMap) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage);
     io::sstream vs;
-    cg.generateProlog(vs, ShaderType::VERTEX, false);
+    cg.generateProlog(vs, ShaderType::VERTEX, material);
 
     cg.generateQualityDefine(vs, material.quality);
 
@@ -566,7 +566,7 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(
         uint8_t variant, const SamplerBindingMap& samplerBindingMap) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage);
     io::sstream fs;
-    cg.generateProlog(fs, ShaderType::FRAGMENT, false);
+    cg.generateProlog(fs, ShaderType::FRAGMENT, material);
 
     cg.generateQualityDefine(fs, material.quality);
 

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -86,6 +86,7 @@ static void printStringChunk(ostream& json, const ChunkContainer& container,
 static bool printMaterial(ostream& json, const ChunkContainer& container) {
     printStringChunk(json, container, MaterialName, "name");
     printUint32Chunk(json, container, MaterialVersion, "version");
+    printUint32Chunk(json, container, MaterialFeatureLevel, "feature_level");
     json << "\"shading\": {\n";
     printChunk<Shading, uint8_t>(json, container, MaterialShading, "model");
     printChunk<MaterialDomain, uint8_t>(json, container, ChunkType::MaterialDomain, "material_domain");

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -95,6 +95,12 @@ static bool printMaterial(ostream& text, const ChunkContainer& container) {
         text << version << endl;
     }
 
+    uint8_t featureLevel;
+    if (read(container, MaterialFeatureLevel, &featureLevel)) {
+        text << "    " << setw(alignment) << left << "Feature level: ";
+        text << featureLevel << endl;
+    }
+
     CString name;
     if (read(container, MaterialName, &name)) {
         text << "    " << setw(alignment) << left << "Name: ";

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -391,6 +391,12 @@ class_<Engine>("Engine")
 
     .function("isAutomaticInstancingEnabled", &Engine::isAutomaticInstancingEnabled)
 
+    .function("getSupportedFeatureLevel", &Engine::getSupportedFeatureLevel)
+
+    .function("setActiveFeatureLevel", &Engine::setActiveFeatureLevel)
+
+    .function("getActiveFeatureLevel", &Engine::getActiveFeatureLevel)
+
     .function("_execute", EMBIND_LAMBDA(void, (Engine* engine), {
         EM_ASM_INT({
             const handle = window.filament_contextHandle;

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -399,6 +399,10 @@ enum_<backend::CullingMode>("CullingMode")
     .value("BACK", backend::CullingMode::BACK)
     .value("FRONT_AND_BACK", backend::CullingMode::FRONT_AND_BACK);
 
+enum_<backend::FeatureLevel>("FeatureLevel")
+    .value("FEATURE_LEVEL_1", backend::FeatureLevel::FEATURE_LEVEL_1)
+    .value("FEATURE_LEVEL_2", backend::FeatureLevel::FEATURE_LEVEL_2);
+
 enum_<ktxreader::Ktx2Reader::TransferFunction>("Ktx2Reader$TransferFunction")
     .value("LINEAR", ktxreader::Ktx2Reader::TransferFunction::LINEAR)
     .value("sRGB", ktxreader::Ktx2Reader::TransferFunction::sRGB);


### PR DESCRIPTION
backend can now return a "feature level", each level corresponds to a
"bundle" of features.
Level1: ES3.0 capabilities
Level2: ES3.1 capabilities + 31 textures + cubemap arrays


Currently metal always returns level 1, GL and Vulkan return level 2
if 31 textures or more are supported.