### PR TITLE
fix a race condition with acquired streams

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -152,8 +152,6 @@ public:
     struct GLStream : public HwStream {
         using HwStream::HwStream;
         struct Info {
-            // storage for the read/write textures below
-            Platform::ExternalTexture* ets = nullptr;
             GLuint width = 0;
             GLuint height = 0;
         };
@@ -347,7 +345,12 @@ private:
     std::array<GLSamplerGroup*, Program::SAMPLER_BINDING_COUNT> mSamplerBindings = {};   // 4 pointers
 
     mutable tsl::robin_map<uint32_t, GLuint> mSamplerMap;
-    mutable std::vector<GLTexture*> mExternalStreams;
+
+    // this must be accessed from the driver thread only
+    std::vector<GLTexture*> mTexturesWithStreamsAttached;
+
+    // the must be accessed from the user thread only
+    std::vector<GLStream*> mStreamsWithPendingAquiredImage;
 
     void attachStream(GLTexture* t, GLStream* stream) noexcept;
     void detachStream(GLTexture* t) noexcept;
@@ -355,7 +358,6 @@ private:
 
     OpenGLPlatform& mPlatform;
 
-    void updateStreamAcquired(GLTexture* t, DriverApi* driver) noexcept;
     void updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept;
 
     void setExternalTexture(GLTexture* t, void* image);


### PR DESCRIPTION
The race coud lead to user after free and crashes.

We now keep a list of acquired streams with pending images on the  main thread, and use that to update the streams synchronously in beginFrame. We can then enqueue a command for the driver thread that will look for that stream in the active list of textures with stream attached. Race avoided.


The previous code used the later list from both threads.