### PR TITLE
skinning: fix a possible crash/assert

### DIFF
--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -208,7 +208,8 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* const gld) const noexcept {
     auto const& UTILS_RESTRICT usedBindingPoints = mUsedSamplerBindingPoints;
 
     for (uint8_t i = 0, tmu = 0, n = mUsedBindingsCount; i < n; i++) {
-        auto const binding = usedBindingPoints[i];
+        size_t const binding = usedBindingPoints[i];
+        assert_invariant(binding < Program::SAMPLER_BINDING_COUNT);
         auto const * const sb = samplerBindings[binding];
         assert_invariant(sb);
         for (uint8_t j = 0, m = sb->textureUnitEntries.size(); j < m; ++j, ++tmu) { // "<=" on purpose here

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -875,14 +875,12 @@ void RenderPass::Executor::execute(backend::DriverApi& driver,
                         info.skinningHandle,
                         info.skinningOffset * sizeof(PerRenderableBoneUib::BoneData),
                         sizeof(PerRenderableBoneUib));
+                // note: always bind the skinningTexture because the shader needs it.
+                driver.bindSamplers(+SamplerBindingPoints::PER_RENDERABLE_SKINNING,
+                        info.skinningTexture);
                 // note: even if only skinning is enabled, binding morphTargetBuffer is needed.
                 driver.bindSamplers(+SamplerBindingPoints::PER_RENDERABLE_MORPHING,
                         info.morphTargetBuffer);
-
-                if (UTILS_UNLIKELY(info.skinningTexture)) {
-                    driver.bindSamplers(+SamplerBindingPoints::PER_RENDERABLE_SKINNING,
-                                      info.skinningTexture);
-                }
            }
 
             if (UTILS_UNLIKELY(info.morphWeightBuffer)) {
@@ -892,6 +890,9 @@ void RenderPass::Executor::execute(backend::DriverApi& driver,
                         info.morphWeightBuffer);
                 driver.bindSamplers(+SamplerBindingPoints::PER_RENDERABLE_MORPHING,
                         info.morphTargetBuffer);
+                // note: even if only morphing is enabled, binding skinningTexture is needed.
+                driver.bindSamplers(+SamplerBindingPoints::PER_RENDERABLE_SKINNING,
+                        info.skinningTexture);
             }
 
             driver.draw(pipeline, info.primitiveHandle, instanceCount);

--- a/filament/src/details/SkinningBuffer.cpp
+++ b/filament/src/details/SkinningBuffer.cpp
@@ -169,11 +169,12 @@ void FSkinningBuffer::setBones(FEngine& engine, Handle<backend::HwBufferObject> 
 constexpr size_t MAX_SKINNING_BUFFER_WIDTH = 2048;
 
 static inline size_t getSkinningBufferWidth(size_t pairCount) noexcept {
-    return std::min(pairCount, MAX_SKINNING_BUFFER_WIDTH);
+    return std::clamp(pairCount, size_t(1), MAX_SKINNING_BUFFER_WIDTH);
 }
 
 static inline size_t getSkinningBufferHeight(size_t pairCount) noexcept {
-    return (pairCount + MAX_SKINNING_BUFFER_WIDTH - 1) / MAX_SKINNING_BUFFER_WIDTH;
+    return std::max(size_t(1),
+            (pairCount + MAX_SKINNING_BUFFER_WIDTH - 1) / MAX_SKINNING_BUFFER_WIDTH);
 }
 
 inline size_t getSkinningBufferSize(size_t pairCount) noexcept {

--- a/filament/src/details/SkinningBuffer.h
+++ b/filament/src/details/SkinningBuffer.h
@@ -79,9 +79,9 @@ private:
         backend::Handle<backend::HwSamplerGroup> sampler;
         backend::Handle<backend::HwTexture> texture;
     };
-    HandleIndicesAndWeights createIndicesAndWeightsHandle(FEngine& engine,
+    static HandleIndicesAndWeights createIndicesAndWeightsHandle(FEngine& engine,
             size_t count);
-    void setIndicesAndWeightsData(FEngine& engine,
+    static void setIndicesAndWeightsData(FEngine& engine,
           backend::Handle<backend::HwTexture> textureHandle,
           const utils::FixedCapacityVector<math::float2>& pairs,
           size_t count);


### PR DESCRIPTION
all textures declared in a shader must be bound, in the case of the
new skinning API, if less than 4 bone weights are used the texture is 
not needed, but it must still be bound.