### PR TITLE
fix ios samples missing functional header (#7153)

### DIFF
--- a/ios/samples/hello-gltf/hello-gltf/CameraManipulator.h
+++ b/ios/samples/hello-gltf/hello-gltf/CameraManipulator.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_SAMPLE_CAMERA_MANIPULATOR_H
 #define TNT_FILAMENT_SAMPLE_CAMERA_MANIPULATOR_H
 
+#include <functional>
+
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>

--- a/ios/samples/hello-pbr/hello-pbr/CameraManipulator.h
+++ b/ios/samples/hello-pbr/hello-pbr/CameraManipulator.h
@@ -17,6 +17,8 @@
 #ifndef TNT_FILAMENT_SAMPLE_CAMERA_MANIPULATOR_H
 #define TNT_FILAMENT_SAMPLE_CAMERA_MANIPULATOR_H
 
+#include <functional>
+
 #include <math/vec2.h>
 #include <math/vec3.h>
 #include <math/vec4.h>


### PR DESCRIPTION
1. ios sample: ios/samples/hello-gltf;
2. ios sample: ios/samples/hello-pbr;

see #7153 