### PR TITLE
Preserve iOS stack traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,12 @@ endif()
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
 if (ANDROID OR IOS OR WEBGL)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
+
+    if (ANDROID OR WEBGL)
+        # Omitting unwind info prevents the generation of readable stack traces in crash reports on iOS
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-unwind-tables -fno-asynchronous-unwind-tables")
+    endif()
 endif()
 
 # With WebGL, we disable RTTI even for debug builds because we pass emscripten::val back and forth

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,13 +337,12 @@ endif()
 # ==================================================================================================
 # Release compiler flags
 # ==================================================================================================
-if (NOT MSVC)
+if (NOT MSVC AND NOT IOS)
+    # Omitting stack frame pointers prevents the generation of readable stack traces in crash reports on iOS
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
 
     # These aren't compatible with -fembed-bitcode (and seem to have no effect on Apple platforms anyway)
-    if (NOT IOS)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
-    endif()
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
 endif()
 
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB


### PR DESCRIPTION
This PR follows up on #624 and adds back unwind tables and frame pointers to the generated code **on iOS**.

Our iOS app uses Filament for PBR rendering and uses Crashlytics for tracking crashes. We faced the problem of not seeing stack frames of Filament code in our crash reports because unwind tables and frame pointers were emitted from the Filament lib:
![image](https://user-images.githubusercontent.com/12460850/156014856-2f27f33a-5ca0-43c4-88de-52a62becb7e0.png)

Adding them back fixed the issue without significantly increasing the app size. In our case, our Filament static lib grew from 137.1 MB to 139.5 MB. (The lib file in question includes  x86_64 and arm64 binaries of the following libraries and their dependencies: `backend`, `filabridge`, `filaflat`, `filament`, `ibl`, `image`, `utils`).

We tested these changes on the following platforms:
 - iPadOS (arm64 devices only)
 - iOS Simulator (x86_64 and arm64 host machines too)
 - Mac Catalyst app on macOS (x86_64 and arm64 machines too)

### Would it be worth adding them back on Android too?
We can't test Android and haven't investigated if similar problems would arise on WebGL. Since we are unfamiliar with these platforms we decided not to touch their build settings in Filament.
 
### What about Windows?
For the record, our crash reports on Windows didn't suffer from missing stack Filament stack frames. Either because the MSVC settings are different for Filament (didn't check) or because we use Sentry instead of Crashlytics.