### PR TITLE
Fix a "dangling" texture in a SamplerGroup

### DIFF
--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -193,7 +193,7 @@ const char* MaterialInstance::getName() const noexcept {
 
 void MaterialInstance::setParameter(const char* name, size_t nameLength, Texture const* texture,
         TextureSampler const& sampler) {
-    return upcast(this)->setParameterImpl({ name, nameLength }, texture, sampler);
+    return upcast(this)->setParameterImpl({ name, nameLength }, upcast(texture), sampler);
 }
 
 void MaterialInstance::setParameter(const char* name, size_t nameLength, RgbType type, float3 color) {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1951,11 +1951,13 @@ PostProcessManager::BloomPassOutput PostProcessManager::bloomPass(FrameGraph& fg
                     render(hwDstRT, pipeline, driver);
 
                     // prepare the next level
-                    mi->setParameter("source", parity ? hwOut : hwStage, {
-                            .filterMag = SamplerMagFilter::LINEAR,
-                            .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
-                    });
-                    mi->setParameter("level", float(i));
+                    if (i != inoutBloomOptions.levels - 1) {
+                        mi->setParameter("source", parity ? hwOut : hwStage, {
+                                .filterMag = SamplerMagFilter::LINEAR,
+                                .filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST
+                        });
+                        mi->setParameter("level", float(i));
+                    }
                 }
             });
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -152,11 +152,11 @@ void FMaterialInstance::setParameter(std::string_view name,
 }
 
 void FMaterialInstance::setParameterImpl(std::string_view name,
-        Texture const* texture, TextureSampler const& sampler) {
+        FTexture const* texture, TextureSampler const& sampler) {
 
 #ifndef NDEBUG
     // Per GLES3.x specification, depth texture can't be filtered unless in compare mode.
-    if (isDepthFormat(texture->getFormat())) {
+    if (texture && isDepthFormat(texture->getFormat())) {
         if (sampler.getCompareMode() == SamplerCompareMode::NONE) {
             SamplerMinFilter minFilter = sampler.getMinFilter();
             SamplerMagFilter magFilter = sampler.getMagFilter();
@@ -174,7 +174,11 @@ void FMaterialInstance::setParameterImpl(std::string_view name,
     }
 #endif
 
-    setParameter(name, upcast(texture)->getHwHandle(), sampler.getSamplerParams());
+    Handle<HwTexture> handle{};
+    if (UTILS_LIKELY(texture)) {
+        handle = texture->getHwHandle();
+    }
+    setParameter(name, handle, sampler.getSamplerParams());
 }
 
 void FMaterialInstance::setMaskThreshold(float threshold) noexcept {

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -212,7 +212,7 @@ private:
     void setParameterImpl(std::string_view name, const T* value, size_t count);
 
     void setParameterImpl(std::string_view name,
-            Texture const* texture, TextureSampler const& sampler);
+            FTexture const* texture, TextureSampler const& sampler);
 
     FMaterialInstance() noexcept;
     void initDefaultInstance(FEngine& engine, FMaterial const* material);


### PR DESCRIPTION
One of the bloom texture ended-up dangling in the material's
SamplerGroup. That sampler group was never used to draw with, but was
made active which caused problem with the backends.


Also make sure the public API can unset a texture in a MaterialInstance
by passing nullptr for the texture.