### PR TITLE
Add new outputColorSpace() API to ColorGrading

### DIFF
--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PUBLIC_HDRS
         include/filament/Camera.h
         include/filament/Color.h
         include/filament/ColorGrading.h
+        include/filament/ColorSpace.h
         include/filament/DebugRegistry.h
         include/filament/Engine.h
         include/filament/Exposure.h
@@ -53,7 +54,7 @@ set(SRCS
         src/BufferObject.cpp
         src/Camera.cpp
         src/Color.cpp
-        src/ColorSpace.cpp
+        src/ColorSpaceUtils.cpp
         src/Culler.cpp
         src/DFG.cpp
         src/DebugRegistry.cpp
@@ -135,7 +136,7 @@ set(SRCS
 set(PRIVATE_HDRS
         src/Allocators.h
         src/BufferPoolAllocator.h
-        src/ColorSpace.h
+        src/ColorSpaceUtils.h
         src/Culler.h
         src/DFG.h
         src/FilamentAPI-impl.h

--- a/filament/include/filament/Color.h
+++ b/filament/include/filament/Color.h
@@ -40,33 +40,33 @@ using sRGBColorA  = math::float4;
 
 //! types of RGB colors
 enum class RgbType : uint8_t {
-    sRGB,   //!< the color is defined in sRGB space
-    LINEAR, //!< the color is defined in linear space
+    sRGB,   //!< the color is defined in Rec.709-sRGB-D65 (sRGB) space
+    LINEAR, //!< the color is defined in Rec.709-Linear-D65 ("linear sRGB") space
 };
 
 //! types of RGBA colors
 enum class RgbaType : uint8_t {
     /**
-     * the color is defined in sRGB space and the RGB values
-     * have not been premultiplied by the alpha (for instance, a 50%
+     * the color is defined in Rec.709-sRGB-D65 (sRGB) space and the RGB values
+     * have not been pre-multiplied by the alpha (for instance, a 50%
      * transparent red is <1,0,0,0.5>)
      */
     sRGB,
     /**
-     * the color is defined in linear space and the RGB values
-     * have not been premultiplied by the alpha (for instance, a 50%
+     * the color is defined in Rec.709-Linear-D65 ("linear sRGB") space and the
+     * RGB values have not been pre-multiplied by the alpha (for instance, a 50%
      * transparent red is <1,0,0,0.5>)
      */
     LINEAR,
     /**
-     * the color is defined in sRGB space and the RGB values
-     * have been premultiplied by the alpha (for instance, a 50%
+     * the color is defined in Rec.709-sRGB-D65 (sRGB) space and the RGB values
+     * have been pre-multiplied by the alpha (for instance, a 50%
      * transparent red is <0.5,0,0,0.5>)
      */
     PREMULTIPLIED_sRGB,
     /**
-     * the color is defined in linear space and the RGB values
-     * have been premultiplied by the alpha (for instance, a 50%
+     * the color is defined in Rec.709-Linear-D65 ("linear sRGB") space and the
+     * RGB values have been pre-multiplied by the alpha (for instance, a 50%
      * transparent red is <0.5,0,0,0.5>)
      */
     PREMULTIPLIED_LINEAR
@@ -93,40 +93,44 @@ public:
     template<ColorConversion = ACCURATE>
     static LinearColor toLinear(sRGBColor const& color);
 
-    //! converts an RGB color in linear space to an RGB color in sRGB space
+    /**
+     * Converts an RGB color in Rec.709-Linear-D65 ("linear sRGB") space to an
+     * RGB color in Rec.709-sRGB-D65 (sRGB) space.
+     */
     template<ColorConversion = ACCURATE>
     static sRGBColor toSRGB(LinearColor const& color);
 
     /**
-     * converts an RGBA color in sRGB space to an RGBA color in linear space
-     * the alpha component is left unmodified
+     * Converts an RGBA color in Rec.709-sRGB-D65 (sRGB) space to an RGBA color in
+     * Rec.709-Linear-D65 ("linear sRGB") space the alpha component is left unmodified.
      */
     template<ColorConversion = ACCURATE>
     static LinearColorA toLinear(sRGBColorA const& color);
 
     /**
-     * converts an RGBA color in linear space to an RGBA color in sRGB space
-     * the alpha component is left unmodified
+     * Converts an RGBA color in Rec.709-Linear-D65 ("linear sRGB") space to
+     * an RGBA color in Rec.709-sRGB-D65 (sRGB) space the alpha component is
+     * left unmodified.
      */
     template<ColorConversion = ACCURATE>
     static sRGBColorA toSRGB(LinearColorA const& color);
 
     /**
-     * converts a correlated color temperature to a linear RGB color in sRGB
+     * Converts a correlated color temperature to a linear RGB color in sRGB
      * space the temperature must be expressed in kelvin and must be in the
-     * range 1,000K to 15,000K
+     * range 1,000K to 15,000K.
      */
     static LinearColor cct(float K);
 
     /**
-     * converts a CIE standard illuminant series D to a linear RGB color in
+     * Converts a CIE standard illuminant series D to a linear RGB color in
      * sRGB space the temperature must be expressed in kelvin and must be in
      * the range 4,000K to 25,000K
      */
     static LinearColor illuminantD(float K);
 
     /**
-     * computes the Beer-Lambert absorption coefficients from the specified
+     * Computes the Beer-Lambert absorption coefficients from the specified
      * transmittance color and distance. The computed absorption will guarantee
      * the white light will become the specified color at the specified distance.
      * The output of this function can be used as the absorption parameter of

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -31,6 +31,10 @@ namespace filament {
 class Engine;
 class FColorGrading;
 
+namespace color {
+class ColorSpace;
+}
+
 /**
  * ColorGrading is used to transform (either to modify or correct) the colors of the HDR buffer
  * rendered by Filament. Color grading transforms are applied after lighting, and after any lens
@@ -97,6 +101,7 @@ class FColorGrading;
  * - Tone mapping: ACESLegacyToneMapper
  * - Luminance scaling: false
  * - Gamut mapping: false
+ * - Output color space: Rec709-sRGB-D65
  *
  * @see View
  */
@@ -446,6 +451,19 @@ public:
          * @return This Builder, for chaining calls
          */
         Builder& curves(math::float3 shadowGamma, math::float3 midPoint, math::float3 highlightScale) noexcept;
+
+        /**
+         * Sets the output color space for this ColorGrading object. After all color grading steps
+         * have been applied, the final color will be converted in the desired color space.
+         *
+         * NOTE: Currently the output color space must be one of Rec709-sRGB-D65 or
+         *       Rec709-Linear-D65. Only the transfer function is taken into account.
+         *
+         * @param colorSpace The output color space.
+         *
+         * @return This Builder, for chaining calls
+         */
+        Builder& outputColorSpace(const color::ColorSpace& colorSpace) noexcept;
 
         /**
          * Creates the ColorGrading object and returns a pointer to it.

--- a/filament/include/filament/ColorSpace.h
+++ b/filament/include/filament/ColorSpace.h
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_COLOR_SPACE_H
+#define TNT_FILAMENT_COLOR_SPACE_H
+
+#include <math/vec2.h>
+#include <math/vec3.h>
+
+namespace filament {
+namespace color {
+
+using namespace math;
+
+/**
+ * Holds the chromaticities of a color space's primaries as xy coordinates
+ * in xyY (Y is assumed to be 1).
+ */
+struct Primaries {
+    float2 r;
+    float2 g;
+    float2 b;
+
+    bool operator==(const Primaries& rhs) const noexcept {
+        return r == rhs.r && b == rhs.b && g == rhs.b;
+    }
+};
+
+//! Reference white for a color space, defined as the xy coordinates in the xyY space.
+using WhitePoint = float2;
+
+/**
+ * <p>Defines the parameters for the ICC parametric curve type 4, as
+ * defined in ICC.1:2004-10, section 10.15.</p>
+ *
+ * <p>The EOTF is of the form:</p>
+ *
+ * \(\begin{equation}
+ * Y = \begin{cases}c X + f & X \lt d \\\
+ * \left( a X + b \right) ^{g} + e & X \ge d \end{cases}
+ * \end{equation}\)
+ *
+ * <p>The corresponding OETF is simply the inverse function.</p>
+ *
+ * <p>The parameters defined by this class form a valid transfer
+ * function only if all the following conditions are met:</p>
+ * <ul>
+ *     <li>No parameter is a NaN</li>
+ *     <li>\(d\) is in the range \([0..1]\)</li>
+ *     <li>The function is not constant</li>
+ *     <li>The function is positive and increasing</li>
+ * </ul>
+ */
+struct TransferFunction {
+    /**
+     * <p>Defines the parameters for the ICC parametric curve type 3, as
+     * defined in ICC.1:2004-10, section 10.15.</p>
+     *
+     * <p>The EOTF is of the form:</p>
+     *
+     * \(\begin{equation}
+     * Y = \begin{cases}c X & X \lt d \\\
+     * \left( a X + b \right) ^{g} & X \ge d \end{cases}
+     * \end{equation}\)
+     *
+     * <p>This constructor is equivalent to setting  \(e\) and \(f\) to 0.</p>
+     *
+     * @param a The value of \(a\) in the equation of the EOTF described above
+     * @param b The value of \(b\) in the equation of the EOTF described above
+     * @param c The value of \(c\) in the equation of the EOTF described above
+     * @param d The value of \(d\) in the equation of the EOTF described above
+     * @param g The value of \(g\) in the equation of the EOTF described above
+     */
+    constexpr TransferFunction(
+            double a,
+            double b,
+            double c,
+            double d,
+            double e,
+            double f,
+            double g
+    ) : a(a),
+        b(b),
+        c(c),
+        d(d),
+        e(e),
+        f(f),
+        g(g) {
+    }
+
+    constexpr TransferFunction(
+            double a,
+            double b,
+            double c,
+            double d,
+            double g
+    ) : TransferFunction(a, b, c, d, 0.0, 0.0, g) {
+    }
+
+    bool operator==(const TransferFunction& rhs) const noexcept {
+        return
+                a == rhs.a &&
+                b == rhs.b &&
+                c == rhs.c &&
+                d == rhs.d &&
+                e == rhs.e &&
+                f == rhs.f &&
+                g == rhs.g;
+    }
+
+    double a;
+    double b;
+    double c;
+    double d;
+    double e;
+    double f;
+    double g;
+};
+
+/**
+ * <p>A color space in Filament is always an RGB color space. A specific RGB color space
+ * is defined by the following properties:</p>
+ * <ul>
+ *     <li>Three chromaticities of the red, green and blue primaries, which
+ *     define the gamut of the color space.</li>
+ *     <li>A white point chromaticity that defines the stimulus to which
+ *     color space values are normalized (also just called "white").</li>
+ *     <li>An opto-electronic transfer function, also called opto-electronic
+ *     conversion function or often, and approximately, gamma function.</li>
+ *     <li>An electro-optical transfer function, also called electo-optical
+ *     conversion function or often, and approximately, gamma function.</li>
+ * </ul>
+ *
+ * <h3>Primaries and white point chromaticities</h3>
+ * <p>In this implementation, the chromaticity of the primaries and the white
+ * point of an RGB color space is defined in the CIE xyY color space. This
+ * color space separates the chromaticity of a color, the x and y components,
+ * and its luminance, the Y component. Since the primaries and the white
+ * point have full brightness, the Y component is assumed to be 1 and only
+ * the x and y components are needed to encode them.</p>
+ *
+ * <h3>Transfer functions</h3>
+ * <p>A transfer function is a color component conversion function, defined as
+ * a single variable, monotonic mathematical function. It is applied to each
+ * individual component of a color. They are used to perform the mapping
+ * between linear tristimulus values and non-linear electronic signal value.</p>
+ * <p>The <em>opto-electronic transfer function</em> (OETF or OECF) encodes
+ * tristimulus values in a scene to a non-linear electronic signal value.</p>
+ */
+class ColorSpace {
+public:
+    constexpr ColorSpace(
+            const Primaries primaries,
+            const TransferFunction transferFunction,
+            const WhitePoint whitePoint
+    ) : mPrimaries(primaries),
+        mTransferFunction(transferFunction),
+        mWhitePoint(whitePoint) {
+    }
+
+    bool operator==(const ColorSpace& rhs) const noexcept {
+        return mPrimaries == rhs.mPrimaries &&
+                mTransferFunction == rhs.mTransferFunction &&
+                mWhitePoint == rhs.mWhitePoint;
+    }
+
+    constexpr const Primaries& getPrimaries() const { return mPrimaries; }
+    constexpr const TransferFunction& getTransferFunction() const { return mTransferFunction; }
+    constexpr const WhitePoint& getWhitePoint() const { return mWhitePoint; }
+
+private:
+    Primaries mPrimaries;
+    TransferFunction mTransferFunction;
+    WhitePoint mWhitePoint;
+};
+
+/**
+ * Intermediate class used when building a color space using the "-" syntax:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * // Declares a "linear sRGB" color space.
+ * ColorSpace myColorSpace = Rec709-Linear-sRGB;
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+class PartialColorSpace {
+public:
+    constexpr ColorSpace operator-(const WhitePoint whitePoint) const {
+        return ColorSpace(mPrimaries, mTransferFunction, whitePoint);
+    }
+
+private:
+    constexpr PartialColorSpace(
+            const Primaries primaries,
+            const TransferFunction transferFunction
+    ) : mPrimaries(primaries),
+        mTransferFunction(transferFunction) {
+    }
+
+    Primaries mPrimaries;
+    TransferFunction mTransferFunction;
+
+    friend class Gamut;
+};
+
+/**
+ * Defines the chromaticities of the primaries for a color space. The chromaticities
+ * are expressed as three pairs of xy coordinates (in xyY) for the red, green, and blue
+ * chromaticities.
+ */
+class Gamut {
+public:
+    constexpr Gamut(const Primaries primaries) : mPrimaries(primaries) {
+    }
+
+    constexpr Gamut(float2 r, float2 g, float2 b) : Gamut(Primaries{r, g, b}) {
+    }
+
+    constexpr PartialColorSpace operator-(const TransferFunction transferFunction) const {
+        return PartialColorSpace(mPrimaries, transferFunction);
+    }
+
+    constexpr const Primaries& getPrimaries() const { return mPrimaries; }
+
+private:
+    Primaries mPrimaries;
+};
+
+//! Rec.709 color gamut, used in the sRGB and DisplayP3 color spaces.
+constexpr Gamut Rec709 = Gamut({0.640f, 0.330f}, {0.300f, 0.600f}, {0.150f, 0.060f});
+
+//! Linear transfer function.
+constexpr TransferFunction Linear = TransferFunction(1.0, 0.0, 0.0, 0.0, 1.0);
+//! sRGB transfer function.
+constexpr TransferFunction sRGB =
+        TransferFunction(1.0 / 1.055, 0.055 / 1.055, 1.0 / 12.92, 0.04045, 2.4);
+
+//! Standard CIE 1931 2° illuminant D65. This illuminant has a color temperature of 6504K.
+constexpr WhitePoint D65 = WhitePoint({0.31271f, 0.32902f});
+
+} // namespace color
+} // namespace filament
+
+#endif // TNT_FILAMENT_COLOR_SPACE_H

--- a/filament/src/Color.cpp
+++ b/filament/src/Color.cpp
@@ -16,7 +16,7 @@
 
 #include <filament/Color.h>
 
-#include "ColorSpace.h"
+#include "ColorSpaceUtils.h"
 
 #include <math/mat3.h>
 #include <math/scalar.h>

--- a/filament/src/ColorSpaceUtils.cpp
+++ b/filament/src/ColorSpaceUtils.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "ColorSpace.h"
+#include "ColorSpaceUtils.h"
 
 namespace filament {
 

--- a/filament/src/ColorSpaceUtils.h
+++ b/filament/src/ColorSpaceUtils.h
@@ -296,6 +296,10 @@ inline float3 linearAP1_to_ACEScct(float3 x) noexcept {
     return x;
 }
 
+inline float3 OETF_Linear(float3 x) noexcept {
+    return x;
+}
+
 inline float3 OETF_sRGB(float3 x) noexcept {
     constexpr float a  = 0.055f;
     constexpr float a1 = 1.055f;

--- a/filament/src/ToneMapper.cpp
+++ b/filament/src/ToneMapper.cpp
@@ -16,7 +16,7 @@
 
 #include <filament/ToneMapper.h>
 
-#include "ColorSpace.h"
+#include "ColorSpaceUtils.h"
 
 #include <math/vec3.h>
 #include <math/scalar.h>


### PR DESCRIPTION
This allows the application to select the desired output color space. The default is set to Rec709-sRGB-D65 ("sRGB") but can be changed to Rec709-Linear-D65.

Currently only the transfer function is taken into account and must be either sRGB or Linear. Future updates will add support for different gamuts and white points.