### PR TITLE
gltfio: add 'detach' methods to allow ownership transfer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@ A new header is inserted each time a *tag* is created.
 - WebGL: added missing IBL builder to TypeScript annotations
 - engine: Fix incorrect precision restoration when computing accurate world translations
 - engine: make `MaterialInstance` public API friendly to `std::string_view` parameters
+- gltfio: add 'detach' methods to allow ownership transfer of entities and components
 
 ## v1.25.4
 

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -334,6 +334,23 @@ public:
     void addEntitiesToScene(filament::Scene& targetScene, const Entity* entities, size_t count,
             SceneMask sceneFilter);
 
+    /**
+     * Releases ownership of entities and their Filament components.
+     *
+     * This makes the client take responsibility for destroying Filament
+     * components (e.g. Renderable, TransformManager component) as well as
+     * the underlying entities.
+     */
+    void detachFilamentComponents();
+
+    /**
+     * Releases ownership of material instances.
+     *
+     * This makes the client take responsibility for destroying MaterialInstance
+     * objects. The getMaterialInstances query becomes invalid after detachment.
+     */
+    void detachMaterialInstances();
+
     /*! \cond PRIVATE */
 
     FilamentInstance** getAssetInstances() noexcept;

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -255,9 +255,17 @@ struct FFilamentAsset : public FilamentAsset {
     void addEntitiesToScene(filament::Scene& targetScene, const Entity* entities, size_t count,
             SceneMask sceneFilter);
 
+    void detachFilamentComponents() {
+        mDetachedFilamentComponents = true;
+    }
+
+    void detachMaterialInstances() {
+        mMaterialInstances.clear();
+    }
+
     // end public API
 
-    void takeOwnership(filament::Texture* texture) {
+    void attachTexture(filament::Texture* texture) {
         mTextures.push_back(texture);
     }
 
@@ -299,6 +307,7 @@ struct FFilamentAsset : public FilamentAsset {
     DependencyGraph mDependencyGraph;
     tsl::htrie_map<char, std::vector<utils::Entity>> mNameToEntity;
     utils::CString mAssetExtras;
+    bool mDetachedFilamentComponents = false;
 
     // Sentinels for situations where ResourceLoader needs to generate data.
     const cgltf_accessor mGenerateNormals = {};

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -687,7 +687,7 @@ Texture* ResourceLoader::Impl::getOrCreateTexture(FFilamentAsset* asset, const T
                 << provider->getPushMessage() << io::endl;
         asset->mDependencyGraph.markAsError(tb.materialInstance);
     } else {
-        asset->takeOwnership(texture);
+        asset->attachTexture(texture);
     }
 
     return texture;


### PR DESCRIPTION
These new methods allow gltfio to be integrated into internal Google
libraries.