### PR TITLE
vulkan: swapchain resize condition update

### DIFF
--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -107,7 +107,7 @@ void VulkanSwapChain::acquire(bool& resized) {
     }
 
     // Check if the swapchain should be resized.
-    if (!mHeadless && (resized = mPlatform->hasResized(swapChain))) {
+    if ((resized = mPlatform->hasResized(swapChain))) {
         mCommands->flush();
         mCommands->wait();
         mPlatform->recreate(swapChain);


### PR DESCRIPTION
Headless swapchains will use this signal to update their backing images if necessary.