### PR TITLE
vulkan: Implement async readPixels

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -195,6 +195,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanStagePool.h
             src/vulkan/VulkanSwapChain.cpp
             src/vulkan/VulkanSwapChain.h
+            src/vulkan/VulkanReadPixels.cpp
+            src/vulkan/VulkanReadPixels.h
             src/vulkan/VulkanTexture.cpp
             src/vulkan/VulkanTexture.h
             src/vulkan/VulkanUtility.cpp

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -197,6 +197,7 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform, VulkanContext const& contex
     mPipelineCache.setDummyTexture(mEmptyTexture->getPrimaryImageView());
     mBlitter.initialize(mPlatform->getPhysicalDevice(), mPlatform->getDevice(), mAllocator,
             mCommands.get(), mEmptyTexture.get());
+    mReadPixels.initialize(mContext.device);
 }
 
 VulkanDriver::~VulkanDriver() noexcept = default;
@@ -227,6 +228,7 @@ void VulkanDriver::terminate() {
     mTimestamps.reset();
 
     mBlitter.terminate();
+    mReadPixels.terminate();
 
     // Allow the stage pool and disposer to clean up.
     mStagePool.gc();
@@ -292,6 +294,9 @@ void VulkanDriver::flush(int) {
 
 void VulkanDriver::finish(int dummy) {
     mCommands->flush();
+    mCommands->wait();
+
+    mReadPixels.runUntilComplete();
 }
 
 void VulkanDriver::createSamplerGroupR(Handle<HwSamplerGroup> sbh, uint32_t count) {
@@ -1398,145 +1403,18 @@ void VulkanDriver::startCapture(int) {}
 
 void VulkanDriver::stopCapture(int) {}
 
-void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
-        uint32_t width, uint32_t height, PixelBufferDescriptor&& pbd) {
-    const VkDevice device = mPlatform->getDevice();
+void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y, uint32_t width,
+        uint32_t height, PixelBufferDescriptor&& pbd) {
     VulkanRenderTarget* srcTarget = handle_cast<VulkanRenderTarget*>(src);
-    VulkanTexture* srcTexture = (VulkanTexture*) srcTarget->getColor(0).texture;
-    assert_invariant(srcTexture);
-    const VkFormat srcFormat = srcTexture->getVkFormat();
-    const bool swizzle = srcFormat == VK_FORMAT_B8G8R8A8_UNORM ||
-        srcFormat == VK_FORMAT_B8G8R8A8_SRGB;
-
-    // Create a host visible, linearly tiled image as a staging area.
-    VkImageCreateInfo imageInfo {
-        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
-        .imageType = VK_IMAGE_TYPE_2D,
-        .format = srcFormat,
-        .extent = { width, height, 1 },
-        .mipLevels = 1,
-        .arrayLayers = 1,
-        .samples = VK_SAMPLE_COUNT_1_BIT,
-        .tiling = VK_IMAGE_TILING_LINEAR,
-        .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-        .initialLayout = ImgUtil::getVkLayout(VulkanLayout::UNDEFINED),
-    };
-
-    VkImage stagingImage;
-    vkCreateImage(device, &imageInfo, VKALLOC, &stagingImage);
-
-#if FILAMENT_VULKAN_VERBOSE
-    utils::slog.d << "readPixels created image=" << stagingImage
-                  << " to copy from image=" << srcTexture->getVkImage()
-                  << " src-layout=" << srcTexture->getLayout(0, 0) << utils::io::endl;
-#endif
-
-    VkMemoryRequirements memReqs;
-    VkDeviceMemory stagingMemory;
-    vkGetImageMemoryRequirements(device, stagingImage, &memReqs);
-    VkMemoryAllocateInfo allocInfo = {
-        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-        .allocationSize = memReqs.size,
-        .memoryTypeIndex = mContext.selectMemoryType(memReqs.memoryTypeBits,
-                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT |
-                VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
-    };
-
-    vkAllocateMemory(device, &allocInfo, nullptr, &stagingMemory);
-    vkBindImageMemory(device, stagingImage, stagingMemory, 0);
-
-    // TODO: don't flush/wait here, this should be asynchronous
-
-    mCommands->flush();
-    mCommands->wait();
-
-    // Transition the staging image layout.
-    const VkCommandBuffer cmdbuffer = mCommands->get().cmdbuffer;
-    ImgUtil::transitionLayout(cmdbuffer, {
-        .image = stagingImage,
-        .oldLayout = VulkanLayout::UNDEFINED,
-        .newLayout = VulkanLayout::TRANSFER_DST,
-        .subresources = {
-            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-            .baseMipLevel = 0,
-            .levelCount = 1,
-            .baseArrayLayer = 0,
-            .layerCount = 1,
-        },
-    });
-
-    const VulkanAttachment srcAttachment = srcTarget->getColor(0);
-
-    VkImageCopy imageCopyRegion = {
-        .srcSubresource = {
-            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-            .mipLevel = srcAttachment.level,
-            .baseArrayLayer = srcAttachment.layer,
-            .layerCount = 1,
-        },
-        .srcOffset = {
-            .x = (int32_t) x,
-            .y = (int32_t) (srcTarget->getExtent().height - (height + y)),
-        },
-        .dstSubresource = {
-            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-            .layerCount = 1,
-        },
-        .extent = {
-            .width = width,
-            .height = height,
-            .depth = 1,
-        },
-    };
-
-    // Transition the source image layout (which might be the swap chain)
-
-    const VkImageSubresourceRange srcRange
-            = srcAttachment.getSubresourceRange(VK_IMAGE_ASPECT_COLOR_BIT);
-    srcTexture->transitionLayout(cmdbuffer, srcRange, VulkanLayout::TRANSFER_SRC);
-
-    // Perform the copy into the staging area. At this point we know that the src layout is
-    // TRANSFER_SRC_OPTIMAL and the staging area is GENERAL.
-
-    UTILS_UNUSED_IN_RELEASE VkExtent2D srcExtent = srcAttachment.getExtent2D();
-    assert_invariant(imageCopyRegion.srcOffset.x + imageCopyRegion.extent.width <= srcExtent.width);
-    assert_invariant(imageCopyRegion.srcOffset.y + imageCopyRegion.extent.height <= srcExtent.height);
-
-    vkCmdCopyImage(cmdbuffer, srcAttachment.getImage(),
-            ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), stagingImage,
-            ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 1, &imageCopyRegion);
-
-    // Restore the source image layout. Between driver API calls, color images are always kept in
-    // UNDEFINED layout or in their "usage default" layout.
-
-    srcTexture->transitionLayout(cmdbuffer, srcRange, VulkanLayout::COLOR_ATTACHMENT);
-
-    // TODO: don't flush/wait here -- we should do this asynchronously
-
-    // Flush and wait.
-    mCommands->flush();
-    mCommands->wait();
-
-    VkImageSubresource subResource { .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT };
-    VkSubresourceLayout subResourceLayout;
-    vkGetImageSubresourceLayout(device, stagingImage, &subResource, &subResourceLayout);
-
-    // Map image memory so we can start copying from it.
-
-    const uint8_t* srcPixels;
-    vkMapMemory(device, stagingMemory, 0, VK_WHOLE_SIZE, 0, (void**) &srcPixels);
-    srcPixels += subResourceLayout.offset;
-
-    if (!DataReshaper::reshapeImage(&pbd, getComponentType(srcFormat), getComponentCount(srcFormat),
-                srcPixels, subResourceLayout.rowPitch, width, height, swizzle)) {
-        utils::slog.e << "Unsupported PixelDataFormat or PixelDataType" << utils::io::endl;
-    }
-
-    vkUnmapMemory(device, stagingMemory);
-    vkDestroyImage(device, stagingImage, nullptr);
-    vkFreeMemory(device, stagingMemory, nullptr);
-
-    scheduleDestroy(std::move(pbd));
+    mContext.commands->flush();
+    mReadPixels.run(
+            srcTarget, x, y, width, height, mContext.graphicsQueueFamilyIndex, std::move(pbd),
+            [&context = mContext](uint32_t reqs, VkFlags flags) {
+                return context.selectMemoryType(reqs, flags);
+            },
+            [this](PixelBufferDescriptor&& pbd) {
+                scheduleDestroy(std::move(pbd));
+            });
 }
 
 void VulkanDriver::readBufferSubData(backend::BufferObjectHandle boh,

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -23,6 +23,7 @@
 #include "VulkanConstants.h"
 #include "VulkanContext.h"
 #include "VulkanFboCache.h"
+#include "VulkanReadPixels.h"
 #include "VulkanSamplerCache.h"
 #include "VulkanStagePool.h"
 #include "VulkanUtility.h"
@@ -158,6 +159,7 @@ private:
     VulkanSamplerCache mSamplerCache;
     VulkanBlitter mBlitter;
     VulkanSamplerGroup* mSamplerBindings[VulkanPipelineCache::SAMPLER_BINDING_COUNT] = {};
+    VulkanReadPixels mReadPixels;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanReadPixels.cpp
+++ b/filament/backend/src/vulkan/VulkanReadPixels.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanReadPixels.h"
+
+#include "DataReshaper.h"
+#include "VulkanCommands.h"
+#include "VulkanHandles.h"
+#include "VulkanTexture.h"
+
+#include <utils/Log.h>
+
+using namespace bluevk;
+
+namespace filament::backend {
+
+using TaskHandler = VulkanReadPixels::TaskHandler;
+using WorkloadFunc = TaskHandler::WorkloadFunc;
+using OnCompleteFunc = TaskHandler::OnCompleteFunc;
+
+TaskHandler::TaskHandler()
+    : mShouldStop(false),
+      mThread(&TaskHandler::loop, this) {}
+
+void TaskHandler::post(WorkloadFunc&& workload, OnCompleteFunc&& oncomplete) {
+    assert_invariant(!mShouldStop);
+    {
+        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        mTaskQueue.push(std::make_pair(std::move(workload), std::move(oncomplete)));
+    }
+    mHasTaskCondition.notify_one();
+}
+
+void TaskHandler::drain() {
+    assert_invariant(!mShouldStop);
+
+    std::mutex syncPointMutex;
+    std::condition_variable syncCondition;
+    bool done = false;
+    post([] {},
+            [&syncPointMutex, &syncCondition, &done] {
+                {
+                    std::unique_lock<std::mutex> lock(syncPointMutex);
+                    done = true;
+                }
+                syncCondition.notify_one();
+            });
+
+    std::unique_lock<std::mutex> lock(syncPointMutex);
+    syncCondition.wait(lock, [&done] { return done; });
+}
+
+void TaskHandler::shutdown() {
+    {
+        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        mShouldStop = true;
+    }
+    mHasTaskCondition.notify_one();
+    mThread.join();
+    ASSERT_POSTCONDITION(mTaskQueue.empty(),
+            "ReadPixels handler has tasks in the queue after shutdown");
+}
+
+void TaskHandler::loop() {
+    while (true) {
+        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        mHasTaskCondition.wait(lock, [this] { return !mTaskQueue.empty() || mShouldStop; });
+        if (mShouldStop) {
+            break;
+        }
+        auto [workload, oncomplete] = mTaskQueue.front();
+        mTaskQueue.pop();
+        lock.unlock();
+        workload();
+        oncomplete();
+    }
+
+    // Clean-up: we still need to call oncomplete for clients to do clean-up.
+    while (true) {
+        std::unique_lock<std::mutex> lock(mTaskQueueMutex);
+        if (mTaskQueue.empty()) {
+            break;
+        }
+        auto [workload, oncomplete] = mTaskQueue.front();
+        mTaskQueue.pop();
+        lock.unlock();
+        oncomplete();
+    }
+}
+
+void VulkanReadPixels::shutdown() noexcept {
+    assert_invariant(mDevice != VK_NULL_HANDLE);
+    if (mCommandPool == VK_NULL_HANDLE) {
+        return;
+    }
+    vkDestroyCommandPool(mDevice, mCommandPool, VKALLOC);
+    mDevice = VK_NULL_HANDLE;
+
+    mTaskHandler->shutdown();
+    mTaskHandler.reset();
+}
+
+void VulkanReadPixels::initialize(VkDevice device) noexcept {
+    mDevice = device;
+}
+
+void VulkanReadPixels::run(VulkanRenderTarget const* srcTarget, uint32_t const x, uint32_t const y,
+        uint32_t const width, uint32_t const height, uint32_t const graphicsQueueFamilyIndex,
+        PixelBufferDescriptor&& pbd, SelecteMemoryFunction const& selectMemoryFunc,
+        OnReadCompleteFunction const& readCompleteFunc) {
+    assert_invariant(mDevice != VK_NULL_HANDLE);
+
+    VkDevice& device = mDevice;
+
+    if (mCommandPool == VK_NULL_HANDLE) {
+        // Create a command pool if one has not been created.
+        VkCommandPoolCreateInfo createInfo = {
+                .sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+                .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
+                         | VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+                .queueFamilyIndex = graphicsQueueFamilyIndex,
+        };
+        vkCreateCommandPool(device, &createInfo, VKALLOC, &mCommandPool);
+    }
+
+    // We don't create a task handler (start a thread) unless readPixels is called.
+    if (!mTaskHandler) {
+        mTaskHandler = std::make_unique<TaskHandler>();
+    }
+
+    VkCommandPool& cmdpool = mCommandPool;
+
+    VulkanTexture* srcTexture = srcTarget->getColor(0).texture;
+    assert_invariant(srcTexture);
+    VkFormat const srcFormat = srcTexture->getVkFormat();
+    bool const swizzle
+            = srcFormat == VK_FORMAT_B8G8R8A8_UNORM || srcFormat == VK_FORMAT_B8G8R8A8_SRGB;
+
+    // Create a host visible, linearly tiled image as a staging area.
+    VkImageCreateInfo const imageInfo{
+            .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+            .imageType = VK_IMAGE_TYPE_2D,
+            .format = srcFormat,
+            .extent = {width, height, 1},
+            .mipLevels = 1,
+            .arrayLayers = 1,
+            .samples = VK_SAMPLE_COUNT_1_BIT,
+            .tiling = VK_IMAGE_TILING_LINEAR,
+            .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+            .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+
+    VkImage stagingImage;
+    vkCreateImage(device, &imageInfo, VKALLOC, &stagingImage);
+
+    VkMemoryRequirements memReqs;
+    VkDeviceMemory stagingMemory;
+    vkGetImageMemoryRequirements(device, stagingImage, &memReqs);
+    VkMemoryAllocateInfo const allocInfo = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .allocationSize = memReqs.size,
+            .memoryTypeIndex = selectMemoryFunc(memReqs.memoryTypeBits,
+                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
+                            | VK_MEMORY_PROPERTY_HOST_CACHED_BIT),
+    };
+
+    vkAllocateMemory(device, &allocInfo, VKALLOC, &stagingMemory);
+    vkBindImageMemory(device, stagingImage, stagingMemory, 0);
+
+    VkCommandBuffer cmdbuffer;
+    VkCommandBufferAllocateInfo const allocateInfo{
+            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+            .commandPool = cmdpool,
+            .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+            .commandBufferCount = 1,
+    };
+    vkAllocateCommandBuffers(device, &allocateInfo, &cmdbuffer);
+
+    VkCommandBufferBeginInfo const binfo{
+            .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+            .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+    };
+    vkBeginCommandBuffer(cmdbuffer, &binfo);
+
+    transitionImageLayout(cmdbuffer, {
+            .image = stagingImage,
+            .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+            .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+            .subresources = {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .baseMipLevel = 0,
+                .levelCount = 1,
+                .baseArrayLayer = 0,
+                .layerCount = 1,
+            },
+            .srcStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+            .srcAccessMask = 0,
+            .dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT,
+            .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+        });
+
+    VulkanAttachment const srcAttachment = srcTarget->getColor(0);
+    srcTexture->transitionLayoutForReadPixels(cmdbuffer, srcAttachment.level, srcAttachment.layer,
+            true /* forward */);
+
+    VkImageCopy const imageCopyRegion = {
+        .srcSubresource = {
+            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+            .mipLevel = srcAttachment.level,
+            .baseArrayLayer = srcAttachment.layer,
+            .layerCount = 1,
+        },
+        .srcOffset = {
+            .x = (int32_t)x,
+            .y = (int32_t)(srcTarget->getExtent().height - (height + y)),
+        },
+        .dstSubresource = {
+            .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+            .layerCount = 1,
+        },
+        .extent = {
+            .width = width,
+            .height = height,
+            .depth = 1,
+        },
+    };
+
+    // Perform the copy into the staging area. At this point we know that the src
+    // layout is TRANSFER_SRC_OPTIMAL and the staging area is GENERAL.
+    UTILS_UNUSED_IN_RELEASE VkExtent2D srcExtent = srcAttachment.getExtent2D();
+    assert_invariant(imageCopyRegion.srcOffset.x + imageCopyRegion.extent.width <= srcExtent.width);
+    assert_invariant(
+            imageCopyRegion.srcOffset.y + imageCopyRegion.extent.height <= srcExtent.height);
+
+    vkCmdCopyImage(cmdbuffer, srcAttachment.getImage(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+            stagingImage, VK_IMAGE_LAYOUT_GENERAL, 1, &imageCopyRegion);
+
+    // Restore the source image layout. Between driver API calls, color images are always kept in
+    // UNDEFINED layout or in their "usage default" layout (see comment for getDefaultImageLayout).
+    srcTexture->transitionLayoutForReadPixels(cmdbuffer, srcAttachment.level, srcAttachment.layer,
+            false /* forward */);
+    vkEndCommandBuffer(cmdbuffer);
+
+    VkQueue queue;
+    vkGetDeviceQueue(device, graphicsQueueFamilyIndex, 0, &queue);
+    VkFence readCompleteFence;
+    VkFenceCreateInfo const fenceCreateInfo{
+            .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+    };
+    vkCreateFence(device, &fenceCreateInfo, VKALLOC, &readCompleteFence);
+    VkSubmitInfo const submitInfo{
+            .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+            .waitSemaphoreCount = 0,
+            .pWaitSemaphores = VK_NULL_HANDLE,
+            .pWaitDstStageMask = VK_NULL_HANDLE,
+            .commandBufferCount = 1,
+            .pCommandBuffers = &cmdbuffer,
+            .signalSemaphoreCount = 0,
+            .pSignalSemaphores = VK_NULL_HANDLE,
+    };
+    vkQueueSubmit(queue, 1, &submitInfo, readCompleteFence);
+
+    auto* const pUserBuffer = new PixelBufferDescriptor(std::move(pbd));
+    auto cleanPbdFunc = [pUserBuffer, readCompleteFunc]() {
+        PixelBufferDescriptor& p = *pUserBuffer;
+        readCompleteFunc(std::move(p));
+        delete pUserBuffer;
+    };
+    auto waitFenceFunc = [device, width, height, swizzle, srcFormat, stagingImage, stagingMemory,
+                                 cmdpool, cmdbuffer, pUserBuffer,
+                                 fence = readCompleteFence]() mutable {
+        VkResult status = vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+        // Fence hasn't been reached. Try waiting again.
+        if (status != VK_SUCCESS) {
+            utils::slog.e << "Failed to wait for readPixels fence" << utils::io::endl;
+            return;
+        }
+
+        PixelBufferDescriptor& p = *pUserBuffer;
+        VkImageSubresource subResource{.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT};
+        VkSubresourceLayout subResourceLayout;
+        vkGetImageSubresourceLayout(device, stagingImage, &subResource, &subResourceLayout);
+
+        // Map image memory so that we can start copying from it.
+        uint8_t const* srcPixels;
+        vkMapMemory(device, stagingMemory, 0, VK_WHOLE_SIZE, 0, (void**) &srcPixels);
+        srcPixels += subResourceLayout.offset;
+
+        if (!DataReshaper::reshapeImage(&p, getComponentType(srcFormat),
+                    getComponentCount(srcFormat), srcPixels,
+                    static_cast<int>(subResourceLayout.rowPitch), static_cast<int>(width),
+                    static_cast<int>(height), swizzle)) {
+            utils::slog.e << "Unsupported PixelDataFormat or PixelDataType" << utils::io::endl;
+        }
+
+        vkUnmapMemory(device, stagingMemory);
+        vkDestroyImage(device, stagingImage, VKALLOC);
+        vkFreeMemory(device, stagingMemory, VKALLOC);
+        vkDestroyFence(device, fence, VKALLOC);
+        vkFreeCommandBuffers(device, cmdpool, 1, &cmdbuffer);
+    };
+    mTaskHandler->post(std::move(waitFenceFunc), std::move(cleanPbdFunc));
+}
+
+void VulkanReadPixels::runUntilComplete() noexcept {
+    if (!mTaskHandler) {
+        return;
+    }
+    mTaskHandler->drain();
+}
+
+}// namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanReadPixels.h
+++ b/filament/backend/src/vulkan/VulkanReadPixels.h
@@ -22,7 +22,9 @@
 #include <bluevk/BlueVK.h>
 #include <math/vec4.h>
 
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <queue>
 #include <set>
 #include <thread>

--- a/filament/backend/src/vulkan/VulkanReadPixels.h
+++ b/filament/backend/src/vulkan/VulkanReadPixels.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKANREADPIXELS_H
+#define TNT_FILAMENT_BACKEND_VULKANREADPIXELS_H
+
+#include "private/backend/Driver.h"
+
+#include <bluevk/BlueVK.h>
+#include <math/vec4.h>
+
+#include <functional>
+#include <queue>
+#include <set>
+#include <thread>
+#include <vector>
+
+namespace filament::backend {
+
+struct VulkanRenderTarget;
+
+class VulkanReadPixels {
+public:
+    // A helper class that runs tasks on a separate thread.
+    class TaskHandler {
+    public:
+        using WorkloadFunc = std::function<void()>;
+        using OnCompleteFunc = std::function<void()>;
+        using Task = std::pair<WorkloadFunc, OnCompleteFunc>;
+
+        TaskHandler();
+
+        // In addition to the workload that the handler will call, client must also provide an
+        // oncomplete function that the handler will call either when the workload completes or when
+        // the handler is shutdown (so that we can clean-up even when the task was not carried out).
+        void post(WorkloadFunc&& workload, OnCompleteFunc&& oncomplete);
+
+        // This will block until all of the tasks are done.
+        void drain();
+
+        // This will quit without running the workloads, but oncomplete callbacks will still be
+        // called.
+        void shutdown();
+
+    private:
+        void loop();
+
+        bool mShouldStop;
+        std::condition_variable mHasTaskCondition;
+        std::mutex mTaskQueueMutex;
+        std::queue<Task> mTaskQueue;
+        std::thread mThread;
+    };
+
+public:
+    using OnReadCompleteFunction = std::function<void(PixelBufferDescriptor&&)>;
+    using SelecteMemoryFunction = std::function<uint32_t(uint32_t, VkFlags)>;
+
+    void initialize(VkDevice device) noexcept;
+
+    void shutdown() noexcept;
+
+    void run(VulkanRenderTarget const* srcTarget, uint32_t x, uint32_t y, uint32_t width,
+            uint32_t height, uint32_t graphicsQueueFamilyIndex, PixelBufferDescriptor&& pbd,
+            SelecteMemoryFunction const& selectMemoryFunc,
+            OnReadCompleteFunction const& readCompleteFunc);
+
+    // This method will block until all of the in-flight requests are complete.
+    void runUntilComplete() noexcept;
+
+private:
+    VkDevice mDevice = VK_NULL_HANDLE;
+    VkCommandPool mCommandPool = VK_NULL_HANDLE;
+    std::unique_ptr<TaskHandler> mTaskHandler;
+};
+
+}// namespace filament::backend
+
+#endif// TNT_FILAMENT_BACKEND_VULKANREADPIXELS_H

--- a/filament/backend/src/vulkan/VulkanReadPixels.h
+++ b/filament/backend/src/vulkan/VulkanReadPixels.h
@@ -67,13 +67,12 @@ public:
         std::thread mThread;
     };
 
-public:
     using OnReadCompleteFunction = std::function<void(PixelBufferDescriptor&&)>;
     using SelecteMemoryFunction = std::function<uint32_t(uint32_t, VkFlags)>;
 
-    void initialize(VkDevice device) noexcept;
+    explicit VulkanReadPixels(VkDevice device);
 
-    void shutdown() noexcept;
+    void terminate() noexcept;
 
     void run(VulkanRenderTarget const* srcTarget, uint32_t x, uint32_t y, uint32_t width,
             uint32_t height, uint32_t graphicsQueueFamilyIndex, PixelBufferDescriptor&& pbd,


### PR DESCRIPTION
 - Carry out readPixels without blocking and wait for the read to complete own a separate thread.
 - Add mContext.commands->wait() in finish()
 - Wait for readPixels to complete in finish()
 - Remove unused commandBuffer in Context