### PR TITLE
gltfio: allow zero-instance assets.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- gltfio: allow zero-instance assets
+
 ## v1.27.1
 
 - Java: add methods for TransformManager.getChildCount(), TransformManager.getChildren() and Scene.hasEntity()

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentAsset.java
@@ -182,6 +182,9 @@ public class FilamentAsset {
 
     /**
      * Gets the bounding box computed from the supplied min / max values in glTF accessors.
+     *
+     * This does not return a bounding box over all FilamentInstance, it's just a straightforward
+     * AAAB that can be determined at load time from the asset data.
      */
     public @NonNull Box getBoundingBox() {
         float[] box = new float[6];

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -139,6 +139,8 @@ public:
      *
      *    while (Entity e = popRenderable()) { scene.addEntity(e); }
      *
+     * Progressive reveal is not supported for dynamically added instances.
+     *
      * \see ResourceLoader#asyncBeginLoad
      * \see popRenderables()
      */
@@ -170,7 +172,12 @@ public:
     /** Gets the number of resource URIs returned by getResourceUris(). */
     size_t getResourceUriCount() const noexcept;
 
-    /** Gets the bounding box computed from the supplied min / max values in glTF accessors. */
+    /**
+     * Gets the bounding box computed from the supplied min / max values in glTF accessors.
+     *
+     * This does not return a bounding box over all FilamentInstance, it's just a straightforward
+     * AAAB that can be determined at load time from the asset data.
+     */
     filament::Aabb getBoundingBox() const noexcept;
 
     /** Gets the NameComponentManager label for the given entity, if it exists. */
@@ -319,9 +326,11 @@ public:
     void detachMaterialInstances();
 
     /**
-     * Convenience function to get the first instance (which always exists).
+     * Convenience function to get the first instance, or null if it doesn't exist.
      */
-    FilamentInstance* getInstance() noexcept { return getAssetInstances()[0]; }
+    FilamentInstance* getInstance() noexcept {
+        return getAssetInstanceCount() > 0 ? getAssetInstances()[0] : nullptr;
+    }
 
     /*! \cond PRIVATE */
 

--- a/libs/gltfio/src/DependencyGraph.h
+++ b/libs/gltfio/src/DependencyGraph.h
@@ -79,6 +79,10 @@ public:
     // Marks the given texture as being fully decoded, with all miplevels initialized.
     void markAsReady(Texture* texture);
 
+    // Causes the dependency graph to enter a disabled state, whereby adding Entity <=> Material
+    // edges will immediately mark the entity as ready without actually growing the graph.
+    void disableProgressiveReveal();
+
 private:
     struct TextureNode {
         Texture* texture;
@@ -110,6 +114,7 @@ private:
     tsl::robin_map<Texture*, std::unique_ptr<TextureNode>> mTextureNodes;
 
     std::queue<Entity> mReadyRenderables;
+    bool mDisabled = false;
 };
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -331,6 +331,11 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     }
     asset->mResourcesLoaded = true;
 
+    // At this point, any entities that are created in the future (i.e. dynamically added instances)
+    // will not need the progressive feature to be enabled. This simplifies the dependency graph and
+    // prevents it from growing.
+    asset->mDependencyGraph.disableProgressiveReveal();
+
     // Clear our texture caches. Previous calls to loadResources may have populated these, but the
     // Texture objects could have since been destroyed.
     pImpl->mBufferTextureCache.clear();

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -457,7 +457,9 @@ void ViewerGui::updateRootTransform() {
     auto root = tcm.getInstance(mAsset->getRoot());
     filament::math::mat4f transform;
     if (mSettings.viewer.autoScaleEnabled) {
-        transform = fitIntoUnitCube(mAsset->getInstance()->getBoundingBox(), 4);
+        FilamentInstance* instance = mAsset->getInstance();
+        Aabb aabb = instance ? instance->getBoundingBox() : mAsset->getBoundingBox();
+        transform = fitIntoUnitCube(aabb, 4);
     }
     tcm.setTransform(root, transform);
 }

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -89,8 +89,8 @@ static void printUsage(char* name) {
         "       Specify the backend API: opengl (default), vulkan, or metal\n\n"
         "   --ibl=<path to cmgen IBL>, -i <path>\n"
         "       Override the built-in IBL\n\n"
-        "   --num=<number of instances>, -n <num>\n"
-        "       Number of instances (defaults to 5)\n\n"
+        "   --num=<number of initial instances>, -n <num>\n"
+        "       Number of instances to start with (defaults to 0)\n\n"
         "   --animate=<instance index>, -m <num>\n"
         "       Instance to animate (defaults to all instances)\n\n"
         "   --ubershader, -u\n"
@@ -147,9 +147,6 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
                 app->materialSource = UBERSHADER;
                 break;
         }
-    }
-    if (app->instances.empty()) {
-        app->instances.resize(5);
     }
     return optind;
 }
@@ -248,7 +245,7 @@ int main(int argc, char** argv) {
     auto setup = [&](Engine* engine, View* view, Scene* scene) {
         app.engine = engine;
         app.names = new NameComponentManager(EntityManager::get());
-        app.viewer = new ViewerGui(engine, scene, view, app.instanceToAnimate);
+        app.viewer = new ViewerGui(engine, scene, view);
 
         app.materials = (app.materialSource == JITSHADER) ? createJitShaderProvider(engine) :
                 createUbershaderProvider(engine, UBERARCHIVE_DEFAULT_DATA, UBERARCHIVE_DEFAULT_SIZE);
@@ -262,8 +259,10 @@ int main(int argc, char** argv) {
             loadAsset(filename);
         }
 
-        FilamentInstance* const instance = app.instanceToAnimate > -1 ?
-                app.instances[app.instanceToAnimate] : nullptr;
+        FilamentInstance* instance = nullptr;
+        if (app.instanceToAnimate > -1 && app.instanceToAnimate < app.instances.size()) {
+            instance = app.instances[app.instanceToAnimate];
+        }
 
         arrangeIntoCircle();
         loadResources(filename);


### PR DESCRIPTION
This is a feature request from Google. It allows users to "preload" an asset, ie you can now create all VertexBuffer objects, Texture objects, etc, without actually creating any entities or renderable components.

In the past we used TransformManager to help out with computing the big asset-level bounding box, but now we use `gltf_node_transform_world()` because entities might not yet exist.