### PR TITLE
Vulkan: fix `stack-use-after-scope` ASAN error in VulkanContext.cpp

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -396,12 +396,12 @@ void pruneExtensions(VkPhysicalDevice device, InstanceExtensions* instExtensions
         };
         vkGetPhysicalDeviceProperties2KHR(device, &physicalDeviceProperties2);
         driverInfo = driverProperties.driverInfo;
-    }
 
-    if (instExtensions->debugUtilsSupported) {
-        // Workaround for Mesa drivers. See issue #6192
-        if (driverInfo && strstr(driverInfo, "Mesa")) {
-            instExtensions->debugUtilsSupported = false;
+        if (instExtensions->debugUtilsSupported) {
+            // Workaround for Mesa drivers. See issue #6192
+            if (driverInfo && strstr(driverInfo, "Mesa")) {
+                instExtensions->debugUtilsSupported = false;
+            }
         }
     }
 

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -385,8 +385,8 @@ VkDevice createLogicalDevice(VkPhysicalDevice physicalDevice, const VkPhysicalDe
 // driver/device workarounds).
 void pruneExtensions(VkPhysicalDevice device, InstanceExtensions* instExtensions,
         DeviceExtensions* deviceExtensions) {
-    char* driverInfo = nullptr;
     if (vkGetPhysicalDeviceProperties2KHR) {
+        char* driverInfo = nullptr;
         VkPhysicalDeviceDriverProperties driverProperties = {
             .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
         };


### PR DESCRIPTION
`driverInfo` points to a string inside `driverProperties`, whose scope is limited to the `if` block.

```
=================================================================
==8587==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffa9f3f33c4 at pc 0x562128c65111 bp 0x7ffaa66ce010 sp 0x7ffaa66cd7d0
READ of size 1 at 0x7ffa9f3f33c4 thread T109 (FEngine::loop)
    #0 0x562128c65110 in StrstrCheck(void*, char*, char const*, char const*) third_party/llvm/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:652:5
    #1 0x562128c64dac in strstr third_party/llvm/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors.inc:669:5
    #2 0x56212b8a9689 in strstr third_party/crosstool/v18/stable/toolchain/bin/../include/c++/v1/string.h:106:10
    #3 0x56212b8a9689 in pruneExtensions third_party/filament/filament/backend/src/vulkan/VulkanContext.cpp:403:27
    #4 0x56212b8a9689 in filament::backend::VulkanContext::initialize(char const* const*, unsigned int) third_party/filament/filament/backend/src/vulkan/VulkanContext.cpp:537:5
```
