### PR TITLE
Bug: fix underscores literal operators c++ compatible error.

### DIFF
--- a/libs/math/include/math/half.h
+++ b/libs/math/include/math/half.h
@@ -160,7 +160,7 @@ constexpr inline half makeHalf(uint16_t bits) noexcept {
 
 #endif // __ARM_NEON
 
-inline constexpr half operator "" _h(long double v) {
+inline constexpr half operator""_h(long double v) {
     return half( static_cast<float>(v) );
 }
 

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -174,27 +174,27 @@ typedef details::TQuaternion<double> quat;
 typedef details::TQuaternion<float> quatf;
 typedef details::TQuaternion<half> quath;
 
-constexpr inline quat operator "" _i(long double v) {
+constexpr inline quat operator""_i(long double v) {
     return quat(0.0, double(v), 0.0, 0.0);
 }
 
-constexpr inline quat operator "" _j(long double v) {
+constexpr inline quat operator""_j(long double v) {
     return quat(0.0, 0.0, double(v), 0.0);
 }
 
-constexpr inline quat operator "" _k(long double v) {
+constexpr inline quat operator""_k(long double v) {
     return quat(0.0, 0.0, 0.0, double(v));
 }
 
-constexpr inline quat operator "" _i(unsigned long long v) {
+constexpr inline quat operator""_i(unsigned long long v) {
     return quat(0.0, double(v), 0.0, 0.0);
 }
 
-constexpr inline quat operator "" _j(unsigned long long v) {
+constexpr inline quat operator""_j(unsigned long long v) {
     return quat(0.0, 0.0, double(v), 0.0);
 }
 
-constexpr inline quat operator "" _k(unsigned long long v) {
+constexpr inline quat operator""_k(unsigned long long v) {
     return quat(0.0, 0.0, 0.0, double(v));
 }
 


### PR DESCRIPTION
try to fix issue #7013

I tried to use emsdk 3.1.44 to compile `webgl` platform. 

`./build.sh -p webgl release`

with following errors:
```
filament/libs/math/include/math/half.h:163:35: error: identifier '_h' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
163 | inline constexpr half operator "" _h(long double v) {
      |                       ~~~~~~~~~~~~^~
      |                       operator""_h
1 error generated.
```

the clang version of `emsdk` is `17.0.0`.
```
emsdk/upstream/bin/clang++ --version
clang version 17.0.0 (https://github.com/llvm/llvm-project a8cbd27d1f238e104a5d5ca345d93bc1f4d4ab1f)
Target: x86_64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Users/jacob/hack/emscripten/emsdk/upstream/bin
```

issue #7013  said use emsdk `3.1.15`, which can fix the building errors.
But according to `BUILDING.md`
```
cd <your chosen parent folder for the emscripten SDK>
curl -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.15.zip > emsdk.zip
unzip emsdk.zip ; mv emsdk-* emsdk ; cd emsdk
python ./emsdk.py install latest
python ./emsdk.py activate latest
source ./emsdk_env.sh
```

I guess the doc said to use  the `latest` emsdk version.
And this error is C++ compiler compatible problem, check this link: https://stackoverflow.com/questions/13793996/underscores-names-and-literal-operators

So I sent this PR to fix this c++ operator naming problem.
