### PR TITLE
Suppress numerous libz warnings

### DIFF
--- a/third_party/libassimp/tnt/CMakeLists.txt
+++ b/third_party/libassimp/tnt/CMakeLists.txt
@@ -252,11 +252,6 @@ add_definitions(
     -DASSIMP_BUILD_NO_OWN_ZLIB
 )
 
-# See https://github.com/madler/zlib/issues/633
-add_compile_options(
-    -Wno-deprecated-non-prototype
-)
-
 # specify where our headers are
 include_directories(${SRC_DIR}/contrib/irrXML)
 include_directories(${SRC_DIR}/contrib/rapidjson/include)
@@ -283,6 +278,7 @@ if(NOT MSVC)
         PRIVATE -Wno-unused-const-variable
         PRIVATE -Wno-unused-private-field
         PRIVATE -Wno-unused-variable
+        PRIVATE -Wno-deprecated-non-prototype # See https://github.com/madler/zlib/issues/633
     )
 else()
     target_compile_options(${TARGET} PRIVATE /bigobj)

--- a/third_party/libassimp/tnt/CMakeLists.txt
+++ b/third_party/libassimp/tnt/CMakeLists.txt
@@ -252,6 +252,11 @@ add_definitions(
     -DASSIMP_BUILD_NO_OWN_ZLIB
 )
 
+# See https://github.com/madler/zlib/issues/633
+add_compile_options(
+    -Wno-deprecated-non-prototype
+)
+
 # specify where our headers are
 include_directories(${SRC_DIR}/contrib/irrXML)
 include_directories(${SRC_DIR}/contrib/rapidjson/include)

--- a/third_party/libz/tnt/CMakeLists.txt
+++ b/third_party/libz/tnt/CMakeLists.txt
@@ -53,6 +53,11 @@ if (NOT MSVC)
     )
 endif()
 
+# See https://github.com/madler/zlib/issues/633
+add_compile_options(
+    -Wno-deprecated-non-prototype
+)
+
 # we're building a library
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 

--- a/third_party/libz/tnt/CMakeLists.txt
+++ b/third_party/libz/tnt/CMakeLists.txt
@@ -46,20 +46,16 @@ set(SRCS
     ${SRC_DIR}/zutil.c
 )
 
-if (NOT MSVC)
-    add_definitions(
-        -Wno-implicit-function-declaration
-        -Wno-shift-negative-value
-    )
-endif()
-
-# See https://github.com/madler/zlib/issues/633
-add_compile_options(
-    -Wno-deprecated-non-prototype
-)
-
 # we're building a library
 add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
+
+if (NOT MSVC)
+    target_compile_options(${TARGET}
+        PRIVATE -Wno-implicit-function-declaration
+        PRIVATE -Wno-shift-negative-value
+        PRIVATE -Wno-deprecated-non-prototype # See https://github.com/madler/zlib/issues/633
+    )
+endif()
 
 # specify where the public headers of this library are
 target_include_directories (${TARGET} PUBLIC ${PUBLIC_HDR_DIR})


### PR DESCRIPTION
zlib will fix this issue later (see https://github.com/madler/zlib/issues/633).
For now we will just turn off the warning.
