### PR TITLE
gltfio: fix regression when textures are "shared"

### DIFF
--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -81,6 +81,9 @@ public:
     /**
      * Creates a Filament texture and pushes it to the asynchronous decoding queue.
      *
+     * The provider synchronously determines the texture dimensions in order to create a Filament
+     * texture object, then populates the miplevels asynchronously.
+     *
      * If construction fails, nothing is pushed to the queue and null is returned. The failure
      * reason can be obtained with getPushMessage(). The given buffer pointer is not held, so the
      * caller can free it immediately. It is also the caller's responsibility to free the returned

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -313,10 +313,14 @@ struct FFilamentAsset : public FilamentAsset {
     SourceHandle mSourceAsset;
 
     // Stores all information related to a single cgltf_texture.
+    // Note that more than one cgltf_texture can map to a single Filament texture,
+    // e.g. if several have the same URL or bufferView. For each Filament texture,
+    // only one of its corresponding TextureInfo slots will have isOwner=true.
     struct TextureInfo {
         std::vector<TextureSlot> bindings;
         Texture* texture;
         TextureProvider::TextureFlags flags;
+        bool isOwner;
     };
 
     // Mapping from cgltf_texture to Texture* is required when creating new instances.

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -84,7 +84,9 @@ FFilamentAsset::~FFilamentAsset() {
         mEngine->destroy(ib);
     }
     for (auto tx : mTextures) {
-        mEngine->destroy(tx.texture);
+        if (UTILS_LIKELY(tx.isOwner)) {
+            mEngine->destroy(tx.texture);
+        }
     }
     for (auto tb : mMorphTargetBuffers) {
         mEngine->destroy(tb);


### PR DESCRIPTION
Some (poorly authored) glTF assets have several `image` elements that all refer to the same URL or buffer view. When this occurs, we create only 1 Filament Texture.

These assets regressed after #6051, which consolidated the texture-related fields in `FilamentAsset`, but did not include an ownership flag in the new `TextureInfo` struct.