### PR TITLE
Fix build warnings

### DIFF
--- a/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Half.kt
+++ b/android/filament-utils-android/src/main/java/com/google/android/filament/utils/Half.kt
@@ -17,6 +17,8 @@
 // Operators +, *, / based on http://half.sourceforge.net/ by Christian Rau
 // and licensed under MIT
 
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.google.android.filament.utils
 
 import com.google.android.filament.utils.Half.Companion.POSITIVE_INFINITY

--- a/build.sh
+++ b/build.sh
@@ -752,7 +752,10 @@ function run_tests {
 }
 
 function check_debug_release_build {
-    if [[ "${ISSUE_DEBUG_BUILD}" == "true" || "${ISSUE_RELEASE_BUILD}" == "true" ]]; then
+    if [[ "${ISSUE_DEBUG_BUILD}" == "true" || \
+          "${ISSUE_RELEASE_BUILD}" == "true" || \
+          "${ISSUE_CLEAN}" == "true" || \
+          "${ISSUE_WEB_DOCS}" == "true" ]]; then
         "$@";
     else
         echo "You must declare a debug or release target for $@ builds."

--- a/filament/benchmark/CMakeLists.txt
+++ b/filament/benchmark/CMakeLists.txt
@@ -10,6 +10,6 @@ set(BENCHMARK_SRCS
 
 add_executable(benchmark_filament ${BENCHMARK_SRCS})
 
-target_link_libraries(benchmark_filament PRIVATE benchmark_main utils math filament)
+target_link_libraries(benchmark_filament PRIVATE benchmark_main filament)
 
 set_target_properties(benchmark_filament PROPERTIES FOLDER Benchmarks)

--- a/libs/image/CMakeLists.txt
+++ b/libs/image/CMakeLists.txt
@@ -55,6 +55,6 @@ install(DIRECTORY ${PUBLIC_HDR_DIR}/image DESTINATION include)
 # ==================================================================================================
 if (NOT ANDROID AND NOT WEBGL AND NOT IOS AND NOT FILAMENT_SKIP_SDL2)
     add_executable(test_${TARGET} tests/test_image.cpp)
-    target_link_libraries(test_${TARGET} PRIVATE image imageio gtest)
+    target_link_libraries(test_${TARGET} PRIVATE imageio gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 endif()

--- a/tools/cmgen/CMakeLists.txt
+++ b/tools/cmgen/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SRCS
 # ==================================================================================================
 add_executable(${TARGET} ${HDRS} ${SRCS})
 
-target_link_libraries(${TARGET} PRIVATE math utils ibl z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE ibl imageio getopt)
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 
 # ==================================================================================================
@@ -54,6 +54,6 @@ install(TARGETS ${TARGET} RUNTIME DESTINATION bin)
 # ==================================================================================================
 if (NOT ANDROID)
     add_executable(test_${TARGET} tests/test_cmgen.cpp)
-    target_link_libraries(test_${TARGET} PRIVATE image imageio gtest)
+    target_link_libraries(test_${TARGET} PRIVATE imageio gtest)
     set_target_properties(test_${TARGET} PROPERTIES FOLDER Tests)
 endif()

--- a/tools/cso-lut/CMakeLists.txt
+++ b/tools/cso-lut/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SRCS src/main.cpp)
 # ==================================================================================================
 add_executable(${TARGET} ${HDRS} ${SRCS})
 
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE imageio getopt)
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 
 # ==================================================================================================

--- a/tools/filamesh/CMakeLists.txt
+++ b/tools/filamesh/CMakeLists.txt
@@ -16,10 +16,7 @@ set(SRCS
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
 
-target_link_libraries(${TARGET} PUBLIC math)
-target_link_libraries(${TARGET} PUBLIC utils)
-target_link_libraries(${TARGET} PUBLIC assimp)
-target_link_libraries(${TARGET} PRIVATE getopt filameshio meshoptimizer)
+target_link_libraries(${TARGET} PRIVATE assimp getopt filameshio meshoptimizer)
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 
 # ==================================================================================================

--- a/tools/matinfo/CMakeLists.txt
+++ b/tools/matinfo/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SRCS src/main.cpp)
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
 
-target_link_libraries(${TARGET} matdbg filaflat backend_headers utils getopt SPIRV-Tools spirv-cross-glsl)
+target_link_libraries(${TARGET} matdbg filaflat backend_headers getopt)
 
 # glslang contains a copy of the SPIRV headers, so let's just use those. The leading ".." in the
 # following variable refers to the project name that we define in glslang/tnt, and the trailing ".."

--- a/tools/mipgen/CMakeLists.txt
+++ b/tools/mipgen/CMakeLists.txt
@@ -12,7 +12,7 @@ set(SRCS src/main.cpp)
 # Target definitions
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE imageio getopt)
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 
 # =================================================================================================

--- a/tools/normal-blending/CMakeLists.txt
+++ b/tools/normal-blending/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SRCS src/main.cpp)
 # ==================================================================================================
 add_executable(${TARGET} ${HDRS} ${SRCS})
 
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE imageio getopt)
 
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 

--- a/tools/roughness-prefilter/CMakeLists.txt
+++ b/tools/roughness-prefilter/CMakeLists.txt
@@ -15,7 +15,7 @@ set(SRCS src/main.cpp)
 # ==================================================================================================
 add_executable(${TARGET} ${HDRS} ${SRCS})
 
-target_link_libraries(${TARGET} PRIVATE math utils z image imageio getopt)
+target_link_libraries(${TARGET} PRIVATE imageio getopt)
 
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 

--- a/tools/uberz/CMakeLists.txt
+++ b/tools/uberz/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SRCS
 # Target definitions
 # ==================================================================================================
 add_executable(${TARGET} ${SRCS})
-target_link_libraries(${TARGET} PRIVATE utils getopt uberzlib)
+target_link_libraries(${TARGET} PRIVATE getopt uberzlib)
 set_target_properties(${TARGET} PROPERTIES FOLDER Tools)
 
 # =================================================================================================


### PR DESCRIPTION
The latest macOS toolchain triggers warnings for duplicate libraries at link time. This is caused by our dependency chains.

Also remove an inlining warning in Kotlin and unnecessary warnings in build.sh when doing a clean or generating web docs.