### PR TITLE
Fix: remove package attributes for AndroidManifest.xml

### DIFF
--- a/android/filamat-android/src/main/AndroidManifest.xml
+++ b/android/filamat-android/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.android.filament.filamat" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/android/filament-utils-android/src/main/AndroidManifest.xml
+++ b/android/filament-utils-android/src/main/AndroidManifest.xml
@@ -14,5 +14,4 @@
   limitations under the License.
  -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.android.filament.utils" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
Fix warning and Recommendation when `./build.sh -p android -i release`

```
> Task :filament-android:processReleaseManifest
package="com.google.android.filament" found in source AndroidManifest.xml: /Users/jacobsu/hack/graphics/filament/android/filament-android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="com.google.android.filament" from the source AndroidManifest.xml: /Users/jacobsu/hack/graphics/filament/android/filament-android/src/main/AndroidManifest.xml.

> Task :filament-utils-android:processReleaseManifest
package="com.google.android.filament.utils" found in source AndroidManifest.xml: /Users/jacobsu/hack/graphics/filament/android/filament-utils-android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="com.google.android.filament.utils" from the source AndroidManifest.xml: /Users/jacobsu/hack/graphics/filament/android/filament-utils-android/src/main/AndroidManifest.xml.
```

The Android package name is configured in `android/filament-utils-android/build.gradle` & `android/filamat-android/build.gradle`'s `android.namespace` property, no-longer inside the `AndroidManifest.xml`.