### PR TITLE
gltfio: change instancing behavior for punctual lights

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- gltfio: punctual lights are now duplicated when adding new asset instances
 - gltfio: allow zero-instance assets
 - gltfio: fix regression with meshes that have no material
 - gltfio: fix regression with recomputeBoundingBoxes()

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -505,7 +505,6 @@ FFilamentInstance* FAssetLoader::createInstance(const cgltf_data* srcAsset) {
 
     importSkins(mAsset, instance, srcAsset);
 
-    // This needs to stay near the end of the method to allow detection of the first instance.
     mAsset->mInstances.push_back(instance);
 
     // Bounding boxes are not shared because users might call recomputeBoundingBoxes() which can
@@ -572,7 +571,7 @@ void FAssetLoader::recurseEntities(const cgltf_data* srcAsset, const cgltf_node*
         }
     }
 
-    if (node->light && mAsset->mInstances.empty()) {
+    if (node->light ) {
         createLight(node->light, entity);
     }
 


### PR DESCRIPTION
Punctual lights are now duplicated when adding new asset instances.  This makes sense for objects like lamp posts.