### PR TITLE
Metal: fix memory leak in readPixels

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1287,6 +1287,7 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
                          fromRegion:srcRegion
                         mipmapLevel:0];
         scheduleDestroy(std::move(*p));
+        delete p;
     }];
 }
 


### PR DESCRIPTION
The PixelBufferDescriptor was not being deallocated properly, which resulted in the leak. This patch explicitly deletes the PixelBufferDescriptor at the end of the callback to prevent the leak .This is necessary as the move constructor does not automatically deallocate the existing PixelBufferDescriptor.