### PR TITLE
fix a couple shadow stability bugs

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -14,3 +14,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - engine: New tone mapper: `AgXTonemapper`.
 - matinfo: Add support for viewing ESSL 1.0 shaders
 - engine: Add support for stencil buffer when post-processing is disabled (Metal backend only).
+- engine: Fix stable shadows (again) when an IBL rotation is used

--- a/filament/src/PerShadowMapUniforms.cpp
+++ b/filament/src/PerShadowMapUniforms.cpp
@@ -60,7 +60,7 @@ void PerShadowMapUniforms::prepareCamera(Transaction const& transaction,
     s.viewFromClipMatrix  = viewFromClip;     // 1/projection
     s.clipFromWorldMatrix[0] = clipFromWorld; // projection * view
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
-    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldOrigin));
+    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldTransform));
     s.clipTransform = camera.clipTransform;
     s.cameraFar = camera.zf;
     s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -74,7 +74,7 @@ void PerViewUniforms::prepareCamera(FEngine& engine, const CameraInfo& camera) n
     s.clipFromViewMatrix  = clipFromView;     // projection
     s.viewFromClipMatrix  = viewFromClip;     // 1/projection
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
-    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldOrigin));
+    s.userWorldFromWorldMatrix = mat4f(inverse(camera.worldTransform));
     s.clipTransform = camera.clipTransform;
     s.cameraFar = camera.zf;
     s.oneOverFarMinusNear = 1.0f / (camera.zf - camera.zn);
@@ -150,7 +150,7 @@ void PerViewUniforms::prepareFog(FEngine& engine, const CameraInfo& cameraInfo,
     // why we store the cofactor matrix.
 
     mat4f const viewFromWorld       = cameraInfo.view;
-    mat4 const worldFromUserWorld   = cameraInfo.worldOrigin;
+    mat4 const worldFromUserWorld   = cameraInfo.worldTransform;
     mat4 const worldFromFog         = worldFromUserWorld * userWorldFromFog;
     mat4 const viewFromFog          = viewFromWorld * worldFromFog;
 

--- a/filament/src/ShadowMap.h
+++ b/filament/src/ShadowMap.h
@@ -122,8 +122,8 @@ public:
         uint8_t visibleLayers;
     };
 
-    static math::mat4f getDirectionalLightViewMatrix(
-            math::float3 direction, math::float3 position = {}) noexcept;
+    static math::mat4f getDirectionalLightViewMatrix(math::float3 direction, math::float3 up,
+            math::float3 position = {}) noexcept;
 
     static math::mat4f getPointLightViewMatrix(backend::TextureCubemapFace face,
             math::float3 position) noexcept;
@@ -246,16 +246,15 @@ private:
 
     static inline math::mat4f computeLightRotation(math::float3 const& lsDirection) noexcept;
 
-    static inline math::mat4f computeFocusMatrix(
-            const math::mat4f& LMpMv,
-            const math::mat4f& WLMp,
-            Aabb const& wsShadowReceiversVolume,
+    static inline math::float4 computeFocusParams(
+            math::mat4f const& LMpMv,
+            math::mat4f const& WLMp,
             FrustumBoxIntersection const& lsShadowVolume, size_t vertexCount,
             filament::CameraInfo const& camera, math::float2 const& csNearFar,
-            uint16_t shadowDimension, bool stable) noexcept;
+            float shadowFar, bool stable) noexcept;
 
     static inline void snapLightFrustum(math::float2& s, math::float2& o,
-            math::mat4f const& Mv, math::double3 wsSnapCoords, math::int2 resolution) noexcept;
+            math::double2 lsRef, math::int2 resolution) noexcept;
 
     static inline Aabb computeLightFrustumBounds(const math::mat4f& lightView,
             Aabb const& wsShadowReceiversVolume, Aabb const& wsShadowCastersVolume,

--- a/filament/src/ShadowMapManager.cpp
+++ b/filament/src/ShadowMapManager.cpp
@@ -527,7 +527,8 @@ ShadowMapManager::ShadowTechnique ShadowMapManager::updateCascadeShadowMaps(FEng
         // We compute the directional light's model matrix using the origin's as the light position.
         // The choice of the light's origin initially doesn't matter for a directional light.
         // This will be adjusted later because of how we compute the depth metric for VSM.
-        const mat4f MvAtOrigin = ShadowMap::getDirectionalLightViewMatrix(direction);
+        const mat4f MvAtOrigin = ShadowMap::getDirectionalLightViewMatrix(direction,
+                normalize(cameraInfo.worldTransform[0].xyz));
 
         // Compute scene-dependent values shared across all cascades
         ShadowMap::updateSceneInfoDirectional(MvAtOrigin, *scene, sceneInfo);
@@ -695,7 +696,7 @@ void ShadowMapManager::prepareSpotShadowMap(ShadowMap& shadowMap,
     const auto outerConeAngle = lcm.getSpotLightOuterCone(li);
 
     // compute shadow map frustum for culling
-    const mat4f Mv = ShadowMap::getDirectionalLightViewMatrix(direction, position);
+    const mat4f Mv = ShadowMap::getDirectionalLightViewMatrix(direction, { 0, 1, 0 }, position);
     const mat4f Mp = mat4f::perspective(outerConeAngle * f::RAD_TO_DEG * 2.0f, 1.0f, 0.01f, radius);
     const mat4f MpMv = math::highPrecisionMultiply(Mp, Mv);
     const Frustum frustum(MpMv);

--- a/filament/src/details/Camera.cpp
+++ b/filament/src/details/Camera.cpp
@@ -266,8 +266,8 @@ CameraInfo::CameraInfo(FCamera const& camera) noexcept {
     d                  = std::max(zn, camera.getFocusDistance());
 }
 
-CameraInfo::CameraInfo(FCamera const& camera, const math::mat4& worldOriginCamera) noexcept {
-    const mat4 modelMatrix{ worldOriginCamera * camera.getModelMatrix() };
+CameraInfo::CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept {
+    const mat4 modelMatrix{ inWorldTransform * camera.getModelMatrix() };
     for (uint8_t i = 0; i < CONFIG_STEREOSCOPIC_EYES; i++) {
         eyeProjection[i]   = mat4f{ camera.getProjectionMatrix(i) };
         eyeFromView[i]     = mat4f{ camera.getEyeFromViewMatrix(i) };
@@ -275,7 +275,7 @@ CameraInfo::CameraInfo(FCamera const& camera, const math::mat4& worldOriginCamer
     cullingProjection  = mat4f{ camera.getCullingProjectionMatrix() };
     model              = mat4f{ modelMatrix };
     view               = mat4f{ inverse(modelMatrix) };
-    worldOrigin        = worldOriginCamera;
+    worldTransform     = inWorldTransform;
     zn                 = (float)camera.getNear();
     zf                 = (float)camera.getCullingFar();
     ev100              = Exposure::ev100(camera);

--- a/filament/src/details/Camera.h
+++ b/filament/src/details/Camera.h
@@ -223,7 +223,7 @@ private:
 struct CameraInfo {
     CameraInfo() noexcept {}
     explicit CameraInfo(FCamera const& camera) noexcept;
-    CameraInfo(FCamera const& camera, const math::mat4& worldOriginCamera) noexcept;
+    CameraInfo(FCamera const& camera, math::mat4 const& inWorldTransform) noexcept;
 
     union {
         // projection matrix for drawing (infinite zfar)
@@ -239,7 +239,7 @@ struct CameraInfo {
     math::mat4f model;                                  // camera model matrix
     math::mat4f view;                                   // camera view matrix (inverse(model))
     math::mat4f eyeFromView[CONFIG_STEREOSCOPIC_EYES];  // eye view matrix (only for stereoscopic)
-    math::mat4 worldOrigin;                             // world origin transform (already applied
+    math::mat4 worldTransform;                          // world transform (already applied
                                                         // to model and view)
     math::float4 clipTransform{1, 1, 0, 0};  // clip-space transform, only for VERTEX_DOMAIN_DEVICE
     float zn{};                              // distance (positive) to the near plane
@@ -250,7 +250,7 @@ struct CameraInfo {
     float d{};                               // focus distance [m]
     math::float3 const& getPosition() const noexcept { return model[3].xyz; }
     math::float3 getForwardVector() const noexcept { return normalize(-model[2].xyz); }
-    math::mat4 getUserViewMatrix() const noexcept { return view * worldOrigin; }
+    math::mat4 getUserViewMatrix() const noexcept { return view * worldTransform; }
 };
 
 FILAMENT_DOWNCAST(Camera)

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -33,6 +33,8 @@
 #include <utils/Range.h>
 #include <utils/Systrace.h>
 
+#include <math/quat.h>
+
 #include <algorithm>
 
 using namespace filament::backend;
@@ -52,7 +54,7 @@ FScene::~FScene() noexcept = default;
 
 void FScene::prepare(utils::JobSystem& js,
         LinearAllocatorArena& allocator,
-        const mat4& worldOriginTransform,
+        mat4 const& worldTransform,
         bool shadowReceiversAreCasters) noexcept {
     // TODO: can we skip this in most cases? Since we rely on indices staying the same,
     //       we could only skip, if nothing changed in the RCM.
@@ -168,7 +170,7 @@ void FScene::prepare(utils::JobSystem& js,
      * Fill the SoA with the JobSystem
      */
 
-    auto renderableWork = [first = renderableInstances.data(), &rcm, &tcm, &worldOriginTransform,
+    auto renderableWork = [first = renderableInstances.data(), &rcm, &tcm, &worldTransform,
                  &sceneData, shadowReceiversAreCasters](auto* p, auto c) {
         SYSTRACE_NAME("renderableWork");
 
@@ -176,12 +178,12 @@ void FScene::prepare(utils::JobSystem& js,
             auto [ri, ti] = p[i];
 
             // this is where we go from double to float for our transforms
-            const mat4f worldTransform{
-                    worldOriginTransform * tcm.getWorldTransformAccurate(ti) };
-            const bool reversedWindingOrder = det(worldTransform.upperLeft()) < 0;
+            const mat4f shaderWorldTransform{
+                    worldTransform * tcm.getWorldTransformAccurate(ti) };
+            const bool reversedWindingOrder = det(shaderWorldTransform.upperLeft()) < 0;
 
             // compute the world AABB so we can perform culling
-            const Box worldAABB = rigidTransform(rcm.getAABB(ri), worldTransform);
+            const Box worldAABB = rigidTransform(rcm.getAABB(ri), shaderWorldTransform);
 
             auto visibility = rcm.getVisibility(ri);
             visibility.reversedWindingOrder = reversedWindingOrder;
@@ -199,7 +201,7 @@ void FScene::prepare(utils::JobSystem& js,
             assert_invariant(index < sceneData.size());
 
             sceneData.elementAt<RENDERABLE_INSTANCE>(index) = ri;
-            sceneData.elementAt<WORLD_TRANSFORM>(index)     = worldTransform;
+            sceneData.elementAt<WORLD_TRANSFORM>(index)     = shaderWorldTransform;
             sceneData.elementAt<VISIBILITY_STATE>(index)    = visibility;
             sceneData.elementAt<SKINNING_BUFFER>(index)     = rcm.getSkinningBufferInfo(ri);
             sceneData.elementAt<MORPHING_BUFFER>(index)     = rcm.getMorphingBufferInfo(ri);
@@ -216,19 +218,20 @@ void FScene::prepare(utils::JobSystem& js,
         }
     };
 
-    auto lightWork = [first = lightInstances.data(), &lcm, &tcm, &worldOriginTransform,
+    auto lightWork = [first = lightInstances.data(), &lcm, &tcm, &worldTransform,
             &lightData](auto* p, auto c) {
         SYSTRACE_NAME("lightWork");
         for (size_t i = 0; i < c; i++) {
             auto [li, ti] = p[i];
             // this is where we go from double to float for our transforms
-            const mat4f worldTransform{ worldOriginTransform * tcm.getWorldTransformAccurate(ti) };
-            const float4 position = worldTransform * float4{ lcm.getLocalPosition(li), 1 };
+            mat4f const shaderWorldTransform{
+                    worldTransform * tcm.getWorldTransformAccurate(ti) };
+            float4 const position = shaderWorldTransform * float4{ lcm.getLocalPosition(li), 1 };
             float3 d = 0;
             if (!lcm.isPointLight(li) || lcm.isIESLight(li)) {
                 d = lcm.getLocalDirection(li);
                 // using mat3f::getTransformForNormals handles non-uniform scaling
-                d = normalize(mat3f::getTransformForNormals(worldTransform.upperLeft()) * d);
+                d = normalize(mat3f::getTransformForNormals(shaderWorldTransform.upperLeft()) * d);
             }
             size_t const index = DIRECTIONAL_LIGHTS_COUNT + std::distance(first, p) + i;
             assert_invariant(index < lightData.size());
@@ -261,14 +264,43 @@ void FScene::prepare(utils::JobSystem& js,
      */
 
     if (auto [li, ti] = directionalLightInstances ; li) {
-        const mat4f worldTransform{
-                worldOriginTransform * tcm.getWorldTransformAccurate(ti) };
-        // using mat3f::getTransformForNormals handles non-uniform scaling
-        float3 d = lcm.getLocalDirection(li);
-        d = normalize(mat3f::getTransformForNormals(worldTransform.upperLeft()) * d);
+        // in the code below, we only transform directions, so the translation of the
+        // world transform is irrelevant, and we don't need to use getWorldTransformAccurate()
+
+        FLightManager::ShadowParams const params = lcm.getShadowParams(li);
+        float3 const localDirection = lcm.getLocalDirection(li);
+        float3 const shadowLocalDirection = params.options.transform * localDirection;
+        mat3 const worldDirectionTransform = tcm.getWorldTransformAccurate(ti).upperLeft();
+        mat3 const shaderWorldTransform = worldTransform.upperLeft() * worldDirectionTransform;
+
+        // using mat3::getTransformForNormals handles non-uniform scaling
+        // note: in the common case of the rigid-body transform, getTransformForNormals() returns
+        // identity.
+        mat3 const worlTransformNormals = mat3::getTransformForNormals(shaderWorldTransform);
+        double3 const d = worlTransformNormals * localDirection;
+        double3 const s = worlTransformNormals * shadowLocalDirection;
+
+        // We compute the reference point for snapping shadowmaps without applying the
+        // rotation of `worldOriginTransform` on both sides, so that we don't have any instability
+        // due to the limited precision of the "light space" matrix (even at double precision).
+
+        // getMv() Returns the world-to-lightspace transformation. See ShadowMap.cpp.
+        auto getMv = [](double3 direction) -> mat3 {
+            // We use the x-axis as the "up" reference so that the math is stable when the light
+            // is pointing down, which is a common case for lights. See ShadowMap.cpp.
+            return transpose(mat3::lookTo(direction, double3{ 1, 0, 0 }));
+        };
+        double3 const worldDirection =
+                mat3::getTransformForNormals(worldDirectionTransform) * shadowLocalDirection;
+        double3 const worldOrigin = transpose(worldTransform.upperLeft()) * worldTransform[3].xyz;
+        mat3 const Mv = getMv(worldDirection);
+        double2 const lsReferencePoint = (Mv * worldOrigin).xy;
+
         constexpr float inf = std::numeric_limits<float>::infinity();
         lightData.elementAt<POSITION_RADIUS>(0) = float4{ 0, 0, 0, inf };
-        lightData.elementAt<DIRECTION>(0) = d;
+        lightData.elementAt<DIRECTION>(0) = normalize(d);
+        lightData.elementAt<SHADOW_DIRECTION>(0) = normalize(s);
+        lightData.elementAt<SHADOW_REF>(0) = lsReferencePoint;
         lightData.elementAt<LIGHT_INSTANCE>(0) = li;
     } else {
         lightData.elementAt<LIGHT_INSTANCE>(0) = 0;

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -71,7 +71,7 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(utils::JobSystem& js, LinearAllocatorArena& allocator,
-            math::mat4 const& worldOriginTransform, bool shadowReceiversAreCasters) noexcept;
+            math::mat4 const& worldTransform, bool shadowReceiversAreCasters) noexcept;
 
     void prepareVisibleRenderables(utils::Range<uint32_t> visibleRenderables) noexcept;
 
@@ -162,6 +162,8 @@ public:
     enum {
         POSITION_RADIUS,
         DIRECTION,
+        SHADOW_DIRECTION,
+        SHADOW_REF,
         LIGHT_INSTANCE,
         VISIBILITY,
         SCREEN_SPACE_Z_RANGE,
@@ -171,6 +173,8 @@ public:
     using LightSoa = utils::StructureOfArrays<
             math::float4,
             math::float3,
+            math::float3,
+            math::double2,
             FLightManager::Instance,
             Culler::result_type,
             math::float2,

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -397,8 +397,8 @@ CameraInfo FView::computeCameraInfo(FEngine& engine) const noexcept {
      * The "world origin" is also used to keep the origin close to the camera position to
      * improve fp precision in the shader for large scenes.
      */
-    mat4 translation;
-    mat4 rotation;
+    double3 translation;
+    mat3 rotation;
 
     /*
      * Calculate all camera parameters needed to render this View for this frame.
@@ -409,16 +409,18 @@ CameraInfo FView::computeCameraInfo(FEngine& engine) const noexcept {
         // view-space, which improves floating point precision in the shader by staying around
         // zero, where fp precision is highest. This also ensures that when the camera is placed
         // very far from the origin, objects are still rendered and lit properly.
-        translation = mat4::translation( -camera->getPosition() );
+        translation = -camera->getPosition();
     }
 
     FIndirectLight const* const ibl = scene->getIndirectLight();
     if (ibl) {
         // the IBL transformation must be a rigid transform
-        rotation = mat4{ transpose(scene->getIndirectLight()->getRotation()) };
+        rotation = mat3{ transpose(scene->getIndirectLight()->getRotation()) };
+        // it is important to orthogonalize the matrix when converting it to doubles, because
+        // as float, it only has about a 1e-8 precision on the size of the basis vectors
+        rotation = orthogonalize(rotation);
     }
-
-    return { *camera, rotation * translation };
+    return { *camera, mat4{ rotation } * mat4::translation(translation) };
 }
 
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
@@ -446,7 +448,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
             // intent of the code, which is that we should only depend on CameraInfo here.
             // This is an extremely uncommon case.
             const mat4 projection = mCullingCamera->getCullingProjectionMatrix();
-            const mat4 view = inverse(cameraInfo.worldOrigin * mCullingCamera->getModelMatrix());
+            const mat4 view = inverse(cameraInfo.worldTransform * mCullingCamera->getModelMatrix());
             return Frustum{ mat4f{ projection * view }};
         }
     };
@@ -459,7 +461,9 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
      * Gather all information needed to render this scene. Apply the world origin to all
      * objects in the scene.
      */
-    scene->prepare(js, arena.getAllocator(), cameraInfo.worldOrigin, hasVSM());
+    scene->prepare(js, arena.getAllocator(),
+            cameraInfo.worldTransform,
+            hasVSM());
 
     /*
      * Light culling: runs in parallel with Renderable culling (below)

--- a/filament/test/filament_test.cpp
+++ b/filament/test/filament_test.cpp
@@ -702,8 +702,8 @@ TEST(FilamentTest, FroxelData) {
     LightManager::Instance instance = engine->getLightManager().getInstance(e);
 
     FScene::LightSoa lights;
-    lights.push_back({}, {}, {}, {}, {}, {});   // first one is always skipped
-    lights.push_back(float4{ 0, 0, -5, 1 }, {}, instance, 1, {}, {});
+    lights.push_back({}, {}, {}, {}, {}, {}, {}, {});   // first one is always skipped
+    lights.push_back(float4{ 0, 0, -5, 1 }, {}, {}, {}, instance, 1, {}, {});
 
     {
         froxelData.froxelizeLights(*engine, {}, lights);

--- a/libs/math/include/math/mat3.h
+++ b/libs/math/include/math/mat3.h
@@ -289,6 +289,14 @@ public:
         return matrix::cof(m);
     }
 
+    /*
+     * Returns a matrix representing the pose of a virtual camera looking towards -Z in its
+     * local Y-up coordinate system. "up" defines where the Y axis of the camera's local coordinate
+     * system is.
+     */
+    template<typename A, typename B>
+    static TMat33 lookTo(const TVec3<A>& direction, const TVec3<B>& up) noexcept;
+
     /**
      * Packs the tangent frame represented by the specified matrix into a quaternion.
      * Reflection is preserved by encoding it as the sign of the w component in the
@@ -404,6 +412,29 @@ constexpr TMat33<T>::TMat33(const TQuaternion<U>& q) noexcept : m_value{} {
     m_value[0] = col_type(1 - yy - zz, xy + zw, xz - yw);  // NOLINT
     m_value[1] = col_type(xy - zw, 1 - xx - zz, yz + xw);  // NOLINT
     m_value[2] = col_type(xz + yw, yz - xw, 1 - xx - yy);  // NOLINT
+}
+
+template<typename T>
+constexpr T dot_tolerance() noexcept;
+
+template<>
+constexpr float dot_tolerance<float>() noexcept { return 0.999f; }
+
+template<>
+constexpr double dot_tolerance<double>() noexcept { return 0.9999; }
+
+template<typename T>
+template<typename A, typename B>
+TMat33<T> TMat33<T>::lookTo(const TVec3<A>& direction, const TVec3<B>& up) noexcept {
+    auto const z_axis = direction;
+    auto norm_up = up;
+    if (std::abs(dot(z_axis, norm_up)) > dot_tolerance< arithmetic_result_t<A, B> >()) {
+        // Fix up vector if we're degenerate (looking straight up, basically)
+        norm_up = { norm_up.z, norm_up.x, norm_up.y };
+    }
+    auto const x_axis = normalize(cross(z_axis, norm_up));
+    auto const y_axis = cross(x_axis, z_axis);
+    return { x_axis, y_axis, -z_axis };
 }
 
 //------------------------------------------------------------------------------

--- a/libs/math/include/math/mat4.h
+++ b/libs/math/include/math/mat4.h
@@ -285,6 +285,9 @@ public:
     template<typename A, typename B, typename C>
     static TMat44 lookAt(const TVec3<A>& eye, const TVec3<B>& center, const TVec3<C>& up) noexcept;
 
+    template<typename A, typename B, typename C>
+    static TMat44 lookTo(const TVec3<A>& direction, const TVec3<B>& position, const TVec3<C>& up) noexcept;
+
     template<typename A>
     static constexpr TVec3<A> project(const TMat44& projectionMatrix, TVec3<A> vertice) noexcept{
         TVec4<A> r = projectionMatrix * TVec4<A>{ vertice, 1 };
@@ -517,19 +520,19 @@ template<typename T>
 template<typename A, typename B, typename C>
 TMat44<T> TMat44<T>::lookAt(const TVec3<A>& eye, const TVec3<B>& center,
         const TVec3<C>& up) noexcept {
-    TVec3<T> z_axis(normalize(center - eye));
-    TVec3<T> norm_up(normalize(up));
-    if (std::abs(dot(z_axis, norm_up)) > T(0.999)) {
-        // Fix up vector if we're degenerate (looking straight up, basically)
-        norm_up = { norm_up.z, norm_up.x, norm_up.y };
-    }
-    TVec3<T> x_axis(normalize(cross(z_axis, norm_up)));
-    TVec3<T> y_axis(cross(x_axis, z_axis));
-    return TMat44<T>(
-            TVec4<T>(x_axis, 0),
-            TVec4<T>(y_axis, 0),
-            TVec4<T>(-z_axis, 0),
-            TVec4<T>(eye, 1));
+    return lookTo(normalize(center - eye), eye, normalize(up));
+}
+
+template<typename T>
+template<typename A, typename B, typename C>
+TMat44<T> TMat44<T>::lookTo(const TVec3<A>& direction, const TVec3<B>& position,
+        const TVec3<C>& up) noexcept {
+    auto r = TMat33<T>::lookTo(direction, up);
+    return TMat44<T>{
+            TVec4<T>{     r[0], 0 },
+            TVec4<T>{     r[1], 0 },
+            TVec4<T>{     r[2], 0 },
+            TVec4<T>{ position, 1 } };
 }
 
 // ----------------------------------------------------------------------------------------

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -101,7 +101,7 @@ struct App {
 
     bool actualSize = false;
     bool originIsFarAway = false;
-    float originDistance = 6378137; // Earth's radius in [m]
+    float originDistance = 1.0f;
 
     struct Scene {
         Entity groundPlane;
@@ -760,7 +760,7 @@ int main(int argc, char** argv) {
                 ImGui::Checkbox("Disable buffer padding", debug.getPropertyAddress<bool>("d.renderer.disable_buffer_padding"));
                 ImGui::Checkbox("Camera at origin", debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
                 ImGui::Checkbox("Far Origin", &app.originIsFarAway);
-                ImGui::SliderFloat("Origin", &app.originDistance, 0, 10000000);
+                ImGui::SliderFloat("Origin", &app.originDistance, 0, 1);
                 ImGui::Checkbox("Far uses shadow casters", debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
                 ImGui::Checkbox("Focus shadow casters", debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
                 auto dataSource = debug.getDataSource("d.view.frame_info");
@@ -960,7 +960,11 @@ int main(int argc, char** argv) {
         tcm.setParent(tcm.getInstance(camera.getEntity()), root);
         tcm.setParent(tcm.getInstance(app.asset->getRoot()), root);
         tcm.setParent(tcm.getInstance(view->getFogEntity()), root);
-        tcm.setTransform(root, mat4f::translation(float3{ app.originIsFarAway ? app.originDistance : 0.0f }));
+
+        // these values represent a point somewhere on Earth's surface
+        float const d = app.originIsFarAway ? app.originDistance : 0.0f;
+//        tcm.setTransform(root, mat4::translation(double3{ 67.0, -6366759.0, -21552.0 } * d));
+        tcm.setTransform(root, mat4::translation(double3{ 2304097.1410110965, -4688442.9915525438, -3639452.5611694567 } * d));
 
         // Check if color grading has changed.
         ColorGradingSettings& options = app.viewer->getSettings().view.colorGrading;


### PR DESCRIPTION
- shadows are now stable (in stable mode) when an IBL rotation is used.

- fix the shadow transform option which didn't work when an IBL rotation was used

- also use the x-axis as a reference for the "up" direction when computing the light space matrix so that we don't fall into the degenerate case when the light points straight down, which is a common case

FIXES=[299310624]