### PR TITLE
 getNormalizedViewportCoord() now returns the logical viewport coords

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,9 @@ A new header is inserted each time a *tag* is created.
   please refer to the documentation for more details
 - Support for RGTC and BPTC texture compression
 - engine: fix TransformManager high precision mode when using transactions
-- web: added TypeScript definition for Engine.destroy
+- web: added TypeScript definition for `Engine.destroy`
+- materials: `getNormalizedViewportCoord()` now returns the logical (i.e. user) viewport
+             normalized position and keeps z reversed [⚠️ **Recompile Materials**]
 
 ## v1.30.0
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2263,7 +2263,7 @@ type aliases:
 
                  Name               |   Type   |            Description
 :-----------------------------------|:--------:|:------------------------------------
-**getResolution()**                 | float4   |  Dimensions of the view's effective viewport in pixels: `width`, `height`, `1 / width`, `1 / height`. This might be different from `View::getViewport()` for instance because of added rendering guard-bands. This can be used in conjunction with `getNormalizedViewportCoord()` to generate pixel coordinates.
+**getResolution()**                 | float4   |  Dimensions of the view's effective (physical) viewport in pixels: `width`, `height`, `1 / width`, `1 / height`. This might be different from `View::getViewport()` for instance because of added rendering guard-bands.
 **getWorldCameraPosition()**        | float3   |  Position of the camera/eye in world space
 **getWorldOffset()**                | float3   |  The shift required to obtain API-level world space
 **getTime()**                       | float    |  Current time as a remainder of 1 second. Yields a value between 0 and 1
@@ -2301,7 +2301,7 @@ The following APIs are only available from the fragment block:
 **getWorldNormalVector()**              | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
-**getNormalizedViewportCoord()**        | float3   |  Normalized viewport position (i.e. NDC coordinates normalized to [0, 1], can be used before `prepareMaterial()`)
+**getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
 **getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
 **getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required
 **getUV0()**                            | float2   |  First interpolated set of UV coordinates, only available if the uv0 attribute is required

--- a/filament/src/PerShadowMapUniforms.cpp
+++ b/filament/src/PerShadowMapUniforms.cpp
@@ -79,14 +79,12 @@ void PerShadowMapUniforms::prepareLodBias(Transaction const& transaction,
 }
 
 void PerShadowMapUniforms::prepareViewport(Transaction const& transaction,
-        backend::Viewport const& viewport,
-        uint32_t xoffset, uint32_t yoffset) noexcept {
-    const float w = float(viewport.width);
-    const float h = float(viewport.height);
+        backend::Viewport const& viewport) noexcept {
+    float2 const dimensions{ viewport.width, viewport.height };
     auto& s = edit(transaction);
-    s.resolution = float4{ w, h, 1.0f / w, 1.0f / h };
-    s.origin = float2{ viewport.left, viewport.bottom };
-    s.offset = float2{ xoffset, yoffset };
+    s.resolution = { dimensions, 1.0f / dimensions };
+    s.logicalViewportScale = 1.0f;
+    s.logicalViewportOffset = 0.0f;
 }
 
 void PerShadowMapUniforms::prepareTime(Transaction const& transaction,

--- a/filament/src/PerShadowMapUniforms.h
+++ b/filament/src/PerShadowMapUniforms.h
@@ -65,7 +65,7 @@ public:
             float bias) noexcept;
 
     static void prepareViewport(Transaction const& transaction,
-            backend::Viewport const& viewport, uint32_t xoffset, uint32_t yoffset) noexcept;
+            backend::Viewport const& viewport) noexcept;
 
     static void prepareTime(Transaction const& transaction,
             FEngine& engine, math::float4 const& userTime) noexcept;

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -100,14 +100,17 @@ void PerViewUniforms::prepareExposure(float ev100) noexcept {
     s.ev100 = ev100;
 }
 
-void PerViewUniforms::prepareViewport(const filament::Viewport& viewport,
-        uint32_t xoffset, uint32_t yoffset) noexcept {
-    const float w = float(viewport.width);
-    const float h = float(viewport.height);
+void PerViewUniforms::prepareViewport(
+        const filament::Viewport& physicalViewport,
+        const filament::Viewport& logicalViewport) noexcept {
+    float4 const physical{ physicalViewport.left, physicalViewport.bottom,
+                           physicalViewport.width, physicalViewport.height };
+    float4 const logical{ logicalViewport.left, logicalViewport.bottom,
+                          logicalViewport.width, logicalViewport.height };
     auto& s = mUniforms.edit();
-    s.resolution = float4{ w, h, 1.0f / w, 1.0f / h };
-    s.origin = float2{ viewport.left, viewport.bottom };
-    s.offset = float2{ xoffset, yoffset };
+    s.resolution = { physical.zw, 1.0f / physical.zw };
+    s.logicalViewportScale = physical.zw / logical.zw;
+    s.logicalViewportOffset = -logical.xy / logical.zw;
 }
 
 void PerViewUniforms::prepareTime(FEngine& engine, math::float4 const& userTime) noexcept {

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -78,7 +78,9 @@ public:
      * @param yoffset   vertical rendering offset *within* the viewport.
      *                  Non-zero when we have guard bands.
      */
-    void prepareViewport(const filament::Viewport& viewport, uint32_t xoffset, uint32_t yoffset) noexcept;
+    void prepareViewport(
+            const filament::Viewport& physicalViewport,
+            const filament::Viewport& logicalViewport) noexcept;
 
     void prepareTime(FEngine& engine, math::float4 const& userTime) noexcept;
     void prepareTemporalNoise(FEngine& engine, TemporalAntiAliasingOptions const& options) noexcept;

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -194,7 +194,7 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                         out.params.viewport.height == resources.getDescriptor(data.color).height);
 
                 view.prepareViewport(static_cast<filament::Viewport&>(out.params.viewport),
-                        config.xoffset, config.yoffset);
+                        config.logicalViewport);
 
                 view.commitUniforms(driver);
 
@@ -269,8 +269,8 @@ std::pair<FrameGraphId<FrameGraphTexture>, bool> RendererUtils::refractionPass(
         input = RendererUtils::colorPass(fg, "Color Pass (opaque)", engine, view, {
                         // When rendering the opaques, we need to conserve the sample buffer,
                         // so create config that specifies the sample count.
-                        .width = config.width,
-                        .height = config.height,
+                        .width = config.physicalViewport.width,
+                        .height = config.physicalViewport.height,
                         .samples = config.msaa,
                         .format = config.hdrFormat
                 }, config, { .asSubpass = false },
@@ -292,8 +292,9 @@ std::pair<FrameGraphId<FrameGraphTexture>, bool> RendererUtils::refractionPass(
         // and we'd end up clearing the opaque pass. This scenario never happens because it is
         // prevented in Renderer.cpp's final blit.
         config.clearFlags = TargetBufferFlags::NONE;
-        output = RendererUtils::colorPass(fg, "Color Pass (transparent)", engine, view,
-                { .width = config.width, .height = config.height },
+        output = RendererUtils::colorPass(fg, "Color Pass (transparent)", engine, view, {
+                        .width = config.physicalViewport.width,
+                        .height = config.physicalViewport.height },
                 config, colorGradingConfig, pass.getExecutor(refraction, pass.end()));
 
         if (config.msaa > 1 && !colorGradingConfig.asSubpass) {

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -42,14 +42,11 @@ class RendererUtils {
 public:
 
     struct ColorPassConfig {
-        // Rendering viewport width (e.g. scaled down viewport from dynamic resolution)
-        uint32_t width;
-        // Rendering viewport height (e.g. scaled down viewport from dynamic resolution)
-        uint32_t height;
-        // Rendering offset within the viewport (e.g. non-zero when we have guard bands)
-        uint32_t xoffset;
-        // Rendering offset within the viewport (e.g. non-zero when we have guard bands)
-        uint32_t yoffset;
+        // Rendering viewport (e.g. scaled down viewport from dynamic resolution)
+        Viewport physicalViewport;
+        // Logical viewport (e.g. left-bottom non-zero when we have guard bands), origin
+        // relative to physicalViewport
+        Viewport logicalViewport;
         // dynamic resolution scale
         math::float2 scale;
         // HDR format

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -1258,7 +1258,7 @@ void ShadowMap::prepareCamera(Transaction const& transaction,
 
 void ShadowMap::prepareViewport(Transaction const& transaction,
         backend::Viewport const& viewport) noexcept {
-    PerShadowMapUniforms::prepareViewport(transaction, viewport, 0, 0);
+    PerShadowMapUniforms::prepareViewport(transaction, viewport);
 }
 
 void ShadowMap::prepareTime(Transaction const& transaction,

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -677,12 +677,13 @@ void FView::prepareCamera(FEngine& engine, const CameraInfo& cameraInfo) const n
     mPerViewUniforms.prepareCamera(engine, cameraInfo);
 }
 
-void FView::prepareViewport(const filament::Viewport& viewport,
-        uint32_t xoffset, uint32_t yoffset) const noexcept {
+void FView::prepareViewport(
+        const filament::Viewport& physicalViewport,
+        const filament::Viewport& logicalViewport) const noexcept {
     SYSTRACE_CALL();
     // TODO: we should pass viewport.{left|bottom} to the backend, so it can offset the
     //       scissor properly.
-    mPerViewUniforms.prepareViewport(viewport, xoffset, yoffset);
+    mPerViewUniforms.prepareViewport(physicalViewport, logicalViewport);
 }
 
 void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -135,7 +135,11 @@ public:
 
     void prepareUpscaler(math::float2 scale) const noexcept;
     void prepareCamera(FEngine& engine, const CameraInfo& cameraInfo) const noexcept;
-    void prepareViewport(const Viewport& viewport, uint32_t xoffset, uint32_t yoffset) const noexcept;
+
+    void prepareViewport(
+            const Viewport& physicalViewport,
+            const filament::Viewport& logicalViewport) const noexcept;
+
     void prepareShadowing(FEngine& engine, backend::DriverApi& driver,
             FScene::RenderableSoa& renderableData, FScene::LightSoa& lightData,
             CameraInfo const& cameraInfo) noexcept;

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 30;
+static constexpr size_t MATERIAL_VERSION = 31;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -61,9 +61,9 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // (i.e.: not in the post-processing materials)
     // --------------------------------------------------------------------------------------------
 
-    math::float2 origin;            // viewport left, bottom (in pixels)
-    math::float2 offset;            // rendering offset left, bottom (in pixels)
-    math::float4 resolution;        // viewport width, height, 1/width, 1/height
+    math::float4 resolution;        // physical viewport width, height, 1/width, 1/height
+    math::float2 logicalViewportScale;  // scale-factor to go from physical to logical viewport
+    math::float2 logicalViewportOffset; // offset to go from physical to logical viewport
 
     float lodBias;                  // load bias to apply to user materials
     float refractionLodOffset;

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -32,7 +32,7 @@ static_assert(CONFIG_MAX_SHADOW_CASCADES == 4,
 BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     using Type = BufferInterfaceBlock::Type;
 
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerViewUib::_name)
             .add({
             { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH },
@@ -52,9 +52,9 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // values below should only be accessed in surface materials
             // ------------------------------------------------------------------------------------
 
-            { "origin",                 0, Type::FLOAT2, Precision::HIGH },
-            { "offset",                 0, Type::FLOAT2, Precision::HIGH },
             { "resolution",             0, Type::FLOAT4, Precision::HIGH },
+            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH },
+            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH },
 
             { "lodBias",                0, Type::FLOAT                   },
             { "refractionLodOffset",    0, Type::FLOAT                   },
@@ -150,7 +150,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 }
 
 BufferInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
-    static BufferInterfaceBlock uib =  BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib =  BufferInterfaceBlock::Builder()
             .name(PerRenderableUib::_name)
             .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {},
                     "PerRenderableData", sizeof(PerRenderableData), "CONFIG_MAX_INSTANCES" }})
@@ -159,7 +159,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
 }
 
 BufferInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(LightsUib::_name)
             .add({{ "lights", CONFIG_MAX_LIGHT_COUNT,
                     BufferInterfaceBlock::Type::MAT4, Precision::HIGH }})
@@ -168,7 +168,7 @@ BufferInterfaceBlock const& UibGenerator::getLightsUib() noexcept {
 }
 
 BufferInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(ShadowUib::_name)
             .add({{ "shadows", CONFIG_MAX_SHADOWMAPS,
                     BufferInterfaceBlock::Type::STRUCT, {},
@@ -178,7 +178,7 @@ BufferInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
 }
 
 BufferInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerRenderableBoneUib::_name)
             .add({{ "bones", CONFIG_MAX_BONE_COUNT,
                     BufferInterfaceBlock::Type::STRUCT, {},
@@ -188,7 +188,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
 }
 
 BufferInterfaceBlock const& UibGenerator::getPerRenderableMorphingUib() noexcept {
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerRenderableMorphingUib::_name)
             .add({{ "weights", CONFIG_MAX_MORPH_TARGET_COUNT,
                     BufferInterfaceBlock::Type::FLOAT4 }})
@@ -197,7 +197,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableMorphingUib() noexcept
 }
 
 BufferInterfaceBlock const& UibGenerator::getFroxelRecordUib() noexcept {
-    static BufferInterfaceBlock uib = BufferInterfaceBlock::Builder()
+    static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(FroxelRecordUib::_name)
             .add({{ "records", 1024, BufferInterfaceBlock::Type::UINT4, Precision::HIGH }})
             .build();

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -60,11 +60,12 @@ highp float getUserTimeMod(float m) {
  *
  * @public-api
  */
-highp vec2 uvToRenderTargetUV(highp vec2 uv) {
+highp vec2 uvToRenderTargetUV(const highp vec2 uv) {
 #if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
-    uv.y = 1.0 - uv.y;
-#endif
+    return vec2(uv.x, 1.0 - uv.y);
+#else
     return uv;
+#endif
 }
 
 // TODO: below shouldn't be accessible from post-process materials

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -76,21 +76,23 @@ float getNdotV() {
     return shading_NoV;
 }
 
+highp vec3 getNormalizedPhysicalViewportCoord() {
+    // make sure to handle our reversed-z
+    return vec3(shading_normalizedViewportCoord, gl_FragCoord.z);
+}
+
 /**
- * Returns the normalized [0, 1] viewport coordinates with the origin at the viewport's bottom-left.
- * Z coordinate is in the [0, 1] range as well.
+ * Returns the normalized [0, 1] logical viewport coordinates with the origin at the viewport's
+ * bottom-left. Z coordinate is in the [1, 0] range (reversed).
  *
  * @public-api
  */
 highp vec3 getNormalizedViewportCoord() {
     // make sure to handle our reversed-z
-    return vec3(shading_normalizedViewportCoord, 1.0 - gl_FragCoord.z);
-}
-
-// This new version doesn't invert Z.
-// TODO: Should we make it public?
-highp vec3 getNormalizedViewportCoord2() {
-    return vec3(shading_normalizedViewportCoord, gl_FragCoord.z);
+    highp vec2 scale = frameUniforms.logicalViewportScale;
+    highp vec2 offset = frameUniforms.logicalViewportOffset;
+    highp vec2 logicalUv = shading_normalizedViewportCoord * scale + offset;
+    return vec3(logicalUv, gl_FragCoord.z);
 }
 
 #if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DYNAMIC_LIGHTING)

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -549,7 +549,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
 
     SSAOInterpolationCache interpolationCache;
 #if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED) || defined(MATERIAL_HAS_REFLECTIONS)
-    interpolationCache.uv = uvToRenderTargetUV(getNormalizedViewportCoord().xy);
+    interpolationCache.uv = uvToRenderTargetUV(getNormalizedPhysicalViewportCoord().xy);
 #endif
 
     // screen-space reflections

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -181,7 +181,7 @@ void evaluatePunctualLights(const MaterialInputs material,
 
     // Fetch the light information stored in the froxel that contains the
     // current fragment
-    FroxelParams froxel = getFroxelParams(getFroxelIndex(getNormalizedViewportCoord2()));
+    FroxelParams froxel = getFroxelParams(getFroxelIndex(getNormalizedPhysicalViewportCoord()));
 
     // Each froxel contains how many lights can influence
     // the current fragment. A froxel also contains a record offset that


### PR DESCRIPTION
It is useful when the viewport-relative coordinates of the "logical" (i.e. user) viewport are needed, for instance when generating UVs.