### PR TITLE
gltfio: fix crash when compute morph target without material

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,5 +8,6 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 
+- gltfio: fix crash when compute morph target without material
 - matc: fix buggy `variant-filter` flag
 - web: Added missing setMat3Parameter()/setMat4Parameter() to MaterialInstance

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -854,7 +854,7 @@ void ResourceLoader::Impl::computeTangents(FFilamentAsset* asset) {
                     break;
                 }
                 // Generate flat normals if necessary.
-                if (!hasNormals && !prim.material->unlit) {
+                if (!hasNormals && prim.material && !prim.material->unlit) {
                     jobParams.emplace_back(Params { { &prim, (int) tindex },
                                                     { nullptr, tb, (uint8_t) pindex } });
                 }


### PR DESCRIPTION
see a example gltf from [gltf-Tutorial](https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_017_SimpleMorphTarget.md)