### PR TITLE
Remove the limit to 14 spot shadow maps, now 64.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ A new header is inserted each time a *tag* is created.
 - gltfio: fix reloading crash in ubershader mode
 - Vulkan: improve performance in the readPixels path
 - Vulkan: fix black screen regression
+- engine: raise the spot shadows limit to 64, from 14.
 
 ## v1.28.0
 

--- a/filament/src/Culler.cpp
+++ b/filament/src/Culler.cpp
@@ -86,7 +86,10 @@ void Culler::intersects(
             visible &= fast::signbit(dot) << bit;
         }
 
-        results[i] |= result_type(visible);
+        auto r = results[i];
+        r &= ~result_type(1u << bit);
+        r |= result_type(visible);
+        results[i] = r;
     }
 }
 
@@ -101,22 +104,20 @@ bool Culler::intersects(Frustum const& frustum, Box const& box) noexcept {
     Culler::result_type results[MODULO];
     centers[0] = box.center;
     extents[0] = box.halfExtent;
-    results[0] = 0;
     Culler::intersects(results, frustum, centers, extents, MODULO, 0);
-    return bool(results[0]);
+    return bool(results[0] & 1);
 }
 
 /*
- * returns whether an sphere intersects with the frustum
+ * returns whether a sphere intersects with the frustum
  */
 bool Culler::intersects(Frustum const& frustum, float4 const& sphere) noexcept {
     // The main intersection routine assumes multiples of 8 items
     float4 spheres[MODULO];
     Culler::result_type results[MODULO];
     spheres[0] = sphere;
-    results[0] = 0;
     Culler::intersects(results, frustum, spheres, MODULO);
-    return bool(results[0]);
+    return bool(results[0] & 1);
 }
 
 // For testing...

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -394,7 +394,7 @@ private:
             math::float3 cameraPosition, math::float3 cameraForward) noexcept;
 
     template<uint32_t commandTypeFlags>
-    static inline void generateCommandsImpl(uint32_t, Command* commands,
+    static inline Command* generateCommandsImpl(uint32_t extraFlags, Command* curr,
             FScene::RenderableSoa const& soa, utils::Range<uint32_t> range,
             Variant variant, RenderFlags renderFlags, FScene::VisibleMaskType visibilityMask,
             math::float3 cameraPosition, math::float3 cameraForward) noexcept;

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -656,7 +656,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
         RenderPass shadowPass(pass);
         shadowPass.setVariant(shadowVariant);
-        auto shadows = view.renderShadowMaps(fg, engine, driver, shadowPass);
+        auto shadows = view.renderShadowMaps(fg, engine, cameraInfo, shadowPass);
         blackboard["shadows"] = shadows;
     }
 

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -99,7 +99,7 @@ FView::FView(FEngine& engine)
 FView::~FView() noexcept = default;
 
 void FView::terminate(FEngine& engine) {
-    // Here we would cleanly free resources we've allocated or we own (currently none).
+    // Here we would cleanly free resources we've allocated, or we own (currently none).
 
     while (mActivePickingQueriesList) {
         FPickingQuery* const pQuery = mActivePickingQueriesList;
@@ -507,11 +507,11 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
          * Partition the SoA so that renderables are partitioned w.r.t their visibility into the
          * following groups:
          *
-         * 1. renderables
-         * 2. renderables and directional shadow casters
+         * 1. visible (main camera) renderables
+         * 2. visible (main camera) renderables and directional shadow casters
          * 3. directional shadow casters only
-         * 4. punctual light shadow casters only
-         * 5. invisible renderables
+         * 4. potential punctual light shadow casters only
+         * 5. definitely invisible renderables
          *
          * Note that the first three groups are partitioned based only on the lowest two bits of the
          * VISIBLE_MASK (VISIBLE_RENDERABLE and VISIBLE_DIR_SHADOW_CASTER), and thus can also
@@ -522,6 +522,9 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
          * of sort(), which gives us O(4.N) instead of O(N.log(N)) application of swap().
          */
 
+        // TODO: we need to compare performance of doing this partitioning vs not doing it.
+        //       and rely on checking visibility in the loops
+
         // calculate the sorting key for all elements, based on their visibility
         uint8_t const* layers = renderableData.data<FScene::LAYERS>();
         auto const* visibility = renderableData.data<FScene::VISIBILITY_STATE>();
@@ -529,24 +532,42 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
                 renderableData.size());
 
         auto const beginRenderables = renderableData.begin();
-        auto beginCasters = partition(beginRenderables, renderableData.end(), VISIBLE_RENDERABLE);
-        auto beginCastersOnly = partition(beginCasters, renderableData.end(),
+
+        auto beginDirCasters = partition(beginRenderables, renderableData.end(),
+                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE,
+                VISIBLE_RENDERABLE);
+
+        auto beginDirCastersOnly = partition(beginDirCasters, renderableData.end(),
+                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE,
                 VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE);
-        auto beginSpotLightCastersOnly = partition(beginCastersOnly, renderableData.end(),
+
+        auto endDirCastersOnly = partition(beginDirCastersOnly, renderableData.end(),
+                VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE,
                 VISIBLE_DIR_SHADOW_RENDERABLE);
-        auto endSpotLightCastersOnly = std::partition(beginSpotLightCastersOnly,
-                renderableData.end(), [](auto it) {
-                    return (it.template get<FScene::VISIBLE_MASK>() & VISIBLE_SPOT_SHADOW_RENDERABLE);
-                });
+
+        auto endPotentialSpotCastersOnly = partition(endDirCastersOnly, renderableData.end(),
+                VISIBLE_DYN_SHADOW_RENDERABLE,
+                VISIBLE_DYN_SHADOW_RENDERABLE);
 
         // convert to indices
-        uint32_t iEnd = uint32_t(beginSpotLightCastersOnly - beginRenderables);
-        uint32_t iSpotLightCastersEnd = uint32_t(endSpotLightCastersOnly - beginRenderables);
-        mVisibleRenderables = Range{ 0, uint32_t(beginCastersOnly - beginRenderables) };
-        mVisibleDirectionalShadowCasters = Range{ uint32_t(beginCasters - beginRenderables), iEnd };
-        mSpotLightShadowCasters = Range{ 0, iSpotLightCastersEnd };
-        merged = Range{ 0, iSpotLightCastersEnd };
+        mVisibleRenderables = { 0, uint32_t(beginDirCastersOnly - beginRenderables) };
 
+        mVisibleDirectionalShadowCasters = {
+                uint32_t(beginDirCasters - beginRenderables),
+                uint32_t(endDirCastersOnly - beginRenderables)};
+
+        merged = { 0, uint32_t(endPotentialSpotCastersOnly - beginRenderables) };
+        if (!mShadowMapManager.hasSpotShadows()) {
+            // we know we don't have spot shadows, we can reduce the range to not even include
+            // the potential spot casters
+            merged = { 0, uint32_t(endDirCastersOnly - beginRenderables) };
+        }
+
+        mSpotLightShadowCasters = merged;
+
+        // TODO: when any spotlight is used, `merged` ends-up being the whole list. However,
+        //       some of the items will end-up not being visible by any light. Can we do better?
+        //       e.g. could we deffer some of the prepareVisibleRenderables() to later?
         scene->prepareVisibleRenderables(merged);
 
         // update those UBOs
@@ -568,8 +589,8 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
     }
 
     /*
-     * Prepare lighting -- this is where we update the lights UBOs, set-up the IBL,
-     * set-up the froxelization parameters.
+     * Prepare lighting -- this is where we update the lights UBOs, set up the IBL,
+     * set up the froxelization parameters.
      * Relies on FScene::prepare() and prepareVisibleLights()
      */
 
@@ -598,37 +619,24 @@ void FView::computeVisibilityMasks(
     // This is vectorized 16x.
     count = (count + 0xFu) & ~0xFu; // capacity guaranteed to be multiple of 16
     for (size_t i = 0; i < count; ++i) {
-        Culler::result_type mask = visibleMask[i];
-        FRenderableManager::Visibility v = visibility[i];
-        bool inVisibleLayer = layers[i] & visibleLayers;
+        const Culler::result_type mask = visibleMask[i];
+        const FRenderableManager::Visibility v = visibility[i];
+        const bool inVisibleLayer = layers[i] & visibleLayers;
 
-        // The logic below essentially does the following:
-        //
-        // if inVisibleLayer:
-        //     if !v.culling:
-        //         set all bits in visibleMask to 1
-        // else:
-        //     set all bits in visibleMask to 0
-        // if !v.castShadows:
-        //     if !vsm or !v.receivesShadows:       // with vsm, we also render shadow receivers
-        //         set shadow visibility bits in visibleMask to 0
-        //
-        // It is written without if statements to avoid branches, which allows it to be vectorized 16x.
+        const bool visibleRenderable = inVisibleLayer &&
+                (!v.culling || (mask & VISIBLE_RENDERABLE));
 
-        const bool visRenderables = (!v.culling || (mask & VISIBLE_RENDERABLE)) && inVisibleLayer;
-        const bool visShadowParticipant = v.castShadows;
-        const bool visShadowRenderable = (!v.culling || (mask & VISIBLE_DIR_SHADOW_RENDERABLE))
-                && inVisibleLayer && visShadowParticipant;
-        visibleMask[i] = Culler::result_type(visRenderables) |
-                Culler::result_type(visShadowRenderable << 1u);
-        // this loop gets fully unrolled
-        for (size_t j = 0; j < CONFIG_MAX_SHADOW_CASTING_SPOTS; ++j) {
-            const bool visSpotShadowRenderable =
-                    (!v.culling || (mask & VISIBLE_SPOT_SHADOW_RENDERABLE_N(j))) &&
-                        inVisibleLayer && visShadowParticipant;
-            visibleMask[i] |=
-                Culler::result_type(visSpotShadowRenderable << VISIBLE_SPOT_SHADOW_RENDERABLE_N_BIT(j));
-        }
+        const bool visibleDirectionalShadowRenderable = (v.castShadows && inVisibleLayer) &&
+                (!v.culling || (mask & VISIBLE_DIR_SHADOW_RENDERABLE));
+
+        const bool potentialSpotShadowRenderable = v.castShadows && inVisibleLayer;
+
+        using Type = Culler::result_type;
+
+        visibleMask[i] =
+                Type(visibleRenderable << VISIBLE_RENDERABLE_BIT) |
+                Type(visibleDirectionalShadowRenderable << VISIBLE_DIR_SHADOW_RENDERABLE_BIT) |
+                Type(potentialSpotShadowRenderable << VISIBLE_DYN_SHADOW_RENDERABLE_BIT);
     }
 }
 
@@ -636,12 +644,11 @@ UTILS_NOINLINE
 /* static */ FScene::RenderableSoa::iterator FView::partition(
         FScene::RenderableSoa::iterator begin,
         FScene::RenderableSoa::iterator end,
-        uint8_t mask) noexcept {
-    return std::partition(begin, end, [mask](auto it) {
+        Culler::result_type mask, Culler::result_type value) noexcept {
+    return std::partition(begin, end, [mask, value](auto it) {
         // Mask VISIBLE_MASK to ignore higher bits related to spot shadows. We only partition based
         // on renderable and directional shadow visibility.
-        return (it.template get<FScene::VISIBLE_MASK>() &
-                (VISIBLE_RENDERABLE | VISIBLE_DIR_SHADOW_RENDERABLE)) == mask;
+        return (it.template get<FScene::VISIBLE_MASK>() & mask) == value;
     });
 }
 
@@ -834,7 +841,7 @@ void FView::prepareVisibleLights(FLightManager const& lcm, ArenaScope& rootArena
 
     ArenaScope arena(rootArena.getAllocator());
     size_t const size = visibleLightCount;
-    // number of point/spot lights
+    // number of point/spotlights
     size_t const positionalLightCount = size - FScene::DIRECTIONAL_LIGHTS_COUNT;
     if (positionalLightCount) {
         // always allocate at least 4 entries, because the vectorized loops below rely on that
@@ -886,9 +893,8 @@ void FView::updatePrimitivesLod(FEngine& engine, const CameraInfo&,
 }
 
 FrameGraphId<FrameGraphTexture> FView::renderShadowMaps(FrameGraph& fg, FEngine& engine,
-        FEngine::DriverApi& driver,
-        RenderPass const& pass) noexcept {
-    return mShadowMapManager.render(fg, engine, pass, *this);
+        CameraInfo const& cameraInfo, RenderPass const& pass) noexcept {
+    return mShadowMapManager.render(fg, engine, pass, *this, cameraInfo);
 }
 
 void FView::commitFrameHistory(FEngine& engine) noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -166,7 +166,7 @@ public:
     bool hasPicking() const noexcept { return mActivePickingQueriesList != nullptr; }
 
     FrameGraphId<FrameGraphTexture> renderShadowMaps(FrameGraph& fg, FEngine& engine,
-            FEngine::DriverApi& driver, RenderPass const& pass) noexcept;
+            CameraInfo const& cameraInfo, RenderPass const& pass) noexcept;
 
     void updatePrimitivesLod(
             FEngine& engine, const CameraInfo& camera,
@@ -467,7 +467,7 @@ private:
     static FScene::RenderableSoa::iterator partition(
             FScene::RenderableSoa::iterator begin,
             FScene::RenderableSoa::iterator end,
-            uint8_t mask) noexcept;
+            Culler::result_type mask, Culler::result_type value) noexcept;
 
     // these are accessed in the render loop, keep together
     backend::Handle<backend::HwBufferObject> mLightUbh;

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -251,7 +251,7 @@ ResourceNode* FrameGraph::createNewVersionForSubresourceIfNeeded(ResourceNode* n
     ResourceSlot& slot = getResourceSlot(node->resourceHandle);
     if (slot.sid < 0) {
         // if we don't already have a new ResourceNode for this resource, create one.
-        // we keep the old ResourceNode index so we can direct all the reads to it.
+        // we keep the old ResourceNode index, so we can direct all the reads to it.
         slot.sid = slot.nid; // record the current ResourceNode of the parent
         slot.nid = mResourceNodes.size();   // create the new parent node
         node = mArena.make<ResourceNode>(*this, node->resourceHandle, node->getParentHandle());

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -61,12 +61,19 @@ constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
 constexpr size_t CONFIG_MAX_LIGHT_INDEX = CONFIG_MAX_LIGHT_COUNT - 1;
 
 // The maximum number of spotlights in a scene that can cast shadows.
-// There is currently a limit to 14 spot shadow due to how we store the culling result
-// (see View.h).
-constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 14;
+// There is currently a limit to 142 spot shadow, as we are limited to 146 shadowmaps in totality.
+// Several factors are contributing to this limit:
+// - minspec for 2d texture arrays layer is 256
+// - we're using uint8_t to store the number of layers (255 max)
+// - minspec for UBOs is 16KiB, which currently can hold a maximum of 146 entries
+// - we need to reserve 4 entries for the cascaded shadow map
+// We use 64, which is a reasonable value.
+constexpr size_t CONFIG_MAX_SHADOW_CASTING_SPOTS = 64;
 
 // The maximum number of shadow cascades that can be used for directional lights.
 constexpr size_t CONFIG_MAX_SHADOW_CASCADES = 4;
+
+static_assert(CONFIG_MAX_SHADOW_CASCADES + CONFIG_MAX_SHADOW_CASTING_SPOTS <= 146);
 
 // The maximum UBO size, in bytes. This value is set to 16 KiB due to the ES3.0 spec.
 // Note that this value constrains the maximum number of skinning bones, morph targets,

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -249,15 +249,15 @@ static_assert(sizeof(LightsUib) == 64,
 struct ShadowUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     static constexpr std::string_view _name{ "ShadowUniforms" };
     struct alignas(16) ShadowData {
-        math::mat4f lightFromWorldMatrix;
-        math::float3 direction;
-        float normalBias;
-        math::float4 lightFromWorldZ;
+        math::mat4f lightFromWorldMatrix;       // 64
+        math::float3 direction;                 // 12
+        float normalBias;                       //  4
+        math::float4 lightFromWorldZ;           // 16
 
-        float texelSizeAtOneMeter;
-        float bulbRadiusLs;
-        float nearOverFarMinusNear;
-        bool elvsm;
+        float texelSizeAtOneMeter;              //  4
+        float bulbRadiusLs;                     //  4
+        float nearOverFarMinusNear;             //  4
+        bool elvsm;                             //  4
     };
     ShadowData shadows[CONFIG_MAX_SHADOW_CASTING_SPOTS];
 };


### PR DESCRIPTION
Spotlight shadow maps are now limited only by h/w limits (UBO size and
2d array maximum layers), which works out to about 146 shadows.

In practice we hardcode the limite to 64, but this can be changed at
compile time. A higher maximum increases memory usage.

There used to be a bitfield per renderable with a bit for each shadow
map indicating if the renderable was "visible" from this light. The
limit to 14 came from that bitfield. All shadow maps used to be culled
first, setting the bitfield appropriately.

Instead, we are now processing spotlight shadows one at a time,
performing culling as we go. For this reason we don't need a bit per
shadow map.