### PR TITLE
many improvements around sampler groups

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -16,6 +16,7 @@ set(PUBLIC_HDRS
         include/backend/PipelineState.h
         include/backend/PixelBufferDescriptor.h
         include/backend/Platform.h
+        include/backend/SamplerDescriptor.h
         include/backend/TargetBufferInfo.h
 )
 

--- a/filament/backend/include/backend/SamplerDescriptor.h
+++ b/filament/backend/include/backend/SamplerDescriptor.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! \file
+
+#ifndef TNT_FILAMENT_BACKEND_SAMPLERDESCRIPTOR_H
+#define TNT_FILAMENT_BACKEND_SAMPLERDESCRIPTOR_H
+
+#include <backend/DriverEnums.h>
+#include <backend/Handle.h>
+
+#include <utils/compiler.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace filament::backend {
+
+struct UTILS_PUBLIC SamplerDescriptor {
+    Handle<HwTexture> t;
+    SamplerParams s{};
+};
+
+} // namespace filament::backend
+
+#endif // TNT_FILAMENT_BACKEND_SAMPLERDESCRIPTOR_H

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -335,7 +335,7 @@ DECL_DRIVER_API_N(resetBufferObject,
 
 DECL_DRIVER_API_N(updateSamplerGroup,
         backend::SamplerGroupHandle, ubh,
-        backend::SamplerGroup&&, samplerGroup)
+        backend::BufferDescriptor&&, data)
 
 DECL_DRIVER_API_N(setMinMaxLevels,
         backend::TextureHandle, th,

--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -45,9 +45,9 @@ public:
     // create a sampler group
     explicit SamplerGroup(size_t count) noexcept;
 
-    // can be copied -- this preserves dirty bits
-    SamplerGroup(const SamplerGroup& rhs) noexcept;
-    SamplerGroup& operator=(const SamplerGroup& rhs) noexcept;
+    // can't be copied
+    SamplerGroup(const SamplerGroup& rhs) noexcept = delete;
+    SamplerGroup& operator=(const SamplerGroup& rhs) noexcept = delete;
 
     // and moved -- this cleans rhs's dirty flags
     SamplerGroup(SamplerGroup&& rhs) noexcept;
@@ -69,17 +69,13 @@ public:
     size_t getSize() const noexcept { return mBuffer.size(); }
 
     // return if any samplers has been changed
-    bool isDirty() const noexcept { return mDirty.any(); }
+    bool isDirty() const noexcept { return mDirty; }
 
     // mark the whole group as clean (no modified uniforms)
-    void clean() const noexcept { mDirty.reset(); }
+    void clean() const noexcept { mDirty = false; }
 
     // set sampler at given index
     void setSampler(size_t index, Sampler sampler) noexcept;
-
-    inline void setSampler(size_t index, Handle<HwTexture> t, SamplerParams s)  {
-        setSampler(index, { t, s });
-    }
 
     inline void clearSampler(size_t index)  {
         setSampler(index, {});
@@ -149,7 +145,7 @@ private:
     };
 
     static_vector<Sampler, backend::MAX_SAMPLER_COUNT> mBuffer;    // 128 bytes
-    mutable utils::bitset32 mDirty;
+    mutable bool mDirty = false;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -104,10 +104,7 @@ struct HwProgram : public HwBase {
 };
 
 struct HwSamplerGroup : public HwBase {
-    // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
-    std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
     HwSamplerGroup() noexcept = default;
-    explicit HwSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
 };
 
 struct HwTexture : public HwBase {

--- a/filament/backend/src/SamplerGroup.cpp
+++ b/filament/backend/src/SamplerGroup.cpp
@@ -23,33 +23,11 @@ SamplerGroup::SamplerGroup(size_t count) noexcept
         : mBuffer(count) {
 }
 
-SamplerGroup::SamplerGroup(SamplerGroup&& rhs) noexcept
-        : mBuffer(rhs.mBuffer), mDirty(rhs.mDirty) {
-    rhs.clean();
+SamplerGroup::SamplerGroup(const SamplerGroup& rhs) noexcept :
+    mBuffer(rhs.mBuffer), mDirty(true) {
 }
 
-SamplerGroup& SamplerGroup::operator=(SamplerGroup&& rhs) noexcept {
-    if (this != &rhs) {
-        mBuffer = rhs.mBuffer;
-        mDirty = rhs.mDirty;
-        rhs.clean();
-    }
-    return *this;
-}
-
-SamplerGroup& SamplerGroup::toCommandStream() const noexcept {
-    /*
-     * This works because our move ctor preserves the data and cleans the dirty flags.
-     * if we changed the implementation in the future to do a real move, we'd have to change
-     * this method to return SamplerGroup by value, e.g.:
-     *    SamplerGroup copy(*this);
-     *    this->clean();
-     *    return copy;
-     */
-    return const_cast<SamplerGroup&>(*this);
-}
-
-SamplerGroup& SamplerGroup::setSamplers(SamplerGroup const& rhs) noexcept {
+SamplerGroup& SamplerGroup::operator=(const SamplerGroup& rhs) noexcept {
     if (this != &rhs) {
         mBuffer = rhs.mBuffer;
         mDirty = true;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -125,7 +125,7 @@ private:
             uint32_t offset, uint32_t minIndex, uint32_t maxIndex, uint32_t count);
 
     void enumerateSamplerGroups(const MetalProgram* program, ShaderType shaderType,
-            const std::function<void(const SamplerGroup::Sampler*, size_t)>& f);
+            const std::function<void(const SamplerDescriptor*, size_t)>& f);
     void enumerateBoundUniformBuffers(const std::function<void(const UniformBufferState&,
             MetalBuffer*, uint32_t)>& f);
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -809,7 +809,7 @@ bool MetalDriver::canGenerateMipmaps() {
 void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     auto sb = handle_cast<MetalSamplerGroup>(sbh);
-    *sb->sb = samplerGroup;
+    *sb->sb = std::move(samplerGroup);
 }
 
 void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -228,7 +228,9 @@ struct MetalTexture : public HwTexture {
 };
 
 struct MetalSamplerGroup : public HwSamplerGroup {
-    explicit MetalSamplerGroup(size_t size) : HwSamplerGroup(size) {}
+    // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
+    std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
+    explicit MetalSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
 };
 
 class MetalRenderTarget : public HwRenderTarget {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -247,7 +247,8 @@ bool NoopDriver::canGenerateMipmaps() {
 }
 
 void NoopDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
-        SamplerGroup&& samplerGroup) {
+        BufferDescriptor&& data) {
+    scheduleDestroy(std::move(data));
 }
 
 void NoopDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1763,7 +1763,7 @@ void OpenGLDriver::resetBufferObject(Handle<HwBufferObject> boh) {
 }
 
 void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
-        SamplerGroup&& samplerGroup) {
+        BufferDescriptor&& data) {
     DEBUG_MARKER()
 
 #if defined(GL_EXT_texture_filter_anisotropic)
@@ -1774,9 +1774,9 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 #endif
 
     GLSamplerGroup* const sb = handle_cast<GLSamplerGroup *>(sbh);
-    assert_invariant(sb->textureUnitEntries.size() == samplerGroup.getSize());
+    assert_invariant(sb->textureUnitEntries.size() == data.size / sizeof(SamplerDescriptor));
 
-    SamplerGroup::Sampler const* const UTILS_RESTRICT pSamplers = samplerGroup.getSamplers();
+    auto const* const pSamplers = (SamplerDescriptor const*)data.buffer;
     for (size_t i = 0, c = sb->textureUnitEntries.size(); i < c; i++) {
         GLuint samplerId = 0u;
         const GLTexture* t = nullptr;
@@ -1824,6 +1824,7 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 
         sb->textureUnitEntries[i] = { t, samplerId };
     }
+    scheduleDestroy(std::move(data));
 }
 
 void OpenGLDriver::setMinMaxLevels(Handle<HwTexture> th, uint32_t minLevel, uint32_t maxLevel) {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -230,8 +230,8 @@ ShaderModel OpenGLDriver::getShaderModel() const noexcept {
 // Change and track GL state
 // ------------------------------------------------------------------------------------------------
 
-void OpenGLDriver::bindSampler(GLuint unit, SamplerParams params) noexcept {
-    mContext.bindSampler(unit, getSampler(params));
+void OpenGLDriver::bindSampler(GLuint unit, GLuint sampler) noexcept {
+    mContext.bindSampler(unit, sampler);
 }
 
 void OpenGLDriver::bindTexture(GLuint unit, GLTexture const* t) noexcept {
@@ -1766,8 +1766,64 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     DEBUG_MARKER()
 
-    GLSamplerGroup* sb = handle_cast<GLSamplerGroup *>(sbh);
-    *sb->sb = std::move(samplerGroup); // NOLINT(performance-move-const-arg)
+#if defined(GL_EXT_texture_filter_anisotropic)
+    OpenGLContext& context = getContext();
+    const bool anisotropyWorkaround =
+            context.ext.EXT_texture_filter_anisotropic &&
+            context.bugs.texture_filter_anisotropic_broken_on_sampler;
+#endif
+
+    GLSamplerGroup* const sb = handle_cast<GLSamplerGroup *>(sbh);
+    assert_invariant(sb->textureUnitEntries.size() == samplerGroup.getSize());
+
+    SamplerGroup::Sampler const* const UTILS_RESTRICT pSamplers = samplerGroup.getSamplers();
+    for (size_t i = 0, c = sb->textureUnitEntries.size(); i < c; i++) {
+        GLuint samplerId = 0u;
+        const GLTexture* t = nullptr;
+        if (UTILS_LIKELY(pSamplers[i].t)) {
+            t = handle_cast<const GLTexture*>(pSamplers[i].t);
+            assert_invariant(t);
+
+            SamplerParams params = pSamplers[i].s;
+            if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
+                // From OES_EGL_image_external spec:
+                // "The default s and t wrap modes are CLAMP_TO_EDGE and it is an INVALID_ENUM
+                //  error to set the wrap mode to any other value."
+                params.wrapS = SamplerWrapMode::CLAMP_TO_EDGE;
+                params.wrapT = SamplerWrapMode::CLAMP_TO_EDGE;
+                params.wrapR = SamplerWrapMode::CLAMP_TO_EDGE;
+            }
+            // GLES3.x specification forbids depth textures to be filtered.
+            if (UTILS_UNLIKELY(isDepthFormat(t->format)
+                               && params.compareMode == SamplerCompareMode::NONE
+                               && params.filterMag != SamplerMagFilter::NEAREST
+                               && params.filterMin != SamplerMinFilter::NEAREST
+                               && params.filterMin != SamplerMinFilter::NEAREST_MIPMAP_NEAREST)) {
+                params.filterMag = SamplerMagFilter::NEAREST;
+                params.filterMin = SamplerMinFilter::NEAREST;
+#ifndef NDEBUG
+                slog.w << "SamplerGroup specifies a filtered depth texture, which is not allowed."
+                       << io::endl;
+#endif
+            }
+#if defined(GL_EXT_texture_filter_anisotropic)
+            if (UTILS_UNLIKELY(anisotropyWorkaround)) {
+                // Driver claims to support anisotropic filtering, but it fails when set on
+                // the sampler, we have to set it on the texture instead.
+                // The texture is already bound here.
+                GLfloat anisotropy = float(1u << params.anisotropyLog2);
+                glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+                        std::min(context.gets.max_anisotropy, anisotropy));
+            }
+#endif
+            samplerId = getSampler(params);
+        } else {
+            // this happens if the program doesn't use all samplers of a sampler group,
+            // which is not an error.
+        }
+
+        sb->textureUnitEntries[i] = { t, samplerId };
+    }
 }
 
 void OpenGLDriver::setMinMaxLevels(Handle<HwTexture> th, uint32_t minLevel, uint32_t maxLevel) {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -97,12 +97,15 @@ public:
         } gl;
     };
 
+    struct GLTexture;
     struct GLSamplerGroup : public HwSamplerGroup {
         using HwSamplerGroup::HwSamplerGroup;
-
-        // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
-        std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
-        explicit GLSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
+        struct Entry {
+            GLTexture const* texture = nullptr;
+            GLuint sampler = 0u;
+        };
+        utils::FixedCapacityVector<Entry> textureUnitEntries;
+        explicit GLSamplerGroup(size_t size) noexcept : textureUnitEntries(size) { }
     };
 
     struct GLRenderPrimitive : public HwRenderPrimitive {
@@ -304,7 +307,7 @@ private:
     /* State tracking GL wrappers... */
 
            void bindTexture(GLuint unit, GLTexture const* t) noexcept;
-           void bindSampler(GLuint unit, SamplerParams params) noexcept;
+           void bindSampler(GLuint unit, GLuint sampler) noexcept;
     inline void useProgram(OpenGLProgram* p) noexcept;
 
     enum class ResolveAction { LOAD, STORE };

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -99,6 +99,10 @@ public:
 
     struct GLSamplerGroup : public HwSamplerGroup {
         using HwSamplerGroup::HwSamplerGroup;
+
+        // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
+        std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
+        explicit GLSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
     };
 
     struct GLRenderPrimitive : public HwRenderPrimitive {
@@ -321,7 +325,7 @@ private:
         return pos->second;
     }
 
-    const std::array<HwSamplerGroup*, Program::BINDING_COUNT>& getSamplerBindings() const {
+    const std::array<GLSamplerGroup*, Program::BINDING_COUNT>& getSamplerBindings() const {
         return mSamplerBindings;
     }
 
@@ -343,7 +347,7 @@ private:
     void setViewportScissor(Viewport const& viewportScissor) noexcept;
 
     // sampler buffer binding points (nullptr if not used)
-    std::array<HwSamplerGroup*, Program::BINDING_COUNT> mSamplerBindings = {};   // 12 pointers
+    std::array<GLSamplerGroup*, Program::BINDING_COUNT> mSamplerBindings = {};   // 12 pointers
 
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
     mutable std::vector<GLTexture*> mExternalStreams;

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -346,71 +346,25 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
     using GLTexture = OpenGLDriver::GLTexture;
 
     // cache a few member variable locally, outside the loop
-    OpenGLContext& context = gld->getContext();
-#if defined(GL_EXT_texture_filter_anisotropic)
-    const bool anisotropyWorkaround = context.ext.EXT_texture_filter_anisotropic &&
-                                      context.bugs.texture_filter_anisotropic_broken_on_sampler;
-#endif
     auto const& UTILS_RESTRICT samplerBindings = gld->getSamplerBindings();
     auto const& UTILS_RESTRICT usedBindingPoints = mUsedBindingPoints;
 
     for (uint8_t i = 0, tmu = 0, n = mUsedBindingsCount; i < n; i++) {
-        const auto binding = usedBindingPoints[i];
-        OpenGLDriver::GLSamplerGroup const * const hwsb = samplerBindings[binding];
-        assert_invariant(hwsb);
-
-        SamplerGroup const& sb = *(hwsb->sb);
-        SamplerGroup::Sampler const* const samplers = sb.getSamplers();
-        for (uint8_t j = 0, m = sb.getSize(); j < m; ++j, ++tmu) { // "<=" on purpose here
-            Handle<HwTexture> th = samplers[j].t;
-            if (!th) {
-                // this happens if the program doesn't use all samplers of a sampler group,
-                // which is not an error.
-                continue;
+        auto const binding = usedBindingPoints[i];
+        auto const * const sb = samplerBindings[binding];
+        assert_invariant(sb);
+        for (uint8_t j = 0, m = sb->textureUnitEntries.size(); j < m; ++j, ++tmu) { // "<=" on purpose here
+            const GLTexture* const t = sb->textureUnitEntries[j].texture;
+            GLuint s = sb->textureUnitEntries[j].sampler;
+            if (t) { // program may not use all samplers of sampler group
+                if (UTILS_UNLIKELY(t->gl.fence)) {
+                    glWaitSync(t->gl.fence, 0, GL_TIMEOUT_IGNORED);
+                    glDeleteSync(t->gl.fence);
+                    t->gl.fence = nullptr;
+                }
+                gld->bindTexture(tmu, t);
+                gld->bindSampler(tmu, s);
             }
-
-            const GLTexture* const UTILS_RESTRICT t = gld->handle_cast<const GLTexture*>(th);
-            if (UTILS_UNLIKELY(t->gl.fence)) {
-                glWaitSync(t->gl.fence, 0, GL_TIMEOUT_IGNORED);
-                glDeleteSync(t->gl.fence);
-                t->gl.fence = nullptr;
-            }
-
-            SamplerParams params{ samplers[j].s };
-            if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
-                // From OES_EGL_image_external spec:
-                // "The default s and t wrap modes are CLAMP_TO_EDGE and it is an INVALID_ENUM
-                //  error to set the wrap mode to any other value."
-                params.wrapS = SamplerWrapMode::CLAMP_TO_EDGE;
-                params.wrapT = SamplerWrapMode::CLAMP_TO_EDGE;
-                params.wrapR = SamplerWrapMode::CLAMP_TO_EDGE;
-            }
-
-#ifndef NDEBUG
-            // GLES3.x specification forbids depth textures to be filtered.
-            if (isDepthFormat(t->format)
-                && params.compareMode == SamplerCompareMode::NONE
-                && params.filterMag != SamplerMagFilter::NEAREST
-                && params.filterMin != SamplerMinFilter::NEAREST
-                && params.filterMin != SamplerMinFilter::NEAREST_MIPMAP_NEAREST) {
-                slog.w << "In program " << name.c_str()
-                       << ": depth texture used with filtering sampler, tmu = "
-                       << +tmu << io::endl;
-            }
-#endif
-            gld->bindTexture(tmu, t);
-            gld->bindSampler(tmu, params);
-
-#if defined(GL_EXT_texture_filter_anisotropic)
-            if (UTILS_UNLIKELY(anisotropyWorkaround)) {
-                // Driver claims to support anisotropic filtering, but it fails when set on
-                // the sampler, we have to set it on the texture instead.
-                // The texture is already bound here.
-                GLfloat anisotropy = float(1u << params.anisotropyLog2);
-                glTexParameterf(t->gl.target, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-                        std::min(context.gets.max_anisotropy, anisotropy));
-            }
-#endif
         }
     }
     CHECK_GL_ERROR(utils::slog.e)

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -356,7 +356,7 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
 
     for (uint8_t i = 0, tmu = 0, n = mUsedBindingsCount; i < n; i++) {
         const auto binding = usedBindingPoints[i];
-        HwSamplerGroup const * const hwsb = samplerBindings[binding];
+        OpenGLDriver::GLSamplerGroup const * const hwsb = samplerBindings[binding];
         assert_invariant(hwsb);
 
         SamplerGroup const& sb = *(hwsb->sb);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1038,7 +1038,7 @@ bool VulkanDriver::canGenerateMipmaps() {
 void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         SamplerGroup&& samplerGroup) {
     auto* sb = handle_cast<VulkanSamplerGroup*>(sbh);
-    *sb->sb = samplerGroup;
+    *sb->sb = std::move(samplerGroup);
 }
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -101,7 +101,9 @@ struct VulkanBufferObject : public HwBufferObject {
 };
 
 struct VulkanSamplerGroup : public HwSamplerGroup {
-    VulkanSamplerGroup(uint32_t count) : HwSamplerGroup(count) {}
+    // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
+    std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
+    explicit VulkanSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
 };
 
 struct VulkanRenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -185,7 +185,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             SamplerParams sparams = {};
             sparams.filterMag = SamplerMagFilter::LINEAR;
             sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-            samplers.setSampler(0, texture, sparams);
+            samplers.setSampler(0, { texture, sparams });
             auto sgroup = api.createSamplerGroup(samplers.getSize());
             api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
             auto ubuffer = api.createBufferObject(sizeof(MaterialParams),

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -187,7 +187,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
             samplers.setSampler(0, { texture, sparams });
             auto sgroup = api.createSamplerGroup(samplers.getSize());
-            api.updateSamplerGroup(sgroup, std::move(samplers));
+            api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
             auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
                     BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
             api.makeCurrent(swapChain, swapChain);

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -187,7 +187,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
             samplers.setSampler(0, { texture, sparams });
             auto sgroup = api.createSamplerGroup(samplers.getSize());
-            api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
+            api.updateSamplerGroup(sgroup, std::move(samplers));
             auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
                     BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
             api.makeCurrent(swapChain, swapChain);

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -381,7 +381,7 @@ TEST_F(BackendTest, UpdateImage2D) {
         sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
         samplers.setSampler(0, { texture, sparams });
         auto sgroup = api.createSamplerGroup(samplers.getSize());
-        api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
+        api.updateSamplerGroup(sgroup, std::move(samplers));
 
         api.bindSamplers(0, sgroup);
 
@@ -467,7 +467,7 @@ TEST_F(BackendTest, UpdateImageSRGB) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
+    api.updateSamplerGroup(sgroup, std::move(samplers));
 
     api.bindSamplers(0, sgroup);
 
@@ -537,7 +537,7 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
+    api.updateSamplerGroup(sgroup, std::move(samplers));
 
     api.bindSamplers(0, sgroup);
 
@@ -619,7 +619,7 @@ TEST_F(BackendTest, UpdateImage3D) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams});
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
+    api.updateSamplerGroup(sgroup, std::move(samplers));
 
     api.bindSamplers(0, sgroup);
 

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -379,7 +379,7 @@ TEST_F(BackendTest, UpdateImage2D) {
         SamplerParams sparams = {};
         sparams.filterMag = SamplerMagFilter::LINEAR;
         sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-        samplers.setSampler(0, texture, sparams);
+        samplers.setSampler(0, { texture, sparams });
         auto sgroup = api.createSamplerGroup(samplers.getSize());
         api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
 
@@ -465,7 +465,7 @@ TEST_F(BackendTest, UpdateImageSRGB) {
     SamplerParams sparams = {};
     sparams.filterMag = SamplerMagFilter::LINEAR;
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-    samplers.setSampler(0, texture, sparams);
+    samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
     api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
 
@@ -535,7 +535,7 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
     SamplerParams sparams = {};
     sparams.filterMag = SamplerMagFilter::LINEAR;
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-    samplers.setSampler(0, texture, sparams);
+    samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
     api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
 
@@ -617,7 +617,7 @@ TEST_F(BackendTest, UpdateImage3D) {
     SamplerParams sparams = {};
     sparams.filterMag = SamplerMagFilter::LINEAR;
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-    samplers.setSampler(0, texture, sparams);
+    samplers.setSampler(0, { texture, sparams});
     auto sgroup = api.createSamplerGroup(samplers.getSize());
     api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
 

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -381,7 +381,7 @@ TEST_F(BackendTest, UpdateImage2D) {
         sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
         samplers.setSampler(0, { texture, sparams });
         auto sgroup = api.createSamplerGroup(samplers.getSize());
-        api.updateSamplerGroup(sgroup, std::move(samplers));
+        api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
 
         api.bindSamplers(0, sgroup);
 
@@ -467,7 +467,7 @@ TEST_F(BackendTest, UpdateImageSRGB) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers));
+    api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
 
     api.bindSamplers(0, sgroup);
 
@@ -537,7 +537,7 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams });
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers));
+    api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
 
     api.bindSamplers(0, sgroup);
 
@@ -619,7 +619,7 @@ TEST_F(BackendTest, UpdateImage3D) {
     sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
     samplers.setSampler(0, { texture, sparams});
     auto sgroup = api.createSamplerGroup(samplers.getSize());
-    api.updateSamplerGroup(sgroup, std::move(samplers));
+    api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
 
     api.bindSamplers(0, sgroup);
 

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -104,10 +104,10 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
     getDriverApi().makeCurrent(swapChain, swapChain);
     getDriverApi().beginFrame(0, 0);
 
-    SamplerGroup mSamplers(1);
-    mSamplers.setSampler(0, { texture, {} });
+    SamplerGroup samplers(1);
+    samplers.setSampler(0, { texture, {} });
     backend::Handle<HwSamplerGroup> samplerGroup = getDriverApi().createSamplerGroup(1);
-    getDriverApi().updateSamplerGroup(samplerGroup, std::move(mSamplers.toCommandStream()));
+    getDriverApi().updateSamplerGroup(samplerGroup, std::move(samplers));
     getDriverApi().bindSamplers(0, samplerGroup);
 
     // Render a triangle.
@@ -220,10 +220,10 @@ TEST_F(BackendTest, RenderExternalImage) {
     getDriverApi().makeCurrent(swapChain, swapChain);
     getDriverApi().beginFrame(0, 0);
 
-    SamplerGroup mSamplers(1);
-    mSamplers.setSampler(0, { texture, {} });
+    SamplerGroup samplers(1);
+    samplers.setSampler(0, { texture, {} });
     backend::Handle<HwSamplerGroup> samplerGroup = getDriverApi().createSamplerGroup(1);
-    getDriverApi().updateSamplerGroup(samplerGroup, std::move(mSamplers.toCommandStream()));
+    getDriverApi().updateSamplerGroup(samplerGroup, std::move(samplers));
     getDriverApi().bindSamplers(0, samplerGroup);
 
     // Render a triangle.

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -107,7 +107,7 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
     SamplerGroup samplers(1);
     samplers.setSampler(0, { texture, {} });
     backend::Handle<HwSamplerGroup> samplerGroup = getDriverApi().createSamplerGroup(1);
-    getDriverApi().updateSamplerGroup(samplerGroup, std::move(samplers));
+    getDriverApi().updateSamplerGroup(samplerGroup, samplers.toBufferDescriptor(getDriverApi()));
     getDriverApi().bindSamplers(0, samplerGroup);
 
     // Render a triangle.
@@ -223,7 +223,7 @@ TEST_F(BackendTest, RenderExternalImage) {
     SamplerGroup samplers(1);
     samplers.setSampler(0, { texture, {} });
     backend::Handle<HwSamplerGroup> samplerGroup = getDriverApi().createSamplerGroup(1);
-    getDriverApi().updateSamplerGroup(samplerGroup, std::move(samplers));
+    getDriverApi().updateSamplerGroup(samplerGroup, samplers.toBufferDescriptor(getDriverApi()));
     getDriverApi().bindSamplers(0, samplerGroup);
 
     // Render a triangle.

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -361,7 +361,8 @@ void PerViewUniforms::commit(backend::DriverApi& driver) noexcept {
         driver.updateBufferObject(mUniformBufferHandle, mUniforms.toBufferDescriptor(driver), 0);
     }
     if (mSamplers.isDirty()) {
-        driver.updateSamplerGroup(mSamplerGroupHandle, std::move(mSamplers.toCommandStream()));
+        driver.updateSamplerGroup(mSamplerGroupHandle, SamplerGroup(mSamplers));
+        mSamplers.clean();
     }
 }
 

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -361,8 +361,7 @@ void PerViewUniforms::commit(backend::DriverApi& driver) noexcept {
         driver.updateBufferObject(mUniformBufferHandle, mUniforms.toBufferDescriptor(driver), 0);
     }
     if (mSamplers.isDirty()) {
-        driver.updateSamplerGroup(mSamplerGroupHandle, SamplerGroup(mSamplers));
-        mSamplers.clean();
+        driver.updateSamplerGroup(mSamplerGroupHandle, mSamplers.toBufferDescriptor(driver));
     }
 }
 

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -55,7 +55,7 @@ PerViewUniforms::PerViewUniforms(FEngine& engine) noexcept
     if (engine.getDFG().isValid()) {
         TextureSampler sampler(TextureSampler::MagFilter::LINEAR);
         mSamplers.setSampler(PerViewSib::IBL_DFG_LUT,
-                engine.getDFG().getTexture(), sampler.getSamplerParams());
+                { engine.getDFG().getTexture(), sampler.getSamplerParams() });
     }
 }
 
@@ -160,10 +160,10 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao,
             && options.resolution < 1.0f;
 
     // LINEAR filtering is only needed when AO is enabled and low-quality upsampling is used.
-    mSamplers.setSampler(PerViewSib::SSAO, ssao, {
+    mSamplers.setSampler(PerViewSib::SSAO, { ssao, {
         .filterMag = options.enabled && !highQualitySampling ?
                 SamplerMagFilter::LINEAR : SamplerMagFilter::NEAREST
-    });
+    }});
 
     const float edgeDistance = 1.0f / options.bilateralThreshold;
     auto& s = mUniforms.edit();
@@ -180,10 +180,10 @@ void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
         float refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
-    mSamplers.setSampler(PerViewSib::SSR, ssr, {
+    mSamplers.setSampler(PerViewSib::SSR, { ssr, {
         .filterMag = SamplerMagFilter::LINEAR,
         .filterMin = SamplerMinFilter::LINEAR_MIPMAP_LINEAR
-    });
+    }});
 
     auto& s = mUniforms.edit();
     s.refractionLodOffset = refractionLodOffset;
@@ -195,10 +195,10 @@ void PerViewUniforms::prepareHistorySSR(Handle<HwTexture> ssr,
         math::mat4f const& uvFromViewMatrix,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
-    mSamplers.setSampler(PerViewSib::SSR, ssr, {
+    mSamplers.setSampler(PerViewSib::SSR, { ssr, {
         .filterMag = SamplerMagFilter::LINEAR,
         .filterMin = SamplerMinFilter::LINEAR
-    });
+    }});
 
     auto& s = mUniforms.edit();
     s.ssrReprojection = historyProjection;
@@ -211,7 +211,7 @@ void PerViewUniforms::prepareHistorySSR(Handle<HwTexture> ssr,
 
 void PerViewUniforms::prepareStructure(Handle<HwTexture> structure) noexcept {
     // sampler must be NEAREST
-    mSamplers.setSampler(PerViewSib::STRUCTURE, structure, {});
+    mSamplers.setSampler(PerViewSib::STRUCTURE, { structure, {}});
 }
 
 void PerViewUniforms::prepareDirectionalLight(

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -133,8 +133,7 @@ void FMaterialInstance::commitSlow(DriverApi& driver) const {
         driver.updateBufferObject(mUbHandle, mUniforms.toBufferDescriptor(driver), 0);
     }
     if (mSamplers.isDirty()) {
-        driver.updateSamplerGroup(mSbHandle, SamplerGroup(mSamplers));
-        mSamplers.clean();
+        driver.updateSamplerGroup(mSbHandle, mSamplers.toBufferDescriptor(driver));
     }
 }
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -58,7 +58,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {
-        mSamplers.setSamplers(other->getSamplerGroup());
+        mSamplers = other->getSamplerGroup();
         mSbHandle = driver.createSamplerGroup(mSamplers.getSize());
     }
 
@@ -133,7 +133,8 @@ void FMaterialInstance::commitSlow(DriverApi& driver) const {
         driver.updateBufferObject(mUbHandle, mUniforms.toBufferDescriptor(driver), 0);
     }
     if (mSamplers.isDirty()) {
-        driver.updateSamplerGroup(mSbHandle, std::move(mSamplers.toCommandStream()));
+        driver.updateSamplerGroup(mSbHandle, SamplerGroup(mSamplers));
+        mSamplers.clean();
     }
 }
 

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -125,7 +125,7 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
     SamplerGroup samplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
     samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::POSITIONS, { mPbHandle, {}});
     samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::TANGENTS, { mTbHandle, {}});
-    driver.updateSamplerGroup(mSbHandle, std::move(samplerGroup));
+    driver.updateSamplerGroup(mSbHandle, samplerGroup.toBufferDescriptor(driver));
 }
 
 void FMorphTargetBuffer::terminate(FEngine& engine) {

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -125,7 +125,7 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
     SamplerGroup samplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
     samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::POSITIONS, { mPbHandle, {}});
     samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::TANGENTS, { mTbHandle, {}});
-    driver.updateSamplerGroup(mSbHandle, std::move(samplerGroup.toCommandStream()));
+    driver.updateSamplerGroup(mSbHandle, std::move(samplerGroup));
 }
 
 void FMorphTargetBuffer::terminate(FEngine& engine) {

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -123,8 +123,8 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
     // create and update sampler group
     mSbHandle = driver.createSamplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
     SamplerGroup samplerGroup(PerRenderPrimitiveMorphingSib::SAMPLER_COUNT);
-    samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::POSITIONS, mPbHandle, {});
-    samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::TANGENTS, mTbHandle, {});
+    samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::POSITIONS, { mPbHandle, {}});
+    samplerGroup.setSampler(PerRenderPrimitiveMorphingSib::TANGENTS, { mTbHandle, {}});
     driver.updateSamplerGroup(mSbHandle, std::move(samplerGroup.toCommandStream()));
 }
 


### PR DESCRIPTION
reviewers: it'll be much easier to review each CL separately.

The main changes are:
- updateSamplerGroup() now uses a BufferDescriptor
- SamplerGroup is "almost" a filament-only API. It's still in the backend right now because metal/vk still use it.

`SamplerGroup` was supposed to be just a helper to set/create/manager a set of samplers, while HwSamplerGroup was the backend object. However, the later used to "own" a `SamplerGroup` which was confusing and just bad design.

In the GL backend we now take advantage of the HwSamplerGroup abstraction by resolving the sampler (i.e. creating a GL sampler object) when the data changes, rather than each time when setting a program.