### PR TITLE
Add a missing #include <exception>

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -17,6 +17,7 @@
 #ifndef TNT_FILAMENT_CODEGENERATOR_H
 #define TNT_FILAMENT_CODEGENERATOR_H
 
+#include <exception>
 #include <iosfwd>
 #include <string>
 #include <variant>


### PR DESCRIPTION
... which is needed to avoid compilation error with recent LLVM libc++ (after https://reviews.llvm.org/D146097). Previously, symbols like std::terminate() were available through other headers (e.g. <functional>, <vector>, etc.).