### PR TITLE
basic ES2 support for filament

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - engine: a local transform can now be supplied for each GPU instance [⚠️ **Recompile materials**]
+- everything: Add limited support for OpenGL ES 2.0 devices. [⚠️ **Recompile Materials**]

--- a/android/samples/sample-hello-triangle/src/main/AndroidManifest.xml
+++ b/android/samples/sample-hello-triangle/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+  <uses-permission android:name="android.permission.INTERNET" />
+
   <application
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"

--- a/android/samples/sample-hello-triangle/src/main/java/com/google/android/filament/hellotriangle/MainActivity.kt
+++ b/android/samples/sample-hello-triangle/src/main/java/com/google/android/filament/hellotriangle/MainActivity.kt
@@ -120,8 +120,13 @@ class MainActivity : Activity() {
     private fun setupView() {
         scene.skybox = Skybox.Builder().color(0.035f, 0.035f, 0.035f, 1.0f).build(engine)
 
-        // NOTE: Try to disable post-processing (tone-mapping, etc.) to see the difference
-        // view.isPostProcessingEnabled = false
+        if (engine.activeFeatureLevel == Engine.FeatureLevel.FEATURE_LEVEL_0) {
+            // post-processing is not supported at feature level 0
+            view.isPostProcessingEnabled = false
+        } else {
+            // NOTE: Try to disable post-processing (tone-mapping, etc.) to see the difference
+            // view.isPostProcessingEnabled = false
+        }
 
         // Tell the view which camera we want to use
         view.camera = camera
@@ -155,7 +160,11 @@ class MainActivity : Activity() {
     }
 
     private fun loadMaterial() {
-        readUncompressedAsset("materials/baked_color.filamat").let {
+        var name = "materials/baked_color.filamat"
+        if (engine.activeFeatureLevel == Engine.FeatureLevel.FEATURE_LEVEL_0) {
+            name = "materials/baked_color_es2.filamat"
+        }
+        readUncompressedAsset(name).let {
             material = Material.Builder().payload(it, it.remaining()).build(engine)
         }
     }
@@ -305,7 +314,15 @@ class MainActivity : Activity() {
     inner class SurfaceCallback : UiHelper.RendererCallback {
         override fun onNativeWindowChanged(surface: Surface) {
             swapChain?.let { engine.destroySwapChain(it) }
-            swapChain = engine.createSwapChain(surface, uiHelper.swapChainFlags)
+
+            // at feature level 0, we don't have post-processing, so we need to set
+            // the colorspace to sRGB (FIXME: it's not supported everywhere!)
+            var flags = uiHelper.swapChainFlags
+            if (engine.activeFeatureLevel == Engine.FeatureLevel.FEATURE_LEVEL_0) {
+                flags = flags or SwapChain.CONFIG_SRGB_COLORSPACE
+            }
+
+            swapChain = engine.createSwapChain(surface, flags)
             displayHelper.attach(renderer, surfaceView.display);
         }
 

--- a/android/samples/sample-hello-triangle/src/main/java/com/google/android/filament/hellotriangle/MainActivity.kt
+++ b/android/samples/sample-hello-triangle/src/main/java/com/google/android/filament/hellotriangle/MainActivity.kt
@@ -319,7 +319,9 @@ class MainActivity : Activity() {
             // the colorspace to sRGB (FIXME: it's not supported everywhere!)
             var flags = uiHelper.swapChainFlags
             if (engine.activeFeatureLevel == Engine.FeatureLevel.FEATURE_LEVEL_0) {
-                flags = flags or SwapChain.CONFIG_SRGB_COLORSPACE
+                if (SwapChain.isSRGBSwapChainSupported(engine)) {
+                    flags = flags or SwapChain.CONFIG_SRGB_COLORSPACE
+                }
             }
 
             swapChain = engine.createSwapChain(surface, flags)

--- a/android/samples/sample-hello-triangle/src/main/materials/baked_color_es2.mat
+++ b/android/samples/sample-hello-triangle/src/main/materials/baked_color_es2.mat
@@ -17,7 +17,8 @@ material {
     ],
 
     // This material disables all lighting
-    shadingModel : unlit
+    shadingModel : unlit,
+    featureLevel : 0
 }
 
 fragment {

--- a/filament/CMakeLists.txt
+++ b/filament/CMakeLists.txt
@@ -250,6 +250,11 @@ set(MATERIAL_SRCS
         src/materials/vsmMipmap.mat
 )
 
+set(MATERIAL_ES2_SRCS
+        src/materials/defaultMaterial0.mat
+        src/materials/skybox0.mat
+)
+
 # Embed the binary resource blob for materials.
 get_resgen_vars(${RESOURCE_DIR} materials)
 list(APPEND PRIVATE_HDRS ${RESGEN_HEADER})
@@ -314,6 +319,23 @@ foreach (mat_src ${MATERIAL_SRCS})
     )
     list(APPEND MATERIAL_BINS ${output_path})
 endforeach()
+
+if (IS_MOBILE_TARGET AND FILAMENT_SUPPORTS_OPENGL)
+    foreach (mat_src ${MATERIAL_ES2_SRCS})
+        get_filename_component(localname "${mat_src}" NAME_WE)
+        get_filename_component(fullname "${mat_src}" ABSOLUTE)
+        set(output_path "${MATERIAL_DIR}/${localname}.filamat")
+
+        add_custom_command(
+                OUTPUT ${output_path}
+                COMMAND matc -a opengl -p ${MATC_TARGET} ${MATC_OPT_FLAGS} -o ${output_path} ${fullname}
+                MAIN_DEPENDENCY ${fullname}
+                DEPENDS matc
+                COMMENT "Compiling material ${mat_src} to ${output_path}"
+        )
+        list(APPEND MATERIAL_BINS ${output_path})
+    endforeach ()
+endif ()
 
 # Additional dependencies on included files for materials
 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -106,7 +106,8 @@ static constexpr size_t CONFIG_SAMPLER_BINDING_COUNT = 4;   // This is guarantee
  * Defines the backend's feature levels.
  */
 enum class FeatureLevel : uint8_t {
-    FEATURE_LEVEL_1 = 1,  //!< OpenGL ES 3.0 features (default)
+    FEATURE_LEVEL_0 = 0,  //!< OpenGL ES 2.0 features
+    FEATURE_LEVEL_1,      //!< OpenGL ES 3.0 features (default)
     FEATURE_LEVEL_2,      //!< OpenGL ES 3.1 features + 16 textures units + cubemap arrays
     FEATURE_LEVEL_3       //!< OpenGL ES 3.1 features + 31 textures units + cubemap arrays
 };

--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -90,6 +90,10 @@ public:
     // the program everything it needs to know about the uniforms at a given binding
     Program& uniforms(uint32_t index, UniformInfo const& uniforms) noexcept;
 
+    // Note: This is only needed for GLES2.0.
+    Program& attributes(
+            utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> attributes) noexcept;
+
     // sets the 'bindingPoint' sampler group descriptor for this program.
     // 'samplers' can be destroyed after this call.
     // This effectively associates a set of (BindingPoints, index) to a texture unit in the shader.
@@ -118,6 +122,9 @@ public:
     auto const& getBindingUniformInfo() const { return mBindingUniformInfo; }
     auto& getBindingUniformInfo() { return mBindingUniformInfo; }
 
+    auto const& getAttributes() const { return mAttributes; }
+    auto& getAttributes() { return mAttributes; }
+
     utils::CString const& getName() const noexcept { return mName; }
     utils::CString& getName() noexcept { return mName; }
 
@@ -137,6 +144,7 @@ private:
     utils::CString mName;
     utils::Invocable<utils::io::ostream&(utils::io::ostream& out)> mLogger;
     utils::FixedCapacityVector<SpecializationConstant> mSpecializationConstants;
+    utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> mAttributes;
     std::array<UniformInfo, Program::UNIFORM_BINDING_COUNT> mBindingUniformInfo;
 };
 

--- a/filament/backend/include/backend/Program.h
+++ b/filament/backend/include/backend/Program.h
@@ -48,7 +48,15 @@ public:
         ShaderStageFlags stageFlags = ShaderStageFlags::ALL_SHADER_STAGE_FLAGS;
     };
 
+    struct Uniform {
+        utils::CString name;    // full qualified name of the uniform field
+        uint16_t offset;        // offset in 'uint32_t' into the uniform buffer
+        uint8_t size;           // >1 for arrays
+        UniformType type;       // uniform type
+    };
+
     using UniformBlockInfo = std::array<utils::CString, UNIFORM_BINDING_COUNT>;
+    using UniformInfo = utils::FixedCapacityVector<Uniform>;
     using SamplerGroupInfo = std::array<SamplerGroupData, SAMPLER_BINDING_COUNT>;
     using ShaderBlob = utils::FixedCapacityVector<uint8_t>;
     using ShaderSource = std::array<ShaderBlob, SHADER_TYPE_COUNT>;
@@ -78,6 +86,10 @@ public:
     Program& uniformBlockBindings(
             utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> const& uniformBlockBindings) noexcept;
 
+    // Note: This is only needed for GLES2.0, this is used to emulate UBO. This function tells
+    // the program everything it needs to know about the uniforms at a given binding
+    Program& uniforms(uint32_t index, UniformInfo const& uniforms) noexcept;
+
     // sets the 'bindingPoint' sampler group descriptor for this program.
     // 'samplers' can be destroyed after this call.
     // This effectively associates a set of (BindingPoints, index) to a texture unit in the shader.
@@ -103,6 +115,9 @@ public:
     SamplerGroupInfo const& getSamplerGroupInfo() const { return mSamplerGroups; }
     SamplerGroupInfo& getSamplerGroupInfo() { return mSamplerGroups; }
 
+    auto const& getBindingUniformInfo() const { return mBindingUniformInfo; }
+    auto& getBindingUniformInfo() { return mBindingUniformInfo; }
+
     utils::CString const& getName() const noexcept { return mName; }
     utils::CString& getName() noexcept { return mName; }
 
@@ -122,6 +137,7 @@ private:
     utils::CString mName;
     utils::Invocable<utils::io::ostream&(utils::io::ostream& out)> mLogger;
     utils::FixedCapacityVector<SpecializationConstant> mSpecializationConstants;
+    std::array<UniformInfo, Program::UNIFORM_BINDING_COUNT> mBindingUniformInfo;
 };
 
 } // namespace filament::backend

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -131,8 +131,10 @@ protected:
             bool OES_EGL_image_external_essl3 = false;
         } gl;
         struct {
-            bool KHR_no_config_context = false;
+            bool ANDROID_recordable = false;
+            bool KHR_create_context = false;
             bool KHR_gl_colorspace = false;
+            bool KHR_no_config_context = false;
         } egl;
     } ext;
 

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -32,6 +32,8 @@ Program& Program::operator=(Program&& rhs) noexcept {
     mShadersSource.operator=(std::move(rhs.mShadersSource));
     mName.operator=(std::move(rhs.mName));
     mLogger.operator=(std::move(rhs.mLogger));
+    mSpecializationConstants.operator=(std::move(rhs.mSpecializationConstants));
+    mBindingUniformInfo.operator=(std::move(rhs.mBindingUniformInfo));
     return *this;
 }
 
@@ -57,6 +59,12 @@ Program& Program::uniformBlockBindings(
         assert_invariant(item.second < UNIFORM_BINDING_COUNT);
         mUniformBlocks[item.second] = item.first;
     }
+    return *this;
+}
+
+Program& Program::uniforms(uint32_t index, UniformInfo const& uniforms) noexcept {
+    assert_invariant(index < UNIFORM_BINDING_COUNT);
+    mBindingUniformInfo[index] = uniforms;
     return *this;
 }
 

--- a/filament/backend/src/Program.cpp
+++ b/filament/backend/src/Program.cpp
@@ -68,6 +68,13 @@ Program& Program::uniforms(uint32_t index, UniformInfo const& uniforms) noexcept
     return *this;
 }
 
+
+Program& Program::attributes(
+        utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> attributes) noexcept {
+    mAttributes = std::move(attributes);
+    return *this;
+}
+
 Program& Program::setSamplerGroup(size_t bindingPoint, ShaderStageFlags stageFlags,
         const Program::Sampler* samplers, size_t count) noexcept {
     auto& groupData = mSamplerGroups[bindingPoint];

--- a/filament/backend/src/opengl/GLUtils.cpp
+++ b/filament/backend/src/opengl/GLUtils.cpp
@@ -81,9 +81,6 @@ const char* getFramebufferStatus(GLenum status) noexcept {
         case GL_FRAMEBUFFER_COMPLETE:
             string = "GL_FRAMEBUFFER_COMPLETE";
             break;
-        case GL_FRAMEBUFFER_UNDEFINED:
-            string = "GL_FRAMEBUFFER_UNDEFINED";
-            break;
         case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
             string = "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
             break;
@@ -93,9 +90,14 @@ const char* getFramebufferStatus(GLenum status) noexcept {
         case GL_FRAMEBUFFER_UNSUPPORTED:
             string = "GL_FRAMEBUFFER_UNSUPPORTED";
             break;
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+        case GL_FRAMEBUFFER_UNDEFINED:
+            string = "GL_FRAMEBUFFER_UNDEFINED";
+            break;
         case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
             string = "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE";
             break;
+#endif
         default:
             break;
     }

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -118,9 +118,14 @@ constexpr inline GLenum getBufferBindingType(BufferObjectBinding bindingType) no
         case BufferObjectBinding::VERTEX:
             return GL_ARRAY_BUFFER;
         case BufferObjectBinding::UNIFORM:
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             return GL_UNIFORM_BUFFER;
+#else
+            utils::panic(__func__, __FILE__, __LINE__, "UNIFORM not supported");
+            return 0x8A11;
+#endif
         case BufferObjectBinding::SHADER_STORAGE:
-#if defined(BACKEND_OPENGL_LEVEL_GLES31)
+#ifdef BACKEND_OPENGL_LEVEL_GLES31
             return GL_SHADER_STORAGE_BUFFER;
 #else
             utils::panic(__func__, __FILE__, __LINE__, "SHADER_STORAGE not supported");
@@ -169,7 +174,12 @@ constexpr inline GLenum getComponentType(ElementType type) noexcept {
         case ElementType::HALF2:
         case ElementType::HALF3:
         case ElementType::HALF4:
+            // on ES2 we should never end-up here
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             return GL_HALF_FLOAT;
+#else
+            return GL_HALF_FLOAT_OES;
+#endif
     }
 }
 
@@ -238,13 +248,7 @@ constexpr inline GLenum getBlendFunctionMode(BlendFunction mode) noexcept {
     }
 }
 
-constexpr inline GLenum getTextureCompareMode(SamplerCompareMode mode) noexcept {
-    return mode == SamplerCompareMode::NONE ?
-           GL_NONE : GL_COMPARE_REF_TO_TEXTURE;
-}
-
-constexpr inline GLenum getTextureCompareFunc(SamplerCompareFunc func) noexcept {
-    using SamplerCompareFunc = SamplerCompareFunc;
+constexpr inline GLenum getCompareFunc(SamplerCompareFunc func) noexcept {
     switch (func) {
         case SamplerCompareFunc::LE:    return GL_LEQUAL;
         case SamplerCompareFunc::GE:    return GL_GEQUAL;
@@ -257,12 +261,23 @@ constexpr inline GLenum getTextureCompareFunc(SamplerCompareFunc func) noexcept 
     }
 }
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+constexpr inline GLenum getTextureCompareMode(SamplerCompareMode mode) noexcept {
+    return mode == SamplerCompareMode::NONE ?
+           GL_NONE : GL_COMPARE_REF_TO_TEXTURE;
+}
+
+constexpr inline GLenum getTextureCompareFunc(SamplerCompareFunc func) noexcept {
+    return getCompareFunc(func);
+}
+#endif
+
 constexpr inline GLenum getDepthFunc(SamplerCompareFunc func) noexcept {
-    return getTextureCompareFunc(func);
+    return getCompareFunc(func);
 }
 
 constexpr inline GLenum getStencilFunc(SamplerCompareFunc func) noexcept {
-    return getTextureCompareFunc(func);
+    return getCompareFunc(func);
 }
 
 constexpr inline GLenum getStencilOp(StencilOperation op) noexcept {
@@ -281,18 +296,24 @@ constexpr inline GLenum getStencilOp(StencilOperation op) noexcept {
 constexpr inline GLenum getFormat(PixelDataFormat format) noexcept {
     using PixelDataFormat = PixelDataFormat;
     switch (format) {
+        case PixelDataFormat::RGB:              return GL_RGB;
+        case PixelDataFormat::RGBA:             return GL_RGBA;
+        case PixelDataFormat::UNUSED:           return GL_RGBA; // should never happen (used to be rgbm)
+        case PixelDataFormat::DEPTH_COMPONENT:  return GL_DEPTH_COMPONENT;
+        case PixelDataFormat::ALPHA:            return GL_ALPHA;
+        case PixelDataFormat::DEPTH_STENCIL:    return GL_DEPTH_STENCIL;
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+        // when context is ES2 we should never end-up here
         case PixelDataFormat::R:                return GL_RED;
         case PixelDataFormat::R_INTEGER:        return GL_RED_INTEGER;
         case PixelDataFormat::RG:               return GL_RG;
         case PixelDataFormat::RG_INTEGER:       return GL_RG_INTEGER;
-        case PixelDataFormat::RGB:              return GL_RGB;
         case PixelDataFormat::RGB_INTEGER:      return GL_RGB_INTEGER;
-        case PixelDataFormat::RGBA:             return GL_RGBA;
         case PixelDataFormat::RGBA_INTEGER:     return GL_RGBA_INTEGER;
-        case PixelDataFormat::UNUSED:           return GL_RGBA; // should never happen (used to be rgbm)
-        case PixelDataFormat::DEPTH_COMPONENT:  return GL_DEPTH_COMPONENT;
-        case PixelDataFormat::DEPTH_STENCIL:    return GL_DEPTH_STENCIL;
-        case PixelDataFormat::ALPHA:            return GL_ALPHA;
+#else
+        // silence compiler warning in ES2 headers mode
+        default: return GL_NONE;
+#endif
     }
 }
 
@@ -305,32 +326,34 @@ constexpr inline GLenum getType(PixelDataType type) noexcept {
         case PixelDataType::SHORT:                return GL_SHORT;
         case PixelDataType::UINT:                 return GL_UNSIGNED_INT;
         case PixelDataType::INT:                  return GL_INT;
-        case PixelDataType::HALF:                 return GL_HALF_FLOAT;
         case PixelDataType::FLOAT:                return GL_FLOAT;
-        case PixelDataType::UINT_10F_11F_11F_REV: return GL_UNSIGNED_INT_10F_11F_11F_REV;
         case PixelDataType::USHORT_565:           return GL_UNSIGNED_SHORT_5_6_5;
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+        // when context is ES2 we should never end-up here
+        case PixelDataType::HALF:                 return GL_HALF_FLOAT;
+        case PixelDataType::UINT_10F_11F_11F_REV: return GL_UNSIGNED_INT_10F_11F_11F_REV;
         case PixelDataType::UINT_2_10_10_10_REV:  return GL_UNSIGNED_INT_2_10_10_10_REV;
         case PixelDataType::COMPRESSED:           return 0; // should never happen
+#else
+        // silence compiler warning in ES2 headers mode
+        default: return GL_NONE;
+#endif
     }
 }
 
+#if !defined(__EMSCRIPTEN__)  && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
 constexpr inline GLenum getSwizzleChannel(TextureSwizzle c) noexcept {
     using TextureSwizzle = TextureSwizzle;
     switch (c) {
-        case TextureSwizzle::SUBSTITUTE_ZERO:
-            return GL_ZERO;
-        case TextureSwizzle::SUBSTITUTE_ONE:
-            return GL_ONE;
-        case TextureSwizzle::CHANNEL_0:
-            return GL_RED;
-        case TextureSwizzle::CHANNEL_1:
-            return GL_GREEN;
-        case TextureSwizzle::CHANNEL_2:
-            return GL_BLUE;
-        case TextureSwizzle::CHANNEL_3:
-            return GL_ALPHA;
+        case TextureSwizzle::SUBSTITUTE_ZERO:   return GL_ZERO;
+        case TextureSwizzle::SUBSTITUTE_ONE:    return GL_ONE;
+        case TextureSwizzle::CHANNEL_0:         return GL_RED;
+        case TextureSwizzle::CHANNEL_1:         return GL_GREEN;
+        case TextureSwizzle::CHANNEL_2:         return GL_BLUE;
+        case TextureSwizzle::CHANNEL_3:         return GL_ALPHA;
     }
 }
+#endif
 
 constexpr inline GLenum getCullingMode(CullingMode mode) noexcept {
     switch (mode) {
@@ -346,18 +369,56 @@ constexpr inline GLenum getCullingMode(CullingMode mode) noexcept {
     }
 }
 
-// clang looses it on this one, and generates a huge jump table when
+// ES2 supported internal formats for texturing and how they  map to a format/type
+constexpr inline std::pair<GLenum, GLenum> textureFormatToFormatAndType(
+        TextureFormat format) noexcept {
+    switch (format) {
+        case TextureFormat::RGB8:       return { GL_RGB,                GL_UNSIGNED_BYTE };
+        case TextureFormat::RGBA8:      return { GL_RGBA,               GL_UNSIGNED_BYTE };
+        case TextureFormat::RGB565:     return { GL_RGB,                GL_UNSIGNED_SHORT_5_6_5 };
+        case TextureFormat::RGB5_A1:    return { GL_RGBA,               GL_UNSIGNED_SHORT_5_5_5_1 };
+        case TextureFormat::RGBA4:      return { GL_RGBA,               GL_UNSIGNED_SHORT_4_4_4_4 };
+        case TextureFormat::DEPTH16:    return { GL_DEPTH_COMPONENT,    GL_UNSIGNED_SHORT };
+        case TextureFormat::DEPTH24:    return { GL_DEPTH_COMPONENT,    GL_UNSIGNED_INT };
+        case TextureFormat::DEPTH24_STENCIL8:
+                                        return { GL_DEPTH24_STENCIL8,   GL_UNSIGNED_INT_24_8 };
+        default:                        return { GL_NONE,               GL_NONE };
+    }
+}
+
+// clang loses it on this one, and generates a huge jump table when
 // inlined. So we don't  mark it as inline (only constexpr) which solves the problem,
 // strangely, when not inlined, clang simply generates an array lookup.
 constexpr /* inline */ GLenum getInternalFormat(TextureFormat format) noexcept {
-    using TextureFormat = TextureFormat;
     switch (format) {
+
+        /* Formats supported by our ES2 implementations */
+
+        // 8-bits per element
+        case TextureFormat::STENCIL8:          return GL_STENCIL_INDEX8;
+
+        // 16-bits per element
+        case TextureFormat::RGB565:            return GL_RGB565;
+        case TextureFormat::RGB5_A1:           return GL_RGB5_A1;
+        case TextureFormat::RGBA4:             return GL_RGBA4;
+        case TextureFormat::DEPTH16:           return GL_DEPTH_COMPONENT16;
+
+        // 24-bits per element
+        case TextureFormat::RGB8:              return GL_RGB8;
+        case TextureFormat::DEPTH24:           return GL_DEPTH_COMPONENT24;
+
+        // 32-bits per element
+        case TextureFormat::RGBA8:             return GL_RGBA8;
+        case TextureFormat::DEPTH24_STENCIL8:  return GL_DEPTH24_STENCIL8;
+
+        /* Formats not supported by our ES2 implementations */
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
         // 8-bits per element
         case TextureFormat::R8:                return GL_R8;
         case TextureFormat::R8_SNORM:          return GL_R8_SNORM;
         case TextureFormat::R8UI:              return GL_R8UI;
         case TextureFormat::R8I:               return GL_R8I;
-        case TextureFormat::STENCIL8:          return GL_STENCIL_INDEX8;
 
         // 16-bits per element
         case TextureFormat::R16F:              return GL_R16F;
@@ -367,18 +428,12 @@ constexpr /* inline */ GLenum getInternalFormat(TextureFormat format) noexcept {
         case TextureFormat::RG8_SNORM:         return GL_RG8_SNORM;
         case TextureFormat::RG8UI:             return GL_RG8UI;
         case TextureFormat::RG8I:              return GL_RG8I;
-        case TextureFormat::RGB565:            return GL_RGB565;
-        case TextureFormat::RGB5_A1:           return GL_RGB5_A1;
-        case TextureFormat::RGBA4:             return GL_RGBA4;
-        case TextureFormat::DEPTH16:           return GL_DEPTH_COMPONENT16;
 
         // 24-bits per element
-        case TextureFormat::RGB8:              return GL_RGB8;
         case TextureFormat::SRGB8:             return GL_SRGB8;
         case TextureFormat::RGB8_SNORM:        return GL_RGB8_SNORM;
         case TextureFormat::RGB8UI:            return GL_RGB8UI;
         case TextureFormat::RGB8I:             return GL_RGB8I;
-        case TextureFormat::DEPTH24:           return GL_DEPTH_COMPONENT24;
 
         // 32-bits per element
         case TextureFormat::R32F:              return GL_R32F;
@@ -389,14 +444,12 @@ constexpr /* inline */ GLenum getInternalFormat(TextureFormat format) noexcept {
         case TextureFormat::RG16I:             return GL_RG16I;
         case TextureFormat::R11F_G11F_B10F:    return GL_R11F_G11F_B10F;
         case TextureFormat::RGB9_E5:           return GL_RGB9_E5;
-        case TextureFormat::RGBA8:             return GL_RGBA8;
         case TextureFormat::SRGB8_A8:          return GL_SRGB8_ALPHA8;
         case TextureFormat::RGBA8_SNORM:       return GL_RGBA8_SNORM;
         case TextureFormat::RGB10_A2:          return GL_RGB10_A2;
         case TextureFormat::RGBA8UI:           return GL_RGBA8UI;
         case TextureFormat::RGBA8I:            return GL_RGBA8I;
         case TextureFormat::DEPTH32F:          return GL_DEPTH_COMPONENT32F;
-        case TextureFormat::DEPTH24_STENCIL8:  return GL_DEPTH24_STENCIL8;
         case TextureFormat::DEPTH32F_STENCIL8: return GL_DEPTH32F_STENCIL8;
 
         // 48-bits per element
@@ -421,6 +474,12 @@ constexpr /* inline */ GLenum getInternalFormat(TextureFormat format) noexcept {
         case TextureFormat::RGBA32F:           return GL_RGBA32F;
         case TextureFormat::RGBA32UI:          return GL_RGBA32UI;
         case TextureFormat::RGBA32I:           return GL_RGBA32I;
+#else
+        default:
+            // this is just to squash the IDE warning about not having all cases when in
+            // ES2 header mode.
+            return 0;
+#endif
 
         // compressed formats
 #if defined(GL_ES_VERSION_3_0) || defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_ARB_ES3_compatibility)

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -433,11 +433,11 @@ Handle<HwSync> OpenGLDriver::createSyncS() noexcept {
 }
 
 Handle<HwSwapChain> OpenGLDriver::createSwapChainS() noexcept {
-    return initHandle<HwSwapChain>();
+    return initHandle<GLSwapChain>();
 }
 
 Handle<HwSwapChain> OpenGLDriver::createSwapChainHeadlessS() noexcept {
-    return initHandle<HwSwapChain>();
+    return initHandle<GLSwapChain>();
 }
 
 Handle<HwTimerQuery> OpenGLDriver::createTimerQueryS() noexcept {
@@ -1188,7 +1188,7 @@ void OpenGLDriver::createDefaultRenderTargetR(
 
     construct<GLRenderTarget>(rth, 0, 0);  // FIXME: we don't know the width/height
 
-    uint32_t framebuffer = mPlatform.createDefaultRenderTarget();
+    uint32_t const framebuffer = mPlatform.createDefaultRenderTarget();
 
     GLRenderTarget* rt = handle_cast<GLRenderTarget*>(rth);
     rt->gl.fbo = framebuffer;
@@ -1347,7 +1347,7 @@ void OpenGLDriver::createSyncR(Handle<HwSync> fh, int) {
 void OpenGLDriver::createSwapChainR(Handle<HwSwapChain> sch, void* nativeWindow, uint64_t flags) {
     DEBUG_MARKER()
 
-    HwSwapChain* sc = handle_cast<HwSwapChain*>(sch);
+    GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
     sc->swapChain = mPlatform.createSwapChain(nativeWindow, flags);
 }
 
@@ -1355,7 +1355,7 @@ void OpenGLDriver::createSwapChainHeadlessR(Handle<HwSwapChain> sch,
         uint32_t width, uint32_t height, uint64_t flags) {
     DEBUG_MARKER()
 
-    HwSwapChain* sc = handle_cast<HwSwapChain*>(sch);
+    GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
     sc->swapChain = mPlatform.createSwapChain(width, height, flags);
 }
 
@@ -1485,7 +1485,7 @@ void OpenGLDriver::destroySwapChain(Handle<HwSwapChain> sch) {
     DEBUG_MARKER()
 
     if (sch) {
-        HwSwapChain* sc = handle_cast<HwSwapChain*>(sch);
+        GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
         mPlatform.destroySwapChain(sc->swapChain);
         destruct(sch, sc);
     }
@@ -1855,15 +1855,15 @@ uint8_t OpenGLDriver::getMaxDrawBuffers() {
 void OpenGLDriver::commit(Handle<HwSwapChain> sch) {
     DEBUG_MARKER()
 
-    HwSwapChain* sc = handle_cast<HwSwapChain*>(sch);
+    GLSwapChain* sc = handle_cast<GLSwapChain*>(sch);
     mPlatform.commit(sc->swapChain);
 }
 
 void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> schRead) {
     DEBUG_MARKER()
 
-    HwSwapChain* scDraw = handle_cast<HwSwapChain*>(schDraw);
-    HwSwapChain* scRead = handle_cast<HwSwapChain*>(schRead);
+    GLSwapChain* scDraw = handle_cast<GLSwapChain*>(schDraw);
+    GLSwapChain* scRead = handle_cast<GLSwapChain*>(schRead);
     mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain);
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -132,8 +132,8 @@ Driver* OpenGLDriver::create(OpenGLPlatform* const platform,
     }
 
 #if defined(BACKEND_OPENGL_VERSION_GLES)
-    if (UTILS_UNLIKELY(!(major >= 3 && minor >= 0))) {
-        PANIC_LOG("OpenGL ES 3.0 minimum needed (current %d.%d)", major, minor);
+    if (UTILS_UNLIKELY(!(major >= 2 && minor >= 0))) {
+        PANIC_LOG("OpenGL ES 2.0 minimum needed (current %d.%d)", major, minor);
         goto cleanup;
     }
 #else
@@ -231,11 +231,15 @@ void OpenGLDriver::terminate() {
     // because we called glFinish(), all callbacks should have been executed
     assert_invariant(mGpuCommandCompleteOps.empty());
 
-    for (auto& item : mSamplerMap) {
-        mContext.unbindSampler(item.second);
-        glDeleteSamplers(1, &item.second);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!getContext().isES2()) {
+        for (auto& item: mSamplerMap) {
+            mContext.unbindSampler(item.second);
+            glDeleteSamplers(1, &item.second);
+        }
+        mSamplerMap.clear();
     }
-    mSamplerMap.clear();
+#endif
 
     delete mTimerQueryImpl;
 
@@ -497,7 +501,7 @@ void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph,
     rp->minIndex = minIndex;
     rp->maxIndex = maxIndex > minIndex ? maxIndex : rp->maxVertexCount - 1; // sanitize max index
 
-    glGenVertexArrays(1, &rp->gl.vao);
+    gl.procs.genVertexArrays(1, &rp->gl.vao);
 
     gl.bindVertexArray(&rp->gl);
 
@@ -535,18 +539,49 @@ void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
     switch (t->gl.target) {
         case GL_TEXTURE_2D:
         case GL_TEXTURE_CUBE_MAP:
-            glTexStorage2D(t->gl.target, GLsizei(t->levels), t->gl.internalFormat,
-                    GLsizei(width), GLsizei(height));
+            if (UTILS_LIKELY(!gl.isES2())) {
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+                glTexStorage2D(t->gl.target, GLsizei(t->levels), t->gl.internalFormat,
+                        GLsizei(width), GLsizei(height));
+#endif
+            }
+#ifdef BACKEND_OPENGL_VERSION_GLES
+            else {
+                // FIXME: handle compressed texture format
+                auto [format, type] = textureFormatToFormatAndType(t->format);
+                assert_invariant(format != GL_NONE && type != GL_NONE);
+                for (GLint level = 0 ; level < t->levels ; level++ ) {
+                    if (t->gl.target == GL_TEXTURE_CUBE_MAP) {
+                        for (GLint face = 0 ; face < 6 ; face++) {
+                            glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + face,
+                                    level, GLint(t->gl.internalFormat),
+                                    GLsizei(width), GLsizei(height), 0,
+                                    format, type, nullptr);
+                        }
+                    } else {
+                        glTexImage2D(t->gl.target, level, GLint(t->gl.internalFormat),
+                                GLsizei(width), GLsizei(height), 0,
+                                format, type, nullptr);
+                    }
+                }
+            }
+#endif
             break;
         case GL_TEXTURE_3D:
         case GL_TEXTURE_2D_ARRAY: {
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             glTexStorage3D(t->gl.target, GLsizei(t->levels), t->gl.internalFormat,
                     GLsizei(width), GLsizei(height), GLsizei(depth));
+#endif
             break;
         }
         case GL_TEXTURE_CUBE_MAP_ARRAY: {
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             glTexStorage3D(t->gl.target, GLsizei(t->levels), t->gl.internalFormat,
                     GLsizei(width), GLsizei(height), GLsizei(depth) * 6);
+#endif
             break;
         }
 #ifdef BACKEND_OPENGL_LEVEL_GLES31
@@ -555,7 +590,7 @@ void OpenGLDriver::textureStorage(OpenGLDriver::GLTexture* t,
                 // NOTE: if there is a mix of texture and renderbuffers, "fixed_sample_locations" must be true
                 // NOTE: what's the benefit of setting "fixed_sample_locations" to false?
 
-                if (mContext.isAtLeastGL(4, 3) || mContext.isAtLeastGLES(3, 1)) {
+                if (mContext.isAtLeastGL<4, 3>() || mContext.isAtLeastGLES<3, 1>()) {
                     // only supported from GL 4.3 and GLES 3.1 headers
                     glTexStorage2DMultisample(t->gl.target, t->samples, t->gl.internalFormat,
                             GLsizei(width), GLsizei(height), GL_TRUE);
@@ -587,10 +622,20 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
         TextureUsage usage) {
     DEBUG_MARKER()
 
+    GLenum internalFormat = getInternalFormat(format);
+    assert_invariant(internalFormat);
+
     auto& gl = mContext;
     samples = std::clamp(samples, uint8_t(1u), uint8_t(gl.gets.max_samples));
     GLTexture* t = construct<GLTexture>(th, target, levels, samples, w, h, depth, format, usage);
     if (UTILS_LIKELY(usage & TextureUsage::SAMPLEABLE)) {
+
+        if (UTILS_UNLIKELY(gl.isES2())) {
+            // on ES2, format and internal format must match
+            // FIXME: handle compressed texture format
+            internalFormat = textureFormatToFormatAndType(format).first;
+        }
+
         if (UTILS_UNLIKELY(t->target == SamplerType::SAMPLER_EXTERNAL)) {
             t->externalTexture = mPlatform.createExternalImageTexture();
             if (t->externalTexture) {
@@ -599,15 +644,14 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
                 t->gl.targetIndex = (uint8_t)OpenGLContext::getIndexForTextureTarget(t->gl.target);
                 // internalFormat actually depends on the external image, but it doesn't matter
                 // because it's not used anywhere for anything important.
-                t->gl.internalFormat = getInternalFormat(format);
+                t->gl.internalFormat = internalFormat;
                 t->gl.baseLevel = 0;
                 t->gl.maxLevel = 0;
             }
         } else {
             glGenTextures(1, &t->gl.id);
 
-            t->gl.internalFormat = getInternalFormat(format);
-            assert_invariant(t->gl.internalFormat);
+            t->gl.internalFormat = internalFormat;
 
             // We DO NOT update targetIndex at function exit to take advantage of the fact that
             // getIndexForTextureTarget() is constexpr -- so all of this disappears at compile time.
@@ -659,10 +703,10 @@ void OpenGLDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint
                 TextureUsage::STENCIL_ATTACHMENT)));
         assert_invariant(levels == 1);
         assert_invariant(target == SamplerType::SAMPLER_2D);
-        t->gl.internalFormat = getInternalFormat(format);
+        t->gl.internalFormat = internalFormat;
         t->gl.target = GL_RENDERBUFFER;
         glGenRenderbuffers(1, &t->gl.id);
-        renderBufferStorage(t->gl.id, t->gl.internalFormat, w, h, samples);
+        renderBufferStorage(t->gl.id, internalFormat, w, h, samples);
     }
 
     CHECK_GL_ERROR(utils::slog.e)
@@ -680,16 +724,15 @@ void OpenGLDriver::createTextureSwizzledR(Handle<HwTexture> th,
 
     // WebGL does not support swizzling. We assert for this in the Texture builder,
     // so it is probably fine to silently ignore the swizzle state here.
-#if !defined(__EMSCRIPTEN__)
-
-    // the texture is still bound and active from createTextureR
-    GLTexture* t = handle_cast<GLTexture *>(th);
-
-    glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_R, (GLint)getSwizzleChannel(r));
-    glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_G, (GLint)getSwizzleChannel(g));
-    glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_B, (GLint)getSwizzleChannel(b));
-    glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_A, (GLint)getSwizzleChannel(a));
-
+#if !defined(__EMSCRIPTEN__)  && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
+    if (!mContext.isES2()) {
+        // the texture is still bound and active from createTextureR
+        GLTexture* t = handle_cast<GLTexture*>(th);
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_R, (GLint)getSwizzleChannel(r));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_G, (GLint)getSwizzleChannel(g));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_B, (GLint)getSwizzleChannel(b));
+        glTexParameteri(t->gl.target, GL_TEXTURE_SWIZZLE_A, (GLint)getSwizzleChannel(a));
+    }
 #endif
 
     CHECK_GL_ERROR(utils::slog.e)
@@ -762,11 +805,11 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
     // NOTE: this is called from draw() and must be as efficient as possible.
 
     // The VAO for the given render primitive must already be bound.
-    #ifndef NDEBUG
+#ifndef NDEBUG
     GLint vaoBinding;
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vaoBinding);
     assert_invariant(vaoBinding == (GLint) rp->gl.vao);
-    #endif
+#endif
 
     rp->gl.vertexBufferVersion = vb->bufferObjectsVersion;
     rp->maxVertexCount = vb->vertexCount;
@@ -778,14 +821,20 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
         // take care to avoid it. This can occur when VertexBuffer is only partially populated with
         // BufferObject items.
         if (bi != Attribute::BUFFER_UNUSED && UTILS_LIKELY(vb->gl.buffers[bi] != 0)) {
+
+            assert_invariant(!(gl.isES2() && (attribute.flags & Attribute::FLAG_INTEGER_TARGET)));
+
             gl.bindBuffer(GL_ARRAY_BUFFER, vb->gl.buffers[bi]);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
                 glVertexAttribIPointer(GLuint(i),
                         (GLint)getComponentCount(attribute.type),
                         getComponentType(attribute.type),
                         attribute.stride,
                         (void*) uintptr_t(attribute.offset));
-            } else {
+            } else
+#endif
+            {
                 glVertexAttribPointer(GLuint(i),
                         (GLint)getComponentCount(attribute.type),
                         getComponentType(attribute.type),
@@ -798,10 +847,16 @@ void OpenGLDriver::updateVertexArrayObject(GLRenderPrimitive* rp, GLVertexBuffer
         } else {
 
             // In some OpenGL implementations, we must supply a properly-typed placeholder for
-            // every integer input that is declared in the vertex shader.
+            // every integer input that is declared in the vertex shader, even if disabled.
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             if (UTILS_UNLIKELY(attribute.flags & Attribute::FLAG_INTEGER_TARGET)) {
-                glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
-            } else {
+                if (!gl.isES2()) {
+                    // on ES2, we know the shader doesn't have integer attributes
+                    glVertexAttribI4ui(GLuint(i), 0, 0, 0, 0);
+                }
+            } else
+#endif
+            {
                 glVertexAttrib4f(GLuint(i), 0, 0, 0, 0);
             }
 
@@ -832,6 +887,7 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
 
     switch (attachment) {
         case GL_COLOR_ATTACHMENT0:
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
         case GL_COLOR_ATTACHMENT1:
         case GL_COLOR_ATTACHMENT2:
         case GL_COLOR_ATTACHMENT3:
@@ -839,7 +895,12 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
         case GL_COLOR_ATTACHMENT5:
         case GL_COLOR_ATTACHMENT6:
         case GL_COLOR_ATTACHMENT7:
+#endif
+            assert_invariant((attachment != GL_COLOR_ATTACHMENT0 && !mContext.isES2())
+                             || attachment == GL_COLOR_ATTACHMENT0);
+
             static_assert(MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT == 8);
+
             resolveFlags = getTargetBufferFlagsAt(attachment - GL_COLOR_ATTACHMENT0);
             break;
         case GL_DEPTH_ATTACHMENT:
@@ -848,10 +909,13 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
         case GL_STENCIL_ATTACHMENT:
             resolveFlags = TargetBufferFlags::STENCIL;
             break;
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
         case GL_DEPTH_STENCIL_ATTACHMENT:
+            assert_invariant(!mContext.isES2());
             resolveFlags = TargetBufferFlags::DEPTH;
             resolveFlags |= TargetBufferFlags::STENCIL;
             break;
+#endif
         default:
             break;
     }
@@ -861,9 +925,13 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
     // is resolved.
     UTILS_UNUSED bool attachmentTypeNotSupportedByMSRTT = false;
     switch (attachment) {
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+        case GL_DEPTH_STENCIL_ATTACHMENT:
+            assert_invariant(!mContext.isES2());
+            UTILS_FALLTHROUGH;
+#endif
         case GL_DEPTH_ATTACHMENT:
         case GL_STENCIL_ATTACHMENT:
-        case GL_DEPTH_STENCIL_ATTACHMENT:
             attachmentTypeNotSupportedByMSRTT = rt->gl.samples != t->samples;
             break;
         default:
@@ -944,9 +1012,11 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
                 break;
             case GL_TEXTURE_2D_ARRAY:
             case GL_TEXTURE_CUBE_MAP_ARRAY:
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
                 // GL_TEXTURE_2D_MULTISAMPLE_ARRAY is not supported in GLES
                 glFramebufferTextureLayer(GL_FRAMEBUFFER, attachment,
                         t->gl.id, binfo.level, binfo.layer);
+#endif
                 break;
             default:
                 // we shouldn't be here
@@ -1042,8 +1112,10 @@ void OpenGLDriver::framebufferTexture(TargetBufferInfo const& binfo,
                 break;
             case GL_TEXTURE_2D_ARRAY:
             case GL_TEXTURE_CUBE_MAP_ARRAY:
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
                 glFramebufferTextureLayer(GL_FRAMEBUFFER, attachment,
                         t->gl.id, binfo.level, binfo.layer);
+#endif
                 break;
             default:
                 // we shouldn't be here
@@ -1080,8 +1152,10 @@ void OpenGLDriver::renderBufferStorage(GLuint rbo, GLenum internalformat, uint32
         } else
 #endif
         {
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             glRenderbufferStorageMultisample(GL_RENDERBUFFER,
                     samples, internalformat, (GLsizei)width, (GLsizei)height);
+#endif
         }
     } else {
         glRenderbufferStorage(GL_RENDERBUFFER, internalformat, (GLsizei)width, (GLsizei)height);
@@ -1170,6 +1244,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
     };
 
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     if (any(targets & TargetBufferFlags::COLOR_ALL)) {
         GLenum bufs[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { GL_NONE };
         const size_t maxDrawBuffers = getMaxDrawBuffers();
@@ -1185,10 +1260,14 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
         glDrawBuffers((GLsizei)maxDrawBuffers, bufs);
         CHECK_GL_ERROR(utils::slog.e)
     }
+#endif
 
     // handle special cases first (where depth/stencil are packed)
     bool specialCased = false;
-    if ((targets & TargetBufferFlags::DEPTH_AND_STENCIL) == TargetBufferFlags::DEPTH_AND_STENCIL) {
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!getContext().isES2() &&
+            (targets & TargetBufferFlags::DEPTH_AND_STENCIL) == TargetBufferFlags::DEPTH_AND_STENCIL) {
         assert_invariant(depth.handle);
         // either we supplied only the depth handle or both depth/stencil are identical and not null
         if (depth.handle && (stencil.handle == depth.handle || !stencil.handle)) {
@@ -1198,6 +1277,7 @@ void OpenGLDriver::createRenderTargetR(Handle<HwRenderTarget> rth,
             checkDimensions(rt->gl.depth, depth.level);
         }
     }
+#endif
 
     if (!specialCased) {
         if (any(targets & TargetBufferFlags::DEPTH)) {
@@ -1267,7 +1347,7 @@ void OpenGLDriver::createTimerQueryR(Handle<HwTimerQuery> tqh, int) {
     DEBUG_MARKER()
 
     GLTimerQuery* tq = handle_cast<GLTimerQuery*>(tqh);
-    glGenQueries(1u, &tq->gl.query);
+    mContext.procs.genQueries(1u, &tq->gl.query);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
@@ -1424,7 +1504,7 @@ void OpenGLDriver::destroyTimerQuery(Handle<HwTimerQuery> tqh) {
 
     if (tqh) {
         GLTimerQuery* tq = handle_cast<GLTimerQuery*>(tqh);
-        glDeleteQueries(1u, &tq->gl.query);
+        getContext().procs.deleteQueries(1u, &tq->gl.query);
         destruct(tqh, tq);
     }
 }
@@ -1587,6 +1667,9 @@ bool OpenGLDriver::isTextureFormatSupported(TextureFormat format) {
     if (isASTCCompression(format)) {
         return ext.KHR_texture_compression_astc_hdr;
     }
+    if (mContext.isES2()) {
+        return textureFormatToFormatAndType(format).first != GL_NONE;
+    }
     return getInternalFormat(format) != 0;
 }
 
@@ -1595,6 +1678,8 @@ bool OpenGLDriver::isTextureSwizzleSupported() {
     // WebGL2 doesn't support texture swizzle
     // see https://registry.khronos.org/webgl/specs/latest/2.0/#5.19
     return false;
+#elif defined(BACKEND_OPENGL_VERSION_GLES)
+    return !mContext.isES2();
 #else
     return true;
 #endif
@@ -1657,7 +1742,7 @@ bool OpenGLDriver::isRenderTargetFormatSupported(TextureFormat format) {
 
         // Three-component SRGB is a color-renderable texture format in core OpenGL on desktop.
         case TextureFormat::SRGB8:
-            return mContext.isAtLeastGL(4, 5);
+            return mContext.isAtLeastGL<4, 5>();
 
         // Half-float formats, requires extension.
         case TextureFormat::R16F:
@@ -1889,8 +1974,9 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         BufferDescriptor&& data) {
     DEBUG_MARKER()
 
-#if defined(GL_EXT_texture_filter_anisotropic)
     OpenGLContext const& context = getContext();
+
+#if defined(GL_EXT_texture_filter_anisotropic)
     const bool anisotropyWorkaround =
             context.ext.EXT_texture_filter_anisotropic &&
             context.bugs.texture_filter_anisotropic_broken_on_sampler;
@@ -1898,6 +1984,10 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 
     GLSamplerGroup* const sb = handle_cast<GLSamplerGroup *>(sbh);
     assert_invariant(sb->textureUnitEntries.size() == data.size / sizeof(SamplerDescriptor));
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    bool const es2 = context.isES2();
+#endif
 
     auto const* const pSamplers = (SamplerDescriptor const*)data.buffer;
     for (size_t i = 0, c = sb->textureUnitEntries.size(); i < c; i++) {
@@ -1939,7 +2029,22 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
                         std::min(context.gets.max_anisotropy, anisotropy));
             }
 #endif
-            samplerId = getSampler(params);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+            if (UTILS_LIKELY(!es2)) {
+                samplerId = getSampler(params);
+            } else
+#endif
+            {
+                // in ES2 the sampler parameters need to be set on the texture itself
+                glTexParameteri(t->gl.target, GL_TEXTURE_MIN_FILTER,
+                        (GLint)getTextureFilter(params.filterMin));
+                glTexParameteri(t->gl.target, GL_TEXTURE_MAG_FILTER,
+                        (GLint)getTextureFilter(params.filterMag));
+                glTexParameteri(t->gl.target, GL_TEXTURE_WRAP_S,
+                        (GLint)getWrapMode(params.wrapS));
+                glTexParameteri(t->gl.target, GL_TEXTURE_WRAP_T,
+                        (GLint)getWrapMode(params.wrapT));
+            }
         } else {
             // this happens if the program doesn't use all samplers of a sampler group,
             // which is not an error.
@@ -1952,20 +2057,25 @@ void OpenGLDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
 
 void OpenGLDriver::setMinMaxLevels(Handle<HwTexture> th, uint32_t minLevel, uint32_t maxLevel) {
     DEBUG_MARKER()
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     auto& gl = mContext;
+    if (!gl.isES2()) {
+        GLTexture* t = handle_cast<GLTexture*>(th);
+        bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
+        gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
 
-    GLTexture* t = handle_cast<GLTexture *>(th);
-    bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
-    gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
+        // Must fit within int8_t.
+        assert_invariant(minLevel <= 0x7f && maxLevel <= 0x7f);
 
-    // Must fit within int8_t.
-    assert_invariant(minLevel <= 0x7f && maxLevel <= 0x7f);
+        t->gl.baseLevel = (int8_t)minLevel;
+        glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
 
-    t->gl.baseLevel = (int8_t)minLevel;
-    glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
-
-    t->gl.maxLevel = (int8_t)maxLevel; // NOTE: according to the GL spec, the default value of this 1000
-    glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+        t->gl
+         .maxLevel = (int8_t)maxLevel; // NOTE: according to the GL spec, the default value of this 1000
+        glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+    }
+#endif
 }
 
 void OpenGLDriver::update3DImage(Handle<HwTexture> th,
@@ -2000,8 +2110,12 @@ void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     t->gl.baseLevel = 0;
     t->gl.maxLevel = static_cast<int8_t>(t->levels - 1);
 
-    glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
-    glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!gl.isES2()) {
+        glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+        glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+    }
+#endif
 
     glGenerateMipmap(t->gl.target);
 
@@ -2030,7 +2144,11 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
     GLenum const glFormat = getFormat(p.format);
     GLenum const glType = getType(p.type);
 
-    gl.pixelStore(GL_UNPACK_ROW_LENGTH, GLint(p.stride));
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!gl.isES2()) {
+        gl.pixelStore(GL_UNPACK_ROW_LENGTH, GLint(p.stride));
+    }
+#endif
     gl.pixelStore(GL_UNPACK_ALIGNMENT, GLint(p.alignment));
 
     // This is equivalent to using GL_UNPACK_SKIP_PIXELS and GL_UNPACK_SKIP_ROWS
@@ -2055,6 +2173,8 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
                     GLsizei(width), GLsizei(height), glFormat, glType, buffer);
             break;
         case SamplerType::SAMPLER_3D:
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             assert_invariant(zoffset + depth <= std::max(1u, t->depth >> level));
             bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
             gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
@@ -2062,9 +2182,12 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
             glTexSubImage3D(t->gl.target, GLint(level),
                     GLint(xoffset), GLint(yoffset), GLint(zoffset),
                     GLsizei(width), GLsizei(height), GLsizei(depth), glFormat, glType, buffer);
+#endif
             break;
         case SamplerType::SAMPLER_2D_ARRAY:
         case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             assert_invariant(zoffset + depth <= t->depth);
             // NOTE: GL_TEXTURE_2D_MULTISAMPLE is not allowed
             bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
@@ -2074,6 +2197,7 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
             glTexSubImage3D(t->gl.target, GLint(level),
                     GLint(xoffset), GLint(yoffset), GLint(zoffset),
                     GLsizei(width), GLsizei(height), GLsizei(depth), glFormat, glType, buffer);
+#endif
             break;
         case SamplerType::SAMPLER_CUBEMAP: {
             assert_invariant(t->gl.target == GL_TEXTURE_CUBE_MAP);
@@ -2095,17 +2219,20 @@ void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
         }
     }
 
-    // update the base/max LOD, so we don't access undefined LOD. this allows the app to
-    // specify levels as they become available.
-
-    if (int8_t(level) < t->gl.baseLevel) {
-        t->gl.baseLevel = int8_t(level);
-        glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!gl.isES2()) {
+        // update the base/max LOD, so we don't access undefined LOD. this allows the app to
+        // specify levels as they become available.
+        if (int8_t(level) < t->gl.baseLevel) {
+            t->gl.baseLevel = int8_t(level);
+            glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+        }
+        if (int8_t(level) > t->gl.maxLevel) {
+            t->gl.maxLevel = int8_t(level);
+            glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+        }
     }
-    if (int8_t(level) > t->gl.maxLevel) {
-        t->gl.maxLevel = int8_t(level);
-        glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
-    }
+#endif
 
     scheduleDestroy(std::move(p));
 
@@ -2150,6 +2277,8 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t, uint32_t level,
                     t->gl.internalFormat, imageSize, p.buffer);
             break;
         case SamplerType::SAMPLER_3D:
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, t);
             gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
             assert_invariant(t->gl.target == GL_TEXTURE_3D);
@@ -2157,15 +2286,19 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t, uint32_t level,
                     GLint(xoffset), GLint(yoffset), GLint(zoffset),
                     GLsizei(width), GLsizei(height), GLsizei(depth),
                     t->gl.internalFormat, imageSize, p.buffer);
+#endif
             break;
         case SamplerType::SAMPLER_2D_ARRAY:
         case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+            assert_invariant(!gl.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
             assert_invariant(t->gl.target == GL_TEXTURE_2D_ARRAY ||
                     t->gl.target == GL_TEXTURE_CUBE_MAP_ARRAY);
             glCompressedTexSubImage3D(t->gl.target, GLint(level),
                     GLint(xoffset), GLint(yoffset), GLint(zoffset),
                     GLsizei(width), GLsizei(height), GLsizei(depth),
                     t->gl.internalFormat, imageSize, p.buffer);
+#endif
             break;
         case SamplerType::SAMPLER_CUBEMAP: {
             assert_invariant(t->gl.target == GL_TEXTURE_CUBE_MAP);
@@ -2187,17 +2320,20 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t, uint32_t level,
         }
     }
 
-    // update the base/max LOD, so we don't access undefined LOD. this allows the app to
-    // specify levels as they become available.
-
-    if (uint8_t(level) < t->gl.baseLevel) {
-        t->gl.baseLevel = int8_t(level);
-        glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (!gl.isES2()) {
+        // update the base/max LOD, so we don't access undefined LOD. this allows the app to
+        // specify levels as they become available.
+        if (int8_t(level) < t->gl.baseLevel) {
+            t->gl.baseLevel = int8_t(level);
+            glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+        }
+        if (int8_t(level) > t->gl.maxLevel) {
+            t->gl.maxLevel = int8_t(level);
+            glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+        }
     }
-    if (uint8_t(level) > t->gl.maxLevel) {
-        t->gl.maxLevel = int8_t(level);
-        glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
-    }
+#endif
 
     scheduleDestroy(std::move(p));
 
@@ -2395,19 +2531,15 @@ void OpenGLDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     gl.bindFramebuffer(GL_FRAMEBUFFER, rt->gl.fbo);
     CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_FRAMEBUFFER)
 
-    // glInvalidateFramebuffer appeared on GLES 3.0 and GL4.3
-#if defined(BACKEND_OPENGL_LEVEL_GLES30) || defined(BACKEND_OPENGL_VERSION_GL)
-    if ((mContext.isAtLeastGLES(3, 0) || mContext.isAtLeastGL(4, 3))
+    if (gl.ext.EXT_discard_framebuffer
             && !gl.bugs.disable_invalidate_framebuffer) {
         AttachmentArray attachments; // NOLINT
         GLsizei const attachmentCount = getAttachments(attachments, rt, discardFlags);
         if (attachmentCount) {
-            glInvalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
+            gl.procs.invalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
         }
         CHECK_GL_ERROR(utils::slog.e)
-    } else
-#endif
-    {
+    } else {
         // It's important to clear the framebuffer before drawing, as it resets
         // the fb to a known state (resets fb compression and possibly other things).
         // So we use glClear instead of glInvalidateFramebuffer
@@ -2478,10 +2610,7 @@ void OpenGLDriver::endRenderPass(int) {
         discardFlags &= ~TargetBufferFlags::STENCIL;
     }
 
-    // glInvalidateFramebuffer appeared on GLES 3.0 and GL4.3, for simplicity we just
-    // ignore it on GL (rather than having to do a runtime check).
-#if defined(BACKEND_OPENGL_LEVEL_GLES30) || defined(BACKEND_OPENGL_VERSION_GL)
-    if (mContext.isAtLeastGLES(3, 0) || mContext.isAtLeastGL(4, 3)) {
+    if (gl.ext.EXT_discard_framebuffer) {
         auto effectiveDiscardFlags = discardFlags;
         if (gl.bugs.invalidate_end_only_if_invalidate_start) {
             effectiveDiscardFlags &= mRenderPassParams.flags.discardStart;
@@ -2492,12 +2621,11 @@ void OpenGLDriver::endRenderPass(int) {
             AttachmentArray attachments; // NOLINT
             GLsizei const attachmentCount = getAttachments(attachments, rt, effectiveDiscardFlags);
             if (attachmentCount) {
-                glInvalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
+                gl.procs.invalidateFramebuffer(GL_FRAMEBUFFER, attachmentCount, attachments.data());
             }
            CHECK_GL_ERROR(utils::slog.e)
         }
     }
-#endif
 
 #ifndef NDEBUG
     // clear the discarded buffers in debug builds
@@ -2516,6 +2644,13 @@ void OpenGLDriver::nextSubpass(int) {}
 
 void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
         TargetBufferFlags discardFlags) noexcept {
+
+    if (UTILS_UNLIKELY(getContext().isES2())) {
+        // ES2 doesn't have manual resolve capabilities
+        return;
+    }
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     assert_invariant(rt->gl.fbo_read);
     auto& gl = mContext;
     const TargetBufferFlags resolve = rt->gl.resolve & ~discardFlags;
@@ -2542,6 +2677,7 @@ void OpenGLDriver::resolvePass(ResolveAction action, GLRenderTarget const* rt,
                 0, 0, (GLint)rt->width, (GLint)rt->height, mask, GL_NEAREST);
         CHECK_GL_ERROR(utils::slog.e)
     }
+#endif
 }
 
 GLsizei OpenGLDriver::getAttachments(AttachmentArray& attachments,
@@ -2554,6 +2690,7 @@ GLsizei OpenGLDriver::getAttachments(AttachmentArray& attachments,
     if (any(buffers & TargetBufferFlags::COLOR0)) {
         attachments[attachmentCount++] = defaultFramebuffer ? GL_COLOR : GL_COLOR_ATTACHMENT0;
     }
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     if (any(buffers & TargetBufferFlags::COLOR1)) {
         assert_invariant(!defaultFramebuffer);
         attachments[attachmentCount++] = GL_COLOR_ATTACHMENT1;
@@ -2582,6 +2719,7 @@ GLsizei OpenGLDriver::getAttachments(AttachmentArray& attachments,
         assert_invariant(!defaultFramebuffer);
         attachments[attachmentCount++] = GL_COLOR_ATTACHMENT7;
     }
+#endif
     if (any(buffers & TargetBufferFlags::DEPTH)) {
         attachments[attachmentCount++] = defaultFramebuffer ? GL_DEPTH : GL_DEPTH_ATTACHMENT;
     }
@@ -2660,6 +2798,7 @@ void OpenGLDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
 }
 
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
 GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     assert_invariant(mSamplerMap.find(params.u) == mSamplerMap.end());
 
@@ -2686,6 +2825,7 @@ GLuint OpenGLDriver::getSamplerSlow(SamplerParams params) const noexcept {
     mSamplerMap[params.u] = s;
     return s;
 }
+#endif
 
 void OpenGLDriver::insertEventMarker(char const* string, uint32_t len) {
 #ifdef GL_EXT_debug_marker
@@ -2770,15 +2910,42 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
 
     GLRenderTarget const* s = handle_cast<GLRenderTarget const*>(src);
 
-    // glReadPixel doesn't resolve automatically, but it does with the auto-resolve extension,
-    // which we're always emulating. So if we have a resolved fbo (fbo_read), use that instead.
-    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo_read ? s->gl.fbo_read : s->gl.fbo);
-
     using PBD = PixelBufferDescriptor;
 
     // The PBO only needs to accommodate the area we're reading, with alignment.
     auto const pboSize = (GLsizeiptr)PBD::computeDataSize(
             p.format, p.type, width, height, p.alignment);
+
+    if (UTILS_UNLIKELY(gl.isES2())) {
+        void* buffer = malloc(pboSize);
+        if (buffer) {
+            gl.bindFramebuffer(GL_FRAMEBUFFER, s->gl.fbo_read ? s->gl.fbo_read : s->gl.fbo);
+            glReadPixels(GLint(x), GLint(y), GLint(width), GLint(height), glFormat, glType, buffer);
+            CHECK_GL_ERROR(utils::slog.e)
+
+            // now we need to flip the buffer vertically to match our API
+            size_t const stride = p.stride ? p.stride : width;
+            size_t const bpp = PBD::computeDataSize(p.format, p.type, 1, 1, 1);
+            size_t const dstBpr = PBD::computeDataSize(p.format, p.type, stride, 1, p.alignment);
+            char* pDst = (char*)p.buffer + p.left * bpp + dstBpr * (p.top + height - 1);
+
+            size_t const srcBpr = PBD::computeDataSize(p.format, p.type, width, 1, p.alignment);
+            char const* pSrc = (char const*)buffer;
+            for (size_t i = 0; i < height; ++i) {
+                memcpy(pDst, pSrc, bpp * width);
+                pSrc += srcBpr;
+                pDst -= dstBpr;
+            }
+        }
+        free(buffer);
+        scheduleDestroy(std::move(p));
+        return;
+    }
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    // glReadPixel doesn't resolve automatically, but it does with the auto-resolve extension,
+    // which we're always emulating. So if we have a resolved fbo (fbo_read), use that instead.
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo_read ? s->gl.fbo_read : s->gl.fbo);
 
     GLuint pbo;
     glGenBuffers(1, &pbo);
@@ -2828,12 +2995,15 @@ void OpenGLDriver::readPixels(Handle<HwRenderTarget> src,
         delete pUserBuffer;
         CHECK_GL_ERROR(utils::slog.e)
     });
+#endif
 }
 
 void OpenGLDriver::readBufferSubData(backend::BufferObjectHandle boh,
         uint32_t offset, uint32_t size, backend::BufferDescriptor&& p) {
     auto& gl = mContext;
+    assert_invariant(!gl.isES2());
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     GLBufferObject const* bo = handle_cast<GLBufferObject const*>(boh);
 
     // TODO: measure the two solutions
@@ -2880,6 +3050,7 @@ void OpenGLDriver::readBufferSubData(backend::BufferObjectHandle boh,
         scheduleDestroy(std::move(p));
         CHECK_GL_ERROR(utils::slog.e)
     }
+#endif
 }
 
 void OpenGLDriver::whenGpuCommandsComplete(std::function<void()> fn) noexcept {
@@ -3048,41 +3219,63 @@ void OpenGLDriver::clearWithRasterPipe(TargetBufferFlags clearFlags,
         mContext.stencilMaskSeparate(0xFF, mContext.state.stencil.back.stencilMask);
     }
 
-    if (any(clearFlags & TargetBufferFlags::COLOR0)) {
-        glClearBufferfv(GL_COLOR, 0, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR1)) {
-        glClearBufferfv(GL_COLOR, 1, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR2)) {
-        glClearBufferfv(GL_COLOR, 2, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR3)) {
-        glClearBufferfv(GL_COLOR, 3, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR4)) {
-        glClearBufferfv(GL_COLOR, 4, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR5)) {
-        glClearBufferfv(GL_COLOR, 5, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR6)) {
-        glClearBufferfv(GL_COLOR, 6, linearColor.v);
-    }
-    if (any(clearFlags & TargetBufferFlags::COLOR7)) {
-        glClearBufferfv(GL_COLOR, 7, linearColor.v);
-    }
-
-    if ((clearFlags & TargetBufferFlags::DEPTH_AND_STENCIL) == TargetBufferFlags::DEPTH_AND_STENCIL) {
-        glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
-    } else {
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+    if (UTILS_LIKELY(!mContext.isES2())) {
+        if (any(clearFlags & TargetBufferFlags::COLOR0)) {
+            glClearBufferfv(GL_COLOR, 0, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR1)) {
+            glClearBufferfv(GL_COLOR, 1, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR2)) {
+            glClearBufferfv(GL_COLOR, 2, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR3)) {
+            glClearBufferfv(GL_COLOR, 3, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR4)) {
+            glClearBufferfv(GL_COLOR, 4, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR5)) {
+            glClearBufferfv(GL_COLOR, 5, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR6)) {
+            glClearBufferfv(GL_COLOR, 6, linearColor.v);
+        }
+        if (any(clearFlags & TargetBufferFlags::COLOR7)) {
+            glClearBufferfv(GL_COLOR, 7, linearColor.v);
+        }
+        if ((clearFlags & TargetBufferFlags::DEPTH_AND_STENCIL) == TargetBufferFlags::DEPTH_AND_STENCIL) {
+            glClearBufferfi(GL_DEPTH_STENCIL, 0, depth, stencil);
+        } else {
+            if (any(clearFlags & TargetBufferFlags::DEPTH)) {
+                glClearBufferfv(GL_DEPTH, 0, &depth);
+            }
+            if (any(clearFlags & TargetBufferFlags::STENCIL)) {
+                glClearBufferiv(GL_STENCIL, 0, &stencil);
+            }
+        }
+    } else
+#endif
+    {
+        GLbitfield mask = 0;
+        if (any(clearFlags & TargetBufferFlags::COLOR0)) {
+            glClearColor(linearColor.r, linearColor.g, linearColor.b, linearColor.a);
+            mask |= GL_COLOR_BUFFER_BIT;
+        }
         if (any(clearFlags & TargetBufferFlags::DEPTH)) {
-            glClearBufferfv(GL_DEPTH, 0, &depth);
+            glClearDepthf(depth);
+            mask |= GL_DEPTH_BUFFER_BIT;
         }
         if (any(clearFlags & TargetBufferFlags::STENCIL)) {
-            glClearBufferiv(GL_STENCIL, 0, &stencil);
+            glClearStencil(stencil);
+            mask |= GL_STENCIL_BUFFER_BIT;
+        }
+        if (mask) {
+            glClear(mask);
         }
     }
+
     CHECK_GL_ERROR(utils::slog.e)
 }
 
@@ -3092,7 +3285,9 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
         SamplerMagFilter filter) {
     DEBUG_MARKER()
     auto& gl = mContext;
+    assert_invariant(!gl.isES2());
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     GLbitfield const mask = getAttachmentBitfield(buffers);
     if (mask) {
         GLenum glFilterMode = (filter == SamplerMagFilter::NEAREST) ? GL_NEAREST : GL_LINEAR;
@@ -3153,25 +3348,30 @@ void OpenGLDriver::blit(TargetBufferFlags buffers,
                 mask, glFilterMode);
         CHECK_GL_ERROR(utils::slog.e)
     }
+#endif
 }
 
 void OpenGLDriver::updateTextureLodRange(GLTexture* texture, int8_t targetLevel) noexcept {
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     auto& gl = mContext;
-    if (texture && any(texture->usage & TextureUsage::SAMPLEABLE)) {
-        if (targetLevel < texture->gl.baseLevel || targetLevel > texture->gl.maxLevel) {
-            bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, texture);
-            gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
-            if (targetLevel < texture->gl.baseLevel) {
-                texture->gl.baseLevel = targetLevel;
-                glTexParameteri(texture->gl.target, GL_TEXTURE_BASE_LEVEL, targetLevel);
+    if (!gl.isES2()) {
+        if (texture && any(texture->usage & TextureUsage::SAMPLEABLE)) {
+            if (targetLevel < texture->gl.baseLevel || targetLevel > texture->gl.maxLevel) {
+                bindTexture(OpenGLContext::DUMMY_TEXTURE_BINDING, texture);
+                gl.activeTexture(OpenGLContext::DUMMY_TEXTURE_BINDING);
+                if (targetLevel < texture->gl.baseLevel) {
+                    texture->gl.baseLevel = targetLevel;
+                    glTexParameteri(texture->gl.target, GL_TEXTURE_BASE_LEVEL, targetLevel);
+                }
+                if (targetLevel > texture->gl.maxLevel) {
+                    texture->gl.maxLevel = targetLevel;
+                    glTexParameteri(texture->gl.target, GL_TEXTURE_MAX_LEVEL, targetLevel);
+                }
             }
-            if (targetLevel > texture->gl.maxLevel) {
-                texture->gl.maxLevel = targetLevel;
-                glTexParameteri(texture->gl.target, GL_TEXTURE_MAX_LEVEL, targetLevel);
-            }
+            CHECK_GL_ERROR(utils::slog.e)
         }
-        CHECK_GL_ERROR(utils::slog.e)
     }
+#endif
 }
 
 void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph, uint32_t instanceCount) {
@@ -3213,12 +3413,15 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph, uint
     setScissor(state.scissor);
 
     if (UTILS_LIKELY(instanceCount <= 1)) {
-        glDrawRangeElements(GLenum(rp->type), rp->minIndex, rp->maxIndex, (GLsizei)rp->count,
-                rp->gl.getIndicesType(), reinterpret_cast<const void*>(rp->offset));
+        glDrawElements(GLenum(rp->type), (GLsizei)rp->count, rp->gl.getIndicesType(),
+                reinterpret_cast<const void*>(rp->offset));
     } else {
+        assert_invariant(!mContext.isES2());
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
         glDrawElementsInstanced(GLenum(rp->type), (GLsizei)rp->count,
                 rp->gl.getIndicesType(), reinterpret_cast<const void*>(rp->offset),
                 (GLsizei)instanceCount);
+#endif
     }
 
 #ifdef FILAMENT_ENABLE_MATDBG

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -71,6 +71,7 @@ public:
 
     struct GLSwapChain : public HwSwapChain {
         using HwSwapChain::HwSwapChain;
+        bool rec709 = false;
     };
 
     struct GLBufferObject : public HwBufferObject {
@@ -189,6 +190,7 @@ public:
             mutable GLuint fbo_read = 0;
             mutable TargetBufferFlags resolve = TargetBufferFlags::NONE; // attachments in fbo_draw to resolve
             uint8_t samples = 1;
+            bool isDefault = false;
         } gl;
         TargetBufferFlags targets = {};
     };
@@ -393,6 +395,10 @@ private:
     // timer query implementation
     OpenGLTimerQueryInterface* mTimerQueryImpl = nullptr;
     bool mFrameTimeSupported = false;
+
+    // for ES2 sRGB support
+    GLSwapChain* mCurrentDrawSwapChain = nullptr;
+    bool mRec709OutputColorspace = false;
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -69,6 +69,10 @@ public:
 
     // OpenGLDriver specific fields
 
+    struct GLSwapChain : public HwSwapChain {
+        using HwSwapChain::HwSwapChain;
+    };
+
     struct GLBufferObject : public HwBufferObject {
         using HwBufferObject::HwBufferObject;
         GLBufferObject(uint32_t size,

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -306,6 +306,7 @@ private:
     void resolvePass(ResolveAction action, GLRenderTarget const* rt,
             TargetBufferFlags discardFlags) noexcept;
 
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
     GLuint getSamplerSlow(SamplerParams sp) const noexcept;
 
     inline GLuint getSampler(SamplerParams sp) const noexcept {
@@ -323,6 +324,7 @@ private:
     const std::array<GLSamplerGroup*, Program::SAMPLER_BINDING_COUNT>& getSamplerBindings() const {
         return mSamplerBindings;
     }
+#endif
 
     using AttachmentArray = std::array<GLenum, MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + 2>;
     static GLsizei getAttachments(AttachmentArray& attachments,

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -80,6 +80,7 @@ private:
         Program::UniformBlockInfo uniformBlockInfo;
         Program::SamplerGroupInfo samplerGroupInfo;
         std::array<Program::UniformInfo, Program::UNIFORM_BINDING_COUNT> bindingUniformInfo;
+        utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> attributes;
         std::array<utils::CString, Program::SHADER_TYPE_COUNT> shaderSourceCode;
     };
 
@@ -96,7 +97,9 @@ private:
 
     static std::array<std::string_view, 2> splitShaderSource(std::string_view source) noexcept;
 
-    static GLuint linkProgram(const GLuint shaderIds[Program::SHADER_TYPE_COUNT]) noexcept;
+    static GLuint linkProgram(OpenGLContext& context,
+            LazyInitializationData* lazyInitializationData,
+            const GLuint shaderIds[Program::SHADER_TYPE_COUNT]) noexcept;
 
     static bool checkProgramStatus(const char* name,
             GLuint& program, GLuint shaderIds[Program::SHADER_TYPE_COUNT],

--- a/filament/backend/src/opengl/OpenGLProgram.h
+++ b/filament/backend/src/opengl/OpenGLProgram.h
@@ -73,6 +73,7 @@ public:
 
     // For ES2 only
     void updateUniforms(uint32_t index, void const* buffer, uint16_t age) noexcept;
+    void setRec709ColorSpace(bool rec709) const noexcept;
 
 private:
     // keep these away from of other class attributes
@@ -140,6 +141,7 @@ private:
 
     // only needed for ES2
     UniformsRecord const* mUniformsRecords = nullptr;
+    GLint mRec709Location = -1;
 };
 
 // if OpenGLProgram is larger tha 64 bytes, it'll fall in a larger Handle bucket.

--- a/filament/backend/src/opengl/OpenGLTimerQuery.cpp
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.cpp
@@ -36,7 +36,7 @@ OpenGLTimerQueryInterface::~OpenGLTimerQueryInterface() = default;
 
 #if defined(BACKEND_OPENGL_VERSION_GL) || defined(GL_EXT_disjoint_timer_query)
 
-TimerQueryNative::TimerQueryNative(OpenGLContext&) {
+TimerQueryNative::TimerQueryNative(OpenGLContext& context) : mContext(context) {
 }
 
 TimerQueryNative::~TimerQueryNative() = default;
@@ -45,18 +45,18 @@ void TimerQueryNative::flush() {
 }
 
 void TimerQueryNative::beginTimeElapsedQuery(GLTimerQuery* query) {
-    glBeginQuery(GL_TIME_ELAPSED, query->gl.query);
+    mContext.procs.beginQuery(GL_TIME_ELAPSED, query->gl.query);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
 void TimerQueryNative::endTimeElapsedQuery(GLTimerQuery*) {
-    glEndQuery(GL_TIME_ELAPSED);
+    mContext.procs.endQuery(GL_TIME_ELAPSED);
     CHECK_GL_ERROR(utils::slog.e)
 }
 
 bool TimerQueryNative::queryResultAvailable(GLTimerQuery* query) {
     GLuint available = 0;
-    glGetQueryObjectuiv(query->gl.query, GL_QUERY_RESULT_AVAILABLE, &available);
+    mContext.procs.getQueryObjectuiv(query->gl.query, GL_QUERY_RESULT_AVAILABLE, &available);
     CHECK_GL_ERROR(utils::slog.e)
     return available != 0;
 }
@@ -64,7 +64,7 @@ bool TimerQueryNative::queryResultAvailable(GLTimerQuery* query) {
 uint64_t TimerQueryNative::queryResult(GLTimerQuery* query) {
     GLuint64 elapsedTime = 0;
     // we won't end-up here if we're on ES and don't have GL_EXT_disjoint_timer_query
-    glGetQueryObjectui64v(query->gl.query, GL_QUERY_RESULT, &elapsedTime);
+    mContext.procs.getQueryObjectui64v(query->gl.query, GL_QUERY_RESULT, &elapsedTime);
     CHECK_GL_ERROR(utils::slog.e)
     return elapsedTime;
 }

--- a/filament/backend/src/opengl/OpenGLTimerQuery.h
+++ b/filament/backend/src/opengl/OpenGLTimerQuery.h
@@ -60,6 +60,7 @@ private:
     void endTimeElapsedQuery(GLTimerQuery* query) override;
     bool queryResultAvailable(GLTimerQuery* query) override;
     uint64_t queryResult(GLTimerQuery* query) override;
+    OpenGLContext& mContext;
 };
 
 #endif

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -45,13 +45,26 @@ PFNGLDEBUGMESSAGECALLBACKKHRPROC glDebugMessageCallbackKHR;
 PFNGLGETDEBUGMESSAGELOGKHRPROC glGetDebugMessageLogKHR;
 #endif
 #ifdef GL_EXT_disjoint_timer_query
-PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
+PFNGLGENQUERIESEXTPROC glGenQueriesEXT;
+PFNGLDELETEQUERIESEXTPROC glDeleteQueriesEXT;
+PFNGLBEGINQUERYEXTPROC glBeginQueryEXT;
+PFNGLENDQUERYEXTPROC glEndQueryEXT;
+PFNGLGETQUERYOBJECTUIVEXTPROC glGetQueryObjectuivEXT;
+PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64vEXT;
+#endif
+#ifdef GL_OES_vertex_array_object
+PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;
+PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOES;
+PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOES;
 #endif
 #ifdef GL_EXT_clip_control
 PFNGLCLIPCONTROLEXTPROC glClipControlEXT;
 #endif
+#ifdef GL_EXT_discard_framebuffer
+PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
+#endif
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
 // On Android, If we want to support a build system less than ANDROID_API 21, we need to
 // use getProcAddress for ES3.1 and above entry points.
 PFNGLDISPATCHCOMPUTEPROC glDispatchCompute;
@@ -78,12 +91,25 @@ void importGLESExtensionsEntryPoints() {
     getProcAddress(glGetDebugMessageLogKHR, "glGetDebugMessageLogKHR");
 #endif
 #ifdef GL_EXT_disjoint_timer_query
-    getProcAddress(glGetQueryObjectui64v, "glGetQueryObjectui64vEXT");
+    getProcAddress(glGenQueriesEXT, "glGenQueriesEXT");
+    getProcAddress(glDeleteQueriesEXT, "glDeleteQueriesEXT");
+    getProcAddress(glBeginQueryEXT, "glBeginQueryEXT");
+    getProcAddress(glEndQueryEXT, "glEndQueryEXT");
+    getProcAddress(glGetQueryObjectuivEXT, "glGetQueryObjectuivEXT");
+    getProcAddress(glGetQueryObjectui64vEXT, "glGetQueryObjectui64vEXT");
+#endif
+#if defined(GL_OES_vertex_array_object)
+    getProcAddress(glBindVertexArrayOES, "glBindVertexArrayOES");
+    getProcAddress(glDeleteVertexArraysOES, "glDeleteVertexArraysOES");
+    getProcAddress(glGenVertexArraysOES, "glGenVertexArraysOES");
 #endif
 #ifdef GL_EXT_clip_control
     getProcAddress(glClipControlEXT, "glClipControlEXT");
 #endif
-#if defined(__ANDROID__)
+#ifdef GL_EXT_discard_framebuffer
+        getProcAddress(glDiscardFramebufferEXT, "glDiscardFramebufferEXT");
+#endif
+#if defined(__ANDROID__) && !defined(FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2)
         getProcAddress(glDispatchCompute, "glDispatchCompute");
 #endif
     });

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -707,6 +707,9 @@ public:
          * The viewport, projection and model matrices can be obtained from Camera. Because
          * pick() has some latency, it might be more accurate to obtain these values at the
          * time the View::pick() call is made.
+         *
+         * Note: if the Engine is running at FEATURE_LEVEL_0, the precision or `depth` and
+         *       `fragCoords.z` is only 8-bits.
          */
         math::float3 fragCoords;        //! screen space coordinates in GL convention
     };

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -105,6 +105,10 @@ Froxelizer::Froxelizer(FEngine& engine)
           mZLightNear(FROXEL_FIRST_SLICE_DEPTH),
           mZLightFar(FROXEL_LAST_SLICE_DISTANCE)
 {
+    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)) {
+        return;
+    }
+
     DriverApi& driverApi = engine.getDriverApi();
 
     static_assert(std::is_same_v<RecordBufferType, uint8_t>,
@@ -132,8 +136,12 @@ void Froxelizer::terminate(DriverApi& driverApi) noexcept {
     mPlanesX = nullptr;
     mDistancesZ = nullptr;
 
-    driverApi.destroyBufferObject(mRecordsBuffer);
-    driverApi.destroyTexture(mFroxelTexture);
+    if (mRecordsBuffer) {
+        driverApi.destroyBufferObject(mRecordsBuffer);
+    }
+    if (mFroxelTexture) {
+        driverApi.destroyTexture(mFroxelTexture);
+    }
 }
 
 void Froxelizer::setOptions(float zLightNear, float zLightFar) noexcept {

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -27,6 +27,7 @@
 #include <private/filament/Variant.h>
 
 #include <backend/DriverEnums.h>
+#include <backend/Program.h>
 
 #include <utils/compiler.h>
 #include <utils/CString.h>
@@ -73,6 +74,16 @@ public:
     bool getSamplerBlockBindings(SamplerGroupBindingInfoList* pSamplerGroupInfoList,
             SamplerBindingToNameMap* pSamplerBindingToNameMap) const noexcept;
     bool getConstants(utils::FixedCapacityVector<MaterialConstant>* value) const noexcept;
+
+    using BindingUniformInfoContainer = utils::FixedCapacityVector<
+            std::pair<filament::UniformBindingPoints, backend::Program::UniformInfo>>;
+
+    bool getBindingUniformInfo(BindingUniformInfoContainer* container) const noexcept;
+
+    using AttributeInfoContainer = utils::FixedCapacityVector<
+            std::pair<utils::CString, uint8_t>>;
+
+    bool getAttributeInfo(AttributeInfoContainer* container) const noexcept;
 
     bool getDepthWriteSet(bool* value) const noexcept;
     bool getDepthWrite(bool* value) const noexcept;
@@ -164,6 +175,16 @@ struct ChunkSubpassInterfaceBlock {
 struct ChunkUniformBlockBindings {
     static bool unflatten(filaflat::Unflattener& unflattener,
             utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>>* uniformBlockBindings);
+};
+
+struct ChunkBindingUniformInfo {
+    static bool unflatten(filaflat::Unflattener& unflattener,
+            MaterialParser::BindingUniformInfoContainer* bindingUniformInfo);
+};
+
+struct ChunkAttributeInfo {
+    static bool unflatten(filaflat::Unflattener& unflattener,
+            MaterialParser::AttributeInfoContainer* attributeInfoContainer);
 };
 
 struct ChunkSamplerBlockBindings {

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -367,10 +367,11 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
     // generate depth pass at the requested resolution
     auto& structurePass = fg.addPass<StructurePassData>("Structure Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
+                bool const isES2 = mEngine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0;
                 data.depth = builder.createTexture("Structure Buffer", {
                         .width = width, .height = height,
                         .levels = uint8_t(levelCount),
-                        .format = TextureFormat::DEPTH32F });
+                        .format = isES2 ? TextureFormat::DEPTH24 : TextureFormat::DEPTH32F });
 
                 // workaround: since we have levels, this implies SAMPLEABLE (because of the gl
                 // backend, which implements non-sampleables with renderbuffers, which don't have levels).
@@ -381,7 +382,7 @@ PostProcessManager::StructurePassOutput PostProcessManager::structure(FrameGraph
                 if (config.picking) {
                     data.picking = builder.createTexture("Picking Buffer", {
                             .width = width, .height = height,
-                            .format = TextureFormat::RG32F });
+                            .format = isES2 ? TextureFormat::RGBA8 : TextureFormat::RG32F });
 
                     data.picking = builder.write(data.picking,
                             FrameGraphTexture::Usage::COLOR_ATTACHMENT);

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -98,8 +98,14 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                             TargetBufferFlags::STENCIL : TargetBufferFlags::NONE;
                     const char* const name = config.enabledStencilBuffer ?
                              "Depth/Stencil Buffer" : "Depth Buffer";
-                    TextureFormat const format = config.enabledStencilBuffer ?
+                    TextureFormat format = config.enabledStencilBuffer ?
                             TextureFormat::DEPTH32F_STENCIL8 : TextureFormat::DEPTH32F;
+
+                    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)) {
+                        // FIXME: handle stencil buffer
+                        format = TextureFormat::DEPTH24;
+                    }
+
                     data.depth = builder.createTexture(name, {
                             .width = colorBufferDesc.width,
                             .height = colorBufferDesc.height,

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -98,13 +98,18 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                             TargetBufferFlags::STENCIL : TargetBufferFlags::NONE;
                     const char* const name = config.enabledStencilBuffer ?
                              "Depth/Stencil Buffer" : "Depth Buffer";
-                    TextureFormat format = config.enabledStencilBuffer ?
-                            TextureFormat::DEPTH32F_STENCIL8 : TextureFormat::DEPTH32F;
 
-                    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)) {
-                        // FIXME: handle stencil buffer
-                        format = TextureFormat::DEPTH24;
-                    }
+                    bool const isES2 =
+                            engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0;
+
+                    TextureFormat const stencilFormat = isES2 ?
+                            TextureFormat::DEPTH24_STENCIL8 : TextureFormat::DEPTH32F_STENCIL8;
+
+                    TextureFormat const depthOnlyFormat = isES2 ?
+                            TextureFormat::DEPTH24 : TextureFormat::DEPTH32F;
+
+                    TextureFormat const format = config.enabledStencilBuffer ?
+                            stencilFormat : depthOnlyFormat;
 
                     data.depth = builder.createTexture(name, {
                             .width = colorBufferDesc.width,

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -314,11 +314,18 @@ void FEngine::init() {
         });
     }
 
+    // initialize the dummy textures so that their contents are not undefined
+    static const uint32_t zeroes[6] = {0};
+    static const uint32_t ones = 0xffffffff;
+
     mDefaultIblTexture = downcast(Texture::Builder()
             .width(1).height(1).levels(1)
             .format(Texture::InternalFormat::RGBA8)
             .sampler(Texture::Sampler::SAMPLER_CUBEMAP)
             .build(*this));
+
+    driverApi.update3DImage(mDefaultIblTexture->getHwHandle(), 0, 0, 0, 0, 1, 1, 6,
+            { zeroes, sizeof(zeroes), Texture::Format::RGBA, Texture::Type::UBYTE });
 
     // 3 bands = 9 float3
     const float sh[9 * 3] = { 0.0f };
@@ -326,62 +333,62 @@ void FEngine::init() {
             .irradiance(3, reinterpret_cast<const float3*>(sh))
             .build(*this));
 
-    mDefaultColorGrading = downcast(ColorGrading::Builder().build(*this));
+    mDefaultRenderTarget = driverApi.createDefaultRenderTarget();
 
-    // Always initialize the default material, most materials' depth shaders fallback on it.
-    mDefaultMaterial = downcast(
-            FMaterial::DefaultMaterialBuilder()
-                    .package(MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE)
-                    .build(*const_cast<FEngine*>(this)));
-
-    // Create a dummy morph target buffer.
-    mDummyMorphTargetBuffer = createMorphTargetBuffer(FMorphTargetBuffer::EmptyMorphTargetBuilder());
-
-    float3 dummyPositions[1] = {};
-    short4 dummyTangents[1] = {};
-    mDummyMorphTargetBuffer->setPositionsAt(*this, 0, dummyPositions, 1, 0);
-    mDummyMorphTargetBuffer->setTangentsAt(*this, 0, dummyTangents, 1, 0);
+    // Create a dummy morph target buffer, without using the builder
+    mDummyMorphTargetBuffer = createMorphTargetBuffer(
+            FMorphTargetBuffer::EmptyMorphTargetBuilder());
 
     // create dummy textures we need throughout the engine
-
     mDummyOneTexture = driverApi.createTexture(SamplerType::SAMPLER_2D, 1,
-            TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
-
-    mDummyOneTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
-            TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
-
-    mDummyZeroTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     mDummyZeroTexture = driverApi.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
-
-    // initialize the dummy textures so that their contents are not undefined
-
-    static const uint32_t zeroes[6] = {0};
-    static const uint32_t ones = 0xffffffff;
-
-    driverApi.update3DImage(mDefaultIblTexture->getHwHandle(), 0, 0, 0, 0, 1, 1, 6,
-            { zeroes, sizeof(zeroes), Texture::Format::RGBA, Texture::Type::UBYTE });
-
     driverApi.update3DImage(mDummyOneTexture, 0, 0, 0, 0, 1, 1, 1,
-            { &ones, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
-
-    driverApi.update3DImage(mDummyOneTextureArray, 0, 0, 0, 0, 1, 1, 1,
             { &ones, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
 
     driverApi.update3DImage(mDummyZeroTexture, 0, 0, 0, 0, 1, 1, 1,
             { zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
 
-    driverApi.update3DImage(mDummyZeroTextureArray, 0, 0, 0, 0, 1, 1, 1,
-            { zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+#ifdef FILAMENT_TARGET_MOBILE
+    if (UTILS_UNLIKELY(mActiveFeatureLevel == FeatureLevel::FEATURE_LEVEL_0)) {
+        FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
+        defaultMaterialBuilder.package(
+                MATERIALS_DEFAULTMATERIAL0_DATA, MATERIALS_DEFAULTMATERIAL0_SIZE);
+        mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
+    } else
+#endif
+    {
+        mDefaultColorGrading = downcast(ColorGrading::Builder().build(*this));
 
-    mDefaultRenderTarget = driverApi.createDefaultRenderTarget();
+        FMaterial::DefaultMaterialBuilder defaultMaterialBuilder;
+        defaultMaterialBuilder.package(
+                MATERIALS_DEFAULTMATERIAL_DATA, MATERIALS_DEFAULTMATERIAL_SIZE);
+        mDefaultMaterial = downcast(defaultMaterialBuilder.build(*const_cast<FEngine*>(this)));
 
-    mPostProcessManager.init();
-    mLightManager.init(*this);
-    mDFG.init(*this);
+        float3 dummyPositions[1] = {};
+        short4 dummyTangents[1] = {};
+        mDummyMorphTargetBuffer->setPositionsAt(*this, 0, dummyPositions, 1, 0);
+        mDummyMorphTargetBuffer->setTangentsAt(*this, 0, dummyTangents, 1, 0);
+
+        mDummyOneTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
+                TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
+        mDummyZeroTextureArray = driverApi.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
+                TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
+        driverApi.update3DImage(mDummyOneTextureArray, 0, 0, 0, 0, 1, 1, 1,
+                { &ones, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+
+        driverApi.update3DImage(mDummyZeroTextureArray, 0, 0, 0, 0, 1, 1, 1,
+                { zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
+
+        mPostProcessManager.init();
+        mLightManager.init(*this);
+        mDFG.init(*this);
+    }
 }
 
 FEngine::~FEngine() noexcept {

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -266,7 +266,11 @@ void FEngine::init() {
 
     DriverApi& driverApi = getDriverApi();
 
-    slog.i << "FEngine feature level: " << int(driverApi.getFeatureLevel()) << io::endl;
+    mActiveFeatureLevel = std::min(mActiveFeatureLevel, driverApi.getFeatureLevel());
+
+    slog.i << "Backend feature level: " << int(driverApi.getFeatureLevel()) << io::endl;
+    slog.i << "FEngine feature level: " << int(mActiveFeatureLevel) << io::endl;
+
 
     mResourceAllocator = new ResourceAllocator(driverApi);
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -353,7 +353,10 @@ public:
     }
 
     void setAutomaticInstancingEnabled(bool enable) noexcept {
-        mAutomaticInstancingEnabled = enable;
+        // instancing is not allowed at feature level 0
+        if (hasFeatureLevel(FeatureLevel::FEATURE_LEVEL_1)) {
+            mAutomaticInstancingEnabled = enable;
+        }
     }
 
     bool isAutomaticInstancingEnabled() const noexcept {

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -238,9 +238,21 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
             engine.getDriverApi().isWorkaroundNeeded(Workaround::A8X_STATIC_TEXTURE_TARGET_ERROR);
 
     mSpecializationConstants.reserve(constants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
-    mSpecializationConstants.push_back({0, (int)engine.getSupportedFeatureLevel()});
-    mSpecializationConstants.push_back({1, (int)maxInstanceCount});
-    mSpecializationConstants.push_back({2, (bool)staticTextureWorkaround});
+    mSpecializationConstants.push_back({
+                    +ReservedSpecializationConstants::BACKEND_FEATURE_LEVEL,
+                    (int)engine.getSupportedFeatureLevel() });
+    mSpecializationConstants.push_back({
+                    +ReservedSpecializationConstants::CONFIG_MAX_INSTANCES,
+                    (int)maxInstanceCount });
+    mSpecializationConstants.push_back({
+                    +ReservedSpecializationConstants::CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND,
+                    (bool)staticTextureWorkaround });
+    if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        // The actual value of this spec-constant is set in the OpenGLDriver backend.
+        mSpecializationConstants.push_back({
+            +ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION,
+            false});
+    }
 
     for (const auto& [name, value] : builder->mConstantSpecializations) {
         auto found = std::find_if(

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -152,17 +152,27 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     UTILS_UNUSED_IN_RELEASE bool const nameOk = parser->getName(&mName);
     assert_invariant(nameOk);
 
-    uint8_t featureLevel = 1;
-    parser->getFeatureLevel(&featureLevel);
-    assert_invariant(featureLevel <= 3);
-    mFeatureLevel = [featureLevel]() -> FeatureLevel {
-        switch (featureLevel) {
-            default:
-            case 1: return FeatureLevel::FEATURE_LEVEL_1;
-            case 2: return FeatureLevel::FEATURE_LEVEL_2;
-            case 3: return FeatureLevel::FEATURE_LEVEL_3;
+    mFeatureLevel = [parser]() -> FeatureLevel {
+        // code written this way so the IDE will complain when/if we add a FeatureLevel
+        uint8_t level = 1;
+        parser->getFeatureLevel(&level);
+        assert_invariant(level <= 3);
+        FeatureLevel featureLevel = FeatureLevel::FEATURE_LEVEL_1;
+        switch (FeatureLevel(level)) {
+            case FeatureLevel::FEATURE_LEVEL_0:
+            case FeatureLevel::FEATURE_LEVEL_1:
+            case FeatureLevel::FEATURE_LEVEL_2:
+            case FeatureLevel::FEATURE_LEVEL_3:
+                featureLevel = FeatureLevel(level);
+                break;
         }
+        return featureLevel;
     }();
+
+    // TODO: this should probably be checked in build()
+    // if the engine is at feature level 0, so must the material be.
+    assert_invariant((engine.getActiveFeatureLevel() != FeatureLevel::FEATURE_LEVEL_0) ||
+                     (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0));
 
     UTILS_UNUSED_IN_RELEASE bool success;
 
@@ -172,9 +182,27 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     success = parser->getUIB(&mUniformInterfaceBlock);
     assert_invariant(success);
 
-    // read the uniform binding list
-    success = parser->getUniformBlockBindings(&mUniformBlockBindings);
-    assert_invariant(success || mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_2);
+    // TODO: currently, the feature level used is determined by the material because we
+    //       don't have "feature level" variants. In the future, we could instead pick
+    //       the code path based on the engine's feature level.
+
+    if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        // these chunks are only needed for materials at feature level 0
+        // TODO: remove this assert when we support feature level variants
+        assert_invariant(engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0);
+
+        success = parser->getBindingUniformInfo(&mBindingUniformInfo);
+        assert_invariant(success);
+
+        success = parser->getAttributeInfo(&mAttributeInfo);
+        assert_invariant(success);
+    }
+
+    if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_1) {
+        // this chunk is not needed for materials at feature level 2 and above
+        success = parser->getUniformBlockBindings(&mUniformBlockBindings);
+        assert_invariant(success);
+    }
 
     success = parser->getSamplerBlockBindings(
             &mSamplerGroupBindingInfoList, &mSamplerBindingToNameMap);
@@ -201,19 +229,27 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     // Verify that all the constant specializations exist in the material and that their types match.
     // The first specialization constants are defined internally by Filament.
     // The subsequent constants are user-defined in the material.
-    mSpecializationConstants.reserve(constants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
-    mSpecializationConstants.push_back({0, (int)mEngine.getSupportedFeatureLevel()});
-    mSpecializationConstants.push_back({1, (int)CONFIG_MAX_INSTANCES});
+
+    // Feature level 0 doesn't support instancing
+    int const maxInstanceCount = (engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)
+            ? 1 : CONFIG_MAX_INSTANCES;
+
     const bool staticTextureWorkaround =
-            mEngine.getDriverApi().isWorkaroundNeeded(Workaround::A8X_STATIC_TEXTURE_TARGET_ERROR);
+            engine.getDriverApi().isWorkaroundNeeded(Workaround::A8X_STATIC_TEXTURE_TARGET_ERROR);
+
+    mSpecializationConstants.reserve(constants.size() + CONFIG_MAX_RESERVED_SPEC_CONSTANTS);
+    mSpecializationConstants.push_back({0, (int)engine.getSupportedFeatureLevel()});
+    mSpecializationConstants.push_back({1, (int)maxInstanceCount});
     mSpecializationConstants.push_back({2, (bool)staticTextureWorkaround});
+
     for (const auto& [name, value] : builder->mConstantSpecializations) {
         auto found = std::find_if(
                 constants.begin(), constants.end(), [name = name](const auto& constant) {
                     return strncmp(constant.name.data(), name.data(), name.length()) == 0;
                 });
         ASSERT_PRECONDITION(found != constants.end(),
-                "The material %s does not have a constant parameter named %s.", mName.c_str_safe(), name.c_str());
+                "The material %s does not have a constant parameter named %s.",
+                mName.c_str_safe(), name.c_str());
         const char* const types[3] = {"an int", "a float", "a bool"};
         const char* const errorMessage =
                 "The constant parameter %s on material %s is of type %s, but %s was "
@@ -232,8 +268,9 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
                         name.c_str(), mName.c_str_safe(), "bool", types[value.index()]);
                 break;
         }
-        uint32_t index = std::distance(constants.begin(), found) + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
-        mSpecializationConstants.push_back({index, value});
+        uint32_t const index =
+                std::distance(constants.begin(), found) + CONFIG_MAX_RESERVED_SPEC_CONSTANTS;
+        mSpecializationConstants.push_back({ index, value });
     }
 
     parser->getShading(&mShading);
@@ -463,14 +500,15 @@ Program FMaterial::getProgramWithVariants(
         Variant variant,
         Variant vertexVariant,
         Variant fragmentVariant) const noexcept {
-    const ShaderModel sm = mEngine.getShaderModel();
-    const bool isNoop = mEngine.getBackend() == Backend::NOOP;
-
+    FEngine const& engine = mEngine;
+    const ShaderModel sm = engine.getShaderModel();
+    const bool isNoop = engine.getBackend() == Backend::NOOP;
+    const FeatureLevel engineFeatureLevel = engine.getActiveFeatureLevel();
     /*
      * Vertex shader
      */
 
-    ShaderContent& vsBuilder = mEngine.getVertexShaderContent();
+    ShaderContent& vsBuilder = engine.getVertexShaderContent();
 
     UTILS_UNUSED_IN_RELEASE bool const vsOK = mMaterialParser->getShader(vsBuilder, sm,
             vertexVariant, ShaderStage::VERTEX);
@@ -484,10 +522,16 @@ Program FMaterial::getProgramWithVariants(
      * Fragment shader
      */
 
-    ShaderContent& fsBuilder = mEngine.getFragmentShaderContent();
+    ShaderContent& fsBuilder = engine.getFragmentShaderContent();
 
     UTILS_UNUSED_IN_RELEASE bool const fsOK = mMaterialParser->getShader(fsBuilder, sm,
             fragmentVariant, ShaderStage::FRAGMENT);
+
+    ASSERT_POSTCONDITION(
+            (engineFeatureLevel != FeatureLevel::FEATURE_LEVEL_0) ||
+            (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0),
+            "Engine is running a FEATURE_LEVEL_0 but material '%s' is not.",
+            mName.c_str());
 
     ASSERT_POSTCONDITION(isNoop || (fsOK && !fsBuilder.empty()),
             "The material '%s' has not been compiled to include the required "
@@ -517,6 +561,14 @@ Program FMaterial::getProgramWithVariants(
             program.setSamplerGroup(+bindingPoint, info.shaderStageFlags,
                     samplers.data(), info.count);
         }
+    }
+
+    if (engineFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        assert_invariant(!mBindingUniformInfo.empty());
+        for (auto const& [index, uniforms] : mBindingUniformInfo) {
+            program.uniforms(uint32_t(index), uniforms);
+        }
+        program.attributes(mAttributeInfo);
     }
 
     program.specializationConstants(mSpecializationConstants);

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -231,6 +231,15 @@ private:
     utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>> mUniformBlockBindings;
     utils::FixedCapacityVector<Variant> mDepthVariants; // only populated with default material
 
+    using BindingUniformInfoContainer = utils::FixedCapacityVector<
+            std::pair<filament::UniformBindingPoints, backend::Program::UniformInfo>>;
+
+    BindingUniformInfoContainer mBindingUniformInfo;
+
+    using AttributeInfoContainer = utils::FixedCapacityVector<std::pair<utils::CString, uint8_t>>;
+
+    AttributeInfoContainer mAttributeInfo;
+
     SamplerGroupBindingInfoList mSamplerGroupBindingInfoList;
     SamplerBindingToNameMap mSamplerBindingToNameMap;
     utils::FixedCapacityVector<backend::Program::SpecializationConstant> mSpecializationConstants;

--- a/filament/src/details/MorphTargetBuffer.cpp
+++ b/filament/src/details/MorphTargetBuffer.cpp
@@ -102,6 +102,11 @@ FMorphTargetBuffer::EmptyMorphTargetBuilder::EmptyMorphTargetBuilder() {
 FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
         : mVertexCount(builder->mVertexCount),
           mCount(builder->mCount) {
+
+    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == FeatureLevel::FEATURE_LEVEL_0)) {
+        return;
+    }
+
     FEngine::DriverApi& driver = engine.getDriverApi();
 
     // create buffer (here a texture) to store the morphing vertex data
@@ -129,9 +134,15 @@ FMorphTargetBuffer::FMorphTargetBuffer(FEngine& engine, const Builder& builder)
 
 void FMorphTargetBuffer::terminate(FEngine& engine) {
     FEngine::DriverApi& driver = engine.getDriverApi();
-    driver.destroySamplerGroup(mSbHandle);
-    driver.destroyTexture(mTbHandle);
-    driver.destroyTexture(mPbHandle);
+    if (UTILS_LIKELY(mSbHandle)) {
+        driver.destroySamplerGroup(mSbHandle);
+    }
+    if (UTILS_LIKELY(mTbHandle)) {
+        driver.destroyTexture(mTbHandle);
+    }
+    if (UTILS_LIKELY(mPbHandle)) {
+        driver.destroyTexture(mPbHandle);
+    }
 }
 
 void FMorphTargetBuffer::setPositionsAt(FEngine& engine, size_t targetIndex,

--- a/filament/src/details/Skybox.cpp
+++ b/filament/src/details/Skybox.cpp
@@ -117,9 +117,17 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
 }
 
 FMaterial const* FSkybox::createMaterial(FEngine& engine) {
-    FMaterial const* material = downcast(Material::Builder().package(
-            MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE).build(engine));
-    return material;
+    Material::Builder builder;
+#ifdef FILAMENT_TARGET_MOBILE
+    if (UTILS_UNLIKELY(engine.getActiveFeatureLevel() == Engine::FeatureLevel::FEATURE_LEVEL_0)) {
+        builder.package(MATERIALS_SKYBOX0_DATA, MATERIALS_SKYBOX0_SIZE);
+    } else
+#endif
+    {
+        builder.package(MATERIALS_SKYBOX_DATA, MATERIALS_SKYBOX_SIZE);
+    }
+    auto material = builder.build(engine);
+    return downcast(material);
 }
 
 void FSkybox::terminate(FEngine& engine) noexcept {

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -651,6 +651,11 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
 void FView::bindPerViewUniformsAndSamplers(FEngine::DriverApi& driver) const noexcept {
     mPerViewUniforms.bind(driver);
 
+    if (UTILS_UNLIKELY(driver.getFeatureLevel() == backend::FeatureLevel::FEATURE_LEVEL_0)) {
+        // FIXME: should be okay to use driver (instead of engine) for FEATURE_LEVEL_0 checks
+        return;
+    }
+
     driver.bindUniformBuffer(+UniformBindingPoints::LIGHTS,
             mLightUbh);
 

--- a/filament/src/materials/defaultMaterial0.mat
+++ b/filament/src/materials/defaultMaterial0.mat
@@ -1,0 +1,12 @@
+material {
+    name : "Filament Default Material",
+    shadingModel : unlit,
+    featureLevel: 0
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        material.baseColor.rgb = vec3(0.8);
+    }
+}

--- a/filament/src/materials/skybox0.mat
+++ b/filament/src/materials/skybox0.mat
@@ -1,0 +1,60 @@
+material {
+    name : Skybox,
+    parameters : [
+        {
+           type : int,
+           name : showSun
+        },
+        {
+           type : int,
+           name : constantColor
+        },
+        {
+           type : samplerCubemap,
+           name : skybox
+        },
+        {
+           type : float4,
+           name : color
+        }
+    ],
+    variables : [
+         eyeDirection
+    ],
+    vertexDomain : device,
+    depthWrite : false,
+    shadingModel : unlit,
+    variantFilter : [ skinning, shadowReceiver, vsm ],
+    culling: none,
+    featureLevel: 0
+}
+
+fragment {
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        vec4 sky;
+        if (materialParams.constantColor != 0) {
+            sky = materialParams.color;
+        } else {
+            sky = vec4(textureCube(materialParams_skybox, variable_eyeDirection.xyz).rgb, 1.0);
+            sky.rgb *= frameUniforms.iblLuminance;
+        }
+        if (materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0) {
+            vec3 direction = normalize(variable_eyeDirection.xyz);
+            // Assume the sun is a sphere
+            vec3 sun = frameUniforms.lightColorIntensity.rgb *
+                    (frameUniforms.lightColorIntensity.a * (4.0 * PI));
+            float cosAngle = dot(direction, frameUniforms.lightDirection);
+            float x = (cosAngle - frameUniforms.sun.x) * frameUniforms.sun.z;
+            float gradient = pow(1.0 - saturate(x), frameUniforms.sun.w);
+            sky.rgb = sky.rgb + gradient * sun;
+        }
+        material.baseColor = sky;
+    }
+}
+
+vertex {
+    void materialVertex(inout MaterialVertexInputs material) {
+        material.eyeDirection.xyz = material.worldPosition.xyz;
+    }
+}

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -47,6 +47,8 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialShaderModels = charTo64bitNum("MAT_SMDL"),
     MaterialSamplerBindings = charTo64bitNum("MAT_SAMP"),
     MaterialUniformBindings = charTo64bitNum("MAT_UNIF"),
+    MaterialBindingUniformInfo = charTo64bitNum("MAT_UFRM"),
+    MaterialAttributeInfo = charTo64bitNum("MAT_ATTR"),
     MaterialProperties = charTo64bitNum("MAT_PROP"),
     MaterialConstants = charTo64bitNum("MAT_CONS"),
 

--- a/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
@@ -41,6 +41,7 @@ public:
         uint32_t size;
         backend::UniformType type;
         backend::Precision precision{};
+        backend::FeatureLevel minFeatureLevel = backend::FeatureLevel::FEATURE_LEVEL_1;
         std::string_view structName{};
         uint32_t stride{};
         std::string_view sizeName{};
@@ -67,6 +68,7 @@ public:
         bool isArray;               // true if the field is an array
         uint32_t size;              // size of the array in elements, or 0 if not an array
         Precision precision;        // precision of this field
+        backend::FeatureLevel minFeatureLevel; // below this feature level, this field is not needed
         utils::CString structName;  // name of this field structure if type is STRUCT
         utils::CString sizeName;    // name of the size parameter in the shader
         // returns offset in bytes of this field (at index if an array)

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -55,6 +55,13 @@ enum class SamplerBindingPoints : uint8_t {
     // These are limited by CONFIG_SAMPLER_BINDING_COUNT (currently 4)
 };
 
+enum class ReservedSpecializationConstants : uint8_t {
+    BACKEND_FEATURE_LEVEL = 0,
+    CONFIG_MAX_INSTANCES = 1,
+    CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND = 2,
+    CONFIG_SRGB_SWAPCHAIN_EMULATION = 3 // don't change (hardcoded in OpenGLDriver.cpp)
+};
+
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.
 // It's also limited by the Froxelizer's record buffer data type (uint8_t).
 constexpr size_t CONFIG_MAX_LIGHT_COUNT = 256;
@@ -113,6 +120,8 @@ template<>
 struct utils::EnableIntegerOperators<filament::UniformBindingPoints> : public std::true_type {};
 template<>
 struct utils::EnableIntegerOperators<filament::SamplerBindingPoints> : public std::true_type {};
+template<>
+struct utils::EnableIntegerOperators<filament::ReservedSpecializationConstants> : public std::true_type {};
 
 template<>
 inline constexpr size_t utils::Enum::count<filament::UniformBindingPoints>() { return 8; }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -163,8 +163,16 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // --------------------------------------------------------------------------------------------
     math::float4 custom[4];
 
+    // --------------------------------------------------------------------------------------------
+    // for feature level 0 / es2 usage
+    // --------------------------------------------------------------------------------------------
+    int32_t rec709;                     // Only for ES2, 0 or 1, whether we need to do sRGB conversion
+    float es2Reserved0;
+    float es2Reserved1;
+    float es2Reserved2;
+
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[56];
+    math::float4 reserved[55];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filabridge/src/BufferInterfaceBlock.cpp
+++ b/libs/filabridge/src/BufferInterfaceBlock.cpp
@@ -58,7 +58,7 @@ BufferInterfaceBlock::Builder& BufferInterfaceBlock::Builder::add(
     for (auto const& item : list) {
         mEntries.push_back({
                 { item.name.data(), item.name.size() },
-                0, uint8_t(item.stride), item.type, item.size > 0, item.size, item.precision,
+                0, uint8_t(item.stride), item.type, item.size > 0, item.size, item.precision, item.minFeatureLevel,
                 { item.structName.data(), item.structName.size() },
                 { item.sizeName.data(), item.sizeName.size() }
         });
@@ -71,7 +71,7 @@ BufferInterfaceBlock::Builder& BufferInterfaceBlock::Builder::addVariableSizedAr
     mHasVariableSizeArray = true;
     mEntries.push_back({
             { item.name.data(), item.name.size() },
-            0, uint8_t(item.stride), item.type, true, 0, item.precision,
+            0, uint8_t(item.stride), item.type, true, 0, item.precision, item.minFeatureLevel,
             { item.structName.data(), item.structName.size() },
             { item.sizeName.data(), item.sizeName.size() }
     });
@@ -143,7 +143,7 @@ BufferInterfaceBlock::BufferInterfaceBlock(Builder const& builder) noexcept
 
         FieldInfo& info = uniformsInfoList[i];
         info = { e.name, offset, uint8_t(stride), e.type, e.isArray, e.size,
-                 e.precision, e.structName, e.sizeName };
+                 e.precision, e.minFeatureLevel, e.structName, e.sizeName };
 
         // record this uniform info
         infoMap[{ info.name.data(), info.name.size() }] = i;

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -524,6 +524,12 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
         glslOptions.fragment.default_int_precision = glslOptions.es ?
                 CompilerGLSL::Options::Precision::Mediump : CompilerGLSL::Options::Precision::Highp;
 
+        // TODO: this should be done only on the "feature level 0" variant
+        if (config.featureLevel == 0) {
+            // convert UBOs to plain uniforms if we're at feature level 0
+            glslOptions.emit_uniform_buffer_as_plain_uniforms = true;
+        }
+
         CompilerGLSL glslCompiler(std::move(spirv));
         glslCompiler.set_common_options(glslOptions);
 

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.cpp
@@ -130,7 +130,7 @@ void MaterialSamplerBlockBindingChunk::flatten(Flattener& f) {
     f.writeUint8(utils::Enum::count<SamplerBindingPoints>());
     UTILS_NOUNROLL
     for (size_t i = 0; i < utils::Enum::count<SamplerBindingPoints>(); i++) {
-        SamplerBindingPoints bindingPoint = (SamplerBindingPoints)i;
+        SamplerBindingPoints const bindingPoint = (SamplerBindingPoints)i;
         auto const& bindingInfo = mSamplerBindings.getSamplerGroupBindingInfo(bindingPoint);
         f.writeUint8(bindingInfo.bindingOffset);
         f.writeUint8((uint8_t)bindingInfo.shaderStageFlags);
@@ -148,6 +148,44 @@ void MaterialSamplerBlockBindingChunk::flatten(Flattener& f) {
         }
     }
     assert_invariant(c == mSamplerBindings.getActiveSamplerCount());
+}
+
+// ------------------------------------------------------------------------------------------------
+
+MaterialBindingUniformInfoChunk::MaterialBindingUniformInfoChunk(Container list) noexcept
+        : Chunk(ChunkType::MaterialBindingUniformInfo),
+          mBindingUniformInfo(std::move(list))
+{
+}
+
+void MaterialBindingUniformInfoChunk::flatten(Flattener& f) {
+    f.writeUint8(mBindingUniformInfo.size());
+    for (auto const& [index, uniforms] : mBindingUniformInfo) {
+        f.writeUint8(uint8_t(index));
+        f.writeUint8(uint8_t(uniforms.size()));
+        for (auto const& uniform: uniforms) {
+            f.writeString({ uniform.name.data(), uniform.name.size() });
+            f.writeUint16(uniform.offset);
+            f.writeUint8(uniform.size);
+            f.writeUint8(uint8_t(uniform.type));
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+
+MaterialAttributesInfoChunk::MaterialAttributesInfoChunk(Container list) noexcept
+        : Chunk(ChunkType::MaterialAttributeInfo),
+          mAttributeInfo(std::move(list))
+{
+}
+
+void MaterialAttributesInfoChunk::flatten(Flattener& f) {
+    f.writeUint8(mAttributeInfo.size());
+    for (auto const& [attribute, location]: mAttributeInfo) {
+        f.writeString({ attribute.data(), attribute.size() });
+        f.writeUint8(location);
+    }
 }
 
 } // namespace filamat

--- a/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
+++ b/libs/filamat/src/eiff/MaterialInterfaceBlockChunk.h
@@ -21,6 +21,8 @@
 
 #include <private/filament/EngineEnums.h>
 
+#include <backend/Program.h>
+
 #include <utils/FixedCapacityVector.h>
 
 namespace filament {
@@ -87,15 +89,16 @@ private:
 // ------------------------------------------------------------------------------------------------
 
 class MaterialUniformBlockBindingsChunk final : public Chunk {
+    using Container = utils::FixedCapacityVector<
+            std::pair<std::string_view, filament::UniformBindingPoints>>;
 public:
-    explicit MaterialUniformBlockBindingsChunk(
-            utils::FixedCapacityVector<std::pair<std::string_view, filament::UniformBindingPoints>> list);
+    explicit MaterialUniformBlockBindingsChunk(Container list);
     ~MaterialUniformBlockBindingsChunk() final = default;
 
 private:
     void flatten(Flattener&) final;
 
-    utils::FixedCapacityVector<std::pair<std::string_view, filament::UniformBindingPoints>> mBindingList;
+    Container mBindingList;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -109,6 +112,35 @@ private:
     void flatten(Flattener &) final;
 
     filament::SamplerBindingMap const& mSamplerBindings;
+};
+
+// ------------------------------------------------------------------------------------------------
+
+class MaterialBindingUniformInfoChunk final : public Chunk {
+    using Container = FixedCapacityVector<
+            std::pair<filament::UniformBindingPoints, filament::backend::Program::UniformInfo>>;
+public:
+    explicit MaterialBindingUniformInfoChunk(Container list) noexcept;
+    ~MaterialBindingUniformInfoChunk() final = default;
+
+private:
+    void flatten(Flattener &) final;
+
+    Container mBindingUniformInfo;
+};
+
+// ------------------------------------------------------------------------------------------------
+
+class MaterialAttributesInfoChunk final : public Chunk {
+    using Container = FixedCapacityVector<std::pair<utils::CString, uint8_t>>;
+public:
+    explicit MaterialAttributesInfoChunk(Container list) noexcept;
+    ~MaterialAttributesInfoChunk() final = default;
+
+private:
+    void flatten(Flattener &) final;
+
+    Container mAttributeInfo;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -381,7 +381,12 @@ std::pair<int, bool> GLSLTools::getShadingLanguageVersion(ShaderModel model,
     using FeatureLevel = filament::backend::FeatureLevel;
     switch (model) {
         case ShaderModel::MOBILE:
-            return { featureLevel >= FeatureLevel::FEATURE_LEVEL_2 ? 310 : 300, true };
+            switch (featureLevel) {
+                case FeatureLevel::FEATURE_LEVEL_0:     return { 100, true };
+                case FeatureLevel::FEATURE_LEVEL_1:     return { 300, true };
+                case FeatureLevel::FEATURE_LEVEL_2:     return { 310, true };
+                case FeatureLevel::FEATURE_LEVEL_3:     return { 310, true };
+            }
         case ShaderModel::DESKTOP:
             return { featureLevel >= FeatureLevel::FEATURE_LEVEL_2 ? 430 : 410, false };
     }

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -207,6 +207,12 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
     // "Could not statically determine the target of a texture". See light_indirect.fs
     generateSpecializationConstant(out, "CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND", 2, false);
 
+    if (material.featureLevel == 0) {
+        // On ES2 since we don't have post-processing, we need to emulate EGL_GL_COLORSPACE_KHR,
+        // when it's not supported.
+        generateSpecializationConstant(out, "CONFIG_SRGB_SWAPCHAIN_EMULATION", 3, false);
+    }
+
     out << '\n';
     out << SHADERS_COMMON_DEFINES_GLSL_DATA;
 

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -189,7 +189,8 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
 
     // Filament-reserved specification constants (limited by CONFIG_MAX_RESERVED_SPEC_CONSTANTS)
     out << '\n';
-    generateSpecializationConstant(out, "BACKEND_FEATURE_LEVEL", 0, 1);
+    generateSpecializationConstant(out, "BACKEND_FEATURE_LEVEL",
+            +ReservedSpecializationConstants::BACKEND_FEATURE_LEVEL, 1);
 
     if (mTargetApi == TargetApi::VULKAN) {
         // Note: This is a hack for a hack.
@@ -200,17 +201,20 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
         // some Adreno drivers on Android. see: https://github.com/google/filament/issues/6444
         out << "const int CONFIG_MAX_INSTANCES = " << (int)CONFIG_MAX_INSTANCES << ";\n";
     } else {
-        generateSpecializationConstant(out, "CONFIG_MAX_INSTANCES", 1, (int)CONFIG_MAX_INSTANCES);
+        generateSpecializationConstant(out, "CONFIG_MAX_INSTANCES",
+                +ReservedSpecializationConstants::CONFIG_MAX_INSTANCES, (int)CONFIG_MAX_INSTANCES);
     }
 
     // Workaround a Metal pipeline compilation error with the message:
     // "Could not statically determine the target of a texture". See light_indirect.fs
-    generateSpecializationConstant(out, "CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND", 2, false);
+    generateSpecializationConstant(out, "CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND",
+            +ReservedSpecializationConstants::CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND, false);
 
     if (material.featureLevel == 0) {
         // On ES2 since we don't have post-processing, we need to emulate EGL_GL_COLORSPACE_KHR,
         // when it's not supported.
-        generateSpecializationConstant(out, "CONFIG_SRGB_SWAPCHAIN_EMULATION", 3, false);
+        generateSpecializationConstant(out, "CONFIG_SRGB_SWAPCHAIN_EMULATION",
+                +ReservedSpecializationConstants::CONFIG_SRGB_SWAPCHAIN_EMULATION, false);
     }
 
     out << '\n';

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -130,15 +130,34 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
         out << "#define FILAMENT_HAS_FEATURE_TEXTURE_GATHER\n";
     }
 
+    if (material.featureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
+        out << "#define FILAMENT_HAS_FEATURE_INSTANCING\n";
+    }
+
     if (stage == ShaderStage::VERTEX) {
         CodeGenerator::generateDefine(out, "FLIP_UV_ATTRIBUTE", material.flipUV);
         CodeGenerator::generateDefine(out, "LEGACY_MORPHING", material.useLegacyMorphing);
     }
 
-    if (stage == ShaderStage::VERTEX) {
-        generateDefine(out, "VARYING", "out");
-    } else if (stage == ShaderStage::FRAGMENT) {
-        generateDefine(out, "VARYING", "in");
+    if (mTargetLanguage == TargetLanguage::SPIRV ||
+        mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
+        if (stage == ShaderStage::VERTEX) {
+            generateDefine(out, "VARYING", "out");
+        } else if (stage == ShaderStage::FRAGMENT) {
+            generateDefine(out, "VARYING", "in");
+        }
+    } else {
+        generateDefine(out, "VARYING", "varying");
+    }
+
+    if (mTargetLanguage == TargetLanguage::SPIRV &&
+            mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        generateDefine(out, "texture2D", "texture");
+        generateDefine(out, "textureCube", "texture");
+        if (stage == ShaderStage::VERTEX) {
+            generateDefine(out, "texture2DLod", "textureLod");
+            generateDefine(out, "textureCubeLod", "textureLod");
+        }
     }
 
     auto getShadingDefine = [](Shading shading) -> const char* {
@@ -162,8 +181,10 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
     out << "precision " << precision << " float;\n";
     out << "precision " << precision << " int;\n";
     if (mShaderModel == ShaderModel::MOBILE) {
-        out << "precision lowp sampler2DArray;\n";
-        out << "precision lowp sampler3D;\n";
+        if (material.featureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
+            out << "precision lowp sampler2DArray;\n";
+            out << "precision lowp sampler3D;\n";
+        }
     }
 
     // Filament-reserved specification constants (limited by CONFIG_MAX_RESERVED_SPEC_CONSTANTS)
@@ -271,16 +292,16 @@ io::sstream& CodeGenerator::generateVariable(io::sstream& out, ShaderStage stage
         if (stage == ShaderStage::VERTEX) {
             out << "\n#define VARIABLE_CUSTOM" << index << " " << name.c_str() << "\n";
             out << "\n#define VARIABLE_CUSTOM_AT" << index << " variable_" << name.c_str() << "\n";
-            out << "LAYOUT_LOCATION(" << index << ") out vec4 variable_" << name.c_str() << ";\n";
+            out << "LAYOUT_LOCATION(" << index << ") VARYING vec4 variable_" << name.c_str() << ";\n";
         } else if (stage == ShaderStage::FRAGMENT) {
-            out << "\nLAYOUT_LOCATION(" << index << ") in highp vec4 variable_" << name.c_str() << ";\n";
+            out << "\nLAYOUT_LOCATION(" << index << ") VARYING highp vec4 variable_" << name.c_str() << ";\n";
         }
     }
     return out;
 }
 
 io::sstream& CodeGenerator::generateShaderInputs(io::sstream& out, ShaderStage type,
-        const AttributeBitset& attributes, Interpolation interpolation) {
+        const AttributeBitset& attributes, Interpolation interpolation) const {
 
     auto const& attributeDatabase = MaterialBuilder::getAttributeDatabase();
 
@@ -294,12 +315,16 @@ io::sstream& CodeGenerator::generateShaderInputs(io::sstream& out, ShaderStage t
 
     if (type == ShaderStage::VERTEX) {
         out << "\n";
-        attributes.forEachSetBit([&out, &attributeDatabase](size_t i) {
+        attributes.forEachSetBit([&out, &attributeDatabase, this](size_t i) {
             auto const& attribute = attributeDatabase[i];
             assert_invariant( i == attribute.location );
-            out << "layout(location = " << size_t(attribute.location) << ") in "
-                << getTypeName(attribute.type) << " "
-                << attribute.getAttributeName() << ";\n";
+            if (mTargetLanguage == TargetLanguage::SPIRV ||
+                    mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
+                out << "layout(location = " << size_t(attribute.location) << ") in ";
+            } else {
+                out << "attribute ";
+            }
+            out << getTypeName(attribute.type) << " " << attribute.getAttributeName() << ";\n";
         });
     }
 
@@ -394,6 +419,57 @@ io::sstream& CodeGenerator::generateUniforms(io::sstream& out, ShaderStage stage
     return generateBufferInterfaceBlock(out, stage, +binding, uib);
 }
 
+io::sstream& CodeGenerator::generateInterfaceFields(io::sstream& out,
+        FixedCapacityVector<BufferInterfaceBlock::FieldInfo> const& infos,
+        Precision defaultPrecision) const {
+    Precision const uniformPrecision = getDefaultUniformPrecision();
+
+    for (auto const& info : infos) {
+        if (mFeatureLevel < info.minFeatureLevel) {
+            continue;
+        }
+        char const* const type = getUniformTypeName(info);
+        char const* const precision = getUniformPrecisionQualifier(info.type, info.precision,
+                uniformPrecision, defaultPrecision);
+        out << "    " << precision;
+        if (precision[0] != '\0') out << " ";
+        out << type << " " << info.name.c_str();
+        if (info.isArray) {
+            if (info.sizeName.empty()) {
+                if (info.size) {
+                    out << "[" << info.size << "]";
+                } else {
+                    out << "[]";
+                }
+            } else {
+                out << "[" << info.sizeName.c_str() << "]";
+            }
+        }
+        out << ";\n";
+    }
+    return out;
+}
+
+io::sstream& CodeGenerator::generateUboAsPlainUniforms(io::sstream& out, ShaderStage stage,
+        const BufferInterfaceBlock& uib) const {
+
+    auto const& infos = uib.getFieldInfoList();
+
+    std::string blockName{ uib.getName() };
+    std::string instanceName{ uib.getName() };
+    blockName.front() = char(std::toupper((unsigned char)blockName.front()));
+    instanceName.front() = char(std::tolower((unsigned char)instanceName.front()));
+
+    out << "\nstruct " << blockName << " {\n";
+
+    generateInterfaceFields(out, infos, Precision::DEFAULT);
+
+    out << "};\n";
+    out << "uniform " << blockName << " " << instanceName << ";\n";
+
+    return out;
+}
+
 io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, ShaderStage stage,
         uint32_t binding, const BufferInterfaceBlock& uib) const {
     auto const& infos = uib.getFieldInfoList();
@@ -401,13 +477,18 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
         return out;
     }
 
+    if (mTargetLanguage == TargetLanguage::GLSL &&
+            mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        // we need to generate a structure instead
+        assert_invariant(mTargetApi == TargetApi::OPENGL);
+        assert_invariant(uib.getTarget() == BufferInterfaceBlock::Target::UNIFORM);
+        return generateUboAsPlainUniforms(out, stage, uib);
+    }
+
     std::string blockName{ uib.getName() };
     std::string instanceName{ uib.getName() };
     blockName.front() = char(std::toupper((unsigned char)blockName.front()));
     instanceName.front() = char(std::tolower((unsigned char)instanceName.front()));
-
-    Precision const uniformPrecision = getDefaultUniformPrecision();
-    Precision const defaultPrecision = getDefaultPrecision(stage);
 
     auto metalBufferBindingOffset = 0;
     switch (uib.getTarget()) {
@@ -477,26 +558,8 @@ io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, Shade
 
     out << "{\n";
 
-    for (auto const& info : infos) {
-        char const* const type = getUniformTypeName(info);
-        char const* const precision = getUniformPrecisionQualifier(info.type, info.precision,
-                uniformPrecision, defaultPrecision);
-        out << "    " << precision;
-        if (precision[0] != '\0') out << " ";
-        out << type << " " << info.name.c_str();
-        if (info.isArray) {
-            if (info.sizeName.empty()) {
-                if (info.size) {
-                    out << "[" << info.size << "]";
-                } else {
-                    out << "[]";
-                }
-            } else {
-                out << "[" << info.sizeName.c_str() << "]";
-            }
-        }
-        out << ";\n";
-    }
+    generateInterfaceFields(out, infos, getDefaultPrecision(stage));
+
     out << "} " << instanceName << ";\n";
 
     return out;

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -17,30 +17,30 @@
 #ifndef TNT_FILAMENT_CODEGENERATOR_H
 #define TNT_FILAMENT_CODEGENERATOR_H
 
-#include <exception>
-#include <iosfwd>
-#include <string>
-#include <variant>
 
 #include "MaterialInfo.h"
 
-#include <utils/compiler.h>
-#include <utils/Log.h>
-
 #include <filamat/MaterialBuilder.h>
+
 #include <filament/MaterialEnums.h>
 
 #include <private/filament/EngineEnums.h>
 #include <private/filament/SamplerInterfaceBlock.h>
 #include <private/filament/BufferInterfaceBlock.h>
 #include <private/filament/SubpassInfo.h>
+#include <private/filament/Variant.h>
 
 #include <backend/DriverEnums.h>
 
+#include <utils/compiler.h>
+#include <utils/FixedCapacityVector.h>
+#include <utils/Log.h>
 #include <utils/sstream.h>
 
-#include <private/filament/Variant.h>
-#include "private/filament/EngineEnums.h"
+#include <exception>
+#include <iosfwd>
+#include <string>
+#include <variant>
 
 namespace filamat {
 
@@ -106,8 +106,8 @@ public:
             const utils::CString& name, size_t index);
 
     // generate declarations for non-custom "in" variables
-    static utils::io::sstream& generateShaderInputs(utils::io::sstream& out, ShaderStage type,
-        const filament::AttributeBitset& attributes, filament::Interpolation interpolation);
+    utils::io::sstream& generateShaderInputs(utils::io::sstream& out, ShaderStage type,
+        const filament::AttributeBitset& attributes, filament::Interpolation interpolation) const;
     static utils::io::sstream& generatePostProcessInputs(utils::io::sstream& out, ShaderStage type);
 
     // generate declarations for custom output variables
@@ -172,6 +172,13 @@ public:
 private:
     filament::backend::Precision getDefaultPrecision(ShaderStage stage) const;
     filament::backend::Precision getDefaultUniformPrecision() const;
+
+    utils::io::sstream& generateInterfaceFields(utils::io::sstream& out,
+            utils::FixedCapacityVector<filament::BufferInterfaceBlock::FieldInfo> const& infos,
+            filament::backend::Precision defaultPrecision) const;
+
+    utils::io::sstream& generateUboAsPlainUniforms(utils::io::sstream& out, ShaderStage stage,
+            const filament::BufferInterfaceBlock& uib) const;
 
     static const char* getUniformPrecisionQualifier(filament::backend::UniformType type,
             filament::backend::Precision precision,

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -69,6 +69,9 @@ void ShaderGenerator::generateSurfaceMaterialVariantDefines(utils::io::sstream& 
     }
 
     out << '\n';
+    CodeGenerator::generateDefine(out, "MATERIAL_FEATURE_LEVEL",
+            uint32_t(material.featureLevel));
+
     CodeGenerator::generateDefine(out, "MATERIAL_HAS_SHADOW_MULTIPLIER",
             material.hasShadowMultiplier);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -404,7 +404,7 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
             attributes.set(VertexAttribute::MORPH_TANGENTS_3);
         }
     }
-    CodeGenerator::generateShaderInputs(vs, ShaderStage::VERTEX, attributes, interpolation);
+    cg.generateShaderInputs(vs, ShaderStage::VERTEX, attributes, interpolation);
 
     CodeGenerator::generateCommonTypes(vs, ShaderStage::VERTEX);
 
@@ -502,7 +502,7 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     generateSurfaceMaterialVariantProperties(fs, mProperties, mDefines);
 
 
-    CodeGenerator::generateShaderInputs(fs, ShaderStage::FRAGMENT,
+    cg.generateShaderInputs(fs, ShaderStage::FRAGMENT,
             material.requiredAttributes, interpolation);
 
     CodeGenerator::generateCommonTypes(fs, ShaderStage::FRAGMENT);
@@ -541,9 +541,11 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
 
     CodeGenerator::generateSeparator(fs);
 
-    cg.generateSamplers(fs, SamplerBindingPoints::PER_VIEW,
-            material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_VIEW),
-            SibGenerator::getPerViewSib(variant));
+    if (material.featureLevel >= FeatureLevel::FEATURE_LEVEL_1) { // FIXME: generate only what we need
+        cg.generateSamplers(fs, SamplerBindingPoints::PER_VIEW,
+                material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_VIEW),
+                SibGenerator::getPerViewSib(variant));
+    }
 
     cg.generateSamplers(fs, SamplerBindingPoints::PER_MATERIAL_INSTANCE,
             material.samplerBindings.getBlockOffset(SamplerBindingPoints::PER_MATERIAL_INSTANCE),
@@ -556,7 +558,10 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     CodeGenerator::generateGetters(fs, ShaderStage::FRAGMENT);
     CodeGenerator::generateCommonMaterial(fs, ShaderStage::FRAGMENT);
     CodeGenerator::generateParameters(fs, ShaderStage::FRAGMENT);
-    CodeGenerator::generateFog(fs, ShaderStage::FRAGMENT);
+
+    if (filament::Variant::isFogVariant(variant)) {
+        CodeGenerator::generateFog(fs, ShaderStage::FRAGMENT);
+    }
 
     // shading model
     if (filament::Variant::isValidDepthVariant(variant)) {

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -145,6 +145,14 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // --------------------------------------------------------------------------------------------
             { "custom",                  4, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
+            // --------------------------------------------------------------------------------------------
+            // for feature level 0 / es2 usage
+            // --------------------------------------------------------------------------------------------
+            { "rec709",                  0, Type::INT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "es2Reserved0",            0, Type::FLOAT                  },
+            { "es2Reserved1",            0, Type::FLOAT                  },
+            { "es2Reserved2",            0, Type::FLOAT                  },
+
             // bring PerViewUib to 2 KiB
             { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4 }
             })

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -35,37 +35,37 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerViewUib::_name)
             .add({
-            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH },
-            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH },
-            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH },
-            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH },
-            { "clipFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH },
-            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH },
-            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH },
-            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH },
+            { "viewFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromViewMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipFromViewMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "viewFromClipMatrix",     0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipFromWorldMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "worldFromClipMatrix",    0, Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userWorldFromWorldMatrix",0,Type::MAT4,   Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "clipTransform",          0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "clipControl",            0, Type::FLOAT2                  },
-            { "time",                   0, Type::FLOAT,  Precision::HIGH },
-            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH },
-            { "userTime",               0, Type::FLOAT4, Precision::HIGH },
+            { "clipControl",            0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "time",                   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "temporalNoise",          0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "userTime",               0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // values below should only be accessed in surface materials
             // ------------------------------------------------------------------------------------
 
-            { "resolution",             0, Type::FLOAT4, Precision::HIGH },
-            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH },
-            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH },
+            { "resolution",             0, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportScale",   0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "logicalViewportOffset",  0, Type::FLOAT2, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "lodBias",                0, Type::FLOAT                   },
-            { "refractionLodOffset",    0, Type::FLOAT                   },
+            { "lodBias",                0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "refractionLodOffset",    0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
 
-            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH },
-            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH },
-            { "cameraFar",              0, Type::FLOAT                   },
-            { "exposure",               0, Type::FLOAT,  Precision::HIGH }, // high precision to work around #3602 (qualcom),
-            { "ev100",                  0, Type::FLOAT                   },
-            { "needsAlphaChannel",      0, Type::FLOAT                   },
+            { "oneOverFarMinusNear",    0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "nearOverFarMinusNear",   0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "cameraFar",              0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "exposure",               0, Type::FLOAT,  Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 }, // high precision to work around #3602 (qualcom),
+            { "ev100",                  0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "needsAlphaChannel",      0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
 
             // AO
             { "aoSamplingQualityAndEdgeDistance", 0, Type::FLOAT         },
@@ -81,17 +81,17 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "lightChannels",          0, Type::INT                     },
             { "froxelCountXY",          0, Type::FLOAT2                  },
 
-            { "iblLuminance",           0, Type::FLOAT                   },
-            { "iblRoughnessOneLevel",   0, Type::FLOAT                   },
+            { "iblLuminance",           0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "iblRoughnessOneLevel",   0, Type::FLOAT,  Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "iblSH",                  9, Type::FLOAT3                  },
 
             // ------------------------------------------------------------------------------------
             // Directional Lighting [variant: DIR]
             // ------------------------------------------------------------------------------------
-            { "lightDirection",         0, Type::FLOAT3                  },
+            { "lightDirection",         0, Type::FLOAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "padding0",               0, Type::FLOAT                   },
-            { "lightColorIntensity",    0, Type::FLOAT4                  },
-            { "sun",                    0, Type::FLOAT4                  },
+            { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "lightFarAttenuationParams", 0, Type::FLOAT2               },
 
             // ------------------------------------------------------------------------------------
@@ -117,16 +117,16 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // ------------------------------------------------------------------------------------
             // Fog [variant: FOG]
             // ------------------------------------------------------------------------------------
-            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH },
-            { "fogStart",                0, Type::FLOAT, Precision::HIGH },
-            { "fogMaxOpacity",           0, Type::FLOAT                  },
-            { "fogHeight",               0, Type::FLOAT, Precision::HIGH },
-            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH },
-            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH },
-            { "fogColor",                0, Type::FLOAT3                 },
-            { "fogColorFromIbl",         0, Type::FLOAT                  },
-            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH },
-            { "fogInscatteringSize",     0, Type::FLOAT                  },
+            { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogStart",                0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogHeight",               0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogColorFromIbl",         0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringStart",    0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogReserved1",            0, Type::FLOAT                  },
             { "fogReserved2",            0, Type::FLOAT                  },
 
@@ -143,7 +143,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // --------------------------------------------------------------------------------------------
             // user defined global variables
             // --------------------------------------------------------------------------------------------
-            { "custom",                  4, Type::FLOAT4, Precision::HIGH },
+            { "custom",                  4, Type::FLOAT4, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // bring PerViewUib to 2 KiB
             { "reserved", sizeof(PerViewUib::reserved)/16, Type::FLOAT4 }
@@ -156,7 +156,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
 BufferInterfaceBlock const& UibGenerator::getPerRenderableUib() noexcept {
     static BufferInterfaceBlock const uib =  BufferInterfaceBlock::Builder()
             .name(PerRenderableUib::_name)
-            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {},
+            .add({{ "data", CONFIG_MAX_INSTANCES, BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "PerRenderableData", sizeof(PerRenderableData), "CONFIG_MAX_INSTANCES" }})
             .build();
     return uib;
@@ -175,7 +175,7 @@ BufferInterfaceBlock const& UibGenerator::getShadowUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(ShadowUib::_name)
             .add({{ "shadows", CONFIG_MAX_SHADOWMAPS,
-                    BufferInterfaceBlock::Type::STRUCT, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "ShadowData", sizeof(ShadowUib::ShadowData) }})
             .build();
     return uib;
@@ -185,7 +185,7 @@ BufferInterfaceBlock const& UibGenerator::getPerRenderableBonesUib() noexcept {
     static BufferInterfaceBlock const uib = BufferInterfaceBlock::Builder()
             .name(PerRenderableBoneUib::_name)
             .add({{ "bones", CONFIG_MAX_BONE_COUNT,
-                    BufferInterfaceBlock::Type::STRUCT, {},
+                    BufferInterfaceBlock::Type::STRUCT, {}, {},
                     "BoneData", sizeof(PerRenderableBoneUib::BoneData) }})
             .build();
     return uib;

--- a/shaders/src/common_instancing.glsl
+++ b/shaders/src/common_instancing.glsl
@@ -5,6 +5,7 @@
 PerRenderableData object_uniforms;
 
 void initInstanceUniforms(out PerRenderableData p) {
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING)
     // We're copying each field separately to workaround an issue in some Adreno drivers
     // that fail on non-const array access in a UBO. Accessing the fields works however.
     // e.g.: this fails `p = objectUniforms.data[instance_index];`
@@ -14,19 +15,25 @@ void initInstanceUniforms(out PerRenderableData p) {
     p.flagsChannels = objectUniforms.data[instance_index].flagsChannels;
     p.objectId = objectUniforms.data[instance_index].objectId;
     p.userData = objectUniforms.data[instance_index].userData;
+#else
+    p.worldFromModelMatrix = objectUniforms.data[0].worldFromModelMatrix;
+    p.worldFromModelNormalMatrix = objectUniforms.data[0].worldFromModelNormalMatrix;
+    p.morphTargetCount = objectUniforms.data[0].morphTargetCount;
+    p.flagsChannels = objectUniforms.data[0].flagsChannels;
+    p.objectId = objectUniforms.data[0].objectId;
+    p.userData = objectUniforms.data[0].userData;
+#endif
 }
 
 void initObjectUniforms(out PerRenderableData p) {
-#if defined(MATERIAL_HAS_INSTANCES)
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING) && defined(MATERIAL_HAS_INSTANCES)
     if ((objectUniforms.data[0].flagsChannels & FILAMENT_OBJECT_INSTANCE_BUFFER_BIT) != 0) {
         // the object has an instance buffer
         initInstanceUniforms(p);
         return;
     }
-
     // the material manages instancing, all instances share the same uniform block.
     p = objectUniforms.data[0];
-
 #else
     // automatic instancing was used, each instance has its own uniform block.
     initInstanceUniforms(p);
@@ -37,9 +44,11 @@ void initObjectUniforms(out PerRenderableData p) {
 // Instance access
 //------------------------------------------------------------------------------
 
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING)
 #if defined(MATERIAL_HAS_INSTANCES)
 /** @public-api */
 int getInstanceIndex() {
     return instance_index;
 }
+#endif
 #endif

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -1,7 +1,11 @@
 #if defined(VARIANT_HAS_VSM)
 layout(location = 0) out vec4 fragColor;
 #elif defined(VARIANT_HAS_PICKING)
+#   if __VERSION__ == 100
+highp vec2 outPicking;
+#   else
 layout(location = 0) out highp vec2 outPicking;
+#   endif
 #else
 // not color output
 #endif
@@ -51,6 +55,9 @@ void main() {
 #elif defined(VARIANT_HAS_PICKING)
     outPicking.x = float(object_uniforms.objectId);
     outPicking.y = vertex_position.z / vertex_position.w;
+#if __VERSION__ == 100
+    gl_FragData[0].xy = outPicking;
+#endif
 #else
     // that's it
 #endif

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -2,9 +2,13 @@
 layout(location = 0) out vec4 fragColor;
 #elif defined(VARIANT_HAS_PICKING)
 #   if __VERSION__ == 100
-highp vec2 outPicking;
+highp vec4 outPicking;
 #   else
+#       if MATERIAL_FEATURE_LEVEL == 0
+layout(location = 0) out highp vec4 outPicking;
+#       else
 layout(location = 0) out highp vec2 outPicking;
+#       endif
 #   endif
 #else
 // not color output
@@ -53,10 +57,17 @@ void main() {
     fragColor.xy = computeDepthMomentsVSM(depth);
     fragColor.zw = computeDepthMomentsVSM(-1.0 / depth); // requires at least RGBA16F
 #elif defined(VARIANT_HAS_PICKING)
+#if MATERIAL_FEATURE_LEVEL == 0
+    outPicking.a = float((object_uniforms.objectId / 65536) % 256) / 255.0;
+    outPicking.b = float((object_uniforms.objectId /   256) % 256) / 255.0;
+    outPicking.g = float( object_uniforms.objectId          % 256) / 255.0;
+    outPicking.r = vertex_position.z / vertex_position.w;
+#else
     outPicking.x = float(object_uniforms.objectId);
     outPicking.y = vertex_position.z / vertex_position.w;
+#endif
 #if __VERSION__ == 100
-    gl_FragData[0].xy = outPicking;
+    gl_FragData[0] = outPicking;
 #endif
 #else
     // that's it

--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -21,6 +21,7 @@ float getObjectUserData() {
 // Attributes access
 //------------------------------------------------------------------------------
 
+#if __VERSION__ >= 300
 /** @public-api */
 int getVertexIndex() {
 #if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
@@ -29,6 +30,7 @@ int getVertexIndex() {
     return gl_VertexID;
 #endif
 }
+#endif
 
 #if defined(VARIANT_HAS_SKINNING_OR_MORPHING)
 vec3 mulBoneNormal(vec3 n, uint i) {

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -47,6 +47,16 @@ void main() {
     fragColor = fog(fragColor, view);
 #endif
 
+#if MATERIAL_FEATURE_LEVEL == 0
+    if (CONFIG_SRGB_SWAPCHAIN_EMULATION) {
+        if (frameUniforms.rec709 != 0) {
+            fragColor.r = pow(fragColor.r, 0.45454);
+            fragColor.g = pow(fragColor.g, 0.45454);
+            fragColor.b = pow(fragColor.b, 0.45454);
+        }
+    }
+#endif
+
 #if __VERSION__ == 100
     gl_FragData[0] = fragColor;
 #endif

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -1,4 +1,8 @@
+#if __VERSION__ == 100
+vec4 fragColor;
+#else
 layout(location = 0) out vec4 fragColor;
+#endif
 
 #if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
 void blendPostLightingColor(const MaterialInputs material, inout vec4 color) {
@@ -41,5 +45,9 @@ void main() {
 #if defined(VARIANT_HAS_FOG)
     highp vec3 view = getWorldPosition() - getWorldCameraPosition();
     fragColor = fog(fragColor, view);
+#endif
+
+#if __VERSION__ == 100
+    gl_FragData[0] = fragColor;
 #endif
 }

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -7,10 +7,12 @@
  */
 
 void main() {
-#if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING)
+#   if defined(TARGET_METAL_ENVIRONMENT) || defined(TARGET_VULKAN_ENVIRONMENT)
     instance_index = gl_InstanceIndex;
-#else
+#   else
     instance_index = gl_InstanceID;
+#   endif
 #endif
 
     initObjectUniforms(object_uniforms);

--- a/shaders/src/varyings.glsl
+++ b/shaders/src/varyings.glsl
@@ -13,7 +13,9 @@ LAYOUT_LOCATION(6) SHADING_INTERPOLATION VARYING mediump vec4 vertex_worldTangen
 
 LAYOUT_LOCATION(7) VARYING highp vec4 vertex_position;
 
+#if defined(FILAMENT_HAS_FEATURE_INSTANCING)
 LAYOUT_LOCATION(8) flat VARYING highp int instance_index;
+#endif
 
 #if defined(HAS_ATTRIBUTE_COLOR)
 LAYOUT_LOCATION(9) VARYING mediump vec4 vertex_color;

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -256,6 +256,7 @@ bool CommandlineConfig::parse() {
                 auto featureLevel = filament::backend::FeatureLevel(std::atoi(arg.c_str()));
                 mFeatureLevel = filament::backend::FeatureLevel::FEATURE_LEVEL_3;
                 switch (featureLevel) {
+                    case filament::backend::FeatureLevel::FEATURE_LEVEL_0:
                     case filament::backend::FeatureLevel::FEATURE_LEVEL_1:
                     case filament::backend::FeatureLevel::FEATURE_LEVEL_2:
                     case filament::backend::FeatureLevel::FEATURE_LEVEL_3:

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -748,7 +748,9 @@ static bool processFeatureLevel(MaterialBuilder& builder, const JsonishValue& va
     using filament::backend::FeatureLevel;
     JsonishNumber const* const number = value.toJsonNumber();
     FeatureLevel featureLevel;
-    if (number->getFloat() == 1.0f) {
+    if (number->getFloat() == 0.0f) {
+        featureLevel = FeatureLevel::FEATURE_LEVEL_0;
+    } else if (number->getFloat() == 1.0f) {
         featureLevel = FeatureLevel::FEATURE_LEVEL_1;
     } else if (number->getFloat() == 2.0f) {
         featureLevel = FeatureLevel::FEATURE_LEVEL_2;


### PR DESCRIPTION
Limitations include (but are not limited to):
- no post processing
- no lighting (only `unlit` materials are supported)
- no skinning or morphing
- no instancing
- all ES2 shader limitation apply
- all ES2 texture formats apply
- materials must be written specifically for ES2 and work only on an ES2 context

Fog is supported. 

Some extensions are mandatory:
OES_depth_texture
OES_depth24
OES_packed_depth_stencil
OES_rgb8_rgba8
OES_standard_derivatives
OES_texture_npot
OES_vertex_array_object
