### PR TITLE
Fix no-opt build option for materials

### DIFF
--- a/android/buildSrc/src/main/groovy/FilamentPlugin.groovy
+++ b/android/buildSrc/src/main/groovy/FilamentPlugin.groovy
@@ -142,6 +142,14 @@ abstract class MaterialCompiler extends TaskWithBinary {
                 if (!exclude_vulkan) {
                     matcArgs += ['-a', 'vulkan']
                 }
+
+                def mat_no_opt = providers
+                        .gradleProperty("com.google.android.filament.matnopt")
+                        .forUseAtConfigurationTime().present
+                if (mat_no_opt) {
+                    matcArgs += ['-g']
+                }
+
                 matcArgs += ['-a', 'opengl', '-p', 'mobile', '-o', getOutputFile(file), file]
 
                 exec.exec {

--- a/build.sh
+++ b/build.sh
@@ -491,6 +491,7 @@ function build_android {
                 ./gradlew \
                     -Pcom.google.android.filament.dist-dir=../out/android-debug/filament \
                     -Pcom.google.android.filament.abis=${ABI_GRADLE_OPTION} \
+                    ${MATOPT_GRADLE_OPTION} \
                     :samples:${sample}:assembleDebug
             done
         fi
@@ -539,6 +540,7 @@ function build_android {
                 ./gradlew \
                     -Pcom.google.android.filament.dist-dir=../out/android-release/filament \
                     -Pcom.google.android.filament.abis=${ABI_GRADLE_OPTION} \
+                    ${MATOPT_GRADLE_OPTION} \
                     :samples:${sample}:assembleRelease
             done
         fi
@@ -756,7 +758,7 @@ function run_tests {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfijmp:q:uvslwtedk:b" opt; do
+while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
     case ${opt} in
         h)
             print_help


### PR DESCRIPTION
 - `-g` option was missing from `build.sh`
 - `-Pcom.google.android.filament.matnopt` should be passed to the sample apps as well.
 - Add logic to respect `-Pcom.google.android.filament.matnopt` in `FilamentPlugin.groovy`