### PR TITLE
gltfio: big simplification for textures + add sRGB related assert.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - Java: add methods for TransformManager.getChildCount(), TransformManager.getChildren() and Scene.hasEntity()
 - engine: Fix stencil buffer writes with OpenGL backend.
 - gltfio: add new virtual method to MaterialProvider that all plugins must implement
+- gltfio: add an assert for inconsistent sRGB flags among usages of a particular texture
 
 ## v1.27.0
 

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -230,8 +230,6 @@ private:
     void createCamera(const cgltf_camera* camera, Entity entity);
     MaterialInstance* createMaterialInstance(const cgltf_data* srcAsset,
             const cgltf_material* inputMat, UvMap* uvmap, bool vertexColor);
-    void addTextureBinding(MaterialInstance* materialInstance, const char* parameterName,
-            const cgltf_texture* srcTexture, bool srgb);
     void createMaterialVariants(const cgltf_data* srcAsset, const cgltf_mesh* mesh, Entity entity,
             FFilamentInstance* instance);
 
@@ -1226,7 +1224,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasBaseColorTexture) {
-        addTextureBinding(mi, "baseColorMap", baseColorTexture.texture, true);
+        mResult->addTextureBinding(mi, "baseColorMap", baseColorTexture.texture, true);
         if (matkey.hasTextureTransforms) {
             const cgltf_texture_transform& uvt = baseColorTexture.transform;
             auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1240,7 +1238,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
         // specularGlossinessTexture are both sRGB, whereas the core glTF spec stipulates that
         // metallicRoughness is not sRGB.
         bool srgb = inputMat->has_pbr_specular_glossiness;
-        addTextureBinding(mi, "metallicRoughnessMap", metallicRoughnessTexture.texture, srgb);
+        mResult->addTextureBinding(mi, "metallicRoughnessMap", metallicRoughnessTexture.texture, srgb);
         if (matkey.hasTextureTransforms) {
             const cgltf_texture_transform& uvt = metallicRoughnessTexture.transform;
             auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1249,7 +1247,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasNormalTexture) {
-        addTextureBinding(mi, "normalMap", inputMat->normal_texture.texture, false);
+        mResult->addTextureBinding(mi, "normalMap", inputMat->normal_texture.texture, false);
         if (matkey.hasTextureTransforms) {
             const cgltf_texture_transform& uvt = inputMat->normal_texture.transform;
             auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1261,7 +1259,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasOcclusionTexture) {
-        addTextureBinding(mi, "occlusionMap", inputMat->occlusion_texture.texture, false);
+        mResult->addTextureBinding(mi, "occlusionMap", inputMat->occlusion_texture.texture, false);
         if (matkey.hasTextureTransforms) {
             const cgltf_texture_transform& uvt = inputMat->occlusion_texture.transform;
             auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1273,7 +1271,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasEmissiveTexture) {
-        addTextureBinding(mi, "emissiveMap", inputMat->emissive_texture.texture, true);
+        mResult->addTextureBinding(mi, "emissiveMap", inputMat->emissive_texture.texture, true);
         if (matkey.hasTextureTransforms) {
             const cgltf_texture_transform& uvt = inputMat->emissive_texture.transform;
             auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1286,7 +1284,8 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
         mi->setParameter("clearCoatRoughnessFactor", ccConfig.clearcoat_roughness_factor);
 
         if (matkey.hasClearCoatTexture) {
-            addTextureBinding(mi, "clearCoatMap", ccConfig.clearcoat_texture.texture, false);
+            mResult->addTextureBinding(mi, "clearCoatMap", ccConfig.clearcoat_texture.texture,
+                    false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = ccConfig.clearcoat_texture.transform;
                 auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1294,7 +1293,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
             }
         }
         if (matkey.hasClearCoatRoughnessTexture) {
-            addTextureBinding(mi, "clearCoatRoughnessMap",
+            mResult->addTextureBinding(mi, "clearCoatRoughnessMap",
                     ccConfig.clearcoat_roughness_texture.texture, false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = ccConfig.clearcoat_roughness_texture.transform;
@@ -1303,7 +1302,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
             }
         }
         if (matkey.hasClearCoatNormalTexture) {
-            addTextureBinding(mi, "clearCoatNormalMap",
+            mResult->addTextureBinding(mi, "clearCoatNormalMap",
                     ccConfig.clearcoat_normal_texture.texture, false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = ccConfig.clearcoat_normal_texture.transform;
@@ -1320,7 +1319,8 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
         mi->setParameter("sheenRoughnessFactor", shConfig.sheen_roughness_factor);
 
         if (matkey.hasSheenColorTexture) {
-            addTextureBinding(mi, "sheenColorMap", shConfig.sheen_color_texture.texture, true);
+            mResult->addTextureBinding(mi, "sheenColorMap", shConfig.sheen_color_texture.texture,
+                    true);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = shConfig.sheen_color_texture.transform;
                 auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1328,7 +1328,7 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
             }
         }
         if (matkey.hasSheenRoughnessTexture) {
-            addTextureBinding(mi, "sheenRoughnessMap",
+            mResult->addTextureBinding(mi, "sheenRoughnessMap",
                     shConfig.sheen_roughness_texture.texture, false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = shConfig.sheen_roughness_texture.transform;
@@ -1349,7 +1349,8 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
         mi->setParameter("volumeAbsorption", RgbType::LINEAR, absorption);
 
         if (matkey.hasVolumeThicknessTexture) {
-            addTextureBinding(mi, "volumeThicknessMap", vlConfig.thickness_texture.texture, false);
+            mResult->addTextureBinding(mi, "volumeThicknessMap", vlConfig.thickness_texture.texture,
+                    false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = vlConfig.thickness_texture.transform;
                 auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1361,7 +1362,8 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     if (matkey.hasTransmission) {
         mi->setParameter("transmissionFactor", trConfig.transmission_factor);
         if (matkey.hasTransmissionTexture) {
-            addTextureBinding(mi, "transmissionMap", trConfig.transmission_texture.texture, false);
+            mResult->addTextureBinding(mi, "transmissionMap", trConfig.transmission_texture.texture,
+                    false);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = trConfig.transmission_texture.transform;
                 auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);
@@ -1391,45 +1393,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
 
     *cacheEntry = { mi, *uvmap };
     return mi;
-}
-
-void FAssetLoader::addTextureBinding(MaterialInstance* materialInstance, const char* parameterName,
-        const cgltf_texture* srcTexture, bool srgb) {
-    if (!srcTexture->image && !srcTexture->basisu_image) {
-#ifndef NDEBUG
-        slog.w << "Texture is missing image (" << srcTexture->name << ")." << io::endl;
-#endif
-        return;
-    }
-
-    TextureSampler dstSampler;
-    auto srcSampler = srcTexture->sampler;
-    if (srcSampler) {
-        dstSampler.setWrapModeS(getWrapMode(srcSampler->wrap_s));
-        dstSampler.setWrapModeT(getWrapMode(srcSampler->wrap_t));
-        dstSampler.setMagFilter(getMagFilter(srcSampler->mag_filter));
-        dstSampler.setMinFilter(getMinFilter(srcSampler->min_filter));
-    } else {
-        // These defaults are stipulated by the spec:
-        dstSampler.setWrapModeS(TextureSampler::WrapMode::REPEAT);
-        dstSampler.setWrapModeT(TextureSampler::WrapMode::REPEAT);
-
-        // These defaults are up to the implementation but since we try to provide mipmaps,
-        // we might as well use them. In practice the conformance models look awful without
-        // using mipmapping by default.
-        dstSampler.setMagFilter(TextureSampler::MagFilter::LINEAR);
-        dstSampler.setMinFilter(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR);
-    }
-
-    const intptr_t textureIndex = srcTexture - mResult->mSourceAsset->hierarchy->textures;
-
-    mResult->addTextureSlot({
-        .sourceTexture = (size_t) textureIndex,
-        .materialInstance = materialInstance,
-        .materialParameter = parameterName,
-        .sampler = dstSampler,
-        .srgb = srgb
-    });
 }
 
 void FAssetLoader::importSkins(FFilamentAsset* primary,

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -25,6 +25,7 @@
 #include <utils/Log.h>
 #include <utils/NameComponentManager.h>
 
+#include "GltfEnums.h"
 #include "Wireframe.h"
 
 using namespace filament;
@@ -83,7 +84,7 @@ FFilamentAsset::~FFilamentAsset() {
         mEngine->destroy(ib);
     }
     for (auto tx : mTextures) {
-        mEngine->destroy(tx);
+        mEngine->destroy(tx.texture);
     }
     for (auto tb : mMorphTargetBuffers) {
         mEngine->destroy(tb);
@@ -95,6 +96,59 @@ const char* FFilamentAsset::getExtras(utils::Entity entity) const noexcept {
         return mAssetExtras.c_str();
     }
     return mNodeManager->getExtras(mNodeManager->getInstance(entity)).c_str();
+}
+
+void FFilamentAsset::addTextureBinding(MaterialInstance* materialInstance,
+        const char* parameterName, const cgltf_texture* srcTexture, bool srgb) {
+    if (!srcTexture->image && !srcTexture->basisu_image) {
+#ifndef NDEBUG
+        slog.w << "Texture is missing image (" << srcTexture->name << ")." << io::endl;
+#endif
+        return;
+    }
+
+    const size_t textureIndex = (size_t) (srcTexture - mSourceAsset->hierarchy->textures);
+    TextureInfo& info = mTextures[textureIndex];
+
+    // All bindings for a particular glTF texture must have the same transform function.
+    assert_invariant(info.bindings.size() == 0 || info.srgb == srgb);
+    info.srgb = srgb;
+
+    const TextureSlot slot = { materialInstance, parameterName };
+    if (info.texture) {
+        applyTextureBinding(textureIndex, slot, false);
+    } else {
+        mDependencyGraph.addEdge(materialInstance, parameterName);
+        info.bindings.push_back(slot);
+    }
+}
+
+void FFilamentAsset::applyTextureBinding(size_t textureIndex, const TextureSlot& tb,
+        bool addDependency) {
+    const TextureInfo& info = mTextures[textureIndex];
+    assert_invariant(info.texture);
+    const cgltf_sampler* srcSampler = mSourceAsset->hierarchy->textures[textureIndex].sampler;
+    TextureSampler sampler;
+    if (srcSampler) {
+        sampler.setWrapModeS(getWrapMode(srcSampler->wrap_s));
+        sampler.setWrapModeT(getWrapMode(srcSampler->wrap_t));
+        sampler.setMagFilter(getMagFilter(srcSampler->mag_filter));
+        sampler.setMinFilter(getMinFilter(srcSampler->min_filter));
+    } else {
+        // These defaults are stipulated by the spec:
+        sampler.setWrapModeS(TextureSampler::WrapMode::REPEAT);
+        sampler.setWrapModeT(TextureSampler::WrapMode::REPEAT);
+
+        // These defaults are up to the implementation but since we try to provide mipmaps,
+        // we might as well use them. In practice the conformance models look awful without
+        // using mipmapping by default.
+        sampler.setMagFilter(TextureSampler::MagFilter::LINEAR);
+        sampler.setMinFilter(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR);
+    }
+    tb.materialInstance->setParameter(tb.materialParameter, info.texture, sampler);
+    if (addDependency) {
+        mDependencyGraph.addEdge(info.texture, tb.materialInstance, tb.materialParameter);
+    }
 }
 
 void FFilamentAsset::createAnimators() {
@@ -162,8 +216,9 @@ void FFilamentAsset::releaseSourceData() noexcept {
     // To ensure that all possible memory is freed, we reassign to new containers rather than
     // calling clear(). With many container types, clearing is a fast operation that merely frees
     // the storage for the items but not the actual container.
-    mTextureBindings = {};
-    mTextureSlots = {};
+    for (auto& info : mTextures) {
+        info.bindings = {};
+    }
     mMeshCache = {};
     mResourceUris = {};
     mSourceAsset.reset();


### PR DESCRIPTION
`FilamentAsset` previously had three confusing fields related to textures: mTextures, mTextureSlots, and mTextureBindings.

These are now consolidated into a single field, which simply has one top level array item per `cgltf_texture`.

The memory footprint is smaller because we no longer bother to store `TextureSampler` objects, instead we simply defer their construction until calling setParameter.

Last but not least, we now assert in debug builds if the usages of a particular texture have inconsistent sRGB flags. In the past, inconsistent sRGB would be silently ignored.

In other words, we will now assert if you try to use the same texture for `baseColor` and `normalMap`, whereas in the past we would exhibit non-deterministic behavior in this situation (with respect to sRGB semantics).