### PR TITLE
fix dynamic lighting with custom projections

### DIFF
--- a/filament/src/Froxelizer.h
+++ b/filament/src/Froxelizer.h
@@ -195,8 +195,20 @@ private:
             utils::Slice<RecordBufferType> const& lightList,
             const FScene::LightSoa& lightData, size_t lightRecordsOffset) noexcept;
 
+    static void updateBoundingSpheres(
+            math::float4* UTILS_RESTRICT boundingSpheres,
+            size_t froxelCountX, size_t froxelCountY, size_t froxelCountZ,
+            math::float4 const* UTILS_RESTRICT planesX,
+            math::float4 const* UTILS_RESTRICT planesY,
+            float const* UTILS_RESTRICT planesZ) noexcept;
+
+    static size_t getFroxelIndex(size_t ix, size_t iy, size_t iz,
+            size_t froxelCountX, size_t froxelCountY) noexcept {
+        return ix + (iy * froxelCountX) + (iz * froxelCountX * froxelCountY);
+    }
+
     size_t getFroxelIndex(size_t ix, size_t iy, size_t iz) const noexcept {
-        return ix + (iy * mFroxelCountX) + (iz * mFroxelCountX * mFroxelCountY);
+        return getFroxelIndex(ix, iy, iz, mFroxelCountX, mFroxelCountY);
     }
 
     size_t findSliceZ(float viewSpaceZ) const noexcept UTILS_PURE;

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -34,15 +34,22 @@ Frustum::Frustum(const mat4f& pv) {
 
 UTILS_NOINLINE
 void Frustum::setProjection(const mat4f& pv) {
+    // see: "Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix"
+    // by Gil Gribb & Klaus Hartmann
+    //
+    // Another way to think about this is that we're transforming each plane in clip-space to
+    // view-space. Such transform is performed as:
+    //      transpose(inverse(viewFromClipMatrix)), i.e.: transpose(projection)
+
     const mat4f m(transpose(pv));
 
     // Note: these "normals" are not normalized -- it's not necessary for the culling tests.
-    float4 l = -m[3] - m[0];
-    float4 r = -m[3] + m[0];
-    float4 b = -m[3] - m[1];
-    float4 t = -m[3] + m[1];
-    float4 n = -m[3] - m[2];
-    float4 f = -m[3] + m[2];
+    float4 l = -m[3] - m[0];    // m * { -1,  0,  0, -1 }
+    float4 r = -m[3] + m[0];    // m * {  1,  0,  0, -1 }
+    float4 b = -m[3] - m[1];    // m * {  0, -1,  0, -1 }
+    float4 t = -m[3] + m[1];    // m * {  0,  1,  0, -1 }
+    float4 n = -m[3] - m[2];    // m * {  0,  0, -1, -1 }
+    float4 f = -m[3] + m[2];    // m * {  0,  0,  1, -1 }
 
     // NOTE: for our box/frustum intersection routine normalizing these vectors is not required
     // however, they must be normalized for the sphere/frustum tests.
@@ -83,12 +90,12 @@ bool Frustum::intersects(const float4& sphere) const noexcept {
 }
 
 float Frustum::contains(float3 p) const noexcept {
-    float l = dot(mPlanes[0].xyz, p) + mPlanes[0].w;
-    float b = dot(mPlanes[1].xyz, p) + mPlanes[1].w;
-    float r = dot(mPlanes[2].xyz, p) + mPlanes[2].w;
-    float t = dot(mPlanes[3].xyz, p) + mPlanes[3].w;
-    float f = dot(mPlanes[4].xyz, p) + mPlanes[4].w;
-    float n = dot(mPlanes[5].xyz, p) + mPlanes[5].w;
+    float const l = dot(mPlanes[0].xyz, p) + mPlanes[0].w;
+    float const b = dot(mPlanes[1].xyz, p) + mPlanes[1].w;
+    float const r = dot(mPlanes[2].xyz, p) + mPlanes[2].w;
+    float const t = dot(mPlanes[3].xyz, p) + mPlanes[3].w;
+    float const f = dot(mPlanes[4].xyz, p) + mPlanes[4].w;
+    float const n = dot(mPlanes[5].xyz, p) + mPlanes[5].w;
     float d = l;
     d = std::max(d, b);
     d = std::max(d, r);

--- a/filament/src/Intersections.h
+++ b/filament/src/Intersections.h
@@ -38,44 +38,30 @@ inline constexpr math::float4 spherePlaneIntersection(math::float4 s, math::floa
 }
 
 // sphere radius must be squared
-// plane equation must be normalized and have the form {x,0,z,0}, sphere radius must be squared
-// return float4.w <= 0 if no intersection
-inline float spherePlaneDistanceSquared(math::float4 s, float px, float pz) noexcept {
-    return spherePlaneIntersection(s, { px, 0.f, pz, 0.f }).w;
-}
-
-// sphere radius must be squared
-// plane equation must be normalized and have the form {0,y,z,0}, sphere radius must be squared
-// return float4.w <= 0 if no intersection
-inline math::float4 spherePlaneIntersection(math::float4 s, float py, float pz) noexcept {
-    return spherePlaneIntersection(s, { 0.f, py, pz, 0.f });
-}
-
-// sphere radius must be squared
 // plane equation must be normalized and have the form {0,0,1,w}, sphere radius must be squared
 // return float4.w <= 0 if no intersection
-inline math::float4 spherePlaneIntersection(math::float4 s, float pw) noexcept {
+inline constexpr math::float4 spherePlaneIntersection(math::float4 s, float pw) noexcept {
     return spherePlaneIntersection(s, { 0.f, 0.f, 1.f, pw });
 }
 
 // sphere radius must be squared
 // this version returns a false-positive intersection in a small area near the origin
 // of the cone extended outward by the sphere's radius.
-inline bool sphereConeIntersectionFast(
+inline constexpr bool sphereConeIntersectionFast(
         math::float4 const& sphere,
         math::float3 const& conePosition,
         math::float3 const& coneAxis,
         float coneSinInverse,
         float coneCosSquared) noexcept {
     const math::float3 u = conePosition - (sphere.w * coneSinInverse) * coneAxis;
-    math::float3 d = sphere.xyz - u;
-    float e = dot(coneAxis, d);
-    float dd = dot(d, d);
+    math::float3 const d = sphere.xyz - u;
+    float const e = dot(coneAxis, d);
+    float const dd = dot(d, d);
     // we do the e>0 last here to avoid a branch
     return (e * e >= dd * coneCosSquared && e > 0);
 }
 
-inline bool sphereConeIntersection(
+inline constexpr bool sphereConeIntersection(
         math::float4 const& sphere,
         math::float3 const& conePosition,
         math::float3 const& coneAxis,
@@ -83,15 +69,32 @@ inline bool sphereConeIntersection(
         float coneCosSquared) noexcept {
     if (sphereConeIntersectionFast(sphere,
             conePosition, coneAxis, coneSinInverse, coneCosSquared)) {
-        math::float3 d = sphere.xyz - conePosition;
-        float e = -dot(coneAxis, d);
-        float dd = dot(d, d);
+        math::float3 const d = sphere.xyz - conePosition;
+        float const e = -dot(coneAxis, d);
+        float const dd = dot(d, d);
         if (e * e >= dd * (1 - coneCosSquared) && e > 0) {
             return dd <= sphere.w * sphere.w;
         }
         return true;
     }
     return false;
+}
+
+// returns the intersection of 3 planes.
+// Assumes all planes are intersecting.
+//
+// 3-planes intersection:
+//      -d0.(n1 x n2) - d1.(n2 x n0) - d2.(n0 x n1)
+// P = ---------------------------------------------
+//                      n0.(n1 x n2)
+inline constexpr math::float3 planeIntersection(
+        math::float4 const& p0,
+        math::float4 const& p1,
+        math::float4 const& p2) noexcept {
+    auto const c0 = cross(p1.xyz, p2.xyz);
+    auto const c1 = cross(p2.xyz, p0.xyz);
+    auto const c2 = cross(p0.xyz, p1.xyz);
+    return -(p0.w * c0 + p1.w * c1 + p2.w * c2) * (1.0f / dot(p0.xyz, c0));
 }
 
 } // namespace filament


### PR DESCRIPTION
Forxelization made many assumptions about the shape of the projection
matrix, the gist of these fixes is to remove those assumptions.

Fix https://github.com/google/filament/issues/6390