### PR TITLE
fix clear options

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Renderer.java
@@ -124,7 +124,24 @@ public class Renderer {
      */
     public static class ClearOptions {
         /**
-         * Color to use to clear the SwapChain
+         * Color (sRGB linear) to use to clear the RenderTarget (typically the SwapChain).
+         *
+         * The RenderTarget is cleared using this color, which won't be tone-mapped since
+         * tone-mapping is part of View rendering (this is not).
+         *
+         * When a View is rendered, there are 3 scenarios to consider:
+         * - Pixels rendered by the View replace the clear color (or blend with it in
+         *   `BlendMode.TRANSLUCENT` mode).
+         *
+         * - With blending mode set to `BlendMode.TRANSLUCENT`, Pixels untouched by the View
+         *   are considered fulling transparent and let the clear color show through.
+         *
+         * - With blending mode set to `BlendMode.OPAQUE`, Pixels untouched by the View
+         *   are set to the clear color. However, because it is now used in the context of a View,
+         *   it will go through the post-processing stage, which includes tone-mapping.
+         *
+         * For consistency, it is recommended to always use a Skybox to clear an opaque View's
+         * background, or to use black or fully-transparent (i.e. {0,0,0,0}) as the clear color.
          */
         @NonNull
         public float[] clearColor = { 0.0f, 0.0f, 0.0f, 0.0f };

--- a/android/samples/sample-multi-view/src/main/java/com/google/android/filament/multiview/MainActivity.kt
+++ b/android/samples/sample-multi-view/src/main/java/com/google/android/filament/multiview/MainActivity.kt
@@ -27,6 +27,7 @@ import android.view.animation.LinearInterpolator
 
 import com.google.android.filament.*
 import com.google.android.filament.RenderableManager.*
+import com.google.android.filament.Renderer.ClearOptions
 import com.google.android.filament.VertexBuffer.*
 import com.google.android.filament.android.DisplayHelper
 import com.google.android.filament.android.UiHelper
@@ -64,7 +65,6 @@ class MainActivity : Activity() {
     private lateinit var view0: View
     private lateinit var view1: View
     private lateinit var view2: View
-    private lateinit var view3: View
     private lateinit var view4: View
     // We need skybox to set the background color
     private lateinit var skybox: Skybox
@@ -119,14 +119,18 @@ class MainActivity : Activity() {
         view0 = engine.createView()
         view1 = engine.createView()
         view2 = engine.createView()
-        view3 = engine.createView()
         view4 = engine.createView()
 
         view0.setName("view0");
         view1.setName("view1");
         view2.setName("view2");
-        view3.setName("view3");
         view4.setName("view4");
+
+//  Useful for debugging issues
+//        view0.isPostProcessingEnabled = false
+//        view1.isPostProcessingEnabled = false
+//        view2.isPostProcessingEnabled = false
+//        view4.isPostProcessingEnabled = false
 
         view4.blendMode = View.BlendMode.TRANSLUCENT;
 
@@ -140,13 +144,11 @@ class MainActivity : Activity() {
         view0.camera = camera
         view1.camera = camera
         view2.camera = camera
-        view3.camera = camera
         view4.camera = camera
 
         view0.scene = scene
         view1.scene = scene
         view2.scene = scene
-        view3.scene = scene
         view4.scene = scene
     }
 
@@ -379,7 +381,6 @@ class MainActivity : Activity() {
         engine.destroyView(view0)
         engine.destroyView(view1)
         engine.destroyView(view2)
-        engine.destroyView(view3)
         engine.destroyView(view4)
         engine.destroySkybox(skybox)
         engine.destroyScene(scene)
@@ -407,19 +408,18 @@ class MainActivity : Activity() {
                 // If beginFrame() returns false you should skip the frame
                 // This means you are sending frames too quickly to the GPU
                 if (renderer.beginFrame(swapChain!!, frameTimeNanos)) {
-                    skybox.setColor(0.035f, 0.035f, 0.035f, 1.0f);
+                    scene.skybox = skybox
+                    skybox.setColor(0.35f, 0.35f, 0.35f, 1.0f);
+
                     renderer.render(view0)
 
-                    skybox.setColor(1.0f, 0.0f, 0.0f, 1.0f);
+                    skybox.setColor(1.0f, 1.0f, 0.0f, 1.0f);
+
                     renderer.render(view1)
 
-                    skybox.setColor(0.0f, 1.0f, 0.0f, 1.0f);
+                    scene.skybox = null
+
                     renderer.render(view2)
-
-                    skybox.setColor(0.0f, 0.0f, 1.0f, 1.0f);
-                    renderer.render(view3)
-
-                    skybox.setColor(0.0f, 0.0f, 0.0f, 0.0f);
                     renderer.render(view4)
 
                     renderer.endFrame()
@@ -433,6 +433,10 @@ class MainActivity : Activity() {
             swapChain?.let { engine.destroySwapChain(it) }
             swapChain = engine.createSwapChain(surface)
             renderer.setDisplayInfo(DisplayHelper.getDisplayInfo(surfaceView.display, Renderer.DisplayInfo()))
+            renderer.clearOptions = renderer.clearOptions.apply {
+                clear = true
+                clearColor = floatArrayOf( 0.0f, 0.0f, 1.0f, 0.0f )
+            }
         }
 
         override fun onDetachedFromSurface() {
@@ -453,7 +457,6 @@ class MainActivity : Activity() {
             view0.viewport = Viewport(0,         0,          width / 2, height / 2)
             view1.viewport = Viewport(width / 2, 0,          width / 2, height / 2)
             view2.viewport = Viewport(0,         height / 2, width / 2, height / 2)
-            view3.viewport = Viewport(width / 2, height / 2, width / 2, height / 2)
             view4.viewport = Viewport(width / 4, height / 4, width / 2, height / 2)
         }
     }

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -117,15 +117,37 @@ public:
      * ClearOptions are used at the beginning of a frame to clear or retain the SwapChain content.
      */
     struct ClearOptions {
-        /** Color to use to clear the SwapChain */
+        /**
+         * Color (sRGB linear) to use to clear the RenderTarget (typically the SwapChain).
+         *
+         * The RenderTarget is cleared using this color, which won't be tone-mapped since
+         * tone-mapping is part of View rendering (this is not).
+         *
+         * When a View is rendered, there are 3 scenarios to consider:
+         * - Pixels rendered by the View replace the clear color (or blend with it in
+         *   `BlendMode::TRANSLUCENT` mode).
+         *
+         * - With blending mode set to `BlendMode::TRANSLUCENT`, Pixels untouched by the View
+         *   are considered fulling transparent and let the clear color show through.
+         *
+         * - With blending mode set to `BlendMode::OPAQUE`, Pixels untouched by the View
+         *   are set to the clear color. However, because it is now used in the context of a View,
+         *   it will go through the post-processing stage, which includes tone-mapping.
+         *
+         * For consistency, it is recommended to always use a Skybox to clear an opaque View's
+         * background, or to use black or fully-transparent (i.e. {0,0,0,0}) as the clear color.
+         */
         math::float4 clearColor = {};
+
         /** Value to clear the stencil buffer */
         uint8_t clearStencil = 0u;
+
         /**
          * Whether the SwapChain should be cleared using the clearColor. Use this if translucent
          * View will be drawn, for instance.
          */
         bool clear = false;
+
         /**
          * Whether the SwapChain content should be discarded. clear implies discard. Set this
          * to false (along with clear to false as well) if the SwapChain already has content that

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -47,8 +47,6 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
         FrameGraphId<FrameGraphTexture> ssao;
         FrameGraphId<FrameGraphTexture> ssr;    // either screen-space reflections or refractions
         FrameGraphId<FrameGraphTexture> structure;
-        float4 clearColor{};
-        TargetBufferFlags clearFlags{};
     };
 
     Blackboard& blackboard = fg.getBlackboard();
@@ -56,8 +54,8 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
     auto& colorPass = fg.addPass<ColorPassData>(name,
             [&](FrameGraph::Builder& builder, ColorPassData& data) {
 
+                TargetBufferFlags const clearColorFlags = config.clearFlags & TargetBufferFlags::COLOR;
                 TargetBufferFlags clearDepthFlags = config.clearFlags & TargetBufferFlags::DEPTH;
-                TargetBufferFlags clearColorFlags = config.clearFlags & TargetBufferFlags::COLOR;
                 TargetBufferFlags clearStencilFlags = config.clearFlags & TargetBufferFlags::STENCIL;
 
                 data.shadows = blackboard.get<FrameGraphTexture>("shadows");
@@ -100,7 +98,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                             TargetBufferFlags::STENCIL : TargetBufferFlags::NONE;
                     const char* const name = config.enabledStencilBuffer ?
                              "Depth/Stencil Buffer" : "Depth Buffer";
-                    TextureFormat format = config.enabledStencilBuffer ?
+                    TextureFormat const format = config.enabledStencilBuffer ?
                             TextureFormat::DEPTH32F_STENCIL8 : TextureFormat::DEPTH32F;
                     data.depth = builder.createTexture(name, {
                             .width = colorBufferDesc.width,
@@ -155,14 +153,11 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                  */
                 builder.declareRenderPass("Color Pass Target", {
                         .attachments = { .color = { data.color, data.output },
-                                .depth = data.depth,
-                                .stencil = data.stencil },
-                                .samples = config.msaa,
+                        .depth = data.depth,
+                        .stencil = data.stencil },
+                        .clearColor = config.clearColor,
+                        .samples = config.msaa,
                         .clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags });
-
-                data.clearColor = config.clearColor;
-                data.clearFlags = clearColorFlags | clearDepthFlags | clearStencilFlags;
-
                 blackboard["depth"] = data.depth;
             },
             [=, &view, &engine](FrameGraphResources const& resources,
@@ -184,7 +179,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                         resources.getTexture(data.structure) : engine.getOneTexture());
 
                 // set screen-space reflections and screen-space refractions
-                TextureHandle ssr = data.ssr ?
+                TextureHandle const ssr = data.ssr ?
                         resources.getTexture(data.ssr) : engine.getOneTextureArray();
 
                 view.prepareSSR(ssr, config.ssrLodOffset,
@@ -203,9 +198,8 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
 
                 view.commitUniforms(driver);
 
-                out.params.clearColor = data.clearColor;
+                // TODO: this should be a parameter of FrameGraphRenderPass::Descriptor
                 out.params.clearStencil = config.clearStencil;
-                out.params.flags.clear = data.clearFlags;
                 if (view.getBlendMode() == BlendMode::TRANSLUCENT) {
                     if (any(out.params.flags.discardStart & TargetBufferFlags::COLOR0)) {
                         // if the buffer is discarded (e.g. it's new) and we're blending,
@@ -241,7 +235,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
     return output;
 }
 
-FrameGraphId<FrameGraphTexture> RendererUtils::refractionPass(
+std::pair<FrameGraphId<FrameGraphTexture>, bool> RendererUtils::refractionPass(
         FrameGraph& fg, FEngine& engine, FView const& view,
         ColorPassConfig config,
         PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,
@@ -291,6 +285,12 @@ FrameGraphId<FrameGraphTexture> RendererUtils::refractionPass(
         // automatically because these are set in the Blackboard (they were set by the opaque
         // pass). For this reason, `desc` below is only used in colorPass() for the width and
         // height.
+
+        // Since we're reusing the existing target we don't want to clear any of its buffer.
+        // Important: if this target ended up being an imported target, then the clearFlags
+        // specified here wouldn't apply (the clearFlags of the imported target take precedence),
+        // and we'd end up clearing the opaque pass. This scenario never happens because it is
+        // prevented in Renderer.cpp's final blit.
         config.clearFlags = TargetBufferFlags::NONE;
         output = RendererUtils::colorPass(fg, "Color Pass (transparent)", engine, view,
                 { .width = config.width, .height = config.height },
@@ -306,7 +306,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::refractionPass(
     } else {
         output = input;
     }
-    return output;
+    return { output, hasScreenSpaceRefraction };
 }
 
 UTILS_NOINLINE

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -29,6 +29,8 @@
 
 #include <stdint.h>
 
+#include <utility>
+
 namespace filament {
 
 class FRenderTarget;
@@ -77,7 +79,7 @@ public:
             PostProcessManager::ColorGradingConfig colorGradingConfig,
             RenderPass::Executor const& passExecutor) noexcept;
 
-    static FrameGraphId<FrameGraphTexture> refractionPass(
+    static std::pair<FrameGraphId<FrameGraphTexture>, bool> refractionPass(
             FrameGraph& fg, FEngine& engine, FView const& view,
             ColorPassConfig config,
             PostProcessManager::ScreenSpaceRefConfig const& ssrConfig,

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -103,8 +103,8 @@ FRenderer::~FRenderer() noexcept {
     // There shouldn't be any resource left when we get here, but if there is, make sure
     // to free what we can (it would probably mean something when wrong).
 #ifndef NDEBUG
-    size_t wm = getCommandsHighWatermark();
-    size_t wmpct = wm / (mEngine.getPerFrameCommandsSize() / 100);
+    size_t const wm = getCommandsHighWatermark();
+    size_t const wmpct = wm / (mEngine.getPerFrameCommandsSize() / 100);
     slog.d << "Renderer: Commands High watermark "
     << wm / 1024 << " KiB (" << wmpct << "%), "
     << wm / sizeof(Command) << " commands, " << sizeof(Command) << " bytes/command"
@@ -154,25 +154,30 @@ TextureFormat FRenderer::getLdrFormat(bool translucent) const noexcept {
     return (translucent || !mIsRGB8Supported) ? TextureFormat::RGBA8 : TextureFormat::RGB8;
 }
 
-void FRenderer::getRenderTarget(FView const& view,
-        TargetBufferFlags& outAttachementMask, Handle<HwRenderTarget>& outTarget) const noexcept {
-    outTarget = view.getRenderTargetHandle();
-    outAttachementMask = view.getRenderTargetAttachmentMask();
+std::pair<Handle<HwRenderTarget>, TargetBufferFlags>
+        FRenderer::getRenderTarget(FView const& view) const noexcept {
+    Handle<HwRenderTarget> outTarget = view.getRenderTargetHandle();
+    TargetBufferFlags outAttachementMask = view.getRenderTargetAttachmentMask();
     if (!outTarget) {
         outTarget = mRenderTargetHandle;
         outAttachementMask = TargetBufferFlags::COLOR0 | TargetBufferFlags::DEPTH;
     }
+    return {outTarget, outAttachementMask };
 }
 
-void FRenderer::initializeClearFlags() {
+backend::TargetBufferFlags FRenderer::getClearFlags() const noexcept {
+    return (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
+           | TargetBufferFlags::DEPTH_AND_STENCIL;
+}
+
+void FRenderer::initializeClearFlags() noexcept {
     // We always discard and clear the depth+stencil buffers -- we don't allow sharing these
     // across views (clear implies discard)
     mDiscardStartFlags = ((mClearOptions.discard || mClearOptions.clear) ?
                           TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
                          | TargetBufferFlags::DEPTH_AND_STENCIL;
 
-    mClearFlags = (mClearOptions.clear ? TargetBufferFlags::COLOR : TargetBufferFlags::NONE)
-                  | TargetBufferFlags::DEPTH_AND_STENCIL;
+    mClearFlags = getClearFlags();
 }
 
 void FRenderer::setPresentationTime(int64_t monotonic_clock_ns) {
@@ -209,9 +214,9 @@ bool FRenderer::beginFrame(FSwapChain* swapChain, uint64_t vsyncSteadyClockTimeN
     }
 
     // latch the frame time
-    std::chrono::duration<double> time(appVsync - mUserEpoch);
-    float h = float(time.count());
-    float l = float(time.count() - h);
+    std::chrono::duration<double> const time(appVsync - mUserEpoch);
+    float const h = float(time.count());
+    float const l = float(time.count() - h);
     mShaderUserTime = { h, l, 0, 0 };
 
     mPreviousRenderTargets.clear();
@@ -461,6 +466,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     driver.debugThreading();
 
     const bool hasPostProcess = view.hasPostProcessPass();
+    bool hasScreenSpaceRefraction = false;
     bool hasColorGrading = hasPostProcess;
     bool hasDithering = view.getDithering() == Dithering::TEMPORAL;
     bool hasFXAA = view.getAntiAliasing() == AntiAliasing::FXAA;
@@ -544,7 +550,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     const bool noBufferPadding = colorGradingConfig.asSubpass && !hasFXAA && !scaled;
 
     // guardBand must be a multiple of 16 to guarantee the same exact rendering up to 4 mip levels.
-    float guardBand = guardBandOptions.enabled ? 16.0f : 0.0f;
+    float const guardBand = guardBandOptions.enabled ? 16.0f : 0.0f;
 
     if (hasPostProcess && !noBufferPadding) {
         // We always pad the rendering viewport to dimensions multiple of 16, this guarantees
@@ -621,7 +627,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     // Allocate some space for our commands in the per-frame Arena, and use that space as
     // an Arena for commands. All this space is released when we exit this method.
-    size_t perFrameCommandsSize = engine.getPerFrameCommandsSize();
+    size_t const perFrameCommandsSize = engine.getPerFrameCommandsSize();
     void* const arenaBegin = arena.allocate(perFrameCommandsSize, CACHELINE_SIZE);
     void* const arenaEnd = pointermath::add(arenaBegin, perFrameCommandsSize);
     RenderPass::Arena commandArena("Command Arena", { arenaBegin, arenaEnd });
@@ -671,11 +677,17 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         initializeClearFlags();
     }
 
+    // Note:  it is not well-defined what colorspace this clearColor is defined into. This leads
+    //        to inconsistent colors depending on enabled features. When the clear is performed
+    //        into a temporary buffer (common case), the clearColor is color-graded. A problem
+    //        arises when transparent views are used, in this case the clear color is not
+    //        color-graded.
     const float4 clearColor = mClearOptions.clearColor;
+
     const uint8_t clearStencil = mClearOptions.clearStencil;
     const TargetBufferFlags clearFlags = mClearFlags;
     const TargetBufferFlags discardStartFlags = mDiscardStartFlags;
-    TargetBufferFlags keepOverrideStartFlags = TargetBufferFlags::ALL & ~discardStartFlags;
+    const TargetBufferFlags keepOverrideStartFlags = TargetBufferFlags::ALL & ~discardStartFlags;
     TargetBufferFlags keepOverrideEndFlags = TargetBufferFlags::NONE;
 
     if (currentRenderTarget) {
@@ -691,23 +703,27 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     mDiscardStartFlags &= ~TargetBufferFlags::COLOR;
     mClearFlags &= ~TargetBufferFlags::COLOR;
 
-    Handle<HwRenderTarget> viewRenderTarget;
-    TargetBufferFlags attachmentMask;
-    getRenderTarget(view, attachmentMask, viewRenderTarget);
-    FrameGraphId<FrameGraphTexture> fgViewRenderTarget = fg.import("viewRenderTarget",
-            {
-                    .attachments = attachmentMask,
-                    .viewport = DEBUG_DYNAMIC_SCALING ? svp : vp,
-                    .clearColor = clearColor,
-                    .samples = 0,
-                    .clearFlags = clearFlags,
-                    .keepOverrideStart = keepOverrideStartFlags,
-                    .keepOverrideEnd = keepOverrideEndFlags
-            }, viewRenderTarget);
+    // the clearFlags and clearColor set below are "sticky" to the imported target, meaning
+    // they will apply anytime we render into this target, THIS INCLUDES when this target
+    // is "replacing" another one. E.g. typically when the color pass ends-up drawing directly
+    // here.
+    auto [viewRenderTarget, attachmentMask] = getRenderTarget(view);
+    FrameGraphId<FrameGraphTexture> const fgViewRenderTarget = fg.import("viewRenderTarget", {
+            .attachments = attachmentMask,
+            .viewport = DEBUG_DYNAMIC_SCALING ? svp : vp,
+            .clearColor = clearColor,
+            .samples = 0,
+            .clearFlags = clearFlags,
+            .keepOverrideStart = keepOverrideStartFlags,
+            .keepOverrideEnd = keepOverrideEndFlags
+    }, viewRenderTarget);
 
     const bool blending = blendModeTranslucent;
     const TextureFormat hdrFormat = getHdrFormat(view, needsAlphaChannel);
 
+    // the clearFlags and clearColor specified below will only apply when rendering into the
+    // temporary color buffer. In particular, they won't apply when rendering into the main
+    // swapchain (imported render target above)
     RendererUtils::ColorPassConfig config{
             .width = svp.width,
             .height = svp.height,
@@ -716,7 +732,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             .scale = scale,
             .hdrFormat = hdrFormat,
             .msaa = msaaSampleCount,
-            .clearFlags = clearFlags,
+            .clearFlags = getClearFlags(),
             .clearColor = clearColor,
             .clearStencil = clearStencil,
             .ssrLodOffset = 0.0f,
@@ -799,7 +815,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                     builder.sideEffect();
                 },
                 [=, &view](FrameGraphResources const& resources,
-                        auto const& data, DriverApi& driver) mutable {
+                        auto const&, DriverApi& driver) mutable {
                     auto out = resources.getRenderPassInfo();
                     view.executePickingQueries(driver, out.target, aoOptions.resolution);
                 });
@@ -824,7 +840,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     // --------------------------------------------------------------------------------------------
     // prepare screen-space reflection/refraction passes
 
-    PostProcessManager::ScreenSpaceRefConfig ssrConfig = PostProcessManager::prepareMipmapSSR(
+    PostProcessManager::ScreenSpaceRefConfig const ssrConfig = PostProcessManager::prepareMipmapSSR(
             fg, svp.width, svp.height,
             ssReflectionsOptions.enabled ? TextureFormat::RGBA16F : TextureFormat::R11F_G11F_B10F,
             view.getCameraUser().getFieldOfView(Camera::Fov::VERTICAL), config.scale);
@@ -843,7 +859,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 { .width = svp.width, .height = svp.height });
 
         // generate the mipchain
-        reflections = PostProcessManager::generateMipmapSSR(ppm, fg,
+        PostProcessManager::generateMipmapSSR(ppm, fg,
                 reflections, ssrConfig.reflection, false, ssrConfig);
     }
 
@@ -856,7 +872,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     pass.appendCommands(engine, RenderPass::COLOR);
     pass.sortCommands(engine);
 
-    FrameGraphTexture::Descriptor desc = {
+    FrameGraphTexture::Descriptor const desc = {
             .width = config.width,
             .height = config.height,
             .format = config.hdrFormat
@@ -920,8 +936,10 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     if (view.isScreenSpaceRefractionEnabled() && !pass.empty()) {
         // this cancels the colorPass() call above if refraction is active.
         // the color pass + refraction + color-grading as subpass if needed
-        colorPassOutput = RendererUtils::refractionPass(fg, mEngine, view,
+        const auto [output, enabled] = RendererUtils::refractionPass(fg, mEngine, view,
                 config, ssrConfig, colorGradingConfigForColor, pass);
+        colorPassOutput = output;
+        hasScreenSpaceRefraction = enabled;
     }
 
     if (colorGradingConfig.customResolve) {
@@ -992,7 +1010,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             // The bokeh height is always correct regardless of the dynamic resolution scaling.
             // (because the CoC is calculated w.r.t. the height), so we only need to adjust
             // the width.
-            float bokehAspectRatio = scale.x / scale.y;
+            float const bokehAspectRatio = scale.x / scale.y;
             input = ppm.dof(fg, input, depth, cameraInfo, needsAlphaChannel,
                     bokehAspectRatio, dofOptions);
         }
@@ -1047,6 +1065,8 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     //   as a subpass)
     // * And we also can't use the default rendertarget if frame history is needed (e.g. with
     //   screen-space reflections)
+    // * And we also can't use the default rendertarget with refractions, which need to reuse
+    //   the rendertarget due to how the clear flags work.
     // * We also need an extra blit if we haven't yet handled "xvp"
     //   TODO: in that specific scenario it would be better to just not use xvp
     // The intermediate buffer is accomplished with a "fake" opaqueBlit (i.e. blit) operation.
@@ -1058,6 +1078,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             (outputIsSwapChain &&
                     (msaaSampleCount > 1 ||
                     colorGradingConfig.asSubpass ||
+                    hasScreenSpaceRefraction ||
                     ssReflectionsOptions.enabled))) {
             assert_invariant(!scaled);
             input = ppm.blit(fg, blending, input, xvp, {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -134,21 +134,21 @@ private:
     using Epoch = clock::time_point;
     using duration = clock::duration;
 
-    void initializeClearFlags();
+    backend::TargetBufferFlags getClearFlags() const noexcept;
+    void initializeClearFlags() noexcept;
 
     backend::TextureFormat getHdrFormat(const FView& view, bool translucent) const noexcept;
     backend::TextureFormat getLdrFormat(bool translucent) const noexcept;
 
     Epoch getUserEpoch() const { return mUserEpoch; }
     double getUserTime() const noexcept {
-        duration d = clock::now() - getUserEpoch();
+        duration const d = clock::now() - getUserEpoch();
         // convert the duration (whatever it is) to a duration in seconds encoded as double
         return std::chrono::duration<double>(d).count();
     }
 
-    void getRenderTarget(FView const& view,
-            backend::TargetBufferFlags& outAttachementMask,
-            backend::Handle<backend::HwRenderTarget>& outTarget) const noexcept;
+    std::pair<backend::Handle<backend::HwRenderTarget>, backend::TargetBufferFlags>
+            getRenderTarget(FView const& view) const noexcept;
 
     void recordHighWatermark(size_t watermark) noexcept {
         mCommandsHighWatermark = std::max(mCommandsHighWatermark, watermark);


### PR DESCRIPTION
When more than one view was used, only the first view was cleared with the ClearOption. This was actually intended when the views are rendering into the swapchain (e.g. post process disabled), but that's incorrect  when the views render into intermediate buffers.

The clear flags are now associated with the actual rendertarget.