### PR TITLE
Vulkan samplers: fit incorrect bitset logic.

### DIFF
--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -35,15 +35,14 @@ namespace filament::backend {
 
 static VulkanPipelineCache::RasterState createDefaultRasterState();
 
-static constexpr size_t MAX_VERTEX_SAMPLER_COUNT = FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_2].MAX_VERTEX_SAMPLER_COUNT;
-
 static VkShaderStageFlags getShaderStageFlags(VulkanPipelineCache::UsageFlags key, uint16_t binding) {
     // NOTE: if you modify this function, you also need to modify getUsageFlags.
+    assert_invariant(binding < MAX_SAMPLER_COUNT);
     VkShaderStageFlags flags = 0;
     if (key.test(binding)) {
         flags |= VK_SHADER_STAGE_VERTEX_BIT;
     }
-    if (key.test(MAX_VERTEX_SAMPLER_COUNT + binding)) {
+    if (key.test(MAX_SAMPLER_COUNT + binding)) {
         flags |= VK_SHADER_STAGE_FRAGMENT_BIT;
     }
     return flags;
@@ -52,11 +51,12 @@ static VkShaderStageFlags getShaderStageFlags(VulkanPipelineCache::UsageFlags ke
 VulkanPipelineCache::UsageFlags
 VulkanPipelineCache::getUsageFlags(uint16_t binding, ShaderStageFlags flags, UsageFlags src) {
     // NOTE: if you modify this function, you also need to modify getShaderStageFlags.
+    assert_invariant(binding < MAX_SAMPLER_COUNT);
     if (any(flags & ShaderStageFlags::VERTEX)) {
         src.set(binding);
     }
     if (any(flags & ShaderStageFlags::FRAGMENT)) {
-        src.set(MAX_VERTEX_SAMPLER_COUNT + binding);
+        src.set(MAX_SAMPLER_COUNT + binding);
     }
     assert_invariant(!any(flags & ~(ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT)));
     return src;

--- a/filament/backend/src/vulkan/VulkanPipelineCache.h
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.h
@@ -192,9 +192,7 @@ private:
 
     using PipelineLayoutKey = utils::bitset128;
 
-    static_assert(PipelineLayoutKey::BIT_COUNT >=
-            FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_2].MAX_VERTEX_SAMPLER_COUNT +
-            FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_2].MAX_FRAGMENT_SAMPLER_COUNT);
+    static_assert(PipelineLayoutKey::BIT_COUNT >= 2 * MAX_SAMPLER_COUNT);
 
     struct PipelineLayoutKeyHashFn {
         size_t operator()(const PipelineLayoutKey& key) const;


### PR DESCRIPTION
In VulkanPipelineCache, `getShaderStageFlags()` and `getUsageFlags()` are used to track which samplers are used in the VERTEX stage and which are used in the FRAGMENT stage. The recent change I made was incorrect because it did not account for samplers that are used in BOTH stages.

This fixes the recent regression where we see validation errors when running `gltf_viewer` in ubershader mode.