### PR TITLE
Sample Full PBR fixes

### DIFF
--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -281,9 +281,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             vec2 uvDy = dFdy(uv0);
 
             mat3 tangentFromWorld = transpose(getWorldTangentFrame());
-            vec3 tangentCameraPosition = tangentFromWorld * getWorldCameraPosition();
-            vec3 tangentFragPosition = tangentFromWorld * getWorldPosition();
-            vec3 v = normalize(tangentCameraPosition - tangentFragPosition);
+            vec3 v = tangentFromWorld * getWorldViewVector();
 
             float minLayers = 8.0;
             float maxLayers = 48.0;

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -295,7 +295,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             vec2 deltaUV = v.xy * heightScale / (v.z * numLayers);
             vec2 currUV = uv0;
             float height = 1.0 - textureGrad(materialParams_heightMap, currUV, uvDx, uvDy).r;
-            for (int i = 0; i < numLayers; i++) {
+            for (int i = 0; i < int(numLayers); i++) {
                 currLayerDepth += layerDepth;
                 currUV -= deltaUV;
                 height = 1.0 - textureGrad(materialParams_heightMap, currUV, uvDx, uvDy).r;

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -443,7 +443,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             .direction({0.6, -1, -0.8})
             .castShadows(true)
             .build(*engine, g_light);
-    //scene->addEntity(g_light);
+    scene->addEntity(g_light);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This PR aims to fix sample_full_pbr.

### 1: Material parsing error on startup
Material parsing fails if the directory passed to `--material` contains a height map:
 `for (int i = 0; i < numLayers; i++) {`

```metal
ERROR: 0:24: '<' :  wrong operand types: no operation '<' exists that takes a left-hand operand of type ' temp mediump int' and a right operand of type ' temp mediump float' (or there is no acceptable conversion)
ERROR: 0:24: '' : compilation terminated 
ERROR: 2 compilation errors.  No code generated.
```

### 2. Dark scene
The sun was not added to the scene (commented out).
Now it's added although for me the intensity is still way too low.

### 3. Ortho camera fixes
Parallax mapping was using camera eye position to calculate tangent-space view vector. This is problematic with ortho camera, as explained in #6453.

Since here `tangentFromWorld` is [the usual TBN matrix](https://github.com/google/filament/blob/main/shaders/src/shading_parameters.fs#L31) containing only rotation and mirroring, it is safe to use it to transform direction vectors (no need to transform eye/fragment pos to tangent space). It also keeps the vector's length, so the normalizing at the end is not needed (because `getWorldViewVector()` is already normalized)

### 4. Render target is not cleared
I couldn't figure out why. I compared this sample to shadowtest (which works fine) and I can't understand what's the difference. If I hardcode `MTLLoadActionClear` in `MetalRenderTarget::getLoadAction` the problem is solved, so it's sth about setting up the (opaque?) render pass.

sample_full_pbr does this on macOS:

https://user-images.githubusercontent.com/12460850/214685919-e3628004-56f3-4d25-a696-4e437fe2136c.mov

I am keeping this as a draft, because I need help figuring out what's going on here. I tested using the [sample_full_pbr_fixes_monkey branch](https://github.com/shapr3d/filament/compare/sample_full_pbr_fixes...shapr3d:filament:sample_full_pbr_fixes_monkey) with the following command:

`sample_full_pbr -m <FILAMENT_REPO>/assets/models/monkey <FILAMENT_REPO>assets/models/monkey/monkey.obj`