### PR TITLE
vulkan: implicitly free command buffers

### DIFF
--- a/filament/backend/src/vulkan/VulkanBlitter.cpp
+++ b/filament/backend/src/vulkan/VulkanBlitter.cpp
@@ -147,7 +147,7 @@ void VulkanBlitter::blitColor(BlitArgs args) {
     }
 #endif
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuffer = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands.buffer();
     commands.acquire(src.texture);
     commands.acquire(dst.texture);
 
@@ -184,7 +184,7 @@ void VulkanBlitter::blitDepth(BlitArgs args) {
     }
 
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuffer = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands.buffer();
     commands.acquire(src.texture);
     commands.acquire(dst.texture);
     blitFast(cmdbuffer, aspect, args.filter, args.srcTarget->getExtent(), src, dst, args.srcRectPair,
@@ -197,13 +197,11 @@ void VulkanBlitter::terminate() noexcept {
         mDepthResolveProgram = nullptr;
 
         if (mTriangleBuffer) {
-            mTriangleBuffer->terminate();
             delete mTriangleBuffer;
             mTriangleBuffer = nullptr;
         }
 
         if (mParamsBuffer) {
-            mParamsBuffer->terminate();
             delete mParamsBuffer;
             mParamsBuffer = nullptr;
         }
@@ -257,7 +255,7 @@ void VulkanBlitter::lazyInit() noexcept {
     };
 
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuffer = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands.buffer();
 
     mTriangleBuffer = new VulkanBuffer(mAllocator, mStagePool, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
             sizeof(kTriangleVertices));
@@ -278,7 +276,7 @@ void VulkanBlitter::blitSlowDepth(VkFilter filter, const VkExtent2D srcExtent, V
     lazyInit();
 
     VulkanCommandBuffer* commands = &mCommands->get();
-    VkCommandBuffer const cmdbuffer = commands->cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands->buffer();
     commands->acquire(src.texture);
     commands->acquire(dst.texture);
 

--- a/filament/backend/src/vulkan/VulkanBuffer.cpp
+++ b/filament/backend/src/vulkan/VulkanBuffer.cpp
@@ -45,14 +45,7 @@ VulkanBuffer::VulkanBuffer(VmaAllocator allocator, VulkanStagePool& stagePool,
 }
 
 VulkanBuffer::~VulkanBuffer() {
-    assert_invariant(mGpuMemory == VK_NULL_HANDLE);
-    assert_invariant(mGpuBuffer == VK_NULL_HANDLE);
-}
-
-void VulkanBuffer::terminate() {
     vmaDestroyBuffer(mAllocator, mGpuBuffer, mGpuMemory);
-    mGpuMemory = VK_NULL_HANDLE;
-    mGpuBuffer = VK_NULL_HANDLE;
 }
 
 void VulkanBuffer::loadFromCpu(VkCommandBuffer cmdbuf, const void* cpuData, uint32_t byteOffset,

--- a/filament/backend/src/vulkan/VulkanBuffer.h
+++ b/filament/backend/src/vulkan/VulkanBuffer.h
@@ -28,7 +28,6 @@ public:
     VulkanBuffer(VmaAllocator allocator, VulkanStagePool& stagePool, VkBufferUsageFlags usage,
             uint32_t numBytes);
     ~VulkanBuffer();
-    void terminate();
     void loadFromCpu(VkCommandBuffer cmdbuf, const void* cpuData, uint32_t byteOffset,
             uint32_t numBytes) const;
     VkBuffer getGpuBuffer() const {

--- a/filament/backend/src/vulkan/VulkanContext.cpp
+++ b/filament/backend/src/vulkan/VulkanContext.cpp
@@ -117,8 +117,9 @@ void VulkanTimestamps::beginQuery(VulkanCommandBuffer const* commands,
         VulkanTimerQuery* query) {
     uint32_t const index = query->getStartingQueryIndex();
 
-    vkCmdResetQueryPool(commands->cmdbuffer, mPool, index, 2);
-    vkCmdWriteTimestamp(commands->cmdbuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, mPool, index);
+    auto const cmdbuffer = commands->buffer();
+    vkCmdResetQueryPool(cmdbuffer, mPool, index, 2);
+    vkCmdWriteTimestamp(cmdbuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, mPool, index);
 
     // We stash this because getResult might come before the query is actually processed.
     query->setFence(commands->fence);
@@ -127,7 +128,7 @@ void VulkanTimestamps::beginQuery(VulkanCommandBuffer const* commands,
 void VulkanTimestamps::endQuery(VulkanCommandBuffer const* commands,
         VulkanTimerQuery const* query) {
     uint32_t const index = query->getStoppingQueryIndex();
-    vkCmdWriteTimestamp(commands->cmdbuffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, mPool, index);
+    vkCmdWriteTimestamp(commands->buffer(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, mPool, index);
 }
 
 VulkanTimestamps::QueryResult VulkanTimestamps::getResult(VulkanTimerQuery const* query) {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -872,7 +872,7 @@ void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor
     VulkanCommandBuffer& commands = mCommands->get();
     auto ib = mResourceAllocator.handle_cast<VulkanIndexBuffer*>(ibh);
     commands.acquire(ib);
-    ib->buffer.loadFromCpu(commands.cmdbuffer, p.buffer, byteOffset, p.size);
+    ib->buffer.loadFromCpu(commands.buffer(), p.buffer, byteOffset, p.size);
 
     scheduleDestroy(std::move(p));
 }
@@ -883,7 +883,7 @@ void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescript
 
     auto bo = mResourceAllocator.handle_cast<VulkanBufferObject*>(boh);
     commands.acquire(bo);
-    bo->buffer.loadFromCpu(commands.cmdbuffer, bd.buffer, byteOffset, bd.size);
+    bo->buffer.loadFromCpu(commands.buffer(), bd.buffer, byteOffset, bd.size);
 
     scheduleDestroy(std::move(bd));
 }
@@ -894,7 +894,7 @@ void VulkanDriver::updateBufferObjectUnsynchronized(Handle<HwBufferObject> boh,
     auto bo = mResourceAllocator.handle_cast<VulkanBufferObject*>(boh);
     commands.acquire(bo);
     // TODO: implement unsynchronized version
-    bo->buffer.loadFromCpu(commands.cmdbuffer, bd.buffer, byteOffset, bd.size);
+    bo->buffer.loadFromCpu(commands.buffer(), bd.buffer, byteOffset, bd.size);
     mResourceManager.acquire(bo);
     scheduleDestroy(std::move(bd));
 }
@@ -1020,7 +1020,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
     // the non-sampling case.
     bool samplingDepthAttachment = false;
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuffer = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands.buffer();
 
     UTILS_NOUNROLL
     for (uint8_t samplerGroupIdx = 0; samplerGroupIdx < Program::SAMPLER_BINDING_COUNT;
@@ -1246,7 +1246,7 @@ void VulkanDriver::beginRenderPass(Handle<HwRenderTarget> rth, const RenderPassP
 
 void VulkanDriver::endRenderPass(int) {
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer cmdbuffer = commands.cmdbuffer;
+    VkCommandBuffer cmdbuffer = commands.buffer();
     vkCmdEndRenderPass(cmdbuffer);
 
     VulkanRenderTarget* rt = mCurrentRenderPass.renderTarget;
@@ -1298,7 +1298,7 @@ void VulkanDriver::nextSubpass(int) {
     assert_invariant(renderTarget);
     assert_invariant(mCurrentRenderPass.params.subpassMask);
 
-    vkCmdNextSubpass(mCommands->get().cmdbuffer, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdNextSubpass(mCommands->get().buffer(), VK_SUBPASS_CONTENTS_INLINE);
 
     mPipelineCache.bindRenderPass(mCurrentRenderPass.renderPass,
             ++mCurrentRenderPass.currentSubpass);
@@ -1483,7 +1483,7 @@ void VulkanDriver::blit(TargetBufferFlags buffers, Handle<HwRenderTarget> dst, V
 void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph,
         const uint32_t instanceCount) {
     VulkanCommandBuffer* commands = &mCommands->get();
-    VkCommandBuffer cmdbuffer = commands->cmdbuffer;
+    VkCommandBuffer cmdbuffer = commands->buffer();
     const VulkanRenderPrimitive& prim = *mResourceAllocator.handle_cast<VulkanRenderPrimitive*>(rph);
 
     Handle<HwProgram> programHandle = pipelineState.program;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -96,10 +96,6 @@ struct VulkanVertexBuffer : public HwVertexBuffer, VulkanResource {
 
     void setBuffer(VulkanBufferObject* bufferObject, uint32_t index);
 
-    inline void terminate() {
-        mResources.clear();
-    }
-
     utils::FixedCapacityVector<VulkanBuffer const*> buffers;
 
 private:
@@ -114,9 +110,6 @@ struct VulkanIndexBuffer : public HwIndexBuffer, VulkanResource {
           buffer(allocator, stagePool, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount),
           indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32) {}
 
-    void terminate() {
-        buffer.terminate();
-    }
     VulkanBuffer buffer;
     const VkIndexType indexType;
 };
@@ -124,9 +117,7 @@ struct VulkanIndexBuffer : public HwIndexBuffer, VulkanResource {
 struct VulkanBufferObject : public HwBufferObject, VulkanResource {
     VulkanBufferObject(VmaAllocator allocator, VulkanStagePool& stagePool, uint32_t byteCount,
             BufferObjectBinding bindingType, BufferUsage usage);
-    void terminate() {
-        buffer.terminate();
-    }
+
     VulkanBuffer buffer;
     const BufferObjectBinding bindingType;
 };

--- a/filament/backend/src/vulkan/VulkanPipelineCache.cpp
+++ b/filament/backend/src/vulkan/VulkanPipelineCache.cpp
@@ -166,7 +166,7 @@ bool VulkanPipelineCache::bindDescriptors(VkCommandBuffer cmdbuffer) noexcept {
 }
 
 bool VulkanPipelineCache::bindPipeline(VulkanCommandBuffer* commands) noexcept {
-    VkCommandBuffer const cmdbuffer = commands->cmdbuffer;
+    VkCommandBuffer const cmdbuffer = commands->buffer();
 
     PipelineMap::iterator pipelineIter = mPipelines.find(mPipelineRequirements);
 
@@ -678,7 +678,7 @@ void VulkanPipelineCache::terminate() noexcept {
     mDummyMemory = VK_NULL_HANDLE;
 }
 
-void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& cmdbuffer) {
+void VulkanPipelineCache::onCommandBuffer(const VulkanCommandBuffer& commands) {
     // The timestamp associated with a given cache entry represents "time" as a count of flush
     // events since the cache was constructed. If any cache entry was most recently used over
     // VK_MAX_PIPELINE_AGE flush events in the past, then we can be sure that it is no longer

--- a/filament/backend/src/vulkan/VulkanResourceAllocator.h
+++ b/filament/backend/src/vulkan/VulkanResourceAllocator.h
@@ -101,10 +101,6 @@ public:
     template<typename D, typename B>
     inline void destruct(Handle<B> handle) noexcept {
         auto obj = handle_cast<D*>(handle);
-        if constexpr (std::is_base_of_v<VulkanIndexBuffer, D>
-                      || std::is_base_of_v<VulkanBufferObject, D>) {
-            obj->terminate();
-        }
         TRACK_DECREMENT();
         mHandleAllocatorImpl.deallocate(handle, obj);
     }

--- a/filament/backend/src/vulkan/VulkanResources.h
+++ b/filament/backend/src/vulkan/VulkanResources.h
@@ -164,6 +164,10 @@ private:
 public:
     using const_iterator = FixedSizeArray::const_iterator;
 
+    inline ~FixedCapacityResourceSet() {
+        clear();
+    }
+
     inline const_iterator begin() {
         if (mInd == 0) {
             return mArray.cend();

--- a/filament/backend/src/vulkan/VulkanStagePool.cpp
+++ b/filament/backend/src/vulkan/VulkanStagePool.cpp
@@ -111,7 +111,7 @@ VulkanStageImage const* VulkanStagePool::acquireImage(PixelDataFormat format, Pi
     assert_invariant(result == VK_SUCCESS);
 
     VkImageAspectFlags const aspectFlags = getImageAspect(vkformat);
-    const VkCommandBuffer cmdbuffer = mCommands->get().cmdbuffer;
+    VkCommandBuffer const cmdbuffer = mCommands->get().buffer();
 
     // We use VK_IMAGE_LAYOUT_GENERAL here because the spec says:
     // "Host access to image memory is only well-defined for linear images and for image

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -79,7 +79,7 @@ void VulkanSwapChain::update() {
 
 void VulkanSwapChain::present() {
     if (!mHeadless) {
-        VkCommandBuffer const cmdbuf = mCommands->get().cmdbuffer;
+        VkCommandBuffer const cmdbuf = mCommands->get().buffer();
         VkImageSubresourceRange const subresources{
                 .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
                 .baseMipLevel = 0,

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -227,7 +227,7 @@ VulkanTexture::VulkanTexture(VkDevice device, VkPhysicalDevice physicalDevice,
         VkImageSubresourceRange range = { getImageAspect(), 0, levels, 0, layers };
 
         VulkanCommandBuffer& commands = mCommands->get();
-        VkCommandBuffer const cmdbuf = commands.cmdbuffer;
+        VkCommandBuffer const cmdbuf = commands.buffer();
         commands.acquire(this);
 
         transitionLayout(cmdbuf, range, ImgUtil::getDefaultLayout(imageInfo.usage));
@@ -280,7 +280,7 @@ void VulkanTexture::updateImage(const PixelBufferDescriptor& data, uint32_t widt
     vmaFlushAllocation(mAllocator, stage->memory, 0, hostData->size);
 
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuf = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuf = commands.buffer();
     commands.acquire(this);
 
     VkBufferImageCopy copyRegion = {
@@ -343,7 +343,7 @@ void VulkanTexture::updateImageWithBlit(const PixelBufferDescriptor& hostData, u
     vmaFlushAllocation(mAllocator, stage->memory, 0, hostData.size);
 
     VulkanCommandBuffer& commands = mCommands->get();
-    VkCommandBuffer const cmdbuf = commands.cmdbuffer;
+    VkCommandBuffer const cmdbuf = commands.buffer();
     commands.acquire(this);
 
     // TODO: support blit-based format conversion for 3D images and cubemaps.


### PR DESCRIPTION
We were calling vkFreeCommandBuffers directly, but resetting the buffers implicitly (when vkBeginCommandBuffer is called) seems to be a lot more performant.

Also, cleaned up destructor for VkBuffer to no longer require a separate terminate() method.