### PR TITLE
vulkan: fix taa validations

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.h
+++ b/filament/backend/src/vulkan/VulkanBlitter.h
@@ -55,9 +55,8 @@ public:
 private:
     void lazyInit() noexcept;
 
-    void blitSlowDepth(VkImageAspectFlags aspect, VkFilter filter, const VkExtent2D srcExtent,
-            VulkanAttachment src, VulkanAttachment dst, const VkOffset3D srcRect[2],
-            const VkOffset3D dstRect[2]);
+    void blitSlowDepth(VkFilter filter, const VkExtent2D srcExtent, VulkanAttachment src,
+            VulkanAttachment dst, const VkOffset3D srcRect[2], const VkOffset3D dstRect[2]);
 
     VulkanBuffer* mTriangleBuffer = nullptr;
     VulkanBuffer* mParamsBuffer = nullptr;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1179,7 +1179,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     VkClearValue clearValues[
             MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT + MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT +
             1] = {};
-    if (params.flags.clear != TargetBufferFlags::NONE) {
+    if (clearVal != TargetBufferFlags::NONE) {
 
         // NOTE: clearValues must be populated in the same order as the attachments array in
         // VulkanFboCache::getFramebuffer. Values must be provided regardless of whether Vulkan is

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -108,9 +108,8 @@ VulkanProgram::VulkanProgram(VkDevice device, const Program& builder) noexcept :
     // Make a copy of the binding map
     samplerGroupInfo = builder.getSamplerGroupInfo();
     if constexpr (FILAMENT_VULKAN_VERBOSE) {
-        utils::slog.d << "Created VulkanProgram " << builder
-                    << ", shaders = (" << bundle.vertex << ", " << bundle.fragment << ")"
-                    << utils::io::endl;
+        utils::slog.d << "Created VulkanProgram " << builder << ", shaders = (" << bundle.vertex
+                      << ", " << bundle.fragment << ")" << utils::io::endl;
     }
 }
 

--- a/filament/backend/src/vulkan/VulkanImageUtility.h
+++ b/filament/backend/src/vulkan/VulkanImageUtility.h
@@ -65,7 +65,11 @@ public:
 
     inline static VulkanLayout getDefaultLayout(TextureUsage usage) {
         if (any(usage & TextureUsage::DEPTH_ATTACHMENT)) {
-            return VulkanLayout::DEPTH_ATTACHMENT;
+            if (any(usage & TextureUsage::SAMPLEABLE)) {
+                return VulkanLayout::DEPTH_SAMPLER;
+            } else {
+                return VulkanLayout::DEPTH_ATTACHMENT;
+            }
         }
 
         if (any(usage & TextureUsage::COLOR_ATTACHMENT)) {
@@ -73,6 +77,20 @@ public:
         }
         // Finally, the layout for an immutable texture is optimal read-only.        
         return VulkanLayout::READ_ONLY;
+    }
+
+    inline static VulkanLayout getDefaultLayout(VkImageUsageFlags vkusage) {
+        TextureUsage usage {};
+        if (vkusage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+            usage = usage | TextureUsage::DEPTH_ATTACHMENT;
+        }
+        if (vkusage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) {
+            usage = usage | TextureUsage::COLOR_ATTACHMENT;
+        }
+        if (vkusage & VK_IMAGE_USAGE_SAMPLED_BIT) {
+            usage = usage | TextureUsage::SAMPLEABLE;
+        }
+        return getDefaultLayout(usage);
     }
 
     static VkImageLayout getVkLayout(VulkanLayout layout);

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -154,10 +154,12 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
             << "handle = " << utils::io::hex << mTextureImage << utils::io::dec << ", "
             << "extent = " << w << "x" << h << "x"<< depth << ", "
             << "mipLevels = " << int(levels) << ", "
+            << "TextureUsage = " << static_cast<int>(usage) << ", "            
             << "usage = " << imageInfo.usage << ", "
             << "samples = " << imageInfo.samples << ", "
             << "type = " << imageInfo.imageType << ", "
             << "flags = " << imageInfo.flags << ", "
+            << "target = " << static_cast<int>(target) <<", "
             << "format = " << mVkFormat << utils::io::endl;
     }
     ASSERT_POSTCONDITION(!error, "Unable to create image.");
@@ -199,11 +201,13 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
     // Transition the layout of each image slice that might be used as a render target.
     // We do not transition images that are merely SAMPLEABLE, this is deferred until upload time
     // because we do not know how many layers and levels will actually be used.
-    if (any(usage & (TextureUsage::COLOR_ATTACHMENT | TextureUsage::DEPTH_ATTACHMENT))) {
+    if (imageInfo.usage
+        & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+           | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         const uint32_t layers = mPrimaryViewRange.layerCount;
         VkImageSubresourceRange range = { getImageAspect(), 0, levels, 0, layers };
         VkCommandBuffer cmdbuf = mCommands->get().cmdbuffer;
-        transitionLayout(cmdbuf, range, ImgUtil::getDefaultLayout(usage));
+        transitionLayout(cmdbuf, range, ImgUtil::getDefaultLayout(imageInfo.usage));
     }
 }
 


### PR DESCRIPTION
 - Validation failing due to incorrect layout wrt Blitter render pass.
 - Clear colors are also not needed for blitter renderpass.
 - SAMPLEABLE + DEPTH_ATTACHMENT needs to have the correct layout.