### PR TITLE
fix a use after free when setting a Program's uniform infos

### DIFF
--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -48,7 +48,7 @@ public:
         ShaderStageFlags stageFlags = ShaderStageFlags::ALL_SHADER_STAGE_FLAGS;
     };
 
-    using UniformBlockInfo = std::array<const char*, UNIFORM_BINDING_COUNT>;
+    using UniformBlockInfo = std::array<utils::CString, UNIFORM_BINDING_COUNT>;
     using SamplerGroupInfo = std::array<SamplerGroupData, SAMPLER_BINDING_COUNT>;
     using ShaderBlob = utils::FixedCapacityVector<uint8_t>;
     using ShaderSource = std::array<ShaderBlob, SHADER_TYPE_COUNT>;
@@ -76,7 +76,7 @@ public:
     //       not permitted in glsl. The backend needs a way to associate a uniform block
     //       to a binding point.
     Program& uniformBlockBindings(
-            utils::FixedCapacityVector<std::pair<const char*, uint8_t>> const& uniformBlockBindings) noexcept;
+            utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> const& uniformBlockBindings) noexcept;
 
     // sets the 'bindingPoint' sampler group descriptor for this program.
     // 'samplers' can be destroyed after this call.
@@ -98,6 +98,7 @@ public:
     ShaderSource& getShadersSource() noexcept { return mShadersSource; }
 
     UniformBlockInfo const& getUniformBlockBindings() const noexcept { return mUniformBlocks; }
+    UniformBlockInfo& getUniformBlockBindings() noexcept { return mUniformBlocks; }
 
     SamplerGroupInfo const& getSamplerGroupInfo() const { return mSamplerGroups; }
     SamplerGroupInfo& getSamplerGroupInfo() { return mSamplerGroups; }

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -16,9 +16,9 @@
 
 #include "backend/Program.h"
 
-using namespace utils;
-
 namespace filament::backend {
+
+using namespace utils;
 
 // We want these in the .cpp file, so they're not inlined (not worth it)
 Program::Program() noexcept { // NOLINT(modernize-use-equals-default)
@@ -37,8 +37,8 @@ Program& Program::operator=(Program&& rhs) noexcept {
 
 Program::~Program() noexcept = default;
 
-Program& Program::diagnostics(utils::CString const& name,
-        utils::Invocable<io::ostream&(utils::io::ostream&)>&& logger) {
+Program& Program::diagnostics(CString const& name,
+        Invocable<io::ostream&(io::ostream&)>&& logger) {
     mName = name;
     mLogger = std::move(logger);
     return *this;
@@ -52,7 +52,7 @@ Program& Program::shader(ShaderType shader, void const* data, size_t size) {
 }
 
 Program& Program::uniformBlockBindings(
-        utils::FixedCapacityVector<std::pair<const char*, uint8_t>> const& uniformBlockBindings) noexcept {
+        FixedCapacityVector<std::pair<utils::CString, uint8_t>> const& uniformBlockBindings) noexcept {
     for (auto const& item : uniformBlockBindings) {
         assert_invariant(item.second < UNIFORM_BINDING_COUNT);
         mUniformBlocks[item.second] = item.first;

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -51,7 +51,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver& gld, Program&& programBuilder) noexce
 
     OpenGLContext& context = gld.getContext();
 
-    mLazyInitializationData->uniformBlockInfo = programBuilder.getUniformBlockBindings();
+    mLazyInitializationData->uniformBlockInfo = std::move(programBuilder.getUniformBlockBindings());
     mLazyInitializationData->samplerGroupInfo = std::move(programBuilder.getSamplerGroupInfo());
 
     // this cannot fail because we check compilation status after linking the program
@@ -339,9 +339,9 @@ void OpenGLProgram::initializeProgramState(OpenGLContext& context, GLuint progra
     // (ES3.0 and GL4.1). The backend needs a way to associate a uniform block to a binding point.
     UTILS_NOUNROLL
     for (GLuint binding = 0, n = lazyInitializationData.uniformBlockInfo.size(); binding < n; binding++) {
-        const char* name = lazyInitializationData.uniformBlockInfo[binding];
-        if (name) {
-            GLint index = glGetUniformBlockIndex(program, name);
+        auto const& name = lazyInitializationData.uniformBlockInfo[binding];
+        if (!name.empty()) {
+            GLint index = glGetUniformBlockIndex(program, name.c_str());
             if (index >= 0) {
                 glUniformBlockBinding(program, GLuint(index), binding);
             }

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -154,16 +154,8 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
 
     // read the uniform binding list
     utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> uniformBlockBindings;
-    success = parser->getUniformBlockBindings(&uniformBlockBindings);
+    success = parser->getUniformBlockBindings(&mUniformBlockBindings);
     assert_invariant(success);
-    // store the name in an array (so we can use pointers), and create the uniform block binding
-    // list for the backend (to be used with Program)
-    mUniformBlockNames.reserve(uniformBlockBindings.size());
-    mUniformBlockBindings.reserve(uniformBlockBindings.size());
-    for (auto& item : uniformBlockBindings) {
-        mUniformBlockNames.emplace_back(std::move(item.first));
-        mUniformBlockBindings.emplace_back(mUniformBlockNames.back().c_str(), item.second);
-    }
 
     success = parser->getSamplerBlockBindings(&mSamplerGroupBindingInfoList, &mSamplerBindingToNameMap);
     assert_invariant(success);

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -226,8 +226,7 @@ private:
     SamplerInterfaceBlock mSamplerInterfaceBlock;
     UniformInterfaceBlock mUniformInterfaceBlock;
     SubpassInfo mSubpassInfo;
-    utils::FixedCapacityVector<std::pair<const char*, uint8_t>> mUniformBlockBindings;
-    utils::FixedCapacityVector<utils::CString> mUniformBlockNames;
+    utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> mUniformBlockBindings;
     SamplerGroupBindingInfoList mSamplerGroupBindingInfoList;
     SamplerBindingToNameMap mSamplerBindingToNameMap;
 


### PR DESCRIPTION
We were keeping the list if uniform names in Material and passing
pointers to the backend. Unfortunately, HwProgram can outlive
Material because it is legal to destroy a Material once it's not
needed on the client side. e.g. just after rendering something.

This was happening with the IBLPrefilter code, but probably elsewhere
too.

We now just store CStrings in HwProgram.