### PR TITLE
gltfio Android: Fix double free error.

### DIFF
--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -57,6 +57,12 @@
 #define GLTFIO_WARN(msg) slog.w << msg << io::endl
 #endif
 
+#if defined(__EMSCRIPTEN__) || defined(__ANDROID__) || defined(IOS)
+#define GLTFIO_USE_FILESYSTEM 0
+#else
+#define GLTFIO_USE_FILESYSTEM 1
+#endif
+
 namespace utils {
     class NameComponentManager;
     class EntityManager;


### PR DESCRIPTION
The custom release callback that I provided was in the wrong place; it
was only being used for a path string, not the actual buffer content.
The cgltf API is a bit awkward in this area.

No need to update RELEASE_NOTES because this will be cherry picked to
the RC branch, which is where the bug introduced.

Fixes #5918.