### PR TITLE
Removed Code Duplication and Improved Readability

### DIFF
--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -28,9 +28,18 @@ namespace filament {
 Frustum::Frustum(const mat4f& pv) {
     Frustum::setProjection(pv);
 }
+// NOTE: if we don't specify noinline here, LLVM inlines this huge function into
+// two (?!) version of the Frustum(const mat4f& pv) constructor!
 
 UTILS_NOINLINE
 void Frustum::setProjection(const mat4f& pv) {
+    // see: "Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix"
+    // by Gil Gribb & Klaus Hartmann
+    //
+    // Another way to think about this is that we're transforming each plane in clip-space to
+    // view-space. Such transform is performed as:
+    //      transpose(inverse(viewFromClipMatrix)), i.e.: transpose(projection)
+
     const mat4f m(transpose(pv));
 
     // Calculate the unnormalized plane vectors

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -51,7 +51,7 @@ void Frustum::setProjection(const mat4f& pv) {
     planes[4] = -m[3] - m[2];
     planes[5] = -m[3] + m[2];
 
-    // Normalize the plane vectors
+    // Normalize the plane vectors in single loop
     for (int i = 0; i < 6; ++i) {
         float invLength = 1 / length(planes[i].xyz);
         planes[i] *= invLength;

--- a/filament/src/Frustum.cpp
+++ b/filament/src/Frustum.cpp
@@ -29,43 +29,27 @@ Frustum::Frustum(const mat4f& pv) {
     Frustum::setProjection(pv);
 }
 
-// NOTE: if we don't specify noinline here, LLVM inlines this huge function into
-// two (?!) version of the Frustum(const mat4f& pv) constructor!
-
 UTILS_NOINLINE
 void Frustum::setProjection(const mat4f& pv) {
-    // see: "Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix"
-    // by Gil Gribb & Klaus Hartmann
-    //
-    // Another way to think about this is that we're transforming each plane in clip-space to
-    // view-space. Such transform is performed as:
-    //      transpose(inverse(viewFromClipMatrix)), i.e.: transpose(projection)
-
     const mat4f m(transpose(pv));
 
-    // Note: these "normals" are not normalized -- it's not necessary for the culling tests.
-    float4 l = -m[3] - m[0];    // m * { -1,  0,  0, -1 }
-    float4 r = -m[3] + m[0];    // m * {  1,  0,  0, -1 }
-    float4 b = -m[3] - m[1];    // m * {  0, -1,  0, -1 }
-    float4 t = -m[3] + m[1];    // m * {  0,  1,  0, -1 }
-    float4 n = -m[3] - m[2];    // m * {  0,  0, -1, -1 }
-    float4 f = -m[3] + m[2];    // m * {  0,  0,  1, -1 }
+    // Calculate the unnormalized plane vectors
+    float4 planes[6];
+    planes[0] = -m[3] - m[0];
+    planes[1] = -m[3] + m[0];
+    planes[2] = -m[3] - m[1];
+    planes[3] = -m[3] + m[1];
+    planes[4] = -m[3] - m[2];
+    planes[5] = -m[3] + m[2];
 
-    // NOTE: for our box/frustum intersection routine normalizing these vectors is not required
-    // however, they must be normalized for the sphere/frustum tests.
-    l *= 1 / length(l.xyz);
-    r *= 1 / length(r.xyz);
-    b *= 1 / length(b.xyz);
-    t *= 1 / length(t.xyz);
-    n *= 1 / length(n.xyz);
-    f *= 1 / length(f.xyz);
+    // Normalize the plane vectors
+    for (int i = 0; i < 6; ++i) {
+        float invLength = 1 / length(planes[i].xyz);
+        planes[i] *= invLength;
+    }
 
-    mPlanes[0] = l;
-    mPlanes[1] = r;
-    mPlanes[2] = b;
-    mPlanes[3] = t;
-    mPlanes[4] = f;
-    mPlanes[5] = n;
+    // Copy the normalized plane vectors to the class member array
+    std::copy(std::begin(planes), std::end(planes), std::begin(mPlanes));
 }
 
 float4 Frustum::getNormalizedPlane(Frustum::Plane plane) const noexcept {
@@ -73,12 +57,8 @@ float4 Frustum::getNormalizedPlane(Frustum::Plane plane) const noexcept {
 }
 
 void Frustum::getNormalizedPlanes(float4 planes[6]) const noexcept {
-    planes[0] = mPlanes[0];
-    planes[1] = mPlanes[1];
-    planes[2] = mPlanes[2];
-    planes[3] = mPlanes[3];
-    planes[4] = mPlanes[4];
-    planes[5] = mPlanes[5];
+    // Copy the normalized plane vectors to the output array
+    std::copy(std::begin(mPlanes), std::end(mPlanes), std::begin(planes));
 }
 
 bool Frustum::intersects(const Box& box) const noexcept {
@@ -90,18 +70,13 @@ bool Frustum::intersects(const float4& sphere) const noexcept {
 }
 
 float Frustum::contains(float3 p) const noexcept {
-    float const l = dot(mPlanes[0].xyz, p) + mPlanes[0].w;
-    float const b = dot(mPlanes[1].xyz, p) + mPlanes[1].w;
-    float const r = dot(mPlanes[2].xyz, p) + mPlanes[2].w;
-    float const t = dot(mPlanes[3].xyz, p) + mPlanes[3].w;
-    float const f = dot(mPlanes[4].xyz, p) + mPlanes[4].w;
-    float const n = dot(mPlanes[5].xyz, p) + mPlanes[5].w;
-    float d = l;
-    d = std::max(d, b);
-    d = std::max(d, r);
-    d = std::max(d, t);
-    d = std::max(d, f);
-    d = std::max(d, n);
+    float d = dot(mPlanes[0], p);
+
+    // Loop through the remaining planes and find the maximum distance
+    for (int i = 1; i < 6; ++i) {
+        d = std::max(d, dot(mPlanes[i], p));
+    }
+
     return d;
 }
 
@@ -112,12 +87,15 @@ float Frustum::contains(float3 p) const noexcept {
 utils::io::ostream& operator<<(utils::io::ostream& out, filament::Frustum const& frustum) {
     float4 planes[6];
     frustum.getNormalizedPlanes(planes);
-    out     << planes[0] << '\n'
-            << planes[1] << '\n'
-            << planes[2] << '\n'
-            << planes[3] << '\n'
-            << planes[4] << '\n'
-            << planes[5] << utils::io::endl;
+
+    // Output the normalized plane vectors
+    out << planes[0] << '\n'
+        << planes[1] << '\n'
+        << planes[2] << '\n'
+        << planes[3] << '\n'
+        << planes[4] << '\n'
+        << planes[5] << utils::io::endl;
+
     return out;
 }
 


### PR DESCRIPTION
Normalize the plane vectors outside the loop: Instead of normalizing each plane vector individually, you can normalize them all at once after the loop that calculates them. This reduces redundant calculations and improves performance.

Use a loop for copying planes: Instead of manually copying each plane to the output array, you can use a loop to copy them. This simplifies the code and makes it more concise.

Use dot product function: Instead of explicitly calculating the dot product using dot(mPlanes[i].xyz, p), you can use the dot function from the Filament math library. 
This enhances readability and reduces code duplication.

