### PR TITLE
Increase FrameGraph Arena to 256KiB

### DIFF
--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -61,7 +61,7 @@ FrameGraphId<FrameGraphTexture> FrameGraph::Builder::declareRenderPass(
 
 FrameGraph::FrameGraph(ResourceAllocatorInterface& resourceAllocator)
         : mResourceAllocator(resourceAllocator),
-          mArena("FrameGraph Arena", 131072),
+          mArena("FrameGraph Arena", 262144),
           mResourceSlots(mArena),
           mResources(mArena),
           mResourceNodes(mArena),


### PR DESCRIPTION
It was possible to run out of space with the Bistro scene and  everything enabled.