### PR TITLE
gltfio: remove a memcpy via custom cgltf_file_options.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- gltfio: minor efficiency improvement for Android and WebGL builds.
+
 ## v1.25.5
 
 - WebGL: upgraded the JS bindings to work with emsdk 3.1.15


### PR DESCRIPTION
Earlier versions of cgltf did not support file reader customization.
This was fixed back in Dec 2019 but at the time I did not notice, so
we never bothered cleaning up our usage.

In the future we would like WebGL + Android builds to permit texture
downloads to occur concurrently with the texture decoder jobs. This PR
is basically a preparatory refactoring, but with the nice side effect of
removing a memcpy.