### PR TITLE
fix fuzzyEqual

### DIFF
--- a/libs/math/include/math/mat2.h
+++ b/libs/math/include/math/mat2.h
@@ -235,23 +235,6 @@ public:
         return r;
     }
 
-    // returns false if the two matrices are different. May return false if they're the
-    // same, with some elements only differing by +0 or -0. Behaviour is undefined with NaNs.
-    static constexpr bool fuzzyEqual(TMat22 l, TMat22 r) noexcept {
-        uint64_t const* const li = reinterpret_cast<uint64_t const*>(&l);
-        uint64_t const* const ri = reinterpret_cast<uint64_t const*>(&r);
-        uint64_t result = 0;
-        // For some reason clang is not able to vectoize this loop when the number of iteration
-        // is known and constant (!?!?!). Still this is better than operator==.
-#if defined(__clang__)
-#pragma clang loop vectorize_width(2)
-#endif
-        for (size_t i = 0; i < sizeof(TMat22) / sizeof(uint64_t); i++) {
-            result |= li[i] ^ ri[i];
-        }
-        return result != 0;
-    }
-
     template<typename A>
     static constexpr TMat22 translation(const TVec2<A>& t) noexcept {
         TMat22 r;

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -272,24 +272,6 @@ public:
     template<typename U, typename V>
     constexpr TMat44(const TMat33<U>& matrix, const TVec4<V>& column3) noexcept;
 
-    /*
-     *  helpers
-     */
-
-    // returns false if the two matrices are different. May return false if they're the
-    // same, with some elements only differing by +0 or -0. Behaviour is undefined with NaNs.
-    static constexpr bool fuzzyEqual(TMat44 const& l, TMat44 const& r) noexcept {
-        uint64_t const* const li = reinterpret_cast<uint64_t const*>(&l);
-        uint64_t const* const ri = reinterpret_cast<uint64_t const*>(&r);
-        uint64_t result = 0;
-        // For some reason clang is not able to vectorize this loop when the number of iteration
-        // is known and constant (!?!?!). Still this is better than operator==.
-        for (size_t i = 0; i < sizeof(TMat44) / sizeof(uint64_t); i++) {
-            result |= li[i] ^ ri[i];
-        }
-        return result != 0;
-    }
-
     static constexpr TMat44 ortho(T left, T right, T bottom, T top, T near, T far) noexcept;
 
     static constexpr TMat44 frustum(T left, T right, T bottom, T top, T near, T far) noexcept;


### PR DESCRIPTION
- the return value was inverted
- fuzzyEqual could generate alignment faults
- move it out of mat4 and mat2 because it was only used in one place.