### PR TITLE
cleanup Camera code and docs

### DIFF
--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -26,6 +26,7 @@
 #include <math/mathfwd.h>
 #include <math/vec2.h>
 #include <math/vec4.h>
+#include <math/mat4.h>
 
 namespace utils {
 class Entity;
@@ -172,6 +173,30 @@ public:
         HORIZONTAL      //!< the field-of-view angle is defined on the horizontal axis
     };
 
+    /** Returns the projection matrix from the field-of-view.
+     *
+     * @param fovInDegrees full field-of-view in degrees. 0 < \p fov < 180.
+     * @param aspect       aspect ratio \f$ \frac{width}{height} \f$. \p aspect > 0.
+     * @param near         distance in world units from the camera to the near plane. \p near > 0.
+     * @param far          distance in world units from the camera to the far plane. \p far > \p near.
+     * @param direction    direction of the \p fovInDegrees parameter.
+     *
+     * @see Fov.
+     */
+    static math::mat4 projection(Fov direction, double fovInDegrees,
+            double aspect, double near, double far = std::numeric_limits<double>::infinity());
+
+    /** Returns the projection matrix from the focal length.
+     *
+     * @param focalLengthInMillimeters lens's focal length in millimeters. \p focalLength > 0.
+     * @param aspect      aspect ratio \f$ \frac{width}{height} \f$. \p aspect > 0.
+     * @param near        distance in world units from the camera to the near plane. \p near > 0.
+     * @param far         distance in world units from the camera to the far plane. \p far > \p near.
+     */
+    static math::mat4 projection(double focalLengthInMillimeters,
+            double aspect, double near, double far = std::numeric_limits<double>::infinity());
+
+
     /** Sets the projection matrix from a frustum defined by six planes.
      *
      * @param projection    type of #Projection to use.
@@ -209,7 +234,8 @@ public:
             double bottom, double top,
             double near, double far);
 
-    /** Sets the projection matrix from the field-of-view.
+
+    /** Utility to set the projection matrix from the field-of-view.
      *
      * @param fovInDegrees full field-of-view in degrees. 0 < \p fov < 180.
      * @param aspect       aspect ratio \f$ \frac{width}{height} \f$. \p aspect > 0.
@@ -222,7 +248,7 @@ public:
     void setProjection(double fovInDegrees, double aspect, double near, double far,
                        Fov direction = Fov::VERTICAL);
 
-    /** Sets the projection matrix from the focal length.
+    /** Utility to set the projection matrix from the focal length.
      *
      * @param focalLengthInMillimeters lens's focal length in millimeters. \p focalLength > 0.
      * @param aspect      aspect ratio \f$ \frac{width}{height} \f$. \p aspect > 0.
@@ -232,13 +258,8 @@ public:
     void setLensProjection(double focalLengthInMillimeters,
             double aspect, double near, double far);
 
+
     /** Sets a custom projection matrix.
-     *
-     * The projection matrix must be of one of the following form:
-     *       a 0 tx 0              a 0 0 tx
-     *       0 b ty 0              0 b 0 ty
-     *       0 0 tz c              0 0 c tz
-     *       0 0 -1 0              0 0 0 1
      *
      * The projection matrix must define an NDC system that must match the OpenGL convention,
      * that is all 3 axis are mapped to [-1, 1].
@@ -248,6 +269,19 @@ public:
      * @param far         distance in world units from the camera to the far plane. \p far > \p near.
      */
     void setCustomProjection(math::mat4 const& projection, double near, double far) noexcept;
+
+    /** Sets the projection matrix.
+     *
+     * The projection matrices must define an NDC system that must match the OpenGL convention,
+     * that is all 3 axis are mapped to [-1, 1].
+     *
+     * @param projection  custom projection matrix used for rendering
+     * @param projectionForCulling  custom projection matrix used for culling
+     * @param near        distance in world units from the camera to the near plane. \p near > 0.
+     * @param far         distance in world units from the camera to the far plane. \p far > \p near.
+     */
+    void setCustomProjection(math::mat4 const& projection, math::mat4 const& projectionForCulling,
+            double near, double far) noexcept;
 
     /** Sets a custom projection matrix for each eye.
      *
@@ -266,25 +300,6 @@ public:
      */
     void setCustomEyeProjection(math::mat4 const* projection, size_t count,
             math::mat4 const& projectionForCulling, double near, double far);
-
-    /** Sets the projection matrix.
-     *
-     * The projection matrices must be of one of the following form:
-     *       a 0 tx 0              a 0 0 tx
-     *       0 b ty 0              0 b 0 ty
-     *       0 0 tz c              0 0 c tz
-     *       0 0 -1 0              0 0 0 1
-     *
-     * The projection matrices must define an NDC system that must match the OpenGL convention,
-     * that is all 3 axis are mapped to [-1, 1].
-     *
-     * @param projection  custom projection matrix used for rendering
-     * @param projectionForCulling  custom projection matrix used for culling
-     * @param near        distance in world units from the camera to the near plane. \p near > 0.
-     * @param far         distance in world units from the camera to the far plane. \p far > \p near.
-     */
-    void setCustomProjection(math::mat4 const& projection, math::mat4 const& projectionForCulling,
-            double near, double far) noexcept;
 
     /** Sets an additional matrix that scales the projection matrix.
      *
@@ -524,33 +539,6 @@ public:
      *
      * \param p the projection matrix to inverse
      * \returns the inverse of the projection matrix \p p
-     *
-     * \warning the projection matrix to invert must have one of the form below:
-     * - perspective projection
-     *
-     *      \f$
-     *      \left(
-     *      \begin{array}{cccc}
-     *      a & 0 & tx & 0 \\
-     *      0 & b & ty & 0 \\
-     *      0 & 0 & tz & c \\
-     *      0 & 0 & -1 & 0 \\
-     *      \end{array}
-     *      \right)
-     *      \f$
-     *
-     * - orthographic projection
-     *
-     *      \f$
-     *      \left(
-     *      \begin{array}{cccc}
-     *      a & 0 & 0 & tx \\
-     *      0 & b & 0 & ty \\
-     *      0 & 0 & c & tz \\
-     *      0 & 0 & 0 & 1  \\
-     *      \end{array}
-     *      \right)
-     *      \f$
      */
     static math::mat4 inverseProjection(const math::mat4& p) noexcept;
 

--- a/filament/src/Camera.cpp
+++ b/filament/src/Camera.cpp
@@ -22,49 +22,28 @@ namespace filament {
 
 using namespace math;
 
-template<typename T>
-details::TMat44<T> inverseProjection(const details::TMat44<T>& p) noexcept {
-    details::TMat44<T> r;
-    const T A = 1 / p[0][0];
-    const T B = 1 / p[1][1];
-    if (p[2][3] != T(0)) {
-        // perspective projection
-        // a 0 tx 0
-        // 0 b ty 0
-        // 0 0 tz c
-        // 0 0 -1 0
-        const T C = 1 / p[3][2];
-        r[0][0] = A;
-        r[1][1] = B;
-        r[2][2] = 0;
-        r[2][3] = C;
-        r[3][0] = p[2][0] * A;    // not needed if symmetric
-        r[3][1] = p[2][1] * B;    // not needed if symmetric
-        r[3][2] = -1;
-        r[3][3] = p[2][2] * C;
-    } else {
-        // orthographic projection
-        // a 0 0 tx
-        // 0 b 0 ty
-        // 0 0 c tz
-        // 0 0 0 1
-        const T C = 1 / p[2][2];
-        r[0][0] = A;
-        r[1][1] = B;
-        r[2][2] = C;
-        r[3][3] = 1;
-        r[3][0] = -p[3][0] * A;
-        r[3][1] = -p[3][1] * B;
-        r[3][2] = -p[3][2] * C;
-    }
-    return r;
+void Camera::setProjection(double fovInDegrees, double aspect, double near, double far,
+        Camera::Fov direction) {
+    setCustomProjection(
+            projection(direction, fovInDegrees, aspect, near),
+            projection(direction, fovInDegrees, aspect, near, far),
+            near, far);
+}
+
+void Camera::setLensProjection(double focalLengthInMillimeters,
+        double aspect, double near, double far) {
+    setCustomProjection(
+            projection(focalLengthInMillimeters, aspect, near),
+            projection(focalLengthInMillimeters, aspect, near, far),
+            near, far);
 }
 
 mat4f Camera::inverseProjection(const mat4f& p) noexcept {
-    return filament::inverseProjection(p);
+    return inverse(p);
 }
-mat4 Camera::inverseProjection(const mat4 & p) noexcept {
-    return filament::inverseProjection(p);
+
+mat4 Camera::inverseProjection(const mat4& p) noexcept {
+    return inverse(p);
 }
 
 void Camera::setEyeModelMatrix(uint8_t eyeId, math::mat4 const& model) {
@@ -79,16 +58,6 @@ void Camera::setCustomEyeProjection(math::mat4 const* projection, size_t count,
 void Camera::setProjection(Camera::Projection projection, double left, double right, double bottom,
         double top, double near, double far) {
     downcast(this)->setProjection(projection, left, right, bottom, top, near, far);
-}
-
-void Camera::setProjection(double fovInDegrees, double aspect, double near, double far,
-        Camera::Fov direction) {
-    downcast(this)->setProjection(fovInDegrees, aspect, near, far, direction);
-}
-
-void Camera::setLensProjection(double focalLengthInMillimeters,
-        double aspect, double near, double far) {
-    downcast(this)->setLensProjection(focalLengthInMillimeters, aspect, near, far);
 }
 
 void Camera::setCustomProjection(mat4 const& projection, double near, double far) noexcept {
@@ -214,6 +183,16 @@ double Camera::computeEffectiveFocalLength(double focalLength, double focusDista
 
 double Camera::computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept {
     return FCamera::computeEffectiveFov(fovInDegrees, focusDistance);
+}
+
+math::mat4 Camera::projection(Fov direction, double fovInDegrees,
+        double aspect, double near, double far) {
+    return FCamera::projection(direction, fovInDegrees, aspect, near, far);
+}
+
+math::mat4 Camera::projection(double focalLengthInMillimeters,
+        double aspect, double near, double far) {
+    return FCamera::projection(focalLengthInMillimeters, aspect, near, far);
 }
 
 } // namespace filament

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -47,11 +47,11 @@ FCamera::FCamera(FEngine& engine, Entity e)
           mEntity(e) {
 }
 
-void UTILS_NOINLINE FCamera::setProjection(double fovInDegrees, double aspect, double near, double far,
-        Camera::Fov direction) {
+math::mat4 FCamera::projection(Fov direction, double fovInDegrees,
+        double aspect, double near, double far) {
     double w;
     double h;
-    double s = std::tan(fovInDegrees * math::d::DEG_TO_RAD / 2.0) * near;
+    double const s = std::tan(fovInDegrees * math::d::DEG_TO_RAD / 2.0) * near;
     if (direction == Fov::VERTICAL) {
         w = s * aspect;
         h = s;
@@ -59,29 +59,35 @@ void UTILS_NOINLINE FCamera::setProjection(double fovInDegrees, double aspect, d
         w = s;
         h = s / aspect;
     }
-    FCamera::setProjection(Projection::PERSPECTIVE, -w, w, -h, h, near, far);
+    mat4 p = math::mat4::frustum(-w, w, -h, h, near, far);
+    if (far == std::numeric_limits<double>::infinity()) {
+        p[2][2] = -1.0f;           // lim(far->inf) = -1
+        p[3][2] = -2.0f * near;    // lim(far->inf) = -2*near
+    }
+    return p;
 }
 
-void FCamera::setLensProjection(double focalLengthInMillimeters,
+math::mat4 FCamera::projection(double focalLengthInMillimeters,
         double aspect, double near, double far) {
     // a 35mm camera has a 36x24mm wide frame size
-    double h = (0.5 * near) * ((SENSOR_SIZE * 1000.0) / focalLengthInMillimeters);
-    double w = h * aspect;
-    FCamera::setProjection(Projection::PERSPECTIVE, -w, w, -h, h, near, far);
+    double const h = (0.5 * near) * ((SENSOR_SIZE * 1000.0) / focalLengthInMillimeters);
+    double const w = h * aspect;
+    mat4 p = math::mat4::frustum(-w, w, -h, h, near, far);
+    if (far == std::numeric_limits<double>::infinity()) {
+        p[2][2] = -1.0f;           // lim(far->inf) = -1
+        p[3][2] = -2.0f * near;    // lim(far->inf) = -2*near
+    }
+    return p;
 }
 
 /*
  * All methods for setting the projection funnel through here
  */
 
-void UTILS_NOINLINE FCamera::setCustomProjection(mat4 const& p, double near, double far) noexcept {
-    setCustomProjection(p, p, near, far);
-}
-
 void UTILS_NOINLINE FCamera::setCustomProjection(mat4 const& p,
         mat4 const& c, double near, double far) noexcept {
-    for (uint8_t i = 0; i < CONFIG_STEREOSCOPIC_EYES; i++) {
-        mEyeProjection[i] = p;
+    for (auto& eyeProjection: mEyeProjection) {
+        eyeProjection = p;
     }
     mProjectionForCulling = c;
     mNear = near;
@@ -237,48 +243,10 @@ double FCamera::computeEffectiveFocalLength(double focalLength, double focusDist
 }
 
 double FCamera::computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept {
-    double f = 0.5 * FCamera::SENSOR_SIZE / std::tan(fovInDegrees * math::d::DEG_TO_RAD * 0.5);
+    double const f = 0.5 * FCamera::SENSOR_SIZE / std::tan(fovInDegrees * math::d::DEG_TO_RAD * 0.5);
     focusDistance = std::max(f, focusDistance);
-    double fov = 2.0 * std::atan(FCamera::SENSOR_SIZE * (focusDistance - f) / (2.0 * focusDistance * f));
+    double const fov = 2.0 * std::atan(FCamera::SENSOR_SIZE * (focusDistance - f) / (2.0 * focusDistance * f));
     return fov * math::d::RAD_TO_DEG;
-}
-
-template<typename T>
-math::details::TMat44<T> inverseProjection(const math::details::TMat44<T>& p) noexcept {
-    math::details::TMat44<T> r;
-    const T A = 1 / p[0][0];
-    const T B = 1 / p[1][1];
-    if (p[2][3] != T(0)) {
-        // perspective projection
-        // a 0 tx 0
-        // 0 b ty 0
-        // 0 0 tz c
-        // 0 0 -1 0
-        const T C = 1 / p[3][2];
-        r[0][0] = A;
-        r[1][1] = B;
-        r[2][2] = 0;
-        r[2][3] = C;
-        r[3][0] = p[2][0] * A;    // not needed if symmetric
-        r[3][1] = p[2][1] * B;    // not needed if symmetric
-        r[3][2] = -1;
-        r[3][3] = p[2][2] * C;
-    } else {
-        // orthographic projection
-        // a 0 0 tx
-        // 0 b 0 ty
-        // 0 0 c tz
-        // 0 0 0 1
-        const T C = 1 / p[2][2];
-        r[0][0] = A;
-        r[1][1] = B;
-        r[2][2] = C;
-        r[3][3] = 1;
-        r[3][0] = -p[3][0] * A;
-        r[3][1] = -p[3][1] * B;
-        r[3][2] = -p[3][2] * C;
-    }
-    return r;
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -46,30 +46,26 @@ public:
 
     FCamera(FEngine& engine, utils::Entity e);
 
-    void terminate(FEngine& engine) noexcept { }
+    void terminate(FEngine&) noexcept { }
 
-    void setEyeModelMatrix(uint8_t eyeId, math::mat4 const& model);
 
-    void setCustomEyeProjection(math::mat4 const* projection, size_t count,
-            math::mat4 const& projectionForCulling, double near, double far);
-
-    // sets the projection matrix
+    // Sets the projection matrices (viewing and culling). The viewing matrice has infinite far.
     void setProjection(Projection projection,
                        double left, double right, double bottom, double top,
                        double near, double far);
 
-    // sets the projection matrix
-    void setProjection(double fovInDegrees, double aspect, double near, double far,
-                       Fov direction = Fov::VERTICAL);
-
-    // sets the projection matrix
-    void setLensProjection(double focalLengthInMillimeters,
-            double aspect, double near, double far);
-
-    // Sets a custom projection matrix (sets both the viewing and culling projections).
-    void setCustomProjection(math::mat4 const& projection, double near, double far) noexcept;
+    // Sets custom projection matrices (sets both the viewing and culling projections).
     void setCustomProjection(math::mat4 const& projection,
             math::mat4 const& projectionForCulling, double near, double far) noexcept;
+
+    inline void setCustomProjection(math::mat4 const& projection,
+            double near, double far) noexcept {
+        setCustomProjection(projection, projection, near, far);
+    }
+
+    void setCustomEyeProjection(math::mat4 const* projection, size_t count,
+            math::mat4 const& projectionForCulling, double near, double far);
+
 
     void setScaling(math::double2 scaling) noexcept { mScalingCS = scaling; }
 
@@ -105,6 +101,7 @@ public:
     // sets the camera's model matrix (must be a rigid transform)
     void setModelMatrix(const math::mat4& modelMatrix) noexcept;
     void setModelMatrix(const math::mat4f& modelMatrix) noexcept;
+    void setEyeModelMatrix(uint8_t eyeId, math::mat4 const& model);
 
     // sets the camera's model matrix
     void lookAt(math::double3 const& eye, math::double3 const& center, math::double3 const& up) noexcept;
@@ -195,6 +192,12 @@ public:
     utils::Entity getEntity() const noexcept {
         return mEntity;
     }
+
+    static math::mat4 projection(Fov direction, double fovInDegrees,
+            double aspect, double near, double far);
+
+    static math::mat4 projection(double focalLengthInMillimeters,
+            double aspect, double near, double far);
 
 private:
     FEngine& mEngine;


### PR DESCRIPTION
- setProjection and setLensProjection are now less special, they can now be entirely implemented by the user thanks to two new helper functions. Everything can now be done with setCustomProjection.

- fix some out-dated comments

- remove dead code

- reorder methods in Camera.h