### PR TITLE
Improve blitting APIs

### DIFF
--- a/android/filament-android/src/main/java/com/google/android/filament/Texture.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/Texture.java
@@ -849,6 +849,10 @@ public class Texture {
         public static final int SAMPLEABLE = 0x10;
         /** Texture can be used as a subpass input */
         public static final int SUBPASS_INPUT = 0x20;
+        /** Texture can be used the source of a blit() */
+        public static final int BLIT_SRC = 0x40;
+        /** Texture can be used the destination of a blit() */
+        public static final int BLIT_DST = 0x80;
         /** by default textures are <code>UPLOADABLE</code> and <code>SAMPLEABLE</code>*/
         public static final int DEFAULT = UPLOADABLE | SAMPLEABLE;
     }

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -227,6 +227,7 @@ struct Viewport {
     int32_t top() const noexcept { return bottom + int32_t(height); }
 };
 
+
 /**
  * Specifies the mapping of the near and far clipping plane to window coordinates.
  */
@@ -658,13 +659,15 @@ enum class TextureFormat : uint16_t {
 
 //! Bitmask describing the intended Texture Usage
 enum class TextureUsage : uint8_t {
-    NONE                = 0x0,
-    COLOR_ATTACHMENT    = 0x1,                      //!< Texture can be used as a color attachment
-    DEPTH_ATTACHMENT    = 0x2,                      //!< Texture can be used as a depth attachment
-    STENCIL_ATTACHMENT  = 0x4,                      //!< Texture can be used as a stencil attachment
-    UPLOADABLE          = 0x8,                      //!< Data can be uploaded into this texture (default)
+    NONE                = 0x00,
+    COLOR_ATTACHMENT    = 0x01,                     //!< Texture can be used as a color attachment
+    DEPTH_ATTACHMENT    = 0x02,                     //!< Texture can be used as a depth attachment
+    STENCIL_ATTACHMENT  = 0x04,                     //!< Texture can be used as a stencil attachment
+    UPLOADABLE          = 0x08,                     //!< Data can be uploaded into this texture (default)
     SAMPLEABLE          = 0x10,                     //!< Texture can be sampled (default)
     SUBPASS_INPUT       = 0x20,                     //!< Texture can be used as a subpass input
+    BLIT_SRC            = 0x40,                     //!< Texture can be used the source of a blit()
+    BLIT_DST            = 0x80,                     //!< Texture can be used the destination of a blit()
     DEFAULT             = UPLOADABLE | SAMPLEABLE   //!< Default texture usage
 };
 
@@ -686,6 +689,17 @@ static constexpr bool isDepthFormat(TextureFormat format) noexcept {
         case TextureFormat::DEPTH16:
         case TextureFormat::DEPTH32F_STENCIL8:
         case TextureFormat::DEPTH24_STENCIL8:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static constexpr bool isStencilFormat(TextureFormat format) noexcept {
+    switch (format) {
+        case TextureFormat::STENCIL8:
+        case TextureFormat::DEPTH24_STENCIL8:
+        case TextureFormat::DEPTH32F_STENCIL8:
             return true;
         default:
             return false;

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -303,7 +303,6 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isParallelShaderCompileSupported)
 DECL_DRIVER_API_SYNCHRONOUS_0(uint8_t, getMaxDrawBuffers)
 DECL_DRIVER_API_SYNCHRONOUS_0(size_t, getMaxUniformBufferSize)
 DECL_DRIVER_API_SYNCHRONOUS_0(math::float2, getClipSpaceParams)
-DECL_DRIVER_API_SYNCHRONOUS_0(bool, canGenerateMipmaps)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalImage, void*, image)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, getTimerQueryValue, backend::TimerQueryHandle, query, uint64_t*, elapsedTime)
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isWorkaroundNeeded, backend::Workaround, workaround)
@@ -468,13 +467,28 @@ DECL_DRIVER_API_N(readBufferSubData,
  * --------------------
  */
 
-DECL_DRIVER_API_N(blit,
+DECL_DRIVER_API_N(blitDEPRECATED,
         backend::TargetBufferFlags, buffers,
         backend::RenderTargetHandle, dst,
         backend::Viewport, dstRect,
         backend::RenderTargetHandle, src,
         backend::Viewport, srcRect,
         backend::SamplerMagFilter, filter)
+
+DECL_DRIVER_API_N(resolve,
+        backend::TextureHandle, dst,
+        uint8_t, dstLevel, uint8_t, dstLayer,
+        backend::TextureHandle, src,
+        uint8_t, srcLevel, uint8_t, srcLayer)
+
+DECL_DRIVER_API_N(blit,
+        backend::TextureHandle, dst,
+        uint8_t, dstLevel, uint8_t, dstLayer,
+        math::uint2, dstOrigin,
+        backend::TextureHandle, src,
+        uint8_t, srcLevel, uint8_t, srcLayer,
+        math::uint2, srcOrigin,
+        math::uint2, size)
 
 DECL_DRIVER_API_N(draw,
         backend::PipelineState, state,

--- a/filament/backend/src/metal/MetalBlitter.h
+++ b/filament/backend/src/metal/MetalBlitter.h
@@ -24,8 +24,7 @@
 #include <tsl/robin_map.h>
 #include <utils/Hash.h>
 
-namespace filament {
-namespace backend {
+namespace filament::backend {
 
 struct MetalContext;
 
@@ -35,36 +34,45 @@ public:
 
     explicit MetalBlitter(MetalContext& context) noexcept;
 
+    enum class FormatType { NONE, COLOR, DEPTH, STENCIL, DEPTH_STENCIL };
+    static FormatType getFormatType(TextureFormat format) noexcept {
+        bool const depth = isDepthFormat(format);
+        bool const stencil = isStencilFormat(format);
+        if (depth && stencil) return FormatType::DEPTH_STENCIL;
+        if (depth) return FormatType::DEPTH;
+        if (stencil) return FormatType::STENCIL;
+        return FormatType::COLOR;
+    }
+
     struct BlitArgs {
         struct Attachment {
-            id<MTLTexture> color = nil;
-            id<MTLTexture> depth = nil;
+            using Type = FormatType;
+            id<MTLTexture> texture = nil;
             MTLRegion region = {};
             uint8_t level = 0;
             uint32_t slice = 0;      // must be 0 on source attachment
+            Type type = Type::NONE;
         };
 
         // Valid source formats:       2D, 2DArray, 2DMultisample, 3D
         // Valid destination formats:  2D, 2DArray, 3D, Cube
-        Attachment source, destination;
+        Attachment source;
+        Attachment destination;
         SamplerMagFilter filter;
 
         bool blitColor() const {
-            return source.color != nil && destination.color != nil;
+            return source.type == Attachment::Type::COLOR &&
+                   destination.type == Attachment::Type::COLOR;
         }
 
         bool blitDepth() const {
-            return source.depth != nil && destination.depth != nil;
+            return source.type == Attachment::Type::DEPTH &&
+                   destination.type == Attachment::Type::DEPTH;
         }
 
-        bool colorDestinationIsFullAttachment() const {
-            return destination.color.width == destination.region.size.width &&
-                   destination.color.height == destination.region.size.height;
-        }
-
-        bool depthDestinationIsFullAttachment() const {
-            return destination.depth.width == destination.region.size.width &&
-                   destination.depth.height == destination.region.size.height;
+        bool destinationIsFullAttachment() const {
+            return destination.texture.width == destination.region.size.width &&
+                   destination.texture.height == destination.region.size.height;
         }
     };
 
@@ -78,10 +86,8 @@ public:
 
 private:
 
-    static void setupColorAttachment(const BlitArgs& args, MTLRenderPassDescriptor* descriptor,
-            uint32_t depthPlane);
-    static void setupDepthAttachment(const BlitArgs& args, MTLRenderPassDescriptor* descriptor,
-            uint32_t depthPlane);
+    static void setupAttachment(MTLRenderPassAttachmentDescriptor* descriptor,
+            const BlitArgs& args, uint32_t depthPlane);
 
     struct BlitFunctionKey {
         bool blitColor;
@@ -94,7 +100,7 @@ private:
 
         bool isValid() const noexcept {
             // MSAA 3D textures do not exist.
-            bool hasMsaa = msaaColorSource || msaaDepthSource;
+            bool const hasMsaa = msaaColorSource || msaaDepthSource;
             return !(hasMsaa && sources3D);
         }
 
@@ -111,15 +117,17 @@ private:
         }
     };
 
-    void blitFastPath(id<MTLCommandBuffer> cmdBuffer, bool& blitColor, bool& blitDepth,
+    static bool blitFastPath(id<MTLCommandBuffer> cmdBuffer,
             const BlitArgs& args, const char* label);
-    void blitSlowPath(id<MTLCommandBuffer> cmdBuffer, bool& blitColor, bool& blitDepth,
+
+    void blitSlowPath(id<MTLCommandBuffer> cmdBuffer,
             const BlitArgs& args, const char* label);
+
     void blitDepthPlane(id<MTLCommandBuffer> cmdBuffer, bool blitColor, bool blitDepth,
             const BlitArgs& args, uint32_t depthPlaneSource, uint32_t depthPlaneDest,
             const char* label);
-    id<MTLTexture> createIntermediateTexture(id<MTLTexture> t, MTLSize size);
-    id<MTLFunction> compileFragmentFunction(BlitFunctionKey key);
+
+    id<MTLFunction> compileFragmentFunction(BlitFunctionKey key) const;
     id<MTLFunction> getBlitVertexFunction();
     id<MTLFunction> getBlitFragmentFunction(BlitFunctionKey key);
 
@@ -130,10 +138,9 @@ private:
     tsl::robin_map<BlitFunctionKey, Function, HashFn> mBlitFunctions;
 
     id<MTLFunction> mVertexFunction = nil;
-
 };
 
-} // namespace backend
-} // namespace filament
+} // namespace filament::backend
+
 
 #endif //TNT_METALBLITTER_H

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -252,10 +252,6 @@ void NoopDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 
 void NoopDriver::generateMipmaps(Handle<HwTexture> th) { }
 
-bool NoopDriver::canGenerateMipmaps() {
-    return true;
-}
-
 void NoopDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
         BufferDescriptor&& data) {
     scheduleDestroy(std::move(data));
@@ -322,10 +318,21 @@ void NoopDriver::readBufferSubData(backend::BufferObjectHandle boh,
     scheduleDestroy(std::move(p));
 }
 
-void NoopDriver::blit(TargetBufferFlags buffers,
+void NoopDriver::blitDEPRECATED(TargetBufferFlags buffers,
         Handle<HwRenderTarget> dst, Viewport dstRect,
         Handle<HwRenderTarget> src, Viewport srcRect,
         SamplerMagFilter filter) {
+}
+
+void NoopDriver::resolve(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
+}
+
+void NoopDriver::blit(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, math::uint2 dstOrigin,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, math::uint2 srcOrigin,
+        math::uint2 size) {
 }
 
 void NoopDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> rph,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -2227,8 +2227,7 @@ void OpenGLDriver::setMinMaxLevels(Handle<HwTexture> th, uint32_t minLevel, uint
         t->gl.baseLevel = (int8_t)minLevel;
         glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
 
-        t->gl
-         .maxLevel = (int8_t)maxLevel; // NOTE: according to the GL spec, the default value of this 1000
+        t->gl.maxLevel = (int8_t)maxLevel; // NOTE: according to the GL spec, the default value of this 1000
         glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
     }
 #endif
@@ -2276,10 +2275,6 @@ void OpenGLDriver::generateMipmaps(Handle<HwTexture> th) {
     glGenerateMipmap(t->gl.target);
 
     CHECK_GL_ERROR(utils::slog.e)
-}
-
-bool OpenGLDriver::canGenerateMipmaps() {
-    return true;
 }
 
 void OpenGLDriver::setTextureData(GLTexture* t, uint32_t level,
@@ -3438,75 +3433,230 @@ void OpenGLDriver::clearWithRasterPipe(TargetBufferFlags clearFlags,
     CHECK_GL_ERROR(utils::slog.e)
 }
 
-void OpenGLDriver::blit(TargetBufferFlags buffers,
-        Handle<HwRenderTarget> dst, Viewport dstRect,
-        Handle<HwRenderTarget> src, Viewport srcRect,
-        SamplerMagFilter filter) {
+void OpenGLDriver::resolve(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
+    DEBUG_MARKER()
+    GLTexture const* const s = handle_cast<GLTexture*>(src);
+    GLTexture const* const d = handle_cast<GLTexture*>(dst);
+    assert_invariant(s);
+    assert_invariant(d);
+
+    ASSERT_PRECONDITION(
+            d->width == s->width && d->height == s->height,
+            "invalid resolve: src and dst sizes don't match");
+
+    ASSERT_PRECONDITION(s->samples > 1 && d->samples == 1,
+            "invalid resolve: src.samples=%u, dst.samples=%u",
+            +s->samples, +d->samples);
+
+    blit(   dst, dstLevel, dstLayer, {},
+            src, srcLevel, srcLayer, {},
+            { d->width, d->height });
+}
+
+void OpenGLDriver::blit(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, uint2 dstOrigin,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, uint2 srcOrigin,
+        uint2 size) {
     DEBUG_MARKER()
     UTILS_UNUSED_IN_RELEASE auto& gl = mContext;
     assert_invariant(!gl.isES2());
 
 #ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
-    GLbitfield const mask = getAttachmentBitfield(buffers);
-    if (mask) {
-        GLenum glFilterMode = (filter == SamplerMagFilter::NEAREST) ? GL_NEAREST : GL_LINEAR;
-        if (mask & (GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT)) {
-            // GL_INVALID_OPERATION is generated if mask contains any of the GL_DEPTH_BUFFER_BIT or
-            // GL_STENCIL_BUFFER_BIT and filter is not GL_NEAREST.
-            glFilterMode = GL_NEAREST;
-        }
 
-        // note: for msaa RenderTargets with non-msaa attachments, we copy from the msaa sidecar
-        // buffer -- this should produce the same output that if we copied from the resolved
-        // texture. EXT_multisampled_render_to_texture seems to allow both behaviours, and this
-        // is an emulation of that.  We cannot use the resolved texture easily because it's not
-        // actually attached to the RenderTarget. Another implementation would be to do a
-        // reverse-resolve, but that wouldn't buy us anything.
-        GLRenderTarget const* s = handle_cast<GLRenderTarget const*>(src);
-        GLRenderTarget const* d = handle_cast<GLRenderTarget const*>(dst);
+    GLTexture* d = handle_cast<GLTexture*>(dst);
+    GLTexture* s = handle_cast<GLTexture*>(src);
+    assert_invariant(d);
+    assert_invariant(s);
 
-        // blit operations are only supported from RenderTargets that have only COLOR0 (or
-        // no color buffer at all)
-        assert_invariant(
-                !(s->targets & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
+    ASSERT_PRECONDITION_NON_FATAL(any(d->usage & TextureUsage::BLIT_DST),
+            "texture doesn't have BLIT_DST");
 
-        assert_invariant(
-                !(d->targets & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
+    ASSERT_PRECONDITION_NON_FATAL(any(s->usage & TextureUsage::BLIT_SRC),
+            "texture doesn't have BLIT_SRC");
 
-        // With GLES 3.x, GL_INVALID_OPERATION is generated if the value of GL_SAMPLE_BUFFERS
-        // for the draw buffer is greater than zero. This works with OpenGL, so we want to
-        // make sure to catch this scenario.
-        assert_invariant(d->gl.samples <= 1);
+    ASSERT_PRECONDITION_NON_FATAL(s->format == d->format,
+            "src and dst texture format don't match");
 
-        // GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater
-        // than zero and the formats of draw and read buffers are not identical.
-        // However, it's not well-defined in the spec what "format" means. So it's difficult
-        // to have an assert here -- especially when dealing with the default framebuffer
+    enum class AttachmentType : GLenum {
+        COLOR = GL_COLOR_ATTACHMENT0,
+        DEPTH = GL_DEPTH_ATTACHMENT,
+        STENCIL = GL_STENCIL_ATTACHMENT,
+        DEPTH_STENCIL = GL_DEPTH_STENCIL_ATTACHMENT,
+    };
 
-        // GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater
-        // than zero and (...) the source and destination rectangles are not defined with the
-        // same (X0, Y0) and (X1, Y1) bounds.
+    auto getFormatType = [](TextureFormat format) -> AttachmentType {
+        bool const depth = isDepthFormat(format);
+        bool const stencil = isStencilFormat(format);
+        if (depth && stencil) return AttachmentType::DEPTH_STENCIL;
+        if (depth) return AttachmentType::DEPTH;
+        if (stencil) return AttachmentType::STENCIL;
+        return AttachmentType::COLOR;
+    };
 
-        // Additionally, the EXT_multisampled_render_to_texture extension doesn't specify what
-        // happens when blitting from an "implicit" resolve render target (does it work?), so
-        // to ere on the safe side, we don't allow it.
-        if (s->gl.samples > 1) {
-            assert_invariant(!memcmp(&dstRect, &srcRect, sizeof(srcRect)));
-        }
+    AttachmentType const type = getFormatType(d->format);
+    assert_invariant(type == getFormatType(s->format));
 
-        gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
-        gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl.fbo);
+    // GL_INVALID_OPERATION is generated if mask contains any of the GL_DEPTH_BUFFER_BIT or
+    // GL_STENCIL_BUFFER_BIT and filter is not GL_NEAREST.
+    GLbitfield mask = {};
+    switch (type) {
+        case AttachmentType::COLOR:
+            mask = GL_COLOR_BUFFER_BIT;
+            break;
+        case AttachmentType::DEPTH:
+            mask = GL_DEPTH_BUFFER_BIT;
+            break;
+        case AttachmentType::STENCIL:
+            mask = GL_STENCIL_BUFFER_BIT;
+            break;
+        case AttachmentType::DEPTH_STENCIL:
+            mask = GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
+            break;
+    };
 
-        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
-        CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+    GLuint fbo[2] = {};
+    glGenFramebuffers(2, fbo);
 
-        gl.disable(GL_SCISSOR_TEST);
-        glBlitFramebuffer(
-                srcRect.left, srcRect.bottom, srcRect.right(), srcRect.top(),
-                dstRect.left, dstRect.bottom, dstRect.right(), dstRect.top(),
-                mask, glFilterMode);
-        CHECK_GL_ERROR(utils::slog.e)
+    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, fbo[0]);
+    switch (d->target) {
+        case SamplerType::SAMPLER_2D:
+            if (any(d->usage & TextureUsage::SAMPLEABLE)) {
+                glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GLenum(type),
+                        GL_TEXTURE_2D, d->gl.id, dstLevel);
+            } else {
+                glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GLenum(type),
+                        GL_RENDERBUFFER, d->gl.id);
+            }
+            break;
+        case SamplerType::SAMPLER_CUBEMAP:
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GLenum(type),
+                    GL_TEXTURE_CUBE_MAP_POSITIVE_X + dstLayer, d->gl.id, dstLevel);
+            break;
+        case SamplerType::SAMPLER_2D_ARRAY:
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+        case SamplerType::SAMPLER_3D:
+            glFramebufferTextureLayer(GL_DRAW_FRAMEBUFFER, GLenum(type),
+                    d->gl.id, dstLevel, dstLayer);
+            break;
+        case SamplerType::SAMPLER_EXTERNAL:
+            break;
     }
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, fbo[1]);
+    switch (s->target) {
+        case SamplerType::SAMPLER_2D:
+            if (any(s->usage & TextureUsage::SAMPLEABLE)) {
+                glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GLenum(type),
+                        GL_TEXTURE_2D, s->gl.id, srcLevel);
+            } else {
+                glFramebufferRenderbuffer(GL_READ_FRAMEBUFFER, GLenum(type),
+                        GL_RENDERBUFFER, s->gl.id);
+            }
+            break;
+        case SamplerType::SAMPLER_CUBEMAP:
+            glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GLenum(type),
+                    GL_TEXTURE_CUBE_MAP_POSITIVE_X + srcLayer, s->gl.id, srcLevel);
+            break;
+        case SamplerType::SAMPLER_2D_ARRAY:
+        case SamplerType::SAMPLER_CUBEMAP_ARRAY:
+        case SamplerType::SAMPLER_3D:
+            glFramebufferTextureLayer(GL_READ_FRAMEBUFFER, GLenum(type),
+                    s->gl.id, srcLevel, srcLayer);
+            break;
+        case SamplerType::SAMPLER_EXTERNAL:
+            break;
+    }
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+
+    gl.disable(GL_SCISSOR_TEST);
+    glBlitFramebuffer(
+            srcOrigin.x, srcOrigin.y, srcOrigin.x + size.x, srcOrigin.y + size.y,
+            dstOrigin.x, dstOrigin.y, dstOrigin.x + size.x, dstOrigin.y + size.y,
+            mask, GL_NEAREST);
+    CHECK_GL_ERROR(utils::slog.e)
+
+    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glDeleteFramebuffers(2, fbo);
+
+    if (any(d->usage & TextureUsage::SAMPLEABLE)) {
+        // In a sense, blitting to a texture level is similar to calling setTextureData on it; in
+        // both cases, we update the base/max LOD to give shaders access to levels as they become
+        // available.  Note that this can only expand the LOD range (never shrink it), and that
+        // users can override this range by calling setMinMaxLevels().
+        updateTextureLodRange(d, int8_t(dstLevel));
+    }
+
+#endif
+}
+
+void OpenGLDriver::blitDEPRECATED(TargetBufferFlags buffers,
+        Handle<HwRenderTarget> dst, Viewport dstRect,
+        Handle<HwRenderTarget> src, Viewport srcRect,
+        SamplerMagFilter filter) {
+
+    // Note: blitDEPRECATED is only used by Renderer::copyFrame
+
+    DEBUG_MARKER()
+    UTILS_UNUSED_IN_RELEASE auto& gl = mContext;
+    assert_invariant(!gl.isES2());
+
+    ASSERT_PRECONDITION(buffers == TargetBufferFlags::COLOR0,
+            "blitDEPRECATED only supports COLOR0");
+
+    ASSERT_PRECONDITION(srcRect.left >= 0 && srcRect.bottom >= 0 &&
+                        dstRect.left >= 0 && dstRect.bottom >= 0,
+            "Source and destination rects must be positive.");
+
+#ifndef FILAMENT_SILENCE_NOT_SUPPORTED_BY_ES2
+
+    GLenum const glFilterMode = (filter == SamplerMagFilter::NEAREST) ? GL_NEAREST : GL_LINEAR;
+
+    // note: for msaa RenderTargets with non-msaa attachments, we copy from the msaa sidecar
+    // buffer -- this should produce the same output that if we copied from the resolved
+    // texture. EXT_multisampled_render_to_texture seems to allow both behaviours, and this
+    // is an emulation of that.  We cannot use the resolved texture easily because it's not
+    // actually attached to the RenderTarget. Another implementation would be to do a
+    // reverse-resolve, but that wouldn't buy us anything.
+    GLRenderTarget const* s = handle_cast<GLRenderTarget const*>(src);
+    GLRenderTarget const* d = handle_cast<GLRenderTarget const*>(dst);
+
+    // With GLES 3.x, GL_INVALID_OPERATION is generated if the value of GL_SAMPLE_BUFFERS
+    // for the draw buffer is greater than zero. This works with OpenGL, so we want to
+    // make sure to catch this scenario.
+    assert_invariant(d->gl.samples <= 1);
+
+    // GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater
+    // than zero and the formats of draw and read buffers are not identical.
+    // However, it's not well-defined in the spec what "format" means. So it's difficult
+    // to have an assert here -- especially when dealing with the default framebuffer
+
+    // GL_INVALID_OPERATION is generated if GL_SAMPLE_BUFFERS for the read buffer is greater
+    // than zero and (...) the source and destination rectangles are not defined with the
+    // same (X0, Y0) and (X1, Y1) bounds.
+
+    // Additionally, the EXT_multisampled_render_to_texture extension doesn't specify what
+    // happens when blitting from an "implicit" resolve render target (does it work?), so
+    // to ere on the safe side, we don't allow it.
+    if (s->gl.samples > 1) {
+        assert_invariant(!memcmp(&dstRect, &srcRect, sizeof(srcRect)));
+    }
+
+    gl.bindFramebuffer(GL_READ_FRAMEBUFFER, s->gl.fbo);
+    gl.bindFramebuffer(GL_DRAW_FRAMEBUFFER, d->gl.fbo);
+
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+
+    gl.disable(GL_SCISSOR_TEST);
+    glBlitFramebuffer(
+            srcRect.left, srcRect.bottom, srcRect.right(), srcRect.top(),
+            dstRect.left, dstRect.bottom, dstRect.right(), dstRect.top(),
+            GL_COLOR_BUFFER_BIT, glFilterMode);
+    CHECK_GL_ERROR(utils::slog.e)
 #endif
 }
 

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -293,20 +293,6 @@ io::ostream& operator<<(io::ostream& out, TextureFormat format) {
     return out;
 }
 
-io::ostream& operator<<(io::ostream& out, TextureUsage usage) {
-    switch (usage) {
-        CASE(TextureUsage, NONE)
-        CASE(TextureUsage, DEFAULT)
-        CASE(TextureUsage, COLOR_ATTACHMENT)
-        CASE(TextureUsage, DEPTH_ATTACHMENT)
-        CASE(TextureUsage, STENCIL_ATTACHMENT)
-        CASE(TextureUsage, UPLOADABLE)
-        CASE(TextureUsage, SAMPLEABLE)
-        CASE(TextureUsage, SUBPASS_INPUT)
-    }
-    return out;
-}
-
 io::ostream& operator<<(io::ostream& out, TextureCubemapFace face) {
     switch (face) {
         CASE(TextureCubemapFace, NEGATIVE_X)

--- a/filament/backend/src/vulkan/VulkanBlitter.h
+++ b/filament/backend/src/vulkan/VulkanBlitter.h
@@ -38,25 +38,18 @@ public:
     void initialize(VkPhysicalDevice physicalDevice, VkDevice device, VmaAllocator allocator,
             VulkanCommands* commands, VulkanTexture* emptyTexture) noexcept;
 
-    struct BlitArgs {
-        const VulkanRenderTarget* dstTarget;
-        const VkOffset3D* dstRectPair;
-        const VulkanRenderTarget* srcTarget;
-        const VkOffset3D* srcRectPair;
-        VkFilter filter = VK_FILTER_NEAREST;
-        int targetIndex = 0;
-    };
+    void blit(VkFilter filter,
+            VulkanAttachment dst, const VkOffset3D* dstRectPair,
+            VulkanAttachment src, const VkOffset3D* srcRectPair);
 
-    void blitColor(BlitArgs args);
-    void blitDepth(BlitArgs args);
+    void resolve(VulkanAttachment dst, VulkanAttachment src);
 
     void terminate() noexcept;
 
 private:
     void lazyInit() noexcept;
 
-    void blitSlowDepth(VkFilter filter, const VkExtent2D srcExtent, VulkanAttachment src,
-            VulkanAttachment dst, const VkOffset3D srcRect[2], const VkOffset3D dstRect[2]);
+    void resolveSlowDepth(VulkanAttachment src, VulkanAttachment dst);
 
     VulkanBuffer* mTriangleBuffer = nullptr;
     VulkanBuffer* mParamsBuffer = nullptr;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -953,10 +953,43 @@ void VulkanDriver::setExternalImagePlane(Handle<HwTexture> th, void* image, uint
 void VulkanDriver::setExternalStream(Handle<HwTexture> th, Handle<HwStream> sh) {
 }
 
-void VulkanDriver::generateMipmaps(Handle<HwTexture> th) { }
+void VulkanDriver::generateMipmaps(Handle<HwTexture> th) {
+    auto* const t = mResourceAllocator.handle_cast<VulkanTexture*>(th);
+    assert_invariant(t);
 
-bool VulkanDriver::canGenerateMipmaps() {
-    return false;
+    int32_t layerCount = int32_t(t->depth);
+    if (t->target == SamplerType::SAMPLER_CUBEMAP_ARRAY ||
+        t->target == SamplerType::SAMPLER_CUBEMAP) {
+        layerCount *= 6;
+    }
+
+    // FIXME: the loop below can perform many layout transitions and back. We should be
+    //        able to optimize that.
+
+    uint8_t level = 0;
+    int32_t srcw = int32_t(t->width);
+    int32_t srch = int32_t(t->height);
+    do {
+        int32_t const dstw = std::max(srcw >> 1, 1);
+        int32_t const dsth = std::max(srch >> 1, 1);
+        const VkOffset3D srcOffsets[2] = {{ 0, 0, 0 }, { srcw, srch, 1 }};
+        const VkOffset3D dstOffsets[2] = {{ 0, 0, 0 }, { dstw, dsth, 1 }};
+
+        // TODO: there should be a way to do this using layerCount in vkBlitImage
+        // TODO: vkBlitImage should be able to handle 3D textures too
+        for (int32_t layer = 0; layer < layerCount; layer++) {
+            mBlitter.blit(VK_FILTER_LINEAR,
+                    { .texture = t, .level = uint8_t(level + 1), .layer = (uint16_t)layer },
+                    dstOffsets,
+                    { .texture = t, .level = uint8_t(level    ), .layer = (uint16_t)layer },
+                    srcOffsets);
+        }
+
+        level++;
+        srcw = dstw;
+        srch = dsth;
+    } while ((srcw > 1 || srch > 1) && level < t->levels);
+    t->setPrimaryRange(0, t->levels - 1);
 }
 
 void VulkanDriver::updateSamplerGroup(Handle<HwSamplerGroup> sbh,
@@ -1437,50 +1470,132 @@ void VulkanDriver::readBufferSubData(backend::BufferObjectHandle boh,
     scheduleDestroy(std::move(p));
 }
 
-void VulkanDriver::blit(TargetBufferFlags buffers, Handle<HwRenderTarget> dst, Viewport dstRect,
-        Handle<HwRenderTarget> src, Viewport srcRect, SamplerMagFilter filter) {
+void VulkanDriver::resolve(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer) {
+    FVK_SYSTRACE_CONTEXT();
+    FVK_SYSTRACE_START("resolve");
+
+    ASSERT_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE,
+            "resolve() cannot be invoked inside a render pass.");
+
+    auto* const srcTexture = mResourceAllocator.handle_cast<VulkanTexture*>(src);
+    auto* const dstTexture = mResourceAllocator.handle_cast<VulkanTexture*>(dst);
+    assert_invariant(srcTexture);
+    assert_invariant(dstTexture);
+
+    ASSERT_PRECONDITION(
+            dstTexture->width == srcTexture->width && dstTexture->height == srcTexture->height,
+            "invalid resolve: src and dst sizes don't match");
+
+    ASSERT_PRECONDITION(srcTexture->samples > 1 && dstTexture->samples == 1,
+            "invalid resolve: src.samples=%u, dst.samples=%u",
+            +srcTexture->samples, +dstTexture->samples);
+
+    ASSERT_PRECONDITION(srcTexture->format == dstTexture->format,
+            "src and dst texture format don't match");
+
+    ASSERT_PRECONDITION(any(dstTexture->usage & TextureUsage::BLIT_DST),
+            "texture doesn't have BLIT_DST");
+
+    ASSERT_PRECONDITION(any(srcTexture->usage & TextureUsage::BLIT_SRC),
+            "texture doesn't have BLIT_SRC");
+
+    mBlitter.resolve(
+            { .texture = dstTexture, .level = dstLevel, .layer = dstLayer },
+            { .texture = srcTexture, .level = srcLevel, .layer = srcLayer });
+
+    FVK_SYSTRACE_END();
+}
+
+void VulkanDriver::blit(
+        Handle<HwTexture> dst, uint8_t srcLevel, uint8_t srcLayer, math::uint2 dstOrigin,
+        Handle<HwTexture> src, uint8_t dstLevel, uint8_t dstLayer, math::uint2 srcOrigin,
+        math::uint2 size) {
     FVK_SYSTRACE_CONTEXT();
     FVK_SYSTRACE_START("blit");
 
-    assert_invariant(mCurrentRenderPass.renderPass == VK_NULL_HANDLE);
+    ASSERT_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE,
+            "blit() cannot be invoked inside a render pass.");
 
-    // blit operation only support COLOR0 color buffer
-    assert_invariant(
-            !(buffers & (TargetBufferFlags::COLOR_ALL & ~TargetBufferFlags::COLOR0)));
+    auto* const srcTexture = mResourceAllocator.handle_cast<VulkanTexture*>(src);
+    auto* const dstTexture = mResourceAllocator.handle_cast<VulkanTexture*>(dst);
 
-    if (UTILS_UNLIKELY(mCurrentRenderPass.renderPass)) {
-        utils::slog.e << "Blits cannot be invoked inside a render pass." << utils::io::endl;
-        return;
-    }
+    ASSERT_PRECONDITION(any(dstTexture->usage & TextureUsage::BLIT_DST),
+            "texture doesn't have BLIT_DST");
+
+    ASSERT_PRECONDITION(any(srcTexture->usage & TextureUsage::BLIT_SRC),
+            "texture doesn't have BLIT_SRC");
+
+    ASSERT_PRECONDITION(srcTexture->format == dstTexture->format,
+            "src and dst texture format don't match");
+
+    // The Y inversion below makes it so that Vk matches GL and Metal.
+
+    auto const srcLeft   = int32_t(srcOrigin.x);
+    auto const dstLeft   = int32_t(dstOrigin.x);
+    auto const srcTop    = int32_t(srcTexture->height - (srcOrigin.y + size.y));
+    auto const dstTop    = int32_t(dstTexture->height - (dstOrigin.y + size.y));
+    auto const srcRight  = int32_t(srcOrigin.x + size.x);
+    auto const dstRight  = int32_t(dstOrigin.x + size.x);
+    auto const srcBottom = int32_t(srcTop + size.y);
+    auto const dstBottom = int32_t(dstTop + size.y);
+    VkOffset3D const srcOffsets[2] = { { srcLeft, srcTop, 0 }, { srcRight, srcBottom, 1 }};
+    VkOffset3D const dstOffsets[2] = { { dstLeft, dstTop, 0 }, { dstRight, dstBottom, 1 }};
+
+    // no scallng guaranteed
+    mBlitter.blit(VK_FILTER_NEAREST,
+            { .texture = dstTexture, .level = dstLevel, .layer = dstLayer }, dstOffsets,
+            { .texture = srcTexture, .level = srcLevel, .layer = srcLayer }, srcOffsets);
+
+    FVK_SYSTRACE_END();
+}
+
+void VulkanDriver::blitDEPRECATED(TargetBufferFlags buffers,
+        Handle<HwRenderTarget> dst, Viewport dstRect,
+        Handle<HwRenderTarget> src, Viewport srcRect,
+        SamplerMagFilter filter) {
+    FVK_SYSTRACE_CONTEXT();
+    FVK_SYSTRACE_START("blitDEPRECATED");
+
+    // Note: blitDEPRECATED is only used for Renderer::copyFrame()
+
+    ASSERT_PRECONDITION(mCurrentRenderPass.renderPass == VK_NULL_HANDLE,
+            "blitDEPRECATED() cannot be invoked inside a render pass.");
+
+    ASSERT_PRECONDITION(buffers == TargetBufferFlags::COLOR0,
+            "blitDEPRECATED only supports COLOR0");
+
+    ASSERT_PRECONDITION(srcRect.left >= 0 && srcRect.bottom >= 0 &&
+                        dstRect.left >= 0 && dstRect.bottom >= 0,
+            "Source and destination rects must be positive.");
 
     VulkanRenderTarget* dstTarget = mResourceAllocator.handle_cast<VulkanRenderTarget*>(dst);
     VulkanRenderTarget* srcTarget = mResourceAllocator.handle_cast<VulkanRenderTarget*>(src);
 
-    VkFilter vkfilter = filter == SamplerMagFilter::NEAREST ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
+    VkFilter const vkfilter = (filter == SamplerMagFilter::NEAREST) ?
+            VK_FILTER_NEAREST : VK_FILTER_LINEAR;
 
     // The Y inversion below makes it so that Vk matches GL and Metal.
 
-    const VkExtent2D srcExtent = srcTarget->getExtent();
-    const int32_t srcLeft = srcRect.left;
-    const int32_t srcTop = srcExtent.height - srcRect.bottom - srcRect.height;
-    const int32_t srcRight = srcRect.left + srcRect.width;
-    const int32_t srcBottom = srcTop + srcRect.height;
-    const VkOffset3D srcOffsets[2] = { { srcLeft, srcTop, 0 }, { srcRight, srcBottom, 1 }};
+    VkExtent2D const srcExtent = srcTarget->getExtent();
+    VkExtent2D const dstExtent = dstTarget->getExtent();
 
-    const VkExtent2D dstExtent = dstTarget->getExtent();
-    const int32_t dstLeft = dstRect.left;
-    const int32_t dstTop = dstExtent.height - dstRect.bottom - dstRect.height;
-    const int32_t dstRight = dstRect.left + dstRect.width;
-    const int32_t dstBottom = dstTop + dstRect.height;
-    const VkOffset3D dstOffsets[2] = { { dstLeft, dstTop, 0 }, { dstRight, dstBottom, 1 }};
+    auto const dstLeft   = int32_t(dstRect.left);
+    auto const srcLeft   = int32_t(srcRect.left);
+    auto const dstTop    = int32_t(dstExtent.height - (dstRect.bottom + dstRect.height));
+    auto const srcTop    = int32_t(srcExtent.height - (srcRect.bottom + srcRect.height));
+    auto const dstRight  = int32_t(dstRect.left + dstRect.width);
+    auto const srcRight  = int32_t(srcRect.left + srcRect.width);
+    auto const dstBottom = int32_t(dstTop + dstRect.height);
+    auto const srcBottom = int32_t(srcTop + srcRect.height);
+    VkOffset3D const srcOffsets[2] = { { srcLeft, srcTop, 0 }, { srcRight, srcBottom, 1 }};
+    VkOffset3D const dstOffsets[2] = { { dstLeft, dstTop, 0 }, { dstRight, dstBottom, 1 }};
 
-    if (any(buffers & TargetBufferFlags::DEPTH) && srcTarget->hasDepth() && dstTarget->hasDepth()) {
-        mBlitter.blitDepth({dstTarget, dstOffsets, srcTarget, srcOffsets});
-    }
+    mBlitter.blit(vkfilter,
+            dstTarget->getColor(0), dstOffsets,
+            srcTarget->getColor(0), srcOffsets);
 
-    if (any(buffers & TargetBufferFlags::COLOR0)) {
-        mBlitter.blitColor({ dstTarget, dstOffsets, srcTarget, srcOffsets, vkfilter, int(0) });
-    }
     FVK_SYSTRACE_END();
 }
 

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -450,12 +450,13 @@ public:
 
     /**
      * Generates all the mipmap levels automatically. This requires the texture to have a
-     * color-renderable format.
+     * color-renderable format and usage set to BLIT_SRC | BLIT_DST. If unspecified,
+     * usage bits are set automatically.
      *
      * @param engine        Engine this texture is associated to.
      *
      * @attention \p engine must be the instance passed to Builder::build()
-     * @attention This Texture instance must NOT use Sampler::SAMPLER_CUBEMAP or it has no effect
+     * @attention This Texture instance must NOT use SamplerType::SAMPLER_3D or it has no effect
      */
     void generateMipmaps(Engine& engine) const noexcept;
 

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -221,32 +221,30 @@ public:
             TemporalAntiAliasingOptions const& taaOptions,
             ColorGradingConfig const& colorGradingConfig) noexcept;
 
-    // Blit/rescaling/resolves
-    FrameGraphId<FrameGraphTexture> opaqueBlit(FrameGraph& fg,
-            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
-            FrameGraphTexture::Descriptor const& outDesc,
-            backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
+    /*
+     * Blit/rescaling/resolves
+     */
 
+    // high quality upscaler
+    //  - when translucent, reverts to LINEAR
+    //  - doens't handle sub-resouces
     FrameGraphId<FrameGraphTexture> upscale(FrameGraph& fg, bool translucent,
             DynamicResolutionOptions dsrOptions, FrameGraphId<FrameGraphTexture> input,
             filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
-            backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
+            backend::SamplerMagFilter filter) noexcept;
 
+    // upscale/downscale blitter using shaders
     FrameGraphId<FrameGraphTexture> blit(FrameGraph& fg, bool translucent,
-            FrameGraphId<FrameGraphTexture> input, filament::Viewport const& vp,
-            FrameGraphTexture::Descriptor const& outDesc,
-            backend::SamplerMagFilter filter = backend::SamplerMagFilter::LINEAR) noexcept;
+            FrameGraphId<FrameGraphTexture> input,
+            filament::Viewport const& vp, FrameGraphTexture::Descriptor const& outDesc,
+            backend::SamplerMagFilter filterMag,
+            backend::SamplerMinFilter filterMin) noexcept;
 
-    // resolve base level of input and outputs a 1-level texture
-    FrameGraphId<FrameGraphTexture> resolveBaseLevel(FrameGraph& fg,
-            const char* outputBufferName, FrameGraphId<FrameGraphTexture> input) noexcept;
-
-    // resolves base level of input and outputs a texture from outDesc. outDesc must
-    // have the same dimensions and format as input, or this will fail.
-    // outDesc can have mipmaps.
-    FrameGraphId<FrameGraphTexture> resolveBaseLevelNoCheck(FrameGraph& fg,
+    // Resolves base level of input and outputs a texture from outDesc.
+    // outDesc with, height, format and samples will be overridden.
+    FrameGraphId<FrameGraphTexture> resolve(FrameGraph& fg,
             const char* outputBufferName, FrameGraphId<FrameGraphTexture> input,
-            FrameGraphTexture::Descriptor const& outDesc) noexcept;
+            FrameGraphTexture::Descriptor outDesc) noexcept;
 
     // VSM shadow mipmap pass
     FrameGraphId<FrameGraphTexture> vsmMipmapPass(FrameGraph& fg,

--- a/filament/src/fg/FrameGraph.cpp
+++ b/filament/src/fg/FrameGraph.cpp
@@ -204,7 +204,7 @@ void FrameGraph::execute(backend::DriverApi& driver) noexcept {
         }
 
         // call execute
-        FrameGraphResources resources(*this, *node);
+        FrameGraphResources const resources(*this, *node);
         node->execute(resources, driver);
 
         // destroy concrete resources

--- a/web/filament-js/jsenums.cpp
+++ b/web/filament-js/jsenums.cpp
@@ -274,6 +274,8 @@ enum_<Texture::Usage>("Texture$Usage") // aka backend::TextureUsage
     .value("STENCIL_ATTACHMENT", Texture::Usage::STENCIL_ATTACHMENT)
     .value("UPLOADABLE", Texture::Usage::UPLOADABLE)
     .value("SAMPLEABLE", Texture::Usage::SAMPLEABLE)
+    .value("BLIT_SRC", Texture::Usage::BLIT_SRC)
+    .value("BLIT_DST", Texture::Usage::BLIT_DST)
     .value("SUBPASS_INPUT", Texture::Usage::SUBPASS_INPUT);
 
 enum_<Texture::CubemapFace>("Texture$CubemapFace") // aka backend::TextureCubemapFace


### PR DESCRIPTION
- deprecate blit(), renamed to blitDEPRECATED. It's only used in one
  place in copyFrame() now. We can't void it because we don't have
  access to the texture from the RenderTarget.

- add a new blit() api that works with textures instead of render 
  targets.

- add a new resolve() api that works with textures instead of render 
  targets. doesn't support scaling.

- always use a shader when scaling in the framegraph
  (there was only one place where we used blit)

- use the new blit() for:
	- for mipmap generation on vk (fixme)
	- copying the depth buffer to avoid ssao feedback loop

- use the new resolve() for:
    - manually resolving MSAA color/depth
