### PR TITLE
Move stencil state out of RasterState

### DIFF
--- a/filament/backend/include/backend/PipelineState.h
+++ b/filament/backend/include/backend/PipelineState.h
@@ -31,6 +31,7 @@ namespace filament::backend {
 struct PipelineState {
     Handle<HwProgram> program;
     RasterState rasterState;
+    StencilState stencilState;
     PolygonOffset polygonOffset;
     Viewport scissor{ 0, 0,
                       (uint32_t)std::numeric_limits<int32_t>::max(),

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1234,12 +1234,13 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
         depthState.depthWriteEnabled = rs.depthWrite;
     }
     if (stencilAttachment) {
-        depthState.stencilCompare = getMetalCompareFunction(rs.stencilFunc);
-        depthState.stencilOperationDepthStencilPass = getMetalStencilOperation(rs.stencilOpDepthStencilPass);
-        depthState.stencilOperationDepthFail = getMetalStencilOperation(rs.stencilOpDepthFail);
-        depthState.stencilOperationStencilFail = getMetalStencilOperation(rs.stencilOpStencilFail);
-        depthState.stencilWriteEnabled = rs.stencilWrite;
-        [mContext->currentRenderPassEncoder setStencilReferenceValue:rs.stencilRef];
+        const auto& ss = ps.stencilState;
+        depthState.stencilCompare = getMetalCompareFunction(ss.frontBack.stencilFunc);
+        depthState.stencilOperationDepthStencilPass = getMetalStencilOperation(ss.frontBack.stencilOpDepthStencilPass);
+        depthState.stencilOperationDepthFail = getMetalStencilOperation(ss.frontBack.stencilOpDepthFail);
+        depthState.stencilOperationStencilFail = getMetalStencilOperation(ss.frontBack.stencilOpStencilFail);
+        depthState.stencilWriteEnabled = ss.stencilWrite;
+        [mContext->currentRenderPassEncoder setStencilReferenceValue:ss.referenceValue];
     }
     mContext->depthStencilState.updateState(depthState);
     if (mContext->depthStencilState.stateChanged()) {

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -52,7 +52,7 @@ constexpr inline MTLCompareFunction getMetalCompareFunction(RasterState::DepthFu
     }
 }
 
-constexpr inline MTLStencilOperation getMetalStencilOperation(RasterState::StencilOperation op) {
+constexpr inline MTLStencilOperation getMetalStencilOperation(StencilOperation op) {
     switch (op) {
         case StencilOperation::KEEP: return MTLStencilOperationKeep;
         case StencilOperation::ZERO: return MTLStencilOperationZero;

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -286,6 +286,13 @@ private:
         }
     }
 
+    void setStencilStateSlow(StencilState ss) noexcept;
+    void setStencilState(StencilState ss) noexcept {
+        if (UTILS_UNLIKELY(ss != mStencilState)) {
+            setStencilStateSlow(ss);
+        }
+    }
+
     void setTextureData(GLTexture* t,
             uint32_t level,
             uint32_t xoffset, uint32_t yoffset, uint32_t zoffset,
@@ -337,6 +344,7 @@ private:
             GLRenderTarget const* rt, TargetBufferFlags buffers) noexcept;
 
     RasterState mRasterState;
+    StencilState mStencilState;
 
     // state required to represent the current render pass
     Handle<HwRenderTarget> mRenderPassTarget;

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -106,8 +106,8 @@ public:
         ps.program = program;
         ps.rasterState.colorWrite = false;
         ps.rasterState.depthWrite = false;
-        ps.rasterState.stencilWrite = true;
-        ps.rasterState.stencilOpDepthStencilPass = StencilOperation::INCR;
+        ps.stencilState.stencilWrite = true;
+        ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::INCR;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
@@ -120,10 +120,10 @@ public:
         params.flags.clear = TargetBufferFlags::NONE;
         params.flags.discardStart = TargetBufferFlags::NONE;
         ps.rasterState.colorWrite = true;
-        ps.rasterState.stencilWrite = false;
-        ps.rasterState.stencilOpDepthStencilPass = StencilOperation::KEEP;
-        ps.rasterState.stencilFunc = RasterState::StencilFunction::E;
-        ps.rasterState.stencilRef = 0u;
+        ps.stencilState.stencilWrite = false;
+        ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::KEEP;
+        ps.stencilState.frontBack.stencilFunc = StencilState::StencilFunction::E;
+        ps.stencilState.referenceValue = 0u;
 
         api.beginRenderPass(renderTarget, params);
         api.draw(ps, triangle.getRenderPrimitive(), 1);
@@ -233,8 +233,8 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     ps.program = program;
     ps.rasterState.colorWrite = false;
     ps.rasterState.depthWrite = false;
-    ps.rasterState.stencilWrite = true;
-    ps.rasterState.stencilOpDepthStencilPass = StencilOperation::INCR;
+    ps.stencilState.stencilWrite = true;
+    ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::INCR;
 
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
@@ -249,10 +249,10 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     params.flags.discardEnd = TargetBufferFlags::STENCIL;
     params.clearColor = math::float4(0.0f, 0.0f, 1.0f, 1.0f);
     ps.rasterState.colorWrite = true;
-    ps.rasterState.stencilWrite = false;
-    ps.rasterState.stencilOpDepthStencilPass = StencilOperation::KEEP;
-    ps.rasterState.stencilFunc = RasterState::StencilFunction::E;
-    ps.rasterState.stencilRef = 0u;
+    ps.stencilState.stencilWrite = false;
+    ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::KEEP;
+    ps.stencilState.frontBack.stencilFunc = StencilState::StencilFunction::E;
+    ps.stencilState.referenceValue = 0u;
 
     api.beginRenderPass(renderTarget1, params);
     api.draw(ps, triangle.getRenderPrimitive(), 1);


### PR DESCRIPTION
This allows us to grow the stencil state without having to pack additional bits into `RasterState`. In a separate PR I'll add support for separate front/back stencil states and masking.