### PR TITLE
Compute shading_view will full precision

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 fog: fixed fog height falloff and computation precision on mobile [⚠️ **Recompile Materials**]
 materials: new alphaToCoverage property can be used to control alpha to coverage behavior
+engine: fix precision issue with `shading_view` in large scenes

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -36,10 +36,10 @@ void computeShadingParams() {
 
     // With perspective camera, the view vector is cast from the fragment pos to the eye position,
     // With ortho camera, however, the view vector is the same for all fragments:
-    shading_view = isPerspectiveProjection() ?
+    highp vec3 sv = isPerspectiveProjection() ?
         (frameUniforms.cameraPosition - shading_position) :
         frameUniforms.worldFromViewMatrix[2].xyz; // ortho camera backward dir
-    shading_view = normalize(shading_view);
+    shading_view = normalize(sv);
 
     // we do this so we avoid doing (matrix multiply), but we burn 4 varyings:
     //    p = clipFromWorldMatrix * shading_position;


### PR DESCRIPTION
[`shading_view`](https://github.com/google/filament/blob/9c3304af78b67105efdced0d920407115436971b/shaders/src/common_shading.fs#L5) is not marked `highp`. This is fine, as it stores a normalized vector. However, we need to take care that we keep full precision _until_ we normalize it. Otherwise we max out the float with large scenes which leads to numerical instability.
