### PR TITLE
make all camera APIs double

### DIFF
--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -356,17 +356,9 @@ public:
      * @param center    The point in world space the camera is looking at.
      * @param up        A unit vector denoting the camera's "up" direction.
      */
-    void lookAt(const math::float3& eye,
-                const math::float3& center,
-                const math::float3& up) noexcept;
-
-    /** Sets the camera's model matrix, assuming up is along the y axis
-     *
-     * @param eye       The position of the camera in world space.
-     * @param center    The point in world space the camera is looking at.
-     */
-    void lookAt(const math::float3& eye,
-                const math::float3& center) noexcept;
+    void lookAt(math::double3 const& eye,
+                math::double3 const& center,
+                math::double3 const& up = math::double3{0, 1, 0}) noexcept;
 
     /** Returns the camera's model matrix
      *

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -379,7 +379,7 @@ public:
     math::mat4 getViewMatrix() const noexcept;
 
     //! Returns the camera's position in world space
-    math::float3 getPosition() const noexcept;
+    math::double3 getPosition() const noexcept;
 
     //! Returns the camera's normalized left vector
     math::float3 getLeftVector() const noexcept;

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -143,7 +143,7 @@ mat4 Camera::getViewMatrix() const noexcept {
     return upcast(this)->getViewMatrix();
 }
 
-float3 Camera::getPosition() const noexcept {
+double3 Camera::getPosition() const noexcept {
     return upcast(this)->getPosition();
 }
 

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -131,12 +131,8 @@ void Camera::setModelMatrix(const mat4f& modelMatrix) noexcept {
     upcast(this)->setModelMatrix(modelMatrix);
 }
 
-void Camera::lookAt(const float3& eye, const float3& center, float3 const& up) noexcept {
+void Camera::lookAt(double3 const& eye, double3 const& center, double3 const& up) noexcept {
     upcast(this)->lookAt(eye, center, up);
-}
-
-void Camera::lookAt(const float3& eye, const float3& center) noexcept {
-    upcast(this)->lookAt(eye, center, {0, 1, 0});
 }
 
 mat4 Camera::getModelMatrix() const noexcept {

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -177,7 +177,7 @@ void UTILS_NOINLINE FCamera::setModelMatrix(const mat4& modelMatrix) noexcept {
     transformManager.setTransform(transformManager.getInstance(mEntity), modelMatrix);
 }
 
-void FCamera::lookAt(const float3& eye, const float3& center, const float3& up) noexcept {
+void FCamera::lookAt(double3 const& eye, double3 const& center, double3 const& up) noexcept {
     FTransformManager& transformManager = mEngine.getTransformManager();
     transformManager.setTransform(transformManager.getInstance(mEntity),
             mat4::lookAt(eye, center, up));

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -93,8 +93,7 @@ public:
     void setModelMatrix(const math::mat4f& modelMatrix) noexcept;
 
     // sets the camera's model matrix
-    void lookAt(const math::float3& eye, const math::float3& center,
-            const math::float3& up = { 0, 1, 0 })  noexcept;
+    void lookAt(math::double3 const& eye, math::double3 const& center, math::double3 const& up) noexcept;
 
     // returns the model matrix
     math::mat4 getModelMatrix() const noexcept;


### PR DESCRIPTION
This was already mostly the case, but we had two stray APIs that were still `float3` at the public API level, but were already `double3` internally. 