### PR TITLE
rename `ShaderModel` enums

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -177,16 +177,18 @@ static constexpr uint64_t FENCE_WAIT_FOR_EVER = uint64_t(-1);
 /**
  * Shader model.
  *
- * These enumerants are used across all backends and refer to a level of functionality, rather
- * than to an OpenGL specific shader model.
+ * These enumerants are used across all backends and refer to a level of functionality and quality.
+ *
+ * For example, the OpenGL backend returns `MOBILE` if it supports OpenGL ES, or `DESKTOP` if it
+ * supports Desktop OpenGL, this is later used to select the proper shader.
+ *
+ * Shader quality vs. performance is also affected by ShaderModel.
  */
 enum class ShaderModel : uint8_t {
-    //! For testing
-    UNKNOWN    = 0,
-    GL_ES_30   = 1,    //!< Mobile level functionality
-    GL_CORE_41 = 2,    //!< Desktop level functionality
+    MOBILE  = 1,    //!< Mobile level functionality
+    DESKTOP = 2,    //!< Desktop level functionality
 };
-static constexpr size_t SHADER_MODEL_COUNT = 3;
+static constexpr size_t SHADER_MODEL_COUNT = 2;
 
 /**
  * Primitive types

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -550,9 +550,9 @@ void MetalDriver::terminate() {
 
 ShaderModel MetalDriver::getShaderModel() const noexcept {
 #if defined(IOS)
-    return ShaderModel::GL_ES_30;
+    return ShaderModel::MOBILE;
 #else
-    return ShaderModel::GL_CORE_41;
+    return ShaderModel::DESKTOP;
 #endif
 }
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -33,9 +33,9 @@ Dispatcher NoopDriver::getDispatcher() const noexcept {
 
 ShaderModel NoopDriver::getShaderModel() const noexcept {
 #if defined(__ANDROID__) || defined(IOS) || defined(__EMSCRIPTEN__)
-    return ShaderModel::GL_ES_30;
+    return ShaderModel::MOBILE;
 #else
-    return ShaderModel::GL_CORE_41;
+    return ShaderModel::DESKTOP;
 #endif
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -58,7 +58,7 @@ OpenGLContext::OpenGLContext() noexcept {
     if constexpr (BACKEND_OPENGL_VERSION == BACKEND_OPENGL_VERSION_GLES) {
         // This works on all versions of GLES
         if (state.major == 3 && state.minor >= 0) {
-            mShaderModel = ShaderModel::GL_ES_30;
+            mShaderModel = ShaderModel::MOBILE;
         }
         if (state.major == 3 && state.minor >= 1) {
             features.multisample_texture = true;
@@ -67,15 +67,13 @@ OpenGLContext::OpenGLContext() noexcept {
     } else if constexpr (BACKEND_OPENGL_VERSION == BACKEND_OPENGL_VERSION_GL) {
         // OpenGL version
         if (state.major == 4 && state.minor >= 1) {
-            mShaderModel = ShaderModel::GL_CORE_41;
+            mShaderModel = ShaderModel::DESKTOP;
         }
         features.multisample_texture = true;
         // feedback loops are allowed on GL desktop as long as writes are disabled
         bugs.allow_read_only_ancillary_feedback_loop = true;
         initExtensionsGL();
     }
-
-    assert_invariant(mShaderModel != ShaderModel::UNKNOWN);
 
     /*
      * Figure out which driver bugs we need to workaround

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -221,7 +221,7 @@ public:
     void resetProgram() noexcept { state.program.use = 0; }
 
 private:
-    ShaderModel mShaderModel = ShaderModel::UNKNOWN;
+    ShaderModel mShaderModel = ShaderModel::MOBILE;
 
     const std::array<std::tuple<bool const&, char const*, char const*>, sizeof(bugs)> mBugDatabase{{
             {   bugs.disable_glFlush,

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -220,51 +220,6 @@ public:
     }
     void resetProgram() noexcept { state.program.use = 0; }
 
-private:
-    ShaderModel mShaderModel = ShaderModel::MOBILE;
-
-    const std::array<std::tuple<bool const&, char const*, char const*>, sizeof(bugs)> mBugDatabase{{
-            {   bugs.disable_glFlush,
-                    "disable_glFlush",
-                    ""},
-            {   bugs.vao_doesnt_store_element_array_buffer_binding,
-                    "vao_doesnt_store_element_array_buffer_binding",
-                    ""},
-            {   bugs.disable_shared_context_draws,
-                    "disable_shared_context_draws",
-                    ""},
-            {   bugs.texture_external_needs_rebind,
-                    "texture_external_needs_rebind",
-                    ""},
-            {   bugs.disable_invalidate_framebuffer,
-                    "disable_invalidate_framebuffer",
-                    ""},
-            {   bugs.texture_filter_anisotropic_broken_on_sampler,
-                    "texture_filter_anisotropic_broken_on_sampler",
-                    ""},
-            {   bugs.disable_feedback_loops,
-                    "disable_feedback_loops",
-                    ""},
-            {   bugs.dont_use_timer_query,
-                    "dont_use_timer_query",
-                    ""},
-            {   bugs.disable_sidecar_blit_into_texture_array,
-                    "disable_sidecar_blit_into_texture_array",
-                    ""},
-            {   bugs.split_easu,
-                    "split_easu",
-                    ""},
-            {   bugs.invalidate_end_only_if_invalidate_start,
-                    "invalidate_end_only_if_invalidate_start",
-                    ""},
-            {   bugs.allow_read_only_ancillary_feedback_loop,
-                    "allow_read_only_ancillary_feedback_loop",
-                    ""},
-            {   bugs.enable_initialize_non_used_uniform_array,
-                    "enable_initialize_non_used_uniform_array",
-                    ""},
-    }};
-
     // Try to keep the State structure sorted by data-access patterns
     struct State {
         GLint major = 0;
@@ -374,6 +329,51 @@ private:
             GLuint timer = -1u;
         } queries;
     } state;
+
+private:
+    ShaderModel mShaderModel = ShaderModel::MOBILE;
+
+    const std::array<std::tuple<bool const&, char const*, char const*>, sizeof(bugs)> mBugDatabase{{
+            {   bugs.disable_glFlush,
+                    "disable_glFlush",
+                    ""},
+            {   bugs.vao_doesnt_store_element_array_buffer_binding,
+                    "vao_doesnt_store_element_array_buffer_binding",
+                    ""},
+            {   bugs.disable_shared_context_draws,
+                    "disable_shared_context_draws",
+                    ""},
+            {   bugs.texture_external_needs_rebind,
+                    "texture_external_needs_rebind",
+                    ""},
+            {   bugs.disable_invalidate_framebuffer,
+                    "disable_invalidate_framebuffer",
+                    ""},
+            {   bugs.texture_filter_anisotropic_broken_on_sampler,
+                    "texture_filter_anisotropic_broken_on_sampler",
+                    ""},
+            {   bugs.disable_feedback_loops,
+                    "disable_feedback_loops",
+                    ""},
+            {   bugs.dont_use_timer_query,
+                    "dont_use_timer_query",
+                    ""},
+            {   bugs.disable_sidecar_blit_into_texture_array,
+                    "disable_sidecar_blit_into_texture_array",
+                    ""},
+            {   bugs.split_easu,
+                    "split_easu",
+                    ""},
+            {   bugs.invalidate_end_only_if_invalidate_start,
+                    "invalidate_end_only_if_invalidate_start",
+                    ""},
+            {   bugs.allow_read_only_ancillary_feedback_loop,
+                    "allow_read_only_ancillary_feedback_loop",
+                    ""},
+            {   bugs.enable_initialize_non_used_uniform_array,
+                    "enable_initialize_non_used_uniform_array",
+                    ""},
+    }};
 
     RenderPrimitive mDefaultVAO;
 

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -131,8 +131,8 @@ void OpenGLProgram::compileShaders(OpenGLContext& context,
                 }
             }
 
-            if (UTILS_UNLIKELY(context.getShaderModel() == ShaderModel::GL_CORE_41 &&
-                !context.ext.ARB_shading_language_packing)) {
+            if (UTILS_UNLIKELY(context.getShaderModel() == ShaderModel::DESKTOP &&
+                               !context.ext.ARB_shading_language_packing)) {
                 // Tragically, OpenGL 4.1 doesn't support unpackHalf2x16 and
                 // MacOS doesn't support GL_ARB_shading_language_packing
                 if (temp.empty()) {

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -41,9 +41,8 @@ using namespace utils;
 
 io::ostream& operator<<(io::ostream& out, ShaderModel model) {
     switch (model) {
-        CASE(ShaderModel, UNKNOWN)
-        CASE(ShaderModel, GL_ES_30)
-        CASE(ShaderModel, GL_CORE_41)
+        CASE(ShaderModel, MOBILE)
+        CASE(ShaderModel, DESKTOP)
     }
     return out;
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -326,9 +326,9 @@ Driver* VulkanDriver::create(VulkanPlatform* const platform,
 
 ShaderModel VulkanDriver::getShaderModel() const noexcept {
 #if defined(__ANDROID__) || defined(IOS)
-    return ShaderModel::GL_ES_30;
+    return ShaderModel::MOBILE;
 #else
-    return ShaderModel::GL_CORE_41;
+    return ShaderModel::DESKTOP;
 #endif
 }
 

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -113,9 +113,8 @@ Material* Material::Builder::build(Engine& engine) {
         materialParser->getName(&name);
         slog.e << "The material '" << name.c_str_safe() << "' was not built for ";
         switch (shaderModel) {
-            case ShaderModel::GL_ES_30: slog.e << "mobile.\n"; break;
-            case ShaderModel::GL_CORE_41: slog.e << "desktop.\n"; break;
-            case ShaderModel::UNKNOWN: /* should never happen */ break;
+            case ShaderModel::MOBILE: slog.e << "mobile.\n"; break;
+            case ShaderModel::DESKTOP: slog.e << "desktop.\n"; break;
         }
         slog.e << "Compiled material contains shader models 0x"
                 << io::hex << shaderModels.getValue() << io::dec << "." << io::endl;

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -114,7 +114,7 @@ protected:
     // For finding properties and running semantic analysis, we always use the same code gen
     // permutation. This is the first permutation generated with default arguments passed to matc.
     const CodeGenParams mSemanticCodeGenParams = {
-        .shaderModel = (int) ShaderModel::GL_ES_30,
+        .shaderModel = (int) ShaderModel::MOBILE,
         .targetApi = TargetApi::OPENGL,
         .targetLanguage = TargetLanguage::SPIRV
     };

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -71,12 +71,12 @@ void MaterialBuilderBase::prepare(bool vulkanSemantics) {
     mShaderModels.reset();
 
     if (mPlatform == Platform::MOBILE) {
-        mShaderModels.set(static_cast<size_t>(ShaderModel::GL_ES_30));
+        mShaderModels.set(static_cast<size_t>(ShaderModel::MOBILE));
     } else if (mPlatform == Platform::DESKTOP) {
-        mShaderModels.set(static_cast<size_t>(ShaderModel::GL_CORE_41));
+        mShaderModels.set(static_cast<size_t>(ShaderModel::DESKTOP));
     } else if (mPlatform == Platform::ALL) {
-        mShaderModels.set(static_cast<size_t>(ShaderModel::GL_ES_30));
-        mShaderModels.set(static_cast<size_t>(ShaderModel::GL_CORE_41));
+        mShaderModels.set(static_cast<size_t>(ShaderModel::MOBILE));
+        mShaderModels.set(static_cast<size_t>(ShaderModel::DESKTOP));
     }
 
     // OpenGL is a special case. If we're doing any optimization, then we need to go to Spir-V.

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -322,12 +322,11 @@ bool GLSLTools::findSymbolsUsage(const std::string& functionSignature, TIntermNo
 int GLSLTools::glslangVersionFromShaderModel(ShaderModel model) {
     int version = 110;
     switch (model) {
-        case ShaderModel::UNKNOWN:
-            break;
-        case ShaderModel::GL_ES_30:
+        case ShaderModel::MOBILE:
             version = 100;
             break;
-        case ShaderModel::GL_CORE_41:
+        case ShaderModel::DESKTOP:
+            version = 110;
             break;
     }
     return version;

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -141,7 +141,7 @@ public:
             const std::string& shaderCode,
             MaterialBuilder::PropertyList& properties,
             MaterialBuilder::TargetApi targetApi = MaterialBuilder::TargetApi::OPENGL,
-            ShaderModel model = ShaderModel::GL_CORE_41) const noexcept;
+            ShaderModel model = ShaderModel::DESKTOP) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::backend::ShaderModel model);
 

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -153,9 +153,8 @@ const char* toString(backend::ShaderType stage) noexcept {
 inline
 const char* toString(backend::ShaderModel model) noexcept {
     switch (model) {
-        case backend::ShaderModel::UNKNOWN: return "--";
-        case backend::ShaderModel::GL_ES_30: return "gles30";
-        case backend::ShaderModel::GL_CORE_41: return "gl41";
+        case backend::ShaderModel::MOBILE: return "mobile";
+        case backend::ShaderModel::DESKTOP: return "desktop";
     }
 }
 


### PR DESCRIPTION
GL_ES_30   becomes MOBILE
GL_CORE_41 becomes DESKTOP

ShaderModel controls which flavor of GLSL (GL or ES) is used both when 
reading and outputting materials.

It's also used to set default quality settings and the default precision
of all fragment shaders.

Technically, Vulkan and Metal don't need this distinction, but the GL
backend does.