### PR TITLE
Add glslang/OSDependent to ThirdParty folder

### DIFF
--- a/third_party/glslang/glslang/OSDependent/Unix/CMakeLists.txt
+++ b/third_party/glslang/glslang/OSDependent/Unix/CMakeLists.txt
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 add_library(OSDependent STATIC ossource.cpp ../osinclude.h)
-set_property(TARGET OSDependent PROPERTY FOLDER glslang)
+set_property(TARGET OSDependent PROPERTY FOLDER ThirdParty/glslang)
 set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Link pthread

--- a/third_party/glslang/glslang/OSDependent/Windows/CMakeLists.txt
+++ b/third_party/glslang/glslang/OSDependent/Windows/CMakeLists.txt
@@ -34,7 +34,7 @@
 set(SOURCES ossource.cpp ../osinclude.h)
 
 add_library(OSDependent STATIC ${SOURCES})
-set_property(TARGET OSDependent PROPERTY FOLDER glslang)
+set_property(TARGET OSDependent PROPERTY FOLDER ThirdParty/glslang)
 set_property(TARGET OSDependent PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # MinGW GCC complains about function pointer casts to void*.


### PR DESCRIPTION
Apologies for the repeat PR after https://github.com/google/filament/pull/5934; I accidentally undid one-too-many folder additions in https://github.com/google/filament/pull/5934/commits/4f8e3ed4449ab7342540b6bcc5908a31629296d6 which left the `glslang/OSDependent` subproject as the sole sub-project not sorted into a folder.   This should fix that.