### PR TITLE
don't use eglMakeCurrent with EGL_NO_SURFACE unless we're allowed

### DIFF
--- a/android/samples/sample-image-based-lighting/src/main/java/com/google/android/filament/ibl/MainActivity.kt
+++ b/android/samples/sample-image-based-lighting/src/main/java/com/google/android/filament/ibl/MainActivity.kt
@@ -118,9 +118,10 @@ class MainActivity : Activity() {
     }
 
     private fun setupView() {
-        val ssaoOptions = view.ambientOcclusionOptions
-        ssaoOptions.enabled = true
-        view.ambientOcclusionOptions = ssaoOptions
+        // ambient occlusion is the cheapest effect that adds a lot of quality
+        view.ambientOcclusionOptions = view.ambientOcclusionOptions.apply {
+            enabled = true
+        }
 
         // NOTE: Try to disable post-processing (tone-mapping, etc.) to see the difference
         // view.isPostProcessingEnabled = false

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -139,6 +139,7 @@ protected:
             bool KHR_create_context = false;
             bool KHR_gl_colorspace = false;
             bool KHR_no_config_context = false;
+            bool KHR_surfaceless_context = false;
         } egl;
     } ext;
 


### PR DESCRIPTION
EGL_KHR_surfaceless_context is needed to be able to use eglMakeCurrent without an EGLSurface.