### PR TITLE
Ensure UTILS_DEPRECATED is used in the public API

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -80,8 +80,8 @@ public:
         // refresh-rate of the display in Hz. set to 0 for offscreen or turn off frame-pacing.
         float refreshRate = 60.0f;
 
-        [[deprecated]] uint64_t presentationDeadlineNanos = 0;
-        [[deprecated]] uint64_t vsyncOffsetNanos = 0;
+        UTILS_DEPRECATED uint64_t presentationDeadlineNanos = 0;
+        UTILS_DEPRECATED uint64_t vsyncOffsetNanos = 0;
     };
 
     /**

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -367,7 +367,7 @@ public:
      *              uint32_t width, uint32_t height, uint32_t depth,
      *              PixelBufferDescriptor&& buffer)
      */
-    [[deprecated]]
+    UTILS_DEPRECATED
     void setImage(Engine& engine, size_t level,
             PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const;
 

--- a/filament/src/details/Texture.h
+++ b/filament/src/details/Texture.h
@@ -52,7 +52,7 @@ public:
             uint32_t width, uint32_t height, uint32_t depth,
             PixelBufferDescriptor&& buffer) const;
 
-    [[deprecated]]
+    UTILS_DEPRECATED
     void setImage(FEngine& engine, size_t level,
             PixelBufferDescriptor&& buffer, const FaceOffsets& faceOffsets) const;
 


### PR DESCRIPTION
Renderer and Texture headers use the Attribute Specifier Sequence syntax instead of the UTILS_DEPRECATED macro which could cause issues when interfacing with compilers without support for this syntax. 

This merge request simply changes any occurrence of [[deprecated]] in the headers to UTILS_DEPRECATED