### PR TITLE
dynamic shadowmap visualization 

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -1930,6 +1930,7 @@ public class View {
          * PCF with soft shadows and contact hardening
          */
         PCSS,
+        PCFd,
     }
 
     /**

--- a/filament/include/filament/DebugRegistry.h
+++ b/filament/include/filament/DebugRegistry.h
@@ -67,15 +67,28 @@ public:
      * @return Address of the data of the \p name property
      * @{
      */
-    void* getPropertyAddress(const char* name) noexcept;
+    void* getPropertyAddress(const char* name);
+
+    void const* getPropertyAddress(const char* name) const noexcept;
 
     template<typename T>
-    inline T* getPropertyAddress(const char* name) noexcept {
+    inline T* getPropertyAddress(const char* name) {
         return static_cast<T*>(getPropertyAddress(name));
     }
 
     template<typename T>
-    inline bool getPropertyAddress(const char* name, T** p) noexcept {
+    inline T const* getPropertyAddress(const char* name) const noexcept {
+        return static_cast<T*>(getPropertyAddress(name));
+    }
+
+    template<typename T>
+    inline bool getPropertyAddress(const char* name, T** p) {
+        *p = getPropertyAddress<T>(name);
+        return *p != nullptr;
+    }
+
+    template<typename T>
+    inline bool getPropertyAddress(const char* name, T* const* p) const noexcept {
         *p = getPropertyAddress<T>(name);
         return *p != nullptr;
     }

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -479,7 +479,8 @@ enum class ShadowType : uint8_t {
     PCF,        //!< percentage-closer filtered shadows (default)
     VSM,        //!< variance shadows
     DPCF,       //!< PCF with contact hardening simulation
-    PCSS        //!< PCF with soft shadows and contact hardening
+    PCSS,       //!< PCF with soft shadows and contact hardening
+    PCFd,       // for debugging only, don't use.
 };
 
 /**

--- a/filament/src/DebugRegistry.cpp
+++ b/filament/src/DebugRegistry.cpp
@@ -77,7 +77,11 @@ bool DebugRegistry::getProperty(const char* name, float4* v) const noexcept {
     return downcast(this)->getProperty(name, v);
 }
 
-void *DebugRegistry::getPropertyAddress(const char *name) noexcept {
+void *DebugRegistry::getPropertyAddress(const char *name) {
+    return  downcast(this)->getPropertyAddress(name);
+}
+
+void const *DebugRegistry::getPropertyAddress(const char *name) const noexcept {
     return  downcast(this)->getPropertyAddress(name);
 }
 

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -428,6 +428,17 @@ void PerViewUniforms::prepareShadowPCSS(Handle<HwTexture> texture,
     PerViewUniforms::prepareShadowSampling(s, shadowMappingUniforms);
 }
 
+void PerViewUniforms::prepareShadowPCFDebug(Handle<HwTexture> texture,
+        ShadowMappingUniforms const& shadowMappingUniforms) noexcept {
+    mSamplers.setSampler(PerViewSib::SHADOW_MAP, { texture, {
+            .filterMag = SamplerMagFilter::NEAREST,
+            .filterMin = SamplerMinFilter::NEAREST
+    }});
+    auto& s = mUniforms.edit();
+    s.shadowSamplingType = SHADOW_SAMPLING_RUNTIME_PCF;
+    PerViewUniforms::prepareShadowSampling(s, shadowMappingUniforms);
+}
+
 void PerViewUniforms::commit(backend::DriverApi& driver) noexcept {
     if (mUniforms.isDirty()) {
         driver.updateBufferObject(mUniformBufferHandle, mUniforms.toBufferDescriptor(driver), 0);

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -128,6 +128,9 @@ public:
             ShadowMappingUniforms const& shadowMappingUniforms,
             SoftShadowOptions const& options) noexcept;
 
+    void prepareShadowPCFDebug(TextureHandle texture,
+            ShadowMappingUniforms const& shadowMappingUniforms) noexcept;
+
     // update local data into GPU UBO
     void commit(backend::DriverApi& driver) noexcept;
 

--- a/filament/src/details/DebugRegistry.h
+++ b/filament/src/details/DebugRegistry.h
@@ -23,8 +23,10 @@
 
 #include <utils/compiler.h>
 
+#include <functional>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 
 namespace filament {
 
@@ -58,6 +60,37 @@ public:
         registerProperty(name, p, FLOAT4);
     }
 
+
+    void registerProperty(std::string_view name, bool* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, BOOL, std::move(fn));
+    }
+
+    void registerProperty(std::string_view name, int* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, INT, std::move(fn));
+    }
+
+    void registerProperty(std::string_view name, float* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, FLOAT, std::move(fn));
+    }
+
+    void registerProperty(std::string_view name, math::float2* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, FLOAT2, std::move(fn));
+    }
+
+    void registerProperty(std::string_view name, math::float3* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, FLOAT3, std::move(fn));
+    }
+
+    void registerProperty(std::string_view name, math::float4* p,
+            std::function<void()> fn) noexcept {
+        registerProperty(name, p, FLOAT4, std::move(fn));
+    }
+
     void registerDataSource(std::string_view name, void const* data, size_t count) noexcept;
 
 #if !defined(_MSC_VER)
@@ -67,12 +100,15 @@ private:
     template<typename T> bool setProperty(const char* name, T v) noexcept;
 
 private:
+    using PropertyInfo = std::pair<void*, std::function<void()>>;
     friend class DebugRegistry;
-    void registerProperty(std::string_view name, void* p, Type type) noexcept;
+    void registerProperty(std::string_view name, void* p, Type type, std::function<void()> fn = {}) noexcept;
     bool hasProperty(const char* name) const noexcept;
-    void* getPropertyAddress(const char* name) noexcept;
+    PropertyInfo getPropertyInfo(const char* name) noexcept;
+    void* getPropertyAddress(const char* name);
+    void const* getPropertyAddress(const char* name) const noexcept;
     DataSource getDataSource(const char* name) const noexcept;
-    std::unordered_map<std::string_view, void*> mPropertyMap;
+    std::unordered_map<std::string_view, PropertyInfo> mPropertyMap;
     std::unordered_map<std::string_view, DataSource> mDataSourceMap;
 };
 

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -363,6 +363,17 @@ void FEngine::init() {
         mLightManager.init(*this);
         mDFG.init(*this);
     }
+
+    mDebugRegistry.registerProperty("d.shadowmap.debug_directional_shadowmap",
+            &debug.shadowmap.debug_directional_shadowmap, [this]() {
+                mMaterials.forEach([](FMaterial* material) {
+                    if (material->getMaterialDomain() == MaterialDomain::SURFACE) {
+                        material->invalidate(
+                                Variant::DIR | Variant::SRE | Variant::DEP,
+                                Variant::DIR | Variant::SRE);
+                    }
+                });
+            });
 }
 
 FEngine::~FEngine() noexcept {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -543,6 +543,7 @@ public:
     // these are the debug properties used by FDebug. They're accessed directly by modules who need them.
     struct {
         struct {
+            bool debug_directional_shadowmap = false;
             bool far_uses_shadowcasters = true;
             bool focus_shadowcasters = true;
             bool visualize_cascades = false;

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -464,7 +464,7 @@ void FMaterial::invalidate(Variant::type_t variantMask, Variant::type_t variantV
     DriverApi& driverApi = mEngine.getDriverApi();
     auto& cachedPrograms = mCachedPrograms;
     for (size_t k = 0, n = VARIANT_COUNT; k < n; ++k) {
-        const Variant variant(k);
+        Variant const variant(k);
         if ((k & variantMask) == variantValue) {
             if (UTILS_LIKELY(!mIsDefaultMaterial)) {
                 // The depth variants may be shared with the default material, in which case

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -86,6 +86,8 @@ public:
         return bool(mCachedPrograms[variant.key]);
     }
 
+    void invalidate(Variant::type_t variantMask = 0, Variant::type_t variantValue = 0) noexcept;
+
     // prepareProgram creates the program for the material's given variant at the backend level.
     // Must be called outside of backend render pass.
     // Must be called before getProgram() below.

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -772,6 +772,9 @@ void FView::prepareShadow(Handle<HwTexture> texture) const noexcept {
         case filament::ShadowType::PCSS:
             mPerViewUniforms.prepareShadowPCSS(texture, uniforms, mSoftShadowOptions);
             break;
+        case filament::ShadowType::PCFd:
+            mPerViewUniforms.prepareShadowPCFDebug(texture, uniforms);
+            break;
     }
 }
 

--- a/libs/filabridge/include/private/filament/EngineEnums.h
+++ b/libs/filabridge/include/private/filament/EngineEnums.h
@@ -64,6 +64,7 @@ enum class ReservedSpecializationConstants : uint8_t {
     CONFIG_SRGB_SWAPCHAIN_EMULATION = 3, // don't change (hardcoded in OpenGLDriver.cpp)
     CONFIG_FROXEL_BUFFER_HEIGHT = 4,
     CONFIG_POWER_VR_SHADER_WORKAROUNDS = 5,
+    CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP = 6,
 };
 
 // This value is limited by UBO size, ES3.0 only guarantees 16 KiB.

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -234,6 +234,10 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
                 +ReservedSpecializationConstants::CONFIG_FROXEL_BUFFER_HEIGHT, 1024);
     }
 
+    // directional shadowmap visualization
+    generateSpecializationConstant(out, "CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP",
+            +ReservedSpecializationConstants::CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP, false);
+
     // Workaround a Metal pipeline compilation error with the message:
     // "Could not statically determine the target of a texture". See light_indirect.fs
     generateSpecializationConstant(out, "CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND",

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -782,6 +782,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ShadowType* out
     else if (0 == compare(tokens[i], jsonChunk, "VSM")) { *out = ShadowType::VSM; }
     else if (0 == compare(tokens[i], jsonChunk, "DPCF")) { *out = ShadowType::DPCF; }
     else if (0 == compare(tokens[i], jsonChunk, "PCSS")) { *out = ShadowType::PCSS; }
+    else if (0 == compare(tokens[i], jsonChunk, "PCFd")) { *out = ShadowType::PCFd; }
     else {
         slog.w << "Invalid ShadowType: '" << STR(tokens[i], jsonChunk) << "'" << io::endl;
     }
@@ -794,6 +795,7 @@ std::ostream& operator<<(std::ostream& out, ShadowType in) {
         case ShadowType::VSM: return out << "\"VSM\"";
         case ShadowType::DPCF: return out << "\"DPCF\"";
         case ShadowType::PCSS: return out << "\"PCSS\"";
+        case ShadowType::PCFd: return out << "\"PCFd\"";
     }
     return out << "\"INVALID\"";
 }

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -881,7 +881,7 @@ void ViewerGui::updateUserInterface() {
             ImGui::Checkbox("Enable LiSPSM", &light.shadowOptions.lispsm);
 
             int shadowType = (int)mSettings.view.shadowType;
-            ImGui::Combo("Shadow type", &shadowType, "PCF\0VSM\0DPCF\0PCSS\0\0");
+            ImGui::Combo("Shadow type", &shadowType, "PCF\0VSM\0DPCF\0PCSS\0PCFd\0\0");
             mSettings.view.shadowType = (ShadowType)shadowType;
 
             if (mSettings.view.shadowType == ShadowType::VSM) {

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -135,7 +135,7 @@ struct App {
 static const char* DEFAULT_IBL = "assets/ibl/lightroom_14b";
 
 static void printUsage(char* name) {
-    std::string exec_name(Path(name).getName());
+    std::string const exec_name(Path(name).getName());
     std::string usage(
         "SHOWCASE renders the specified glTF file, or a built-in file if none is specified\n"
         "Usage:\n"
@@ -222,7 +222,7 @@ static int handleCommandLineArguments(int argc, char* argv[], App* app) {
     int opt;
     int option_index = 0;
     while ((opt = getopt_long(argc, argv, OPTSTR, OPTIONS, &option_index)) >= 0) {
-        std::string arg(optarg ? optarg : "");
+        std::string const arg(optarg ? optarg : "");
         switch (opt) {
             default:
             case 'h':
@@ -326,7 +326,7 @@ static void createGroundPlane(Engine* engine, Scene* scene, App& app) {
 
     Aabb aabb = app.asset->getBoundingBox();
     if (!app.actualSize) {
-        mat4f transform = fitIntoUnitCube(aabb, 4);
+        mat4f const transform = fitIntoUnitCube(aabb, 4);
         aabb = aabb.transform(transform);
     }
 
@@ -339,7 +339,7 @@ static void createGroundPlane(Engine* engine, Scene* scene, App& app) {
             {  planeExtent.x, 0, -planeExtent.z },
     };
 
-    short4 tbn = packSnorm16(
+    short4 const tbn = packSnorm16(
             mat3f::packTangentFrame(
                     mat3f{
                             float3{ 1.0f, 0.0f, 0.0f },
@@ -372,7 +372,7 @@ static void createGroundPlane(Engine* engine, Scene* scene, App& app) {
     indexBuffer->setBuffer(*engine, IndexBuffer::BufferDescriptor(
             indices, indexBuffer->getIndexCount() * sizeof(uint32_t)));
 
-    Entity groundPlane = em.create();
+    Entity const groundPlane = em.create();
     RenderableManager::Builder(1)
             .boundingBox({
                     {}, { planeExtent.x, 1e-4f, planeExtent.z }
@@ -491,10 +491,10 @@ int main(int argc, char** argv) {
     app.config.title = "Filament";
     app.config.iblDirectory = FilamentApp::getRootAssetsPath() + DEFAULT_IBL;
 
-    int optionIndex = handleCommandLineArguments(argc, argv, &app);
+    int const optionIndex = handleCommandLineArguments(argc, argv, &app);
 
     utils::Path filename;
-    int num_args = argc - optionIndex;
+    int const num_args = argc - optionIndex;
     if (num_args >= 1) {
         filename = argv[optionIndex];
         if (!filename.exists()) {
@@ -503,7 +503,7 @@ int main(int argc, char** argv) {
         }
         if (filename.isDirectory()) {
             auto files = filename.listContents();
-            for (auto file : files) {
+            for (const auto& file : files) {
                 if (file.getExtension() == "gltf" || file.getExtension() == "glb") {
                     filename = file;
                     break;
@@ -516,9 +516,9 @@ int main(int argc, char** argv) {
         }
     }
 
-    auto loadAsset = [&app](utils::Path filename) {
+    auto loadAsset = [&app](const utils::Path& filename) {
         // Peek at the file size to allow pre-allocation.
-        long contentSize = static_cast<long>(getFileSize(filename.c_str()));
+        long const contentSize = static_cast<long>(getFileSize(filename.c_str()));
         if (contentSize <= 0) {
             std::cerr << "Unable to open " << filename << std::endl;
             exit(1);
@@ -544,9 +544,9 @@ int main(int argc, char** argv) {
         }
     };
 
-    auto loadResources = [&app] (utils::Path filename) {
+    auto loadResources = [&app] (const utils::Path& filename) {
         // Load external textures and buffers.
-        std::string gltfPath = filename.getAbsolutePath();
+        std::string const gltfPath = filename.getAbsolutePath();
         ResourceConfiguration configuration = {};
         configuration.engine = app.engine;
         configuration.gltfPath = gltfPath.c_str();
@@ -637,8 +637,8 @@ int main(int argc, char** argv) {
             app.viewer->stopAnimation();
         }
 
-        if (app.settingsFile.size() > 0) {
-            bool success = loadSettings(app.settingsFile.c_str(), &app.viewer->getSettings());
+        if (!app.settingsFile.empty()) {
+            bool const success = loadSettings(app.settingsFile.c_str(), &app.viewer->getSettings());
             if (success) {
                 std::cout << "Loaded settings from " << app.settingsFile << std::endl;
             } else {
@@ -688,7 +688,7 @@ int main(int argc, char** argv) {
                 ImGui::Spacing();
             }
 
-            float progress = app.resourceLoader->asyncGetLoadProgress();
+            float const progress = app.resourceLoader->asyncGetLoadProgress();
             if (progress < 1.0) {
                 ImGui::ProgressBar(progress);
             } else {
@@ -735,7 +735,7 @@ int main(int argc, char** argv) {
                 }
 
                 if (ImGui::Button("Export view settings")) {
-                    automation.exportSettings(app.viewer->getSettings(), "settings.json");
+                    AutomationEngine::exportSettings(app.viewer->getSettings(), "settings.json");
                     app.messageBoxText = automation.getStatusMessage();
                     ImGui::OpenPopup("MessageBox");
                 }
@@ -757,12 +757,25 @@ int main(int argc, char** argv) {
                             debug.getPropertyAddress<bool>("d.renderer.doFrameCapture");
                     *captureFrame = true;
                 }
-                ImGui::Checkbox("Disable buffer padding", debug.getPropertyAddress<bool>("d.renderer.disable_buffer_padding"));
-                ImGui::Checkbox("Camera at origin", debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
+                ImGui::Checkbox("Disable buffer padding",
+                        debug.getPropertyAddress<bool>("d.renderer.disable_buffer_padding"));
+                ImGui::Checkbox("Camera at origin",
+                        debug.getPropertyAddress<bool>("d.view.camera_at_origin"));
                 ImGui::Checkbox("Far Origin", &app.originIsFarAway);
                 ImGui::SliderFloat("Origin", &app.originDistance, 0, 1);
-                ImGui::Checkbox("Far uses shadow casters", debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
-                ImGui::Checkbox("Focus shadow casters", debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
+                ImGui::Checkbox("Far uses shadow casters",
+                        debug.getPropertyAddress<bool>("d.shadowmap.far_uses_shadowcasters"));
+                ImGui::Checkbox("Focus shadow casters",
+                        debug.getPropertyAddress<bool>("d.shadowmap.focus_shadowcasters"));
+
+                bool debugDirectionalShadowmap;
+                if (debug.getProperty("d.shadowmap.debug_directional_shadowmap",
+                        &debugDirectionalShadowmap)) {
+                    ImGui::Checkbox("Debug DIR shadowmap", &debugDirectionalShadowmap);
+                    debug.setProperty("d.shadowmap.debug_directional_shadowmap",
+                            debugDirectionalShadowmap);
+                }
+
                 auto dataSource = debug.getDataSource("d.view.frame_info");
                 if (dataSource.data) {
                     ImGuiExt::PlotLinesSeries("FrameInfo", 6,
@@ -815,7 +828,7 @@ int main(int argc, char** argv) {
                 view->setStencilBufferEnabled(visualizeOverdraw);
             }
 
-            if (ImGui::BeginPopupModal("MessageBox", NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
+            if (ImGui::BeginPopupModal("MessageBox", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
                 ImGui::Text("%s", app.messageBoxText.c_str());
                 if (ImGui::Button("OK", ImVec2(120, 0))) {
                     ImGui::CloseCurrentPopup();
@@ -861,7 +874,7 @@ int main(int argc, char** argv) {
         AssetLoader::destroy(&app.assetLoader);
     };
 
-    auto animate = [&app](Engine* engine, View* view, double now) {
+    auto animate = [&app](Engine*, View*, double now) {
         app.resourceLoader->asyncUpdateLoad();
 
         // Optionally fit the model into a unit cube at the origin.
@@ -873,7 +886,7 @@ int main(int argc, char** argv) {
         app.viewer->applyAnimation(now);
     };
 
-    auto resize = [&app](Engine* engine, View* view) {
+    auto resize = [&app](Engine*, View* view) {
         Camera& camera = view->getCamera();
         if (&camera == app.mainCamera) {
             // Don't adjust the aspect ratio of the main camera, this is done inside of
@@ -881,11 +894,11 @@ int main(int argc, char** argv) {
             return;
         }
         const Viewport& vp = view->getViewport();
-        double aspectRatio = (double) vp.width / vp.height;
+        double const aspectRatio = (double) vp.width / vp.height;
         camera.setScaling({1.0 / aspectRatio, 1.0 });
     };
 
-    auto gui = [&app](Engine* engine, View* view) {
+    auto gui = [&app](Engine*, View*) {
         app.viewer->updateUserInterface();
 
         FilamentApp::get().setSidebarWidth(app.viewer->getSidebarWidth());
@@ -918,7 +931,7 @@ int main(int argc, char** argv) {
             // Override the aspect ratio in the glTF file and adjust the aspect ratio of this
             // camera to the viewport.
             const Viewport& vp = view->getViewport();
-            double aspectRatio = (double) vp.width / vp.height;
+            double const aspectRatio = (double) vp.width / vp.height;
             camera->setScaling({1.0 / aspectRatio, 1.0});
         }
 
@@ -964,10 +977,11 @@ int main(int argc, char** argv) {
         // these values represent a point somewhere on Earth's surface
         float const d = app.originIsFarAway ? app.originDistance : 0.0f;
 //        tcm.setTransform(root, mat4::translation(double3{ 67.0, -6366759.0, -21552.0 } * d));
-        tcm.setTransform(root, mat4::translation(double3{ 2304097.1410110965, -4688442.9915525438, -3639452.5611694567 } * d));
+        tcm.setTransform(root, mat4::translation(
+                double3{ 2304097.1410110965, -4688442.9915525438, -3639452.5611694567 } * d));
 
         // Check if color grading has changed.
-        ColorGradingSettings& options = app.viewer->getSettings().view.colorGrading;
+        ColorGradingSettings const& options = app.viewer->getSettings().view.colorGrading;
         if (options.enabled) {
             if (options != app.lastColorGradingOptions) {
                 ColorGrading *colorGrading = createColorGrading(options, engine);
@@ -981,12 +995,12 @@ int main(int argc, char** argv) {
         }
     };
 
-    auto postRender = [&app](Engine* engine, View* view, Scene* scene, Renderer* renderer) {
+    auto postRender = [&app](Engine* engine, View* view, Scene*, Renderer* renderer) {
         if (app.automationEngine->shouldClose()) {
             FilamentApp::get().close();
             return;
         }
-        AutomationEngine::ViewerContent content = {
+        AutomationEngine::ViewerContent const content = {
             .view = view,
             .renderer = renderer,
             .materials = app.instance->getMaterialInstances(),

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -66,6 +66,26 @@ void main() {
     fragColor = fog(fragColor, view);
 #endif
 
+#if defined(VARIANT_HAS_SHADOWING) && defined(VARIANT_HAS_DIRECTIONAL_LIGHTING)
+    if (CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP) {
+        float a = fragColor.a;
+        highp vec4 p = getShadowPosition(getShadowCascade());
+        p.xy = p.xy * (1.0 / p.w);
+        if (p.xy != saturate(p.xy)) {
+            vec4 c = vec4(1.0, 0, 1.0, 1.0) * a;
+            fragColor = mix(fragColor, c, 0.2);
+        } else {
+            p.xy = saturate(p.xy);
+            highp vec2 size = vec2(textureSize(light_shadowMap, 0));
+            highp int ix = int(floor(p.x * size.x));
+            highp int iy = int(floor(p.y * size.y));
+            float t = float((ix ^ iy) & 1) * 0.2;
+            vec4 c = vec4(vec3(t * a), a);
+            fragColor = mix(fragColor, c, 0.5);
+        }
+    }
+#endif
+
 #if MATERIAL_FEATURE_LEVEL == 0
     if (CONFIG_SRGB_SWAPCHAIN_EMULATION) {
         if (frameUniforms.rec709 != 0) {

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -75,7 +75,6 @@ void main() {
             vec4 c = vec4(1.0, 0, 1.0, 1.0) * a;
             fragColor = mix(fragColor, c, 0.2);
         } else {
-            p.xy = saturate(p.xy);
             highp vec2 size = vec2(textureSize(light_shadowMap, 0));
             highp int ix = int(floor(p.x * size.x));
             highp int iy = int(floor(p.y * size.y));

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -1712,6 +1712,7 @@ export enum View$ShadowType {
     VSM, // variance shadows
     DPCF, // PCF with contact hardening simulation
     PCSS, // PCF with soft shadows and contact hardening
+    PCFd,
 }
 
 /**

--- a/web/filament-js/jsenums_generated.cpp
+++ b/web/filament-js/jsenums_generated.cpp
@@ -48,6 +48,7 @@ enum_<View::ShadowType>("View$ShadowType")
     .value("VSM", View::ShadowType::VSM)
     .value("DPCF", View::ShadowType::DPCF)
     .value("PCSS", View::ShadowType::PCSS)
+    .value("PCFd", View::ShadowType::PCFd)
     ;
 
 } // EMSCRIPTEN_BINDINGS


### PR DESCRIPTION
The directional shadowmap visualizer is implemented behind a 
specialization constant. Add the DebugRegistry infrastructure to be
able to update the spec-constant at runtime and have a subset of 
all materials invalidated.

This allows to toggle the visualization at runtime using a debug
property.

This is also a proof of concept that we can update spec-constants
at runtime; we could probably leverage this work for engine-wide
shader configurations.

![Screenshot 2023-10-18 at 12 06 35](https://github.com/google/filament/assets/1240896/ab54b543-b939-4f35-bda1-8f4b02983e84)
