### PR TITLE
It was a mistake to change Program's ctor

### DIFF
--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -24,7 +24,6 @@
 #include <utils/Log.h>
 #include <utils/ostream.h>
 
-#include <backend/DriverApiForward.h>
 #include <backend/DriverEnums.h>
 
 #include <array>
@@ -53,7 +52,7 @@ public:
     using ShaderBlob = utils::FixedCapacityVector<uint8_t>;
     using ShaderSource = std::array<ShaderBlob, SHADER_TYPE_COUNT>;
 
-    explicit Program(DriverApi& driver) noexcept;
+    Program() noexcept;
 
     Program(const Program& rhs) = delete;
     Program& operator=(const Program& rhs) = delete;
@@ -99,7 +98,6 @@ public:
 private:
     friend utils::io::ostream& operator<<(utils::io::ostream& out, const Program& builder);
 
-    UTILS_UNUSED DriverApi& mDriverApi;
     UniformBlockInfo mUniformBlocks = {};
     SamplerGroupInfo mSamplerGroups = {};
     ShaderSource mShadersSource;

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -21,8 +21,7 @@ using namespace utils;
 namespace filament::backend {
 
 // We want these in the .cpp file, so they're not inlined (not worth it)
-Program::Program(DriverApi& driver) noexcept
-        : mDriverApi(driver) {
+Program::Program() noexcept { // NOLINT(modernize-use-equals-default)
 }
 
 Program::Program(Program&& rhs) noexcept = default;

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -180,8 +180,8 @@ ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isM
     return {};
 }
 
-Program ShaderGenerator::getProgram(filament::backend::DriverApi& driverApi) noexcept {
-    Program program(driverApi);
+Program ShaderGenerator::getProgram(filament::backend::DriverApi&) noexcept {
+    Program program;
     program.shader(ShaderType::VERTEX, mVertexBlob.data(), mVertexBlob.size());
     program.shader(ShaderType::FRAGMENT, mFragmentBlob.data(), mFragmentBlob.size());
     return program;

--- a/filament/backend/test/ShaderGenerator.cpp
+++ b/filament/backend/test/ShaderGenerator.cpp
@@ -101,14 +101,16 @@ void ShaderGenerator::shutdown() {
     FinalizeProcess();
 }
 
-ShaderGenerator::ShaderGenerator(std::string vertex, std::string fragment, Backend backend,
-        bool isMobile) noexcept : mBackend(backend), mIsMobile(isMobile) {
-    mVertexBlob = transpileShader(backend, isMobile, std::move(vertex), ShaderStage::VERTEX);
-    mFragmentBlob = transpileShader(backend, isMobile, std::move(fragment), ShaderStage::FRAGMENT);
+ShaderGenerator::ShaderGenerator(std::string vertex, std::string fragment,
+        Backend backend, bool isMobile) noexcept
+        : mBackend(backend),
+          mVertexBlob(transpileShader(ShaderStage::VERTEX, std::move(vertex), backend, isMobile)),
+          mFragmentBlob(transpileShader(ShaderStage::FRAGMENT, std::move(fragment), backend,
+                  isMobile)) {
 }
 
-ShaderGenerator::Blob ShaderGenerator::transpileShader(Backend backend, bool isMobile, std::string shader,
-            ShaderStage stage) noexcept {
+ShaderGenerator::Blob ShaderGenerator::transpileShader(
+        ShaderStage stage, std::string shader, Backend backend, bool isMobile) noexcept {
     TProgram program;
     const EShLanguage language = stage == ShaderStage::VERTEX ? EShLangVertex : EShLangFragment;
     TShader tShader(language);

--- a/filament/backend/test/ShaderGenerator.h
+++ b/filament/backend/test/ShaderGenerator.h
@@ -46,18 +46,13 @@ public:
     filament::backend::Program getProgram(filament::backend::DriverApi&) noexcept;
 
 private:
-
-    enum class ShaderStage {
-        VERTEX,
-        FRAGMENT
-    };
+    using ShaderStage = filament::backend::ShaderType;
 
     using Blob = std::vector<char>;
-    static Blob transpileShader(Backend backend, bool isMobile, std::string shader,
-            ShaderStage stage) noexcept;
+    static Blob transpileShader(ShaderStage stage, std::string shader, Backend backend,
+            bool isMobile) noexcept;
 
     Backend mBackend;
-    bool mIsMobile;
 
     Blob mVertexBlob;
     Blob mFragmentBlob;

--- a/filament/backend/test/ShaderGenerator.h
+++ b/filament/backend/test/ShaderGenerator.h
@@ -43,7 +43,7 @@ public:
     ShaderGenerator(const ShaderGenerator& rhs) = delete;
     ShaderGenerator& operator=(const ShaderGenerator& rhs) = delete;
 
-    filament::backend::Program getProgram(filament::backend::DriverApi& driverApi) noexcept;
+    filament::backend::Program getProgram(filament::backend::DriverApi&) noexcept;
 
 private:
 

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -453,7 +453,7 @@ Program FMaterial::getProgramBuilderWithVariants(
             "GLSL or SPIR-V chunks for the fragment shader (variant=0x%x, filtered=0x%x).",
             mName.c_str(), variant.key, fragmentVariant.key);
 
-    Program program(mEngine.getDriverApi());
+    Program program;
     program.shader(ShaderType::VERTEX, vsBuilder.data(), vsBuilder.size())
            .shader(ShaderType::FRAGMENT, fsBuilder.data(), fsBuilder.size())
            .uniformBlockBindings(mUniformBlockBindings)


### PR DESCRIPTION
partially revert a recent change where Program needs a DriverApi in its
ctor. This was a misguided change. Backend API never take a DriverApi
as parameter.

Checking the feature level, for instance, should happen as a 
precondition, or in the backend as postcondition.
