### PR TITLE
Metal: fix microshadowing artifacts

### DIFF
--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -67,7 +67,7 @@ struct PixelParams {
 
 float computeMicroShadowing(float NoL, float visibility) {
     // Chan 2018, "Material Advances in Call of Duty: WWII"
-    float aperture = inversesqrt(1.0 - visibility);
+    float aperture = inversesqrt(1.0 - min(visibility, 0.9999));
     float microShadow = saturate(NoL * aperture);
     return microShadow * microShadow;
 }


### PR DESCRIPTION
[`inversesqrt`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/inversesqrt.xhtml) is undefined for values <= 0. This resulted in black "patches" in Metal where `aperture` was being set to 0.