### PR TITLE
Reduce size of ShadowMap object

### DIFF
--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -186,6 +186,8 @@ private:
         size_t mSplitCount;
     };
 
+    FEngine& mEngine;
+
     // Atlas requirements, updated in ShadowMapManager::update(),
     // consumed in ShadowMapManager::render()
     struct TextureAtlasRequirements {


### PR DESCRIPTION
- remove mEngine from ShadowMap
- remove storage of ShadowMapInfo in ShadowMap
- ShadowMap::render should be on ShadowMapManager
- remove more attributes from ShadowMap

ShadowMap is now reduced to 32 bytes.