### PR TITLE
Add View API to enable the stencil buffer

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1176,6 +1176,7 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
     const auto& stencilAttachment = mContext->currentRenderTarget->getStencilAttachment();
     if (stencilAttachment) {
         stencilPixelFormat = stencilAttachment.getPixelFormat();
+        assert_invariant(isMetalFormatStencil(stencilPixelFormat));
     }
     MetalPipelineState pipelineState {
         .vertexFunction = program->vertexFunction,

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -265,10 +265,12 @@ constexpr inline bool isMetalFormatInteger(MTLPixelFormat format) {
 constexpr inline bool isMetalFormatStencil(MTLPixelFormat format) {
     switch (format) {
         case MTLPixelFormatStencil8:
-        case MTLPixelFormatDepth24Unorm_Stencil8:
         case MTLPixelFormatDepth32Float_Stencil8:
         case MTLPixelFormatX32_Stencil8:
+#if !defined(IOS)
+        case MTLPixelFormatDepth24Unorm_Stencil8:
         case MTLPixelFormatX24_Stencil8:
+#endif
             return true;
 
         default:

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -262,6 +262,20 @@ constexpr inline bool isMetalFormatInteger(MTLPixelFormat format) {
     }
 }
 
+constexpr inline bool isMetalFormatStencil(MTLPixelFormat format) {
+    switch (format) {
+        case MTLPixelFormatStencil8:
+        case MTLPixelFormatDepth24Unorm_Stencil8:
+        case MTLPixelFormatDepth32Float_Stencil8:
+        case MTLPixelFormatX32_Stencil8:
+        case MTLPixelFormatX24_Stencil8:
+            return true;
+
+        default:
+            return false;
+    }
+}
+
 constexpr inline MTLTextureType getMetalType(SamplerType target) {
     switch (target) {
         case SamplerType::SAMPLER_2D:

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -119,6 +119,8 @@ public:
     struct ClearOptions {
         /** Color to use to clear the SwapChain */
         math::float4 clearColor = {};
+        /** Value to clear the stencil buffer */
+        uint8_t clearStencil = 0u;
         /**
          * Whether the SwapChain should be cleared using the clearColor. Use this if translucent
          * View will be drawn, for instance.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -637,6 +637,33 @@ public:
      */
     bool isFrontFaceWindingInverted() const noexcept;
 
+    /**
+     * Enables use of the stencil buffer. This API is currently a WIP and experimental.
+     *
+     * The stencil buffer is an 8-bit, per-fragment unsigned integer stored alongside the depth
+     * buffer. The stencil buffer is cleared at the beginning of a frame and discarded after the
+     * color pass.
+     *
+     * Each fragment's stencil value is set during rasterization by specifying stencil operations on
+     * a Material. The stencil buffer can be used as a mask for later rendering by setting a
+     * Material's stencil comparison function and reference value. Fragments that don't pass the
+     * stencil test are then discarded.
+     *
+     * Post-processing must be enabled in order to use the stencil buffer.
+     *
+     * A renderable's priority (see RenderableManager::setPriority) is useful to control the order
+     * in which primitives are drawn.
+     *
+     * @param enabled True to enable the stencil buffer, false disables it (default)
+     */
+    void setStencilBufferEnabled(bool enabled) noexcept;
+
+    /**
+     * Returns true if the stencil buffer is enabled.
+     * See setStencilBufferEnabled() for more information.
+     */
+    bool getStencilBufferEnabled() const noexcept;
+
     // for debugging...
 
     //! debugging: allows to entirely disable frustum culling. (culling enabled by default).

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -58,12 +58,16 @@ public:
         backend::TargetBufferFlags clearFlags;
         // Clear color
         math::float4 clearColor = {};
+        // Clear stencil
+        uint8_t clearStencil = 0u;
         // Lod offset for the SSR passes
         float ssrLodOffset;
         // Contact shadow enabled?
         bool hasContactShadows;
         // Screen space reflections enabled
         bool hasScreenSpaceReflectionsOrRefractions;
+        // Use a depth format with a stencil component.
+        bool enabledStencilBuffer;
     };
 
     static FrameGraphId<FrameGraphTexture> colorPass(

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -275,6 +275,14 @@ bool View::isScreenSpaceRefractionEnabled() const noexcept {
     return upcast(this)->isScreenSpaceRefractionEnabled();
 }
 
+void View::setStencilBufferEnabled(bool enabled) noexcept {
+    upcast(this)->setStencilBufferEnabled(enabled);
+}
+
+bool View::getStencilBufferEnabled() const noexcept {
+    return upcast(this)->getStencilBufferEnabled();
+}
+
 View::PickingQuery& View::pick(uint32_t x, uint32_t y, backend::CallbackHandler* handler,
         View::PickingQueryResultCallback callback) noexcept {
     return upcast(this)->pick(x, y, handler, callback);

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -668,6 +668,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     }
 
     const float4 clearColor = mClearOptions.clearColor;
+    const uint8_t clearStencil = mClearOptions.clearStencil;
     const TargetBufferFlags clearFlags = mClearFlags;
     const TargetBufferFlags discardStartFlags = mDiscardStartFlags;
     TargetBufferFlags keepOverrideStartFlags = TargetBufferFlags::ALL & ~discardStartFlags;
@@ -713,10 +714,12 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             .msaa = msaaSampleCount,
             .clearFlags = clearFlags,
             .clearColor = clearColor,
+            .clearStencil = clearStencil,
             .ssrLodOffset = 0.0f,
             .hasContactShadows = scene.hasContactShadows(),
             // at this point we don't know if we have refraction, but that's handled later
-            .hasScreenSpaceReflectionsOrRefractions = ssReflectionsOptions.enabled
+            .hasScreenSpaceReflectionsOrRefractions = ssReflectionsOptions.enabled,
+            .enabledStencilBuffer = view.getStencilBufferEnabled()
     };
 
     /*

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -182,6 +182,10 @@ public:
 
     bool isScreenSpaceReflectionEnabled() const noexcept { return mScreenSpaceReflectionsOptions.enabled; }
 
+    void setStencilBufferEnabled(bool enabled) noexcept { mStencilBufferEnabled = enabled; }
+
+    bool getStencilBufferEnabled() const noexcept { return mStencilBufferEnabled; }
+
     FCamera const* getDirectionalLightCamera() const noexcept {
         return &mShadowMapManager.getCascadeShadowMap(0)->getDebugCamera();
     }
@@ -489,6 +493,7 @@ private:
     bool mShadowingEnabled = true;
     bool mScreenSpaceRefractionEnabled = true;
     bool mHasPostProcessPass = true;
+    bool mStencilBufferEnabled = false;
     AmbientOcclusionOptions mAmbientOcclusionOptions{};
     ShadowType mShadowType = ShadowType::PCF;
     VsmShadowOptions mVsmShadowOptions; // FIXME: this should probably be per-light


### PR DESCRIPTION
Will update RELEASE_NOTES when the Material API is added, otherwise at the moment there's no way to use the stencil buffer.