### PR TITLE
fog: disable fog color from IBL when unlit

### DIFF
--- a/shaders/src/fog.fs
+++ b/shaders/src/fog.fs
@@ -40,12 +40,14 @@ vec4 fog(vec4 color, highp vec3 view) {
     // compute fog color
     vec3 fogColor = frameUniforms.fogColor;
 
+#if !defined(SHADING_MODEL_UNLIT)
     if (frameUniforms.fogColorFromIbl > 0.0) {
         // get fog color from envmap
         // TODO: use a lower resolution mip as we get further (problem we don't have mips!)
         float lod = frameUniforms.iblRoughnessOneLevel;
         fogColor *= textureLod(light_iblSpecular, view, lod).rgb;
     }
+#endif
 
     fogColor *= frameUniforms.iblLuminance * fogOpacity;
 


### PR DESCRIPTION
When unlit, the IBL specular map is not defined.