### PR TITLE
Use staging buffers to implement Metal buffer updates

### DIFF
--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -52,9 +52,6 @@ public:
      * @return The MTLBuffer representing the current state of the buffer to bind, or nil if there
      * is no device allocation.
      *
-     * For STREAM buffers, getGpuBufferStreamOffset() should be called to retrieve the correct
-     * buffer offset.
-     *
      */
     id<MTLBuffer> getGpuBufferForDraw(id<MTLCommandBuffer> cmdBuffer) noexcept;
 
@@ -77,9 +74,8 @@ public:
 
 private:
 
-    BufferUsage mUsage;
+    id<MTLBuffer> mBuffer = nil;
     size_t mBufferSize = 0;
-    const MetalBufferPoolEntry* mBufferPoolEntry = nullptr;
     void* mCpuBuffer = nullptr;
     MetalContext& mContext;
 };

--- a/filament/backend/src/metal/MetalBufferPool.mm
+++ b/filament/backend/src/metal/MetalBufferPool.mm
@@ -43,6 +43,7 @@ MetalBufferPoolEntry const* MetalBufferPool::acquireBuffer(size_t numBytes) {
     // We were not able to find a sufficiently large stage, so create a new one.
     id<MTLBuffer> buffer = [mContext.device newBufferWithLength:numBytes
                                                         options:MTLResourceStorageModeShared];
+    ASSERT_POSTCONDITION(buffer, "Could not allocate Metal staging buffer of size %zu.", numBytes);
     MetalBufferPoolEntry* stage = new MetalBufferPoolEntry({
         .buffer = buffer,
         .capacity = numBytes,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -703,6 +703,8 @@ void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&
 
 void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& data,
         uint32_t byteOffset) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "updateBufferObject must be called outside of a render pass.");
     auto* bo = handle_cast<MetalBufferObject>(boh);
     bo->updateBuffer(data.buffer, data.size, byteOffset);
     scheduleDestroy(std::move(data));

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -110,16 +110,16 @@ void BackendTest::fullViewport(Viewport& viewport) {
 }
 
 void BackendTest::renderTriangle(Handle<HwRenderTarget> renderTarget,
-        Handle<HwSwapChain> swapChain, Handle<HwProgram> program) {
+        Handle<HwSwapChain> swapChain, Handle<HwProgram> program, bool clear) {
     auto& api = getDriverApi();
 
     TrianglePrimitive triangle(api);
 
     RenderPassParams params = {};
     fullViewport(params);
-    params.flags.clear = TargetBufferFlags::COLOR;
+    params.flags.clear = clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE;
     params.clearColor = {0.f, 0.f, 1.f, 1.f};
-    params.flags.discardStart = TargetBufferFlags::ALL;
+    params.flags.discardStart = clear ? TargetBufferFlags::ALL : TargetBufferFlags::NONE;
     params.flags.discardEnd = TargetBufferFlags::NONE;
     params.viewport.height = 512;
     params.viewport.width = 512;

--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -109,20 +109,26 @@ void BackendTest::fullViewport(Viewport& viewport) {
     viewport.height = view.height;
 }
 
-void BackendTest::renderTriangle(Handle<HwRenderTarget> renderTarget,
-        Handle<HwSwapChain> swapChain, Handle<HwProgram> program, bool clear) {
-    auto& api = getDriverApi();
-
-    TrianglePrimitive triangle(api);
-
+void BackendTest::renderTriangle(
+        filament::backend::Handle<filament::backend::HwRenderTarget> renderTarget,
+        filament::backend::Handle<filament::backend::HwSwapChain> swapChain,
+        filament::backend::Handle<filament::backend::HwProgram> program) {
     RenderPassParams params = {};
     fullViewport(params);
-    params.flags.clear = clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE;
+    params.flags.clear = TargetBufferFlags::COLOR;
     params.clearColor = {0.f, 0.f, 1.f, 1.f};
-    params.flags.discardStart = clear ? TargetBufferFlags::ALL : TargetBufferFlags::NONE;
+    params.flags.discardStart = TargetBufferFlags::ALL;
     params.flags.discardEnd = TargetBufferFlags::NONE;
     params.viewport.height = 512;
     params.viewport.width = 512;
+    renderTriangle(renderTarget, swapChain, program, params);
+}
+
+void BackendTest::renderTriangle(Handle<HwRenderTarget> renderTarget,
+        Handle<HwSwapChain> swapChain, Handle<HwProgram> program, const RenderPassParams& params) {
+    auto& api = getDriverApi();
+
+    TrianglePrimitive triangle(api);
 
     api.makeCurrent(swapChain, swapChain);
 

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -53,7 +53,8 @@ protected:
 
     void renderTriangle(filament::backend::Handle<filament::backend::HwRenderTarget> renderTarget,
             filament::backend::Handle<filament::backend::HwSwapChain> swapChain,
-            filament::backend::Handle<filament::backend::HwProgram> program);
+            filament::backend::Handle<filament::backend::HwProgram> program,
+            bool clear = false);
 
     void readPixelsAndAssertHash(const char* testName, size_t width, size_t height,
             filament::backend::Handle<filament::backend::HwRenderTarget> rt, uint32_t expectedHash,

--- a/filament/backend/test/BackendTest.h
+++ b/filament/backend/test/BackendTest.h
@@ -53,8 +53,11 @@ protected:
 
     void renderTriangle(filament::backend::Handle<filament::backend::HwRenderTarget> renderTarget,
             filament::backend::Handle<filament::backend::HwSwapChain> swapChain,
+            filament::backend::Handle<filament::backend::HwProgram> program);
+    void renderTriangle(filament::backend::Handle<filament::backend::HwRenderTarget> renderTarget,
+            filament::backend::Handle<filament::backend::HwSwapChain> swapChain,
             filament::backend::Handle<filament::backend::HwProgram> program,
-            bool clear = false);
+            const filament::backend::RenderPassParams& params);
 
     void readPixelsAndAssertHash(const char* testName, size_t width, size_t height,
             filament::backend::Handle<filament::backend::HwRenderTarget> rt, uint32_t expectedHash,

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -27,7 +27,7 @@ static constexpr filament::math::float2 gVertices[3] = {
     { -1.0,  1.0 }
 };
 
-static constexpr short gIndices[3] = { 0, 1, 2 };
+static constexpr TrianglePrimitive::index_type gIndices[3] = { 0, 1, 2 };
 
 TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
         bool allocateLargeBuffers) : mDriverApi(driverApi) {
@@ -53,9 +53,10 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     BufferDescriptor vertexBufferDesc(gVertices, size);
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
 
-    mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
-            BufferUsage::STATIC);
-    BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3);
+    ElementType elementType = ElementType::UINT;
+    static_assert(sizeof(index_type) == 4);
+    mIndexBuffer = mDriverApi.createIndexBuffer(elementType, mIndexCount, BufferUsage::STATIC);
+    BufferDescriptor indexBufferDesc(gIndices, sizeof(index_type) * 3);
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 
     mRenderPrimitive = mDriverApi.createRenderPrimitive(
@@ -74,28 +75,28 @@ void TrianglePrimitive::updateVertices(const filament::math::float2 vertices[3])
     mDriverApi.updateBufferObject(mBufferObject, std::move(vBuffer), 0);
 }
 
-void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
-    void* buffer = malloc(sizeof(short) * mIndexCount);
-    short* indexBuffer = (short*) buffer;
+void TrianglePrimitive::updateIndices(const index_type indices[3]) noexcept {
+    void* buffer = malloc(sizeof(index_type) * mIndexCount);
+    index_type* indexBuffer = (index_type*) buffer;
     std::copy(indices, indices + 3, indexBuffer);
 
-    BufferDescriptor bufferDesc(indexBuffer, sizeof(short) * mIndexCount,
+    BufferDescriptor bufferDesc(indexBuffer, sizeof(index_type) * mIndexCount,
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), 0);
 }
 
-void TrianglePrimitive::updateIndices(const short* indices, int count, int offset) noexcept {
-    void* buffer = malloc(sizeof(short) * count);
-    short* indexBuffer = (short*) buffer;
+void TrianglePrimitive::updateIndices(const index_type* indices, int count, int offset) noexcept {
+    void* buffer = malloc(sizeof(index_type) * count);
+    index_type* indexBuffer = (index_type*) buffer;
     std::copy(indices, indices + count, indexBuffer);
 
-    BufferDescriptor bufferDesc(indexBuffer, sizeof(short) * count,
+    BufferDescriptor bufferDesc(indexBuffer, sizeof(index_type) * count,
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
-    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), offset * sizeof(short));
+    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), offset * sizeof(index_type));
 }
 
 TrianglePrimitive::~TrianglePrimitive() {

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -43,14 +43,16 @@ public:
     using VertexHandle = filament::backend::Handle<filament::backend::HwVertexBuffer>;
     using IndexHandle = filament::backend::Handle<filament::backend::HwIndexBuffer>;
 
+    using index_type = uint32_t;
+
     TrianglePrimitive(filament::backend::DriverApi& driverApi, bool allocateLargeBuffers = false);
     ~TrianglePrimitive();
 
     PrimitiveHandle getRenderPrimitive() const noexcept;
 
     void updateVertices(const filament::math::float2 vertices[3]) noexcept;
-    void updateIndices(const short* indices) noexcept;
-    void updateIndices(const short* indices, int count, int offset) noexcept;
+    void updateIndices(const index_type* indices) noexcept;
+    void updateIndices(const index_type* indices, int count, int offset) noexcept;
 
 private:
 

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -233,7 +233,14 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
         getDriverApi().updateBufferObject(ubuffer, std::move(bd), 64);
     }
 
-    renderTriangle(renderTarget, swapChain, program, true);
+    RenderPassParams params = {};
+    params.flags.clear = TargetBufferFlags::COLOR;
+    params.clearColor = {0.f, 0.f, 1.f, 1.f};
+    params.flags.discardStart = TargetBufferFlags::ALL;
+    params.flags.discardEnd = TargetBufferFlags::NONE;
+    params.viewport.height = 512;
+    params.viewport.width = 512;
+    renderTriangle(renderTarget, swapChain, program, params);
 
     // Upload uniforms for the second triangle. To test partial buffer updates, we'll only update
     // color.b, color.a, offset.x, and offset.y.
@@ -251,7 +258,9 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
         getDriverApi().updateBufferObject(ubuffer, std::move(bd), 64 + offsetof(MaterialParams, color.b));
     }
 
-    renderTriangle(renderTarget, swapChain, program);
+    params.flags.clear = TargetBufferFlags::NONE;
+    params.flags.discardStart = TargetBufferFlags::NONE;
+    renderTriangle(renderTarget, swapChain, program, params);
 
     static const uint32_t expectedHash = 91322442;
     readPixelsAndAssertHash(


### PR DESCRIPTION
This PR changes how Metal handles buffer updates. Previously, Metal allocated a full new buffer each time an `updateBufferObject` command was issued; however, it did not copy the previous contents of the buffer over to the new buffer, so partial updates did not work correctly.

Now, Metal allocates a single, private GPU buffer and employs temporary staging buffers whose contents get blitted to the private buffer at each update.

There's still some room for optimizations, and I need to give more thought to how I want to implement `updateBufferObjectUnsynchronized`.