### PR TITLE
fix SSR artifact when enabling SSR

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -245,6 +245,7 @@ void PerViewUniforms::prepareMaterialGlobals(
 }
 
 void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
+        bool disableSSR,
         float refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) noexcept {
 
@@ -255,7 +256,7 @@ void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr,
 
     auto& s = mUniforms.edit();
     s.refractionLodOffset = refractionLodOffset;
-    s.ssrDistance = ssrOptions.enabled ? ssrOptions.maxDistance : 0.0f;
+    s.ssrDistance = (ssrOptions.enabled && !disableSSR) ? ssrOptions.maxDistance : 0.0f;
 }
 
 void PerViewUniforms::prepareHistorySSR(Handle<HwTexture> ssr,

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -95,6 +95,7 @@ public:
 
     // screen-space reflection and/or refraction (SSR)
     void prepareSSR(TextureHandle ssr,
+            bool disableSSR,
             float refractionLodOffset,
             ScreenSpaceReflectionsOptions const& ssrOptions) noexcept;
 

--- a/filament/src/RendererUtils.cpp
+++ b/filament/src/RendererUtils.cpp
@@ -193,8 +193,8 @@ FrameGraphId<FrameGraphTexture> RendererUtils::colorPass(
                 TextureHandle const ssr = data.ssr ?
                         resources.getTexture(data.ssr) : engine.getOneTextureArray();
 
-                view.prepareSSR(ssr, config.ssrLodOffset,
-                        view.getScreenSpaceReflectionsOptions());
+                view.prepareSSR(ssr, config.screenSpaceReflectionHistoryNotReady,
+                        config.ssrLodOffset, view.getScreenSpaceReflectionsOptions());
 
                 // Note: here we can't use data.color's descriptor for the viewport because
                 // the actual viewport might be offset when the target is the swapchain.

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -67,6 +67,8 @@ public:
         bool hasScreenSpaceReflectionsOrRefractions;
         // Use a depth format with a stencil component.
         bool enabledStencilBuffer;
+        // whether the screenspace reflections history buffer is initialized
+        bool screenSpaceReflectionHistoryNotReady;
     };
 
     static FrameGraphId<FrameGraphTexture> colorPass(

--- a/filament/src/details/Renderer.cpp
+++ b/filament/src/details/Renderer.cpp
@@ -859,6 +859,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
             PostProcessManager::generateMipmapSSR(ppm, fg,
                     reflections, ssrConfig.reflection, false, ssrConfig);
         }
+        config.screenSpaceReflectionHistoryNotReady = !reflections;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -746,9 +746,11 @@ void FView::prepareSSAO(Handle<HwTexture> ssao) const noexcept {
     mPerViewUniforms.prepareSSAO(ssao, mAmbientOcclusionOptions);
 }
 
-void FView::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset,
+void FView::prepareSSR(Handle<HwTexture> ssr,
+        bool disableSSR,
+        float refractionLodOffset,
         ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept {
-    mPerViewUniforms.prepareSSR(ssr, refractionLodOffset, ssrOptions);
+    mPerViewUniforms.prepareSSR(ssr, disableSSR, refractionLodOffset, ssrOptions);
 }
 
 void FView::prepareStructure(Handle<HwTexture> structure) const noexcept {

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -145,7 +145,8 @@ public:
     void prepareLighting(FEngine& engine, ArenaScope& arena, CameraInfo const& cameraInfo) noexcept;
 
     void prepareSSAO(backend::Handle<backend::HwTexture> ssao) const noexcept;
-    void prepareSSR(backend::Handle<backend::HwTexture> ssr, float refractionLodOffset,
+    void prepareSSR(backend::Handle<backend::HwTexture> ssr, bool disableSSR,
+            float refractionLodOffset,
             ScreenSpaceReflectionsOptions const& ssrOptions) const noexcept;
     void prepareStructure(backend::Handle<backend::HwTexture> structure) const noexcept;
     void prepareShadow(backend::Handle<backend::HwTexture> structure) const noexcept;


### PR DESCRIPTION
When we enable SSR the first time, the SSR buffer is not initialized, this can result in the color pass fragment shader aborting, which in  turn prevents the SSR history buffer from being initialized (since  it's made from the result of the color pass), repeating the cycle.

In some other case, the system somehow recovers but we still see a flicker when enabling SSR.

The solution here is to disable SSR in the shader until the history buffer is ready (i.e. a frame later).