### PR TITLE
Extend OpenGLPlatform to support preserving attachments on commit

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - engine: a local transform can now be supplied for each GPU instance [⚠️ **Recompile materials**]
 - everything: Add limited support for OpenGL ES 2.0 devices. [⚠️ **Recompile Materials**]
+- platform: New virtual on `OpenGLPlatform` to preserve ancillary buffers

--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -96,6 +96,19 @@ public:
     virtual void destroySwapChain(SwapChain* swapChain) noexcept = 0;
 
     /**
+     * Returns the set of buffers that must be preserved up to the call to commit().
+     * The default value is TargetBufferFlags::NONE.
+     * The color buffer is always preserved, however ancillary buffers, such as the depth buffer
+     * are generally discarded. The preserve flags can be used to make sure those ancillary
+     * buffers are preserved until the call to commit.
+     *
+     * @param swapChain
+     * @return buffer that must be preserved
+     * @see commit()
+     */
+    virtual TargetBufferFlags getPreservedFlags(SwapChain* swapChain) noexcept;
+
+    /**
      * Called by the driver to establish the default FBO. The default implementation returns 0.
       * @return a GLuint casted to a uint32_t that is an OpenGL framebuffer object.
      */

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2706,6 +2706,12 @@ void OpenGLDriver::endRenderPass(int) {
         discardFlags &= ~TargetBufferFlags::STENCIL;
     }
 
+    if (rt->gl.isDefault) {
+        assert_invariant(mCurrentDrawSwapChain);
+        assert_invariant(mCurrentDrawSwapChain->swapChain);
+        discardFlags &= ~mPlatform.getPreservedFlags(mCurrentDrawSwapChain->swapChain);
+    }
+
     if (gl.ext.EXT_discard_framebuffer) {
         auto effectiveDiscardFlags = discardFlags;
         if (gl.bugs.invalidate_end_only_if_invalidate_start) {

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -105,5 +105,8 @@ AcquiredImage OpenGLPlatform::transformAcquiredImage(AcquiredImage source) noexc
     return source;
 }
 
+TargetBufferFlags OpenGLPlatform::getPreservedFlags(UTILS_UNUSED SwapChain* swapChain) noexcept {
+    return TargetBufferFlags::NONE;
+}
 
 } // namespace filament::backend

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -709,7 +709,6 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             .keepOverrideEnd = keepOverrideEndFlags
     }, viewRenderTarget);
 
-    const bool blending = blendModeTranslucent;
     const TextureFormat hdrFormat = getHdrFormat(view, needsAlphaChannel);
 
     // the clearFlags and clearColor specified below will only apply when rendering into the
@@ -1046,7 +1045,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (scaled) {
             mightNeedFinalBlit = false;
             auto viewport = DEBUG_DYNAMIC_SCALING ? xvp : vp;
-            input = ppm.upscale(fg, blending, dsrOptions, input, xvp, {
+            input = ppm.upscale(fg, blendModeTranslucent, dsrOptions, input, xvp, {
                     .width = viewport.width, .height = viewport.height,
                     .format = colorGradingConfig.ldrFormat });
             xvp.left = xvp.bottom = 0;
@@ -1073,7 +1072,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
 
     const bool outputIsSwapChain = (input == colorPassOutput) && (viewRenderTarget == mRenderTargetHandle);
     if (mightNeedFinalBlit) {
-        if (blending ||
+        if (blendModeTranslucent ||
             xvp != svp ||
             (outputIsSwapChain &&
                     (msaaSampleCount > 1 ||
@@ -1081,7 +1080,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                     hasScreenSpaceRefraction ||
                     ssReflectionsOptions.enabled))) {
             assert_invariant(!scaled);
-            input = ppm.blit(fg, blending, input, xvp, {
+            input = ppm.blit(fg, blendModeTranslucent, input, xvp, {
                     .width = vp.width, .height = vp.height,
                     .format = colorGradingConfig.ldrFormat }, SamplerMagFilter::NEAREST);
         }


### PR DESCRIPTION
By default ancillary buffers are discarded on commit (eg. depth buffer), but in certain situations the platform may want to preserve them. this new virtual allows a concrete implementation to specify which buffers need to be preserved.