### PR TITLE
cleanup SamplerBindingMap usages

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -290,6 +290,7 @@ void OpenGLProgram::initializeProgramState(OpenGLContext& context, GLuint progra
         Program::UniformBlockInfo const& uniformBlockInfo,
         Program::SamplerGroupInfo const& samplerGroupInfo) noexcept {
 
+    // TODO: we shouldn't need this at feature level 2 (but requires a change in generateUniforms)
     // Associate each UniformBlock in the program to a known binding.
     UTILS_NOUNROLL
     for (GLuint binding = 0, n = uniformBlockInfo.size(); binding < n; binding++) {

--- a/libs/filabridge/src/SibGenerator.cpp
+++ b/libs/filabridge/src/SibGenerator.cpp
@@ -67,7 +67,7 @@ SamplerInterfaceBlock const& SibGenerator::getPerViewSib(Variant variant) noexce
             )
             .build();
 
-    // SamplerBindingMap relies the assumption that Sibs have the same names and offsets
+    // SamplerBindingMap relies on the assumption that Sibs have the same names and offsets
     // regardless of variant.
     assert(sibPcf.getSize() == PerViewSib::SAMPLER_COUNT);
     assert(sibVsm.getSize() == PerViewSib::SAMPLER_COUNT);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -969,9 +969,7 @@ Package MaterialBuilder::build(JobSystem& jobSystem) noexcept {
         return Package::invalidPackage();
     }
 
-    filament::SamplerBindingMap map;
-    map.populate(&info.sib, mMaterialName.c_str());
-    info.samplerBindings = std::move(map);
+    info.samplerBindings.populate(&info.sib, mMaterialName.c_str());
 
     // Create chunk tree.
     ChunkContainer container;
@@ -1029,10 +1027,7 @@ std::string MaterialBuilder::peek(filament::backend::ShaderType type,
 
     MaterialInfo info;
     prepareToBuild(info);
-
-    filament::SamplerBindingMap map;
-    map.populate(&info.sib, mMaterialName.c_str());
-    info.samplerBindings = std::move(map);
+    info.samplerBindings.populate(&info.sib, mMaterialName.c_str());
 
     if (type == filament::backend::ShaderType::VERTEX) {
         return sg.createVertexProgram(ShaderModel(params.shaderModel),

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -330,6 +330,7 @@ io::sstream& CodeGenerator::generateUniforms(io::sstream& out, ShaderType shader
     Precision defaultPrecision = getDefaultPrecision(shaderType);
 
     out << "\nlayout(";
+    // TODO: at feature level 2, GLSL should support the binding qualifier
     if (mTargetLanguage == TargetLanguage::SPIRV) {
         uint32_t bindingIndex = (uint32_t) binding; // avoid char output
         out << "binding = " << bindingIndex << ", ";

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -173,7 +173,7 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
         VertexDomain vertexDomain) const noexcept {
     if (mMaterialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
         return createPostProcessVertexProgram(shaderModel, targetApi,
-                targetLanguage, material, variant.key, material.samplerBindings);
+                targetLanguage, material, variant.key);
     }
 
     io::sstream vs;
@@ -308,7 +308,7 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
         Interpolation interpolation) const noexcept {
     if (mMaterialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
         return createPostProcessFragmentProgram(shaderModel, targetApi, targetLanguage, material,
-                variant.key, material.samplerBindings);
+                variant.key);
     }
 
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage);
@@ -530,10 +530,9 @@ void ShaderGenerator::fixupExternalSamplers(ShaderModel sm,
     }
 }
 
-std::string ShaderGenerator::createPostProcessVertexProgram(
-        ShaderModel sm, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetLanguage targetLanguage, MaterialInfo const& material,
-        const filament::Variant::type_t variantKey, SamplerBindingMap const& samplerBindingMap) const noexcept {
+std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel sm,
+        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
+        MaterialInfo const& material, const filament::Variant::type_t variantKey) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage);
     io::sstream vs;
     cg.generateProlog(vs, ShaderType::VERTEX, material);
@@ -571,10 +570,9 @@ std::string ShaderGenerator::createPostProcessVertexProgram(
     return vs.c_str();
 }
 
-std::string ShaderGenerator::createPostProcessFragmentProgram(
-        ShaderModel sm, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetLanguage targetLanguage, MaterialInfo const& material,
-        uint8_t variant, const SamplerBindingMap& samplerBindingMap) const noexcept {
+std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel sm,
+        MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
+        MaterialInfo const& material, uint8_t variant) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage);
     io::sstream fs;
     cg.generateProlog(fs, ShaderType::FRAGMENT, material);

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -73,13 +73,11 @@ private:
 
     std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-            MaterialInfo const& material, filament::Variant::type_t variantKey,
-            const filament::SamplerBindingMap& samplerBindingMap) const noexcept;
+            MaterialInfo const& material, filament::Variant::type_t variantKey) const noexcept;
 
     std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-            MaterialInfo const& material, uint8_t variant,
-            const filament::SamplerBindingMap& samplerBindingMap) const noexcept;
+            MaterialInfo const& material, uint8_t variant) const noexcept;
 
     MaterialBuilder::PropertyList mProperties;
     MaterialBuilder::VariableList mVariables;


### PR DESCRIPTION
- remove unused SamplerBindingMap parameter 
  In fact, the SamplerBindingMap is used, but it is passed inside the
  MaterialInfo structure, so it doesn't need to be passed as parameter.

- Don't create unneeded SamplerBindingMap temporaries