### PR TITLE
spirv-cross: use a reasonable float to string conversion

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -11,3 +11,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - fog: added an option to disable the fog after a certain distance [⚠️ **Recompile Materials**].
 - fog: fog color now takes exposure and IBL intensity into account [⚠️ **Recompile Materials**].
 - materials: implement cascades debugging as a post-process [⚠️ **Recompile Materials**].
+- materials: use 9 digits or less for floats [⚠️ **Recompile Materials**].

--- a/libs/utils/include/utils/ostream.h
+++ b/libs/utils/include/utils/ostream.h
@@ -107,7 +107,7 @@ private:
     friend ostream& flush(ostream& s) noexcept;
 
     enum type {
-        SHORT, USHORT, CHAR, UCHAR, INT, UINT, LONG, ULONG, LONG_LONG, ULONG_LONG, DOUBLE,
+        SHORT, USHORT, CHAR, UCHAR, INT, UINT, LONG, ULONG, LONG_LONG, ULONG_LONG, FLOAT, DOUBLE,
         LONG_DOUBLE
     };
 

--- a/libs/utils/src/ostream.cpp
+++ b/libs/utils/src/ostream.cpp
@@ -55,7 +55,8 @@ const char* ostream::getFormat(ostream::type t) const noexcept {
         case type::ULONG:       return mImpl->mShowHex ? "0x%lx"  : "%lu";
         case type::LONG_LONG:   return mImpl->mShowHex ? "0x%llx" : "%lld";
         case type::ULONG_LONG:  return mImpl->mShowHex ? "0x%llx" : "%llu";
-        case type::DOUBLE:      return "%f";
+        case type::FLOAT:       return "%.9g";
+        case type::DOUBLE:      return "%.17g";
         case type::LONG_DOUBLE: return "%Lf";
     }
 }
@@ -143,7 +144,8 @@ ostream& ostream::operator<<(unsigned long long value) noexcept {
 }
 
 ostream& ostream::operator<<(float value) noexcept {
-    return operator<<((double)value);
+    const char* format = getFormat(type::FLOAT);
+    return print(format, value);
 }
 
 ostream& ostream::operator<<(double value) noexcept {

--- a/third_party/spirv-cross/spirv_common.hpp
+++ b/third_party/spirv-cross/spirv_common.hpp
@@ -241,8 +241,29 @@ static inline void fixup_radix_point(char *str, char radix_point)
 	}
 }
 
+static inline std::string convert_to_smallest_string(float f, char locale_radix_point) {
+    char buf[16]; // e.g.: -0.12345678e-12, 16 bytes needed
+    float r;
+    for (int i = 1; i < 9; i++) {
+        sprintf(buf, "%.*g", i, f);
+        sscanf(buf, "%f", &r);
+        if (r == f) {
+            break;
+        }
+    }
+    fixup_radix_point(buf, locale_radix_point);
+
+    // Ensure that the literal is float.
+    if (!strchr(buf, '.') && !strchr(buf, 'e'))
+        strcat(buf, ".0");
+
+    return { buf };
+}
+
 inline std::string convert_to_string(float t, char locale_radix_point)
 {
+    return convert_to_smallest_string(t, locale_radix_point);
+
 	// std::to_string for floating point values is broken.
 	// Fallback to something more sane.
 	char buf[64];

--- a/third_party/spirv-cross/tnt/0001-convert-floats-to-their-smallest-string-representati.patch
+++ b/third_party/spirv-cross/tnt/0001-convert-floats-to-their-smallest-string-representati.patch
@@ -1,0 +1,34 @@
+diff --git a/third_party/spirv-cross/spirv_common.hpp b/third_party/spirv-cross/spirv_common.hpp
+index f0024d7ed..909543a24 100644
+--- a/third_party/spirv-cross/spirv_common.hpp
++++ b/third_party/spirv-cross/spirv_common.hpp
+@@ -241,8 +241,29 @@ static inline void fixup_radix_point(char *str, char radix_point)
+ 	}
+ }
+ 
++static inline std::string convert_to_smallest_string(float f, char locale_radix_point) {
++    char buf[16]; // e.g.: -0.12345678e-12, 16 bytes needed
++    float r;
++    for (int i = 1; i < 9; i++) {
++        sprintf(buf, "%.*g", i, f);
++        sscanf(buf, "%f", &r);
++        if (r == f) {
++            break;
++        }
++    }
++    fixup_radix_point(buf, locale_radix_point);
++
++    // Ensure that the literal is float.
++    if (!strchr(buf, '.') && !strchr(buf, 'e'))
++        strcat(buf, ".0");
++
++    return { buf };
++}
++
+ inline std::string convert_to_string(float t, char locale_radix_point)
+ {
++    return convert_to_smallest_string(t, locale_radix_point);
++
+ 	// std::to_string for floating point values is broken.
+ 	// Fallback to something more sane.
+ 	char buf[64];

--- a/third_party/spirv-cross/tnt/README.md
+++ b/third_party/spirv-cross/tnt/README.md
@@ -8,6 +8,7 @@ curl -L https://github.com/KhronosGroup/SPIRV-Cross/archive/master.zip > master.
 unzip master.zip
 rsync -r SPIRV-Cross-master/ spirv-cross/ --delete
 git checkout spirv-cross/tnt/*
+patch -p2 < spirv-cross/tnt/0001-convert-floats-to-their-smallest-string-representati.patch
 rm -rf SPIRV-Cross-master master.zip
 git add spirv-cross
 ```
@@ -23,6 +24,7 @@ The Filament-specific `CMakeLists.txt` under the `tnt` directory has the followi
 - Removal of unused `spirv-cross` libraries
 - Removal of the `spirv-cross` executable
 - Removal of `spirv-cross` test cases
+- Added `convert_to_smallest_string` in `spirv_common.hpp` and used for float conversion
 
 To see all changes, run the following diff command from the `third_party/spirv-cross` directory:
 


### PR DESCRIPTION
We only need 9 digits, not 34, to represent floats. This reduces material packages size.