### PR TITLE
Fix skybox shader in orthographic view

### DIFF
--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -54,8 +54,6 @@ fragment {
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        float3 p = getPosition().xyz;
-        float3 unprojected = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;
-        material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), unprojected);
+        material.eyeDirection.xyz = material.worldPosition.xyz;
     }
 }


### PR DESCRIPTION
We noticed that skybox looks weird in ortho view too. In the image below the background should be a vertical gradient but instead it's focused at the center:
![image](https://user-images.githubusercontent.com/12460850/212151191-5b37dd44-3548-4b1e-bc5d-5a6aa7e559c8.png)

Based on frame captures the `eye_position` varying was miscalculated in skybox.mat. I didn't quite follow what went wrong in the maths, but saw that `computeWorldPosition()` (called in `initMaterialVertex()`) correctly calculates the world position for DEVICE domain vertex shaders (such as skybox.mat) so I reused that and now skyboxes look correct.

Here is a before/after from gltf viewer sample (modified to use an ORTHO camera):
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/12460850/212196542-582f0c89-4291-4074-a8c3-c37f00b40cd8.png">
