### PR TITLE
Fix guard bands and TAA with VERTEX_DOMAIN_DEVICE

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@ A new header is inserted each time a *tag* is created.
 - Add CONFIG_MINSPEC_UBO_SIZE as a nicer way to allow exceeding the ES3.0 minspec.
 - gltfio: minor efficiency improvement for Android and WebGL builds.
 - gltfio: add support for concurrent texture downloading and decoding.
+- engine: Fix guard bands and TAA with `vertexDomain:Device` [⚠️ **Recompile Materials**]
+- engine: `clipSpaceTransform` is now only available with `vertexDomain:Device` [⚠️ **API Change**]
 
 ## v1.25.5
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -1141,6 +1141,29 @@ material {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+### General: vertexDomainDeviceJittered
+
+Type
+:    `boolean`
+
+Value
+:     `true` or `false`. Defaults to `false`.
+
+Description
+:    Only meaningful for `vertexDomain:Device` materials, this parameter specifies whether the
+     filament clip-space transforms need to be applied or not, which affects TAA and guard bands.
+     Generally it needs to be applied because by definition `vertexDomain:Device` materials
+     vertices are not transformed and used *as is*.
+     However, if the vertex shader uses for instance `getViewFromClipMatrix()` (or other
+     matrices based on the projection), the clip-space transform is already applied.
+     Setting this parameter incorrectly can prevent TAA or the guard bands to work correctly.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ JSON
+material {
+    vertexDomainDeviceJittered : true
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 ### Vertex and attributes: requires
 
 Type
@@ -1846,7 +1869,7 @@ struct MaterialVertexInputs {
     float3 worldNormal;        // only if the shading model is not unlit
     float4 worldPosition;      // always available (see note below about world-space)
 
-    mat4   clipSpaceTransform; // default: identity, transforms the clip-space position
+    mat4   clipSpaceTransform; // default: identity, transforms the clip-space position, only available for `vertexDomain:device`
 
     // variable* names are replaced with actual names
     float4 variable0;          // if 1 or more variables is defined

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -80,6 +80,7 @@ void PerViewUniforms::prepareCamera(const CameraInfo& camera) noexcept {
     s.viewFromClipMatrix  = viewFromClip;     // 1/projection
     s.clipFromWorldMatrix = clipFromWorld;    // projection * view
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+    s.clipTransform = camera.clipTransfrom;
     s.cameraPosition = float3{ camera.getPosition() };
     s.worldOffset = camera.getWorldOffset();
     s.cameraFar = camera.zf;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2429,6 +2429,9 @@ void PostProcessManager::prepareTaa(FrameGraph& fg, filament::Viewport const& sv
 
     // update projection matrix
     inoutCameraInfo->projection[2].xy -= jitterInClipSpace;
+    // VERTEX_DOMAIN_DEVICE doesn't apply the projection, but it still needs this
+    // clip transform, so we apply it separately (see main.vs)
+    inoutCameraInfo->clipTransfrom.zw -= jitterInClipSpace;
 
     fg.addTrivialSideEffectPass("Jitter Camera",
             [=, &uniforms] (DriverApi& driver) {

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -210,6 +210,7 @@ struct CameraInfo {
     math::mat4f model;              // camera model matrix
     math::mat4f view;               // camera view matrix (inverse(model))
     math::mat4 worldOrigin;         // world origin transform (already applied to model and view)
+    math::float4 clipTransfrom{1,1,0,0}; // clip-space transform, only for VERTEX_DOMAIN_DEVICE
     float zn{};                     // distance (positive) to the near plane
     float zf{};                     // distance (positive) to the far plane
     float ev100{};                  // exposure

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -590,6 +590,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         // update the camera projection
         cameraInfo.projection = highPrecisionMultiply(ts, cameraInfo.projection);
 
+        // VERTEX_DOMAIN_DEVICE doesn't apply the projection, but it still needs this
+        // clip transform, so we apply it separately (see main.vs)
+        cameraInfo.clipTransfrom = { ts[0][0], ts[1][1], ts[3].x, ts[3].y };
+
         // adjust svp to the new, larger, rendering dimensions
         svp.width  = uint32_t(width);
         svp.height = uint32_t(height);

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 25;
+static constexpr size_t MATERIAL_VERSION = 26;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -51,6 +51,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::mat4f viewFromClipMatrix;
     math::mat4f clipFromWorldMatrix;
     math::mat4f worldFromClipMatrix;
+    math::float4 clipTransform;     // [sx, sy, tx, ty] only used by VERTEX_DOMAIN_DEVICE
 
     math::float2 clipControl;       // clip control
     float time;                     // time in seconds, with a 1 second period
@@ -164,7 +165,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float ssrStride;                    // ssr texel stride, >= 1.0
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[48];
+    math::float4 reserved[47];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -531,6 +531,8 @@ public:
 
     MaterialBuilder& enableFramebufferFetch() noexcept;
 
+    MaterialBuilder& vertexDomainDeviceJittered(bool enabled) noexcept;
+
     /**
      * Legacy morphing uses the data in the VertexAttribute slots (\c MORPH_POSITION_0, etc) and is
      * limited to 4 morph targets. See filament::RenderableManager::Builder::morphing().
@@ -752,6 +754,8 @@ private:
     bool mCustomSurfaceShading = false;
 
     bool mEnableFramebufferFetch = false;
+
+    bool mVertexDomainDeviceJittered = false;
 
     bool mUseLegacyMorphing = false;
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -498,6 +498,7 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     info.hasCustomSurfaceShading = mCustomSurfaceShading;
     info.useLegacyMorphing = mUseLegacyMorphing;
     info.instanced = mInstanced;
+    info.vertexDomainDeviceJittered = mVertexDomainDeviceJittered;
 }
 
 bool MaterialBuilder::findProperties(filament::backend::ShaderType type,
@@ -741,10 +742,9 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .shaderModel = shaderModel,
                         .domain = mMaterialDomain,
                         .materialInfo = &info,
+                        .hasFramebufferFetch = mEnableFramebufferFetch,
                         .glsl = {},
                 };
-
-                config.hasFramebufferFetch = mEnableFramebufferFetch;
 
                 if (mEnableFramebufferFetch) {
                     config.glsl.subpassInputToColorLocation.emplace_back(0, 0);
@@ -914,6 +914,11 @@ MaterialBuilder& MaterialBuilder::enableFramebufferFetch() noexcept {
     // This API is temporary, it is used to enable EXT_framebuffer_fetch for GLSL shaders,
     // this is used sparingly by filament's post-processing stage.
     mEnableFramebufferFetch = true;
+    return *this;
+}
+
+MaterialBuilder& MaterialBuilder::vertexDomainDeviceJittered(bool enabled) noexcept {
+    mVertexDomainDeviceJittered = enabled;
     return *this;
 }
 

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -40,6 +40,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("viewFromClipMatrix",      UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("clipFromWorldMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
             .add("worldFromClipMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add("clipTransform",           UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
 
             .add("clipControl",             UniformInterfaceBlock::Type::FLOAT2)
             .add("time",                    UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -47,6 +47,7 @@ struct UTILS_PUBLIC MaterialInfo {
     bool hasCustomSurfaceShading;
     bool useLegacyMorphing;
     bool instanced;
+    bool vertexDomainDeviceJittered;
     filament::SpecularAmbientOcclusion specularAO;
     filament::RefractionMode refractionMode;
     filament::RefractionType refractionType;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -386,6 +386,8 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
 
     // material defines
     CodeGenerator::generateDefine(fs, "MATERIAL_HAS_INSTANCES", material.instanced);
+    CodeGenerator::generateDefine(fs, "MATERIAL_HAS_VERTEX_DOMAIN_DEVICE_JITTERED",
+            material.vertexDomainDeviceJittered);
 
     CodeGenerator::generateDefine(fs, "MATERIAL_HAS_DOUBLE_SIDED_CAPABILITY",
             material.hasDoubleSidedCapability);

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -152,15 +152,20 @@ void main() {
 #if defined(VERTEX_DOMAIN_DEVICE)
     // The other vertex domains are handled in initMaterialVertex()->computeWorldPosition()
     gl_Position = getPosition();
-#else
-    gl_Position = getClipFromWorldMatrix() * getWorldPosition(material);
-#endif
 
 #if !defined(USE_OPTIMIZED_DEPTH_VERTEX_SHADER)
 #if defined(MATERIAL_HAS_CLIP_SPACE_TRANSFORM)
-    gl_Position = getClipSpaceTransform(material) * gl_Position;
+    gl_Position = getMaterialClipSpaceTransform(material) * gl_Position;
 #endif
 #endif // !USE_OPTIMIZED_DEPTH_VERTEX_SHADER
+
+#if defined(MATERIAL_HAS_VERTEX_DOMAIN_DEVICE_JITTERED)
+    // Apply the clip-space transform which is normally part of the projection
+    gl_Position.xy = gl_Position.xy * frameUniforms.clipTransform.xy + (gl_Position.w * frameUniforms.clipTransform.zw);
+#endif
+#else
+    gl_Position = getClipFromWorldMatrix() * getWorldPosition(material);
+#endif
 
 #if defined(VERTEX_DOMAIN_DEVICE)
     // GL convention to inverted DX convention (must happen after clipSpaceTransform)

--- a/shaders/src/material_inputs.vs
+++ b/shaders/src/material_inputs.vs
@@ -24,9 +24,11 @@ struct MaterialVertexInputs {
     vec3 worldNormal;
 #endif
     vec4 worldPosition;
+#ifdef VERTEX_DOMAIN_DEVICE
 #ifdef MATERIAL_HAS_CLIP_SPACE_TRANSFORM
     mat4 clipSpaceTransform;
-#endif
+#endif // MATERIAL_HAS_CLIP_SPACE_TRANSFORM
+#endif // VERTEX_DOMAIN_DEVICE
 };
 
 // Workaround for a driver bug on ARM Bifrost GPUs. Assigning a structure member
@@ -35,11 +37,13 @@ vec4 getWorldPosition(const MaterialVertexInputs material) {
     return material.worldPosition;
 }
 
+#ifdef VERTEX_DOMAIN_DEVICE
 #ifdef MATERIAL_HAS_CLIP_SPACE_TRANSFORM
-mat4 getClipSpaceTransform(const MaterialVertexInputs material) {
+mat4 getMaterialClipSpaceTransform(const MaterialVertexInputs material) {
     return material.clipSpaceTransform;
 }
-#endif
+#endif // MATERIAL_HAS_CLIP_SPACE_TRANSFORM
+#endif // VERTEX_DOMAIN_DEVICE
 
 void initMaterialVertex(out MaterialVertexInputs material) {
 #ifdef HAS_ATTRIBUTE_COLOR
@@ -72,7 +76,9 @@ void initMaterialVertex(out MaterialVertexInputs material) {
     material.VARIABLE_CUSTOM3 = vec4(0.0);
 #endif
     material.worldPosition = computeWorldPosition();
+#ifdef VERTEX_DOMAIN_DEVICE
 #ifdef MATERIAL_HAS_CLIP_SPACE_TRANSFORM
     material.clipSpaceTransform = mat4(1.0);
+#endif
 #endif
 }

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -595,6 +595,11 @@ static bool processFramebufferFetch(MaterialBuilder& builder, const JsonishValue
     return true;
 }
 
+static bool processVertexDomainDeviceJittered(MaterialBuilder& builder, const JsonishValue& value) {
+    builder.vertexDomainDeviceJittered(value.toJsonBool()->getBool());
+    return true;
+}
+
 static bool processLegacyMorphing(MaterialBuilder& builder, const JsonishValue& value) {
     if (value.toJsonBool()->getBool()) {
         builder.useLegacyMorphing();
@@ -775,6 +780,7 @@ ParametersProcessor::ParametersProcessor() {
     mParameters["refractionMode"]                = { &processRefractionMode, Type::STRING };
     mParameters["refractionType"]                = { &processRefractionType, Type::STRING };
     mParameters["framebufferFetch"]              = { &processFramebufferFetch, Type::BOOL };
+    mParameters["vertexDomainDeviceJittered"]    = { &processVertexDomainDeviceJittered, Type::BOOL };
     mParameters["legacyMorphing"]                = { &processLegacyMorphing, Type::BOOL };
     mParameters["outputs"]                       = { &processOutputs, Type::ARRAY };
     mParameters["quality"]                       = { &processQuality, Type::STRING };


### PR DESCRIPTION
With VERTEX_DOMAIN_DEVICE the vertex shader doesn't apply the 
projection (since the vertices are already in clip space), however,
both TAA and guard bands need to jitter/offset the clip space, and
it is done at the projection level.
We now store the clip space offset separately so that it can be applied
to VERTEX_DOMAIN_DEVICE vertices.

Fixes #5917