### PR TITLE
vulkan: fix readPixels

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -24,6 +24,8 @@
 #include <utils/Condition.h>
 #include <utils/Mutex.h>
 
+#include <vector>
+
 namespace filament::backend {
 
 // Wrapper to enable use of shared_ptr for implementing shared ownership of low-level Vulkan fences.
@@ -114,6 +116,12 @@ class VulkanCommands {
         // Sets an observer who is notified every time a new command buffer has been made "current".
         // The observer's event handler can only be called during get().
         void setObserver(CommandBufferObserver* observer) { mObserver = observer; }
+
+        // Expose the fences to external waiters (e.g. ReadPixels).
+        std::vector<VkFence> getFences() const;
+
+        // Whether a fence provided via getFences() is still valid.
+        bool isValidFence(VkFence fence) const;
 
     private:
         static constexpr int CAPACITY = VK_MAX_COMMAND_BUFFERS;

--- a/filament/backend/src/vulkan/VulkanReadPixels.h
+++ b/filament/backend/src/vulkan/VulkanReadPixels.h
@@ -23,6 +23,9 @@
 #include <bluevk/BlueVK.h>
 #include <math/vec4.h>
 
+#include <functional>
+#include <vector>
+
 namespace filament::backend {
 
 struct VulkanContext;
@@ -32,14 +35,18 @@ class VulkanReadPixels {
 public:
     using OnReadCompleteFunction = std::function<void(PixelBufferDescriptor&&)>;
     using SelecteMemoryFunction = std::function<uint32_t(uint32_t, VkFlags)>;
+    using IsValidFenceFunction = std::function<bool(VkFence)>;
+    using FenceList = std::vector<VkFence>;
 
-    ~VulkanReadPixels() noexcept;
+    void initialize(VkDevice device) noexcept;
 
-    void initialize(VkDevice device);
+    void shutdown() noexcept;
 
     void run(VulkanRenderTarget const* srcTarget, uint32_t x, uint32_t y, uint32_t width,
             uint32_t height, uint32_t graphicsQueueFamilyIndex, PixelBufferDescriptor&& pbd,
-            VulkanTaskHandler& taskHandler, SelecteMemoryFunction const& selectMemoryFunc,
+            const FenceList& fences, VulkanTaskHandler& taskHandler,
+            SelecteMemoryFunction const& selectMemoryFunc,
+            IsValidFenceFunction const& isValidFenceFunc,
             OnReadCompleteFunction const& readCompleteFunc);
 
 private:
@@ -47,6 +54,6 @@ private:
     VkCommandPool mCommandPool = VK_NULL_HANDLE;
 };
 
-}// namespace filament::backend
+}  // namespace filament::backend
 
-#endif//TNT_FILAMENT_BACKEND_VULKANREADPIXELS_H
+#endif  // TNT_FILAMENT_BACKEND_VULKANREADPIXELS_H


### PR DESCRIPTION
 - Need to explicitly clean-up ReadPixels and not use its destructor
 - Wait on previously created fences (for the current frame) before submitting the commands for reading pixels
 - Fix passing block-scoped var into Vk