### PR TITLE
Fix masked materials

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -14,3 +14,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - build: fix emscripten-1.3.46 build
 - engine: materials built for feature level 0 can now also be loaded in higher feature levels [⚠️
   **New Material Version**]
+- materials: fix alpha masked materials when MSAA is turned on [⚠️ **Recompile materials**]

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -3,11 +3,6 @@
 //------------------------------------------------------------------------------
 
 #if defined(BLEND_MODE_MASKED)
-float computeMaskedAlpha(float a) {
-    // Use derivatives to smooth alpha tested edges
-    return (a - getMaskThreshold()) / max(fwidth(a), 1e-3) + 0.5;
-}
-
 float computeDiffuseAlpha(float a) {
     // If we reach this point in the code, we already know that the fragment is not discarded due
     // to the threshold factor. Therefore we can just output 1.0, which prevents a "punch through"
@@ -15,14 +10,6 @@ float computeDiffuseAlpha(float a) {
     // of ALPHA_TO_COVERAGE.
     return (frameUniforms.needsAlphaChannel == 1.0) ? 1.0 : a;
 }
-
-void applyAlphaMask(inout vec4 baseColor) {
-    baseColor.a = computeMaskedAlpha(baseColor.a);
-    if (baseColor.a <= 0.0) {
-        discard;
-    }
-}
-
 #else // not masked
 
 float computeDiffuseAlpha(float a) {
@@ -32,9 +19,6 @@ float computeDiffuseAlpha(float a) {
     return 1.0;
 #endif
 }
-
-void applyAlphaMask(inout vec4 baseColor) {}
-
 #endif
 
 #if defined(GEOMETRIC_SPECULAR_AA)
@@ -65,7 +49,6 @@ float normalFiltering(float perceptualRoughness, const vec3 worldNormal) {
 
 void getCommonPixelParams(const MaterialInputs material, inout PixelParams pixel) {
     vec4 baseColor = material.baseColor;
-    applyAlphaMask(baseColor);
 
 #if defined(BLEND_MODE_FADE) && !defined(SHADING_MODEL_UNLIT)
     // Since we work in premultiplied alpha mode, we need to un-premultiply

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -9,13 +9,6 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #endif
 }
 
-#if defined(BLEND_MODE_MASKED)
-float computeMaskedAlpha(float a) {
-    // Use derivatives to smooth alpha tested edges
-    return (a - getMaskThreshold()) / max(fwidth(a), 1e-3) + 0.5;
-}
-#endif
-
 /**
  * Evaluates unlit materials. In this lighting model, only the base color and
  * emissive properties are taken into account:
@@ -32,19 +25,6 @@ float computeMaskedAlpha(float a) {
  */
 vec4 evaluateMaterial(const MaterialInputs material) {
     vec4 color = material.baseColor;
-
-#if defined(BLEND_MODE_MASKED)
-    color.a = computeMaskedAlpha(color.a);
-    if (color.a <= 0.0) {
-        discard;
-    }
-
-    // Output 1.0 for translucent view to prevent "punch through" artifacts. We do not do this
-    // for opaque views to enable proper usage of ALPHA_TO_COVERAGE.
-    if (frameUniforms.needsAlphaChannel == 1.0) {
-        color.a = 1.0;
-    }
-#endif
 
 #if defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
 #if defined(VARIANT_HAS_SHADOWING)

--- a/shaders/src/shading_unlit.fs
+++ b/shaders/src/shading_unlit.fs
@@ -9,6 +9,18 @@ void addEmissive(const MaterialInputs material, inout vec4 color) {
 #endif
 }
 
+vec4 fixupAlpha(vec4 color) {
+#if defined(BLEND_MODE_MASKED)
+    // If we reach this point in the code, we already know that the fragment is not discarded due
+    // to the threshold factor. Therefore we can just output 1.0, which prevents a "punch through"
+    // effect from occuring. We do this only for TRANSLUCENT views in order to prevent breakage
+    // of ALPHA_TO_COVERAGE.
+    return vec4(color.rgb, (frameUniforms.needsAlphaChannel == 1.0) ? 1.0 : color.a);
+#else
+    return color;
+#endif
+}
+
 /**
  * Evaluates unlit materials. In this lighting model, only the base color and
  * emissive properties are taken into account:
@@ -51,5 +63,5 @@ vec4 evaluateMaterial(const MaterialInputs material) {
 
     addEmissive(material, color);
 
-    return color;
+    return fixupAlpha(color);
 }


### PR DESCRIPTION
When a material using the MASKED blend mode, we sharpen the alpha channel to avoid banding and unwanted translucency with MSAA. To do this properly however, we must output the *sharpened* alpha value, and not the *original* alpha value. This change moves the alpha masking test to right after we initialize the material inputs with the user code so that the rest of our shaders will user the correct alpha value. The line that was causing problems in our case was the last line in evaluateLights() which returns a vec4 containing an alpha computed from the input's alpha instead of the sharpened alpha.

This change has the added benefit of unifying the alpha masking code between lit and unlit shaders, which contained duplicated code for not good reason. Note that moving the call to the applyAlphaMask() function has no effect of *when* a discard happens in the flow of our shaders.

Before (GL backend, MSAA on):
<img width="1136" alt="Screenshot 2023-09-27 at 6 46 32 PM" src="https://github.com/google/filament/assets/869684/e5dedf5c-0b1f-4a2f-87ad-2f42ea9a68ea">

After:
<img width="1136" alt="Screenshot 2023-09-27 at 6 46 39 PM" src="https://github.com/google/filament/assets/869684/30022f9f-aa20-4734-8a74-13ddaf9c0c02">

