### PR TITLE
Add support for cubemap arrays in the backends

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -235,11 +235,12 @@ enum class Precision : uint8_t {
 
 //! Texture sampler type
 enum class SamplerType : uint8_t {
-    SAMPLER_2D,         //!< 2D texture
-    SAMPLER_2D_ARRAY,   //!< 2D array texture
-    SAMPLER_CUBEMAP,    //!< Cube map texture
-    SAMPLER_EXTERNAL,   //!< External texture
-    SAMPLER_3D,         //!< 3D texture
+    SAMPLER_2D,             //!< 2D texture
+    SAMPLER_2D_ARRAY,       //!< 2D array texture
+    SAMPLER_CUBEMAP,        //!< Cube map texture
+    SAMPLER_EXTERNAL,       //!< External texture
+    SAMPLER_3D,             //!< 3D texture
+    SAMPLER_CUBEMAP_ARRAY,  //!< Cube map array texture (feature level 2)
 };
 
 //! Subpass type

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -260,6 +260,8 @@ constexpr inline MTLTextureType getMetalType(SamplerType target) {
             return MTLTextureTypeCube;
         case SamplerType::SAMPLER_3D:
             return MTLTextureType3D;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            return MTLTextureTypeCubeArray;
     }
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -346,7 +346,7 @@ private:
                 GLuint sampler = 0;
                 struct {
                     GLuint texture_id = 0;
-                } targets[6];  // this must match getIndexForTextureTarget()
+                } targets[7];  // this must match getIndexForTextureTarget()
             } units[MAX_TEXTURE_UNIT_COUNT];
         } textures;
 
@@ -399,13 +399,15 @@ private:
 constexpr size_t OpenGLContext::getIndexForTextureTarget(GLuint target) noexcept {
     // this must match state.textures[].targets[]
     switch (target) {
-        case GL_TEXTURE_2D:             return 0;
-        case GL_TEXTURE_2D_ARRAY:       return 1;
-        case GL_TEXTURE_CUBE_MAP:       return 2;
-        case GL_TEXTURE_2D_MULTISAMPLE: return 3;
-        case GL_TEXTURE_EXTERNAL_OES:   return 4;
-        case GL_TEXTURE_3D:             return 5;
-        default:                        return 0;
+        case GL_TEXTURE_2D:                     return 0;
+        case GL_TEXTURE_2D_ARRAY:               return 1;
+        case GL_TEXTURE_CUBE_MAP:               return 2;
+        case GL_TEXTURE_2D_MULTISAMPLE:         return 3;
+        case GL_TEXTURE_EXTERNAL_OES:           return 4;
+        case GL_TEXTURE_3D:                     return 5;
+        case GL_TEXTURE_CUBE_MAP_ARRAY:         return 6;
+        default:
+            return 0;
     }
 }
 

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -55,10 +55,10 @@
 #ifdef GL_EXT_clip_control
         extern PFNGLCLIPCONTROLEXTPROC glClipControl;
         #ifndef GL_LOWER_LEFT
-        #define GL_LOWER_LEFT GL_LOWER_LEFT_EXT
+        #   define GL_LOWER_LEFT GL_LOWER_LEFT_EXT
         #endif
         #ifndef GL_ZERO_TO_ONE
-        #define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
+        #   define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
         #endif
 #endif
     }
@@ -82,7 +82,17 @@
 
     #define glDebugMessageCallback            glext::glDebugMessageCallbackKHR
 
-    using namespace glext;
+    #define GL_TEXTURE_CUBE_MAP_ARRAY               0x9009
+    #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
+    #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C
+    #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW        0x900D
+    #define GL_INT_SAMPLER_CUBE_MAP_ARRAY           0x900E
+    #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY  0x900F
+    #define GL_IMAGE_CUBE_MAP_ARRAY                 0x9054
+    #define GL_INT_IMAGE_CUBE_MAP_ARRAY             0x905F
+    #define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY    0x906A
+
+using namespace glext;
 
 #elif defined(IOS)
 
@@ -96,6 +106,16 @@
 
     #define GL_TEXTURE_2D_MULTISAMPLE         0x9100
     #define GL_TIME_ELAPSED                   0x88BF
+
+    #define GL_TEXTURE_CUBE_MAP_ARRAY               0x9009
+    #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
+    #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C
+    #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW        0x900D
+    #define GL_INT_SAMPLER_CUBE_MAP_ARRAY           0x900E
+    #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY  0x900F
+    #define GL_IMAGE_CUBE_MAP_ARRAY                 0x9054
+    #define GL_INT_IMAGE_CUBE_MAP_ARRAY             0x905F
+    #define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY    0x906A
 
 #ifdef GL_EXT_multisampled_render_to_texture
     extern PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -117,6 +117,7 @@ io::ostream& operator<<(io::ostream& out, SamplerType type) {
         CASE(SamplerType, SAMPLER_2D_ARRAY)
         CASE(SamplerType, SAMPLER_3D)
         CASE(SamplerType, SAMPLER_CUBEMAP)
+        CASE(SamplerType, SAMPLER_CUBEMAP_ARRAY)
         CASE(SamplerType, SAMPLER_EXTERNAL)
     }
     return out;

--- a/filament/backend/src/vulkan/VulkanUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanUtility.cpp
@@ -607,6 +607,8 @@ VkImageViewType getImageViewType(SamplerType target) {
             return VK_IMAGE_VIEW_TYPE_CUBE;
         case SamplerType::SAMPLER_2D_ARRAY:
             return VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            return VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         case  SamplerType::SAMPLER_3D:
             return VK_IMAGE_VIEW_TYPE_3D;
         default:

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -218,6 +218,8 @@ static const char* getSamplerTypeName(SamplerType samplerType) {
             return "samplerCube";
         case SamplerType::SAMPLER_3D:
             return "sampler3D";
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            return "samplerCubeArray";
     }
 }
 

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -160,6 +160,7 @@ FTexture::FTexture(FEngine& engine, const Builder& builder) {
         case SamplerType::SAMPLER_2D_ARRAY:
         case SamplerType::SAMPLER_CUBEMAP:
         case SamplerType::SAMPLER_EXTERNAL:
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
             maxLevelCount = FTexture::maxLevelCount(mWidth, mHeight);
             break;
         case SamplerType::SAMPLER_3D:
@@ -218,6 +219,8 @@ void FTexture::setImage(FEngine& engine, size_t level,
                 return true;
             case SamplerType::SAMPLER_EXTERNAL:
                 return false;
+            case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+                return false; // feature level 2
         }
     };
 
@@ -276,6 +279,9 @@ void FTexture::setImage(FEngine& engine, size_t level,
         case SamplerType::SAMPLER_CUBEMAP:
             textureDepthOrLayers = 6;
             break;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            textureDepthOrLayers = mDepth * 6;
+            break;
     }
 
     if (!ASSERT_POSTCONDITION_NON_FATAL(zoffset + depth <= textureDepthOrLayers,
@@ -303,6 +309,7 @@ void FTexture::setImage(FEngine& engine, size_t level,
             case SamplerType::SAMPLER_2D:
             case SamplerType::SAMPLER_3D:
             case SamplerType::SAMPLER_2D_ARRAY:
+            case SamplerType::SAMPLER_CUBEMAP_ARRAY:
             case SamplerType::SAMPLER_EXTERNAL:
                 return false;
         }
@@ -440,6 +447,12 @@ void FTexture::generateMipmaps(FEngine& engine) const noexcept {
         case SamplerType::SAMPLER_2D_ARRAY:
             UTILS_NOUNROLL
             for (uint16_t layer = 0, c = mDepth; layer < c; ++layer) {
+                generateMipsForLayer({ .layer = layer });
+            }
+            break;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            UTILS_NOUNROLL
+            for (uint16_t layer = 0, c = mDepth * 6; layer < c; ++layer) {
                 generateMipsForLayer({ .layer = layer });
             }
             break;

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -776,6 +776,13 @@ char const* CodeGenerator::getSamplerTypeName(SamplerType type, SamplerFormat fo
             // are created via VK_ANDROID_external_memory_android_hardware_buffer, but they are
             // backed by VkImage just like a normal texture, and sampled from normally.
             return (mTargetLanguage == TargetLanguage::SPIRV) ? "sampler2D" : "samplerExternalOES";
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            switch (format) {
+                case SamplerFormat::INT:    return "isamplerCubeArray";
+                case SamplerFormat::UINT:   return "usamplerCubeArray";
+                case SamplerFormat::FLOAT:  return "samplerCubeArray";
+                case SamplerFormat::SHADOW: return "samplerCubeArrayShadow";
+            }
     }
 }
 

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -192,6 +192,7 @@ const char* toString(backend::SamplerType type) noexcept {
         case backend::SamplerType::SAMPLER_2D_ARRAY: return "sampler2DArray";
         case backend::SamplerType::SAMPLER_CUBEMAP: return "samplerCubemap";
         case backend::SamplerType::SAMPLER_EXTERNAL: return "samplerExternal";
+        case backend::SamplerType::SAMPLER_CUBEMAP_ARRAY: return "samplerCubeArray";
     }
 }
 


### PR DESCRIPTION
This is not intended to be used yet because we're not currently
checking that cubemap array are actually supported, however, if they
are, they should work.