### PR TITLE
fix "stable" shadows

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: fix ubershader issues with assignment of dummy textures
 - gltfio: material instances and variants are now accessed via `FilamentInstance` [⚠️ **API Change**]
 - gltfio: the animator can now only be accessed via `FilamentInstance` [⚠️ **API Change**]
+- engine: fix "stable" shadows and make the default cascade splits logarithmic.
 
 ## v1.27.2
 

--- a/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/LightManager.java
@@ -240,7 +240,7 @@ public class LightManager {
          */
         @NonNull
         @Size(min = 3)
-        public float[] cascadeSplitPositions = { 0.25f, 0.50f, 0.75f };
+        public float[] cascadeSplitPositions = { 0.125f, 0.25f, 0.50f };
 
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -226,7 +226,7 @@ public:
          * @see ShadowCascades::computeLogSplits
          * @see ShadowCascades::computePracticalSplits
          */
-        float cascadeSplitPositions[3] = { 0.25f, 0.50f, 0.75f };
+        float cascadeSplitPositions[3] = { 0.125f, 0.25f, 0.50f };
 
         /** Constant bias in world units (e.g. meters) by which shadows are moved away from the
          * light. 1mm by default.

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -397,7 +397,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     // Adjust the near and far planes to tightly bound the scene.
     float vsNear = -cameraInfo.zn;
     float vsFar = -cameraInfo.zf;
-    if (engine.debug.shadowmap.tightly_bound_scene) {
+    if (engine.debug.shadowmap.tightly_bound_scene && !params.options.stable) {
         vsNear = std::min(vsNear, sceneInfo.vsNearFar.x);
         vsFar = std::max(vsFar, sceneInfo.vsNearFar.y);
     }


### PR DESCRIPTION
We were always adjusting the near/far of the view volume based on the scene content for shadowing, which defeated the "stable" shadows.

Also changed the default cascade splits from a linear split to a log2 split, because due to the perspective projection, the log2 split actually looks linear. Also intuitively, it makes more sense to give more resolution to the shadows close to the camera.