### PR TITLE
Miscellaneous feature level 0 fixes

### DIFF
--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -12,4 +12,6 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - matc: Enable `GL_OES_standard_derivatives` extension in ESSL 1.0 shaders
 - matc: Fix code generation of double sided and masked materials in ESSL 1.0 shaders
 - filagui: Add support for feature level 0
-- mtac: Add support for post-process materials in feature level 0
+- matc: Add support for post-process materials in feature level 0
+- engine: Add `Material::getFeatureLevel()`
+- engine: Add missing `Material::getReflectionMode()` method in Java

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,3 +9,6 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - engine: Allow instantiating Engine at a given feature level via `Engine::Builder::featureLevel`
+- matc: Enable `GL_OES_standard_derivatives` extension in ESSL 1.0 shaders
+- matc: Fix code generation of double sided and masked materials in ESSL 1.0 shaders
+- filagui: Add support for feature level 0

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -15,3 +15,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - matc: Add support for post-process materials in feature level 0
 - engine: Add `Material::getFeatureLevel()`
 - engine: Add missing `Material::getReflectionMode()` method in Java
+- engine: Support basic usage of post-processing materials on feature level 0

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -12,3 +12,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 - matc: Enable `GL_OES_standard_derivatives` extension in ESSL 1.0 shaders
 - matc: Fix code generation of double sided and masked materials in ESSL 1.0 shaders
 - filagui: Add support for feature level 0
+- mtac: Add support for post-process materials in feature level 0

--- a/android/filament-android/src/main/cpp/Material.cpp
+++ b/android/filament-android/src/main/cpp/Material.cpp
@@ -107,6 +107,22 @@ Java_com_google_android_filament_Material_nGetRefractionType(JNIEnv*, jclass,
 
 extern "C"
 JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Material_nGetReflectionMode(JNIEnv*, jclass,
+        jlong nativeMaterial) {
+    Material* material = (Material*) nativeMaterial;
+    return (jint) material->getReflectionMode();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Material_nGetFeatureLevel(JNIEnv*, jclass,
+        jlong nativeMaterial) {
+    Material* material = (Material*) nativeMaterial;
+    return (jint) material->getFeatureLevel();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Material_nGetVertexDomain(JNIEnv*, jclass,
         jlong nativeMaterial) {
     Material* material = (Material*) nativeMaterial;

--- a/android/filament-android/src/main/java/com/google/android/filament/Material.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Material.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Size;
 
 import com.google.android.filament.proguard.UsedByNative;
+import com.google.android.filament.Engine.FeatureLevel;
 
 import java.nio.Buffer;
 import java.util.ArrayList;
@@ -46,6 +47,8 @@ public class Material {
         static final BlendingMode[] sBlendingModeValues = BlendingMode.values();
         static final RefractionMode[] sRefractionModeValues = RefractionMode.values();
         static final RefractionType[] sRefractionTypeValues = RefractionType.values();
+        static final ReflectionMode[] sReflectionModeValues = ReflectionMode.values();
+        static final FeatureLevel[] sFeatureLevelValues = FeatureLevel.values();
         static final VertexDomain[] sVertexDomainValues = VertexDomain.values();
         static final CullingMode[] sCullingModeValues = CullingMode.values();
         static final VertexBuffer.VertexAttribute[] sVertexAttributeValues =
@@ -179,6 +182,18 @@ public class Material {
     public enum RefractionType {
         SOLID,
         THIN
+    }
+
+    /**
+     * Supported reflection modes
+     *
+     * @see
+     * <a href="https://google.github.io/filament/Materials.html#materialdefinitions/materialblock/lighting:reflections">
+     * Lighting: reflections</a>
+     */
+    public enum ReflectionMode {
+        DEFAULT,
+        SCREEN_SPACE
     }
 
     /**
@@ -435,6 +450,28 @@ public class Material {
      */
     public RefractionType getRefractionType() {
         return EnumCache.sRefractionTypeValues[nGetRefractionType(getNativeObject())];
+    }
+
+    /**
+     * Returns the reflection mode of this material.
+     *
+     * @see
+     * <a href="https://google.github.io/filament/Materials.html#materialdefinitions/materialblock/lighting:reflections">
+     * Lighting: reflections</a>
+     */
+    public ReflectionMode getReflectionMode() {
+        return EnumCache.sReflectionModeValues[nGetReflectionMode(getNativeObject())];
+    }
+
+    /**
+     * Returns the minimum required feature level for this material.
+     *
+     * @see
+     * <a href="https://google.github.io/filament/Materials.html#materialdefinitions/materialblock/general:featurelevel">
+     * General: featureLevel</a>
+     */
+    public FeatureLevel getFeatureLevel() {
+        return EnumCache.sFeatureLevelValues[nGetFeatureLevel(getNativeObject())];
     }
 
     /**
@@ -932,6 +969,8 @@ public class Material {
     private static native float nGetSpecularAntiAliasingThreshold(long nativeMaterial);
     private static native int nGetRefractionMode(long nativeMaterial);
     private static native int nGetRefractionType(long nativeMaterial);
+    private static native int nGetReflectionMode(long nativeMaterial);
+    private static native int nGetFeatureLevel(long nativeMaterial);
 
 
     private static native int nGetParameterCount(long nativeMaterial);

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -373,16 +373,19 @@ constexpr inline GLenum getCullingMode(CullingMode mode) noexcept {
 constexpr inline std::pair<GLenum, GLenum> textureFormatToFormatAndType(
         TextureFormat format) noexcept {
     switch (format) {
-        case TextureFormat::RGB8:       return { GL_RGB,                GL_UNSIGNED_BYTE };
-        case TextureFormat::RGBA8:      return { GL_RGBA,               GL_UNSIGNED_BYTE };
-        case TextureFormat::RGB565:     return { GL_RGB,                GL_UNSIGNED_SHORT_5_6_5 };
-        case TextureFormat::RGB5_A1:    return { GL_RGBA,               GL_UNSIGNED_SHORT_5_5_5_1 };
-        case TextureFormat::RGBA4:      return { GL_RGBA,               GL_UNSIGNED_SHORT_4_4_4_4 };
-        case TextureFormat::DEPTH16:    return { GL_DEPTH_COMPONENT,    GL_UNSIGNED_SHORT };
-        case TextureFormat::DEPTH24:    return { GL_DEPTH_COMPONENT,    GL_UNSIGNED_INT };
+        case TextureFormat::R8:         return { 0x1909 /*GL_LUMINANCE*/, GL_UNSIGNED_BYTE };
+        case TextureFormat::RGB8:       return { GL_RGB,                  GL_UNSIGNED_BYTE };
+        case TextureFormat::SRGB8:      return { GL_RGB,                  GL_UNSIGNED_BYTE };
+        case TextureFormat::RGBA8:      return { GL_RGBA,                 GL_UNSIGNED_BYTE };
+        case TextureFormat::SRGB8_A8:   return { GL_RGBA,                 GL_UNSIGNED_BYTE };
+        case TextureFormat::RGB565:     return { GL_RGB,                  GL_UNSIGNED_SHORT_5_6_5 };
+        case TextureFormat::RGB5_A1:    return { GL_RGBA,                 GL_UNSIGNED_SHORT_5_5_5_1 };
+        case TextureFormat::RGBA4:      return { GL_RGBA,                 GL_UNSIGNED_SHORT_4_4_4_4 };
+        case TextureFormat::DEPTH16:    return { GL_DEPTH_COMPONENT,      GL_UNSIGNED_SHORT };
+        case TextureFormat::DEPTH24:    return { GL_DEPTH_COMPONENT,      GL_UNSIGNED_INT };
         case TextureFormat::DEPTH24_STENCIL8:
-                                        return { GL_DEPTH24_STENCIL8,   GL_UNSIGNED_INT_24_8 };
-        default:                        return { GL_NONE,               GL_NONE };
+                                        return { GL_DEPTH24_STENCIL8,     GL_UNSIGNED_INT_24_8 };
+        default:                        return { GL_NONE,                 GL_NONE };
     }
 }
 

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -294,6 +294,9 @@ public:
     //! Returns the reflection mode used by this material.
     ReflectionMode getReflectionMode() const noexcept;
 
+    //! Returns the minimum required feature level for this material.
+    backend::FeatureLevel getFeatureLevel() const noexcept;
+
     /**
      * Returns the number of parameters declared by this material.
      * The returned value can be 0.

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -120,6 +120,10 @@ ReflectionMode Material::getReflectionMode() const noexcept {
     return downcast(this)->getReflectionMode();
 }
 
+FeatureLevel Material::getFeatureLevel() const noexcept {
+    return downcast(this)->getFeatureLevel();
+}
+
 bool Material::hasParameter(const char* name) const noexcept {
     return downcast(this)->hasParameter(name);
 }

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -207,10 +207,13 @@ PostProcessManager::PostProcessMaterial& PostProcessManager::getPostProcessMater
 
 #define MATERIAL(n) MATERIALS_ ## n ## _DATA, MATERIALS_ ## n ## _SIZE
 
+static const PostProcessManager::MaterialInfo sMaterialListFeatureLevel0[] = {
+        { "blitLow",                    MATERIAL(BLITLOW) },
+};
+
 static const PostProcessManager::MaterialInfo sMaterialList[] = {
         { "bilateralBlur",              MATERIAL(BILATERALBLUR) },
         { "bilateralBlurBentNormals",   MATERIAL(BILATERALBLURBENTNORMALS) },
-        { "blitLow",                    MATERIAL(BLITLOW) },
         { "bloomDownsample",            MATERIAL(BLOOMDOWNSAMPLE) },
         { "bloomDownsample2x",          MATERIAL(BLOOMDOWNSAMPLE2X) },
         { "bloomDownsample9",           MATERIAL(BLOOMDOWNSAMPLE9) },
@@ -273,8 +276,15 @@ void PostProcessManager::init() noexcept {
             driver.isWorkaroundNeeded(Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP);
 
     #pragma nounroll
-    for (auto const& info : sMaterialList) {
+    for (auto const& info : sMaterialListFeatureLevel0) {
         registerPostProcessMaterial(info.name, info);
+    }
+
+    if (mEngine.getActiveFeatureLevel() >= FeatureLevel::FEATURE_LEVEL_1) {
+        #pragma nounroll
+        for (auto const& info : sMaterialList) {
+            registerPostProcessMaterial(info.name, info);
+        }
     }
 
     mStarburstTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,

--- a/filament/src/details/Engine.cpp
+++ b/filament/src/details/Engine.cpp
@@ -358,10 +358,11 @@ void FEngine::init() {
         driverApi.update3DImage(mDummyZeroTextureArray, 0, 0, 0, 0, 1, 1, 1,
                 { zeroes, 4, Texture::Format::RGBA, Texture::Type::UBYTE });
 
-        mPostProcessManager.init();
         mLightManager.init(*this);
         mDFG.init(*this);
     }
+
+    mPostProcessManager.init();
 
     mDebugRegistry.registerProperty("d.shadowmap.debug_directional_shadowmap",
             &debug.shadowmap.debug_directional_shadowmap, [this]() {

--- a/filament/src/materials/blitLow.mat
+++ b/filament/src/materials/blitLow.mat
@@ -23,7 +23,6 @@ material {
     depthWrite : false,
     depthCulling : false,
     domain: postprocess,
-    shadingModel : unlit,
     featureLevel : 0
 }
 

--- a/filament/src/materials/blitLow.mat
+++ b/filament/src/materials/blitLow.mat
@@ -22,7 +22,9 @@ material {
     ],
     depthWrite : false,
     depthCulling : false,
-    domain: postprocess
+    domain: postprocess,
+    shadingModel : unlit,
+    featureLevel : 0
 }
 
 vertex {
@@ -34,7 +36,10 @@ vertex {
 
 fragment {
     void postProcess(inout PostProcessInputs postProcess) {
+#if __VERSION__ == 100
+        postProcess.color = texture2D(materialParams_color, variable_vertex.xy);
+#else
         postProcess.color = textureLod(materialParams_color, variable_vertex.xy, 0.0);
+#endif
     }
 }
-

--- a/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
+++ b/libs/filabridge/include/private/filament/BufferInterfaceBlock.h
@@ -160,6 +160,8 @@ public:
 
     bool isEmpty() const noexcept { return mFieldInfoList.empty(); }
 
+    bool isEmptyForFeatureLevel(backend::FeatureLevel featureLevel) const noexcept;
+
     Alignment getAlignment() const noexcept { return mAlignment; }
 
     Target getTarget() const noexcept { return mTarget; }

--- a/libs/filabridge/src/BufferInterfaceBlock.cpp
+++ b/libs/filabridge/src/BufferInterfaceBlock.cpp
@@ -171,6 +171,14 @@ BufferInterfaceBlock::FieldInfo const* BufferInterfaceBlock::getFieldInfo(
     return &mFieldInfoList[pos->second];
 }
 
+bool BufferInterfaceBlock::isEmptyForFeatureLevel(
+        backend::FeatureLevel featureLevel) const noexcept {
+    return std::all_of(mFieldInfoList.begin(), mFieldInfoList.end(),
+                       [featureLevel](auto const &info) {
+                           return featureLevel < info.minFeatureLevel;
+                       });
+}
+
 uint8_t UTILS_NOINLINE BufferInterfaceBlock::baseAlignmentForType(BufferInterfaceBlock::Type type) noexcept {
     switch (type) {
         case Type::BOOL:
@@ -230,4 +238,3 @@ uint8_t UTILS_NOINLINE BufferInterfaceBlock::strideForType(BufferInterfaceBlock:
 }
 
 } // namespace filament
-

--- a/libs/filagui/src/materials/uiBlit.mat
+++ b/libs/filagui/src/materials/uiBlit.mat
@@ -13,7 +13,8 @@ material {
     shadingModel : unlit,
     culling : none,
     depthCulling: false,
-    blending : transparent
+    blending : transparent,
+    featureLevel : 0
 }
 
 fragment {
@@ -21,7 +22,7 @@ fragment {
 	prepareMaterial(material);
         vec2 uv = getUV0();
         uv.y = 1.0 - uv.y;
-        vec4 albedo = texture(materialParams_albedo, uv);
+        vec4 albedo = texture2D(materialParams_albedo, uv);
         material.baseColor = getColor() * albedo;
         material.baseColor.rgb *= material.baseColor.a;
     }

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -587,11 +587,11 @@ void MaterialBuilder::prepareToBuild(MaterialInfo& info) noexcept {
     }
 
     if (mBlendingMode == BlendingMode::MASKED) {
-        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT }});
+        ibb.add({{ "_maskThreshold", 0, UniformType::FLOAT, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     if (mDoubleSidedCapability) {
-        ibb.add({{ "_doubleSided", 0, UniformType::BOOL }});
+        ibb.add({{ "_doubleSided", 0, UniformType::BOOL, Precision::DEFAULT, FeatureLevel::FEATURE_LEVEL_0 }});
     }
 
     mRequiredAttributes.set(VertexAttribute::POSITION);

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -1098,6 +1098,12 @@ error:
         return Package::invalidPackage();
     }
 
+    // Force post process materials to be unlit. This prevents imposing a lot of extraneous
+    // data, code, and expectations for materials which do not need them.
+    if (mMaterialDomain == MaterialDomain::POST_PROCESS) {
+        mShading = Shading::UNLIT;
+    }
+
     // Add a default color output.
     if (mMaterialDomain == MaterialDomain::POST_PROCESS && mOutputs.empty()) {
         output(VariableQualifier::OUT,

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -164,11 +164,13 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
         mFeatureLevel >= FeatureLevel::FEATURE_LEVEL_1) {
         if (stage == ShaderStage::VERTEX) {
             generateDefine(out, "VARYING", "out");
+            generateDefine(out, "ATTRIBUTE", "in");
         } else if (stage == ShaderStage::FRAGMENT) {
             generateDefine(out, "VARYING", "in");
         }
     } else {
         generateDefine(out, "VARYING", "varying");
+        generateDefine(out, "ATTRIBUTE", "attribute");
     }
 
     auto getShadingDefine = [](Shading shading) -> const char* {

--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -63,9 +63,6 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
                     out << "#extension GL_OES_EGL_image_external : require\n\n";
                 }
             }
-            if (material.has3dSamplers && mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
-                out << "#extension GL_OES_texture_3D : require\n\n";
-            }
             if (v.hasInstancedStereo() && stage == ShaderStage::VERTEX) {
                 // If we're not processing the shader through glslang (in the case of unoptimized
                 // OpenGL shaders), then we need to add the #extension string ourselves.
@@ -87,6 +84,10 @@ utils::io::sstream& CodeGenerator::generateProlog(utils::io::sstream& out, Shade
                 out << "#extension GL_ARB_shading_language_packing : enable\n\n";
             }
             break;
+    }
+
+    if (mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {
+        out << "#extension GL_OES_standard_derivatives : require\n\n";
     }
 
     // This allows our includer system to use the #line directive to denote the source file for
@@ -554,10 +555,11 @@ io::sstream& CodeGenerator::generateUboAsPlainUniforms(io::sstream& out, ShaderS
 
 io::sstream& CodeGenerator::generateBufferInterfaceBlock(io::sstream& out, ShaderStage stage,
         uint32_t binding, const BufferInterfaceBlock& uib) const {
-    auto const& infos = uib.getFieldInfoList();
-    if (infos.empty()) {
+    if (uib.isEmptyForFeatureLevel(mFeatureLevel)) {
         return out;
     }
+
+    auto const& infos = uib.getFieldInfoList();
 
     if (mTargetLanguage == TargetLanguage::GLSL &&
             mFeatureLevel == FeatureLevel::FEATURE_LEVEL_0) {

--- a/shaders/src/post_process_inputs.vs
+++ b/shaders/src/post_process_inputs.vs
@@ -1,4 +1,4 @@
-LAYOUT_LOCATION(LOCATION_POSITION) in vec4 position;
+LAYOUT_LOCATION(LOCATION_POSITION) ATTRIBUTE vec4 position;
 
 struct PostProcessVertexInputs {
 


### PR DESCRIPTION
Fix edge case where an empty struct could be generated in an ESSL 1.0 shader.

Include _maskThreshold and _doubleSided in ESSL 1.0 shaders.

Add GL_OES_standard_derivatives extension to ESSL 1.0 shaders. According to gpuinfo.org, this has 96% device coverage and supports both Mali-400 and Adreno (TM) 304.

Remove 3D sampler support from ESSL 1.0 shaders. This extension is only supported by 62% of devices.

Change filagui material to a FL0 material.