### PR TITLE
improvements to material code and material creation

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -44,21 +44,21 @@ OpenGLProgram::OpenGLProgram() noexcept
     : mInitialized(false), mValid(true), mLazyInitializationData(nullptr) {
 }
 
-OpenGLProgram::OpenGLProgram(OpenGLDriver& gld, Program&& programBuilder) noexcept
-        : HwProgram(std::move(programBuilder.getName())),
+OpenGLProgram::OpenGLProgram(OpenGLDriver& gld, Program&& program) noexcept
+        : HwProgram(std::move(program.getName())),
           mInitialized(false), mValid(true),
           mLazyInitializationData{ new(LazyInitializationData) } {
 
     OpenGLContext& context = gld.getContext();
 
-    mLazyInitializationData->uniformBlockInfo = std::move(programBuilder.getUniformBlockBindings());
-    mLazyInitializationData->samplerGroupInfo = std::move(programBuilder.getSamplerGroupInfo());
+    mLazyInitializationData->uniformBlockInfo = std::move(program.getUniformBlockBindings());
+    mLazyInitializationData->samplerGroupInfo = std::move(program.getSamplerGroupInfo());
 
     // this cannot fail because we check compilation status after linking the program
     // shaders[] is filled with id of shader stages present.
     OpenGLProgram::compileShaders(context,
-            std::move(programBuilder.getShadersSource()),
-            programBuilder.getSpecializationConstants(),
+            std::move(program.getShadersSource()),
+            program.getSpecializationConstants(),
             gl.shaders,
             mLazyInitializationData->shaderSourceCode);
 

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -38,7 +38,7 @@ class OpenGLProgram : public HwProgram {
 public:
 
     OpenGLProgram() noexcept;
-    OpenGLProgram(OpenGLDriver& gld, Program&& builder) noexcept;
+    OpenGLProgram(OpenGLDriver& gld, Program&& program) noexcept;
     ~OpenGLProgram() noexcept;
 
     bool isValid() const noexcept { return mValid; }

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -311,7 +311,7 @@ bool MaterialParser::getReflectionMode(ReflectionMode* value) const noexcept {
 bool MaterialParser::getShader(ShaderContent& shader,
         ShaderModel shaderModel, Variant variant, ShaderStage stage) noexcept {
     return mImpl.mMaterialChunk.getShader(shader,
-            mImpl.mBlobDictionary, uint8_t(shaderModel), variant, uint8_t(stage));
+            mImpl.mBlobDictionary, shaderModel, variant, stage);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -103,6 +103,8 @@ public:
     bool getShader(filaflat::ShaderContent& shader, backend::ShaderModel shaderModel,
             Variant variant, backend::ShaderStage stage) noexcept;
 
+    filaflat::MaterialChunk const& getMaterialChunk() const noexcept { return mImpl.mMaterialChunk; }
+
 private:
     struct MaterialParserDetails {
         MaterialParserDetails(backend::Backend backend, const void* data, size_t size);

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -383,16 +383,16 @@ void FMaterial::getSurfaceProgramSlow(Variant variant) const noexcept {
     Variant const vertexVariant   = Variant::filterVariantVertex(variant);
     Variant const fragmentVariant = Variant::filterVariantFragment(variant);
 
-    Program pb{ getProgramBuilderWithVariants(variant, vertexVariant, fragmentVariant) };
+    Program pb{ getProgramWithVariants(variant, vertexVariant, fragmentVariant) };
     createAndCacheProgram(std::move(pb), variant);
 }
 
 void FMaterial::getPostProcessProgramSlow(Variant variant) const noexcept {
-    Program pb{ getProgramBuilderWithVariants(variant, variant, variant) };
+    Program pb{ getProgramWithVariants(variant, variant, variant) };
     createAndCacheProgram(std::move(pb), variant);
 }
 
-Program FMaterial::getProgramBuilderWithVariants(
+Program FMaterial::getProgramWithVariants(
         Variant variant,
         Variant vertexVariant,
         Variant fragmentVariant) const noexcept {

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -509,6 +509,8 @@ size_t FMaterial::getParameters(ParameterInfo* parameters, size_t count) const n
     return count;
 }
 
+#if FILAMENT_ENABLE_MATDBG
+
 // Swaps in an edited version of the original package that was used to create the material. The
 // edited package was stashed in response to a debugger event. This is invoked only when the
 // Material Debugger is attached. The only editable features of a material package are the shader
@@ -531,8 +533,6 @@ void FMaterial::applyPendingEdits() noexcept {
  *
  * @{
  */
-
-#if FILAMENT_ENABLE_MATDBG
 
 void FMaterial::onEditCallback(void* userdata, const utils::CString&, const void* packageData,
         size_t packageSize) {

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -99,9 +99,6 @@ public:
         return mCachedPrograms[variant.key];
     }
 
-    backend::Program getProgramWithVariants(Variant variant, Variant vertexVariant,
-            Variant fragmentVariant) const noexcept;
-
     bool isVariantLit() const noexcept { return mIsVariantLit; }
 
     const utils::CString& getName() const noexcept { return mName; }
@@ -149,11 +146,11 @@ public:
 
     uint32_t generateMaterialInstanceId() const noexcept { return mMaterialInstanceId++; }
 
-    void applyPendingEdits() noexcept;
-
     void destroyPrograms(FEngine& engine);
 
 #if FILAMENT_ENABLE_MATDBG
+    void applyPendingEdits() noexcept;
+
     /**
      * Callback handlers for the debug server, potentially called from any thread. The userdata
      * argument has the same value that was passed to DebugServer::addMaterial(), which should
@@ -187,6 +184,9 @@ private:
     void prepareProgramSlow(Variant variant) const noexcept;
     void getSurfaceProgramSlow(Variant variant) const noexcept;
     void getPostProcessProgramSlow(Variant variant) const noexcept;
+    backend::Program getProgramWithVariants(Variant variant, Variant vertexVariant,
+            Variant fragmentVariant) const noexcept;
+
 
     void createAndCacheProgram(backend::Program&& p,
             Variant variant) const noexcept;
@@ -235,6 +235,7 @@ private:
     matdbg::MaterialKey mDebuggerId;
     mutable utils::Mutex mActiveProgramsLock;
     mutable VariantList mActivePrograms;
+    std::atomic<MaterialParser*> mPendingEdits = {};
 #endif
 
     utils::CString mName;
@@ -242,7 +243,6 @@ private:
     const uint32_t mMaterialId;
     mutable uint32_t mMaterialInstanceId = 0;
     MaterialParser* mMaterialParser = nullptr;
-    std::atomic<MaterialParser*> mPendingEdits = {};
 };
 
 

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -228,6 +228,8 @@ private:
     BufferInterfaceBlock mUniformInterfaceBlock;
     SubpassInfo mSubpassInfo;
     utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> mUniformBlockBindings;
+    utils::FixedCapacityVector<Variant> mDepthVariants; // only populated with default material
+
     SamplerGroupBindingInfoList mSamplerGroupBindingInfoList;
     SamplerBindingToNameMap mSamplerBindingToNameMap;
 

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -99,7 +99,7 @@ public:
         return mCachedPrograms[variant.key];
     }
 
-    backend::Program getProgramBuilderWithVariants(Variant variant, Variant vertexVariant,
+    backend::Program getProgramWithVariants(Variant variant, Variant vertexVariant,
             Variant fragmentVariant) const noexcept;
 
     bool isVariantLit() const noexcept { return mIsVariantLit; }

--- a/libs/filaflat/include/filaflat/MaterialChunk.h
+++ b/libs/filaflat/include/filaflat/MaterialChunk.h
@@ -26,12 +26,17 @@
 
 #include <tsl/robin_map.h>
 
+#include <backend/DriverEnums.h>
+
 #include <utils/Invocable.h>
+#include <utils/FixedCapacityVector.h>
 
 namespace filaflat {
 
 class MaterialChunk {
 public:
+    using ShaderModel = filament::backend::ShaderModel;
+    using ShaderStage = filament::backend::ShaderStage;
     using Variant = filament::Variant;
 
     explicit MaterialChunk(ChunkContainer const& container);
@@ -43,14 +48,14 @@ public:
     // call this as many times as needed
     // populates "shaderContent" with the requested shader, or returns false on failure.
     bool getShader(ShaderContent& shaderContent, BlobDictionary const& dictionary,
-            uint8_t shaderModel, Variant variant, uint8_t stage);
+            ShaderModel shaderModel, filament::Variant variant, ShaderStage stage);
 
-    void visitTextShaders(
-            utils::Invocable<void(uint8_t, Variant::type_t, uint8_t)>&& visitor) const;
+    void visitShaders(utils::Invocable<void(ShaderModel, Variant, ShaderStage)>&& visitor) const;
 
     // These methods are for debugging purposes only (matdbg)
     // @{
-    static void decodeKey(uint32_t key, uint8_t* model, Variant::type_t* variant, uint8_t* stage);
+    static void decodeKey(uint32_t key,
+            ShaderModel* outModel, Variant* outVariant, ShaderStage* outStage);
     const tsl::robin_map<uint32_t, uint32_t>& getOffsets() const { return mOffsets; }
     // @}
 
@@ -63,11 +68,11 @@ private:
 
     bool getTextShader(Unflattener unflattener,
             BlobDictionary const& dictionary, ShaderContent& shaderContent,
-            uint8_t shaderModel, Variant variant, uint8_t stage);
+            ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage);
 
     bool getSpirvShader(
             BlobDictionary const& dictionary, ShaderContent& shaderContent,
-            uint8_t shaderModel, Variant variant, uint8_t stage);
+            ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage);
 };
 
 } // namespace filamat

--- a/libs/filaflat/include/filaflat/MaterialChunk.h
+++ b/libs/filaflat/include/filaflat/MaterialChunk.h
@@ -50,6 +50,8 @@ public:
     bool getShader(ShaderContent& shaderContent, BlobDictionary const& dictionary,
             ShaderModel shaderModel, filament::Variant variant, ShaderStage stage);
 
+    uint32_t getShaderCount() const noexcept;
+
     void visitShaders(utils::Invocable<void(ShaderModel, Variant, ShaderStage)>&& visitor) const;
 
     // These methods are for debugging purposes only (matdbg)

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -183,6 +183,13 @@ bool MaterialChunk::getShader(ShaderContent& shaderContent, BlobDictionary const
     }
 }
 
+uint32_t MaterialChunk::getShaderCount() const noexcept {
+    Unflattener unflattener{ mUnflattener }; // make a copy
+    uint64_t numShaders;
+    unflattener.read(&numShaders);
+    return uint32_t(numShaders);
+}
+
 void MaterialChunk::visitShaders(
         utils::Invocable<void(ShaderModel, Variant, ShaderStage)>&& visitor) const {
 

--- a/libs/filaflat/src/MaterialChunk.cpp
+++ b/libs/filaflat/src/MaterialChunk.cpp
@@ -17,20 +17,27 @@
 #include <filaflat/MaterialChunk.h>
 #include <filaflat/ChunkContainer.h>
 
+#include <backend/DriverEnums.h>
+
 #include <utils/Log.h>
 
 namespace filaflat {
 
-static inline uint32_t makeKey(uint8_t shaderModel, filament::Variant variant, uint8_t stage) noexcept {
+static inline uint32_t makeKey(
+        MaterialChunk::ShaderModel shaderModel,
+        MaterialChunk::Variant variant,
+        MaterialChunk::ShaderStage stage) noexcept {
     static_assert(sizeof(variant.key) * 8 <= 8);
-    return (shaderModel << 16) | (stage << 8) | variant.key;
+    return (uint32_t(shaderModel) << 16) | (uint32_t(stage) << 8) | variant.key;
 }
 
-void MaterialChunk::decodeKey(uint32_t key, uint8_t* model, filament::Variant::type_t* variant,
-        uint8_t* stage) {
-    *variant = key & 0xff;
-    *stage = (key >> 8) & 0xff;
-    *model = (key >> 16) & 0xff;
+void MaterialChunk::decodeKey(uint32_t key,
+        MaterialChunk::ShaderModel* model,
+        MaterialChunk::Variant* variant,
+        MaterialChunk::ShaderStage* stage) {
+    variant->key = key & 0xff;
+    *model = MaterialChunk::ShaderModel((key >> 16) & 0xff);
+    *stage = MaterialChunk::ShaderStage((key >> 8) & 0xff);
 }
 
 MaterialChunk::MaterialChunk(ChunkContainer const& container)
@@ -61,12 +68,12 @@ bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
 
     // Read all index entries.
     for (uint64_t i = 0 ; i < numShaders; i++) {
-        uint8_t shaderModelValue;
-        filament::Variant variant;
-        uint8_t pipelineStageValue;
+        uint8_t model;
+        Variant variant;
+        uint8_t stage;
         uint32_t offsetValue;
 
-        if (!unflattener.read(&shaderModelValue)) {
+        if (!unflattener.read(&model)) {
             return false;
         }
 
@@ -74,7 +81,7 @@ bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
             return false;
         }
 
-        if (!unflattener.read(&pipelineStageValue)) {
+        if (!unflattener.read(&stage)) {
             return false;
         }
 
@@ -82,20 +89,21 @@ bool MaterialChunk::initialize(filamat::ChunkType materialTag) {
             return false;
         }
 
-        uint32_t key = makeKey(shaderModelValue, variant, pipelineStageValue);
+        uint32_t key = makeKey(ShaderModel(model), variant, ShaderStage(stage));
         mOffsets[key] = offsetValue;
     }
     return true;
 }
 
-bool MaterialChunk::getTextShader(Unflattener unflattener, BlobDictionary const& dictionary,
-        ShaderContent& shaderContent, uint8_t shaderModel, filament::Variant variant, uint8_t ps) {
+bool MaterialChunk::getTextShader(Unflattener unflattener,
+        BlobDictionary const& dictionary, ShaderContent& shaderContent,
+        ShaderModel shaderModel, Variant variant, ShaderStage shaderStage) {
     if (mBase == nullptr) {
         return false;
     }
 
     // Jump and read
-    uint32_t key = makeKey(shaderModel, variant, ps);
+    uint32_t key = makeKey(shaderModel, variant, shaderStage);
     auto pos = mOffsets.find(key);
     if (pos == mOffsets.end()) {
         return false;
@@ -146,13 +154,13 @@ bool MaterialChunk::getTextShader(Unflattener unflattener, BlobDictionary const&
 }
 
 bool MaterialChunk::getSpirvShader(BlobDictionary const& dictionary,
-        ShaderContent& shaderContent, uint8_t shaderModel, filament::Variant variant, uint8_t stage) {
+        ShaderContent& shaderContent, ShaderModel shaderModel, filament::Variant variant, ShaderStage shaderStage) {
 
     if (mBase == nullptr) {
         return false;
     }
 
-    uint32_t key = makeKey(shaderModel, variant, stage);
+    uint32_t key = makeKey(shaderModel, variant, shaderStage);
     auto pos = mOffsets.find(key);
     if (pos == mOffsets.end()) {
         return false;
@@ -162,8 +170,8 @@ bool MaterialChunk::getSpirvShader(BlobDictionary const& dictionary,
     return true;
 }
 
-bool MaterialChunk::getShader(ShaderContent& shaderContent,
-        BlobDictionary const& dictionary, uint8_t shaderModel, filament::Variant variant, uint8_t stage) {
+bool MaterialChunk::getShader(ShaderContent& shaderContent, BlobDictionary const& dictionary,
+        ShaderModel shaderModel, filament::Variant variant, ShaderStage stage) {
     switch (mMaterialTag) {
         case filamat::ChunkType::MaterialGlsl:
         case filamat::ChunkType::MaterialMetal:
@@ -175,9 +183,8 @@ bool MaterialChunk::getShader(ShaderContent& shaderContent,
     }
 }
 
-void MaterialChunk::visitTextShaders(
-        utils::Invocable<void(uint8_t, Variant::type_t, uint8_t)>&& visitor) const {
-    assert_invariant(mMaterialTag != filamat::ChunkType::MaterialSpirv);
+void MaterialChunk::visitShaders(
+        utils::Invocable<void(ShaderModel, Variant, ShaderStage)>&& visitor) const {
 
     Unflattener unflattener{ mUnflattener }; // make a copy
 
@@ -200,7 +207,7 @@ void MaterialChunk::visitTextShaders(
         unflattener.read(&pipelineStageValue);
         unflattener.read(&offsetValue);
 
-        visitor(shaderModelValue, variant.key, pipelineStageValue);
+        visitor(ShaderModel(shaderModelValue), variant, ShaderStage(pipelineStageValue));
     }
 }
 

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -742,17 +742,17 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                 std::vector<uint32_t>* pSpirv = targetApiNeedsSpirv ? &spirv : nullptr;
                 std::string* pMsl = targetApiNeedsMsl ? &msl : nullptr;
 
-                TextEntry glslEntry{0};
-                SpirvEntry spirvEntry{0};
-                TextEntry metalEntry{0};
+                TextEntry glslEntry{};
+                SpirvEntry spirvEntry{};
+                TextEntry metalEntry{};
 
-                glslEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
-                spirvEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
-                metalEntry.shaderModel = static_cast<uint8_t>(params.shaderModel);
+                glslEntry.shaderModel  = params.shaderModel;
+                spirvEntry.shaderModel = params.shaderModel;
+                metalEntry.shaderModel = params.shaderModel;
 
-                glslEntry.variantKey  = v.variant.key;
-                spirvEntry.variantKey = v.variant.key;
-                metalEntry.variantKey = v.variant.key;
+                glslEntry.variant  = v.variant;
+                spirvEntry.variant = v.variant;
+                metalEntry.variant = v.variant;
 
                 // Generate raw shader code.
                 // The quotes in Google-style line directives cause problems with certain drivers. These
@@ -828,14 +828,14 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         // should never happen
                         break;
                     case TargetApi::OPENGL:
-                        glslEntry.stage = uint8_t(v.stage);
+                        glslEntry.stage = v.stage;
                         glslEntry.shader = shader;
                         glslEntries.push_back(glslEntry);
                         break;
                     case TargetApi::VULKAN:
 #ifndef FILAMAT_LITE
                         assert(!spirv.empty());
-                        spirvEntry.stage = uint8_t(v.stage);
+                        spirvEntry.stage = v.stage;
                         spirvEntry.spirv = std::move(spirv);
                         spirvEntries.push_back(spirvEntry);
 #endif
@@ -844,7 +844,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 #ifndef FILAMAT_LITE
                         assert(!spirv.empty());
                         assert(msl.length() > 0);
-                        metalEntry.stage = uint8_t(v.stage);
+                        metalEntry.stage = v.stage;
                         metalEntry.shader = msl;
                         metalEntries.push_back(metalEntry);
 #endif
@@ -872,10 +872,10 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
 
     // Sort the variants.
     auto compare = [](const auto& a, const auto& b) {
-        static_assert(sizeof(decltype(a.variantKey)) == 1);
-        static_assert(sizeof(decltype(b.variantKey)) == 1);
-        const uint32_t akey = (a.shaderModel << 16) | (a.variantKey << 8) | a.stage;
-        const uint32_t bkey = (b.shaderModel << 16) | (b.variantKey << 8) | b.stage;
+        static_assert(sizeof(decltype(a.variant.key)) == 1);
+        static_assert(sizeof(decltype(b.variant.key)) == 1);
+        const uint32_t akey = (uint32_t(a.shaderModel) << 16) | (uint32_t(a.variant.key) << 8) | uint32_t(a.stage);
+        const uint32_t bkey = (uint32_t(b.shaderModel) << 16) | (uint32_t(b.variant.key) << 8) | uint32_t(b.stage);
         return akey < bkey;
     };
     std::sort(glslEntries.begin(), glslEntries.end(), compare);

--- a/libs/filamat/src/eiff/MaterialSpirvChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialSpirvChunk.cpp
@@ -24,9 +24,9 @@ MaterialSpirvChunk::MaterialSpirvChunk(const std::vector<SpirvEntry>&& entries) 
 void MaterialSpirvChunk::flatten(Flattener &f) {
     f.writeUint64(mEntries.size());
     for (const SpirvEntry& entry : mEntries) {
-        f.writeUint8(entry.shaderModel);
-        f.writeUint8(entry.variantKey);
-        f.writeUint8(entry.stage);
+        f.writeUint8(uint8_t(entry.shaderModel));
+        f.writeUint8(entry.variant.key);
+        f.writeUint8(uint8_t(entry.stage));
         f.writeUint32(entry.dictionaryIndex);
     }
 }

--- a/libs/filamat/src/eiff/MaterialTextChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialTextChunk.cpp
@@ -20,9 +20,9 @@ namespace filamat {
 
 void MaterialTextChunk::writeEntryAttributes(size_t entryIndex, Flattener& f) const noexcept {
     const TextEntry& entry = mEntries[entryIndex];
-    f.writeUint8(entry.shaderModel);
-    f.writeUint8(entry.variantKey);
-    f.writeUint8(entry.stage);
+    f.writeUint8(uint8_t(entry.shaderModel));
+    f.writeUint8(entry.variant.key);
+    f.writeUint8(uint8_t(entry.stage));
 }
 
 void compressShader(std::string_view src, Flattener &f, const LineDictionary& dictionary) {

--- a/libs/filamat/src/eiff/ShaderEntry.h
+++ b/libs/filamat/src/eiff/ShaderEntry.h
@@ -17,26 +17,27 @@
 #ifndef TNT_FILAMAT_SHADER_ENTRY_H
 #define TNT_FILAMAT_SHADER_ENTRY_H
 
+#include <private/filament/Variant.h>
+
+#include <backend/DriverEnums.h>
+
 #include <string>
 #include <vector>
-
-#include <private/filament/Variant.h>
 
 namespace filamat {
 
 // TextEntry stores a shader in ASCII text format, like GLSL.
 struct TextEntry {
-    uint8_t shaderModel;
-    filament::Variant::type_t variantKey;
-    uint8_t stage;
+    filament::backend::ShaderModel shaderModel;
+    filament::Variant variant;
+    filament::backend::ShaderStage stage;
     std::string shader;
 };
 
-
 struct SpirvEntry {
-    uint8_t shaderModel;
-    filament::Variant::type_t variantKey;
-    uint8_t stage;
+    filament::backend::ShaderModel shaderModel;
+    filament::Variant variant;
+    filament::backend::ShaderStage stage;
     size_t dictionaryIndex;
 
 #ifndef FILAMAT_LITE

--- a/libs/matdbg/src/ShaderExtractor.cpp
+++ b/libs/matdbg/src/ShaderExtractor.cpp
@@ -82,8 +82,7 @@ bool ShaderExtractor::getShader(ShaderModel shaderModel,
         return false;
     }
 
-    return mMaterialChunk.getShader(shader, blobDictionary,
-            uint8_t(shaderModel), variant, uint8_t(stage));
+    return mMaterialChunk.getShader(shader, blobDictionary, shaderModel, variant, stage);
 }
 
 CString ShaderExtractor::spirvToGLSL(ShaderModel shaderModel, const uint32_t* data,


### PR DESCRIPTION
- `ProgramBuilder` is a relic, rename to `Program`
- use the enum instead of ints everywhere for `ShaderModel` and `ShaderStage`
- Improve how we cache shared shaders:

Some shaders can be shared across all materials (e.g. the depth 
shaders). We use the filament default material as the "source" of
the cache, but until now we relied on an a priori knowledge of which
variants were present in the default material.

With this change, we now query once the list of variants (of interest)
in the default material and reuse that list for caching these variants
later.

This is better because the cached variants are now entirely driven by
the default material (which they depend on anyways). This is also faster
because we don't need to query which variant we need each time we create
a material.