### PR TITLE
filter out VSM variant for unlit materials DEPTH shaders

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -13,3 +13,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - materials: implement cascades debugging as a post-process [⚠️ **Recompile Materials**].
 - materials: use 9 digits or less for floats [⚠️ **Recompile Materials**].
 - gltfio: fix skinning when objects are far from the origin
+- materials: remove 4 unneeded variants from `unlit` materials [⚠️ **Recompile Materials**].

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -282,12 +282,14 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     mIsDefaultMaterial = builder->mDefaultMaterial;
 
     // pre-cache the shared variants -- these variants are shared with the default material.
+    // (note: the default material is unlit, so only unlit variants can be shared)
     if (UTILS_UNLIKELY(!mIsDefaultMaterial && !mHasCustomDepthShader)) {
+        FMaterial const* const pMaterial = engine.getDefaultMaterial();
         auto& cachedPrograms = mCachedPrograms;
         for (Variant::type_t k = 0, n = VARIANT_COUNT; k < n; ++k) {
             const Variant variant(k);
-            if (Variant::isValidDepthVariant(variant)) {
-                FMaterial const* const pMaterial = engine.getDefaultMaterial();
+            if (Variant::isValidDepthVariant(variant) &&
+                (Variant::filterVariant(variant, false) == variant)) {
                 pMaterial->prepareProgram(variant);
                 cachedPrograms[k] = pMaterial->getProgram(variant);
             }

--- a/libs/filabridge/include/private/filament/Variant.h
+++ b/libs/filabridge/include/private/filament/Variant.h
@@ -217,6 +217,10 @@ struct Variant {
     static constexpr Variant filterVariant(Variant variant, bool isLit) noexcept {
         // special case for depth variant
         if (isValidDepthVariant(variant)) {
+            if (!isLit) {
+                // if we're unlit, we never need the VSM variant
+                return variant & ~VSM;
+            }
             return variant;
         }
         if (isSSRVariant(variant)) {

--- a/libs/matdbg/src/CommonWriter.cpp
+++ b/libs/matdbg/src/CommonWriter.cpp
@@ -46,7 +46,11 @@ std::string formatVariantString(Variant variant, MaterialDomain domain) noexcept
         if (variant.key & Variant::SRE) variantString += "SRE|";
         if (variant.key & Variant::SKN) variantString += "SKN|";
         if (variant.key & Variant::DEP) variantString += "DEP|";
-        if (variant.key & Variant::FOG) variantString += "FOG|";
+        if (variant.key & Variant::DEP) {
+            if (variant.key & Variant::PCK) variantString += "PCK|";
+        } else {
+            if (variant.key & Variant::FOG) variantString += "FOG|";
+        }
         if (variant.key & Variant::VSM) variantString += "VSM|";
         variantString = variantString.substr(0, variantString.length() - 1);
     }


### PR DESCRIPTION
The VSM variant is never needed for unlit materials, it was filtered out correctly for color shaders but not for the depth shaders. This removes 4 variants from all unlit materials.

Also improve matinfo variants output.