### PR TITLE
Include the windows.h header after packing alignment

### DIFF
--- a/third_party/libsdl2/include/SDL_syswm.h
+++ b/third_party/libsdl2/include/SDL_syswm.h
@@ -33,12 +33,6 @@
 #include "SDL_video.h"
 #include "SDL_version.h"
 
-#include "begin_code.h"
-/* Set up for C function definitions, even when using C++ */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  *  \file SDL_syswm.h
  *
@@ -108,6 +102,12 @@ typedef void *EGLSurface;
 
 #if defined(SDL_VIDEO_DRIVER_VIVANTE)
 #include "SDL_egl.h"
+#endif
+
+#include "begin_code.h"
+/* Set up for C function definitions, even when using C++ */
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /**


### PR DESCRIPTION
Fix winnt.h(2501): error C2118: negative subscript.