### PR TITLE
Fix Mat cofactor UT error on Mac M2 chip machine.

### DIFF
--- a/libs/math/tests/test_mat.cpp
+++ b/libs/math/tests/test_mat.cpp
@@ -574,6 +574,18 @@ do {                                                            \
 } while(0)
 
 //------------------------------------------------------------------------------
+// A macro to help with vector comparisons within a range.
+#define EXPECT_VEC_NEAR(VEC1, VEC2, eps)                        \
+do {                                                            \
+    const decltype(VEC1) v1 = VEC1;                             \
+    const decltype(VEC2) v2 = VEC2;                             \
+    for (int i = 0; i < v1.size(); ++i) {                       \
+        EXPECT_NEAR(v1[i], v2[i], eps);                         \
+    }                                                           \
+} while(0)
+
+
+//------------------------------------------------------------------------------
 // A macro to help with type comparisons within floating point range.
 #define ASSERT_TYPE_EQ(T1, T2)                                  \
 do {                                                            \
@@ -834,9 +846,10 @@ TYPED_TEST(MatTestT, cofactor) {
         M33T r = M33T::eulerZYX(rand_gen(), rand_gen(), rand_gen());
         M33T c0 = details::matrix::cofactor(r);
         M33T c1 = details::matrix::fastCofactor3(r);
-        EXPECT_VEC_EQ(c0[0], c1[0]);
-        EXPECT_VEC_EQ(c0[1], c1[1]);
-        EXPECT_VEC_EQ(c0[2], c1[2]);
+
+        EXPECT_VEC_NEAR(c0[0], c1[0], value_eps);
+        EXPECT_VEC_NEAR(c0[1], c1[1], value_eps);
+        EXPECT_VEC_NEAR(c0[2], c1[2], value_eps);
     }
 }
 


### PR DESCRIPTION
```
TYPED_TEST(MatTestT, cofactor) {
    static constexpr TypeParam value_eps =
            TypeParam(1000) * std::numeric_limits<TypeParam>::epsilon();
    typedef filament::math::details::TMat33<TypeParam> M33T;

    std::default_random_engine generator(992626); // NOLINT
    std::uniform_real_distribution<TypeParam> distribution(-100.0, 100.0);
    auto rand_gen = std::bind(distribution, generator);

    for (size_t i = 0; i < 100; ++i) {
        M33T r = M33T::eulerZYX(rand_gen(), rand_gen(), rand_gen());
        M33T c0 = details::matrix::cofactor(r);
        M33T c1 = details::matrix::fastCofactor3(r);
        EXPECT_VEC_EQ(c0[0], c1[0]);
        EXPECT_VEC_EQ(c0[1], c1[1]);
        EXPECT_VEC_EQ(c0[2], c1[2]);
    }
}
```
This UT failed on Mac M2 chip machine. The root cause is the floating point calculations is not exactly like intel chip.
check this link: https://eclecticlight.co/2021/04/22/can-you-trust-floating-point-arithmetic-on-apple-silicon/
and https://stackoverflow.com/questions/71441137/np-float32-floating-point-differences-between-intel-macbook-and-m1

Inside googletest lib, it expect two float/double number equal when the difference between them are less than 4 `ULP`.
Obviously, the math calculations in M2 chip generate deviation larger than 4 `ULP`. So why not use another `googletest` MARCO `EXPECT_NEAR` to compare the float/double numbers? Then here is this PR.

The UT errors in M2 Chip Macbook:

`./build.sh -u`

```
Expected equality of these values:
  v1[i]
    Which is: -0.0026573246830202154
  v2[i]
    Which is: -0.0026573246830202107
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:838: Failure
Expected equality of these values:
  v1[i]
    Which is: -0.012149651719700156
  v2[i]
    Which is: -0.012149651719700165
[  FAILED  ] MatTestT/1.cofactor, where TypeParam = double (1 ms)
```

```
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:838: Failure
Expected equality of these values:
  v1[i]
    Which is: -0.0092618372
  v2[i]
    Which is: -0.0092618316
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:837: Failure
Expected equality of these values:
  v1[i]
    Which is: 0.0014829413
  v2[i]
    Which is: 0.0014829515
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:839: Failure
Expected equality of these values:
  v1[i]
    Which is: 0.00015730385
  v2[i]
    Which is: 0.00015729926
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:838: Failure
Expected equality of these values:
  v1[i]
    Which is: 0.00046745772
  v2[i]
    Which is: 0.00046746305
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:839: Failure
Expected equality of these values:
  v1[i]
    Which is: 0.00077459431
  v2[i]
    Which is: 0.00077459269
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:838: Failure
Expected equality of these values:
  v1[i]
    Which is: -0.010445163
  v2[i]
    Which is: -0.010445156
/Users/jacobsu/hack/graphics/filament/libs/math/tests/test_mat.cpp:838: Failure
Expected equality of these values:
  v1[i]
    Which is: 0.0031573069
  v2[i]
    Which is: 0.0031573004
[  FAILED  ] MatTestT/0.cofactor, where TypeParam = float (1 ms)
```