### PR TITLE
Fix the output of Windows release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,6 @@ jobs:
           TAG: ${{ steps.git_ref.outputs.tag }}
         run: |
           build\windows\build-github.bat release
-          cd ..\..
           move out\filament-windows.tgz out\filament-$Env:TAG-windows.tgz
         shell: cmd
       - uses: actions/github-script@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           build\windows\build-github.bat release
           cd ..\..
-          move out\filament-windows.tgz out\filament-%TAG%-windows.tgz
+          move out\filament-windows.tgz out\filament-$Env:TAG-windows.tgz
         shell: cmd
       - uses: actions/github-script@v6
         env:


### PR DESCRIPTION
This probably broke due to a change from old windows command prompt to powershell. The way to refer to env variables in powershell is `$Env:var`