### PR TITLE
material instanced property must be false by default.

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -740,7 +740,7 @@ private:
     bool mDoubleSidedCapability = false;
     bool mColorWrite = true;
     bool mDepthTest = true;
-    bool mInstanced = true;
+    bool mInstanced = false;
     bool mDepthWrite = true;
     bool mDepthWriteSet = false;
 


### PR DESCRIPTION
this fix auto-instancing.