### PR TITLE
Fix texture upload callbacks in Java/Kotlin

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- Java/Kotlin: user callbacks were not invoked on successful texture upload

--- a/android/filament-android/src/main/cpp/Texture.cpp
+++ b/android/filament-android/src/main/cpp/Texture.cpp
@@ -511,9 +511,7 @@ public:
 
 private:
     void* mData = nullptr;
-    jobject mBitmap = nullptr;
-    jobject mHandler = nullptr;
-    jobject mCallback = nullptr;
+    jobject mBitmap{};
     AndroidBitmapInfo mInfo{};
 };
 

--- a/android/samples/sample-textured-object/src/main/java/com/google/android/filament/textured/MainActivity.kt
+++ b/android/samples/sample-textured-object/src/main/java/com/google/android/filament/textured/MainActivity.kt
@@ -231,7 +231,7 @@ class MainActivity : Activity() {
         animator.repeatCount = ValueAnimator.INFINITE
         animator.addUpdateListener { a ->
             val v = (a.animatedValue as Float)
-            camera.lookAt(cos(v) * 4.5, 1.5, sin(v) * 4.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+            camera.lookAt(cos(v) * 5.5, 1.5, sin(v) * 5.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0)
         }
         animator.start()
     }
@@ -253,7 +253,7 @@ class MainActivity : Activity() {
 
         // Stop the animation and any pending frame
         choreographer.removeFrameCallback(frameScheduler)
-        animator.cancel();
+        animator.cancel()
 
         // Always detach the surface before destroying the engine
         uiHelper.detach()


### PR DESCRIPTION
`AutoBitmap` extends `JniCallback` but they *both* define fields called `mHandler` and `mCallback`. This name
shadowing caused `AutoBitmap` to reference to its own `null`-initialized fields instead of the fields initialized by the
base class. This in turn caused user callbacks to not be invoked upon successful texture upload.

This issue was found while investigating bug #6936.