### PR TITLE
better handle "urgent" shader compilation

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -100,7 +100,7 @@ private:
         void init(bool useSharedContexts, uint32_t threadCount, OpenGLPlatform& platform) noexcept;
         void terminate() noexcept;
         void queue(CompilerPriorityQueue priorityQueue, program_token_t const& token, Job&& job);
-        void makeUrgent(program_token_t const& token);
+        Job dequeue(program_token_t const& token);
 
     private:
         using Queue = std::deque<std::pair<program_token_t, Job>>;
@@ -109,8 +109,7 @@ private:
         std::mutex mQueueLock;
         std::condition_variable mQueueCondition;
         std::array<Queue, 2> mQueues;
-        Job mUrgentJob; // needs mQueueLock as well
-        Job dequeue(program_token_t const& token); // lock must be held
+        // lock must be held for methods below
         std::pair<Queue&, Queue::iterator> find(program_token_t const& token);
     };
 


### PR DESCRIPTION
instead of moving the "urgent" compilation to the head of the queue, we simply remove it from the queue and process it immediately. This has the benefit that on drivers that truly support parallel compilation, the latency will be reduced as we don't need to wait for the current compile to finish.