### PR TITLE
Increase the number of morph targets to 1024 instead of 256

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -683,9 +683,9 @@ static void updateMorphWeights(FEngine& engine, backend::Handle<backend::HwBuffe
 void FRenderableManager::setMorphWeights(Instance instance, float const* weights,
         size_t count, size_t offset) {
     if (instance) {
-        ASSERT_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT,
+        ASSERT_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT / 4,
                 "Only %d morph targets are supported (count=%d, offset=%d)",
-                CONFIG_MAX_MORPH_TARGET_COUNT, count, offset);
+                CONFIG_MAX_MORPH_TARGET_COUNT / 4, count, offset);
 
         MorphWeights& morphWeights = mManager[instance].morphWeights;
         if (morphWeights.handle) {

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -667,10 +667,16 @@ void FRenderableManager::setSkinningBuffer(FRenderableManager::Instance ci,
 static void updateMorphWeights(FEngine& engine, backend::Handle<backend::HwBufferObject> handle,
         float const* weights, size_t count, size_t offset) noexcept {
     auto& driver = engine.getDriverApi();
-    auto size = sizeof(float4) * count;
+    auto size = sizeof(float4) * ((count + 3) / 4);
     auto* UTILS_RESTRICT out = (float4*)driver.allocate(size);
-    std::transform(weights, weights + count, out,
-            [](float value) { return float4(value, 0, 0, 0); });
+
+    for (size_t i = 0; i < count; i++)
+    {
+        auto pos = i / 4;
+        auto pos_idx = i % 4;
+        out[pos][pos_idx] = weights[i];
+    }
+
     driver.updateBufferObject(handle, { out, size }, sizeof(float4) * offset);
 }
 

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -683,9 +683,9 @@ static void updateMorphWeights(FEngine& engine, backend::Handle<backend::HwBuffe
 void FRenderableManager::setMorphWeights(Instance instance, float const* weights,
         size_t count, size_t offset) {
     if (instance) {
-        ASSERT_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT / 4,
+        ASSERT_PRECONDITION(count + offset <= CONFIG_MAX_MORPH_TARGET_COUNT * 4,
                 "Only %d morph targets are supported (count=%d, offset=%d)",
-                CONFIG_MAX_MORPH_TARGET_COUNT / 4, count, offset);
+                CONFIG_MAX_MORPH_TARGET_COUNT * 4, count, offset);
 
         MorphWeights& morphWeights = mManager[instance].morphWeights;
         if (morphWeights.handle) {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -151,7 +151,7 @@ enum VertexAttribute : uint8_t {
 };
 
 static constexpr size_t MAX_LEGACY_MORPH_TARGETS = 4;
-static constexpr size_t MAX_MORPH_TARGETS = 256; // this is limited by filament::CONFIG_MAX_MORPH_TARGET_COUNT
+static constexpr size_t MAX_MORPH_TARGETS = 256 * 4; // this is limited by filament::CONFIG_MAX_MORPH_TARGET_COUNT
 static constexpr size_t MAX_CUSTOM_ATTRIBUTES = 8;
 
 /**

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -107,7 +107,7 @@ constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 // The maximum number of morph targets associated with a single renderable.
 // Note that ES3.0 only guarantees 256 layers in an array texture.
 // Furthermore, this is constrained by CONFIG_MINSPEC_UBO_SIZE (16 bytes per morph target).
-constexpr size_t CONFIG_MAX_MORPH_TARGET_COUNT = 256;
+constexpr size_t CONFIG_MAX_MORPH_TARGET_COUNT = 256 * 4;
 
 } // namespace filament
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -107,7 +107,7 @@ constexpr size_t CONFIG_MAX_BONE_COUNT = 256;
 // The maximum number of morph targets associated with a single renderable.
 // Note that ES3.0 only guarantees 256 layers in an array texture.
 // Furthermore, this is constrained by CONFIG_MINSPEC_UBO_SIZE (16 bytes per morph target).
-constexpr size_t CONFIG_MAX_MORPH_TARGET_COUNT = 256 * 4;
+constexpr size_t CONFIG_MAX_MORPH_TARGET_COUNT = 256;
 
 } // namespace filament
 

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -100,7 +100,9 @@ void morphPosition(inout vec4 p) {
     ivec3 texcoord = ivec3(getVertexIndex() % MAX_MORPH_TARGET_BUFFER_WIDTH, getVertexIndex() / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
     uint c = getObjectUniforms().morphTargetCount;
     for (uint i = 0u; i < c; ++i) {
-        float w = morphingUniforms.weights[i][0];
+        uint pos = i / 4;
+        uint idx_pos = i % 4;
+        float w = morphingUniforms.weights[pos][idx_pos];
         if (w != 0.0) {
             texcoord.z = int(i);
             p += w * texelFetch(morphTargetBuffer_positions, texcoord, 0);


### PR DESCRIPTION
I'm using the fact that we are passing float4 so I can pass 4x data for the morph weights