### PR TITLE
Add additional state to StencilState

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -977,7 +977,7 @@ struct StencilState {
     }
     bool operator!=(StencilState rhs) const noexcept { return !(*this == rhs); }
 
-    bool stencilEnabled() const noexcept {
+    bool isStencilEnabled() const noexcept {
         return stencilWrite ||
                 front.stencilFunc != StencilState::StencilFunction::A ||
                 back.stencilFunc != StencilState::StencilFunction::A;
@@ -1010,9 +1010,15 @@ struct StencilState {
         uint32_t u = 0;
     };
 
+    //! Stencil operations for front-facing polygons
     StencilOperations front;
+
+    //! Stencil operations for back-facing polygons
     StencilOperations back;
+
+    //! Reference value for stencil comparison tests
     uint8_t referenceValue;
+
     //! Whether stencil-buffer writes are enabled
     bool stencilWrite;
 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -960,41 +960,63 @@ struct PolygonOffset {
 struct StencilState {
     using StencilFunction = SamplerCompareFunc;
 
-    StencilState() noexcept : referenceValue(0u), stencilWrite(false) {
-        static_assert(sizeof(StencilState) == 4u, "StencilState size not what was intended");
-        frontBack.u = 0u;
-        frontBack.stencilFunc = StencilFunction::A;
+    StencilState() noexcept : referenceValue(0u), stencilWrite(false), padding(0u) {
+        static_assert(sizeof(StencilOperations) == sizeof(uint32_t), "StencilOperations size not what was intended");
+        static_assert(sizeof(StencilState) == 12u, "StencilState size not what was intended");
+        front.u = back.u = 0u;
+        front.stencilFunc = back.stencilFunc = StencilFunction::A;
+        front.readMask = back.readMask = 0xFF;
+        front.writeMask = back.writeMask = 0xFF;
     }
 
     bool operator==(StencilState rhs) const noexcept {
-        return frontBack.u == rhs.frontBack.u &&
+        return front.u == rhs.front.u &&
+                back.u == rhs.back.u &&
                 referenceValue == rhs.referenceValue &&
                 stencilWrite == rhs.stencilWrite;
     }
     bool operator!=(StencilState rhs) const noexcept { return !(*this == rhs); }
 
+    bool stencilEnabled() const noexcept {
+        return stencilWrite ||
+                front.stencilFunc != StencilState::StencilFunction::A ||
+                back.stencilFunc != StencilState::StencilFunction::A;
+    }
+
     union StencilOperations {
         struct {
             //! Stencil test function
-            StencilFunction stencilFunc                     : 3;
+            StencilFunction stencilFunc                     : 3;                    // 3
 
             //! Stencil operation when stencil test fails
-            StencilOperation stencilOpStencilFail           : 3;
+            StencilOperation stencilOpStencilFail           : 3;                    // 6
+
+            uint8_t padding0                                : 2;                    // 8
 
             //! Stencil operation when stencil test passes but depth test fails
-            StencilOperation stencilOpDepthFail             : 3;
+            StencilOperation stencilOpDepthFail             : 3;                    // 11
 
             //! Stencil operation when both stencil and depth test pass
-            StencilOperation stencilOpDepthStencilPass      : 3;
+            StencilOperation stencilOpDepthStencilPass      : 3;                    // 14
+
+            uint8_t padding1                                : 2;                    // 16
+
+            //! Masks the bits of the stencil values participating in the stencil comparison test.
+            uint8_t readMask                                : 8;                    // 24
+
+            //! Masks the bits of the stencil values updated by the stencil test.
+            uint8_t writeMask                               : 8;                    // 32
         };
-        uint16_t u = 0;
+        uint32_t u = 0;
     };
 
-    // TODO: separate out front and back stencil states.
-    StencilOperations frontBack;
+    StencilOperations front;
+    StencilOperations back;
     uint8_t referenceValue;
     //! Whether stencil-buffer writes are enabled
     bool stencilWrite;
+
+    uint16_t padding;
 };
 
 using FrameScheduledCallback = void(*)(PresentCallable callable, void* user);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1235,10 +1235,25 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
     }
     if (stencilAttachment) {
         const auto& ss = ps.stencilState;
-        depthState.stencilCompare = getMetalCompareFunction(ss.frontBack.stencilFunc);
-        depthState.stencilOperationDepthStencilPass = getMetalStencilOperation(ss.frontBack.stencilOpDepthStencilPass);
-        depthState.stencilOperationDepthFail = getMetalStencilOperation(ss.frontBack.stencilOpDepthFail);
-        depthState.stencilOperationStencilFail = getMetalStencilOperation(ss.frontBack.stencilOpStencilFail);
+
+        auto& front = depthState.front;
+        front.stencilCompare = getMetalCompareFunction(ss.front.stencilFunc);
+        front.stencilOperationStencilFail = getMetalStencilOperation(ss.front.stencilOpStencilFail);
+        front.stencilOperationDepthFail = getMetalStencilOperation(ss.front.stencilOpDepthFail);
+        front.stencilOperationDepthStencilPass =
+                getMetalStencilOperation(ss.front.stencilOpDepthStencilPass);
+        front.readMask = ss.front.readMask;
+        front.writeMask = ss.front.writeMask;
+
+        auto& back = depthState.back;
+        back.stencilCompare = getMetalCompareFunction(ss.back.stencilFunc);
+        back.stencilOperationStencilFail = getMetalStencilOperation(ss.back.stencilOpStencilFail);
+        back.stencilOperationDepthFail = getMetalStencilOperation(ss.back.stencilOpDepthFail);
+        back.stencilOperationDepthStencilPass =
+                getMetalStencilOperation(ss.back.stencilOpDepthStencilPass);
+        back.readMask = ss.back.readMask;
+        back.writeMask = ss.back.writeMask;
+
         depthState.stencilWriteEnabled = ss.stencilWrite;
         [mContext->currentRenderPassEncoder setStencilReferenceValue:ss.referenceValue];
     }

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -258,23 +258,39 @@ using PipelineStateCache = StateCache<MetalPipelineState, id<MTLRenderPipelineSt
 // Depth-stencil State
 
 struct DepthStencilState {
+    struct StencilDescriptor {
+        MTLCompareFunction stencilCompare = MTLCompareFunctionAlways;                   // 8 bytes
+        MTLStencilOperation stencilOperationStencilFail = MTLStencilOperationKeep;      // 8 bytes
+        MTLStencilOperation stencilOperationDepthFail = MTLStencilOperationKeep;        // 8 bytes
+        MTLStencilOperation stencilOperationDepthStencilPass = MTLStencilOperationKeep; // 8 bytes
+        uint32_t readMask = 0xFFFF;                                                     // 4 bytes
+        uint32_t writeMask = 0xFFFF;                                                    // 4 bytes
+
+        bool operator==(const StencilDescriptor& rhs) const {
+            return stencilCompare == rhs.stencilCompare &&
+                   stencilOperationStencilFail == rhs.stencilOperationStencilFail &&
+                   stencilOperationDepthFail == rhs.stencilOperationDepthFail &&
+                   stencilOperationDepthStencilPass == rhs.stencilOperationDepthStencilPass &&
+                   readMask == rhs.readMask &&
+                   writeMask == rhs.writeMask;
+        }
+
+        bool operator!=(const StencilDescriptor& rhs) const {
+            return !(rhs == *this);
+        }
+    } front, back;
+
     MTLCompareFunction depthCompare = MTLCompareFunctionAlways;                         // 8 bytes
-    MTLCompareFunction stencilCompare = MTLCompareFunctionAlways;                       // 8 bytes
-    MTLStencilOperation stencilOperationStencilFail = MTLStencilOperationKeep;          // 8 bytes
-    MTLStencilOperation stencilOperationDepthFail = MTLStencilOperationKeep;            // 8 bytes
-    MTLStencilOperation stencilOperationDepthStencilPass = MTLStencilOperationKeep;     // 8 bytes
     bool depthWriteEnabled = false;                                                     // 1 byte
     bool stencilWriteEnabled = false;                                                   // 1 byte
-    char padding[6] = { 0 };                                                            // 7 bytes
+    uint8_t padding[6] = { 0 };                                                         // 6 bytes
 
     bool operator==(const DepthStencilState& rhs) const {
         return depthCompare == rhs.depthCompare &&
-               stencilCompare == rhs.stencilCompare &&
-               stencilOperationStencilFail == rhs.stencilOperationStencilFail &&
-               stencilOperationDepthFail == rhs.stencilOperationDepthFail &&
-               stencilOperationDepthStencilPass == rhs.stencilOperationDepthStencilPass &&
-               depthWriteEnabled == rhs.depthWriteEnabled &&
-               stencilWriteEnabled == rhs.stencilWriteEnabled;
+                depthWriteEnabled == rhs.depthWriteEnabled &&
+                front == rhs.front &&
+                back == rhs.back &&
+                stencilWriteEnabled == rhs.stencilWriteEnabled;
     }
 
     bool operator!=(const DepthStencilState& rhs) const noexcept {
@@ -284,7 +300,7 @@ struct DepthStencilState {
 
 // This assert checks that the struct is the size we expect without any "hidden" padding bytes
 // inserted by the compiler.
-static_assert(sizeof(DepthStencilState) == 48, "DepthStencilState unexpected size.");
+static_assert(sizeof(DepthStencilState) == 96, "DepthStencilState unexpected size.");
 
 struct DepthStateCreator {
     id<MTLDepthStencilState> operator()(id<MTLDevice> device, const DepthStencilState& state)

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -102,15 +102,27 @@ id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
     MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
     depthStencilDescriptor.depthCompareFunction = state.depthCompare;
     depthStencilDescriptor.depthWriteEnabled = BOOL(state.depthWriteEnabled);
-    MTLStencilDescriptor* stencilDescriptor = [MTLStencilDescriptor new];
-    stencilDescriptor.stencilCompareFunction = state.stencilCompare;
-    stencilDescriptor.stencilFailureOperation = state.stencilOperationStencilFail;
-    stencilDescriptor.depthFailureOperation = state.stencilOperationDepthFail;
-    stencilDescriptor.depthStencilPassOperation = state.stencilOperationDepthStencilPass;
-    stencilDescriptor.readMask = 0xFFFFFFFF;
-    stencilDescriptor.writeMask = state.stencilWriteEnabled ? 0xFFFFFFFF : 0x0;
-    depthStencilDescriptor.backFaceStencil = stencilDescriptor;
-    depthStencilDescriptor.frontFaceStencil = stencilDescriptor;
+
+    // Front-facing stencil.
+    MTLStencilDescriptor* frontStencilDescriptor = [MTLStencilDescriptor new];
+    frontStencilDescriptor.stencilCompareFunction = state.front.stencilCompare;
+    frontStencilDescriptor.stencilFailureOperation = state.front.stencilOperationStencilFail;
+    frontStencilDescriptor.depthFailureOperation = state.front.stencilOperationDepthFail;
+    frontStencilDescriptor.depthStencilPassOperation = state.front.stencilOperationDepthStencilPass;
+    frontStencilDescriptor.readMask = state.front.readMask;
+    frontStencilDescriptor.writeMask = state.stencilWriteEnabled ? state.front.writeMask : 0x0;
+    depthStencilDescriptor.frontFaceStencil = frontStencilDescriptor;
+
+    // Back-facing stencil.
+    MTLStencilDescriptor* backStencilDescriptor = [MTLStencilDescriptor new];
+    backStencilDescriptor.stencilCompareFunction = state.back.stencilCompare;
+    backStencilDescriptor.stencilFailureOperation = state.back.stencilOperationStencilFail;
+    backStencilDescriptor.depthFailureOperation = state.back.stencilOperationDepthFail;
+    backStencilDescriptor.depthStencilPassOperation = state.back.stencilOperationDepthStencilPass;
+    backStencilDescriptor.readMask = state.back.readMask;
+    backStencilDescriptor.writeMask = state.stencilWriteEnabled ? state.back.writeMask : 0x0;
+    depthStencilDescriptor.backFaceStencil = backStencilDescriptor;
+
     return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -316,16 +316,26 @@ void OpenGLDriver::setStencilStateSlow(StencilState ss) noexcept {
     auto& gl = mContext;
 
     // stencil test / operation
-    if (ss.frontBack.stencilFunc == StencilState::StencilFunction::A && !ss.stencilWrite) {
+    if (!ss.stencilEnabled()) {
         gl.disable(GL_STENCIL_TEST);
+        gl.stencilOpSeparate(GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP);
     } else {
         gl.enable(GL_STENCIL_TEST);
-        gl.stencilFunc(getStencilFunc(ss.frontBack.stencilFunc), ss.referenceValue, ~GLuint(0));
-        gl.stencilOp(getStencilOp(ss.frontBack.stencilOpStencilFail),
-                getStencilOp(ss.frontBack.stencilOpDepthFail),
-                getStencilOp(ss.frontBack.stencilOpDepthStencilPass));
-        GLuint stencilMask = ss.stencilWrite ? ~GLuint(0) : 0x00;
-        gl.stencilMask(stencilMask);
+        gl.stencilFuncSeparate(
+                getStencilFunc(ss.front.stencilFunc), ss.referenceValue, ss.front.readMask,
+                getStencilFunc(ss.back.stencilFunc), ss.referenceValue, ss.back.readMask);
+        gl.stencilOpSeparate(
+                getStencilOp(ss.front.stencilOpStencilFail),
+                getStencilOp(ss.front.stencilOpDepthFail),
+                getStencilOp(ss.front.stencilOpDepthStencilPass),
+                getStencilOp(ss.back.stencilOpStencilFail),
+                getStencilOp(ss.back.stencilOpDepthFail),
+                getStencilOp(ss.back.stencilOpDepthStencilPass));
+        if (!ss.stencilWrite) {
+            gl.stencilMaskSeparate(0x00, 0x00);
+        } else {
+            gl.stencilMaskSeparate(ss.front.writeMask, ss.back.writeMask);
+        }
     }
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -316,7 +316,7 @@ void OpenGLDriver::setStencilStateSlow(StencilState ss) noexcept {
     auto& gl = mContext;
 
     // stencil test / operation
-    if (!ss.stencilEnabled()) {
+    if (!ss.isStencilEnabled()) {
         gl.disable(GL_STENCIL_TEST);
         gl.stencilOpSeparate(GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP, GL_KEEP);
     } else {

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -107,7 +107,7 @@ public:
         ps.rasterState.colorWrite = false;
         ps.rasterState.depthWrite = false;
         ps.stencilState.stencilWrite = true;
-        ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::INCR;
+        ps.stencilState.front.stencilOpDepthStencilPass = StencilOperation::INCR;
 
         api.makeCurrent(swapChain, swapChain);
         api.beginFrame(0, 0);
@@ -121,8 +121,8 @@ public:
         params.flags.discardStart = TargetBufferFlags::NONE;
         ps.rasterState.colorWrite = true;
         ps.stencilState.stencilWrite = false;
-        ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::KEEP;
-        ps.stencilState.frontBack.stencilFunc = StencilState::StencilFunction::E;
+        ps.stencilState.front.stencilOpDepthStencilPass = StencilOperation::KEEP;
+        ps.stencilState.front.stencilFunc = StencilState::StencilFunction::E;
         ps.stencilState.referenceValue = 0u;
 
         api.beginRenderPass(renderTarget, params);
@@ -234,7 +234,7 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     ps.rasterState.colorWrite = false;
     ps.rasterState.depthWrite = false;
     ps.stencilState.stencilWrite = true;
-    ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::INCR;
+    ps.stencilState.front.stencilOpDepthStencilPass = StencilOperation::INCR;
 
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
@@ -250,8 +250,8 @@ TEST_F(BasicStencilBufferTest, StencilBufferMSAA) {
     params.clearColor = math::float4(0.0f, 0.0f, 1.0f, 1.0f);
     ps.rasterState.colorWrite = true;
     ps.stencilState.stencilWrite = false;
-    ps.stencilState.frontBack.stencilOpDepthStencilPass = StencilOperation::KEEP;
-    ps.stencilState.frontBack.stencilFunc = StencilState::StencilFunction::E;
+    ps.stencilState.front.stencilOpDepthStencilPass = StencilOperation::KEEP;
+    ps.stencilState.front.stencilFunc = StencilState::StencilFunction::E;
     ps.stencilState.referenceValue = 0u;
 
     api.beginRenderPass(renderTarget1, params);


### PR DESCRIPTION
Separate out stencil operations for back/front facing primitives and add read/write masks.