### PR TITLE
The default render channel is now 2 instead of 0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ A new header is inserted each time a *tag* is created.
 
 - engine: fix broken picking [⚠️ **Recompile Materials to get the fix**]
 - engine: added support for sRGB swapchains. See `SwapChain.h`
+- engine: the default render channel is now 2 instead of 0
 - bluegl: support Windows32
 
 ## v1.31.3

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -307,11 +307,16 @@ public class RenderableManager {
 
         /**
          * Set the channel this renderable is associated to. There can be 4 channels.
-         * All renderables in a given channel are rendered together, regardless of anything else.
-         * They are sorted as usual withing a channel.
-         * Channels work similarly to priorities, except that they enforce the strongest ordering.
          *
-         * @param channel clamped to the range [0..3], defaults to 0.
+         * <p>All renderables in a given channel are rendered together, regardless of anything else.
+         * They are sorted as usual within a channel.</p>
+         * <p>Channels work similarly to priorities, except that they enforce the strongest
+         * ordering.</p>
+         *
+         * <p>Channels 0 and 1 may not have render primitives using a material with `refractionType`
+         * set to `screenspace`.</p>
+         *
+         * @param channel clamped to the range [0..3], defaults to 2.
          *
          * @return Builder reference for chaining calls.
          *

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -120,6 +120,12 @@ public:
         enum Result { Error = -1, Success = 0  };
 
         /**
+         * Default render channel
+         * @see Builder::channel()
+         */
+        static constexpr uint8_t DEFAULT_CHANNEL = 2u;
+
+        /**
          * Creates a builder for renderable components.
          *
          * @param count the number of primitives that will be supplied to the builder
@@ -231,10 +237,13 @@ public:
         /**
          * Set the channel this renderable is associated to. There can be 4 channels.
          * All renderables in a given channel are rendered together, regardless of anything else.
-         * They are sorted as usual withing a channel.
+         * They are sorted as usual within a channel.
          * Channels work similarly to priorities, except that they enforce the strongest ordering.
          *
-         * @param channel clamped to the range [0..3], defaults to 0.
+         * Channels 0 and 1 may not have render primitives using a material with `refractionType`
+         * set to `screenspace`.
+         *
+         * @param channel clamped to the range [0..3], defaults to 2.
          *
          * @return Builder reference for chaining calls.
          *

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -246,10 +246,13 @@ std::pair<FrameGraphId<FrameGraphTexture>, bool> RendererUtils::refractionPass(
     auto input = blackboard.get<FrameGraphTexture>("color");
     FrameGraphId<FrameGraphTexture> output;
 
-    // find the first refractive object
+    // find the first refractive object in channel 2
     RenderPass::Command const* const refraction = std::partition_point(pass.begin(), pass.end(),
             [](auto const& command) {
-                return (command.key & RenderPass::PASS_MASK) < uint64_t(RenderPass::Pass::REFRACT);
+                constexpr uint64_t mask  = RenderPass::CHANNEL_MASK | RenderPass::PASS_MASK;
+                constexpr uint64_t channel = uint64_t(RenderableManager::Builder::DEFAULT_CHANNEL) << RenderPass::CHANNEL_SHIFT;
+                constexpr uint64_t value = channel | uint64_t(RenderPass::Pass::REFRACT);
+                return (command.key & mask) < value;
             });
 
     const bool hasScreenSpaceRefraction =

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -51,7 +51,7 @@ struct RenderableManager::BuilderDetails {
     Box mAABB;
     uint8_t mLayerMask = 0x1;
     uint8_t mPriority = 0x4;
-    uint8_t mCommandChannel = 0x0;
+    uint8_t mCommandChannel = RenderableManager::Builder::DEFAULT_CHANNEL;
     uint8_t mLightChannels = 1;
     uint16_t mInstanceCount = 1;
     bool mCulling : 1;


### PR DESCRIPTION
This also fixes some potential issues with refraction when using render channels.