### PR TITLE
improvements to EntityManagers and Filament APIs

### DIFF
--- a/android/filament-android/src/main/cpp/Scene.cpp
+++ b/android/filament-android/src/main/cpp/Scene.cpp
@@ -72,6 +72,13 @@ Java_com_google_android_filament_Scene_nRemoveEntities(JNIEnv *env, jclass type,
 }
 
 extern "C" JNIEXPORT jint JNICALL
+Java_com_google_android_filament_Scene_nGetEntityCount(JNIEnv *env, jclass type,
+        jlong nativeScene) {
+    Scene* scene = (Scene*) nativeScene;
+    return (jint) scene->getEntityCount();
+}
+
+extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Scene_nGetRenderableCount(JNIEnv *env, jclass type,
         jlong nativeScene) {
     Scene* scene = (Scene*) nativeScene;

--- a/android/filament-android/src/main/java/com/google/android/filament/Scene.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Scene.java
@@ -146,18 +146,29 @@ public class Scene {
     }
 
     /**
-     * Returns the number of {@link RenderableManager} components in the <code>Scene</code>.
+     * Returns the total number of Entities in the <code>Scene</code>, whether alive or not.
      *
-     * @return number of {@link RenderableManager} components in the <code>Scene</code>..
+     * @return the total number of Entities in the <code>Scene</code>.
+     */
+    public int getEntityCount() {
+        return nGetEntityCount(getNativeObject());
+    }
+
+    /**
+     * Returns the number of active (alive) {@link RenderableManager} components in the
+     * <code>Scene</code>.
+     *
+     * @return number of {@link RenderableManager} components in the <code>Scene</code>.
      */
     public int getRenderableCount() {
         return nGetRenderableCount(getNativeObject());
     }
 
     /**
-     * Returns the number of {@link LightManager} components in the <code>Scene</code>.
+     * Returns the number of active (alive) {@link LightManager} components in the
+     * <code>Scene</code>.
      *
-     * @return number of {@link LightManager} components in the <code>Scene</code>..
+     * @return number of {@link LightManager} components in the <code>Scene</code>.
      */
     public int getLightCount() {
         return nGetLightCount(getNativeObject());
@@ -189,6 +200,7 @@ public class Scene {
     private static native void nAddEntities(long nativeScene, int[] entities);
     private static native void nRemove(long nativeScene, int entity);
     private static native void nRemoveEntities(long nativeScene, int[] entities);
+    private static native int nGetEntityCount(long nativeScene);
     private static native int nGetRenderableCount(long nativeScene);
     private static native int nGetLightCount(long nativeScene);
     private static native boolean nHasEntity(long nativeScene, int entity);

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -110,6 +110,10 @@ public:
      * @return The maximum capacity of the BufferObject.
      */
     size_t getByteCount() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~BufferObject() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Camera.h
+++ b/filament/include/filament/Camera.h
@@ -565,6 +565,10 @@ public:
      * @return                  effective full field of view in degrees
      */
     static double computeEffectiveFov(double fovInDegrees, double focusDistance) noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Camera() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/ColorGrading.h
+++ b/filament/include/filament/ColorGrading.h
@@ -478,6 +478,10 @@ public:
     private:
         friend class FColorGrading;
     };
+
+protected:
+    // prevent heap allocation
+    ~ColorGrading() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/DebugRegistry.h
+++ b/filament/include/filament/DebugRegistry.h
@@ -142,6 +142,10 @@ public:
         float pid_i = 0.0f;
         float pid_d = 0.0f;
     };
+
+protected:
+    // prevent heap allocation
+    ~DebugRegistry() = default;
 };
 
 

--- a/filament/include/filament/Fence.h
+++ b/filament/include/filament/Fence.h
@@ -75,6 +75,10 @@ public:
      *          FenceStatus::ERROR otherwise.
      */
     static FenceStatus waitAndDestroy(Fence* fence, Mode mode = Mode::FLUSH);
+
+protected:
+    // prevent heap allocation
+    ~Fence() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/FilamentAPI.h
+++ b/filament/include/filament/FilamentAPI.h
@@ -49,8 +49,6 @@ public:
     // prevent heap allocation
     static void *operator new     (size_t) = delete;
     static void *operator new[]   (size_t) = delete;
-    static void  operator delete  (void*)  = delete;
-    static void  operator delete[](void*)  = delete;
 };
 
 template<typename T>

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -118,6 +118,10 @@ public:
      * @return The number of indices the IndexBuffer holds.
      */
     size_t getIndexCount() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~IndexBuffer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -342,6 +342,10 @@ public:
     /** @deprecated use static versions instead */
     UTILS_DEPRECATED
     math::float4 getColorEstimate(math::float3 direction) const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~IndirectLight() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/InstanceBuffer.h
+++ b/filament/include/filament/InstanceBuffer.h
@@ -91,6 +91,10 @@ public:
      * @param offset index of the first instance to set local transforms
      */
     void setLocalTransforms(math::mat4f const* localTransforms, size_t count, size_t offset = 0);
+
+protected:
+    // prevent heap allocation
+    ~InstanceBuffer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -966,6 +966,10 @@ public:
             func(pEntity[i], Instance(i + 1));
         }
     }
+
+protected:
+    // prevent heap allocation
+    ~LightManager() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/LightManager.h
+++ b/filament/include/filament/LightManager.h
@@ -143,7 +143,7 @@ public:
     using Instance = utils::EntityInstance<LightManager>;
 
     /**
-     * Returns the number of component in the LightManager, not that component are not
+     * Returns the number of component in the LightManager, note that component are not
      * guaranteed to be active. Use the EntityManager::isAlive() before use if needed.
      *
      * @return number of component in the LightManager
@@ -151,18 +151,29 @@ public:
     size_t getComponentCount() const noexcept;
 
     /**
-     * Returns the list of Entity for all components. Use getComponentCount() to know the size
-     * of the list.
-     * @return a pointer to Entity
-     */
-    utils::Entity const* getEntities() const noexcept;
-
-    /**
      * Returns whether a particular Entity is associated with a component of this LightManager
      * @param e An Entity.
      * @return true if this Entity has a component associated with this manager.
      */
     bool hasComponent(utils::Entity e) const noexcept;
+
+    /**
+     * @return true if the this manager has no components
+     */
+    bool empty() const noexcept;
+
+    /**
+     * Retrieve the `Entity` of the component from its `Instance`.
+     * @param i Instance of the component obtained from getInstance()
+     * @return
+     */
+    utils::Entity getEntity(Instance i) const noexcept;
+
+    /**
+     * Retrieve the Entities of all the components of this manager.
+     * @return A list, in no particular order, of all the entities managed by this manager.
+     */
+    utils::Entity const* getEntities() const noexcept;
 
     /**
      * Gets an Instance representing the Light component associated with the given Entity.
@@ -952,20 +963,6 @@ public:
      * @param i     Instance of the component obtained from getInstance().
      */
     bool isShadowCaster(Instance i) const noexcept;
-
-    /**
-     * Helper to process all components with a given function
-     * @tparam F    a void(Entity entity, Instance instance)
-     * @param func  a function of type F
-     */
-    template<typename F>
-    void forEachComponent(F func) noexcept {
-        utils::Entity const* const pEntity = getEntities();
-        for (size_t i = 0, c = getComponentCount(); i < c; i++) {
-            // Instance 0 is the invalid instance
-            func(pEntity[i], Instance(i + 1));
-        }
-    }
 
 protected:
     // prevent heap allocation

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -375,6 +375,10 @@ public:
 
     //! Returns this material's default instance.
     MaterialInstance const* getDefaultInstance() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Material() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -479,6 +479,10 @@ public:
      */
     void setStencilWriteMask(uint8_t writeMask,
             StencilFace face = StencilFace::FRONT_AND_BACK) noexcept;
+
+protected:
+    // prevent heap allocation
+    ~MaterialInstance() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/MorphTargetBuffer.h
+++ b/filament/include/filament/MorphTargetBuffer.h
@@ -136,6 +136,10 @@ public:
      * @return The number of targets the MorphTargetBuffer holds.
      */
     size_t getCount() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~MorphTargetBuffer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/RenderTarget.h
+++ b/filament/include/filament/RenderTarget.h
@@ -180,6 +180,10 @@ public:
      * @return Number of color attachments usable in a render target.
      */
     uint8_t getSupportedColorAttachmentsCount() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~RenderTarget() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -829,6 +829,10 @@ public:
             typename = typename is_supported_index_type<INDEX>::type>
     static Box computeAABB(VECTOR const* vertices, INDEX const* indices, size_t count,
             size_t stride = sizeof(VECTOR)) noexcept;
+
+protected:
+    // prevent heap allocation
+    ~RenderableManager() = default;
 };
 
 RenderableManager::Builder& RenderableManager::Builder::morphing(uint8_t level, size_t primitiveIndex,

--- a/filament/include/filament/RenderableManager.h
+++ b/filament/include/filament/RenderableManager.h
@@ -103,6 +103,29 @@ public:
     Instance getInstance(utils::Entity e) const noexcept;
 
     /**
+     * @return the number of Components
+     */
+    size_t getComponentCount() const noexcept;
+
+    /**
+     * @return true if the this manager has no components
+     */
+    bool empty() const noexcept;
+
+    /**
+     * Retrieve the `Entity` of the component from its `Instance`.
+     * @param i Instance of the component obtained from getInstance()
+     * @return
+     */
+    utils::Entity getEntity(Instance i) const noexcept;
+
+    /**
+     * Retrieve the Entities of all the components of this manager.
+     * @return A list, in no particular order, of all the entities managed by this manager.
+     */
+    utils::Entity const* getEntities() const noexcept;
+
+    /**
      * The transformation associated with a skinning joint.
      *
      * Clients can specify bones either using this quat-vec3 pair, or by using 4x4 matrices.

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -579,6 +579,10 @@ public:
      * getUserTime()
      */
     void resetUserTime();
+
+protected:
+    // prevent heap allocation
+    ~Renderer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -168,6 +168,10 @@ public:
      * @param functor User provided functor called for each entity in the scene
      */
     void forEach(utils::Invocable<void(utils::Entity entity)>&& functor) const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Scene() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Scene.h
+++ b/filament/include/filament/Scene.h
@@ -140,16 +140,22 @@ public:
     void removeEntities(const utils::Entity* entities, size_t count);
 
     /**
-     * Returns the number of Renderable objects in the Scene.
+     * Returns the total number of Entities in the Scene, whether alive or not.
+     * @return Total number of Entities in the Scene.
+     */
+    size_t getEntityCount() const noexcept;
+
+    /**
+     * Returns the number of active (alive) Renderable objects in the Scene.
      *
-     * @return number of Renderable objects in the Scene.
+     * @return The number of active (alive) Renderable objects in the Scene.
      */
     size_t getRenderableCount() const noexcept;
 
     /**
-     * Returns the total number of Light objects in the Scene.
+     * Returns the number of active (alive) Light objects in the Scene.
      *
-     * @return The total number of Light objects in the Scene.
+     * @return The number of active (alive) Light objects in the Scene.
      */
     size_t getLightCount() const noexcept;
 

--- a/filament/include/filament/SkinningBuffer.h
+++ b/filament/include/filament/SkinningBuffer.h
@@ -115,6 +115,10 @@ public:
      * @return The number of bones the SkinningBuffer holds.
      */
     size_t getBoneCount() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~SkinningBuffer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -174,6 +174,10 @@ public:
      * @return the associated texture, or null if it does not exist
      */
     Texture const* getTexture() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Skybox() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Stream.h
+++ b/filament/include/filament/Stream.h
@@ -207,6 +207,10 @@ public:
      * @return timestamp in nanosecond.
      */
     int64_t getTimestamp() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~Stream() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -286,6 +286,10 @@ public:
     void setFrameCompletedCallback(backend::CallbackHandler* handler = nullptr,
             FrameCompletedCallback&& callback = {}) noexcept;
 
+
+protected:
+    // prevent heap allocation
+    ~SwapChain() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -541,6 +541,10 @@ public:
             return *this;
         }
     };
+
+protected:
+    // prevent heap allocation
+    ~Texture() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -308,6 +308,10 @@ public:
      * @see openLocalTransformTransaction(), setTransform()
      */
     void commitLocalTransformTransaction() noexcept;
+
+protected:
+    // prevent heap allocation
+    ~TransformManager() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -119,6 +119,29 @@ public:
     Instance getInstance(utils::Entity e) const noexcept;
 
     /**
+     * @return the number of Components
+     */
+    size_t getComponentCount() const noexcept;
+
+    /**
+     * @return true if the this manager has no components
+     */
+    bool empty() const noexcept;
+
+    /**
+     * Retrieve the `Entity` of the component from its `Instance`.
+     * @param i Instance of the component obtained from getInstance()
+     * @return
+     */
+    utils::Entity getEntity(Instance i) const noexcept;
+
+    /**
+     * Retrieve the Entities of all the components of this manager.
+     * @return A list, in no particular order, of all the entities managed by this manager.
+     */
+    utils::Entity const* getEntities() const noexcept;
+
+    /**
      * Enables or disable the accurate translation mode. Disabled by default.
      *
      * When accurate translation mode is active, the translation component of all transforms is
@@ -261,7 +284,7 @@ public:
      *         returns the value set by setTransform().
      * @see setTransform()
      */
-    const math::mat4 getTransformAccurate(Instance ci) const noexcept;
+    math::mat4 getTransformAccurate(Instance ci) const noexcept;
 
     /**
      * Return the world transform of a transform component.
@@ -279,7 +302,7 @@ public:
      *         composition of this component's local transform with its parent's world transform.
      * @see setTransform()
      */
-    const math::mat4 getWorldTransformAccurate(Instance ci) const noexcept;
+    math::mat4 getWorldTransformAccurate(Instance ci) const noexcept;
 
     /**
      * Opens a local transform transaction. During a transaction, getWorldTransform() can

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -207,6 +207,10 @@ public:
      * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
      */
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
+
+protected:
+    // prevent heap allocation
+    ~VertexBuffer() = default;
 };
 
 } // namespace filament

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -894,6 +894,10 @@ public:
      */
     UTILS_DEPRECATED
     AmbientOcclusion getAmbientOcclusion() const noexcept;
+
+protected:
+    // prevent heap allocation
+    ~View() = default;
 };
 
 } // namespace filament

--- a/filament/src/LightManager.cpp
+++ b/filament/src/LightManager.cpp
@@ -22,16 +22,24 @@ namespace filament {
 
 using namespace math;
 
+bool LightManager::hasComponent(Entity e) const noexcept {
+    return downcast(this)->hasComponent(e);
+}
+
 size_t LightManager::getComponentCount() const noexcept {
     return downcast(this)->getComponentCount();
 }
 
-utils::Entity const* LightManager::getEntities() const noexcept {
-    return downcast(this)->getEntities();
+bool LightManager::empty() const noexcept {
+    return downcast(this)->empty();
 }
 
-bool LightManager::hasComponent(Entity e) const noexcept {
-    return downcast(this)->hasComponent(e);
+utils::Entity LightManager::getEntity(LightManager::Instance i) const noexcept {
+    return downcast(this)->getEntity(i);
+}
+
+utils::Entity const* LightManager::getEntities() const noexcept {
+    return downcast(this)->getEntities();
 }
 
 LightManager::Instance LightManager::getInstance(Entity e) const noexcept {

--- a/filament/src/RenderableManager.cpp
+++ b/filament/src/RenderableManager.cpp
@@ -31,6 +31,22 @@ bool RenderableManager::hasComponent(utils::Entity e) const noexcept {
     return downcast(this)->hasComponent(e);
 }
 
+size_t RenderableManager::getComponentCount() const noexcept {
+    return downcast(this)->getComponentCount();
+}
+
+bool RenderableManager::empty() const noexcept {
+    return downcast(this)->empty();
+}
+
+utils::Entity RenderableManager::getEntity(RenderableManager::Instance i) const noexcept {
+    return downcast(this)->getEntity(i);
+}
+
+utils::Entity const* RenderableManager::getEntities() const noexcept {
+    return downcast(this)->getEntities();
+}
+
 RenderableManager::Instance
 RenderableManager::getInstance(utils::Entity e) const noexcept {
     return downcast(this)->getInstance(e);

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -55,6 +55,10 @@ void Scene::removeEntities(const Entity* entities, size_t count) {
     downcast(this)->removeEntities(entities, count);
 }
 
+size_t Scene::getEntityCount() const noexcept {
+    return downcast(this)->getEntityCount();
+}
+
 size_t Scene::getRenderableCount() const noexcept {
     return downcast(this)->getRenderableCount();
 }

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -22,6 +22,30 @@ namespace filament {
 
 using namespace math;
 
+bool TransformManager::hasComponent(Entity e) const noexcept {
+    return downcast(this)->hasComponent(e);
+}
+
+size_t TransformManager::getComponentCount() const noexcept {
+    return downcast(this)->getComponentCount();
+}
+
+bool TransformManager::empty() const noexcept {
+    return downcast(this)->empty();
+}
+
+utils::Entity TransformManager::getEntity(TransformManager::Instance i) const noexcept {
+    return downcast(this)->getEntity(i);
+}
+
+utils::Entity const* TransformManager::getEntities() const noexcept {
+    return downcast(this)->getEntities();
+}
+
+TransformManager::Instance TransformManager::getInstance(Entity e) const noexcept {
+    return downcast(this)->getInstance(e);
+}
+
 void TransformManager::create(Entity entity, Instance parent, const mat4f& worldTransform) {
     downcast(this)->create(entity, parent, worldTransform);
 }
@@ -38,14 +62,6 @@ void TransformManager::destroy(Entity e) noexcept {
     downcast(this)->destroy(e);
 }
 
-bool TransformManager::hasComponent(Entity e) const noexcept {
-    return downcast(this)->hasComponent(e);
-}
-
-TransformManager::Instance TransformManager::getInstance(Entity e) const noexcept {
-    return downcast(this)->getInstance(e);
-}
-
 void TransformManager::setTransform(Instance ci, const mat4f& model) noexcept {
     downcast(this)->setTransform(ci, model);
 }
@@ -58,7 +74,7 @@ const mat4f& TransformManager::getTransform(Instance ci) const noexcept {
     return downcast(this)->getTransform(ci);
 }
 
-const mat4 TransformManager::getTransformAccurate(Instance ci) const noexcept {
+mat4 TransformManager::getTransformAccurate(Instance ci) const noexcept {
     return downcast(this)->getTransformAccurate(ci);
 }
 
@@ -66,7 +82,7 @@ const mat4f& TransformManager::getWorldTransform(Instance ci) const noexcept {
     return downcast(this)->getWorldTransform(ci);
 }
 
-const mat4 TransformManager::getWorldTransformAccurate(Instance ci) const noexcept {
+mat4 TransformManager::getWorldTransformAccurate(Instance ci) const noexcept {
     return downcast(this)->getWorldTransformAccurate(ci);
 }
 
@@ -110,7 +126,7 @@ void TransformManager::setAccurateTranslationsEnabled(bool enable) noexcept {
 }
 
 bool TransformManager::isAccurateTranslationsEnabled() const noexcept {
-    return downcast(this)->isAccurateTranslationsEnabled();;
+    return downcast(this)->isAccurateTranslationsEnabled();
 }
 
 } // namespace filament

--- a/filament/src/components/CameraManager.cpp
+++ b/filament/src/components/CameraManager.cpp
@@ -53,7 +53,7 @@ void FCameraManager::terminate() noexcept {
 
 void FCameraManager::gc(utils::EntityManager& em) noexcept {
     auto& manager = mManager;
-    manager.gc(em, 4, [this](Entity e) {
+    manager.gc(em, [this](Entity e) {
         destroy(e);
     });
 }

--- a/filament/src/components/CameraManager.h
+++ b/filament/src/components/CameraManager.h
@@ -57,7 +57,23 @@ public:
     }
 
     Instance getInstance(utils::Entity e) const noexcept {
-        return Instance(mManager.getInstance(e));
+        return { mManager.getInstance(e) };
+    }
+
+    size_t getComponentCount() const noexcept {
+        return mManager.getComponentCount();
+    }
+
+    bool empty() const noexcept {
+        return mManager.empty();
+    }
+
+    utils::Entity getEntity(Instance i) const noexcept {
+        return mManager.getEntity(i);
+    }
+
+    utils::Entity const* getEntities() const noexcept {
+        return mManager.getEntities();
     }
 
     FCamera* getCamera(Instance i) noexcept {

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -227,7 +227,9 @@ void FLightManager::terminate() noexcept {
     }
 }
 void FLightManager::gc(utils::EntityManager& em) noexcept {
-    mManager.gc(em);
+    mManager.gc(em, [this](Entity e) {
+        destroy(e);
+    });
 }
 
 void FLightManager::setShadowOptions(Instance i, ShadowOptions const& options) noexcept {

--- a/filament/src/components/LightManager.h
+++ b/filament/src/components/LightManager.h
@@ -46,20 +46,32 @@ public:
 
     void gc(utils::EntityManager& em) noexcept;
 
-    size_t getComponentCount() const noexcept {
-        return mManager.getComponentCount();
-    }
-
-    utils::Entity const* getEntities() const noexcept {
-        return mManager.getEntities();
-    }
+    /*
+     * Component Manager APIs
+     */
 
     bool hasComponent(utils::Entity e) const noexcept {
         return mManager.hasComponent(e);
     }
 
     Instance getInstance(utils::Entity e) const noexcept {
-        return mManager.getInstance(e);
+        return { mManager.getInstance(e) };
+    }
+
+    size_t getComponentCount() const noexcept {
+        return mManager.getComponentCount();
+    }
+
+    bool empty() const noexcept {
+        return mManager.empty();
+    }
+
+    utils::Entity getEntity(Instance i) const noexcept {
+        return mManager.getEntity(i);
+    }
+
+    utils::Entity const* getEntities() const noexcept {
+        return mManager.getEntities();
     }
 
     void create(const FLightManager::Builder& builder, utils::Entity entity);

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -678,7 +678,9 @@ void FRenderableManager::terminate() noexcept {
 }
 
 void FRenderableManager::gc(utils::EntityManager& em) noexcept {
-    mManager.gc(em);
+    mManager.gc(em, [this](Entity e) {
+        destroy(e);
+    });
 }
 
 // This is basically a Renderable's destructor.

--- a/filament/src/components/RenderableManager.h
+++ b/filament/src/components/RenderableManager.h
@@ -92,7 +92,23 @@ public:
     }
 
     Instance getInstance(utils::Entity e) const noexcept {
-        return mManager.getInstance(e);
+        return { mManager.getInstance(e) };
+    }
+
+    size_t getComponentCount() const noexcept {
+        return mManager.getComponentCount();
+    }
+
+    bool empty() const noexcept {
+        return mManager.empty();
+    }
+
+    utils::Entity getEntity(Instance i) const noexcept {
+        return mManager.getEntity(i);
+    }
+
+    utils::Entity const* getEntities() const noexcept {
+        return mManager.getEntities();
     }
 
     void create(const RenderableManager::Builder& builder, utils::Entity entity);
@@ -175,10 +191,6 @@ public:
     };
     static_assert(sizeof(InstancesInfo) == 16);
     inline InstancesInfo getInstancesInfo(Instance instance) const noexcept;
-
-    utils::Entity getEntity(Instance instance) const noexcept {
-        return mManager.getEntity(instance);
-    }
 
     inline size_t getLevelCount(Instance) const noexcept { return 1u; }
     size_t getPrimitiveCount(Instance instance, uint8_t level) const noexcept;

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -471,8 +471,7 @@ void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance i) noexcep
 }
 
 void FTransformManager::gc(utils::EntityManager& em) noexcept {
-    auto& manager = mManager;
-    manager.gc(em, 4, [this](Entity e) {
+    mManager.gc(em, [this](Entity e) {
                 destroy(e);
             });
 }

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -50,7 +50,23 @@ public:
     }
 
     Instance getInstance(utils::Entity e) const noexcept {
-        return Instance(mManager.getInstance(e));
+        return { mManager.getInstance(e) };
+    }
+
+    size_t getComponentCount() const noexcept {
+        return mManager.getComponentCount();
+    }
+
+    bool empty() const noexcept {
+        return mManager.empty();
+    }
+
+    utils::Entity getEntity(Instance i) const noexcept {
+        return mManager.getEntity(i);
+    }
+
+    utils::Entity const* getEntities() const noexcept {
+        return mManager.getEntities();
     }
 
     void setAccurateTranslationsEnabled(bool enable) noexcept;
@@ -103,7 +119,7 @@ public:
 
     math::mat4 getTransformAccurate(Instance ci) const noexcept {
         math::mat4f const& local = mManager[ci].local;
-        math::float3 localTranslationLo = mManager[ci].localTranslationLo;
+        math::float3 const localTranslationLo = mManager[ci].localTranslationLo;
         math::mat4 r(local);
         r[3].xyz += localTranslationLo;
         return r;
@@ -111,7 +127,7 @@ public:
 
     math::mat4 getWorldTransformAccurate(Instance ci) const noexcept {
         math::mat4f const& world = mManager[ci].world;
-        math::float3 worldTranslationLo = mManager[ci].worldTranslationLo;
+        math::float3 const worldTranslationLo = mManager[ci].worldTranslationLo;
         math::mat4 r(world);
         r[3].xyz += worldTranslationLo;
         return r;

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -55,7 +55,7 @@ class FSkybox;
 class FScene : public Scene {
 public:
     /*
-     * Filaments-scope Public API
+     * Filament-scope Public API
      */
 
     FSkybox* getSkybox() const noexcept { return mSkybox; }
@@ -197,6 +197,7 @@ private:
     void addEntities(const utils::Entity* entities, size_t count);
     void remove(utils::Entity entity);
     void removeEntities(const utils::Entity* entities, size_t count);
+    size_t getEntityCount() const noexcept { return mEntities.size(); }
     size_t getRenderableCount() const noexcept;
     size_t getLightCount() const noexcept;
     bool hasEntity(utils::Entity entity) const noexcept;

--- a/libs/gltfio/src/FNodeManager.h
+++ b/libs/gltfio/src/FNodeManager.h
@@ -57,13 +57,15 @@ public:
     }
 
     void destroy(utils::Entity e) noexcept {
-        if (Instance ci = mManager.getInstance(e); ci) {
+        if (Instance const ci = mManager.getInstance(e); ci) {
             mManager.removeComponent(e);
         }
     }
 
     void gc(utils::EntityManager& em) noexcept {
-        mManager.gc(em);
+        mManager.gc(em, [this](Entity e) {
+            destroy(e);
+        });
     }
 
     void setMorphTargetNames(Instance ci, utils::FixedCapacityVector<CString> names) noexcept {

--- a/libs/gltfio/src/FTrsTransformManager.h
+++ b/libs/gltfio/src/FTrsTransformManager.h
@@ -70,13 +70,15 @@ public:
     }
 
     void destroy(utils::Entity e) noexcept {
-        if (Instance ci = mManager.getInstance(e); ci) {
+        if (Instance const ci = mManager.getInstance(e); ci) {
             mManager.removeComponent(e);
         }
     }
 
     void gc(utils::EntityManager& em) noexcept {
-        mManager.gc(em);
+        mManager.gc(em, [this](Entity e) {
+            destroy(e);
+        });
     }
 
     void setTranslation(Instance ci, const float3& translation) noexcept {

--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -44,9 +44,8 @@ public:
     public:
         virtual void onEntitiesDestroyed(size_t n, Entity const* entities) noexcept = 0;
     protected:
-        ~Listener() noexcept;
+        virtual ~Listener() noexcept;
     };
-
 
     // maximum number of entities that can exist at the same time
     static size_t getMaxEntityCount() noexcept {

--- a/libs/utils/include/utils/EntityManager.h
+++ b/libs/utils/include/utils/EntityManager.h
@@ -53,13 +53,16 @@ public:
         return RAW_INDEX_COUNT - 1;
     }
 
-    // create n entities. Thread safe.
+    // number of active Entities
+    size_t getEntityCount() const noexcept;
+
+    // Create n entities. Thread safe.
     void create(size_t n, Entity* entities);
 
     // destroys n entities. Thread safe.
     void destroy(size_t n, Entity* entities) noexcept;
 
-    // create a new Entity. Thread safe.
+    // Create a new Entity. Thread safe.
     // Return Entity.isNull() if the entity cannot be allocated.
     Entity create() {
         Entity e;
@@ -67,20 +70,20 @@ public:
         return e;
     }
 
-    // destroys an Entity. Thread safe.
+    // Destroys an Entity. Thread safe.
     void destroy(Entity e) noexcept {
         destroy(1, &e);
     }
 
-    // return whether the given Entity has been destroyed (false) or not (true).
+    // Return whether the given Entity has been destroyed (false) or not (true).
     // Thread safe.
     bool isAlive(Entity e) const noexcept {
         assert(getIndex(e) < RAW_INDEX_COUNT);
         return (!e.isNull()) && (getGeneration(e) == mGens[getIndex(e)]);
     }
 
-    // registers a listener to be called when an entity is destroyed. thread safe.
-    // if the listener is already register, this method has no effect.
+    // Registers a listener to be called when an entity is destroyed. Thread safe.
+    // If the listener is already registered, this method has no effect.
     void registerListener(Listener* l) noexcept;
 
     // unregisters a listener.
@@ -93,6 +96,7 @@ public:
     uint8_t getGenerationForIndex(size_t index) const noexcept {
         return mGens[index];
     }
+
     // singleton, can't be copied
     EntityManager(const EntityManager& rhs) = delete;
     EntityManager& operator=(const EntityManager& rhs) = delete;

--- a/libs/utils/include/utils/NameComponentManager.h
+++ b/libs/utils/include/utils/NameComponentManager.h
@@ -48,7 +48,7 @@ class EntityManager;
  * printf("%s\n", names->getName(names->getInstance(myEntity));
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
-class UTILS_PUBLIC NameComponentManager : public SingleInstanceComponentManager<utils::CString> {
+class UTILS_PUBLIC NameComponentManager : private SingleInstanceComponentManager<utils::CString> {
 public:
     using Instance = EntityInstance<NameComponentManager>;
 
@@ -75,15 +75,6 @@ public:
         return { SingleInstanceComponentManager::getInstance(e) };
     }
 
-    /*! \cond PRIVATE */
-    // these are implemented in SingleInstanceComponentManager<>, but we need to
-    // reimplement them in each manager, to ensure they are generated in an implementation file
-    // for backward binary compatibility reasons.
-    size_t getComponentCount() const noexcept;
-    Entity const* getEntities() const noexcept;
-    void gc(const EntityManager& em, size_t ratio = 4) noexcept;
-    /*! \endcond */
-
     /**
      * Adds a name component to the given entity if it doesn't already exist.
      */
@@ -105,6 +96,12 @@ public:
      * @return pointer to the copy that was made during setName()
      */
     const char* getName(Instance instance) const noexcept;
+
+    void gc(EntityManager& em) noexcept {
+        SingleInstanceComponentManager<utils::CString>::gc(em, [this](Entity e) {
+            removeComponent(e);
+        });
+    }
 };
 
 } // namespace utils

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -57,6 +57,10 @@ void EntityManager::unregisterListener(EntityManager::Listener* l) noexcept {
     static_cast<EntityManagerImpl *>(this)->unregisterListener(l);
 }
 
+size_t EntityManager::getEntityCount() const noexcept {
+    return static_cast<EntityManagerImpl const *>(this)->getEntityCount();
+}
+
 #if FILAMENT_UTILS_TRACK_ENTITIES
 std::vector<Entity> EntityManager::getActiveEntities() const {
     return static_cast<EntityManagerImpl const *>(this)->getActiveEntities();

--- a/libs/utils/src/EntityManager.cpp
+++ b/libs/utils/src/EntityManager.cpp
@@ -22,6 +22,8 @@
 
 namespace utils {
 
+EntityManager::Listener::~Listener() noexcept = default;
+
 EntityManager::EntityManager()
         : mGens(new uint8_t[RAW_INDEX_COUNT]) {
     // initialize all the generations to 0
@@ -31,8 +33,6 @@ EntityManager::EntityManager()
 EntityManager::~EntityManager() {
     delete [] mGens;
 }
-
-EntityManager::Listener::~Listener() noexcept = default;
 
 EntityManager& EntityManager::get() noexcept {
     // note: we leak the EntityManager because it's more important that it survives everything else

--- a/libs/utils/src/EntityManagerImpl.h
+++ b/libs/utils/src/EntityManagerImpl.h
@@ -49,6 +49,16 @@ public:
     using EntityManager::destroy;
 
     UTILS_NOINLINE
+    size_t getEntityCount() const noexcept {
+        std::lock_guard<Mutex> const lock(mFreeListLock);
+        if (mCurrentIndex < RAW_INDEX_COUNT) {
+            return (mCurrentIndex - 1) - mFreeList.size();
+        } else {
+            return getMaxEntityCount() - mFreeList.size();
+        }
+    }
+
+    UTILS_NOINLINE
     void create(size_t n, Entity* entities) {
         Entity::Type index{};
         auto& freeList = mFreeList;

--- a/libs/utils/src/NameComponentManager.cpp
+++ b/libs/utils/src/NameComponentManager.cpp
@@ -21,7 +21,7 @@ namespace utils {
 
 static constexpr size_t NAME = 0;
 
-NameComponentManager::NameComponentManager(EntityManager& em) {
+NameComponentManager::NameComponentManager(EntityManager&) {
 }
 
 NameComponentManager::~NameComponentManager() = default;
@@ -36,24 +36,12 @@ const char* NameComponentManager::getName(Instance instance) const noexcept {
     return elementAt<NAME>(instance).c_str();
 }
 
-size_t NameComponentManager::getComponentCount() const noexcept {
-    return SingleInstanceComponentManager::getComponentCount();
-}
-
-Entity const* NameComponentManager::getEntities() const noexcept {
-    return SingleInstanceComponentManager::getEntities();
-}
-
 void NameComponentManager::addComponent(Entity e) {
     SingleInstanceComponentManager::addComponent(e);
 }
 
 void NameComponentManager::removeComponent(Entity e) {
     SingleInstanceComponentManager::removeComponent(e);
-}
-
-void NameComponentManager::gc(const EntityManager& em, size_t ratio) noexcept {
-    SingleInstanceComponentManager::gc(em, ratio);
 }
 
 } // namespace utils

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -612,8 +612,10 @@ void applySettings(Engine* engine, const LightSettings& settings, IndirectLight*
     }
     for (size_t i = 0; i < sceneLightCount; i++) {
         auto const li = lm->getInstance(sceneLights[i]);
-        lm->setShadowCaster(li, settings.enableShadows);
-        lm->setShadowOptions(li, settings.shadowOptions);
+        if (li) {
+            lm->setShadowCaster(li, settings.enableShadows);
+            lm->setShadowOptions(li, settings.shadowOptions);
+        }
     }
     view->setSoftShadowOptions(settings.softShadowOptions);
 }

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1045,7 +1045,7 @@ void ViewerGui::updateUserInterface() {
 
             std::vector<std::string> names;
             names.reserve(cameraCount + 1);
-            names.push_back("Free camera");
+            names.emplace_back("Free camera");
             int c = 0;
             for (size_t i = 0; i < cameraCount; i++) {
                 const char* n = mAsset->getName(cameras[i]);
@@ -1060,8 +1060,8 @@ void ViewerGui::updateUserInterface() {
 
             std::vector<const char*> cstrings;
             cstrings.reserve(names.size());
-            for (size_t i = 0; i < names.size(); i++) {
-                cstrings.push_back(names[i].c_str());
+            for (const auto & name : names) {
+                cstrings.push_back(name.c_str());
             }
 
             ImGui::ListBox("Cameras", &mCurrentCamera, cstrings.data(), cstrings.size());
@@ -1083,8 +1083,16 @@ void ViewerGui::updateUserInterface() {
     // At this point, all View settings have been modified,
     //  so we can now push them into the Filament View.
     applySettings(mEngine, mSettings.view, mView);
+
+    auto lights = utils::FixedCapacityVector<utils::Entity>::with_capacity(mScene->getEntityCount());
+    mScene->forEach([&](utils::Entity entity) {
+        if (lm.hasComponent(entity)) {
+            lights.push_back(entity);
+        }
+    });
+
     applySettings(mEngine, mSettings.lighting, mIndirectLight, mSunlight,
-                  lm.getEntities(), lm.getComponentCount(), &lm, mScene, mView);
+            lights.data(), lights.size(), &lm, mScene, mView);
 
     // TODO(prideout): add support for hierarchy, animation and variant selection in remote mode. To
     // support these features, we will need to send a message (list of strings) from DebugServer to

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -688,6 +688,7 @@ class_<Scene>("Scene")
     .function("getSkybox", &Scene::getSkybox, allow_raw_pointers())
     .function("setIndirectLight", &Scene::setIndirectLight, allow_raw_pointers())
     .function("getIndirectLight", &Scene::getIndirectLight, allow_raw_pointers())
+    .function("getEntityCount", &Scene::getEntityCount)
     .function("getRenderableCount", &Scene::getRenderableCount)
     .function("getLightCount", &Scene::getLightCount);
 


### PR DESCRIPTION
- we used to to this by deleting operator delete, but this prevented
  the internal "F" classes from being virtual; which can be useful
  when using EntityManger::Listener.
  now we just make the destructor protected in each class.

- EntityManger::Listener now has a virtual destructor so that
  objects could be correctly destroyed from Listener*

- all component managers now have the same "base" API
    - getComponentCount()
	- empty()
    - getEntity()
    - getEntities()

- Scene now has getEntityCount()

- EntityManager now has getEntityCount()

- all component manager implement gc() the same way, by calling destroy()

- SingleInstanceComponentManager::gc() that calls removeComponent() has
  been removed because it's dangerous. removeComponent() is often
  not enough, some additional cleanup might be needed.