### PR TITLE
Metal: generate argument buffer structures ourselves

### DIFF
--- a/build/common/check-metal-shaders.sh
+++ b/build/common/check-metal-shaders.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -e
+
+function print_help {
+    local self_name=$(basename "$0")
+    echo "This tool verifies that every Metal shader in the given Filament material file(s) successfully compiles."
+    echo "Requires the matinfo tool and xcrun to be on the system PATH."
+    echo ""
+    echo "Usage:"
+    echo "    $self_name [options] [<material> ...]"
+    echo ""
+    echo "Options:"
+    echo "    -h"
+    echo "        Print this help message."
+    echo "    -w"
+    echo "        Pass the -w flag to the Metal compiler, to disable warnings."
+    echo ""
+}
+
+COMP_FLAGS=""
+while getopts ":hw" opt; do
+    case ${opt} in
+        h)
+            print_help
+            exit 1
+            ;;
+        w)
+            COMP_FLAGS="${COMP_FLAGS} -w"
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ "$#" == "0" ]]; then
+    print_help
+    exit 1
+fi
+
+# Make sure matinfo and xcrun are available.
+if [[ ! $(command -v matinfo) ]]; then
+    echo "Error: matinfo not on PATH."
+    exit 1
+fi
+if [[ ! $(command -v xcrun) ]]; then
+    echo "Error: xcrun not on PATH."
+    exit 1
+fi
+
+function check_material {
+    local material="$1"
+
+    tmpdir="$(mktemp -d /tmp/check_metal_shaders.XXXXX)"
+
+    # First check that the material is valid.
+    if [[ ! $(matinfo "${material}") ]]; then
+        echo "Invalid material file: ${material}"
+        exit 1
+    fi
+
+    echo "Checking that Metal shaders compile: ${material}"
+
+    set +e
+    local i=0
+    while true; do
+        # The file must have a .metal extension.
+        metalFile="${tmpdir}/${i}.metal"
+
+        # Extract shader i. matinfo will return a non-zero exit code if the shader doesn't exist,
+        # which means we're finished with this material.
+        matinfo --print-metal=${i} "${material}" > "${metalFile}" 2> /dev/null
+
+        if [[ "$?" -ne 0 ]]; then
+            break
+        fi
+
+        echo "Testing Metal shader ${i}"
+
+        # Attempt to compile the Metal shader.
+        xcrun -sdk macosx metal ${COMP_FLAGS} -c "${metalFile}" -o /dev/null
+
+        if [[ "$?" -ne 0 ]]; then
+            echo "Error compiling Metal shader: ${metalFile}"
+            exit 1
+        fi
+
+        ((i++))
+    done
+    set -e
+
+    rm -r "${tmpdir}"
+}
+
+for material in "$@"
+do
+    check_material "${material}"
+done
+

--- a/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/SamplerInterfaceBlock.h
@@ -49,7 +49,7 @@ public:
 
     struct SamplerInfo { // NOLINT(cppcoreguidelines-pro-type-member-init)
         utils::CString name;        // name of this sampler
-        utils::CString uniformName; // name of the uniform holding this sampler (needed for glsl)
+        utils::CString uniformName; // name of the uniform holding this sampler (needed for glsl/MSL)
         uint8_t offset;             // offset in "Sampler" of this sampler in the buffer
         Type type;                  // type of this sampler
         Format format;              // format of this sampler

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -57,6 +57,7 @@ set(PRIVATE_HDRS
         src/eiff/DictionarySpirvChunk.h
         src/eiff/MaterialSpirvChunk.h
         src/GLSLPostProcessor.h
+        src/MetalArgumentBuffer.h
         src/ShaderMinifier.h
         src/sca/ASTHelpers.h
         src/sca/GLSLTools.h
@@ -67,6 +68,7 @@ set(SRCS
         src/eiff/BlobDictionary.cpp
         src/eiff/DictionarySpirvChunk.cpp
         src/eiff/MaterialSpirvChunk.cpp
+        src/MetalArgumentBuffer.cpp
         src/sca/ASTHelpers.cpp
         src/sca/GLSLTools.cpp
         src/GLSLPostProcessor.cpp
@@ -163,6 +165,7 @@ project(test_filamat)
 set(TARGET test_filamat)
 set(SRCS
         tests/test_filamat.cpp
+        tests/test_argBufferFixup.cpp
         tests/test_includes.cpp)
 
 add_executable(${TARGET} ${SRCS})

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -286,10 +286,10 @@ void GLSLPostProcessor::spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl
     *outMsl = minifier.removeWhitespace(*outMsl);
 
     // Replace spirv-cross' generated argument buffers with our own.
-    for (const auto* argBuffer : argumentBuffers) {
+    for (auto* argBuffer : argumentBuffers) {
         auto argBufferMsl = argBuffer->getMsl();
         MetalArgumentBuffer::replaceInShader(*outMsl, argBuffer->getName(), argBufferMsl);
-        delete argBuffer;
+        MetalArgumentBuffer::destroy(&argBuffer);
     }
 }
 

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -28,6 +28,8 @@
 #include "shaders/CodeGenerator.h"
 #include "shaders/MaterialInfo.h"
 
+#include "MetalArgumentBuffer.h"
+
 #include <filament/MaterialEnums.h>
 #include <private/filament/Variant.h>
 #include "SibGenerator.h"
@@ -165,8 +167,31 @@ void GLSLPostProcessor::spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl
 
     mslOptions.argument_buffers = true;
 
-    // Necessary to keep all argument buffers the same size across material variants.
-    mslOptions.pad_argument_buffer_resources = true;
+    // We're using argument buffers for texture resources, however, we cannot rely on spirv-cross to
+    // generate the argument buffer definitions.
+    //
+    // Consider a shader with 3 textures:
+    // layout (set = 0, binding = 0) uniform sampler2D texture1;
+    // layout (set = 0, binding = 1) uniform sampler2D texture2;
+    // layout (set = 0, binding = 2) uniform sampler2D texture3;
+    //
+    // If only texture1 and texture2 are used in the material, then texture3 will be optimized away.
+    // This results in an argument buffer like the following:
+    // struct spvDescriptorSetBuffer0 {
+    //     texture2d<float> texture1 [[id(0)]];
+    //     sampler texture1Smplr [[id(1)]];
+    //     texture2d<float> texture2 [[id(2)]];
+    //     sampler texture2Smplr [[id(3)]];
+    // };
+    // Note that this happens even if "pad_argument_buffer_resources" and
+    // "force_active_argument_buffer_resources" are true.
+    //
+    // This would be fine, except older Apple devices don't like it when the argument buffer in the
+    // shader doesn't precisely match the one generated at runtime.
+    //
+    // So, we use the MetalArgumentBuffer class to replace spirv-cross' argument buffer definitions
+    // with our own that contain all the textures/samples, even those optimized away.
+    std::vector<MetalArgumentBuffer*> argumentBuffers;
 
     mslCompiler.set_msl_options(mslOptions);
 
@@ -196,28 +221,25 @@ void GLSLPostProcessor::spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl
     //
     // Which is then bound to the vertex/fragment functions:
     // constant spvDescriptorSetBuffer1& spvDescriptorSet1 [[buffer(27)]]
-    forEachSib(config, [&executionModel, &mslCompiler](uint8_t bindingPoint, const SamplerInterfaceBlock* sib) {
+    forEachSib(config,
+            [&executionModel, &mslCompiler, &argumentBuffers](
+                    uint8_t bindingPoint, const SamplerInterfaceBlock* sib) {
         const auto& infoList = sib->getSamplerInfoList();
+
+        // bindingPoint + 1, because the first descriptor set is for uniforms
+        auto argBufferBuilder = MetalArgumentBuffer::Builder()
+                .name("spvDescriptorSetBuffer" + std::to_string(int(bindingPoint + 1)));
+
         for (const auto& info: infoList) {
-            // A MSLResourceBinding tells SPIRV-Cross how to map a sampler2D with a given set and
-            // binding to Metal resources.
-            // For example, textureB in the above example has:
-            //   bindingPoint = 0      (it's the first sampler group)
-            //   set = 1               (bindingPoint + 1, the first descriptor set is for uniforms)
-            //   offset = 1            (it's the second sampler in the sampler group)
-            // The equivalent MSL texture argument is assigned the [[id(2)]] binding and its sampler
-            // resource assigned the [[id(3)]] binding (controlled via msl_texture and msl_sampler).
-            MSLResourceBinding newBinding;
-            newBinding.basetype = SPIRType::BaseType::SampledImage;
-            newBinding.stage = executionModel;
-            newBinding.desc_set = bindingPoint + 1;
-            newBinding.binding = info.offset;
-            newBinding.count = 1;
-            newBinding.msl_texture = info.offset * 2;
-            newBinding.msl_sampler = info.offset * 2 + 1;
-            mslCompiler.add_msl_resource_binding(newBinding);
+            const std::string name = info.uniformName.c_str();
+            argBufferBuilder
+                    .texture(info.offset * 2, name, info.type, info.format)
+                    .sampler(info.offset * 2 + 1, name + "Smplr");
         }
-        // This final MSLResourceBinding is how we control the [[buffer(n)]] binding of the argument
+
+        argumentBuffers.push_back(argBufferBuilder.build());
+
+        // This MSLResourceBinding is how we control the [[buffer(n)]] binding of the argument
         // buffer itself;
         MSLResourceBinding argBufferBinding;
         // the baseType doesn't matter, but can't be UNKNOWN
@@ -262,6 +284,13 @@ void GLSLPostProcessor::spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl
 
     *outMsl = mslCompiler.compile();
     *outMsl = minifier.removeWhitespace(*outMsl);
+
+    // Replace spirv-cross' generated argument buffers with our own.
+    for (const auto* argBuffer : argumentBuffers) {
+        auto argBufferMsl = argBuffer->getMsl();
+        MetalArgumentBuffer::replaceInShader(*outMsl, argBuffer->getName(), argBufferMsl);
+        delete argBuffer;
+    }
 }
 
 bool GLSLPostProcessor::process(const std::string& inputShader, Config const& config,

--- a/libs/filamat/src/MetalArgumentBuffer.cpp
+++ b/libs/filamat/src/MetalArgumentBuffer.cpp
@@ -131,6 +131,11 @@ MetalArgumentBuffer::MetalArgumentBuffer(Builder& builder) {
     mShaderText = ss.str();
 }
 
+void MetalArgumentBuffer::destroy(MetalArgumentBuffer** argumentBuffer) {
+    delete *argumentBuffer;
+    *argumentBuffer = nullptr;
+}
+
 static bool isWhitespace(char c) {
     return (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v');
 }

--- a/libs/filamat/src/MetalArgumentBuffer.cpp
+++ b/libs/filamat/src/MetalArgumentBuffer.cpp
@@ -1,0 +1,216 @@
+/*
+* Copyright (C) 2022 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "MetalArgumentBuffer.h"
+
+#include <sstream>
+#include <utility>
+
+namespace filamat {
+
+MetalArgumentBuffer::Builder& filamat::MetalArgumentBuffer::Builder::name(
+        const std::string& name) noexcept {
+    mName = name;
+    return *this;
+}
+
+MetalArgumentBuffer::Builder& MetalArgumentBuffer::Builder::texture(size_t index,
+        const std::string& name, filament::backend::SamplerType type,
+        filament::backend::SamplerFormat format) noexcept {
+    // All combinations of SamplerType and SamplerFormat are valid except for SAMPLER_3D / SHADOW.
+    assert_invariant(type != filament::backend::SamplerType::SAMPLER_3D ||
+            format != filament::backend::SamplerFormat::SHADOW);
+    mArguments.emplace_back(TextureArgument { name, index, type, format });
+    return *this;
+}
+
+MetalArgumentBuffer::Builder& MetalArgumentBuffer::Builder::sampler(
+        size_t index, const std::string& name) noexcept {
+    mArguments.emplace_back(SamplerArgument { name , index });
+    return *this;
+}
+
+MetalArgumentBuffer* MetalArgumentBuffer::Builder::build() {
+    assert_invariant(!mName.empty());
+    return new MetalArgumentBuffer(*this);
+}
+
+std::ostream& MetalArgumentBuffer::Builder::TextureArgument::write(std::ostream& os) const {
+    switch (format) {
+        case filament::backend::SamplerFormat::INT:
+        case filament::backend::SamplerFormat::UINT:
+        case filament::backend::SamplerFormat::FLOAT:
+            os << "texture";
+            break;
+        case filament::backend::SamplerFormat::SHADOW:
+            os << "depth";
+            break;
+    }
+
+    switch (type) {
+        case filament::backend::SamplerType::SAMPLER_EXTERNAL:
+        case filament::backend::SamplerType::SAMPLER_2D:
+            os << "2d";
+            break;
+        case filament::backend::SamplerType::SAMPLER_2D_ARRAY:
+            os << "2d_array";
+            break;
+        case filament::backend::SamplerType::SAMPLER_CUBEMAP:
+            os << "cube";
+            break;
+        case filament::backend::SamplerType::SAMPLER_3D:
+            os << "3d";
+            break;
+        case filament::backend::SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            os << "cube_array";
+            break;
+    }
+
+    switch (format) {
+        case filament::backend::SamplerFormat::INT:
+            os << "<int>";
+            break;
+        case filament::backend::SamplerFormat::UINT:
+            os << "<uint>";
+            break;
+        case filament::backend::SamplerFormat::FLOAT:
+        case filament::backend::SamplerFormat::SHADOW:
+            os << "<float>";
+            break;
+    }
+
+    os << " " << name << " [[id(" << index << ")]];" << std::endl;
+    return os;
+}
+
+std::ostream& MetalArgumentBuffer::Builder::SamplerArgument::write(std::ostream& os) const {
+    os << "sampler " << name << " [[id(" << index << ")]];" << std::endl;
+    return os;
+}
+
+MetalArgumentBuffer::MetalArgumentBuffer(Builder& builder) {
+    mName = builder.mName;
+
+    std::stringstream ss;
+    ss << "struct " << mName << " {" << std::endl;
+
+    auto& args = builder.mArguments;
+
+    // Sort the arguments by index.
+    std::sort(std::begin(args), std::end(args), [](auto const& lhs, auto const& rhs) {
+        return std::visit([](auto const& x, auto const& y) { return x.index < y.index; }, lhs, rhs);
+    });
+
+    // Check that all the indices are unique.
+    assert_invariant(
+            std::adjacent_find(args.begin(), args.end(), [](auto const& lhs, auto const& rhs) {
+                return std::visit(
+                        [](auto const& x, auto const& y) { return x.index == y.index; }, lhs, rhs);
+            }) == args.end());
+
+    for (const auto& a : builder.mArguments) {
+        std::visit([&](auto&& arg) {
+            arg.write(ss);
+        }, a);
+    }
+
+    ss << "}";
+    mShaderText = ss.str();
+}
+
+static bool isWhitespace(char c) {
+    return (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v');
+}
+
+bool MetalArgumentBuffer::replaceInShader(std::string& shader,
+        const std::string& targetArgBufferName, const std::string& replacement) noexcept {
+    // We make some assumptions here, e.g., that the MSL is well-formed and has no comments.
+    // This algorithm isn't a full-fledged parser, and isn't foolproof. In particular, we can't tell
+    // the difference between source code and comments. However, at this stage, the MSL should have
+    // all comments stripped.
+
+    // In order to do the replacement, we look for 4 key locations in the source shader.
+    // s: the beginning of the 'struct' token
+    // n: the beginning of the argument buffer name
+    // b: the beginning of the structure block
+    // e: the end of the argument buffer structure
+    //
+    // s      n               b e
+    // struct targetArgBuffer { }
+
+    // We only want to match the definition of the argument buffer, not any of its usages.
+    // For example:
+    // struct ArgBuffer { };                // this should match
+    // void aFunction(ArgBuffer& args);     // this should not
+
+    const auto argBufferNameLength = targetArgBufferName.length();
+
+    // First, find n.
+    size_t n = shader.find(targetArgBufferName);
+    while (n != std::string::npos) {
+        // Now, find b, the opening curly brace {.
+        size_t b = shader.find('{', n);
+        if (b == std::string::npos) {
+            // If there's no { character in the rest of the shader, the arg buffer definition
+            // definitely doesn't exit.
+            return false;
+        }
+
+        // After the arg buffer name, ensure that only whitespace characters exist until b.
+        if (!std::all_of(shader.begin() + n + argBufferNameLength, shader.begin() + b,
+                    isWhitespace)) {
+            // If there is a non-whitespace character, start over by looking for the next occurrence
+            // of the arg buffer name.
+            n = shader.find(targetArgBufferName, n + 1);
+            continue;
+        }
+
+        // Now, we find s.
+        size_t s = shader.rfind("struct", n);
+        if (s == std::string::npos) {
+            // If we can't find the "struct" keyword, it's not necessarily an error.
+            // Start over and Look for the next occurrence of the arg buffer name.
+            n = shader.find(targetArgBufferName, n + 1);
+            continue;
+        }
+
+        // After the struct keyword, ensure that only whitespace characters exist until n.
+        if (!std::all_of(shader.begin() + s + 6, shader.begin() + n, isWhitespace)) {
+            // Look for the next occurrence of the arg buffer name.
+            n = shader.find(targetArgBufferName, n + 1);
+            continue;
+        }
+
+        // Now, we find e.
+        size_t e = shader.find('}', n);
+        if (e == std::string::npos) {
+            // If there's no } character in the rest of the shader, the arg buffer definition
+            // definitely doesn't exit.
+            return false;
+        }
+
+        // Perform the replacement.
+        shader.replace(s, e - s + 1, replacement);
+
+        // Theoretically we could continue to find and replace other occurrences, but there should
+        // only ever be a single definition of the argument buffer structure.
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace filamat

--- a/libs/filamat/src/MetalArgumentBuffer.h
+++ b/libs/filamat/src/MetalArgumentBuffer.h
@@ -27,10 +27,10 @@
 namespace filamat {
 
 class MetalArgumentBuffer {
-   public:
+public:
 
     class Builder {
-       public:
+    public:
 
         /**
          * Set the name of the argument buffer structure.
@@ -61,7 +61,7 @@ class MetalArgumentBuffer {
 
         friend class MetalArgumentBuffer;
 
-       private:
+    private:
         std::string mName;
 
         struct TextureArgument {
@@ -84,6 +84,8 @@ class MetalArgumentBuffer {
         std::vector<ArgumentType> mArguments;
     };
 
+    static void destroy(MetalArgumentBuffer** argumentBuffer);
+
     const std::string& getName() const noexcept { return mName; }
 
     /**
@@ -101,9 +103,10 @@ class MetalArgumentBuffer {
      */
     static bool replaceInShader(std::string& shader, const std::string& targetArgBufferName,
             const std::string& replacement) noexcept;
-   private:
+private:
 
     MetalArgumentBuffer(Builder& builder);
+    ~MetalArgumentBuffer() = default;
 
     std::string mName;
     std::string mShaderText;

--- a/libs/filamat/src/MetalArgumentBuffer.h
+++ b/libs/filamat/src/MetalArgumentBuffer.h
@@ -1,0 +1,114 @@
+/*
+* Copyright (C) 2022 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+#ifndef TNT_METALARGUMENTBUFFER_H
+#define TNT_METALARGUMENTBUFFER_H
+
+#include <iostream>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <backend/DriverEnums.h>
+
+namespace filamat {
+
+class MetalArgumentBuffer {
+   public:
+
+    class Builder {
+       public:
+
+        /**
+         * Set the name of the argument buffer structure.
+         */
+        Builder& name(const std::string& name) noexcept;
+
+        /**
+         * Add a texture argument to the argument buffer structure.
+         * All combinations of type/format are supported, except for SAMPLER_3D/SHADOW.
+         *
+         * @param index the [[id(n)]] index of the texture argument
+         * @param name the name of the texture argument
+         * @param type controls the texture data type, e.g., texture2d, texturecube, etc
+         * @param format controls the data format of the texture, e.g., int, float, etc
+         */
+        Builder& texture(size_t index, const std::string& name,
+                filament::backend::SamplerType type,
+                filament::backend::SamplerFormat format) noexcept;
+
+        /**
+         * Add a sampler argument to the argument buffer structure.
+         * @param index the [[id(n)]] index of the texture argument
+         * @param name the name of the texture argument
+         */
+        Builder& sampler(size_t index, const std::string& name) noexcept;
+
+        MetalArgumentBuffer* build();
+
+        friend class MetalArgumentBuffer;
+
+       private:
+        std::string mName;
+
+        struct TextureArgument {
+            std::string name;
+            size_t index;
+            filament::backend::SamplerType type;
+            filament::backend::SamplerFormat format;
+
+            std::ostream& write(std::ostream& os) const;
+        };
+
+        struct SamplerArgument {
+            std::string name;
+            size_t index;
+
+            std::ostream& write(std::ostream& os) const;
+        };
+
+        using ArgumentType = std::variant<TextureArgument, SamplerArgument>;
+        std::vector<ArgumentType> mArguments;
+    };
+
+    const std::string& getName() const noexcept { return mName; }
+
+    /**
+     * Returns the generated MSL argument buffer definition.
+     */
+    const std::string& getMsl() const noexcept { return mShaderText; }
+
+    /**
+     * Searches shader for the target argument buffer, and replaces it with the replacement string.
+     *
+     * @param shader the source MSL shader that contains the target argument buffer definition
+     * @param targetArgBufferName the name of the argument buffer definition to replace
+     * @param replacement the replacement argument buffer definition
+     * @return true if the target was found, false otherwise
+     */
+    static bool replaceInShader(std::string& shader, const std::string& targetArgBufferName,
+            const std::string& replacement) noexcept;
+   private:
+
+    MetalArgumentBuffer(Builder& builder);
+
+    std::string mName;
+    std::string mShaderText;
+};
+
+} // namespace filamat
+
+#endif  // TNT_METALARGUMENTBUFFER_H

--- a/libs/filamat/tests/test_argBufferFixup.cpp
+++ b/libs/filamat/tests/test_argBufferFixup.cpp
@@ -1,0 +1,196 @@
+/*
+* Copyright (C) 2022 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+
+#include "MetalArgumentBuffer.h"
+
+using namespace filamat;
+using namespace filament::backend;
+
+// -------------------------------------------------------------------------------------------------
+
+TEST(ArgBufferFixup, Empty) {
+    auto argBuffer =
+            MetalArgumentBuffer::Builder()
+                    .name("spvDescriptorSet0")
+                    .build();
+    auto argBufferStr = argBuffer->getMsl();
+
+    const std::string expected =
+            "struct spvDescriptorSet0 {\n"
+            "}";
+
+    EXPECT_EQ(argBuffer->getMsl(), expected);
+
+    delete argBuffer;
+}
+
+TEST(ArgBufferFixup, NoName) {
+    // A valid arg buffer name must be provided to MetalArgumentBuffer.
+    // This assertion is only fired in debug builds.
+#ifndef NDEBUG
+    EXPECT_DEATH({
+        auto argBuffer = MetalArgumentBuffer::Builder().build();
+        delete argBuffer;
+    }, "failed assertion");
+    EXPECT_DEATH({
+        auto argBuffer = MetalArgumentBuffer::Builder().name("").build();
+        delete argBuffer;
+    }, "failed assertion");
+#endif
+}
+
+TEST(ArgBufferFixup, DuplicateIndices) {
+    // Each index must be unique.
+#ifndef NDEBUG
+    EXPECT_DEATH({
+                auto argBuffer = MetalArgumentBuffer::Builder()
+                                         .name("myArgumentBuffer")
+                                         .sampler(0, "samplerA")
+                                         .sampler(0, "samplerB")
+                        .build();
+                delete argBuffer;
+    }, "failed assertion");
+#endif
+}
+
+TEST(ArgBufferFixup, TextureAndSampler) {
+    auto argBuffer =
+            MetalArgumentBuffer::Builder()
+                    .name("myArgumentBuffer")
+                    .texture(0, "textureA", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT)
+                    .sampler(1, "samplerA")
+                    .build();
+    auto argBufferStr = argBuffer->getMsl();
+
+    const std::string expected =
+            "struct myArgumentBuffer {\n"
+            "texture2d<float> textureA [[id(0)]];\n"
+            "sampler samplerA [[id(1)]];\n"
+            "}";
+
+    EXPECT_EQ(argBuffer->getMsl(), expected);
+
+    delete argBuffer;
+}
+
+TEST(ArgBufferFixup, Sorted) {
+    auto argBuffer =
+            MetalArgumentBuffer::Builder()
+                    .name("myArgumentBuffer")
+                    .sampler(3, "samplerB")
+                    .texture(0, "textureA", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT)
+                    .texture(2, "textureB", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT)
+                    .sampler(1, "samplerA")
+                    .build();
+    auto argBufferStr = argBuffer->getMsl();
+
+    const std::string expected =
+            "struct myArgumentBuffer {\n"
+            "texture2d<float> textureA [[id(0)]];\n"
+            "sampler samplerA [[id(1)]];\n"
+            "texture2d<float> textureB [[id(2)]];\n"
+            "sampler samplerB [[id(3)]];\n"
+            "}";
+
+    EXPECT_EQ(argBuffer->getMsl(), expected);
+
+    delete argBuffer;
+}
+
+TEST(ArgBufferFixup, TextureTypes) {
+    auto argBuffer =
+            MetalArgumentBuffer::Builder()
+                    .name("myArgumentBuffer")
+                    .texture(0, "textureA", SamplerType::SAMPLER_2D, SamplerFormat::INT)
+                    .texture(1, "textureB", SamplerType::SAMPLER_2D_ARRAY, SamplerFormat::UINT)
+                    .texture(2, "textureC", SamplerType::SAMPLER_CUBEMAP, SamplerFormat::FLOAT)
+                    .texture(3, "textureD", SamplerType::SAMPLER_EXTERNAL, SamplerFormat::FLOAT)
+                    .texture(4, "textureE", SamplerType::SAMPLER_3D, SamplerFormat::FLOAT)
+                    .texture(5, "textureF", SamplerType::SAMPLER_CUBEMAP_ARRAY, SamplerFormat::SHADOW)
+                    .build();
+    auto argBufferStr = argBuffer->getMsl();
+
+    const std::string expected =
+            "struct myArgumentBuffer {\n"
+            "texture2d<int> textureA [[id(0)]];\n"
+            "texture2d_array<uint> textureB [[id(1)]];\n"
+            "texturecube<float> textureC [[id(2)]];\n"
+            "texture2d<float> textureD [[id(3)]];\n"
+            "texture3d<float> textureE [[id(4)]];\n"
+            "depthcube_array<float> textureF [[id(5)]];\n"
+            "}";
+
+    EXPECT_EQ(argBuffer->getMsl(), expected);
+
+    delete argBuffer;
+}
+
+TEST(ArgBufferFixup, InvalidType) {
+    // All combinations of SamplerType and SamplerFormat are valid except for SAMPLER_3D / SHADOW.
+#ifndef NDEBUG
+    EXPECT_DEATH({
+        auto argBuffer =
+                MetalArgumentBuffer::Builder()
+                        .name("myArgumentBuffer")
+                        .texture(0, "textureA", SamplerType::SAMPLER_3D, SamplerFormat::SHADOW)
+                        .build();
+        delete argBuffer;
+    }, "failed assertion");
+#endif
+}
+
+TEST(ArgBufferFixup, ReplaceInShader) {
+    {
+        std::string shader = "struct argBuffer {}"; // different name
+        EXPECT_FALSE(MetalArgumentBuffer::replaceInShader(shader, "argBufferX", "xyz"));
+    }
+    {
+        std::string shader = "argBuffer {}   struct";    // no 'struct' keyword before
+        EXPECT_FALSE(MetalArgumentBuffer::replaceInShader(shader, "argBuffer", "xyz"));
+    }
+    {
+        std::string shader = "struct argBuffer";    // no braces
+        EXPECT_FALSE(MetalArgumentBuffer::replaceInShader(shader, "argBuffer", "xyz"));
+    }
+    {
+        std::string shader = "## struct argBuffer {}  ###";
+        EXPECT_TRUE(MetalArgumentBuffer::replaceInShader(shader, "argBuffer", "replacement"));
+        EXPECT_EQ(shader, "## replacement  ###");
+    }
+    {
+        std::string shader = "argBuffer {} struct argBuffer {}  argBuffer";
+        EXPECT_TRUE(MetalArgumentBuffer::replaceInShader(shader, "argBuffer", "replacement"));
+        EXPECT_EQ(shader, "argBuffer {} replacement  argBuffer");
+    }
+    {
+        std::string shader =
+            "struct FooBar {};\n"
+            "targetArgBuffer {};\n"
+            "struct targetArgBufferX {};\n"
+            "void someFunctionThatTakesAnArgBuffer(targetArgBuffer& arg);\n"
+            "struct targetArgBuffer{};\n";
+        std::string expected =
+                "struct FooBar {};\n"
+                "targetArgBuffer {};\n"
+                "struct targetArgBufferX {};\n"
+                "void someFunctionThatTakesAnArgBuffer(targetArgBuffer& arg);\n"
+                "replacement;\n";
+        EXPECT_TRUE(MetalArgumentBuffer::replaceInShader(shader, "targetArgBuffer", "replacement"));
+        EXPECT_EQ(shader, expected);
+    }
+}

--- a/libs/filamat/tests/test_argBufferFixup.cpp
+++ b/libs/filamat/tests/test_argBufferFixup.cpp
@@ -36,7 +36,7 @@ TEST(ArgBufferFixup, Empty) {
 
     EXPECT_EQ(argBuffer->getMsl(), expected);
 
-    delete argBuffer;
+    MetalArgumentBuffer::destroy(&argBuffer);
 }
 
 TEST(ArgBufferFixup, NoName) {
@@ -45,11 +45,11 @@ TEST(ArgBufferFixup, NoName) {
 #ifndef NDEBUG
     EXPECT_DEATH({
         auto argBuffer = MetalArgumentBuffer::Builder().build();
-        delete argBuffer;
+        MetalArgumentBuffer::destroy(&argBuffer);
     }, "failed assertion");
     EXPECT_DEATH({
         auto argBuffer = MetalArgumentBuffer::Builder().name("").build();
-        delete argBuffer;
+        MetalArgumentBuffer::destroy(&argBuffer);
     }, "failed assertion");
 #endif
 }
@@ -63,7 +63,7 @@ TEST(ArgBufferFixup, DuplicateIndices) {
                                          .sampler(0, "samplerA")
                                          .sampler(0, "samplerB")
                         .build();
-                delete argBuffer;
+                MetalArgumentBuffer::destroy(&argBuffer);
     }, "failed assertion");
 #endif
 }
@@ -85,7 +85,7 @@ TEST(ArgBufferFixup, TextureAndSampler) {
 
     EXPECT_EQ(argBuffer->getMsl(), expected);
 
-    delete argBuffer;
+    MetalArgumentBuffer::destroy(&argBuffer);
 }
 
 TEST(ArgBufferFixup, Sorted) {
@@ -109,7 +109,7 @@ TEST(ArgBufferFixup, Sorted) {
 
     EXPECT_EQ(argBuffer->getMsl(), expected);
 
-    delete argBuffer;
+    MetalArgumentBuffer::destroy(&argBuffer);
 }
 
 TEST(ArgBufferFixup, TextureTypes) {
@@ -137,7 +137,7 @@ TEST(ArgBufferFixup, TextureTypes) {
 
     EXPECT_EQ(argBuffer->getMsl(), expected);
 
-    delete argBuffer;
+    MetalArgumentBuffer::destroy(&argBuffer);
 }
 
 TEST(ArgBufferFixup, InvalidType) {
@@ -149,7 +149,7 @@ TEST(ArgBufferFixup, InvalidType) {
                         .name("myArgumentBuffer")
                         .texture(0, "textureA", SamplerType::SAMPLER_3D, SamplerFormat::SHADOW)
                         .build();
-        delete argBuffer;
+        MetalArgumentBuffer::destroy(&argBuffer);
     }, "failed assertion");
 #endif
 }

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -32,13 +32,6 @@ void main() {
 
     fragColor = evaluateMaterial(inputs);
 
-#if defined(TARGET_METAL_ENVIRONMENT)
-    // Hack to force spirv-cross to keep the light_structure texture present in the argument buffer.
-    float hack = textureLod(light_structure, vec2(0.0, 0.0), 0.0).r;
-    fragColor.x += hack;
-    fragColor.x -= hack;
-#endif
-
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING) && defined(VARIANT_HAS_SHADOWING)
     bool visualizeCascades = bool(frameUniforms.cascades & 0x10u);
     if (visualizeCascades) {


### PR DESCRIPTION
We're using argument buffers for texture resources, however, we cannot rely on spirv-cross to generate the argument buffer definitions.

Consider a shader with 3 textures:
```
layout (set = 0, binding = 0) uniform sampler2D texture1;
layout (set = 0, binding = 1) uniform sampler2D texture2;
layout (set = 0, binding = 2) uniform sampler2D texture3;
```

If only texture1 and texture2 are used in the material, then texture3 will be optimized away.
This results in an argument buffer like the following:
```
struct spvDescriptorSetBuffer0 {
    texture2d<float> texture1 [[id(0)]];
    sampler texture1Smplr [[id(1)]];
    texture2d<float> texture2 [[id(2)]];
    sampler texture2Smplr [[id(3)]];
};
```

Note that this happens even if the "pad_argument_buffer_resources" and "force_active_argument_buffer_resources" options are true, because the optimization has already happened by the time the SPIR-V gets to spirv-cross.

This would be fine, except older Apple devices don't like it when the argument buffer in the shader doesn't precisely match the one generated at runtime.

So, this PR adds a`MetalArgumentBuffer ` class to replace spirv-cross' argument buffer definitions with our own that contain all the textures/samples, even those that would be optimized away.
