### PR TITLE
Fix test_gltfio cmake duplicate libs and failed UT.

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -225,8 +225,9 @@ if (TNT_DEV AND NOT WEBGL AND NOT ANDROID AND NOT IOS)
 
     add_executable(${TEST_TARGET} test/gltfio_test.cpp)
     add_dependencies(${TEST_TARGET} test_gltfio_files)
+    set_property(TARGET test_gltfio PROPERTY LINK_LIBRARIES)
 
-    target_link_libraries(${TEST_TARGET} PRIVATE ${TARGET} filament filabridge gtest uberarchive)
+    target_link_libraries(${TEST_TARGET} PRIVATE ${TARGET} gtest uberarchive)
     if (NOT MSVC)
         target_compile_options(${TEST_TARGET} PRIVATE -Wno-deprecated-register)
     endif()

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -160,6 +160,21 @@ TEST_F(glTFIOTest, AnimatedMorphCubeMaterials) {
     EXPECT_EQ(name, "Material");
 }
 
+// A macro to help with mat comparisons within a range.
+#define EXPECT_MAT_NEAR(MAT1, MAT2, eps)                        \
+do {                                                            \
+    const decltype(MAT1) v1 = MAT1;                             \
+    const decltype(MAT2) v2 = MAT2;                             \
+    EXPECT_EQ(v1.NUM_ROWS, v2.NUM_ROWS);                        \
+    EXPECT_EQ(v1.NUM_COLS, v2.NUM_COLS);                        \
+    for (int i = 0; i < v1.NUM_ROWS; ++i) {                     \
+        for (int j = 0; j < v1.NUM_COLS; ++j)                   \
+            EXPECT_NEAR(v1[i][j], v2[i][j], eps) <<             \
+                "v[" << i << "][" << j << "]";                  \
+    }                                                           \
+} while(0)
+
+
 TEST_F(glTFIOTest, AnimatedMorphCubeTransforms) {
     FilamentAsset const& morphCubeAsset = *mData[ANIMATED_MORPH_CUBE_GLB]->getAsset();
     auto const& transformManager = mEngine->getTransformManager();
@@ -177,8 +192,10 @@ TEST_F(glTFIOTest, AnimatedMorphCubeTransforms) {
 
     auto const result = inverse(transform) * expectedTransform;
 
+    float const value_eps = float(0.00001) * std::numeric_limits<float>::epsilon();
+
     // We expect the result to be identity
-    EXPECT_EQ(result, math::mat4f{});
+    EXPECT_MAT_NEAR(result, math::mat4f{}, value_eps);
 }
 
 TEST_F(glTFIOTest, AnimatedMorphCubeRenderables) {


### PR DESCRIPTION
1. **Fix the `ld` test_gltfio duplicated libraries**:
```
[2/2] Linking CXX executable libs/gltfio/test_gltfio
ld: warning: ignoring duplicate libraries: 'filament/libfilament.a', 'libs/filabridge/libfilabridge.a', 'libs/geometry/libgeometry.a', 'libs/ktxreader/libktxreader.a', 'libs/math/libmath.a', 'libs/uberz/libuberzlib.a', 'libs/utils/libutils.a', 'third_party/stb/tnt/libstb.a'
```

**Cause**:
the cmake file `libs/gltfio/CMakeLists.txt` config `link_libraries(math utils filament cgltf stb ktxreader geometry tsl trie uberzlib)` for the targets includes `test_gltfio`.

**Solution**:
clear `link_libraries` property for `test_gltfio` target.
```
set_property(TARGET test_gltfio PROPERTY LINK_LIBRARIES)
```

2. **Fix UT `glTFIOTest.AnimatedMorphCubeTransforms`**

run `test_gltfio`: `./out/cmake-debug/libs/gltfio/test_gltfio`;

with errors:
```
Expected equality of these values:
  result
    Which is: 64-byte object <00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-29 00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 80-3F>
  math::mat4f{}
    Which is: 64-byte object <00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 80-3F 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 00-00 80-3F>
CircularBuffer: High watermark 0 KiB (0%)
FEngine::mHeapAllocator arena: High watermark 4 KiB
[  FAILED  ] glTFIOTest.AnimatedMorphCubeTransforms (15 ms)
```

**Solution**:
use gtest `EXPECT_NEAR` to compare floats. 