### PR TITLE
a few optimizations for powervr

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -1143,6 +1143,9 @@ enum class Workaround : uint16_t {
     DISABLE_BLIT_INTO_TEXTURE_ARRAY,
     // Multiple workarounds needed for PowerVR GPUs
     POWER_VR_SHADER_WORKAROUNDS,
+    // The driver has some threads pinned, and we can't easily know on which core, it can hurt
+    // performance more if we end-up pinned on the same one.
+    DISABLE_THREAD_AFFINITY
 };
 
 } // namespace filament::backend

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -294,6 +294,8 @@ OpenGLContext::OpenGLContext() noexcept {
             bugs.delay_fbo_destruction = true;
             // PowerVR seems to have no problem with this (which is good for us)
             bugs.allow_read_only_ancillary_feedback_loop = true;
+            // PowerVR has a shader compiler thread pinned on the last core
+            bugs.disable_thread_affinity = true;
         } else if (strstr(state.renderer, "Apple")) {
             // Apple GPU
         } else if (strstr(state.renderer, "Tegra") ||

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -271,6 +271,10 @@ public:
         // a glFinish. So we must delay the destruction until we know the GPU is finished.
         bool delay_fbo_destruction;
 
+        // The driver has some threads pinned, and we can't easily know on which core, it can hurt
+        // performance more if we end-up pinned on the same one.
+        bool disable_thread_affinity;
+
     } bugs = {};
 
     // state getters -- as needed.
@@ -459,6 +463,9 @@ private:
                     ""},
             {   bugs.delay_fbo_destruction,
                     "delay_fbo_destruction",
+                    ""},
+            {   bugs.disable_thread_affinity,
+                    "disable_thread_affinity",
                     ""},
     }};
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1933,6 +1933,8 @@ bool OpenGLDriver::isWorkaroundNeeded(Workaround workaround) {
             return mContext.bugs.disable_blit_into_texture_array;
         case Workaround::POWER_VR_SHADER_WORKAROUNDS:
             return mContext.bugs.powervr_shader_workarounds;
+        case Workaround::DISABLE_THREAD_AFFINITY:
+            return mContext.bugs.disable_thread_affinity;
         default:
             return false;
     }

--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -266,10 +266,11 @@ void ShaderCompilerService::init() noexcept {
 
             auto const& renderer = mDriver.getContext().state.renderer;
             if (UTILS_UNLIKELY(strstr(renderer, "PowerVR"))) {
-                // The PowerVR driver support parallel shader compilation well, so we use 4
+                // The PowerVR driver support parallel shader compilation well, so we use 2
                 // threads, we can use lower priority threads here because urgent compilations
-                // will most likely happen on the main gl thread.
-                poolSize = 4;
+                // will most likely happen on the main gl thread. Using too many thread can
+                // increase memory pressure significantly.
+                poolSize = 2;
                 priority = JobSystem::Priority::BACKGROUND;
             }
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -617,15 +617,18 @@ int FEngine::loop() {
         return 0;
     }
 
-    // We use the highest affinity bit, assuming this is a Big core in a  big.little
-    // configuration. This is also a core not used by the JobSystem.
-    // Either way the main reason to do this is to avoid this thread jumping from core to core
-    // and lose its caches in the process.
-    uint32_t const id = std::thread::hardware_concurrency() - 1;
+    // Set thread affinity for the backend thread.
+    //  see https://developer.android.com/agi/sys-trace/threads-scheduling#cpu_core_affinity
+    // Certain backends already have some threads pinned, and we can't easily know on which core.
+    const bool disableThreadAffinity
+            = mDriver->isWorkaroundNeeded(Workaround::DISABLE_THREAD_AFFINITY);
 
+    uint32_t const id = std::thread::hardware_concurrency() - 1;
     while (true) {
         // looks like thread affinity needs to be reset regularly (on Android)
-        JobSystem::setThreadAffinityById(id);
+        if (!disableThreadAffinity) {
+            JobSystem::setThreadAffinityById(id);
+        }
         if (!execute()) {
             break;
         }


### PR DESCRIPTION
1. we don't pin the GL thread on PowerVR
2. reduce the number of thread in the compiler service to two