### PR TITLE
New RenderableManager API to opt-out of fog

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - engine: a new feature to set a transform on the global-scale fog  [⚠️ **Recompile materials**]
+- engine: large-scale fog can now be opted-out on a per-renderable basis

--- a/android/filament-android/src/main/cpp/RenderableManager.cpp
+++ b/android/filament-android/src/main/cpp/RenderableManager.cpp
@@ -201,10 +201,17 @@ Java_com_google_android_filament_RenderableManager_nBuilderSkinning(JNIEnv*, jcl
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_android_filament_RenderableManager_nEnableSkinningBuffers(JNIEnv*, jclass,
+Java_com_google_android_filament_RenderableManager_nBuilderEnableSkinningBuffers(JNIEnv*, jclass,
         jlong nativeBuilder, jboolean enabled) {
     RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
     builder->enableSkinningBuffers(enabled);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nBuilderFog(JNIEnv*, jclass,
+        jlong nativeBuilder, jboolean enabled) {
+    RenderableManager::Builder *builder = (RenderableManager::Builder *) nativeBuilder;
+    builder->fog(enabled);
 }
 
 extern "C" JNIEXPORT jint JNICALL
@@ -358,6 +365,20 @@ Java_com_google_android_filament_RenderableManager_nSetCulling(JNIEnv*, jclass,
         jlong nativeRenderableManager, jint i, jboolean enabled) {
     RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
     rm->setCulling((RenderableManager::Instance) i, enabled);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_google_android_filament_RenderableManager_nSetFogEnabled(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i, jboolean enabled) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    rm->setFogEnabled((RenderableManager::Instance) i, enabled);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_google_android_filament_RenderableManager_nGetFogEnabled(JNIEnv*, jclass,
+        jlong nativeRenderableManager, jint i) {
+    RenderableManager *rm = (RenderableManager *) nativeRenderableManager;
+    return (jboolean)rm->getFogEnabled((RenderableManager::Instance) i);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderableManager.java
@@ -417,7 +417,19 @@ public class RenderableManager {
          */
         @NonNull
         public Builder enableSkinningBuffers(boolean enabled) {
-            nEnableSkinningBuffers(mNativeBuilder, enabled);
+            nBuilderEnableSkinningBuffers(mNativeBuilder, enabled);
+            return this;
+        }
+
+        /**
+         * Controls if this renderable is affected by the large-scale fog.
+         * @param enabled If true, enables large-scale fog on this object. Disables it otherwise.
+         *                True by default.
+         * @return this <code>Builder</code> object for chaining calls
+         */
+         @NonNull
+        public Builder fog(boolean enabled) {
+            nBuilderFog(mNativeBuilder, enabled);
             return this;
         }
 
@@ -730,6 +742,23 @@ public class RenderableManager {
     }
 
     /**
+     * Changes whether or not the large-scale fog is applied to this renderable
+     * @see Builder#fog
+     */
+    public void setFogEnabled(@EntityInstance int i, boolean enabled) {
+        nSetFogEnabled(mNativeObject, i, enabled);
+    }
+
+    /**
+     * Returns whether large-scale fog is enabled for this renderable.
+     * @return True if fog is enabled for this renderable.
+     * @see Builder#fog
+     */
+    public boolean getFogEnabled(@EntityInstance int i) {
+        return nGetFogEnabled(mNativeObject, i);
+    }
+
+    /**
      * Enables or disables a light channel.
      * Light channel 0 is enabled by default.
      *
@@ -951,7 +980,8 @@ public class RenderableManager {
     private static native void nBuilderSkinningBuffer(long nativeBuilder, long nativeSkinningBuffer, int boneCount, int offset);
     private static native void nBuilderMorphing(long nativeBuilder, int targetCount);
     private static native void nBuilderSetMorphTargetBufferAt(long nativeBuilder, int level, int primitiveIndex, long nativeMorphTargetBuffer, int offset, int count);
-    private static native void nEnableSkinningBuffers(long nativeBuilder, boolean enabled);
+    private static native void nBuilderEnableSkinningBuffers(long nativeBuilder, boolean enabled);
+    private static native void nBuilderFog(long nativeBuilder, boolean enabled);
     private static native void nBuilderLightChannel(long nativeRenderableManager, int channel, boolean enable);
     private static native void nBuilderInstances(long nativeRenderableManager, int instances);
 
@@ -966,6 +996,8 @@ public class RenderableManager {
     private static native void nSetPriority(long nativeRenderableManager, int i, int priority);
     private static native void nSetChannel(long nativeRenderableManager, int i, int channel);
     private static native void nSetCulling(long nativeRenderableManager, int i, boolean enabled);
+    private static native void nSetFogEnabled(long nativeRenderableManager, int i, boolean enabled);
+    private static native boolean nGetFogEnabled(long nativeRenderableManager, int i);
     private static native void nSetLightChannel(long nativeRenderableManager, int i, int channel, boolean enable);
     private static native boolean nGetLightChannel(long nativeRenderableManager, int i, int channel);
     private static native void nSetCastShadows(long nativeRenderableManager, int i, boolean enabled);

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -304,6 +304,14 @@ public:
         Builder& enableSkinningBuffers(bool enabled = true) noexcept;
 
         /**
+         * Controls if this renderable is affected by the large-scale fog.
+         * @param enabled If true, enables large-scale fog on this object. Disables it otherwise.
+         *                True by default.
+         * @return A reference to this Builder for chaining calls.
+         */
+        Builder& fog(bool enabled = true) noexcept;
+
+        /**
          * Enables GPU vertex skinning for up to 255 bones, 0 by default.
          *
          * Skinning Buffer mode must be enabled.
@@ -535,6 +543,19 @@ public:
      * \see Builder::culling()
      */
     void setCulling(Instance instance, bool enable) noexcept;
+
+    /**
+     * Changes whether or not the large-scale fog is applied to this renderable
+     * @see Builder::fog()
+     */
+    void setFogEnabled(Instance instance, bool enable) noexcept;
+
+    /**
+     * Returns whether large-scale fog is enabled for this renderable.
+     * @return True if fog is enabled for this renderable.
+     * @see Builder::fog()
+     */
+    bool getFogEnabled(Instance instance) const noexcept;
 
     /**
      * Enables or disables a light channel.

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -165,4 +165,12 @@ bool RenderableManager::getLightChannel(Instance instance, unsigned int channel)
     return downcast(this)->getLightChannel(instance, channel);
 }
 
+void RenderableManager::setFogEnabled(RenderableManager::Instance instance, bool enable) noexcept {
+    downcast(this)->setFogEnabled(instance, enable);
+}
+
+bool RenderableManager::getFogEnabled(RenderableManager::Instance instance) const noexcept {
+    return downcast(this)->getFogEnabled(instance);
+}
+
 } // namespace filament

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -60,6 +60,7 @@ struct RenderableManager::BuilderDetails {
     bool mReceiveShadows : 1;
     bool mScreenSpaceContactShadows : 1;
     bool mSkinningBufferMode : 1;
+    bool mFogEnabled : 1;
     size_t mSkinningBoneCount = 0;
     size_t mMorphTargetCount = 0;
     Bone const* mUserBones = nullptr;
@@ -70,7 +71,7 @@ struct RenderableManager::BuilderDetails {
 
     explicit BuilderDetails(size_t count)
             : mEntries(count), mCulling(true), mCastShadows(false), mReceiveShadows(true),
-              mScreenSpaceContactShadows(false), mSkinningBufferMode(false) {
+              mScreenSpaceContactShadows(false), mSkinningBufferMode(false), mFogEnabled(true) {
     }
     // this is only needed for the explicit instantiation below
     BuilderDetails() = default;
@@ -201,6 +202,11 @@ RenderableManager::Builder& RenderableManager::Builder::skinning(
 
 RenderableManager::Builder& RenderableManager::Builder::enableSkinningBuffers(bool enabled) noexcept {
     mImpl->mSkinningBufferMode = enabled;
+    return *this;
+}
+
+RenderableManager::Builder& RenderableManager::Builder::fog(bool enabled) noexcept {
+    mImpl->mFogEnabled = enabled;
     return *this;
 }
 
@@ -373,6 +379,7 @@ void FRenderableManager::create(
         setCulling(ci, builder->mCulling);
         setSkinning(ci, false);
         setMorphing(ci, builder->mMorphTargetCount);
+        setFogEnabled(ci, builder->mFogEnabled);
         mManager[ci].channels = builder->mLightChannels;
 
         InstancesInfo& instances = manager[ci].instances;

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -64,6 +64,7 @@ public:
         bool morphing                   : 1;
         bool screenSpaceContactShadows  : 1;
         bool reversedWindingOrder       : 1;
+        bool fog                        : 1;
     };
 
     static_assert(sizeof(Visibility) == sizeof(uint16_t), "Visibility should be 16 bits");
@@ -114,6 +115,8 @@ public:
     inline void setReceiveShadows(Instance instance, bool enable) noexcept;
     inline void setScreenSpaceContactShadows(Instance instance, bool enable) noexcept;
     inline void setCulling(Instance instance, bool enable) noexcept;
+    inline void setFogEnabled(Instance instance, bool enable) noexcept;
+    inline bool getFogEnabled(Instance instance) const noexcept;
 
     inline void setPrimitives(Instance instance, utils::Slice<FRenderPrimitive> const& primitives) noexcept;
 
@@ -337,6 +340,17 @@ void FRenderableManager::setCulling(Instance instance, bool enable) noexcept {
         Visibility& visibility = mManager[instance].visibility;
         visibility.culling = enable;
     }
+}
+
+void FRenderableManager::setFogEnabled(Instance instance, bool enable) noexcept {
+    if (instance) {
+        Visibility& visibility = mManager[instance].visibility;
+        visibility.fog = enable;
+    }
+}
+
+bool FRenderableManager::getFogEnabled(RenderableManager::Instance instance) const noexcept {
+    return getVisibility(instance).fog;
 }
 
 void FRenderableManager::setSkinning(Instance instance, bool enable) noexcept {

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -905,11 +905,22 @@ class_<RenderableBuilder>("RenderableManager$Builder")
     .BUILDER_FUNCTION("culling", RenderableBuilder, (RenderableBuilder* builder, bool enable), {
         return &builder->culling(enable); })
 
+    .BUILDER_FUNCTION("lightChannel", RenderableBuilder,
+            (RenderableBuilder* builder, unsigned int channel, bool enable), {
+        return &builder->lightChannel(channel, enable); })
+
     .BUILDER_FUNCTION("castShadows", RenderableBuilder, (RenderableBuilder* builder, bool enable), {
         return &builder->castShadows(enable); })
 
     .BUILDER_FUNCTION("receiveShadows", RenderableBuilder, (RenderableBuilder* builder, bool enable), {
         return &builder->receiveShadows(enable); })
+
+    .BUILDER_FUNCTION("screenSpaceContactShadows", RenderableBuilder,
+            (RenderableBuilder* builder, bool enable), {
+        return &builder->screenSpaceContactShadows(enable); })
+
+    .BUILDER_FUNCTION("fog", RenderableBuilder, (RenderableBuilder* builder, bool enable), {
+        return &builder->fog(enable); })
 
     .BUILDER_FUNCTION("skinning", RenderableBuilder, (RenderableBuilder* builder, size_t boneCount), {
         return &builder->skinning(boneCount); })
@@ -945,9 +956,9 @@ class_<RenderableBuilder>("RenderableManager$Builder")
             (RenderableBuilder* builder, size_t index, bool enabled), {
         return &builder->globalBlendOrderEnabled(index, enabled); })
 
-    .BUILDER_FUNCTION("lightChannel", RenderableBuilder,
-            (RenderableBuilder* builder, unsigned int channel, bool enable), {
-        return &builder->lightChannel(channel, enable); })
+    .BUILDER_FUNCTION("instances", RenderableBuilder,
+            (RenderableBuilder* builder, size_t instanceCount), {
+        return &builder->instances(instanceCount); })
 
     .function("_build", EMBIND_LAMBDA(int, (RenderableBuilder* builder,
             Engine* engine, utils::Entity entity), {
@@ -978,6 +989,8 @@ class_<RenderableManager>("RenderableManager")
     .function("isShadowReceiver", &RenderableManager::isShadowReceiver)
     .function("setLightChannel", &RenderableManager::setLightChannel)
     .function("getLightChannel", &RenderableManager::getLightChannel)
+    .function("setFogEnabled", &RenderableManager::setFogEnabled)
+    .function("getFogEnabled", &RenderableManager::getFogEnabled)
 
     .function("setBones", EMBIND_LAMBDA(void, (RenderableManager* self,
             RenderableManager::Instance instance, emscripten::val transforms, size_t offset), {


### PR DESCRIPTION
Fog can now be opted-out on a per renderable basis. When fog is disabled on a renderable it removes the requirement that this renderable's  materials have the FOG variant.