### PR TITLE
gltfio: Store default transform for animated entities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@ A new header is inserted each time a *tag* is created.
 
 ## main branch
 
+- gltfio: fix incorrct orientation applied to entities with scale animated to near 0
+
 ## v1.30.0
 
 - engine: optimize per-shadow UBO [⚠️ **Recompile Materials**]

--- a/libs/gltfio/src/Animator.cpp
+++ b/libs/gltfio/src/Animator.cpp
@@ -57,6 +57,7 @@ struct Sampler {
 struct Channel {
     const Sampler* sourceData;
     Entity targetEntity;
+    math::mat4f restTransform;  // the default transform of targetEntity, with no animation applied
     enum { TRANSLATION, ROTATION, SCALE, WEIGHTS } transformType;
 };
 
@@ -417,9 +418,11 @@ void AnimatorImpl::addChannels(const FixedCapacityVector<Entity>& nodeMap,
             }
             continue;
         }
+        TransformManager::Instance node = transformManager->getInstance(targetEntity);
         Channel dstChannel;
         dstChannel.sourceData = samplers + (srcChannel.sampler - srcSamplers);
         dstChannel.targetEntity = targetEntity;
+        dstChannel.restTransform = transformManager->getTransform(node);
         setTransformType(srcChannel, dstChannel);
         dst.channels.push_back(dstChannel);
     }
@@ -434,7 +437,7 @@ void AnimatorImpl::applyAnimation(const Channel& channel, float t, size_t prevIn
     // Perform the interpolation. This is a simple but inefficient implementation; Filament
     // stores transforms as mat4's but glTF animation is based on TRS (translation rotation
     // scale).
-    mat4f xform = transformManager->getTransform(node);
+    mat4f xform = channel.restTransform;
     float3 scale;
     quatf rotation;
     float3 translation;


### PR DESCRIPTION
If an entity has its scale animated to 0 its transformation matrix can't store rotation information, so it effectively "resets" its orientation. To fix, we store the original, unanimated transform matrix.

Fixes #6311