### PR TITLE
Make initializeGlExtensions protected

### DIFF
--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -142,8 +142,9 @@ protected:
         } egl;
     } ext;
 
-private:
     void initializeGlExtensions() noexcept;
+
+private:
     EGLConfig findSwapChainConfig(uint64_t flags) const;
 };
 


### PR DESCRIPTION
This function is used in subclass PlatformEGLHeadless (see [here](https://github.com/google/filament/blob/1edad92d7341cb3f8dee59ef532aa6f13a411b61/filament/backend/src/opengl/platforms/PlatformEGLHeadless.cpp#L196)) resulting in build errors.