### PR TITLE
fix shadow stability when eye is far from world origin

### DIFF
--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -222,7 +222,7 @@ private:
             const math::float3& dir);
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,
-            math::mat4f const& Mv, math::float3 worldOrigin, math::float2 shadowMapResolution) noexcept;
+            math::mat4f const& Mv, math::mat4 worldOrigin, math::int2 resolution) noexcept;
 
     static inline void computeFrustumCorners(math::float3* out,
             const math::mat4f& projectionViewInverse, math::float2 csNearFar = { -1.0f, 1.0f }) noexcept;

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -504,19 +504,13 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
             splitPercentages[i] = options.cascadeSplitPositions[i - 1];
         }
 
-        const CascadeSplits::Params p{
+        const CascadeSplits splits({
                 .proj = cameraInfo.cullingProjection,
                 .near = vsNear,
                 .far = vsFar,
                 .cascadeCount = cascadeCount,
                 .splitPositions = splitPercentages
-        };
-        if (p != mCascadeSplitParams) {
-            mCascadeSplits = CascadeSplits{ p };
-            mCascadeSplitParams = p;
-        }
-
-        const CascadeSplits& splits = mCascadeSplits;
+        });
 
         // The split positions uniform is a float4. To save space, we chop off the first split position
         // (which is the near plane, and doesn't need to be communicated to the shaders).
@@ -530,7 +524,7 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
 
         mShadowMappingUniforms.cascadeSplits = wsSplitPositionUniform;
 
-        // when computing the required bias we need a half-texel size, so we multiply by 0.5 here.
+        // When computing the required bias we need a half-texel size, so we multiply by 0.5 here.
         // note: normalBias is set to zero for VSM
         const float normalBias = shadowMapInfo.vsm ? 0.0f : 0.5f * lcm.getShadowNormalBias(0);
 

--- a/filament/src/ShadowMapManager.h
+++ b/filament/src/ShadowMapManager.h
@@ -145,17 +145,8 @@ private:
             float far = 0.0f;
             size_t cascadeCount = 1;
             std::array<float, SPLIT_COUNT> splitPositions = { 0.0f };
-
-            bool operator!=(const Params& rhs) const {
-                return proj != rhs.proj ||
-                       near != rhs.near ||
-                       far != rhs.far ||
-                       cascadeCount != rhs.cascadeCount ||
-                       splitPositions != rhs.splitPositions;
-            }
         };
 
-        CascadeSplits() noexcept : CascadeSplits(Params{}) {}
         explicit CascadeSplits(Params const& params) noexcept;
 
         // Split positions in world-space.
@@ -186,9 +177,6 @@ private:
 
     SoftShadowOptions mSoftShadowOptions;
 
-    CascadeSplits::Params mCascadeSplitParams;
-    CascadeSplits mCascadeSplits;
-
     mutable TypedUniformBuffer<ShadowUib> mShadowUb;
     backend::Handle<backend::HwBufferObject> mShadowUbh;
 
@@ -204,8 +192,8 @@ private:
             utils::FixedCapacityVector<ShadowMap*>::with_capacity(
                     CONFIG_MAX_SHADOWMAPS - CONFIG_MAX_SHADOW_CASCADES) };
 
-    // inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
-    // because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.
+    // Inline storage for all our ShadowMap objects, we can't easily use a std::array<> directly.
+    // Because ShadowMap doesn't have a default ctor, and we avoid out-of-line allocations.
     // Each ShadowMap is currently 40 bytes (total of 2.5KB for 64 shadow maps)
     using ShadowMapStorage = std::aligned_storage<sizeof(ShadowMap), alignof(ShadowMap)>::type;
     std::array<ShadowMapStorage, CONFIG_MAX_SHADOWMAPS> mShadowMapCache;

--- a/libs/math/include/math/TVecHelpers.h
+++ b/libs/math/include/math/TVecHelpers.h
@@ -443,6 +443,37 @@ private:
         return v;
     }
 
+    template<typename U>
+    friend inline
+    VECTOR<T> MATH_PURE fmod(VECTOR<T> const& x, VECTOR<U> const& y) {
+        VECTOR<T> r;
+        for (size_t i = 0; i < r.size(); i++) {
+            r[i] = std::fmod(x[i], y[i]);
+        }
+        return r;
+    }
+
+    template<typename U>
+    friend inline
+    VECTOR<T> MATH_PURE remainder(VECTOR<T> const& x, VECTOR<U> const& y) {
+        VECTOR<T> r;
+        for (size_t i = 0; i < r.size(); i++) {
+            r[i] = std::remainder(x[i], y[i]);
+        }
+        return r;
+    }
+
+    template<typename U>
+    friend inline
+    VECTOR<T> MATH_PURE remquo(VECTOR<T> const& x, VECTOR<U> const& y,
+            VECTOR<int>* q) {
+        VECTOR<T> r;
+        for (size_t i = 0; i < r.size(); i++) {
+            r[i] = std::remquo(x[i], y[i], &((*q)[i]));
+        }
+        return r;
+    }
+
     friend inline VECTOR<T> MATH_PURE inversesqrt(VECTOR<T> v) {
         for (size_t i = 0; i < v.size(); i++) {
             v[i] = T(1) / std::sqrt(v[i]);


### PR DESCRIPTION
in stable mode the scale was ever so slightly varying with the  camera position, because it was calculated from the camera frustum in world-space, this variation was amplified when the camera is far from  the origin, which eventually caused the modulo needed for snapping the shadowmap projection to widely vary, leading to the instability.

We now calculate the camera frustum sphere in view space, which is guaranteed to be constant. If "shadow caster mode" is chosen, we  quantize the scale a little bit so it stays constant.

The snapping code itself has been cleaned.