### PR TITLE
repair gltf_viewer drag&drop

### DIFF
--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -69,8 +69,11 @@ class UTILS_PUBLIC ResourceLoader {
 public:
     using BufferDescriptor = filament::backend::BufferDescriptor;
 
-    ResourceLoader(const ResourceConfiguration& config);
+    explicit ResourceLoader(const ResourceConfiguration& config);
     ~ResourceLoader();
+
+
+    void setConfiguration(const ResourceConfiguration& config);
 
     /**
      * Feeds the binary content of an external resource into the loader's URI cache.

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -74,15 +74,15 @@ enum class CacheResult {
 };
 
 struct ResourceLoader::Impl {
-    Impl(const ResourceConfiguration& config) :
+    explicit Impl(const ResourceConfiguration& config) :
         mEngine(config.engine),
         mNormalizeSkinningWeights(config.normalizeSkinningWeights),
         mGltfPath(config.gltfPath ? config.gltfPath : ""),
         mUriDataCache(std::make_shared<UriDataCache>()) {}
 
     Engine* const mEngine;
-    const bool mNormalizeSkinningWeights;
-    const std::string mGltfPath;
+    bool mNormalizeSkinningWeights;
+    std::string mGltfPath;
 
     // User-provided resource data with URI string keys, populated with addResourceData().
     // This is used on platforms without traditional file systems, such as Android, iOS, and WebGL.
@@ -318,6 +318,11 @@ ResourceLoader::ResourceLoader(const ResourceConfiguration& config) : pImpl(new 
 
 ResourceLoader::~ResourceLoader() {
     delete pImpl;
+}
+
+void ResourceLoader::setConfiguration(const ResourceConfiguration& config) {
+    pImpl->mNormalizeSkinningWeights = config.normalizeSkinningWeights;
+    pImpl->mGltfPath = config.gltfPath;
 }
 
 void ResourceLoader::addResourceData(const char* uri, BufferDescriptor&& buffer) {


### PR DESCRIPTION
Drag and dropping a gltf folder was broken:
- the handle didn't find the gltf file on drag&drop
- the ResourceLoader cached the asset path
- don't exit(1) when drag&dropping an invalid file