### PR TITLE
change picking to use floats

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - materials: prepare ES2 support [⚠️ **New Material Version**]
+- materials: picking is done in float (prepare for ES2) [⚠️ **New Material Version**]

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -381,7 +381,7 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
                 if (config.picking) {
                     data.picking = builder.createTexture("Picking Buffer", {
                             .width = width, .height = height,
-                            .format = TextureFormat::RG32UI });
+                            .format = TextureFormat::RG32F });
 
                     data.picking = builder.write(data.picking,
                             FrameGraphTexture::Usage::COLOR_ATTACHMENT);

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -968,13 +968,14 @@ void FView::executePickingQueries(backend::DriverApi& driver,
         const uint32_t x = uint32_t(float(pQuery->x) * (scale * mScale.x));
         const uint32_t y = uint32_t(float(pQuery->y) * (scale * mScale.y));
         driver.readPixels(handle, x, y, 1, 1, {
-                &pQuery->result.renderable, 4 * 4, // 4*uint
-                // FIXME: RGBA_INTEGER is guaranteed to work. R_INTEGER must be queried.
-                backend::PixelDataFormat::RG_INTEGER, backend::PixelDataType::UINT,
+                &pQuery->result.renderable, 4u * 4u, // 4*float
+                backend::PixelDataFormat::RG, backend::PixelDataType::FLOAT,
                 pQuery->handler, [](void*, size_t, void* user) {
                     FPickingQuery* pQuery = static_cast<FPickingQuery*>(user);
+                    float const identity = *((float*)((char*)&pQuery->result.renderable));
+                    pQuery->result.renderable = Entity::import(identity);
                     pQuery->result.fragCoords = {
-                            pQuery->x, pQuery->y,float(1.0 - pQuery->result.depth) };
+                            pQuery->x, pQuery->y, float(1.0 - pQuery->result.depth) };
                     pQuery->callback(pQuery->result, pQuery);
                     FPickingQuery::put(pQuery);
                 }, pQuery

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -1,7 +1,7 @@
 #if defined(VARIANT_HAS_VSM)
 layout(location = 0) out vec4 fragColor;
 #elif defined(VARIANT_HAS_PICKING)
-layout(location = 0) out highp uint2 outPicking;
+layout(location = 0) out highp vec2 outPicking;
 #else
 // not color output
 #endif
@@ -49,8 +49,8 @@ void main() {
     fragColor.xy = computeDepthMomentsVSM(depth);
     fragColor.zw = computeDepthMomentsVSM(-1.0 / depth); // requires at least RGBA16F
 #elif defined(VARIANT_HAS_PICKING)
-    outPicking.x = uint(object_uniforms.objectId);
-    outPicking.y = floatBitsToUint(vertex_position.z / vertex_position.w);
+    outPicking.x = float(object_uniforms.objectId);
+    outPicking.y = vertex_position.z / vertex_position.w;
 #else
     // that's it
 #endif


### PR DESCRIPTION
floats can have up to 16.7M unique integers which is enough for encoding an Entity. 
This change will help a later one that adds support for ES2