### PR TITLE
fix filamat unit tests

### DIFF
--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -70,7 +70,7 @@ std::string shaderWithAllProperties(JobSystem& jobSystem, ShaderType type,
     builder.build(jobSystem);
 
     return builder.peek(type,
-            {1, MaterialBuilder::TargetApi::OPENGL, MaterialBuilder::TargetLanguage::GLSL},
+            { 1, MaterialBuilder::TargetApi::OPENGL, MaterialBuilder::TargetLanguage::SPIRV },
             allProperties);
 }
 


### PR DESCRIPTION
We use TargetLanguage::SPIRV instead of GLSL which affects how the
source GLSL is generated, in particular which version is used.

This change is not a problem for these unit tests, but is probably
exposing another problem -- we will address that separately.