### PR TITLE
Skip rendering renderables with missing geometry

### DIFF
--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -750,6 +750,11 @@ void RenderPass::Executor::execute(backend::DriverApi& driver,
                 continue;
             }
 
+            // primitiveHandle may be invalid if no geometry was set on the renderable.
+            if (UTILS_UNLIKELY(!first->primitive.primitiveHandle)) {
+                continue;
+            }
+
             // per-renderable uniform
             const PrimitiveInfo info = first->primitive;
             pipeline.rasterState = info.rasterState;


### PR DESCRIPTION
If a client creates a renderable, but doesn't set geometry during `RenderableManager::Builder::Build()` and also never calls `setGeometryAt`, then Filament asserts. This happens because there's no valid render primitive for the renderable. This was fine before 1.28.3, because by default we were setting the `primitiveType` to `NONE`, which would cause the command to automatically get skipped. However, when `PrimitiveType::NONE` was removed, it forced all primitives to have valid geometry.

This PR allows renderables to have missing geometry without triggering an assertion.
