### PR TITLE
Fix the dangling pointer to the destroyed sampler group

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1450,6 +1450,11 @@ void OpenGLDriver::destroySamplerGroup(Handle<HwSamplerGroup> sbh) {
     DEBUG_MARKER()
     if (sbh) {
         GLSamplerGroup* sb = handle_cast<GLSamplerGroup*>(sbh);
+        for (size_t i = 0; i < mSamplerBindings.size(); ++i) { // Deregistered from the list
+            if (mSamplerBindings[i] == sb) {
+                mSamplerBindings[i] = nullptr;
+            }
+        }
         destruct(sbh, sb);
     }
 }

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -211,6 +211,9 @@ void OpenGLProgram::updateSamplers(OpenGLDriver* const gld) const noexcept {
         size_t const binding = usedBindingPoints[i];
         assert_invariant(binding < Program::SAMPLER_BINDING_COUNT);
         auto const * const sb = samplerBindings[binding];
+        if (!sb) { // A sampler may not need to be used, although it's declared in the shader
+            continue;
+        }
         assert_invariant(sb);
         for (uint8_t j = 0, m = sb->textureUnitEntries.size(); j < m; ++j, ++tmu) { // "<=" on purpose here
             const GLTexture* const t = sb->textureUnitEntries[j].texture;


### PR DESCRIPTION
This PR aims to fix the two scenarios:

1. The dangling pointer to the destroyed sampler group, which may cause a crash when the program updates samplers;
2. Besides scenario 1, there may be such a requirement, that is, although the sampler is defined in the shader, there is no need to bind any sampler during rendering due to business needs.

Hope it makes sense :)