### PR TITLE
improvements to CompilerThreadPool and OpenGLPlatform

### DIFF
--- a/filament/backend/include/backend/platforms/OpenGLPlatform.h
+++ b/filament/backend/include/backend/platforms/OpenGLPlatform.h
@@ -288,6 +288,12 @@ public:
      * @see terminate()
      */
     virtual void createContext(bool shared);
+
+    /**
+     * Detach and destroy the current context if any and releases all resources associated to
+     * this thread.
+     */
+    virtual void releaseContext() noexcept;
 };
 
 } // namespace filament

--- a/filament/backend/include/backend/platforms/PlatformEGL.h
+++ b/filament/backend/include/backend/platforms/PlatformEGL.h
@@ -40,6 +40,7 @@ public:
     PlatformEGL() noexcept;
     bool isExtraContextSupported() const noexcept override;
     void createContext(bool shared) override;
+    void releaseContext() noexcept override;
 
 protected:
 

--- a/filament/backend/src/opengl/OpenGLPlatform.cpp
+++ b/filament/backend/src/opengl/OpenGLPlatform.cpp
@@ -116,4 +116,7 @@ bool OpenGLPlatform::isExtraContextSupported() const noexcept {
 void OpenGLPlatform::createContext(bool) {
 }
 
+void OpenGLPlatform::releaseContext() noexcept {
+}
+
 } // namespace filament::backend


### PR DESCRIPTION
CompilerThreadPool:
- it now supports a thread cleanup function
- some initialization is moved to the setup function

OpenGLPlatform:
- now cleans-up the thread pool threads upon exit