### PR TITLE
Re-land #1 "[vulkan] Refactor vkEnumerate methods (#6423)"

### DIFF
--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -109,10 +109,9 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
 
     // Determine if the VK_EXT_debug_utils instance extension is available.
     mContext.debugUtilsSupported = false;
-    uint32_t availableExtsCount = 0;
-    vkEnumerateInstanceExtensionProperties(nullptr, &availableExtsCount, nullptr);
-    utils::FixedCapacityVector<VkExtensionProperties> availableExts(availableExtsCount);
-    vkEnumerateInstanceExtensionProperties(nullptr, &availableExtsCount, availableExts.data());
+    const FixedCapacityVector<VkExtensionProperties> availableExts = enumerate(
+            vkEnumerateInstanceExtensionProperties,
+            static_cast<const char*>(nullptr) /* pLayerName */);
     for  (const auto& extProps : availableExts) {
         if (!strcmp(extProps.extensionName, VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
             mContext.debugUtilsSupported = true;
@@ -138,10 +137,9 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
 
     constexpr size_t kMaxEnabledLayersCount = sizeof(DESIRED_LAYERS) / sizeof(DESIRED_LAYERS[0]);
 
-    uint32_t layerCount;
-    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
-    FixedCapacityVector<VkLayerProperties> availableLayers(layerCount);
-    vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
+    const FixedCapacityVector<VkLayerProperties> availableLayers = enumerate(
+            vkEnumerateInstanceLayerProperties);
+
     auto enabledLayers = FixedCapacityVector<const char*>::with_capacity(kMaxEnabledLayersCount);
     for (const auto& desired : DESIRED_LAYERS) {
         for (const VkLayerProperties& layer : availableLayers) {
@@ -158,10 +156,8 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform,
         instanceCreateInfo.ppEnabledLayerNames = enabledLayers.data();
 
         // Check if VK_EXT_validation_features is supported.
-        uint32_t availableExtsCount = 0;
-        vkEnumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation", &availableExtsCount, nullptr);
-        utils::FixedCapacityVector<VkExtensionProperties> availableExts(availableExtsCount);
-        vkEnumerateInstanceExtensionProperties("VK_LAYER_KHRONOS_validation", &availableExtsCount, availableExts.data());
+        const FixedCapacityVector<VkExtensionProperties> availableExts = enumerate(
+                vkEnumerateInstanceExtensionProperties, "VK_LAYER_KHRONOS_validation");
         for  (const auto& extProps : availableExts) {
             if (!strcmp(extProps.extensionName, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
                 validationFeaturesSupported = true;

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -89,19 +89,21 @@ uint8_t reduceSampleCount(uint8_t sampleCount, VkSampleCountFlags mask);
 #define EXPAND_ENUM_ARGS(...) EXPAND_ENUM(__VA_ARGS__, &size)
 
 template <typename OutType>
-utils::FixedCapacityVector<OutType> enumerate(VKAPI_ATTR VkResult (*func)(uint32_t*, OutType*)) {
+utils::FixedCapacityVector<OutType> enumerate(
+        VKAPI_ATTR VkResult VKAPI_CALL (*func)(uint32_t*, OutType*)) {
     EXPAND_ENUM_NO_ARGS();
 }
 
 template <typename InType, typename OutType>
 utils::FixedCapacityVector<OutType> enumerate(
-        VKAPI_ATTR VkResult (*func)(InType, uint32_t*, OutType*), InType inData) {
+        VKAPI_ATTR VkResult VKAPI_CALL (*func)(InType, uint32_t*, OutType*), InType inData) {
     EXPAND_ENUM_ARGS(inData);
 }
 
 template <typename InTypeA, typename InTypeB, typename OutType>
 utils::FixedCapacityVector<OutType> enumerate(
-        VKAPI_ATTR VkResult (*func)(InTypeA, InTypeB, uint32_t*, OutType*), InTypeA inDataA, InTypeB inDataB) {
+        VKAPI_ATTR VkResult VKAPI_CALL (*func)(InTypeA, InTypeB, uint32_t*, OutType*),
+        InTypeA inDataA, InTypeB inDataB) {
     EXPAND_ENUM_ARGS(inDataA, inDataB);
 }
 

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -89,21 +89,20 @@ uint8_t reduceSampleCount(uint8_t sampleCount, VkSampleCountFlags mask);
 #define EXPAND_ENUM_ARGS(...) EXPAND_ENUM(__VA_ARGS__, &size)
 
 template <typename OutType>
-utils::FixedCapacityVector<OutType> enumerate(
-        VKAPI_ATTR VkResult VKAPI_CALL (*func)(uint32_t*, OutType*)) {
+utils::FixedCapacityVector<OutType> enumerate(VKAPI_ATTR VkResult (*func)(uint32_t*, OutType*)) {
     EXPAND_ENUM_NO_ARGS();
 }
 
 template <typename InType, typename OutType>
 utils::FixedCapacityVector<OutType> enumerate(
-        VKAPI_ATTR VkResult VKAPI_CALL (*func)(InType, uint32_t*, OutType*), InType inData) {
+        VKAPI_ATTR VkResult (*func)(InType, uint32_t*, OutType*), InType inData) {
     EXPAND_ENUM_ARGS(inData);
 }
 
 template <typename InTypeA, typename InTypeB, typename OutType>
 utils::FixedCapacityVector<OutType> enumerate(
-        VKAPI_ATTR VkResult VKAPI_CALL (*func)(InTypeA, InTypeB, uint32_t*, OutType*),
-        InTypeA inDataA, InTypeB inDataB) {
+        VKAPI_ATTR VkResult (*func)(InTypeA, InTypeB, uint32_t*, OutType*), InTypeA inDataA,
+        InTypeB inDataB) {
     EXPAND_ENUM_ARGS(inDataA, inDataB);
 }
 

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -19,6 +19,8 @@
 
 #include <backend/DriverEnums.h>
 
+#include <utils/FixedCapacityVector.h>
+
 #include <bluevk/BlueVK.h>
 
 namespace filament::backend {
@@ -65,6 +67,47 @@ bool equivalent(const VkRect2D& a, const VkRect2D& b);
 bool equivalent(const VkExtent2D& a, const VkExtent2D& b);
 bool isDepthFormat(VkFormat format);
 uint8_t reduceSampleCount(uint8_t sampleCount, VkSampleCountFlags mask);
+
+
+// Helper function for the vkEnumerateX methods. These methods have the format of
+// VkResult vkEnumerateX(InputType1 arg1, InputTyp2 arg2, ..., uint32_t* size,
+//         OutputType* output_arg)
+// Instead of macros and explicitly listing the template params, Variadic Template was also
+// considered, but because the "variadic" part of the vk methods (i.e. the inputs) are before the
+// non-variadic parts, this breaks the template type matching logic. Hence, we use a macro approach
+// here.
+#define EXPAND_ENUM(...)\
+    uint32_t size = 0;\
+    VkResult result = func(__VA_ARGS__, nullptr);\
+    ASSERT_POSTCONDITION(result == VK_SUCCESS && size > 0, "enumerate size error");\
+    utils::FixedCapacityVector<OutType> ret(size);\
+    result = func(__VA_ARGS__, ret.data());\
+    ASSERT_POSTCONDITION(result == VK_SUCCESS, "enumerate error");\
+    return std::move(ret);
+
+#define EXPAND_ENUM_NO_ARGS() EXPAND_ENUM(&size)
+#define EXPAND_ENUM_ARGS(...) EXPAND_ENUM(__VA_ARGS__, &size)
+
+template <typename OutType>
+utils::FixedCapacityVector<OutType> enumerate(VKAPI_ATTR VkResult (*func)(uint32_t*, OutType*)) {
+    EXPAND_ENUM_NO_ARGS();
+}
+
+template <typename InType, typename OutType>
+utils::FixedCapacityVector<OutType> enumerate(
+        VKAPI_ATTR VkResult (*func)(InType, uint32_t*, OutType*), InType inData) {
+    EXPAND_ENUM_ARGS(inData);
+}
+
+template <typename InTypeA, typename InTypeB, typename OutType>
+utils::FixedCapacityVector<OutType> enumerate(
+        VKAPI_ATTR VkResult (*func)(InTypeA, InTypeB, uint32_t*, OutType*), InTypeA inDataA, InTypeB inDataB) {
+    EXPAND_ENUM_ARGS(inDataA, inDataB);
+}
+
+#undef EXPAND_ENUM
+#undef EXPAND_ENUM_NO_ARGS
+#undef EXPAND_ENUM_ARGS
 
 } // namespace filament::backend
 


### PR DESCRIPTION
This reverts commit 6f7d203adb23dd62396646248c82ecaddec21c3b. The above commit (6f7d20) is the revert of #6423. Commit 6f7d20 is PR #6425.

"[vulkan] Refactor vkEnumerate methods (#6423)" failed [1] due to a missing function attribute (VKAPI_ATTR in bluevk) for ARM64 compilers.

[1]: https://github.com/google/filament/actions/runs/3841550984