### PR TITLE
Improve size optimizations when compiling material

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,4 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - materials: improved size reduction of OpenGL/Metal shaders by ~65% when compiling materials with
-             size optimizations (`matc -S`)
+             size optimizations (`matc -S`) [⚠️ **Recompile Materials**]

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,5 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- materials: improved size reduction of OpenGL/Metal shaders by ~65% when compiling materials with
+             size optimizations (`matc -S`)

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -75,7 +75,7 @@ static void collectSibs(const GLSLPostProcessor::Config& config, SibVector& sibs
             &config.materialInfo->sib);
 }
 
-}; // namespace msl
+} // namespace msl
 
 GLSLPostProcessor::GLSLPostProcessor(MaterialBuilder::Optimization optimization, uint32_t flags)
         : mOptimization(optimization),
@@ -395,7 +395,9 @@ bool GLSLPostProcessor::process(const std::string& inputShader, Config const& co
 
     if (internalConfig.glslOutput) {
         *internalConfig.glslOutput =
-                internalConfig.minifier.removeWhitespace(*internalConfig.glslOutput);
+                internalConfig.minifier.removeWhitespace(
+                        *internalConfig.glslOutput,
+                        mOptimization == MaterialBuilder::Optimization::SIZE);
 
         // In theory this should only be enabled for SIZE, but in practice we often use PERFORMANCE.
         if (mOptimization != MaterialBuilder::Optimization::NONE) {
@@ -470,14 +472,33 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
         GLSLPostProcessor::Config const& config, InternalConfig& internalConfig) const {
     SpirvBlob spirv;
 
+    bool optimizeForSize = mOptimization == MaterialBuilderBase::Optimization::SIZE;
+
     // Compile GLSL to to SPIR-V
     SpvOptions options;
     options.generateDebugInfo = mGenerateDebugInfo;
+    // This step is required for what we attempt later using spirvbin_t::remap()
+    if (!internalConfig.spirvOutput && optimizeForSize) {
+        options.emitNonSemanticShaderDebugInfo = true;
+    }
     GlslangToSpv(*tShader.getIntermediate(), spirv, &options);
 
-    // Run the SPIR-V optimizer
-    OptimizerPtr optimizer = createOptimizer(mOptimization, config);
-    optimizeSpirv(optimizer, spirv);
+    if (internalConfig.spirvOutput) {
+        // Run the SPIR-V optimizer
+        OptimizerPtr optimizer = createOptimizer(mOptimization, config);
+        optimizeSpirv(optimizer, spirv);
+    } else {
+        // When we optimize for size, and we generate text-based shaders, we save much more
+        // by preserving variable names and running a simple DCE pass instead of using spirv-opt
+        if (optimizeForSize) {
+            std::vector<std::string> whiteListStrings;
+            spv::spirvbin_t(0).remap(
+                    spirv, whiteListStrings, spv::spirvbin_t::DCE_ALL | spv::spirvbin_t::OPT_ALL);
+        } else {
+            OptimizerPtr optimizer = createOptimizer(mOptimization, config);
+            optimizeSpirv(optimizer, spirv);
+        }
+    }
 
     if (internalConfig.spirvOutput) {
         *internalConfig.spirvOutput = spirv;

--- a/libs/filamat/src/ShaderMinifier.cpp
+++ b/libs/filamat/src/ShaderMinifier.cpp
@@ -137,7 +137,7 @@ namespace {
  * - Remove leading white spaces at the beginning of each line
  * - Remove empty lines
  */
-std::string ShaderMinifier::removeWhitespace(const std::string& s) const {
+std::string ShaderMinifier::removeWhitespace(const std::string& s, bool mergeBraces) const {
     size_t cur = 0;
 
     std::string r;
@@ -155,7 +155,13 @@ std::string ShaderMinifier::removeWhitespace(const std::string& s) const {
         size_t newPos = s.find_first_not_of(" \t", pos);
         if (newPos == std::string::npos) newPos = pos;
 
-        r.append(s, newPos, len - (newPos - pos));
+        // If we have a single { or } on a line, move it to the previous line instead
+        size_t subLen = len - (newPos - pos);
+        if (mergeBraces && subLen == 1 && (s[newPos] == '{' || s[newPos] == '}')) {
+            r.replace(r.size() - 1, 1, 1, s[newPos]);
+        } else {
+            r.append(s, newPos, subLen);
+        }
         r += '\n';
 
         while (s[cur] == '\n') {

--- a/libs/filamat/src/ShaderMinifier.h
+++ b/libs/filamat/src/ShaderMinifier.h
@@ -30,7 +30,7 @@ namespace filamat {
 // This custom minifier is designed for generated code such as uniform structs.
 class ShaderMinifier {
     public:
-        std::string removeWhitespace(const std::string& source) const;
+        std::string removeWhitespace(const std::string& source, bool mergeBraces = false) const;
         std::string renameStructFields(const std::string& source);
 
     private:


### PR DESCRIPTION
This changes the behavior of the size optimizer in matc (-S), but only for GLSL and MSL. With this change we gain a ~65% size reduction on a lit material compiled for OpenGL. To get those gains we generate extra SPIRV debug information to preserve variable names and better utilize the line dictionary. Unfortunately this break the SPIRV optimizer so we skip it and instead rely on a simple DCE pass provided by glslang. We also enhance the whitespace removal pass of the GLSL minifier to move lone { and } to the previous line, which avoids generating an extra index in each shader variant. Each index being at least as big as the character itself, this is quite wasteful.

When generating SPIRV for Vulkan, we rely on spirv-opt for size optimizations as before.