### PR TITLE
fix materials that write to the depth or use discard

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -8,3 +8,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 
 ## Release notes for next branch cut
 - materials: fix alpha masked materials when MSAA is turned on [⚠️ **Recompile materials**]
+- materials: better support materials with custom depth [**Recompile Materials**]

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -755,7 +755,7 @@ private:
             MaterialBuilder::PropertyList& allProperties,
             CodeGenParams const& semanticCodeGenParams) noexcept;
 
-    bool runSemanticAnalysis(MaterialInfo const& info,
+    bool runSemanticAnalysis(MaterialInfo* inOutInfo,
             CodeGenParams const& semanticCodeGenParams) noexcept;
 
     bool checkLiteRequirements() noexcept;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -711,15 +711,15 @@ bool MaterialBuilder::runSemanticAnalysis(MaterialInfo const& info,
     if (mMaterialDomain == filament::MaterialDomain::COMPUTE) {
         shaderCode = peek(ShaderStage::COMPUTE, semanticCodeGenParams, mProperties);
         result = GLSLTools::analyzeComputeShader(shaderCode, model,
-                targetApi, targetLanguage, info);
+                targetApi, targetLanguage);
     } else {
         shaderCode = peek(ShaderStage::VERTEX, semanticCodeGenParams, mProperties);
         result = GLSLTools::analyzeVertexShader(shaderCode, model, mMaterialDomain,
-                targetApi, targetLanguage, info);
+                targetApi, targetLanguage);
         if (result) {
             shaderCode = peek(ShaderStage::FRAGMENT, semanticCodeGenParams, mProperties);
             result = GLSLTools::analyzeFragmentShader(shaderCode, model, mMaterialDomain,
-                    targetApi, targetLanguage, mCustomSurfaceShading, info);
+                    targetApi, targetLanguage, mCustomSurfaceShading);
         }
     }
     if (!result && mPrintShaders) {

--- a/libs/filamat/src/sca/ASTHelpers.cpp
+++ b/libs/filamat/src/sca/ASTHelpers.cpp
@@ -144,8 +144,7 @@ std::string_view getFunctionName(std::string_view functionSignature) noexcept {
 }
 
 glslang::TIntermAggregate* getFunctionBySignature(std::string_view functionSignature,
-        TIntermNode& rootNode)
-        noexcept {
+        TIntermNode& rootNode) noexcept {
     FunctionDefinitionFinder functionDefinitionFinder(functionSignature);
     rootNode.traverse(&functionDefinitionFinder);
     return functionDefinitionFinder.getFunctionDefinitionNode();

--- a/libs/filamat/src/sca/ASTHelpers.cpp
+++ b/libs/filamat/src/sca/ASTHelpers.cpp
@@ -25,7 +25,7 @@
 
 using namespace glslang;
 
-namespace ASTUtils {
+namespace ASTHelpers {
 
 // Traverse the AST to find the definition of a function based on its name/signature.
 // e.g: prepareMaterial(struct-MaterialInputs-vf4-vf41;
@@ -41,8 +41,8 @@ public:
             if (mUseFQN) {
                 match = node->getName() == mFunctionName;
             } else {
-                std::string_view prospectFunctionName = getFunctionName(node->getName());
-                std::string_view cleanedFunctionName = getFunctionName(mFunctionName);
+                std::string_view const prospectFunctionName = getFunctionName(node->getName());
+                std::string_view const cleanedFunctionName = getFunctionName(mFunctionName);
                 match = prospectFunctionName == cleanedFunctionName;
             }
             if (match) {
@@ -78,7 +78,7 @@ public:
         if (node->getOp() != EOpFunctionCall) {
             return true;
         }
-        std::string_view functionCalledName = node->getName();
+        std::string_view const functionCalledName = node->getName();
         if (functionCalledName == mFunctionName) {
             mFunctionFound = true;
         } else {
@@ -102,201 +102,46 @@ private:
 
 // For debugging and printing out an AST portion. Mostly incomplete but complete enough for our need
 // TODO: Add more switch cases as needed.
-const char* op2Str(TOperator op) {
+std::string to_string(TOperator op) {
     switch (op) {
-        case EOpAssign : return "EOpAssign";
-        case EOpAddAssign: return "EOpAddAssign";
-        case EOpSubAssign: return "EOpSubAssign";
-        case EOpMulAssign: return "EOpMulAssign";
-        case EOpDivAssign: return "EOpDivAssign";
-        case EOpVectorSwizzle: return "EOpVectorSwizzle";
-        case EOpIndexDirectStruct :return "EOpIndexDirectStruct";
-        case EOpFunction:return "EOpFunction";
-        case EOpFunctionCall:return "EOpFunctionCall";
-        case EOpParameters:return "EOpParameters";
-        default: return "???";
+        case EOpSequence:               return "EOpSequence";
+        case EOpAssign:                 return "EOpAssign";
+        case EOpAddAssign:              return "EOpAddAssign";
+        case EOpSubAssign:              return "EOpSubAssign";
+        case EOpMulAssign:              return "EOpMulAssign";
+        case EOpDivAssign:              return "EOpDivAssign";
+        case EOpVectorSwizzle:          return "EOpVectorSwizzle";
+        case EOpIndexDirectStruct:      return "EOpIndexDirectStruct";
+        case EOpFunction:               return "EOpFunction";
+        case EOpFunctionCall:           return "EOpFunctionCall";
+        case EOpParameters:             return "EOpParameters";
+        // branch
+        case EOpKill:                   return "EOpKill";
+        case EOpTerminateInvocation:    return "EOpTerminateInvocation";
+        case EOpDemote:                 return "EOpDemote";
+        case EOpTerminateRayKHR:        return "EOpTerminateRayKHR";
+        case EOpIgnoreIntersectionKHR:  return "EOpIgnoreIntersectionKHR";
+        case EOpReturn:                 return "EOpReturn";
+        case EOpBreak:                  return "EOpBreak";
+        case EOpContinue:               return "EOpContinue";
+        case EOpCase:                   return "EOpCase";
+        case EOpDefault:                return "EOpDefault";
+        default:
+            return std::to_string((int)op);
     }
 }
 
-static std::string getIndexDirectStructString(const TIntermBinary& node) {
+std::string getIndexDirectStructString(const TIntermBinary& node) {
     const TTypeList& structNode = *(node.getLeft()->getType().getStruct());
     TIntermConstantUnion* index =   node.getRight() ->getAsConstantUnion();
     return structNode[index->getConstArray()[0].getIConst()].type->getFieldName().c_str();
 }
 
-// Meant to explore the Lvalue in an assignment. Depth traverse the left child of an assignment
-// binary node to find out the symbol and all access applied on it.
-static const TIntermTyped* findLValueBase(const TIntermTyped* node, Symbol& symbol)
-{
-    do {
-        // Make sure we have a binary node
-        const TIntermBinary* binary = node->getAsBinaryNode();
-        if (binary == nullptr) {
-            return node;
-        }
-
-        // Check Operator
-        TOperator op = binary->getOp();
-        if (op != EOpIndexDirect && op != EOpIndexIndirect && op != EOpIndexDirectStruct && op !=
-                EOpVectorSwizzle && op != EOpMatrixSwizzle) {
-            return nullptr;
-        }
-        Access access;
-        if (op == EOpIndexDirectStruct) {
-            access.string = getIndexDirectStructString(*binary);
-            access.type = Access::DirectIndexForStruct;
-        } else {
-            access.string = op2Str(op) ;
-            access.type = Access::Swizzling;
-        }
-        symbol.add(access);
-        node = node->getAsBinaryNode()->getLeft();
-    } while (true);
-}
-
-
-class SymbolsTracer : public TIntermTraverser {
-public:
-    explicit SymbolsTracer(std::deque<Symbol>& events) : mEvents(events) {
-    }
-
-    // Function call site.
-    bool visitAggregate(TVisit, TIntermAggregate* node) override {
-        if (node->getOp() != EOpFunctionCall) {
-            return true;
-        }
-
-        // Find function name.
-        std::string functionName = node->getName().c_str();
-
-        // Iterate on function parameters.
-        for (size_t parameterIdx = 0; parameterIdx < node->getSequence().size(); parameterIdx++) {
-            TIntermNode* parameter = node->getSequence().at(parameterIdx);
-            // Parameter is not a pure symbol. It is indexed or swizzled.
-            if (parameter->getAsBinaryNode()) {
-                Symbol symbol;
-                std::vector<Symbol> events;
-                const TIntermTyped* n = findLValueBase(parameter->getAsBinaryNode(), symbol);
-                if (n != nullptr && n->getAsSymbolNode() != nullptr) {
-                    const TString& symbolTString = n->getAsSymbolNode()->getName();
-                    symbol.setName(symbolTString.c_str());
-                    events.push_back(symbol);
-                }
-
-                for (Symbol symbol: events) {
-                    Access fCall = {Access::FunctionCall, functionName, parameterIdx};
-                    symbol.add(fCall);
-                    mEvents.push_back(symbol);
-                }
-
-            }
-            // Parameter is a pure symbol.
-            if (parameter->getAsSymbolNode()) {
-                Symbol s(parameter->getAsSymbolNode()->getName().c_str());
-                Access fCall = {Access::FunctionCall, functionName, parameterIdx};
-                s.add(fCall);
-                mEvents.push_back(s);
-            }
-        }
-
-        return true;
-    }
-
-    // Assign operations
-    bool visitBinary(TVisit, TIntermBinary* node) override {
-        TOperator op = node->getOp();
-        Symbol symbol;
-        if (op == EOpAssign || op == EOpAddAssign || op == EOpDivAssign || op == EOpSubAssign
-                || op == EOpMulAssign ) {
-            const TIntermTyped* n = findLValueBase(node->getLeft(), symbol);
-            if (n != nullptr && n->getAsSymbolNode() != nullptr) {
-                const TString& symbolTString = n->getAsSymbolNode()->getName();
-                symbol.setName(symbolTString.c_str());
-                mEvents.push_back(symbol);
-                return false; // Don't visit subtree since we just traced it with findLValueBase()
-            }
-        }
-        return true;
-    }
-
-private:
-    std::deque<Symbol>& mEvents;
-};
 
 std::string_view getFunctionName(std::string_view functionSignature) noexcept {
-  auto indexParenthesis = functionSignature.find('(');
-  return functionSignature.substr(0, indexParenthesis);
+    auto indexParenthesis = functionSignature.find('(');
+    return functionSignature.substr(0, indexParenthesis);
 }
-
-class NodeToString: public TIntermTraverser {
-public:
-
-    void pad() {
-       for (int i = 0; i < depth; ++i) {
-           utils::slog.e << "    ";
-       }
-    }
-
-    bool visitBinary(TVisit, TIntermBinary* node) override {
-        pad();
-        utils::slog.e << "Binary " << op2Str(node->getOp());
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    bool visitUnary(TVisit, TIntermUnary* node) override {
-        pad();
-        utils::slog.e << "Unary" << op2Str(node->getOp());
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    bool visitAggregate(TVisit, TIntermAggregate* node) override {
-        pad();
-        utils::slog.e << "Aggregate" << op2Str(node->getOp());
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    bool visitSelection(TVisit, TIntermSelection* node) override {
-        pad();
-        utils::slog.e << "Selection";
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    void visitConstantUnion(TIntermConstantUnion* node) override {
-        pad();
-        utils::slog.e << "ConstantUnion";
-        utils::slog.e << utils::io::endl;
-    }
-
-    void visitSymbol(TIntermSymbol* node) override {
-        pad();
-        utils::slog.e << "Symbol " << node->getAsSymbolNode()->getName().c_str();
-        utils::slog.e << utils::io::endl;
-    }
-
-    bool visitLoop(TVisit, TIntermLoop* node) override {
-        pad();
-        utils::slog.e << "Loop";
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    bool visitBranch(TVisit, TIntermBranch* node) override {
-        pad();
-        utils::slog.e << "Branch";
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-
-    bool visitSwitch(TVisit, TIntermSwitch* node) override {
-        utils::slog.e << "Binary ";
-        utils::slog.e << utils::io::endl;
-        return true;
-    }
-};
 
 glslang::TIntermAggregate* getFunctionBySignature(std::string_view functionSignature,
         TIntermNode& rootNode)
@@ -320,11 +165,6 @@ bool isFunctionCalled(std::string_view functionName, TIntermNode& functionNode,
     return traverser.functionWasCalled();
 }
 
-void traceSymbols(TIntermNode& functionNode, std::deque<Symbol>& events) {
-    SymbolsTracer variableTracer(events);
-    functionNode.traverse(&variableTracer);
-}
-
 static FunctionParameter::Qualifier glslangQualifier2FunctionParameter(TStorageQualifier q) {
     switch (q) {
         case EvqIn: return FunctionParameter::Qualifier::IN;
@@ -335,14 +175,15 @@ static FunctionParameter::Qualifier glslangQualifier2FunctionParameter(TStorageQ
     }
 }
 
-void getFunctionParameters(TIntermAggregate* func, std::vector<FunctionParameter>& output) noexcept {
+void getFunctionParameters(TIntermAggregate* func,
+        std::vector<FunctionParameter>& output) noexcept {
     if (func == nullptr) {
         return;
     }
 
     // Does it have a list of params
     // The second aggregate is the list of instructions, but the function may be empty
-    if (func->getSequence().size() < 1) {
+    if (func->getSequence().empty()) {
         return;
     }
 
@@ -350,7 +191,7 @@ void getFunctionParameters(TIntermAggregate* func, std::vector<FunctionParameter
     // Index 0 is a list of params (IntermSymbol).
     for(TIntermNode* parameterNode : func->getSequence().at(0)->getAsAggregate()->getSequence()) {
         TIntermSymbol* parameter = parameterNode->getAsSymbolNode();
-        FunctionParameter p = {
+        FunctionParameter const p = {
                 parameter->getName().c_str(),
                 parameter->getType().getCompleteString().c_str(),
                 glslangQualifier2FunctionParameter(parameter->getType().getQualifier().storage)
@@ -359,105 +200,63 @@ void getFunctionParameters(TIntermAggregate* func, std::vector<FunctionParameter
     }
 }
 
-template <typename F>
-class TraverserAdapter: public TIntermTraverser {
-    F closure;
-public:
-    explicit TraverserAdapter(F closure)
-        : TIntermTraverser(true, false, false, false),
-          closure(closure) {
+void NodeToString::pad() {
+    for (int i = 0; i < depth; ++i) {
+        utils::slog.d << "    ";
     }
-    bool visitAggregate(TVisit visit, TIntermAggregate* node) override {
-        return closure(visit, node);
-    }
-};
+}
 
-void textureLodBias(TIntermediate* intermediate, TIntermNode* root,
-        const char* entryPointSignatureish, const char* lodBiasSymbolName) {
+bool NodeToString::visitBinary(TVisit, TIntermBinary* node) {
+    pad();
+    utils::slog.d << "Binary " << to_string(node->getOp()) << utils::io::endl;
+    return true;
+}
 
-    // First, find the "lodBias" symbol and entry point
-    const std::string functionName{ entryPointSignatureish };
-    TIntermSymbol* pIntermSymbolLodBias = nullptr;
-    TIntermNode* pEntryPointRoot = nullptr;
-    TraverserAdapter findLodBiasSymbol(
-            [&](TVisit visit, TIntermAggregate* node) {
-                if (node->getOp() == glslang::EOpSequence) {
-                    return true;
-                }
-                if (node->getOp() == glslang::EOpFunction) {
-                    if (node->getName().rfind(functionName, 0) == 0) {
-                        pEntryPointRoot = node;
-                    }
-                    return false;
-                }
-                if (node->getOp() == glslang::EOpLinkerObjects) {
-                    for (TIntermNode* item: node->getSequence()) {
-                        TIntermSymbol* symbol = item->getAsSymbolNode();
-                        if (symbol && symbol->getBasicType() == TBasicType::EbtFloat) {
-                            if (symbol->getName() == lodBiasSymbolName) {
-                                pIntermSymbolLodBias = symbol;
-                                break;
-                            }
-                        }
-                    }
-                }
-                return true;
-            });
-    root->traverse(&findLodBiasSymbol);
+bool NodeToString::visitUnary(TVisit, TIntermUnary* node) {
+    pad();
+    utils::slog.d << "Unary " << to_string(node->getOp()) << utils::io::endl;
+    return true;
+}
 
-    if (!pEntryPointRoot) {
-        // This can happen if the material doesn't have user defined code,
-        // e.g. with the depth material. We just do nothing then.
-        return;
-    }
+bool NodeToString::visitAggregate(TVisit, TIntermAggregate* node) {
+    pad();
+    utils::slog.d << "Aggregate " << to_string(node->getOp());
+    utils::slog.d << " " << node->getName().c_str();
+    utils::slog.d << utils::io::endl;
+    return true;
+}
 
-    if (!pIntermSymbolLodBias) {
-        // something went wrong
-        utils::slog.e << "lod bias ignored because \"" << lodBiasSymbolName << "\" was not found!"
-                      << utils::io::endl;
-        return;
-    }
+bool NodeToString::visitSelection(TVisit, TIntermSelection*) {
+    pad();
+    utils::slog.d << "Selection " << utils::io::endl;
+    return true;
+}
 
-    // add lod bias to texture calls
-    TraverserAdapter addLodBiasToTextureCalls(
-            [&](TVisit visit, TIntermAggregate* node) {
-                // skip everything that's not a texture() call
-                if (node->getOp() != glslang::EOpTexture) {
-                    return true;
-                }
+void NodeToString::visitConstantUnion(TIntermConstantUnion*) {
+    pad();
+    utils::slog.d << "ConstantUnion " << utils::io::endl;
+}
 
-                TIntermSequence& sequence = node->getSequence();
+void NodeToString::visitSymbol(TIntermSymbol* node) {
+    pad();
+    utils::slog.d << "Symbol " << node->getAsSymbolNode()->getName().c_str() << utils::io::endl;
+}
 
-                // first check that we have the correct sampler
-                TIntermTyped* pTyped = sequence[0]->getAsTyped();
-                if (!pTyped) {
-                    return false;
-                }
+bool NodeToString::visitLoop(TVisit, TIntermLoop*) {
+    pad();
+    utils::slog.d << "Loop " << utils::io::endl;
+    return true;
+}
 
-                TSampler const& sampler = pTyped->getType().getSampler();
-                if (sampler.isArrayed() && sampler.isShadow()) {
-                    // sampler2DArrayShadow is not supported
-                    return false;
-                }
+bool NodeToString::visitBranch(TVisit, TIntermBranch* branch) {
+    pad();
+    utils::slog.d << "Branch " << to_string(branch->getFlowOp()) << utils::io::endl;
+    return true;
+}
 
-                // Then add the lod bias to the texture() call
-                if (sequence.size() == 2) {
-                    // we only have 2 parameters, add the 3rd one
-                    TIntermSymbol* symbol = intermediate->addSymbol(*pIntermSymbolLodBias);
-                    sequence.push_back(symbol);
-                } else if (sequence.size() == 3) {
-                    // load bias is already specified
-                    TIntermSymbol* symbol = intermediate->addSymbol(*pIntermSymbolLodBias);
-                    TIntermTyped* pAdd = intermediate->addBinaryMath(TOperator::EOpAdd,
-                            sequence[2]->getAsTyped(), symbol,
-                            node->getLoc());
-                    sequence[2] = pAdd;
-                }
-
-                return false;
-            });
-    // we need to run this only from the user's main entry point
-    pEntryPointRoot->traverse(&addLodBiasToTextureCalls);
+bool NodeToString::visitSwitch(TVisit, TIntermSwitch*) {
+    utils::slog.d << "Binary " << utils::io::endl;
+    return true;
 }
 
 } // namespace ASTHelpers

--- a/libs/filamat/src/sca/ASTHelpers.h
+++ b/libs/filamat/src/sca/ASTHelpers.h
@@ -17,18 +17,48 @@
 #ifndef TNT_SCAHELPERS_H_H
 #define TNT_SCAHELPERS_H_H
 
-#include <deque>
 #include <string>
 #include <vector>
 #include <intermediate.h>
 
-#include "GLSLTools.h"
-
 class TIntermNode;
 
-using namespace filamat;
+namespace ASTHelpers {
 
-namespace ASTUtils {
+template<typename F>
+class TraverserAdapter : public glslang::TIntermTraverser {
+    F closure;
+public:
+    explicit TraverserAdapter(F closure)
+            : TIntermTraverser(true, false, false, false),
+              closure(closure) {
+    }
+
+    bool visitAggregate(glslang::TVisit visit, glslang::TIntermAggregate* node) override {
+        return closure(visit, node);
+    }
+};
+
+template<typename F>
+void traverse(TIntermNode* root, F&& closure) {
+    TraverserAdapter adapter(std::forward<std::decay_t<F>>(closure));
+    root->traverse(&adapter);
+}
+
+class NodeToString : public glslang::TIntermTraverser {
+    void pad();
+public:
+    using TVisit = glslang::TVisit;
+    bool visitBinary(TVisit, glslang::TIntermBinary* node) override;
+    bool visitUnary(TVisit, glslang::TIntermUnary* node) override;
+    bool visitAggregate(TVisit, glslang::TIntermAggregate* node) override;
+    bool visitSelection(TVisit, glslang::TIntermSelection*) override;
+    void visitConstantUnion(glslang::TIntermConstantUnion*) override;
+    void visitSymbol(glslang::TIntermSymbol* node) override;
+    bool visitLoop(TVisit, glslang::TIntermLoop*) override;
+    bool visitBranch(TVisit, glslang::TIntermBranch*) override;
+    bool visitSwitch(TVisit, glslang::TIntermSwitch*) override;
+};
 
 // Extract the name of a function from its glslang mangled signature. e.g: Returns prepareMaterial
 // for input "prepareMaterial(struct-MaterialInputs-vf4-f1-f1-f1-f1-vf41;".
@@ -48,17 +78,13 @@ glslang::TIntermAggregate* getFunctionBySignature(std::string_view functionSigna
 // This function is useful when looking for a function with variable signature. e.g: prepareMaterial
 // and material functions take a struct which can vary in size depending on the property of the
 // material processed.
-glslang::TIntermAggregate* getFunctionByNameOnly(std::string_view functionName, TIntermNode& root)
-        noexcept;
+glslang::TIntermAggregate* getFunctionByNameOnly(std::string_view functionName,
+        TIntermNode& root) noexcept;
 
 // Recursively traverse the AST function node provided, looking for a call to the specified
 // function. Traverse all function calls found in each function.
 bool isFunctionCalled(std::string_view functionName, TIntermNode& functionNode,
         TIntermNode& rootNode) noexcept;
-
-// Traverse the function node provided and record all symbol writes operation and all function call
-// involving symbols.
-void traceSymbols(TIntermNode& functionNode, std::deque<Symbol>& vector);
 
 struct FunctionParameter {
     enum Qualifier { IN, OUT, INOUT, CONST };
@@ -68,13 +94,12 @@ struct FunctionParameter {
 };
 
 // Traverse function definition node, looking for parameters and populate params vector.
-void getFunctionParameters(glslang::TIntermAggregate* func, std::vector<FunctionParameter>& output)
-        noexcept;
+void getFunctionParameters(glslang::TIntermAggregate* func,
+        std::vector<FunctionParameter>& output) noexcept;
 
-// add lod bias to texture() calls
-void textureLodBias(glslang::TIntermediate* intermediate, TIntermNode* root,
-        const char* entryPointSignatureish, const char* lodBiasSymbolName);
+std::string to_string(glslang::TOperator op);
 
+std::string getIndexDirectStructString(const glslang::TIntermBinary& node);
 
 } // namespace ASTutils
 #endif //TNT_SCAHELPERS_H_H

--- a/libs/filamat/src/sca/ASTHelpers.h
+++ b/libs/filamat/src/sca/ASTHelpers.h
@@ -25,26 +25,6 @@ class TIntermNode;
 
 namespace ASTHelpers {
 
-template<typename F>
-class TraverserAdapter : public glslang::TIntermTraverser {
-    F closure;
-public:
-    explicit TraverserAdapter(F closure)
-            : TIntermTraverser(true, false, false, false),
-              closure(closure) {
-    }
-
-    bool visitAggregate(glslang::TVisit visit, glslang::TIntermAggregate* node) override {
-        return closure(visit, node);
-    }
-};
-
-template<typename F>
-void traverse(TIntermNode* root, F&& closure) {
-    TraverserAdapter adapter(std::forward<std::decay_t<F>>(closure));
-    root->traverse(&adapter);
-}
-
 class NodeToString : public glslang::TIntermTraverser {
     void pad();
 public:

--- a/libs/filamat/src/sca/GLSLTools.cpp
+++ b/libs/filamat/src/sca/GLSLTools.cpp
@@ -16,13 +16,11 @@
 
 #include "GLSLTools.h"
 
+#include <filamat/Enums.h>
 #include <filament/MaterialEnums.h>
 #include <filamat/MaterialBuilder.h>
-#include "../shaders/MaterialInfo.h"
 
 #include <utils/Log.h>
-
-#include "filamat/Enums.h"
 
 #include "ASTHelpers.h"
 
@@ -34,7 +32,6 @@
 
 using namespace utils;
 using namespace glslang;
-using namespace ASTUtils;
 using namespace filament::backend;
 
 namespace filamat {
@@ -48,6 +45,8 @@ GLSLangCleaner::~GLSLangCleaner() {
     SetThreadPoolAllocator(mAllocator);
 }
 
+// ------------------------------------------------------------------------------------------------
+
 static std::string_view getMaterialFunctionName(MaterialBuilder::MaterialDomain domain) noexcept {
     switch (domain) {
         case MaterialBuilder::MaterialDomain::SURFACE:
@@ -59,10 +58,109 @@ static std::string_view getMaterialFunctionName(MaterialBuilder::MaterialDomain 
     }
 };
 
+// ------------------------------------------------------------------------------------------------
+
+class SymbolsTracer : public TIntermTraverser {
+public:
+    explicit SymbolsTracer(std::deque<Symbol>& events) : mEvents(events) {
+    }
+
+    // Function call site.
+    bool visitAggregate(TVisit, TIntermAggregate* node) override {
+        if (node->getOp() != EOpFunctionCall) {
+            return true;
+        }
+
+        // Find function name.
+        std::string const functionName = node->getName().c_str();
+
+        // Iterate on function parameters.
+        for (size_t parameterIdx = 0; parameterIdx < node->getSequence().size(); parameterIdx++) {
+            TIntermNode* parameter = node->getSequence().at(parameterIdx);
+            // Parameter is not a pure symbol. It is indexed or swizzled.
+            if (parameter->getAsBinaryNode()) {
+                Symbol symbol;
+                std::vector<Symbol> events;
+                const TIntermTyped* n = findLValueBase(parameter->getAsBinaryNode(), symbol);
+                if (n != nullptr && n->getAsSymbolNode() != nullptr) {
+                    const TString& symbolTString = n->getAsSymbolNode()->getName();
+                    symbol.setName(symbolTString.c_str());
+                    events.push_back(symbol);
+                }
+
+                for (Symbol symbol : events) {
+                    Access const fCall = { Access::FunctionCall, functionName, parameterIdx };
+                    symbol.add(fCall);
+                    mEvents.push_back(symbol);
+                }
+            }
+            // Parameter is a pure symbol.
+            if (parameter->getAsSymbolNode()) {
+                Symbol s(parameter->getAsSymbolNode()->getName().c_str());
+                Access const fCall = {Access::FunctionCall, functionName, parameterIdx};
+                s.add(fCall);
+                mEvents.push_back(s);
+            }
+        }
+
+        return true;
+    }
+
+    // Assign operations
+    bool visitBinary(TVisit, TIntermBinary* node) override {
+        TOperator const op = node->getOp();
+        Symbol symbol;
+        if (op == EOpAssign || op == EOpAddAssign || op == EOpDivAssign || op == EOpSubAssign
+            || op == EOpMulAssign ) {
+            const TIntermTyped* n = findLValueBase(node->getLeft(), symbol);
+            if (n != nullptr && n->getAsSymbolNode() != nullptr) {
+                const TString& symbolTString = n->getAsSymbolNode()->getName();
+                symbol.setName(symbolTString.c_str());
+                mEvents.push_back(symbol);
+                return false; // Don't visit subtree since we just traced it with findLValueBase()
+            }
+        }
+        return true;
+    }
+
+private:
+    std::deque<Symbol>& mEvents;
+
+    // Meant to explore the Lvalue in an assignment. Depth traverse the left child of an assignment
+    // binary node to find out the symbol and all access applied on it.
+    static const TIntermTyped* findLValueBase(const TIntermTyped* node, Symbol& symbol) {
+        do {
+            // Make sure we have a binary node
+            const TIntermBinary* binary = node->getAsBinaryNode();
+            if (binary == nullptr) {
+                return node;
+            }
+
+            // Check Operator
+            TOperator const op = binary->getOp();
+            if (op != EOpIndexDirect && op != EOpIndexIndirect && op != EOpIndexDirectStruct
+                && op != EOpVectorSwizzle && op != EOpMatrixSwizzle) {
+                return nullptr;
+            }
+            Access access;
+            if (op == EOpIndexDirectStruct) {
+                access.string = ASTHelpers::getIndexDirectStructString(*binary);
+                access.type = Access::DirectIndexForStruct;
+            } else {
+                access.string = ASTHelpers::to_string(op) ;
+                access.type = Access::Swizzling;
+            }
+            symbol.add(access);
+            node = node->getAsBinaryNode()->getLeft();
+        } while (true);
+    }
+};
+
+// ------------------------------------------------------------------------------------------------
+
 bool GLSLTools::analyzeComputeShader(const std::string& shaderCode,
         filament::backend::ShaderModel model, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetLanguage targetLanguage,
-        MaterialInfo const& info) noexcept {
+        MaterialBuilder::TargetLanguage targetLanguage) noexcept {
 
     // Parse to check syntax and semantic.
     const char* shaderCString = shaderCode.c_str();
@@ -70,10 +168,10 @@ bool GLSLTools::analyzeComputeShader(const std::string& shaderCode,
     TShader tShader(EShLanguage::EShLangCompute);
     tShader.setStrings(&shaderCString, 1);
 
-    GLSLangCleaner cleaner;
+    GLSLangCleaner const cleaner;
     const int version = getGlslDefaultVersion(model);
-    EShMessages msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
-    bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
+    EShMessages const msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
+    bool const ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
     if (!ok) {
         utils::slog.e << "ERROR: Unable to parse compute shader:" << utils::io::endl;
         utils::slog.e << tShader.getInfoLog() << utils::io::flush;
@@ -84,7 +182,7 @@ bool GLSLTools::analyzeComputeShader(const std::string& shaderCode,
 
     TIntermNode* root = tShader.getIntermediate()->getTreeRoot();
     // Check there is a material function definition in this shader.
-    TIntermNode* materialFctNode = ASTUtils::getFunctionByNameOnly(materialFunctionName, *root);
+    TIntermNode* materialFctNode = ASTHelpers::getFunctionByNameOnly(materialFunctionName, *root);
     if (materialFctNode == nullptr) {
         utils::slog.e << "ERROR: Invalid compute shader:" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find " << materialFunctionName << "() function" << utils::io::endl;
@@ -97,7 +195,7 @@ bool GLSLTools::analyzeComputeShader(const std::string& shaderCode,
 bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
         filament::backend::ShaderModel model, MaterialBuilder::MaterialDomain materialDomain,
         MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
-        bool hasCustomSurfaceShading, MaterialInfo const& info) noexcept {
+        bool hasCustomSurfaceShading) noexcept {
 
     assert_invariant(materialDomain != MaterialBuilder::MaterialDomain::COMPUTE);
 
@@ -107,10 +205,10 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
     TShader tShader(EShLanguage::EShLangFragment);
     tShader.setStrings(&shaderCString, 1);
 
-    GLSLangCleaner cleaner;
+    GLSLangCleaner const cleaner;
     const int version = getGlslDefaultVersion(model);
-    EShMessages msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
-    bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
+    EShMessages const msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
+    bool const ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
     if (!ok) {
         utils::slog.e << "ERROR: Unable to parse fragment shader:" << utils::io::endl;
         utils::slog.e << tShader.getInfoLog() << utils::io::flush;
@@ -121,7 +219,7 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
 
     TIntermNode* root = tShader.getIntermediate()->getTreeRoot();
     // Check there is a material function definition in this shader.
-    TIntermNode* materialFctNode = ASTUtils::getFunctionByNameOnly(materialFunctionName, *root);
+    TIntermNode* materialFctNode = ASTHelpers::getFunctionByNameOnly(materialFunctionName, *root);
     if (materialFctNode == nullptr) {
         utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find " << materialFunctionName << "() function" << utils::io::endl;
@@ -136,16 +234,16 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
 
     // Check there is a prepareMaterial function definition in this shader.
     TIntermAggregate* prepareMaterialNode =
-            ASTUtils::getFunctionByNameOnly("prepareMaterial", *root);
+            ASTHelpers::getFunctionByNameOnly("prepareMaterial", *root);
     if (prepareMaterialNode == nullptr) {
         utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find prepareMaterial() function" << utils::io::endl;
         return false;
     }
 
-    std::string_view prepareMaterialSignature = prepareMaterialNode->getName();
-    bool prepareMaterialCalled = isFunctionCalled(prepareMaterialSignature,
-            *materialFctNode, *root);
+    std::string_view const prepareMaterialSignature = prepareMaterialNode->getName();
+    bool const prepareMaterialCalled = ASTHelpers::isFunctionCalled(
+            prepareMaterialSignature, *materialFctNode, *root);
     if (!prepareMaterialCalled) {
         utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
         utils::slog.e << "ERROR: prepareMaterial() is not called" << utils::io::endl;
@@ -153,7 +251,7 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
     }
 
     if (hasCustomSurfaceShading) {
-        materialFctNode = ASTUtils::getFunctionByNameOnly("surfaceShading", *root);
+        materialFctNode = ASTHelpers::getFunctionByNameOnly("surfaceShading", *root);
         if (materialFctNode == nullptr) {
             utils::slog.e << "ERROR: Invalid fragment shader:" << utils::io::endl;
             utils::slog.e << "ERROR: Unable to find surfaceShading() function"
@@ -168,7 +266,7 @@ bool GLSLTools::analyzeFragmentShader(const std::string& shaderCode,
 bool GLSLTools::analyzeVertexShader(const std::string& shaderCode,
         filament::backend::ShaderModel model,
         MaterialBuilder::MaterialDomain materialDomain, MaterialBuilder::TargetApi targetApi,
-        MaterialBuilder::TargetLanguage targetLanguage, MaterialInfo const& info) noexcept {
+        MaterialBuilder::TargetLanguage targetLanguage) noexcept {
 
     assert_invariant(materialDomain != MaterialBuilder::MaterialDomain::COMPUTE);
 
@@ -183,10 +281,10 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode,
     TShader tShader(EShLanguage::EShLangVertex);
     tShader.setStrings(&shaderCString, 1);
 
-    GLSLangCleaner cleaner;
+    GLSLangCleaner const cleaner;
     const int version = getGlslDefaultVersion(model);
-    EShMessages msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
-    bool ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
+    EShMessages const msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
+    bool const ok = tShader.parse(&DefaultTBuiltInResource, version, false, msg);
     if (!ok) {
         utils::slog.e << "ERROR: Unable to parse vertex shader" << utils::io::endl;
         utils::slog.e << tShader.getInfoLog() << utils::io::flush;
@@ -195,7 +293,7 @@ bool GLSLTools::analyzeVertexShader(const std::string& shaderCode,
 
     TIntermNode* root = tShader.getIntermediate()->getTreeRoot();
     // Check there is a material function definition in this shader.
-    TIntermNode* materialFctNode = ASTUtils::getFunctionByNameOnly("materialVertex", *root);
+    TIntermNode* materialFctNode = ASTHelpers::getFunctionByNameOnly("materialVertex", *root);
     if (materialFctNode == nullptr) {
         utils::slog.e << "ERROR: Invalid vertex shader" << utils::io::endl;
         utils::slog.e << "ERROR: Unable to find materialVertex() function" << utils::io::endl;
@@ -234,11 +332,11 @@ bool GLSLTools::findProperties(
     TShader tShader(getShaderStage(type));
     tShader.setStrings(&shaderCString, 1);
 
-    GLSLangCleaner cleaner;
+    GLSLangCleaner const cleaner;
     const int version = getGlslDefaultVersion(model);
-    EShMessages msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
+    EShMessages const msg = glslangFlagsFromTargetApi(targetApi, targetLanguage);
     const TBuiltInResource* builtins = &DefaultTBuiltInResource;
-    bool ok = tShader.parse(builtins, version, false, msg);
+    bool const ok = tShader.parse(builtins, version, false, msg);
     if (!ok) {
         // Even with all properties set the shader doesn't build. This is likely a syntax error
         // with user provided code.
@@ -248,11 +346,11 @@ bool GLSLTools::findProperties(
 
     TIntermNode* rootNode = tShader.getIntermediate()->getTreeRoot();
 
-    std::string_view mainFunction(type == ShaderStage::FRAGMENT ?
+    std::string_view const mainFunction(type == ShaderStage::FRAGMENT ?
             "material" : "materialVertex");
 
-    TIntermAggregate* functionMaterialDef = ASTUtils::getFunctionByNameOnly(mainFunction, *rootNode);
-    std::string_view materialFullyQualifiedName = functionMaterialDef->getName();
+    TIntermAggregate* functionMaterialDef = ASTHelpers::getFunctionByNameOnly(mainFunction, *rootNode);
+    std::string_view const materialFullyQualifiedName = functionMaterialDef->getName();
     return findPropertyWritesOperations(materialFullyQualifiedName, 0, rootNode, properties);
 }
 
@@ -260,15 +358,15 @@ bool GLSLTools::findPropertyWritesOperations(std::string_view functionName, size
         TIntermNode* rootNode, MaterialBuilder::PropertyList& properties) const noexcept {
 
     glslang::TIntermAggregate* functionMaterialDef =
-            ASTUtils::getFunctionBySignature(functionName, *rootNode);
+            ASTHelpers::getFunctionBySignature(functionName, *rootNode);
     if (functionMaterialDef == nullptr) {
         utils::slog.e << "Unable to find function '" << functionName << "' definition."
                 << utils::io::endl;
         return false;
     }
 
-    std::vector<FunctionParameter> functionMaterialParameters;
-    ASTUtils::getFunctionParameters(functionMaterialDef, functionMaterialParameters);
+    std::vector<ASTHelpers::FunctionParameter> functionMaterialParameters;
+    ASTHelpers::getFunctionParameters(functionMaterialDef, functionMaterialParameters);
 
     if (functionMaterialParameters.size() <= parameterIdx) {
         utils::slog.e << "Unable to find function '" << functionName <<  "' parameterIndex: " <<
@@ -283,8 +381,10 @@ bool GLSLTools::findPropertyWritesOperations(std::string_view functionName, size
 
     // Make sure the parameter is either out or inout. Othwerise (const or in), there is no point
     // tracing its usage.
-    FunctionParameter::Qualifier qualifier = functionMaterialParameters.at(parameterIdx).qualifier;
-    if (qualifier == FunctionParameter::IN || qualifier == FunctionParameter::CONST) {
+    ASTHelpers::FunctionParameter::Qualifier const qualifier =
+            functionMaterialParameters.at(parameterIdx).qualifier;
+    if (qualifier == ASTHelpers::FunctionParameter::IN ||
+        qualifier == ASTHelpers::FunctionParameter::CONST) {
         return true;
     }
 
@@ -292,7 +392,7 @@ bool GLSLTools::findPropertyWritesOperations(std::string_view functionName, size
     findSymbolsUsage(functionName, *rootNode, symbols);
 
     // Iterate over symbols to see if the parameter we are interested in what written.
-    std::string parameterName = functionMaterialParameters.at(parameterIdx).name;
+    std::string const parameterName = functionMaterialParameters.at(parameterIdx).name;
     for (Symbol symbol: symbols) {
         // This is not the symbol we are interested in.
         if (symbol.getName() != parameterName) {
@@ -323,16 +423,17 @@ void GLSLTools::scanSymbolForProperty(Symbol& symbol,
             // if the parameter is out or inout.
             if (symbol.hasDirectIndexForStruct()) {
                 TIntermAggregate* functionCall =
-                        ASTUtils::getFunctionBySignature(access.string, *rootNode);
-                std::vector<FunctionParameter> functionCallParameters;
-                ASTUtils::getFunctionParameters(functionCall, functionCallParameters);
+                        ASTHelpers::getFunctionBySignature(access.string, *rootNode);
+                std::vector<ASTHelpers::FunctionParameter> functionCallParameters;
+                ASTHelpers::getFunctionParameters(functionCall, functionCallParameters);
 
-                FunctionParameter& parameter = functionCallParameters.at(access.parameterIdx);
-                if (parameter.qualifier == FunctionParameter::OUT || parameter.qualifier ==
-                        FunctionParameter::INOUT) {
+                ASTHelpers::FunctionParameter const& parameter =
+                        functionCallParameters.at(access.parameterIdx);
+                if (parameter.qualifier == ASTHelpers::FunctionParameter::OUT ||
+                    parameter.qualifier == ASTHelpers::FunctionParameter::INOUT) {
                     const std::string& propName = symbol.getDirectIndexStructName();
                     if (Enums::isValid<Property>(propName)) {
-                        MaterialBuilder::Property p = Enums::toEnum<Property>(propName);
+                        MaterialBuilder::Property const p = Enums::toEnum<Property>(propName);
                         properties[size_t(p)] = true;
                     }
                 }
@@ -346,7 +447,7 @@ void GLSLTools::scanSymbolForProperty(Symbol& symbol,
         // If DirectIndexForStruct, issue the appropriate setProperty.
         if (access.type == Access::Type::DirectIndexForStruct) {
             if (Enums::isValid<Property>(access.string)) {
-                MaterialBuilder::Property p = Enums::toEnum<Property>(access.string);
+                MaterialBuilder::Property const p = Enums::toEnum<Property>(access.string);
                 properties[size_t(p)] = true;
             }
             return;
@@ -358,8 +459,9 @@ void GLSLTools::scanSymbolForProperty(Symbol& symbol,
 
 bool GLSLTools::findSymbolsUsage(std::string_view functionSignature, TIntermNode& root,
         std::deque<Symbol>& symbols) noexcept {
-    TIntermNode* functionAST = ASTUtils::getFunctionBySignature(functionSignature, root);
-    ASTUtils::traceSymbols(*functionAST, symbols);
+    TIntermNode* functionAST = ASTHelpers::getFunctionBySignature(functionSignature, root);
+    SymbolsTracer variableTracer(symbols);
+    functionAST->traverse(&variableTracer);
     return true;
 }
 
@@ -447,9 +549,95 @@ void GLSLTools::prepareShaderParser(MaterialBuilder::TargetApi targetApi,
 void GLSLTools::textureLodBias(TShader& shader) {
     TIntermediate* intermediate = shader.getIntermediate();
     TIntermNode* root = intermediate->getTreeRoot();
-    ASTUtils::textureLodBias(intermediate, root,
+    textureLodBias(intermediate, root,
             "material(struct-MaterialInputs",
             "filament_lodBias");
+}
+
+void GLSLTools::textureLodBias(TIntermediate* intermediate, TIntermNode* root,
+        const char* entryPointSignatureish, const char* lodBiasSymbolName) noexcept {
+
+    // First, find the "lodBias" symbol and entry point
+    const std::string functionName{ entryPointSignatureish };
+    TIntermSymbol* pIntermSymbolLodBias = nullptr;
+    TIntermNode* pEntryPointRoot = nullptr;
+    ASTHelpers::traverse(root,
+            [&](TVisit, TIntermAggregate* node) {
+                if (node->getOp() == glslang::EOpSequence) {
+                    return true;
+                }
+                if (node->getOp() == glslang::EOpFunction) {
+                    if (node->getName().rfind(functionName, 0) == 0) {
+                        pEntryPointRoot = node;
+                    }
+                    return false;
+                }
+                if (node->getOp() == glslang::EOpLinkerObjects) {
+                    for (TIntermNode* item: node->getSequence()) {
+                        TIntermSymbol* symbol = item->getAsSymbolNode();
+                        if (symbol && symbol->getBasicType() == TBasicType::EbtFloat) {
+                            if (symbol->getName() == lodBiasSymbolName) {
+                                pIntermSymbolLodBias = symbol;
+                                break;
+                            }
+                        }
+                    }
+                }
+                return true;
+            });
+
+    if (!pEntryPointRoot) {
+        // This can happen if the material doesn't have user defined code,
+        // e.g. with the depth material. We just do nothing then.
+        return;
+    }
+
+    if (!pIntermSymbolLodBias) {
+        // something went wrong
+        utils::slog.e << "lod bias ignored because \"" << lodBiasSymbolName << "\" was not found!"
+                      << utils::io::endl;
+        return;
+    }
+
+    // add lod bias to texture calls
+    // we need to run this only from the user's main entry point
+    ASTHelpers::traverse(pEntryPointRoot,
+            [&](TVisit, TIntermAggregate* node) {
+                // skip everything that's not a texture() call
+                if (node->getOp() != glslang::EOpTexture) {
+                    return true;
+                }
+
+                TIntermSequence& sequence = node->getSequence();
+
+                // first check that we have the correct sampler
+                TIntermTyped* pTyped = sequence[0]->getAsTyped();
+                if (!pTyped) {
+                    return false;
+                }
+
+                TSampler const& sampler = pTyped->getType().getSampler();
+                if (sampler.isArrayed() && sampler.isShadow()) {
+                    // sampler2DArrayShadow is not supported
+                    return false;
+                }
+
+                // Then add the lod bias to the texture() call
+                if (sequence.size() == 2) {
+                    // we only have 2 parameters, add the 3rd one
+                    TIntermSymbol* symbol = intermediate->addSymbol(*pIntermSymbolLodBias);
+                    sequence.push_back(symbol);
+                } else if (sequence.size() == 3) {
+                    // load bias is already specified
+                    TIntermSymbol* symbol = intermediate->addSymbol(*pIntermSymbolLodBias);
+                    TIntermTyped* pAdd = intermediate->addBinaryMath(TOperator::EOpAdd,
+                            sequence[2]->getAsTyped(), symbol,
+                            node->getLoc());
+                    sequence[2] = pAdd;
+                }
+
+                return false;
+            });
 }
 
 } // namespace filamat

--- a/libs/filamat/src/sca/GLSLTools.h
+++ b/libs/filamat/src/sca/GLSLTools.h
@@ -19,6 +19,7 @@
 
 #include <deque>
 #include <list>
+#include <optional>
 #include <set>
 #include <string>
 
@@ -116,12 +117,16 @@ public:
     static void init();
     static void shutdown();
 
+    struct FragmentShaderInfo {
+        bool userMaterialHasCustomDepth = false;
+    };
+
     // Return true if:
     // The shader is syntactically and semantically valid AND
     // The shader features a material() function AND
     // The shader features a prepareMaterial() function AND
     // prepareMaterial() is called at some point in material() call chain.
-    static bool analyzeFragmentShader(const std::string& shaderCode,
+    static std::optional<FragmentShaderInfo> analyzeFragmentShader(const std::string& shaderCode,
             filament::backend::ShaderModel model, MaterialBuilder::MaterialDomain materialDomain,
             MaterialBuilder::TargetApi targetApi, MaterialBuilder::TargetLanguage targetLanguage,
             bool hasCustomSurfaceShading) noexcept;
@@ -167,6 +172,9 @@ public:
             EShLanguage stage, int version);
 
     static void textureLodBias(glslang::TShader& shader);
+
+    static bool hasCustomDepth(TIntermNode* root, TIntermNode* entryPoint);
+
 
 private:
     // Traverse a function definition and retrieve all symbol written to and all symbol passed down

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -154,6 +154,10 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
         CodeGenerator::generateDefine(out, "FLIP_UV_ATTRIBUTE", material.flipUV);
         CodeGenerator::generateDefine(out, "LEGACY_MORPHING", material.useLegacyMorphing);
     }
+    if (stage == ShaderStage::FRAGMENT) {
+        CodeGenerator::generateDefine(out, "MATERIAL_HAS_CUSTOM_DEPTH",
+                material.userMaterialHasCustomDepth);
+    }
 
     if (mTargetLanguage == TargetLanguage::SPIRV ||
         mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_1) {

--- a/libs/filamat/src/shaders/MaterialInfo.h
+++ b/libs/filamat/src/shaders/MaterialInfo.h
@@ -53,6 +53,7 @@ struct UTILS_PUBLIC MaterialInfo {
     bool useLegacyMorphing;
     bool instanced;
     bool vertexDomainDeviceJittered;
+    bool userMaterialHasCustomDepth;
     filament::SpecularAmbientOcclusion specularAO;
     filament::RefractionMode refractionMode;
     filament::RefractionType refractionType;

--- a/libs/filamat/src/shaders/ShaderGenerator.cpp
+++ b/libs/filamat/src/shaders/ShaderGenerator.cpp
@@ -579,7 +579,11 @@ std::string ShaderGenerator::createFragmentProgram(ShaderModel shaderModel,
     if (filament::Variant::isValidDepthVariant(variant)) {
         // In MASKED mode or with transparent shadows, we need the alpha channel computed by
         // the material (user code), so we append it here.
-        if (material.blendingMode == BlendingMode::MASKED || material.hasTransparentShadow) {
+        if (material.userMaterialHasCustomDepth ||
+            material.blendingMode == BlendingMode::MASKED || ((
+                     material.blendingMode == BlendingMode::TRANSPARENT ||
+                     material.blendingMode == BlendingMode::FADE)
+             && material.hasTransparentShadow)) {
             appendShader(fs, mMaterialFragmentCode, mMaterialLineOffset);
         }
         // These variants are special and are treated as DEPTH variants. Filament will never

--- a/libs/filamat/tests/test_filamat.cpp
+++ b/libs/filamat/tests/test_filamat.cpp
@@ -17,18 +17,21 @@
 #include <gtest/gtest.h>
 
 #include "sca/ASTHelpers.h"
+#include "sca/GLSLTools.h"
 #include "shaders/ShaderGenerator.h"
 
 #include "MockIncluder.h"
 
 #include <filamat/Enums.h>
+#include <filamat/MaterialBuilder.h>
 
 #include <utils/JobSystem.h>
 
 #include <memory>
 
 using namespace utils;
-using namespace ASTUtils;
+using namespace ASTHelpers;
+using namespace filamat;
 using namespace filament::backend;
 
 static ::testing::AssertionResult PropertyListsMatch(const MaterialBuilder::PropertyList& expected,

--- a/shaders/src/depth_main.fs
+++ b/shaders/src/depth_main.fs
@@ -27,7 +27,7 @@ void main() {
 
     initObjectUniforms();
 
-#if defined(BLEND_MODE_MASKED) || ((defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)) && defined(MATERIAL_HAS_TRANSPARENT_SHADOW))
+#if defined(MATERIAL_HAS_CUSTOM_DEPTH) || defined(BLEND_MODE_MASKED) || ((defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE)) && defined(MATERIAL_HAS_TRANSPARENT_SHADOW))
     MaterialInputs inputs;
     initMaterial(inputs);
     material(inputs);


### PR DESCRIPTION
these materials would not generate proper structure or shadow buffer,
because they used a special variant that in most case removed the
user code.

now when the user code writes the depth or calls discard, the user
shader is kept.