### PR TITLE
Fix dynamic resolution with quality > low and translucency

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- rendering: dynamic resolution would not work with a translucent render target and quality > low

--- a/android/samples/sample-transparent-view/src/main/java/com/google/android/filament/transparentrendering/MainActivity.kt
+++ b/android/samples/sample-transparent-view/src/main/java/com/google/android/filament/transparentrendering/MainActivity.kt
@@ -140,9 +140,9 @@ class MainActivity : Activity() {
         camera = engine.createCamera(engine.entityManager.create())
 
         // clear the swapchain with transparent pixels
-        val options = renderer.clearOptions
-        options.clear = true
-        renderer.clearOptions = options
+        renderer.clearOptions = renderer.clearOptions.apply {
+            clear = true
+        }
     }
 
     private fun setupView() {

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -1050,7 +1050,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
         if (scaled) {
             mightNeedFinalBlit = false;
             auto viewport = DEBUG_DYNAMIC_SCALING ? xvp : vp;
-            input = ppm.upscale(fg, blendModeTranslucent, dsrOptions, input, xvp, {
+            input = ppm.upscale(fg, needsAlphaChannel, dsrOptions, input, xvp, {
                     .width = viewport.width, .height = viewport.height,
                     .format = colorGradingConfig.ldrFormat });
             xvp.left = xvp.bottom = 0;


### PR DESCRIPTION
The scene graph was using the wrong boolean to decide whether to fallback to low quality upscaling when the render target is translucent. It was instead only looking at the view's blending mode. We need to check both, as color grading does in the same function.

Fixes #6927
