### PR TITLE
Handle shadow borders better

### DIFF
--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -130,6 +130,7 @@ public:
     struct ShaderParameters {
         math::mat4f lightSpace{};
         math::float4 lightFromWorldZ{};
+        math::float4 scissorNormalized{};
         float texelSizeAtOneMeterWs{};
     };
 
@@ -174,13 +175,14 @@ public:
     static void updateSceneInfoSpot(const math::mat4f& Mv, FScene const& scene,
             SceneInfo& sceneInfo);
 
-    backend::Viewport getViewport() const noexcept;
-
     LightManager::ShadowOptions const* getShadowOptions() const noexcept { return mOptions; }
     size_t getLightIndex() const { return mLightIndex; }
     uint16_t getShadowIndex() const { return mShadowIndex; }
     void setLayer(uint8_t layer) noexcept { mLayer = layer; }
     uint8_t getLayer() const noexcept { return mLayer; }
+    backend::Viewport getViewport() const noexcept;
+    backend::Viewport getScissor() const noexcept;
+
     bool isDirectionalShadow() const noexcept { return mShadowType == ShadowType::DIRECTIONAL; }
     bool isSpotShadow() const noexcept { return mShadowType == ShadowType::SPOT; }
     bool isPointShadow() const noexcept { return mShadowType == ShadowType::POINT; }
@@ -287,6 +289,8 @@ private:
 
     static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpacePcf,
             const math::mat4f& Mv, float znear, float zfar) noexcept;
+
+    math::float4 getViewportNormalized(ShadowMapInfo const& shadowMapInfo) const noexcept;
 
     float texelSizeWorldSpace(const math::mat3f& worldToShadowTexture,
             uint16_t shadowDimension) const noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -396,7 +396,7 @@ FrameGraphId<FrameGraphTexture> ShadowMapManager::render(FEngine& engine, FrameG
                     engine.flush();
                     driver.beginRenderPass(rt.target, rt.params);
                     entry.shadowMap->bind(driver);
-                    entry.executor.overrideScissor(entry.shadowMap->getViewport());
+                    entry.executor.overrideScissor(entry.shadowMap->getScissor());
                     entry.executor.execute(engine, "Shadow Pass");
                     driver.endRenderPass();
                 });
@@ -546,6 +546,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
                 auto& s = mShadowUb.edit();
                 s.shadows[shadowIndex].layer = shadowMap.getLayer();
                 s.shadows[shadowIndex].lightFromWorldMatrix = shaderParameters.lightSpace;
+                s.shadows[shadowIndex].scissorNormalized = shaderParameters.scissorNormalized;
                 s.shadows[shadowIndex].normalBias = normalBias * wsTexelSize;
                 s.shadows[shadowIndex].texelSizeAtOneMeter = wsTexelSize;
                 s.shadows[shadowIndex].elvsm = options.vsm.elvsm;
@@ -681,6 +682,7 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap,
         const double f = shadowMap.getCamera().getCullingFar();
         s.shadows[shadowIndex].layer = shadowMap.getLayer();
         s.shadows[shadowIndex].lightFromWorldMatrix = shaderParameters.lightSpace;
+        s.shadows[shadowIndex].scissorNormalized = shaderParameters.scissorNormalized;
         s.shadows[shadowIndex].normalBias = normalBias * wsTexelSizeAtOneMeter;
         s.shadows[shadowIndex].lightFromWorldZ = shaderParameters.lightFromWorldZ;
         s.shadows[shadowIndex].texelSizeAtOneMeter = wsTexelSizeAtOneMeter;
@@ -762,6 +764,7 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
         const double f = shadowMap.getCamera().getCullingFar();
         s.shadows[shadowIndex].layer = shadowMap.getLayer();
         s.shadows[shadowIndex].lightFromWorldMatrix = shaderParameters.lightSpace;
+        s.shadows[shadowIndex].scissorNormalized = shaderParameters.scissorNormalized;
         s.shadows[shadowIndex].normalBias = normalBias * wsTexelSizeAtOneMeter;
         s.shadows[shadowIndex].lightFromWorldZ = shaderParameters.lightFromWorldZ;
         s.shadows[shadowIndex].texelSizeAtOneMeter = wsTexelSizeAtOneMeter;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -249,7 +249,7 @@ struct ShadowUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     struct alignas(16) ShadowData {
         math::mat4f lightFromWorldMatrix;       // 64
         math::float4 lightFromWorldZ;           // 16
-        math::float4 reserved0;                 // 12
+        math::float4 scissorNormalized;         // 16
         float texelSizeAtOneMeter;              //  4
         float bulbRadiusLs;                     //  4
         float nearOverFarMinusNear;             //  4

--- a/shaders/src/common_types.glsl
+++ b/shaders/src/common_types.glsl
@@ -3,7 +3,7 @@
 struct ShadowData {
     highp mat4 lightFromWorldMatrix;
     highp vec4 lightFromWorldZ;
-    highp vec4 reserved0;
+    highp vec4 scissorNormalized;
     float texelSizeAtOneMeter;
     float bulbRadiusLs;
     float nearOverFarMinusNear;


### PR DESCRIPTION
All shadow maps need a 1-px border for different reasons. The directional shadow needs a "not in shadow" border because it uses the intersection of receivers and casters in light-space. Other shadow types need a border because of bilinear access at the  edges. Until now, the spot/point shadow border was handled with the sampler's CLAMP.

Instead, now, we always generate a border and in one case we fill it with "not in shadow" (by not rendering into it), in the other cases we render the 2px larger shadowmap so we get completely correct bilinear  filter.

Additionally, for PCF, DPCF and PCSS we use a large filter kernel which accesses data outside the texture, until now this was handled with CLAMP, but that failed (2 of the edges were not handled in the same way) when  the shadowmap was smaller than the texture.
We fix this by clamping manually the texture coordinates.


The real motivation for these changes is to allow the use of a shadow Atlas later.