### PR TITLE
Implement setThreadName() on Windows

### DIFF
--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -37,7 +37,11 @@ static constexpr bool DEBUG_FINISH_HANGS = false;
 
 #include <math.h>
 
-#if !defined(WIN32)
+#if defined(WIN32)
+#    define NOMINMAX
+#    include <windows.h>
+#    include <string>
+# else
 #    include <pthread.h>
 #endif
 
@@ -77,8 +81,15 @@ void JobSystem::setThreadName(const char* name) noexcept {
     pthread_setname_np(pthread_self(), name);
 #elif defined(__APPLE__)
     pthread_setname_np(name);
-#else
-// TODO: implement setting thread name on WIN32
+#elif defined(WIN32)
+    std::string_view u8name(name);
+    size_t size = MultiByteToWideChar(CP_UTF8, 0, u8name.data(), u8name.size(), nullptr, 0);
+
+    std::wstring u16name;
+    u16name.resize(size);
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, u8name.data(), u8name.size(), u16name.data(), u16name.size());
+    
+    SetThreadDescription(GetCurrentThread(), u16name.data());
 #endif
 }
 


### PR DESCRIPTION
This PR completes a TODO, thread names are now set on Windows too (e.g. `FEngine::loop`, `JobSystem::loop`).

Windows API requires conversion of input string to UTF-16. I assumed that the input `const char*` may not only contain ASCII characters, but also can be a UTF-8 string.

![filament-threadname](https://user-images.githubusercontent.com/53563131/186912098-0be61740-7adb-4e9d-a702-2adb8c4a38e4.png)