### PR TITLE
Fixing PPM export and windows build errors with VS 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,6 @@ if (WIN32)
     # "VCRUNTIME140.dll not found. Try reinstalling the app.", but give users
     # a choice to opt for the shared runtime if they want.
     option(USE_STATIC_CRT "Link against the static runtime libraries." ON)
-    set(CMAKE_CXX_STANDARD 20)
 
     # On Windows we need to instruct cmake to generate the .def in order to get the .lib required
     # when linking against dlls. CL.EXE will not generate .lib without .def file (or without pragma
@@ -283,11 +282,11 @@ endif()
 # ==================================================================================================
 set(CXX_STANDARD "-std=c++17")
 if (WIN32)
-    set(CXX_STANDARD "/std:c++17")
+    set(CXX_STANDARD "/std:c++20")
 endif()
 
 if (MSVC)
-    set(CXX_STANDARD "/std:c++latest")
+    set(CXX_STANDARD "/std:c++20")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} /W0 /Zc:__cplusplus")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function -Wno-deprecated-declarations")
@@ -453,7 +452,6 @@ endif()
 
 # By default, build with Vulkan support on desktop platforms, although clients must request to use
 # it at run time.
-# if (WIN32 OR WEBGL OR IOS)
 if (WEBGL OR IOS)
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" OFF)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ if (WIN32)
     # "VCRUNTIME140.dll not found. Try reinstalling the app.", but give users
     # a choice to opt for the shared runtime if they want.
     option(USE_STATIC_CRT "Link against the static runtime libraries." ON)
+    set(CMAKE_CXX_STANDARD 20)
 
     # On Windows we need to instruct cmake to generate the .def in order to get the .lib required
     # when linking against dlls. CL.EXE will not generate .lib without .def file (or without pragma
@@ -452,7 +453,8 @@ endif()
 
 # By default, build with Vulkan support on desktop platforms, although clients must request to use
 # it at run time.
-if (WIN32 OR WEBGL OR IOS)
+# if (WIN32 OR WEBGL OR IOS)
+if (WEBGL OR IOS)
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" OFF)
 else()
     option(FILAMENT_SUPPORTS_VULKAN "Include the Vulkan backend" ON)

--- a/libs/viewer/src/AutomationEngine.cpp
+++ b/libs/viewer/src/AutomationEngine.cpp
@@ -80,7 +80,7 @@ static void exportScreenshot(View* view, Renderer* renderer, std::string filenam
             convertRGBAtoRGB(buffer, vp.width, vp.height);
 
             Path out(state->filename);
-            std::ofstream ppmStream(out);
+            std::ofstream ppmStream(out, std::ios_base::binary);
             ppmStream << "P6 " << vp.width << " " << vp.height << " " << 255 << std::endl;
             ppmStream.write(static_cast<char*>(buffer), vp.width * vp.height * 3);
             delete[] static_cast<uint8_t*>(buffer);


### PR DESCRIPTION
This small PR implements all fixes that I needed to make this project compile under Windows 10 with Visual Studio 2022.

- added vulkan: fixed missing "bluevk" library
- set c++ standard to 20. Did not compile with 17, and defaulted at least on my system to latest experimental which did not compile.
- fixed PPM export writing additional bytes which break the file format. This happened, because the file was not opened explicitly as a binary

(reupload because of some CLA/email conflicts)