### PR TITLE
Android: Fix wrong package name

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/TextureLoader.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.android.filament.textured
+package com.google.android.filament.utils
 
 import android.content.res.Resources
 import android.graphics.Bitmap


### PR DESCRIPTION
Hello, I do believe this was meant to be in the `com.google.android.filament.utils` package.

There where issues copying the `android/samples/sample-textured-object` into a new sample due to having this utility under the ".textured" package.

By changing to ".utils", it has allowed me to use these functions on other samples than "`sample-textured-object`".

Best Regards,
// Daniel