### PR TITLE
Fix emscripten compilation errors and warnings

### DIFF
--- a/third_party/basisu/encoder/basisu_enc.cpp
+++ b/third_party/basisu/encoder/basisu_enc.cpp
@@ -227,7 +227,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__wasm__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{

--- a/third_party/basisu/tnt/README.md
+++ b/third_party/basisu/tnt/README.md
@@ -9,6 +9,23 @@ This folder was last updated as follows:
     rm -rf ${ver}.zip basis_new
     git add basisu ; git status
 
+!!! IMPORTANT:
+If using a version of basisu <= 1.16.3, the following patch is required:
+ https://github.com/BinomialLLC/basis_universal/commit/53372fc512e6b91c06b28fd47248f269b9b5b010
+
+!!! IMPORTANT:
+If basisu doesn't have that change, in basisu_containers.h, update the following macro:
+
+   #if defined(__GNUC__) && __GNUC__<5
+       #define BASISU_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+
+to:
+
+   #if defined(__GNUC__) && __GNUC__<5
+       #define BASISU_IS_TRIVIALLY_COPYABLE(...) __is_trivially_copyable(__VA_ARGS__)
+
+
+
 Our CMakeLists differs from the one in basisu as follows.
 
 (1)

--- a/third_party/basisu/transcoder/basisu_containers.h
+++ b/third_party/basisu/transcoder/basisu_containers.h
@@ -189,7 +189,7 @@ namespace basisu
 #define BASISU_IS_SCALAR_TYPE(T) (scalar_type<T>::cFlag)
 
 #if defined(__GNUC__) && __GNUC__<5
-   #define BASISU_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+   #define BASISU_IS_TRIVIALLY_COPYABLE(...) __is_trivially_copyable(__VA_ARGS__)
 #else
    #define BASISU_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
 #endif


### PR DESCRIPTION
These errors and warnings only appear with more recent versions of the emscripten SDK.