### PR TITLE
upgrade gradle wrapper version from 8.0 -> 8.1

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Nov 17 10:40:18 PST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade gradle wrapper version from 8.0 -> 8.1 for following reasons:
1. using JDK 20 will has build failed exception:

```
> Task :buildSrc:compileGroovy FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':buildSrc:compileGroovy'.
> BUG! exception in phase 'semantic analysis' in source unit '/Users/jacob/hack/graphics/filament/android/buildSrc/src/main/groovy/FilamentPlugin.groovy' Unsupported class file major version 64
```

The solution is to upgrade gradle wrapper to 8.1.
The `BUILDING.md` said to use `Java 17`, but it's better to let `Java 20` also works.

2. Android official doc recommend the minimum required Gradle version is `8.1` to support the latest android gradle plugin.

https://developer.android.com/build/releases/gradle-plugin#updating-gradle

So why not upgrade gradle to 8.1?