### PR TITLE
Upgrade to emscripten 3.1.15 and remove workaround.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -352,7 +352,7 @@ same version that our continuous builds use.
 
 ```
 cd <your chosen parent folder for the emscripten SDK>
-curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.9.zip > emsdk.zip
+curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.15.zip > emsdk.zip
 unzip emsdk.zip ; mv emsdk-* emsdk ; cd emsdk
 python ./emsdk.py install latest
 python ./emsdk.py activate latest

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- WebGL: upgraded the JS bindings to work with emsdk 3.1.15
+
 ## v1.25.4
 
 - backend: streamline texture upload APIs [⚠️ **API Change**]

--- a/build/web/ci-common.sh
+++ b/build/web/ci-common.sh
@@ -17,7 +17,7 @@ export PATH="$PWD:$PATH"
 # npm install -g typescript
 
 # Install emscripten.
-curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.9.zip > emsdk.zip
+curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.15.zip > emsdk.zip
 unzip emsdk.zip ; mv emsdk-* emsdk ; cd emsdk
 ./emsdk install latest
 ./emsdk activate latest

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -145,53 +145,6 @@ namespace emscripten {
         BIND(utils::EntityManager)
         BIND(VertexBuffer)
         BIND(View)
-
-        // embind is missing a template definition for "noexcept" methods, so
-        // we're supplying it ourselves while waiting for the upstream fix.
-        template<typename ClassType, typename ReturnType, typename... Args>
-        struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept> {
-
-            template <typename CT, typename... Policies>
-            static void invoke(const char* methodName,
-                               ReturnType (ClassType::*memberFunction)(Args...) noexcept)  {
-                auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, ClassType*, Args...>::invoke;
-
-                typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<ClassType>, Args...> args;
-                _embind_register_class_function(
-                    TypeID<ClassType>::get(),
-                    methodName,
-                    args.getCount(),
-                    args.getTypes(),
-                    getSignature(invoker),
-                    reinterpret_cast<GenericFunction>(invoker),
-                    getContext(memberFunction),
-                    isPureVirtual<Policies...>::value);
-            }
-        };
-
-        // embind is missing a template definition for "const noexcept" methods, so
-        // we're supplying it ourselves while waiting for the upstream fix.
-        template<typename ClassType, typename ReturnType, typename... Args>
-        struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept> {
-
-            template <typename CT, typename... Policies>
-            static void invoke(const char* methodName,
-                               ReturnType (ClassType::*memberFunction)(Args...) const noexcept)  {
-                auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, const ClassType*, Args...>::invoke;
-
-                typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<const ClassType>, Args...> args;
-                _embind_register_class_function(
-                    TypeID<ClassType>::get(),
-                    methodName,
-                    args.getCount(),
-                    args.getTypes(),
-                    getSignature(invoker),
-                    reinterpret_cast<GenericFunction>(invoker),
-                    getContext(memberFunction),
-                    isPureVirtual<Policies...>::value);
-            }
-        };
-
     }
 }
 #undef BIND


### PR DESCRIPTION
Starting with 3.1.14, embind started to support for `noexcept`
which caused multiple definition errors since we have a workaround
in place that alreadys supplies template instantiations for `noexcept`.

This change should not affect G3 since our JS bindings are not used
in G3.

The upstream fix is here:
https://github.com/emscripten-core/emscripten/pull/17140

Fixes #5789.