### PR TITLE
make all public API pre-condition violation fatal

### DIFF
--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -281,6 +281,7 @@ public:
      * By default, this is an identity matrix.
      *
      * @param shift     x and y translation added to the projection matrix, specified in NDC
+     * @param shift     x and y translation added to the projection matrix, specified in NDC
      *                  coordinates, that is, if the translation must be specified in pixels,
      *                  shift must be scaled by 1.0 / { viewport.width, viewport.height }.
      *

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -291,18 +291,14 @@ UTILS_NOINLINE
 void RendererUtils::readPixels(backend::DriverApi& driver, Handle<HwRenderTarget> renderTargetHandle,
         uint32_t xoffset, uint32_t yoffset, uint32_t width, uint32_t height,
         backend::PixelBufferDescriptor&& buffer) {
-    if (!ASSERT_POSTCONDITION_NON_FATAL(
+    ASSERT_PRECONDITION(
             buffer.type != PixelDataType::COMPRESSED,
-            "buffer.format cannot be COMPRESSED")) {
-        return;
-    }
+            "buffer.format cannot be COMPRESSED");
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(
+    ASSERT_PRECONDITION(
             buffer.alignment > 0 && buffer.alignment <= 8 &&
             !(buffer.alignment & (buffer.alignment - 1u)),
-            "buffer.alignment must be 1, 2, 4 or 8")) {
-        return;
-    }
+            "buffer.alignment must be 1, 2, 4 or 8");
 
     // It's not really possible to know here which formats will be supported because
     // it can vary depending on the RenderTarget, in GL the following are ALWAYS supported though:
@@ -315,10 +311,8 @@ void RendererUtils::readPixels(backend::DriverApi& driver, Handle<HwRenderTarget
             buffer.top + height,
             buffer.alignment);
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(buffer.size >= sizeNeeded,
-            "Pixel buffer too small: has %u bytes, needs %u bytes", buffer.size, sizeNeeded)) {
-        return;
-    }
+    ASSERT_PRECONDITION(buffer.size >= sizeNeeded,
+            "Pixel buffer too small: has %u bytes, needs %u bytes", buffer.size, sizeNeeded);
 
     driver.readPixels(renderTargetHandle, xoffset, yoffset, width, height, std::move(buffer));
 }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -231,10 +231,8 @@ RenderableManager::Builder& RenderableManager::Builder::globalBlendOrderEnabled(
 RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& engine, Entity entity) {
     bool isEmpty = true;
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT,
-            "bone count > %u", CONFIG_MAX_BONE_COUNT)) {
-        return Error;
-    }
+    ASSERT_PRECONDITION(mImpl->mSkinningBoneCount <= CONFIG_MAX_BONE_COUNT,
+            "bone count > %u", CONFIG_MAX_BONE_COUNT);
 
     for (size_t i = 0, c = mImpl->mEntries.size(); i < c; i++) {
         auto& entry = mImpl->mEntries[i];
@@ -254,21 +252,15 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
         }
 
         // reject invalid geometry parameters
-        if (!ASSERT_PRECONDITION_NON_FATAL(entry.offset + entry.count <= entry.indices->getIndexCount(),
+        ASSERT_PRECONDITION(entry.offset + entry.count <= entry.indices->getIndexCount(),
                 "[entity=%u, primitive @ %u] offset (%u) + count (%u) > indexCount (%u)",
                 i, entity.getId(),
-                entry.offset, entry.count, entry.indices->getIndexCount())) {
-            entry.vertices = nullptr;
-            return Error;
-        }
+                entry.offset, entry.count, entry.indices->getIndexCount());
 
-        if (!ASSERT_PRECONDITION_NON_FATAL(entry.minIndex <= entry.maxIndex,
+        ASSERT_PRECONDITION(entry.minIndex <= entry.maxIndex,
                 "[entity=%u, primitive @ %u] minIndex (%u) > maxIndex (%u)",
                 i, entity.getId(),
-                entry.minIndex, entry.maxIndex)) {
-            entry.vertices = nullptr;
-            return Error;
-        }
+                entry.minIndex, entry.maxIndex);
 
         // this can't be an error because (1) those values are not immutable, so the caller
         // could fix later, and (2) the material's shader will work (i.e. compile), and
@@ -285,16 +277,13 @@ RenderableManager::Builder::Result RenderableManager::Builder::build(Engine& eng
         isEmpty = false;
     }
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(
+    ASSERT_PRECONDITION(
             !mImpl->mAABB.isEmpty() ||
             (!mImpl->mCulling && (!(mImpl->mReceiveShadows || mImpl->mCastShadows)) ||
              isEmpty),
             "[entity=%u] AABB can't be empty, unless culling is disabled and "
-                    "the object is not a shadow caster/receiver", entity.getId())) {
-        return Error;
-    }
+                    "the object is not a shadow caster/receiver", entity.getId());
 
-    // we get here only if there was no POSTCONDITION errors.
     upcast(engine).createRenderable(*this, entity);
     return Success;
 }

--- a/filament/src/details/IndirectLight.cpp
+++ b/filament/src/details/IndirectLight.cpp
@@ -150,23 +150,19 @@ IndirectLight::Builder& IndirectLight::Builder::rotation(mat3f const& rotation) 
 
 IndirectLight* IndirectLight::Builder::build(Engine& engine) {
     if (mImpl->mReflectionsMap) {
-        if (!ASSERT_POSTCONDITION_NON_FATAL(
+        ASSERT_PRECONDITION(
                 mImpl->mReflectionsMap->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP,
-                "reflection map must a cubemap")) {
-            return nullptr;
-        }
+                "reflection map must a cubemap");
 
-        if (IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING) {
+        if constexpr (IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING) {
             mImpl->mReflectionsMap->generateMipmaps(engine);
         }
     }
 
     if (mImpl->mIrradianceMap) {
-        if (!ASSERT_POSTCONDITION_NON_FATAL(
+        ASSERT_PRECONDITION(
                 mImpl->mIrradianceMap->getTarget() == Texture::Sampler::SAMPLER_CUBEMAP,
-                "irradiance map must a cubemap")) {
-            return nullptr;
-        }
+                "irradiance map must a cubemap");
     }
 
     return upcast(engine).createIndirectLight(*this);

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -53,15 +53,11 @@ static MaterialParser* createParser(Backend backend, const void* data, size_t si
         return materialParser;
     }
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult != MaterialParser::ParseResult::ERROR_MISSING_BACKEND,
-                "the material was not built for the %s backend\n", backendToString(backend))) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(materialResult != MaterialParser::ParseResult::ERROR_MISSING_BACKEND,
+                "the material was not built for the %s backend\n", backendToString(backend));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(materialResult == MaterialParser::ParseResult::SUCCESS,
-                "could not parse the material package")) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(materialResult == MaterialParser::ParseResult::SUCCESS,
+                "could not parse the material package");
 
     uint32_t version = 0;
     materialParser->getMaterialVersion(&version);

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -68,27 +68,21 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
     using backend::TextureUsage;
     const FRenderTarget::Attachment& color = mImpl->mAttachments[(size_t)AttachmentPoint::COLOR0];
     const FRenderTarget::Attachment& depth = mImpl->mAttachments[(size_t)AttachmentPoint::DEPTH];
-    if (!ASSERT_PRECONDITION_NON_FATAL(color.texture, "COLOR0 attachment not set")) {
-        return nullptr;
-    }
-    if (!ASSERT_PRECONDITION_NON_FATAL(color.texture->getUsage() & TextureUsage::COLOR_ATTACHMENT,
-            "Texture usage must contain COLOR_ATTACHMENT")) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(color.texture, "COLOR0 attachment not set");
+
+    ASSERT_PRECONDITION(color.texture->getUsage() & TextureUsage::COLOR_ATTACHMENT,
+            "Texture usage must contain COLOR_ATTACHMENT");
+
     if (depth.texture) {
-        if (!ASSERT_PRECONDITION_NON_FATAL(depth.texture->getUsage() & TextureUsage::DEPTH_ATTACHMENT,
-                "Texture usage must contain DEPTH_ATTACHMENT")) {
-            return nullptr;
-        }
+        ASSERT_PRECONDITION(depth.texture->getUsage() & TextureUsage::DEPTH_ATTACHMENT,
+                "Texture usage must contain DEPTH_ATTACHMENT");
     }
 
     const size_t maxDrawBuffers = upcast(engine).getDriverApi().getMaxDrawBuffers();
     for (size_t i = maxDrawBuffers; i < MAX_SUPPORTED_COLOR_ATTACHMENTS_COUNT; i++) {
-        if (!ASSERT_PRECONDITION_NON_FATAL(!mImpl->mAttachments[i].texture,
+        ASSERT_PRECONDITION(!mImpl->mAttachments[i].texture,
                 "Only %u color attachments are supported, but COLOR%u attachment is set",
-                maxDrawBuffers, i)) {
-            return nullptr;
-        }
+                maxDrawBuffers, i);
     }
     
     uint32_t minWidth = std::numeric_limits<uint32_t>::max();
@@ -106,10 +100,8 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
         }
     }
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(minWidth == maxWidth && minHeight == maxHeight,
-            "All attachments dimensions must match")) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(minWidth == maxWidth && minHeight == maxHeight,
+            "All attachments dimensions must match");
 
     mImpl->mWidth  = minWidth;
     mImpl->mHeight = minHeight;

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -78,10 +78,8 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
 Skybox* Skybox::Builder::build(Engine& engine) {
     FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(!cubemap || cubemap->isCubemap(),
-            "environment maps must be a cubemap")) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(!cubemap || cubemap->isCubemap(),
+            "environment maps must be a cubemap");
 
     return upcast(engine).createSkybox(*this);
 }

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -122,23 +122,21 @@ Texture::Builder& Texture::Builder::swizzle(Swizzle r, Swizzle g, Swizzle b, Swi
 }
 
 Texture* Texture::Builder::build(Engine& engine) {
-    if (!ASSERT_POSTCONDITION_NON_FATAL(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
-            "Texture format %u not supported on this platform", mImpl->mFormat)) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(Texture::isTextureFormatSupported(engine, mImpl->mFormat),
+            "Texture format %u not supported on this platform", mImpl->mFormat);
 
     const bool sampleable = bool(mImpl->mUsage & TextureUsage::SAMPLEABLE);
     const bool swizzled = mImpl->mTextureIsSwizzled;
     const bool imported = mImpl->mImportedId;
 
     #if defined(__EMSCRIPTEN__)
-    ASSERT_POSTCONDITION_NON_FATAL(!swizzled, "WebGL does not support texture swizzling.");
+    ASSERT_PRECONDITION(!swizzled, "WebGL does not support texture swizzling.");
     #endif
 
-    ASSERT_POSTCONDITION_NON_FATAL((swizzled && sampleable) || !swizzled,
+    ASSERT_PRECONDITION((swizzled && sampleable) || !swizzled,
             "Swizzled texture must be SAMPLEABLE");
 
-    ASSERT_POSTCONDITION_NON_FATAL((imported && sampleable) || !imported,
+    ASSERT_PRECONDITION((imported && sampleable) || !imported,
             "Imported texture must be SAMPLEABLE");
 
     return upcast(engine).createTexture(*this);
@@ -224,43 +222,31 @@ void FTexture::setImage(FEngine& engine, size_t level,
         }
     };
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(buffer.type == PixelDataType::COMPRESSED ||
-                         validatePixelFormatAndType(mFormat, buffer.format, buffer.type),
+    ASSERT_PRECONDITION(buffer.type == PixelDataType::COMPRESSED ||
+            validatePixelFormatAndType(mFormat, buffer.format, buffer.type),
             "The combination of internal format=%u and {format=%u, type=%u} is not supported.",
-            unsigned(mFormat), unsigned(buffer.format), unsigned(buffer.type))) {
-        return;
-    }
+            unsigned(mFormat), unsigned(buffer.format), unsigned(buffer.type));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(!mStream, "setImage() called on a Stream texture.")) {
-        return;
-    }
+    ASSERT_PRECONDITION(!mStream, "setImage() called on a Stream texture.");
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(level < mLevelCount,
-            "level=%u is >= to levelCount=%u.", unsigned(level), unsigned(mLevelCount))) {
-        return;
-    }
+    ASSERT_PRECONDITION(level < mLevelCount,
+            "level=%u is >= to levelCount=%u.", unsigned(level), unsigned(mLevelCount));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(validateTarget(mTarget),
-            "Texture Sampler type (%u) not supported for this operation.", unsigned(mTarget))) {
-        return;
-    }
+    ASSERT_PRECONDITION(validateTarget(mTarget),
+            "Texture Sampler type (%u) not supported for this operation.", unsigned(mTarget));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(mSampleCount <= 1,
-            "Operation not supported with multisample (%u) texture.", unsigned(mSampleCount))) {
-        return;
-    }
+    ASSERT_PRECONDITION(mSampleCount <= 1,
+            "Operation not supported with multisample (%u) texture.", unsigned(mSampleCount));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(xoffset + width <= valueForLevel(level, mWidth),
+    ASSERT_PRECONDITION(xoffset + width <= valueForLevel(level, mWidth),
             "xoffset (%u) + width (%u) > texture width (%u) at level (%u)",
-            unsigned(xoffset), unsigned(width), unsigned(valueForLevel(level, mWidth)), unsigned(level))) {
-        return;
-    }
+            unsigned(xoffset), unsigned(width), unsigned(valueForLevel(level, mWidth)), unsigned(level));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(yoffset + height <= valueForLevel(level, mHeight),
+    ASSERT_PRECONDITION(yoffset + height <= valueForLevel(level, mHeight),
             "yoffset (%u) + height (%u) > texture height (%u) at level (%u)",
-            unsigned(yoffset), unsigned(height), unsigned(valueForLevel(level, mHeight)), unsigned(level))) {
-        return;
-    }
+            unsigned(yoffset), unsigned(height), unsigned(valueForLevel(level, mHeight)), unsigned(level));
+
+    ASSERT_PRECONDITION(buffer.buffer, "Data buffer is nullptr.");
 
     uint32_t textureDepthOrLayers;
     switch (mTarget) {
@@ -284,15 +270,9 @@ void FTexture::setImage(FEngine& engine, size_t level,
             break;
     }
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(zoffset + depth <= textureDepthOrLayers,
+    ASSERT_PRECONDITION(zoffset + depth <= textureDepthOrLayers,
             "zoffset (%u) + depth (%u) > texture depth (%u) at level (%u)",
-            unsigned(zoffset), unsigned(depth), textureDepthOrLayers, unsigned(level))) {
-        return;
-    }
-
-    if (!ASSERT_POSTCONDITION_NON_FATAL(buffer.buffer, "Data buffer is nullptr.")) {
-        return;
-    }
+            unsigned(zoffset), unsigned(depth), textureDepthOrLayers, unsigned(level));
 
     engine.getDriverApi().update3DImage(mHandle,
             uint8_t(level), xoffset, yoffset, zoffset, width, height, depth, std::move(buffer));
@@ -315,30 +295,20 @@ void FTexture::setImage(FEngine& engine, size_t level,
         }
     };
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(buffer.type == PixelDataType::COMPRESSED ||
+    ASSERT_PRECONDITION(buffer.type == PixelDataType::COMPRESSED ||
                         validatePixelFormatAndType(mFormat, buffer.format, buffer.type),
             "The combination of internal format=%u and {format=%u, type=%u} is not supported.",
-            unsigned(mFormat), unsigned(buffer.format), unsigned(buffer.type))) {
-        return;
-    }
+            unsigned(mFormat), unsigned(buffer.format), unsigned(buffer.type));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(!mStream, "setImage() called on a Stream texture.")) {
-        return;
-    }
+    ASSERT_PRECONDITION(!mStream, "setImage() called on a Stream texture.");
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(level < mLevelCount,
-            "level=%u is >= to levelCount=%u.", unsigned(level), unsigned(mLevelCount))) {
-        return;
-    }
+    ASSERT_PRECONDITION(level < mLevelCount,
+            "level=%u is >= to levelCount=%u.", unsigned(level), unsigned(mLevelCount));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(validateTarget(mTarget),
-            "Texture Sampler type (%u) not supported for this operation.", unsigned(mTarget))) {
-        return;
-    }
+    ASSERT_PRECONDITION(validateTarget(mTarget),
+            "Texture Sampler type (%u) not supported for this operation.", unsigned(mTarget));
 
-    if (!ASSERT_POSTCONDITION_NON_FATAL(buffer.buffer, "Data buffer is nullptr.")) {
-        return;
-    }
+    ASSERT_PRECONDITION(buffer.buffer, "Data buffer is nullptr.");
 
     auto w = std::max(1u, mWidth >> level);
     auto h = std::max(1u, mHeight >> level);
@@ -375,10 +345,9 @@ void FTexture::setExternalImage(FEngine& engine, void* image, size_t plane) noex
 
 void FTexture::setExternalStream(FEngine& engine, FStream* stream) noexcept {
     if (stream) {
-        if (!ASSERT_POSTCONDITION_NON_FATAL(mTarget == Sampler::SAMPLER_EXTERNAL,
-                "Texture target must be SAMPLER_EXTERNAL")) {
-            return;
-        }
+        ASSERT_PRECONDITION(mTarget == Sampler::SAMPLER_EXTERNAL,
+                "Texture target must be SAMPLER_EXTERNAL");
+
         mStream = stream;
         engine.getDriverApi().setExternalStream(mHandle, stream->getHandle());
     } else {
@@ -388,16 +357,12 @@ void FTexture::setExternalStream(FEngine& engine, FStream* stream) noexcept {
 }
 
 void FTexture::generateMipmaps(FEngine& engine) const noexcept {
-    if (!ASSERT_POSTCONDITION_NON_FATAL(mTarget != SamplerType::SAMPLER_EXTERNAL,
-            "External Textures are not mipmappable.")) {
-        return;
-    }
+    ASSERT_PRECONDITION(mTarget != SamplerType::SAMPLER_EXTERNAL,
+            "External Textures are not mipmappable.");
 
     const bool formatMipmappable = engine.getDriverApi().isTextureFormatMipmappable(mFormat);
-    if (!ASSERT_POSTCONDITION_NON_FATAL(formatMipmappable,
-            "Texture format %u is not mipmappable.", (unsigned)mFormat)) {
-        return;
-    }
+    ASSERT_PRECONDITION(formatMipmappable,
+            "Texture format %u is not mipmappable.", (unsigned)mFormat);
 
     if (mLevelCount < 2 || (mWidth == 1 && mHeight == 1)) {
         return;
@@ -503,31 +468,23 @@ void FTexture::generatePrefilterMipmap(FEngine& engine,
 
     /* validate input data */
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(buffer.format == PixelDataFormat::RGB ||
+    ASSERT_PRECONDITION(buffer.format == PixelDataFormat::RGB ||
                                        buffer.format == PixelDataFormat::RGBA,
-            "input data format must be RGB or RGBA")) {
-        return;
-    }
+            "input data format must be RGB or RGBA");
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(
+    ASSERT_PRECONDITION(
             buffer.type == PixelDataType::FLOAT ||
             buffer.type == PixelDataType::HALF ||
             buffer.type == PixelDataType::UINT_10F_11F_11F_REV,
-            "input data type must be FLOAT, HALF or UINT_10F_11F_11F_REV")) {
-        return;
-    }
+            "input data type must be FLOAT, HALF or UINT_10F_11F_11F_REV");
 
     /* validate texture */
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(!(size & (size-1)),
-            "input data cubemap dimensions must be a power-of-two")) {
-        return;
-    }
+    ASSERT_PRECONDITION(!(size & (size-1)),
+            "input data cubemap dimensions must be a power-of-two");
 
-    if (!ASSERT_PRECONDITION_NON_FATAL(!isCompressed(),
-            "reflections texture cannot be compressed")) {
-        return;
-    }
+    ASSERT_PRECONDITION(!isCompressed(),
+            "reflections texture cannot be compressed");
 
 
     PrefilterOptions defaultOptions;

--- a/filament/src/details/VertexBuffer.cpp
+++ b/filament/src/details/VertexBuffer.cpp
@@ -113,16 +113,10 @@ VertexBuffer::Builder& VertexBuffer::Builder::normalized(VertexAttribute attribu
 }
 
 VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
-    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mVertexCount > 0, "vertexCount cannot be 0")) {
-        return nullptr;
-    }
-    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount > 0, "bufferCount cannot be 0")) {
-        return nullptr;
-    }
-    if (!ASSERT_PRECONDITION_NON_FATAL(mImpl->mBufferCount <= MAX_VERTEX_BUFFER_COUNT,
-            "bufferCount cannot be more than %d", MAX_VERTEX_BUFFER_COUNT)) {
-        return nullptr;
-    }
+    ASSERT_PRECONDITION(mImpl->mVertexCount > 0, "vertexCount cannot be 0");
+    ASSERT_PRECONDITION(mImpl->mBufferCount > 0, "bufferCount cannot be 0");
+    ASSERT_PRECONDITION(mImpl->mBufferCount <= MAX_VERTEX_BUFFER_COUNT,
+            "bufferCount cannot be more than %d", MAX_VERTEX_BUFFER_COUNT);
 
     // Next we check if any unused buffer slots have been allocated. This helps prevent errors
     // because uploading to an unused slot can trigger undefined behavior in the backend.
@@ -134,10 +128,9 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
             attributedBuffers.set(attributes[j].buffer);
         }
     }
-    if (!ASSERT_PRECONDITION_NON_FATAL(attributedBuffers.count() == mImpl->mBufferCount,
-            "At least one buffer slot was never assigned to an attribute.")) {
-        return nullptr;
-    }
+
+    ASSERT_PRECONDITION(attributedBuffers.count() == mImpl->mBufferCount,
+            "At least one buffer slot was never assigned to an attribute.");
 
     return upcast(engine).createVertexBuffer(*this);
 }

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -279,20 +279,16 @@ FrameGraphHandle FrameGraph::addSubResourceInternal(FrameGraphHandle parent,
 FrameGraphHandle FrameGraph::readInternal(FrameGraphHandle handle, PassNode* passNode,
         const std::function<bool(ResourceNode*, VirtualResource*)>& connect) {
 
-    if (!assertValid(handle)) {
-        return {};
-    }
+    assertValid(handle);
 
     VirtualResource* const resource = getResource(handle);
     ResourceNode* const node = getActiveResourceNode(handle);
 
     // Check preconditions
     bool passAlreadyAWriter = node->hasWriteFrom(passNode);
-    if (!ASSERT_PRECONDITION_NON_FATAL(!passAlreadyAWriter,
+    ASSERT_PRECONDITION(!passAlreadyAWriter,
             "Pass \"%s\" already writes to \"%s\"",
-            passNode->getName(), node->getName())) {
-        return {};
-    }
+            passNode->getName(), node->getName());
 
     if (!node->hasWriterPass() && !resource->isImported()) {
         // TODO: we're attempting to read from a resource that was never written and is not
@@ -340,9 +336,8 @@ FrameGraphHandle FrameGraph::readInternal(FrameGraphHandle handle, PassNode* pas
 
 FrameGraphHandle FrameGraph::writeInternal(FrameGraphHandle handle, PassNode* passNode,
         const std::function<bool(ResourceNode*, VirtualResource*)>& connect) {
-    if (!assertValid(handle)) {
-        return {};
-    }
+
+    assertValid(handle);
 
     VirtualResource* const resource = getResource(handle);
     ResourceNode* node = getActiveResourceNode(handle);
@@ -391,13 +386,9 @@ FrameGraphHandle FrameGraph::writeInternal(FrameGraphHandle handle, PassNode* pa
 FrameGraphHandle FrameGraph::forwardResourceInternal(FrameGraphHandle resourceHandle,
         FrameGraphHandle replaceResourceHandle) {
 
-    if (!assertValid(resourceHandle)) {
-        return {};
-    }
+    assertValid(resourceHandle);
 
-    if (!assertValid(replaceResourceHandle)) {
-        return {};
-    }
+    assertValid(replaceResourceHandle);
 
     ResourceSlot& replacedResourceSlot = getResourceSlot(replaceResourceHandle);
     ResourceNode* const replacedResourceNode = getActiveResourceNode(replaceResourceHandle);
@@ -456,8 +447,8 @@ bool FrameGraph::isValid(FrameGraphHandle handle) const {
     return true;
 }
 
-bool FrameGraph::assertValid(FrameGraphHandle handle) const {
-    return ASSERT_PRECONDITION_NON_FATAL(isValid(handle),
+void FrameGraph::assertValid(FrameGraphHandle handle) const {
+    ASSERT_PRECONDITION(isValid(handle),
             "Resource handle is invalid or uninitialized {id=%u, version=%u}",
             (int)handle.index, (int)handle.version);
 }

--- a/filament/src/fg/FrameGraph.h
+++ b/filament/src/fg/FrameGraph.h
@@ -460,7 +460,7 @@ private:
     FrameGraphHandle forwardResourceInternal(FrameGraphHandle resourceHandle,
             FrameGraphHandle replaceResourceHandle);
 
-    bool assertValid(FrameGraphHandle handle) const;
+    void assertValid(FrameGraphHandle handle) const;
 
     template<typename RESOURCE>
     FrameGraphId<RESOURCE> create(char const* name,

--- a/filament/src/fg/Resource.cpp
+++ b/filament/src/fg/Resource.cpp
@@ -95,12 +95,12 @@ ImportedRenderTarget::ImportedRenderTarget(char const* resourceName,
 }
 
 UTILS_NOINLINE
-bool ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
+void ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
     constexpr auto ANY_ATTACHMENT = FrameGraphTexture::Usage::COLOR_ATTACHMENT |
                                     FrameGraphTexture::Usage::DEPTH_ATTACHMENT |
                                     FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
 
-    return ASSERT_PRECONDITION_NON_FATAL(none(u & ~ANY_ATTACHMENT),
+    ASSERT_PRECONDITION(none(u & ~ANY_ATTACHMENT),
             "Imported render target resource \"%s\" can only be used as an attachment (usage=%s)",
             name, utils::to_string(u).c_str());
 }
@@ -108,18 +108,14 @@ bool ImportedRenderTarget::assertConnect(FrameGraphTexture::Usage u) {
 bool ImportedRenderTarget::connect(DependencyGraph& graph, PassNode* passNode,
         ResourceNode* resourceNode, TextureUsage u) {
     // pass Node to resource Node edge (a write to)
-    if (UTILS_UNLIKELY(!assertConnect(u))) {
-        return false;
-    }
+    assertConnect(u);
     return Resource::connect(graph, passNode, resourceNode, u);
 }
 
 bool ImportedRenderTarget::connect(DependencyGraph& graph, ResourceNode* resourceNode,
         PassNode* passNode, TextureUsage u) {
     // resource Node to pass Node edge (a read from)
-    if (UTILS_UNLIKELY(!assertConnect(u))) {
-        return false;
-    }
+    assertConnect(u);
     return Resource::connect(graph, resourceNode, passNode, u);
 }
 

--- a/filament/src/fg/details/Resource.h
+++ b/filament/src/fg/details/Resource.h
@@ -280,25 +280,21 @@ protected:
     UTILS_NOINLINE
     bool connect(DependencyGraph& graph,
             PassNode* passNode, ResourceNode* resourceNode, FrameGraphTexture::Usage u) override {
-        if (UTILS_UNLIKELY(!assertConnect(u))) {
-            return false;
-        }
+        assertConnect(u);
         return Resource<RESOURCE>::connect(graph, passNode, resourceNode, u);
     }
 
     UTILS_NOINLINE
     bool connect(DependencyGraph& graph,
             ResourceNode* resourceNode, PassNode* passNode, FrameGraphTexture::Usage u) override {
-        if (UTILS_UNLIKELY(!assertConnect(u))) {
-            return false;
-        }
+        assertConnect(u);
         return Resource<RESOURCE>::connect(graph, resourceNode, passNode, u);
     }
 
 private:
     UTILS_NOINLINE
-    bool assertConnect(FrameGraphTexture::Usage u) {
-        return ASSERT_PRECONDITION_NON_FATAL((u & this->usage) == u,
+    void assertConnect(FrameGraphTexture::Usage u) {
+        ASSERT_PRECONDITION((u & this->usage) == u,
                 "Requested usage %s not available on imported resource \"%s\" with usage %s",
                 utils::to_string(u).c_str(), this->name, utils::to_string(this->usage).c_str());
     }
@@ -330,7 +326,7 @@ protected:
     ImportedRenderTarget* asImportedRenderTarget() noexcept override { return this; }
 
 private:
-    bool assertConnect(FrameGraphTexture::Usage u);
+    void assertConnect(FrameGraphTexture::Usage u);
 
     static FrameGraphTexture::Usage usageFromAttachmentsFlags(
             backend::TargetBufferFlags attachments) noexcept;


### PR DESCRIPTION
We used to have a mix of fatal and non-fatal assertions for precondtions
errors. From now on, we always throw if exceptions are enabled or 
crash with a log otherwise.