### PR TITLE
gltfio: concurrent texture downloading and decoding.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ A new header is inserted each time a *tag* is created.
 ## main branch
 
 - gltfio: minor efficiency improvement for Android and WebGL builds.
+- gltfio: add support for concurrent texture downloading and decoding.
 
 ## v1.25.5
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -303,7 +303,10 @@ struct FFilamentAsset : public FilamentAsset {
     SkinVector mSkins; // unused for instanced assets
     Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;
+
+    // Indicates if resource decoding has started (not necessarily finished)
     bool mResourcesLoaded = false;
+
     DependencyGraph mDependencyGraph;
     tsl::htrie_map<char, std::vector<utils::Entity>> mNameToEntity;
     utils::CString mAssetExtras;

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -10,7 +10,7 @@ html, body { height: 100%; }
 body       { margin: 0; overflow: hidden; }
 #container { position: relative; height: 100%; }
 canvas     { position: absolute; width: 100%; height: 100%; }
-#messages  { position: absolute; width: 100%; height: 100%; padding-left: 10px; color:white; pointer-events: none; }
+#messages  { position: absolute; width: 100%; height: 100%; padding-left: 10px; color:blue; pointer-events: none; }
 </style>
 </head>
 <body>
@@ -43,12 +43,15 @@ class App {
         const scene = this.scene = engine.createScene();
         this.trackball = new Trackball(canvas, {startSpin: 0.035});
 
+        const messages = document.getElementById('messages');
+
         canvas.addEventListener('pointerdown', evt => {
             const x = evt.clientX;
             const y = this.canvas.getBoundingClientRect().height - 1 - evt.clientY;
             const dpr = window.devicePixelRatio;
             this.view.pick(x * dpr, y * dpr, (results) => {
-                document.getElementById('messages').innerText = this.asset.getName(results.renderable);
+                const name = this.asset.getName(results.renderable);
+                messages.innerText = name ? ('Picked ' + name) : '';
             });
         });
 
@@ -87,8 +90,6 @@ class App {
         this.allowRefresh = false;
         const asset = this.asset = loader.createAssetFromJson(mesh_url);
         this.assetRoot = this.asset.getRoot();
-
-        const messages = document.getElementById('messages');
 
         // Crudely indicate progress by printing the URI of each resource as it is loaded.
         const onFetched = (uri) => messages.innerText += `Downloaded ${uri}\n`;


### PR DESCRIPTION
This feature can improve load time when textures are downloaded from the
web on non-filesystem platforms like Android.

More specifically, this allows downloaded texture assets to arrive after
the user calls asyncBeginLoad(), which means that decoding and
downloading can occur concurrently.

Prior to this PR, we already used JobSystem for decoding, but we did not
kick off any jobs until after all assets were downloaded.

Still TBD: add this feature for external vertex data.

Partial fix for #5909.