### PR TITLE
rework how we set the viewport for shadows

### DIFF
--- a/filament/src/PerShadowMapUniforms.cpp
+++ b/filament/src/PerShadowMapUniforms.cpp
@@ -79,7 +79,7 @@ void PerShadowMapUniforms::prepareLodBias(Transaction const& transaction,
 }
 
 void PerShadowMapUniforms::prepareViewport(Transaction const& transaction,
-        const filament::Viewport& viewport,
+        backend::Viewport const& viewport,
         uint32_t xoffset, uint32_t yoffset) noexcept {
     const float w = float(viewport.width);
     const float h = float(viewport.height);

--- a/filament/src/PerShadowMapUniforms.h
+++ b/filament/src/PerShadowMapUniforms.h
@@ -65,7 +65,7 @@ public:
             float bias) noexcept;
 
     static void prepareViewport(Transaction const& transaction,
-            const filament::Viewport& viewport, uint32_t xoffset, uint32_t yoffset) noexcept;
+            backend::Viewport const& viewport, uint32_t xoffset, uint32_t yoffset) noexcept;
 
     static void prepareTime(Transaction const& transaction,
             FEngine& engine, math::float4 const& userTime) noexcept;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -707,6 +707,10 @@ void RenderPass::Executor::overrideScissor(backend::Viewport const* scissor) noe
     }
 }
 
+void RenderPass::Executor::overrideScissor(backend::Viewport const& scissor) noexcept {
+    mScissor = scissor;
+}
+
 void RenderPass::Executor::execute(FEngine& engine, const char* name) const noexcept {
     execute(engine.getDriverApi(), mCommands.begin(), mCommands.end());
 }

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -349,6 +349,7 @@ public:
 
         // if non-null, overrides the material's scissor
         void overrideScissor(backend::Viewport const* scissor) noexcept;
+        void overrideScissor(backend::Viewport const& scissor) noexcept;
 
         void execute(FEngine& engine, const char* name) const noexcept;
     };

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -174,7 +174,7 @@ public:
     static void updateSceneInfoSpot(const math::mat4f& Mv, FScene const& scene,
             SceneInfo& sceneInfo);
 
-    filament::Viewport getViewport() const noexcept;
+    backend::Viewport getViewport() const noexcept;
 
     LightManager::ShadowOptions const* getShadowOptions() const noexcept { return mOptions; }
     size_t getLightIndex() const { return mLightIndex; }
@@ -192,7 +192,7 @@ public:
     static void prepareCamera(Transaction const& transaction,
             FEngine& engine, const CameraInfo& cameraInfo) noexcept;
     static void prepareViewport(Transaction const& transaction,
-            const filament::Viewport& viewport) noexcept;
+            backend::Viewport const& viewport) noexcept;
     static void prepareTime(Transaction const& transaction,
             FEngine& engine, math::float4 const& userTime) noexcept;
     static void prepareShadowMapping(Transaction const& transaction,
@@ -214,7 +214,7 @@ private:
     // 8 corners, 12 segments w/ 2 intersection max -- all of this twice (8 + 12 * 2) * 2 (768 bytes)
     using FrustumBoxIntersection = std::array<math::float3, 64>;
 
-    ShaderParameters updateSpotOrPoint(
+    ShaderParameters updatePunctual(
             math::mat4f const& Mv, float outerConeAngle, float nearPlane, float farPlane,
             const ShadowMapInfo& shadowMapInfo,
             const FLightManager::ShadowParams& params) noexcept;
@@ -278,7 +278,12 @@ private:
 
     static math::mat4f directionalLightFrustum(float n, float f) noexcept;
 
-    static math::mat4 getTextureCoordsMapping(ShadowMapInfo const& info) noexcept;
+    struct TextureCoordsMapping {
+        math::mat4f clipToTexture;
+        math::mat4f clipToNdc;
+    };
+    static TextureCoordsMapping getTextureCoordsMapping(ShadowMapInfo const& info,
+            backend::Viewport const& viewport) noexcept;
 
     static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpacePcf,
             const math::mat4f& Mv, float znear, float zfar) noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -393,11 +393,11 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     // initialized, as this happens in an `execute` block.
 
                     auto rt = resources.getRenderPassInfo(data.rt);
-                    rt.params.viewport = entry.shadowMap->getViewport();
 
                     engine.flush();
                     driver.beginRenderPass(rt.target, rt.params);
                     entry.shadowMap->bind(driver);
+                    entry.executor.overrideScissor(entry.shadowMap->getViewport());
                     entry.executor.execute(engine, "Shadow Pass");
                     driver.endRenderPass();
                 });
@@ -632,7 +632,7 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap,
     // compute shadow map frustum for culling
     const mat4f Mv = ShadowMap::getDirectionalLightViewMatrix(direction, position);
     const mat4f Mp = mat4f::perspective(outerConeAngle * f::RAD_TO_DEG * 2.0f, 1.0f, 0.01f, radius);
-    const mat4f MpMv(math::highPrecisionMultiply(Mp, Mv));
+    const mat4f MpMv = math::highPrecisionMultiply(Mp, Mv);
     const Frustum frustum(MpMv);
 
     // Cull shadow casters

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -588,6 +588,26 @@ constexpr mat4f highPrecisionMultiply(mat4f const& lhs, mat4f const& rhs) noexce
     };
 }
 
+// mat4 * float4, with double precision intermediates
+constexpr double4 highPrecisionMultiplyd(mat4f const& lhs, float4 const& rhs) noexcept {
+    double4 result{};
+    result += lhs[0] * rhs[0];
+    result += lhs[1] * rhs[1];
+    result += lhs[2] * rhs[2];
+    result += lhs[3] * rhs[3];
+    return result;
+}
+
+// mat4 * mat4, with double precision intermediates
+constexpr mat4 highPrecisionMultiplyd(mat4f const& lhs, mat4f const& rhs) noexcept {
+    return {
+            highPrecisionMultiplyd(lhs, rhs[0]),
+            highPrecisionMultiplyd(lhs, rhs[1]),
+            highPrecisionMultiplyd(lhs, rhs[2]),
+            highPrecisionMultiplyd(lhs, rhs[3])
+    };
+}
+
 // ----------------------------------------------------------------------------------------
 }  // namespace math
 }  // namespace filament


### PR DESCRIPTION
The viewport is now entirely handled by ShadowMap, that is, we're no longer setting a viewport in the renderpass, instead the ShadowMap uses a post projection transform to achieve the same effect. This will become useful when store shadow maps in an Atlas.