### PR TITLE
gltfio MaterialProvider: add new method for getting `Material`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - Java: add methods for TransformManager.getChildCount(), TransformManager.getChildren() and Scene.hasEntity()
 - engine: Fix stencil buffer writes with OpenGL backend.
+- gltfio: add new virtual method to MaterialProvider that all plugins must implement
 
 ## v1.27.0
 

--- a/android/gltfio-android/src/main/cpp/AssetLoader.cpp
+++ b/android/gltfio-android/src/main/cpp/AssetLoader.cpp
@@ -42,6 +42,7 @@ class JavaMaterialProvider : public MaterialProvider {
 
     jmethodID mMaterialKeyConstructor;
     jmethodID mCreateMaterialInstance;
+    jmethodID mGetMaterial;
     jmethodID mGetMaterials;
     jmethodID mNeedsDummyData;
     jmethodID mDestroyMaterials;
@@ -71,6 +72,10 @@ public:
         mCreateMaterialInstance = env->GetMethodID(providerClass, "createMaterialInstance",
                 "(L" JAVA_MATERIAL_KEY ";[ILjava/lang/String;Ljava/lang/String;)Lcom/google/android/filament/MaterialInstance;");
         assert_invariant(mCreateMaterialInstance);
+
+        mGetMaterial = env->GetMethodID(providerClass, "getMaterial",
+                "(L" JAVA_MATERIAL_KEY ";[ILjava/lang/String;)Lcom/google/android/filament/Material;");
+        assert_invariant(mGetMaterial);
 
         mGetMaterials = env->GetMethodID(providerClass, "getMaterials",
                 "()[Lcom/google/android/filament/Material;");
@@ -103,7 +108,7 @@ public:
         jstring stringExtras = extras ? mEnv->NewStringUTF(extras) : nullptr;
 
         // Allocate space for the output argument.
-        jintArray uvMapArray = mEnv->NewIntArray(8);
+        jintArray uvMapArray = mEnv->NewIntArray(uvmap->size());
 
         // Call the Java-based material provider.
         jobject materialInstance = mEnv->CallObjectMethod(mJavaProvider, mCreateMaterialInstance,
@@ -137,6 +142,49 @@ public:
         }
 
         return (MaterialInstance*) mEnv->CallLongMethod(materialInstance, mMaterialInstanceGetNativeObject);
+    }
+
+    Material* getMaterial(MaterialKey* config, UvMap* uvmap, const char* label) override {
+        // Create a Java object for the material key and copy the native fields into it.
+        jobject javaKey = mEnv->NewObject(mMaterialKeyClass, mMaterialKeyConstructor);
+
+        auto& helper = MaterialKeyHelper::get();
+        helper.copy(mEnv, javaKey, *config);
+
+        // Convert the optional label into a Java string.
+        jstring stringLabel = label ? mEnv->NewStringUTF(label) : nullptr;
+
+        // Allocate space for the output argument.
+        jintArray uvMapArray = mEnv->NewIntArray(uvmap->size());
+
+        // Call the Java-based material provider.
+        jobject material = mEnv->CallObjectMethod(mJavaProvider, mGetMaterial,
+                javaKey, uvMapArray, stringLabel);
+
+        // Copy the UvMap results from the JVM array into the native array.
+        if (uvmap) {
+            jint* elements = mEnv->GetIntArrayElements(uvMapArray, nullptr);
+            for (size_t i = 0; i < uvmap->size(); i++) {
+                (*uvmap)[i] = (UvSet) elements[i];
+            }
+            mEnv->ReleaseIntArrayElements(uvMapArray, elements, JNI_ABORT);
+        }
+
+        // The config parameter is an in-out parameter so we need to copy the results from Java.
+        helper.copy(mEnv, *config, javaKey);
+
+        mEnv->DeleteLocalRef(javaKey);
+        mEnv->DeleteLocalRef(uvMapArray);
+
+        if (stringLabel) {
+            mEnv->DeleteLocalRef(stringLabel);
+        }
+
+        if (material == nullptr) {
+            return nullptr;
+        }
+
+        return (Material*) mEnv->CallLongMethod(material, mMaterialGetNativeObject);
     }
 
     const Material* const* getMaterials() const noexcept override {

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/MaterialProvider.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/MaterialProvider.java
@@ -109,6 +109,12 @@ public interface MaterialProvider {
             @NonNull @Size(min = 8) int[] uvmap, @Nullable String label, @Nullable String extras);
 
     /**
+     * Creates or fetches a compiled Filament material corresponding to the given config.
+     */
+    public @Nullable Material getMaterial(MaterialKey config, @NonNull @Size(min = 8) int[] uvmap,
+            @Nullable String label);
+
+    /**
      * Creates and returns an array containing all cached materials.
      */
     public @NonNull Material[] getMaterials();

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
@@ -57,8 +57,14 @@ public class UbershaderProvider implements MaterialProvider {
 
     public @Nullable MaterialInstance createMaterialInstance(MaterialKey config,
             @NonNull @Size(min = 8) int[] uvmap, @Nullable String label, @Nullable String extras) {
-        long nativeMaterialInstance = nCreateMaterialInstance(mNativeObject, config, uvmap, label);
+        long nativeMaterialInstance = nCreateMaterialInstance(mNativeObject, config, uvmap, label, extras);
         return nativeMaterialInstance == 0 ? null : new MaterialInstance(null, nativeMaterialInstance);
+    }
+
+    public @Nullable Material getMaterial(MaterialKey config, @NonNull @Size(min = 8) int[] uvmap,
+            @Nullable String label) {
+        long nativeMaterial = nGetMaterial(mNativeObject, config, uvmap, label);
+        return nativeMaterial == 0 ? null : new Material(nativeMaterial);
     }
 
     public @NonNull Material[] getMaterials() {
@@ -96,6 +102,8 @@ public class UbershaderProvider implements MaterialProvider {
     private static native void nDestroyUbershaderProvider(long nativeProvider);
     private static native void nDestroyMaterials(long nativeProvider);
     private static native long nCreateMaterialInstance(long nativeProvider,
+            MaterialKey config, int[] uvmap, String label, String extras);
+    private static native long nGetMaterial(long nativeProvider,
             MaterialKey config, int[] uvmap, String label);
     private static native int nGetMaterialCount(long nativeProvider);
     private static native void nGetMaterials(long nativeProvider, long[] result);

--- a/libs/gltfio/include/gltfio/MaterialProvider.h
+++ b/libs/gltfio/include/gltfio/MaterialProvider.h
@@ -141,15 +141,22 @@ public:
      * @param uvmap Output argument that gets populated with a small table that maps from a glTF uv
      *              index to a Filament uv index.
      * @param label Optional tag that is not a part of the cache key.
-     * @param extras Optional extras as stringified JSON (not a part of the cache key). Don't store the pointer.
+     * @param extras Optional extras as stringified JSON (not a part of the cache key).
+     *               Does not store the pointer.
      */
-    virtual filament::MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+    virtual MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label = "material", const char* extras = nullptr) = 0;
+
+    /**
+     * Creates or fetches a compiled Filament material corresponding to the given config.
+     */
+    virtual Material* getMaterial(MaterialKey* config, UvMap* uvmap,
+            const char* label = "material") { return nullptr; }
 
     /**
      * Gets a weak reference to the array of cached materials.
      */
-    virtual const filament::Material* const* getMaterials() const noexcept = 0;
+    virtual const Material* const* getMaterials() const noexcept = 0;
 
     /**
      * Gets the number of cached materials.
@@ -170,7 +177,7 @@ public:
      * Some types of providers (e.g. ubershader) require dummy attribute values
      * if the glTF model does not provide them.
      */
-    virtual bool needsDummyData(filament::VertexAttribute attrib) const noexcept = 0;
+    virtual bool needsDummyData(VertexAttribute attrib) const noexcept = 0;
 };
 
 void constrainMaterial(MaterialKey* key, UvMap* uvmap);
@@ -189,7 +196,7 @@ void processShaderString(std::string* shader, const UvMap& uvmap,
  * @see createUbershaderProvider
  */
 UTILS_PUBLIC
-MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimizeShaders = false);
+MaterialProvider* createJitShaderProvider(Engine* engine, bool optimizeShaders = false);
 
 /**
  * Creates a material provider that loads a small set of pre-built materials.
@@ -199,7 +206,7 @@ MaterialProvider* createJitShaderProvider(filament::Engine* engine, bool optimiz
  * @see createJitShaderProvider
  */
 UTILS_PUBLIC
-MaterialProvider* createUbershaderProvider(filament::Engine* engine, const void* archive,
+MaterialProvider* createUbershaderProvider(Engine* engine, const void* archive,
         size_t archiveByteCount);
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/JitShaderProvider.cpp
+++ b/libs/gltfio/src/JitShaderProvider.cpp
@@ -39,6 +39,8 @@ public:
     MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label, const char* extras) override;
 
+    Material* getMaterial(MaterialKey* config, UvMap* uvmap, const char* label) override;
+
     size_t getMaterialsCount() const noexcept override;
     const Material* const* getMaterials() const noexcept override;
     void destroyMaterials() override;
@@ -536,8 +538,7 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
     return Material::Builder().package(pkg.getData(), pkg.getSize()).build(*engine);
 }
 
-MaterialInstance* JitShaderProvider::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
-        const char* label, const char* extras) {
+Material* JitShaderProvider::getMaterial(MaterialKey* config, UvMap* uvmap, const char* label) {
     constrainMaterial(config, uvmap);
     auto iter = mCache.find(*config);
     if (iter == mCache.end()) {
@@ -550,9 +551,14 @@ MaterialInstance* JitShaderProvider::createMaterialInstance(MaterialKey* config,
         Material* mat = createMaterial(mEngine, *config, *uvmap, label, optimizeShaders);
         mCache.emplace(std::make_pair(*config, mat));
         mMaterials.push_back(mat);
-        return mat->createInstance(label);
+        return mat;
     }
-    return iter->second->createInstance(label);
+    return iter.value();
+}
+
+MaterialInstance* JitShaderProvider::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
+        const char* label, const char* extras) {
+    return getMaterial(config, uvmap, label)->createInstance(label);
 }
 
 } // anonymous namespace

--- a/libs/gltfio/src/UbershaderProvider.cpp
+++ b/libs/gltfio/src/UbershaderProvider.cpp
@@ -38,7 +38,30 @@ io::ostream& operator<<(io::ostream& out, const ArchiveRequirements& reqs);
 
 namespace {
 
-using CullingMode = MaterialInstance::CullingMode;
+static void prepareConfig(MaterialKey* config, const char* label) {
+    if (config->hasVolume && config->hasSheen) {
+        slog.w << "Volume and sheen are not supported together in ubershader mode,"
+                  " removing sheen (" << label << ")." << io::endl;
+        config->hasSheen = false;
+    }
+
+    if (config->hasTransmission && config->hasSheen) {
+        slog.w << "Transmission and sheen are not supported together in ubershader mode,"
+                  " removing sheen (" << label << ")." << io::endl;
+        config->hasSheen = false;
+    }
+
+    const bool clearCoatConflict = config->hasVolume || config->hasTransmission || config->hasSheen;
+
+    // Due to sampler overload, disable transmission if necessary and print a friendly warning.
+    if (config->hasClearCoat && clearCoatConflict) {
+        slog.w << "Volume, transmission and sheen are not supported in ubershader mode for clearcoat"
+                  " materials (" << label << ")." << io::endl;
+        config->hasVolume = false;
+        config->hasTransmission = false;
+        config->hasSheen = false;
+    }
+}
 
 class UbershaderProvider : public MaterialProvider {
 public:
@@ -47,6 +70,8 @@ public:
 
     MaterialInstance* createMaterialInstance(MaterialKey* config, UvMap* uvmap,
             const char* label, const char* extras) override;
+
+    Material* getMaterial(MaterialKey* config, UvMap* uvmap, const char* label) override;
 
     size_t getMaterialsCount() const noexcept override;
     const Material* const* getMaterials() const noexcept override;
@@ -140,6 +165,20 @@ Material* UbershaderProvider::getMaterial(const MaterialKey& config) const {
     return nullptr;
 }
 
+Material* UbershaderProvider::getMaterial(MaterialKey* config, UvMap* uvmap, const char* label) {
+    prepareConfig(config, label);
+    constrainMaterial(config, uvmap);
+    Material* material = getMaterial(*config);
+    if (material == nullptr) {
+#ifndef NDEBUG
+        slog.w << "Using fallback material for " << label << "." << io::endl;
+#endif
+        material = mMaterials.getDefaultMaterial();
+    }
+    return material;
+}
+
+
 MaterialInstance* UbershaderProvider::createMaterialInstance(MaterialKey* config, UvMap* uvmap,
         const char* label, const char* extras) {
     // Diagnostics are not supported with LOAD_UBERSHADERS, please use GENERATE_SHADERS instead.
@@ -147,41 +186,11 @@ MaterialInstance* UbershaderProvider::createMaterialInstance(MaterialKey* config
         return nullptr;
     }
 
-    if (config->hasVolume && config->hasSheen) {
-        slog.w << "Volume and sheen are not supported together in ubershader mode,"
-                  " removing sheen (" << label << ")." << io::endl;
-        config->hasSheen = false;
-    }
+    Material* material = getMaterial(config, uvmap, label);
 
-    if (config->hasTransmission && config->hasSheen) {
-        slog.w << "Transmission and sheen are not supported together in ubershader mode,"
-                  " removing sheen (" << label << ")." << io::endl;
-        config->hasSheen = false;
-    }
-
-    const bool clearCoatConflict = config->hasVolume || config->hasTransmission || config->hasSheen;
-
-    // Due to sampler overload, disable transmission if necessary and print a friendly warning.
-    if (config->hasClearCoat && clearCoatConflict) {
-        slog.w << "Volume, transmission and sheen are not supported in ubershader mode for clearcoat"
-                  " materials (" << label << ")." << io::endl;
-        config->hasVolume = false;
-        config->hasTransmission = false;
-        config->hasSheen = false;
-    }
-
-    constrainMaterial(config, uvmap);
     auto getUvIndex = [uvmap](uint8_t srcIndex, bool hasTexture) -> int {
         return hasTexture ? int(uvmap->at(srcIndex)) - 1 : -1;
     };
-    Material* material = getMaterial(*config);
-
-    if (material == nullptr) {
-#ifndef NDEBUG
-        slog.w << "Using fallback material for " << label << "." << io::endl;
-#endif
-        material = mMaterials.getDefaultMaterial();
-    }
 
     MaterialInstance* mi = material->createInstance(label);
     mi->setParameter("baseColorIndex",
@@ -193,7 +202,11 @@ MaterialInstance* UbershaderProvider::createMaterialInstance(MaterialKey* config
     mi->setParameter("emissiveIndex", getUvIndex(config->emissiveUV, config->hasEmissiveTexture));
 
     mi->setDoubleSided(config->doubleSided);
-    mi->setCullingMode(config->doubleSided ? CullingMode::NONE : CullingMode::BACK);
+
+    mi->setCullingMode(config->doubleSided ?
+            MaterialInstance::CullingMode::NONE :
+            MaterialInstance::CullingMode::BACK);
+
     mi->setTransparencyMode(config->doubleSided ?
             MaterialInstance::TransparencyMode::TWO_PASSES_TWO_SIDES :
             MaterialInstance::TransparencyMode::DEFAULT);


### PR DESCRIPTION
gltfio can now ask the material provider plugin which `Material` would be used for a given set of requirements.  Prior to this change, gltfio could only create a new `MaterialInstance`.

This method is necessary to support an upcoming gltfio feature.