### PR TITLE
Fix compilation for GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,16 +228,12 @@ if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     if (CMAKE_C_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
         message(FATAL_ERROR "Detected C compiler Clang ${CMAKE_C_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
     endif()
-elseif (NOT MSVC)
-    message(FATAL_ERROR "Detected C compiler ${CMAKE_C_COMPILER_ID} is unsupported")
 endif()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS MIN_CLANG_VERSION)
         message(FATAL_ERROR "Detected CXX compiler Clang ${CMAKE_CXX_COMPILER_VERSION} < ${MIN_CLANG_VERSION}")
     endif()
-elseif (NOT MSVC)
-    message(FATAL_ERROR "Detected CXX compiler ${CMAKE_CXX_COMPILER_ID} is unsupported")
 endif()
 
 # Detect use of the clang-cl.exe frontend, which does not support all of clangs normal options
@@ -293,13 +289,13 @@ if (WIN32)
 endif()
 
 if (LINUX)
-    option(USE_STATIC_LIBCXX "Link against the static runtime libraries." ON)
-    if (${USE_STATIC_LIBCXX})
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-        link_libraries("-static-libgcc -static-libstdc++")
-        link_libraries(libc++.a)
-        link_libraries(libc++abi.a)
-    endif()
+#    option(USE_STATIC_LIBCXX "Link against the static runtime libraries." ON)
+#    if (${USE_STATIC_LIBCXX})
+#        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+        #link_libraries("-static-libgcc -static-libstdc++")
+#        link_libraries(libc++.a)
+        #link_libraries(libc++abi.a)
+#    endif()
 
     # Only linux, clang doesn't want to use a shared library that is not PIC.
     # /usr/bin/ld: ../bluegl/libbluegl.a(BlueGL.cpp.o): relocation R_X86_64_32S

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -558,7 +558,7 @@ if (MSVC)
 elseif(WEBGL)
     # Avoid strict-vtable-pointers here, it is broken in WebAssembly.
     set(OPTIMIZATION_FLAGS -fvisibility-inlines-hidden)
-else()
+elseif(APPLE)
     set(OPTIMIZATION_FLAGS
         -ffast-math
         -ffp-contract=fast
@@ -566,6 +566,12 @@ else()
         #        -fslp-vectorize-aggressive
         -fvisibility-inlines-hidden
         -fstrict-vtable-pointers
+    )
+else()
+    set(OPTIMIZATION_FLAGS
+    -ffast-math
+    -ffp-contract=fast
+    -fvisibility-inlines-hidden
     )
 endif()
 
@@ -578,13 +584,19 @@ set(LINUX_COMPILER_FLAGS
 
 if (MSVC)
     set(FILAMENT_WARNINGS /W3)
-else()
+elseif(APPLE)
     set(FILAMENT_WARNINGS
             -Wall -Wextra -Wno-unused-parameter
             -Wextra-semi -Wnewline-eof -Wdeprecated -Wundef
             -Wgnu-conditional-omitted-operand
             -Wweak-vtables -Wnon-virtual-dtor -Wclass-varargs -Wimplicit-fallthrough
             -Wover-aligned
+    )
+else()
+    set(FILAMENT_WARNINGS
+            -Wall -Wextra -Wno-unused-parameter
+            -Wextra-semi -Wdeprecated -Wundef
+            -Wnon-virtual-dtor -Wimplicit-fallthrough
     )
 endif()
 

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -219,6 +219,12 @@ include_directories(${GENERATION_ROOT})
 # we're building a library
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 # specify where the public headers of this library are
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 
@@ -324,7 +330,7 @@ if (MSVC)
 elseif(WEBGL)
     # Avoid strict-vtable-pointers here, it is broken in WebAssembly.
     set(OPTIMIZATION_FLAGS -fvisibility-inlines-hidden)
-else()
+elseif(APPLE)
     set(OPTIMIZATION_FLAGS
         -ffast-math
         -ffp-contract=fast
@@ -332,6 +338,11 @@ else()
         #        -fslp-vectorize-aggressive
         -fvisibility-inlines-hidden
         -fstrict-vtable-pointers
+    )
+    set(OPTIMIZATION_FLAGS
+        -ffast-math
+        -ffp-contract=fast
+        -fvisibility-inlines-hidden
     )
 endif()
 
@@ -341,13 +352,19 @@ set(LINUX_LINKER_OPTIMIZATION_FLAGS
 
 if (MSVC)
     set(FILAMENT_WARNINGS /W3)
-else()
+elseif(APPLE)
     set(FILAMENT_WARNINGS
             -Wall -Wextra -Wno-unused-parameter
             -Wextra-semi -Wnewline-eof -Wdeprecated -Wundef
             -Wgnu-conditional-omitted-operand
             -Wweak-vtables -Wnon-virtual-dtor -Wclass-varargs -Wimplicit-fallthrough
             -Wover-aligned
+    )
+else()
+    set(FILAMENT_WARNINGS
+            -Wall -Wextra -Wno-unused-parameter
+            -Wextra-semi -Wdeprecated -Wundef
+            -Wnon-virtual-dtor -Wimplicit-fallthrough
     )
 endif()
 

--- a/filament/backend/include/private/backend/CommandStream.h
+++ b/filament/backend/include/private/backend/CommandStream.h
@@ -180,7 +180,7 @@ class NoopCommand : public CommandBase {
         *next = static_cast<NoopCommand*>(self)->mNext;
     }
 public:
-    inline constexpr explicit NoopCommand(void* next) noexcept
+    inline explicit NoopCommand(void* next) noexcept
             : CommandBase(execute), mNext(intptr_t((char *)next - (char *)this)) { }
 };
 

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -123,8 +123,8 @@ class VulkanCommands {
         VulkanCommandBuffer* mCurrent = nullptr;
         VkSemaphore mSubmissionSignal = {};
         VkSemaphore mInjectedSignal = {};
-        VulkanCommandBuffer mStorage[CAPACITY] = {};
-        VkSemaphore mSubmissionSignals[CAPACITY] = {};
+        VulkanCommandBuffer mStorage[CAPACITY];
+        VkSemaphore mSubmissionSignals[CAPACITY];
         size_t mAvailableCount = CAPACITY;
         CommandBufferObserver* mObserver = nullptr;
 };

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -594,12 +594,12 @@ void VulkanPipelineCache::unbindUniformBuffer(VkBuffer uniformBuffer) noexcept {
 void VulkanPipelineCache::unbindImageView(VkImageView imageView) noexcept {
     for (auto& sampler : mDescriptorRequirements.samplers) {
         if (sampler.imageView == imageView) {
-            sampler = {};
+            sampler = DescriptorImageInfo();
         }
     }
     for (auto& target : mDescriptorRequirements.inputAttachments) {
         if (target.imageView == imageView) {
-            target = {};
+            target = DescriptorImageInfo();
         }
     }
 }

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -48,11 +48,11 @@ class UTILS_PUBLIC Material : public FilamentAPI {
     struct BuilderDetails;
 
 public:
-    using BlendingMode = BlendingMode;
-    using Shading = Shading;
-    using Interpolation = Interpolation;
-    using VertexDomain = VertexDomain;
-    using TransparencyMode = TransparencyMode;
+    using BlendingMode = filament::BlendingMode;
+    using Shading = filament::Shading;
+    using Interpolation = filament::Interpolation;
+    using VertexDomain = filament::VertexDomain;
+    using TransparencyMode = filament::TransparencyMode;
 
     using ParameterType = backend::UniformType;
     using Precision = backend::Precision;

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -16,7 +16,7 @@
 
 #ifndef TNT_FILAMENT_MATERIALINSTANCE_H
 #define TNT_FILAMENT_MATERIALINSTANCE_H
-
+#include <cstring>
 #include <filament/FilamentAPI.h>
 #include <filament/Color.h>
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -66,25 +66,25 @@ class Viewport;
  */
 class UTILS_PUBLIC View : public FilamentAPI {
 public:
-    using QualityLevel = QualityLevel;
-    using BlendMode = BlendMode;
-    using AntiAliasing = AntiAliasing;
-    using Dithering = Dithering;
-    using ShadowType = ShadowType;
+    using QualityLevel = filament::QualityLevel;
+    using BlendMode = filament::BlendMode;
+    using AntiAliasing = filament::AntiAliasing;
+    using Dithering = filament::Dithering;
+    using ShadowType = filament::ShadowType;
 
-    using DynamicResolutionOptions = DynamicResolutionOptions;
-    using BloomOptions = BloomOptions;
-    using FogOptions = FogOptions;
-    using DepthOfFieldOptions = DepthOfFieldOptions;
-    using VignetteOptions = VignetteOptions;
-    using RenderQuality = RenderQuality;
-    using AmbientOcclusionOptions = AmbientOcclusionOptions;
-    using TemporalAntiAliasingOptions = TemporalAntiAliasingOptions;
-    using MultiSampleAntiAliasingOptions = MultiSampleAntiAliasingOptions;
-    using VsmShadowOptions = VsmShadowOptions;
-    using SoftShadowOptions = SoftShadowOptions;
-    using ScreenSpaceReflectionsOptions = ScreenSpaceReflectionsOptions;
-    using GuardBandOptions = GuardBandOptions;
+    using DynamicResolutionOptions = filament::DynamicResolutionOptions;
+    using BloomOptions = filament::BloomOptions;
+    using FogOptions = filament::FogOptions;
+    using DepthOfFieldOptions = filament::DepthOfFieldOptions;
+    using VignetteOptions = filament::VignetteOptions;
+    using RenderQuality = filament::RenderQuality;
+    using AmbientOcclusionOptions = filament::AmbientOcclusionOptions;
+    using TemporalAntiAliasingOptions = filament::TemporalAntiAliasingOptions;
+    using MultiSampleAntiAliasingOptions = filament::MultiSampleAntiAliasingOptions;
+    using VsmShadowOptions = filament::VsmShadowOptions;
+    using SoftShadowOptions = filament::SoftShadowOptions;
+    using ScreenSpaceReflectionsOptions = filament::ScreenSpaceReflectionsOptions;
+    using GuardBandOptions = filament::GuardBandOptions;
 
     /**
      * Sets the View's name. Only useful for debugging.

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -694,10 +694,9 @@ void Froxelizer::froxelizeAssignRecordsCompress() noexcept {
 
         // We have a limitation of 255 spot + 255 point lights per froxel.
         // note: initializer list for union cannot have more than one element
-        FroxelEntry entry{
-                .offset = offset,
-                .count = (uint8_t)std::min(size_t(255), b.lights.count()),
-        };
+        FroxelEntry entry;
+        entry.offset = offset;
+        entry.count = (uint8_t)std::min(size_t(255), b.lights.count());
         const size_t lightCount = entry.count;
 
         if (UTILS_UNLIKELY(offset + lightCount >= RECORD_BUFFER_ENTRY_COUNT)) {
@@ -707,7 +706,8 @@ void Froxelizer::froxelizeAssignRecordsCompress() noexcept {
             // note: instead of dropping froxels we could look for similar records we've already
             // filed up.
             do {
-                froxels[i] = { .offset = 0, .count = allLightsCount };
+              froxels[i].offset = 0;
+              froxels[i].count = allLightsCount;
                 if (records[i].lights.none()) {
                     froxels[i].u32 = 0;
                 }

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -153,12 +153,13 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                  * be (the imported resource viewport is set to 'vp', see  how 'fgViewRenderTarget'
                  * is initialized in this file).
                  */
-                builder.declareRenderPass("Color Pass Target", {
-                        .attachments = { .color = { data.color, data.output },
-                                .depth = data.depth,
-                                .stencil = data.stencil },
-                                .samples = config.msaa,
-                        .clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags });
+                FrameGraphRenderPass::Descriptor descr;
+                descr.attachments.content.color[0] = data.color;
+                descr.attachments.content.color[1] = data.output;
+                descr.attachments.content.depth = data.depth;
+                descr.samples = config.msaa;
+                descr.clearFlags = clearColorFlags | clearDepthFlags;
+                builder.declareRenderPass("Color Pass Target", descr);
 
                 data.clearColor = config.clearColor;
                 data.clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -241,8 +241,8 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FrameGraph& fg, FEngine
                         data.output = builder.write(data.output,
                                 FrameGraphTexture::Usage::COLOR_ATTACHMENT);
 
-                        renderTargetDesc.attachments.color[0] = data.output;
-                        renderTargetDesc.attachments.depth = depth;
+                        renderTargetDesc.attachments.content.color[0] = data.output;
+                        renderTargetDesc.attachments.content.depth = depth;
                         renderTargetDesc.clearFlags =
                                 TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH;
                         // we need to clear the shadow map with the max EVSM moments
@@ -253,21 +253,19 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FrameGraph& fg, FEngine
                             data.tempBlurSrc = builder.write(data.tempBlurSrc,
                                     FrameGraphTexture::Usage::COLOR_ATTACHMENT);
 
-                            data.blurRt = builder.declareRenderPass("Temp Shadow RT", {
-                                    .attachments = {
-                                            .color = { data.tempBlurSrc },
-                                            .depth = depth },
-                                    .clearColor = vsmClearColor,
-                                    .samples = options->vsm.msaaSamples,
-                                    .clearFlags = TargetBufferFlags::COLOR
-                                                  | TargetBufferFlags::DEPTH
-                            });
+                            FrameGraphRenderPass::Descriptor descr;
+                            descr.attachments.content.color[0] = data.tempBlurSrc;
+                            descr.attachments.content.depth = depth;
+                            descr.clearColor = vsmClearColor;
+                            descr.samples = options->vsm.msaaSamples;
+                            descr.clearFlags = TargetBufferFlags::COLOR | TargetBufferFlags::DEPTH;
+                            data.blurRt = builder.declareRenderPass("Temp Shadow RT", descr);
                         }
                     } else {
                         // the shadowmap layer
                         data.output = builder.write(data.output,
                                 FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
-                        renderTargetDesc.attachments.depth = data.output;
+                        renderTargetDesc.attachments.content.depth = data.output;
                         renderTargetDesc.clearFlags = TargetBufferFlags::DEPTH;
                     }
 

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -60,7 +60,7 @@ struct ShadowMappingUniforms {
 class ShadowMapManager {
 public:
 
-    using ShadowMappingUniforms = ShadowMappingUniforms;
+    using ShadowMappingUniforms = filament::ShadowMappingUniforms;
 
     enum class ShadowTechnique : uint8_t {
         NONE = 0x0u,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -790,9 +790,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 [&](FrameGraph::Builder& builder, auto& data) {
                     data.picking = builder.read(picking,
                             FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                    builder.declareRenderPass("Picking Resolve Target", {
-                            .attachments = { .color = { data.picking }}
-                    });
+
+                    FrameGraphRenderPass::Descriptor descr;
+                    descr.attachments.content.color[0] = data.picking;
+                    builder.declareRenderPass("Picking Resolve Target", descr);
                     builder.sideEffect();
                 },
                 [=, &view](FrameGraphResources const& resources,

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -51,8 +51,12 @@ uint32_t FrameGraph::Builder::declareRenderPass(const char* name,
 FrameGraphId<FrameGraphTexture> FrameGraph::Builder::declareRenderPass(
         FrameGraphId<FrameGraphTexture> color, uint32_t* index) {
     color = write(color);
+
+  FrameGraphRenderPass::Descriptor descr;
+  descr.attachments.content.color[0] = color;
+
     uint32_t id = declareRenderPass(getName(color),
-            { .attachments = { .color = { color }}});
+            descr);
     if (index) *index = id;
     return color;
 }

--- a/filament/src/fg/FrameGraphId.h
+++ b/filament/src/fg/FrameGraphId.h
@@ -86,7 +86,7 @@ template<typename RESOURCE>
 class FrameGraphId : public FrameGraphHandle {
 public:
     using FrameGraphHandle::FrameGraphHandle;
-    FrameGraphId() noexcept = default;
+    FrameGraphId() {}
     explicit FrameGraphId(FrameGraphHandle r) : FrameGraphHandle(r) { }
 };
 

--- a/filament/src/fg/FrameGraphRenderPass.h
+++ b/filament/src/fg/FrameGraphRenderPass.h
@@ -33,13 +33,14 @@ namespace filament {
 struct FrameGraphRenderPass {
     static constexpr size_t ATTACHMENT_COUNT = backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 2;
     struct Attachments {
+        struct Content {
+            FrameGraphId<FrameGraphTexture> color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
+            FrameGraphId<FrameGraphTexture> depth;
+            FrameGraphId<FrameGraphTexture> stencil;
+        };
         union {
             FrameGraphId<FrameGraphTexture> array[ATTACHMENT_COUNT] = {};
-            struct {
-                FrameGraphId<FrameGraphTexture> color[backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT];
-                FrameGraphId<FrameGraphTexture> depth;
-                FrameGraphId<FrameGraphTexture> stencil;
-            };
+            Content content;
         };
     };
 

--- a/filament/test/filament_framegraph_test.cpp
+++ b/filament/test/filament_framegraph_test.cpp
@@ -341,7 +341,9 @@ TEST_F(FrameGraphTest, Basic) {
             [&](FrameGraph::Builder& builder, auto& data) {
                 data.depth = builder.create<FrameGraphTexture>("Depth Buffer", {.width=16, .height=32});
                 data.depth = builder.write(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
-                builder.declareRenderPass("Depth target", { .attachments = { .depth = data.depth }});
+                FrameGraphRenderPass::Descriptor descr;
+                descr.attachments.content.depth = data.depth;
+                builder.declareRenderPass("Depth target", descr);
                 EXPECT_TRUE(fg.isValid(data.depth));
             },
             [=](FrameGraphResources const& resources, auto const& data, backend::DriverApi& driver) {
@@ -372,10 +374,13 @@ TEST_F(FrameGraphTest, Basic) {
                 data.gbuf1 = builder.write(data.gbuf1, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 data.gbuf2 = builder.write(data.gbuf2, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
                 data.gbuf3 = builder.write(data.gbuf3, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                builder.declareRenderPass("Gbuffer target", { .attachments = {
-                        .color = { data.gbuf1, data.gbuf2, data.gbuf3 },
-                        .depth = data.depth
-                }});
+                FrameGraphRenderPass::Descriptor descr;
+                descr.attachments.content.color[0] = data.gbuf1;
+                descr.attachments.content.color[1] = data.gbuf2;
+                descr.attachments.content.color[2] = data.gbuf3;
+                descr.attachments.content.depth = data.depth;
+            
+                builder.declareRenderPass("Gbuffer target", descr);
 
                 EXPECT_TRUE(fg.isValid(data.depth));
             },

--- a/libs/camutils/CMakeLists.txt
+++ b/libs/camutils/CMakeLists.txt
@@ -28,6 +28,12 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 target_link_libraries(${TARGET} PUBLIC math)
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})

--- a/libs/filabridge/CMakeLists.txt
+++ b/libs/filabridge/CMakeLists.txt
@@ -24,6 +24,12 @@ add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 target_link_libraries(${TARGET} utils)
 target_link_libraries(${TARGET} math)
 target_link_libraries(${TARGET} backend_headers)

--- a/libs/filaflat/CMakeLists.txt
+++ b/libs/filaflat/CMakeLists.txt
@@ -24,6 +24,12 @@ add_library(${TARGET} ${HDRS} ${SRCS})
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 target_link_libraries(${TARGET} filabridge utils)
 
 if (FILAMENT_SUPPORTS_VULKAN)

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -94,6 +94,12 @@ target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
 set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
 target_link_libraries(${TARGET} shaders filabridge utils smol-v)
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 # Filamat Lite
 add_library(filamat_lite STATIC ${HDRS} ${LITE_PRIVATE_HDRS} ${LITE_SRCS})
 target_include_directories(filamat_lite PUBLIC ${PUBLIC_HDR_DIR})

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -142,10 +142,10 @@ protected:
     std::vector<CodeGenParams> mCodeGenPermutations;
     // For finding properties and running semantic analysis, we always use the same code gen
     // permutation. This is the first permutation generated with default arguments passed to matc.
-    static constexpr const CodeGenParams mSemanticCodeGenParams = {
-            .shaderModel = ShaderModel::MOBILE,
-            .targetApi = TargetApi::OPENGL,
-            .targetLanguage = TargetLanguage::SPIRV
+    const CodeGenParams mSemanticCodeGenParams = {
+        (int) ShaderModel::GL_ES_30,
+        TargetApi::OPENGL,
+        TargetLanguage::SPIRV
     };
 
     // Keeps track of how many times MaterialBuilder::init() has been called without a call to

--- a/libs/filameshio/CMakeLists.txt
+++ b/libs/filameshio/CMakeLists.txt
@@ -27,6 +27,12 @@ target_link_libraries(${TARGET}
     PUBLIC filament # Public only because the filamesh API needs Box.h
 )
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 # ==================================================================================================
 # Installation
 # ==================================================================================================

--- a/libs/geometry/CMakeLists.txt
+++ b/libs/geometry/CMakeLists.txt
@@ -24,6 +24,12 @@ include_directories(${PUBLIC_HDR_DIR})
 
 add_library(${TARGET} STATIC ${PUBLIC_HDRS} ${SRCS})
 
+if (CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${TARGET} PROPERTIES
+                          C_VISIBILITY_PRESET default
+                          CXX_VISIBILITY_PRESET default)
+endif()
+
 target_link_libraries(${TARGET} PUBLIC math utils)
 
 target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})

--- a/libs/iblprefilter/CMakeLists.txt
+++ b/libs/iblprefilter/CMakeLists.txt
@@ -108,7 +108,7 @@ if (MSVC)
 elseif(WEBGL)
     # Avoid strict-vtable-pointers here, it is broken in WebAssembly.
     set(OPTIMIZATION_FLAGS -fvisibility-inlines-hidden)
-else()
+elseif(APPLE)
     set(OPTIMIZATION_FLAGS
         -ffast-math
         -ffp-contract=fast
@@ -116,6 +116,12 @@ else()
         #        -fslp-vectorize-aggressive
         -fvisibility-inlines-hidden
         -fstrict-vtable-pointers
+    )
+else()
+    set(OPTIMIZATION_FLAGS
+        -ffast-math
+        -ffp-contract=fast
+        -fvisibility-inlines-hidden
     )
 endif()
 

--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include <algorithm>
 #include <array>        // note: this is safe, see how std::array is used below (inline / private)
 #include <cstddef>
 #include <utility>

--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -18,7 +18,7 @@
 #define TNT_UTILS_ALGORITHM_H
 
 #include <utils/compiler.h>
-
+#include <cstddef>
 #include <type_traits>      // for std::enable_if
 
 #include <limits.h>

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -6,7 +6,9 @@
 #include <utils/Log.h>
 
 #include <ostream>
-
+#if defined(__GNUC__)
+#include <string.h>
+#endif
 #include "jsonParseUtils.h"
 
 using namespace utils;

--- a/tools/beamsplitter/emitters/serializer.template
+++ b/tools/beamsplitter/emitters/serializer.template
@@ -6,7 +6,9 @@
 #include <utils/Log.h>
 
 #include <ostream>
-
+#if defined(__GNUC__)
+#include <string.h>
+#endif
 #include "jsonParseUtils.h"
 
 using namespace utils;

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -120,6 +120,8 @@ static ssize_t extractArraySize(std::string& type) {
         return 0;
     }
 
+    const std::string typeWithSizeStr = type;
+
     // Remove the [...] bit
     type.erase(start);
 
@@ -129,7 +131,7 @@ static ssize_t extractArraySize(std::string& type) {
     }
 
     // Return the size (we already validated this part of the string contains only digits)
-    return (ssize_t)std::stoul(type.c_str() + start + 1, nullptr);
+    return std::stoul(typeWithSizeStr.c_str() + start + 1, nullptr);
 }
 
 static bool processParameter(MaterialBuilder& builder, const JsonishObject& jsonObject) noexcept {


### PR DESCRIPTION
This PR fixes multiple issues that prevented GCC from being used. 
This addresses the following issues:
- C++ 20 designated initializers were used here and there, preventing compilation with C++17
- The anonymous struct in FrameGraphRenderPass was not compiling
- removed some noexcept which would fail the compilation
- ambiguous typedefs
- missing inludes
- symbols visibility at lnk time


This PR is a bunch of cherry picks in-between other feature commits, please make sure to review and test it on your side.