### PR TITLE
gltfio: add ownership query

### DIFF
--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -306,7 +306,9 @@ public:
      * components (e.g. Renderable, TransformManager component) as well as
      * the underlying entities.
      */
-    void detachFilamentComponents();
+    void detachFilamentComponents() noexcept;
+
+    bool areFilamentComponentsDetached() const noexcept;
 
     /**
      * Releases ownership of material instances.

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -249,7 +249,7 @@ struct FFilamentAsset : public FilamentAsset {
     void addEntitiesToScene(filament::Scene& targetScene, const Entity* entities, size_t count,
             SceneMask sceneFilter);
 
-    void detachFilamentComponents() {
+    void detachFilamentComponents() noexcept {
         mDetachedFilamentComponents = true;
     }
 

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -253,8 +253,12 @@ void FFilamentAsset::addEntitiesToScene(Scene& targetScene, const Entity* entiti
     }
 }
 
-void FilamentAsset::detachFilamentComponents() {
+void FilamentAsset::detachFilamentComponents() noexcept {
     upcast(this)->detachFilamentComponents();
+}
+
+bool FilamentAsset::areFilamentComponentsDetached() const noexcept {
+    return upcast(this)->mDetachedFilamentComponents;
 }
 
 void FilamentAsset::detachMaterialInstances() {


### PR DESCRIPTION
Adding this getter lets us remove some duplicated state from an
internal client at Google.