### PR TITLE
disable multiple context support on WGL

### DIFF
--- a/filament/backend/src/opengl/platforms/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/platforms/PlatformWGL.cpp
@@ -168,7 +168,7 @@ error:
 }
 
 bool PlatformWGL::isExtraContextSupported() const noexcept {
-    return true;
+    return false;
 }
 
 void PlatformWGL::createContext(bool shared) {


### PR DESCRIPTION
The reason is that some implementations of WGL require all contexts to be created on the same thread, which we're not necessarily doing here.

fixes #7078