### PR TITLE
The sun disc should be computed in high quality only.

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,6 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- lighting: the sun disc was computed in low/medium quality instead of high quality. This will
+  provide performance improvements to mobile devices [⚠️ **Recompile Materials**]

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -645,9 +645,9 @@ io::sstream& CodeGenerator::generateQualityDefine(io::sstream& out, ShaderQualit
     switch (quality) {
         case ShaderQuality::DEFAULT:
             switch (mShaderModel) {
-                default:                        goto quality_normal;
-                case ShaderModel::DESKTOP:   goto quality_high;
-                case ShaderModel::MOBILE:     goto quality_low;
+                default:                   goto quality_normal;
+                case ShaderModel::DESKTOP: goto quality_high;
+                case ShaderModel::MOBILE:  goto quality_low;
             }
         case ShaderQuality::LOW:
         quality_low:

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -2,7 +2,7 @@
 // Directional light evaluation
 //------------------------------------------------------------------------------
 
-#if FILAMENT_QUALITY < FILAMENT_QUALITY_HIGH
+#if FILAMENT_QUALITY >= FILAMENT_QUALITY_HIGH
 #define SUN_AS_AREA_LIGHT
 #endif
 


### PR DESCRIPTION
This will provide a boost to mobile devices by not computing the sun disc as it was intended.