### PR TITLE
fix error reporting with ShaderCompilerService

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -120,7 +120,7 @@ private:
 
     GLuint initialize(ShaderCompilerService::program_token_t& token) noexcept;
 
-    void getProgramFromCompilerPool(program_token_t& token) noexcept;
+    static void getProgramFromCompilerPool(program_token_t& token) noexcept;
 
         static void compileShaders(
             OpenGLContext& context,


### PR DESCRIPTION
when using the thread pool we were destroying the shaders immediately, we need to defer this until we query the program link status, so that  in case of failure we can query each shader compile status.

we make the shader handles part of the promise/future so they can be  transferred to the main thread, just like the program id is.