### PR TITLE
fix a crash when using Material::compile with a callback

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -10,3 +10,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 - matc: fix buggy `variant-filter` flag
 - web: Added missing setMat3Parameter()/setMat4Parameter() to MaterialInstance
+- engine: fix a crash with `Material::compile()` when a callback is specified

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -389,6 +389,7 @@ DECL_DRIVER_API_N(endTimerQuery,
         backend::TimerQueryHandle, query)
 
 DECL_DRIVER_API_N(compilePrograms,
+        backend::CompilerPriorityQueue, priority,
         backend::CallbackHandler*, handler,
         backend::CallbackHandler::Callback, callback,
         void*, user)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -975,8 +975,8 @@ void MetalDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh, BufferDescripto
     scheduleDestroy(std::move(data));
 }
 
-void MetalDriver::compilePrograms(CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user) {
+void MetalDriver::compilePrograms(CompilerPriorityQueue priority,
+        CallbackHandler* handler, CallbackHandler::Callback callback, void* user) {
     if (callback) {
         scheduleCallback(handler, user, callback);
     }

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -260,8 +260,8 @@ void NoopDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
     scheduleDestroy(std::move(data));
 }
 
-void NoopDriver::compilePrograms(CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user) {
+void NoopDriver::compilePrograms(CompilerPriorityQueue priority,
+        CallbackHandler* handler, CallbackHandler::Callback callback, void* user) {
     if (callback) {
         scheduleCallback(handler, user, callback);
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2607,10 +2607,10 @@ SyncStatus OpenGLDriver::getSyncStatus(Handle<HwSync> sh) {
     }
 }
 
-void OpenGLDriver::compilePrograms(CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user) {
+void OpenGLDriver::compilePrograms(CompilerPriorityQueue priority,
+        CallbackHandler* handler, CallbackHandler::Callback callback, void* user) {
     if (callback) {
-        getShaderCompilerService().notifyWhenAllProgramsAreReady(handler, callback, user);
+        getShaderCompilerService().notifyWhenAllProgramsAreReady(priority, handler, callback, user);
     }
 }
 

--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -87,8 +87,8 @@ public:
     static void* getUserData(const program_token_t& token) noexcept;
 
     // call the callback when all active programs are ready
-    void notifyWhenAllProgramsAreReady(CallbackHandler* handler,
-            CallbackHandler::Callback callback, void* user);
+    void notifyWhenAllProgramsAreReady(CompilerPriorityQueue priority,
+            CallbackHandler* handler, CallbackHandler::Callback callback, void* user);
 
 private:
     class CompilerThreadPool {
@@ -143,11 +143,13 @@ private:
 
     static bool checkProgramStatus(program_token_t const& token) noexcept;
 
-    void runAtNextTick(const program_token_t& token, std::function<bool()> fn) noexcept;
+    void runAtNextTick(CompilerPriorityQueue priority,
+            const program_token_t& token, std::function<bool()> fn) noexcept;
     void executeTickOps() noexcept;
     void cancelTickOp(program_token_t token) noexcept;
     // order of insertion is important
-    std::vector<std::pair<program_token_t, std::function<bool()>>> mRunAtNextTickOps;
+    using ContainerType = std::tuple<CompilerPriorityQueue, program_token_t, std::function<bool()>>;
+    std::vector<ContainerType> mRunAtNextTickOps;
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -974,8 +974,8 @@ void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
     scheduleDestroy(std::move(data));
 }
 
-void VulkanDriver::compilePrograms(CallbackHandler* handler,
-        CallbackHandler::Callback callback, void* user) {
+void VulkanDriver::compilePrograms(CompilerPriorityQueue priority,
+        CallbackHandler* handler, CallbackHandler::Callback callback, void* user) {
     if (callback) {
         scheduleCallback(handler, user, callback);
     }

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -496,9 +496,9 @@ void FMaterial::compile(CompilerPriorityQueue priority,
             }
         };
         auto* const user = new(std::nothrow) Callback{ std::move(callback), this };
-        mEngine.getDriverApi().compilePrograms(handler, &Callback::func, static_cast<void*>(user));
+        mEngine.getDriverApi().compilePrograms(priority, handler, &Callback::func, static_cast<void*>(user));
     } else {
-        mEngine.getDriverApi().compilePrograms(nullptr, nullptr, nullptr);
+        mEngine.getDriverApi().compilePrograms(priority, nullptr, nullptr, nullptr);
     }
 }
 


### PR DESCRIPTION
The work queue is sorted by priority but when we insert a notification job we didn't have a priority to use for insertion, in addition the priority was taken from the token, but for the notification job we don't have a token.

The fix consists in passing the priority around so we have it when needed.