### PR TITLE
vulkan: Fix Adreno issue with optimized material

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - materials: prepare ES2 support [⚠️ **New Material Version**]
+- vulkan: fix adreno optimized material artifacts [⚠️ Recompile Materials].

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -11,4 +11,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - materials: prepare ES2 support [⚠️ **New Material Version**]
 - materials: picking is done in float (prepare for ES2) [⚠️ **New Material Version**]
 - materials: postLightingBlending is now applied before the fog [⚠️ **Recompile materials**]
-- vulkan: fix adreno optimized material artifacts [⚠️ Recompile Materials].
+- vulkan: fix adreno optimized material artifacts [⚠️ **Recompile Materials**].

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,7 +8,6 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
-- materials: prepare ES2 support [⚠️ **New Material Version**]
 - materials: picking is done in float (prepare for ES2) [⚠️ **New Material Version**]
 - materials: postLightingBlending is now applied before the fog [⚠️ **Recompile materials**]
 - vulkan: fix adreno optimized material artifacts [⚠️ **Recompile Materials**].

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,4 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - materials: picking is done in float (prepare for ES2) [⚠️ **New Material Version**]
 - materials: postLightingBlending is now applied before the fog [⚠️ **Recompile materials**]
-- vulkan: fix adreno optimized material artifacts [⚠️ **Recompile Materials**].
+- vulkan: fix adreno optimized material artifacts [⚠️ **Recompile Materials**]


### PR DESCRIPTION
Turning off the simplification pass seems to remove all of the artifacts associated with Adreno GPUs.

Fixes #5885, Fixes #5884, Fixes #4381, Fixes #6465