### PR TITLE
Fix skipped depth bias set on Metal

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -96,6 +96,8 @@ struct MetalContext {
     SamplerStateCache samplerStateCache;
     ArgumentEncoderCache argumentEncoderCache;
 
+    PolygonOffset currentPolygonOffset = {0.0f, 0.0f};
+
     MetalSamplerGroup* samplerBindings[Program::SAMPLER_BINDING_COUNT] = {};
 
     // Keeps track of sampler groups we've finalized for the current render pass.

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1005,6 +1005,7 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     mContext->depthStencilState.invalidate();
     mContext->cullModeState.invalidate();
     mContext->windingState.invalidate();
+    mContext->currentPolygonOffset = {0.0f, 0.0f};
 
     mContext->finalizedSamplerGroups.clear();
 }
@@ -1590,10 +1591,12 @@ void MetalDriver::draw(PipelineState ps, Handle<HwRenderPrimitive> rph, uint32_t
         [mContext->currentRenderPassEncoder setDepthStencilState:state];
     }
 
-    if (ps.polygonOffset.constant != 0.0 || ps.polygonOffset.slope != 0.0) {
+    if (ps.polygonOffset.constant != mContext->currentPolygonOffset.constant ||
+        ps.polygonOffset.slope != mContext->currentPolygonOffset.slope) {
         [mContext->currentRenderPassEncoder setDepthBias:ps.polygonOffset.constant
                                               slopeScale:ps.polygonOffset.slope
                                                    clamp:0.0];
+        mContext->currentPolygonOffset = ps.polygonOffset;
     }
 
     // Set scissor-rectangle.


### PR DESCRIPTION
This PR adds caching for depth bias in the Metal backend. The previous check didn't eliminate redundant `setDepthBias:slopeScale:clamp` calls, instead it blocked setting `{0.0, 0.0}` which could create incorrect results if a primitive *without* bias was drawn after a primitive *with* bias.