### PR TITLE
fog color from ibl should work with unlit

### DIFF
--- a/shaders/src/fog.fs
+++ b/shaders/src/fog.fs
@@ -40,7 +40,7 @@ vec4 fog(vec4 color, highp vec3 view) {
     // compute fog color
     vec3 fogColor = frameUniforms.fogColor;
 
-#if !defined(SHADING_MODEL_UNLIT)
+#if MATERIAL_FEATURE_LEVEL > 0
     if (frameUniforms.fogColorFromIbl > 0.0) {
         // get fog color from envmap
         // TODO: use a lower resolution mip as we get further (problem we don't have mips!)


### PR DESCRIPTION
the skybox is unlit for instance, but for should still get the color from the ibl. that can't work with ES2 though.