### PR TITLE
lots of cleanup around materials and uniforms

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,8 @@ A new header is inserted each time a *tag* is created.
 
 - engine: new feature level APIs, see `Engine::getSupportedFeatureLevel()`
 - engine: add new stencil API to `View` and stencil state APIs to `MaterialInstance` [**NEW API**].
+- engine: Fix guard bands and TAA with `vertexDomain:Device` [⚠️ **Recompile Materials**]
+- engine: `clipSpaceTransform` is now only available with `vertexDomain:Device` [⚠️ **API Change**]
 - gltfio: add unified `AssetLoader::createAsset()` method [⚠️ **API Change**]
 - gltfio: all assets are now "instanced" [⚠️ **API Change**]
 
@@ -15,8 +17,6 @@ A new header is inserted each time a *tag* is created.
 - Add CONFIG_MINSPEC_UBO_SIZE as a nicer way to allow exceeding the ES3.0 minspec.
 - gltfio: minor efficiency improvement for Android and WebGL builds.
 - gltfio: add support for concurrent texture downloading and decoding.
-- engine: Fix guard bands and TAA with `vertexDomain:Device` [⚠️ **Recompile Materials**]
-- engine: `clipSpaceTransform` is now only available with `vertexDomain:Device` [⚠️ **API Change**]
 
 ## v1.25.5
 

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -24,6 +24,8 @@
 #include <utils/Log.h>
 #include <utils/ostream.h>
 
+#include <private/backend/DriverApiForward.h>
+
 #include <backend/DriverEnums.h>
 
 #include <array>
@@ -51,11 +53,14 @@ public:
     using SamplerGroupInfo = std::array<SamplerGroupData, BINDING_COUNT>;
     using UniformBlockInfo = std::array<utils::CString, BINDING_COUNT>;
 
-    Program() noexcept;
+    explicit Program(DriverApi& driver) noexcept;
+
     Program(const Program& rhs) = delete;
     Program& operator=(const Program& rhs) = delete;
+
     Program(Program&& rhs) noexcept;
     Program& operator=(Program&& rhs) noexcept;
+
     ~Program() noexcept;
 
     // sets the material name and variant for diagnostic purposes only
@@ -65,7 +70,7 @@ public:
     // sets one of the program's shader (e.g. vertex, fragment)
     // string-based shaders are null terminated, consequently the size parameter must include the
     // null terminating character.
-    Program& shader(ShaderType shader, void const* data, size_t size) noexcept;
+    Program& shader(ShaderType shader, void const* data, size_t size);
 
     // sets the 'bindingPoint' uniform block's name for this program.
     //
@@ -112,6 +117,7 @@ public:
 private:
     friend utils::io::ostream& operator<<(utils::io::ostream& out, const Program& builder);
 
+    DriverApi& mDriverApi;
     UniformBlockInfo mUniformBlocks = {};
     SamplerGroupInfo mSamplerGroups = {};
     ShaderSource mShadersSource;

--- a/filament/backend/include/private/backend/Program.h
+++ b/filament/backend/include/private/backend/Program.h
@@ -37,11 +37,6 @@ public:
     static constexpr size_t SHADER_TYPE_COUNT = 2;
     static constexpr size_t BINDING_COUNT = CONFIG_BINDING_COUNT;
 
-    enum class Shader : uint8_t {
-        VERTEX = 0,
-        FRAGMENT = 1
-    };
-
     struct Sampler {
         utils::CString name = {};   // name of the sampler in the shader
         uint16_t binding = 0;       // binding point of the sampler in the shader
@@ -70,7 +65,7 @@ public:
     // sets one of the program's shader (e.g. vertex, fragment)
     // string-based shaders are null terminated, consequently the size parameter must include the
     // null terminating character.
-    Program& shader(Shader shader, void const* data, size_t size) noexcept;
+    Program& shader(ShaderType shader, void const* data, size_t size) noexcept;
 
     // sets the 'bindingPoint' uniform block's name for this program.
     //
@@ -90,13 +85,13 @@ public:
     // string-based shaders are null terminated, consequently the size parameter must include the
     // null terminating character.
     Program& withVertexShader(void const* data, size_t size) {
-        return shader(Shader::VERTEX, data, size);
+        return shader(ShaderType::VERTEX, data, size);
     }
 
     // string-based shaders are null terminated, consequently the size parameter must include the
     // null terminating character.
     Program& withFragmentShader(void const* data, size_t size) {
-        return shader(Shader::FRAGMENT, data, size);
+        return shader(ShaderType::FRAGMENT, data, size);
     }
 
     using ShaderBlob = utils::FixedCapacityVector<uint8_t>;

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -33,7 +33,7 @@ Program& Program::diagnostics(utils::CString const& name,
     return *this;
 }
 
-Program& Program::shader(Program::Shader shader, void const* data, size_t size) noexcept {
+Program& Program::shader(ShaderType shader, void const* data, size_t size) noexcept {
     ShaderBlob blob(size);
     std::copy_n((const uint8_t *)data, size, blob.data());
     mShadersSource[size_t(shader)] = std::move(blob);

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -28,10 +28,9 @@ Program::Program(DriverApi& driver) noexcept
 Program::Program(Program&& rhs) noexcept = default;
 
 Program& Program::operator=(Program&& rhs) noexcept {
-    mUniformBlocks.operator=(std::move(rhs.mUniformBlocks));
+    mUniformBlocks.operator=(rhs.mUniformBlocks);
     mSamplerGroups.operator=(std::move(rhs.mSamplerGroups));
     mShadersSource.operator=(std::move(rhs.mShadersSource));
-    mHasSamplers = rhs.mHasSamplers;
     mName.operator=(std::move(rhs.mName));
     mLogger.operator=(std::move(rhs.mLogger));
     return *this;
@@ -53,8 +52,12 @@ Program& Program::shader(ShaderType shader, void const* data, size_t size) {
     return *this;
 }
 
-Program& Program::setUniformBlock(size_t bindingPoint, std::string_view uniformBlockName) noexcept {
-    mUniformBlocks[bindingPoint] = { uniformBlockName.data(), uniformBlockName.size() };
+Program& Program::uniformBlockBindings(
+        utils::FixedCapacityVector<std::pair<const char*, uint8_t>> const& uniformBlockBindings) noexcept {
+    for (auto const& item : uniformBlockBindings) {
+        assert_invariant(item.second < BINDING_COUNT);
+        mUniformBlocks[item.second] = item.first;
+    }
     return *this;
 }
 
@@ -66,7 +69,6 @@ Program& Program::setSamplerGroup(size_t bindingPoint, ShaderStageFlags stageFla
     samplerList.reserve(count);
     samplerList.resize(count);
     std::copy_n(samplers, count, samplerList.data());
-    mHasSamplers = true;
     return *this;
 }
 

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -20,10 +20,23 @@ using namespace utils;
 
 namespace filament::backend {
 
-// We want these in the .cpp file so they're not inlined (not worth it)
-Program::Program() noexcept {}  // = default; does not work with msvc because of noexcept
+// We want these in the .cpp file, so they're not inlined (not worth it)
+Program::Program(DriverApi& driver) noexcept
+        : mDriverApi(driver) {
+}
+
 Program::Program(Program&& rhs) noexcept = default;
-Program& Program::operator=(Program&& rhs) noexcept = default;
+
+Program& Program::operator=(Program&& rhs) noexcept {
+    mUniformBlocks.operator=(std::move(rhs.mUniformBlocks));
+    mSamplerGroups.operator=(std::move(rhs.mSamplerGroups));
+    mShadersSource.operator=(std::move(rhs.mShadersSource));
+    mHasSamplers = rhs.mHasSamplers;
+    mName.operator=(std::move(rhs.mName));
+    mLogger.operator=(std::move(rhs.mLogger));
+    return *this;
+}
+
 Program::~Program() noexcept = default;
 
 Program& Program::diagnostics(utils::CString const& name,
@@ -33,7 +46,7 @@ Program& Program::diagnostics(utils::CString const& name,
     return *this;
 }
 
-Program& Program::shader(ShaderType shader, void const* data, size_t size) noexcept {
+Program& Program::shader(ShaderType shader, void const* data, size_t size) {
     ShaderBlob blob(size);
     std::copy_n((const uint8_t *)data, size, blob.data());
     mShadersSource[size_t(shader)] = std::move(blob);

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -34,7 +34,7 @@ using namespace utils;
 using namespace backend;
 
 static void logCompilationError(utils::io::ostream& out,
-        Program::Shader shaderType, const char* name,
+        ShaderType shaderType, const char* name,
         GLuint shaderId, CString const& sourceCode) noexcept;
 
 static void logProgramLinkError(utils::io::ostream& out,
@@ -104,13 +104,13 @@ void OpenGLProgram::compileShaders(OpenGLContext& context,
     // build all shaders
     UTILS_NOUNROLL
     for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
-        Program::Shader type = static_cast<Program::Shader>(i);
+        ShaderType type = static_cast<ShaderType>(i);
         GLenum glShaderType;
         switch (type) {
-            case Program::Shader::VERTEX:
+            case ShaderType::VERTEX:
                 glShaderType = GL_VERTEX_SHADER;
                 break;
-            case Program::Shader::FRAGMENT:
+            case ShaderType::FRAGMENT:
                 glShaderType = GL_FRAGMENT_SHADER;
                 break;
         }
@@ -226,7 +226,7 @@ GLuint OpenGLProgram::linkProgram(const GLuint shaderIds[Program::SHADER_TYPE_CO
  */
 bool OpenGLProgram::checkProgramStatus(const char* name,
         GLuint& program, GLuint shaderIds[Program::SHADER_TYPE_COUNT],
-        std::array<CString, 2> const& shaderSourceCode) noexcept {
+        std::array<CString, Program::SHADER_TYPE_COUNT> const& shaderSourceCode) noexcept {
 
     GLint status;
     glGetProgramiv(program, GL_LINK_STATUS, &status);
@@ -237,7 +237,7 @@ bool OpenGLProgram::checkProgramStatus(const char* name,
     // only if the link fails, we check the compilation status
     UTILS_NOUNROLL
     for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
-        const Program::Shader type = static_cast<Program::Shader>(i);
+        const ShaderType type = static_cast<ShaderType>(i);
         const GLuint shader = shaderIds[i];
         glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
         if (status != GL_TRUE) {
@@ -374,13 +374,13 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* gld) noexcept {
 }
 
 UTILS_NOINLINE
-void logCompilationError(io::ostream& out, Program::Shader shaderType,
+void logCompilationError(io::ostream& out, ShaderType shaderType,
         const char* name, GLuint shaderId, CString const& sourceCode) noexcept {
 
-    auto to_string = [](Program::Shader type) -> const char* {
+    auto to_string = [](ShaderType type) -> const char* {
         switch (type) {
-            case Program::Shader::VERTEX:       return "vertex";
-            case Program::Shader::FRAGMENT:     return "fragment";
+            case ShaderType::VERTEX:   return "vertex";
+            case ShaderType::FRAGMENT: return "fragment";
         }
     };
 

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -72,10 +72,6 @@ public:
     } gl; // 12 bytes
 
 private:
-    static constexpr uint8_t TEXTURE_UNIT_COUNT = OpenGLContext::MAX_TEXTURE_UNIT_COUNT;
-    static constexpr uint8_t VERTEX_SHADER_BIT   = uint8_t(1) << size_t(Program::Shader::VERTEX);
-    static constexpr uint8_t FRAGMENT_SHADER_BIT = uint8_t(1) << size_t(Program::Shader::FRAGMENT);
-
     static void compileShaders(OpenGLContext& context,
             Program::ShaderSource shadersSource,
             GLuint shaderIds[Program::SHADER_TYPE_COUNT],
@@ -85,7 +81,7 @@ private:
 
     static bool checkProgramStatus(const char* name,
             GLuint& program, GLuint shaderIds[Program::SHADER_TYPE_COUNT],
-            std::array<utils::CString, 2> const& shaderSourceCode) noexcept;
+            std::array<utils::CString, Program::SHADER_TYPE_COUNT> const& shaderSourceCode) noexcept;
 
     void initialize(OpenGLContext& context);
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -68,7 +68,7 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
     // Output a warning because it's okay to encounter empty blobs, but it's not okay to use
     // this program handle in a draw call.
     if (missing) {
-        utils::slog.w << "Missing SPIR-V shader: " << builder.getName().c_str() << utils::io::endl;
+        utils::slog.w << "Missing SPIR-V shader: " << this->name.c_str() << utils::io::endl;
         return;
     }
 

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -18,7 +18,6 @@
 
 #include <GlslangToSpv.h>
 #include <SPVRemapper.h>
-#include <localintermediate.h>
 
 #include <spirv_glsl.hpp>
 #include <spirv_msl.hpp>
@@ -26,6 +25,7 @@
 #include "builtinResource.h"
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
 namespace test {
@@ -103,8 +103,8 @@ void ShaderGenerator::shutdown() {
 
 ShaderGenerator::ShaderGenerator(std::string vertex, std::string fragment, Backend backend,
         bool isMobile) noexcept : mBackend(backend), mIsMobile(isMobile) {
-    mVertexBlob = transpileShader(backend, isMobile, vertex, ShaderStage::VERTEX);
-    mFragmentBlob = transpileShader(backend, isMobile, fragment, ShaderStage::FRAGMENT);
+    mVertexBlob = transpileShader(backend, isMobile, std::move(vertex), ShaderStage::VERTEX);
+    mFragmentBlob = transpileShader(backend, isMobile, std::move(fragment), ShaderStage::FRAGMENT);
 }
 
 ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isMobile, std::string shader,
@@ -169,12 +169,12 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
         } else {
             SpvToGlsl(&spirv, &result);
         }
-        return Blob(result.c_str(), result.c_str() + result.length() + 1);
+        return { result.c_str(), result.c_str() + result.length() + 1 };
     } else if (backend == Backend::METAL) {
         SpvToMsl(&spirv, &result);
-        return Blob(result.c_str(), result.c_str() + result.length() + 1);
+        return { result.c_str(), result.c_str() + result.length() + 1 };
     } else if (backend == Backend::VULKAN) {
-        return Blob((uint8_t*) spirv.data(), (uint8_t*) (spirv.data() + spirv.size()));
+        return { (uint8_t*)spirv.data(), (uint8_t*)(spirv.data() + spirv.size()) };
     }
 
     return {};
@@ -182,8 +182,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
 
 Program ShaderGenerator::getProgram() noexcept {
     Program program;
-    program.shader(Program::Shader::VERTEX, mVertexBlob.data(), mVertexBlob.size());
-    program.shader(Program::Shader::FRAGMENT, mFragmentBlob.data(), mFragmentBlob.size());
+    program.shader(ShaderType::VERTEX, mVertexBlob.data(), mVertexBlob.size());
+    program.shader(ShaderType::FRAGMENT, mFragmentBlob.data(), mFragmentBlob.size());
     return program;
 }
 

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -180,8 +180,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
     return {};
 }
 
-Program ShaderGenerator::getProgram() noexcept {
-    Program program;
+Program ShaderGenerator::getProgram(filament::backend::DriverApi& driverApi) noexcept {
+    Program program(driverApi);
     program.shader(ShaderType::VERTEX, mVertexBlob.data(), mVertexBlob.size());
     program.shader(ShaderType::FRAGMENT, mFragmentBlob.data(), mFragmentBlob.size());
     return program;

--- a/filament/backend/test/ShaderGenerator.h
+++ b/filament/backend/test/ShaderGenerator.h
@@ -20,6 +20,7 @@
 #include "PlatformRunner.h"
 
 #include "private/backend/DriverApi.h"
+#include "private/backend/Program.h"
 
 #include <string>
 
@@ -35,14 +36,14 @@ public:
     /**
      * Generates shaders transpiled for the given backend / mobile combination.
      * @param vertex The vertex shader, written in GLSL 450 core.
-     * @param fragment The framgnet shader, written in GLSL 450 core.
+     * @param fragment The fragment shader, written in GLSL 450 core.
      */
     ShaderGenerator(std::string vertex, std::string fragment, Backend backend, bool isMobile) noexcept;
 
     ShaderGenerator(const ShaderGenerator& rhs) = delete;
     ShaderGenerator& operator=(const ShaderGenerator& rhs) = delete;
 
-    filament::backend::Program getProgram() noexcept;
+    filament::backend::Program getProgram(filament::backend::DriverApi& driverApi) noexcept;
 
 private:
 

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -419,7 +419,7 @@ TEST_F(BackendTest, DepthMinify) {
         Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-        prog.setUniformBlock(1, "params");
+        prog.uniformBlockBindings({{"params", 1}});
         program = api.createProgram(std::move(prog));
     }
 
@@ -561,7 +561,7 @@ TEST_F(BackendTest, ColorResolve) {
         Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-        prog.setUniformBlock(1, "params");
+        prog.uniformBlockBindings({{"params", 1}});
         program = api.createProgram(std::move(prog));
     }
 
@@ -669,7 +669,7 @@ TEST_F(BackendTest, DepthResolve) {
         Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-        prog.setUniformBlock(1, "params");
+        prog.uniformBlockBindings({{"params", 1}});
         program = api.createProgram(std::move(prog));
     }
 

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -416,7 +416,7 @@ TEST_F(BackendTest, DepthMinify) {
     ProgramHandle program;
     {
         ShaderGenerator shaderGen(triangleVs, triangleFs, sBackend, sIsMobilePlatform);
-        Program prog = shaderGen.getProgram();
+        Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
         prog.setUniformBlock(1, "params");
@@ -558,7 +558,7 @@ TEST_F(BackendTest, ColorResolve) {
     ProgramHandle program;
     {
         ShaderGenerator shaderGen(triangleVs, triangleFs, sBackend, sIsMobilePlatform);
-        Program prog = shaderGen.getProgram();
+        Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
         prog.setUniformBlock(1, "params");
@@ -666,7 +666,7 @@ TEST_F(BackendTest, DepthResolve) {
     ProgramHandle program;
     {
         ShaderGenerator shaderGen(triangleVs, triangleFs, sBackend, sIsMobilePlatform);
-        Program prog = shaderGen.getProgram();
+        Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
         prog.setUniformBlock(1, "params");

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -95,7 +95,7 @@ TEST_F(BackendTest, VertexBufferUpdate) {
 
         // Create a program.
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(getDriverApi());
         auto program = getDriverApi().createProgram(std::move(p));
 
         auto defaultRenderTarget = getDriverApi().createDefaultRenderTarget(0);
@@ -201,7 +201,7 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
 
     // Create a program.
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-    Program p = shaderGen.getProgram();
+    Program p = shaderGen.getProgram(getDriverApi());
     p.setUniformBlock(1, "params");
     auto program = getDriverApi().createProgram(std::move(p));
 

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -202,7 +202,7 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
     // Create a program.
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
     Program p = shaderGen.getProgram(getDriverApi());
-    p.setUniformBlock(1, "params");
+    p.uniformBlockBindings({{"params", 1}});
     auto program = getDriverApi().createProgram(std::move(p));
 
     // Create a uniform buffer.

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -135,7 +135,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             Program prog = shaderGen.getProgram(api);
             Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
             prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-            prog.setUniformBlock(1, "params");
+            prog.uniformBlockBindings({{"params", 1}});
             program = api.createProgram(std::move(prog));
         }
 

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -132,7 +132,7 @@ TEST_F(BackendTest, FeedbackLoops) {
         ProgramHandle program;
         {
             ShaderGenerator shaderGen(fullscreenVs, fullscreenFs, sBackend, sIsMobilePlatform);
-            Program prog = shaderGen.getProgram();
+            Program prog = shaderGen.getProgram(api);
             Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
             prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
             prog.setUniformBlock(1, "params");

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -347,7 +347,7 @@ TEST_F(BackendTest, UpdateImage2D) {
         std::string fragment = stringReplace("{samplerType}",
                 getSamplerTypeName(t.textureFormat), fragmentTemplate);
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program prog = shaderGen.getProgram();
+        Program prog = shaderGen.getProgram(api);
         Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
         prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
         program = api.createProgram(std::move(prog));
@@ -426,7 +426,7 @@ TEST_F(BackendTest, UpdateImageSRGB) {
     std::string fragment = stringReplace("{samplerType}",
             getSamplerTypeName(textureFormat), fragmentTemplate);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-    Program prog = shaderGen.getProgram();
+    Program prog = shaderGen.getProgram(api);
     Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
     prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
     ProgramHandle program = api.createProgram(std::move(prog));
@@ -512,7 +512,7 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
     std::string fragment = stringReplace("{samplerType}",
             getSamplerTypeName(textureFormat), fragmentUpdateImageMip);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-    Program prog = shaderGen.getProgram();
+    Program prog = shaderGen.getProgram(api);
     Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
     prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
     ProgramHandle program = api.createProgram(std::move(prog));
@@ -584,7 +584,7 @@ TEST_F(BackendTest, UpdateImage3D) {
     std::string fragment = stringReplace("{samplerType}",
             getSamplerTypeName(samplerType), fragmentUpdateImage3DTemplate);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-    Program prog = shaderGen.getProgram();
+    Program prog = shaderGen.getProgram(api);
     Program::Sampler psamplers[] = { utils::CString("tex"), 0, false };
     prog.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
     ProgramHandle program = api.createProgram(std::move(prog));

--- a/filament/backend/test/test_MRT.cpp
+++ b/filament/backend/test/test_MRT.cpp
@@ -69,7 +69,7 @@ TEST_F(BackendTest, MRT) {
 
         // Create a program.
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(getDriverApi());
         auto program = getDriverApi().createProgram(std::move(p));
 
         TrianglePrimitive triangle(getDriverApi());

--- a/filament/backend/test/test_MissingRequiredAttributes.cpp
+++ b/filament/backend/test/test_MissingRequiredAttributes.cpp
@@ -76,7 +76,7 @@ TEST_F(BackendTest, MissingRequiredAttributes) {
 
         // Create a program.
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(getDriverApi());
         auto program = getDriverApi().createProgram(std::move(p));
 
         auto defaultRenderTarget = getDriverApi().createDefaultRenderTarget(0);

--- a/filament/backend/test/test_ReadPixels.cpp
+++ b/filament/backend/test/test_ReadPixels.cpp
@@ -238,12 +238,12 @@ TEST_F(ReadPixelsTest, ReadPixels) {
     Handle<HwProgram> programFloat, programUint;
     {
         ShaderGenerator shaderGen(vertex, fragmentFloat, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(getDriverApi());
         programFloat = getDriverApi().createProgram(std::move(p));
     }
     {
         ShaderGenerator shaderGen(vertex, fragmentUint, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(getDriverApi());
         programUint = getDriverApi().createProgram(std::move(p));
     }
 
@@ -385,7 +385,7 @@ TEST_F(ReadPixelsTest, ReadPixelsPerformance) {
 
     // Create a program.
     ShaderGenerator shaderGen(vertex, fragmentFloat, sBackend, sIsMobilePlatform);
-    Program p = shaderGen.getProgram();
+    Program p = shaderGen.getProgram(getDriverApi());
     auto program = getDriverApi().createProgram(std::move(p));
 
     // Create a Texture and RenderTarget to render into.

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -66,7 +66,7 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
 
     // Create a program that samples a texture.
-    Program p = shaderGen.getProgram();
+    Program p = shaderGen.getProgram(getDriverApi());
     Program::Sampler sampler { utils::CString("tex"), 6 };
     p.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, &sampler, 1);
     backend::Handle<HwProgram> program = getDriverApi().createProgram(std::move(p));
@@ -140,7 +140,7 @@ TEST_F(BackendTest, RenderExternalImage) {
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
 
     // Create a program that samples a texture.
-    Program p = shaderGen.getProgram();
+    Program p = shaderGen.getProgram(getDriverApi());
     Program::Sampler sampler { utils::CString("tex"), 6 };
     p.setSamplerGroup(0, ALL_SHADER_STAGE_FLAGS, &sampler, 1);
     auto program = getDriverApi().createProgram(std::move(p));

--- a/filament/backend/test/test_Scissor.cpp
+++ b/filament/backend/test/test_Scissor.cpp
@@ -85,7 +85,7 @@ TEST_F(BackendTest, ScissorViewportRegion) {
 
         // Create a program.
         ShaderGenerator shaderGen(triangleVs, triangleFs, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(api);
         ProgramHandle program = api.createProgram(std::move(p));
 
         // Create source color and depth textures.

--- a/filament/backend/test/test_StencilBuffer.cpp
+++ b/filament/backend/test/test_StencilBuffer.cpp
@@ -75,7 +75,7 @@ public:
 
         // Create a program.
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform);
-        Program p = shaderGen.getProgram();
+        Program p = shaderGen.getProgram(api);
         program = api.createProgram(std::move(p));
     }
 

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -344,9 +344,10 @@ bool ChunkUniformInterfaceBlock::unflatten(Unflattener& unflattener,
         }
 
         // a size of 1 means not an array
-        builder.add({ fieldName.data(), fieldName.size() }, fieldSize == 1 ? 0 : fieldSize,
-                UniformInterfaceBlock::Type(fieldType),
-                UniformInterfaceBlock::Precision(fieldPrecision));
+        builder.add({{{ fieldName.data(), fieldName.size() },
+                      uint32_t(fieldSize == 1 ? 0 : fieldSize),
+                      UniformInterfaceBlock::Type(fieldType),
+                      UniformInterfaceBlock::Precision(fieldPrecision) }});
     }
 
     *uib = builder.build();

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -65,6 +65,7 @@ public:
     bool getSubpasses(SubpassInfo* subpass) const noexcept;
     bool getShaderModels(uint32_t* value) const noexcept;
     bool getMaterialProperties(uint64_t* value) const noexcept;
+    bool getUniformBlockBindings(utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>>* value) const noexcept;
 
     bool getDepthWriteSet(bool* value) const noexcept;
     bool getDepthWrite(bool* value) const noexcept;
@@ -147,6 +148,11 @@ struct ChunkSamplerInterfaceBlock {
 
 struct ChunkSubpassInterfaceBlock {
     static bool unflatten(filaflat::Unflattener& unflattener, SubpassInfo* sib);
+};
+
+struct ChunkUniformBlockBindings {
+    static bool unflatten(filaflat::Unflattener& unflattener,
+            utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>>* uniformBlockBindings);
 };
 
 } // namespace filament

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -136,7 +136,7 @@ public:
 
     ~FEngine() noexcept;
 
-    backend::Driver& getDriver() const noexcept { return *mDriver; }
+    backend::ShaderModel getShaderModel() const noexcept { return getDriver().getShaderModel(); }
 
     DriverApi& getDriverApi() noexcept {
         return *std::launder(reinterpret_cast<DriverApi*>(&mDriverApiStorage));
@@ -383,6 +383,8 @@ private:
 
     int loop();
     void flushCommandBuffer(backend::CommandBufferQueue& commandBufferQueue);
+
+    backend::Driver& getDriver() const noexcept { return *mDriver; }
 
     template<typename T>
     bool terminateAndDestroy(const T* p, ResourceList<T>& list);

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -108,7 +108,7 @@ Material* Material::Builder::build(Engine& engine) {
     utils::bitset32 shaderModels;
     shaderModels.setValue(v);
 
-    ShaderModel shaderModel = upcast(engine).getDriver().getShaderModel();
+    ShaderModel shaderModel = upcast(engine).getShaderModel();
     if (!shaderModels.test(static_cast<uint32_t>(shaderModel))) {
         CString name;
         materialParser->getName(&name);
@@ -424,7 +424,7 @@ Program FMaterial::getProgramBuilderWithVariants(
         Variant variant,
         Variant vertexVariant,
         Variant fragmentVariant) const noexcept {
-    const ShaderModel sm = mEngine.getDriver().getShaderModel();
+    const ShaderModel sm = mEngine.getShaderModel();
     const bool isNoop = mEngine.getBackend() == Backend::NOOP;
 
     /*
@@ -455,7 +455,7 @@ Program FMaterial::getProgramBuilderWithVariants(
             "GLSL or SPIR-V chunks for the fragment shader (variant=0x%x, filtered=0x%x).",
             mName.c_str(), variant.key, fragmentVariant.key);
 
-    Program pb;
+    Program pb(mEngine.getDriverApi());
     pb.diagnostics(mName,
               [this, variant](io::ostream& out) -> io::ostream& {
                   return out << mName.c_str_safe()

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -227,6 +227,8 @@ private:
     UniformInterfaceBlock mUniformInterfaceBlock;
     SubpassInfo mSubpassInfo;
     SamplerBindingMap mSamplerBindings;
+    utils::FixedCapacityVector<std::pair<const char*, uint8_t>> mUniformBlockBindings;
+    utils::FixedCapacityVector<utils::CString> mUniformBlockNames;
 
 #if FILAMENT_ENABLE_MATDBG
     matdbg::MaterialKey mDebuggerId;

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -282,21 +282,23 @@ TEST(FilamentTest, UniformInterfaceBlock) {
     UniformInterfaceBlock::Builder b;
 
     b.name("TestUniformInterfaceBlock");
-    b.add("a_float_0", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_1", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_2", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_3", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_vec4_0",  UniformInterfaceBlock::Type::FLOAT4);
-    b.add("a_float_4", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_5", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_6", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_vec3_0",  UniformInterfaceBlock::Type::FLOAT3);
-    b.add("a_float_7", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float[3]",3, UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_8", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_mat3_0",  UniformInterfaceBlock::Type::MAT3);
-    b.add("a_mat4_0",  UniformInterfaceBlock::Type::MAT4);
-    b.add("a_mat3[3]", 3, UniformInterfaceBlock::Type::MAT3);
+    b.add({
+            { "a_float_0",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_1",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_2",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_3",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_vec4_0",   0, UniformInterfaceBlock::Type::FLOAT4 },
+            { "a_float_4",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_5",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_6",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_vec3_0",   0, UniformInterfaceBlock::Type::FLOAT3 },
+            { "a_float_7",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float[3]", 3, UniformInterfaceBlock::Type::FLOAT },
+            { "a_float_8",  0, UniformInterfaceBlock::Type::FLOAT },
+            { "a_mat3_0",   0, UniformInterfaceBlock::Type::MAT3 },
+            { "a_mat4_0",   0, UniformInterfaceBlock::Type::MAT4 },
+            { "a_mat3[3]",  3, UniformInterfaceBlock::Type::MAT3 }
+        });
 
 
     UniformInterfaceBlock ib(b.build());
@@ -402,20 +404,22 @@ TEST(FilamentTest, UniformBuffer) {
 
     UniformInterfaceBlock::Builder b;
     b.name("TestUniformBuffer");
-    b.add("a_float_0", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_1", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_2", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_3", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_vec4_0",  UniformInterfaceBlock::Type::FLOAT4);
-    b.add("a_float_4", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_5", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_6", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_vec3_0",  UniformInterfaceBlock::Type::FLOAT3);
-    b.add("a_float_7", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float[3]",3, UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_float_8", UniformInterfaceBlock::Type::FLOAT);
-    b.add("a_mat3_0",  UniformInterfaceBlock::Type::MAT3);
-    b.add("a_mat4_0",  UniformInterfaceBlock::Type::MAT4);
+    b.add({
+        { "a_float_0", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_1", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_2", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_3", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_vec4_0",  0, UniformInterfaceBlock::Type::FLOAT4 },
+        { "a_float_4", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_5", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_6", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_vec3_0",  0, UniformInterfaceBlock::Type::FLOAT3 },
+        { "a_float_7", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float[3]",3, UniformInterfaceBlock::Type::FLOAT },
+        { "a_float_8", 0, UniformInterfaceBlock::Type::FLOAT },
+        { "a_mat3_0",  0, UniformInterfaceBlock::Type::MAT3 },
+        { "a_mat4_0",  0, UniformInterfaceBlock::Type::MAT4 },
+    });
     UniformInterfaceBlock ib(b.build());
 
     CHECK2(ib.getUniformInfoList());
@@ -448,24 +452,26 @@ TEST(FilamentTest, UniformBuffer) {
     CHECK(data);
     CHECK(&copy);
 
-    ubo move(std::move(copy));
+    ubo move(copy);
     CHECK(&move);
 
     copy = *data;
     CHECK(data);
     CHECK(&copy);
 
-    move = std::move(copy);
+    move = copy;
     CHECK(&move);
 }
 
 TEST(FilamentTest, UniformBufferSize1) {
     UniformInterfaceBlock::Builder b;
     b.name("UniformBufferSize1");
-    b.add("f4a", UniformInterfaceBlock::Type::FLOAT4); // offset = 0
-    b.add("f4b", UniformInterfaceBlock::Type::FLOAT4); // offset = 16
-    b.add("f1a", UniformInterfaceBlock::Type::FLOAT);  // offset = 32
-    b.add("f1b", UniformInterfaceBlock::Type::FLOAT);  // offset = 36
+    b.add({
+            { "f4a", 0, UniformInterfaceBlock::Type::FLOAT4 }, // offset = 0
+            { "f4b", 0, UniformInterfaceBlock::Type::FLOAT4 }, // offset = 16
+            { "f1a", 0, UniformInterfaceBlock::Type::FLOAT },  // offset = 32
+            { "f1b", 0, UniformInterfaceBlock::Type::FLOAT },  // offset = 36
+    });
     UniformInterfaceBlock uib(b.build());
     UniformBuffer buffer(uib.getSize());
 
@@ -483,10 +489,12 @@ TEST(FilamentTest, UniformBufferSize1) {
 TEST(FilamentTest, UniformBufferSize2) {
     UniformInterfaceBlock::Builder b;
     b.name("UniformBufferSize2");
-    b.add("f4a", UniformInterfaceBlock::Type::FLOAT4); // offset = 0
-    b.add("f4b", UniformInterfaceBlock::Type::FLOAT4); // offset = 16
-    b.add("f1a", UniformInterfaceBlock::Type::FLOAT);  // offset = 32
-    b.add("f2a", UniformInterfaceBlock::Type::FLOAT2); // offset = 36
+    b.add({
+            { "f4a", 0, UniformInterfaceBlock::Type::FLOAT4 }, // offset = 0
+            { "f4b", 0, UniformInterfaceBlock::Type::FLOAT4 }, // offset = 16
+            { "f1a", 0, UniformInterfaceBlock::Type::FLOAT },  // offset = 32
+            { "f2a", 0, UniformInterfaceBlock::Type::FLOAT2 }, // offset = 36
+    });
     UniformInterfaceBlock uib(b.build());
     UniformBuffer buffer(uib.getSize());
 

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -46,6 +46,7 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialMetal = charTo64bitNum("MAT_METL"),
     MaterialShaderModels = charTo64bitNum("MAT_SMDL"),
     MaterialSamplerBindings = charTo64bitNum("MAT_SAMP"),   // no longer used
+    MaterialUniformBindings = charTo64bitNum("MAT_UNIF"),
     MaterialProperties = charTo64bitNum("MAT_PROP"),
 
     MaterialName = charTo64bitNum("MAT_NAME"),

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -33,9 +33,7 @@
 namespace filament {
 
 /*
- * These structures are only used to call offsetof() and make it easy to visualize the UBO.
- *
- * IMPORTANT NOTE: Respect std140 layout, don't update without updating getUib()
+ * IMPORTANT NOTE: Respect std140 layout, don't update without updating UibGenerator::get{*}Uib()
  */
 
 struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)

--- a/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
@@ -25,6 +25,7 @@
 
 #include <math/vec4.h>
 
+#include <initializer_list>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -35,6 +36,15 @@ namespace filament {
 
 class UniformInterfaceBlock {
 public:
+    struct UniformBlockEntry {
+        std::string_view name;
+        uint32_t size;
+        backend::UniformType type;
+        backend::Precision precision{};
+        std::string_view structName{};
+        uint32_t stride{};
+    };
+
     UniformInterfaceBlock();
 
     UniformInterfaceBlock(const UniformInterfaceBlock& rhs) = delete;
@@ -47,48 +57,6 @@ public:
 
     using Type = backend::UniformType;
     using Precision = backend::Precision;
-
-    class Builder {
-    public:
-        Builder() noexcept;
-        ~Builder() noexcept;
-
-        // Give a name to this uniform interface block
-        Builder& name(std::string_view interfaceBlockName);
-
-        // Add a uniform field
-        Builder& add(std::string_view uniformName,
-                Type type, Precision precision = Precision::DEFAULT);
-
-        // Add a uniform array
-        Builder& add(std::string_view uniformName, size_t size,
-                Type type, Precision precision = Precision::DEFAULT);
-
-        // Add a known struct field
-        Builder& add(std::string_view uniformName,
-                std::string_view structName, size_t stride);
-
-        // Add a known struct array
-        Builder& add(std::string_view uniformName, size_t size,
-                std::string_view structName, size_t stride);
-
-        // build and return the UniformInterfaceBlock
-        UniformInterfaceBlock build();
-    private:
-        friend class UniformInterfaceBlock;
-        struct Entry {
-            Entry(std::string_view name, uint32_t size, Type type, Precision precision) noexcept;
-            Entry(std::string_view name, uint32_t size, std::string_view structName, size_t stride) noexcept;
-            utils::CString name;
-            uint32_t size;
-            Type type;
-            Precision precision{};
-            utils::CString structName{};
-            uint32_t stride;
-        };
-        utils::CString mName;
-        std::vector<Entry> mEntries;
-    };
 
     struct UniformInfo {
         utils::CString name;        // name of this uniform
@@ -103,6 +71,25 @@ public:
             assert_invariant(index < std::max(1u, size));
             return (offset + stride * index) * sizeof(uint32_t);
         }
+    };
+
+    class Builder {
+    public:
+        Builder() noexcept;
+        ~Builder() noexcept;
+
+        // Give a name to this uniform interface block
+        Builder& name(std::string_view interfaceBlockName);
+
+        // a list of uniform fields
+        Builder& add(std::initializer_list<UniformBlockEntry> list);
+
+        // build and return the UniformInterfaceBlock
+        UniformInterfaceBlock build();
+    private:
+        friend class UniformInterfaceBlock;
+        utils::CString mName;
+        std::vector<UniformInfo> mEntries;
     };
 
     // name of this uniform interface block

--- a/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/UniformInterfaceBlock.h
@@ -25,6 +25,7 @@
 
 #include <math/vec4.h>
 
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -105,7 +106,7 @@ public:
     };
 
     // name of this uniform interface block
-    const utils::CString& getName() const noexcept { return mName; }
+    std::string_view getName() const noexcept { return { mName.data(), mName.size() }; }
 
     // size in bytes needed to store the uniforms described by this interface block in a UniformBuffer
     size_t getSize() const noexcept { return mSize; }

--- a/libs/filabridge/src/UniformInterfaceBlock.cpp
+++ b/libs/filabridge/src/UniformInterfaceBlock.cpp
@@ -25,19 +25,6 @@ using namespace utils;
 
 namespace filament {
 
-UniformInterfaceBlock::Builder::Entry::Entry(std::string_view name, uint32_t size,
-        UniformInterfaceBlock::Type type, UniformInterfaceBlock::Precision precision) noexcept
-        : name(name.data(), name.size()), size(size), type(type), precision(precision),
-          stride(strideForType(type, 0)) {
-}
-
-UniformInterfaceBlock::Builder::Entry::Entry(std::string_view name, uint32_t size,
-        std::string_view structName, size_t stride) noexcept
-        : name(name.data(), name.size()), size(size), type(Type::STRUCT),
-          structName(structName.data(), structName.size()),
-          stride(stride) {
-}
-
 UniformInterfaceBlock::Builder::Builder() noexcept = default;
 UniformInterfaceBlock::Builder::~Builder() noexcept = default;
 
@@ -48,30 +35,14 @@ UniformInterfaceBlock::Builder::name(std::string_view interfaceBlockName) {
 }
 
 UniformInterfaceBlock::Builder& UniformInterfaceBlock::Builder::add(
-        std::string_view uniformName, UniformInterfaceBlock::Type type,
-        UniformInterfaceBlock::Precision precision) {
-    mEntries.emplace_back(uniformName, 0u, type, precision);
-    return *this;
-}
-
-UniformInterfaceBlock::Builder& UniformInterfaceBlock::Builder::add(
-        std::string_view uniformName, size_t size, UniformInterfaceBlock::Type type,
-        UniformInterfaceBlock::Precision precision) {
-    mEntries.emplace_back(uniformName, (uint32_t)size, type, precision);
-    return *this;
-}
-
-UniformInterfaceBlock::Builder& UniformInterfaceBlock::Builder::add(
-        std::string_view uniformName,
-        std::string_view structName, size_t stride) {
-    mEntries.emplace_back(uniformName, 0u, structName, stride);
-    return *this;
-}
-
-UniformInterfaceBlock::Builder& UniformInterfaceBlock::Builder::add(
-        std::string_view uniformName, size_t size,
-        std::string_view structName, size_t stride) {
-    mEntries.emplace_back(uniformName, (uint32_t)size, structName, stride);
+        std::initializer_list<UniformBlockEntry> list) {
+    mEntries.reserve(mEntries.size() + list.size());
+    for (auto const& item : list) {
+        mEntries.push_back({
+                { item.name.data(), item.name.size() },
+                0, uint8_t(item.stride), item.type, item.size, item.precision,
+                { item.structName.data(), item.structName.size() }});
+    }
     return *this;
 }
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -448,8 +448,8 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
             sbb.add({ param.name.data(), param.name.size() },
                     param.samplerType, param.format, param.precision);
         } else if (param.isUniform()) {
-            ibb.add({ param.name.data(), param.name.size() },
-                    param.size == 1 ? 0 : param.size, param.uniformType, param.precision);
+            ibb.add({{{ param.name.data(), param.name.size() },
+                      uint32_t(param.size == 1u ? 0u : param.size), param.uniformType, param.precision }});
         } else if (param.isSubpass()) {
             // For now, we only support a single subpass for attachment 0.
             // Subpasses belong to the "MaterialParams" block.
@@ -461,16 +461,18 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     }
 
     if (mSpecularAntiAliasing) {
-        ibb.add("_specularAntiAliasingVariance", UniformType::FLOAT);
-        ibb.add("_specularAntiAliasingThreshold", UniformType::FLOAT);
+        ibb.add({
+                { "_specularAntiAliasingVariance",  0, UniformType::FLOAT },
+                { "_specularAntiAliasingThreshold", 0, UniformType::FLOAT },
+        });
     }
 
     if (mBlendingMode == BlendingMode::MASKED) {
-        ibb.add("_maskThreshold", UniformType::FLOAT);
+        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT }});
     }
 
     if (mDoubleSidedCapability) {
-        ibb.add("_doubleSided", UniformType::BOOL);
+        ibb.add({{ "_doubleSided", 0, UniformType::BOOL }});
     }
 
     mRequiredAttributes.set(filament::VertexAttribute::POSITION);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -27,6 +27,7 @@
 
 #include <private/filament/UniformInterfaceBlock.h>
 #include <private/filament/SamplerInterfaceBlock.h>
+#include <private/filament/UibStructs.h>
 
 #include <private/filament/SibGenerator.h>
 
@@ -1046,6 +1047,20 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
     container.addSimpleChild<uint8_t>(ChunkType::MaterialDomain, static_cast<uint8_t>(mMaterialDomain));
     container.addSimpleChild<uint8_t>(ChunkType::MaterialRefraction, static_cast<uint8_t>(mRefractionMode));
     container.addSimpleChild<uint8_t>(ChunkType::MaterialRefractionType, static_cast<uint8_t>(mRefractionType));
+
+    // note: this chunk is only needed for OpenGL backends, which don't all support layout(binding=)
+    using namespace filament;
+    utils::FixedCapacityVector<std::pair<std::string_view, uint8_t>> list = {
+            { PerViewUib::_name,                  BindingPoints::PER_VIEW },
+            { PerRenderableUib::_name,            BindingPoints::PER_RENDERABLE },
+            { LightsUib::_name,                   BindingPoints::LIGHTS },
+            { ShadowUib::_name,                   BindingPoints::SHADOW },
+            { FroxelRecordUib::_name,             BindingPoints::FROXEL_RECORDS },
+            { PerRenderableBoneUib::_name,        BindingPoints::PER_RENDERABLE_BONES },
+            { PerRenderableMorphingUib::_name,    BindingPoints::PER_RENDERABLE_MORPHING },
+            { info.uib.getName(),                 BindingPoints::PER_MATERIAL_INSTANCE }
+    };
+    container.addChild<MaterialUniformBlockBindingsChunk>(std::move(list));
 
     // UIB
     container.addChild<MaterialUniformInterfaceBlockChunk>(info.uib);

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -30,7 +30,6 @@ static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
         "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
 UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
-    // IMPORTANT NOTE: Respect std140 layout, don't update without updating Engine::PerViewUib
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(PerViewUib::_name)
             // transforms

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -30,126 +30,130 @@ static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
         "Changing CONFIG_MAX_SHADOW_CASCADES affects PerView size and breaks materials.");
 
 UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
+
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(PerViewUib::_name)
-            // transforms
-            .add("viewFromWorldMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("worldFromViewMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("clipFromViewMatrix",      UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("viewFromClipMatrix",      UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("clipFromWorldMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("worldFromClipMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("clipTransform",           UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
+            .add({
+            { "viewFromWorldMatrix",    0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "worldFromViewMatrix",    0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "clipFromViewMatrix",     0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "viewFromClipMatrix",     0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "clipFromWorldMatrix",    0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "worldFromClipMatrix",    0, UniformInterfaceBlock::Type::MAT4,   Precision::HIGH },
+            { "clipTransform",          0, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH },
 
-            .add("clipControl",             UniformInterfaceBlock::Type::FLOAT2)
-            .add("time",                    UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
-            .add("temporalNoise",           UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
-            .add("userTime",                UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
+            { "clipControl",            0, UniformInterfaceBlock::Type::FLOAT2                  },
+            { "time",                   0, UniformInterfaceBlock::Type::FLOAT,  Precision::HIGH },
+            { "temporalNoise",          0, UniformInterfaceBlock::Type::FLOAT,  Precision::HIGH },
+            { "userTime",               0, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
             // values below should only be accessed in surface materials
             // ------------------------------------------------------------------------------------
 
-            .add("origin",                  UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH)
-            .add("offset",                  UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH)
-            .add("resolution",              UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
+            { "origin",                 0, UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH },
+            { "offset",                 0, UniformInterfaceBlock::Type::FLOAT2, Precision::HIGH },
+            { "resolution",             0, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH },
 
-            .add("lodBias",                 UniformInterfaceBlock::Type::FLOAT)
-            .add("refractionLodOffset",     UniformInterfaceBlock::Type::FLOAT)
-            .add("padding1",                UniformInterfaceBlock::Type::FLOAT)
-            .add("padding2",                UniformInterfaceBlock::Type::FLOAT)
+            { "lodBias",                0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "refractionLodOffset",    0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "padding1",               0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "padding2",               0, UniformInterfaceBlock::Type::FLOAT                   },
 
-            .add("cameraPosition",          UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
-            .add("oneOverFarMinusNear",     UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
-            .add("worldOffset",             UniformInterfaceBlock::Type::FLOAT3)
-            .add("nearOverFarMinusNear",    UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
-            .add("cameraFar",               UniformInterfaceBlock::Type::FLOAT)
-            .add("exposure",                UniformInterfaceBlock::Type::FLOAT, Precision::HIGH) // high precision to work around #3602 (qualcomm)
-            .add("ev100",                   UniformInterfaceBlock::Type::FLOAT)
-            .add("needsAlphaChannel",       UniformInterfaceBlock::Type::FLOAT)
+            { "cameraPosition",         0, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH },
+            { "oneOverFarMinusNear",    0, UniformInterfaceBlock::Type::FLOAT,  Precision::HIGH },
+            { "worldOffset",            0, UniformInterfaceBlock::Type::FLOAT3                  },
+            { "nearOverFarMinusNear",   0, UniformInterfaceBlock::Type::FLOAT,  Precision::HIGH },
+            { "cameraFar",              0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "exposure",               0, UniformInterfaceBlock::Type::FLOAT,  Precision::HIGH }, // high precision to work around #3602 (qualcom),
+            { "ev100",                  0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "needsAlphaChannel",      0, UniformInterfaceBlock::Type::FLOAT                   },
 
             // AO
-            .add("aoSamplingQualityAndEdgeDistance", UniformInterfaceBlock::Type::FLOAT)
-            .add("aoBentNormals",           UniformInterfaceBlock::Type::FLOAT)
-            .add("aoReserved0",             UniformInterfaceBlock::Type::FLOAT)
-            .add("aoReserved1",             UniformInterfaceBlock::Type::FLOAT)
+            { "aoSamplingQualityAndEdgeDistance", 0, UniformInterfaceBlock::Type::FLOAT         },
+            { "aoBentNormals",          0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "aoReserved0",            0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "aoReserved1",            0, UniformInterfaceBlock::Type::FLOAT                   },
 
             // ------------------------------------------------------------------------------------
             // Dynamic Lighting [variant: DYN]
             // ------------------------------------------------------------------------------------
-            .add("zParams",                 UniformInterfaceBlock::Type::FLOAT4)
-            .add("fParams",                 UniformInterfaceBlock::Type::UINT3)
-            .add("lightChannels",           UniformInterfaceBlock::Type::UINT)
-            .add("froxelCountXY",           UniformInterfaceBlock::Type::FLOAT2)
+            { "zParams",                0, UniformInterfaceBlock::Type::FLOAT4                  },
+            { "fParams",                0, UniformInterfaceBlock::Type::UINT3                   },
+            { "lightChannels",          0, UniformInterfaceBlock::Type::UINT                    },
+            { "froxelCountXY",          0, UniformInterfaceBlock::Type::FLOAT2                  },
 
-            .add("iblLuminance",            UniformInterfaceBlock::Type::FLOAT)
-            .add("iblRoughnessOneLevel",    UniformInterfaceBlock::Type::FLOAT)
-            .add("iblSH",                   9, UniformInterfaceBlock::Type::FLOAT3)
+            { "iblLuminance",           0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "iblRoughnessOneLevel",   0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "iblSH",                  9, UniformInterfaceBlock::Type::FLOAT3                  },
 
             // ------------------------------------------------------------------------------------
             // Directional Lighting [variant: DIR]
             // ------------------------------------------------------------------------------------
-            .add("lightDirection",            UniformInterfaceBlock::Type::FLOAT3)
-            .add("padding0",                  UniformInterfaceBlock::Type::FLOAT)
-            .add("lightColorIntensity",       UniformInterfaceBlock::Type::FLOAT4)
-            .add("sun",                       UniformInterfaceBlock::Type::FLOAT4)
-            .add("lightFarAttenuationParams", UniformInterfaceBlock::Type::FLOAT2)
+            { "lightDirection",         0, UniformInterfaceBlock::Type::FLOAT3                  },
+            { "padding0",               0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "lightColorIntensity",    0, UniformInterfaceBlock::Type::FLOAT4                  },
+            { "sun",                    0, UniformInterfaceBlock::Type::FLOAT4                  },
+            { "lightFarAttenuationParams", 0, UniformInterfaceBlock::Type::FLOAT2               },
 
             // ------------------------------------------------------------------------------------
             // Directional light shadowing [variant: SRE | DIR]
             // ------------------------------------------------------------------------------------
-            .add("directionalShadows",      UniformInterfaceBlock::Type::UINT)
-            .add("ssContactShadowDistance", UniformInterfaceBlock::Type::FLOAT)
+            { "directionalShadows",     0, UniformInterfaceBlock::Type::UINT                    },
+            { "ssContactShadowDistance",0, UniformInterfaceBlock::Type::FLOAT                   },
 
-            .add("cascadeSplits",            UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
-            .add("cascades",                 UniformInterfaceBlock::Type::UINT)
-            .add("shadowBulbRadiusLs",       UniformInterfaceBlock::Type::FLOAT)
-            .add("shadowBias",               UniformInterfaceBlock::Type::FLOAT)
-            .add("shadowPenumbraRatioScale", UniformInterfaceBlock::Type::FLOAT)
-            .add("lightFromWorldMatrix",    4, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            { "cascadeSplits",          0, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH },
+            { "cascades",               0, UniformInterfaceBlock::Type::UINT                    },
+            { "shadowBulbRadiusLs",     0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "shadowBias",             0, UniformInterfaceBlock::Type::FLOAT                   },
+            { "shadowPenumbraRatioScale", 0, UniformInterfaceBlock::Type::FLOAT                 },
+            { "lightFromWorldMatrix",   4, UniformInterfaceBlock::Type::MAT4, Precision::HIGH   },
 
             // ------------------------------------------------------------------------------------
             // VSM shadows [variant: VSM]
             // ------------------------------------------------------------------------------------
-            .add("vsmExponent",             UniformInterfaceBlock::Type::FLOAT)
-            .add("vsmDepthScale",           UniformInterfaceBlock::Type::FLOAT)
-            .add("vsmLightBleedReduction",  UniformInterfaceBlock::Type::FLOAT)
-            .add("shadowSamplingType",      UniformInterfaceBlock::Type::UINT)
+            { "vsmExponent",             0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "vsmDepthScale",           0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "vsmLightBleedReduction",  0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "shadowSamplingType",      0, UniformInterfaceBlock::Type::UINT                   },
 
             // ------------------------------------------------------------------------------------
             // Fog [variant: FOG]
             // ------------------------------------------------------------------------------------
-            .add("fogStart",                UniformInterfaceBlock::Type::FLOAT)
-            .add("fogMaxOpacity",           UniformInterfaceBlock::Type::FLOAT)
-            .add("fogHeight",               UniformInterfaceBlock::Type::FLOAT)
-            .add("fogHeightFalloff",        UniformInterfaceBlock::Type::FLOAT)
-            .add("fogColor",                UniformInterfaceBlock::Type::FLOAT3)
-            .add("fogDensity",              UniformInterfaceBlock::Type::FLOAT)
-            .add("fogInscatteringStart",    UniformInterfaceBlock::Type::FLOAT)
-            .add("fogInscatteringSize",     UniformInterfaceBlock::Type::FLOAT)
-            .add("fogColorFromIbl",         UniformInterfaceBlock::Type::FLOAT)
-            .add("fogReserved0",            UniformInterfaceBlock::Type::FLOAT)
+            { "fogStart",                0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogMaxOpacity",           0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogHeight",               0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogHeightFalloff",        0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogColor",                0, UniformInterfaceBlock::Type::FLOAT3                 },
+            { "fogDensity",              0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogInscatteringStart",    0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogInscatteringSize",     0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogColorFromIbl",         0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "fogReserved0",            0, UniformInterfaceBlock::Type::FLOAT                  },
 
             // ------------------------------------------------------------------------------------
             // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]
             // ------------------------------------------------------------------------------------
-            .add("ssrReprojection",         UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("ssrUvFromViewMatrix",     UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
-            .add("ssrThickness",            UniformInterfaceBlock::Type::FLOAT)
-            .add("ssrBias",                 UniformInterfaceBlock::Type::FLOAT)
-            .add("ssrDistance",             UniformInterfaceBlock::Type::FLOAT)
-            .add("ssrStride",               UniformInterfaceBlock::Type::FLOAT)
+            { "ssrReprojection",         0, UniformInterfaceBlock::Type::MAT4, Precision::HIGH  },
+            { "ssrUvFromViewMatrix",     0, UniformInterfaceBlock::Type::MAT4, Precision::HIGH  },
+            { "ssrThickness",            0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "ssrBias",                 0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "ssrDistance",             0, UniformInterfaceBlock::Type::FLOAT                  },
+            { "ssrStride",               0, UniformInterfaceBlock::Type::FLOAT                  },
 
             // bring PerViewUib to 2 KiB
-            .add("reserved", sizeof(PerViewUib::reserved)/16, UniformInterfaceBlock::Type::FLOAT4)
+            { "reserved", sizeof(PerViewUib::reserved)/16, UniformInterfaceBlock::Type::FLOAT4 }
+            })
             .build();
+
     return uib;
 }
 
 UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
     static UniformInterfaceBlock uib =  UniformInterfaceBlock::Builder()
             .name(PerRenderableUib::_name)
-            .add("data", 64, "PerRenderableData", sizeof(PerRenderableData))
+            .add({{ "data", 64, UniformInterfaceBlock::Type::STRUCT, {},
+                    "PerRenderableData", sizeof(PerRenderableData) }})
             .build();
     return uib;
 }
@@ -157,7 +161,8 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
 UniformInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(LightsUib::_name)
-            .add("lights", CONFIG_MAX_LIGHT_COUNT, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
+            .add({{ "lights", CONFIG_MAX_LIGHT_COUNT,
+                    UniformInterfaceBlock::Type::MAT4, Precision::HIGH }})
             .build();
     return uib;
 }
@@ -165,7 +170,9 @@ UniformInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
 UniformInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(ShadowUib::_name)
-            .add("shadows", CONFIG_MAX_SHADOW_CASTING_SPOTS, "ShadowData", sizeof(ShadowUib::ShadowData))
+            .add({{ "shadows", CONFIG_MAX_SHADOW_CASTING_SPOTS,
+                    UniformInterfaceBlock::Type::STRUCT, {},
+                    "ShadowData", sizeof(ShadowUib::ShadowData) }})
             .build();
     return uib;
 }
@@ -173,7 +180,9 @@ UniformInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
 UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(PerRenderableBoneUib::_name)
-            .add("bones", CONFIG_MAX_BONE_COUNT, "BoneData", sizeof(PerRenderableBoneUib::BoneData))
+            .add({{ "bones", CONFIG_MAX_BONE_COUNT,
+                     UniformInterfaceBlock::Type::STRUCT, {},
+                     "BoneData", sizeof(PerRenderableBoneUib::BoneData) }})
             .build();
     return uib;
 }
@@ -181,7 +190,8 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
 UniformInterfaceBlock const& UibGenerator::getPerRenderableMorphingUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(PerRenderableMorphingUib::_name)
-            .add("weights", CONFIG_MAX_MORPH_TARGET_COUNT, UniformInterfaceBlock::Type::FLOAT4)
+            .add({{ "weights", CONFIG_MAX_MORPH_TARGET_COUNT,
+                    UniformInterfaceBlock::Type::FLOAT4 }})
             .build();
     return uib;
 }
@@ -189,7 +199,7 @@ UniformInterfaceBlock const& UibGenerator::getPerRenderableMorphingUib() noexcep
 UniformInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
     static UniformInterfaceBlock uib = UniformInterfaceBlock::Builder()
             .name(FroxelRecordUib::_name)
-            .add("records", 1024, UniformInterfaceBlock::Type::UINT4, Precision::HIGH)
+            .add({{ "records", 1024, UniformInterfaceBlock::Type::UINT4, Precision::HIGH }})
             .build();
     return uib;
 }

--- a/libs/filamat/src/UibGenerator.h
+++ b/libs/filamat/src/UibGenerator.h
@@ -31,7 +31,7 @@ public:
     static UniformInterfaceBlock const& getPerRenderableMorphingUib() noexcept;
     static UniformInterfaceBlock const& getFroxelRecordUib() noexcept;
     // When adding an UBO here, make sure to also update
-    //      FMaterial::getSurfaceProgramSlow and FMaterial::getPostProcessProgramSlow if needed
+    //      MaterialBuilder::writeCommonChunks() if needed
 };
 
 } // namespace filament

--- a/libs/filamat/src/eiff/Chunk.h
+++ b/libs/filamat/src/eiff/Chunk.h
@@ -36,7 +36,7 @@ public:
     virtual void flatten(Flattener &f) = 0;
 
 protected:
-    Chunk(ChunkType type) : mType(type) {
+    explicit Chunk(ChunkType type) : mType(type) {
     }
 
 private:

--- a/libs/filamat/src/eiff/Flattener.h
+++ b/libs/filamat/src/eiff/Flattener.h
@@ -106,6 +106,15 @@ public:
         mCursor += len + 1;
     }
 
+    void writeString(std::string_view str) {
+        size_t len = str.length();
+        if (mStart != nullptr) {
+            memcpy(reinterpret_cast<char*>(mCursor), str.data(), len);
+            mCursor[len] = 0;
+        }
+        mCursor += len + 1;
+    }
+
     void writeBlob(const char* blob, size_t nbytes) {
         writeUint64(nbytes);
         if (mStart != nullptr) {

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
@@ -15,6 +15,8 @@
  */
 #include "MaterialInterfaceBlockChunk.h"
 
+#include <utility>
+
 #include "filament/MaterialChunkType.h"
 
 using namespace filament;
@@ -27,7 +29,7 @@ MaterialUniformInterfaceBlockChunk::MaterialUniformInterfaceBlockChunk(UniformIn
 }
 
 void MaterialUniformInterfaceBlockChunk::flatten(Flattener &f) {
-    f.writeString(mUib.getName().c_str());
+    f.writeString(mUib.getName());
     auto uibFields = mUib.getUniformInfoList();
     f.writeUint64(uibFields.size());
     for (auto uInfo: uibFields) {
@@ -71,6 +73,20 @@ void MaterialSubpassInterfaceBlockChunk::flatten(Flattener &f) {
         f.writeUint8(static_cast<uint8_t>(mSubpass.precision));
         f.writeUint8(static_cast<uint8_t>(mSubpass.attachmentIndex));
         f.writeUint8(static_cast<uint8_t>(mSubpass.binding));
+    }
+}
+
+MaterialUniformBlockBindingsChunk::MaterialUniformBlockBindingsChunk(
+        utils::FixedCapacityVector<std::pair<std::string_view, uint8_t>> list)
+        : Chunk(ChunkType::MaterialUniformBindings),
+          mBindingList(std::move(list)) {
+}
+
+void MaterialUniformBlockBindingsChunk::flatten(Flattener& f) {
+    f.writeUint8(mBindingList.size());
+    for (auto const& item: mBindingList) {
+        f.writeString(item.first);
+        f.writeUint8(item.second);
     }
 }
 

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
@@ -28,10 +28,10 @@ namespace filamat {
 class MaterialUniformInterfaceBlockChunk final : public Chunk {
 public:
     explicit MaterialUniformInterfaceBlockChunk(filament::UniformInterfaceBlock& uib);
-    ~MaterialUniformInterfaceBlockChunk() = default;
+    ~MaterialUniformInterfaceBlockChunk() final = default;
 
 private:
-    void flatten(Flattener &) override;
+    void flatten(Flattener &) final;
 
     filament::UniformInterfaceBlock& mUib;
 };
@@ -39,10 +39,10 @@ private:
 class MaterialSamplerInterfaceBlockChunk final : public Chunk {
 public:
     explicit MaterialSamplerInterfaceBlockChunk(filament::SamplerInterfaceBlock& sib);
-    ~MaterialSamplerInterfaceBlockChunk() = default;
+    ~MaterialSamplerInterfaceBlockChunk() final = default;
 
 private:
-    void flatten(Flattener &) override;
+    void flatten(Flattener &) final;
 
     filament::SamplerInterfaceBlock& mSib;
 };
@@ -50,12 +50,24 @@ private:
 class MaterialSubpassInterfaceBlockChunk final : public Chunk {
 public:
     explicit MaterialSubpassInterfaceBlockChunk(filament::SubpassInfo& subpass);
-    ~MaterialSubpassInterfaceBlockChunk() = default;
+    ~MaterialSubpassInterfaceBlockChunk() final = default;
 
 private:
-    void flatten(Flattener &) override;
+    void flatten(Flattener &) final;
 
     filament::SubpassInfo& mSubpass;
+};
+
+class MaterialUniformBlockBindingsChunk final : public Chunk {
+public:
+    explicit MaterialUniformBlockBindingsChunk(
+            utils::FixedCapacityVector<std::pair<std::string_view, uint8_t>> list);
+    ~MaterialUniformBlockBindingsChunk() final = default;
+
+private:
+    void flatten(Flattener &) final;
+
+    utils::FixedCapacityVector<std::pair<std::string_view, uint8_t>> mBindingList;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -322,8 +322,8 @@ io::sstream& CodeGenerator::generateUniforms(io::sstream& out, ShaderType shader
         return out;
     }
 
-    const CString& blockName = uib.getName();
-    std::string instanceName(uib.getName().c_str());
+    const std::string_view blockName = uib.getName();
+    std::string instanceName(uib.getName());
     instanceName.front() = char(std::tolower((unsigned char)instanceName.front()));
 
     Precision uniformPrecision = getDefaultUniformPrecision();
@@ -335,7 +335,7 @@ io::sstream& CodeGenerator::generateUniforms(io::sstream& out, ShaderType shader
         uint32_t bindingIndex = (uint32_t) binding; // avoid char output
         out << "binding = " << bindingIndex << ", ";
     }
-    out << "std140) uniform " << blockName.c_str() << " {\n";
+    out << "std140) uniform " << blockName << " {\n";
     for (auto const& info : infos) {
         char const* const type = getUniformTypeName(info);
         char const* const precision = getUniformPrecisionQualifier(info.type, info.precision,

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -20,6 +20,7 @@
 #include <utils/compressed_pair.h>
 #include <utils/Panic.h>
 
+#include <initializer_list>
 #include <limits>
 #include <memory>
 #include <type_traits>
@@ -89,6 +90,14 @@ public:
               mCapacityAllocator(size, allocator) {
         mData = this->allocator().allocate(this->capacity());
         construct(begin(), end());
+    }
+
+    FixedCapacityVector(std::initializer_list<T> list,
+            const allocator_type& alloc = allocator_type())
+            : mSize(list.size()),
+              mCapacityAllocator(list.size(), alloc) {
+        mData = this->allocator().allocate(this->capacity());
+        std::uninitialized_copy(list.begin(), list.end(), begin());
     }
 
     FixedCapacityVector(size_type size, const_reference value,


### PR DESCRIPTION
reviewers: another PR that will be a lot easier to review each CL separately

The biggest change is that we are now storing the uniform block bindings inside the material file, instead of hardcoding them in two places. This info is only needed for GLES3.0/GL4.1 though.

Another big change is that we keep only a single entry point for UniformInterfaceBlock::add