### PR TITLE
Handle Vulkan and Metal shadow coordinates in the same way

### DIFF
--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -87,10 +87,7 @@ public:
         // e.g., for a texture dimension of 512, shadowDimension would be 510
         uint16_t shadowDimension = 0;
 
-        // e.g. Vulkan clip-space
-        bool clipSpaceFlipped = false;
-
-        // e.g. metal textures
+        // e.g. metal and vulkan textures
         bool textureSpaceFlipped = false;
 
         // whether we're using vsm

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -447,8 +447,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options.mapSize),
             .shadowDimension     = uint16_t(options.mapSize - 2u),
-            .clipSpaceFlipped    = engine.getBackend() == Backend::VULKAN,
-            .textureSpaceFlipped = engine.getBackend() == Backend::METAL,
+            .textureSpaceFlipped = engine.getBackend() == Backend::METAL ||
+                                   engine.getBackend() == Backend::VULKAN,
             .vsm                 = view.hasVSM()
     };
 
@@ -662,8 +662,8 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap,
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options->mapSize),
             .shadowDimension     = uint16_t(options->mapSize - 2u),
-            .clipSpaceFlipped    = engine.getBackend() == Backend::VULKAN,
-            .textureSpaceFlipped = engine.getBackend() == Backend::METAL,
+            .textureSpaceFlipped = engine.getBackend() == Backend::METAL ||
+                                   engine.getBackend() == Backend::VULKAN,
             .vsm                 = view.hasVSM()
     };
 
@@ -743,8 +743,8 @@ void ShadowMapManager::preparePointShadowMap(ShadowMap& shadowMap,
             .atlasDimension      = mTextureAtlasRequirements.size,
             .textureDimension    = uint16_t(options->mapSize),
             .shadowDimension     = uint16_t(options->mapSize), // point-lights don't have a border
-            .clipSpaceFlipped    = engine.getBackend() == Backend::VULKAN,
-            .textureSpaceFlipped = engine.getBackend() == Backend::METAL,
+            .textureSpaceFlipped = engine.getBackend() == Backend::METAL ||
+                                   engine.getBackend() == Backend::VULKAN,
             .vsm                 = view.hasVSM()
     };
 


### PR DESCRIPTION
Vulkan and Metal should be handled exactly the same within filament, when it comes to texture-space and clip-space because filament always transforms vulkan's clip-space to gl's/metal's).

Our shadow code took different paths, both equivalent though, but it's confusing.