### PR TITLE
gltfio API change: assets are now always 'instanced' etc

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ A new header is inserted each time a *tag* is created.
 ## main branch
 
 - engine: new feature level APIs, see `Engine::getSupportedFeatureLevel()`
+- gltfio: add unified `AssetLoader::createAsset()` method [⚠️ **API Change**]
+- gltfio: all assets are now "instanced" [⚠️ **API Change**]
 
 ## v1.25.6
 

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -178,7 +178,7 @@ class ModelViewer(
      */
     fun loadModelGlb(buffer: Buffer) {
         destroyModel()
-        asset = assetLoader.createAssetFromBinary(buffer)
+        asset = assetLoader.createAsset(buffer)
         asset?.let { asset ->
             resourceLoader.asyncBeginLoad(asset)
             animator = asset.animator
@@ -193,7 +193,7 @@ class ModelViewer(
      */
     fun loadModelGltf(buffer: Buffer, callback: (String) -> Buffer?) {
         destroyModel()
-        asset = assetLoader.createAssetFromJson(buffer)
+        asset = assetLoader.createAsset(buffer)
         asset?.let { asset ->
             for (uri in asset.resourceUris) {
                 val resourceBuffer = callback(uri)
@@ -216,7 +216,7 @@ class ModelViewer(
      */
     fun loadModelGltfAsync(buffer: Buffer, callback: (String) -> Buffer) {
         destroyModel()
-        asset = assetLoader.createAssetFromJson(buffer)
+        asset = assetLoader.createAsset(buffer)
         fetchResourcesJob = CoroutineScope(Dispatchers.IO).launch {
             fetchResources(asset!!, callback)
         }

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -207,20 +207,11 @@ Java_com_google_android_filament_gltfio_AssetLoader_nDestroyAssetLoader(JNIEnv*,
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetFromBinary(JNIEnv* env, jclass,
+Java_com_google_android_filament_gltfio_AssetLoader_nCreateAsset(JNIEnv* env, jclass,
         jlong nativeLoader, jobject javaBuffer, jint remaining) {
     AssetLoader* loader = (AssetLoader*) nativeLoader;
     AutoBuffer buffer(env, javaBuffer, remaining);
-    return (jlong) loader->createAssetFromBinary((const uint8_t *) buffer.getData(),
-            buffer.getSize());
-}
-
-extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_AssetLoader_nCreateAssetFromJson(JNIEnv* env, jclass,
-        jlong nativeLoader, jobject javaBuffer, jint remaining) {
-    AssetLoader* loader = (AssetLoader*) nativeLoader;
-    AutoBuffer buffer(env, javaBuffer, remaining);
-    return (jlong) loader->createAssetFromJson((const uint8_t *) buffer.getData(),
+    return (jlong) loader->createAsset((const uint8_t *) buffer.getData(),
             buffer.getSize());
 }
 

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -228,44 +228,6 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetExtras(JNIEnv* env, jc
     return val ? env->NewStringUTF(val) : nullptr;
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetSkinCount(JNIEnv* , jclass,
-        jlong nativeAsset) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    return (jint) asset->getSkinCount();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetSkinNames(JNIEnv* env, jclass,
-        jlong nativeAsset, jobjectArray result) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    jsize available = env->GetArrayLength(result);
-    for (int i = 0; i < available; ++i) {
-        const char* name = asset->getSkinNameAt(i);
-        if (name) {
-            env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(name));
-        }
-    }
-}
-
-extern "C" JNIEXPORT jint JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetJointCountAt(JNIEnv* , jclass,
-        jlong nativeAsset, jint skinIndex) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    return (jint) asset->getJointCountAt(skinIndex);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetJointsAt(JNIEnv* env, jclass,
-        jlong nativeAsset, jint skinIndex, jintArray result) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    jsize available = env->GetArrayLength(result);
-    Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
-    std::copy_n(asset->getJointsAt(skinIndex),
-        std::min(available, (jsize) asset->getJointCountAt(skinIndex)), entities);
-    env->ReleaseIntArrayElements(result, (jint*) entities, 0);
-}
-
 extern "C" JNIEXPORT jlong JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetAnimator(JNIEnv* , jclass,
         jlong nativeAsset) {
@@ -339,20 +301,4 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nReleaseSourceData(JNIEnv*
         jlong nativeAsset) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
     asset->releaseSourceData();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nAttachSkin(JNIEnv* env, jclass,
-        jlong nativeAsset, jint skinIndex, jint targetEntity) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    Entity target = Entity::import(targetEntity);
-    asset->attachSkin(skinIndex, target);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nDetachSkin(JNIEnv* env, jclass,
-        jlong nativeAsset, jint skinIndex, jint targetEntity) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    Entity target = Entity::import(targetEntity);
-    asset->detachSkin(skinIndex, target);
 }

--- a/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
@@ -61,3 +61,57 @@ Java_com_google_android_filament_gltfio_FilamentInstance_nApplyMaterialVariant(J
     FilamentInstance* instance = (FilamentInstance*) nativeInstance;
     instance->applyMaterialVariant(variantIndex);
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nAttachSkin(JNIEnv* env, jclass,
+        jlong nativeInstance, jint skinIndex, jint targetEntity) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    Entity target = Entity::import(targetEntity);
+    instance->attachSkin(skinIndex, target);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nDetachSkin(JNIEnv* env, jclass,
+        jlong nativeInstance, jint skinIndex, jint targetEntity) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    Entity target = Entity::import(targetEntity);
+    instance->detachSkin(skinIndex, target);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetSkinCount(JNIEnv* , jclass,
+        jlong nativeInstance) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    return (jint) instance->getSkinCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetSkinNames(JNIEnv* env, jclass,
+        jlong nativeInstance, jobjectArray result) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    jsize available = env->GetArrayLength(result);
+    for (int i = 0; i < available; ++i) {
+        const char* name = instance->getSkinNameAt(i);
+        if (name) {
+            env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(name));
+        }
+    }
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetJointCountAt(JNIEnv* , jclass,
+        jlong nativeInstance, jint skinIndex) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    return (jint) instance->getJointCountAt(skinIndex);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetJointsAt(JNIEnv* env, jclass,
+        jlong nativeInstance, jint skinIndex, jintArray result) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    jsize available = env->GetArrayLength(result);
+    Entity* entities = (Entity*) env->GetIntArrayElements(result, nullptr);
+    std::copy_n(instance->getJointsAt(skinIndex),
+        std::min(available, (jsize) instance->getJointCountAt(skinIndex)), entities);
+    env->ReleaseIntArrayElements(result, (jint*) entities, 0);
+}

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/AssetLoader.java
@@ -26,8 +26,8 @@ import java.nio.Buffer;
 
 /**
  * Consumes a blob of glTF 2.0 content (either JSON or GLB) and produces a {@link FilamentAsset}
- * object, which is a bundle of Filament entities, material instances, textures, vertex buffers,
- * and index buffers.
+ * object, which is a bundle of Filament textures, vertex buffers, index buffers, etc. An asset is
+ * composed of 1 or more FilamentInstance objects which contain entities and components.
  *
  * <p>AssetLoader does not fetch external buffer data or create textures on its own. Clients can use
  * the provided {@link ResourceLoader} class for this, which obtains the URI list from the asset.
@@ -51,7 +51,7 @@ import java.nio.Buffer;
  *     filamentAsset = assets.open("models/lucy.gltf").use { input -&gt;
  *         val bytes = ByteArray(input.available())
  *         input.read(bytes)
- *         assetLoader.createAssetFromJson(ByteBuffer.wrap(bytes))!!
+ *         assetLoader.createAsset(ByteBuffer.wrap(bytes))!!
  *     }
  *
  *     val resourceLoader = ResourceLoader(engine)
@@ -115,20 +115,11 @@ public class AssetLoader {
     }
 
     /**
-     * Creates a {@link FilamentAsset} from the contents of a GLB file.
+     * Creates a {@link FilamentAsset} from the contents of a GLB or GLTF file.
      */
     @Nullable
-    public FilamentAsset createAssetFromBinary(@NonNull Buffer buffer) {
-        long nativeAsset = nCreateAssetFromBinary(mNativeObject, buffer, buffer.remaining());
-        return nativeAsset != 0 ? new FilamentAsset(mEngine, nativeAsset) : null;
-    }
-
-    /**
-     * Creates a {@link FilamentAsset} from the contents of a GLTF file.
-     */
-    @Nullable
-    public FilamentAsset createAssetFromJson(@NonNull Buffer buffer) {
-        long nativeAsset = nCreateAssetFromJson(mNativeObject, buffer, buffer.remaining());
+    public FilamentAsset createAsset(@NonNull Buffer buffer) {
+        long nativeAsset = nCreateAsset(mNativeObject, buffer, buffer.remaining());
         return nativeAsset != 0 ? new FilamentAsset(mEngine, nativeAsset) : null;
     }
 
@@ -158,7 +149,7 @@ public class AssetLoader {
     }
 
     /**
-     * Adds a new instance to an instanced asset.
+     * Adds a new instance to the asset.
      *
      * Use this with caution. It is more efficient to pre-allocate a max number of instances, and
      * gradually add them to the scene as needed. Instances can also be "recycled" by removing and
@@ -169,7 +160,6 @@ public class AssetLoader {
      * create/destroy churn, as noted above.
      *
      * This cannot be called after FilamentAsset#releaseSourceData().
-     * This cannot be called on a non-instanced asset.
      * Animation is not supported in new instances.
      * See also AssetLoader#createInstancedAsset().
      */
@@ -202,8 +192,7 @@ public class AssetLoader {
     private static native long nCreateAssetLoader(long nativeEngine, Object provider,
             long nativeEntities);
     private static native void nDestroyAssetLoader(long nativeLoader);
-    private static native long nCreateAssetFromBinary(long nativeLoader, Buffer buffer, int remaining);
-    private static native long nCreateAssetFromJson(long nativeLoader, Buffer buffer, int remaining);
+    private static native long nCreateAsset(long nativeLoader, Buffer buffer, int remaining);
     private static native long nCreateInstancedAsset(long nativeLoader, Buffer buffer, int remaining,
             long[] nativeInstances);
     private static native long nCreateInstance(long nativeLoader, long nativeAsset);

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -226,58 +226,6 @@ public class FilamentAsset {
     }
 
     /**
-     * Gets the skin count of this asset.
-     */
-    public int getSkinCount() {
-        return nGetSkinCount(getNativeObject());
-    }
-
-    /**
-     * Gets the skin name at skin index in this asset.
-     */
-    public @NonNull String[] getSkinNames() {
-        String[] result = new String[getSkinCount()];
-        nGetSkinNames(getNativeObject(), result);
-        return result;
-    }
-
-    /**
-     * Attaches the given skin to the given node, which must have an associated mesh with
-     * BONE_INDICES and BONE_WEIGHTS attributes.
-     *
-     * This is a no-op if the given skin index or target is invalid.
-     */
-    public void attachSkin(@IntRange(from = 0) int skinIndex, @Entity int target) {
-        nAttachSkin(getNativeObject(), skinIndex, target);
-    }
-
-    /**
-     * Attaches the given skin to the given node, which must have an associated mesh with
-     * BONE_INDICES and BONE_WEIGHTS attributes.
-     *
-     * This is a no-op if the given skin index or target is invalid.
-     */
-    public void detachSkin(@IntRange(from = 0) int skinIndex, @Entity int target) {
-        nDetachSkin(getNativeObject(), skinIndex, target);
-    }
-
-    /**
-     * Gets the joint count at skin index in this asset.
-     */
-    public int getJointCountAt(@IntRange(from = 0) int skinIndex) {
-        return nGetJointCountAt(getNativeObject(), skinIndex);
-    }
-
-    /**
-     * Gets joints at skin index in this asset.
-     */
-    public @NonNull @Entity int[] getJointsAt(@IntRange(from = 0) int skinIndex) {
-        int[] result = new int[getJointCountAt(skinIndex)];
-        nGetJointsAt(getNativeObject(), skinIndex, result);
-        return result;
-    }
-
-    /**
      * Gets the names of all morph targets in the given entity.
      */
     public @NonNull String[] getMorphTargetNames(@Entity int entity) {
@@ -365,18 +313,11 @@ public class FilamentAsset {
     private static native int nGetMorphTargetCount(long nativeAsset, int entity);
     private static native void nGetMorphTargetNames(long nativeAsset, int entity, String[] result);
 
-    private static native void nAttachSkin(long nativeAsset, int skinIndex, int entity);
-    private static native void nDetachSkin(long nativeAsset, int skinIndex, int entity);
-
     private static native void nGetBoundingBox(long nativeAsset, float[] box);
     private static native String nGetName(long nativeAsset, int entity);
     private static native String nGetExtras(long nativeAsset, int entity);
     private static native long nGetAnimator(long nativeAsset);
     private static native void nApplyMaterialVariant(long nativeAsset, int variantIndex);
-    private static native int nGetSkinCount(long nativeAsset);
-    private static native void nGetSkinNames(long nativeAsset, String[] result);
-    private static native int nGetJointCountAt(long nativeAsset, int skinIndex);
-    private static native void nGetJointsAt(long nativeAsset, int skinIndex, int[] result);
     private static native int nGetResourceUriCount(long nativeAsset);
     private static native void nGetResourceUris(long nativeAsset, String[] result);
     private static native void nReleaseSourceData(long nativeAsset);

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
@@ -86,6 +86,58 @@ public class FilamentInstance {
     }
 
     /**
+     * Gets the skin count of this instance.
+     */
+    public int getSkinCount() {
+        return nGetSkinCount(getNativeObject());
+    }
+
+    /**
+     * Gets the skin name at skin index in this instance.
+     */
+    public @NonNull String[] getSkinNames() {
+        String[] result = new String[getSkinCount()];
+        nGetSkinNames(getNativeObject(), result);
+        return result;
+    }
+
+    /**
+     * Attaches the given skin to the given node, which must have an associated mesh with
+     * BONE_INDICES and BONE_WEIGHTS attributes.
+     *
+     * This is a no-op if the given skin index or target is invalid.
+     */
+    public void attachSkin(@IntRange(from = 0) int skinIndex, @Entity int target) {
+        nAttachSkin(getNativeObject(), skinIndex, target);
+    }
+
+    /**
+     * Attaches the given skin to the given node, which must have an associated mesh with
+     * BONE_INDICES and BONE_WEIGHTS attributes.
+     *
+     * This is a no-op if the given skin index or target is invalid.
+     */
+    public void detachSkin(@IntRange(from = 0) int skinIndex, @Entity int target) {
+        nDetachSkin(getNativeObject(), skinIndex, target);
+    }
+
+    /**
+     * Gets the joint count at skin index in this instance.
+     */
+    public int getJointCountAt(@IntRange(from = 0) int skinIndex) {
+        return nGetJointCountAt(getNativeObject(), skinIndex);
+    }
+
+    /**
+     * Gets joints at skin index in this instance.
+     */
+    public @NonNull @Entity int[] getJointsAt(@IntRange(from = 0) int skinIndex) {
+        int[] result = new int[getJointCountAt(skinIndex)];
+        nGetJointsAt(getNativeObject(), skinIndex, result);
+        return result;
+    }
+
+    /**
      * Applies the given material variant to all primitives in this instance.
      *
      * Ignored if variantIndex is out of bounds.
@@ -94,9 +146,15 @@ public class FilamentInstance {
         nApplyMaterialVariant(mNativeObject, variantIndex);
     }
 
-    private static native int nGetRoot(long nativeAsset);
-    private static native int nGetEntityCount(long nativeAsset);
-    private static native void nGetEntities(long nativeAsset, int[] result);
-    private static native long nGetAnimator(long nativeAsset);
-    private static native void nApplyMaterialVariant(long nativeAsset, int variantIndex);
+    private static native int nGetRoot(long nativeInstance);
+    private static native int nGetEntityCount(long nativeInstance);
+    private static native void nGetEntities(long nativeInstance, int[] result);
+    private static native long nGetAnimator(long nativeInstance);
+    private static native void nApplyMaterialVariant(long nativeInstance, int variantIndex);
+    private static native void nGetJointsAt(long nativeInstance, int skinIndex, int[] result);
+    private static native int nGetSkinCount(long nativeInstance);
+    private static native void nGetSkinNames(long nativeInstance, String[] result);
+    private static native int nGetJointCountAt(long nativeInstance, int skinIndex);
+    private static native void nAttachSkin(long nativeInstance, int skinIndex, int entity);
+    private static native void nDetachSkin(long nativeInstance, int skinIndex, int entity);
 }

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -198,7 +198,7 @@ const float kSensitivity = 100.0f;
 
 - (void)loadModelGlb:(NSData*)buffer {
     [self destroyModel];
-    _asset = _assetLoader->createAssetFromBinary(
+    _asset = _assetLoader->createAsset(
             static_cast<const uint8_t*>(buffer.bytes), static_cast<uint32_t>(buffer.length));
 
     if (!_asset) {
@@ -213,7 +213,7 @@ const float kSensitivity = 100.0f;
 
 - (void)loadModelGltf:(NSData*)buffer callback:(ResourceCallback)callback {
     [self destroyModel];
-    _asset = _assetLoader->createAssetFromJson(
+    _asset = _assetLoader->createAsset(
             static_cast<const uint8_t*>(buffer.bytes), static_cast<uint32_t>(buffer.length));
 
     if (!_asset) {

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
@@ -137,7 +137,7 @@ void App::setupMesh() {
         std::cerr << "Unable to read glTF" << std::endl;
         exit(1);
     }
-    app.asset = app.assetLoader->createAssetFromBinary(buffer.data(), static_cast<uint32_t>(size));
+    app.asset = app.assetLoader->createAsset(buffer.data(), static_cast<uint32_t>(size));
 
     filament::gltfio::ResourceLoader({
         .engine = engine,

--- a/libs/gltfio/include/gltfio/Animator.h
+++ b/libs/gltfio/include/gltfio/Animator.h
@@ -104,6 +104,7 @@ private:
     friend struct FFilamentInstance;
     /*! \endcond */
 
+    // If "instance" is null, then this is the primary animator.
     Animator(FFilamentAsset* asset, FFilamentInstance* instance);
     ~Animator();
 

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -69,8 +69,8 @@ struct AssetConfiguration {
  * \brief Consumes glTF content and produces FilamentAsset objects.
  *
  * AssetLoader consumes a blob of glTF 2.0 content (either JSON or GLB) and produces a FilamentAsset
- * object, which is a bundle of Filament entities, material instances, textures, vertex buffers,
- * and index buffers.
+ * object, which is a bundle of Filament textures, vertex buffers, index buffers, etc. An asset is
+ * composed of 1 or more FilamentInstance objects which contain entities and components.
  *
  * Clients must use AssetLoader to create and destroy FilamentAsset objects. This is similar to
  * how filament::Engine is used to create and destroy core objects like VertexBuffer.
@@ -92,7 +92,7 @@ struct AssetConfiguration {
  *
  * // Parse the glTF content and create Filament entities.
  * std::vector<uint8_t> content(...);
- * FilamentAsset* asset = loader->createAssetFromJson(content.data(), content.size());
+ * FilamentAsset* asset = loader->createAsset(content.data(), content.size());
  * content.clear();
  *
  * // Load buffers and textures from disk.
@@ -148,16 +148,10 @@ public:
     static void destroy(AssetLoader** loader);
 
     /**
-     * Takes a pointer to the contents of a JSON-based glTF 2.0 file and returns a bundle
-     * of Filament objects. Returns null on failure.
+     * Takes a pointer to the contents of a GLB or a JSON-based glTF 2.0 file and returns an asset
+     * with one instance, or null on failure.
      */
-    FilamentAsset* createAssetFromJson(const uint8_t* bytes, uint32_t nbytes);
-
-    /**
-     * Takes a pointer to the contents of a GLB glTF 2.0 file and returns a bundle
-     * of Filament objects. Returns null on failure.
-     */
-    FilamentAsset* createAssetFromBinary(const uint8_t* bytes, uint32_t nbytes);
+    FilamentAsset* createAsset(const uint8_t* bytes, uint32_t nbytes);
 
     /**
      * Consumes the contents of a glTF 2.0 file and produces a primary asset with one or more
@@ -186,7 +180,7 @@ public:
             FilamentInstance** instances, size_t numInstances);
 
     /**
-     * Adds a new instance to an instanced asset.
+     * Adds a new instance to the asset.
      *
      * Use this with caution. It is more efficient to pre-allocate a max number of instances, and
      * gradually add them to the scene as needed. Instances can also be "recycled" by removing and
@@ -197,7 +191,6 @@ public:
      * create/destroy churn, as noted above.
      *
      * This cannot be called after FilamentAsset::releaseSourceData().
-     * This cannot be called on a non-instanced asset.
      * See also AssetLoader::createInstancedAsset().
      */
     FilamentInstance* createInstance(FilamentAsset* primary);

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -219,41 +219,6 @@ public:
     Animator* getAnimator() const noexcept;
 
     /**
-     * Gets the number of skins.
-     */
-    size_t getSkinCount() const noexcept;
-
-    /**
-     * Gets the skin name at skin index.
-     */
-    const char* getSkinNameAt(size_t skinIndex) const noexcept;
-
-    /**
-     * Gets the number of joints at skin index.
-     */
-    size_t getJointCountAt(size_t skinIndex) const noexcept;
-
-    /**
-     * Gets joints at skin index.
-     */
-    const Entity* getJointsAt(size_t skinIndex) const noexcept;
-
-    /**
-     * Attaches the given skin to the given node, which must have an associated mesh with
-     * BONE_INDICES and BONE_WEIGHTS attributes.
-     *
-     * This is a no-op if the given skin index or target is invalid.
-     */
-    void attachSkin(size_t skinIndex, Entity target) noexcept;
-
-    /**
-     * Detaches the given skin from the given node.
-     *
-     * This is a no-op if the given skin index or target is invalid.
-     */
-    void detachSkin(size_t skinIndex, Entity target) noexcept;
-
-    /**
      * Gets the morph target name at the given index in the given entity.
      */
     const char* getMorphTargetNameAt(Entity entity, size_t targetIndex) const noexcept;

--- a/libs/gltfio/include/gltfio/FilamentInstance.h
+++ b/libs/gltfio/include/gltfio/FilamentInstance.h
@@ -74,6 +74,41 @@ public:
      * The animator is owned by the asset and should not be manually deleted.
      */
     Animator* getAnimator() noexcept;
+
+    /**
+     * Gets the number of skins.
+     */
+    size_t getSkinCount() const noexcept;
+
+    /**
+     * Gets the skin name at skin index.
+     */
+    const char* getSkinNameAt(size_t skinIndex) const noexcept;
+
+    /**
+     * Gets the number of joints at skin index.
+     */
+    size_t getJointCountAt(size_t skinIndex) const noexcept;
+
+    /**
+     * Gets joints at skin index.
+     */
+    const utils::Entity* getJointsAt(size_t skinIndex) const noexcept;
+
+    /**
+     * Attaches the given skin to the given node, which must have an associated mesh with
+     * BONE_INDICES and BONE_WEIGHTS attributes.
+     *
+     * This is a no-op if the given skin index or target is invalid.
+     */
+    void attachSkin(size_t skinIndex, utils::Entity target) noexcept;
+
+    /**
+     * Detaches the given skin from the given node.
+     *
+     * This is a no-op if the given skin index or target is invalid.
+     */
+    void detachSkin(size_t skinIndex, utils::Entity target) noexcept;
 };
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -217,8 +217,6 @@ Animator::Animator(FFilamentAsset* asset, FFilamentInstance* instance) {
         // Import each glTF channel into a custom data structure.
         if (instance) {
             mImpl->addChannels(instance->nodeMap, srcAnim, dstAnim);
-        } else if (!asset->isInstanced()) {
-            mImpl->addChannels(asset->mNodeMap, srcAnim, dstAnim);
         } else {
             for (FFilamentInstance* instance : asset->mInstances) {
                 mImpl->addChannels(instance->nodeMap, srcAnim, dstAnim);
@@ -320,8 +318,6 @@ void Animator::resetBoneMatrices() {
 
     if (mImpl->instance) {
         update(mImpl->instance->skins, mImpl->boneMatrices);
-    } else if (!mImpl->asset->isInstanced()) {
-        update(mImpl->asset->mSkins, mImpl->boneMatrices);
     } else {
         for (FFilamentInstance* instance : mImpl->asset->mInstances) {
             update(instance->skins, mImpl->boneMatrices);
@@ -363,8 +359,6 @@ void Animator::updateBoneMatrices() {
 
     if (mImpl->instance) {
         update(mImpl->instance->skins, mImpl->boneMatrices);
-    } else if (!mImpl->asset->isInstanced()) {
-        update(mImpl->asset->mSkins, mImpl->boneMatrices);
     } else {
         for (FFilamentInstance* instance : mImpl->asset->mInstances) {
             update(instance->skins, mImpl->boneMatrices);

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -210,18 +210,6 @@ struct FFilamentAsset : public FilamentAsset {
 
     Animator* getAnimator() const noexcept { return mAnimator; }
 
-    size_t getSkinCount() const noexcept;
-
-    const char* getSkinNameAt(size_t skinIndex) const noexcept;
-
-    size_t getJointCountAt(size_t skinIndex) const noexcept;
-
-    const utils::Entity* getJointsAt(size_t skinIndex) const noexcept;
-
-    void attachSkin(size_t skinIndex, Entity target) noexcept;
-
-    void detachSkin(size_t skinIndex, Entity target) noexcept;
-
     const char* getMorphTargetNameAt(utils::Entity entity, size_t targetIndex) const noexcept;
 
     size_t getMorphTargetCountAt(utils::Entity entity) const noexcept;
@@ -281,10 +269,6 @@ struct FFilamentAsset : public FilamentAsset {
         mDependencyGraph.addEdge(texture, tb.materialInstance, tb.materialParameter);
     }
 
-    bool isInstanced() const {
-        return mInstances.size() > 0;
-    }
-
     void createAnimators();
 
     filament::Engine* const mEngine;
@@ -306,7 +290,6 @@ struct FFilamentAsset : public FilamentAsset {
     filament::Aabb mBoundingBox;
     utils::Entity mRoot;
     std::vector<FFilamentInstance*> mInstances;
-    SkinVector mSkins; // unused for instanced assets
     Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;
 
@@ -341,7 +324,6 @@ struct FFilamentAsset : public FilamentAsset {
     std::vector<BufferSlot> mBufferSlots;
     std::vector<TextureSlot> mTextureSlots;
     std::vector<const char*> mResourceUris;
-    NodeMap mNodeMap; // unused for instanced assets
     std::vector<std::pair<const cgltf_primitive*, filament::VertexBuffer*> > mPrimitives;
     MatInstanceCache mMatInstanceCache;
     MeshCache mMeshCache;

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -86,6 +86,8 @@ struct FFilamentInstance : public FilamentInstance {
     const char* getSkinNameAt(size_t skinIndex) const noexcept;
     size_t getJointCountAt(size_t skinIndex) const noexcept;
     const utils::Entity* getJointsAt(size_t skinIndex) const noexcept;
+    void attachSkin(size_t skinIndex, utils::Entity target) noexcept;
+    void detachSkin(size_t skinIndex, utils::Entity target) noexcept;
     void applyMaterialVariant(size_t variantIndex) noexcept;
 };
 

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -105,45 +105,6 @@ void FFilamentAsset::createAnimators() {
     }
 }
 
-size_t FFilamentAsset::getSkinCount() const noexcept {
-    return mSkins.size();
-}
-
-const char* FFilamentAsset::getSkinNameAt(size_t skinIndex) const noexcept {
-    if (mSkins.size() <= skinIndex) {
-        return nullptr;
-    }
-    return mSkins[skinIndex].name.c_str();
-}
-
-size_t FFilamentAsset::getJointCountAt(size_t skinIndex) const noexcept {
-    if (mSkins.size() <= skinIndex) {
-        return 0;
-    }
-    return mSkins[skinIndex].joints.size();
-}
-
-const utils::Entity* FFilamentAsset::getJointsAt(size_t skinIndex) const noexcept {
-    if (mSkins.size() <= skinIndex) {
-        return nullptr;
-    }
-    return mSkins[skinIndex].joints.data();
-}
-
-void FFilamentAsset::attachSkin(size_t skinIndex, Entity target) noexcept {
-    if (UTILS_UNLIKELY(mSkins.size() <= skinIndex || target.isNull())) {
-        return;
-    }
-    mSkins[skinIndex].targets.insert(target);
-}
-
-void FFilamentAsset::detachSkin(size_t skinIndex, Entity target) noexcept {
-    if (UTILS_UNLIKELY(mSkins.size() <= skinIndex || target.isNull())) {
-        return;
-    }
-    mSkins[skinIndex].targets.erase(target);
-}
-
 const char* FFilamentAsset::getMorphTargetNameAt(utils::Entity entity,
         size_t targetIndex) const noexcept {
     if (!mResourcesLoaded) {
@@ -185,7 +146,7 @@ void FFilamentAsset::applyMaterialVariant(size_t variantIndex) noexcept {
     const std::vector<VariantMapping>& mappings = mVariants[variantIndex].mappings;
     RenderableManager& rm = mEngine->getRenderableManager();
     for (const auto& mapping : mappings) {
-        auto instance = rm.getInstance(mapping.renderable);
+        RenderableManager::Instance instance = rm.getInstance(mapping.renderable);
         rm.setMaterialInstanceAt(instance, mapping.primitiveIndex, mapping.material);
     }
 }
@@ -204,7 +165,6 @@ void FFilamentAsset::releaseSourceData() noexcept {
     mMatInstanceCache = {};
     mMeshCache = {};
     mResourceUris = {};
-    mNodeMap = {};
     mPrimitives = {};
     mBufferSlots = {};
     mTextureSlots = {};
@@ -395,30 +355,6 @@ const char* FilamentAsset::getExtras(Entity entity) const noexcept {
 
 Animator* FilamentAsset::getAnimator() const noexcept {
     return upcast(this)->getAnimator();
-}
-
-size_t FilamentAsset::getSkinCount() const noexcept {
-    return upcast(this)->getSkinCount();
-}
-
-const char* FilamentAsset::getSkinNameAt(size_t skinIndex) const noexcept {
-    return upcast(this)->getSkinNameAt(skinIndex);
-}
-
-size_t FilamentAsset::getJointCountAt(size_t skinIndex) const noexcept {
-    return upcast(this)->getJointCountAt(skinIndex);
-}
-
-const utils::Entity* FilamentAsset::getJointsAt(size_t skinIndex) const noexcept {
-    return upcast(this)->getJointsAt(skinIndex);
-}
-
-void FilamentAsset::attachSkin(size_t skinIndex, Entity target) noexcept {
-    upcast(this)->attachSkin(skinIndex, target);
-}
-
-void FilamentAsset::detachSkin(size_t skinIndex, Entity target) noexcept {
-    upcast(this)->detachSkin(skinIndex, target);
 }
 
 const char* FilamentAsset::getMorphTargetNameAt(utils::Entity entity,

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -61,6 +61,20 @@ const utils::Entity* FFilamentInstance::getJointsAt(size_t skinIndex) const noex
     return skins[skinIndex].joints.data();
 }
 
+void FFilamentInstance::attachSkin(size_t skinIndex, Entity target) noexcept {
+    if (UTILS_UNLIKELY(skins.size() <= skinIndex || target.isNull())) {
+        return;
+    }
+    skins[skinIndex].targets.insert(target);
+}
+
+void FFilamentInstance::detachSkin(size_t skinIndex, Entity target) noexcept {
+    if (UTILS_UNLIKELY(skins.size() <= skinIndex || target.isNull())) {
+        return;
+    }
+    skins[skinIndex].targets.erase(target);
+}
+
 void FFilamentInstance::applyMaterialVariant(size_t variantIndex) noexcept {
     if (variantIndex >= variants.size()) {
         return;
@@ -97,5 +111,30 @@ void FilamentInstance::applyMaterialVariant(size_t variantIndex) noexcept {
 Animator* FilamentInstance::getAnimator() noexcept {
     return upcast(this)->getAnimator();
 }
+
+size_t FilamentInstance::getSkinCount() const noexcept {
+    return upcast(this)->getSkinCount();
+}
+
+const char* FilamentInstance::getSkinNameAt(size_t skinIndex) const noexcept {
+    return upcast(this)->getSkinNameAt(skinIndex);
+}
+
+size_t FilamentInstance::getJointCountAt(size_t skinIndex) const noexcept {
+    return upcast(this)->getJointCountAt(skinIndex);
+}
+
+const Entity* FilamentInstance::getJointsAt(size_t skinIndex) const noexcept {
+    return upcast(this)->getJointsAt(skinIndex);
+}
+
+void FilamentInstance::attachSkin(size_t skinIndex, Entity target) noexcept {
+    return upcast(this)->attachSkin(skinIndex, target);
+}
+
+void FilamentInstance::detachSkin(size_t skinIndex, Entity target) noexcept {
+    return upcast(this)->detachSkin(skinIndex, target);
+}
+
 
 } // namespace filament::gltfio

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -220,7 +220,11 @@ int main(int argc, char** argv) {
             app.resourceLoader->addTextureProvider("image/jpeg", app.stbDecoder);
             app.resourceLoader->addTextureProvider("image/ktx2", app.ktxDecoder);
         }
-        app.resourceLoader->asyncBeginLoad(app.asset);
+
+        if (!app.resourceLoader->asyncBeginLoad(app.asset)) {
+            std::cerr << "Unable to start loading resources for " << filename << std::endl;
+            exit(1);
+        }
 
         // Load animation data.
         app.asset->getAnimator();

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -517,22 +517,9 @@ Filament.loadClassExtensions = function() {
         return new Float32Array(arrayBuffer);
     };
 
-    Filament.gltfio$AssetLoader.prototype.createAssetFromJson = function(buffer) {
-        if ('string' == typeof buffer && buffer.endsWith('.glb')) {
-            console.error('Please use createAssetFromBinary for glb files.');
-        }
+    Filament.gltfio$AssetLoader.prototype.createAsset = function(buffer) {
         buffer = getBufferDescriptor(buffer);
-        const result = this._createAssetFromJson(buffer);
-        buffer.delete();
-        return result;
-    };
-
-    Filament.gltfio$AssetLoader.prototype.createAssetFromBinary = function(buffer) {
-        if ('string' == typeof buffer && buffer.endsWith('.gltf')) {
-            console.error('Please use createAssetFromJson for gltf files.');
-        }
-        buffer = getBufferDescriptor(buffer);
-        const result = this._createAssetFromBinary(buffer);
+        const result = this._createAsset(buffer);
         buffer.delete();
         return result;
     };

--- a/web/filament-js/filament-viewer.js
+++ b/web/filament-js/filament-viewer.js
@@ -287,7 +287,7 @@ class FilamentViewer extends LitElement {
         // Dropping a glb file is simple because there are no external resources.
         if (this.srcBlob && this.srcBlob.name.endsWith(".glb")) {
             this.srcBlob.arrayBuffer().then(buffer => {
-                this.asset = this.loader.createAssetFromBinary(new Uint8Array(buffer));
+                this.asset = this.loader.createAsset(new Uint8Array(buffer));
                 const aabb = this.asset.getBoundingBox();
                 this.assetRoot = this.asset.getRoot();
                 this.unitCubeTransform = Filament.fitIntoUnitCube(aabb, zoffset);
@@ -327,7 +327,7 @@ class FilamentViewer extends LitElement {
             };
 
             this.srcBlob.arrayBuffer().then(buffer => {
-                this.asset = this.loader.createAssetFromJson(new Uint8Array(buffer));
+                this.asset = this.loader.createAsset(new Uint8Array(buffer));
                 const aabb = this.asset.getBoundingBox();
                 this.assetRoot = this.asset.getRoot();
                 this.unitCubeTransform = Filament.fitIntoUnitCube(aabb, zoffset);
@@ -367,12 +367,7 @@ class FilamentViewer extends LitElement {
             return response.arrayBuffer();
         }).then(arrayBuffer => {
             const modelData = new Uint8Array(arrayBuffer);
-            if (this.src.endsWith(".glb")) {
-                this.asset = this.loader.createAssetFromBinary(modelData);
-            } else {
-                this.asset = this.loader.createAssetFromJson(modelData);
-            }
-
+            this.asset = this.loader.createAsset(modelData);
             const aabb = this.asset.getBoundingBox();
             this.assetRoot = this.asset.getRoot();
             this.unitCubeTransform = Filament.fitIntoUnitCube(aabb, zoffset);

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -568,8 +568,7 @@ export class Ktx2Reader {
 }
 
 export class gltfio$AssetLoader {
-    public createAssetFromJson(urlOrBuffer: BufferReference): gltfio$FilamentAsset;
-    public createAssetFromBinary(urlOrBuffer: BufferReference): gltfio$FilamentAsset;
+    public createAsset(urlOrBuffer: BufferReference): gltfio$FilamentAsset;
     public createInstancedAsset(urlOrBuffer: BufferReference,
             instances: (gltfio$FilamentInstance | null)[]): gltfio$FilamentAsset;
     public destroyAsset(asset: gltfio$FilamentAsset): void;
@@ -591,9 +590,6 @@ export class gltfio$FilamentAsset {
     public popRenderable(): Entity;
     public getMaterialInstances(): Vector<MaterialInstance>;
     public getResourceUris(): Vector<string>;
-    public getSkinNames(): Vector<string>;
-    public attachSkin(skinIndex: number, entity: Entity): void;
-    public detachSkin(skinIndex: number, entity: Entity): void;
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
     public getExtras(entity: Entity): string;
@@ -608,6 +604,9 @@ export class gltfio$FilamentInstance {
     public getEntities(): Vector<Entity>;
     public getRoot(): Entity;
     public getAnimator(): gltfio$Animator;
+    public getSkinNames(): Vector<string>;
+    public attachSkin(skinIndex: number, entity: Entity): void;
+    public detachSkin(skinIndex: number, entity: Entity): void;
 }
 
 export class gltfio$Animator {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1785,17 +1785,6 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         return retval;
     }), allow_raw_pointers())
 
-    .function("getSkinNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentAsset* self), {
-        std::vector<std::string> names(self->getSkinCount());
-        for (size_t i = 0; i < names.size(); ++i) {
-            names[i] = self->getSkinNameAt(i);
-        }
-        return names;
-    }), allow_raw_pointers())
-
-    .function("attachSkin", &FilamentAsset::attachSkin)
-    .function("detachSkin", &FilamentAsset::detachSkin)
-
     .function("getBoundingBox", &FilamentAsset::getBoundingBox)
     .function("getName", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
         return std::string(self->getName(entity));
@@ -1816,7 +1805,18 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
     }), allow_raw_pointers())
     .function("getRoot", &FilamentInstance::getRoot)
     .function("applyMaterialVariant", &FilamentInstance::applyMaterialVariant)
-    .function("getAnimator", &FilamentInstance::getAnimator, allow_raw_pointers());
+    .function("getAnimator", &FilamentInstance::getAnimator, allow_raw_pointers())
+
+    .function("getSkinNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentInstance* self), {
+        std::vector<std::string> names(self->getSkinCount());
+        for (size_t i = 0; i < names.size(); ++i) {
+            names[i] = self->getSkinNameAt(i);
+        }
+        return names;
+    }), allow_raw_pointers())
+
+    .function("attachSkin", &FilamentInstance::attachSkin)
+    .function("detachSkin", &FilamentInstance::detachSkin);
 
 // These little wrappers exist to get around RTTI requirements in embind.
 
@@ -1852,20 +1852,12 @@ class_<AssetLoader>("gltfio$AssetLoader")
         return AssetLoader::create({ engine, materials.provider, names });
     }), allow_raw_pointers())
 
-    /// createAssetFromJson ::method::
+    /// createAsset ::method::
     /// buffer ::argument:: asset string, or Uint8Array, or [Buffer]
     /// ::retval:: an instance of [FilamentAsset]
-    .function("_createAssetFromJson", EMBIND_LAMBDA(FilamentAsset*,
+    .function("_createAsset", EMBIND_LAMBDA(FilamentAsset*,
             (AssetLoader* self, BufferDescriptor buffer), {
-        return self->createAssetFromJson((const uint8_t*) buffer.bd->buffer, buffer.bd->size);
-    }), allow_raw_pointers())
-
-    /// createAssetFromBinary ::method::
-    /// buffer ::argument:: asset string, or Uint8Array, or [Buffer]
-    /// ::retval:: an instance of [FilamentAsset]
-    .function("_createAssetFromBinary", EMBIND_LAMBDA(FilamentAsset*,
-            (AssetLoader* self, BufferDescriptor buffer), {
-        return self->createAssetFromBinary((const uint8_t*) buffer.bd->buffer, buffer.bd->size);
+        return self->createAsset((const uint8_t*) buffer.bd->buffer, buffer.bd->size);
     }), allow_raw_pointers())
 
     /// createInstancedAsset ::method::

--- a/web/samples/animation.html
+++ b/web/samples/animation.html
@@ -32,7 +32,7 @@ class App {
         const scene = this.scene = engine.createScene();
 
         const loader = engine.createAssetLoader();
-        const asset = this.asset = loader.createAssetFromJson(mesh_url);
+        const asset = this.asset = loader.createAsset(mesh_url);
 
         const sunlight = Filament.EntityManager.get().create();
         Filament.LightManager.Builder(LightType.SUN).direction([0, 0, -1]).build(engine, sunlight);

--- a/web/samples/helmet.html
+++ b/web/samples/helmet.html
@@ -88,7 +88,7 @@ class App {
         const loader = this.loader = engine.createAssetLoader();
 
         this.allowRefresh = false;
-        const asset = this.asset = loader.createAssetFromJson(mesh_url);
+        const asset = this.asset = loader.createAsset(mesh_url);
         this.assetRoot = this.asset.getRoot();
 
         // Crudely indicate progress by printing the URI of each resource as it is loaded.
@@ -138,7 +138,7 @@ class App {
         this.allowRefresh = false;
         this.scene.removeEntities(this.asset.getEntities());
         this.loader.destroyAsset(this.asset);
-        this.asset = this.loader.createAssetFromJson(mesh_url);
+        this.asset = this.loader.createAsset(mesh_url);
         const onDone = () => { this.allowRefresh = true; }
         this.asset.loadResources(onDone);
     }

--- a/web/samples/morphing.html
+++ b/web/samples/morphing.html
@@ -33,7 +33,7 @@ class App {
         this.trackball = new Trackball(canvas, {startSpin: 0.035});
 
         const loader = engine.createAssetLoader();
-        const asset = this.asset = loader.createAssetFromBinary(mesh_url);
+        const asset = this.asset = loader.createAsset(mesh_url);
 
         const onDone = () => {
             loader.delete();


### PR DESCRIPTION
This change was motivated by some internal work at Google and has the benefit of simplifying the gltfio API and
implementation. There are 2 major API changes:

(1) Consolidate separate loader entry points for GLB and GLTF.

The distinction between GLB and GLTF can be made from the file content alone, because GLB has a 4-byte magic string in its header. There is no need for separate entry points.  Clients do not (and should not) need to check the file name extension.

(2) Remove the distinction between "instanced" and "non-instanced" glTF assets.

In the new scheme, all assets have at least 1 instance.

Broadly speaking, in gltfio an "asset" is a collection of Filament objects like textures and vertex buffers, while an "instance" is a collection of entities and components (e.g. the transform hierarchy).

This API change makes life easier for clients because they no longer need to decide a priori if they will ever need to add instances.

This change also moves some public-facing methods from `FilamentAsset` to `FilamentInstance`:

    - getSkinCount, getSkinNameAt
    - getJointCountAt, getJointsAt
    - attachSkin, detachSkin