### PR TITLE
add support for custom fog color in gltf_viewer

### DIFF
--- a/libs/filamentapp/include/filamentapp/IBL.h
+++ b/libs/filamentapp/include/filamentapp/IBL.h
@@ -55,6 +55,10 @@ public:
         return mSkybox;
     }
 
+    filament::Texture* getFogTexture() const noexcept {
+        return mFogTexture;
+    }
+
     bool hasSphericalHarmonics() const { return mHasSphericalHarmonics; }
     filament::math::float3 const* getSphericalHarmonics() const { return mBands; }
 
@@ -77,6 +81,7 @@ private:
     filament::Texture* mTexture = nullptr;
     filament::IndirectLight* mIndirectLight = nullptr;
     filament::Texture* mSkyboxTexture = nullptr;
+    filament::Texture* mFogTexture = nullptr;
     filament::Skybox* mSkybox = nullptr;
 };
 

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -160,6 +160,10 @@ struct DynamicLightingSettings {
     float zLightFar = 100;
 };
 
+struct FogSettings {
+    Texture* fogColorTexture = nullptr;
+};
+
 // This defines fields in the same order as the setter methods in filament::View.
 struct ViewSettings {
     // standalone View settings
@@ -185,6 +189,7 @@ struct ViewSettings {
     // Custom View Options
     ColorGradingSettings colorGrading;
     DynamicLightingSettings dynamicLighting;
+    FogSettings fogSettings;
 };
 
 template <typename T>

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -889,6 +889,13 @@ void ViewerGui::updateUserInterface() {
     }
 
     if (ImGui::CollapsingHeader("Fog")) {
+        int fogColorSource = 0;
+        if (mSettings.view.fog.skyColor) {
+            fogColorSource = 2;
+        } else if (mSettings.view.fog.fogColorFromIbl) {
+            fogColorSource = 1;
+        }
+
         bool excludeSkybox = !std::isinf(mSettings.view.fog.cutOffDistance);
         ImGui::Indent();
         ImGui::Checkbox("Enable large-scale fog", &mSettings.view.fog.enabled);
@@ -899,11 +906,25 @@ void ViewerGui::updateUserInterface() {
         ImGui::SliderFloat("Sun Scattering start [m]", &mSettings.view.fog.inScatteringStart, 0.0f, 100.0f);
         ImGui::SliderFloat("Sun Scattering size", &mSettings.view.fog.inScatteringSize, 0.1f, 100.0f);
         ImGui::Checkbox("Exclude Skybox", &excludeSkybox);
-        ImGui::Checkbox("Color from IBL", &mSettings.view.fog.fogColorFromIbl);
+        ImGui::Combo("Color##fogColor", &fogColorSource, "Constant\0IBL\0Skybox\0\0");
         ImGui::ColorPicker3("Color", mSettings.view.fog.color.v);
         ImGui::Unindent();
         mSettings.view.fog.cutOffDistance =
                 excludeSkybox ? 1e6f : std::numeric_limits<float>::infinity();
+        switch (fogColorSource) {
+            case 0:
+                mSettings.view.fog.skyColor = nullptr;
+                mSettings.view.fog.fogColorFromIbl = false;
+                break;
+            case 1:
+                mSettings.view.fog.skyColor = nullptr;
+                mSettings.view.fog.fogColorFromIbl = true;
+                break;
+            case 2:
+                mSettings.view.fog.skyColor = mSettings.view.fogSettings.fogColorTexture;
+                mSettings.view.fog.fogColorFromIbl = false;
+                break;
+        }
     }
 
     if (ImGui::CollapsingHeader("Scene")) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -573,6 +573,7 @@ int main(int argc, char** argv) {
         auto ibl = FilamentApp::get().getIBL();
         if (ibl) {
             app.viewer->setIndirectLight(ibl->getIndirectLight(), ibl->getSphericalHarmonics());
+            app.viewer->getSettings().view.fogSettings.fogColorTexture = ibl->getFogTexture();
         }
     };
 


### PR DESCRIPTION
this is implemented by here by using the skybox texture and blurring it with the irradiance filter + mipmapping. This only creates a subtle anisotropic phase-function effect.