### PR TITLE
fix shadowing when the scene is outside the "shadow" view frustum

### DIFF
--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -296,7 +296,7 @@ void FView::prepareShadowing(FEngine& engine, DriverApi& driver,
     // Find all shadow-casting spotlights.
     size_t shadowCastingSpotCount = 0;
 
-    // We allow a max of CONFIG_MAX_SHADOW_CASTING_SPOTS spot light shadows. Any additional
+    // We allow a max of CONFIG_MAX_SHADOW_CASTING_SPOTS spotlight shadows. Any additional
     // shadow-casting spotlights are ignored.
     for (size_t l = FScene::DIRECTIONAL_LIGHTS_COUNT; l < lightData.size(); l++) {
 


### PR DESCRIPTION
this case was causing uninitialized variables to be used creating a false positive "shadows on" in the first cascade.

The main change here is to bail out as soon as we know there is no shadowing.