### PR TITLE
Fix incorrect precision restoration when computing accurate world translations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - WebGL: upgraded the JS bindings to work with emsdk 3.1.15
 - WebGL: added missing IBL builder to TypeScript annotations
+- engine : Fix incorrect precision restoration when computing accurate world translations
 
 ## v1.25.4
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -412,10 +412,10 @@ void FTransformManager::computeWorldTransform(
 
         const mat4 ptd{
                 pt[0], pt[1], pt[2],
-                double4{ pt[3].xyz + ptTranslationLo, pt[3].w }};
+                double4{ double3(pt[3].xyz) + double3(ptTranslationLo), pt[3].w }};
 
         const double4 worldTranslation =
-                ptd * double4{ local[3].xyz + localTranslationLo, local[3].w };
+                ptd * double4{ double3(local[3].xyz) + double3(localTranslationLo), local[3].w };
 
         inoutWorldTranslationLo = worldTranslation.xyz - float3{ worldTranslation.xyz };
         outWorld[3] = worldTranslation;


### PR DESCRIPTION
When FTransformManager computes accurate world transforms, it adds downcasted leftover to translation part to restore precision.
However, both translation and leftover are given as float3 - simply adding them resut float3, so addling leftover become meaningless.
one or both should be upcasted first.