### PR TITLE
vulkan: fix present layout warning on mac

### DIFF
--- a/filament/backend/src/vulkan/VulkanImageUtility.cpp
+++ b/filament/backend/src/vulkan/VulkanImageUtility.cpp
@@ -101,9 +101,12 @@ getVkTransition(const VulkanLayoutTransition& transition) {
             srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
             srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
             break;
-        case VulkanLayout::PRESENT:
         case VulkanLayout::COLOR_ATTACHMENT_RESOLVE:
             srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            break;
+        case VulkanLayout::PRESENT:
+            srcAccessMask = VK_ACCESS_NONE;
             srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
             break;
     }


### PR DESCRIPTION
Fixing validation warning of the form:
(UNASSIGNED-BestPractices-ImageBarrierAccessLayout) Validation Warning: [ UNASSIGNED-BestPractices-ImageBarrierAccessLayout ] Object 0: handle = 0x7f824f057218, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x849fcec7 | vkCmdPipelineBarrier: accessMask is VK_ACCESS_2_TRANSFER_READ_BIT, but for layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR expected accessMask are VkAccessFlags2(0).