### PR TITLE
Support EXT_clip_cull_distance for future use

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -453,11 +453,7 @@ void OpenGLContext::setDefaultState() noexcept {
     }
 
     if (ext.EXT_clip_cull_distance) {
-#if defined(BACKEND_OPENGL_VERSION_GL)
         glEnable(GL_CLIP_DISTANCE0);
-#elif defined(GL_CLIP_DISTANCE0_EXT)
-        glEnable(GL_CLIP_DISTANCE0_EXT);
-#endif
     }
 }
 

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -451,6 +451,14 @@ void OpenGLContext::setDefaultState() noexcept {
         glClipControlEXT(GL_LOWER_LEFT_EXT, GL_ZERO_TO_ONE_EXT);
 #endif
     }
+
+    if (ext.EXT_clip_cull_distance) {
+#if defined(BACKEND_OPENGL_VERSION_GL)
+        glEnable(GL_CLIP_DISTANCE0);
+#elif defined(GL_CLIP_DISTANCE0_EXT)
+        glEnable(GL_CLIP_DISTANCE0_EXT);
+#endif
+    }
 }
 
 #ifdef BACKEND_OPENGL_VERSION_GLES
@@ -469,6 +477,7 @@ void OpenGLContext::initExtensionsGLES() noexcept {
     using namespace std::literals;
     ext.APPLE_color_buffer_packed_float = exts.has("GL_APPLE_color_buffer_packed_float"sv);
     ext.EXT_clip_control = exts.has("GL_EXT_clip_control"sv);
+    ext.EXT_clip_cull_distance = exts.has("GL_EXT_clip_cull_distance"sv);
     ext.EXT_color_buffer_float = exts.has("GL_EXT_color_buffer_float"sv);
     ext.EXT_color_buffer_half_float = exts.has("GL_EXT_color_buffer_half_float"sv);
     ext.EXT_debug_marker = exts.has("GL_EXT_debug_marker"sv);
@@ -537,6 +546,7 @@ void OpenGLContext::initExtensionsGL() noexcept {
     ext.ARB_shading_language_packing = exts.has("GL_ARB_shading_language_packing"sv);
     ext.EXT_color_buffer_float = true;  // Assumes core profile.
     ext.EXT_color_buffer_half_float = true;  // Assumes core profile.
+    ext.EXT_clip_cull_distance = true;
     ext.EXT_debug_marker = exts.has("GL_EXT_debug_marker"sv);
     ext.EXT_discard_framebuffer = false;
     ext.EXT_disjoint_timer_query = true;

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -194,6 +194,7 @@ public:
         bool APPLE_color_buffer_packed_float;
         bool ARB_shading_language_packing;
         bool EXT_clip_control;
+        bool EXT_clip_cull_distance;
         bool EXT_color_buffer_float;
         bool EXT_color_buffer_half_float;
         bool EXT_debug_marker;

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -188,6 +188,12 @@ using namespace glext;
 #   define GL_TEXTURE_CUBE_MAP_ARRAY                0x9009
 #endif
 
+#if defined(GL_EXT_clip_cull_distance)
+#   define GL_CLIP_DISTANCE0                        GL_CLIP_DISTANCE0_EXT
+#else
+#   define GL_CLIP_DISTANCE0                        0x3000
+#endif
+
 #if defined(GL_KHR_debug)
 #   define GL_DEBUG_OUTPUT                          GL_DEBUG_OUTPUT_KHR
 #   define GL_DEBUG_OUTPUT_SYNCHRONOUS              GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR

--- a/libs/filamat/CMakeLists.txt
+++ b/libs/filamat/CMakeLists.txt
@@ -59,6 +59,7 @@ set(PRIVATE_HDRS
         src/GLSLPostProcessor.h
         src/MetalArgumentBuffer.h
         src/ShaderMinifier.h
+        src/SpirvFixup.h
         src/sca/ASTHelpers.h
         src/sca/GLSLTools.h
         src/sca/builtinResource.h)
@@ -72,7 +73,8 @@ set(SRCS
         src/sca/ASTHelpers.cpp
         src/sca/GLSLTools.cpp
         src/GLSLPostProcessor.cpp
-        src/ShaderMinifier.cpp)
+        src/ShaderMinifier.cpp
+        src/SpirvFixup.cpp)
 
 # Sources and headers for filamat lite
 
@@ -170,6 +172,7 @@ set(TARGET test_filamat)
 set(SRCS
         tests/test_filamat.cpp
         tests/test_argBufferFixup.cpp
+        tests/test_clipDistanceFixup.cpp
         tests/test_includes.cpp)
 
 add_executable(${TARGET} ${SRCS})

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -616,9 +616,11 @@ void GLSLPostProcessor::fixupClipDistance(
     if (!config.usesClipDistance) {
         return;
     }
+    // This should match the version of SPIR-V used in GLSLTools::prepareShaderParser.
     SpirvTools tools(SPV_ENV_UNIVERSAL_1_3);
     std::string disassembly;
-    tools.Disassemble(spirv, &disassembly);
+    const bool result = tools.Disassemble(spirv, &disassembly);
+    assert_invariant(result);
     if (filamat::fixupClipDistance(disassembly)) {
         spirv.clear();
         tools.Assemble(disassembly, &spirv);

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -335,7 +335,7 @@ bool GLSLPostProcessor::process(const std::string& inputShader, Config const& co
 
     // This allows shaders to query if they will be run through glslang.
     // OpenGL shaders without optimization, for example, won't have this define.
-    tShader.setPreamble("#define FILAMENT_GLSLANG 1\n");
+    tShader.setPreamble("#define FILAMENT_GLSLANG\n");
 
     internalConfig.langVersion = GLSLTools::getGlslDefaultVersion(config.shaderModel);
     GLSLTools::prepareShaderParser(config.targetApi, config.targetLanguage, tShader,

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -18,6 +18,7 @@
 
 #include <GlslangToSpv.h>
 #include <SPVRemapper.h>
+#include <spirv-tools/libspirv.hpp>
 
 #include <spirv_glsl.hpp>
 #include <spirv_msl.hpp>
@@ -30,6 +31,7 @@
 #include "shaders/SibGenerator.h"
 
 #include "MetalArgumentBuffer.h"
+#include "SpirvFixup.h"
 
 #include <filament/MaterialEnums.h>
 
@@ -331,6 +333,10 @@ bool GLSLPostProcessor::process(const std::string& inputShader, Config const& co
     const char* shaderCString = inputShader.c_str();
     tShader.setStrings(&shaderCString, 1);
 
+    // This allows shaders to query if they will be run through glslang.
+    // OpenGL shaders without optimization, for example, won't have this define.
+    tShader.setPreamble("#define FILAMENT_GLSLANG 1\n");
+
     internalConfig.langVersion = GLSLTools::getGlslDefaultVersion(config.shaderModel);
     GLSLTools::prepareShaderParser(config.targetApi, config.targetLanguage, tShader,
             internalConfig.shLang, internalConfig.langVersion);
@@ -372,6 +378,7 @@ bool GLSLPostProcessor::process(const std::string& inputShader, Config const& co
                 options.generateDebugInfo = mGenerateDebugInfo;
                 GlslangToSpv(*program.getIntermediate(internalConfig.shLang),
                         *internalConfig.spirvOutput, &options);
+                fixupClipDistance(*internalConfig.spirvOutput, config);
                 if (internalConfig.mslOutput) {
                     auto sibs = SibVector::with_capacity(CONFIG_SAMPLER_BINDING_COUNT);
                     msl::collectSibs(config, sibs);
@@ -454,6 +461,7 @@ void GLSLPostProcessor::preprocessOptimization(glslang::TShader& tShader,
             options.generateDebugInfo = mGenerateDebugInfo;
             GlslangToSpv(*program.getIntermediate(internalConfig.shLang),
                     *internalConfig.spirvOutput, &options);
+            fixupClipDistance(*internalConfig.spirvOutput, config);
         }
     }
 
@@ -502,6 +510,8 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
         }
     }
 
+    fixupClipDistance(spirv, config);
+
     if (internalConfig.spirvOutput) {
         *internalConfig.spirvOutput = spirv;
     }
@@ -547,6 +557,17 @@ void GLSLPostProcessor::fullOptimization(const TShader& tShader,
         }
 
         *internalConfig.glslOutput = glslCompiler.compile();
+
+        // spirv-cross automatically redeclares gl_ClipDistance if it's used. Some drivers don't
+        // like this, so we simply remove it.
+        // According to EXT_clip_cull_distance, gl_ClipDistance can be
+        // "implicitly sized by indexing it only with integral constant expressions".
+        std::string& str = *internalConfig.glslOutput;
+        const std::string clipDistanceDefinition = "out float gl_ClipDistance[1];";
+        size_t found = str.find(clipDistanceDefinition);
+        if (found != std::string::npos) {
+            str.replace(found, clipDistanceDefinition.length(), "");
+        }
     }
 }
 
@@ -588,6 +609,21 @@ void GLSLPostProcessor::optimizeSpirv(OptimizerPtr optimizer, SpirvBlob& spirv) 
     // Remove dead module-level objects: functions, types, vars
     spv::spirvbin_t remapper(0);
     remapper.remap(spirv, spv::spirvbin_base_t::DCE_ALL);
+}
+
+void GLSLPostProcessor::fixupClipDistance(
+        SpirvBlob& spirv, GLSLPostProcessor::Config const& config) const {
+    if (!config.usesClipDistance) {
+        return;
+    }
+    SpirvTools tools(SPV_ENV_UNIVERSAL_1_3);
+    std::string disassembly;
+    tools.Disassemble(spirv, &disassembly);
+    if (filamat::fixupClipDistance(disassembly)) {
+        spirv.clear();
+        tools.Assemble(disassembly, &spirv);
+        assert_invariant(tools.Validate(spirv));
+    }
 }
 
 void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config const& config) {

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -66,6 +66,7 @@ public:
         filament::MaterialDomain domain;
         const filamat::MaterialInfo* materialInfo;
         bool hasFramebufferFetch;
+        bool usesClipDistance;
         struct {
             std::vector<std::pair<uint32_t, uint32_t>> subpassInputToColorLocation;
         } glsl;
@@ -110,6 +111,8 @@ private:
     static void registerPerformancePasses(spvtools::Optimizer& optimizer, Config const& config);
 
     void optimizeSpirv(OptimizerPtr optimizer, SpirvBlob& spirv) const;
+
+    void fixupClipDistance(SpirvBlob& spirv, GLSLPostProcessor::Config const& config) const;
 
     const MaterialBuilder::Optimization mOptimization;
     const bool mPrintShaders;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -870,6 +870,7 @@ bool MaterialBuilder::generateShaders(JobSystem& jobSystem, const std::vector<Va
                         .domain = mMaterialDomain,
                         .materialInfo = &info,
                         .hasFramebufferFetch = mEnableFramebufferFetch,
+                        .usesClipDistance = false,
                         .glsl = {},
                 };
 

--- a/libs/filamat/src/SpirvFixup.cpp
+++ b/libs/filamat/src/SpirvFixup.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SpirvFixup.h"
+
+namespace filamat {
+
+bool fixupClipDistance(std::string& spirvDisassembly) {
+    size_t p = spirvDisassembly.find("OpDecorate %filament_gl_ClipDistance Location");
+    if (p == std::string::npos) {
+        return false;
+    }
+    size_t lineEnd = spirvDisassembly.find('\n', p);
+    if (lineEnd == std::string::npos) {
+        lineEnd = spirvDisassembly.size();
+    }
+    spirvDisassembly.replace(p, lineEnd - p,
+            "OpDecorate %filament_gl_ClipDistance BuiltIn ClipDistance");
+    return true;
+}
+
+} // namespace filamat

--- a/libs/filamat/src/SpirvFixup.h
+++ b/libs/filamat/src/SpirvFixup.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TNT_SPIRVFIXUP_H
+#define TNT_SPIRVFIXUP_H
+
+#include <string>
+
+namespace filamat {
+
+/**
+ * Performs a "fixup" operation on SPIR-V disassembly text, decorating the filament_gl_ClipDistance
+ * output as the canonical gl_ClipDistance built-in.
+ *
+ * glslang does not support the EXT_clip_cull_distance extension. Writing directly to
+ * gl_ClipDistance results in an error.
+ *
+ * To get around this, an ES shader should write instead to filament_gl_ClipDistance. After
+ * compiling to SPIR-V, this function will modify the SPIR_V disassembly and decorate
+ * filament_gl_ClipDistance as if it were gl_ClipDistance.
+ *
+ * For example, the source GLSL:
+ * ~~~~~~~~~~
+ * #version 310 es
+ *
+ * // The location is required but does not matter and will be replaced.
+ * layout(location = 100) out float filament_gl_ClipDistance[1];
+ *
+ * void main() {
+ *     filament_gl_ClipDistance[0] = 0.0f;
+ * }
+ * ~~~~~~~~~~
+ *
+ * This should only be used in SPIR-V generated for an ES environment.
+ *
+ * @param spirvDisassembly a reference to the SPIR-V disassembly, will be modified
+ * @return true if the replacement was successful, false otherwise
+ */
+bool fixupClipDistance(std::string& spirvDisassembly);
+
+}
+
+#endif  // TNT_SPIRVFIXUP_H

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -40,7 +40,7 @@ io::sstream& CodeGenerator::generateSeparator(io::sstream& out) {
 }
 
 utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, ShaderStage stage,
-        MaterialInfo const& material) const {
+        MaterialInfo const& material, filament::Variant v) const {
     switch (mShaderModel) {
         case ShaderModel::MOBILE:
             // Vulkan requires version 310 or higher
@@ -58,6 +58,15 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
             }
             if (material.hasExternalSamplers) {
                 out << "#extension GL_OES_EGL_image_external_essl3 : require\n\n";
+            }
+            if (false /* variant needs gl_ClipDistance */) {
+                // If we're not processing the shader through glslang (in the case of unoptimized
+                // OpenGL shaders), then we need to add the #extension string ourselves.
+                // If we ARE running the shader through glslang, then we must not include it,
+                // otherwise glslang will complain.
+                out << "#ifndef FILAMENT_GLSLANG\n";
+                out << "#extension GL_EXT_clip_cull_distance : require\n";
+                out << "#endif\n\n";
             }
             break;
         case ShaderModel::DESKTOP:

--- a/libs/filamat/src/shaders/CodeGenerator.h
+++ b/libs/filamat/src/shaders/CodeGenerator.h
@@ -73,7 +73,7 @@ public:
 
     // generate prolog for the given shader
     utils::io::sstream& generateProlog(utils::io::sstream& out, ShaderStage stage,
-            MaterialInfo const& material) const;
+            MaterialInfo const& material, filament::Variant v) const;
 
     static utils::io::sstream& generateEpilog(utils::io::sstream& out);
 

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -367,7 +367,7 @@ std::string ShaderGenerator::createVertexProgram(ShaderModel shaderModel,
 
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, material.featureLevel);
 
-    cg.generateProlog(vs, ShaderStage::VERTEX, material);
+    cg.generateProlog(vs, ShaderStage::VERTEX, material, variant);
 
     generateUserSpecConstants(cg, vs, mConstants);
 
@@ -487,7 +487,7 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, material.featureLevel);
 
     io::sstream fs;
-    cg.generateProlog(fs, ShaderStage::FRAGMENT, material);
+    cg.generateProlog(fs, ShaderStage::FRAGMENT, material, variant);
 
     generateUserSpecConstants(cg, fs, mConstants);
 
@@ -606,7 +606,7 @@ std::string ShaderGenerator::createComputeProgram(filament::backend::ShaderModel
     const CodeGenerator cg(shaderModel, targetApi, targetLanguage, material.featureLevel);
     io::sstream s;
 
-    cg.generateProlog(s, ShaderStage::COMPUTE, material);
+    cg.generateProlog(s, ShaderStage::COMPUTE, material, {});
 
     generateUserSpecConstants(cg, s, mConstants);
 
@@ -644,7 +644,7 @@ std::string ShaderGenerator::createPostProcessVertexProgram(ShaderModel sm,
         MaterialInfo const& material, const filament::Variant::type_t variantKey) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage, material.featureLevel);
     io::sstream vs;
-    cg.generateProlog(vs, ShaderStage::VERTEX, material);
+    cg.generateProlog(vs, ShaderStage::VERTEX, material, {});
 
     generateUserSpecConstants(cg, vs, mConstants);
 
@@ -685,7 +685,7 @@ std::string ShaderGenerator::createPostProcessFragmentProgram(ShaderModel sm,
         MaterialInfo const& material, uint8_t variant) const noexcept {
     const CodeGenerator cg(sm, targetApi, targetLanguage, material.featureLevel);
     io::sstream fs;
-    cg.generateProlog(fs, ShaderStage::FRAGMENT, material);
+    cg.generateProlog(fs, ShaderStage::FRAGMENT, material, {});
 
     generateUserSpecConstants(cg, fs, mConstants);
 

--- a/libs/filamat/tests/test_clipDistanceFixup.cpp
+++ b/libs/filamat/tests/test_clipDistanceFixup.cpp
@@ -1,0 +1,58 @@
+/*
+* Copyright (C) 2023 The Android Open Source Project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "SpirvFixup.h"
+
+TEST(ClipDistanceFixup, NoReplacement) {
+    std::string disassembly =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       %void = OpTypeVoid\n"
+            "       %3 = OpTypeFunction %void\n";
+    std::string expected =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       %void = OpTypeVoid\n"
+            "       %3 = OpTypeFunction %void\n";
+    EXPECT_EQ(filamat::fixupClipDistance(disassembly), false);
+    EXPECT_EQ(disassembly, expected);
+}
+
+TEST(ClipDistanceFixup, BasicReplacement) {
+    std::string disassembly =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       OpDecorate %filament_gl_ClipDistance Location 100\n"
+            "       %void = OpTypeVoid\n"
+            "       %3 = OpTypeFunction %void\n";
+    std::string expected =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       OpDecorate %filament_gl_ClipDistance BuiltIn ClipDistance\n"
+            "       %void = OpTypeVoid\n"
+            "       %3 = OpTypeFunction %void\n";
+    EXPECT_EQ(filamat::fixupClipDistance(disassembly), true);
+    EXPECT_EQ(disassembly, expected);
+}
+
+TEST(ClipDistanceFixup, NoNewline) {
+    std::string disassembly =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       OpDecorate %filament_gl_ClipDistance Location 100";
+    std::string expected =
+            "       OpDecorate %gl_PerVertex Block\n"
+            "       OpDecorate %filament_gl_ClipDistance BuiltIn ClipDistance";
+    EXPECT_EQ(filamat::fixupClipDistance(disassembly), true);
+    EXPECT_EQ(disassembly, expected);
+}

--- a/shaders/src/varyings.glsl
+++ b/shaders/src/varyings.glsl
@@ -32,3 +32,17 @@ LAYOUT_LOCATION(11) VARYING highp vec4 vertex_lightSpacePosition;
 #endif
 
 // Note that fragColor is an output and is not declared here; see main.fs and depth_main.fs
+
+#if 0 // only enable for variants that need gl_ClipDistance
+#if GL_ES && defined(FILAMENT_GLSLANG)
+// On ES, gl_ClipDistance is not a built-in, so we have to rely on EXT_clip_cull_distance
+// However, this extension is not supported by glslang, so we instead write to
+// filament_gl_ClipDistance, which will get decorated at the SPIR-V stage to refer to the built-in.
+// The location here does not matter, so long as it doesn't conflict with others.
+LAYOUT_LOCATION(100) out float filament_gl_ClipDistance[1];
+#define FILAMENT_CLIPDISTANCE filament_gl_ClipDistance
+#else
+// If we're on Desktop GL (or not running shaders through glslang), we're free to use gl_ClipDistance
+#define FILAMENT_CLIPDISTANCE gl_ClipDistance
+#endif // GL_ES
+#endif

--- a/shaders/src/varyings.glsl
+++ b/shaders/src/varyings.glsl
@@ -34,7 +34,7 @@ LAYOUT_LOCATION(11) VARYING highp vec4 vertex_lightSpacePosition;
 // Note that fragColor is an output and is not declared here; see main.fs and depth_main.fs
 
 #if 0 // only enable for variants that need gl_ClipDistance
-#if GL_ES && defined(FILAMENT_GLSLANG)
+#if defined(GL_ES) && defined(FILAMENT_GLSLANG)
 // On ES, gl_ClipDistance is not a built-in, so we have to rely on EXT_clip_cull_distance
 // However, this extension is not supported by glslang, so we instead write to
 // filament_gl_ClipDistance, which will get decorated at the SPIR-V stage to refer to the built-in.


### PR DESCRIPTION
This PR sets up the ability for shaders to use `gl_ClipDistance`, which will be needed in the future. Desktop GL supports this natively. OpenGL ES requires the EXT_clip_cull_distance extension.

Unfortunately glslang does not support this extension, so we have to employ a workaround for mobile when going through glslang. We instead write to `filament_gl_ClipDistance`, and then modify the SPIR-V to decorate this as `gl_ClipDistance`. See the comment in SpirvFixup.h.

Note this PR does not actually use `gl_ClipDistance` yet, so there should be no change to shaders.