### PR TITLE
Add return case to fix G3 compiler error

### DIFF
--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -121,6 +121,7 @@ static LightManager::Type getLightType(const cgltf_light_type light) {
         case cgltf_light_type_max_enum:
         case cgltf_light_type_invalid:
             assert_invariant(false && "Invalid light type");
+            return LightManager::Type::DIRECTIONAL;
         case cgltf_light_type_directional:
             return LightManager::Type::DIRECTIONAL;
         case cgltf_light_type_point:


### PR DESCRIPTION
We need a return case here, otherwise the code implicitly falls-through in release builds which generates a compiler error in Google3.