### PR TITLE
Update getopt to musl-1.1's implementation

### DIFF
--- a/third_party/getopt/LICENSE
+++ b/third_party/getopt/LICENSE
@@ -1,26 +1,20 @@
-Copyright (c) 1987, 1993, 1994, 1995
-	The Regents of the University of California.  All rights reserved.
+Copyright © 2005-2014 Rich Felker, et al.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the names of the copyright holders nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
-IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third_party/getopt/include/getopt/getopt.h
+++ b/third_party/getopt/include/getopt/getopt.h
@@ -1,62 +1,31 @@
-/*
- * Copyright (c) 1987, 1993, 1994, 1995
- *	The Regents of the University of California.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the names of the copyright holders nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
- * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
-#ifndef __GETOPT_H__
-#define __GETOPT_H__
+#ifndef _GETOPT_H
+#define _GETOPT_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int opterr;   /* if error message should be printed */
-extern int optind;   /* index into parent argv vector */
-extern int optopt;   /* character checked for validity */
-extern int optreset; /* reset getopt */
-extern char *optarg; /* argument associated with option */
+int getopt(int, char * const [], const char *);
+extern char *optarg;
+extern int optind, opterr, optopt, optreset;
 
-struct option {
-  const char *name;
-  int has_arg;
-  int *flag;
-  int val;
+struct option
+{
+	const char *name;
+	int has_arg;
+	int *flag;
+	int val;
 };
 
-#define no_argument 0
-#define required_argument 1
-#define optional_argument 2
+int getopt_long(int, char *const *, const char *, const struct option *, int *);
+int getopt_long_only(int, char *const *, const char *, const struct option *, int *);
 
-int getopt(int, char **, const char *);
-
-int getopt_long(int, char **, const char *, const struct option *, int *);
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __GETOPT_H__ */
+#endif

--- a/third_party/getopt/src/getopt.c
+++ b/third_party/getopt/src/getopt.c
@@ -1,5 +1,8 @@
 #ifdef _WIN32
 #include <windows.h>
+# define weak_alias(name, aliasname) _weak_alias (name, aliasname)
+# define _weak_alias(name, aliasname) \
+	extern __typeof (name) aliasname __attribute__ ((weak, alias (#name)));
 #else
 #include <unistd.h>
 #endif

--- a/third_party/getopt/src/getopt.c
+++ b/third_party/getopt/src/getopt.c
@@ -1,139 +1,74 @@
-/*
- * Copyright (c) 1987, 1993, 1994, 1995
- *	The Regents of the University of California.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the names of the copyright holders nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
- * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
-#include <assert.h>
-#include <errno.h>
-#include <stdio.h>
+#include <unistd.h>
+#include <wchar.h>
 #include <string.h>
+#include <limits.h>
+#include <stdlib.h>
+#include "libc.h"
 
-#ifndef __P
-#define __P(x) x
-#endif
-#define _DIAGASSERT(x) assert(x)
+char *optarg;
+int optind=1, opterr=1, optopt, __optpos, __optreset=0;
 
-#ifdef __weak_alias
-__weak_alias(getopt, _getopt);
-#endif
+#define optpos __optpos
+weak_alias(__optreset, optreset);
 
-int opterr = 1, /* if error message should be printed */
-    optind = 1, /* index into parent argv vector */
-    optopt,     /* character checked for validity */
-    optreset;   /* reset getopt */
-char *optarg;   /* argument associated with option */
-
-static char *_progname __P((char *));
-
-int getopt_internal __P((int, char *const *, const char *));
-
-static char *_progname(nargv0)
-
-    char *nargv0;
+int getopt(int argc, char * const argv[], const char *optstring)
 {
-  char *tmp;
+	int i;
+	wchar_t c, d;
+	int k, l;
+	char *optchar;
 
-  _DIAGASSERT(nargv0 != NULL);
+	if (!optind || __optreset) {
+		__optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
 
-  tmp = strrchr(nargv0, '/');
-  if (tmp)
-    tmp++;
-  else
-    tmp = nargv0;
-  return (tmp);
+	if (optind >= argc || !argv[optind] || argv[optind][0] != '-' || !argv[optind][1])
+		return -1;
+	if (argv[optind][1] == '-' && !argv[optind][2])
+		return optind++, -1;
+
+	if (!optpos) optpos++;
+	if ((k = mbtowc(&c, argv[optind]+optpos, MB_LEN_MAX)) < 0) {
+		k = 1;
+		c = 0xfffd; /* replacement char */
+	}
+	optchar = argv[optind]+optpos;
+	optopt = c;
+	optpos += k;
+
+	if (!argv[optind][optpos]) {
+		optind++;
+		optpos = 0;
+	}
+
+	for (i=0; (l = mbtowc(&d, optstring+i, MB_LEN_MAX)) && d!=c; i+=l>0?l:1);
+
+	if (d != c) {
+		if (optstring[0] != ':' && opterr) {
+			write(2, argv[0], strlen(argv[0]));
+			write(2, ": illegal option: ", 18);
+			write(2, optchar, k);
+			write(2, "\n", 1);
+		}
+		return '?';
+	}
+	if (optstring[i+1] == ':') {
+		if (optind >= argc) {
+			if (optstring[0] == ':') return ':';
+			if (opterr) {
+				write(2, argv[0], strlen(argv[0]));
+				write(2, ": option requires an argument: ", 31);
+				write(2, optchar, k);
+				write(2, "\n", 1);
+			}
+			return '?';
+		}
+		optarg = argv[optind++] + optpos;
+		optpos = 0;
+	}
+	return c;
 }
 
-#define BADCH (int)'?'
-#define BADARG (int)':'
-#define EMSG ""
-
-/*
- * getopt --
- *	Parse argc/argv argument vector.
- */
-int getopt(nargc, nargv, ostr)
-
-    int nargc;
-char *const nargv[];
-const char *ostr;
-{
-  static char *__progname = 0;
-  static char *place = EMSG; /* option letter processing */
-  char *oli;                 /* option letter list index */
-  __progname = __progname ? __progname : _progname(*nargv);
-
-  _DIAGASSERT(nargv != NULL);
-  _DIAGASSERT(ostr != NULL);
-
-  if (optreset || !*place) { /* update scanning pointer */
-    optreset = 0;
-    if (optind >= nargc || *(place = nargv[optind]) != '-') {
-      place = EMSG;
-      return (-1);
-    }
-    if (place[1] && *++place == '-' /* found "--" */
-        && place[1] == '\0') {
-      ++optind;
-      place = EMSG;
-      return (-1);
-    }
-  } /* option letter okay? */
-  if ((optopt = (int)*place++) == (int)':' || !(oli = strchr(ostr, optopt))) {
-    /*
-     * if the user didn't specify '-' as an option,
-     * assume it means -1.
-     */
-    if (optopt == (int)'-')
-      return (-1);
-    if (!*place)
-      ++optind;
-    if (opterr && *ostr != ':')
-      (void)fprintf(stderr, "%s: illegal option -- %c\n", __progname, optopt);
-    return (BADCH);
-  }
-  if (*++oli != ':') { /* don't need argument */
-    optarg = NULL;
-    if (!*place)
-      ++optind;
-  } else {      /* need an argument */
-    if (*place) /* no white space */
-      optarg = place;
-    else if (nargc <= ++optind) { /* no arg */
-      place = EMSG;
-      if (*ostr == ':')
-        return (BADARG);
-      if (opterr)
-        (void)fprintf(stderr, "%s: option requires an argument -- %c\n",
-                      __progname, optopt);
-      return (BADCH);
-    } else /* white space */
-      optarg = nargv[optind];
-    place = EMSG;
-    ++optind;
-  }
-  return (optopt); /* dump back option letter */
-}
+weak_alias(getopt, __posix_getopt);

--- a/third_party/getopt/src/getopt.c
+++ b/third_party/getopt/src/getopt.c
@@ -1,8 +1,5 @@
 #ifdef _WIN32
 #include <windows.h>
-# define weak_alias(name, aliasname) _weak_alias (name, aliasname)
-# define _weak_alias(name, aliasname) \
-	extern __typeof (name) aliasname __attribute__ ((weak, alias (#name)));
 #else
 #include <unistd.h>
 #endif
@@ -16,7 +13,9 @@ char *optarg;
 int optind=1, opterr=1, optopt, __optpos, __optreset=0;
 
 #define optpos __optpos
+#ifndef _WIN32
 weak_alias(__optreset, optreset);
+#endif
 
 int getopt(int argc, char * const argv[], const char *optstring)
 {
@@ -78,4 +77,6 @@ int getopt(int argc, char * const argv[], const char *optstring)
 	return c;
 }
 
+#ifndef _WIN32
 weak_alias(getopt, __posix_getopt);
+#endif

--- a/third_party/getopt/src/getopt.c
+++ b/third_party/getopt/src/getopt.c
@@ -1,4 +1,8 @@
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 #include <wchar.h>
 #include <string.h>
 #include <limits.h>

--- a/third_party/getopt/src/getopt_long.c
+++ b/third_party/getopt/src/getopt_long.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <stddef.h>
-#include <getopt.h>
+#include <getopt/getopt.h>
 #include <stdio.h>
 
 extern int __optpos, __optreset;

--- a/third_party/getopt/src/getopt_long.c
+++ b/third_party/getopt/src/getopt_long.c
@@ -1,231 +1,59 @@
-/*
- * Copyright (c) 1987, 1993, 1994, 1996
- *	The Regents of the University of California.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. Neither the names of the copyright holders nor the names of its
- *    contributors may be used to endorse or promote products derived from
- *    this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS
- * IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
-
-#include "getopt/getopt.h"
-
-#include <assert.h>
-#include <errno.h>
+#define _GNU_SOURCE
+#include <stddef.h>
+#include <getopt.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
-extern int opterr;   /* if error message should be printed */
-extern int optind;   /* index into parent argv vector */
-extern int optopt;   /* character checked for validity */
-extern int optreset; /* reset getopt */
-extern char *optarg; /* argument associated with option */
+extern int __optpos, __optreset;
 
-#ifndef __P
-#define __P(x) x
-#endif
-#define _DIAGASSERT(x) assert(x)
-
-static char *__progname __P((char *));
-
-int getopt_internal __P((int, char *const *, const char *));
-
-static char *__progname(nargv0)
-
-    char *nargv0;
+static int __getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx, int longonly)
 {
-  char *tmp;
-
-  _DIAGASSERT(nargv0 != NULL);
-
-  tmp = strrchr(nargv0, '/');
-  if (tmp)
-    tmp++;
-  else
-    tmp = nargv0;
-  return (tmp);
+	if (!optind || __optreset) {
+		__optreset = 0;
+		__optpos = 0;
+		optind = 1;
+	}
+	if (optind >= argc || !argv[optind] || argv[optind][0] != '-') return -1;
+	if ((longonly && argv[optind][1]) ||
+		(argv[optind][1] == '-' && argv[optind][2]))
+	{
+		int i;
+		for (i=0; longopts[i].name; i++) {
+			const char *name = longopts[i].name;
+			char *opt = argv[optind]+1;
+			if (*opt == '-') opt++;
+			for (; *name && *name == *opt; name++, opt++);
+			if (*name || (*opt && *opt != '=')) continue;
+			if (*opt == '=') {
+				if (!longopts[i].has_arg) continue;
+				optarg = opt+1;
+			} else {
+				if (longopts[i].has_arg == required_argument) {
+					if (!(optarg = argv[++optind]))
+						return ':';
+				} else optarg = NULL;
+			}
+			optind++;
+			if (idx) *idx = i;
+			if (longopts[i].flag) {
+				*longopts[i].flag = longopts[i].val;
+				return 0;
+			}
+			return longopts[i].val;
+		}
+		if (argv[optind][1] == '-') {
+			optind++;
+			return '?';
+		}
+	}
+	return getopt(argc, argv, optstring);
 }
 
-#define BADCH (int)'?'
-#define BADARG (int)':'
-#define EMSG ""
-
-/*
- * getopt --
- *	Parse argc/argv argument vector.
- */
-int getopt_internal(nargc, nargv, ostr)
-
-    int nargc;
-char *const *nargv;
-const char *ostr;
+int getopt_long(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
 {
-  static char *place = EMSG; /* option letter processing */
-  char *oli;                 /* option letter list index */
-
-  _DIAGASSERT(nargv != NULL);
-  _DIAGASSERT(ostr != NULL);
-
-  if (optreset || !*place) { /* update scanning pointer */
-    optreset = 0;
-    if (optind >= nargc || *(place = nargv[optind]) != '-') {
-      place = EMSG;
-      return (-1);
-    }
-    if (place[1] && *++place == '-') { /* found "--" */
-      /* ++optind; */
-      place = EMSG;
-      return (-2);
-    }
-  } /* option letter okay? */
-  if ((optopt = (int)*place++) == (int)':' || !(oli = strchr(ostr, optopt))) {
-    /*
-     * if the user didn't specify '-' as an option,
-     * assume it means -1.
-     */
-    if (optopt == (int)'-')
-      return (-1);
-    if (!*place)
-      ++optind;
-    if (opterr && *ostr != ':')
-      (void)fprintf(stderr, "%s: illegal option -- %c\n", __progname(nargv[0]),
-                    optopt);
-    return (BADCH);
-  }
-  if (*++oli != ':') { /* don't need argument */
-    optarg = NULL;
-    if (!*place)
-      ++optind;
-  } else {      /* need an argument */
-    if (*place) /* no white space */
-      optarg = place;
-    else if (nargc <= ++optind) { /* no arg */
-      place = EMSG;
-      if ((opterr) && (*ostr != ':'))
-        (void)fprintf(stderr, "%s: option requires an argument -- %c\n",
-                      __progname(nargv[0]), optopt);
-      return (BADARG);
-    } else /* white space */
-      optarg = nargv[optind];
-    place = EMSG;
-    ++optind;
-  }
-  return (optopt); /* dump back option letter */
+	return __getopt_long(argc, argv, optstring, longopts, idx, 0);
 }
 
-#if 0
-/*
- * getopt --
- *	Parse argc/argv argument vector.
- */
-int
-getopt2(nargc, nargv, ostr)
-    int nargc;
-    char * const *nargv;
-    const char *ostr;
+int getopt_long_only(int argc, char *const *argv, const char *optstring, const struct option *longopts, int *idx)
 {
-    int retval;
-    if ((retval = getopt_internal(nargc, nargv, ostr)) == -2) {
-        retval = -1;
-        ++optind;
-    }
-    return(retval);
-}
-#endif
-
-/*
- * getopt_long --
- *	Parse argc/argv argument vector.
- */
-int getopt_long(nargc, nargv, options, long_options, index) int nargc;
-char **nargv;
-const char *options;
-const struct option *long_options;
-int *index;
-{
-  int retval;
-
-  _DIAGASSERT(nargv != NULL);
-  _DIAGASSERT(options != NULL);
-  _DIAGASSERT(long_options != NULL);
-  /* index may be NULL */
-
-  if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
-    char *current_argv = nargv[optind++] + 2, *has_equal;
-    int i, current_argv_len, match = -1;
-
-    if (*current_argv == '\0') {
-      return (-1);
-    }
-    if ((has_equal = strchr(current_argv, '=')) != NULL) {
-      current_argv_len = has_equal - current_argv;
-      has_equal++;
-    } else
-      current_argv_len = strlen(current_argv);
-
-    for (i = 0; long_options[i].name; i++) {
-      if (strncmp(current_argv, long_options[i].name, current_argv_len))
-        continue;
-
-      if (strlen(long_options[i].name) == (unsigned)current_argv_len) {
-        match = i;
-        break;
-      }
-      if (match == -1)
-        match = i;
-    }
-    if (match != -1) {
-      if (long_options[match].has_arg == required_argument ||
-          long_options[match].has_arg == optional_argument) {
-        if (has_equal)
-          optarg = has_equal;
-        else
-          optarg = nargv[optind++];
-      }
-      if ((long_options[match].has_arg == required_argument) &&
-          (optarg == NULL)) {
-        /*
-         * Missing argument, leading :
-         * indicates no error should be generated
-         */
-        if ((opterr) && (*options != ':'))
-          (void)fprintf(stderr, "%s: option requires an argument -- %s\n",
-                        __progname(nargv[0]), current_argv);
-        return (BADARG);
-      }
-    } else { /* No matching argument */
-      if ((opterr) && (*options != ':'))
-        (void)fprintf(stderr, "%s: illegal option -- %s\n",
-                      __progname(nargv[0]), current_argv);
-      return (BADCH);
-    }
-    if (long_options[match].flag) {
-      *long_options[match].flag = long_options[match].val;
-      retval = 0;
-    } else
-      retval = long_options[match].val;
-    if (index)
-      *index = match;
-  }
-  return (retval);
+	return __getopt_long(argc, argv, optstring, longopts, idx, 1);
 }

--- a/third_party/getopt/src/libc.h
+++ b/third_party/getopt/src/libc.h
@@ -1,0 +1,74 @@
+#ifndef LIBC_H
+#define LIBC_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+
+struct __libc {
+	int has_thread_pointer;
+	int can_do_threads;
+	int threaded;
+	int secure;
+	size_t *auxv;
+	volatile int threads_minus_1;
+	FILE *ofl_head;
+	int ofl_lock[2];
+	size_t tls_size;
+	size_t page_size;
+};
+
+extern size_t __hwcap;
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE libc.page_size
+#endif
+
+#if !defined(__PIC__) || (100*__GNUC__+__GNUC_MINOR__ >= 303 && !defined(__PCC__))
+
+#ifdef __PIC__
+#if __GNUC__ < 4
+#define BROKEN_VISIBILITY 1
+#endif
+#define ATTR_LIBC_VISIBILITY __attribute__((visibility("hidden")))
+#else
+#define ATTR_LIBC_VISIBILITY
+#endif
+
+extern struct __libc __libc ATTR_LIBC_VISIBILITY;
+#define libc __libc
+
+#else
+
+#define USE_LIBC_ACCESSOR
+#define ATTR_LIBC_VISIBILITY
+extern struct __libc *__libc_loc(void) __attribute__((const));
+#define libc (*__libc_loc())
+
+#endif
+
+
+/* Designed to avoid any overhead in non-threaded processes */
+void __lock(volatile int *) ATTR_LIBC_VISIBILITY;
+void __unlock(volatile int *) ATTR_LIBC_VISIBILITY;
+int __lockfile(FILE *) ATTR_LIBC_VISIBILITY;
+void __unlockfile(FILE *) ATTR_LIBC_VISIBILITY;
+#define LOCK(x) __lock(x)
+#define UNLOCK(x) __unlock(x)
+
+void __synccall(void (*)(void *), void *);
+int __setxid(int, int, int, int);
+
+extern char **__environ;
+
+#undef weak_alias
+#define weak_alias(old, new) \
+	extern __typeof(old) new __attribute__((weak))
+
+#undef LFS64_2
+#define LFS64_2(x, y) weak_alias(x, y)
+
+#undef LFS64
+#define LFS64(x) LFS64_2(x, x##64)
+
+#endif

--- a/tnt/README.md
+++ b/tnt/README.md
@@ -1,0 +1,4 @@
+Implementation from musl-1.1.0:
+https://musl.libc.org/
+https://musl.libc.org/releases.html
+


### PR DESCRIPTION
Our former implementation was rather ancient and was using unsupported features of C. This change removes build warnings.