### PR TITLE
Transparency in screen-space refraction

### DIFF
--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -842,7 +842,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     PostProcessManager::ScreenSpaceRefConfig const ssrConfig = PostProcessManager::prepareMipmapSSR(
             fg, svp.width, svp.height,
-            ssReflectionsOptions.enabled ? TextureFormat::RGBA16F : TextureFormat::R11F_G11F_B10F,
+            (ssReflectionsOptions.enabled || view.getBlendMode() == View::BlendMode::TRANSLUCENT) ? TextureFormat::RGBA16F : TextureFormat::R11F_G11F_B10F,
             view.getCameraUser().getFieldOfView(Camera::Fov::VERTICAL), config.scale);
     config.ssrLodOffset = ssrConfig.lodOffset;
     blackboard["ssr"] = ssrConfig.ssr;

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -273,10 +273,11 @@ vec4 evaluateLights(const MaterialInputs material) {
     // until the very end but it costs more ALUs on mobile. The gains are
     // currently not worth the extra operations
     vec3 color = vec3(0.0);
+    float alpha = 1.0;
 
     // We always evaluate the IBL as not having one is going to be uncommon,
     // it also saves 1 shader variant
-    evaluateIBL(material, pixel, color);
+    evaluateIBL(material, pixel, color, alpha);
 
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
     evaluateDirectionalLight(material, pixel, color);
@@ -292,7 +293,11 @@ vec4 evaluateLights(const MaterialInputs material) {
     color *= material.baseColor.a;
 #endif
 
+#if defined(BLEND_MODE_OPAQUE)
+    return vec4(color, alpha);
+#else
     return vec4(color, computeDiffuseAlpha(material.baseColor.a));
+#endif
 }
 
 void addEmissive(const MaterialInputs material, inout vec4 color) {


### PR DESCRIPTION
Hi! In this PR we extended lighting calculations with the ability to retain transparency in screen-space refractive materials. That is, objects with such a material now don't show up as fully opaque in the final image when the background is cleared to `[0,0,0,0]` and `View` is set to `BlendMode::TRANSLUCENT`. 

The use-case: our users can create models and assign materials from a library of fine-tuned presets - including refractive ones. We wanted to let them create snapshots exported as PNG that look reasonable when composited on a background of any color.

It's been quite challenging to figure out how an alpha value sampled from the background should change as the "transparent ray of light" passes through an object with a given base color, transmission etc. So we'd love to hear what you think, it's a rather unconventional extension to PBR.

### More details
We chose our formulas such that results remain unchanged when sampled alpha is `1.0`. We modified `evaluateRefraction()` to take the sampled alpha channel into consideration. Texture `light_ssr` is now read into a `vec4`. For this, we had to set the texture's format to `TextureFormat::RGBA16F` when `View::BlendMode` is `TRANSLUCENT`. 
​
After the background texture is sampled, the color components (`Ft`) of the background are shifted towards white based on if we have a non-opaque sampled alpha (`at`). You can think of it as turning "transparent light" into "white light", which helps in retaining the base color of the materials.

Subsequent steps that adjust `Ft` also update `at` (base color, Fresnel, absorption, transmission).

Finally, the fragment shader only outputs the computed alpha if `BLEND_MODE_OPAQUE` is true. Other blend modes are unsupported: computed alpha value should be stored in the render target directly, alpha-compositing on top of some existing color would be incorrect and pointless. (Notice that an opaque refractive material may "cut a transparent hole" in the render target if the transparent background shows up in the refracted contents).

### Example screenshot
This is how the same snapshot looks before and after these changes - as seen in an image editor (checkerboard), and in front of colorful backgrounds.
![cylinders](https://user-images.githubusercontent.com/53563131/207054996-2a99c25e-8148-4ddb-81eb-7f753159377e.png)

The original PNGs can be downloaded from here:
[cylinders-transparency.zip](https://github.com/google/filament/files/10208304/cylinders-transparency.zip)
