### PR TITLE
Fix OpenGL stencil buffer writes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- engine: Fix stencil buffer writes with OpenGL backend.
+
 ## v1.27.0
 
 - WebGL: reduce max instance count to work around Chrome issues [⚠️ **Recompile Materials**]

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -309,9 +309,16 @@ void OpenGLDriver::setStencilState(StencilState ss) noexcept {
     mRenderPassStencilWrite |= ss.stencilWrite;
 
     // stencil test / operation
+    // GL_STENCIL_TEST must be enabled if we're testing OR writing to the stencil buffer.
     if (UTILS_LIKELY(
             ss.front.stencilFunc == StencilState::StencilFunction::A &&
-            ss.back.stencilFunc == StencilState::StencilFunction::A)) {
+            ss.back.stencilFunc == StencilState::StencilFunction::A &&
+            ss.front.stencilOpDepthFail == StencilOperation::KEEP &&
+            ss.back.stencilOpDepthFail == StencilOperation::KEEP &&
+            ss.front.stencilOpStencilFail == StencilOperation::KEEP &&
+            ss.back.stencilOpStencilFail == StencilOperation::KEEP &&
+            ss.front.stencilOpDepthStencilPass == StencilOperation::KEEP &&
+            ss.back.stencilOpDepthStencilPass == StencilOperation::KEEP)) {
         // that's equivalent to having the stencil test disabled
         gl.disable(GL_STENCIL_TEST);
     } else {


### PR DESCRIPTION
There's a problem with the OpenGL backend with regards to writing to stencil buffers. We need to call `glEnable(GL_STENCIL_TEST)` if we're performing stencil testing *OR* writing to the stencil. Otherwise the writes are ineffective.

Note this contradicts some [documentation](https://www.khronos.org/opengl/wiki/Stencil_Test):

> The stencil operations are still processed when the test is disabled

I verified this is false on macOS and Windows.