### PR TITLE
Fix filamat internal state tracking

### DIFF
--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -127,7 +127,7 @@ protected:
     bool mGenerateDebugInfo = false;
     utils::bitset32 mShaderModels;
     struct CodeGenParams {
-        int shaderModel;
+        ShaderModel shaderModel;
         TargetApi targetApi;
         TargetLanguage targetLanguage;
     };
@@ -135,7 +135,7 @@ protected:
     // For finding properties and running semantic analysis, we always use the same code gen
     // permutation. This is the first permutation generated with default arguments passed to matc.
     const CodeGenParams mSemanticCodeGenParams = {
-        .shaderModel = (int) ShaderModel::MOBILE,
+        .shaderModel = ShaderModel::MOBILE,
         .targetApi = TargetApi::OPENGL,
         .targetLanguage = TargetLanguage::SPIRV
     };

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -64,7 +64,7 @@ public:
 
     /**
      * TargetApi defines which language after transpilation will be used, it is used to
-     * account for some differences between these langages when generating the GLSL.
+     * account for some differences between these languages when generating the GLSL.
      */
     enum class TargetApi : uint8_t {
         OPENGL      = 0x01u,

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -52,6 +52,7 @@ public:
     struct Config {
         filament::Variant variant;
         MaterialBuilder::TargetApi targetApi;
+        MaterialBuilder::TargetLanguage targetLanguage;
         filament::backend::ShaderType shaderType;
         filament::backend::ShaderModel shaderModel;
         filament::MaterialDomain domain;

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -51,7 +51,7 @@ GLSLangCleaner::~GLSLangCleaner() {
 bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel model,
         MaterialBuilder::MaterialDomain materialDomain,
         MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading,
-        MaterialInfo const& info) const noexcept {
+        MaterialInfo const& info) noexcept {
 
     // Parse to check syntax and semantic.
     const char* shaderCString = shaderCode.c_str();
@@ -140,7 +140,7 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode, ShaderModel
 bool GLSLTools::analyzeVertexShader(const std::string& shaderCode, ShaderModel model,
         MaterialBuilder::MaterialDomain materialDomain,
         MaterialBuilder::TargetApi targetApi,
-        MaterialInfo const& info) const noexcept {
+        MaterialInfo const& info) noexcept {
 
     // TODO: After implementing post-process vertex shaders, properly analyze them here.
     if (materialDomain == MaterialBuilder::MaterialDomain::POST_PROCESS) {
@@ -263,12 +263,7 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
     }
 
     std::deque<Symbol> symbols;
-    bool ok = findSymbolsUsage(functionName, *rootNode, symbols);
-    if (!ok) {
-        utils::slog.e << "Unable to trace usage of symbols in function '" << functionName
-                << utils::io::endl;
-        return false;
-    }
+    findSymbolsUsage(functionName, *rootNode, symbols);
 
     // Iterate over symbols to see if the parameter we are interested in what written.
     std::string parameterName = functionMaterialParameters.at(parameterIdx).name;
@@ -279,7 +274,7 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
         }
 
         // This is a direct assignment of the variable. X =
-        if (symbol.getAccesses().size() == 0) {
+        if (symbol.getAccesses().empty()) {
             continue;
         }
 
@@ -291,7 +286,7 @@ bool GLSLTools::findPropertyWritesOperations(const std::string& functionName, si
 void GLSLTools::scanSymbolForProperty(Symbol& symbol,
         TIntermNode* rootNode,
         MaterialBuilder::PropertyList& properties) const noexcept {
-    for (Access access : symbol.getAccesses()) {
+    for (const Access& access : symbol.getAccesses()) {
         if (access.type == Access::Type::FunctionCall) {
             // Do NOT look into prepareMaterial call.
             if (access.string.find("prepareMaterial(struct") != std::string::npos) {
@@ -336,7 +331,7 @@ void GLSLTools::scanSymbolForProperty(Symbol& symbol,
 }
 
 bool GLSLTools::findSymbolsUsage(const std::string& functionSignature, TIntermNode& root,
-        std::deque<Symbol>& symbols) const noexcept {
+        std::deque<Symbol>& symbols) noexcept {
     TIntermNode* functionAST = ASTUtils::getFunctionBySignature(functionSignature, root);
     ASTUtils::traceSymbols(*functionAST, symbols);
     return true;
@@ -365,7 +360,7 @@ EShMessages GLSLTools::glslangFlagsFromTargetApi(MaterialBuilder::TargetApi targ
 
 void GLSLTools::prepareShaderParser(MaterialBuilder::TargetApi targetApi, glslang::TShader& shader,
         EShLanguage language, int version, filamat::MaterialBuilder::Optimization optimization) {
-    // We must only setup the SPIRV environment when we actually need to output SPIRV
+    // We must only set up the SPIRV environment when we actually need to output SPIRV
     if (optimization == filamat::MaterialBuilder::Optimization::SIZE ||
             optimization == filamat::MaterialBuilder::Optimization::PERFORMANCE) {
         shader.setAutoMapBindings(true);

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -35,7 +35,9 @@ namespace filamat {
 
 // Used for symbol tracking during static code analysis.
 struct Access {
-    enum Type {Swizzling, DirectIndexForStruct, FunctionCall};
+    enum Type {
+        Swizzling, DirectIndexForStruct, FunctionCall
+    };
     Type type;
     std::string string;
     size_t parameterIdx = 0; // Only used when type == FunctionCall;
@@ -49,8 +51,8 @@ struct Access {
 // Combinations are possible. e.g: foo(material.baseColor.xyz)
 class Symbol {
 public:
-    Symbol() {}
-    Symbol(const std::string& name) {
+    Symbol() = default;
+    explicit Symbol(const std::string& name) {
         mName = name;
     }
 
@@ -72,7 +74,7 @@ public:
 
     std::string toString() const {
         std::string str(mName);
-        for (Access access: mAccesses) {
+        for (const Access& access: mAccesses) {
             str += ".";
             str += access.string;
         }
@@ -80,7 +82,7 @@ public:
     }
 
     bool hasDirectIndexForStruct() const noexcept {
-        for (Access access : mAccesses) {
+        for (const Access& access : mAccesses) {
             if (access.type == Access::Type::DirectIndexForStruct) {
                 return true;
             }
@@ -88,8 +90,8 @@ public:
         return false;
     }
 
-    const std::string getDirectIndexStructName() const noexcept {
-        for (Access access : mAccesses) {
+    std::string getDirectIndexStructName() const noexcept {
+        for (const Access& access : mAccesses) {
             if (access.type == Access::Type::DirectIndexForStruct) {
                 return access.string;
             }
@@ -121,17 +123,17 @@ public:
     // The shader features a material() function AND
     // The shader features a prepareMaterial() function AND
     // prepareMaterial() is called at some point in material() call chain.
-    bool analyzeFragmentShader(const std::string& shaderCode,
+    static bool analyzeFragmentShader(const std::string& shaderCode,
             filament::backend::ShaderModel model,
             MaterialBuilder::MaterialDomain materialDomain,
             MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading,
-            MaterialInfo const& info) const noexcept;
+            MaterialInfo const& info) noexcept;
 
-    bool analyzeVertexShader(const std::string& shaderCode,
+    static bool analyzeVertexShader(const std::string& shaderCode,
             filament::backend::ShaderModel model,
             MaterialBuilder::MaterialDomain materialDomain,
             MaterialBuilder::TargetApi targetApi,
-            MaterialInfo const& info) const noexcept;
+            MaterialInfo const& info) noexcept;
 
     // Public for unit tests.
     using Property = MaterialBuilder::Property;
@@ -161,8 +163,8 @@ private:
     // in a function call.
     // Start in the function matching the signature provided and follow all out and inout calls.
     // Does NOT recurse to follow function calls.
-    bool findSymbolsUsage(const std::string& functionSignature, TIntermNode& root,
-            std::deque<Symbol>& symbols) const noexcept;
+    static bool findSymbolsUsage(const std::string& functionSignature, TIntermNode& root,
+            std::deque<Symbol>& symbols) noexcept;
 
 
     // Determine how a function affect one of its parameter by following all write and function call

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -124,16 +124,14 @@ public:
     // The shader features a prepareMaterial() function AND
     // prepareMaterial() is called at some point in material() call chain.
     static bool analyzeFragmentShader(const std::string& shaderCode,
-            filament::backend::ShaderModel model,
-            MaterialBuilder::MaterialDomain materialDomain,
-            MaterialBuilder::TargetApi targetApi, bool hasCustomSurfaceShading,
-            MaterialInfo const& info) noexcept;
+            filament::backend::ShaderModel model, MaterialBuilder::MaterialDomain materialDomain,
+            MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
+            bool hasCustomSurfaceShading, MaterialInfo const& info) noexcept;
 
     static bool analyzeVertexShader(const std::string& shaderCode,
             filament::backend::ShaderModel model,
-            MaterialBuilder::MaterialDomain materialDomain,
-            MaterialBuilder::TargetApi targetApi,
-            MaterialInfo const& info) noexcept;
+            MaterialBuilder::MaterialDomain materialDomain, MaterialBuilder::TargetApi targetApi,
+            MaterialBuilder::TargetLanguage targetLanguage, MaterialInfo const& info) noexcept;
 
     // Public for unit tests.
     using Property = MaterialBuilder::Property;
@@ -145,14 +143,17 @@ public:
             const std::string& shaderCode,
             MaterialBuilder::PropertyList& properties,
             MaterialBuilder::TargetApi targetApi = MaterialBuilder::TargetApi::OPENGL,
+            MaterialBuilder::TargetLanguage targetLanguage = MaterialBuilder::TargetLanguage::GLSL,
             ShaderModel model = ShaderModel::DESKTOP) const noexcept;
 
     static int glslangVersionFromShaderModel(filament::backend::ShaderModel model);
 
-    static EShMessages glslangFlagsFromTargetApi(MaterialBuilder::TargetApi targetApi);
+    static EShMessages glslangFlagsFromTargetApi(MaterialBuilder::TargetApi targetApi,
+            MaterialBuilder::TargetLanguage targetLanguage);
 
-    static void prepareShaderParser(MaterialBuilder::TargetApi targetApi, glslang::TShader& shader,
-            EShLanguage language, int version, MaterialBuilder::Optimization optimization);
+    static void prepareShaderParser(MaterialBuilder::TargetApi targetApi,
+            MaterialBuilder::TargetLanguage targetLanguage, glslang::TShader& shader,
+            EShLanguage stage, int version);
 
     static void textureLodBias(glslang::TShader& shader);
 

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -70,9 +70,9 @@ std::string shaderWithAllProperties(JobSystem& jobSystem, ShaderType type,
     builder.build(jobSystem);
 
     return builder.peek(type, {
-                    int(ShaderModel::MOBILE),
+                    ShaderModel::MOBILE,
                     MaterialBuilder::TargetApi::OPENGL,
-                    MaterialBuilder::TargetLanguage::SPIRV
+                    MaterialBuilder::TargetLanguage::GLSL
             },
             allProperties);
 }

--- a/libs/matdbg/src/ShaderReplacer.cpp
+++ b/libs/matdbg/src/ShaderReplacer.cpp
@@ -186,7 +186,8 @@ bool ShaderReplacer::replaceSpirv(ShaderModel shaderModel, Variant variant,
     assert_invariant(targetApi == MaterialBuilder::TargetApi::VULKAN);
 
     const int langVersion = GLSLTools::glslangVersionFromShaderModel(shaderModel);
-    const EShMessages msg = GLSLTools::glslangFlagsFromTargetApi(targetApi);
+    const EShMessages msg = GLSLTools::glslangFlagsFromTargetApi(targetApi,
+            MaterialBuilder::TargetLanguage::SPIRV);
     const bool ok = tShader.parse(&DefaultTBuiltInResource, langVersion, false, msg);
     if (!ok) {
         slog.e << "ShaderReplacer parse:\n" << tShader.getInfoLog() << io::endl;


### PR DESCRIPTION
in a few places filamat loses the value of targetApi and targetLanguage
and attempt to guess it from other values, this lead to inconsistencies.

we now keep both targetApi and targetLanguage and use them appropriately.

in particular we don't use the optimization level to "guess" what 
targetLangage we're on.


In the end this resolve a prior unit test failure and allows us to not
have to use "spirv" rules when generating only GLSL.