### PR TITLE
Fix Metal unused variable warning

### DIFF
--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -91,12 +91,14 @@ blitterFrag(VertexOut in [[stage_in]],
 {
     FragmentOut out = {};
 
+#if defined(BLIT_COLOR) || defined(BLIT_DEPTH)
     // These coordinates match the Vulkan vkCmdBlitImage spec:
     // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdBlitImage.html
     float2 uvbase = in.position.xy; // unnormalized coordinates at center of texel: (1.5, 2.5, etc)
     float2 uvoffset = uvbase - args->dstOffset;
     float2 uvscaled = uvoffset * args->scale;
     float2 uv = uvscaled + args->srcOffset;
+#endif
 
 #ifdef BLIT_COLOR
 #ifdef MSAA_COLOR_SOURCE


### PR DESCRIPTION
This PR resolves a Metal shader compilation warning that bloats our output window. The following unused variable warning is generated:
```
[Metal Compiler Warning] Warning: Compilation succeeded with:
program_source:73:12: warning: unused variable ‘uv’
    float2 uv = uvscaled + args->srcOffset;
```
The warning originates from the `MetalBlitter.mm` implementation file. This code piece is part of the blitter’s fragment function, however the fragment shader compiles without warnings. Actually, the warning is generated when the blitter’s shader source is used for vertex shader compilation, where no `BLIT_COLOR` nor `BLIT_DEPTH` is provided, thus the preprocessor removes all code paths that used the `uv` variable from the fragment entry point. To solve this, I encapsulated the orphaned variables with the mentioned macros. 