### PR TITLE
fix max mipmap levels calculation for 3D textures

### DIFF
--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -149,11 +149,25 @@ Texture* Texture::Builder::build(Engine& engine) {
 FTexture::FTexture(FEngine& engine, const Builder& builder) {
     mWidth  = static_cast<uint32_t>(builder->mWidth);
     mHeight = static_cast<uint32_t>(builder->mHeight);
+    mDepth  = static_cast<uint32_t>(builder->mDepth);
     mFormat = builder->mFormat;
     mUsage = builder->mUsage;
     mTarget = builder->mTarget;
-    mDepth  = static_cast<uint32_t>(builder->mDepth);
-    mLevelCount = std::min(builder->mLevels, FTexture::maxLevelCount(mWidth, mHeight));
+
+    uint8_t maxLevelCount;
+    switch (builder->mTarget) {
+        case SamplerType::SAMPLER_2D:
+        case SamplerType::SAMPLER_2D_ARRAY:
+        case SamplerType::SAMPLER_CUBEMAP:
+        case SamplerType::SAMPLER_EXTERNAL:
+            maxLevelCount = FTexture::maxLevelCount(mWidth, mHeight);
+            break;
+        case SamplerType::SAMPLER_3D:
+            maxLevelCount = FTexture::maxLevelCount(std::max(mWidth, std::max(mHeight, mDepth)));
+            break;
+    }
+
+    mLevelCount = std::min(builder->mLevels, maxLevelCount);
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     if (UTILS_LIKELY(builder->mImportedId == 0)) {

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -43,7 +43,6 @@ public:
     size_t getHeight(size_t level = 0) const noexcept;
     size_t getDepth(size_t level = 0) const noexcept;
     size_t getLevelCount() const noexcept { return mLevelCount; }
-    size_t getMaxLevelCount() const noexcept { return FTexture::maxLevelCount(mWidth, mHeight); }
     Sampler getTarget() const noexcept { return mTarget; }
     InternalFormat getFormat() const noexcept { return mFormat; }
     Usage getUsage() const noexcept { return mUsage; }
@@ -100,12 +99,13 @@ public:
 
     // Returns the max number of levels for a texture of given max dimensions
     static inline uint8_t maxLevelCount(uint32_t maxDimension) noexcept {
-        return std::max(1, std::ilogbf(maxDimension) + 1);
+        return std::max(1, std::ilogbf(float(maxDimension)) + 1);
     }
 
     // Returns the max number of levels for a texture of given dimensions
     static inline uint8_t maxLevelCount(uint32_t width, uint32_t height) noexcept {
-        return std::max(1, std::ilogbf(std::max(width, height)) + 1);
+        uint32_t maxDimension = std::max(width, height);
+        return maxLevelCount(maxDimension);
     }
 
     static bool validatePixelFormatAndType(backend::TextureFormat internalFormat,


### PR DESCRIPTION
the depth of the texture wasn't taken into account. In practice this
would restrict the number of mip levels of a 3d texture that would have
a larger dimension in depth.