### PR TITLE
Reduce the size of ShadowMap to 40 bytes from 2KB+

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -73,6 +73,7 @@ set(SRCS
         src/MaterialParser.cpp
         src/MorphTargetBuffer.cpp
         src/PerViewUniforms.cpp
+        src/PerShadowMapUniforms.cpp
         src/PostProcessManager.cpp
         src/RenderPass.cpp
         src/RenderPrimitive.cpp
@@ -146,6 +147,7 @@ set(PRIVATE_HDRS
         src/Intersections.h
         src/MaterialParser.h
         src/PerViewUniforms.h
+        src/PerShadowMapUniforms.h
         src/PIDController.h
         src/PostProcessManager.h
         src/RendererUtils.h

--- a/filament/src/PerShadowMapUniforms.cpp
+++ b/filament/src/PerShadowMapUniforms.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PerShadowMapUniforms.h"
+
+#include "ShadowMapManager.h"
+
+#include "details/Camera.h"
+#include "details/Engine.h"
+
+#include <private/filament/EngineEnums.h>
+
+namespace filament {
+
+using namespace backend;
+using namespace math;
+
+PerShadowMapUniforms::PerShadowMapUniforms(FEngine& engine) noexcept {
+    DriverApi& driver = engine.getDriverApi();
+    mUniformBufferHandle = driver.createBufferObject(sizeof(PerViewUib),
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
+}
+
+void PerShadowMapUniforms::terminate(DriverApi& driver) {
+    driver.destroyBufferObject(mUniformBufferHandle);
+}
+
+PerViewUib& PerShadowMapUniforms::edit(Transaction const& transaction) noexcept {
+    assert_invariant(transaction.uniforms);
+    return *transaction.uniforms;
+}
+
+void PerShadowMapUniforms::prepareCamera(Transaction const& transaction,
+        FEngine& engine, const CameraInfo& camera) noexcept {
+    mat4f const& viewFromWorld = camera.view;
+    mat4f const& worldFromView = camera.model;
+    mat4f const& clipFromView  = camera.projection;
+
+    const mat4f viewFromClip{ inverse((mat4)camera.projection) };
+    const mat4f clipFromWorld{ highPrecisionMultiply(clipFromView, viewFromWorld) };
+    const mat4f worldFromClip{ highPrecisionMultiply(worldFromView, viewFromClip) };
+
+    auto& s = edit(transaction);
+    s.viewFromWorldMatrix = viewFromWorld;    // view
+    s.worldFromViewMatrix = worldFromView;    // model
+    s.clipFromViewMatrix  = clipFromView;     // projection
+    s.viewFromClipMatrix  = viewFromClip;     // 1/projection
+    s.clipFromWorldMatrix = clipFromWorld;    // projection * view
+    s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
+    s.clipTransform = camera.clipTransfrom;
+    s.cameraPosition = float3{ camera.getPosition() };
+    s.worldOffset = camera.getWorldOffset();
+    s.cameraFar = camera.zf;
+    s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);
+    s.nearOverFarMinusNear = camera.zn / (camera.zf - camera.zn);
+
+    // with a clip-space of [-w, w] ==> z' = -z
+    // with a clip-space of [0,  w] ==> z' = (w - z)/2
+    s.clipControl = engine.getDriverApi().getClipSpaceParams();
+}
+
+void PerShadowMapUniforms::prepareLodBias(Transaction const& transaction,
+        float bias) noexcept {
+    auto& s = edit(transaction);
+    s.lodBias = bias;
+}
+
+void PerShadowMapUniforms::prepareViewport(Transaction const& transaction,
+        const filament::Viewport& viewport,
+        uint32_t xoffset, uint32_t yoffset) noexcept {
+    const float w = float(viewport.width);
+    const float h = float(viewport.height);
+    auto& s = edit(transaction);
+    s.resolution = float4{ w, h, 1.0f / w, 1.0f / h };
+    s.origin = float2{ viewport.left, viewport.bottom };
+    s.offset = float2{ xoffset, yoffset };
+}
+
+void PerShadowMapUniforms::prepareTime(Transaction const& transaction,
+        FEngine& engine, math::float4 const& userTime) noexcept {
+    auto& s = edit(transaction);
+    const uint64_t oneSecondRemainder = engine.getEngineTime().count() % 1000000000;
+    const float fraction = float(double(oneSecondRemainder) / 1000000000.0);
+    s.time = fraction;
+    s.userTime = userTime;
+}
+
+void PerShadowMapUniforms::prepareDirectionalLight(Transaction const& transaction,
+        FEngine& engine,
+        float exposure,
+        float3 const& sceneSpaceDirection,
+        PerShadowMapUniforms::LightManagerInstance directionalLight) noexcept {
+    FLightManager& lcm = engine.getLightManager();
+    auto& s = edit(transaction);
+
+    const float3 l = -sceneSpaceDirection; // guaranteed normalized
+
+    if (directionalLight.isValid()) {
+        const float4 colorIntensity = {
+                lcm.getColor(directionalLight), lcm.getIntensity(directionalLight) * exposure };
+
+        s.lightDirection = l;
+        s.lightColorIntensity = colorIntensity;
+        s.lightChannels = lcm.getLightChannels(directionalLight);
+
+        const bool isSun = lcm.isSunLight(directionalLight);
+        // The last parameter must be < 0.0f for regular directional lights
+        float4 sun{ 0.0f, 0.0f, 0.0f, -1.0f };
+        if (UTILS_UNLIKELY(isSun && colorIntensity.w > 0.0f)) {
+            // currently we have only a single directional light, so it's probably likely that it's
+            // also the Sun. However, conceptually, most directional lights won't be sun lights.
+            float radius = lcm.getSunAngularRadius(directionalLight);
+            float haloSize = lcm.getSunHaloSize(directionalLight);
+            float haloFalloff = lcm.getSunHaloFalloff(directionalLight);
+            sun.x = std::cos(radius);
+            sun.y = std::sin(radius);
+            sun.z = 1.0f / (std::cos(radius * haloSize) - sun.x);
+            sun.w = haloFalloff;
+        }
+        s.sun = sun;
+    } else {
+        // Disable the sun if there's no directional light
+        s.sun = float4{ 0.0f, 0.0f, 0.0f, -1.0f };
+    }
+}
+
+void PerShadowMapUniforms::prepareShadowMapping(Transaction const& transaction,
+        bool highPrecision) noexcept {
+    auto& s = edit(transaction);
+    constexpr float low  = 5.54f; // ~ std::log(std::numeric_limits<math::half>::max()) * 0.5f;
+    constexpr float high = 42.0f; // ~ std::log(std::numeric_limits<float>::max()) * 0.5f;
+    s.vsmExponent = highPrecision ? high : low;
+}
+
+
+PerShadowMapUniforms::Transaction PerShadowMapUniforms::open(backend::DriverApi& driver) noexcept {
+    Transaction transaction;
+    // TODO: use out-of-line buffer if too large
+    transaction.uniforms = (PerViewUib *)driver.allocate(sizeof(PerViewUib));
+    assert_invariant(transaction.uniforms);
+    return transaction;
+}
+
+void PerShadowMapUniforms::commit(Transaction& transaction,
+        backend::DriverApi& driver) noexcept {
+    driver.updateBufferObject(mUniformBufferHandle, {
+        transaction.uniforms, sizeof(PerViewUib) }, 0);
+    transaction.uniforms = nullptr;
+}
+
+void PerShadowMapUniforms::bind(backend::DriverApi& driver) noexcept {
+    driver.bindUniformBuffer(+UniformBindingPoints::PER_VIEW, mUniformBufferHandle);
+}
+
+} // namespace filament
+

--- a/filament/src/PerShadowMapUniforms.h
+++ b/filament/src/PerShadowMapUniforms.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_PERSHADOWMAPUNIFORMS_H
+#define TNT_FILAMENT_PERSHADOWMAPUNIFORMS_H
+
+#include <filament/Viewport.h>
+
+#include <private/filament/UibStructs.h>
+#include <private/backend/SamplerGroup.h>
+
+#include "TypedUniformBuffer.h"
+
+#include <backend/Handle.h>
+
+#include <utils/EntityInstance.h>
+
+#include <random>
+
+namespace filament {
+
+struct CameraInfo;
+
+class FEngine;
+class LightManager;
+
+/*
+ * PerShadowMapUniforms manages the UBO needed to generate our shadow maps. Internally it just
+ * holds onto a `PerViewUniform` UBO handle, but doesn't keep any shadow copy of it, instead it
+ * writes the data directly into the commandstream, for this reason partial update of the data
+ * is not possible.
+ */
+class PerShadowMapUniforms {
+
+    using LightManagerInstance = utils::EntityInstance<LightManager>;
+
+public:
+    class Transaction {
+        friend PerShadowMapUniforms;
+        PerViewUib* uniforms = nullptr;
+        Transaction() = default; // disallow creation by the caller
+    };
+
+    explicit PerShadowMapUniforms(FEngine& engine) noexcept;
+
+    void terminate(backend::DriverApi& driver);
+
+    static void prepareCamera(Transaction const& transaction,
+            FEngine& engine, const CameraInfo& camera) noexcept;
+
+    static void prepareLodBias(Transaction const& transaction,
+            float bias) noexcept;
+
+    static void prepareViewport(Transaction const& transaction,
+            const filament::Viewport& viewport, uint32_t xoffset, uint32_t yoffset) noexcept;
+
+    static void prepareTime(Transaction const& transaction,
+            FEngine& engine, math::float4 const& userTime) noexcept;
+
+    static void prepareShadowMapping(Transaction const& transaction,
+            bool highPrecision) noexcept;
+
+    static void prepareDirectionalLight(Transaction const& transaction,
+            FEngine& engine, float exposure,
+            math::float3 const& sceneSpaceDirection, LightManagerInstance instance) noexcept;
+
+    static Transaction open(backend::DriverApi& driver) noexcept;
+
+    // update local data into GPU UBO
+    void commit(Transaction& transaction, backend::DriverApi& driver) noexcept;
+
+    // bind this UBO
+    void bind(backend::DriverApi& driver) noexcept;
+
+private:
+    static PerViewUib& edit(Transaction const& transaction) noexcept;
+    backend::Handle<backend::HwBufferObject> mUniformBufferHandle;
+};
+
+} // namespace filament
+
+#endif //TNT_FILAMENT_PERSHADOWMAPUNIFORMS_H

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -48,6 +48,11 @@ class FIndirectLight;
 class Froxelizer;
 class LightManager;
 
+/*
+ * PerViewUniforms manages the UBO and samplers needed to render the color passes. Internally it
+ * holds onto handles for the PER_VIEW UBO and SamplerGroup. This class maintains a shadow copy
+ * of the UBO/sampler data, so it is possible to partially update it between commits.
+ */
 class PerViewUniforms {
 
     using LightManagerInstance = utils::EntityInstance<LightManager>;

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -19,7 +19,7 @@
 
 #include "components/LightManager.h"
 
-#include "PerViewUniforms.h"
+#include "PerShadowMapUniforms.h"
 
 #include "details/Camera.h"
 #include "details/Scene.h"
@@ -187,13 +187,22 @@ public:
     ShadowType getShadowType() const noexcept { return mShadowType; }
     uint8_t getFace() const noexcept { return mFace; }
 
-    void prepareCamera(FEngine& engine, const CameraInfo& cameraInfo) noexcept;
-    void prepareViewport(const filament::Viewport& viewport) noexcept;
-    void prepareTime(FEngine& engine, math::float4 const& userTime) noexcept;
-    void prepareDirectionalLight(FEngine& engine, math::float3 const& sceneSpaceDirection,
+    using Transaction = PerShadowMapUniforms::Transaction;
+
+    static void prepareCamera(Transaction const& transaction,
+            FEngine& engine, const CameraInfo& cameraInfo) noexcept;
+    static void prepareViewport(Transaction const& transaction,
+            const filament::Viewport& viewport) noexcept;
+    static void prepareTime(Transaction const& transaction,
+            FEngine& engine, math::float4 const& userTime) noexcept;
+    static void prepareDirectionalLight(Transaction const& transaction,
+            FEngine& engine, math::float3 const& sceneSpaceDirection,
             LightManager::Instance instance) noexcept;
-    void prepareShadowMapping(bool highPrecision) noexcept;
-    void commitUniforms(backend::DriverApi& driver) const noexcept;
+    static void prepareShadowMapping(Transaction const& transaction,
+            bool highPrecision) noexcept;
+    static PerShadowMapUniforms::Transaction open(backend::DriverApi& driver) noexcept;
+    void commit(Transaction& transaction,
+            backend::DriverApi& driver) const noexcept;
     void bindPerViewUniformsAndSamplers(backend::DriverApi& driver) const noexcept;
 
 private:
@@ -292,12 +301,10 @@ private:
             { 2, 6, 7, 3 },  // top
     };
 
-    // TODO: for shadow maps we don't need the whole `PerViewUniforms` which is large.
-    //       replace it with a smaller version that updates only what we need.
-    mutable PerViewUniforms mPerViewUniforms;   // 40 + 2048
+    mutable PerShadowMapUniforms mPerShadowMapUniforms;                     // 4
 
-    FCamera* mCamera = nullptr;                 //  8
-    FCamera* mDebugCamera = nullptr;            //  8
+    FCamera* mCamera = nullptr;                                             //  8
+    FCamera* mDebugCamera = nullptr;                                        //  8
 
     // The data below technically belongs to ShadowMapManager, but it simplifies allocations
     // to store it here. This data is always associated with this shadow map anyway.

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -219,7 +219,7 @@ private:
 
     // inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
     // because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.
-    // Each ShadowMap is currently 2120 bytes (total of 132KB for 64 shadow maps)
+    // Each ShadowMap is currently 40 bytes (total of 2.5KB for 64 shadow maps)
     using ShadowMapStorage = std::aligned_storage<sizeof(ShadowMap), alignof(ShadowMap)>::type;
     std::array<ShadowMapStorage, CONFIG_MAX_SHADOW_LAYERS> mShadowMapCache;
 };


### PR DESCRIPTION
ShadowMap had recently inflated due to its internal use of  PerViewUniforms, which keeps a shadow copy of the uniform data. This copy is not needed for ShadowMaps.