### PR TITLE
refactor build.sh script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -210,7 +210,7 @@ function build_desktop_target {
     echo "Building ${lc_target} in out/cmake-${lc_target}..."
     mkdir -p "out/cmake-${lc_target}"
 
-    cd "out/cmake-${lc_target}"
+    pushd "out/cmake-${lc_target}"
 
     local lc_name=$(echo "${UNAME}" | tr '[:upper:]' '[:lower:]')
     if [[ "${lc_name}" == "darwin" ]]; then
@@ -243,12 +243,13 @@ function build_desktop_target {
     if [[ -d "../${lc_target}/filament" ]]; then
         if [[ "${ISSUE_ARCHIVES}" == "true" ]]; then
             echo "Generating out/filament-${lc_target}-${LC_UNAME}.tgz..."
-            cd "../${lc_target}"
+            pushd "../${lc_target}"
             tar -czvf "../filament-${lc_target}-${LC_UNAME}.tgz" filament
+            popd
         fi
     fi
 
-    cd ../..
+    popd
 }
 
 function build_desktop {
@@ -266,7 +267,7 @@ function build_webgl_with_target {
 
     echo "Building WebGL ${lc_target}..."
     mkdir -p "out/cmake-webgl-${lc_target}"
-    cd "out/cmake-webgl-${lc_target}"
+    pushd "out/cmake-webgl-${lc_target}"
 
     if [[ ! "${BUILD_TARGETS}" ]]; then
         BUILD_TARGETS=${BUILD_CUSTOM_TARGETS}
@@ -303,17 +304,17 @@ function build_webgl_with_target {
 
         if [[ "${ISSUE_ARCHIVES}" == "true" ]]; then
             echo "Generating out/filament-${lc_target}-web.tgz..."
-            cd web/filament-js
+            pushd web/filament-js
             tar -cvf "../../../filament-${lc_target}-web.tar" filament.js
             tar -rvf "../../../filament-${lc_target}-web.tar" filament.wasm
             tar -rvf "../../../filament-${lc_target}-web.tar" filament.d.ts
-            cd -
+            popd
             gzip -c "../filament-${lc_target}-web.tar" > "../filament-${lc_target}-web.tgz"
             rm "../filament-${lc_target}-web.tar"
         fi
     fi
 
-    cd ../..
+    popd
 }
 
 function build_webgl {
@@ -344,7 +345,7 @@ function build_android_target {
     echo "Building Android ${lc_target} (${arch})..."
     mkdir -p "out/cmake-android-${lc_target}-${arch}"
 
-    cd "out/cmake-android-${lc_target}-${arch}"
+    pushd "out/cmake-android-${lc_target}-${arch}"
 
     if [[ ! -d "CMakeFiles" ]] || [[ "${ISSUE_CMAKE_ALWAYS}" == "true" ]]; then
         cmake \
@@ -363,7 +364,7 @@ function build_android_target {
     # We must always install Android libraries to build the AAR
     ${BUILD_COMMAND} install
 
-    cd ../..
+    popd
 }
 
 function build_android_arch {
@@ -384,9 +385,9 @@ function archive_android {
     if [[ -d "out/android-${lc_target}/filament" ]]; then
         if [[ "${ISSUE_ARCHIVES}" == "true" ]]; then
             echo "Generating out/filament-android-${lc_target}-${LC_UNAME}.tgz..."
-            cd "out/android-${lc_target}"
+            pushd "out/android-${lc_target}"
             tar -czvf "../filament-android-${lc_target}-${LC_UNAME}.tgz" filament
-            cd ../..
+            popd
         fi
     fi
 }
@@ -464,7 +465,7 @@ function build_android {
         archive_android "Release"
     fi
 
-    cd android
+    pushd android
 
     if [[ "${ISSUE_DEBUG_BUILD}" == "true" ]]; then
         ./gradlew \
@@ -565,7 +566,7 @@ function build_android {
         fi
     fi
 
-    cd ..
+    popd
 }
 
 function build_ios_target {
@@ -576,7 +577,7 @@ function build_ios_target {
     echo "Building iOS ${lc_target} (${arch}) for ${platform}..."
     mkdir -p "out/cmake-ios-${lc_target}-${arch}"
 
-    cd "out/cmake-ios-${lc_target}-${arch}"
+    pushd "out/cmake-ios-${lc_target}-${arch}"
 
     if [[ ! -d "CMakeFiles" ]] || [[ "${ISSUE_CMAKE_ALWAYS}" == "true" ]]; then
         cmake \
@@ -600,7 +601,7 @@ function build_ios_target {
         ${BUILD_COMMAND} ${INSTALL_COMMAND}
     fi
 
-    cd ../..
+    popd
 }
 
 function archive_ios {
@@ -609,9 +610,9 @@ function archive_ios {
     if [[ -d "out/ios-${lc_target}/filament" ]]; then
         if [[ "${ISSUE_ARCHIVES}" == "true" ]]; then
             echo "Generating out/filament-${lc_target}-ios.tgz..."
-            cd "out/ios-${lc_target}"
+            pushd "out/ios-${lc_target}"
             tar -czvf "../filament-${lc_target}-ios.tgz" filament
-            cd ../..
+            popd
         fi
     fi
 }
@@ -670,14 +671,14 @@ function build_web_docs {
 
     mkdir -p out/web-docs
     cp -f docs/web-docs-package.json out/web-docs/package.json
-    cd out/web-docs
+    pushd out/web-docs
 
     npm install > /dev/null
 
     # Generate documents
     npx markdeep-rasterizer ../../docs/Filament.md.html ../../docs/Materials.md.html  ../../docs/
 
-    cd ../..
+    popd
 }
 
 function validate_build_command {
@@ -750,6 +751,16 @@ function run_tests {
     fi
 }
 
+function check_debug_release_build {
+    if [[ "${ISSUE_DEBUG_BUILD}" == "true" || "${ISSUE_RELEASE_BUILD}" == "true" ]]; then
+        "$@";
+    else
+        echo "You must declare a debug or release target for $@ builds."
+        echo ""
+        exit 1
+    fi
+}
+
 # Beginning of the script
 
 pushd "$(dirname "$0")" > /dev/null
@@ -758,7 +769,7 @@ while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
     case ${opt} in
         h)
             print_help
-            exit 1
+            exit 0
             ;;
         a)
             ISSUE_ARCHIVES=true
@@ -794,7 +805,7 @@ while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
             platforms=$(echo "${OPTARG}" | tr ',' '\n')
             for platform in ${platforms}
             do
-                case ${platform} in
+                case $(echo "${platform}" | tr '[:upper:]' '[:lower:]') in
                     desktop)
                         ISSUE_DESKTOP_BUILD=true
                     ;;
@@ -813,6 +824,12 @@ while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
                         ISSUE_DESKTOP_BUILD=true
                         ISSUE_WEBGL_BUILD=false
                     ;;
+                    *)
+                        echo "Unknown platform ${platform}"
+                        echo "Platform must be one of [desktop|android|ios|webgl|all]"
+                        echo ""
+                        exit 1
+                    ;;    
                 esac
             done
             ;;
@@ -825,7 +842,7 @@ while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
             abis=$(echo "${OPTARG}" | tr ',' '\n')
             for abi in ${abis}
             do
-                case ${abi} in
+                case $(echo "${abi}" | tr '[:upper:]' '[:lower:]') in
                     armeabi-v7a)
                         ABI_ARMEABI_V7A=true
                     ;;
@@ -843,6 +860,12 @@ while getopts ":hacCfgijmp:q:uvslwtedk:b" opt; do
                         ABI_ARM64_V8A=true
                         ABI_X86=true
                         ABI_X86_64=true
+                    ;;
+                    *)
+                        echo "Unknown abi ${abi}"
+                        echo "ABI must be one of [armeabi-v7a|arm64-v8a|x86|x86_64|all]"
+                        echo ""
+                        exit 1
                     ;;
                 esac
             done
@@ -907,9 +930,9 @@ fi
 shift $((OPTIND - 1))
 
 for arg; do
-    if [[ "${arg}" == "release" ]]; then
+    if [[ $(echo "${arg}" | tr '[:upper:]' '[:lower:]') == "release" ]]; then
         ISSUE_RELEASE_BUILD=true
-    elif [[ "${arg}" == "debug" ]]; then
+    elif [[ $(echo "${arg}" | tr '[:upper:]' '[:lower:]') == "debug" ]]; then
         ISSUE_DEBUG_BUILD=true
     else
         BUILD_CUSTOM_TARGETS="${BUILD_CUSTOM_TARGETS} ${arg}"
@@ -927,19 +950,19 @@ if [[ "${ISSUE_CLEAN_AGGRESSIVE}" == "true" ]]; then
 fi
 
 if [[ "${ISSUE_DESKTOP_BUILD}" == "true" ]]; then
-    build_desktop
+    check_debug_release_build build_desktop
 fi
 
 if [[ "${ISSUE_ANDROID_BUILD}" == "true" ]]; then
-    build_android
+    check_debug_release_build build_android
 fi
 
 if [[ "${ISSUE_IOS_BUILD}" == "true" ]]; then
-    build_ios
+    check_debug_release_build build_ios
 fi
 
 if [[ "${ISSUE_WEBGL_BUILD}" == "true" ]]; then
-    build_webgl
+    check_debug_release_build build_webgl
 fi
 
 if [[ "${ISSUE_WEB_DOCS}" == "true" ]]; then


### PR DESCRIPTION
Refactor & Debug build.sh script:

1. Let platforms, ABIs, release/debug targets case insensitive:
```
./build.sh -p Android Debug
```
Above cmd will do nothing, because Android & Debug are case sensitive. So let those keywords case insensitive maybe a good idea.

2. Add error msg to remind the developer:
```
./build.sh -p android
./build.sh -p andr
./build.sh -p android bug
./build.sh -p android -q arm debug
```
Above error cmds will not has hints to remind the developer, so I add error msg to cover: missing targets, invalidate platform, invalidate target, invalidate ABI.

3. Let `ISSUE_DESKTOP_BUILD` as false

This var can be `false`, I just need to rearrange the build orders at the end of the script, and the only dependency is `run_tests`, I add build the desktop `Debug` target manually inside `run_tests`.

4. Debug Android samples build

```
./build.sh -p android -k sample-gltf-viewer debug
```
The above cmd will fail, the backtrace told me the cmd was not found in `out/release/filament/bin/?`, but I'm running the debug build, and the cause is missing property `com.google.android.filament.tools-dir`, so the groovy plugin `filament/android/buildSrc/src/main/groovy/FilamentPlugin.groovy` will use the default config one.
```
                def filamentToolsPath = providers
                        .gradleProperty("com.google.android.filament.tools-dir")
                        .forUseAtConfigurationTime().get()
```
I don't understand where it config the `forUseAtConfigurationTime()`, but the value is `out/release/filament/`.
So config `-Pcom.google.android.filament.tools-dir` will resolve this bug.

5. use `pushd` & `popd` to replace `cd`