### PR TITLE
Fix StructureOfArray alignments

### DIFF
--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -19,6 +19,7 @@
 
 #include <utils/compiler.h>
 #include <utils/Entity.h>
+#include <utils/EntityInstance.h>
 #include <utils/EntityManager.h>
 #include <utils/StructureOfArrays.h>
 


### PR DESCRIPTION
StructureOfArray always aligned each array to the same alignment as
malloc (usually 8 bytes), but that was not enough if one of its type 
has stricter alignment requirements. 

StructureOfArray now always honors at least the alignment requirement
of each array.

Also removed dependency on EntityInstance.h

Fixes #5727