### PR TITLE
Set Frame Delay according to Monitor Refresh Rate

### DIFF
--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -395,7 +395,7 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
         SDL_DisplayMode Mode;
         int refreshIntervalMS = (SDL_GetDesktopDisplayMode(
             SDL_GetWindowDisplayIndex(window->mWindow), &Mode) == 0 && 
-            Mode.refresh_rate != 0) ? 1000 / Mode.refresh_rate : 60;
+            Mode.refresh_rate != 0) ? round(1000.0 / Mode.refresh_rate) : 16;
         SDL_Delay(refreshIntervalMS);
 
         Renderer* renderer = window->getRenderer();

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -390,8 +390,13 @@ void FilamentApp::run(const Config& config, SetupCallback setupCallback,
         lightmapCube->mapFrustum(*mEngine, lightmapCamera);
         cameraCube->mapFrustum(*mEngine, window->mMainCamera);
 
-        // TODO: we need better timing or use SDL_GL_SetSwapInterval
-        SDL_Delay(16);
+        // Delay rendering for roughly one monitor refresh interval
+        // TODO: Use SDL_GL_SetSwapInterval for proper vsync
+        SDL_DisplayMode Mode;
+        int refreshIntervalMS = (SDL_GetDesktopDisplayMode(
+            SDL_GetWindowDisplayIndex(window->mWindow), &Mode) == 0 && 
+            Mode.refresh_rate != 0) ? 1000 / Mode.refresh_rate : 60;
+        SDL_Delay(refreshIntervalMS);
 
         Renderer* renderer = window->getRenderer();
 


### PR DESCRIPTION
This is a simple PR that changes FilamentApp to delay its rendering to be roughly in line with the monitor framerate.

This helps all the samples look temporally smooth on higher refresh rate monitors, while still leaving it clear how to decouple rendering from vsync for new programmers.


Alternative techniques (with finer than 1ms granularity) like using `SDL_GL_SetSwapInterval` or `SDL_RENDERER_PRESENTVSYNC` might be preferable, but I'm still too new to SDL to figure out how to integrate them.    Even with integer milliseconds, the beat-frequency (rate of frame stutters) will never exceed ~1hz~ 0.5hz, so the incremental improvement will be minimal.