### PR TITLE
New API to apply a transform to the large-scale fog.

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- engine: a new feature to set a transform on the global-scale fog  [⚠️ **Recompile materials**]

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -505,3 +505,11 @@ Java_com_google_android_filament_View_nGetMaterialGlobal(JNIEnv *env, jclass cla
     std::copy_n(result.v, 4, out);
     env->ReleaseFloatArrayElements(out_, out, 0);
 }
+
+extern "C"
+JNIEXPORT int JNICALL
+Java_com_google_android_filament_View_nGetFogEntity(JNIEnv *env, jclass clazz,
+        jlong nativeView) {
+    View *view = (View *) nativeView;
+    return (jint)view->getFogEntity().getId();
+}

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1148,6 +1148,20 @@ public class View {
         return out;
     }
 
+    /**
+     * Get an Entity representing the large scale fog object.
+     * This entity is always inherited by the View's Scene.
+     *
+     * It is for example possible to create a TransformManager component with this
+     * Entity and apply a transformation globally on the fog.
+     *
+     * @return an Entity representing the large scale fog object.
+     */
+    @Entity
+    public int getFogEntity() {
+        return nGetFogEntity(getNativeObject());
+    }
+
     public long getNativeObject() {
         if (mNativeObject == 0) {
             throw new IllegalStateException("Calling method on destroyed View");
@@ -1206,6 +1220,7 @@ public class View {
     private static native boolean nIsStencilBufferEnabled(long nativeView);
     private static native void nSetMaterialGlobal(long nativeView, int index, float x, float y, float z, float w);
     private static native void nGetMaterialGlobal(long nativeView, int index, float[] out);
+    private static native int nGetFogEntity(long nativeView);
 
 
     /**

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -828,6 +828,17 @@ public:
     math::float4 getMaterialGlobal(uint32_t index) const;
 
     /**
+     * Get an Entity representing the large scale fog object.
+     * This entity is always inherited by the View's Scene.
+     *
+     * It is for example possible to create a TransformManager component with this
+     * Entity and apply a transformation globally on the fog.
+     *
+     * @return an Entity representing the large scale fog object.
+     */
+    utils::Entity getFogEntity() const noexcept;
+
+    /**
      * List of available ambient occlusion techniques
      * @deprecated use AmbientOcclusionOptions::enabled instead
      */

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -137,7 +137,6 @@ void PerViewUniforms::prepareFog(float3 const& cameraPosition, FogOptions const&
     auto& s = mUniforms.edit();
     s.fogStart             = options.distance;
     s.fogMaxOpacity        = options.maximumOpacity;
-    s.fogHeight            = options.height;
     s.fogHeightFalloff     = heightFalloff;
     s.fogCutOffDistance    = options.cutOffDistance;
     s.fogColor             = options.color;

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -85,7 +85,8 @@ public:
     void prepareTime(FEngine& engine, math::float4 const& userTime) noexcept;
     void prepareTemporalNoise(FEngine& engine, TemporalAntiAliasingOptions const& options) noexcept;
     void prepareExposure(float ev100) noexcept;
-    void prepareFog(math::float3 const& cameraPosition, FogOptions const& options) noexcept;
+    void prepareFog(const CameraInfo& cameraInfo,
+            math::mat4 const& fogTransform, FogOptions const& options) noexcept;
     void prepareStructure(TextureHandle structure) noexcept;
     void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
     void prepareBlending(bool needsAlphaChannel) noexcept;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -296,4 +296,8 @@ math::float4 View::getMaterialGlobal(uint32_t index) const {
     return downcast(this)->getMaterialGlobal(index);
 }
 
+utils::Entity View::getFogEntity() const noexcept {
+    return downcast(this)->getFogEntity();
+}
+
 } // namespace filament

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -415,6 +415,10 @@ public:
 
     math::float4 getMaterialGlobal(uint32_t index) const;
 
+    utils::Entity getFogEntity() const noexcept {
+        return mFogEntity;
+    }
+
 private:
 
     struct FPickingQuery : public PickingQuery {
@@ -511,6 +515,7 @@ private:
     BlendMode mBlendMode = BlendMode::OPAQUE;
     const FColorGrading* mColorGrading = nullptr;
     const FColorGrading* mDefaultColorGrading = nullptr;
+    utils::Entity mFogEntity{};
 
     PIDController mPidController;
     DynamicResolutionOptions mDynamicResolution;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -138,7 +138,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::float3 fogDensity;        // { density, -falloff * yc, density * exp(-fallof * yc) }
     float fogStart;
     float fogMaxOpacity;
-    float fogHeight;
+    float fogReserved0;
     float fogHeightFalloff;
     float fogCutOffDistance;
     math::float3 fogColor;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -32,6 +32,35 @@
 
 namespace filament {
 
+namespace std140 {
+
+struct alignas(16) vec3 : public std::array<float, 3> {};
+struct alignas(16) vec4 : public std::array<float, 4> {};
+
+struct mat33 : public std::array<vec3, 3> {
+    mat33& operator=(math::mat3f const& rhs) noexcept {
+        for (int i = 0; i < 3; i++) {
+            (*this)[i][0] = rhs[i][0];
+            (*this)[i][1] = rhs[i][1];
+            (*this)[i][2] = rhs[i][2];
+        }
+        return *this;
+    }
+};
+
+struct mat44 : public std::array<vec4, 4> {
+    mat44& operator=(math::mat4f const& rhs) noexcept {
+        for (int i = 0; i < 4; i++) {
+            (*this)[i][0] = rhs[i][0];
+            (*this)[i][1] = rhs[i][1];
+            (*this)[i][2] = rhs[i][2];
+            (*this)[i][3] = rhs[i][3];
+        }
+        return *this;
+    }
+};
+
+} // std140
 /*
  * IMPORTANT NOTE: Respect std140 layout, don't update without updating UibGenerator::get{*}Uib()
  */
@@ -147,6 +176,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float fogInscatteringSize;
     float fogReserved1;
     float fogReserved2;
+    std140::mat33 fogFromWorldMatrix;
 
     // --------------------------------------------------------------------------------------------
     // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]
@@ -172,7 +202,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float es2Reserved2;
 
     // bring PerViewUib to 2 KiB
-    math::float4 reserved[55];
+    math::float4 reserved[52];
 };
 
 // 2 KiB == 128 float4s
@@ -183,33 +213,8 @@ static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 128,
 // MARK: -
 
 struct PerRenderableData {
-
-    struct alignas(16) vec3_std140 : public std::array<float, 3> { };
-    struct alignas(16) vec4_std140 : public std::array<float, 4> { };
-    struct mat33_std140 : public std::array<vec3_std140, 3> {
-        mat33_std140& operator=(math::mat3f const& rhs) noexcept {
-            for (int i = 0; i < 3; i++) {
-                (*this)[i][0] = rhs[i][0];
-                (*this)[i][1] = rhs[i][1];
-                (*this)[i][2] = rhs[i][2];
-            }
-            return *this;
-        }
-    };
-    struct mat44_std140 : public std::array<vec4_std140, 4> {
-        mat44_std140& operator=(math::mat4f const& rhs) noexcept {
-            for (int i = 0; i < 4; i++) {
-                (*this)[i][0] = rhs[i][0];
-                (*this)[i][1] = rhs[i][1];
-                (*this)[i][2] = rhs[i][2];
-                (*this)[i][3] = rhs[i][3];
-            }
-            return *this;
-        }
-    };
-
-    mat44_std140 worldFromModelMatrix;
-    mat33_std140 worldFromModelNormalMatrix;
+    std140::mat44 worldFromModelMatrix;
+    std140::mat33 worldFromModelNormalMatrix;
     int32_t morphTargetCount;
     int32_t flagsChannels;                   // see packFlags() below (0x00000fll)
     int32_t objectId;                        // used for picking

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -120,7 +120,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "fogDensity",              0, Type::FLOAT3,Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogStart",                0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogMaxOpacity",           0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "fogHeight",               0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
+            { "fogReserved0",            0, Type::FLOAT                  },
             { "fogHeightFalloff",        0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogCutOffDistance",       0, Type::FLOAT, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogColor",                0, Type::FLOAT3, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -129,6 +129,7 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "fogInscatteringSize",     0, Type::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "fogReserved1",            0, Type::FLOAT                  },
             { "fogReserved2",            0, Type::FLOAT                  },
+            { "fogFromWorldMatrix",      0, Type::MAT3, Precision::HIGH, FeatureLevel::FEATURE_LEVEL_0 },
 
             // ------------------------------------------------------------------------------------
             // Screen-space reflections [variant: SSR (i.e.: VSM | SRE)]

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -586,6 +586,7 @@ int main(int argc, char** argv) {
         auto& tcm = engine->getTransformManager();
         app.rootTransformEntity = engine->getEntityManager().create();
         tcm.create(app.rootTransformEntity);
+        tcm.create(view->getFogEntity());
 
         const bool batchMode = !app.batchFile.empty();
 
@@ -920,6 +921,7 @@ int main(int argc, char** argv) {
         TransformManager::Instance const& root = tcm.getInstance(app.rootTransformEntity);
         tcm.setParent(tcm.getInstance(camera.getEntity()), root);
         tcm.setParent(tcm.getInstance(app.asset->getRoot()), root);
+        tcm.setParent(tcm.getInstance(view->getFogEntity()), root);
         tcm.setTransform(root, mat4f::translation(float3{ app.originIsFarAway ? 1e6f : 0.0f }));
 
         // Check if color grading has changed.

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -44,13 +44,7 @@ void main() {
 
 #if defined(VARIANT_HAS_FOG)
     highp vec3 view = getWorldPosition() - getWorldCameraPosition();
-
-    // fog should be calculated in the "user's world coordinates" so that it's not
-    // affected by the IBL rotation. We're transofrming a vector, so we should use the
-    // cofactor (or inverse-transpose), but since we know this matrix is a rigid transform,
-    // we can use it as is.
-    view = mulMat3x3Float3(frameUniforms.userWorldFromWorldMatrix, view);
-
+    view = frameUniforms.fogFromWorldMatrix * view;
     fragColor = fog(fragColor, view);
 #endif
 

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -617,7 +617,8 @@ class_<View>("View")
     .function("setStencilBufferEnabled", &View::setStencilBufferEnabled)
     .function("isStencilBufferEnabled", &View::isStencilBufferEnabled)
     .function("setMaterialGlobal", &View::setMaterialGlobal)
-    .function("getMaterialGlobal", &View::getMaterialGlobal);
+    .function("getMaterialGlobal", &View::getMaterialGlobal)
+    .function("getFogEntity", &View::getFogEntity);
 
 /// Scene ::core class:: Flat container of renderables and lights.
 /// See also the [Engine] methods `createScene` and `destroyScene`.


### PR DESCRIPTION
This works by making the fog an entity which can be used to create
a TransformManager component an participate to the transform hierarchy.

This feature can be used as more advanced way to set the fog's floor,
which now can have an orientation (essentially be a plane). 
This is useful for coordinate systems that are not y-up.