### PR TITLE
fix mixed-precision quaternion math

### DIFF
--- a/libs/math/include/math/TQuatHelpers.h
+++ b/libs/math/include/math/TQuatHelpers.h
@@ -58,7 +58,8 @@ public:
 
     /* compound assignment products by a scalar
      */
-    constexpr QUATERNION<T>& operator*=(T v) {
+    template<typename U>
+    constexpr QUATERNION<T>& operator*=(U v) {
         QUATERNION<T>& lhs = static_cast<QUATERNION<T>&>(*this);
         for (size_t i = 0; i < QUATERNION<T>::size(); i++) {
             lhs[i] *= v;
@@ -66,7 +67,8 @@ public:
         return lhs;
     }
 
-    constexpr QUATERNION<T>& operator/=(T v) {
+    template<typename U>
+    constexpr QUATERNION<T>& operator/=(U v) {
         QUATERNION<T>& lhs = static_cast<QUATERNION<T>&>(*this);
         for (size_t i = 0; i < QUATERNION<T>::size(); i++) {
             lhs[i] /= v;
@@ -85,28 +87,29 @@ public:
     /* The operators below handle operation between quaternions of the same size
      * but of a different element type.
      */
-    template<typename RT>
-    friend inline
-    constexpr QUATERNION<T> MATH_PURE operator*(const QUATERNION<T>& q, const QUATERNION<RT>& r) {
+    template<typename U>
+    friend inline constexpr
+    QUATERNION<arithmetic_result_t<T, U>> MATH_PURE operator*(
+            const QUATERNION<T>& q, const QUATERNION<U>& r) {
         // could be written as:
         //  return QUATERNION<T>(
         //            q.w*r.w - dot(q.xyz, r.xyz),
         //            q.w*r.xyz + r.w*q.xyz + cross(q.xyz, r.xyz));
-
-        return QUATERNION<T>(
+        return {
                 q.w * r.w - q.x * r.x - q.y * r.y - q.z * r.z,
                 q.w * r.x + q.x * r.w + q.y * r.z - q.z * r.y,
                 q.w * r.y - q.x * r.z + q.y * r.w + q.z * r.x,
-                q.w * r.z + q.x * r.y - q.y * r.x + q.z * r.w);
+                q.w * r.z + q.x * r.y - q.y * r.x + q.z * r.w
+        };
     }
 
-    template<typename RT>
-    friend inline
-    constexpr TVec3<T> MATH_PURE operator*(const QUATERNION<T>& q, const TVec3<RT>& v) {
+    template<typename U>
+    friend inline constexpr
+    TVec3<arithmetic_result_t<T, U>> MATH_PURE operator*(const QUATERNION<T>& q, const TVec3<U>& v) {
         // note: if q is known to be a unit quaternion, then this simplifies to:
         //  TVec3<T> t = 2 * cross(q.xyz, v)
         //  return v + (q.w * t) + cross(q.xyz, t)
-        return imaginary(q * QUATERNION<T>(v, 0) * inverse(q));
+        return imaginary(q * QUATERNION<U>(v, 0) * inverse(q));
     }
 
 
@@ -122,20 +125,23 @@ public:
      *              q.w*r.z + q.x*r.y - q.y*r.x + q.z*r.w);
      *
      */
-    friend inline
-    constexpr QUATERNION<T> MATH_PURE operator*(QUATERNION<T> q, T scalar) {
+    template<typename U>
+    friend inline constexpr
+    QUATERNION<arithmetic_result_t<T, U>> MATH_PURE operator*(QUATERNION<T> q, U scalar) {
         // don't pass q by reference because we need a copy anyway
         return q *= scalar;
     }
 
-    friend inline
-    constexpr QUATERNION<T> MATH_PURE operator*(T scalar, QUATERNION<T> q) {
+    template<typename U>
+    friend inline constexpr
+    QUATERNION<arithmetic_result_t<T, U>> MATH_PURE operator*(T scalar, QUATERNION<U> q) {
         // don't pass q by reference because we need a copy anyway
         return q *= scalar;
     }
 
-    friend inline
-    constexpr QUATERNION<T> MATH_PURE operator/(QUATERNION<T> q, T scalar) {
+    template<typename U>
+    friend inline constexpr
+    QUATERNION<arithmetic_result_t<T, U>> MATH_PURE operator/(QUATERNION<T> q, U scalar) {
         // don't pass q by reference because we need a copy anyway
         return q /= scalar;
     }
@@ -160,9 +166,10 @@ public:
      * (the first one, BASE<T> being known).
      */
 
-    template<typename RT>
-    friend inline
-    constexpr T MATH_PURE dot(const QUATERNION<T>& p, const QUATERNION<RT>& q) {
+    template<typename U>
+    friend inline constexpr
+    arithmetic_result_t<T, U> MATH_PURE dot(
+            const QUATERNION<T>& p, const QUATERNION<U>& q) {
         return p.x * q.x +
                p.y * q.y +
                p.z * q.z +
@@ -196,7 +203,7 @@ public:
 
     friend inline
     constexpr QUATERNION<T> MATH_PURE inverse(const QUATERNION<T>& q) {
-        return conj(q) * (1 / dot(q, q));
+        return conj(q) * (T(1) / dot(q, q));
     }
 
     friend inline
@@ -214,8 +221,10 @@ public:
         return QUATERNION<T>(q.xyz, 0);
     }
 
-    friend inline
-    constexpr QUATERNION<T> MATH_PURE cross(const QUATERNION<T>& p, const QUATERNION<T>& q) {
+    template<typename U>
+    friend inline constexpr
+    QUATERNION<arithmetic_result_t<T, U>> MATH_PURE cross(
+            const QUATERNION<T>& p, const QUATERNION<U>& q) {
         return unreal(p * q);
     }
 


### PR DESCRIPTION
We follow the same rules as C++, e.g. float * double -> double