### PR TITLE
Do not assert for certain custom CONFIG values.

### DIFF
--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -288,8 +288,11 @@ struct PerRenderableBoneUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     };
     BoneData bones[CONFIG_MAX_BONE_COUNT];
 };
-static_assert(sizeof(PerRenderableBoneUib) <= 16384,
-        "PerRenderableUibBone exceed max UBO size");
+
+// ES3.0 only guarantees a max UBO size of 16 KiB, but users may wish to exceed the minspec
+// by adjusting CONFIG_MAX_BONE_COUNT.
+static_assert(sizeof(PerRenderableBoneUib) == CONFIG_MAX_BONE_COUNT * 64,
+        "PerRenderableUibBone has unexpected size");
 
 // ------------------------------------------------------------------------------------------------
 // MARK: -
@@ -299,8 +302,11 @@ struct alignas(16) PerRenderableMorphingUib {
     // The array stride(the bytes between array elements) is always rounded up to the size of a vec4 in std140.
     math::float4 weights[CONFIG_MAX_MORPH_TARGET_COUNT];
 };
-static_assert(sizeof(PerRenderableMorphingUib) <= 16384,
-        "PerRenderableMorphingUib exceed max UBO size");
+
+// ES3.0 only guarantees a max UBO size of 16 KiB, but users may wish to exceed the minspec
+// by adjusting CONFIG_MAX_MORPH_TARGET_COUNT.
+static_assert(sizeof(PerRenderableMorphingUib) == CONFIG_MAX_MORPH_TARGET_COUNT * 16,
+        "PerRenderableMorphingUib has unexpected size");
 
 } // namespace filament
 


### PR DESCRIPTION
Developers who know their users have powerful devices can exceed
minspec constraints by adjust CONFIG_MAX_BONE_COUNT and/or
CONFIG_MAX_MORPH_TARGET_COUNT. If they do this, they should not
hit a `static_asset`.

Fixes #5785.