### PR TITLE
Add Vulkan GGP platform.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ This file contains one line summaries of commits that are worthy of mentioning i
 A new header is inserted each time a *tag* is created.
 
 ## main branch
+- backend: add support for GGP platform
 
 ## v1.28.2
 

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -42,7 +42,9 @@
         #include "vulkan/PlatformVkCocoa.h"
     #endif
 #elif defined(__linux__)
-    #if defined(FILAMENT_SUPPORTS_WAYLAND)
+    #if defined(FILAMENT_SUPPORTS_GGP)
+        #include "vulkan/PlatformVkLinuxGGP.h"
+    #elif defined(FILAMENT_SUPPORTS_WAYLAND)
         #if defined (FILAMENT_DRIVER_SUPPORTS_VULKAN)
             #include "vulkan/PlatformVkLinuxWayland.h"
         #endif
@@ -120,7 +122,9 @@ DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
             #elif defined(IOS)
                 return new PlatformVkCocoaTouch();
             #elif defined(__linux__)
-                #if defined(FILAMENT_SUPPORTS_WAYLAND)
+                #if defined(FILAMENT_SUPPORTS_GGP)
+                    return new PlatformVkLinuxGGP();
+                #elif defined(FILAMENT_SUPPORTS_WAYLAND)
                     return new PlatformVkLinuxWayland();
                 #elif defined(FILAMENT_SUPPORTS_X11)
                     return new PlatformVkLinuxX11();

--- a/filament/backend/src/vulkan/PlatformVkLinuxGGP.cpp
+++ b/filament/backend/src/vulkan/PlatformVkLinuxGGP.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vulkan/PlatformVkLinuxGGP.h"
+
+#include <bluevk/BlueVK.h>
+#if defined(FILAMENT_SUPPORTS_GGP)
+#include <ggp_c/ggp.h>
+#endif
+#include <utils/Panic.h>
+
+#include "VulkanDriverFactory.h"
+
+using namespace bluevk;
+
+namespace filament::backend {
+
+Driver* PlatformVkLinuxGGP::createDriver(
+    void* const sharedContext,
+    const Platform::DriverConfig& driverConfig) noexcept {
+#if defined(FILAMENT_SUPPORTS_GGP)
+  ASSERT_PRECONDITION(sharedContext == nullptr,
+                      "Vulkan does not support shared contexts.");
+  const char* requiredInstanceExtensions[] = {
+      VK_GGP_STREAM_DESCRIPTOR_SURFACE_EXTENSION_NAME};
+  return VulkanDriverFactory::create(this, requiredInstanceExtensions,
+                                     sizeof(requiredInstanceExtensions) /
+                                         sizeof(requiredInstanceExtensions[0]),
+                                     driverConfig);
+#else
+  PANIC_PRECONDITION("Filament does not support GGP.");
+  return nullptr;
+#endif
+}
+
+void* PlatformVkLinuxGGP::createVkSurfaceKHR(void* nativeWindow, void* instance,
+                                             uint64_t flags) noexcept {
+#if defined(FILAMENT_SUPPORTS_GGP)
+  VkStreamDescriptorSurfaceCreateInfoGGP surface_create_info = {
+      VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP};
+  surface_create_info.streamDescriptor = kGgpPrimaryStreamDescriptor;
+  PFN_vkCreateStreamDescriptorSurfaceGGP fpCreateStreamDescriptorSurfaceGGP =
+      reinterpret_cast<PFN_vkCreateStreamDescriptorSurfaceGGP>(
+          vkGetInstanceProcAddr(static_cast<VkInstance>(instance),
+                                "vkCreateStreamDescriptorSurfaceGGP"));
+  ASSERT_PRECONDITION(fpCreateStreamDescriptorSurfaceGGP != nullptr,
+                      "Error getting VkInstance "
+                      "function vkCreateStreamDescriptorSurfaceGGP");
+  VkSurfaceKHR surface = nullptr;
+  VkResult res = fpCreateStreamDescriptorSurfaceGGP(
+      static_cast<VkInstance>(instance), &surface_create_info, nullptr,
+      &surface);
+  ASSERT_PRECONDITION(res == VK_SUCCESS, "Error in vulkan: %d", res);
+  return surface;
+#else
+  PANIC_PRECONDITION("Filament does not support GGP.");
+  return nullptr;
+#endif
+}
+
+}  // namespace filament::backend

--- a/filament/backend/src/vulkan/PlatformVkLinuxGGP.h
+++ b/filament/backend/src/vulkan/PlatformVkLinuxGGP.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKAN_PLATFORM_VK_LINUX_GGP_H
+#define TNT_FILAMENT_BACKEND_VULKAN_PLATFORM_VK_LINUX_GGP_H
+
+#include <backend/DriverEnums.h>
+#include <stdint.h>
+
+#include "VulkanPlatform.h"
+
+namespace filament::backend {
+
+class PlatformVkLinuxGGP final : public VulkanPlatform {
+ public:
+  Driver* createDriver(
+      void* const sharedContext,
+      const Platform::DriverConfig& driverConfig) noexcept override;
+
+  void* createVkSurfaceKHR(void* nativeWindow, void* instance,
+                           uint64_t flags) noexcept override;
+
+  int getOSVersion() const noexcept override { return 0; }
+};
+
+}  // namespace filament::backend
+
+#endif  // TNT_FILAMENT_BACKEND_VULKAN_PLATFORM_VK_LINUX_GGP_H


### PR DESCRIPTION
This PR adds support for a new Vulkan backend that enables the VK_GGP_stream_descriptor_surface vulkan extension and creates the surface using the vkCreateStreamDescriptorSurfaceGGP function provided by that extension.