### PR TITLE
Fix matc variantFilter

### DIFF
--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -232,14 +232,15 @@ enum class Property : uint8_t {
     // when adding new Properties, make sure to update MATERIAL_PROPERTIES_COUNT
 };
 
+// These flags should match the equivalents in Variant.h.
 enum class UserVariantFilterBit : uint32_t {
     DIRECTIONAL_LIGHTING        = 0x01,
     DYNAMIC_LIGHTING            = 0x02,
     SHADOW_RECEIVER             = 0x04,
     SKINNING                    = 0x08,
-    FOG                         = 0x10,
-    VSM                         = 0x20,
-    SSR                         = 0x40,
+    FOG                         = 0x20,
+    VSM                         = 0x40,
+    SSR                         = VSM | SHADOW_RECEIVER,
 };
 
 using UserVariantFilterMask = uint32_t;


### PR DESCRIPTION
I was seeing the VSM variant turned on for the Skybox, when it certainly doesn't need to be. I think the `UserVariantFilterBit` values are out of date. We may want to consider a better way of keeping them in sync with `Variant.h`. 