### PR TITLE
Metal: use argument buffers for SamplerGroups

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - engine: LiSPSM is now a user settable option
 - Java: Fix TransformManager.getChildren()
+- Metal: newer devices are no longer limited to 16 samplers per Material.
 
 ## v1.27.2
 

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -26,7 +26,7 @@
 
 #include <utils/compiler.h>
 
-#include <tuple>
+#include <utility>
 
 namespace filament::backend {
 
@@ -131,7 +131,7 @@ public:
      *                  ring buffer allocation will be freed.
      * @return the id<MTLBuffer> and offset for the new allocation
      */
-    std::tuple<id<MTLBuffer>, NSUInteger> createNewAllocation(id<MTLCommandBuffer> cmdBuffer) {
+    std::pair<id<MTLBuffer>, NSUInteger> createNewAllocation(id<MTLCommandBuffer> cmdBuffer) {
         const auto occupiedSlots = mOccupiedSlots.load(std::memory_order_relaxed);
         assert_invariant(occupiedSlots <= mSlotCount);
         if (UTILS_UNLIKELY(occupiedSlots == mSlotCount)) {
@@ -163,7 +163,7 @@ public:
      *                  ring buffer allocation will be freed.
      * @return the id<MTLBuffer> and offset for the current allocation
      */
-    std::tuple<id<MTLBuffer>, NSUInteger> getCurrentAllocation() const {
+    std::pair<id<MTLBuffer>, NSUInteger> getCurrentAllocation() const {
         if (UTILS_UNLIKELY(mAuxBuffer)) {
             return { mAuxBuffer, 0 };
         }

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -41,11 +41,11 @@ class MetalDriver;
 class MetalBlitter;
 class MetalBufferPool;
 class MetalRenderTarget;
+class MetalSamplerGroup;
 class MetalSwapChain;
 class MetalTimerQueryInterface;
 struct MetalUniformBuffer;
 struct MetalIndexBuffer;
-struct MetalSamplerGroup;
 struct MetalVertexBuffer;
 
 constexpr static uint8_t MAX_SAMPLE_COUNT = 8;  // Metal devices support at most 8 MSAA samples
@@ -79,7 +79,7 @@ struct MetalContext {
     // State trackers.
     PipelineStateTracker pipelineState;
     DepthStencilStateTracker depthStencilState;
-    UniformBufferState uniformState[UNIFORM_BUFFER_COUNT];
+    UniformBufferState uniformState[Program::UNIFORM_BINDING_COUNT];
     CullModeStateTracker cullModeState;
     WindingStateTracker windingState;
 
@@ -87,8 +87,12 @@ struct MetalContext {
     DepthStencilStateCache depthStencilStateCache;
     PipelineStateCache pipelineStateCache;
     SamplerStateCache samplerStateCache;
+    ArgumentEncoderCache argumentEncoderCache;
 
-    MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
+    MetalSamplerGroup* samplerBindings[Program::SAMPLER_BINDING_COUNT] = {};
+
+    // Keeps track of sampler groups we've finalized for the current render pass.
+    tsl::robin_set<MetalSamplerGroup*> finalizedSamplerGroups;
 
     // Keeps track of all alive sampler groups.
     tsl::robin_set<MetalSamplerGroup*> samplerGroups;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -34,6 +34,7 @@ namespace backend {
 class MetalPlatform;
 
 class MetalBuffer;
+class MetalSamplerGroup;
 struct MetalUniformBuffer;
 struct MetalContext;
 struct MetalProgram;
@@ -126,8 +127,7 @@ private:
     inline void setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph, PrimitiveType pt,
             uint32_t offset, uint32_t minIndex, uint32_t maxIndex, uint32_t count);
 
-    void enumerateSamplerGroups(const MetalProgram* program, ShaderStage shaderType,
-            const std::function<void(const SamplerDescriptor*, size_t)>& f);
+    void finalizeSamplerGroup(MetalSamplerGroup* sg);
     void enumerateBoundUniformBuffers(const std::function<void(const UniformBufferState&,
             MetalBuffer*, uint32_t)>& f);
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1063,7 +1063,7 @@ void MetalDriver::bindBufferRange(BufferObjectBinding bindingType, uint32_t inde
 
     // TODO: implement BufferObjectBinding::SHADER_STORAGE case
 
-    assert_invariant(index < Program::UNIFORM_BUFFER_COUNT);
+    assert_invariant(index < Program::UNIFORM_BINDING_COUNT);
     auto* bo = handle_cast<MetalBufferObject>(boh);
     auto* currentBo = mContext->uniformState[index].buffer;
     if (currentBo) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -37,6 +37,8 @@
 #include <utils/Log.h>
 #include <utils/Panic.h>
 
+#include <algorithm>
+
 namespace filament {
 namespace backend {
 
@@ -107,6 +109,7 @@ MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& 
     mContext->pipelineStateCache.setDevice(mContext->device);
     mContext->depthStencilStateCache.setDevice(mContext->device);
     mContext->samplerStateCache.setDevice(mContext->device);
+    mContext->argumentEncoderCache.setDevice(mContext->device);
     mContext->bufferPool = new MetalBufferPool(*mContext);
     mContext->blitter = new MetalBlitter(*mContext);
 
@@ -309,6 +312,8 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         TargetBufferFlags targetBufferFlags, uint32_t width, uint32_t height,
         uint8_t samples, MRT color,
         TargetBufferInfo depth, TargetBufferInfo stencil) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "createRenderTarget must be called outside of a render pass.");
     // Clamp sample count to what the device supports.
     auto& sc = mContext->sampleCountLookup;
     samples = sc[std::min(MAX_SAMPLE_COUNT, samples)];
@@ -322,7 +327,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         ASSERT_PRECONDITION(buffer.handle,
                 "The COLOR%u flag was specified, but invalid color handle provided.", i);
         auto colorTexture = handle_cast<MetalTexture>(buffer.handle);
-        ASSERT_PRECONDITION(colorTexture->texture,
+        ASSERT_PRECONDITION(colorTexture->getMtlTextureForWrite(),
                 "Color texture passed to render target has no texture allocation");
         colorTexture->updateLodRange(buffer.level);
         colorAttachments[i] = { colorTexture, color[i].level, color[i].layer };
@@ -333,7 +338,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         ASSERT_PRECONDITION(depth.handle,
                 "The DEPTH flag was specified, but invalid depth handle provided.");
         auto depthTexture = handle_cast<MetalTexture>(depth.handle);
-        ASSERT_PRECONDITION(depthTexture->texture,
+        ASSERT_PRECONDITION(depthTexture->getMtlTextureForWrite(),
                 "Depth texture passed to render target has no texture allocation.");
         depthTexture->updateLodRange(depth.level);
         depthAttachment = { depthTexture, depth.level, depth.layer };
@@ -344,7 +349,7 @@ void MetalDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         ASSERT_PRECONDITION(stencil.handle,
                 "The STENCIL flag was specified, but invalid stencil handle provided.");
         auto stencilTexture = handle_cast<MetalTexture>(stencil.handle);
-        ASSERT_PRECONDITION(stencilTexture->texture,
+        ASSERT_PRECONDITION(stencilTexture->getMtlTextureForWrite(),
                 "Stencil texture passed to render target has no texture allocation.");
         stencilTexture->updateLodRange(stencil.level);
         stencilAttachment = { stencilTexture, stencil.level, stencil.layer };
@@ -513,17 +518,6 @@ void MetalDriver::destroyTexture(Handle<HwTexture> th) {
 #ifndef NDEBUG
     mContext->aliveTextures.erase(th.getId());
 #endif
-
-    // Unbind this texture from any sampler groups that currently reference it.
-    for (auto* metalSamplerGroup : mContext->samplerGroups) {
-        const SamplerDescriptor* samplers = metalSamplerGroup->sb->data();
-        for (size_t i = 0; i < metalSamplerGroup->sb->getSize(); i++) {
-            const SamplerDescriptor* sampler = samplers + i;
-            if (sampler->t == th) {
-                metalSamplerGroup->sb->setSampler(i, {{}, {}});
-            }
-        }
-    }
 
     destruct_handle<MetalTexture>(th);
 }
@@ -705,10 +699,14 @@ bool MetalDriver::isWorkaroundNeeded(Workaround workaround) {
 }
 
 FeatureLevel MetalDriver::getFeatureLevel() {
-    // TODO: before we can return FEATURE_LEVEL_2 we need to decouple the samplers from
-    //       the textures. Metal only supports 16 samplers, but at least 31 textures on all
-    //       hardware.
-    return FeatureLevel::FEATURE_LEVEL_1;
+    // FEATURE_LEVEL_3 requires >= 31 textures, which all Metal devices support. However, older
+    // Metal devices only support 16 unique samplers. We could get around this in the future by
+    // virtualizing samplers.
+    if (mContext->highestSupportedGpuFamily.apple >= 6 ||
+            mContext->highestSupportedGpuFamily.mac >= 2) {
+        return FeatureLevel::FEATURE_LEVEL_3;
+    }
+    return FeatureLevel::FEATURE_LEVEL_2;
 }
 
 math::float2 MetalDriver::getClipSpaceParams() {
@@ -791,11 +789,15 @@ void MetalDriver::cancelExternalImage(void* image) {
 }
 
 void MetalDriver::setExternalImage(Handle<HwTexture> th, void* image) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "setExternalImage must be called outside of a render pass.");
     auto texture = handle_cast<MetalTexture>(th);
     texture->externalImage.set((CVPixelBufferRef) image);
 }
 
 void MetalDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint32_t plane) {
+    ASSERT_PRECONDITION(!isInRenderPass(mContext),
+            "setExternalImagePlane must be called outside of a render pass.");
     auto texture = handle_cast<MetalTexture>(th);
     texture->externalImage.set((CVPixelBufferRef) image, plane);
 }
@@ -823,11 +825,7 @@ void MetalDriver::generateMipmaps(Handle<HwTexture> th) {
     ASSERT_PRECONDITION(!isInRenderPass(mContext),
                         "generateMipmaps must be called outside of a render pass.");
     auto tex = handle_cast<MetalTexture>(th);
-    id <MTLBlitCommandEncoder> blitEncoder = [getPendingCommandBuffer(mContext) blitCommandEncoder];
-    [blitEncoder generateMipmapsForTexture:tex->texture];
-    [blitEncoder endEncoding];
-    tex->minLod = 0;
-    tex->maxLod = tex->texture.mipmapLevelCount - 1;
+    tex->generateMipmaps();
 }
 
 bool MetalDriver::canGenerateMipmaps() {
@@ -839,11 +837,12 @@ void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh, BufferDescripto
             "updateSamplerGroup must be called outside of a render pass.");
 
     auto sb = handle_cast<MetalSamplerGroup>(sbh);
+    assert_invariant(sb->size == data.size / sizeof(SamplerDescriptor));
+    auto const* const samplers = (SamplerDescriptor const*) data.buffer;
 
 #ifndef NDEBUG
     // In debug builds, verify that all the textures in the sampler group are still alive.
     // These bugs lead to memory corruption and can be difficult to track down.
-    auto const* const samplers = (SamplerDescriptor const*) data.buffer;
     for (size_t s = 0; s < data.size / sizeof(SamplerDescriptor); s++) {
         if (!samplers[s].t) {
             continue;
@@ -858,20 +857,105 @@ void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh, BufferDescripto
     }
 #endif
 
-    // FIXME: we shouldn't be using SamplerGroup here, instead the backend should create
-    //        a descriptor or any internal data-structure that represents the textures/samplers.
-    //        It's preferable to do as much work as possible here.
-    //        Here, we emulate the older backend API by re-creating a SamplerGroup from the
-    //        passed data.
-    SamplerGroup samplerGroup(data.size / sizeof(SamplerDescriptor));
-    memcpy(samplerGroup.data(), data.buffer, data.size);
-    *sb->sb = std::move(samplerGroup);
+    // Create a MTLArgumentEncoder for these textures.
+    // Ideally, we would create this encoder at createSamplerGroup time, but we need to know the
+    // texture type of each texture. It's also not guaranteed that the types won't change between
+    // calls to updateSamplerGroup.
+    utils::FixedCapacityVector<MTLTextureType> textureTypes(sb->size);
+    std::transform(samplers, samplers + data.size / sizeof(SamplerDescriptor), textureTypes.begin(),
+            [this](const SamplerDescriptor& sampler) {
+        if (!sampler.t) {
+            // Use Type2D for non-bound textures.
+            return MTLTextureType2D;
+        }
+        auto* t = handle_cast<MetalTexture>(sampler.t);
+        if (t->target == SamplerType::SAMPLER_EXTERNAL) {
+            // Use Type2D for external image textures.
+            return MTLTextureType2D;
+        }
+        id<MTLTexture> mtlTexture = t->getMtlTextureForRead();
+        assert_invariant(mtlTexture);
+        return mtlTexture.textureType;
+    });
+    auto& encoderCache = mContext->argumentEncoderCache;
+    id<MTLArgumentEncoder> encoder =
+            encoderCache.getOrCreateState(ArgumentEncoderState(std::move(textureTypes)));
+    sb->reset(getPendingCommandBuffer(mContext), encoder);
+
+    // In a perfect world, all the MTLTexture bindings would be known at updateSamplerGroup time.
+    // However, there are two special cases preventing this:
+    // 1. External images
+    // 2. LOD-clamped textures
+    //
+    // Both of these cases prevent us from knowing the final id<MTLTexture> that will be bound into
+    // the argument buffer representing the sampler group. So, we bind what we can now and wait
+    // until draw call time to bind any special cases (done in finalizeSamplerGroup).
+    // The good news is that once a render pass has started, the texture bindings won't change.
+    // A SamplerGroup is "finalized" when all of its textures have been set and is ready for use in
+    // a draw call.
+    // Even if we do know all the final textures at this point, we still wait until draw call time
+    // to call finalizeSamplerGroup, which has one additional responsibility: to call useResources
+    // for all the textures, which is required by Metal.
+    for (size_t s = 0; s < data.size / sizeof(SamplerDescriptor); s++) {
+        if (!samplers[s].t) {
+            // Assign a default texture / sampler to empty slots.
+            // Metal requires all samplers referenced in shaders to be bound.
+            id<MTLTexture> empty = getOrCreateEmptyTexture(mContext);
+            sb->setFinalizedTexture(s, empty);
+
+            id<MTLSamplerState> sampler = mContext->samplerStateCache.getOrCreateState({});
+            sb->setFinalizedSampler(s, sampler);
+
+            continue;
+        }
+
+        // First, bind the sampler state. We always know the full sampler state at
+        // updateSamplerGroup time.
+        SamplerState samplerState {
+                .samplerParams = samplers[s].s,
+        };
+        id<MTLSamplerState> sampler = mContext->samplerStateCache.getOrCreateState(samplerState);
+        sb->setFinalizedSampler(s, sampler);
+
+        sb->setTextureHandle(s, samplers[s].t);
+
+        auto* t = handle_cast<MetalTexture>(samplers[s].t);
+        assert_invariant(t);
+
+        // If this texture is an external texture, we defer binding the texture until draw call time
+        // (in finalizeSamplerGroup).
+        if (t->target == SamplerType::SAMPLER_EXTERNAL) {
+            continue;
+        }
+
+        if (!t->allLodsValid()) {
+            // The texture doesn't have all of its LODs loaded, and this could change by the time we
+            // issue a draw call with this sampler group. So, we defer binding the texture until
+            // draw call time (in finalizeSamplerGroup).
+            continue;
+        }
+
+        // If we get here, we know we have a valid MTLTexture that's guaranteed not to change.
+        id<MTLTexture> mtlTexture = t->getMtlTextureForRead();
+        assert_invariant(mtlTexture);
+        sb->setFinalizedTexture(s, mtlTexture);
+    }
 
     scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
         const RenderPassParams& params) {
+
+#if defined(FILAMENT_METAL_PROFILING)
+    const char* renderPassName = "Unknown";
+    if (!mContext->groupMarkers.empty()) {
+        renderPassName = mContext->groupMarkers.top();
+    }
+    os_signpost_interval_begin(mContext->log, OS_SIGNPOST_ID_EXCLUSIVE, "Render pass", "%s",
+            renderPassName);
+#endif
+
     auto renderTarget = handle_cast<MetalRenderTarget>(rth);
     mContext->currentRenderTarget = renderTarget;
     mContext->currentRenderPassFlags = params.flags;
@@ -901,11 +985,17 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     mContext->depthStencilState.invalidate();
     mContext->cullModeState.invalidate();
     mContext->windingState.invalidate();
+
+    mContext->finalizedSamplerGroups.clear();
 }
 
 void MetalDriver::nextSubpass(int dummy) {}
 
 void MetalDriver::endRenderPass(int dummy) {
+#if defined(FILAMENT_METAL_PROFILING)
+    os_signpost_interval_end(mContext->log, OS_SIGNPOST_ID_EXCLUSIVE, "Render pass");
+#endif
+
     [mContext->currentRenderPassEncoder endEncoding];
 
     // Command encoders are one time use. Set it to nil to release the encoder and ensure we don't
@@ -951,7 +1041,7 @@ void MetalDriver::commit(Handle<HwSwapChain> sch) {
 }
 
 void MetalDriver::bindUniformBuffer(uint32_t index, Handle<HwBufferObject> boh) {
-    assert_invariant(index < UNIFORM_BUFFER_COUNT);
+    assert_invariant(index < Program::UNIFORM_BINDING_COUNT);
     auto* bo = handle_cast<MetalBufferObject>(boh);
     auto* currentBo = mContext->uniformState[index].buffer;
     if (currentBo) {
@@ -973,7 +1063,7 @@ void MetalDriver::bindBufferRange(BufferObjectBinding bindingType, uint32_t inde
 
     // TODO: implement BufferObjectBinding::SHADER_STORAGE case
 
-    assert_invariant(index < UNIFORM_BUFFER_COUNT);
+    assert_invariant(index < Program::UNIFORM_BUFFER_COUNT);
     auto* bo = handle_cast<MetalBufferObject>(boh);
     auto* currentBo = mContext->uniformState[index].buffer;
     if (currentBo) {
@@ -1203,6 +1293,97 @@ void MetalDriver::blit(TargetBufferFlags buffers,
     }
 }
 
+void MetalDriver::finalizeSamplerGroup(MetalSamplerGroup* samplerGroup) {
+    // All of the id<MTLSamplerState> objects have already been bound to the argument buffer.
+    // Here we bind any textures that were unable to be bound in updateSamplerGroup.
+
+    id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
+
+#ifndef NDEBUG
+    // In debug builds, verify that all the textures in the sampler group are still alive.
+    // These bugs lead to memory corruption and can be difficult to track down.
+    const auto& handles = samplerGroup->getTextureHandles();
+    for (size_t s = 0; s < handles.size(); s++) {
+        if (!handles[s]) {
+            continue;
+        }
+        auto iter = mContext->aliveTextures.find(handles[s].getId());
+        if (iter == mContext->aliveTextures.end()) {
+            utils::slog.e << "finalizeSamplerGroup: texture #"
+                          << (int) s << " is dead, texture handle = "
+                          << handles[s] << utils::io::endl;
+        }
+        assert_invariant(iter != mContext->aliveTextures.end());
+    }
+#endif
+
+    for (size_t binding = 0; binding < samplerGroup->size; binding++) {
+        auto [th, t] = samplerGroup->getFinalizedTexture(binding);
+
+        // This may be an external texture, in which case we can't cache the id<MTLTexture>, we
+        // need to refetch it in case the external image has changed.
+        bool isExternalImage = false;
+        if (th) {
+            auto* texture = handle_cast<MetalTexture>(th);
+            isExternalImage = texture->target == SamplerType::SAMPLER_EXTERNAL;
+        }
+
+        // If t is non-nil, then we've already finalized this texture.
+        if (t && !isExternalImage) {
+            continue;
+        }
+
+        // It's possible that some texture handles are null, but we should have already handled
+        // these inside updateSamplerGroup by binding an "empty" texture.
+        assert_invariant(th);
+        auto* texture = handle_cast<MetalTexture>(th);
+
+        // Determine if this SamplerGroup needs mutation.
+        // We can't just simply mutate the SamplerGroup, since it could currently be in use by the
+        // GPU from a prior render pass.
+        // If the SamplerGroup does need mutation, then there's two cases:
+        // 1. The SamplerGroup has not been finalized yet (which means it has not yet been used in a
+        //    draw call). We're free to mutate it.
+        // 2. The SamplerGroup is finalized. We must call mutate(), which will create a new argument
+        //    buffer that we can then mutate freely.
+        // TODO: don't just always call mutate, check to see if the texture is actually different.
+
+        if (samplerGroup->isFinalized()) {
+            samplerGroup->mutate(cmdBuffer);
+        }
+
+        // External images
+        if (texture->target == SamplerType::SAMPLER_EXTERNAL) {
+            if (texture->externalImage.isValid()) {
+                id<MTLTexture> mtlTexture = texture->externalImage.getMetalTextureForDraw();
+                assert_invariant(mtlTexture);
+                samplerGroup->setFinalizedTexture(binding, mtlTexture);
+            } else {
+                // Bind an empty texture.
+                samplerGroup->setFinalizedTexture(binding, getOrCreateEmptyTexture(mContext));
+            }
+            continue;
+        }
+
+        samplerGroup->setFinalizedTexture(binding, texture->getMtlTextureForRead());
+    }
+
+    samplerGroup->finalize();
+
+    // At this point, all the id<MTLTextures> should be set to valid textures. Some of them will be
+    // the "empty" texture. Per Apple documentation, the useResource method must be called once per
+    // render pass.
+    samplerGroup->useResources(mContext->currentRenderPassEncoder);
+
+    // useResources won't retain references to the textures, so we need to do so manually.
+    for (id<MTLTexture> texture : samplerGroup->textures) {
+        const void* retainedTexture = CFBridgingRetain(texture);
+        [cmdBuffer addCompletedHandler:^(id<MTLCommandBuffer> cb) {
+            CFBridgingRelease(retainedTexture);
+        }];
+    }
+}
+
 void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t instanceCount) {
     ASSERT_PRECONDITION(mContext->currentRenderPassEncoder != nullptr,
             "Attempted to draw without a valid command encoder.");
@@ -1377,104 +1558,36 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
             UNIFORM_BUFFER_BINDING_START, MetalBuffer::Stage::VERTEX | MetalBuffer::Stage::FRAGMENT,
             uniformsToBind, offsets, Program::UNIFORM_BINDING_COUNT);
 
-    // Enumerate all the sampler buffers for the program and check which textures and samplers need
-    // to be bound.
-
-    auto getTextureToBind = [this](const SamplerDescriptor* sampler) {
-        const auto metalTexture = handle_const_cast<MetalTexture>(sampler->t);
-        id<MTLTexture> textureToBind = metalTexture->swizzledTextureView ? metalTexture->swizzledTextureView
-                                                                         : metalTexture->texture;
-        if (metalTexture->externalImage.isValid()) {
-            textureToBind = metalTexture->externalImage.getMetalTextureForDraw();
+    // Bind sampler groups (argument buffers).
+    for (size_t s = 0; s < Program::SAMPLER_BINDING_COUNT; s++) {
+        MetalSamplerGroup* const samplerGroup = mContext->samplerBindings[s];
+        if (!samplerGroup) {
+            continue;
         }
-        return textureToBind;
-    };
-
-    auto getSamplerToBind = [this](const SamplerDescriptor* sampler) {
-        const auto metalTexture = handle_const_cast<MetalTexture>(sampler->t);
-        SamplerState s {
-            .samplerParams = sampler->s,
-            .minLod = metalTexture->minLod,
-            .maxLod = metalTexture->maxLod
-        };
-        return mContext->samplerStateCache.getOrCreateState(s);
-    };
-
-    id<MTLTexture> texturesToBindVertex[FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_VERTEX_SAMPLER_COUNT] = {};
-    id<MTLSamplerState> samplersToBindVertex[FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_VERTEX_SAMPLER_COUNT] = {};
-
-    enumerateSamplerGroups(program, ShaderStage::VERTEX,
-            [this, &getTextureToBind, &getSamplerToBind, &texturesToBindVertex, &samplersToBindVertex](
-                    const SamplerDescriptor* sampler, uint8_t binding) {
-        // We currently only support a max of MAX_VERTEX_SAMPLER_COUNT samplers. Ignore any additional
-        // samplers that may be bound.
-        if (binding >= FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_VERTEX_SAMPLER_COUNT) {
-            return;
+        const auto& stageFlags = program->samplerGroupInfo[s].stageFlags;
+        if (stageFlags == ShaderStageFlags::NONE) {
+            continue;
         }
 
-        auto& textureToBind = texturesToBindVertex[binding];
-        textureToBind = getTextureToBind(sampler);
-        if (!textureToBind) {
-            utils::slog.w << "Warning: no texture bound at binding point " << (size_t) binding
-                    << " at the vertex shader." << utils::io::endl;
-            textureToBind = getOrCreateEmptyTexture(mContext);
+        auto iter = mContext->finalizedSamplerGroups.find(samplerGroup);
+        if (iter == mContext->finalizedSamplerGroups.end()) {
+            finalizeSamplerGroup(samplerGroup);
+            mContext->finalizedSamplerGroups.insert(samplerGroup);
         }
 
-        auto& samplerToBind = samplersToBindVertex[binding];
-        samplerToBind = getSamplerToBind(sampler);
-    });
+        assert_invariant(samplerGroup->getArgumentBuffer());
 
-    // Assign a default sampler to empty slots, in case Filament hasn't bound all samplers.
-    // Metal requires all samplers referenced in shaders to be bound.
-    for (auto& sampler : samplersToBindVertex) {
-        if (!sampler) {
-            sampler = mContext->samplerStateCache.getOrCreateState({});
+        if (uint8_t(stageFlags) & uint8_t(ShaderStageFlags::VERTEX)) {
+            [mContext->currentRenderPassEncoder setVertexBuffer:samplerGroup->getArgumentBuffer()
+                                                         offset:samplerGroup->getArgumentBufferOffset()
+                                                        atIndex:(SAMPLER_GROUP_BINDING_START + s)];
+        }
+        if (uint8_t(stageFlags) & uint8_t(ShaderStageFlags::FRAGMENT)) {
+            [mContext->currentRenderPassEncoder setFragmentBuffer:samplerGroup->getArgumentBuffer()
+                                                           offset:samplerGroup->getArgumentBufferOffset()
+                                                          atIndex:(SAMPLER_GROUP_BINDING_START + s)];
         }
     }
-
-    NSRange vertexSamplerRange = NSMakeRange(0, FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_VERTEX_SAMPLER_COUNT);
-    [mContext->currentRenderPassEncoder setVertexTextures:texturesToBindVertex
-                                                withRange:vertexSamplerRange];
-    [mContext->currentRenderPassEncoder setVertexSamplerStates:samplersToBindVertex
-                                                     withRange:vertexSamplerRange];
-
-    id<MTLTexture> texturesToBindFragment[FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_FRAGMENT_SAMPLER_COUNT] = {};
-    id<MTLSamplerState> samplersToBindFragment[FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_FRAGMENT_SAMPLER_COUNT] = {};
-
-    enumerateSamplerGroups(program, ShaderStage::FRAGMENT,
-            [this, &getTextureToBind, &getSamplerToBind, &texturesToBindFragment, &samplersToBindFragment](
-                    const SamplerDescriptor* sampler, uint8_t binding) {
-        // We currently only support a max of MAX_FRAGMENT_SAMPLER_COUNT samplers. Ignore any additional
-        // samplers that may be bound.
-        if (binding >= FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_FRAGMENT_SAMPLER_COUNT) {
-            return;
-        }
-
-        auto& textureToBind = texturesToBindFragment[binding];
-        textureToBind = getTextureToBind(sampler);
-        if (!textureToBind) {
-            utils::slog.w << "Warning: no texture bound at binding point " << (size_t) binding
-                          << " at the fragment shader." << utils::io::endl;
-            textureToBind = getOrCreateEmptyTexture(mContext);
-        }
-
-        auto& samplerToBind = samplersToBindFragment[binding];
-        samplerToBind = getSamplerToBind(sampler);
-    });
-
-    // Assign a default sampler to empty slots, in case Filament hasn't bound all samplers.
-    // Metal requires all samplers referenced in shaders to be bound.
-    for (auto& sampler : samplersToBindFragment) {
-        if (!sampler) {
-            sampler = mContext->samplerStateCache.getOrCreateState({});
-        }
-    }
-
-    NSRange fragmentSamplerRange = NSMakeRange(0, FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_FRAGMENT_SAMPLER_COUNT);
-    [mContext->currentRenderPassEncoder setFragmentTextures:texturesToBindFragment
-                                                  withRange:fragmentSamplerRange];
-    [mContext->currentRenderPassEncoder setFragmentSamplerStates:samplersToBindFragment
-                                                       withRange:fragmentSamplerRange];
 
     // Bind the user vertex buffers.
 
@@ -1534,38 +1647,6 @@ void MetalDriver::endTimerQuery(Handle<HwTimerQuery> tqh) {
             "endTimerQuery must be called outside of a render pass.");
     auto* tq = handle_cast<MetalTimerQuery>(tqh);
     mContext->timerQueryImpl->endTimeElapsedQuery(tq);
-}
-
-void MetalDriver::enumerateSamplerGroups(
-        const MetalProgram* program, ShaderStage shaderType,
-        const std::function<void(const SamplerDescriptor*, size_t)>& f) {
-    auto& samplerBlockInfo = (shaderType == ShaderStage::VERTEX) ?
-            program->vertexSamplerBlockInfo : program->fragmentSamplerBlockInfo;
-    auto maxSamplerCount = (shaderType == ShaderStage::VERTEX) ?
-                           FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_VERTEX_SAMPLER_COUNT :
-                           FEATURE_LEVEL_CAPS[+FeatureLevel::FEATURE_LEVEL_1].MAX_FRAGMENT_SAMPLER_COUNT;
-    for (size_t bindingIdx = 0; bindingIdx != maxSamplerCount; ++bindingIdx) {
-        auto& blockInfo = samplerBlockInfo[bindingIdx];
-        if (blockInfo.samplerGroup == UINT8_MAX) {
-            continue;
-        }
-
-        const auto* metalSamplerGroup = mContext->samplerBindings[blockInfo.samplerGroup];
-        if (!metalSamplerGroup) {
-            // Do not emit warning here. For example this can arise when skinning is enabled
-            // and the morphing texture is unused.
-            continue;
-        }
-
-        SamplerGroup* sb = metalSamplerGroup->sb.get();
-        const SamplerDescriptor* boundSampler = sb->data() + blockInfo.sampler;
-
-        if (!boundSampler->t) {
-            continue;
-        }
-
-        f(boundSampler, bindingIdx);
-    }
 }
 
 void MetalDriver::enumerateBoundUniformBuffers(

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -164,13 +164,7 @@ struct MetalProgram : public HwProgram {
     id<MTLFunction> vertexFunction;
     id<MTLFunction> fragmentFunction;
 
-    struct SamplerBlockInfo {
-        uint8_t samplerGroup = UINT8_MAX;
-        uint8_t sampler = UINT8_MAX;
-    };
-
-    std::array<SamplerBlockInfo, FEATURE_LEVEL_CAPS[1].MAX_VERTEX_SAMPLER_COUNT> vertexSamplerBlockInfo;
-    std::array<SamplerBlockInfo, FEATURE_LEVEL_CAPS[1].MAX_FRAGMENT_SAMPLER_COUNT> fragmentSamplerBlockInfo;
+    Program::SamplerGroupInfo samplerGroupInfo;
 
     bool isValid = false;
 };
@@ -188,7 +182,8 @@ struct PixelBufferShape {
             MTLSize size, uint32_t byteOffset);
 };
 
-struct MetalTexture : public HwTexture {
+class MetalTexture : public HwTexture {
+public:
     MetalTexture(MetalContext& context, SamplerType target, uint8_t levels, TextureFormat format,
             uint8_t samples, uint32_t width, uint32_t height, uint32_t depth, TextureUsage usage,
             TextureSwizzle r, TextureSwizzle g, TextureSwizzle b, TextureSwizzle a)
@@ -201,40 +196,148 @@ struct MetalTexture : public HwTexture {
 
     ~MetalTexture();
 
+    // Returns an id<MTLTexture> suitable for reading in a shader, taking into account swizzle and
+    // LOD clamping.
+    id<MTLTexture> getMtlTextureForRead() noexcept;
+
+    // Returns the id<MTLTexture> for attaching to a render pass.
+    id<MTLTexture> getMtlTextureForWrite() noexcept {
+        return texture;
+    }
+
     void loadImage(uint32_t level, MTLRegion region, PixelBufferDescriptor& p) noexcept;
-    void loadSlice(uint32_t level, MTLRegion region, uint32_t byteOffset, uint32_t slice,
-            PixelBufferDescriptor const& data) noexcept;
-    void loadWithCopyBuffer(uint32_t level, uint32_t slice, MTLRegion region, PixelBufferDescriptor const& data,
-            const PixelBufferShape& shape);
-    void loadWithBlit(uint32_t level, uint32_t slice, MTLRegion region, PixelBufferDescriptor const& data,
-            const PixelBufferShape& shape);
+    void generateMipmaps() noexcept;
+
+    // A texture starts out with none of its mip levels (also referred to as LODs) available for
+    // reading. 3 actions update the range of LODs available:
+    // - calling loadImage
+    // - calling generateMipmaps
+    // - using the texture as a render target attachment
+    // The range of available mips can only increase, never decrease.
+    // A texture's available mips are consistent throughout a render pass.
     void updateLodRange(uint32_t level);
+    void updateLodRange(uint32_t minLevel, uint32_t maxLevel);
+
+    // Returns true if the texture has all of its mip levels accessible for reading.
+    // For any MetalTexture, once this is true, will always return true.
+    // The value returned will remain consistent for an entire render pass.
+    bool allLodsValid() const {
+        return minLod == 0 && maxLod == levels - 1;
+    }
 
     static MTLPixelFormat decidePixelFormat(MetalContext* context, TextureFormat format);
 
     MetalContext& context;
     MetalExternalImage externalImage;
-    id<MTLTexture> texture = nil;
 
     // A "sidecar" texture used to implement automatic MSAA resolve.
     // This is created by MetalRenderTarget and stored here so it can be used with multiple
     // render targets.
     id<MTLTexture> msaaSidecar = nil;
 
+    MTLPixelFormat devicePixelFormat;
+
+private:
+    void loadSlice(uint32_t level, MTLRegion region, uint32_t byteOffset, uint32_t slice,
+            PixelBufferDescriptor const& data) noexcept;
+    void loadWithCopyBuffer(uint32_t level, uint32_t slice, MTLRegion region, PixelBufferDescriptor const& data,
+            const PixelBufferShape& shape);
+    void loadWithBlit(uint32_t level, uint32_t slice, MTLRegion region, PixelBufferDescriptor const& data,
+            const PixelBufferShape& shape);
+
+    id<MTLTexture> texture = nil;
+
     // If non-nil, a swizzled texture view to use instead of "texture".
     // Filament swizzling only affects texture reads, so this should not be used when the texture is
     // bound as a render target attachment.
     id<MTLTexture> swizzledTextureView = nil;
+    id<MTLTexture> lodTextureView = nil;
 
-    MTLPixelFormat devicePixelFormat;
     uint32_t minLod = UINT_MAX;
     uint32_t maxLod = 0;
 };
 
-struct MetalSamplerGroup : public HwSamplerGroup {
-    // NOTE: we have to use out-of-line allocation here because the size of a Handle<> is limited
-    std::unique_ptr<SamplerGroup> sb; // FIXME: this shouldn't depend on filament::SamplerGroup
-    explicit MetalSamplerGroup(size_t size) noexcept : sb(new SamplerGroup(size)) { }
+class MetalSamplerGroup : public HwSamplerGroup {
+public:
+    explicit MetalSamplerGroup(size_t size) noexcept
+        : size(size),
+          textureHandles(size, Handle<HwTexture>()),
+          textures(size, nil),
+          samplers(size, nil) {}
+
+    inline void setTextureHandle(size_t index, Handle<HwTexture> th) {
+        assert_invariant(!finalized);
+        textureHandles[index] = th;
+    }
+
+#ifndef NDEBUG
+    // This method is only used for debugging, to ensure all texture handles are alive.
+    const auto& getTextureHandles() const {
+        return textureHandles;
+    }
+#endif
+
+    // Encode a MTLTexture into this SamplerGroup at the given index.
+    inline void setFinalizedTexture(size_t index, id<MTLTexture> t) {
+        assert_invariant(encoder);
+        assert_invariant(!finalized);
+        [encoder setTexture:t atIndex:(index * 2 + 0)];
+        textures[index] = t;
+    }
+
+    // Encode a MTLSamplerState into this SamplerGroup at the given index.
+    inline void setFinalizedSampler(size_t index, id<MTLSamplerState> s) {
+        assert_invariant(encoder);
+        assert_invariant(!finalized);
+        [encoder setSamplerState:s atIndex:(index * 2 + 1)];
+        samplers[index] = s;
+    }
+
+    // A SamplerGroup is "finalized" when all of its textures have been set and is ready for use in
+    // a draw call.
+    // Once a SamplerGroup is finalized, it must be reset or mutated to be written into again.
+    void finalize() { finalized = true; }
+    bool isFinalized() const noexcept { return finalized; }
+
+    // Both of these methods "unfinalize" a SamplerGroup, allowing it to be updated via calls to
+    // setFinalizedTexture or setFinalizedSampler. The difference is that when reset is called, all
+    // the samplers/textures must be rebound. The MTLArgumentEncoder must be specified, in case
+    // the texture types have changed.
+    // Mutate re-encodes the current set of samplers/textures into the new argument
+    // buffer.
+    void reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEncoder> e);
+    void mutate(id<MTLCommandBuffer> cmdBuffer);
+
+    id<MTLBuffer> getArgumentBuffer() const {
+        assert_invariant(finalized);
+        return argBuffer->getCurrentAllocation().first;
+    }
+
+    NSUInteger getArgumentBufferOffset() const {
+        return argBuffer->getCurrentAllocation().second;
+    }
+
+    inline std::pair<Handle<HwTexture>, id<MTLTexture>> getFinalizedTexture(size_t index) {
+        return {textureHandles[index], textures[index]};
+    }
+
+    // Calls the Metal useResource:usage:stages: method for all the textures in this SamplerGroup.
+    void useResources(id<MTLRenderCommandEncoder> renderPassEncoder);
+
+    size_t size;
+
+public:
+
+    // These vectors are kept in sync with one another.
+    utils::FixedCapacityVector<Handle<HwTexture>> textureHandles;
+    utils::FixedCapacityVector<id<MTLTexture>> textures;
+    utils::FixedCapacityVector<id<MTLSamplerState>> samplers;
+
+    id<MTLArgumentEncoder> encoder;
+
+    std::unique_ptr<MetalRingBuffer> argBuffer = nullptr;
+
+    bool finalized = false;
 };
 
 class MetalRenderTarget : public HwRenderTarget {
@@ -248,7 +351,7 @@ public:
         Attachment() = default;
         Attachment(MetalTexture* metalTexture, uint8_t level = 0, uint16_t layer = 0) :
                 level(level), layer(layer),
-                texture(metalTexture->texture),
+                texture(metalTexture->getMtlTextureForWrite()),
                 metalTexture(metalTexture) { }
 
         id<MTLTexture> getTexture() const {

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -24,6 +24,8 @@
 
 #include <backend/DriverEnums.h>
 
+#include <utils/FixedCapacityVector.h>
+
 #include <memory>
 #include <tsl/robin_map.h>
 #include <utils/Hash.h>
@@ -39,13 +41,10 @@ inline bool operator==(const SamplerParams& lhs, const SamplerParams& rhs) {
 //   ------------------------------------------------------
 //   0           Zero buffer (placeholder vertex buffer)  1
 //   1-16        Filament vertex buffers                 16   limited by MAX_VERTEX_BUFFER_COUNT
-//   17-26       Uniform buffers                         10
-//   27-30       Sampler Uniforms (argument buffers)      4   TODO: use arg buffers for samplers
+//   17-26       Uniform buffers                         10   Program::UNIFORM_BINDING_COUNT
+//   27-30       Sampler groups (argument buffers)        4   Program::SAMPLER_BINDING_COUNT
 //
 //   Total                                               31
-
-static constexpr uint32_t SAMPLER_GROUP_COUNT = Program::SAMPLER_BINDING_COUNT;
-static constexpr uint32_t SAMPLER_BINDING_COUNT = MAX_SAMPLER_COUNT;
 
 // The total number of vertex buffer "slots" that the Metal backend can bind.
 // + 1 to account for the zero buffer, a placeholder buffer used internally by the Metal backend.
@@ -58,10 +57,9 @@ static constexpr uint32_t ZERO_VERTEX_BUFFER_BINDING = 0u;
 
 static constexpr uint32_t USER_VERTEX_BUFFER_BINDING_START = 1u;
 
-// The max number of uniform buffers that the Metal backend can simultaneously bind.
-static constexpr uint32_t UNIFORM_BUFFER_COUNT = 10u;
-// This constant must match the equivalent in CodeGenerator.cpp.
+// These constants must match the equivalent in CodeGenerator.h.
 static constexpr uint32_t UNIFORM_BUFFER_BINDING_START = 17u;
+static constexpr uint32_t SAMPLER_GROUP_BINDING_START = 27u;
 
 // Forward declarations necessary here, definitions at end of file.
 inline bool operator==(const MTLViewport& lhs, const MTLViewport& rhs);
@@ -143,9 +141,11 @@ static_assert(sizeof(BlendState) == 56, "BlendState is unexpected size.");
 // StateCache caches Metal state objects using StateType as a key.
 // MetalType is the corresponding Metal API type.
 // StateCreator is a functor that creates a new state of type MetalType.
+// HashFn is a functor that hashes StateType.
 template<typename StateType,
          typename MetalType,
-         typename StateCreator>
+         typename StateCreator,
+         typename HashFn = utils::hash::MurmurHashFn<StateType>>
 class StateCache {
 
 public:
@@ -158,6 +158,8 @@ public:
     void setDevice(id<MTLDevice> device) noexcept { mDevice = device; }
 
     MetalType getOrCreateState(const StateType& state) noexcept {
+        assert_invariant(mDevice);
+
         // Check if a valid state already exists in the cache.
         auto iter = mStateCache.find(state);
         if (UTILS_LIKELY(iter != mStateCache.end())) {
@@ -167,6 +169,7 @@ public:
 
         // If we reach this point, we couldn't find one in the cache; create a new one.
         const auto& metalObject = creator(mDevice, state);
+        assert_invariant(metalObject);
 
         mStateCache.emplace(std::make_pair(
             state,
@@ -181,7 +184,6 @@ private:
     StateCreator creator;
     id<MTLDevice> mDevice = nil;
 
-    using HashFn = utils::hash::MurmurHashFn<StateType>;
     tsl::robin_map<StateType, MetalType, HashFn> mStateCache;
 
 };
@@ -358,13 +360,9 @@ using UniformBufferStateTracker = StateTracker<UniformBufferState>;
 
 struct SamplerState {
     SamplerParams samplerParams;
-    uint32_t minLod = 0;
-    uint32_t maxLod = UINT_MAX;
 
     bool operator==(const SamplerState& rhs) const noexcept {
-        return this->samplerParams == rhs.samplerParams &&
-               this->minLod == rhs.minLod &&
-               this->maxLod == rhs.maxLod;
+        return this->samplerParams == rhs.samplerParams;
     }
 
     bool operator!=(const SamplerState& rhs) const noexcept {
@@ -372,7 +370,7 @@ struct SamplerState {
     }
 };
 
-static_assert(sizeof(SamplerState) == 12, "SamplerState unexpected size.");
+static_assert(sizeof(SamplerState) == 4, "SamplerState unexpected size.");
 
 struct SamplerStateCreator {
     id<MTLSamplerState> operator()(id<MTLDevice> device, const SamplerState& state) noexcept;
@@ -384,6 +382,37 @@ using SamplerStateCache = StateCache<SamplerState, id<MTLSamplerState>, SamplerS
 
 using CullModeStateTracker = StateTracker<MTLCullMode>;
 using WindingStateTracker = StateTracker<MTLWinding>;
+
+// Argument encoder
+
+struct ArgumentEncoderState {
+    utils::FixedCapacityVector<MTLTextureType> textureTypes;
+
+    explicit ArgumentEncoderState(utils::FixedCapacityVector<MTLTextureType>&& types)
+        : textureTypes(std::move(types)) {}
+
+    bool operator==(const ArgumentEncoderState& rhs) const noexcept {
+        return std::equal(textureTypes.begin(), textureTypes.end(), rhs.textureTypes.begin());
+    }
+
+    bool operator!=(const ArgumentEncoderState& rhs) const noexcept {
+        return !operator==(rhs);
+    }
+};
+
+struct ArgumentEncoderHasher {
+    uint32_t operator()(const ArgumentEncoderState& key) const noexcept {
+        return utils::hash::murmur3((const uint32_t*)key.textureTypes.data(),
+                sizeof(MTLTextureType) * key.textureTypes.size() / 4, 0);
+    }
+};
+
+struct ArgumentEncoderCreator {
+    id<MTLArgumentEncoder> operator()(id<MTLDevice> device, const ArgumentEncoderState& state) noexcept;
+};
+
+using ArgumentEncoderCache = StateCache<ArgumentEncoderState, id<MTLArgumentEncoder>,
+        ArgumentEncoderCreator, ArgumentEncoderHasher>;
 
 } // namespace backend
 } // namespace filament

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -392,7 +392,8 @@ struct ArgumentEncoderState {
         : textureTypes(std::move(types)) {}
 
     bool operator==(const ArgumentEncoderState& rhs) const noexcept {
-        return std::equal(textureTypes.begin(), textureTypes.end(), rhs.textureTypes.begin());
+        return std::equal(textureTypes.begin(), textureTypes.end(), rhs.textureTypes.begin(),
+                rhs.textureTypes.end());
     }
 
     bool operator!=(const ArgumentEncoderState& rhs) const noexcept {

--- a/filament/backend/src/metal/MetalUtils.h
+++ b/filament/backend/src/metal/MetalUtils.h
@@ -30,6 +30,14 @@ id<MTLTexture> createTextureViewWithSwizzle(id<MTLTexture> texture,
         MTLTextureSwizzleChannels swizzle);
 
 /**
+ * Creates a texture view of the passed-in texture with the given lod range (inclusive). If the
+ * range represents all mip levels, simply returns texture.
+ * lodMax must be greater than or equal to lodMin.
+ */
+id<MTLTexture> createTextureViewWithLodRange(id<MTLTexture> texture, NSUInteger lodMin,
+        NSUInteger lodMax);
+
+/**
  * Creates a texture view of the passed-in texture with the given layer.
  *
  * The returned MTLTexture will have a type of MTLTextureType2D.

--- a/filament/backend/src/metal/MetalUtils.mm
+++ b/filament/backend/src/metal/MetalUtils.mm
@@ -16,6 +16,8 @@
 
 #include "MetalUtils.h"
 
+#include <utils/debug.h>
+
 namespace filament::backend {
 
 id<MTLTexture> createTextureViewWithSwizzle(id<MTLTexture> texture,
@@ -35,6 +37,24 @@ id<MTLTexture> createTextureViewWithSwizzle(id<MTLTexture> texture,
                                            levels:NSMakeRange(0, mips)
                                            slices:NSMakeRange(0, slices)
                                           swizzle:swizzle];
+}
+
+id<MTLTexture> createTextureViewWithLodRange(id<MTLTexture> texture, NSUInteger lodMin,
+        NSUInteger lodMax) {
+    assert_invariant(lodMax >= lodMin);
+    if (lodMin == 0 && lodMax >= texture.mipmapLevelCount - 1) {
+        return texture;
+    }
+    NSUInteger slices = texture.arrayLength;
+    if (texture.textureType == MTLTextureTypeCube ||
+        texture.textureType == MTLTextureTypeCubeArray) {
+        slices *= 6;
+    }
+    NSRange levelRange = NSMakeRange(lodMin, lodMax - lodMin + 1);
+    return [texture newTextureViewWithPixelFormat:texture.pixelFormat
+                                      textureType:texture.textureType
+                                           levels:levelRange
+                                           slices:NSMakeRange(0, slices)];
 }
 
 id<MTLTexture> createTextureViewWithSingleSlice(id<MTLTexture> texture, NSUInteger slice) {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 27;
+static constexpr size_t MATERIAL_VERSION = 28;
 
 /**
  * Supported shading models

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -452,8 +452,8 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
 }
 
 io::sstream& CodeGenerator::generateSamplers(
-        io::sstream& out, uint8_t firstBinding, const SamplerInterfaceBlock& sib,
-        SamplerBindingPoints bindingPoint) const {
+        io::sstream& out, SamplerBindingPoints bindingPoint, uint8_t firstBinding,
+        const SamplerInterfaceBlock& sib) const {
     auto const& infos = sib.getSamplerInfoList();
     if (infos.empty()) {
         return out;

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -368,9 +368,6 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
     Precision uniformPrecision = getDefaultUniformPrecision();
     Precision defaultPrecision = getDefaultPrecision(stage);
 
-    // This constant must match the equivalent in MetalState.h.
-    static constexpr uint32_t METAL_UNIFORM_BUFFER_BINDING_START = 17u;
-
     out << "\nlayout(";
     if (mTargetLanguage == TargetLanguage::SPIRV ||
         mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_2) {
@@ -455,7 +452,8 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
 }
 
 io::sstream& CodeGenerator::generateSamplers(
-        io::sstream& out, uint8_t firstBinding, const SamplerInterfaceBlock& sib) const {
+        io::sstream& out, uint8_t firstBinding, const SamplerInterfaceBlock& sib,
+        SamplerBindingPoints bindingPoint) const {
     auto const& infos = sib.getSamplerInfoList();
     if (infos.empty()) {
         return out;
@@ -472,21 +470,28 @@ io::sstream& CodeGenerator::generateSamplers(
         char const* const precision = getPrecisionQualifier(info.precision, Precision::DEFAULT);
         if (mTargetLanguage == TargetLanguage::SPIRV) {
             const uint32_t bindingIndex = (uint32_t) firstBinding + info.offset;
-            out << "layout(binding = " << bindingIndex;
+            switch (mTargetApi) {
+                // For Vulkan, we place uniforms in set 0 (the default set) and samplers in set 1. This
+                // allows the sampler bindings to live in a separate "namespace" that starts at zero.
+                // Note that the set specifier is not covered by the desktop GLSL spec, including
+                // recent versions. It is only documented in the GL_KHR_vulkan_glsl extension.
+                case TargetApi::VULKAN:
+                    out << "layout(binding = " << bindingIndex << ", set = 1) ";
+                    break;
 
-            // For Vulkan, we place uniforms in set 0 (the default set) and samplers in set 1. This
-            // allows the sampler bindings to live in a separate "namespace" that starts at zero.
-            // Note that the set specifier is not covered by the desktop GLSL spec, including
-            // recent versions. It is only documented in the GL_KHR_vulkan_glsl extension.
-            if (mTargetApi == TargetApi::VULKAN ||
-            // For Metal, the sampler binding index must less than 16. But we generate sampler binding
-            // index sequentially regardless binding shader stages, so it could be greater than 15.
-            // To avoid this problem, we have to re-calculate resource binding indices each of shader stages.
-                mTargetApi == TargetApi::METAL) {
-                out << ", set = 1";
+                // For Metal, each sampler group gets its own descriptor set, each of which will
+                // become an argument buffer. The first descriptor set is reserved for uniforms,
+                // hence the +1 here.
+                case TargetApi::METAL:
+                    out << "layout(binding = " << (uint32_t) info.offset
+                        << ", set = " << (uint32_t) bindingPoint + 1 << ") ";
+                    break;
+
+                default:
+                case TargetApi::OPENGL:
+                    out << "layout(binding = " << bindingIndex << ") ";
+                    break;
             }
-
-            out << ") ";
         }
         out << "uniform " << precision << " " << typeName << " " << info.uniformName.c_str();
         out << ";\n";

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -161,6 +161,8 @@ public:
             std::string& shader, filament::SamplerInterfaceBlock const& sib) noexcept;
 
     // These constants must match the equivalent in MetalState.h.
+    // These values represent the starting index for uniform and sampler group [[buffer(n)]]
+    // bindings. See the chart at the top of MetalState.h.
     static constexpr uint32_t METAL_UNIFORM_BUFFER_BINDING_START = 17u;
     static constexpr uint32_t METAL_SAMPLER_GROUP_BINDING_START = 27u;
 

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -119,7 +119,7 @@ public:
 
     // generate samplers
     utils::io::sstream& generateSamplers(utils::io::sstream& out, uint8_t firstBinding,
-            const filament::SamplerInterfaceBlock& sib) const;
+            const filament::SamplerInterfaceBlock& sib, filament::SamplerBindingPoints bindingPoint) const;
 
     // generate subpass
     static utils::io::sstream& generateSubpass(utils::io::sstream& out,
@@ -158,6 +158,10 @@ public:
 
     static void fixupExternalSamplers(
             std::string& shader, filament::SamplerInterfaceBlock const& sib) noexcept;
+
+    // These constants must match the equivalent in MetalState.h.
+    static constexpr uint32_t METAL_UNIFORM_BUFFER_BINDING_START = 17u;
+    static constexpr uint32_t METAL_SAMPLER_GROUP_BINDING_START = 27u;
 
 private:
     filament::backend::Precision getDefaultPrecision(ShaderStage stage) const;

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -118,8 +118,9 @@ public:
     static utils::io::sstream& generateDepthShaderMain(utils::io::sstream& out, ShaderStage type);
 
     // generate samplers
-    utils::io::sstream& generateSamplers(utils::io::sstream& out, uint8_t firstBinding,
-            const filament::SamplerInterfaceBlock& sib, filament::SamplerBindingPoints bindingPoint) const;
+    utils::io::sstream& generateSamplers(utils::io::sstream& out,
+            filament::SamplerBindingPoints bindingPoint, uint8_t firstBinding,
+            const filament::SamplerInterfaceBlock& sib) const;
 
     // generate subpass
     static utils::io::sstream& generateSubpass(utils::io::sstream& out,

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -562,7 +562,7 @@ std::string ShaderGenerator::createComputeProgram(filament::backend::ShaderModel
     cg.generateUniforms(s, ShaderStage::COMPUTE,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
 
-    cg.generateSamplers(s,
+    cg.generateSamplers(s, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
             material.sib);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -298,7 +298,8 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
                 UibGenerator::getPerRenderableMorphingUib());
         cg.generateSamplers(vs,
                 material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_RENDERABLE_MORPHING),
-                SibGenerator::getPerRenderPrimitiveMorphingSib(variant));
+                SibGenerator::getPerRenderPrimitiveMorphingSib(variant),
+                SamplerBindingPoints::PER_RENDERABLE_MORPHING);
     }
     cg.generateUniforms(vs, ShaderStage::VERTEX,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
@@ -306,7 +307,8 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
     // TODO: should we generate per-view SIB in the vertex shader?
     cg.generateSamplers(vs,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib);
+            material.sib,
+            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
 
     // shader code
     CodeGenerator::generateCommon(vs, ShaderStage::VERTEX);
@@ -500,10 +502,12 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     CodeGenerator::generateSeparator(fs);
     cg.generateSamplers(fs,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_VIEW),
-            SibGenerator::getPerViewSib(variant));
+            SibGenerator::getPerViewSib(variant),
+            SamplerBindingPoints::PER_VIEW);
     cg.generateSamplers(fs,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib);
+            material.sib,
+            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
 
     fs << "float filament_lodBias;\n";
 
@@ -610,7 +614,8 @@ std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel sm,
 
     cg.generateSamplers(vs,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib);
+            material.sib,
+            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
 
     CodeGenerator::generatePostProcessCommon(vs, ShaderStage::VERTEX);
     CodeGenerator::generatePostProcessGetters(vs, ShaderStage::VERTEX);
@@ -647,7 +652,8 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel sm,
 
     cg.generateSamplers(fs,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib);
+            material.sib,
+            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
 
     // subpass
     CodeGenerator::generateSubpass(fs, material.subpass);

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -296,19 +296,17 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
         cg.generateUniforms(vs, ShaderStage::VERTEX,
                 UniformBindingPoints::PER_RENDERABLE_MORPHING,
                 UibGenerator::getPerRenderableMorphingUib());
-        cg.generateSamplers(vs,
+        cg.generateSamplers(vs, SamplerBindingPoints::PER_RENDERABLE_MORPHING,
                 material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_RENDERABLE_MORPHING),
-                SibGenerator::getPerRenderPrimitiveMorphingSib(variant),
-                SamplerBindingPoints::PER_RENDERABLE_MORPHING);
+                SibGenerator::getPerRenderPrimitiveMorphingSib(variant));
     }
     cg.generateUniforms(vs, ShaderStage::VERTEX,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
     CodeGenerator::generateSeparator(vs);
     // TODO: should we generate per-view SIB in the vertex shader?
-    cg.generateSamplers(vs,
+    cg.generateSamplers(vs, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib,
-            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
+            material.sib);
 
     // shader code
     CodeGenerator::generateCommon(vs, ShaderStage::VERTEX);
@@ -500,14 +498,12 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     cg.generateUniforms(fs, ShaderStage::FRAGMENT,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
     CodeGenerator::generateSeparator(fs);
-    cg.generateSamplers(fs,
+    cg.generateSamplers(fs, SamplerBindingPoints::PER_VIEW,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_VIEW),
-            SibGenerator::getPerViewSib(variant),
-            SamplerBindingPoints::PER_VIEW);
-    cg.generateSamplers(fs,
+            SibGenerator::getPerViewSib(variant));
+    cg.generateSamplers(fs, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib,
-            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
+            material.sib);
 
     fs << "float filament_lodBias;\n";
 
@@ -612,10 +608,9 @@ std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel sm,
     cg.generateUniforms(vs, ShaderStage::VERTEX,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
 
-    cg.generateSamplers(vs,
+    cg.generateSamplers(vs, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib,
-            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
+            material.sib);
 
     CodeGenerator::generatePostProcessCommon(vs, ShaderStage::VERTEX);
     CodeGenerator::generatePostProcessGetters(vs, ShaderStage::VERTEX);
@@ -650,10 +645,9 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel sm,
     cg.generateUniforms(fs, ShaderStage::FRAGMENT,
             UniformBindingPoints::PER_MATERIAL_INSTANCE, material.uib);
 
-    cg.generateSamplers(fs,
+    cg.generateSamplers(fs, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
-            material.sib,
-            SamplerBindingPoints::PER_MATERIAL_INSTANCE);
+            material.sib);
 
     // subpass
     CodeGenerator::generateSubpass(fs, material.subpass);


### PR DESCRIPTION
This switches Metal to use [argument buffers](https://developer.apple.com/documentation/metal/buffers/about_argument_buffers?language=objc) for referencing samplers and textures in draw calls. Argument buffers are similar to Vulkan descriptors.

The primarily reason for doing this is to support more textures/samplers for feature level 3 on newer Metal devices. This also opens up some potential CPU performance improvements.

The logic is a bit tricky, as we don't necessarily know all the final textures at `updateSamplerGroup` time, so `MetalSamplerGroup` has some additional bookkeeping to do.