### PR TITLE
correctly account for user samplers in matc and document it

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - engine: a new feature to set a transform on the global-scale fog  [⚠️ **Recompile materials**]
 - engine: large-scale fog can now be opted-out on a per-renderable basis
+- matc: better accounting and validation of used samplers in user materials

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2593,4 +2593,22 @@ pre-multiplied ahead of time. On Android, any texture uploaded from a
 [Bitmap](https://developer.android.com/reference/android/graphics/Bitmap.html) will be
 pre-multiplied by default.
 
+# Sampler usage in Materials
+
+The number of usable sampler parameters (e.g.: type is `sampler2d`) in materials is limited and
+depends on the material properties, shading model and feature level.
+
+## Feature level 1 and 2
+
+`unlit` materials can use up to 13 samplers.
+
+`lit` materials can use up to 10 samplers by default, but if `refractionMode` or `reflectionMode` is set to `screenspace` that number becomes 9.
+
+## Feature level 3
+
+16 samplers are available.
+
+!!! TIP: external samplers
+               Be aware that `external` samplers account for 2 regular samplers.
+
 <!-- Markdeep: --><style class="fallback">body{visibility:hidden;white-space:pre;font-family:monospace}</style><script src="../third_party/markdeep/markdeep.min.js"></script><script src="https://casual-effects.com/markdeep/latest/markdeep.min.js"></script><script>window.alreadyProcessedMarkdeep||(document.body.style.visibility="visible")</script>

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -906,7 +906,9 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                 0, [&ppm, &driver, colorGradingConfigForColor]() {
                     ppm.colorGradingSubpass(driver, colorGradingConfigForColor);
                 });
-    } if (colorGradingConfig.customResolve) {
+    }
+
+    if (colorGradingConfig.customResolve) {
         // append custom resolve subpass after all other passes
         pass.appendCustomCommand(3,
                 RenderPass::Pass::BLENDED,
@@ -915,6 +917,11 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
                     ppm.customResolveSubpass(driver);
                 });
     }
+
+    // FIXME: sorting should happen AFTER the appendCustomCommands
+    // FIXME: concern that Material::prepare() is not called
+    // FIXME: concern that calling mi->use() will mess the renering loop
+
 
     // this makes the viewport relative to xvp
     // FIXME: we should use 'vp' when rendering directly into the swapchain, but that's hard to

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -267,6 +267,9 @@ public:
     };
     using PreprocessorDefineList = std::vector<PreprocessorDefine>;
 
+
+    MaterialBuilder& noSamplerValidation(bool enabled) noexcept;
+
     //! Set the name of this material.
     MaterialBuilder& name(const char* name) noexcept;
 
@@ -870,6 +873,8 @@ private:
     PreprocessorDefineList mDefines;
 
     filament::UserVariantFilterMask mVariantFilter = {};
+
+    bool mNoSamplerValidation = false;
 };
 
 } // namespace filamat

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1211,7 +1211,13 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
         flush(slog.e);
     };
 
-    const auto userSamplerCount = info.sib.getSize();
+    auto userSamplerCount = info.sib.getSize();
+    for (auto const& sampler: info.sib.getSamplerInfoList()) {
+        if (sampler.type == SamplerInterfaceBlock::Type::SAMPLER_EXTERNAL) {
+            userSamplerCount += 1;
+        }
+    }
+
     switch (info.featureLevel) {
         case FeatureLevel::FEATURE_LEVEL_0:
             // TODO: check FEATURE_LEVEL_0 features (e.g. unlit only, no texture arrays, etc...)
@@ -1224,11 +1230,29 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
             return true;
         case FeatureLevel::FEATURE_LEVEL_1:
         case FeatureLevel::FEATURE_LEVEL_2: {
+            if (mNoSamplerValidation) {
+                break;
+            }
+
+            auto const maxTextureCount = backend::FEATURE_LEVEL_CAPS[1].MAX_FRAGMENT_SAMPLER_COUNT;
+
+            // count how many samplers filament uses based on the material properties
+            // note: currently SSAO is not used with unlit, but we want to keep that possibility.
+            uint32_t textureUsedByFilamentCount = 3;    // shadowMap, structure, ssao
+            if (info.isLit) {
+                textureUsedByFilamentCount += 3;        // froxels, dfg, specular
+            }
+            if (info.reflectionMode == ReflectionMode::SCREEN_SPACE ||
+                info.refractionMode == RefractionMode::SCREEN_SPACE) {
+                textureUsedByFilamentCount += 1;        // ssr
+            }
+
             // TODO: we need constants somewhere for these values
-            if (userSamplerCount > 9) {
+            if (userSamplerCount > maxTextureCount - textureUsedByFilamentCount) {
                 slog.e << "Error: material \"" << mMaterialName.c_str()
                        << "\" has feature level " << +info.featureLevel
-                       << " and is using more than 9 samplers." << io::endl;
+                       << " and is using more than " << maxTextureCount - textureUsedByFilamentCount
+                       << " samplers." << io::endl;
                 logSamplerOverflow(info.sib);
                 return false;
             }
@@ -1248,10 +1272,11 @@ bool MaterialBuilder::checkMaterialLevelFeatures(MaterialInfo const& info) const
         }
         case FeatureLevel::FEATURE_LEVEL_3: {
             // TODO: we need constants somewhere for these values
-            if (userSamplerCount > 12) {
+            // TODO: 16 is artificially low for now, until we have a better idea of what we want
+            if (userSamplerCount > 16) {
                 slog.e << "Error: material \"" << mMaterialName.c_str()
                        << "\" has feature level " << +info.featureLevel
-                       << " and is using more than 12 samplers" << io::endl;
+                       << " and is using more than 16 samplers" << io::endl;
                 logSamplerOverflow(info.sib);
                 return false;
             }
@@ -1505,6 +1530,11 @@ void MaterialBuilder::writeSurfaceChunks(ChunkContainer& container) const noexce
     container.emplace<uint8_t>(ChunkType::MaterialVertexDomain, static_cast<uint8_t>(mVertexDomain));
     container.emplace<uint8_t>(ChunkType::MaterialInterpolation,
             static_cast<uint8_t>(mInterpolation));
+}
+
+MaterialBuilder& MaterialBuilder::noSamplerValidation(bool enabled) noexcept {
+    mNoSamplerValidation = enabled;
+    return *this;
 }
 
 } // namespace filamat

--- a/tools/matc/src/matc/CommandlineConfig.cpp
+++ b/tools/matc/src/matc/CommandlineConfig.cpp
@@ -91,6 +91,8 @@ static void usage(char* name) {
             "       Specify output format: blob (default) or header\n\n"
             "   --debug, -d\n"
             "       Generate extra data for debugging\n\n"
+            "   --no-sampler-validation, -F\n"
+            "       Skip validation of number of sampler used\n\n"
             "   --print, -t\n"
             "       Print generated shaders for debugging\n\n"
     );
@@ -167,7 +169,7 @@ static void parseDefine(std::string defineString, Config::StringReplacementMap& 
 }
 
 bool CommandlineConfig::parse() {
-    static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:OSEr:vV:gtw";
+    static constexpr const char* OPTSTR = "hLxo:f:dm:a:l:p:D:T:OSEr:vV:gtwF";
     static const struct option OPTIONS[] = {
             { "help",                    no_argument, nullptr, 'h' },
             { "license",                 no_argument, nullptr, 'L' },
@@ -189,6 +191,7 @@ bool CommandlineConfig::parse() {
             { "print",                   no_argument, nullptr, 't' },
             { "version",                 no_argument, nullptr, 'v' },
             { "raw",                     no_argument, nullptr, 'w' },
+            { "no-sampler-validation",   no_argument, nullptr, 'F' },
             { nullptr, 0, nullptr, 0 }  // termination of the option list
     };
 
@@ -302,6 +305,9 @@ bool CommandlineConfig::parse() {
                 break;
             case 'w':
                 mRawShaderMode = true;
+                break;
+            case 'F':
+                mNoSamplerValidation = true;
                 break;
         }
     }

--- a/tools/matc/src/matc/Config.h
+++ b/tools/matc/src/matc/Config.h
@@ -115,6 +115,10 @@ public:
         return mRawShaderMode;
     }
 
+    bool noSamplerValidation() const noexcept {
+        return mNoSamplerValidation;
+    }
+
     filament::UserVariantFilterMask getVariantFilter() const noexcept {
         return mVariantFilter;
     }
@@ -136,6 +140,7 @@ protected:
     bool mIsValid = true;
     bool mPrintShaders = false;
     bool mRawShaderMode = false;
+    bool mNoSamplerValidation = false;
     Optimization mOptimizationLevel = Optimization::PERFORMANCE;
     Metadata mReflectionTarget = Metadata::NONE;
     Platform mPlatform = Platform::ALL;

--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -397,6 +397,7 @@ bool MaterialCompiler::run(const Config& config) {
     includer.setIncludeDirectory(materialFilePath.getParent());
 
     builder
+        .noSamplerValidation(config.noSamplerValidation())
         .includeCallback(includer)
         .fileName(materialFilePath.getName().c_str())
         .platform(config.getPlatform())


### PR DESCRIPTION
The number of usable sampler in materials is now documented and properly accounted for in matc.