### PR TITLE
workaround a bug in spirv-tools causing vsm to fail

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+matc: workaround a bug in spirv-tools causing vsm to fail [⚠️ **Recompile materials**]

--- a/shaders/src/shadowing.fs
+++ b/shaders/src/shadowing.fs
@@ -237,7 +237,7 @@ float filterPCSS(const mediump sampler2DArray map,
         const highp vec2 filterRadii, const mat2 R, const highp vec2 dz_duv,
         const uint tapCount) {
 
-    float occludedCount = 0.0;
+    highp float occludedCount = 0.0; // must be highp to workaround a spirv-tools issue
     for (uint i = 0u; i < tapCount; i++) {
         highp vec2 duv = R * (poissonDisk[i] * filterRadii);
 


### PR DESCRIPTION
it's unclear if the problem was in spirv-cross or spirv-opt, but eitherway, the generated code at the end was invalid.