### PR TITLE
geometry: clean up TangentSpaceMesh

### DIFF
--- a/libs/geometry/include/geometry/TangentSpaceMesh.h
+++ b/libs/geometry/include/geometry/TangentSpaceMesh.h
@@ -27,8 +27,7 @@ namespace geometry {
 struct TangentSpaceMeshInput;
 struct TangentSpaceMeshOutput;
 
- /* WARNING: WORK-IN-PROGRESS, PLEASE DO NOT USE */
-/**
+ /**
  * This class builds Filament-style TANGENTS buffers given an input mesh.
  *
  * This class enables the client to chose between several algorithms. The client can retrieve the
@@ -139,8 +138,8 @@ public:
          */
         Builder& operator=(Builder&& that) noexcept;
 
-        Builder(const Builder&) = delete;
-        Builder& operator=(const Builder&) = delete;
+        Builder(Builder const&) = delete;
+        Builder& operator=(Builder const&) = delete;
 
         /**
          * Client must provide this parameter
@@ -154,7 +153,7 @@ public:
          * @param stride The stride for iterating through `normals`
          * @return Builder
          */
-        Builder& normals(const filament::math::float3* normals, size_t stride = 0) noexcept;
+        Builder& normals(filament::math::float3 const* normals, size_t stride = 0) noexcept;
 
         /**
          * @param tangents The input tangents. The `w` component is for use with
@@ -162,25 +161,25 @@ public:
          * @param stride The stride for iterating through `tangents`
          * @return Builder
          */
-        Builder& tangents(const filament::math::float4* tangents, size_t stride = 0) noexcept;
+        Builder& tangents(filament::math::float4 const* tangents, size_t stride = 0) noexcept;
 
         /**
          * @param uvs The input uvs
          * @param stride The stride for iterating through `uvs`
          * @return Builder
          */
-        Builder& uvs(const filament::math::float2* uvs, size_t stride = 0) noexcept;
+        Builder& uvs(filament::math::float2 const* uvs, size_t stride = 0) noexcept;
 
         /**
          * @param positions The input positions
          * @param stride The stride for iterating through `positions`
          * @return Builder
          */
-        Builder& positions(const filament::math::float3* positions, size_t stride = 0) noexcept;
+        Builder& positions(filament::math::float3 const* positions, size_t stride = 0) noexcept;
 
         Builder& triangleCount(size_t triangleCount) noexcept;
-        Builder& triangles(const filament::math::uint3* triangles) noexcept;
-        Builder& triangles(const filament::math::ushort3* triangles) noexcept;
+        Builder& triangles(filament::math::uint3 const* triangles) noexcept;
+        Builder& triangles(filament::math::ushort3 const* triangles) noexcept;
 
         Builder& algorithm(Algorithm algorithm) noexcept;
 
@@ -215,8 +214,8 @@ public:
      */
     TangentSpaceMesh& operator=(TangentSpaceMesh&& that) noexcept;
 
-    TangentSpaceMesh(const TangentSpaceMesh&) = delete;
-    TangentSpaceMesh& operator=(const TangentSpaceMesh&) = delete;
+    TangentSpaceMesh(TangentSpaceMesh const&) = delete;
+    TangentSpaceMesh& operator=(TangentSpaceMesh const&) = delete;
 
     /**
      * Number of output vertices

--- a/libs/geometry/src/MikktspaceImpl.h
+++ b/libs/geometry/src/MikktspaceImpl.h
@@ -39,28 +39,28 @@ public:
         quatf tangentSpace;
     };
 
-    MikktspaceImpl(const TangentSpaceMeshInput* input) noexcept;
+    MikktspaceImpl(TangentSpaceMeshInput const* input) noexcept;
 
-    MikktspaceImpl(const MikktspaceImpl&) = delete;
-    MikktspaceImpl& operator=(const MikktspaceImpl&) = delete;
+    MikktspaceImpl(MikktspaceImpl const&) = delete;
+    MikktspaceImpl& operator=(MikktspaceImpl const&) = delete;
 
     void run(TangentSpaceMeshOutput* output) noexcept;
 
 private:
     static int getNumFaces(SMikkTSpaceContext const* context) noexcept;
     static int getNumVerticesOfFace(SMikkTSpaceContext const* context, int const iFace) noexcept;
-    static void getPosition(SMikkTSpaceContext const* context, float fvPosOut[], const int iFace,
-            const int iVert) noexcept;
+    static void getPosition(SMikkTSpaceContext const* context, float fvPosOut[], int const iFace,
+            int const iVert) noexcept;
     static void getNormal(SMikkTSpaceContext const* context, float fvNormOut[], int const iFace,
             int const iVert) noexcept;
-    static void getTexCoord(SMikkTSpaceContext const* context, float fvTexcOut[], const int iFace,
-            const int iVert) noexcept;
+    static void getTexCoord(SMikkTSpaceContext const* context, float fvTexcOut[], int const iFace,
+            int const iVert) noexcept;
     static void setTSpaceBasic(SMikkTSpaceContext const* context, float const fvTangent[],
             float const fSign, int const iFace, int const iVert) noexcept;
 
     static MikktspaceImpl* getThis(SMikkTSpaceContext const* context) noexcept;
 
-    inline const uint3 getTriangle(int triangleIndex) const noexcept;
+    inline const uint3 getTriangle(int const triangleIndex) const noexcept;
 
     int const mFaceCount;
     float3 const* mPositions;

--- a/libs/geometry/src/TangentSpaceMeshInternal.h
+++ b/libs/geometry/src/TangentSpaceMeshInternal.h
@@ -22,6 +22,8 @@
 #include <math/mat3.h>
 #include <math/norm.h>
 
+#include <utils/Panic.h>
+
 #include <vector>
 
 namespace filament::geometry {
@@ -32,21 +34,24 @@ using Algorithm = TangentSpaceMesh::Algorithm;
 template<typename T>
 class InternalArray {
 public:
-    void borrow(const T* ptr) noexcept {
+    void borrow(T const* ptr) {
+        assert_invariant(mAllocated.empty());
         mBorrowed = ptr;
     }
 
-    T* allocate(size_t size) noexcept {
+    T* allocate(size_t size) {
+        assert_invariant(!mBorrowed);
         mAllocated.resize(size);
         mAllocated.shrink_to_fit();
         return mAllocated.data();
     }
 
     explicit operator bool() const noexcept {
-        return !mBorrowed && mAllocated.size() > 0;
+        return !mBorrowed && !mAllocated.empty();
     }
 
     const T* get() {
+        assert_invariant((bool) this);
         if (mBorrowed) {
             return mBorrowed;
         }
@@ -55,7 +60,7 @@ public:
 
 private:
     std::vector<T> mAllocated;
-    const T* mBorrowed = nullptr;
+    T const* mBorrowed = nullptr;
 };
 
 struct TangentSpaceMeshInput {


### PR DESCRIPTION
 - Reordered the 'const var' declarations to 'var const'
 - Use std::vector for data arrays instead of manually managing allocations