### PR TITLE
Vulkan: fix black screen regression

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ A new header is inserted each time a *tag* is created.
 
 - gltfio: fix reloading crash in ubershader mode
 - Vulkan: improve performance in the readPixels path
+- Vulkan: fix black screen regression
 
 ## v1.28.0
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -49,14 +49,9 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
         HwProgram(builder.getName()), context(context) {
     auto const& blobs = builder.getShadersSource();
     VkShaderModule* modules[2] = { &bundle.vertex, &bundle.fragment };
-    bool missing = false;
     for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         const auto& blob = blobs[i];
         VkShaderModule* module = modules[i];
-        if (blob.empty()) {
-            missing = true;
-            continue;
-        }
         VkShaderModuleCreateInfo moduleInfo = {};
         moduleInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
         moduleInfo.codeSize = blob.size();
@@ -104,13 +99,6 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
         }
 
         bundle.specializationInfos = pInfo;
-    }
-
-    // Output a warning because it's okay to encounter empty blobs, but it's not okay to use
-    // this program handle in a draw call.
-    if (missing) {
-        utils::slog.w << "Missing SPIR-V shader: " << this->name.c_str() << utils::io::endl;
-        return;
     }
 
     // Make a copy of the binding map

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -58,7 +58,9 @@ VulkanPipelineCache::getUsageFlags(uint16_t binding, ShaderStageFlags flags, Usa
     if (any(flags & ShaderStageFlags::FRAGMENT)) {
         src.set(MAX_SAMPLER_COUNT + binding);
     }
-    assert_invariant(!any(flags & ~(ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT)));
+    // TODO: add support for compute by extending SHADER_MODULE_COUNT and ensuring UsageFlags
+    // has 186 bits (MAX_SAMPLER_COUNT * 3)
+    // assert_invariant(!any(flags & ~(ShaderStageFlags::VERTEX | ShaderStageFlags::FRAGMENT)));
     return src;
 }
 


### PR DESCRIPTION
The VulkanProgram constructor was bailing out early and emitting a warning because it saw that one of the stages wasn't fulfilled. However it's okay for a pipeline to be missing a compute program.

Fixes regression that started with fabba73b1.