### PR TITLE
use our custom mutex/condition only on ANDROID

### DIFF
--- a/libs/utils/include/utils/Condition.h
+++ b/libs/utils/include/utils/Condition.h
@@ -17,7 +17,7 @@
 #ifndef TNT_UTILS_CONDITION_H
 #define TNT_UTILS_CONDITION_H
 
-#if defined(__linux__)
+#if defined(__ANDROID__)
 #include <utils/linux/Condition.h>
 #else
 #include <utils/generic/Condition.h>

--- a/libs/utils/include/utils/Mutex.h
+++ b/libs/utils/include/utils/Mutex.h
@@ -17,7 +17,7 @@
 #ifndef TNT_UTILS_MUTEX_H
 #define TNT_UTILS_MUTEX_H
 
-#if defined(__linux__)
+#if defined(__ANDROID__)
 #include <utils/linux/Mutex.h>
 #else
 #include <utils/generic/Mutex.h>


### PR DESCRIPTION
For other linux distributions we use the generic C++ ones. I think this
is probably safer and more friendly to non-linux unixes.


Fixes #2861