### PR TITLE
vulkan: fix timer query

### DIFF
--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -118,8 +118,8 @@ void VulkanTimestamps::beginQuery(VulkanCommandBuffer const* commands,
     vkCmdResetQueryPool(commands->cmdbuffer, mPool, index, 2);
     vkCmdWriteTimestamp(commands->cmdbuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, mPool, index);
 
-    // We stash this because getResult might come before beginquery.
-    query->cmdbuffer.store(commands);
+    // We stash this because getResult might come before the query is actually processed.
+    query->fence = commands->fence;
 }
 
 void VulkanTimestamps::endQuery(VulkanCommandBuffer const* commands,

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -305,11 +305,16 @@ bool VulkanTimerQuery::isCompleted() const noexcept {
     // into the command buffer, which is an error according to the validation layer that ships in
     // the Android NDK.  Even when AVAILABILITY_BIT is set, validation seems to require that the
     // timestamp has at least been written into a processed command buffer.
-    VulkanCommandBuffer const* cmdbuf = cmdbuffer.load();
-    if (!cmdbuf || !cmdbuf->fence) { return false; }
 
-    VkResult status = cmdbuf->fence->status.load(std::memory_order_relaxed);
-    if (status != VK_SUCCESS) { return false; }
+    // This fence indicates that the corresponding buffer has been completed.
+    if (!fence) {
+        return false;
+    }
+
+    VkResult status = fence->status.load(std::memory_order_relaxed);
+    if (status != VK_SUCCESS) {
+        return false;
+    }
 
     return true;
 }

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -147,9 +147,7 @@ private:
     uint32_t startingQueryIndex;
     uint32_t stoppingQueryIndex;
 
-    // TODO: should be safe to hold this reference (since VulkanCommanBuffers is a ring).
-    // But explore better options.
-    std::atomic<VulkanCommandBuffer const*> cmdbuffer = nullptr;
+    std::shared_ptr<VulkanCmdFence> fence;
     friend class VulkanTimestamps;
 };
 


### PR DESCRIPTION
 - Timer query stashed a pointer to VulkanCommandBuffer, but this points to an object that can be reused.
 - We use the shared_ptr'd fence object instead to track whether the query request has been completed.