### PR TITLE
don't precompile variants in gltfio

### DIFF
--- a/libs/gltfio/src/ArchiveCache.cpp
+++ b/libs/gltfio/src/ArchiveCache.cpp
@@ -118,21 +118,6 @@ Material* ArchiveCache::getMaterial(const ArchiveRequirements& reqs) {
                 mMaterials[i] = Material::Builder()
                     .package(spec.package, spec.packageByteCount)
                     .build(mEngine);
-
-                // Don't attempt to precompile shaders on WebGL.
-                // Chrome already suffers from slow shader compilation:
-                // https://github.com/google/filament/issues/6615
-                // Precompiling shaders exacerbates the problem.
-    #if !defined(__EMSCRIPTEN__)
-                // First compile high priority variants
-                mMaterials[i]->compile(Material::CompilerPriorityQueue::HIGH,
-                        UserVariantFilterBit::DIRECTIONAL_LIGHTING |
-                        UserVariantFilterBit::DYNAMIC_LIGHTING |
-                        UserVariantFilterBit::SHADOW_RECEIVER);
-
-                // and then, everything else at low priority
-                mMaterials[i]->compile(Material::CompilerPriorityQueue::LOW);
-    #endif
             }
 
             return mMaterials[i];


### PR DESCRIPTION
we recently added calls to Material::compile in gltfio to precompile materials are they are discovered. that wasn't a good call, because  this should be the responsibility of the app, not of gltfio, at least not without an option.

This is now done in gltf_viewer. We need something similar for  Android.

Bugs #7318, #7336