### PR TITLE
Only call .put if the tick op was canceled

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.h
+++ b/filament/backend/src/opengl/ShaderCompilerService.h
@@ -141,7 +141,7 @@ private:
     void runAtNextTick(CompilerPriorityQueue priority,
             const program_token_t& token, Job job) noexcept;
     void executeTickOps() noexcept;
-    void cancelTickOp(program_token_t token) noexcept;
+    bool cancelTickOp(program_token_t token) noexcept;
     // order of insertion is important
 
     using ContainerType = std::tuple<CompilerPriorityQueue, program_token_t, Job>;


### PR DESCRIPTION
Otherwise, we end up calling `.put` twice.