### PR TITLE
fade shadows out at shadowFar distance

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 - materials: fix alpha masked materials when MSAA is turned on [⚠️ **Recompile materials**]
 - materials: better support materials with custom depth [**Recompile Materials**]
+- engine: fade shadows at shadowFar distance instead of hard cutoff [⚠️ **New Material Version**]

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -288,6 +288,11 @@ void PerViewUniforms::prepareDirectionalLight(FEngine& engine,
     FLightManager const& lcm = engine.getLightManager();
     auto& s = mUniforms.edit();
 
+    float const shadowFar = lcm.getShadowFar(directionalLight);
+    // TODO: make the falloff rate a parameter
+    s.shadowFarAttenuationParams = shadowFar > 0.0f ?
+            0.5f * float2{ 10.0f, 10.0f / (shadowFar * shadowFar) } : float2{ 1.0f, 0.0f };
+
     const float3 l = -sceneSpaceDirection; // guaranteed normalized
 
     if (directionalLight.isValid()) {
@@ -324,7 +329,7 @@ void PerViewUniforms::prepareAmbientLight(FEngine& engine, FIndirectLight const&
     auto& s = mUniforms.edit();
 
     // Set up uniforms and sampler for the IBL, guaranteed to be non-null at this point.
-    float iblRoughnessOneLevel = ibl.getLevelCount() - 1.0f;
+    float const iblRoughnessOneLevel = ibl.getLevelCount() - 1.0f;
     s.iblRoughnessOneLevel = iblRoughnessOneLevel;
     s.iblLuminance = intensity * exposure;
     std::transform(ibl.getSH(), ibl.getSH() + 9, s.iblSH, [](float3 v) {
@@ -347,6 +352,7 @@ void PerViewUniforms::prepareDynamicLights(Froxelizer& froxelizer) noexcept {
     auto& s = mUniforms.edit();
     froxelizer.updateUniforms(s);
     float const f = froxelizer.getLightFar();
+    // TODO: make the falloff rate a parameter
     s.lightFarAttenuationParams = 0.5f * float2{ 10.0f, 10.0f / (f * f) };
 }
 

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -134,7 +134,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float padding0;
     math::float4 lightColorIntensity;           // directional light
     math::float4 sun;                           // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
-    math::float2 lightFarAttenuationParams;     // a, a/far (a=1/pct-of-far)
+    math::float2 shadowFarAttenuationParams;    // a, a/far (a=1/pct-of-far)
 
     // --------------------------------------------------------------------------------------------
     // Directional light shadowing [variant: SRE | DIR]
@@ -151,9 +151,8 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // bit 0-3: cascade count
     // bit 8-11: cascade has visible shadows
     int32_t cascades;
-    float reserved0;
-    float reserved1;                    // normal bias
     float shadowPenumbraRatioScale;     // For DPCF or PCSS, scale penumbra ratio for artistic use
+    math::float2 lightFarAttenuationParams;     // a, a/far (a=1/pct-of-far)
 
     // --------------------------------------------------------------------------------------------
     // VSM shadows [variant: VSM]

--- a/libs/filamat/src/shaders/UibGenerator.cpp
+++ b/libs/filamat/src/shaders/UibGenerator.cpp
@@ -93,19 +93,18 @@ BufferInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             { "padding0",               0, Type::FLOAT                   },
             { "lightColorIntensity",    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
             { "sun",                    0, Type::FLOAT4, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 },
-            { "lightFarAttenuationParams", 0, Type::FLOAT2               },
+            { "shadowFarAttenuationParams", 0, Type::FLOAT2, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
             // Directional light shadowing [variant: SRE | DIR]
             // ------------------------------------------------------------------------------------
-            { "directionalShadows",     0, Type::INT                     },
-            { "ssContactShadowDistance",0, Type::FLOAT                   },
+            { "directionalShadows",       0, Type::INT                      },
+            { "ssContactShadowDistance",  0, Type::FLOAT                    },
 
-            { "cascadeSplits",          0, Type::FLOAT4, Precision::HIGH },
-            { "cascades",               0, Type::INT                     },
-            { "reserved0",              0, Type::FLOAT                   },
-            { "reserved1",              0, Type::FLOAT                   },
-            { "shadowPenumbraRatioScale", 0, Type::FLOAT                 },
+            { "cascadeSplits",             0, Type::FLOAT4, Precision::HIGH },
+            { "cascades",                  0, Type::INT                     },
+            { "shadowPenumbraRatioScale",  0, Type::FLOAT                   },
+            { "lightFarAttenuationParams", 0, Type::FLOAT2, Precision::HIGH },
 
             // ------------------------------------------------------------------------------------
             // VSM shadows [variant: VSM]

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -846,21 +846,25 @@ void ViewerGui::updateUserInterface() {
         }
         if (ImGui::CollapsingHeader("Sunlight")) {
             ImGui::Checkbox("Enable sunlight", &light.enableSunlight);
-            ImGui::SliderFloat("Sun intensity", &light.sunlightIntensity, 50000.0f, 150000.0f);
+            ImGui::SliderFloat("Sun intensity", &light.sunlightIntensity, 0.0f, 150000.0f);
             ImGui::SliderFloat("Halo size", &light.sunlightHaloSize, 1.01f, 40.0f);
             ImGui::SliderFloat("Halo falloff", &light.sunlightHaloFalloff, 4.0f, 1024.0f);
             ImGui::SliderFloat("Sun radius", &light.sunlightAngularRadius, 0.1f, 10.0f);
             ImGuiExt::DirectionWidget("Sun direction", light.sunlightDirection.v);
+            ImGui::SliderFloat("Shadow Far", &light.shadowOptions.shadowFar, 0.0f,
+                    mSettings.viewer.cameraFar);
 
-            float3 shadowDirection = light.shadowOptions.transform * light.sunlightDirection;
-            ImGuiExt::DirectionWidget("Shadow direction", shadowDirection.v);
-            light.shadowOptions.transform = normalize(quatf{
-                    cross(light.sunlightDirection, shadowDirection),
-                    sqrt(length2(light.sunlightDirection) * length2(shadowDirection))
-                            + dot(light.sunlightDirection, shadowDirection)
-            });
+            if (ImGui::CollapsingHeader("Shadow direction")) {
+                float3 shadowDirection = light.shadowOptions.transform * light.sunlightDirection;
+                ImGuiExt::DirectionWidget("Shadow direction", shadowDirection.v);
+                light.shadowOptions.transform = normalize(quatf{
+                        cross(light.sunlightDirection, shadowDirection),
+                        sqrt(length2(light.sunlightDirection) * length2(shadowDirection))
+                        + dot(light.sunlightDirection, shadowDirection)
+                });
+            }
         }
-        if (ImGui::CollapsingHeader("All lights")) {
+        if (ImGui::CollapsingHeader("Shadows")) {
             ImGui::Checkbox("Enable shadows", &light.enableShadows);
             int mapSize = light.shadowOptions.mapSize;
             ImGui::SliderInt("Shadow map size", &mapSize, 32, 1024);

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -58,6 +58,12 @@ void evaluateDirectionalLight(const MaterialInputs material,
         if (hasDirectionalShadows && cascadeHasVisibleShadows) {
             highp vec4 shadowPosition = getShadowPosition(cascade);
             visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0);
+            // shadow far attenuation
+            highp vec3 v = getWorldPosition() - getWorldCameraPosition();
+            // (viewFromWorld * v).z == dot(transpose(viewFromWorld), v)
+            highp float z = dot(transpose(getViewFromWorldMatrix())[2].xyz, v);
+            highp vec2 p = frameUniforms.shadowFarAttenuationParams;
+            visibility = 1.0 - ((1.0 - visibility) * saturate(p.x - z * z * p.y));
         }
         if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
             if ((object_uniforms_flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -103,8 +103,7 @@ float getDistanceAttenuation(const highp vec3 posToLight, float falloff) {
     float attenuation = getSquareFalloffAttenuation(distanceSquare, falloff);
     // light far attenuation
     highp vec3 v = getWorldPosition() - getWorldCameraPosition();
-    float d = dot(v, v);
-    attenuation *= saturate(frameUniforms.lightFarAttenuationParams.x - d * frameUniforms.lightFarAttenuationParams.y);
+    attenuation *= saturate(frameUniforms.lightFarAttenuationParams.x - dot(v, v) * frameUniforms.lightFarAttenuationParams.y);
     // Assume a punctual light occupies a volume of 1cm to avoid a division by 0
     return attenuation / max(distanceSquare, 1e-4);
 }

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -47,6 +47,12 @@ vec4 evaluateMaterial(const MaterialInputs material) {
     if (hasDirectionalShadows && cascadeHasVisibleShadows) {
         highp vec4 shadowPosition = getShadowPosition(cascade);
         visibility = shadow(true, light_shadowMap, cascade, shadowPosition, 0.0);
+        // shadow far attenuation
+        highp vec3 v = getWorldPosition() - getWorldCameraPosition();
+        // (viewFromWorld * v).z == dot(transpose(viewFromWorld), v)
+        highp float z = dot(transpose(getViewFromWorldMatrix())[2].xyz, v);
+        highp vec2 p = frameUniforms.shadowFarAttenuationParams;
+        visibility = 1.0 - ((1.0 - visibility) * saturate(p.x - z * z * p.y));
     }
     if ((frameUniforms.directionalShadows & 0x2) != 0 && visibility > 0.0) {
         if ((object_uniforms_flagsChannels & FILAMENT_OBJECT_CONTACT_SHADOWS_BIT) != 0) {


### PR DESCRIPTION
Instead of a hard cutoff, we fade shadows out at 
the shadowFar distance if active, fading occurs
over about 10% of the shadowFar distance. 

- this works only for the directional shadow  (other lights don't use shadowFar).