### PR TITLE
the visibility type can be 8 bits instead of 16.

### DIFF
--- a/filament/src/Culler.h
+++ b/filament/src/Culler.h
@@ -37,12 +37,12 @@ namespace filament {
 class Culler {
 public:
     // Culler can only process buffers with a size multiple of MODULO
-    static constexpr size_t MODULO = 4u;
+    static constexpr size_t MODULO = 8u;
     static inline size_t round(size_t count) noexcept {
         return (count + (MODULO - 1)) & ~(MODULO - 1);
     }
 
-    using result_type = uint16_t;
+    using result_type = uint8_t;
 
     /*
      * returns whether each AABB in an array intersects with the frustum

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -39,12 +39,12 @@ class RenderPass;
 // The value of the 'VISIBLE_MASK' after culling. Each bit represents visibility in a frustum
 // (either camera or light).
 //
-//                                    1
-// bits                               5 ... 7 6 5 4 3 2 1 0
-// +------------------------------------------------------+
-// VISIBLE_RENDERABLE                                     X
-// VISIBLE_DIR_SHADOW_RENDERABLE                        X
-// VISIBLE_DYN_SHADOW_RENDERABLE                      X
+//
+// bits                            7 6 5 4 3 2 1 0
+// +---------------------------------------------+
+// VISIBLE_RENDERABLE                            X
+// VISIBLE_DIR_SHADOW_RENDERABLE               X
+// VISIBLE_DYN_SHADOW_RENDERABLE             X
 
 // A "shadow renderable" is a renderable rendered to the shadow map during a shadow pass:
 // PCF shadows: only shadow casters
@@ -54,6 +54,7 @@ static constexpr size_t VISIBLE_RENDERABLE_BIT              = 0u;
 static constexpr size_t VISIBLE_DIR_SHADOW_RENDERABLE_BIT   = 1u;
 static constexpr size_t VISIBLE_DYN_SHADOW_RENDERABLE_BIT   = 2u;
 
+static constexpr Culler::result_type VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
 static constexpr Culler::result_type VISIBLE_DIR_SHADOW_RENDERABLE = 1u << VISIBLE_DIR_SHADOW_RENDERABLE_BIT;
 static constexpr Culler::result_type VISIBLE_DYN_SHADOW_RENDERABLE = 1u << VISIBLE_DYN_SHADOW_RENDERABLE_BIT;
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -73,8 +73,6 @@ class FMaterialInstance;
 class FRenderer;
 class FScene;
 
-static constexpr Culler::result_type VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
-
 // ------------------------------------------------------------------------------------------------
 
 class FView : public View {


### PR DESCRIPTION
It was changed to 16 a while back to handle more shadows, but since then we changed the culling algorithm and 8 bits is enough again.