### PR TITLE
Ortho shading fixes

### DIFF
--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -2708,7 +2708,6 @@ type aliases:
 
 </p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getResolution()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Dimensions of the view's effective viewport in pixels: <code>width</code>, <code>height</code>, <code>1 / width</code>, <code>1 / height</code>. This might be different from <code>View::getViewport()</code> for instance because of added rendering guard-bands. This can be used in conjunction with <code>getNormalizedViewportCoord()</code> to generate pixel coordinates. </td></tr>
-<tr><td style="text-align:left"> <strong class="asterisk">getWorldCameraPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the camera/eye in world space </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldOffset()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> The shift required to obtain API-level world space </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getTime()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Current time as a remainder of 1 second. Yields a value between 0 and 1 </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getUserTime()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Current time in seconds: <code>time</code>, <code>(double)time - time</code>, <code>0</code>, <code>0</code> </td></tr>
@@ -2716,16 +2715,6 @@ type aliases:
 <tr><td style="text-align:left"> <strong class="asterisk">getExposure()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Photometric exposure of the camera </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getEV100()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> <a href="https://en.wikipedia.org/wiki/Exposure_value">Exposure value at ISO 100</a> of the camera </td></tr>
 </tbody></table></div>
-
-<p></p><p>
-
-</p><div class="admonition tip"><div class="admonition-title"> world space</div>
-
-<p></p><p>
-
-    To achieve good precision, the “world space” in Filament's shading system does not necessarily
-    match the API-level world space. To obtain the position of the API-level camera, custom
-    materials can add <code>getWorldOffset()</code> to <code>getWorldCameraPosition()</code>.</p></div>
 
 <p></p>
 <a class="target" name="vertexonly">&nbsp;</a><a class="target" name="materialdefinitions/shaderpublicapis/vertexonly">&nbsp;</a><a class="target" name="toc4.5.5">&nbsp;</a><h3>Vertex only</h3>
@@ -2751,6 +2740,7 @@ The following APIs are only available from the fragment block:
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldTangentFrame()</strong> </td><td style="text-align:center"> float3×3 </td><td style="text-align:left"> Matrix containing in each column the <code>tangent</code> (<code>frame[0]</code>), <code>bi-tangent</code> (<code>frame[1]</code>) and <code>normal</code> (<code>frame[2]</code>) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the <code>normal</code> is valid in this matrix. </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the fragment in world space (see note below about world-space) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldViewVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized vector in world space from the fragment position to the eye </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldViewVectorWithMagnitude()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Vector in world space from the fragment position to the eye </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldNormalVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized normal in world space, after bump mapping (must be used after <code>prepareMaterial()</code>) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldGeometricNormalVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized normal in world space, before bump mapping (can be used before <code>prepareMaterial()</code>) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldReflectedVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Reflection of the view vector about the normal (must be used after <code>prepareMaterial()</code>) </td></tr>
@@ -2773,8 +2763,9 @@ The following APIs are only available from the fragment block:
 
 <p></p><p>
 
-    To obtain API-level world space coordinates, custom materials should add <code>getWorldOffset()</code> to
-    <code>getWorldPosition()</code> (et al).</p></div>
+    To achieve good precision, the “world space” in Filament's shading system does not necessarily
+    match the API-level world space. To obtain API-level world space coordinates, custom materials
+    should add <code>getWorldOffset()</code> to <code>getWorldPosition()</code> (et al).</p></div>
 
 <p></p><p>
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2264,18 +2264,12 @@ type aliases:
                  Name               |   Type   |            Description
 :-----------------------------------|:--------:|:------------------------------------
 **getResolution()**                 | float4   |  Dimensions of the view's effective (physical) viewport in pixels: `width`, `height`, `1 / width`, `1 / height`. This might be different from `View::getViewport()` for instance because of added rendering guard-bands.
-**getWorldCameraPosition()**        | float3   |  Position of the camera/eye in world space
 **getWorldOffset()**                | float3   |  The shift required to obtain API-level world space
 **getTime()**                       | float    |  Current time as a remainder of 1 second. Yields a value between 0 and 1
 **getUserTime()**                   | float4   |  Current time in seconds: `time`, `(double)time - time`, `0`, `0`
 **getUserTimeMode(float m)**        | float    |  Current time modulo m in seconds
 **getExposure()**                   | float    |  Photometric exposure of the camera
 **getEV100()**                      | float    |  [Exposure value at ISO 100](https://en.wikipedia.org/wiki/Exposure_value) of the camera
-
-!!! TIP: world space
-    To achieve good precision, the "world space" in Filament's shading system does not necessarily
-    match the API-level world space. To obtain the position of the API-level camera, custom
-    materials can add `getWorldOffset()` to `getWorldCameraPosition()`.
 
 ### Vertex only
 
@@ -2298,7 +2292,7 @@ The following APIs are only available from the fragment block:
 **getWorldTangentFrame()**              | float3x3 |  Matrix containing in each column the `tangent` (`frame[0]`), `bi-tangent` (`frame[1]`) and `normal` (`frame[2]`) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the `normal` is valid in this matrix.
 **getWorldPosition()**                  | float3   |  Position of the fragment in world space (see note below about world-space)
 **getWorldViewVector()**                | float3   |  Normalized vector in world space from the fragment position to the eye
-**getWorldNormalVector()**              | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
+**getWorldViewVectorWithMagnitude()**   | float3   |  Vector in world space from the fragment position to the eye**getWorldNormalVector()**              | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
 **getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
@@ -2314,8 +2308,9 @@ The following APIs are only available from the fragment block:
 **uvToRenderTargetUV(float2)**          | float2   |  Transforms a UV coordinate to allow sampling from a `RenderTarget` attachment
 
 !!! TIP: world space
-    To obtain API-level world space coordinates, custom materials should add `getWorldOffset()` to
-    `getWorldPosition()` (et al).
+    To achieve good precision, the "world space" in Filament's shading system does not necessarily
+    match the API-level world space. To obtain API-level world space coordinates, custom materials
+    should add `getWorldOffset()` to `getWorldPosition()` (et al).
 
 !!! TIP: sampling from render targets
     When sampling from a `filament::Texture` that is attached to a `filament::RenderTarget` for

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -78,6 +78,7 @@ void PerViewUniforms::prepareCamera(FEngine& engine, const CameraInfo& camera) n
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
     s.clipTransform = camera.clipTransfrom;
     s.cameraPosition = float3{ camera.getPosition() };
+    s.cameraForward = float3{ camera.getForwardVector() };
     s.worldOffset = camera.getWorldOffset();
     s.cameraFar = camera.zf;
     s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -54,8 +54,6 @@ fragment {
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        float3 p = getPosition().xyz;
-        float3 unprojected = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;
-        material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), unprojected);
+        material.eyeDirection.xyz = material.worldPosition.xyz;
     }
 }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -67,7 +67,10 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     float lodBias;                  // load bias to apply to user materials
     float refractionLodOffset;
+    float padding0;
     float padding1;
+
+    math::float3 cameraForward;
     float padding2;
 
     // camera position in view space (when camera_at_origin is enabled), i.e. it's (0,0,0).
@@ -104,7 +107,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // Directional Lighting [variant: DIR]
     // --------------------------------------------------------------------------------------------
     math::float3 lightDirection;                // directional light direction
-    float padding0;
+    float padding3;
     math::float4 lightColorIntensity;           // directional light
     math::float4 sun;                           // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
     math::float2 lightFarAttenuationParams;     // a, a/far (a=1/pct-of-far)
@@ -162,7 +165,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float ssrStride;                    // ssr texel stride, >= 1.0
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[63];
+    math::float4 reserved[62];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -58,7 +58,10 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 
             { "lodBias",                0, Type::FLOAT                   },
             { "refractionLodOffset",    0, Type::FLOAT                   },
+            { "padding0",               0, Type::FLOAT                   },
             { "padding1",               0, Type::FLOAT                   },
+
+            { "cameraForward",          0, Type::FLOAT3, Precision::HIGH },
             { "padding2",               0, Type::FLOAT                   },
 
             { "cameraPosition",         0, Type::FLOAT3, Precision::HIGH },
@@ -92,7 +95,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // Directional Lighting [variant: DIR]
             // ------------------------------------------------------------------------------------
             { "lightDirection",         0, Type::FLOAT3                  },
-            { "padding0",               0, Type::FLOAT                   },
+            { "padding3",               0, Type::FLOAT                   },
             { "lightColorIntensity",    0, Type::FLOAT4                  },
             { "sun",                    0, Type::FLOAT4                  },
             { "lightFarAttenuationParams", 0, Type::FLOAT2               },
@@ -142,7 +145,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "ssrStride",               0, Type::FLOAT                  },
 
             // bring PerViewUib to 2 KiB
-            { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4 }
+            { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4  }
             })
             .build();
 

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -281,9 +281,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             vec2 uvDy = dFdy(uv0);
 
             mat3 tangentFromWorld = transpose(getWorldTangentFrame());
-            vec3 tangentCameraPosition = tangentFromWorld * getWorldCameraPosition();
-            vec3 tangentFragPosition = tangentFromWorld * getWorldPosition();
-            vec3 v = normalize(tangentCameraPosition - tangentFragPosition);
+            vec3 v = tangentFromWorld * getWorldViewVector();
 
             float minLayers = 8.0;
             float maxLayers = 48.0;

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -80,11 +80,6 @@ highp vec4 getResolution() {
 }
 
 /** @public-api */
-highp vec3 getWorldCameraPosition() {
-    return frameUniforms.cameraPosition;
-}
-
-/** @public-api */
 highp vec3 getWorldOffset() {
     return frameUniforms.worldOffset;
 }

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -54,6 +54,10 @@ vec3 getWorldViewVector() {
     return shading_view;
 }
 
+bool isPerspectiveProjection() {
+    return frameUniforms.clipFromViewMatrix[2].w != 0.0;
+}
+
 /** @public-api */
 vec3 getWorldNormalVector() {
     return shading_normal;

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -59,6 +59,19 @@ bool isPerspectiveProjection() {
 }
 
 /** @public-api */
+vec3 getWorldViewVectorWithMagnitude() {
+    vec3 worldPosToEye = frameUniforms.cameraPosition - shading_position;
+    if (isPerspectiveProjection()) {
+        // Perspective camera
+        return worldPosToEye;
+    } else {
+        // 'Magnitude' is the signed distance from plane: (orthoEyePos, -orthoViewDir)
+        float magnitude = dot(shading_view, worldPosToEye);
+        return magnitude * shading_view;
+    }
+}
+
+/** @public-api */
 vec3 getWorldNormalVector() {
     return shading_normal;
 }

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -102,7 +102,7 @@ float getDistanceAttenuation(const highp vec3 posToLight, float falloff) {
     float distanceSquare = dot(posToLight, posToLight);
     float attenuation = getSquareFalloffAttenuation(distanceSquare, falloff);
     // light far attenuation
-    highp vec3 v = getWorldPosition() - getWorldCameraPosition();
+    highp vec3 v = -getWorldViewVectorWithMagnitude();
     float d = dot(v, v);
     attenuation *= saturate(frameUniforms.lightFarAttenuationParams.x - d * frameUniforms.lightFarAttenuationParams.y);
     // Assume a punctual light occupies a volume of 1cm to avoid a division by 0

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -42,7 +42,7 @@ void main() {
 #endif
 
 #if defined(VARIANT_HAS_FOG)
-    vec3 view = getWorldPosition() - getWorldCameraPosition();
+    vec3 view = -getWorldViewVectorWithMagnitude();
     fragColor = fog(fragColor, view);
 #endif
 

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -33,7 +33,10 @@ void computeShadingParams() {
 #endif
 
     shading_position = vertex_worldPosition.xyz;
-    shading_view = normalize(frameUniforms.cameraPosition - shading_position);
+
+    // Perspective or orthographic:
+    shading_view = isPerspectiveProjection() ? (frameUniforms.cameraPosition - shading_position) : -frameUniforms.cameraForward;
+    shading_view = normalize(shading_view);
 
     // we do this so we avoid doing (matrix multiply), but we burn 4 varyings:
     //    p = clipFromWorldMatrix * shading_position;


### PR DESCRIPTION
This PR aims to improve on some artifacts we encountered while using an orthographic camera in a Filament scene. 

### `shading_view`
In shading_parameters.fs, `shading_view` was always calculated as the (normalized) vector from the fragment position to the camera eye position (in world coordinates). But ortho cameras don't have an eye position in a sense as perspective cameras do. With orthographic projection the view direction is uniform for every fragment. Therefore we passed the camera forward direction in `PerViewUniforms`.
Note that sometimes the unnormalized view direction was used too (in other words: `shading_view` with a magnitude). Thus `getWorldViewVectorWithMagnitude()` was born. It replaces code that was dependent on the shaky 'eye position' notion with more correct

### Skyboxes
We noticed that skybox looks weird in ortho view too. In the image below the background should be a vertical gradient but instead it's focused at the center:
![image](https://user-images.githubusercontent.com/12460850/212151191-5b37dd44-3548-4b1e-bc5d-5a6aa7e559c8.png)

Based on frame captures the `eye_position` varying was miscalculated in skybox.mat. I didn't quite follow what went wrong in the maths, but saw that `computeWorldPosition()` (called in `initMaterialVertex()`) correctly calculates the world position for DEVICE domain vertex shaders (such as skybox.mat) so I reused that and now skyboxes look correct.