### PR TITLE
android: fix sample-material-builder app name

### DIFF
--- a/android/samples/sample-material-builder/src/main/res/values/strings.xml
+++ b/android/samples/sample-material-builder/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-  <string name="app_name">Image-Based Lighting</string>
+  <string name="app_name">Material Builder</string>
 </resources>


### PR DESCRIPTION
fixes #6622