### PR TITLE
Fix DoF on WebGL

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1488,7 +1488,13 @@ bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
 }
 
 bool OpenGLDriver::isTextureSwizzleSupported() {
+#if defined(__EMSCRIPTEN__)
+    // WebGL2 doesn't support texture swizzle
+    // see https://registry.khronos.org/webgl/specs/latest/2.0/#5.19
+    return false;
+#else
     return true;
+#endif
 }
 
 bool OpenGLDriver::isTextureFormatMipmappable(TextureFormat format) {

--- a/web/samples/suzanne.html
+++ b/web/samples/suzanne.html
@@ -81,7 +81,7 @@ class App {
             Filament.MagFilter.LINEAR,
             Filament.WrapMode.CLAMP_TO_EDGE);
 
-        // Fiament requests support for the following extensions, but none are guaranteed.
+        // Filament requests support for the following extensions, but none are guaranteed.
         //   WEBGL_compressed_texture_s3tc, WEBGL_compressed_texture_s3tc_srgb
         //   WEBGL_compressed_texture_astc, WEBGL_compressed_texture_etc
         const albedo = engine.createTextureFromKtx2(albedo_url, {


### PR DESCRIPTION
The issue was that WebGL2.0 doesn't support texture swizzle.


Fixes: #5828