### PR TITLE
use ES3.1 headers

### DIFF
--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -19,7 +19,7 @@
 
 #if defined(__ANDROID__) || defined(FILAMENT_USE_EXTERNAL_GLES3) || defined(__EMSCRIPTEN__)
 
-    #include <GLES3/gl3.h>
+    #include <GLES3/gl31.h>
     #include <GLES2/gl2ext.h>
 
     /* The Android NDK doesn't exposes extensions, fake it with eglGetProcAddress */
@@ -50,49 +50,13 @@
 #endif
 #ifdef GL_EXT_disjoint_timer_query
         extern PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
-        #define GL_TIME_ELAPSED               0x88BF
 #endif
 #ifdef GL_EXT_clip_control
         extern PFNGLCLIPCONTROLEXTPROC glClipControl;
-        #ifndef GL_LOWER_LEFT
-        #   define GL_LOWER_LEFT GL_LOWER_LEFT_EXT
-        #endif
-        #ifndef GL_ZERO_TO_ONE
-        #   define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
-        #endif
 #endif
     }
 
-    // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:
-    #define GL_DEBUG_OUTPUT                   0x92E0
-    #define GL_DEBUG_OUTPUT_SYNCHRONOUS       0x8242
-
-    #define GL_DEBUG_SEVERITY_HIGH            0x9146
-    #define GL_DEBUG_SEVERITY_MEDIUM          0x9147
-    #define GL_DEBUG_SEVERITY_LOW             0x9148
-    #define GL_DEBUG_SEVERITY_NOTIFICATION    0x826B
-
-    #define GL_DEBUG_TYPE_MARKER              0x8268
-    #define GL_DEBUG_TYPE_ERROR               0x824C
-    #define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR 0x824D
-    #define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR  0x824E
-    #define GL_DEBUG_TYPE_PORTABILITY         0x824F
-    #define GL_DEBUG_TYPE_PERFORMANCE         0x8250
-    #define GL_DEBUG_TYPE_OTHER               0x8251
-
-    #define glDebugMessageCallback            glext::glDebugMessageCallbackKHR
-
-    #define GL_TEXTURE_CUBE_MAP_ARRAY               0x9009
-    #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
-    #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C
-    #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW        0x900D
-    #define GL_INT_SAMPLER_CUBE_MAP_ARRAY           0x900E
-    #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY  0x900F
-    #define GL_IMAGE_CUBE_MAP_ARRAY                 0x9054
-    #define GL_INT_IMAGE_CUBE_MAP_ARRAY             0x905F
-    #define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY    0x906A
-
-using namespace glext;
+    using namespace glext;
 
 #elif defined(IOS)
 
@@ -100,27 +64,6 @@ using namespace glext;
 
     #include <OpenGLES/ES3/gl.h>
     #include <OpenGLES/ES3/glext.h>
-
-    /* The iOS SDK only provides OpenGL ES headers up to 3.0. Filament works with OpenGL 3.0, but
-     * requires the following 3.1 declarations in order to compile. */
-
-    #define GL_TEXTURE_2D_MULTISAMPLE         0x9100
-    #define GL_TIME_ELAPSED                   0x88BF
-
-    #define GL_TEXTURE_CUBE_MAP_ARRAY               0x9009
-    #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
-    #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C
-    #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW        0x900D
-    #define GL_INT_SAMPLER_CUBE_MAP_ARRAY           0x900E
-    #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY  0x900F
-    #define GL_IMAGE_CUBE_MAP_ARRAY                 0x9054
-    #define GL_INT_IMAGE_CUBE_MAP_ARRAY             0x905F
-    #define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY    0x906A
-
-#ifdef GL_EXT_multisampled_render_to_texture
-    extern PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC glRenderbufferStorageMultisampleEXT;
-    extern PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC glFramebufferTexture2DMultisampleEXT;
-#endif
 
 #else
 
@@ -135,15 +78,61 @@ using namespace glext;
 
 #endif
 
+#if (!defined(GL_ES_VERSION_2_0) && !defined(GL_VERSION_4_1))
+#error "Minimum header version must be OpenGL ES 2.0 or OpenGL 4.1"
+#endif
+
+
+/*
+ * Since we need ES3.1 headers and iOS only has ES3.0, we also define the constants we
+ * need to avoid many #ifdef in the actual code.
+ */
+
+#if defined(GL_ES_VERSION_2_0)
+#ifdef GL_EXT_disjoint_timer_query
+#       define GL_TIME_ELAPSED              0x88BF
+#endif
+
+#ifdef GL_EXT_clip_control
+#   ifndef GL_LOWER_LEFT
+#      define GL_LOWER_LEFT                 0x8CA1
+#   endif
+#   ifndef GL_ZERO_TO_ONE
+#      define GL_ZERO_TO_ONE                0x935F
+#   endif
+#endif
+
+#ifndef GL_TEXTURE_CUBE_MAP_ARRAY
+#   define GL_TEXTURE_CUBE_MAP_ARRAY        0x9009
+#endif
+
+// Prevent lots of #ifdef's between desktop and mobile
+#define glDebugMessageCallback            glDebugMessageCallbackKHR
+
+/* The iOS SDK only provides OpenGL ES headers up to 3.0. Filament works with OpenGL 3.0, but
+ * requires ES3.1 headers */
+#if !defined(GL_ES_VERSION_3_1)
+
+    #define GL_TEXTURE_2D_MULTISAMPLE               0x9100
+    #define GL_TIME_ELAPSED                         0x88BF
+
+    #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
+    #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C
+    #define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW        0x900D
+    #define GL_INT_SAMPLER_CUBE_MAP_ARRAY           0x900E
+    #define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY  0x900F
+    #define GL_IMAGE_CUBE_MAP_ARRAY                 0x9054
+    #define GL_INT_IMAGE_CUBE_MAP_ARRAY             0x905F
+    #define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY    0x906A
+
+#endif
+#endif // GL_ES_VERSION_2_0
+
 // This is an odd duck function that exists in WebGL 2.0 but not in OpenGL ES.
 #if defined(__EMSCRIPTEN__)
 extern "C" {
 void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data);
 }
-#endif
-
-#if (!defined(GL_ES_VERSION_2_0) && !defined(GL_VERSION_4_1))
-#error "Minimum header version must be OpenGL ES 2.0 or OpenGL 4.1"
 #endif
 
 


### PR DESCRIPTION
We now compile with ES3.1 headers but we make sure we can still compile with ES3.0 headers (still needed for iOS).