### PR TITLE
vulkan: address debugUtils bug

### DIFF
--- a/filament/backend/src/vulkan/VulkanCommands.cpp
+++ b/filament/backend/src/vulkan/VulkanCommands.cpp
@@ -77,27 +77,27 @@ void VulkanGroupMarkers::push(std::string const& marker, Timestamp start) noexce
 #endif
 }
 
-std::tuple<std::string, Timestamp> VulkanGroupMarkers::pop() noexcept {
+std::pair<std::string, Timestamp> VulkanGroupMarkers::pop() noexcept {
     auto const marker = mMarkers.top();
     mMarkers.pop();
 
 #if FILAMENT_VULKAN_VERBOSE
     auto const topTimestamp = mTimestamps.top();
     mTimestamps.pop();
-    return std::make_tuple(marker, topTimestamp);
+    return std::make_pair(marker, topTimestamp);
 #else
-    return std::make_tuple(marker, Timestamp{});
+    return std::make_pair(marker, Timestamp{});
 #endif
 }
 
-std::tuple<std::string, Timestamp> VulkanGroupMarkers::top() const {
+std::pair<std::string, Timestamp> VulkanGroupMarkers::top() const {
     assert_invariant(!empty());
     auto const marker = mMarkers.top();
 #if FILAMENT_VULKAN_VERBOSE
     auto const topTimestamp = mTimestamps.top();
-    return std::make_tuple(marker, topTimestamp);
+    return std::make_pair(marker, topTimestamp);
 #else
-    return std::make_tuple(marker, Timestamp{});
+    return std::make_pair(marker, Timestamp{});
 #endif
 }
 
@@ -338,7 +338,7 @@ void VulkanCommands::pushGroupMarker(char const* str, VulkanGroupMarkers::Timest
     // If the timestamp is not 0, then we are carrying over a marker across buffer submits.
     // If it is 0, then this is a normal marker push and we should just print debug line as usual.
     if (timestamp.time_since_epoch().count() == 0.0) {
-        utils::slog.d << "----> " << str << "\n" << utils::io::flush;
+        utils::slog.d << "----> " << str << utils::io::endl;
     }
 #endif
 

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -26,7 +26,30 @@
 
 #include <atomic>
 
+#include <chrono>
+#include <stack>
+#include <string>
+#include <tuple>
+
 namespace filament::backend {
+
+struct VulkanContext;
+
+class VulkanGroupMarkers {
+public:
+    using Timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>;
+
+    void push(std::string const& marker, Timestamp start = {}) noexcept;
+    std::tuple<std::string, Timestamp> pop() noexcept;
+    std::tuple<std::string, Timestamp> top() const;
+    bool empty() const noexcept;
+
+private:
+    std::stack<std::string> mMarkers;
+#if FILAMENT_VULKAN_VERBOSE
+    std::stack<Timestamp> mTimestamps;
+#endif
+};
 
 // Wrapper to enable use of shared_ptr for implementing shared ownership of low-level Vulkan fences.
 struct VulkanCmdFence {
@@ -86,7 +109,8 @@ public:
 //
 class VulkanCommands {
     public:
-        VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex);
+        VulkanCommands(VkDevice device, VkQueue queue, uint32_t queueFamilyIndex,
+                VulkanContext* context);
         ~VulkanCommands();
 
         // Creates a "current" command buffer if none exists, otherwise returns the current one.
@@ -121,11 +145,21 @@ class VulkanCommands {
         // The observer's event handler can only be called during get().
         void setObserver(CommandBufferObserver* observer) { mObserver = observer; }
 
+        void pushGroupMarker(char const* str, VulkanGroupMarkers::Timestamp timestamp = {});
+
+        void popGroupMarker();
+
+        void insertEventMarker(char const* string, uint32_t len);
+
+        std::string getTopGroupMarker() const;
+
     private:
         static constexpr int CAPACITY = VK_MAX_COMMAND_BUFFERS;
-        const VkDevice mDevice;
-        const VkQueue mQueue;
-        const VkCommandPool mPool;
+        VkDevice const mDevice;
+        VkQueue const mQueue;
+        VkCommandPool const mPool;
+        VulkanContext const* mContext;
+
         VulkanCommandBuffer* mCurrent = nullptr;
         VkSemaphore mSubmissionSignal = {};
         VkSemaphore mInjectedSignal = {};
@@ -133,6 +167,9 @@ class VulkanCommands {
         VkSemaphore mSubmissionSignals[CAPACITY] = {};
         size_t mAvailableCount = CAPACITY;
         CommandBufferObserver* mObserver = nullptr;
+
+        std::unique_ptr<VulkanGroupMarkers> mGroupMarkers;
+        std::unique_ptr<VulkanGroupMarkers> mCarriedOverMarkers;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanCommands.h
+++ b/filament/backend/src/vulkan/VulkanCommands.h
@@ -29,7 +29,7 @@
 #include <chrono>
 #include <stack>
 #include <string>
-#include <tuple>
+#include <utility>
 
 namespace filament::backend {
 
@@ -40,8 +40,8 @@ public:
     using Timestamp = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
     void push(std::string const& marker, Timestamp start = {}) noexcept;
-    std::tuple<std::string, Timestamp> pop() noexcept;
-    std::tuple<std::string, Timestamp> top() const;
+    std::pair<std::string, Timestamp> pop() noexcept;
+    std::pair<std::string, Timestamp> top() const;
     bool empty() const noexcept;
 
 private:

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "VulkanContext.h"
+
+#include "VulkanCommands.h"
 #include "VulkanHandles.h"
 #include "VulkanMemory.h"
 #include "VulkanTexture.h"

--- a/filament/backend/src/vulkan/VulkanContext.h
+++ b/filament/backend/src/vulkan/VulkanContext.h
@@ -17,7 +17,6 @@
 #ifndef TNT_FILAMENT_BACKEND_VULKANCONTEXT_H
 #define TNT_FILAMENT_BACKEND_VULKANCONTEXT_H
 
-#include "VulkanCommands.h"
 #include "VulkanConstants.h"
 #include "VulkanImageUtility.h"
 #include "VulkanPipelineCache.h"
@@ -38,6 +37,7 @@ struct VulkanSwapChain;
 struct VulkanTexture;
 class VulkanStagePool;
 struct VulkanTimerQuery;
+struct VulkanCommandBuffer;
 
 struct VulkanAttachment {
     VulkanTexture* texture;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -30,14 +30,10 @@
 #include <utils/CString.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Panic.h>
+#include <utils/Systrace.h>
 
 #ifndef NDEBUG
 #include <set>
-#endif
-
-#if FILAMENT_VULKAN_VERBOSE
-#include <stack>
-static std::stack<std::string> renderPassMarkers;
 #endif
 
 using namespace bluevk;
@@ -186,7 +182,7 @@ VulkanDriver::VulkanDriver(VulkanPlatform* platform, VulkanContext const& contex
 #endif
     mTimestamps = std::make_unique<VulkanTimestamps>(mPlatform->getDevice());
     mCommands = std::make_unique<VulkanCommands>(mPlatform->getDevice(),
-            mPlatform->getGraphicsQueue(), mPlatform->getGraphicsQueueFamilyIndex());
+            mPlatform->getGraphicsQueue(), mPlatform->getGraphicsQueueFamilyIndex(), &mContext);
     mCommands->setObserver(&mPipelineCache);
     mPipelineCache.setDevice(mPlatform->getDevice(), mAllocator);
 
@@ -1146,15 +1142,18 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     VkFramebuffer vkfb = mFramebufferCache.getFramebuffer(fbkey);
 
     // Assign a label to the framebuffer for debugging purposes.
-    if (UTILS_UNLIKELY(mContext.isDebugUtilsSupported()) && !mCurrentDebugMarker.empty()) {
-        const VkDebugUtilsObjectNameInfoEXT info = {
-            VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
-            nullptr,
-            VK_OBJECT_TYPE_FRAMEBUFFER,
-            reinterpret_cast<uint64_t>(vkfb),
-            mCurrentDebugMarker.c_str(),
-        };
-        vkSetDebugUtilsObjectNameEXT(mPlatform->getDevice(), &info);
+    if (UTILS_UNLIKELY(mContext.isDebugUtilsSupported())) {
+        auto const topMarker = mCommands->getTopGroupMarker();
+        if (!topMarker.empty()) {
+            const VkDebugUtilsObjectNameInfoEXT info = {
+                VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
+                nullptr,
+                VK_OBJECT_TYPE_FRAMEBUFFER,
+                reinterpret_cast<uint64_t>(vkfb),
+                topMarker.c_str(),
+            };
+            vkSetDebugUtilsObjectNameEXT(mPlatform->getDevice(), &info);
+        }
     }
 
     // The current command buffer now owns a reference to the render target and its attachments.
@@ -1375,75 +1374,29 @@ void VulkanDriver::bindSamplers(uint32_t index, Handle<HwSamplerGroup> sbh) {
 }
 
 void VulkanDriver::insertEventMarker(char const* string, uint32_t len) {
-    constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
-    VkCommandBuffer const cmdbuffer = mCommands->get().cmdbuffer;
-    if (mContext.isDebugUtilsSupported()) {
-        VkDebugUtilsLabelEXT labelInfo = {
-            .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
-            .pLabelName = string,
-            .color = {1, 1, 0, 1},
-        };
-        vkCmdInsertDebugUtilsLabelEXT(cmdbuffer, &labelInfo);
-    } else if (mContext.isDebugMarkersSupported()) {
-        VkDebugMarkerMarkerInfoEXT markerInfo = {};
-        markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
-        memcpy(markerInfo.color, &MARKER_COLOR[0], sizeof(MARKER_COLOR));
-        markerInfo.pMarkerName = string;
-        vkCmdDebugMarkerInsertEXT(cmdbuffer, &markerInfo);
-    }
+    mCommands->insertEventMarker(string, len);
 }
 
-void VulkanDriver::pushGroupMarker(char const* string, uint32_t len) {
-
-#if FILAMENT_VULKAN_VERBOSE
-    renderPassMarkers.push(std::string(string));
-    utils::slog.d << "----> " << string << utils::io::endl;
-#endif
-
-    // TODO: Add group marker color to the Driver API
-    constexpr float MARKER_COLOR[] = { 0.0f, 1.0f, 0.0f, 1.0f };
-    const VkCommandBuffer cmdbuffer = mCommands->get().cmdbuffer;
-    if (mContext.isDebugUtilsSupported()) {
-        VkDebugUtilsLabelEXT labelInfo = {
-            .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
-            .pLabelName = string,
-            .color = {0, 1, 0, 1},
-        };
-        vkCmdBeginDebugUtilsLabelEXT(cmdbuffer, &labelInfo);
-        mCurrentDebugMarker = string;
-    } else if (mContext.isDebugMarkersSupported()) {
-        VkDebugMarkerMarkerInfoEXT markerInfo = {};
-        markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT;
-        memcpy(markerInfo.color, &MARKER_COLOR[0], sizeof(MARKER_COLOR));
-        markerInfo.pMarkerName = string;
-        vkCmdDebugMarkerBeginEXT(cmdbuffer, &markerInfo);
+void VulkanDriver::pushGroupMarker(char const* string, uint32_t) {
+    // Turns out all the markers are 0-terminated, so we can just pass it without len.
+    mCommands->pushGroupMarker(string);
+    {
+        SYSTRACE_CONTEXT();
+        SYSTRACE_NAME_BEGIN(string);
     }
 }
 
 void VulkanDriver::popGroupMarker(int) {
-
-#if FILAMENT_VULKAN_VERBOSE
-    std::string const& marker = renderPassMarkers.top();
-    renderPassMarkers.pop();
-    utils::slog.d << "<---- " << marker << utils::io::endl;
-#endif
-
-    const VkCommandBuffer cmdbuffer = mCommands->get().cmdbuffer;
-    if (mContext.isDebugUtilsSupported()) {
-        vkCmdEndDebugUtilsLabelEXT(cmdbuffer);
-        mCurrentDebugMarker.clear();
-    } else if (mContext.isDebugMarkersSupported()) {
-        vkCmdDebugMarkerEndEXT(cmdbuffer);
+    mCommands->popGroupMarker();
+    {
+        SYSTRACE_CONTEXT();
+        SYSTRACE_NAME_END();
     }
 }
 
-void VulkanDriver::startCapture(int) {
+void VulkanDriver::startCapture(int) {}
 
-}
-
-void VulkanDriver::stopCapture(int) {
-
-}
+void VulkanDriver::stopCapture(int) {}
 
 void VulkanDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
         uint32_t width, uint32_t height, PixelBufferDescriptor&& pbd) {

--- a/filament/backend/src/vulkan/VulkanDriver.h
+++ b/filament/backend/src/vulkan/VulkanDriver.h
@@ -148,7 +148,6 @@ private:
     VmaAllocator mAllocator = VK_NULL_HANDLE;
     VkDebugReportCallbackEXT mDebugCallback = VK_NULL_HANDLE;
     VkDebugUtilsMessengerEXT mDebugMessenger = VK_NULL_HANDLE;
-    std::string mCurrentDebugMarker;
 
     VulkanContext mContext = {};
     HandleAllocatorVK mHandleAllocator;


### PR DESCRIPTION
vkCmdEndDebugUtilsLabelEXT expects that a label was "pushed" onto the command queue (as described in the spec). It is possible to push labels across command buffers, but the pushed label must still be in the queue (unexecuted) when End is called. This implies that we need to make sure the labels are in a good state (all popped) when vkQueueSubmit is called.

- We add a stack to carry the labels across vkQueueSubmit.
- Also add CPU time durations between push and pop to provide rough CPU execution times (in debug).
- Add systrace markers for Android systrace