### PR TITLE
bugfix: fix the invalid pointer cast.

### DIFF
--- a/filament/backend/include/backend/BufferDescriptor.h
+++ b/filament/backend/include/backend/BufferDescriptor.h
@@ -126,7 +126,7 @@ public:
         return {
                 buffer, size,
                 handler, [](void* b, size_t s, void* u) {
-                    (*static_cast<T**>(u)->*method)(b, s);
+                    (static_cast<T*>(u)->*method)(b, s);
                 }, data
         };
     }


### PR DESCRIPTION
According to my understanding, The BufferDescriptor::make func 's parameter T* should be a pointer to T, not a pointer to a 
 T pointer. So the static_cast in the lambda should cast to T*.  This error can lead to memory errors that are difficult to troubleshoot.