### PR TITLE
Workaround for some PowerVR devices

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 - backend: fix #6997 : picking can fail on Adreno [⚠️ **New Material Version**]
+- backend: A partial workaround for PowerVR devices (#5118, b/190221124) [⚠️ **Recompile Materials**]


### PR DESCRIPTION
The PowerVR compiler systematically crashes on some devices when `gl_Position` is written twice in the vertex shader.

fixes #5118, b/190221124