### PR TITLE
matdbg: refresh spirv properly

### DIFF
--- a/libs/matdbg/CMakeLists.txt
+++ b/libs/matdbg/CMakeLists.txt
@@ -59,6 +59,7 @@ endif()
 set(DUMMY_SRC "${RESOURCE_DIR}/dummy.c")
 add_custom_command(OUTPUT ${DUMMY_SRC} COMMAND echo "//" > ${DUMMY_SRC})
 
+
 add_library(matdbg_resources ${DUMMY_SRC} ${RESGEN_SOURCE})
 set_target_properties(matdbg_resources PROPERTIES FOLDER Libs)
 
@@ -81,7 +82,6 @@ target_link_libraries(${TARGET} PUBLIC
         SPIRV
         spirv-cross-glsl
         SPIRV-Tools
-        utils
         utils
 )
 

--- a/libs/matdbg/web/script.js
+++ b/libs/matdbg/web/script.js
@@ -64,12 +64,16 @@ function rebuildMaterial() {
         console.error("SPIR-V editing is not supported.");
         return;
     }
+
+    const shader = getShaderRecord(gCurrentShader);
+
     switch (getShaderAPI()) {
         case "opengl": api = 1; index = gCurrentShader.glindex; break;
-        case "vulkan": api = 2; index = gCurrentShader.vkindex; break;
+        case "vulkan": api = 2; index = gCurrentShader.vkindex; delete shader["spirv"]; break;
         case "metal":  api = 3; index = gCurrentShader.metalindex; break;
     }
-    const editedText = getShaderRecord(gCurrentShader)[gCurrentLanguage];
+
+    const editedText = shader[gCurrentLanguage];
     const byteCount = new Blob([editedText]).size;
     gSocket.send(`EDIT ${gCurrentShader.matid} ${api} ${index} ${byteCount} ${editedText}`);
 }
@@ -400,17 +404,17 @@ function selectShader(selection) {
     // Change the current language selection if necessary.
     switch (getShaderAPI(selection)) {
         case "opengl":
-            if (gCurrentLanguage != "glsl") {
+            if (gCurrentLanguage !== "glsl") {
                 gCurrentLanguage = "glsl";
             }
             break;
         case "vulkan":
-            if (gCurrentLanguage != "spirv" && gCurrentLanguage != "glsl") {
+            if (gCurrentLanguage !== "spirv" && gCurrentLanguage !== "glsl") {
                 gCurrentLanguage = "spirv";
             }
             break;
         case "metal":
-            if (gCurrentLanguage != "msl") {
+            if (gCurrentLanguage !== "msl") {
                 gCurrentLanguage = "msl";
             }
             break;


### PR DESCRIPTION
we now refresh the spirv code properly after it's rebuilt from the glsl tab.