### PR TITLE
Fix JNI after minification is applied

### DIFF
--- a/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
+++ b/android/gltfio-android/src/main/java/com/google/android/filament/gltfio/UbershaderProvider.java
@@ -20,6 +20,7 @@ import com.google.android.filament.Engine;
 import com.google.android.filament.MaterialInstance;
 import com.google.android.filament.Material;
 import com.google.android.filament.VertexBuffer;
+import com.google.android.filament.proguard.UsedByNative;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -94,6 +95,7 @@ public class UbershaderProvider implements MaterialProvider {
         nDestroyMaterials(mNativeObject);
     }
 
+    @UsedByNative("AssetLoader.cpp")
     public long getNativeObject() {
         return mNativeObject;
     }


### PR DESCRIPTION
`UbershaderProvider.getNativeObject()` is accessed from `AssetLoader.cpp`, so it must be annotated with `@UsedByNative("AssetLoader.cpp")` to avoid runtime crashes when minification is applied.

I'm able to successfully run my application with minification enabled with this change.

Closes #5954