### PR TITLE
gltfio API changes, parts 1 and 2.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,8 @@ A new header is inserted each time a *tag* is created.
 - gltfio: fix interpretation of occlusion strength
 - engine: minsdk is now 21 instead of 19. This allows the use of OpenGL ES 3.1
 - gltfio: fix ubershader issues with assignment of dummy textures
+- gltfio: material instances and variants are now accessed via `FilamentInstance` [⚠️ **API Change**]
+- gltfio: the animator can now only be accessed via `FilamentInstance` [⚠️ **API Change**]
 
 ## v1.27.2
 

--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/ModelViewer.kt
@@ -179,7 +179,7 @@ class ModelViewer(
         asset = assetLoader.createAsset(buffer)
         asset?.let { asset ->
             resourceLoader.asyncBeginLoad(asset)
-            animator = asset.animator
+            animator = asset.getInstance().animator
             asset.releaseSourceData()
         }
     }
@@ -202,7 +202,7 @@ class ModelViewer(
                 resourceLoader.addResourceData(uri, resourceBuffer)
             }
             resourceLoader.asyncBeginLoad(asset)
-            animator = asset.animator
+            animator = asset.getInstance().animator
             asset.releaseSourceData()
         }
     }
@@ -359,7 +359,7 @@ class ModelViewer(
                 resourceLoader.addResourceData(uri, buffer)
             }
             resourceLoader.asyncBeginLoad(asset)
-            animator = asset.animator
+            animator = asset.getInstance().animator
             asset.releaseSourceData()
         }
     }

--- a/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentAsset.cpp
@@ -172,27 +172,6 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetCameraEntityCount(JNIE
     return asset->getCameraEntityCount();
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialInstanceCount(JNIEnv*, jclass,
-        jlong nativeAsset) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    return asset->getMaterialInstanceCount();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialInstances(JNIEnv* env, jclass,
-        jlong nativeAsset, jlongArray result) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    jsize available = env->GetArrayLength(result);
-    jsize count = std::min(available, (jsize) asset->getMaterialInstanceCount());
-    jlong* dst = env->GetLongArrayElements(result, nullptr);
-    const MaterialInstance * const* src = asset->getMaterialInstances();
-    for (jsize i = 0; i < count; i++) {
-        dst[i] = (jlong) src[i];
-    }
-    env->ReleaseLongArrayElements(result, dst, 0);
-}
-
 extern "C" JNIEXPORT void JNICALL
 Java_com_google_android_filament_gltfio_FilamentAsset_nGetBoundingBox(JNIEnv* env, jclass,
         jlong nativeAsset, jfloatArray result) {
@@ -229,10 +208,10 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetExtras(JNIEnv* env, jc
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetAnimator(JNIEnv* , jclass,
+Java_com_google_android_filament_gltfio_FilamentAsset_nGetInstance(JNIEnv* , jclass,
         jlong nativeAsset) {
     FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    return (jlong) asset->getAnimator();
+    return (jlong) asset->getInstance();
 }
 
 extern "C" JNIEXPORT jint JNICALL
@@ -270,30 +249,6 @@ Java_com_google_android_filament_gltfio_FilamentAsset_nGetMorphTargetNames(JNIEn
         const char* name = asset->getMorphTargetNameAt(entity, i);
         env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(name));
     }
-}
-
-extern "C" JNIEXPORT jint JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialVariantCount(JNIEnv*, jclass,
-        jlong nativeAsset) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    return (jint) asset->getMaterialVariantCount();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nGetMaterialVariantNames(JNIEnv* env, jclass,
-        jlong nativeAsset, jobjectArray result) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    for (int i = 0; i < asset->getMaterialVariantCount(); ++i) {
-        const char* name = asset->getMaterialVariantName(i);
-        env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(name));
-    }
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_gltfio_FilamentAsset_nApplyMaterialVariant(JNIEnv* env, jclass,
-        jlong nativeAsset, jint variantIndex) {
-    FilamentAsset* asset = (FilamentAsset*) nativeAsset;
-    asset->applyMaterialVariant(variantIndex);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
+++ b/android/gltfio-android/src/main/cpp/FilamentInstance.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 
+using namespace filament;
 using namespace filament::gltfio;
 using namespace utils;
 
@@ -60,6 +61,44 @@ Java_com_google_android_filament_gltfio_FilamentInstance_nApplyMaterialVariant(J
         jlong nativeInstance, jint variantIndex) {
     FilamentInstance* instance = (FilamentInstance*) nativeInstance;
     instance->applyMaterialVariant(variantIndex);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetMaterialVariantCount(JNIEnv*, jclass,
+        jlong nativeInstance) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    return (jint) instance->getMaterialVariantCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetMaterialVariantNames(JNIEnv* env, jclass,
+        jlong nativeInstance, jobjectArray result) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    for (int i = 0; i < instance->getMaterialVariantCount(); ++i) {
+        const char* name = instance->getMaterialVariantName(i);
+        env->SetObjectArrayElement(result, (jsize) i, env->NewStringUTF(name));
+    }
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetMaterialInstanceCount(JNIEnv*, jclass,
+        jlong nativeInstance) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    return instance->getMaterialInstanceCount();
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_gltfio_FilamentInstance_nGetMaterialInstances(JNIEnv* env, jclass,
+        jlong nativeInstance, jlongArray result) {
+    FilamentInstance* instance = (FilamentInstance*) nativeInstance;
+    jsize available = env->GetArrayLength(result);
+    jsize count = std::min(available, (jsize) instance->getMaterialInstanceCount());
+    jlong* dst = env->GetLongArrayElements(result, nullptr);
+    const MaterialInstance * const* src = instance->getMaterialInstances();
+    for (jsize i = 0; i < count; i++) {
+        dst[i] = (jlong) src[i];
+    }
+    env->ReleaseLongArrayElements(result, dst, 0);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/FilamentInstance.java
@@ -19,7 +19,9 @@ package com.google.android.filament.gltfio;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
+import com.google.android.filament.Engine;
 import com.google.android.filament.Entity;
+import com.google.android.filament.MaterialInstance;
 
 /**
  * Provides access to a hierarchy of entities that have been instanced from a glTF asset.
@@ -146,11 +148,39 @@ public class FilamentInstance {
         nApplyMaterialVariant(mNativeObject, variantIndex);
     }
 
+    public @NonNull MaterialInstance[] getMaterialInstances() {
+        final int count = nGetMaterialInstanceCount(mNativeObject);
+        MaterialInstance[] result = new MaterialInstance[count];
+        long[] natives = new long[count];
+        nGetMaterialInstances(mNativeObject, natives);
+        Engine engine = mAsset.getEngine();
+        for (int i = 0; i < count; i++) {
+            result[i] = new MaterialInstance(engine, natives[i]);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the names of all material variants.
+     */
+    public @NonNull String[] getMaterialVariantNames() {
+        String[] names = new String[nGetMaterialVariantCount(mNativeObject)];
+        nGetMaterialVariantNames(mNativeObject, names);
+        return names;
+    }
+
     private static native int nGetRoot(long nativeInstance);
     private static native int nGetEntityCount(long nativeInstance);
     private static native void nGetEntities(long nativeInstance, int[] result);
     private static native long nGetAnimator(long nativeInstance);
+
+    private static native int nGetMaterialInstanceCount(long nativeAsset);
+    private static native void nGetMaterialInstances(long nativeAsset, long[] nativeResults);
+
     private static native void nApplyMaterialVariant(long nativeInstance, int variantIndex);
+    private static native int nGetMaterialVariantCount(long nativeAsset);
+    private static native void nGetMaterialVariantNames(long nativeAsset, String[] result);
+
     private static native void nGetJointsAt(long nativeInstance, int skinIndex, int[] result);
     private static native int nGetSkinCount(long nativeInstance);
     private static native void nGetSkinNames(long nativeInstance, String[] result);

--- a/android/samples/README.md
+++ b/android/samples/README.md
@@ -112,9 +112,9 @@ the Android SDK.
 
 ## Android Studio
 
-You must use Android Studio 3.6 RC 1 or higher. To open the project, point Studio to the `android`
-folder. After opening the project and syncing to gradle, select the sample of your choice using the
-drop-down widget in the toolbar.
+You must use the latest stable release of Android Studio. To open the project, point Studio to the
+`android` folder. After opening the project and syncing to gradle, select the sample of your choice
+using the drop-down widget in the toolbar.
 
 ## Compiling
 

--- a/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
+++ b/android/samples/sample-gltf-viewer/src/main/java/com/google/android/filament/gltf/MainActivity.kt
@@ -417,7 +417,7 @@ class MainActivity : Activity() {
 
     // Just for testing purposes, this releases the current model and reloads the default model.
     inner class DoubleTapListener : GestureDetector.SimpleOnGestureListener() {
-        override fun onDoubleTap(e: MotionEvent?): Boolean {
+        override fun onDoubleTap(e: MotionEvent): Boolean {
             modelViewer.destroyModel()
             createDefaultRenderables()
             return super.onDoubleTap(e)

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -281,7 +281,6 @@ public:
      * By default, this is an identity matrix.
      *
      * @param shift     x and y translation added to the projection matrix, specified in NDC
-     * @param shift     x and y translation added to the projection matrix, specified in NDC
      *                  coordinates, that is, if the translation must be specified in pixels,
      *                  shift must be scaled by 1.0 / { viewport.width, viewport.height }.
      *

--- a/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
+++ b/ios/samples/gltf-viewer/gltf-viewer/FILModelView.mm
@@ -207,7 +207,7 @@ const float kSensitivity = 100.0f;
 
     _scene->addEntities(_asset->getEntities(), _asset->getEntityCount());
     _resourceLoader->loadResources(_asset);
-    _animator = _asset->getAnimator();
+    _animator = _asset->getInstance()->getAnimator();
     _asset->releaseSourceData();
 }
 
@@ -234,7 +234,7 @@ const float kSensitivity = 100.0f;
     }
 
     _resourceLoader->loadResources(_asset);
-    _animator = _asset->getAnimator();
+    _animator = _asset->getInstance()->getAnimator();
     _asset->releaseSourceData();
 
     _scene->addEntities(_asset->getEntities(), _asset->getEntityCount());

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -107,10 +107,13 @@ struct AssetConfiguration {
  * // Add renderables to the scene.
  * scene->addEntities(asset->getEntities(), asset->getEntityCount());
  *
+ * // Extract the animator interface from the FilamentInstance.
+ * auto animator = asset->getInstance()->getAnimator();
+ *
  * // Execute the render loop and play the first animation.
  * do {
- *      asset->getAnimator()->applyAnimation(0, time);
- *      asset->getAnimator()->updateBoneMatrices();
+ *      animator->applyAnimation(0, time);
+ *      animator->updateBoneMatrices();
  *      if (renderer->beginFrame(swapChain)) {
  *          renderer->render(view);
  *          renderer->endFrame();

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -207,16 +207,6 @@ public:
     const char* getExtras(Entity entity = {}) const noexcept;
 
     /**
-     * Returns the animation engine.
-     *
-     * The animator is owned by the asset and should not be manually deleted.
-     * Must be called after loadResources or asyncBeginLoad, otherwise returns null.
-     * If the asset is instanced, this returns a "primary" animator that controls all instances.
-     * To animate each instance individually, use \see FilamentInstance.
-     */
-    Animator* getAnimator() const noexcept;
-
-    /**
      * Gets the morph target name at the given index in the given entity.
      */
     const char* getMorphTargetNameAt(Entity entity, size_t targetIndex) const noexcept;

--- a/libs/gltfio/include/gltfio/FilamentAsset.h
+++ b/libs/gltfio/include/gltfio/FilamentAsset.h
@@ -48,7 +48,7 @@ class FilamentInstance;
  * \c Light, \c Camera, or \c Node components.
  *
  * In addition to the aforementioned entities, an asset has strong ownership over a list of
- * filament::VertexBuffer, filament::IndexBuffer, filament::MaterialInstance, filament::Texture,
+ * filament::VertexBuffer, filament::IndexBuffer, filament::Texture,
  * and, optionally, a simple animation engine (gltfio::Animator).
  *
  * Clients must use ResourceLoader to create filament::Texture objects, compute tangent quaternions,
@@ -157,15 +157,6 @@ public:
      */
     size_t popRenderables(Entity* entities, size_t count) noexcept;
 
-    /** Gets all material instances. These are already bound to renderables. */
-    const filament::MaterialInstance* const* getMaterialInstances() const noexcept;
-
-    /** Gets all material instances (non-const). These are already bound to renderables. */
-    filament::MaterialInstance* const* getMaterialInstances() noexcept;
-
-    /** Gets the number of materials returned by getMaterialInstances(). */
-    size_t getMaterialInstanceCount() const noexcept;
-
     /** Gets resource URIs for all externally-referenced buffers. */
     const char* const* getResourceUris() const noexcept;
 
@@ -236,30 +227,6 @@ public:
     size_t getMorphTargetCountAt(Entity entity) const noexcept;
 
     /**
-     * Returns the number of material variants in the asset.
-     */
-    size_t getMaterialVariantCount() const noexcept;
-
-    /**
-     * Returns the name of the given material variant, or null if it is out of bounds.
-     */
-    const char* getMaterialVariantName(size_t variantIndex) const noexcept;
-
-    /**
-     * Applies the given material variant to all primitives that it affects.
-     *
-     * This is efficient because it merely swaps around persistent MaterialInstances. If you change
-     * a material parameter while a certain variant is active, the updated value will be remembered
-     * after you re-apply that variant.
-     *
-     * If the asset is instanced, this affects all instances in the same way.
-     * To set the variant on an individual instance, use FilamentInstance::applyMaterialVariant.
-     *
-     * Ignored if variantIndex is out of bounds.
-     */
-    void applyMaterialVariant(size_t variantIndex) noexcept;
-
-    /**
      * Lazily creates a single LINES renderable that draws the transformed bounding-box hierarchy
      * for diagnostic purposes. The wireframe is owned by the asset so clients should not delete it.
      */
@@ -304,7 +271,7 @@ public:
      * and provides filtering functionality.
      */
     void addEntitiesToScene(filament::Scene& targetScene, const Entity* entities, size_t count,
-            SceneMask sceneFilter);
+            SceneMask sceneFilter) const;
 
     /**
      * Releases ownership of entities and their Filament components.
@@ -316,14 +283,6 @@ public:
     void detachFilamentComponents() noexcept;
 
     bool areFilamentComponentsDetached() const noexcept;
-
-    /**
-     * Releases ownership of material instances.
-     *
-     * This makes the client take responsibility for destroying MaterialInstance
-     * objects. The getMaterialInstances query becomes invalid after detachment.
-     */
-    void detachMaterialInstances();
 
     /**
      * Convenience function to get the first instance, or null if it doesn't exist.

--- a/libs/gltfio/include/gltfio/FilamentInstance.h
+++ b/libs/gltfio/include/gltfio/FilamentInstance.h
@@ -22,6 +22,10 @@
 
 #include <filament/Box.h>
 
+namespace filament {
+class MaterialInstance;
+}
+
 namespace filament::gltfio {
 
 class Animator;
@@ -31,7 +35,7 @@ class FilamentAsset;
  * \class FilamentInstance FilamentInstance.h gltfio/FilamentInstance.h
  * \brief Provides access to a hierarchy of entities that have been instanced from a glTF asset.
  *
- * Every entity has a filament::TransformManager component, and some entities also have \c Name or
+ * Every entity has a TransformManager component, and some entities also have \c Name or
  * \c Renderable components.
  *
  * \see AssetLoader::createInstancedAsset()
@@ -64,6 +68,16 @@ public:
      * Ignored if variantIndex is out of bounds.
      */
     void applyMaterialVariant(size_t variantIndex) noexcept;
+
+    /**
+     * Returns the number of material variants in the asset.
+     */
+    size_t getMaterialVariantCount() const noexcept;
+
+    /**
+     * Returns the name of the given material variant, or null if it is out of bounds.
+     */
+    const char* getMaterialVariantName(size_t variantIndex) const noexcept;
 
     /**
      * Returns the animation engine for the instance.
@@ -129,6 +143,23 @@ public:
      * If recomputeBoundingBoxes() has been called, then this returns the recomputed AABB.
      */
     Aabb getBoundingBox() const noexcept;
+
+    /** Gets all material instances. These are already bound to renderables. */
+    const MaterialInstance* const* getMaterialInstances() const noexcept;
+
+    /** Gets all material instances (non-const). These are already bound to renderables. */
+    MaterialInstance* const* getMaterialInstances() noexcept;
+
+    /** Gets the number of materials returned by getMaterialInstances(). */
+    size_t getMaterialInstanceCount() const noexcept;
+
+    /**
+     * Releases ownership of material instances.
+     *
+     * This makes the client take responsibility for destroying MaterialInstance
+     * objects. The getMaterialInstances query becomes invalid after detachment.
+     */
+    void detachMaterialInstances();
 };
 
 } // namespace filament::gltfio

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -141,7 +141,7 @@ static LightManager::Type getLightType(const cgltf_light_type light) {
 //
 // Notes:
 // - The Material objects (used to create instances) are cached in MaterialProvider, not here.
-// - The cache is not responsible for destroying material instances. They are owned by the asset.
+// - The cache is not responsible for destroying material instances.
 class MaterialInstanceCache {
 public:
     struct Entry {
@@ -155,6 +155,44 @@ public:
         mHierarchy(hierarchy),
         mMaterialInstances(hierarchy->materials_count, Entry{}),
         mMaterialInstancesWithVertexColor(hierarchy->materials_count, Entry{}) {}
+
+    void flush(utils::FixedCapacityVector<MaterialInstance*>* dest) {
+        size_t count = 0;
+        for (const Entry& entry : mMaterialInstances) {
+            if (entry.instance) {
+                ++count;
+            }
+        }
+        for (const Entry& entry : mMaterialInstancesWithVertexColor) {
+            if (entry.instance) {
+                ++count;
+            }
+        }
+        if (mDefaultMaterialInstance.instance) {
+            ++count;
+        }
+        if (mDefaultMaterialInstanceWithVertexColor.instance) {
+            ++count;
+        }
+        assert_invariant(dest->size() == 0);
+        dest->reserve(count);
+        for (const Entry& entry : mMaterialInstances) {
+            if (entry.instance) {
+                dest->push_back(entry.instance);
+            }
+        }
+        for (const Entry& entry : mMaterialInstancesWithVertexColor) {
+            if (entry.instance) {
+                dest->push_back(entry.instance);
+            }
+        }
+        if (mDefaultMaterialInstance.instance) {
+            dest->push_back(mDefaultMaterialInstance.instance);
+        }
+        if (mDefaultMaterialInstanceWithVertexColor.instance) {
+            dest->push_back(mDefaultMaterialInstanceWithVertexColor.instance);
+        }
+    }
 
     Entry* getEntry(const cgltf_material** mat, bool vertexColor) {
         if (*mat) {
@@ -231,7 +269,7 @@ private:
     void recurseEntities(const cgltf_data* srcAsset, const cgltf_node* node, SceneMask scenes,
             Entity parent, FFilamentInstance* instance);
     void createRenderable(const cgltf_data* srcAsset, const cgltf_node* node, Entity entity,
-            const char* name);
+            const char* name, FFilamentInstance* instance);
     void createLight(const cgltf_light* light, Entity entity);
     void createCamera(const cgltf_camera* camera, Entity entity);
     void addTextureBinding(MaterialInstance* materialInstance, const char* parameterName,
@@ -331,6 +369,7 @@ FFilamentAsset* FAssetLoader::createInstancedAsset(const uint8_t* bytes, uint32_
     return mAsset;
 }
 
+// note there a two overloads; this is the high-level one
 FilamentInstance* FAssetLoader::createInstance(FFilamentAsset* primary) {
     if (!primary->mSourceAsset) {
         slog.e << "Source data has been released; asset is frozen." << io::endl;
@@ -341,8 +380,6 @@ FilamentInstance* FAssetLoader::createInstance(FFilamentAsset* primary) {
         slog.e << "There is no scene in the asset." << io::endl;
         return nullptr;
     }
-
-    mMaterialInstanceCache = MaterialInstanceCache(srcAsset);
 
     FFilamentInstance* instance = createInstance(srcAsset);
 
@@ -368,8 +405,6 @@ void FAssetLoader::createRootAsset(const cgltf_data* srcAsset) {
 
     mAsset = new FFilamentAsset(&mEngine, mNameManager, &mEntityManager, &mNodeManager, srcAsset);
 
-    mMaterialInstanceCache = MaterialInstanceCache(srcAsset);
-
     // It is not an error for a glTF file to have zero scenes.
     mAsset->mScenes.clear();
     if (srcAsset->scenes == nullptr) {
@@ -385,14 +420,6 @@ void FAssetLoader::createRootAsset(const cgltf_data* srcAsset) {
     const cgltf_size extras_size = asset.extras.end_offset - asset.extras.start_offset;
     if (extras_size > 1) {
         mAsset->mAssetExtras = CString(srcAsset->json + asset.extras.start_offset, extras_size);
-    }
-
-    // Check if the asset has variants.
-    if (srcAsset->variants_count > 0) {
-        mAsset->mVariants.reserve(srcAsset->variants_count);
-        for (cgltf_size i = 0, len = srcAsset->variants_count; i < len; ++i) {
-            mAsset->mVariants.push_back({CString(srcAsset->variants[i].name)});
-        }
     }
 
     // Build a mapping of root nodes to scene membership sets.
@@ -481,10 +508,13 @@ void FAssetLoader::createInstances(const cgltf_data* srcAsset, size_t numInstanc
     }
 }
 
+// note there a two overloads; this is the low-level one
 FFilamentInstance* FAssetLoader::createInstance(const cgltf_data* srcAsset) {
     auto rootTransform = mTransformManager.getInstance(mAsset->mRoot);
     Entity instanceRoot = mEntityManager.create();
     mTransformManager.create(instanceRoot, rootTransform);
+
+    mMaterialInstanceCache = MaterialInstanceCache(srcAsset);
 
     // Create an instance object, which is a just a lightweight wrapper around a vector of
     // entities and an animator. The creation of animator is triggered from ResourceLoader
@@ -504,12 +534,16 @@ FFilamentInstance* FAssetLoader::createInstance(const cgltf_data* srcAsset) {
 
     importSkins(mAsset, instance, srcAsset);
 
+    instance->createAnimator();
+
     mAsset->mInstances.push_back(instance);
 
     // Bounding boxes are not shared because users might call recomputeBoundingBoxes() which can
     // be affected by entity transforms. However, upon instance creation we can safely copy over
     // the asset's bounding box.
     instance->boundingBox = mAsset->mBoundingBox;
+
+    mMaterialInstanceCache.flush(&instance->mMaterialInstances);
 
     return instance;
 }
@@ -564,7 +598,7 @@ void FAssetLoader::recurseEntities(const cgltf_data* srcAsset, const cgltf_node*
 
     // If the node has a mesh, then create a renderable component.
     if (node->mesh) {
-        createRenderable(srcAsset, node, entity, name);
+        createRenderable(srcAsset, node, entity, name, instance);
         if (srcAsset->variants_count > 0) {
             createMaterialVariants(srcAsset, node->mesh, entity, instance);
         }
@@ -623,7 +657,7 @@ void FAssetLoader::createPrimitives(const cgltf_data* srcAsset, const cgltf_node
  }
 
 void FAssetLoader::createRenderable(const cgltf_data* srcAsset, const cgltf_node* node,
-        Entity entity, const char* name) {
+        Entity entity, const char* name, FFilamentInstance* instance) {
     const cgltf_mesh* mesh = node->mesh;
     const cgltf_size primitiveCount = mesh->primitives_count;
 
@@ -740,11 +774,6 @@ void FAssetLoader::createMaterialVariants(const cgltf_data* srcAsset, const cglt
         for (size_t i = 0, m = srcPrim.mappings_count; i < m; i++) {
             const size_t variantIndex = srcPrim.mappings[i].variant;
             const cgltf_material* material = srcPrim.mappings[i].material;
-            assert_invariant(variantIndex < mAsset->mVariants.size());
-            if (variantIndex >= mAsset->mVariants.size()) {
-                mError = true;
-                break;
-            }
             bool hasVertexColor = primitiveHasVertexColor(srcPrim);
             MaterialInstance* mi =
                     createMaterialInstance(srcAsset, material, &uvmap, hasVertexColor);
@@ -755,7 +784,6 @@ void FAssetLoader::createMaterialVariants(const cgltf_data* srcAsset, const cglt
             }
             mAsset->mDependencyGraph.addEdge(entity, mi);
             instance->variants[variantIndex].mappings.push_back({entity, prim, mi});
-            mAsset->mVariants[variantIndex].mappings.push_back({entity, prim, mi});
         }
     }
 }
@@ -1286,8 +1314,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
         slog.e << "No material with the specified requirements exists." << io::endl;
         return nullptr;
     }
-
-    mAsset->mMaterialInstances.push_back(mi);
 
     auto mrConfig = inputMat->pbr_metallic_roughness;
     auto sgConfig = inputMat->pbr_specular_glossiness;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -383,10 +383,6 @@ FilamentInstance* FAssetLoader::createInstance(FFilamentAsset* primary) {
 
     FFilamentInstance* instance = createInstance(srcAsset);
 
-    if (primary->mAnimator) {
-        primary->mAnimator->addInstance(instance);
-    }
-
     primary->mDependencyGraph.commitEdges();
     return instance;
 }
@@ -534,6 +530,8 @@ FFilamentInstance* FAssetLoader::createInstance(const cgltf_data* srcAsset) {
 
     importSkins(mAsset, instance, srcAsset);
 
+    // Now that all entities have been created, the instance can create the animator component.
+    // Note that it may need to defer actual creation until external buffers are fully loaded.
     instance->createAnimator();
 
     mAsset->mInstances.push_back(instance);

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -70,7 +70,6 @@ namespace utils {
 
 namespace filament::gltfio {
 
-class Animator;
 class Wireframe;
 
 // Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
@@ -186,8 +185,6 @@ struct FFilamentAsset : public FilamentAsset {
     size_t getEntitiesByPrefix(const char* prefix, utils::Entity* entities,
             size_t maxCount) const noexcept;
 
-    Animator* getAnimator() const noexcept { return mAnimator; }
-
     const char* getMorphTargetNameAt(utils::Entity entity, size_t targetIndex) const noexcept;
 
     size_t getMorphTargetCountAt(utils::Entity entity) const noexcept;
@@ -258,7 +255,6 @@ struct FFilamentAsset : public FilamentAsset {
     Aabb mBoundingBox;
     utils::Entity mRoot;
     std::vector<FFilamentInstance*> mInstances;
-    Animator* mAnimator = nullptr;
     Wireframe* mWireframe = nullptr;
 
     // Indicates if resource decoding has started (not necessarily finished)

--- a/libs/gltfio/src/FFilamentInstance.h
+++ b/libs/gltfio/src/FFilamentInstance.h
@@ -55,6 +55,29 @@ struct Variant {
 
 struct FFilamentInstance : public FilamentInstance {
     FFilamentInstance(utils::Entity root, FFilamentAsset const* owner);
+    ~FFilamentInstance();
+
+    size_t getMaterialInstanceCount() const noexcept {
+        return mMaterialInstances.size();
+    }
+
+    const MaterialInstance* const* getMaterialInstances() const noexcept {
+        return mMaterialInstances.data();
+    }
+
+    MaterialInstance* const* getMaterialInstances() noexcept {
+        return mMaterialInstances.data();
+    }
+
+    void detachMaterialInstances() {
+        mMaterialInstances.clear();
+    }
+
+    void applyMaterialVariant(size_t variantIndex) noexcept;
+
+    size_t getMaterialVariantCount() const noexcept;
+
+    const char* getMaterialVariantName(size_t variantIndex) const noexcept;
 
     // The per-instance skin structure caches information to allow animation to be applied
     // efficiently at run time. Note that shared immutable data, such as the skin name and inverse
@@ -83,6 +106,9 @@ struct FFilamentInstance : public FilamentInstance {
     utils::FixedCapacityVector<utils::Entity> nodeMap;
 
     Aabb boundingBox;
+
+    utils::FixedCapacityVector<MaterialInstance*> mMaterialInstances;
+
     void createAnimator();
     Animator* getAnimator() const noexcept;
     size_t getSkinCount() const noexcept;
@@ -91,7 +117,6 @@ struct FFilamentInstance : public FilamentInstance {
     const utils::Entity* getJointsAt(size_t skinIndex) const noexcept;
     void attachSkin(size_t skinIndex, utils::Entity target) noexcept;
     void detachSkin(size_t skinIndex, utils::Entity target) noexcept;
-    void applyMaterialVariant(size_t variantIndex) noexcept;
     void recomputeBoundingBoxes();
 };
 

--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -43,7 +43,6 @@ FFilamentAsset::~FFilamentAsset() {
         delete instance;
     }
 
-    delete mAnimator;
     delete mWireframe;
 
     // Destroy name components.
@@ -357,10 +356,6 @@ size_t FilamentAsset::getEntitiesByPrefix(const char* prefix, Entity* entities,
 
 const char* FilamentAsset::getExtras(Entity entity) const noexcept {
     return upcast(this)->getExtras(entity);
-}
-
-Animator* FilamentAsset::getAnimator() const noexcept {
-    return upcast(this)->getAnimator();
 }
 
 const char* FilamentAsset::getMorphTargetNameAt(utils::Entity entity,

--- a/libs/gltfio/src/FilamentInstance.cpp
+++ b/libs/gltfio/src/FilamentInstance.cpp
@@ -46,8 +46,9 @@ Animator* FFilamentInstance::getAnimator() const noexcept {
 }
 
 void FFilamentInstance::createAnimator() {
-    assert_invariant(animator == nullptr);
-    animator = new Animator(owner, this);
+    if (animator == nullptr && owner->mResourcesLoaded) {
+        animator = new Animator(owner, this);
+    }
 }
 
 size_t FFilamentInstance::getSkinCount() const noexcept {

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -521,8 +521,6 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     // materials or textures will be added. Notify the dependency graph.
     asset->mDependencyGraph.commitEdges();
 
-    asset->createAnimators();
-
     return true;
 }
 

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -521,6 +521,10 @@ bool ResourceLoader::loadResources(FFilamentAsset* asset, bool async) {
     // materials or textures will be added. Notify the dependency graph.
     asset->mDependencyGraph.commitEdges();
 
+    for (FFilamentInstance* instance : asset->mInstances) {
+        instance->createAnimator();
+    }
+
     return true;
 }
 

--- a/libs/viewer/include/viewer/ViewerGui.h
+++ b/libs/viewer/include/viewer/ViewerGui.h
@@ -69,7 +69,7 @@ public:
      * Upon construction, the simple viewer may create some additional Filament objects (such as
      * light sources) that it owns.
      */
-    ViewerGui(filament::Engine* engine, filament::Scene* scene, filament::View* view,
+    ViewerGui(Engine* engine, Scene* scene, View* view,
             int sidebarWidth = DEFAULT_SIDEBAR_WIDTH);
 
     /**
@@ -78,17 +78,17 @@ public:
     ~ViewerGui();
 
     /**
-     * Sets the viewer's current asset.
+     * Sets the viewer's current asset and instance.
      *
      * The viewer does not claim ownership over the asset or its entities. Clients should use
      * AssetLoader and ResourceLoader to load an asset before passing it in.
      *
      * This method does not add renderables to the scene; see populateScene().
      *
-     * @param asset The asset to view.
-     * @param instanceToAnimate Optional instance from which to get the animator.
+     * @param instance The asset to view.
+     * @param instance The instance to view.
      */
-    void setAsset(FilamentAsset* asset,  FilamentInstance* instanceToAnimate = nullptr);
+    void setAsset(FilamentAsset* asset, FilamentInstance* instance);
 
     /**
      * Adds the asset's ready-to-render entities into the scene.
@@ -108,13 +108,15 @@ public:
     /**
      * Sets or changes the current scene's IBL to allow the UI manipulate it.
      */
-    void setIndirectLight(filament::IndirectLight* ibl, filament::math::float3 const* sh3);
+    void setIndirectLight(IndirectLight* ibl, math::float3 const* sh3);
 
     /**
      * Applies the currently-selected glTF animation to the transformation hierarchy and updates
      * the bone matrices on all renderables.
+     *
+     * If an instance is provided, animation is applied to it rather than the "set" instance.
      */
-    void applyAnimation(double currentTime);
+    void applyAnimation(double currentTime, FilamentInstance* instance = nullptr);
 
     /**
      * Constructs ImGui controls for the current frame and responds to everything that the user has
@@ -135,7 +137,7 @@ public:
      * its callback. Note that the first call might be slower since it requires the creation of the
      * internal ImGuiHelper instance.
      */
-    void renderUserInterface(float timeStepInSeconds, filament::View* guiView, float pixelRatio);
+    void renderUserInterface(float timeStepInSeconds, View* guiView, float pixelRatio);
 
     /**
      * Event-passing methods, useful only when ViewerGui manages its own instance of ImGuiHelper.
@@ -210,7 +212,7 @@ public:
 
     /**
      * Adjusts the intensity of the IBL.
-     * See also filament::IndirectLight::setIntensity().
+     * See also IndirectLight::setIntensity().
      * Defaults to 30000.0.
      */
     void setIBLIntensity(float brightness) { mSettings.lighting.iblIntensity = brightness; }
@@ -239,9 +241,9 @@ private:
     void sceneSelectionUI();
 
     // Immutable properties set from the constructor.
-    filament::Engine* const mEngine;
-    filament::Scene* const mScene;
-    filament::View* const mView;
+    Engine* const mEngine;
+    Scene* const mScene;
+    View* const mView;
     const utils::Entity mSunlight;
 
     // Lazily instantiated fields.
@@ -249,8 +251,8 @@ private:
 
     // Properties that can be changed from the application.
     FilamentAsset* mAsset = nullptr;
-    Animator* mAnimator = nullptr;
-    filament::IndirectLight* mIndirectLight = nullptr;
+    FilamentInstance* mInstance = nullptr;
+    IndirectLight* mIndirectLight = nullptr;
     std::function<void()> mCustomUI;
 
     // Properties that can be changed from the UI.
@@ -283,7 +285,7 @@ private:
 };
 
 UTILS_PUBLIC
-filament::math::mat4f fitIntoUnitCube(const filament::Aabb& bounds, float zoffset);
+math::mat4f fitIntoUnitCube(const Aabb& bounds, float zoffset);
 
 } // namespace viewer
 } // namespace filament

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -393,19 +393,22 @@ ViewerGui::~ViewerGui() {
     delete mImGuiHelper;
 }
 
-void ViewerGui::setAsset(FilamentAsset* asset,  FilamentInstance* instanceToAnimate) {
-    if (mAsset != asset) {
+void ViewerGui::setAsset(FilamentAsset* asset, FilamentInstance* instance) {
+    if (mInstance != instance || mAsset != asset) {
         removeAsset();
+
+        // We keep a non-const reference to the asset for popRenderables and getWireframe.
         mAsset = asset;
+        mInstance = instance;
+
         mVisibleScenes.reset();
         mVisibleScenes.set(0);
         mCurrentCamera = 0;
-        if (!asset) {
-            mAnimator = nullptr;
+        if (!mAsset) {
+            mAsset = nullptr;
+            mInstance = nullptr;
             return;
         }
-        mAnimator = instanceToAnimate ? instanceToAnimate->getAnimator() : asset->getAnimator();
-        assert_invariant(mAnimator && "Call loadResources or asyncBeginLoad before setAsset.");
         updateRootTransform();
         mScene->addEntities(asset->getLightEntities(), asset->getLightEntityCount());
         auto& rcm = mEngine->getRenderableManager();
@@ -428,7 +431,6 @@ void ViewerGui::removeAsset() {
     if (!isRemoteMode()) {
         mScene->removeEntities(mAsset->getEntities(), mAsset->getEntityCount());
         mAsset = nullptr;
-        mAnimator = nullptr;
     }
 }
 
@@ -500,9 +502,14 @@ void ViewerGui::sceneSelectionUI() {
     }
 }
 
-void ViewerGui::applyAnimation(double currentTime) {
+void ViewerGui::applyAnimation(double currentTime, FilamentInstance* instance) {
+    instance = instance ? instance : mInstance;
     assert_invariant(!isRemoteMode());
-    const size_t numAnimations = mAnimator->getAnimationCount();
+    if (instance == nullptr) {
+        return;
+    }
+    Animator& animator = *instance->getAnimator();
+    const size_t numAnimations = animator.getAnimationCount();
     if (mResetAnimation) {
         mPreviousStartTime = mCurrentStartTime;
         mCurrentStartTime = currentTime;
@@ -510,17 +517,17 @@ void ViewerGui::applyAnimation(double currentTime) {
     }
     const double elapsedSeconds = currentTime - mCurrentStartTime;
     if (numAnimations > 0 && mCurrentAnimation > 0) {
-        mAnimator->applyAnimation(mCurrentAnimation - 1, elapsedSeconds);
+        animator.applyAnimation(mCurrentAnimation - 1, elapsedSeconds);
         if (elapsedSeconds < mCrossFadeDuration && mPreviousAnimation > 0) {
             const double previousSeconds = currentTime - mPreviousStartTime;
             const float lerpFactor = elapsedSeconds / mCrossFadeDuration;
-            mAnimator->applyCrossFade(mPreviousAnimation - 1, previousSeconds, lerpFactor);
+            animator.applyCrossFade(mPreviousAnimation - 1, previousSeconds, lerpFactor);
         }
     }
     if (mShowingRestPose) {
-        mAnimator->resetBoneMatrices();
+        animator.resetBoneMatrices();
     } else {
-        mAnimator->updateBoneMatrices();
+        animator.updateBoneMatrices();
     }
 }
 
@@ -1021,28 +1028,29 @@ void ViewerGui::updateUserInterface() {
             ImGui::Unindent();
         }
 
-        if (mAsset->getMaterialVariantCount() > 0 && ImGui::CollapsingHeader("Variants")) {
+        if (mInstance->getMaterialVariantCount() > 0 && ImGui::CollapsingHeader("Variants")) {
             ImGui::Indent();
             int selectedVariant = mCurrentVariant;
-            for (size_t i = 0, count = mAsset->getMaterialVariantCount(); i < count; ++i) {
-                const char* label = mAsset->getMaterialVariantName(i);
+            for (size_t i = 0, count = mInstance->getMaterialVariantCount(); i < count; ++i) {
+                const char* label = mInstance->getMaterialVariantName(i);
                 ImGui::RadioButton(label, &selectedVariant, i);
             }
             if (selectedVariant != mCurrentVariant) {
                 mCurrentVariant = selectedVariant;
-                mAsset->applyMaterialVariant(mCurrentVariant);
+                mInstance->applyMaterialVariant(mCurrentVariant);
             }
             ImGui::Unindent();
         }
 
-        if (mAnimator->getAnimationCount() > 0 && ImGui::CollapsingHeader("Animation")) {
+        Animator& animator = *mInstance->getAnimator();
+        if (animator.getAnimationCount() > 0 && ImGui::CollapsingHeader("Animation")) {
             ImGui::Indent();
             int selectedAnimation = mCurrentAnimation;
             ImGui::RadioButton("Disable", &selectedAnimation, 0);
             ImGui::SliderFloat("Cross fade", &mCrossFadeDuration, 0.0f, 2.0f,
                     "%4.2f seconds", ImGuiSliderFlags_AlwaysClamp);
-            for (size_t i = 0, count = mAnimator->getAnimationCount(); i < count; ++i) {
-                std::string label = mAnimator->getAnimationName(i);
+            for (size_t i = 0, count = animator.getAnimationCount(); i < count; ++i) {
+                std::string label = animator.getAnimationName(i);
                 if (label.empty()) {
                     label = "Unnamed " + std::to_string(i);
                 }
@@ -1058,7 +1066,7 @@ void ViewerGui::updateUserInterface() {
         }
 
         if (mCurrentMorphingEntity && ImGui::CollapsingHeader("Morphing")) {
-            const bool isAnimating = mCurrentAnimation > 0 && mAnimator->getAnimationCount() > 0;
+            const bool isAnimating = mCurrentAnimation > 0 && animator.getAnimationCount() > 0;
             if (isAnimating) {
                 ImGui::BeginDisabled();
             }

--- a/samples/gltf_instances.cpp
+++ b/samples/gltf_instances.cpp
@@ -287,7 +287,14 @@ int main(int argc, char** argv) {
         app.resourceLoader->asyncUpdateLoad();
         app.viewer->updateRootTransform();
         app.viewer->populateScene();
-        app.viewer->applyAnimation(now);
+
+        if (app.instanceToAnimate == -1) {
+            for (FilamentInstance* instance : app.instances) {
+                app.viewer->applyAnimation(now, instance);
+            }
+        } else {
+            app.viewer->applyAnimation(now);
+        }
 
         // Add a new instance every second until reaching 100 instances.
         static double previous = 0.0;
@@ -295,7 +302,7 @@ int main(int argc, char** argv) {
             FilamentInstance* instance = app.loader->createInstance(app.asset);
 
             // If the asset has variants, rotate through each variant.
-            const size_t variantCount = app.asset->getMaterialVariantCount();
+            const size_t variantCount = instance->getMaterialVariantCount();
             if (variantCount > 1) {
                 instance->applyMaterialVariant(app.instances.size() % variantCount);
             }

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -659,11 +659,15 @@ Filament.loadClassExtensions = function() {
         return Filament.vectorToArray(this._getCameraEntities());
     };
 
-    Filament.gltfio$FilamentAsset.prototype.getResourceUris = function(buffer, instances) {
+    Filament.gltfio$FilamentAsset.prototype.getResourceUris = function() {
         return Filament.vectorToArray(this._getResourceUris());
     }
 
-    Filament.gltfio$FilamentAsset.prototype.getMaterialVariantNames = function(buffer, instances) {
+    Filament.gltfio$FilamentAsset.prototype.getAssetInstances = function() {
+        return Filament.vectorToArray(this._getAssetInstances());
+    }
+
+    Filament.gltfio$FilamentInstance.prototype.getMaterialVariantNames = function() {
         return Filament.vectorToArray(this._getMaterialVariantNames());
     }
 };

--- a/web/filament-js/filament-viewer.js
+++ b/web/filament-js/filament-viewer.js
@@ -292,7 +292,7 @@ class FilamentViewer extends LitElement {
                 this.assetRoot = this.asset.getRoot();
                 this.unitCubeTransform = Filament.fitIntoUnitCube(aabb, zoffset);
                 this.asset.loadResources();
-                this.animator = this.asset.getAnimator();
+                this.animator = this.asset.getInstance().getAnimator();
                 this.animationStartTime = Date.now();
                 this._updateOverlay();
             });
@@ -318,7 +318,7 @@ class FilamentViewer extends LitElement {
                         resourceLoader.delete();
                         stbProvider.delete();
                         ktx2Provider.delete();
-                        this.animator = this.asset.getAnimator();
+                        this.animator = this.asset.getInstance().getAnimator();
                         this.animationStartTime = Date.now();
                     }
                 }, config.asyncInterval);
@@ -371,7 +371,7 @@ class FilamentViewer extends LitElement {
             const basePath = '' + new URL(this.src, document.location);
 
             this.asset.loadResources(() => {
-                this.animator = this.asset.getAnimator();
+                this.animator = this.asset.getInstance().getAnimator();
                 this.animationStartTime = Date.now();
                 this._applyMaterialVariant();
             }, null, basePath);
@@ -432,14 +432,15 @@ class FilamentViewer extends LitElement {
         if (!this.hasAttribute("materialVariant")) {
             return;
         }
-        const names = this.asset.getMaterialVariantNames();
+        const instance = this.asset.getInstance();
+        const names = instance.getMaterialVariantNames();
         const index = this.materialVariant;
         if (index < 0 || index >= names.length) {
             console.error(`Material variant ${index} does not exist in this asset.`);
             return;
         }
         console.info(this.src, `Applying material variant: ${names[index]}`);
-        this.asset.applyMaterialVariant(index);
+        instance.applyMaterialVariant(index);
     }
 }
 

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -598,8 +598,9 @@ export class gltfio$FilamentAsset {
     public getCameraEntities(): Entity[];
     public getRoot(): Entity;
     public popRenderable(): Entity;
-    public getMaterialInstances(): Vector<MaterialInstance>;
-    public getResourceUris(): Vector<string>;
+    public getInstance(): gltfio$FilamentInstance;
+    public geAssetInstances(): gltfio$FilamentInstance[];
+    public getResourceUris(): string[];
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
     public getExtras(entity: Entity): string;
@@ -616,6 +617,10 @@ export class gltfio$FilamentInstance {
     public getSkinNames(): Vector<string>;
     public attachSkin(skinIndex: number, entity: Entity): void;
     public detachSkin(skinIndex: number, entity: Entity): void;
+    public getMaterialInstances(): Vector<MaterialInstance>;
+    public detachMaterialInstances(): void;
+    public getMaterialVariantNames(): string[];
+    public applyMaterialVariant(index: number): void;
 }
 
 export class gltfio$Animator {

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -603,7 +603,6 @@ export class gltfio$FilamentAsset {
     public getBoundingBox(): Aabb;
     public getName(entity: Entity): string;
     public getExtras(entity: Entity): string;
-    public getAnimator(): gltfio$Animator;
     public getWireframe(): Entity;
     public getEngine(): Engine;
     public releaseSourceData(): void;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1793,13 +1793,7 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
 
     .function("popRenderable", &FilamentAsset::popRenderable)
 
-    .function("applyMaterialVariant", &FilamentAsset::applyMaterialVariant)
-
-    .function("getMaterialInstances", EMBIND_LAMBDA(std::vector<const MaterialInstance*>,
-            (FilamentAsset* self), {
-        const filament::MaterialInstance* const* ptr = self->getMaterialInstances();
-        return std::vector<const MaterialInstance*>(ptr, ptr + self->getMaterialInstanceCount());
-    }), allow_raw_pointers())
+    .function("getInstance", &FilamentAsset::getInstance, allow_raw_pointers())
 
     .function("_getAssetInstances", EMBIND_LAMBDA(std::vector<FilamentInstance*>,
             (FilamentAsset* self), {
@@ -1812,14 +1806,6 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
         auto uris = self->getResourceUris();
         for (size_t i = 0, len = self->getResourceUriCount(); i < len; ++i) {
             retval.push_back(uris[i]);
-        }
-        return retval;
-    }), allow_raw_pointers())
-
-    .function("_getMaterialVariantNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentAsset* self), {
-        std::vector<std::string> retval(self->getMaterialVariantCount());
-        for (size_t i = 0, len = retval.size(); i < len; ++i) {
-            retval[i] = self->getMaterialVariantName(i);
         }
         return retval;
     }), allow_raw_pointers())
@@ -1842,7 +1828,7 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
         return EntityVector(ptr, ptr + self->getEntityCount());
     }), allow_raw_pointers())
     .function("getRoot", &FilamentInstance::getRoot)
-    .function("applyMaterialVariant", &FilamentInstance::applyMaterialVariant)
+
     .function("getAnimator", &FilamentInstance::getAnimator, allow_raw_pointers())
 
     .function("getSkinNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentInstance* self), {
@@ -1854,7 +1840,23 @@ class_<FilamentInstance>("gltfio$FilamentInstance")
     }), allow_raw_pointers())
 
     .function("attachSkin", &FilamentInstance::attachSkin)
-    .function("detachSkin", &FilamentInstance::detachSkin);
+    .function("detachSkin", &FilamentInstance::detachSkin)
+
+    .function("applyMaterialVariant", &FilamentInstance::applyMaterialVariant)
+
+    .function("getMaterialInstances", EMBIND_LAMBDA(std::vector<const MaterialInstance*>,
+            (FilamentInstance* self), {
+        const MaterialInstance* const* ptr = self->getMaterialInstances();
+        return std::vector<const MaterialInstance*>(ptr, ptr + self->getMaterialInstanceCount());
+    }), allow_raw_pointers())
+
+    .function("_getMaterialVariantNames", EMBIND_LAMBDA(std::vector<std::string>, (FilamentInstance* self), {
+        std::vector<std::string> retval(self->getMaterialVariantCount());
+        for (size_t i = 0, len = retval.size(); i < len; ++i) {
+            retval[i] = self->getMaterialVariantName(i);
+        }
+        return retval;
+    }), allow_raw_pointers());
 
 // These little wrappers exist to get around RTTI requirements in embind.
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -1831,7 +1831,6 @@ class_<FilamentAsset>("gltfio$FilamentAsset")
     .function("getExtras", EMBIND_LAMBDA(std::string, (FilamentAsset* self, utils::Entity entity), {
         return std::string(self->getExtras(entity));
     }), allow_raw_pointers())
-    .function("getAnimator", &FilamentAsset::getAnimator, allow_raw_pointers())
     .function("getWireframe", &FilamentAsset::getWireframe)
     .function("getEngine", &FilamentAsset::getEngine, allow_raw_pointers())
     .function("releaseSourceData", &FilamentAsset::releaseSourceData);

--- a/web/samples/animation.html
+++ b/web/samples/animation.html
@@ -44,12 +44,12 @@ class App {
             // Dynamically enable two-sided lighting for testing purposes.
             const entities = asset.getEntities();
             const rm = engine.getRenderableManager();
-            const instance = rm.getInstance(entities[0]);
-            rm.getMaterialInstanceAt(instance, 0).setDoubleSided(true)
-            instance.delete();
+            const renderable = rm.getInstance(entities[0]);
+            rm.getMaterialInstanceAt(renderable, 0).setDoubleSided(true)
+            renderable.delete();
 
             scene.addEntities(entities);
-            this.animator = asset.getAnimator();
+            this.animator = asset.getInstance().getAnimator();
             this.animationStartTime = Date.now();
         };
         asset.loadResources(onDone);


### PR DESCRIPTION
This moves `MaterialInstance` objects into the `FilamentInstance` objects that they apply to, rather than storing them in one monolithic list in `FilamentAsset`.

This also removes the "broadcast" animator from FilamentAsset.  Clients should simply use the per-instance animators.

In the near future, we will also move all the entity getter methods from `FilamentAsset` to `FilamentInstance`.

These changes are motivated by the need to allow instance creation from immutable assets, which is a feature request from Google.