### PR TITLE
MaterialInstance public API friendly to std::string_view

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,7 +7,8 @@ A new header is inserted each time a *tag* is created.
 
 - WebGL: upgraded the JS bindings to work with emsdk 3.1.15
 - WebGL: added missing IBL builder to TypeScript annotations
-- engine : Fix incorrect precision restoration when computing accurate world translations
+- engine: Fix incorrect precision restoration when computing accurate world translations
+- engine: make `MaterialInstance` public API friendly to `std::string_view` parameters
 
 ## v1.25.4
 

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -37,6 +37,18 @@ class UniformBuffer;
 class UniformInterfaceBlock;
 
 class UTILS_PUBLIC MaterialInstance : public FilamentAPI {
+    template<size_t N>
+    using StringLiteralHelper = const char[N];
+
+    struct StringLiteral {
+        const char* data;
+        size_t size;
+        template<size_t N>
+        StringLiteral(StringLiteralHelper<N> const& s) noexcept // NOLINT(google-explicit-constructor)
+                : data(s), size(N - 1) {
+        }
+    };
+
 public:
     using CullingMode = filament::backend::CullingMode;
     using TransparencyMode = filament::TransparencyMode;
@@ -88,23 +100,51 @@ public:
     /**
      * Set a uniform by name
      *
-     * @param name      Name of the parameter as defined by Material. Cannot be nullptr.
-     * @param value     Value of the parameter to set.
+     * @param name          Name of the parameter as defined by Material. Cannot be nullptr.
+     * @param nameLength    Length in `char` of the name parameter.
+     * @param value         Value of the parameter to set.
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
     template<typename T, typename = is_supported_parameter_t<T>>
-    void setParameter(const char* name, T const& value) noexcept;
+    void setParameter(const char* name, size_t nameLength, T const& value);
+
+    /** inline helper to provide the name as a null-terminated string literal */
+    template<typename T, typename = is_supported_parameter_t<T>>
+    inline void setParameter(StringLiteral name, T const& value) {
+        setParameter<T>(name.data, name.size, value);
+    }
+
+    /** inline helper to provide the name as a null-terminated C string */
+    template<typename T, typename = is_supported_parameter_t<T>>
+    inline void setParameter(const char* name, T const& value) {
+        setParameter<T>(name, strlen(name), value);
+    }
+
 
     /**
      * Set a uniform array by name
      *
-     * @param name      Name of the parameter array as defined by Material. Cannot be nullptr.
-     * @param values    Array of values to set to the named parameter array.
-     * @param count     Size of the array to set.
+     * @param name          Name of the parameter array as defined by Material. Cannot be nullptr.
+     * @param nameLength    Length in `char` of the name parameter.
+     * @param values        Array of values to set to the named parameter array.
+     * @param count         Size of the array to set.
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
     template<typename T, typename = is_supported_parameter_t<T>>
-    void setParameter(const char* name, const T* values, size_t count) noexcept;
+    void setParameter(const char* name, size_t nameLength, const T* values, size_t count);
+
+    /** inline helper to provide the name as a null-terminated string literal */
+    template<typename T, typename = is_supported_parameter_t<T>>
+    inline void setParameter(StringLiteral name, const T* values, size_t count) {
+        setParameter<T>(name.data, name.size, values, count);
+    }
+
+    /** inline helper to provide the name as a null-terminated C string */
+    template<typename T, typename = is_supported_parameter_t<T>>
+    inline void setParameter(const char* name, const T* values, size_t count) {
+        setParameter<T>(name, strlen(name), values, count);
+    }
+
 
     /**
      * Set a texture as the named parameter
@@ -112,35 +152,73 @@ public:
      * Note: Depth textures can't be sampled with a linear filter unless the comparison mode is set
      *       to COMPARE_TO_TEXTURE.
      *
-     * @param name      Name of the parameter as defined by Material. Cannot be nullptr.
-     * @param texture   Non nullptr Texture object pointer.
-     * @param sampler   Sampler parameters.
+     * @param name          Name of the parameter as defined by Material. Cannot be nullptr.
+     * @param nameLength    Length in `char` of the name parameter.
+     * @param texture       Non nullptr Texture object pointer.
+     * @param sampler       Sampler parameters.
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
-    void setParameter(const char* name,
-            Texture const* texture, TextureSampler const& sampler) noexcept;
+    void setParameter(const char* name, size_t nameLength,
+            Texture const* texture, TextureSampler const& sampler);
+
+    /** inline helper to provide the name as a null-terminated string literal */
+    inline void setParameter(StringLiteral name,
+            Texture const* texture, TextureSampler const& sampler) {
+        setParameter(name.data, name.size, texture, sampler);
+    }
+
+    /** inline helper to provide the name as a null-terminated C string */
+    inline void setParameter(const char* name,
+            Texture const* texture, TextureSampler const& sampler) {
+        setParameter(name, strlen(name), texture, sampler);
+    }
+
 
     /**
      * Set an RGB color as the named parameter.
      * A conversion might occur depending on the specified type
      *
-     * @param name      Name of the parameter as defined by Material. Cannot be nullptr.
-     * @param type      Whether the color value is encoded as Linear or sRGB.
-     * @param color     Array of read, green, blue channels values.
+     * @param name          Name of the parameter as defined by Material. Cannot be nullptr.
+     * @param nameLength    Length in `char` of the name parameter.
+     * @param type          Whether the color value is encoded as Linear or sRGB.
+     * @param color         Array of read, green, blue channels values.
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
-    void setParameter(const char* name, RgbType type, math::float3 color) noexcept;
+    void setParameter(const char* name, size_t nameLength, RgbType type, math::float3 color);
+
+    /** inline helper to provide the name as a null-terminated string literal */
+    inline void setParameter(StringLiteral name, RgbType type, math::float3 color) {
+        setParameter(name.data, name.size, type, color);
+    }
+
+    /** inline helper to provide the name as a null-terminated C string */
+    inline void setParameter(const char* name, RgbType type, math::float3 color) {
+        setParameter(name, strlen(name), type, color);
+    }
+
 
     /**
      * Set an RGBA color as the named parameter.
      * A conversion might occur depending on the specified type
      *
-     * @param name      Name of the parameter as defined by Material. Cannot be nullptr.
-     * @param type      Whether the color value is encoded as Linear or sRGB/A.
-     * @param color     Array of read, green, blue and alpha channels values.
+     * @param name          Name of the parameter as defined by Material. Cannot be nullptr.
+     * @param nameLength    Length in `char` of the name parameter.
+     * @param type          Whether the color value is encoded as Linear or sRGB/A.
+     * @param color         Array of read, green, blue and alpha channels values.
      * @throws utils::PreConditionPanic if name doesn't exist or no-op if exceptions are disabled.
      */
-    void setParameter(const char* name, RgbaType type, math::float4 color) noexcept;
+    void setParameter(const char* name, size_t nameLength, RgbaType type, math::float4 color);
+
+    /** inline helper to provide the name as a null-terminated string literal */
+    inline void setParameter(StringLiteral name, RgbaType type, math::float4 color) {
+        setParameter(name.data, name.size, type, color);
+    }
+
+    /** inline helper to provide the name as a null-terminated C string */
+    inline void setParameter(const char* name, RgbaType type, math::float4 color) {
+        setParameter(name, strlen(name), type, color);
+    }
+
 
     /**
      * Set up a custom scissor rectangle; by default this encompasses the View.

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -342,7 +342,7 @@ bool FMaterial::isSampler(const char* name) const noexcept {
 
 UniformInterfaceBlock::UniformInfo const* FMaterial::reflect(
         utils::StaticString const& name) const noexcept {
-    return mUniformInterfaceBlock.getUniformInfo(name.c_str());
+    return mUniformInterfaceBlock.getUniformInfo({ name.c_str(), name.length() });
 }
 
 void FMaterial::prepareProgramSlow(Variant variant) const noexcept {

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -139,14 +139,14 @@ void FMaterialInstance::commitSlow(DriverApi& driver) const {
 
 // ------------------------------------------------------------------------------------------------
 
-void FMaterialInstance::setParameter(const char* name,
+void FMaterialInstance::setParameter(std::string_view name,
         backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) noexcept {
     size_t index = mMaterial->getSamplerInterfaceBlock().getSamplerInfo(name)->offset;
     mSamplers.setSampler(index, { texture, params });
 }
 
-void FMaterialInstance::setParameterImpl(const char* name,
-        Texture const* texture, TextureSampler const& sampler) noexcept {
+void FMaterialInstance::setParameterImpl(std::string_view name,
+        Texture const* texture, TextureSampler const& sampler) {
 
 #ifndef NDEBUG
     // Per GLES3.x specification, depth texture can't be filtered unless in compare mode.
@@ -161,8 +161,8 @@ void FMaterialInstance::setParameterImpl(const char* name,
                 minFilter == SamplerMinFilter::NEAREST_MIPMAP_LINEAR) {
                 PANIC_LOG("Depth textures can't be sampled with a linear filter "
                           "unless the comparison mode is set to COMPARE_TO_TEXTURE. "
-                          "(material: \"%s\", parameter: \"%s\")",
-                          getMaterial()->getName().c_str(), name);
+                          "(material: \"%s\", parameter: \"%.*s\")",
+                          getMaterial()->getName().c_str(), name.size(), name.data());
             }
         }
     }

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -122,7 +122,7 @@ public:
 
     const char* getName() const noexcept;
 
-    void setParameter(const char* name,
+    void setParameter(std::string_view name,
             backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) noexcept;
 
     using MaterialInstance::setParameter;
@@ -132,19 +132,19 @@ private:
     friend class MaterialInstance;
 
     template<size_t Size>
-    void setParameterUntypedImpl(const char* name, const void* value) noexcept;
+    void setParameterUntypedImpl(std::string_view name, const void* value);
 
     template<size_t Size>
-    void setParameterUntypedImpl(const char* name, const void* value, size_t count) noexcept;
+    void setParameterUntypedImpl(std::string_view name, const void* value, size_t count);
 
     template<typename T>
-    void setParameterImpl(const char* name, T const& value) noexcept;
+    void setParameterImpl(std::string_view name, T const& value);
 
     template<typename T>
-    void setParameterImpl(const char* name, const T* value, size_t count) noexcept;
+    void setParameterImpl(std::string_view name, const T* value, size_t count);
 
-    void setParameterImpl(const char* name,
-            Texture const* texture, TextureSampler const& sampler) noexcept;
+    void setParameterImpl(std::string_view name,
+            Texture const* texture, TextureSampler const& sampler);
 
     FMaterialInstance() noexcept;
     void initDefaultInstance(FEngine& engine, FMaterial const* material);

--- a/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
@@ -26,6 +26,7 @@
 
 #include <initializer_list>
 #include <unordered_map>
+#include <string_view>
 
 namespace filament {
 
@@ -105,9 +106,9 @@ public:
     }
 
     // information record for sampler of the given name
-    SamplerInfo const* getSamplerInfo(const char* name) const;
+    SamplerInfo const* getSamplerInfo(std::string_view name) const;
 
-    bool hasSampler(const char* name) const noexcept {
+    bool hasSampler(std::string_view name) const noexcept {
         return mInfoMap.find(name) != mInfoMap.end();
     }
 
@@ -123,7 +124,7 @@ private:
     utils::CString mName;
     backend::ShaderStageFlags mStageFlags{}; // It's needed to check if MAX_SAMPLER_COUNT is exceeded.
     utils::FixedCapacityVector<SamplerInfo> mSamplersInfoList;
-    std::unordered_map<const char*, uint32_t, utils::hashCStrings, utils::equalCStrings> mInfoMap;
+    std::unordered_map<std::string_view, uint32_t> mInfoMap;
 };
 
 } // namespace filament

--- a/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
@@ -116,11 +116,11 @@ public:
     }
 
     // negative value if name doesn't exist or Panic if exceptions are enabled
-    ssize_t getUniformOffset(const char* name, size_t index) const;
+    ssize_t getUniformOffset(std::string_view name, size_t index) const;
 
-    UniformInfo const* getUniformInfo(const char* name) const;
+    UniformInfo const* getUniformInfo(std::string_view name) const;
 
-    bool hasUniform(const char* name) const noexcept {
+    bool hasUniform(std::string_view name) const noexcept {
         return mInfoMap.find(name) != mInfoMap.end();
     }
 
@@ -136,7 +136,7 @@ private:
 
     utils::CString mName;
     utils::FixedCapacityVector<UniformInfo> mUniformsInfoList;
-    std::unordered_map<const char*, uint32_t, utils::hashCStrings, utils::equalCStrings> mInfoMap;
+    std::unordered_map<std::string_view , uint32_t> mInfoMap;
     uint32_t mSize = 0; // size in bytes rounded to multiple of 4
 };
 

--- a/libs/filabridge/src/SamplerInterfaceBlock.cpp
+++ b/libs/filabridge/src/SamplerInterfaceBlock.cpp
@@ -83,17 +83,16 @@ SamplerInterfaceBlock::SamplerInterfaceBlock(Builder const& builder) noexcept
         assert_invariant(i == e.offset);
         SamplerInfo& info = samplersInfoList[i++];
         info = e;
-        infoMap[info.name.c_str()] = info.offset; // info.name.c_str() guaranteed constant
+        infoMap[{ info.name.data(), info.name.size() }] = info.offset; // info.name.c_str() guaranteed constant
     }
     assert_invariant(i == samplersInfoList.size());
 }
 
 const SamplerInterfaceBlock::SamplerInfo* SamplerInterfaceBlock::getSamplerInfo(
-        const char* name) const {
-    auto const& pos = mInfoMap.find(name);
-    if (!ASSERT_PRECONDITION_NON_FATAL(pos != mInfoMap.end(), "sampler named \"%s\" not found", name)) {
-        return nullptr;
-    }
+        std::string_view name) const {
+    auto pos = mInfoMap.find(name);
+    ASSERT_PRECONDITION(pos != mInfoMap.end(), "sampler named \"%.*s\" not found",
+            name.size(), name.data());
     return &mSamplersInfoList[pos->second];
 }
 


### PR DESCRIPTION
Internally we use std::string_view and the public API is augmented
with APIs that take a length for strings, which makes them useable
with string_view parameters.

Also fix exception specification for all setParameter methods, which
can throw if exceptions are enabled (or exit the program otherwise).