### PR TITLE
scissor improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,8 @@ A new header is inserted each time a *tag* is created.
 - engine: Fix stencil buffer writes with OpenGL backend.
 - gltfio: add new virtual method to MaterialProvider that all plugins must implement
 - gltfio: add an assert for inconsistent sRGB flags among usages of a particular texture
+- engine: improve scissor documentation
+- backend: scissor is no longer clipped to the viewport (done on filament side)
 
 ## v1.27.0
 

--- a/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/MaterialInstance.java
@@ -402,19 +402,40 @@ public class MaterialInstance {
     }
 
     /**
-     * Set up a custom scissor rectangle; by default this encompasses the View.
+     * Set-up a custom scissor rectangle; by default it is disabled.
      *
-     * @param left      left coordinate of the scissor box
-     * @param bottom    bottom coordinate of the scissor box
+     * <p>
+     * The scissor rectangle gets clipped by the View's viewport, in other words, the scissor
+     * cannot affect fragments outside of the View's Viewport.
+     * </p>
+     *
+     * <p>
+     * Currently the scissor is not compatible with dynamic resolution and should always be
+     * disabled when dynamic resolution is used.
+     * </p>
+     *
+     * @param left      left coordinate of the scissor box relative to the viewport
+     * @param bottom    bottom coordinate of the scissor box relative to the viewport
      * @param width     width of the scissor box
      * @param height    height of the scissor box
+     *
+     * @see #unsetScissor
+     * @see View#setViewport
+     * @see View#setDynamicResolutionOptions
      */
     public void setScissor(@IntRange(from = 0) int left, @IntRange(from = 0) int bottom,
             @IntRange(from = 0) int width, @IntRange(from = 0) int height) {
         nSetScissor(getNativeObject(), left, bottom, width, height);
     }
 
-    /** Returns the scissor rectangle to its default setting, which encompasses the View. */
+    /**
+     * Returns the scissor rectangle to its default disabled setting.
+     * <p>
+     * Currently the scissor is not compatible with dynamic resolution and should always be
+     * disabled when dynamic resolution is used.
+     * </p>
+     * @see View#setDynamicResolutionOptions
+     */
     public void unsetScissor() {
         nUnsetScissor(getNativeObject());
     }

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1321,18 +1321,12 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
     // Set scissor-rectangle.
     // In order to do this, we compute the intersection between:
     //  1. the scissor rectangle
-    //  2. the current viewport
-    //  3. the render target attachment dimensions (important, as the scissor can't be set larger)
+    //  2. the render target attachment dimensions (important, as the scissor can't be set larger)
     // fmax/min are used below to guard against NaN and because the MTLViewport/MTLRegion
     // coordinates are doubles.
     MTLRegion scissor = mContext->currentRenderTarget->getRegionFromClientRect(ps.scissor);
     const float sleft = scissor.origin.x, sright = scissor.origin.x + scissor.size.width;
     const float stop = scissor.origin.y, sbottom = scissor.origin.y + scissor.size.height;
-
-    // Viewport extent
-    const MTLViewport& viewport = mContext->currentViewport;
-    const float vleft = viewport.originX, vright = viewport.originX + viewport.width;
-    const float vtop = viewport.originY, vbottom = viewport.originY + viewport.height;
 
     // Attachment extent
     const auto attachmentSize = mContext->currentRenderTarget->getAttachmentSize();
@@ -1340,10 +1334,10 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
     const float aright = static_cast<float>(attachmentSize.x);
     const float abottom = static_cast<float>(attachmentSize.y);
 
-    const auto left   = std::fmax(std::fmax(sleft, vleft), aleft);
-    const auto right  = std::fmin(std::fmin(sright, vright), aright);
-    const auto top    = std::fmax(std::fmax(stop, vtop), atop);
-    const auto bottom = std::fmin(std::fmin(sbottom, vbottom), abottom);
+    const auto left   = std::fmax(sleft, aleft);
+    const auto right  = std::fmin(sright, aright);
+    const auto top    = std::fmax(stop, atop);
+    const auto bottom = std::fmin(sbottom, abottom);
 
     MTLScissorRect scissorRect = {
         .x      = static_cast<NSUInteger>(left),

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -341,7 +341,7 @@ private:
     void clearWithRasterPipe(TargetBufferFlags clearFlags,
             math::float4 const& linearColor, GLfloat depth, GLint stencil) noexcept;
 
-    void setViewportScissor(Viewport const& viewportScissor) noexcept;
+    void setScissor(Viewport const& scissor) noexcept;
 
     // sampler buffer binding points (nullptr if not used)
     std::array<GLSamplerGroup*, Program::SAMPLER_BINDING_COUNT> mSamplerBindings = {};   // 4 pointers

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -222,19 +222,33 @@ public:
         setParameter(name, strlen(name), type, color);
     }
 
-
     /**
-     * Set up a custom scissor rectangle; by default this encompasses the View.
+     * Set-up a custom scissor rectangle; by default it is disabled.
      *
-     * @param left      left coordinate of the scissor box
-     * @param bottom    bottom coordinate of the scissor box
+     * The scissor rectangle gets clipped by the View's viewport, in other words, the scissor
+     * cannot affect fragments outside of the View's Viewport.
+     *
+     * Currently the scissor is not compatible with dynamic resolution and should always be
+     * disabled when dynamic resolution is used.
+     *
+     * @param left      left coordinate of the scissor box relative to the viewport
+     * @param bottom    bottom coordinate of the scissor box relative to the viewport
      * @param width     width of the scissor box
      * @param height    height of the scissor box
+     *
+     * @see unsetScissor
+     * @see View::setViewport
+     * @see View::setDynamicResolutionOptions
      */
     void setScissor(uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) noexcept;
 
     /**
-     * Returns the scissor rectangle to its default setting, which encompasses the View.
+     * Returns the scissor rectangle to its default disabled setting.
+     *
+     * Currently the scissor is not compatible with dynamic resolution and should always be
+     * disabled when dynamic resolution is used.
+     *
+     * @see View::setDynamicResolutionOptions
      */
     void unsetScissor() noexcept;
 

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -196,16 +196,18 @@ void MaterialInstance::setParameter(const char* name, size_t nameLength, Texture
     return upcast(this)->setParameterImpl({ name, nameLength }, upcast(texture), sampler);
 }
 
-void MaterialInstance::setParameter(const char* name, size_t nameLength, RgbType type, float3 color) {
+void MaterialInstance::setParameter(
+        const char* name, size_t nameLength, RgbType type, float3 color) {
     upcast(this)->setParameterImpl<float3>({ name, nameLength }, Color::toLinear(type, color));
 }
 
-void MaterialInstance::setParameter(const char* name, size_t nameLength, RgbaType type, float4 color) {
+void MaterialInstance::setParameter(
+        const char* name, size_t nameLength, RgbaType type, float4 color) {
     upcast(this)->setParameterImpl<float4>({ name, nameLength }, Color::toLinear(type, color));
 }
 
-void MaterialInstance::setScissor(uint32_t left, uint32_t bottom, uint32_t width,
-        uint32_t height) noexcept {
+void MaterialInstance::setScissor(
+        uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) noexcept {
     upcast(this)->setScissor(left, bottom, width, height);
 }
 

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -279,6 +279,9 @@ public:
     // if non-null, overrides the material's polygon offset
     void overridePolygonOffset(backend::PolygonOffset const* polygonOffset) noexcept;
 
+    // a box that both offsets the viewport and clips it
+    void setScissorViewport(backend::Viewport viewport) noexcept;
+
     // if non-null, overrides the material's scissor
     void overrideScissor(backend::Viewport const* scissor) noexcept;
 
@@ -336,6 +339,7 @@ public:
         const backend::Handle<backend::HwBufferObject> mInstancedUboHandle;
         const backend::PolygonOffset mPolygonOffset;
         const backend::Viewport mScissor;
+        const backend::Viewport mScissorViewport;
         const bool mPolygonOffsetOverride : 1;
         const bool mScissorOverride : 1;
 
@@ -447,6 +451,10 @@ private:
 
     // value of scissor override
     backend::Viewport mScissor{};
+
+    backend::Viewport mScissorViewport{ 0, 0,
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<int32_t>::max() };
 
     // a vector for our custom commands
     mutable Executor::CustomCommandVector mCustomCommands;

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -70,21 +70,22 @@ public:
     UniformBuffer const& getUniformBuffer() const noexcept { return mUniforms; }
     backend::SamplerGroup const& getSamplerGroup() const noexcept { return mSamplers; }
 
-    void setScissor(int32_t left, int32_t bottom, uint32_t width, uint32_t height) noexcept {
-        mScissorRect = { left, bottom,
-                std::min(width, (uint32_t)std::numeric_limits<int32_t>::max()),
-                std::min(height, (uint32_t)std::numeric_limits<int32_t>::max())
-        };
+    void setScissor(uint32_t left, uint32_t bottom, uint32_t width, uint32_t height) noexcept {
+        constexpr uint32_t maxvalu = std::numeric_limits<int32_t>::max();
+        mScissorRect = { int32_t(left), int32_t(bottom),
+                std::min(width, maxvalu), std::min(height, maxvalu) };
+        mHasScissor = true;
     }
 
     void unsetScissor() noexcept {
-        mScissorRect = { 0, 0,
-                (uint32_t)std::numeric_limits<int32_t>::max(),
-                (uint32_t)std::numeric_limits<int32_t>::max()
-        };
+        constexpr uint32_t maxvalu = std::numeric_limits<int32_t>::max();
+        mScissorRect = { 0, 0, maxvalu, maxvalu };
+        mHasScissor = false;
     }
 
     backend::Viewport const& getScissor() const noexcept { return mScissorRect; }
+
+    bool hasScissor() const noexcept { return mHasScissor; }
 
     backend::CullingMode getCullingMode() const noexcept { return mCulling; }
 
@@ -230,6 +231,7 @@ private:
     backend::CullingMode mCulling;
     bool mColorWrite;
     bool mDepthWrite;
+    bool mHasScissor = false;
     backend::StencilState mStencilState = {};
     backend::RasterState::DepthFunc mDepthFunc;
     TransparencyMode mTransparencyMode;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -904,6 +904,12 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 });
     }
 
+    // this makes the viewport relative to xvp
+    // FIXME: we should use 'vp' when rendering directly into the swapchain, but that's hard to
+    //        know at this point. This will usually be the case when post-process is disabled.
+    // FIXME: we probably should take the dynamic scaling into account too
+    pass.setScissorViewport(hasPostProcess ? xvp : vp);
+
     // the color pass itself + color-grading as subpass if needed
     auto colorPassOutput = RendererUtils::colorPass(fg, "Color Pass", mEngine, view,
             desc, config, colorGradingConfigForColor, pass.getExecutor());


### PR DESCRIPTION
- improve scissor documentation, specify coordinate system and clipping behavior
- scissor now takes the guard bands into account
- on the backend side the scissor is no longer clipped to the viewport
- clipping to the viewport is now done on the filament side
- don't set scissor when material instance doesn't specify one (common case)