### PR TITLE
align uniform buffer to 16 bytes

### DIFF
--- a/filament/src/PerShadowMapUniforms.cpp
+++ b/filament/src/PerShadowMapUniforms.cpp
@@ -107,7 +107,7 @@ void PerShadowMapUniforms::prepareShadowMapping(Transaction const& transaction,
 PerShadowMapUniforms::Transaction PerShadowMapUniforms::open(backend::DriverApi& driver) noexcept {
     Transaction transaction;
     // TODO: use out-of-line buffer if too large
-    transaction.uniforms = (PerViewUib *)driver.allocate(sizeof(PerViewUib));
+    transaction.uniforms = (PerViewUib *)driver.allocate(sizeof(PerViewUib), 16);
     assert_invariant(transaction.uniforms);
     return transaction;
 }


### PR DESCRIPTION
this is needed on armv7 because we use alignas to get strcture-alignment, but that also implies (to the compiler) that the structure itself is aligned properly.