### PR TITLE
Improvements to shadowing

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -7,3 +7,5 @@ for next branch cut* header.
 appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
+
+- engine: Fixes "stable" shadows (see b/299310624)

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -222,7 +222,7 @@ private:
             const math::float3& dir);
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,
-            math::mat4f const& Mv, math::mat4 worldOrigin, math::int2 resolution) noexcept;
+            math::mat4f const& Mv, math::double3 wsSnapCoords, math::int2 resolution) noexcept;
 
     static inline void computeFrustumCorners(math::float3* out,
             const math::mat4f& projectionViewInverse, math::float2 csNearFar = { -1.0f, 1.0f }) noexcept;
@@ -281,7 +281,7 @@ private:
     static math::mat4f computeVsmLightSpaceMatrix(const math::mat4f& lightSpacePcf,
             const math::mat4f& Mv, float znear, float zfar) noexcept;
 
-    math::float4 getViewportNormalized(ShadowMapInfo const& shadowMapInfo) const noexcept;
+    math::float4 getClampToEdgeCoords(ShadowMapInfo const& shadowMapInfo) const noexcept;
 
     float texelSizeWorldSpace(const math::mat3f& worldToShadowTexture,
             uint16_t shadowDimension) const noexcept;

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -101,6 +101,7 @@ struct App {
 
     bool actualSize = false;
     bool originIsFarAway = false;
+    float originDistance = 6378137; // Earth's radius in [m]
 
     struct Scene {
         Entity groundPlane;
@@ -759,6 +760,7 @@ int main(int argc, char** argv) {
                 ImGui::Checkbox("Disable buffer padding", debug.getPropertyAddress<bool>("d.renderer.disable_buffer_padding"));
                 ImGui::Checkbox("Camera at origin", debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
                 ImGui::Checkbox("Far Origin", &app.originIsFarAway);
+                ImGui::SliderFloat("Origin", &app.originDistance, 0, 10000000);
                 auto dataSource = debug.getDataSource("d.view.frame_info");
                 if (dataSource.data) {
                     ImGuiExt::PlotLinesSeries("FrameInfo", 6,
@@ -956,7 +958,7 @@ int main(int argc, char** argv) {
         tcm.setParent(tcm.getInstance(camera.getEntity()), root);
         tcm.setParent(tcm.getInstance(app.asset->getRoot()), root);
         tcm.setParent(tcm.getInstance(view->getFogEntity()), root);
-        tcm.setTransform(root, mat4f::translation(float3{ app.originIsFarAway ? 1e6f : 0.0f }));
+        tcm.setTransform(root, mat4f::translation(float3{ app.originIsFarAway ? app.originDistance : 0.0f }));
 
         // Check if color grading has changed.
         ColorGradingSettings& options = app.viewer->getSettings().view.colorGrading;

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -109,7 +109,7 @@ highp vec4 getSpotLightSpacePosition(int index, highp vec3 dir, highp float zLig
     // for spotlights, the bias depends on z
     float bias = shadowUniforms.shadows[index].normalBias * zLight;
 
-    return computeLightSpacePosition(getWorldPosition(), getWorldNormalVector(),
+    return computeLightSpacePosition(getWorldPosition(), getWorldGeometricNormalVector(),
             dir, bias, lightFromWorldMatrix);
 }
 #endif
@@ -141,7 +141,7 @@ highp vec4 getCascadeLightSpacePosition(int cascade) {
         return vertex_lightSpacePosition;
     }
 
-    return computeLightSpacePosition(getWorldPosition(), getWorldNormalVector(),
+    return computeLightSpacePosition(getWorldPosition(), getWorldGeometricNormalVector(),
         frameUniforms.lightDirection,
         shadowUniforms.shadows[cascade].normalBias,
         shadowUniforms.shadows[cascade].lightFromWorldMatrix);


### PR DESCRIPTION
- use the geometric normal to apply the shadow bias. This affects
  cascades > 0 and spot/point lights.

- use the scene's origin as a reference point for stabilizing the
  shadowmap, this is more robust.

- clamp directional shadowmap correctly to the 1-texel border, which
  needs to be reachable, as it is a valid value.

- don't snap the shadowmap to texel boundaries if stable mode is not
  active (before we only didn't do it based on lispsm). Stable mode can
  make the shadow unstable when both the camera and the scene move 
  together, so it's better to have a more predictable API where
  "stable" mode means that the snapping occurs and doesn't otherwise.

- add "far origin" distance slider to the debug ui

FIXES=[299310624]