### PR TITLE
Improve Metal vertex buffer bindings

### DIFF
--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -33,7 +33,7 @@
 
 #define HandleAllocatorGL  HandleAllocator<16, 64, 208>
 #define HandleAllocatorVK  HandleAllocator<16, 64, 880>
-#define HandleAllocatorMTL HandleAllocator<16, 64, 576>
+#define HandleAllocatorMTL HandleAllocator<16, 64, 584>
 
 namespace filament::backend {
 
@@ -256,6 +256,7 @@ private:
     HandleBase::HandleId allocateHandle() noexcept {
         if constexpr (SIZE <= P0) { return allocateHandleInPool<P0>(); }
         if constexpr (SIZE <= P1) { return allocateHandleInPool<P1>(); }
+        static_assert(SIZE <= P2);
         return allocateHandleInPool<P2>();
     }
 
@@ -266,6 +267,7 @@ private:
         } else if constexpr (SIZE <= P1) {
             deallocateHandleFromPool<P1>(id);
         } else {
+            static_assert(SIZE <= P2);
             deallocateHandleFromPool<P2>(id);
         }
     }

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -160,6 +160,7 @@ struct MetalIndexBuffer : public HwIndexBuffer {
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {
+    MetalRenderPrimitive();
     void setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer* indexBuffer);
     // The pointers to MetalVertexBuffer and MetalIndexBuffer are "weak".
     // The MetalVertexBuffer and MetalIndexBuffer must outlive the MetalRenderPrimitive.
@@ -169,6 +170,19 @@ struct MetalRenderPrimitive : public HwRenderPrimitive {
 
     // This struct is used to create the pipeline description to describe vertex assembly.
     VertexDescription vertexDescription = {};
+
+    struct Entry {
+        uint8_t sourceBufferIndex = 0;
+        uint8_t stride = 0;
+        // maps to ->
+        uint8_t bufferArgumentIndex = 0;
+
+        Entry(uint8_t sourceBufferIndex, uint8_t stride, uint8_t bufferArgumentIndex)
+                : sourceBufferIndex(sourceBufferIndex),
+                  stride(stride),
+                  bufferArgumentIndex(bufferArgumentIndex) {}
+    };
+    utils::FixedCapacityVector<Entry> bufferMapping;
 };
 
 class MetalProgram : public HwProgram {


### PR DESCRIPTION
Before, each Attribute within a Filament `VertexBuffer` was bound to its own Metal buffer argument index. After this change, two buffers that share the same stride will map to the same index. This improves CPU performance by reducing redundant bindings, especially for scenes with lots of vertex attributes.
