### PR TITLE
Fix TextureFlags for sheenRoughnessMap

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -15,3 +15,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
   instead of forcing `MASKED`
 - Fix a crash in gltfio when not using ubershaders
 - Use flatmat for mat parameter in jsbinding
+- Fix TextureFlags for sheenRoughnessMap when textures of sheenRoughnessMap and sheenColorMap is same

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1467,8 +1467,9 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
             }
         }
         if (matkey.hasSheenRoughnessTexture) {
+            bool sameTexture = shConfig.sheen_color_texture.texture == shConfig.sheen_roughness_texture.texture;
             mAsset->addTextureBinding(mi, "sheenRoughnessMap",
-                    shConfig.sheen_roughness_texture.texture, LINEAR);
+                    shConfig.sheen_roughness_texture.texture, sameTexture ? sRGB : LINEAR);
             if (matkey.hasTextureTransforms) {
                 const cgltf_texture_transform& uvt = shConfig.sheen_roughness_texture.transform;
                 auto uvmat = matrixFromUvTransform(uvt.offset, uvt.rotation, uvt.scale);


### PR DESCRIPTION
For KHR_materials_sheen extensions, spec says color space of sheenColorTexture must be *sRGB*, but not for sheenRoughnessTexture.

Now we use LINEAR for sheenRoughnessTexture, but if sheenColorTexture and sheenRoughnessTexture use the same texture, and the texture compressed use KTX + basisu, then `Source texture is marked sRGB, but client is requesting linear.` will be occured in Ktx2Reader::createTexture.

Here is a KTX + basisu version of [SheenCloth](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/SheenCloth/glTF/SheenCloth.gltf)

[SheenCloth.glb.tar.gz](https://github.com/google/filament/files/12524888/SheenCloth.glb.tar.gz)
