### PR TITLE
Properly apply emissive to masked materials

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,5 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - `setFrameCompletedCallback` now takes a `backend::CallbackHandler`.
+- The `emissive` property was not applied properly to `MASKED` materials, and could cause
+  dark fringes to appear

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -299,7 +299,10 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #if defined(MATERIAL_HAS_EMISSIVE)
     highp vec4 emissive = material.emissive;
     highp float attenuation = mix(1.0, getExposure(), emissive.w);
-    color.rgb += emissive.rgb * (attenuation * color.a);
+#if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)
+    attenuation *= color.a;
+#endif
+    color.rgb += emissive.rgb * attenuation;
 #endif
 }
 

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -2,7 +2,10 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #if defined(MATERIAL_HAS_EMISSIVE)
     highp vec4 emissive = material.emissive;
     highp float attenuation = mix(1.0, getExposure(), emissive.w);
-    color.rgb += emissive.rgb * (attenuation * color.a);
+#if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)
+    attenuation *= color.a;
+#endif
+    color.rgb += emissive.rgb * attenuation;
 #endif
 }
 


### PR DESCRIPTION
The emissive property should not be multiplied by the color alpha in masked materials. The alpha is treated as a coverage value in that case, not an opacity value.

Before:

<img width="1136" alt="Screenshot 2023-08-29 at 4 54 17 PM" src="https://github.com/google/filament/assets/869684/d811d32c-b748-45ab-8477-a4846b19dcdc">

After:

<img width="1136" alt="Screenshot 2023-08-29 at 4 21 52 PM" src="https://github.com/google/filament/assets/869684/2df8dbf3-515b-4ff0-bed9-00379eb73833">
