### PR TITLE
In debug builds, verify destroyed textures aren't in sampler groups

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -123,6 +123,10 @@ struct MetalContext {
     os_log_t log;
     os_signpost_id_t signpostId;
 #endif
+
+#ifndef NDEBUG
+    tsl::robin_set<HandleBase::HandleId> aliveTextures;
+#endif
 };
 
 void initializeSupportedGpuFamilies(MetalContext* context);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -309,8 +309,6 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
-    ASSERT_PRECONDITION(!isInRenderPass(mContext),
-            "createRenderTarget must be called outside of a render pass.");
     // Clamp sample count to what the device supports.
     auto& sc = mContext->sampleCountLookup;
     samples = sc[std::min(MAX_SAMPLE_COUNT, samples)];

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -236,6 +236,10 @@ void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8
     construct_handle<MetalTexture>(th, *mContext, target, levels, format, samples,
             width, height, depth, usage, TextureSwizzle::CHANNEL_0, TextureSwizzle::CHANNEL_1,
             TextureSwizzle::CHANNEL_2, TextureSwizzle::CHANNEL_3);
+
+#ifndef NDEBUG
+    mContext->aliveTextures.insert(th.getId());
+#endif
 }
 
 void MetalDriver::createTextureSwizzledR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
@@ -248,6 +252,10 @@ void MetalDriver::createTextureSwizzledR(Handle<HwTexture> th, SamplerType targe
 
     construct_handle<MetalTexture>(th, *mContext, target, levels, format, samples,
             width, height, depth, usage, r, g, b, a);
+
+#ifndef NDEBUG
+    mContext->aliveTextures.insert(th.getId());
+#endif
 }
 
 void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
@@ -270,6 +278,10 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
             metalTexture.textureType, filamentMetalType);
     construct_handle<MetalTexture>(th, *mContext, target, levels, format, samples,
         width, height, depth, usage, metalTexture);
+
+#ifndef NDEBUG
+    mContext->aliveTextures.insert(th.getId());
+#endif
 }
 
 void MetalDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, uint32_t size) {
@@ -297,6 +309,8 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "createRenderTarget must be called outside of a render pass.");
     // Clamp sample count to what the device supports.
     auto& sc = mContext->sampleCountLookup;
     samples = sc[std::min(MAX_SAMPLE_COUNT, samples)];
@@ -497,6 +511,10 @@ void MetalDriver::destroyTexture(Handle<HwTexture> th) {
     if (!th) {
         return;
     }
+
+#ifndef NDEBUG
+    mContext->aliveTextures.erase(th.getId());
+#endif
 
     // Unbind this texture from any sampler groups that currently reference it.
     for (auto* metalSamplerGroup : mContext->samplerGroups) {
@@ -818,9 +836,29 @@ bool MetalDriver::canGenerateMipmaps() {
     return true;
 }
 
-void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
-        BufferDescriptor&& data) {
+void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh, BufferDescriptor&& data) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "updateSamplerGroup must be called outside of a render pass.");
+
     auto sb = handle_cast<MetalSamplerGroup>(sbh);
+
+#ifndef NDEBUG
+    // In debug builds, verify that all the textures in the sampler group are still alive.
+    // These bugs lead to memory corruption and can be difficult to track down.
+    auto const* const samplers = (SamplerDescriptor const*) data.buffer;
+    for (size_t s = 0; s < data.size / sizeof(SamplerDescriptor); s++) {
+        if (!samplers[s].t) {
+            continue;
+        }
+        auto iter = mContext->aliveTextures.find(samplers[s].t.getId());
+        if (iter == mContext->aliveTextures.end()) {
+            utils::slog.e << "updateSamplerGroup: texture #"
+                          << (int) s << " is dead, texture handle = "
+                          << samplers[s].t << utils::io::endl;
+        }
+        assert_invariant(iter != mContext->aliveTextures.end());
+    }
+#endif
 
     // FIXME: we shouldn't be using SamplerGroup here, instead the backend should create
     //        a descriptor or any internal data-structure that represents the textures/samplers.


### PR DESCRIPTION
This adds a check that dead textures aren't referenced in the sampler group passed to `updateSamplerGroup`.

We also check that sampler groups aren't created or updated during a render pass, which will be a requirement to implement Metal argument buffers.