### PR TITLE
Metal: fix, don't use encoder.device

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -893,7 +893,7 @@ void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh, BufferDescripto
     auto& encoderCache = mContext->argumentEncoderCache;
     id<MTLArgumentEncoder> encoder =
             encoderCache.getOrCreateState(ArgumentEncoderState(std::move(textureTypes)));
-    sb->reset(getPendingCommandBuffer(mContext), encoder);
+    sb->reset(getPendingCommandBuffer(mContext), encoder, mContext->device);
 
     // In a perfect world, all the MTLTexture bindings would be known at updateSamplerGroup time.
     // However, there are two special cases preventing this:

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -305,7 +305,7 @@ public:
     // the texture types have changed.
     // Mutate re-encodes the current set of samplers/textures into the new argument
     // buffer.
-    void reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEncoder> e);
+    void reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEncoder> e, id<MTLDevice> device);
     void mutate(id<MTLCommandBuffer> cmdBuffer);
 
     id<MTLBuffer> getArgumentBuffer() const {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -828,7 +828,8 @@ void MetalSamplerGroup::finalize() {
     finalized = true;
 }
 
-void MetalSamplerGroup::reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEncoder> e) {
+void MetalSamplerGroup::reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEncoder> e,
+        id<MTLDevice> device) {
     encoder = e;
 
     // The number of slots in the ring buffer we use to manage argument buffer allocations.
@@ -846,7 +847,7 @@ void MetalSamplerGroup::reset(id<MTLCommandBuffer> cmdBuffer, id<MTLArgumentEnco
     // Chances are, even though the MTLArgumentEncoder might change, the required size and alignment
     // probably won't. So we can re-use the previous ring buffer.
     if (UTILS_UNLIKELY(!argBuffer || !argBuffer->canAccomodateLayout(argBufferLayout))) {
-        argBuffer = std::make_unique<MetalRingBuffer>(encoder.device, MTLResourceStorageModeShared,
+        argBuffer = std::make_unique<MetalRingBuffer>(device, MTLResourceStorageModeShared,
                 argBufferLayout, METAL_ARGUMENT_BUFFER_SLOTS);
     } else {
         argBuffer->createNewAllocation(cmdBuffer);


### PR DESCRIPTION
In some cases, calling `encoder.device` returns `nil`, even right after a valid `MTLArgumentEncoder` has been initialized. So far this has only been seen on the iOS simulator.