### PR TITLE
Add fallback return to uintToColorDebug()

### DIFF
--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -125,4 +125,7 @@ vec3 uintToColorDebug(uint v) {
     } else if (v == 5u) {
         return vec3(0.0, 1.0, 1.0);     // cyan
     }
+
+    // fallback to handle "not all code-paths return" warnings
+    return vec3(0.0, 0.0, 0.0);
 }


### PR DESCRIPTION
If materials are compiled in debug (`-gd`) then the following Metal shader compilation warning appears at runtime:
```
program_source:552:1: warning: control may reach end of non-void function.
``` 
It originates from `common_graphics.fs` where `uintToColorDebug()` is missing a fallback case.