### PR TITLE
fix UBO handle leak with ShadowMap

### DIFF
--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -62,6 +62,7 @@ void ShadowMap::terminate(FEngine& engine) {
         engine.destroyCameraComponent(e);
     }
     engine.getEntityManager().destroy(sizeof(entities) / sizeof(Entity), entities);
+    mPerViewUniforms.terminate(engine.getDriverApi());
 }
 
 ShadowMap::~ShadowMap() = default;


### PR DESCRIPTION
This wasn't a big issue because the "leak" would be cleaned when the engine is destroyed.