### PR TITLE
TangentSpaceMesh fixes

### DIFF
--- a/libs/geometry/src/TangentSpaceMesh.cpp
+++ b/libs/geometry/src/TangentSpaceMesh.cpp
@@ -353,7 +353,7 @@ void lengyelMethod(TangentSpaceMeshInput const* input, TangentSpaceMeshOutput* o
 
     quatf* quats = output->tangentSpace.allocate(vertexCount);
     for (size_t a = 0; a < vertexCount; a++) {
-        float3 const& n = normals[a];
+        float3 const& n = *pointerAdd(normals, a, normalStride);
         float3 const& t1 = tan1[a];
         float3 const& t2 = tan2[a];
 

--- a/libs/geometry/src/TangentSpaceMeshInternal.h
+++ b/libs/geometry/src/TangentSpaceMeshInternal.h
@@ -47,7 +47,7 @@ public:
     }
 
     explicit operator bool() const noexcept {
-        return !mBorrowed && !mAllocated.empty();
+        return mBorrowed || !mAllocated.empty();
     }
 
     const T* get() {

--- a/libs/geometry/tests/test_tangent_space_mesh.cpp
+++ b/libs/geometry/tests/test_tangent_space_mesh.cpp
@@ -347,6 +347,11 @@ TEST_F(TangentSpaceMeshTest, Lengyel) {
     size_t const vertexCount = mesh->getVertexCount();
     std::vector<quatf> quats(vertexCount);
     mesh->getQuats(quats.data());
+
+    ASSERT_EQ(mesh->getTriangleCount(), CUBE_TRIANGLES.size());
+    std::vector<ushort3> triangles(mesh->getTriangleCount());
+    mesh->getTriangles(triangles.data());
+
     for (size_t i = 0; i < vertexCount; ++i) {
         float3 const n = quats[i] * NORMAL_AXIS;
         EXPECT_PRED2(isAlmostEqual3, n, CUBE_NORMALS[i]);


### PR DESCRIPTION
This PR fixes a bug in the Lengyel method to respect the normal stride.

When using the Lengyel method, there's another bug where `getTriangles(ushort3*)` crashes. Even though 16 bit indices were provided, `is16` is false. I think this is due to a problem with `InternalArray::operator bool`. If the array has a valid "borrowed" pointer, then we should return true.

Note that the Lengyel method doesn't actually remesh, but `getTriangles` should still work.
