### PR TITLE
Fix possible change of scale sign when decomposing matrix

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -13,3 +13,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
   dark fringes to appear (recompile materials)
 - Allow glTF materials with transmission/volume extensions to choose their alpha mode
   instead of forcing `MASKED`
+- Fix possible change of scale sign when decomposing transform matrix for animation

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -223,6 +223,23 @@ public:
     children_iterator getChildrenEnd(Instance parent) const noexcept;
 
     /**
+     * Sets a scale of a transform component.
+     * This scale is preserved for sign check when decomposing transform matrix.
+     * @param ci     The instance of the transform component to set the scale to.
+     * @param scale  The preserved scale.
+     * @see getScale()
+     */
+    void setScale(Instance ci, const math::float3& scale) noexcept;
+
+    /**
+     * Returns the scale of a transform component.
+     * @param ci The instance of the transform component to query the scale.
+     * @return The scale of the component.
+     * @see setTransform()
+     */
+    const math::float3& getScale(Instance ci) const noexcept;
+
+    /**
      * Sets a local transform of a transform component.
      * @param ci              The instance of the transform component to set the local transform to.
      * @param localTransform  The local transform (i.e. relative to the parent).

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -46,6 +46,14 @@ TransformManager::Instance TransformManager::getInstance(Entity e) const noexcep
     return downcast(this)->getInstance(e);
 }
 
+void TransformManager::setScale(Instance ci, const float3& scale) noexcept {
+    downcast(this)->setScale(ci, scale);
+}
+
+const float3& TransformManager::getScale(Instance ci) const noexcept {
+    return downcast(this)->getScale(ci);
+}
+
 void TransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
     downcast(this)->setTransform(ci, model);
 }

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -167,6 +167,14 @@ void FTransformManager::destroy(Entity e) noexcept {
     }
 }
 
+void FTransformManager::setScale(Instance ci, const float3& scale) noexcept {
+    validateNode(ci);
+    if (ci) {
+        auto& manager = mManager;
+        manager[ci].scale = scale;
+    }
+}
+
 void FTransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
     validateNode(ci);
     if (ci) {

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -27,6 +27,7 @@
 #include <utils/Slice.h>
 
 #include <math/mat4.h>
+#include "math/vec3.h"
 
 namespace filament {
 
@@ -89,6 +90,12 @@ public:
         return mManager.slice<WORLD>();
     }
 
+    void setScale(Instance ci, const math::float3& scale) noexcept;
+
+    const math::float3& getScale(Instance ci) const noexcept {
+        return mManager[ci].scale;
+    }
+
     void setTransform(Instance ci, const math::mat4f& model) noexcept;
 
     void setTransform(Instance ci, const math::mat4& model) noexcept;
@@ -142,6 +149,7 @@ private:
         WORLD,          // world transform
         LOCAL_LO,       // accurate local translation
         WORLD_LO,       // accurate world translation
+        SCALE,          // preserved scaling for sign check when decompose matrix
         PARENT,         // instance to the parent
         FIRST_CHILD,    // instance to our first child
         NEXT,           // instance to our next sibling
@@ -153,6 +161,7 @@ private:
             math::mat4f,    // world
             math::float3,   // accurate local translation
             math::float3,   // accurate world translation
+            math::float3,   // preserved scaling for sign check when decompose matrix
             Instance,       // parent
             Instance,       // firstChild
             Instance,       // next
@@ -177,6 +186,7 @@ private:
                 Field<WORLD>        world;
                 Field<LOCAL_LO>     localTranslationLo;
                 Field<WORLD_LO>     worldTranslationLo;
+                Field<SCALE>        scale;
                 Field<PARENT>       parent;
                 Field<FIRST_CHILD>  firstChild;
                 Field<NEXT>         next;

--- a/libs/gltfio/include/gltfio/math.h
+++ b/libs/gltfio/include/gltfio/math.h
@@ -40,7 +40,8 @@ UTILS_PUBLIC T cubicSpline(const T& vert0, const T& tang0, const T& vert1, const
 }
 
 UTILS_PUBLIC inline void decomposeMatrix(const filament::math::mat4f& mat, filament::math::float3* translation,
-        filament::math::quatf* rotation, filament::math::float3* scale) {
+        filament::math::quatf* rotation, filament::math::float3* scale,
+        const filament::math::float3& preservedScale) {
     using namespace filament::math;
 
     // Extract translation.
@@ -66,8 +67,17 @@ UTILS_PUBLIC inline void decomposeMatrix(const filament::math::mat4f& mat, filam
     float scaley = length(float3({d, e, f}));
     float scalez = length(float3({g, h, i}));
     float3 s = { scalex, scaley, scalez };
-    if (det < 0) {
-        s = -s;
+    if (preservedScale != float3{}) {
+        const float signx = (preservedScale.x < 0) ? -1 : 1;
+        const float signy = (preservedScale.y < 0) ? -1 : 1;
+        const float signz = (preservedScale.z < 0) ? -1 : 1;
+        s.x *= signx;
+        s.y *= signy;
+        s.z *= signz;
+    } else {
+        if (det < 0) {
+            s = -s;
+        }
     }
     *scale = s;
 


### PR DESCRIPTION
When animate for rotation or scale path, decompose the transform matrix may change the sign of scale, and then compose the matrix back with scale or rotation changed by animation, the matrix may be wrong.

This PR save the origin scale value of node from gltf data, and then use sign of this value as new decomposed scale's sign. If no origin scale vlaue provided, still use determinant's sign.

According to gltf spec, when a node is targeted for animation (referenced by an animation.channel.target), matrix **MUST NOT** be present, so the origin scale value is always available without decompose for a animation node.

Here is a test gltf:
[animation.glb.tar.gz](https://github.com/google/filament/files/12488413/animation.glb.tar.gz)

Before:
![image](https://github.com/google/filament/assets/2212586/53e653c7-1364-45de-bace-b4cc9d25bab1)


After:
![image](https://github.com/google/filament/assets/2212586/f8bb6882-a711-429b-b1ad-8384abcfb289)
