### PR TITLE
helpers to fix jank when resizing a TextureView

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - matc: fix VSM high precision option on mobile [⚠️ **Recompile materials**]
 - vulkan: support sRGB swap chain
+- UiHelper: fix jank when a `TextureView` is resized (fixes b\282220665)

--- a/android/filament-android/src/main/java/com/google/android/filament/android/FilamentHelper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/android/FilamentHelper.java
@@ -22,17 +22,35 @@ import com.google.android.filament.Fence;
 public class FilamentHelper {
 
     /**
-     * Wait for all pending frames to be processed before returning. This is to
-     * avoid a race between the surface being resized before pending frames are
-     * rendered into it. This is typically called from {@link UiHelper.RendererCallback#onResized},
-     * {@link android.view.SurfaceHolder.Callback#surfaceChanged} or
-     * {@link android.view.TextureView.SurfaceTextureListener#onSurfaceTextureSizeChanged}.
+     * Wait for all pending frames to be processed before returning. This is to avoid a race
+     * between the surface being resized before pending frames are rendered into it.
+     * <p>
+     * For {@link android.view.TextureView} this must be called before the texture's size is
+     * reconfigured, which unfortunately is done by the Android framework before
+     * {@link UiHelper} listeners are invoked. Therefore <code>synchronizePendingFrames</code>
+     * cannot be called from
+     * {@link android.view.TextureView.SurfaceTextureListener#onSurfaceTextureSizeChanged}; instead
+     * a subclass of {@link android.view.TextureView} must be used in order to call it from
+     * {@link android.view.TextureView#onSizeChanged}:
+     * </p>
+     * <pre>
+     * public class MyTextureView extends TextureView {
+     *     private Engine engine;
+     *     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+     *         FilamentHelper.synchronizePendingFrames(engine);
+     *         super.onSizeChanged(w, h, oldw, oldh);
+     *     }
+     * }
+     * </pre>
+     *
+     * Otherwise, this is typically called from {@link UiHelper.RendererCallback#onResized},
+     * {@link android.view.SurfaceHolder.Callback#surfaceChanged}.
      *
      * @param engine Filament engine to synchronize
      *
      * @see UiHelper.RendererCallback#onResized
      * @see android.view.SurfaceHolder.Callback#surfaceChanged
-     * @see android.view.TextureView.SurfaceTextureListener#onSurfaceTextureSizeChanged
+     * @see android.view.TextureView#onSizeChanged
      */
     static public void synchronizePendingFrames(Engine engine) {
         Fence fence = engine.createFence();

--- a/android/filament-android/src/main/java/com/google/android/filament/android/UiHelper.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/android/UiHelper.java
@@ -244,6 +244,10 @@ public class UiHelper {
             }
             mSurface = surface;
         }
+
+        public Surface getSurface() {
+            return mSurface;
+        }
     }
 
     /**
@@ -489,6 +493,14 @@ public class UiHelper {
                     } else {
                         mRenderCallback.onResized(width, height);
                     }
+                    // We must recreate the SwapChain to guarantee that it sees the new size.
+                    // More precisely, for an EGL client, the EGLSurface must be recreated. For
+                    // a Vulkan client, the SwapChain must be recreated. Calling
+                    // onNativeWindowChanged() will accomplish that.
+                    // This requirement comes from SurfaceTexture.setDefaultBufferSize()
+                    // documentation.
+                    TextureViewHandler textureViewHandler = (TextureViewHandler) mRenderSurface;
+                    mRenderCallback.onNativeWindowChanged(textureViewHandler.getSurface());
                 }
 
                 @Override


### PR DESCRIPTION
There was two related issues:
- we need to "latch" the new TextureView size when its resized. That can only be done by recreating the EGLSurface (i.e. recreating the SwapChain). UiHelper now calls onNativeWindowChanged in the case of  the TextureView resize, so clients can recreate their SwapChain.
- we also needed to make sure that all current filament frames have finished to render (i.e. the last eglSwapBuffers has been called) so that they don't pick-up a new size (this happens after  eglSwapBuffers) that doesn't match the viewport.

Fixes b/282220665