### PR TITLE
The "Prepare Shadow Pass" was never executed

### DIFF
--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -181,6 +181,9 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FrameGraph& fg, FEngine
                         .type = SamplerType::SAMPLER_2D_ARRAY,
                         .format = view.hasVSM() ? vsmTextureFormat : mTextureFormat
                 });
+                // This pass must be declared as having a side effect because it never gets a
+                // "read" from one of its resource (only writes), so the FrameGraph culls it.
+                builder.sideEffect();
             },
             [&view](FrameGraphResources const& resources, auto const& data, DriverApi& driver) {
                 // set uniforms needed to render this ShadowMap


### PR DESCRIPTION
It was culled by the frame-graph because it didn't have "read" from 
any of its resource, only writes. However, it does set uniforms, so need
to be called.

fix #5874