### PR TITLE
Fix build errors on macOS

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -353,7 +353,7 @@ else()
             -Wgnu-conditional-omitted-operand
             -Wweak-vtables -Wnon-virtual-dtor -Wclass-varargs -Wimplicit-fallthrough
             -Wover-aligned
-            -Werror
+            -Werror -Wno-deprecated-declarations
     )
 endif()
 


### PR DESCRIPTION
Build errors are caused by deprecated enums.