### PR TITLE
introduce "feature level 3" 

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -938,12 +938,13 @@ Type
 :    `number`
 
 Value
-:     An integer value, either 1 or 2. Defaults to 1.
+:     An integer value, either 1, 2 or 3. Defaults to 1.
 
       Feature Level    |        Guaranteed features
 :----------------------|:---------------------------------
 1                      | 9 textures per material
-2                      | 12 textures per material, cubemap arrays, ESSL 3.10
+2                      | 9 textures per material, cubemap arrays, ESSL 3.10
+3                      | 12 textures per material, cubemap arrays, ESSL 3.10
 [Table [featureLevels]: Feature levels]
 
 Description

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -48,7 +48,7 @@ static constexpr uint64_t SWAP_CHAIN_CONFIG_ENABLE_XCB          = 0x4;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER = 0x8;
 
 static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT  = 16;   // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_SAMPLER_COUNT           = 62;   // Maximum needed at feature level 2.
+static constexpr size_t MAX_SAMPLER_COUNT           = 62;   // Maximum needed at feature level 3.
 static constexpr size_t MAX_VERTEX_BUFFER_COUNT     = 16;   // Max number of bound buffer objects.
 
 // Per feature level caps
@@ -56,8 +56,9 @@ static constexpr size_t MAX_VERTEX_BUFFER_COUNT     = 16;   // Max number of bou
 static constexpr struct {
     const size_t MAX_VERTEX_SAMPLER_COUNT;
     const size_t MAX_FRAGMENT_SAMPLER_COUNT;
-} FEATURE_LEVEL_CAPS[3] = {
+} FEATURE_LEVEL_CAPS[4] = {
         {  0,  0 }, // do not use
+        { 16, 16 }, // guaranteed by OpenGL ES, Vulkan and Metal
         { 16, 16 }, // guaranteed by OpenGL ES, Vulkan and Metal
         { 31, 31 }, // guaranteed by Metal
 };
@@ -74,7 +75,8 @@ static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 4;   // This is guarantee
  */
 enum class FeatureLevel : uint8_t {
     FEATURE_LEVEL_1 = 1,  //!< OpenGL ES 3.0 features (default)
-    FEATURE_LEVEL_2       //!< OpenGL ES 3.1 features + 31 textures units + cubemap arrays
+    FEATURE_LEVEL_2,      //!< OpenGL ES 3.1 features + 16 textures units + cubemap arrays
+    FEATURE_LEVEL_3       //!< OpenGL ES 3.1 features + 31 textures units + cubemap arrays
 };
 
 /**

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -22,6 +22,8 @@
 
 #include <filament/SwapChain.h>
 
+#include <backend/DriverEnums.h>
+
 #include "private/backend/BackendUtils.h"
 
 #include <utils/Panic.h>

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -891,9 +891,13 @@ FeatureLevel VulkanDriver::getFeatureLevel() {
 
     const bool imageCubeArray = (bool)mContext.physicalDeviceFeatures.imageCubeArray;
 
-    return (supportedSamplerCount >= 31 && imageCubeArray) ?
-            FeatureLevel::FEATURE_LEVEL_2 :
-            FeatureLevel::FEATURE_LEVEL_1;
+    if (imageCubeArray) {
+        if (supportedSamplerCount >= 31) {
+            return FeatureLevel::FEATURE_LEVEL_3;
+        }
+        return FeatureLevel::FEATURE_LEVEL_2;
+    }
+    return FeatureLevel::FEATURE_LEVEL_1;
 }
 
 math::float2 VulkanDriver::getClipSpaceParams() {

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -117,18 +117,18 @@ struct VulkanRenderPrimitive : public HwRenderPrimitive {
 };
 
 struct VulkanFence : public HwFence {
-    VulkanFence(const VulkanCommandBuffer& commands) : fence(commands.fence) {}
+    explicit VulkanFence(const VulkanCommandBuffer& commands) : fence(commands.fence) {}
     std::shared_ptr<VulkanCmdFence> fence;
 };
 
 struct VulkanSync : public HwSync {
-    VulkanSync() {}
-    VulkanSync(const VulkanCommandBuffer& commands) : fence(commands.fence) {}
+    VulkanSync() = default;
+    explicit VulkanSync(const VulkanCommandBuffer& commands) : fence(commands.fence) {}
     std::shared_ptr<VulkanCmdFence> fence;
 };
 
 struct VulkanTimerQuery : public HwTimerQuery {
-    VulkanTimerQuery(VulkanContext& context);
+    explicit VulkanTimerQuery(VulkanContext& context);
     ~VulkanTimerQuery();
     uint32_t startingQueryIndex;
     uint32_t stoppingQueryIndex;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -135,12 +135,13 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
 
     uint8_t featureLevel = 1;
     parser->getFeatureLevel(&featureLevel);
-    assert_invariant(featureLevel <= 2);
+    assert_invariant(featureLevel <= 3);
     mFeatureLevel = [featureLevel]() -> FeatureLevel {
         switch (featureLevel) {
             default:
             case 1: return FeatureLevel::FEATURE_LEVEL_1;
             case 2: return FeatureLevel::FEATURE_LEVEL_2;
+            case 3: return FeatureLevel::FEATURE_LEVEL_3;
         }
     }();
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1058,11 +1058,12 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
 
     const auto userSamplerCount = info.sib.getSize();
     switch (info.featureLevel) {
-        case FeatureLevel::FEATURE_LEVEL_1: {
+        case FeatureLevel::FEATURE_LEVEL_1:
+        case FeatureLevel::FEATURE_LEVEL_2: {
             // TODO: we need constants somewhere for these values
             if (userSamplerCount > 9) {
                 slog.e << "Error: material \"" << mMaterialName.c_str()
-                       << "\" has feature level " << (int)info.featureLevel
+                       << "\" has feature level " << +info.featureLevel
                        << " and is using more than 9 samplers." << io::endl;
                 logSamplerOverflow(info.sib);
                 return false;
@@ -1074,18 +1075,18 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
                         return sampler.type == SamplerType::SAMPLER_CUBEMAP_ARRAY;
                     })) {
                 slog.e << "Error: material \"" << mMaterialName.c_str()
-                       << "\" has feature level " << (int)info.featureLevel
+                       << "\" has feature level " << +info.featureLevel
                        << " and uses a samplerCubemapArray." << io::endl;
                 logSamplerOverflow(info.sib);
                 return false;
             }
             break;
         }
-        case FeatureLevel::FEATURE_LEVEL_2: {
+        case FeatureLevel::FEATURE_LEVEL_3: {
             // TODO: we need constants somewhere for these values
             if (userSamplerCount > 12) {
                 slog.e << "Error: material \"" << mMaterialName.c_str()
-                       << "\" has feature level " << (int)info.featureLevel
+                       << "\" has feature level " << +info.featureLevel
                        << " and is using more than 12 samplers" << io::endl;
                 logSamplerOverflow(info.sib);
                 return false;

--- a/libs/filamat/src/SamplerBindingMap.cpp
+++ b/libs/filamat/src/SamplerBindingMap.cpp
@@ -91,12 +91,12 @@ void SamplerBindingMap::init(MaterialDomain materialDomain,
     // by the material. However, we can at least assert for the highest feature level.
 
     constexpr size_t MAX_VERTEX_SAMPLER_COUNT =
-            backend::FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_2].MAX_VERTEX_SAMPLER_COUNT;
+            backend::FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_3].MAX_VERTEX_SAMPLER_COUNT;
 
     assert_invariant(vertexSamplerCount <= MAX_VERTEX_SAMPLER_COUNT);
 
     constexpr size_t MAX_FRAGMENT_SAMPLER_COUNT =
-            backend::FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_2].MAX_FRAGMENT_SAMPLER_COUNT;
+            backend::FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_3].MAX_FRAGMENT_SAMPLER_COUNT;
 
     assert_invariant(fragmentSamplerCount <= MAX_FRAGMENT_SAMPLER_COUNT);
 }

--- a/libs/filamentapp/include/filamentapp/Config.h
+++ b/libs/filamentapp/include/filamentapp/Config.h
@@ -30,7 +30,7 @@ struct Config {
     float scale = 1.0f;
     bool splitView = false;
     mutable filament::Engine::Backend backend = filament::Engine::Backend::DEFAULT;
-    mutable filament::backend::FeatureLevel featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_2;
+    mutable filament::backend::FeatureLevel featureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
     filament::camutils::Mode cameraMode = filament::camutils::Mode::ORBIT;
     bool resizeable = true;
     bool headless = false;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -136,7 +136,7 @@ static void printUsage(char* name) {
         "       Prints this message\n\n"
         "   --api, -a\n"
         "       Specify the backend API: opengl (default), vulkan, or metal\n\n"
-        "   --feature-level=<1|2>, -f <1|2>\n"
+        "   --feature-level=<1|2|3>, -f <1|2|3>\n"
         "       Specify the feature level to use. The default is the highest supported feature level.\n\n"
         "   --batch=<path to JSON file or 'default'>, -b\n"
         "       Start automation using the given JSON spec, then quit the app\n\n"
@@ -219,8 +219,10 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                     app->config.featureLevel = backend::FeatureLevel::FEATURE_LEVEL_1;
                 } else if (arg == "2") {
                     app->config.featureLevel = backend::FeatureLevel::FEATURE_LEVEL_2;
+                } else if (arg == "3") {
+                    app->config.featureLevel = backend::FeatureLevel::FEATURE_LEVEL_3;
                 } else {
-                    std::cerr << "Unrecognized feature level. Must be 1 or 2.\n";
+                    std::cerr << "Unrecognized feature level. Must be 1, 2 or 3.\n";
                 }
                 break;
             case 'c':

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -407,6 +407,8 @@ static bool processFeatureLevel(MaterialBuilder& builder, const JsonishValue& va
         featureLevel = FeatureLevel::FEATURE_LEVEL_1;
     } else if (number->getFloat() == 2.0f) {
         featureLevel = FeatureLevel::FEATURE_LEVEL_2;
+    } else if (number->getFloat() == 3.0f) {
+        featureLevel = FeatureLevel::FEATURE_LEVEL_3;
     } else {
         std::cerr << "featureLevel: invalid value " << number->getFloat() << std::endl;
         return false;


### PR DESCRIPTION
This is because most android devices only support 16 texture in the 
shaders (94.4%), so we can't realistically have feature level 2 demand 
that.

Instead feature level 2 enables compute/ES3.1 features.