### PR TITLE
gltfio: do not clear out the texture slots too early.

### DIFF
--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -163,6 +163,7 @@ void FFilamentAsset::releaseSourceData() noexcept {
     // calling clear(). With many container types, clearing is a fast operation that merely frees
     // the storage for the items but not the actual container.
     mTextureBindings = {};
+    mTextureSlots = {};
     mMeshCache = {};
     mResourceUris = {};
     mSourceAsset.reset();

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -680,7 +680,6 @@ void ResourceLoader::Impl::createTextures(FFilamentAsset* asset, bool async) {
             asset->bindTexture(slot, texture);
         }
     }
-    asset->mTextureSlots = {};
 
     // Non-threaded systems are required to use the asynchronous API.
     assert_invariant(UTILS_HAS_THREADING || async);


### PR DESCRIPTION
This broke asyncGetLoadProgress() and caused WebGL to crash reliably because ResourceLoader got destroyed too soon.

Bug was introduced with de7dfc2ea6dce02f9c8d8002d04df72f39fb8e0d.

I intend to cherry pick this to rc/1.27.0, which is where it was introduced, so there's no need to update the release notes.