### PR TITLE
Fix NaN parameters in material_sandbox

### DIFF
--- a/libs/filamentapp/include/filamentapp/IBL.h
+++ b/libs/filamentapp/include/filamentapp/IBL.h
@@ -55,6 +55,7 @@ public:
         return mSkybox;
     }
 
+    bool hasSphericalHarmonics() const { return mHasSphericalHarmonics; }
     filament::math::float3 const* getSphericalHarmonics() const { return mBands; }
 
 private:
@@ -71,6 +72,7 @@ private:
     filament::Engine& mEngine;
 
     filament::math::float3 mBands[9] = {};
+    bool mHasSphericalHarmonics = false;
 
     filament::Texture* mTexture = nullptr;
     filament::IndirectLight* mIndirectLight = nullptr;

--- a/libs/filamentapp/src/IBL.cpp
+++ b/libs/filamentapp/src/IBL.cpp
@@ -139,6 +139,7 @@ bool IBL::loadFromKtx(const std::string& prefix) {
     if (!iblKtx->getSphericalHarmonics(mBands)) {
         return false;
     }
+    mHasSphericalHarmonics = true;
 
     mIndirectLight = IndirectLight::Builder()
             .reflections(mTexture)
@@ -170,6 +171,7 @@ bool IBL::loadFromDirectory(const utils::Path& path) {
     } else {
         return false;
     }
+    mHasSphericalHarmonics = true;
 
     // Read mip-mapped cubemap
     const std::string prefix = "m";

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -333,10 +333,16 @@ static void setup(Engine* engine, View*, Scene* scene) {
     if (ibl) {
         auto& params = g_params;
         IndirectLight* const pIndirectLight = ibl->getIndirectLight();
-        params.lightDirection = IndirectLight::getDirectionEstimate(ibl->getSphericalHarmonics());
-        float4 c = pIndirectLight->getColorEstimate(ibl->getSphericalHarmonics(), params.lightDirection);
-        params.lightIntensity = c.w * pIndirectLight->getIntensity();
-        params.lightColor = c.rgb;
+        // If we loaded an equirectangular IBL, we don't have spherical harmonics. In that case,
+        // simply skip the estimates.
+        if (ibl->hasSphericalHarmonics()) {
+            params.lightDirection =
+                    IndirectLight::getDirectionEstimate(ibl->getSphericalHarmonics());
+            float4 c = pIndirectLight->getColorEstimate(
+                    ibl->getSphericalHarmonics(), params.lightDirection);
+            params.lightIntensity = c.w * pIndirectLight->getIntensity();
+            params.lightColor = c.rgb;
+        }
     }
 
     g_params.bloomOptions.dirt = FilamentApp::get().getDirtTexture();


### PR DESCRIPTION
`IndirectLight::getDirectionEstimate` and others return `NaN` if we didn't load spherical harmonics (for example, in the case of an equirectangular IBL).