### PR TITLE
reenable compute in the GL backend

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3200,8 +3200,14 @@ void OpenGLDriver::dispatchCompute(Handle<HwProgram> program, math::uint3 workGr
     useProgram(p);
 
 #if defined(GL_ES_VERSION_3_1) || defined(GL_VERSION_4_3)
-    // FIXME: this line is commented-out for now due to issues switching G3 clients to API 21.
-    // glDispatchCompute(workGroupCount.x, workGroupCount.y, workGroupCount.z);
+
+#if defined(__ANDROID__)
+    // on Android, GLES3.1 and above entry-points are defined in glext
+    // (this is temporary, until we phase-out API < 21)
+    using glext::glDispatchCompute;
+#endif
+
+    glDispatchCompute(workGroupCount.x, workGroupCount.y, workGroupCount.z);
 #endif
 
 #ifdef FILAMENT_ENABLE_MATDBG

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -49,6 +49,12 @@ PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
 
+#if defined(__ANDROID__)
+// On Android, If we want to support a build system less than ANDROID_API 21, we need to
+// use getProcAddress for ES3.1 and above entry points.
+PFNGLDISPATCHCOMPUTEPROC glDispatchCompute;
+#endif
+
 static std::once_flag sGlExtInitialized;
 
 void importGLESExtensionsEntryPoints() {
@@ -108,6 +114,12 @@ void importGLESExtensionsEntryPoints() {
     glClipControl =
             (PFNGLCLIPCONTROLEXTPROC)eglGetProcAddress(
                     "glClipControlEXT");
+#endif
+
+#if defined(__ANDROID__)
+    glDispatchCompute =
+            (PFNGLDISPATCHCOMPUTEPROC)eglGetProcAddress(
+                    "glDispatchCompute");
 #endif
 }
 

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -58,6 +58,9 @@
 #ifdef GL_EXT_clip_control
         extern PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
+#if defined(__ANDROID__)
+        extern PFNGLDISPATCHCOMPUTEPROC glDispatchCompute;
+#endif
     }
 
     using namespace glext;


### PR DESCRIPTION
We do some shenanigans so it works with API < 21 on android.