### PR TITLE
vulkan: refactor image layout transition

### DIFF
--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -175,6 +175,8 @@ if (FILAMENT_SUPPORTS_VULKAN)
             src/vulkan/VulkanFboCache.h
             src/vulkan/VulkanHandles.cpp
             src/vulkan/VulkanHandles.h
+            src/vulkan/VulkanImageUtility.cpp
+            src/vulkan/VulkanImageUtility.h
             src/vulkan/VulkanMemory.h
             src/vulkan/VulkanMemory.cpp
             src/vulkan/VulkanPipelineCache.cpp

--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -79,9 +79,10 @@ inline void blitFast(const VkCommandBuffer cmdbuffer, VkImageAspectFlags aspect,
     if (src.texture->samples > 1 && dst.texture->samples == 1) {
         assert_invariant(
                 aspect != VK_IMAGE_ASPECT_DEPTH_BIT && "Resolve with depth is not yet supported.");
-        vkCmdResolveImage(cmdbuffer, src.getImage(),
-                ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), dst.getImage(),
-                ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 1, resolveRegions);
+        vkCmdResolveImage(cmdbuffer, 
+                src.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), 
+                dst.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 
+                1, resolveRegions);
     } else {
         vkCmdBlitImage(cmdbuffer, src.getImage(),
                 ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), dst.getImage(),

--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -79,14 +79,14 @@ inline void blitFast(const VkCommandBuffer cmdbuffer, VkImageAspectFlags aspect,
     if (src.texture->samples > 1 && dst.texture->samples == 1) {
         assert_invariant(
                 aspect != VK_IMAGE_ASPECT_DEPTH_BIT && "Resolve with depth is not yet supported.");
-        vkCmdResolveImage(cmdbuffer, 
-                src.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), 
-                dst.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 
+        vkCmdResolveImage(cmdbuffer,
+                src.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC),
+                dst.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST),
                 1, resolveRegions);
     } else {
-        vkCmdBlitImage(cmdbuffer, 
+        vkCmdBlitImage(cmdbuffer,
                 src.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC),
-                dst.getImage(),ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 
+                dst.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST),
                 1, blitRegions, filter);
     }
 

--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -84,9 +84,10 @@ inline void blitFast(const VkCommandBuffer cmdbuffer, VkImageAspectFlags aspect,
                 dst.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 
                 1, resolveRegions);
     } else {
-        vkCmdBlitImage(cmdbuffer, src.getImage(),
-                ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), dst.getImage(),
-                ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 1, blitRegions, filter);
+        vkCmdBlitImage(cmdbuffer, 
+                src.getImage(), ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC),
+                dst.getImage(),ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 
+                1, blitRegions, filter);
     }
 
     VulkanLayout newSrcLayout = ImgUtil::getDefaultLayout(src.texture->usage);

--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -74,19 +74,19 @@ void VulkanBuffer::loadFromCpu(VulkanContext& context, VulkanStagePool& stagePoo
     VkAccessFlags dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
     if (mUsage & VK_BUFFER_USAGE_VERTEX_BUFFER_BIT) {
-	dstAccessMask |= VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
-	dstStageMask |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+        dstAccessMask |= VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
+        dstStageMask |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
     } else if (mUsage & VK_BUFFER_USAGE_INDEX_BUFFER_BIT) {
-	dstAccessMask |= VK_ACCESS_INDEX_READ_BIT;
-	dstStageMask |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+        dstAccessMask |= VK_ACCESS_INDEX_READ_BIT;
+        dstStageMask |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
     } else if (mUsage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
-	dstAccessMask |= VK_ACCESS_UNIFORM_READ_BIT;
-	// NOTE: ideally dstStageMask would include VERTEX_SHADER_BIT | FRAGMENT_SHADER_BIT, but
-	// this seems to be insufficient on Mali devices. To work around this we are using a more
-	// aggressive ALL_GRAPHICS_BIT barrier.
-	dstStageMask |= VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT;
+        dstAccessMask |= VK_ACCESS_UNIFORM_READ_BIT;
+        // NOTE: ideally dstStageMask would include VERTEX_SHADER_BIT | FRAGMENT_SHADER_BIT, but
+        // this seems to be insufficient on Mali devices. To work around this we are using a more
+        // aggressive ALL_GRAPHICS_BIT barrier.
+        dstStageMask |= VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT;
     } else if (mUsage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) {
-	// TODO: implement me
+        // TODO: implement me
     }
 
     VkBufferMemoryBarrier barrier{

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -20,6 +20,7 @@
 #include "VulkanPipelineCache.h"
 #include "VulkanCommands.h"
 #include "VulkanConstants.h"
+#include "VulkanImageUtility.h"
 
 #include <utils/bitset.h>
 #include <utils/Slice.h>
@@ -41,9 +42,11 @@ struct VulkanAttachment {
     uint16_t layer = 0;
     VkImage getImage() const;
     VkFormat getFormat() const;
-    VkImageLayout getLayout() const;
+    VulkanLayout getLayout() const;
     VkExtent2D getExtent2D() const;
     VkImageView getImageView(VkImageAspectFlags aspect) const;
+    // TODO: maybe embed aspect into the attachment or texture itself.
+    VkImageSubresourceRange getSubresourceRange(VkImageAspectFlags aspect) const;
 };
 
 struct VulkanTimestamps {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -22,6 +22,7 @@
 #include "VulkanCommands.h"
 #include "VulkanDriverFactory.h"
 #include "VulkanHandles.h"
+#include "VulkanImageUtility.h"
 #include "VulkanMemory.h"
 
 #include <backend/platforms/VulkanPlatform.h>
@@ -32,6 +33,11 @@
 
 #ifndef NDEBUG
 #include <set>
+#endif
+
+#if FILAMENT_VULKAN_VERBOSE
+#include <stack>
+static std::stack<std::string> renderPassMarkers;
 #endif
 
 using namespace bluevk;
@@ -45,6 +51,8 @@ using utils::FixedCapacityVector;
 #pragma clang diagnostic ignored "-Wunused-parameter"
 
 namespace filament::backend {
+
+using ImgUtil = VulkanImageUtility;
 
 Driver* VulkanDriverFactory::create(VulkanPlatform* const platform,
         const char* const* ppRequiredExtensions, uint32_t requiredExtensionCount, const Platform::DriverConfig& driverConfig) noexcept {
@@ -871,7 +879,6 @@ void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 
 void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassParams& params) {
     VulkanRenderTarget* const rt = handle_cast<VulkanRenderTarget*>(rth);
-
     const VkExtent2D extent = rt->getExtent();
     assert_invariant(extent.width > 0 && extent.height > 0);
 
@@ -888,12 +895,52 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         }
     }
 
-    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     VulkanAttachment depth = rt->getSamples() == 1 ? rt->getDepth() : rt->getMsaaDepth();
+#ifdef VULKAN_DEBUG_REAL
+    if (depth.texture) {
+        depth.texture->print();
+    }
+#endif
 
-    VulkanDepthLayout initialDepthLayout = fromVkImageLayout(depth.getLayout());
-    VulkanDepthLayout renderPassDepthLayout = VulkanDepthLayout::ATTACHMENT;
-    VulkanDepthLayout finalDepthLayout = VulkanDepthLayout::ATTACHMENT;
+    bool samplingDepthAttachment = false;
+    const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
+    for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::SAMPLER_BINDING_COUNT;
+            samplerGroupIdx++) {
+        VulkanSamplerGroup* vksb = mSamplerBindings[samplerGroupIdx];
+        if (!vksb) {
+            continue;
+        }
+        SamplerGroup* sb = vksb->sb.get();
+        for (size_t i = 0; i < sb->getSize(); i++) {
+            const SamplerDescriptor* boundSampler = sb->data() + i;
+            if (UTILS_LIKELY(boundSampler->t)) {
+                VulkanTexture* texture = handle_cast<VulkanTexture*>(boundSampler->t);
+                if (!any(texture->usage & TextureUsage::DEPTH_ATTACHMENT)) {
+                    continue;
+                }
+                samplingDepthAttachment
+                        = depth.texture && texture->getVkImage() == depth.texture->getVkImage();
+                if (texture->getPrimaryImageLayout() == VulkanLayout::DEPTH_SAMPLER) {
+                    continue;
+                }
+                VkImageSubresourceRange subresources{
+                        .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
+                        .baseMipLevel = 0,
+                        .levelCount = texture->levels,
+                        .baseArrayLayer = 0,
+                        .layerCount = texture->depth,
+                };
+                texture->transitionLayout(cmdbuffer, subresources, VulkanLayout::DEPTH_SAMPLER);
+                break;
+            }
+        }
+    }
+    // The state of the layout after the transition in the above block
+    VulkanLayout currentDepthLayout = depth.getLayout();
+    VulkanLayout const renderPassDepthLayout = samplingDepthAttachment
+                                                       ? VulkanLayout::DEPTH_SAMPLER
+                                                       : VulkanLayout::DEPTH_ATTACHMENT;
+    VulkanLayout const finalDepthLayout = renderPassDepthLayout;
 
     TargetBufferFlags clearVal = params.flags.clear;
     TargetBufferFlags discardEndVal = params.flags.discardEnd;
@@ -902,23 +949,17 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
             discardEndVal &= ~TargetBufferFlags::DEPTH;
             clearVal &= ~TargetBufferFlags::DEPTH;
         }
-        if (initialDepthLayout != VulkanDepthLayout::ATTACHMENT) {
-            VkImageSubresourceRange subresources{
-                    .aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT,
-                    .baseMipLevel = 0,
-                    .levelCount = depth.texture->levels,
-                    .baseArrayLayer = 0,
-                    .layerCount = depth.texture->depth,
-            };
-            depth.texture->transitionLayout(cmdbuffer, subresources,
-                    toVkImageLayout(renderPassDepthLayout));
+        if (currentDepthLayout != renderPassDepthLayout) {
+            depth.texture->transitionLayout(cmdbuffer,
+                    depth.getSubresourceRange(VK_IMAGE_ASPECT_DEPTH_BIT), renderPassDepthLayout);
+            currentDepthLayout = renderPassDepthLayout;
         }
     }
 
     // Create the VkRenderPass or fetch it from cache.
     VulkanFboCache::RenderPassKey rpkey = {
         .initialColorLayoutMask = 0,
-        .initialDepthLayout = initialDepthLayout,
+        .initialDepthLayout = currentDepthLayout,
         .renderPassDepthLayout = renderPassDepthLayout,
         .finalDepthLayout = finalDepthLayout,
         .depthFormat = depth.getFormat(),
@@ -932,11 +973,14 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
         const VulkanAttachment& info = rt->getColor(i);
         if (info.texture) {
             rpkey.initialColorLayoutMask |= 1 << i;
-            info.texture->trackLayout(info.level, info.layer,
-                    getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT));
             rpkey.colorFormat[i] = info.getFormat();
             if (rpkey.samples > 1 && info.texture->samples == 1) {
                 rpkey.needsResolveMask |= (1 << i);
+            }
+            if (info.texture->getPrimaryImageLayout() != VulkanLayout::COLOR_ATTACHMENT) {
+                info.texture->transitionLayout(cmdbuffer,
+                        info.getSubresourceRange(VK_IMAGE_ASPECT_COLOR_BIT),
+                        VulkanLayout::COLOR_ATTACHMENT);
             }
         } else {
             rpkey.colorFormat[i] = VK_FORMAT_UNDEFINED;
@@ -1135,7 +1179,7 @@ void VulkanDriver::nextSubpass(int) {
             VulkanAttachment subpassInput = renderTarget->getColor(i);
             VkDescriptorImageInfo info = {
                 .imageView = subpassInput.getImageView(VK_IMAGE_ASPECT_COLOR_BIT),
-                .imageLayout = subpassInput.getLayout(),
+                .imageLayout = ImgUtil::getVkLayout(subpassInput.getLayout()),
             };
             mPipelineCache.bindInputAttachment(i, info);
         }
@@ -1281,6 +1325,12 @@ void VulkanDriver::insertEventMarker(char const* string, uint32_t len) {
 }
 
 void VulkanDriver::pushGroupMarker(char const* string, uint32_t len) {
+
+#if FILAMENT_VULKAN_VERBOSE
+    renderPassMarkers.push(std::string(string));
+    utils::slog.d << "----> " << string << utils::io::endl;
+#endif
+
     // TODO: Add group marker color to the Driver API
     constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
@@ -1302,6 +1352,13 @@ void VulkanDriver::pushGroupMarker(char const* string, uint32_t len) {
 }
 
 void VulkanDriver::popGroupMarker(int) {
+
+#if FILAMENT_VULKAN_VERBOSE
+    std::string const& marker = renderPassMarkers.top();
+    renderPassMarkers.pop();
+    utils::slog.d << "<---- " << marker << utils::io::endl;
+#endif
+
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
     if (mContext.debugUtilsSupported) {
         vkCmdEndDebugUtilsLabelEXT(cmdbuffer);
@@ -1329,7 +1386,6 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     const bool swizzle = srcFormat == VK_FORMAT_B8G8R8A8_UNORM;
 
     // Create a host visible, linearly tiled image as a staging area.
-
     VkImageCreateInfo imageInfo {
         .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
         .imageType = VK_IMAGE_TYPE_2D,
@@ -1340,11 +1396,17 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
         .samples = VK_SAMPLE_COUNT_1_BIT,
         .tiling = VK_IMAGE_TILING_LINEAR,
         .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .initialLayout = ImgUtil::getVkLayout(VulkanLayout::UNDEFINED),
     };
 
     VkImage stagingImage;
     vkCreateImage(device, &imageInfo, VKALLOC, &stagingImage);
+
+#if FILAMENT_VULKAN_VERBOSE
+    utils::slog.d << "readPixels created image=" << stagingImage
+                  << " to copy from image=" << srcTexture->getVkImage()
+                  << " src-layout=" << srcTexture->getLayout(0, 0) << utils::io::endl;
+#endif
 
     VkMemoryRequirements memReqs;
     VkDeviceMemory stagingMemory;
@@ -1366,13 +1428,11 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     mContext.commands->wait();
 
     // Transition the staging image layout.
-
     const VkCommandBuffer cmdbuffer = mContext.commands->get().cmdbuffer;
-
-    transitionImageLayout(cmdbuffer, {
+    ImgUtil::transitionLayout(cmdbuffer, {
         .image = stagingImage,
-        .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-        .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .oldLayout = VulkanLayout::UNDEFINED,
+        .newLayout = VulkanLayout::TRANSFER_DST,
         .subresources = {
             .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
             .baseMipLevel = 0,
@@ -1380,10 +1440,6 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
             .baseArrayLayer = 0,
             .layerCount = 1,
         },
-        .srcStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-        .srcAccessMask = 0,
-        .dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT,
-        .dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
     });
 
     const VulkanAttachment srcAttachment = srcTarget->getColor(0);
@@ -1412,15 +1468,9 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
 
     // Transition the source image layout (which might be the swap chain)
 
-    const VkImageSubresourceRange srcRange = {
-        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-        .baseMipLevel = srcAttachment.level,
-        .levelCount = 1,
-        .baseArrayLayer = srcAttachment.layer,
-        .layerCount = 1,
-    };
-
-    srcTexture->transitionLayout(cmdbuffer, srcRange, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    const VkImageSubresourceRange srcRange
+            = srcAttachment.getSubresourceRange(VK_IMAGE_ASPECT_COLOR_BIT);
+    srcTexture->transitionLayout(cmdbuffer, srcRange, VulkanLayout::TRANSFER_SRC);
 
     // Perform the copy into the staging area. At this point we know that the src layout is
     // TRANSFER_SRC_OPTIMAL and the staging area is GENERAL.
@@ -1430,14 +1480,13 @@ void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y
     assert_invariant(imageCopyRegion.srcOffset.y + imageCopyRegion.extent.height <= srcExtent.height);
 
     vkCmdCopyImage(cmdbuffer, srcAttachment.getImage(),
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, stagingImage, VK_IMAGE_LAYOUT_GENERAL,
-            1, &imageCopyRegion);
+            ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC), stagingImage,
+            ImgUtil::getVkLayout(VulkanLayout::TRANSFER_DST), 1, &imageCopyRegion);
 
     // Restore the source image layout. Between driver API calls, color images are always kept in
-    // UNDEFINED layout or in their "usage default" layout (see comment for getDefaultImageLayout).
+    // UNDEFINED layout or in their "usage default" layout.
 
-    srcTexture->transitionLayout(cmdbuffer, srcRange,
-            getDefaultImageLayout(TextureUsage::COLOR_ATTACHMENT));
+    srcTexture->transitionLayout(cmdbuffer, srcRange, VulkanLayout::COLOR_ATTACHMENT);
 
     // TODO: don't flush/wait here -- we should do this asynchronously
 
@@ -1646,7 +1695,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 // TODO: can this uninitialized check be checked in a higher layer?
                 // This fallback path is very flaky because the dummy texture might not have
                 // matching characteristics. (e.g. if the missing texture is a 3D texture)
-                if (UTILS_UNLIKELY(texture->getPrimaryImageLayout() == VK_IMAGE_LAYOUT_UNDEFINED)) {
+                if (UTILS_UNLIKELY(texture->getPrimaryImageLayout() == VulkanLayout::UNDEFINED)) {
 #ifndef NDEBUG
                     utils::slog.w << "Uninitialized texture bound to '" << sampler.name.c_str() << "'";
                     utils::slog.w << " in material '" << program->name.c_str() << "'";
@@ -1663,7 +1712,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
                 samplerInfo[sampler.binding] = {
                     .sampler = vksampler,
                     .imageView = texture->getPrimaryImageView(),
-                    .imageLayout = texture->getPrimaryImageLayout()
+                    .imageLayout = ImgUtil::getVkLayout(texture->getPrimaryImageLayout())
                 };
             }
         }

--- a/filament/backend/src/vulkan/VulkanFboCache.h
+++ b/filament/backend/src/vulkan/VulkanFboCache.h
@@ -27,12 +27,6 @@
 
 namespace filament::backend {
 
-// Avoid using VkImageLayout since it requires 4 bytes.
-enum class VulkanDepthLayout : uint8_t {
-    UNDEFINED, // VK_IMAGE_LAYOUT_UNDEFINED
-    ATTACHMENT, // VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-};
-
 // Simple manager for VkFramebuffer and VkRenderPass objects.
 //
 // Note that a VkFramebuffer is just a binding between a render pass and a set of image views. So,
@@ -53,11 +47,12 @@ public:
         // - For each color target, the pre-existing layout is either UNDEFINED (0) or GENERAL (1).
         // - The render pass and final images layout for color buffers is always GENERAL.
         uint8_t initialColorLayoutMask;
-        VulkanDepthLayout initialDepthLayout : 2;
-        VulkanDepthLayout renderPassDepthLayout : 2;
-        VulkanDepthLayout finalDepthLayout : 2;      // for now this is always GENERAL
-        uint8_t padding0 : 2;
-        uint8_t padding1[2];
+
+        // Note that if VulkanLayout grows beyond 16, we'd need to up this.
+        VulkanLayout initialDepthLayout : 4;
+        VulkanLayout renderPassDepthLayout : 4;
+        VulkanLayout finalDepthLayout : 4;
+        uint8_t padding : 4;
 
         VkFormat colorFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT]; // 32 bytes
         VkFormat depthFormat; // 4 bytes
@@ -130,24 +125,6 @@ private:
     tsl::robin_map<VkRenderPass, uint32_t> mRenderPassRefCount;
     uint32_t mCurrentTime = 0;
 };
-
-inline VulkanDepthLayout fromVkImageLayout(VkImageLayout layout) {
-    switch (layout) {
-        case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
-            return VulkanDepthLayout::ATTACHMENT;
-        default:
-            return VulkanDepthLayout::UNDEFINED;
-    }
-}
-
-inline VkImageLayout toVkImageLayout(VulkanDepthLayout layout) {
-    switch (layout) {
-        case VulkanDepthLayout::ATTACHMENT:
-            return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        default:
-            return VK_IMAGE_LAYOUT_UNDEFINED;
-    }
-}
 
 } // namespace filament::backend
 

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -186,10 +186,13 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
         return;
     }
 
+    // MSAA depth texture must have the mipmap count of 1
+    uint8_t const msLevel = 1;
+
     // Create sidecar MSAA texture for the depth attachment if it does not already exist.
     VulkanTexture* msTexture = depthTexture->getSidecar();
     if (UTILS_UNLIKELY(msTexture == nullptr)) {
-        msTexture = new VulkanTexture(context, depthTexture->target, depthTexture->levels,
+        msTexture = new VulkanTexture(context, depthTexture->target, msLevel,
                 depthTexture->format, samples, depthTexture->width, depthTexture->height,
                 depthTexture->depth, depthTexture->usage, stagePool);
         depthTexture->setSidecar(msTexture);
@@ -197,7 +200,7 @@ VulkanRenderTarget::VulkanRenderTarget(VulkanContext& context, uint32_t width, u
 
     mMsaaDepthAttachment = {
         .texture = msTexture,
-        .level = mDepth.level,
+        .level = msLevel,
         .layer = mDepth.layer,
     };
 }

--- a/filament/backend/src/vulkan/VulkanImageUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanImageUtility.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "VulkanImageUtility.h"
+
+#include "VulkanTexture.h"
+
+#include <utils/Panic.h>
+#include <utils/algorithm.h>
+#include <utils/debug.h>
+
+#include <tuple>
+
+using namespace bluevk;
+
+namespace filament::backend {
+
+namespace {
+
+inline VkImageLayout getVkImageLayout(VulkanLayout layout) {
+    switch (layout) {
+        case VulkanLayout::UNDEFINED:
+            return VK_IMAGE_LAYOUT_UNDEFINED;
+        case VulkanLayout::READ_WRITE:
+            return VK_IMAGE_LAYOUT_GENERAL;
+        case VulkanLayout::READ_ONLY:
+            return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        case VulkanLayout::TRANSFER_SRC:
+            return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        case VulkanLayout::TRANSFER_DST:
+            return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        case VulkanLayout::DEPTH_ATTACHMENT:
+            return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        case VulkanLayout::DEPTH_SAMPLER:
+            return VK_IMAGE_LAYOUT_GENERAL;
+        case VulkanLayout::PRESENT:
+            return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+        // Filament sometimes samples from one miplevel while writing to another level in the same
+        // texture (e.g. bloom does this). Moreover we'd like to avoid lots of expensive layout
+        // transitions. So, keep it simple and use GENERAL for all color-attachable textures.
+        case VulkanLayout::COLOR_ATTACHMENT:
+            return VK_IMAGE_LAYOUT_GENERAL;
+        case VulkanLayout::COLOR_ATTACHMENT_RESOLVE:
+            return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    }
+}
+
+inline std::tuple<VkAccessFlags, VkAccessFlags, VkPipelineStageFlags, VkPipelineStageFlags,
+        VkImageLayout, VkImageLayout>
+getVkTransition(const VulkanLayoutTransition& transition) {
+    VkAccessFlags srcAccessMask, dstAccessMask;
+    VkPipelineStageFlags srcStage, dstStage;
+
+    switch (transition.oldLayout) {
+        case VulkanLayout::UNDEFINED:
+            srcAccessMask = 0;
+            srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::COLOR_ATTACHMENT:
+            srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT
+                            | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+                            | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            srcStage = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                       | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            break;
+        case VulkanLayout::READ_WRITE:
+            srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            break;
+        case VulkanLayout::READ_ONLY:
+            srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            break;
+        case VulkanLayout::TRANSFER_SRC:
+            srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::TRANSFER_DST:
+            srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::DEPTH_ATTACHMENT:
+            srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT
+                            | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+            srcStage = VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+            break;
+        case VulkanLayout::DEPTH_SAMPLER:
+            srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+            srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            break;
+        case VulkanLayout::PRESENT:
+        case VulkanLayout::COLOR_ATTACHMENT_RESOLVE:
+            srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+    }
+
+    switch (transition.newLayout) {
+        case VulkanLayout::COLOR_ATTACHMENT:
+            dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT
+                            | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT
+                            | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+            dstStage = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                       | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+            break;
+        case VulkanLayout::READ_WRITE:
+            dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
+            dstStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            break;
+        case VulkanLayout::READ_ONLY:
+            dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            dstStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            break;
+        case VulkanLayout::TRANSFER_SRC:
+            dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::TRANSFER_DST:
+            dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+            dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::DEPTH_ATTACHMENT:
+            dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT
+                            | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+            dstStage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            break;
+        case VulkanLayout::DEPTH_SAMPLER:
+            dstAccessMask
+                    = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+            dstStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                       | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            break;
+        case VulkanLayout::PRESENT:
+        case VulkanLayout::COLOR_ATTACHMENT_RESOLVE:
+        case VulkanLayout::UNDEFINED:
+            dstAccessMask = 0;
+            dstStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+            break;
+    }
+
+    return std::make_tuple(srcAccessMask, dstAccessMask, srcStage, dstStage,
+            getVkImageLayout(transition.oldLayout), getVkImageLayout(transition.newLayout));
+}
+
+}// anonymous namespace
+
+VkImageViewType VulkanImageUtility::getViewType(SamplerType target) {
+    switch (target) {
+        case SamplerType::SAMPLER_CUBEMAP:
+            return VK_IMAGE_VIEW_TYPE_CUBE;
+        case SamplerType::SAMPLER_2D_ARRAY:
+            return VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            return VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
+        case SamplerType::SAMPLER_3D:
+            return VK_IMAGE_VIEW_TYPE_3D;
+        default:
+            return VK_IMAGE_VIEW_TYPE_2D;
+    }
+}
+
+void VulkanImageUtility::transitionLayout(VkCommandBuffer cmdbuffer,
+        VulkanLayoutTransition transition) {
+    if (transition.oldLayout == transition.newLayout) {
+        return;
+    }
+    auto [srcAccessMask, dstAccessMask, srcStage, dstStage, oldLayout, newLayout]
+            = getVkTransition(transition);
+
+    assert_invariant(transition.image != VK_NULL_HANDLE && "No image for transition");
+    VkImageMemoryBarrier barrier = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .srcAccessMask = srcAccessMask,
+            .dstAccessMask = dstAccessMask,
+            .oldLayout = oldLayout,
+            .newLayout = newLayout,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .image = transition.image,
+            .subresourceRange = transition.subresources,
+    };
+    vkCmdPipelineBarrier(cmdbuffer, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+VkImageLayout VulkanImageUtility::getVkLayout(VulkanLayout layout) {
+    return getVkImageLayout(layout);
+}
+
+}// namespace filament::backend
+
+bool operator<(const VkImageSubresourceRange& a, const VkImageSubresourceRange& b) {
+    if (a.aspectMask < b.aspectMask) return true;
+    if (a.aspectMask > b.aspectMask) return false;
+    if (a.baseMipLevel < b.baseMipLevel) return true;
+    if (a.baseMipLevel > b.baseMipLevel) return false;
+    if (a.levelCount < b.levelCount) return true;
+    if (a.levelCount > b.levelCount) return false;
+    if (a.baseArrayLayer < b.baseArrayLayer) return true;
+    if (a.baseArrayLayer > b.baseArrayLayer) return false;
+    if (a.layerCount < b.layerCount) return true;
+    if (a.layerCount > b.layerCount) return false;
+    return false;
+}
+
+#if FILAMENT_VULKAN_VERBOSE
+#define CASE(VALUE)                                                                                \
+    case filament::backend::VulkanLayout::VALUE: {                                                 \
+        out << #VALUE;                                                                             \
+        out << " ["                                                                                \
+            << filament::backend::VulkanImageUtility::getVkLayout(                                 \
+                       filament::backend::VulkanLayout::VALUE)                                     \
+            << "]";                                                                                \
+        break;                                                                                     \
+    }
+
+utils::io::ostream& operator<<(utils::io::ostream& out,
+        const filament::backend::VulkanLayout& layout) {
+    switch (layout) {
+        CASE(UNDEFINED)
+        CASE(READ_WRITE)
+        CASE(TRANSFER_SRC)
+        CASE(TRANSFER_DST)
+        CASE(DEPTH_ATTACHMENT)
+        CASE(DEPTH_SAMPLER)
+        CASE(PRESENT)
+        CASE(COLOR_ATTACHMENT)
+        CASE(COLOR_ATTACHMENT_RESOLVE)
+    }
+    return out;
+}
+#undef CASE
+#endif

--- a/filament/backend/src/vulkan/VulkanImageUtility.h
+++ b/filament/backend/src/vulkan/VulkanImageUtility.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_FILAMENT_BACKEND_VULKANIMAGEUTILITY_H
+#define TNT_FILAMENT_BACKEND_VULKANIMAGEUTILITY_H
+
+#include <backend/DriverEnums.h>
+
+#include <utils/Log.h>
+
+#include <bluevk/BlueVK.h>
+
+namespace filament::backend {
+
+struct VulkanTexture;    
+
+enum class VulkanLayout : uint8_t {
+    UNDEFINED,
+    READ_WRITE,
+    READ_ONLY,
+    TRANSFER_SRC,
+    TRANSFER_DST,
+    DEPTH_ATTACHMENT,
+    DEPTH_SAMPLER,
+    PRESENT,
+    COLOR_ATTACHMENT,
+    COLOR_ATTACHMENT_RESOLVE,
+};
+
+struct VulkanLayoutTransition {
+    VkImage image;
+    VulkanLayout oldLayout;
+    VulkanLayout newLayout;
+    VkImageSubresourceRange subresources;
+};
+
+class VulkanImageUtility {
+public:
+    static VkImageViewType getViewType(SamplerType target);
+
+    inline static VulkanLayout getDefaultLayout(TextureUsage usage) {
+        if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
+            return VulkanLayout::DEPTH_ATTACHMENT;
+        }
+
+        if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
+            return VulkanLayout::COLOR_ATTACHMENT;
+        }
+        // Finally, the layout for an immutable texture is optimal read-only.        
+        return VulkanLayout::READ_ONLY;
+    }
+
+    static VkImageLayout getVkLayout(VulkanLayout layout);
+    
+    static void transitionLayout(VkCommandBuffer cmdbuffer, VulkanLayoutTransition transition);
+};
+
+} // namespace filament::backend
+
+bool operator<(const VkImageSubresourceRange& a, const VkImageSubresourceRange& b);
+
+utils::io::ostream& operator<<(utils::io::ostream& out, const filament::backend::VulkanLayout& layout);
+
+
+#endif // TNT_FILAMENT_BACKEND_VULKANIMAGEUTILITY_H

--- a/filament/backend/src/vulkan/VulkanImageUtility.h
+++ b/filament/backend/src/vulkan/VulkanImageUtility.h
@@ -25,18 +25,30 @@
 
 namespace filament::backend {
 
-struct VulkanTexture;    
+struct VulkanTexture;
 
 enum class VulkanLayout : uint8_t {
+    // The initial layout after the creation of the VkImage. We use this to denote the state before
+    // any transition.
     UNDEFINED,
+    // Fragment/vertex shader accessible layout for reading and writing.
     READ_WRITE,
+    // Fragment/vertex shader accessible layout for reading only.
     READ_ONLY,
+    // For the source of a copy operation.
     TRANSFER_SRC,
+    // For the destination of a copy operation.
     TRANSFER_DST,
+    // For using a depth texture as an attachment.
     DEPTH_ATTACHMENT,
+    // For using a depth texture both as an attachment and as a sampler.
     DEPTH_SAMPLER,
+    // For swapchain images that will be presented.
     PRESENT,
+    // For color attachments, but also used when the image is a sampler.
+    // TODO: explore separate layout policies for attachment+sampling and just attachment.
     COLOR_ATTACHMENT,
+    // For color attachment MSAA resolves.
     COLOR_ATTACHMENT_RESOLVE,
 };
 

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -74,7 +74,7 @@ VulkanPipelineCache::VulkanPipelineCache() : mDefaultRasterState(createDefaultRa
     mDummyBufferWriteInfo.pBufferInfo = &mDummyBufferInfo;
     mDummyBufferWriteInfo.pTexelBufferView = nullptr;
 
-    mDummyTargetInfo.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    mDummyTargetInfo.imageLayout = VulkanImageUtility::getVkLayout(VulkanLayout::READ_ONLY);
     mDummyTargetWriteInfo.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     mDummyTargetWriteInfo.pNext = nullptr;
     mDummyTargetWriteInfo.dstArrayElement = 0;

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -116,13 +116,12 @@ VulkanStageImage const* VulkanStagePool::acquireImage(PixelDataFormat format, Pi
     // VK_IMAGE_LAYOUT_PREINITIALIZED or VK_IMAGE_LAYOUT_GENERAL layout. Calling
     // vkGetImageSubresourceLayout for a linear image returns a subresource layout mapping that is
     // valid for either of those image layouts."
-    transitionImageLayout(cmdbuffer, textureTransitionHelper({
+    VulkanImageUtility::transitionLayout(cmdbuffer, {
             .image = image->image,
-            .oldLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-            .newLayout = VK_IMAGE_LAYOUT_GENERAL,
-            .subresources = { aspectFlags, 0, 1, 0, 1 }
-    }));
-
+            .oldLayout = VulkanLayout::UNDEFINED,
+            .newLayout = VulkanLayout::READ_WRITE, // (= VK_IMAGE_LAYOUT_GENERAL)
+            .subresources = { aspectFlags, 0, 1, 0, 1 },
+        });
     return image;
 }
 

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -28,13 +28,21 @@ using namespace bluevk;
 
 namespace filament::backend {
 
+using ImgUtil = VulkanImageUtility;
 VulkanTexture::VulkanTexture(VulkanContext& context, VkImage image, VkFormat format, uint8_t samples,
         uint32_t width, uint32_t height, TextureUsage tusage, VulkanStagePool& stagePool) :
         HwTexture(SamplerType::SAMPLER_2D, 1, samples, width, height, 1, TextureFormat::UNUSED, tusage),
         mVkFormat(format),
-        mViewType(getImageViewType(target)),
+        mViewType(ImgUtil::getViewType(target)),
         mSwizzle({}),
         mTextureImage(image),
+        mPrimaryViewRange{
+            .aspectMask = getImageAspect(),
+            .baseMipLevel = 0,
+            .levelCount = 1,
+            .baseArrayLayer = 0,
+            .layerCount = 1,
+        },
         mContext(context),
         mStagePool(stagePool) {}
 
@@ -47,7 +55,7 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
         mVkFormat(tformat == TextureFormat::DEPTH24 ? context.finalDepthFormat :
                 backend::getVkFormat(tformat)),
 
-        mViewType(getImageViewType(target)),
+        mViewType(ImgUtil::getViewType(target)),
 
         mSwizzle(swizzle), mContext(context), mStagePool(stagePool) {
 
@@ -128,13 +136,16 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     // any kind of attachment (color or depth).
     const auto& limits = context.physicalDeviceProperties.limits;
     if (imageInfo.usage & VK_IMAGE_USAGE_SAMPLED_BIT) {
-        samples = reduceSampleCount(samples, isDepthFormat(mVkFormat) ?
-                limits.sampledImageDepthSampleCounts : limits.sampledImageColorSampleCounts);
+        samples = reduceSampleCount(samples, isDepthFormat(mVkFormat)
+                                                     ? limits.sampledImageDepthSampleCounts
+                                                     : limits.sampledImageColorSampleCounts);
     }
-    if (imageInfo.usage & (VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
-        samples = reduceSampleCount(samples, limits.framebufferDepthSampleCounts &
-            limits.framebufferColorSampleCounts);
+    if (imageInfo.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+        samples = reduceSampleCount(samples, limits.framebufferColorSampleCounts);
+    }
+
+    if (imageInfo.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+        samples = reduceSampleCount(samples, limits.sampledImageDepthSampleCounts);
     }
     this->samples = samples;
     imageInfo.samples = (VkSampleCountFlagBits) samples;
@@ -142,12 +153,15 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     VkResult error = vkCreateImage(context.device, &imageInfo, VKALLOC, &mTextureImage);
     if (error || FILAMENT_VULKAN_VERBOSE) {
         utils::slog.d << "vkCreateImage: "
+            << "image = " << mTextureImage << ", "
             << "result = " << error << ", "
             << "handle = " << utils::io::hex << mTextureImage << utils::io::dec << ", "
             << "extent = " << w << "x" << h << "x"<< depth << ", "
             << "mipLevels = " << int(levels) << ", "
             << "usage = " << imageInfo.usage << ", "
             << "samples = " << imageInfo.samples << ", "
+            << "type=" << imageInfo.imageType << ", "
+            << "flags=" << imageInfo.flags << ", "
             << "format = " << mVkFormat << utils::io::endl;
     }
     ASSERT_POSTCONDITION(!error, "Unable to create image.");
@@ -184,7 +198,7 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     }
 
     // Go ahead and create the primary image view, no need to do it lazily.
-    getImageView(mPrimaryViewRange);
+    getImageView(mPrimaryViewRange, mViewType, mSwizzle);
 
     // Transition the layout of each image slice that might be used as a render target.
     // We do not transition images that are merely SAMPLEABLE, this is deferred until upload time
@@ -192,9 +206,8 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
     if (any(usage & (TextureUsage::COLOR_ATTACHMENT | TextureUsage::DEPTH_ATTACHMENT))) {
         const uint32_t layers = mPrimaryViewRange.layerCount;
         VkImageSubresourceRange range = { getImageAspect(), 0, levels, 0, layers };
-        VkImageLayout layout = getDefaultImageLayout(usage);
         VkCommandBuffer commands = mContext.commands->get().cmdbuffer;
-        transitionLayout(commands, range, layout);
+        transitionLayout(commands, range, ImgUtil::getDefaultLayout(usage));
     }
 }
 
@@ -280,19 +293,26 @@ void VulkanTexture::updateImage(const PixelBufferDescriptor& data, uint32_t widt
         transitionRange.layerCount = depth;
     }
 
-    transitionLayout(cmdbuffer, transitionRange, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    VulkanLayout const newLayout = VulkanLayout::TRANSFER_DST;
+    VulkanLayout nextLayout = getLayout(0, miplevel);
+    VkImageLayout const newVkLayout = ImgUtil::getVkLayout(newLayout);
 
-    vkCmdCopyBufferToImage(cmdbuffer, stage->buffer, mTextureImage,
-            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copyRegion);
+    if (nextLayout == VulkanLayout::UNDEFINED) {
+        nextLayout = VulkanLayout::READ_WRITE;
+    }
 
-    transitionLayout(cmdbuffer, transitionRange, getDefaultImageLayout(usage));
+    transitionLayout(cmdbuffer, transitionRange, newLayout);
+
+    vkCmdCopyBufferToImage(cmdbuffer, stage->buffer, mTextureImage, newVkLayout, 1, &copyRegion);
+
+    transitionLayout(cmdbuffer, transitionRange, nextLayout);
 }
 
 void VulkanTexture::updateImageWithBlit(const PixelBufferDescriptor& hostData, uint32_t width,
         uint32_t height, uint32_t depth, uint32_t miplevel) {
     void* mapped = nullptr;
-    VulkanStageImage const* stage = mStagePool.acquireImage(
-            hostData.format, hostData.type, width, height);
+    VulkanStageImage const* stage
+            = mStagePool.acquireImage(hostData.format, hostData.type, width, height);
     vmaMapMemory(mContext.allocator, stage->memory, &mapped);
     memcpy(mapped, hostData.buffer, hostData.size);
     vmaUnmapMemory(mContext.allocator, stage->memory);
@@ -316,30 +336,32 @@ void VulkanTexture::updateImageWithBlit(const PixelBufferDescriptor& hostData, u
 
     const VkImageSubresourceRange range = { aspect, miplevel, 1, 0, 1 };
 
-    transitionLayout(cmdbuffer, range, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+    VulkanLayout const newLayout = VulkanLayout::TRANSFER_DST;
+    VulkanLayout const oldLayout = getLayout(0, miplevel);
+    transitionLayout(cmdbuffer, range, newLayout);
 
-    vkCmdBlitImage(cmdbuffer, stage->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, mTextureImage,
-            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, blitRegions, VK_FILTER_NEAREST);
+    vkCmdBlitImage(cmdbuffer, stage->image, ImgUtil::getVkLayout(VulkanLayout::TRANSFER_SRC),
+            mTextureImage, ImgUtil::getVkLayout(newLayout), 1, blitRegions, VK_FILTER_NEAREST);
 
-    transitionLayout(cmdbuffer, range, getDefaultImageLayout(usage));
+    transitionLayout(cmdbuffer, range, oldLayout);
 }
 
 void VulkanTexture::setPrimaryRange(uint32_t minMiplevel, uint32_t maxMiplevel) {
     maxMiplevel = filament::math::min(int(maxMiplevel), int(this->levels - 1));
     mPrimaryViewRange.baseMipLevel = minMiplevel;
     mPrimaryViewRange.levelCount = maxMiplevel - minMiplevel + 1;
-    getImageView(mPrimaryViewRange);
+    getImageView(mPrimaryViewRange, mViewType, mSwizzle);
 }
 
-VkImageView VulkanTexture::getAttachmentView(int singleLevel, int singleLayer,
-        VkImageAspectFlags aspect) {
-    VkImageSubresourceRange range = {
-        .aspectMask = aspect,
-        .baseMipLevel = uint32_t(singleLevel),
-        .levelCount = uint32_t(1),
-        .baseArrayLayer = uint32_t(singleLayer),
-        .layerCount = uint32_t(1),
-    };
+VkImageView VulkanTexture::getAttachmentView(VkImageSubresourceRange range) {
+    // Attachments should only have one mipmap level and one layer.
+    range.levelCount = 1;
+    range.layerCount = 1;
+    return getImageView(range, VK_IMAGE_VIEW_TYPE_2D, {});
+}
+
+VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range, VkImageViewType viewType,
+        VkComponentMapping swizzle) {
     auto iter = mCachedImageViews.find(range);
     if (iter != mCachedImageViews.end()) {
         return iter->second;
@@ -349,31 +371,10 @@ VkImageView VulkanTexture::getAttachmentView(int singleLevel, int singleLayer,
         .pNext = nullptr,
         .flags = 0,
         .image = mTextureImage,
-        .viewType = VK_IMAGE_VIEW_TYPE_2D,
+        .viewType = viewType,
         .format = mVkFormat,
-        .components = VkComponentMapping{},
-        .subresourceRange = range
-    };
-    VkImageView imageView;
-    vkCreateImageView(mContext.device, &viewInfo, VKALLOC, &imageView);
-    mCachedImageViews.emplace(range, imageView);
-    return imageView;
-}
-
-VkImageView VulkanTexture::getImageView(VkImageSubresourceRange range) {
-    auto iter = mCachedImageViews.find(range);
-    if (iter != mCachedImageViews.end()) {
-        return iter->second;
-    }
-    VkImageViewCreateInfo viewInfo = {
-        .sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
-        .pNext = nullptr,
-        .flags = 0,
-        .image = mTextureImage,
-        .viewType = mViewType,
-        .format = mVkFormat,
-        .components = mSwizzle,
-        .subresourceRange = range
+        .components = swizzle,
+        .subresourceRange = range,
     };
     VkImageView imageView;
     vkCreateImageView(mContext.device, &viewInfo, VKALLOC, &imageView);
@@ -387,70 +388,68 @@ VkImageAspectFlags VulkanTexture::getImageAspect() const {
 }
 
 void VulkanTexture::transitionLayout(VkCommandBuffer commands, const VkImageSubresourceRange& range,
-        VkImageLayout newLayout) {
-    // In debug builds, ensure that all subresources in the given range have the same layout.
-    // It's easier to catch a mistake here than with validation, which waits until submission time.
-    VkImageLayout oldLayout = getVkLayout(range.baseArrayLayer, range.baseMipLevel);
-#ifndef NDEBUG
-    if (oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
-        for (uint32_t layer = 0; layer < range.layerCount; ++layer) {
-            for (uint32_t level = 0; level < range.levelCount; ++level) {
-                assert_invariant(getVkLayout(layer + range.baseArrayLayer,
-                        level + range.baseMipLevel) == oldLayout);
-            }
-        }
-    }
-#endif
+        VulkanLayout newLayout) {
+    VulkanLayout oldLayout = getLayout(range.baseArrayLayer, range.baseMipLevel);
 
-    transitionImageLayout(commands, textureTransitionHelper({
+    #if FILAMENT_VULKAN_VERBOSE
+    utils::slog.i << "transition layout of " << mTextureImage << ",layer=" << range.baseArrayLayer
+                  << ",level=" << range.baseMipLevel << " from=" << oldLayout << " to=" << newLayout
+                  << " depth=" << isDepthFormat(mVkFormat) << utils::io::endl;
+    #endif
+
+    ImgUtil::transitionLayout(commands, {
             .image = mTextureImage,
             .oldLayout = oldLayout,
             .newLayout = newLayout,
             .subresources = range,
-    }));
+    });
 
-    const uint32_t first_layer = range.baseArrayLayer;
-    const uint32_t last_layer = first_layer + range.layerCount;
-    const uint32_t first_level = range.baseMipLevel;
-    const uint32_t last_level = first_level + range.levelCount;
+    uint32_t const firstLayer = range.baseArrayLayer;
+    uint32_t const lastLayer = firstLayer + range.layerCount;
+    uint32_t const firstLevel = range.baseMipLevel;
+    uint32_t const lastLevel = firstLevel + range.levelCount;
 
-    assert_invariant(first_level <= 0xffff && last_level <= 0xffff);
-    assert_invariant(first_layer <= 0xffff && last_layer <= 0xffff);
+    assert_invariant(firstLevel <= 0xffff && lastLevel <= 0xffff);
+    assert_invariant(firstLayer <= 0xffff && lastLayer <= 0xffff);
 
-    if (newLayout == VK_IMAGE_LAYOUT_UNDEFINED) {
-        for (uint32_t layer = first_layer; layer < last_layer; ++layer) {
-            const uint32_t first = (layer << 16) | first_level;
-            const uint32_t last = (layer << 16) | last_level;
+    if (newLayout == VulkanLayout::UNDEFINED) {
+        for (uint32_t layer = firstLayer; layer < lastLayer; ++layer) {
+            uint32_t const first = (layer << 16) | firstLevel;
+            uint32_t const last = (layer << 16) | lastLevel;
             mSubresourceLayouts.clear(first, last);
         }
     } else {
-        for (uint32_t layer = first_layer; layer < last_layer; ++layer) {
-            const uint32_t first = (layer << 16) | first_level;
-            const uint32_t last = (layer << 16) | last_level;
+        for (uint32_t layer = firstLayer; layer < lastLayer; ++layer) {
+            uint32_t const first = (layer << 16) | firstLevel;
+            uint32_t const last = (layer << 16) | lastLevel;
             mSubresourceLayouts.add(first, last, newLayout);
         }
     }
 }
 
-// Notifies the texture that a particular subresource's layout has changed.
-void VulkanTexture::trackLayout(uint32_t miplevel, uint32_t layer, VkImageLayout layout) {
-    assert_invariant((miplevel + 1) <= 0xffff && layer <= 0xffff);
-    const uint32_t first = (layer << 16) | miplevel;
-    const uint32_t last = (layer << 16) | (miplevel + 1);
-    if (UTILS_UNLIKELY(layout == VK_IMAGE_LAYOUT_UNDEFINED)) {
-        mSubresourceLayouts.clear(first, last);
-    } else {
-        mSubresourceLayouts.add(first, last, layout);
-    }
-}
-
-VkImageLayout VulkanTexture::getVkLayout(uint32_t layer, uint32_t level) const {
+VulkanLayout VulkanTexture::getLayout(uint32_t layer, uint32_t level) const {
     assert_invariant(level <= 0xffff && layer <= 0xffff);
     const uint32_t key = (layer << 16) | level;
     if (!mSubresourceLayouts.has(key)) {
-        return VK_IMAGE_LAYOUT_UNDEFINED;
+        return VulkanLayout::UNDEFINED;
     }
     return mSubresourceLayouts.get(key);
 }
+
+#if FILAMENT_VULKAN_VERBOSE
+void VulkanTexture::print() const {
+    const uint32_t firstLayer = 0;
+    const uint32_t lastLayer = firstLayer + mPrimaryViewRange.layerCount;
+    const uint32_t firstLevel = 0;
+    const uint32_t lastLevel = firstLevel + mPrimaryViewRange.levelCount;
+
+    for (uint32_t layer = firstLayer; layer < lastLayer; ++layer) {
+        for (uint32_t level = firstLevel; level < lastLevel; ++level) {
+            utils::slog.d << "[" << mTextureImage << "]: (" << layer << "," << level
+                          << ")=" << getLayout(layer, level) << utils::io::endl;
+        }
+    }
+}
+#endif
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -160,8 +160,8 @@ VulkanTexture::VulkanTexture(VulkanContext& context, SamplerType target, uint8_t
             << "mipLevels = " << int(levels) << ", "
             << "usage = " << imageInfo.usage << ", "
             << "samples = " << imageInfo.samples << ", "
-            << "type=" << imageInfo.imageType << ", "
-            << "flags=" << imageInfo.flags << ", "
+            << "type = " << imageInfo.imageType << ", "
+            << "flags = " << imageInfo.flags << ", "
             << "format = " << mVkFormat << utils::io::endl;
     }
     ASSERT_POSTCONDITION(!error, "Unable to create image.");

--- a/filament/backend/src/vulkan/VulkanUtility.h
+++ b/filament/backend/src/vulkan/VulkanUtility.h
@@ -25,17 +25,6 @@
 
 namespace filament::backend {
 
-struct VulkanLayoutTransition {
-    VkImage image;
-    VkImageLayout oldLayout;
-    VkImageLayout newLayout;
-    VkImageSubresourceRange subresources;
-    VkPipelineStageFlags srcStage;
-    VkAccessFlags srcAccessMask;
-    VkPipelineStageFlags dstStage;
-    VkAccessFlags dstAccessMask;
-};
-
 void createSemaphore(VkDevice device, VkSemaphore* semaphore);
 VkFormat getVkFormat(ElementType type, bool normalized, bool integer);
 VkFormat getVkFormat(TextureFormat format);
@@ -49,14 +38,7 @@ VkFrontFace getFrontFace(bool inverseFrontFaces);
 PixelDataType getComponentType(VkFormat format);
 uint32_t getComponentCount(VkFormat format);
 VkComponentMapping getSwizzleMap(TextureSwizzle swizzle[4]);
-VkImageViewType getImageViewType(SamplerType target);
-VkImageLayout getDefaultImageLayout(TextureUsage usage);
 VkShaderStageFlags getShaderStageFlags(ShaderStageFlags stageFlags);
-
-void transitionImageLayout(VkCommandBuffer cmdbuffer, VulkanLayoutTransition transition);
-
-// Helper function for populating barrier fields based on the desired image layout.
-VulkanLayoutTransition textureTransitionHelper(VulkanLayoutTransition transition);
 
 bool equivalent(const VkRect2D& a, const VkRect2D& b);
 bool equivalent(const VkExtent2D& a, const VkExtent2D& b);
@@ -106,7 +88,5 @@ utils::FixedCapacityVector<OutType> enumerate(
 #undef EXPAND_ENUM_ARGS
 
 } // namespace filament::backend
-
-bool operator<(const VkImageSubresourceRange& a, const VkImageSubresourceRange& b);
 
 #endif // TNT_FILAMENT_BACKEND_VULKANUTILITY_H


### PR DESCRIPTION
 - Moved most of the layout transition logic into VulkanImageUtil so that we'd have a single place to consider if failure arises
 - Add an abstraction on top of vk's layouts so that reasoning about our use cases (and corresponding layout is easier).
 - Removed the redundant VulkanDepthLayout
 - Refactor VulkanTexture::transitionLayout so that most of the transition paths can be done through this entry point. It also enables us to handle tracking the current layout.
 - Add a special case to transition the depth attachment/texture if it is both a sampler and an attachment.
 - Add a few debug printing markers across the classe - guarded under the existing FILAMENT_VULKAN_VERBOSE define.