### PR TITLE
fix install android debug samples apk error.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -516,7 +516,7 @@ function build_android {
             if [[ "${BUILD_ANDROID_SAMPLES}" == "true" ]]; then
                 for sample in ${ANDROID_SAMPLES}; do
                     echo "Installing out/${sample}-debug.apk"
-                    cp samples/${sample}/build/outputs/apk/debug/${sample}-debug-unsigned.apk \
+                    cp samples/${sample}/build/outputs/apk/debug/${sample}-debug.apk \
                         ../out/${sample}-debug.apk
                 done
             fi


### PR DESCRIPTION
# cp not exist debug sample apk.

`./build.sh -p android -k sample-gltf-viewer -i debug`
Take `sample-gltf-viewer` as an example, above cmd will result in :

`cp: samples/sample-gltf-viewer/build/outputs/apk/debug/sample-gltf-viewer-debug-unsigned.apk: No such file or directory`

The root cause is that the `android` will signed the `debug` apk with `~/.android/debug.keystore`, which is the default generated by android gradle plugin globally.

# remove unsigned tag from release apk don't make sense

[Cause] the unsigned apk will not installed on the android, the apk must be signed anyway. So I think remove the `unsigned` keyword don't make sense, at lease let people know, it's an unsigned apk.
