### PR TITLE
 Destroy FilamentInstance's mRoot in EntityManager

### DIFF
--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -38,8 +38,10 @@ FFilamentAsset::~FFilamentAsset() {
     releaseSourceData();
 
     // Destroy all instance objects. Instance entities / components are
-    // destroyed later in this method because they are owned by the asset.
+    // destroyed later in this method because they are owned by the asset
+    // (except for the root of the instance).
     for (FFilamentInstance* instance : mInstances) {
+        mEntityManager->destroy(instance->mRoot);
         delete instance;
     }
 


### PR DESCRIPTION
I'd appreciate a second set (or more) eyes on this. I found that some entities remained in `EntityManager` even after all the assets have been released while looking into #6481. 

Found that the [leaked entity is created][AssetLoaderCreateInstance] and set to the instance's root, but is not destroyed from `EntityManager` in the instance's destructor nor in the destructor of `FilamentAsset`. 

[AssetLoaderCreateInstance]: https://github.com/google/filament/blob/v1.31.2/libs/gltfio/src/AssetLoader.cpp#L511