### PR TITLE
[vulkan] Pop markers before commands flush

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ A new header is inserted each time a *tag* is created.
              normalized position and keeps z reversed [⚠️ **Recompile Materials**]
 - backend: workaround Adreno shader compiler bug (#6355) [⚠️ **Recompile Materials**]
 - geometry: change computing tangent basis from normal vector to use Frisvad's method
-- backend: workaround marker/label pop ordering bug (6292)
+- backend: workaround marker/label pop ordering bug (#6192)
 
 ## v1.30.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ A new header is inserted each time a *tag* is created.
              normalized position and keeps z reversed [⚠️ **Recompile Materials**]
 - backend: workaround Adreno shader compiler bug (#6355) [⚠️ **Recompile Materials**]
 - geometry: change computing tangent basis from normal vector to use Frisvad's method
+- backend: workaround marker/label pop ordering bug (6292)
 
 ## v1.30.0
 

--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -157,12 +157,12 @@ bool VulkanCommands::flush() {
     // VUID-vkEndCommandBuffer-commandBuffer-01815
     // TODO: We need to order calls so that there is no outstanding label or markers.
     if (!mCurrentDebugLabel.empty()) {
-      endDebugUtilsLabel();
+        endDebugUtilsLabel();
     }
 
     // VUID-vkEndCommandBuffer-commandBuffer-00062
     if (!mCurrentDebugMarker.empty()) {
-      endDebugMarker();
+        endDebugMarker();
     }
 
     vkEndCommandBuffer(mCurrent->cmdbuffer);
@@ -316,7 +316,7 @@ void VulkanCommands::endDebugUtilsLabel() {
     if (!mCurrent->cmdbuffer) {
 	return;
     }
-    if (!mCurrentDebugLabel.empty()) {
+    if (mCurrentDebugLabel.empty()) {
 	return;
     }
 
@@ -360,7 +360,7 @@ void VulkanCommands::endDebugMarker() {
     if (!mCurrent->cmdbuffer) {
 	return;
     }
-    if (!mCurrentDebugMarker.empty()) {
+    if (mCurrentDebugMarker.empty()) {
         return;
     }
 

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -115,6 +115,26 @@ class VulkanCommands {
         // The observer's event handler can only be called during get().
         void setObserver(CommandBufferObserver* observer) { mObserver = observer; }
 
+        const std::string& getCurrentDebugLabel() { return mCurrentDebugLabel; }
+
+        // Calls vkCmdBeginDebugUtilsLabelEXT for the current command buffer.
+        void beginDebugUtilsLabel(char const* string);
+
+        // Calls vkCmdInsertDebugUtilsLabelEXT for the current command buffer.
+        void insertDebugUtilsLabel(char const* string);
+
+        // Calls vkCmdEndDebugUtilsLabelEXT for the current command buffer.
+        void endDebugUtilsLabel();
+
+        // Calls vkCmdDebugMarkerBeginEXT for the current command buffer.
+        void beginDebugMarker(char const* string);
+
+        // Calls vkCmdDebugMarkerInsertEXT for the current command buffer.
+        void insertDebugMarker(char const* string);
+
+        // Calls vkCmdDebugMarkerEndEXT for the current command buffer.
+        void endDebugMarker();
+
     private:
         static constexpr int CAPACITY = VK_MAX_COMMAND_BUFFERS;
         const VkDevice mDevice;
@@ -127,6 +147,8 @@ class VulkanCommands {
         VkSemaphore mSubmissionSignals[CAPACITY] = {};
         size_t mAvailableCount = CAPACITY;
         CommandBufferObserver* mObserver = nullptr;
+        std::string mCurrentDebugLabel;
+        std::string mCurrentDebugMarker;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -93,7 +93,6 @@ struct VulkanContext {
     VmaAllocator allocator;
     VulkanTexture* emptyTexture = nullptr;
     VulkanCommands* commands = nullptr;
-    std::string currentDebugMarker;
 };
 
 } // namespace filament::backend


### PR DESCRIPTION
The flush call to command buffer resets the mCurrent pointer in VulkanCommands such that popGroupMarker will actually trigger the creation of a new buffer.

Before we flush (and reset the client-side state), we should pop group markers if there is one.

This needs a follow-up where we need to make sure that the pop after flush should never happen.