### PR TITLE
implement cascades visualization as a post-process

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - fog: added an option to disable the fog after a certain distance [⚠️ **Recompile Materials**].
 - fog: fog color now takes exposure and IBL intensity into account [⚠️ **Recompile Materials**].
+- materials: implement cascades debugging as a post-process [⚠️ **Recompile Materials**].

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -212,6 +212,7 @@ set(MATERIAL_SRCS
         src/materials/colorGrading/colorGrading.mat
         src/materials/colorGrading/colorGradingAsSubpass.mat
         src/materials/colorGrading/customResolveAsSubpass.mat
+        src/materials/debugShadowCascades.mat
         src/materials/defaultMaterial.mat
         src/materials/dof/dof.mat
         src/materials/dof/dofCoc.mat

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -242,6 +242,10 @@ public:
             FrameGraphId<FrameGraphTexture> output,
             bool reinhard, size_t kernelWidth, float sigma) noexcept;
 
+    FrameGraphId<FrameGraphTexture> debugShadowCascades(FrameGraph& fg,
+            FrameGraphId<FrameGraphTexture> input,
+            FrameGraphId<FrameGraphTexture> depth) noexcept;
+
     backend::Handle<backend::HwTexture> getOneTexture() const;
     backend::Handle<backend::HwTexture> getZeroTexture() const;
     backend::Handle<backend::HwTexture> getOneTextureArray() const;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -585,9 +585,6 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
     }
 
     uint32_t cascades = 0;
-    if (engine.debug.shadowmap.visualize_cascades) {
-        cascades |= 0x10u;
-    }
     cascades |= uint32_t(mCascadeShadowMaps.size());
     cascades |= cascadeHasVisibleShadows << 8u;
 

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -988,6 +988,12 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
     auto const depth = ppm.resolveBaseLevel(fg, "Resolved Depth Buffer",
             blackboard.get<FrameGraphTexture>("depth"));
 
+    // Debug: CSM visualisation
+    if (UTILS_UNLIKELY(engine.debug.shadowmap.visualize_cascades &&
+                       view.hasShadowing() && view.hasDirectionalLight())) {
+        input = ppm.debugShadowCascades(fg, input, depth);
+    }
+
     // TODO: DoF should be applied here, before TAA -- but if we do this it'll result in a lot of
     //       fireflies due to the instability of the highlights. This can be fixed with a
     //       dedicated TAA pass for the DoF, as explained in

--- a/filament/src/materials/debugShadowCascades.mat
+++ b/filament/src/materials/debugShadowCascades.mat
@@ -1,0 +1,80 @@
+material {
+    name : debugShadowCascades,
+    parameters : [
+        {
+            type : sampler2d,
+            name : color,
+            precision: medium
+        },
+        {
+            type : sampler2d,
+            name : depth,
+            precision: high
+        },
+        {
+            type : float4,
+            name : cascadeSplits,
+            precision: high
+        },
+        {
+            type : uint,
+            name : cascadeCount,
+            precision: high
+        }
+    ],
+    variables : [
+        vertex
+    ],
+    depthWrite : false,
+    depthCulling : false,
+    domain: postprocess
+}
+
+vertex {
+    void postProcessVertex(inout PostProcessVertexInputs postProcess) {
+        postProcess.vertex.xy = uvToRenderTargetUV(postProcess.normalizedUV);
+    }
+}
+
+fragment {
+    void dummy(){}
+
+    vec3 uintToColorDebug(uint v) {
+        if (v == 0u) {
+            return vec3(0.0, 1.0, 0.0);     // green
+        } else if (v == 1u) {
+            return vec3(0.0, 0.0, 1.0);     // blue
+        } else if (v == 2u) {
+            return vec3(1.0, 1.0, 0.0);     // yellow
+        } else if (v == 3u) {
+            return vec3(1.0, 0.0, 0.0);     // red
+        } else if (v == 4u) {
+            return vec3(1.0, 0.0, 1.0);     // purple
+        } else if (v == 5u) {
+            return vec3(0.0, 1.0, 1.0);     // cyan
+        }
+
+        // fallback to handle "not all code-paths return" warnings
+        return vec3(0.0, 0.0, 0.0);
+    }
+
+    uint getShadowCascade(highp float z) {
+        uvec4 greaterZ = uvec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
+        uint cascadeCount = frameUniforms.cascades & 0xFu;
+        return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0u, cascadeCount - 1u);
+    }
+
+    void postProcess(inout PostProcessInputs postProcess) {
+        vec4 color = textureLod(materialParams_color, variable_vertex.xy, 0.0);
+
+        // depth from the depth buffer
+        highp float depth = textureLod(materialParams_depth, variable_vertex.xy, 0.0).r;
+        // convert to view-space (linear z).
+        highp vec4 p = mulMat4x4Float3(getViewFromClipMatrix(), vec3(0, 0, depth));
+        highp float z = p.z / p.w;
+
+        color.rgb *= uintToColorDebug(getShadowCascade(z));
+        postProcess.color = color;
+    }
+}
+

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -118,7 +118,6 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // -Inf stored in unused components
     math::float4 cascadeSplits;
     // bit 0-3: cascade count
-    // bit 4: visualize cascades
     // bit 8-11: cascade has visible shadows
     uint32_t cascades;
     float reserved0;

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -110,22 +110,3 @@ vec3 heatmap(float v) {
     vec3 r = v * 2.1 - vec3(1.8, 1.14, 0.3);
     return 1.0 - r * r;
 }
-
-vec3 uintToColorDebug(uint v) {
-    if (v == 0u) {
-        return vec3(0.0, 1.0, 0.0);     // green
-    } else if (v == 1u) {
-        return vec3(0.0, 0.0, 1.0);     // blue
-    } else if (v == 2u) {
-        return vec3(1.0, 1.0, 0.0);     // yellow
-    } else if (v == 3u) {
-        return vec3(1.0, 0.0, 0.0);     // red
-    } else if (v == 4u) {
-        return vec3(1.0, 0.0, 1.0);     // purple
-    } else if (v == 5u) {
-        return vec3(0.0, 1.0, 1.0);     // cyan
-    }
-
-    // fallback to handle "not all code-paths return" warnings
-    return vec3(0.0, 0.0, 0.0);
-}

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -124,10 +124,10 @@ bool isDoubleSided() {
  * Returns the cascade index for this fragment (between 0 and CONFIG_MAX_SHADOW_CASCADES - 1).
  */
 uint getShadowCascade() {
-    vec3 viewPos = mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).xyz;
-    bvec4 greaterZ = greaterThan(frameUniforms.cascadeSplits, vec4(viewPos.z));
+    highp float z = mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).z;
+    uvec4 greaterZ = uvec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
     uint cascadeCount = frameUniforms.cascades & 0xFu;
-    return clamp(uint(dot(vec4(greaterZ), vec4(1.0))), 0u, cascadeCount - 1u);
+    return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0u, cascadeCount - 1u);
 }
 
 #if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -34,13 +34,6 @@ void main() {
 
     fragColor = evaluateMaterial(inputs);
 
-#if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING) && defined(VARIANT_HAS_SHADOWING)
-    bool visualizeCascades = bool(frameUniforms.cascades & 0x10u);
-    if (visualizeCascades) {
-        fragColor.rgb *= uintToColorDebug(getShadowCascade());
-    }
-#endif
-
 #if defined(VARIANT_HAS_FOG)
     highp vec3 view = getWorldPosition() - getWorldCameraPosition();
     fragColor = fog(fragColor, view);


### PR DESCRIPTION
this allows us to remove code from the main shaders that is basically never used, reducing shader size and runtime costs.