### PR TITLE
Fix a WebGL program link failure

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -286,13 +286,15 @@ bool OpenGLProgram::checkProgramStatus(const char* name,
     for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         const ShaderStage type = static_cast<ShaderStage>(i);
         const GLuint shader = shaderIds[i];
-        glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
-        if (status != GL_TRUE) {
-            logCompilationError(slog.e, type, name, shader, shaderSourceCode[i]);
+        if (shader) {
+            glGetShaderiv(shader, GL_COMPILE_STATUS, &status);
+            if (status != GL_TRUE) {
+                logCompilationError(slog.e, type, name, shader, shaderSourceCode[i]);
+            }
+            glDetachShader(program, shader);
+            glDeleteShader(shader);
+            shaderIds[i] = 0;
         }
-        glDetachShader(program, shader);
-        glDeleteShader(shader);
-        shaderIds[i] = 0;
     }
     // log the link error as well
     logProgramLinkError(slog.e, name, program);

--- a/shaders/src/common_types.glsl
+++ b/shaders/src/common_types.glsl
@@ -3,16 +3,16 @@
 struct ShadowData {
     highp mat4 lightFromWorldMatrix;
     highp vec3 direction;
-    float normalBias;
+    mediump float normalBias;
     highp vec4 lightFromWorldZ;
-    float texelSizeAtOneMeter;
-    float bulbRadiusLs;
-    float nearOverFarMinusNear;
+    mediump float texelSizeAtOneMeter;
+    mediump float bulbRadiusLs;
+    mediump float nearOverFarMinusNear;
     bool elvsm;
-    uint layer;
-    uint reserved0;
-    uint reserved1;
-    uint reserved2;
+    mediump uint layer;
+    mediump uint reserved0;
+    mediump uint reserved1;
+    mediump uint reserved2;
 };
 
 struct BoneData {


### PR DESCRIPTION
WebGL complained about:

Precisions of uniform block 'ShadowUniforms' member 'ShadowUniforms.shadows.texelSizeAtOneMeter' differ between VERTEX and FRAGMENT shaders.


this field didn't have a precision qualifier, this might be specific to WebGL or a Chrome bug, unsure. Either we fix it by specifying all qualifiers.