### PR TITLE
samples: support apply all animations in gltf_viewer

### DIFF
--- a/libs/viewer/include/viewer/ViewerGui.h
+++ b/libs/viewer/include/viewer/ViewerGui.h
@@ -227,7 +227,7 @@ public:
      */
     Settings& getSettings() { return mSettings; }
 
-    void stopAnimation() { mCurrentAnimation = 0; }
+    void stopAnimation() { mCurrentAnimation = -1; }
 
     int getCurrentCamera() const { return mCurrentCamera; }
 
@@ -256,7 +256,7 @@ private:
     std::function<void()> mCustomUI;
 
     // Properties that can be changed from the UI.
-    int mCurrentAnimation = 1; // It is a 1-based index and 0 means not playing animation
+    int mCurrentAnimation = 0; // -1 means not playing animation and count means plays all of them (0-based index)
     int mCurrentVariant = 0;
     bool mEnableWireframe = false;
     int mVsmMsaaSamplesLog2 = 1;
@@ -276,7 +276,7 @@ private:
 
     // Cross fade animation parameters.
     float mCrossFadeDuration = 0.5f;  // number of seconds to transition between animations
-    int mPreviousAnimation = 0;       // one-based index of the previous animation
+    int mPreviousAnimation = -1;      // zero-based index of the previous animation
     double mCurrentStartTime = 0.0f;  // start time of most recent cross-fade (seconds)
     double mPreviousStartTime = 0.0f; // start time of previous cross-fade (seconds)
     bool mResetAnimation = true;      // set when building ImGui widgets, honored in applyAnimation


### PR DESCRIPTION
For gltf models with more than one animations, we now can only check one by one, but sometimes we need to check the whole effect of all animations applied simultaneously.

This patch add a new "Apply All Animations" button for gltf_viewer, for check all animations quickly. 

Now for _mCurrentAnimation_:
_-1_: means not playing animation
_0 ~ numAnimations_: means playing the selected animation
_numAnimations_: means playing all animations