### PR TITLE
Cleanup shader generation

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- materials: prepare ES2 support [⚠️ **New Material Version**]

--- a/filament/src/materials/debugShadowCascades.mat
+++ b/filament/src/materials/debugShadowCascades.mat
@@ -39,18 +39,18 @@ vertex {
 fragment {
     void dummy(){}
 
-    vec3 uintToColorDebug(uint v) {
-        if (v == 0u) {
+    vec3 uintToColorDebug(int v) {
+        if (v == 0) {
             return vec3(0.0, 1.0, 0.0);     // green
-        } else if (v == 1u) {
+        } else if (v == 1) {
             return vec3(0.0, 0.0, 1.0);     // blue
-        } else if (v == 2u) {
+        } else if (v == 2) {
             return vec3(1.0, 1.0, 0.0);     // yellow
-        } else if (v == 3u) {
+        } else if (v == 3) {
             return vec3(1.0, 0.0, 0.0);     // red
-        } else if (v == 4u) {
+        } else if (v == 4) {
             return vec3(1.0, 0.0, 1.0);     // purple
-        } else if (v == 5u) {
+        } else if (v == 5) {
             return vec3(0.0, 1.0, 1.0);     // cyan
         }
 
@@ -58,10 +58,10 @@ fragment {
         return vec3(0.0, 0.0, 0.0);
     }
 
-    uint getShadowCascade(highp float z) {
-        uvec4 greaterZ = uvec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
-        uint cascadeCount = frameUniforms.cascades & 0xFu;
-        return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0u, cascadeCount - 1u);
+    int getShadowCascade(highp float z) {
+        ivec4 greaterZ = ivec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
+        int cascadeCount = frameUniforms.cascades & 0xF;
+        return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0, cascadeCount - 1);
     }
 
     void postProcess(inout PostProcessInputs postProcess) {

--- a/libs/filabridge/include/filament/MaterialEnums.h
+++ b/libs/filabridge/include/filament/MaterialEnums.h
@@ -27,7 +27,7 @@
 namespace filament {
 
 // update this when a new version of filament wouldn't work with older materials
-static constexpr size_t MATERIAL_VERSION = 32;
+static constexpr size_t MATERIAL_VERSION = 33;
 
 /**
  * Supported shading models

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -88,7 +88,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // --------------------------------------------------------------------------------------------
     math::float4 zParams;                       // froxel Z parameters
     math::uint3 fParams;                        // stride-x, stride-y, stride-z
-    uint32_t lightChannels;                     // light channel bits
+    int32_t lightChannels;                      // light channel bits
     math::float2 froxelCountXY;
 
     // IBL
@@ -111,7 +111,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // bit 0: directional (sun) shadow enabled
     // bit 1: directional (sun) screen-space contact shadow enabled
     // bit 8-15: screen-space contact shadows ray casting steps
-    uint32_t directionalShadows;
+    int32_t directionalShadows;
     float ssContactShadowDistance;
 
     // position of cascade splits, in world space (not including the near plane)
@@ -119,7 +119,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::float4 cascadeSplits;
     // bit 0-3: cascade count
     // bit 8-11: cascade has visible shadows
-    uint32_t cascades;
+    int32_t cascades;
     float reserved0;
     float reserved1;                    // normal bias
     float shadowPenumbraRatioScale;     // For DPCF or PCSS, scale penumbra ratio for artistic use
@@ -197,9 +197,9 @@ struct PerRenderableData {
 
     mat44_std140 worldFromModelMatrix;
     mat33_std140 worldFromModelNormalMatrix;
-    uint32_t morphTargetCount;
-    uint32_t flagsChannels;                   // see packFlags() below (0x00000fll)
-    uint32_t objectId;                        // used for picking
+    int32_t morphTargetCount;
+    int32_t flagsChannels;                   // see packFlags() below (0x00000fll)
+    int32_t objectId;                        // used for picking
     // TODO: We need a better solution, this currently holds the average local scale for the renderable
     float userData;
 

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -142,13 +142,6 @@ protected:
         TargetLanguage targetLanguage;
     };
     std::vector<CodeGenParams> mCodeGenPermutations;
-    // For finding properties and running semantic analysis, we always use the same code gen
-    // permutation. This is the first permutation generated with default arguments passed to matc.
-    static constexpr const CodeGenParams mSemanticCodeGenParams = {
-            .shaderModel = ShaderModel::MOBILE,
-            .targetApi = TargetApi::OPENGL,
-            .targetLanguage = TargetLanguage::SPIRV
-    };
 
     // Keeps track of how many times MaterialBuilder::init() has been called without a call to
     // MaterialBuilder::shutdown(). Internally, glslang does something similar. We keep track for
@@ -725,14 +718,16 @@ private:
     // Return true if the shader is syntactically and semantically valid.
     // This method finds all the properties defined in the fragment and
     // vertex shaders of the material.
-    bool findAllProperties() noexcept;
+    bool findAllProperties(CodeGenParams const& semanticCodeGenParams) noexcept;
 
     // Multiple calls to findProperties accumulate the property sets across fragment
     // and vertex shaders in mProperties.
     bool findProperties(filament::backend::ShaderStage type,
-            MaterialBuilder::PropertyList& p) noexcept;
+            MaterialBuilder::PropertyList& allProperties,
+            CodeGenParams const& semanticCodeGenParams) noexcept;
 
-    bool runSemanticAnalysis(MaterialInfo const& info) noexcept;
+    bool runSemanticAnalysis(MaterialInfo const& info,
+            CodeGenParams const& semanticCodeGenParams) noexcept;
 
     bool checkLiteRequirements() noexcept;
 

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -47,10 +47,14 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
             if (mTargetLanguage == TargetLanguage::SPIRV ||
                 material.featureLevel >= FeatureLevel::FEATURE_LEVEL_2) {
                 // Vulkan requires layout locations on ins and outs, which were not supported
-                // in the OpenGL 4.1 GLSL profile.
+                // in ESSL 300
                 out << "#version 310 es\n\n";
             } else {
-                out << "#version 300 es\n\n";
+                if (material.featureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
+                    out << "#version 300 es\n\n";
+                } else {
+                    out << "#version 100\n\n";
+                }
             }
             if (material.hasExternalSamplers) {
                 out << "#extension GL_OES_EGL_image_external_essl3 : require\n\n";

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -77,6 +77,8 @@ public:
 
     static utils::io::sstream& generateEpilog(utils::io::sstream& out);
 
+    static utils::io::sstream& generateCommonTypes(utils::io::sstream& out, ShaderStage stage);
+
     // generate common functions for the given shader
     static utils::io::sstream& generateCommon(utils::io::sstream& out, ShaderStage stage);
     static utils::io::sstream& generatePostProcessCommon(utils::io::sstream& out, ShaderStage type);
@@ -97,11 +99,10 @@ public:
             filament::Variant variant, bool hasShadowMultiplier);
 
     // generate the shader's code for the screen-space reflections
-    static utils::io::sstream& generateShaderReflections(utils::io::sstream& out, ShaderStage type,
-            filament::Variant variant);
+    static utils::io::sstream& generateShaderReflections(utils::io::sstream& out, ShaderStage type);
 
     // generate declarations for custom interpolants
-    static utils::io::sstream& generateVariable(utils::io::sstream& out, ShaderStage type,
+    static utils::io::sstream& generateVariable(utils::io::sstream& out, ShaderStage stage,
             const utils::CString& name, size_t index);
 
     // generate declarations for non-custom "in" variables

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -184,8 +184,7 @@ private:
     // return name of the material property (e.g.: "ROUGHNESS")
     static char const* getConstantName(MaterialBuilder::Property property) noexcept;
 
-    static char const* getPrecisionQualifier(filament::backend::Precision precision,
-            filament::backend::Precision defaultPrecision) noexcept;
+    static char const* getPrecisionQualifier(filament::backend::Precision precision) noexcept;
 
     ShaderModel mShaderModel;
     TargetApi mTargetApi;

--- a/libs/filamat/src/shaders/ShaderGenerator.h
+++ b/libs/filamat/src/shaders/ShaderGenerator.h
@@ -62,7 +62,7 @@ public:
 
     std::string createComputeProgram(filament::backend::ShaderModel shaderModel,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-            MaterialInfo const& material, filament::Variant variant) const noexcept;
+            MaterialInfo const& material) const noexcept;
 
     /**
      * When a GLSL shader is optimized we run it through an intermediate SPIR-V
@@ -75,6 +75,23 @@ public:
             MaterialInfo const& material) noexcept;
 
 private:
+    static void generateVertexDomainDefines(utils::io::sstream& out,
+            filament::VertexDomain domain) noexcept;
+
+    static void generateSurfaceMaterialVariantProperties(utils::io::sstream& out,
+            MaterialBuilder::PropertyList const properties,
+            const MaterialBuilder::PreprocessorDefineList& defines) noexcept;
+
+    static void generateSurfaceMaterialVariantDefines(utils::io::sstream& out,
+            filament::backend::ShaderStage stage,
+            MaterialInfo const& material, filament::Variant variant) noexcept;
+
+    static void generatePostProcessMaterialVariantDefines(utils::io::sstream& out,
+            filament::PostProcessVariant variant) noexcept;
+
+    static void generateUserSpecConstants(
+            const CodeGenerator& cg, utils::io::sstream& fs,
+            MaterialBuilder::ConstantList const& constants);
 
     std::string createPostProcessVertexProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
@@ -83,6 +100,9 @@ private:
     std::string createPostProcessFragmentProgram(filament::backend::ShaderModel sm,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             MaterialInfo const& material, uint8_t variant) const noexcept;
+
+    static void appendShader(utils::io::sstream& ss,
+            const utils::CString& shader, size_t lineOffset) noexcept;
 
     MaterialBuilder::PropertyList mProperties;
     MaterialBuilder::VariableList mVariables;

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -78,7 +78,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ------------------------------------------------------------------------------------
             { "zParams",                0, Type::FLOAT4                  },
             { "fParams",                0, Type::UINT3                   },
-            { "lightChannels",          0, Type::UINT                    },
+            { "lightChannels",          0, Type::INT                     },
             { "froxelCountXY",          0, Type::FLOAT2                  },
 
             { "iblLuminance",           0, Type::FLOAT                   },
@@ -97,11 +97,11 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ------------------------------------------------------------------------------------
             // Directional light shadowing [variant: SRE | DIR]
             // ------------------------------------------------------------------------------------
-            { "directionalShadows",     0, Type::UINT                    },
+            { "directionalShadows",     0, Type::INT                     },
             { "ssContactShadowDistance",0, Type::FLOAT                   },
 
             { "cascadeSplits",          0, Type::FLOAT4, Precision::HIGH },
-            { "cascades",               0, Type::UINT                    },
+            { "cascades",               0, Type::INT                     },
             { "reserved0",              0, Type::FLOAT                   },
             { "reserved1",              0, Type::FLOAT                   },
             { "shadowPenumbraRatioScale", 0, Type::FLOAT                 },

--- a/shaders/src/common_getters.glsl
+++ b/shaders/src/common_getters.glsl
@@ -75,9 +75,9 @@ highp vec2 uvToRenderTargetUV(const highp vec2 uv) {
 
 // TODO: below shouldn't be accessible from post-process materials
 
-#define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x100u
-#define FILAMENT_OBJECT_MORPHING_ENABLED_BIT   0x200u
-#define FILAMENT_OBJECT_CONTACT_SHADOWS_BIT    0x400u
+#define FILAMENT_OBJECT_SKINNING_ENABLED_BIT   0x100
+#define FILAMENT_OBJECT_MORPHING_ENABLED_BIT   0x200
+#define FILAMENT_OBJECT_CONTACT_SHADOWS_BIT    0x400
 
 /** @public-api */
 highp vec4 getResolution() {

--- a/shaders/src/common_lighting.fs
+++ b/shaders/src/common_lighting.fs
@@ -9,8 +9,8 @@ struct Light {
     bool castsShadows;
     bool contactShadows;
     uint type;
-    uint shadowIndex;
-    uint channels;
+    int shadowIndex;
+    int channels;
 };
 
 struct PixelParams {

--- a/shaders/src/common_types.glsl
+++ b/shaders/src/common_types.glsl
@@ -22,9 +22,9 @@ struct BoneData {
 struct PerRenderableData {
     highp mat4 worldFromModelMatrix;
     highp mat3 worldFromModelNormalMatrix;
-    highp uint morphTargetCount;
-    highp uint flagsChannels;                   // see packFlags() below (0x00000fll)
-    highp uint objectId;                        // used for picking
+    highp int morphTargetCount;
+    highp int flagsChannels;                   // see packFlags() below (0x00000fll)
+    highp int objectId;                        // used for picking
     highp float userData;   // TODO: We need a better solution, this currently holds the average local scale for the renderable
     highp vec4 reserved[8];
 };

--- a/shaders/src/common_types.glsl
+++ b/shaders/src/common_types.glsl
@@ -1,5 +1,6 @@
+#if defined(VARIANT_HAS_SHADOWING)
 // Adreno drivers seem to ignore precision qualifiers in structs, unless they're used in
-// UBOs, which is is the case here.
+// UBOs, which is the case here.
 struct ShadowData {
     highp mat4 lightFromWorldMatrix;
     highp vec4 lightFromWorldZ;
@@ -13,11 +14,14 @@ struct ShadowData {
     mediump uint reserved1;
     mediump uint reserved2;
 };
+#endif
 
+#if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
 struct BoneData {
     highp mat3x4 transform;    // bone transform is mat4x3 stored in row-major (last row [0,0,0,1])
     highp uvec4 cof;           // 8 first cofactor matrix of transform's upper left
 };
+#endif
 
 struct PerRenderableData {
     highp mat4 worldFromModelMatrix;

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -49,7 +49,7 @@ void main() {
     fragColor.xy = computeDepthMomentsVSM(depth);
     fragColor.zw = computeDepthMomentsVSM(-1.0 / depth); // requires at least RGBA16F
 #elif defined(VARIANT_HAS_PICKING)
-    outPicking.x = object_uniforms.objectId;
+    outPicking.x = uint(object_uniforms.objectId);
     outPicking.y = floatBitsToUint(vertex_position.z / vertex_position.w);
 #else
     // that's it

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -103,7 +103,7 @@ highp vec3 getNormalizedViewportCoord() {
 }
 
 #if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DYNAMIC_LIGHTING)
-highp vec4 getSpotLightSpacePosition(uint index, highp vec3 dir, highp float zLight) {
+highp vec4 getSpotLightSpacePosition(int index, highp vec3 dir, highp float zLight) {
     highp mat4 lightFromWorldMatrix = shadowUniforms.shadows[index].lightFromWorldMatrix;
 
     // for spotlights, the bias depends on z
@@ -125,18 +125,18 @@ bool isDoubleSided() {
 /**
  * Returns the cascade index for this fragment (between 0 and CONFIG_MAX_SHADOW_CASCADES - 1).
  */
-uint getShadowCascade() {
+int getShadowCascade() {
     highp float z = mulMat4x4Float3(getViewFromWorldMatrix(), getWorldPosition()).z;
-    uvec4 greaterZ = uvec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
-    uint cascadeCount = frameUniforms.cascades & 0xFu;
-    return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0u, cascadeCount - 1u);
+    ivec4 greaterZ = ivec4(greaterThan(frameUniforms.cascadeSplits, vec4(z)));
+    int cascadeCount = frameUniforms.cascades & 0xF;
+    return clamp(greaterZ.x + greaterZ.y + greaterZ.z + greaterZ.w, 0, cascadeCount - 1);
 }
 
-highp vec4 getCascadeLightSpacePosition(uint cascade) {
+highp vec4 getCascadeLightSpacePosition(int cascade) {
     // For the first cascade, return the interpolated light space position.
     // This branch will be coherent (mostly) for neighboring fragments, and it's worth avoiding
     // the matrix multiply inside computeLightSpacePosition.
-    if (cascade == 0u) {
+    if (cascade == 0) {
         // Note: this branch may cause issues with derivatives
         return vertex_lightSpacePosition;
     }

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -188,7 +188,7 @@ vec4 computeWorldPosition() {
     // w could be zero (e.g.: with the skybox) which corresponds to an infinite distance in
     // world-space. However, we want to avoid infinites and divides-by-zero, so we use a very
     // small number instead in that case (2^-63 seem to work well).
-    const highp float ALMOST_ZERO_FLT = 1.08420217249e-19f;
+    const highp float ALMOST_ZERO_FLT = 1.08420217249e-19;
     if (abs(position.w) < ALMOST_ZERO_FLT) {
         position.w = position.w < 0.0 ? -ALMOST_ZERO_FLT : ALMOST_ZERO_FLT;
     }

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -78,11 +78,11 @@ void skinPosition(inout vec3 p, const uvec4 ids, const vec4 weights) {
 
 void morphPosition(inout vec4 p) {
     ivec3 texcoord = ivec3(getVertexIndex() % MAX_MORPH_TARGET_BUFFER_WIDTH, getVertexIndex() / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
-    uint c = object_uniforms.morphTargetCount;
-    for (uint i = 0u; i < c; ++i) {
+    int c = object_uniforms.morphTargetCount;
+    for (int i = 0; i < c; ++i) {
         float w = morphingUniforms.weights[i][0];
         if (w != 0.0) {
-            texcoord.z = int(i);
+            texcoord.z = i;
             p += w * texelFetch(morphTargetBuffer_positions, texcoord, 0);
         }
     }
@@ -91,11 +91,11 @@ void morphPosition(inout vec4 p) {
 void morphNormal(inout vec3 n) {
     vec3 baseNormal = n;
     ivec3 texcoord = ivec3(getVertexIndex() % MAX_MORPH_TARGET_BUFFER_WIDTH, getVertexIndex() / MAX_MORPH_TARGET_BUFFER_WIDTH, 0);
-    uint c = object_uniforms.morphTargetCount;
-    for (uint i = 0u; i < c; ++i) {
+    int c = object_uniforms.morphTargetCount;
+    for (int i = 0; i < c; ++i) {
         float w = morphingUniforms.weights[i][0];
         if (w != 0.0) {
-            texcoord.z = int(i);
+            texcoord.z = i;
             ivec4 tangent = texelFetch(morphTargetBuffer_tangents, texcoord, 0);
             vec3 normal;
             toTangentFrame(float4(tangent) * (1.0 / 32767.0), normal);
@@ -111,7 +111,7 @@ vec4 getPosition() {
 
 #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
 
-    if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
+    if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0) {
 #if defined(LEGACY_MORPHING)
         pos += morphingUniforms.weights[0] * mesh_custom0;
         pos += morphingUniforms.weights[1] * mesh_custom1;
@@ -122,7 +122,7 @@ vec4 getPosition() {
 #endif
     }
 
-    if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
+    if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0) {
         skinPosition(pos.xyz, mesh_bone_indices, mesh_bone_weights);
     }
 

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -57,7 +57,7 @@ void evaluateDirectionalLight(const MaterialInputs material,
         bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1);
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             highp vec4 shadowPosition = getShadowPosition(cascade);
-            visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0f);
+            visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0);
         }
         if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
             if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -27,7 +27,7 @@ Light getDirectionalLight() {
     light.l = sampleSunAreaLight(frameUniforms.lightDirection);
     light.attenuation = 1.0;
     light.NoL = saturate(dot(shading_normal, light.l));
-    light.channels = frameUniforms.lightChannels & 0xFFu;
+    light.channels = frameUniforms.lightChannels & 0xFF;
     return light;
 }
 
@@ -36,8 +36,8 @@ void evaluateDirectionalLight(const MaterialInputs material,
 
     Light light = getDirectionalLight();
 
-    uint channels = object_uniforms.flagsChannels & 0xFFu;
-    if ((light.channels & channels) == 0u) {
+    int channels = object_uniforms.flagsChannels & 0xFF;
+    if ((light.channels & channels) == 0) {
         return;
     }
 
@@ -52,15 +52,15 @@ void evaluateDirectionalLight(const MaterialInputs material,
     if (light.NoL > 0.0) {
         float ssContactShadowOcclusion = 0.0;
 
-        uint cascade = getShadowCascade();
-        bool cascadeHasVisibleShadows = bool(frameUniforms.cascades & ((1u << cascade) << 8u));
-        bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1u);
+        int cascade = getShadowCascade();
+        bool cascadeHasVisibleShadows = bool(frameUniforms.cascades & ((1 << cascade) << 8));
+        bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1);
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             highp vec4 shadowPosition = getShadowPosition(cascade);
             visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0f);
         }
-        if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
-            if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
+        if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
+            if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {
                 ssContactShadowOcclusion = screenSpaceContactShadow(light.l);
             }
         }

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -224,7 +224,7 @@ float prefilteredImportanceSampling(float ipdf, float omegaP) {
 }
 
 vec3 isEvaluateSpecularIBL(const PixelParams pixel, const vec3 n, const vec3 v, const float NoV) {
-    const uint numSamples = uint(IBL_INTEGRATION_IMPORTANCE_SAMPLING_COUNT);
+    const int numSamples = IBL_INTEGRATION_IMPORTANCE_SAMPLING_COUNT;
     const float invNumSamples = 1.0 / float(numSamples);
     const vec3 up = vec3(0.0, 0.0, 1.0);
 
@@ -251,7 +251,7 @@ vec3 isEvaluateSpecularIBL(const PixelParams pixel, const vec3 n, const vec3 v, 
     float omegaP = (4.0 * PI) / (6.0 * dim * dim);
 
     vec3 indirectSpecular = vec3(0.0);
-    for (uint i = 0u; i < numSamples; i++) {
+    for (int i = 0; i < numSamples; i++) {
         vec2 u = hammersley(i);
         vec3 h = T * importanceSamplingNdfDggx(u, roughness);
 
@@ -283,7 +283,7 @@ vec3 isEvaluateSpecularIBL(const PixelParams pixel, const vec3 n, const vec3 v, 
 }
 
 vec3 isEvaluateDiffuseIBL(const PixelParams pixel, vec3 n, vec3 v) {
-    const uint numSamples = uint(IBL_INTEGRATION_IMPORTANCE_SAMPLING_COUNT);
+    const int numSamples = IBL_INTEGRATION_IMPORTANCE_SAMPLING_COUNT;
     const float invNumSamples = 1.0 / float(numSamples);
     const vec3 up = vec3(0.0, 0.0, 1.0);
 
@@ -309,7 +309,7 @@ vec3 isEvaluateDiffuseIBL(const PixelParams pixel, vec3 n, vec3 v) {
     float omegaP = (4.0 * PI) / (6.0 * dim * dim);
 
     vec3 indirectDiffuse = vec3(0.0);
-    for (uint i = 0u; i < numSamples; i++) {
+    for (int i = 0; i < numSamples; i++) {
         vec2 u = hammersley(i);
         vec3 h = T * hemisphereCosSample(u);
 

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -178,7 +178,7 @@ vec3 importanceSamplingNdfDggx(vec2 u, float roughness) {
 }
 
 vec3 hemisphereCosSample(vec2 u) {
-    float phi = 2.0f * PI * u.x;
+    float phi = 2.0 * PI * u.x;
     float cosTheta2 = 1.0 - u.y;
     float cosTheta = sqrt(cosTheta2);
     float sinTheta = sqrt(1.0 - cosTheta2);
@@ -537,7 +537,7 @@ vec3 evaluateRefraction(
 
     // distance to camera plane
     const float invLog2sqrt5 = 0.8614;
-    float lod = max(0.0, (2.0f * log2(perceptualRoughness) + frameUniforms.refractionLodOffset) * invLog2sqrt5);
+    float lod = max(0.0, (2.0 * log2(perceptualRoughness) + frameUniforms.refractionLodOffset) * invLog2sqrt5);
     Ft = textureLod(light_ssr, vec3(p.xy, 0.0), lod).rgb;
 #endif
 
@@ -558,7 +558,7 @@ vec3 evaluateRefraction(
 
 void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout vec3 color) {
     // specular layer
-    vec3 Fr = vec3(0.0f);
+    vec3 Fr = vec3(0.0);
 
     SSAOInterpolationCache interpolationCache;
 #if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED) || defined(MATERIAL_HAS_REFLECTIONS)
@@ -567,10 +567,10 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
 
     // screen-space reflections
 #if defined(MATERIAL_HAS_REFLECTIONS)
-    vec4 ssrFr = vec4(0.0f);
+    vec4 ssrFr = vec4(0.0);
 #if defined(BLEND_MODE_OPAQUE) || defined(BLEND_MODE_MASKED)
     // do the uniform based test first
-    if (frameUniforms.ssrDistance > 0.0f) {
+    if (frameUniforms.ssrDistance > 0.0) {
         // There is no point doing SSR for very high roughness because we're limited by the fov
         // of the screen, in addition it doesn't really add much to the final image.
         // TODO: maybe make this a parameter
@@ -587,21 +587,21 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     // TODO: for blended transparency, we have to ray-march here (limited to mirror reflections)
 #endif
 #else // MATERIAL_HAS_REFLECTIONS
-    const vec4 ssrFr = vec4(0.0f);
+    const vec4 ssrFr = vec4(0.0);
 #endif
 
-    // If screen-space reflections are turned on and have full contribution (ssr.a == 1.0f), then we
+    // If screen-space reflections are turned on and have full contribution (ssr.a == 1.0), then we
     // skip sampling the IBL down below.
 
 #if IBL_INTEGRATION == IBL_INTEGRATION_PREFILTERED_CUBEMAP
     vec3 E = specularDFG(pixel);
-    if (ssrFr.a < 1.0f) { // prevent reading the IBL if possible
+    if (ssrFr.a < 1.0) { // prevent reading the IBL if possible
         vec3 r = getReflectedVector(pixel, shading_normal);
         Fr = E * prefilteredRadiance(r, pixel.perceptualRoughness);
     }
 #elif IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING
     vec3 E = vec3(0.0); // TODO: fix for importance sampling
-    if (ssrFr.a < 1.0f) { // prevent evaluating the IBL if possible
+    if (ssrFr.a < 1.0) { // prevent evaluating the IBL if possible
         Fr = isEvaluateSpecularIBL(pixel, shading_normal, shading_view, shading_NoV);
     }
 #endif

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -153,12 +153,12 @@ Light getLight(const uint lightIndex) {
     light.direction = direction;
     light.NoL = saturate(dot(shading_normal, light.l));
     light.worldPosition = positionFalloff.xyz;
-    light.channels = channels;
+    light.channels = int(channels);
     light.contactShadows = bool(typeShadow & 0x10u);
 #if defined(VARIANT_HAS_DYNAMIC_LIGHTING)
     light.type = (typeShadow & 0x1u);
 #if defined(VARIANT_HAS_SHADOWING)
-    light.shadowIndex = (typeShadow >>  8u) & 0xFFu;
+    light.shadowIndex = int((typeShadow >>  8u) & 0xFFu);
     light.castsShadows   = bool(channels & 0x10000u);
     if (light.type == LIGHT_TYPE_SPOT) {
         light.zLight = dot(shadowUniforms.shadows[light.shadowIndex].lightFromWorldZ, vec4(worldPosition, 1.0));
@@ -191,13 +191,13 @@ void evaluatePunctualLights(const MaterialInputs material,
 
     uint index = froxel.recordOffset;
     uint end = index + froxel.count;
-    uint channels = object_uniforms.flagsChannels & 0xFFu;
+    int channels = object_uniforms.flagsChannels & 0xFF;
 
     // Iterate point lights
     for ( ; index < end; index++) {
         uint lightIndex = getLightIndex(index);
         Light light = getLight(lightIndex);
-        if ((light.channels & channels) == 0u) {
+        if ((light.channels & channels) == 0) {
             continue;
         }
 
@@ -211,11 +211,11 @@ void evaluatePunctualLights(const MaterialInputs material,
 #if defined(VARIANT_HAS_SHADOWING)
         if (light.NoL > 0.0) {
             if (light.castsShadows) {
-                uint shadowIndex = light.shadowIndex;
+                int shadowIndex = light.shadowIndex;
                 if (light.type == LIGHT_TYPE_POINT) {
                     // point-light shadows are sampled from a direction
                     highp vec3 r = getWorldPosition() - light.worldPosition;
-                    uint face = getPointLightFace(r);
+                    int face = getPointLightFace(r);
                     shadowIndex += face;
                     light.zLight = dot(shadowUniforms.shadows[shadowIndex].lightFromWorldZ,
                             vec4(getWorldPosition(), 1.0));
@@ -225,7 +225,7 @@ void evaluatePunctualLights(const MaterialInputs material,
                         shadowPosition, light.zLight);
             }
             if (light.contactShadows && visibility > 0.0) {
-                if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
+                if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {
                     visibility *= 1.0 - screenSpaceContactShadow(light.l);
                 }
             }

--- a/shaders/src/light_reflections.fs
+++ b/shaders/src/light_reflections.fs
@@ -182,11 +182,11 @@ bool traceScreenSpaceRay(const highp vec3 vsOrigin, const highp vec3 vsDirection
 // -- end "BSD 2-clause license" -------------------------------------------------------------------
 
 highp mat4 scaleMatrix(const highp float x, const highp float y) {
-    mat4 m = mat4(1.0f);
+    mat4 m = mat4(1.0);
     m[0].x = x;
     m[1].y = y;
-    m[2].z = 1.0f;
-    m[3].w = 1.0f;
+    m[2].z = 1.0;
+    m[3].w = 1.0;
     return m;
 }
 
@@ -195,13 +195,13 @@ highp mat4 scaleMatrix(const highp float x, const highp float y) {
  * wsRayDirection is the desired reflected vector.
  *
  * The returned color's alpha is set to a value between [0, 1] representing the "opacity" of the
- * reflection. 1.0f is full screen-space reflection. Values < 1.0f should be blended with the
+ * reflection. 1.0 is full screen-space reflection. Values < 1.0 should be blended with the
  * scene's IBL.
  *
  * If there is no hit, the return value is vec4(0).
  */
 vec4 evaluateScreenSpaceReflections(const highp vec3 wsRayDirection) {
-    vec4 Fr = vec4(0.0f);
+    vec4 Fr = vec4(0.0);
     highp vec3 wsRayStart = shading_position + frameUniforms.ssrBias * wsRayDirection;
 
     // ray start/end in view space
@@ -240,11 +240,11 @@ vec4 evaluateScreenSpaceReflections(const highp vec3 wsRayDirection) {
         // Compute the screen-space reflection's contribution.
 
         // TODO: parameterize fadeRate.
-        const float fadeRateEdge = 12.0f;
-        const float fadeRateDistance = 4.0f;
+        const float fadeRateEdge = 12.0;
+        const float fadeRateDistance = 4.0;
 
         // Fade the reflections out near the edges.
-        vec2 edgeFactor = max(fadeRateEdge * abs(reprojected.xy - 0.5f) - (fadeRateEdge * 0.5f - 1.0f), 0.0f);
+        vec2 edgeFactor = max(fadeRateEdge * abs(reprojected.xy - 0.5) - (fadeRateEdge * 0.5 - 1.0), 0.0);
         float fade = saturate(1.0 - dot(edgeFactor, edgeFactor));
 
         // Fade the reflections out near maxRayTraceDistance.

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -43,7 +43,7 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal, vertex_worldTangent.xyz);
 
         #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
-        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
+        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0) {
             #if defined(LEGACY_MORPHING)
             vec3 normal0, normal1, normal2, normal3;
             toTangentFrame(mesh_custom4, normal0);
@@ -61,7 +61,7 @@ void main() {
             #endif
         }
 
-        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
+        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0) {
             skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
             skinNormal(vertex_worldTangent.xyz, mesh_bone_indices, mesh_bone_weights);
         }
@@ -79,7 +79,7 @@ void main() {
         toTangentFrame(mesh_tangents, material.worldNormal);
 
         #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
-        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0u) {
+        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_MORPHING_ENABLED_BIT) != 0) {
             #if defined(LEGACY_MORPHING)
             vec3 normal0, normal1, normal2, normal3;
             toTangentFrame(mesh_custom4, normal0);
@@ -97,7 +97,7 @@ void main() {
             #endif
         }
 
-        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0u) {
+        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_SKINNING_ENABLED_BIT) != 0) {
             skinNormal(material.worldNormal, mesh_bone_indices, mesh_bone_weights);
         }
         #endif

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -46,15 +46,15 @@ vec4 evaluateMaterial(const MaterialInputs material) {
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
 #if defined(VARIANT_HAS_SHADOWING)
     float visibility = 1.0;
-    uint cascade = getShadowCascade();
-    bool cascadeHasVisibleShadows = bool(frameUniforms.cascades & ((1u << cascade) << 8u));
-    bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1u);
+    int cascade = getShadowCascade();
+    bool cascadeHasVisibleShadows = bool(frameUniforms.cascades & ((1 << cascade) << 8));
+    bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1);
     if (hasDirectionalShadows && cascadeHasVisibleShadows) {
         highp vec4 shadowPosition = getShadowPosition(cascade);
         visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0f);
     }
-    if ((frameUniforms.directionalShadows & 0x2u) != 0u && visibility > 0.0) {
-        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0u) {
+    if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
+        if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {
             visibility *= (1.0 - screenSpaceContactShadow(frameUniforms.lightDirection));
         }
     }

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -51,7 +51,7 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     bool hasDirectionalShadows = bool(frameUniforms.directionalShadows & 1);
     if (hasDirectionalShadows && cascadeHasVisibleShadows) {
         highp vec4 shadowPosition = getShadowPosition(cascade);
-        visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0f);
+        visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0);
     }
     if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
         if ((object_uniforms.flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -167,7 +167,7 @@ mat2 getRandomRotationMatrix(highp vec2 fragCoord) {
     return R;
 }
 
-float getPenumbraLs(const bool DIRECTIONAL, const uint index, const highp float zLight) {
+float getPenumbraLs(const bool DIRECTIONAL, const int index, const highp float zLight) {
     float penumbra;
     // This conditional is resolved at compile time
     if (DIRECTIONAL) {
@@ -179,7 +179,7 @@ float getPenumbraLs(const bool DIRECTIONAL, const uint index, const highp float 
     return penumbra;
 }
 
-float getPenumbraRatio(const bool DIRECTIONAL, const uint index,
+float getPenumbraRatio(const bool DIRECTIONAL, const int index,
         float z_receiver, float z_blocker) {
     // z_receiver/z_blocker are not linear depths (i.e. they're not distances)
     // Penumbra ratio for PCSS is given by:  pr = (d_receiver - d_blocker) / d_blocker
@@ -273,7 +273,7 @@ float filterPCSS(const mediump sampler2DArray map,
 float ShadowSample_DPCF(const bool DIRECTIONAL,
         const mediump sampler2DArray map,
         const highp vec4 scissorNormalized,
-        const uint layer, const uint index,
+        const uint layer, const int index,
         const highp vec4 shadowPosition, const highp float zLight) {
     highp vec3 position = shadowPosition.xyz * (1.0 / shadowPosition.w);
     highp vec2 texelSize = vec2(1.0) / vec2(textureSize(map, 0));
@@ -320,7 +320,7 @@ float ShadowSample_DPCF(const bool DIRECTIONAL,
 float ShadowSample_PCSS(const bool DIRECTIONAL,
         const mediump sampler2DArray map,
         const highp vec4 scissorNormalized,
-        const uint layer, const uint index,
+        const uint layer, const int index,
         const highp vec4 shadowPosition, const highp float zLight) {
     highp vec2 size = vec2(textureSize(map, 0));
     highp vec2 texelSize = vec2(1.0) / size;
@@ -395,7 +395,7 @@ void initScreenSpaceRay(out ScreenSpaceRay ray, highp vec3 wsRayStart, vec3 wsRa
 float screenSpaceContactShadow(vec3 lightDirection) {
     // cast a ray in the direction of the light
     float occlusion = 0.0;
-    uint kStepCount = (frameUniforms.directionalShadows >> 8u) & 0xFFu;
+    int kStepCount = (frameUniforms.directionalShadows >> 8) & 0xFF;
     float kDistanceMax = frameUniforms.ssContactShadowDistance;
 
     ScreenSpaceRay rayData;
@@ -414,7 +414,7 @@ float screenSpaceContactShadow(vec3 lightDirection) {
     highp float t = dt * dither + dt;
 
     highp vec3 ray;
-    for (uint i = 0u ; i < kStepCount ; i++, t += dt) {
+    for (int i = 0 ; i < kStepCount ; i++, t += dt) {
         ray = rayData.uvRayStart + rayData.uvRay * t;
         highp float z = textureLod(light_structure, uvToRenderTargetUV(ray.xy), 0.0).r;
         highp float dz = z - ray.z;
@@ -507,36 +507,36 @@ float ShadowSample_VSM(const bool ELVSM, const mediump sampler2DArray shadowMap,
 
 // get texture coordinate for directional and spot shadow maps
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
-highp vec4 getShadowPosition(const uint cascade) {
+highp vec4 getShadowPosition(const int cascade) {
     return getCascadeLightSpacePosition(cascade);
 }
 #endif
 
 #if defined(VARIANT_HAS_DYNAMIC_LIGHTING)
-highp vec4 getShadowPosition(const uint index,  const highp vec3 dir, const highp float zLight) {
+highp vec4 getShadowPosition(const int index,  const highp vec3 dir, const highp float zLight) {
     return getSpotLightSpacePosition(index, dir, zLight);
 }
 #endif
 
-uint getPointLightFace(const highp vec3 r) {
+int getPointLightFace(const highp vec3 r) {
     highp vec4 tc;
     highp float rx = abs(r.x);
     highp float ry = abs(r.y);
     highp float rz = abs(r.z);
     highp float d = max(rx, max(ry, rz));
     if (d == rx) {
-        return (r.x >= 0.0 ? 0u : 1u);
+        return (r.x >= 0.0 ? 0 : 1);
     } else if (d == ry) {
-        return (r.y >= 0.0 ? 2u : 3u);
+        return (r.y >= 0.0 ? 2 : 3);
     } else {
-        return (r.z >= 0.0 ? 4u : 5u);
+        return (r.z >= 0.0 ? 4 : 5);
     }
 }
 
 // PCF sampling
 float shadow(const bool DIRECTIONAL,
         const mediump sampler2DArrayShadow shadowMap,
-        const uint index, highp vec4 shadowPosition, highp float zLight) {
+        const int index, highp vec4 shadowPosition, highp float zLight) {
     highp vec4 scissorNormalized = shadowUniforms.shadows[index].scissorNormalized;
     uint layer = shadowUniforms.shadows[index].layer;
 #if SHADOW_SAMPLING_METHOD == SHADOW_SAMPLING_PCF_HARD
@@ -549,7 +549,7 @@ float shadow(const bool DIRECTIONAL,
 // Shadow requiring a sampler2D sampler (VSM, DPCF and PCSS)
 float shadow(const bool DIRECTIONAL,
         const mediump sampler2DArray shadowMap,
-        const uint index, highp vec4 shadowPosition, highp float zLight) {
+        const int index, highp vec4 shadowPosition, highp float zLight) {
     highp vec4 scissorNormalized = shadowUniforms.shadows[index].scissorNormalized;
     uint layer = shadowUniforms.shadows[index].layer;
     // This conditional is resolved at compile time


### PR DESCRIPTION
- refactor the code so that all defines are generated in the same place
- generate common_type after all defines are generated
- protect (with defines) structures and UBOs that are not needed, based
  on the variant
- don't use a trailing `f` for floats, it's not needed and not supported in ES2

⚠️ new material version needed