### PR TITLE
Updated the gradle flag `filament-skip-samples` in the code snippet to align with the documentation.

### DIFF
--- a/android/Windows.md
+++ b/android/Windows.md
@@ -135,7 +135,7 @@ gradlew -Pcom.google.android.filament.dist-dir=..\out\android-release\filament a
 If you're only interested in building SDK, you may skip samples build by passing a `com.google.android.filament.skip-samples` flag:
 
 ```
-gradlew -Pcom.google.android.filament.dist-dir=..\out\android-release\filament assembleRelease -Pfilament_skip_samples
+gradlew -Pcom.google.android.filament.dist-dir=..\out\android-release\filament assembleRelease -Pcom.google.android.filament.skip-samples
 ```
 
 


### PR DESCRIPTION
This pull request updates the Android build process documentation by replacing the deprecated Gradle flag `filament-skip-samples` in the code snippet with the new flag `com.google.android.filament.skip-samples`.