### PR TITLE
workaround a crash with some adreno drivers

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -12,3 +12,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - opengl: fix b/290388359 : possible crash when shutting down the engine
 - engine: Improve precision of frame time measurement when using emulated TimerQueries
 - backend: Improve frame pacing on Android and Vulkan.
+- backend: workaround b/291140208 (gltf_viewer crashes on Nexus 6P)


### PR DESCRIPTION
The crashes are triggered by spirv-opt's MergeReturnPass, so we  just disable it. This pass also caused issues with AMD drivers on macOS.


fixes b/291140208