### PR TITLE
Turn off iOS exceptions in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,12 @@ if (ANDROID OR IOS OR WEBGL)
     endif()
 endif()
 
+# Turn off exceptions on iOS debug as well. This fixes an availability error we see when using
+# std::visit, which is not supported on iOS 11.0 when exceptions are enabled.
+if (IOS)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-exceptions")
+endif()
+
 # With WebGL, we disable RTTI even for debug builds because we pass emscripten::val back and forth
 # between C++ and JavaScript in order to efficiently access typed arrays, which are unbound.
 # NOTE: This is not documented in emscripten so we should consider a different approach.


### PR DESCRIPTION
Apple added `availability` annotations in the iOS 16.4 SDK to `std::bad_variant_access`. When using `std::visit` with a `std::variant`, several availability warnings are emitted by Clang (because we build for iOS 11.0):

```
OpenGLProgram.cpp:144:19: error: 'visit<(lambda at OpenGLProgram.cpp:144:25), const std::variant<int, float, bool> &, void>' is unavailable: introduced in iOS 12.0
        s += std::visit([](auto&& arg) { return to_string(arg); }, sc.value);
```

Exceptions are already disabled in iOS release builds, and I think we can simply disable exceptions in iOS debug builds as well.

Fixes #6893
