### PR TITLE
WASM: Set CONFIG_MAX_INSTANCES to a small value.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- WebGL: reduce max instance count to work around Chrome issues [⚠️ **Recompile Materials**]
+
 ## v1.26.0
 
 - engine: new feature level APIs, see `Engine::getSupportedFeatureLevel()`

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 26;
+static constexpr size_t MATERIAL_VERSION = 27;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -66,7 +66,14 @@ constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
 constexpr size_t CONFIG_MINSPEC_UBO_SIZE = 16384;
 
 // The maximum number of instances that Filament automatically creates as an optimization.
+// Use a much smaller number for WebGL as a workaround for the following Chrome issues:
+//     https://crbug.com/1348017 Compiling GLSL is very slow with struct arrays
+//     https://crbug.com/1348363 Lighting looks wrong with D3D11 but not OpenGL
+#if defined(__EMSCRIPTEN__)
+constexpr size_t CONFIG_MAX_INSTANCES = 8;
+#else
 constexpr size_t CONFIG_MAX_INSTANCES = 64;
+#endif
 
 // The maximum number of bones that can be associated with a single renderable.
 // We store 32 bytes per bone. Must be a power-of-two, and must fit within CONFIG_MINSPEC_UBO_SIZE.


### PR DESCRIPTION
This is a workaround for the following Chrome issues:

https://crbug.com/1348017 Compiling GLSL is very slow with struct arrays
https://crbug.com/1348363 Lighting looks wrong with D3D11 but not OpenGL

This requires a rebuild of materials for WebGL users.

Fixes #5859.