### PR TITLE
Calculate primitive's AABB correctly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- gltfio: calculate primitive's AABB correctly. 
+
 ## v1.28.2
 
 - gltfio: support EXT_meshopt_compression


### PR DESCRIPTION
AABB of morph target is displacement data so it should be added to primitive's base AABB.

Fix #6231 