### PR TITLE
G3 fixes for 1.28.0

### DIFF
--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -93,8 +93,11 @@
  */
 
 #if defined(GL_ES_VERSION_2_0)
+
 #ifdef GL_EXT_disjoint_timer_query
-#       define GL_TIME_ELAPSED              GL_TIME_ELAPSED_EXT
+#    ifndef GL_TIME_ELAPSED
+#        define GL_TIME_ELAPSED             GL_TIME_ELAPSED_EXT
+#    endif
 #endif
 
 #ifdef GL_EXT_clip_control
@@ -165,7 +168,12 @@
     #define GL_COMPUTE_SHADER                       0x91B9
 
     #define GL_TEXTURE_2D_MULTISAMPLE               0x9100
+
+// FIXME: The GL_TIME_ELAPSED define is used unconditionally in Filament, but
+// requires extension support.
+#ifndef GL_TIME_ELAPSED
     #define GL_TIME_ELAPSED                         0x88BF
+#endif
 
     #define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY       0x900A
     #define GL_SAMPLER_CUBE_MAP_ARRAY               0x900C

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -49,7 +49,8 @@ VulkanProgram::VulkanProgram(VulkanContext& context, const Program& builder) noe
         HwProgram(builder.getName()), context(context) {
     auto const& blobs = builder.getShadersSource();
     VkShaderModule* modules[2] = { &bundle.vertex, &bundle.fragment };
-    for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
+    // TODO: handle compute shaders.
+    for (size_t i = 0; i < 2; i++) {
         const auto& blob = blobs[i];
         VkShaderModule* module = modules[i];
         VkShaderModuleCreateInfo moduleInfo = {};


### PR DESCRIPTION
A couple of fixes for G3:
- iOS does not have `GL_EXT_disjoint_timer_query`, so `GL_TIME_ELAPSED` is not defined though it's used in Filament without any `#ifdef` guard
- Vulkan does not yet support compute shaders