### PR TITLE
Add CONFIG_MINSPEC_UBO_SIZE and fix comment.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- Add CONFIG_MINSPEC_UBO_SIZE as a nicer way to allow exceeding the ES3.0 minspec.
 - gltfio: minor efficiency improvement for Android and WebGL builds.
 - gltfio: add support for concurrent texture downloading and decoding.
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -63,12 +63,17 @@ constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 14;
 // The maximum number of shadow cascades that can be used for directional lights.
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
 
-// This value is also limited by UBO size, ES3.0 only guarantees 16 KiB.
-// We store 64 bytes per bone. Must be a power-of-two.
+// The maximum UBO size, in bytes. This value is set to 16 KiB due to the ES3.0 spec.
+// Note that this value constrains the maximum number of skinning bones and morph targets.
+constexpr size_t CONFIG_MINSPEC_UBO_SIZE = 16384;
+
+// The maximum number of bones that can be associated with a single renderable.
+// We store 32 bytes per bone. Must be a power-of-two, and must fit within CONFIG_MINSPEC_UBO_SIZE.
 constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 
-// The maximum number of morph target count.
-// This value is limited by ES3.0, ES3.0 only guarantees 256 layers in an array texture.
+// The maximum number of morph targets associated with a single renderable.
+// Note that ES3.0 only guarantees 256 layers in an array texture.
+// Furthermore this is constrained by CONFIG_MINSPEC_UBO_SIZE (16 bytes per morph target).
 constexpr size_t CONFIG_MAX_MORPH_TARGET_COUNT = 256;
 
 } // namespace filament

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -288,8 +288,9 @@ struct PerRenderableBoneUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     };
     BoneData bones[CONFIG_MAX_BONE_COUNT];
 };
-static_assert(sizeof(PerRenderableBoneUib) <= 16384,
-        "PerRenderableUibBone exceed max UBO size");
+
+static_assert(sizeof(PerRenderableBoneUib) <= CONFIG_MINSPEC_UBO_SIZE,
+        "PerRenderableUibBone exceeds max UBO size");
 
 // ------------------------------------------------------------------------------------------------
 // MARK: -
@@ -299,8 +300,9 @@ struct alignas(16) PerRenderableMorphingUib {
     // The array stride(the bytes between array elements) is always rounded up to the size of a vec4 in std140.
     math::float4 weights[CONFIG_MAX_MORPH_TARGET_COUNT];
 };
-static_assert(sizeof(PerRenderableMorphingUib) <= 16384,
-        "PerRenderableMorphingUib exceed max UBO size");
+
+static_assert(sizeof(PerRenderableMorphingUib) <= CONFIG_MINSPEC_UBO_SIZE,
+        "PerRenderableMorphingUib exceeds max UBO size");
 
 } // namespace filament
 


### PR DESCRIPTION
Developers who know their users have powerful devices may wish to exceed ES3.0
minspec constraints to allow more bones and / or morph targets.

Fixes #5785.