### PR TITLE
Fix a crash on Vulkan with some Adreno drivers

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -122,7 +122,18 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
     // specification constants
     out << '\n';
     generateSpecializationConstant(out, "BACKEND_FEATURE_LEVEL", 0, 1);
-    generateSpecializationConstant(out, "CONFIG_MAX_INSTANCES", 1, (int)CONFIG_MAX_INSTANCES);
+
+    if (mTargetApi == TargetApi::VULKAN) {
+        // Note: This is a hack for a hack.
+        // Vulkan doesn't fully support sizing arrays within a block with specialization constants,
+        // and since we only need to do this for a hack for WebGL, it's fine to replace it with
+        // regular constant here.
+        // We *could* leave it as a specialization constant, but this triggers a crashing bug with
+        // some Adreno drivers on Android. see: https://github.com/google/filament/issues/6444
+        out << "const int CONFIG_MAX_INSTANCES = " << (int)CONFIG_MAX_INSTANCES << ";\n";
+    } else {
+        generateSpecializationConstant(out, "CONFIG_MAX_INSTANCES", 1, (int)CONFIG_MAX_INSTANCES);
+    }
 
     out << '\n';
     out << SHADERS_COMMON_DEFINES_GLSL_DATA;


### PR DESCRIPTION
We were using a specialization constant to size an array inside an UBO interface block, which caused the crash in the Vulkan driver.

However, this specialization constant was only used to workaround a Chrome bug on WebGL. Additionally, specialized array size inside blocks are not fully supported in spirv.

This workaround simply replaces the specialization constant by a  constant on Vulkan.

Fix #6444