### PR TITLE
Bug: fix underscores literal operators c++ compatible error again.

### DIFF
--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -171,27 +171,27 @@ typedef details::TQuaternion<double> quat;
 typedef details::TQuaternion<float> quatf;
 typedef details::TQuaternion<half> quath;
 
-constexpr inline quat operator "" _i(long double v) {
+constexpr inline quat operator""_i(long double v) {
     return { 0.0, double(v), 0.0, 0.0 };
 }
 
-constexpr inline quat operator "" _j(long double v) {
+constexpr inline quat operator""_j(long double v) {
     return { 0.0, 0.0, double(v), 0.0 };
 }
 
-constexpr inline quat operator "" _k(long double v) {
+constexpr inline quat operator""_k(long double v) {
     return { 0.0, 0.0, 0.0, double(v) };
 }
 
-constexpr inline quat operator "" _i(unsigned long long v) {
+constexpr inline quat operator""_i(unsigned long long v) {
     return { 0.0, double(v), 0.0, 0.0 };
 }
 
-constexpr inline quat operator "" _j(unsigned long long v) {
+constexpr inline quat operator""_j(unsigned long long v) {
     return { 0.0, 0.0, double(v), 0.0 };
 }
 
-constexpr inline quat operator "" _k(unsigned long long v) {
+constexpr inline quat operator""_k(unsigned long long v) {
     return { 0.0, 0.0, 0.0, double(v) };
 }
 


### PR DESCRIPTION
redo #7136 , because #7132 revert the patch.

Check #7132 `libs/math/include/math/quat.h`. Or `git show e0a37de1ba2325d21f191253dd4c2c22bb7f8a9e`.

@pixelflinger could you review this PR?