### PR TITLE
gltfio: Fix crash when a MIME type has no texture provider

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - engine: the default render channel is now 2 instead of 0
+- gltfio: Fix crash when a MIME type has no texture provider

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -670,11 +670,13 @@ std::pair<Texture*, CacheResult> ResourceLoader::Impl::getOrCreateTexture(FFilam
         mime = extension == "jpg" ? "image/jpeg" : "image/" + extension;
     }
 
-    TextureProvider* provider = mTextureProviders[mime];
-    if (!provider) {
+    auto foundProvider = mTextureProviders.find(mime);
+    if (foundProvider == mTextureProviders.end()) {
         slog.e << "Missing texture provider for " << mime << io::endl;
         return {};
     }
+    TextureProvider* provider = foundProvider->second;
+    assert_invariant(provider);
 
     // Check if the texture slot uses BufferView data.
     if (void** bufferViewData = bv ? &bv->buffer->data : nullptr; bufferViewData) {


### PR DESCRIPTION
`operator[]` is sneaky and inserts a `nullptr` element if it can't find a match, which led to a subsequent crash.

Fixes #6568.