### PR TITLE
We now require Vulkan 1.1 for the vulkan backend

### DIFF
--- a/filament/backend/src/vulkan/VulkanConstants.h
+++ b/filament/backend/src/vulkan/VulkanConstants.h
@@ -57,7 +57,7 @@
 constexpr struct VkAllocationCallbacks* VKALLOC = nullptr;
 
 constexpr static const int VK_REQUIRED_VERSION_MAJOR = 1;
-constexpr static const int VK_REQUIRED_VERSION_MINOR = 0;
+constexpr static const int VK_REQUIRED_VERSION_MINOR = 1;
 
 // Maximum number of VkCommandBuffer handles managed simultaneously by VulkanCommands.
 //

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -524,7 +524,7 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
 
 std::shared_ptr<spvtools::Optimizer> GLSLPostProcessor::createOptimizer(
         MaterialBuilder::Optimization optimization, Config const& config) {
-    auto optimizer = std::make_shared<spvtools::Optimizer>(SPV_ENV_UNIVERSAL_1_0);
+    auto optimizer = std::make_shared<spvtools::Optimizer>(SPV_ENV_UNIVERSAL_1_3);
 
     optimizer->SetMessageConsumer([](spv_message_level_t level,
             const char* source, const spv_position_t& position, const char* message) {

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -429,13 +429,13 @@ void GLSLTools::prepareShaderParser(MaterialBuilder::TargetApi targetApi,
             case MaterialBuilderBase::TargetApi::VULKAN:
             case MaterialBuilderBase::TargetApi::METAL:
                 shader.setEnvInput(EShSourceGlsl, stage, EShClientVulkan, version);
-                shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_0);
+                shader.setEnvClient(EShClientVulkan, EShTargetVulkan_1_1);
                 break;
             case MaterialBuilderBase::TargetApi::ALL:
                 // can't happen
                 break;
         }
-        shader.setEnvTarget(EShTargetSpv, EShTargetSpv_1_0);
+        shader.setEnvTarget(EShTargetSpv, EShTargetSpv_1_3);
     }
 }
 

--- a/libs/matdbg/src/DebugServer.cpp
+++ b/libs/matdbg/src/DebugServer.cpp
@@ -70,7 +70,7 @@ static const std::string_view kErrorHeader =
         "Connection: close\r\n\r\n";
 
 static void spirvToAsm(struct mg_connection *conn, const uint32_t* spirv, size_t size) {
-    auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
+    auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
     spv_text text = nullptr;
     const uint32_t options = SPV_BINARY_TO_TEXT_OPTION_INDENT |
             SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -114,7 +114,7 @@ CString ShaderExtractor::spirvToGLSL(ShaderModel shaderModel, const uint32_t* da
 // but please do not submit. We prefer to use the syntax that the standalone "spirv-dis" tool
 // uses, which lets us easily generate test cases for the spirv-cross project.
 CString ShaderExtractor::spirvToText(const uint32_t* begin, size_t wordCount) {
-    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_0);
+    spv_context context = spvContextCreate(SPV_ENV_UNIVERSAL_1_3);
     if (SPV_SUCCESS != spvValidateBinary(context, begin, wordCount, nullptr)) {
         spvContextDestroy(context);
         return CString("Validation failure.");


### PR DESCRIPTION
This should be backward compatible with old materials.