### PR TITLE
Vulkan: handle unused samplers the right way

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -57,6 +57,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallback(VkDebugReportFlagsEXT flags,
                 << pMessage << utils::io::endl;
     }
     utils::slog.e << utils::io::endl;
+    exit(1);
     return VK_FALSE;
 }
 
@@ -75,6 +76,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsCallback(VkDebugUtilsMessageSeverityFla
                 << cbdata->pMessage << utils::io::endl;
     }
     utils::slog.e << utils::io::endl;
+    exit(1);
     return VK_FALSE;
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1824,7 +1824,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     // where "SamplerBinding" is the integer in the GLSL, and SamplerGroupBinding is the abstract
     // Filament concept used to form groups of samplers.
 
-    VkDescriptorImageInfo iInfo[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
+    VkDescriptorImageInfo samplerInfo[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
 
     for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::SAMPLER_BINDING_COUNT; samplerGroupIdx++) {
         const auto& samplerGroup = program->samplerGroupInfo[samplerGroupIdx];
@@ -1861,17 +1861,18 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 const SamplerParams& samplerParams = boundSampler->s;
                 VkSampler vksampler = mSamplerCache.getSampler(samplerParams);
 
-                iInfo[bindingPoint] = {
+                samplerInfo[bindingPoint] = {
                     .sampler = vksampler,
                     .imageView = texture->getPrimaryImageView(),
                     .imageLayout = texture->getPrimaryImageLayout()
                 };
-
+            } else {
+                // samplerInfo[bindingPoint] = {};
             }
         }
     }
 
-    mPipelineCache.bindSamplers(iInfo);
+    mPipelineCache.bindSamplers(samplerInfo);
 
     // Bind new descriptor sets if they need to change.
     // If descriptor set allocation failed, skip the draw call and bail. No need to emit an error

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -37,6 +37,14 @@ namespace filament::backend {
 
 static VulkanPipelineCache::RasterState createDefaultRasterState();
 
+static std::string to_string(bitset64 key) {
+    std::string result;
+    for (int i = 0; i < 64; i++) {
+        result += key.test(i) ? "1" : "0";
+    }
+    return result;
+}
+
 static VkShaderStageFlags getShaderStageFlags(bitset64 key, uint16_t binding) {
     VkShaderStageFlags flags = 0;
     if (key.test(binding * 2 + 0)) {

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -376,6 +376,7 @@ private:
     void destroyLayoutsAndDescriptors() noexcept;
     VkDescriptorPool createDescriptorPool(uint32_t size) const;
     void growDescriptorPool() noexcept;
+    utils::bitset64 getPipelineLayoutKey(const Program::SamplerGroupInfo& samplerGroupInfo) const noexcept;
 
     // Immutable state.
     VkDevice mDevice = VK_NULL_HANDLE;

--- a/libs/gltfio/materials/base.mat.in
+++ b/libs/gltfio/materials/base.mat.in
@@ -12,6 +12,8 @@ material {
     reflections : screenspace,
     parameters : [
 
+        { type : sampler2d, name : Foo },
+
         { type : float3, name : specularFactor },
         { type : float, name : glossinessFactor },
 
@@ -111,6 +113,9 @@ fragment {
         #endif
 
         material.baseColor *= getColor();
+        if (false) {
+             material.baseColor += texture(materialParams_Foo, uvs[0]);
+        }
 
         #if !defined(SHADING_MODEL_UNLIT)
 


### PR DESCRIPTION
If you do:
    gltf_viewer -u -a vulkan

Then you will see:
    UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout