### PR TITLE
fix recently introduced crash on init

### DIFF
--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -80,11 +80,14 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
         setDoubleSided(mIsDoubleSided);
     }
 
-    setMaskThreshold(mMaskThreshold);
+    if (material->getBlendingMode() == BlendingMode::MASKED) {
+        setMaskThreshold(mMaskThreshold);
+    }
 
-    setSpecularAntiAliasingThreshold(mSpecularAntiAliasingThreshold);
-
-    setSpecularAntiAliasingVariance(mSpecularAntiAliasingVariance);
+    if (material->hasSpecularAntiAliasing()) {
+        setSpecularAntiAliasingThreshold(mSpecularAntiAliasingThreshold);
+        setSpecularAntiAliasingVariance(mSpecularAntiAliasingVariance);
+    }
 
     setTransparencyMode(material->getTransparencyMode());
 


### PR DESCRIPTION
certain material properties can only be set if supported by the  material.