### PR TITLE
`RenderTarget` needs not to have a color attachment

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/RenderTarget.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/RenderTarget.java
@@ -81,8 +81,6 @@ public class RenderTarget {
         /**
          * Sets a texture to a given attachment point.
          *
-         * <p>All RenderTargets must have a non-null <code>COLOR</code> attachment.</p>
-         *
          * @param attachment The attachment point of the texture.
          * @param texture The associated texture object.
          * @return A reference to this Builder for chaining calls.

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -91,8 +91,6 @@ public:
         /**
          * Sets a texture to a given attachment point.
          *
-         * All RenderTargets must have a non-null COLOR attachment.
-         *
          * When using a DEPTH attachment, it is important to always disable post-processing
          * in the View. Failing to do so will cause the DEPTH attachment to be ignored in most
          * cases.

--- a/filament/src/details/RenderTarget.cpp
+++ b/filament/src/details/RenderTarget.cpp
@@ -68,10 +68,11 @@ RenderTarget* RenderTarget::Builder::build(Engine& engine) {
     using backend::TextureUsage;
     const FRenderTarget::Attachment& color = mImpl->mAttachments[(size_t)AttachmentPoint::COLOR0];
     const FRenderTarget::Attachment& depth = mImpl->mAttachments[(size_t)AttachmentPoint::DEPTH];
-    ASSERT_PRECONDITION(color.texture, "COLOR0 attachment not set");
 
-    ASSERT_PRECONDITION(color.texture->getUsage() & TextureUsage::COLOR_ATTACHMENT,
-            "Texture usage must contain COLOR_ATTACHMENT");
+    if (color.texture) {
+        ASSERT_PRECONDITION(color.texture->getUsage() & TextureUsage::COLOR_ATTACHMENT,
+                "Texture usage must contain COLOR_ATTACHMENT");
+    }
 
     if (depth.texture) {
         ASSERT_PRECONDITION(depth.texture->getUsage() & TextureUsage::DEPTH_ATTACHMENT,
@@ -135,7 +136,7 @@ FRenderTarget::FRenderTarget(FEngine& engine, const RenderTarget::Builder& build
     for (size_t i = 0; i < MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT; i++) {
         Attachment const& attachment = mAttachments[i];
         if (attachment.texture) {
-            TargetBufferFlags targetBufferBit = getTargetBufferFlagsAt(i);
+            TargetBufferFlags const targetBufferBit = getTargetBufferFlagsAt(i);
             mAttachmentMask |= targetBufferBit;
             setAttachment(mrt[i], (AttachmentPoint)i);
             if (any(attachment.texture->getUsage() &


### PR DESCRIPTION
This was a somewhat arbitrary requirement, some RenderTarget could be depth only for instance.