### PR TITLE
gltfio: Refactor skinning, share duplicated data.

### DIFF
--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -80,6 +80,8 @@ struct AnimatorImpl {
     void applyAnimation(const Channel& channel, float t, size_t prevIndex, size_t nextIndex);
     void stashCrossFade();
     void applyCrossFade(float alpha);
+    void resetBoneMatrices(FFilamentInstance* instance);
+    void updateBoneMatrices(FFilamentInstance* instance);
 };
 
 static void createSampler(const cgltf_animation_sampler& src, Sampler& dst) {
@@ -298,71 +300,28 @@ void Animator::applyAnimation(size_t animationIndex, float time) const {
 }
 
 void Animator::resetBoneMatrices() {
-    auto renderableManager = mImpl->renderableManager;
-
-    auto update = [=](const SkinVector& skins, BoneVector& boneVector) {
-        for (const auto& skin : skins) {
-            size_t njoints = skin.joints.size();
-            boneVector.resize(njoints);
-            for (const auto& entity : skin.targets) {
-                auto renderable = renderableManager->getInstance(entity);
-                if (renderable) {
-                    for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
-                        boneVector[boneIndex] = mat4f();
-                    }
-                    renderableManager->setBones(renderable, boneVector.data(), boneVector.size());
-                }
-            }
-        }
-    };
-
+    // If this is a single-instance animator, then reset only this instance.
     if (mImpl->instance) {
-        update(mImpl->instance->skins, mImpl->boneMatrices);
-    } else {
-        for (FFilamentInstance* instance : mImpl->asset->mInstances) {
-            update(instance->skins, mImpl->boneMatrices);
-        }
+        mImpl->resetBoneMatrices(mImpl->instance);
+        return;
+    }
+
+    // If this is a broadcast animator, then reset all instances.
+    for (FFilamentInstance* instance : mImpl->asset->mInstances) {
+        mImpl->resetBoneMatrices(instance);
     }
 }
 
 void Animator::updateBoneMatrices() {
-    auto renderableManager = mImpl->renderableManager;
-    auto transformManager = mImpl->transformManager;
-
-    auto update = [=](const SkinVector& skins, BoneVector& boneVector) {
-        for (const Skin& skin : skins) {
-            size_t njoints = skin.joints.size();
-            boneVector.resize(njoints);
-            for (Entity entity : skin.targets) {
-                auto renderable = renderableManager->getInstance(entity);
-                if (!renderable) {
-                    continue;
-                }
-                mat4f inverseGlobalTransform;
-                auto xformable = transformManager->getInstance(entity);
-                if (xformable) {
-                    inverseGlobalTransform = inverse(transformManager->getWorldTransform(xformable));
-                }
-                for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
-                    const auto& joint = skin.joints[boneIndex];
-                    TransformManager::Instance jointInstance = transformManager->getInstance(joint);
-                    mat4f globalJointTransform = transformManager->getWorldTransform(jointInstance);
-                    boneVector[boneIndex] =
-                            inverseGlobalTransform *
-                            globalJointTransform *
-                            skin.inverseBindMatrices[boneIndex];
-                }
-                renderableManager->setBones(renderable, boneVector.data(), boneVector.size());
-            }
-        }
-    };
-
+    // If this is a single-instance animator, then update only this instance.
     if (mImpl->instance) {
-        update(mImpl->instance->skins, mImpl->boneMatrices);
-    } else {
-        for (FFilamentInstance* instance : mImpl->asset->mInstances) {
-            update(instance->skins, mImpl->boneMatrices);
-        }
+        mImpl->updateBoneMatrices(mImpl->instance);
+        return;
+    }
+
+    // If this is a broadcast animator, then update all instances.
+    for (FFilamentInstance* instance : mImpl->asset->mInstances) {
+        mImpl->updateBoneMatrices(instance);
     }
 }
 
@@ -554,6 +513,54 @@ void AnimatorImpl::applyAnimation(const Channel& channel, float t, size_t prevIn
 
     xform = composeMatrix(translation, rotation, scale);
     transformManager->setTransform(node, xform);
+}
+
+void AnimatorImpl::resetBoneMatrices(FFilamentInstance* instance) {
+    for (const auto& skin : instance->skins) {
+        size_t njoints = skin.joints.size();
+        boneMatrices.resize(njoints);
+        for (const auto& entity : skin.targets) {
+            auto renderable = renderableManager->getInstance(entity);
+            if (renderable) {
+                for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
+                    boneMatrices[boneIndex] = mat4f();
+                }
+                renderableManager->setBones(renderable, boneMatrices.data(), boneMatrices.size());
+            }
+        }
+    }
+}
+
+void AnimatorImpl::updateBoneMatrices(FFilamentInstance* instance) {
+    assert_invariant(instance->skins.size() == asset->mSkins.size());
+    size_t skinIndex = 0;
+    for (const auto& skin : instance->skins) {
+        const auto& assetSkin = asset->mSkins[skinIndex++];
+        size_t njoints = skin.joints.size();
+        boneMatrices.resize(njoints);
+        for (Entity entity : skin.targets) {
+            auto renderable = renderableManager->getInstance(entity);
+            if (!renderable) {
+                continue;
+            }
+            mat4f inverseGlobalTransform;
+            auto xformable = transformManager->getInstance(entity);
+            if (xformable) {
+                inverseGlobalTransform = inverse(transformManager->getWorldTransform(xformable));
+            }
+            for (size_t boneIndex = 0; boneIndex < njoints; ++boneIndex) {
+                const auto& joint = skin.joints[boneIndex];
+                const mat4f& inverseBindMatrix = assetSkin.inverseBindMatrices[boneIndex];
+                TransformManager::Instance jointInstance = transformManager->getInstance(joint);
+                mat4f globalJointTransform = transformManager->getWorldTransform(jointInstance);
+                boneMatrices[boneIndex] =
+                        inverseGlobalTransform *
+                        globalJointTransform *
+                        inverseBindMatrix;
+            }
+            renderableManager->setBones(renderable, boneMatrices.data(), boneMatrices.size());
+        }
+    }
 }
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -271,6 +271,11 @@ struct FFilamentAsset : public FilamentAsset {
 
     void createAnimators();
 
+    struct Skin {
+        utils::CString name;
+        utils::FixedCapacityVector<math::mat4f> inverseBindMatrices;
+    };
+
     filament::Engine* const mEngine;
     utils::NameComponentManager* const mNameManager;
     utils::EntityManager* const mEntityManager;
@@ -285,6 +290,7 @@ struct FFilamentAsset : public FilamentAsset {
     std::vector<filament::IndexBuffer*> mIndexBuffers;
     std::vector<filament::MorphTargetBuffer*> mMorphTargetBuffers;
     std::vector<filament::Texture*> mTextures;
+    utils::FixedCapacityVector<Skin> mSkins;
     utils::FixedCapacityVector<Variant> mVariants;
     utils::FixedCapacityVector<utils::CString> mScenes;
     filament::Aabb mBoundingBox;

--- a/libs/gltfio/src/TangentsJob.h
+++ b/libs/gltfio/src/TangentsJob.h
@@ -45,8 +45,8 @@ struct TangentsJob {
     // The context of the procedure. These fields are not used by the procedure but are provided as
     // a convenience to clients. You can think of this as a scratch space for clients.
     struct Context {
-        filament::VertexBuffer* const vb;
-        filament::MorphTargetBuffer* const tb;
+        VertexBuffer* const vb;
+        MorphTargetBuffer* const tb;
         const uint8_t slot;
     };
 
@@ -54,7 +54,7 @@ struct TangentsJob {
     // should remember to free it.
     struct OutputParams {
         cgltf_size vertexCount;
-        filament::math::short4* results;
+        math::short4* results;
     };
 
     // Clients might want to track the jobs in an array, so the arguments are bundled into a struct.


### PR DESCRIPTION
The immutable inverse bind matrices can be shared among instances, so
they are now stored in Asset, not in Instance.

Also, there are now two "load" phases for skinning data:

(1) storing the inverse bind matrices
(2) building the Entity mappings (for animation efficiency)

Phase 1 is done in `ResourceLoader` because inverse bind matrices can
live in an external bin file.

Phase 2 is done during Instance creation, because that's when entities
are created.