### PR TITLE
Move stereoscopic debug options to Settings framework

### DIFF
--- a/android/filament-android/src/main/cpp/Engine.cpp
+++ b/android/filament-android/src/main/cpp/Engine.cpp
@@ -428,6 +428,13 @@ Java_com_google_android_filament_Engine_nIsAutomaticInstancingEnabled(JNIEnv*, j
     return (jboolean)engine->isAutomaticInstancingEnabled();
 }
 
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_google_android_filament_Engine_nGetMaxStereoscopicEyes(JNIEnv*, jclass, jlong nativeEngine) {
+    Engine* engine = (Engine*) nativeEngine;
+    return (jlong) engine->getMaxStereoscopicEyes();
+}
+
+
 extern "C" JNIEXPORT jint JNICALL
 Java_com_google_android_filament_Engine_nGetSupportedFeatureLevel(JNIEnv *, jclass,
         jlong nativeEngine) {
@@ -470,7 +477,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
 extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBuilderConfig(JNIEnv*,
         jclass, jlong nativeBuilder, jlong commandBufferSizeMB, jlong perRenderPassArenaSizeMB,
         jlong driverHandleArenaSizeMB, jlong minCommandBufferSizeMB, jlong perFrameCommandsSizeMB,
-        jlong jobSystemThreadCount) {
+        jlong jobSystemThreadCount, jlong stereoscopicEyeCount) {
     Engine::Builder* builder = (Engine::Builder*) nativeBuilder;
     Engine::Config config = {
             .commandBufferSizeMB = (uint32_t) commandBufferSizeMB,
@@ -479,6 +486,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_google_android_filament_Engine_nSetBu
             .minCommandBufferSizeMB = (uint32_t) minCommandBufferSizeMB,
             .perFrameCommandsSizeMB = (uint32_t) perFrameCommandsSizeMB,
             .jobSystemThreadCount = (uint32_t) jobSystemThreadCount,
+            .stereoscopicEyeCount = (uint8_t) stereoscopicEyeCount,
     };
     builder->config(&config);
 }

--- a/android/filament-android/src/main/cpp/View.cpp
+++ b/android/filament-android/src/main/cpp/View.cpp
@@ -468,6 +468,17 @@ Java_com_google_android_filament_View_nIsStencilBufferEnabled(JNIEnv *, jclass, 
 
 extern "C"
 JNIEXPORT void JNICALL
+Java_com_google_android_filament_View_nSetStereoscopicOptions(JNIEnv *, jclass, jlong nativeView,
+        jboolean enabled) {
+    View* view = (View*) nativeView;
+    View::StereoscopicOptions options {
+        .enabled = (bool) enabled
+    };
+    view->setStereoscopicOptions(options);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
 Java_com_google_android_filament_View_nSetGuardBandOptions(JNIEnv *, jclass,
         jlong nativeView, jboolean enabled) {
     View* view = (View*) nativeView;

--- a/android/filament-android/src/main/java/com/google/android/filament/View.java
+++ b/android/filament-android/src/main/java/com/google/android/filament/View.java
@@ -75,6 +75,7 @@ public class View {
     private AmbientOcclusionOptions mAmbientOcclusionOptions;
     private BloomOptions mBloomOptions;
     private FogOptions mFogOptions;
+    private StereoscopicOptions mStereoscopicOptions;
     private RenderTarget mRenderTarget;
     private BlendMode mBlendMode;
     private DepthOfFieldOptions mDepthOfFieldOptions;
@@ -1030,6 +1031,51 @@ public class View {
     }
 
     /**
+     * Sets the stereoscopic rendering options for this view.
+     *
+     * <p>
+     * Currently, only one type of stereoscopic rendering is supported: side-by-side.
+     * Side-by-side stereo rendering splits the viewport into two halves: a left and right half.
+     * Eye 0 will render to the left half, while Eye 1 will render into the right half.
+     * </p>
+     *
+     * <p>
+     * Currently, the following features are not supported with stereoscopic rendering:
+     * - post-processing
+     * - shadowing
+     * - punctual lights
+     * </p>
+     *
+     * <p>
+     * Stereo rendering depends on device and platform support. To check if stereo rendering is
+     * supported, use {@link Engine#isStereoSupported()}. If stereo rendering is not supported, then
+     * the stereoscopic options have no effect.
+     * </p>
+     *
+     * @param options The stereoscopic options to use on this view
+     * @see #getStereoscopicOptions
+     */
+    public void setStereoscopicOptions(@NonNull StereoscopicOptions options) {
+        mStereoscopicOptions = options;
+        nSetStereoscopicOptions(getNativeObject(), options.enabled);
+    }
+
+    /**
+     * Gets the stereoscopic options.
+     *
+     * @return options Stereoscopic options currently set.
+     * @see #setStereoscopicOptions
+     */
+    @NonNull
+    public StereoscopicOptions getStereoscoopicOptions() {
+        if (mStereoscopicOptions == null) {
+            mStereoscopicOptions = new StereoscopicOptions();
+        }
+        return mStereoscopicOptions;
+    }
+
+
+    /**
      * A class containing the result of a picking query
      */
     public static class PickingQueryResult {
@@ -1192,6 +1238,7 @@ public class View {
     private static native void nSetBloomOptions(long nativeView, long dirtNativeObject, float dirtStrength, float strength, int resolution, int levels, int blendMode, boolean threshold, boolean enabled, float highlight,
             boolean lensFlare, boolean starburst, float chromaticAberration, int ghostCount, float ghostSpacing, float ghostThreshold, float haloThickness, float haloRadius, float haloThreshold);
     private static native void nSetFogOptions(long nativeView, float distance, float maximumOpacity, float height, float heightFalloff, float cutOffDistance, float v, float v1, float v2, float density, float inScatteringStart, float inScatteringSize, boolean fogColorFromIbl, long skyColorNativeObject, boolean enabled);
+    private static native void nSetStereoscopicOptions(long nativeView, boolean enabled);
     private static native void nSetBlendMode(long nativeView, int blendMode);
     private static native void nSetDepthOfFieldOptions(long nativeView, float cocScale, float maxApertureDiameter, boolean enabled, int filter,
             boolean nativeResolution, int foregroundRingCount, int backgroundRingCount, int fastGatherRingCount, int maxForegroundCOC, int maxBackgroundCOC);

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -564,6 +564,19 @@ public:
     bool isStereoSupported() const noexcept;
 
     /**
+     * Retrieves the configuration settings of this Engine.
+     *
+     * This method returns the configuration object that was supplied to the Engine's
+     * Builder::config method during the creation of this Engine. If the Builder::config method was
+     * not explicitly called (or called with nullptr), this method returns the default configuration
+     * settings.
+     *
+     * @return a Config object with this Engine's configuration
+     * @see Builder::config
+     */
+    const Config& getConfig() const noexcept;
+
+    /**
      * Returns the maximum number of stereoscopic eyes supported by Filament. The actual number of
      * eyes rendered is set at Engine creation time with the Engine::Config::stereoscopicEyeCount
      * setting.

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -294,9 +294,10 @@ public:
 
         /*
          * The number of eyes to render when stereoscopic rendering is enabled. Supported values are
-         * between 1 and CONFIG_MAX_STEREOSCOPIC_EYES (inclusive).
+         * between 1 and Engine::getMaxStereoscopicEyes() (inclusive).
          *
          * @see View::setStereoscopicOptions
+         * @see Engine::getMaxStereoscopicEyes
          */
         uint8_t stereoscopicEyeCount = 2;
     };
@@ -561,6 +562,16 @@ public:
      * @see View::setStereoscopicOptions
      */
     bool isStereoSupported() const noexcept;
+
+    /**
+     * Returns the maximum number of stereoscopic eyes supported by Filament. The actual number of
+     * eyes rendered is set at Engine creation time with the Engine::Config::stereoscopicEyeCount
+     * setting.
+     *
+     * @return the max number of stereoscopic eyes supported
+     * @see Engine::Config::stereoscopicEyeCount
+     */
+    static size_t getMaxStereoscopicEyes() noexcept;
 
     /**
      * @return EntityManager used by filament

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -670,11 +670,12 @@ public:
      * - punctual lights
      *
      * Stereo rendering depends on device and platform support. To check if stereo rendering is
-     * supported, use Engine::isStereoSupported().
+     * supported, use Engine::isStereoSupported(). If stereo rendering is not supported, then the
+     * stereoscopic options have no effect.
      *
      * @param options The stereoscopic options to use on this view
      */
-    void setStereoscopicOptions(StereoscopicOptions const& options);
+    void setStereoscopicOptions(StereoscopicOptions const& options) noexcept;
 
     /**
      * Returns the stereoscopic options associated with this View.

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -327,6 +327,10 @@ size_t Engine::getMaxAutomaticInstances() const noexcept {
     return downcast(this)->getMaxAutomaticInstances();
 }
 
+const Engine::Config& Engine::getConfig() const noexcept {
+    return downcast(this)->getConfig();
+}
+
 bool Engine::isStereoSupported() const noexcept {
     return downcast(this)->isStereoSupported();
 }

--- a/filament/src/Engine.cpp
+++ b/filament/src/Engine.cpp
@@ -331,6 +331,10 @@ bool Engine::isStereoSupported() const noexcept {
     return downcast(this)->isStereoSupported();
 }
 
+size_t Engine::getMaxStereoscopicEyes() noexcept {
+    return FEngine::getMaxStereoscopicEyes();
+}
+
 #if defined(__EMSCRIPTEN__)
 void Engine::resetBackendState() noexcept {
     downcast(this)->resetBackendState();

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -275,7 +275,7 @@ bool View::isStencilBufferEnabled() const noexcept {
     return downcast(this)->isStencilBufferEnabled();
 }
 
-void View::setStereoscopicOptions(const StereoscopicOptions& options) {
+void View::setStereoscopicOptions(const StereoscopicOptions& options) noexcept {
     return downcast(this)->setStereoscopicOptions(options);
 }
 

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -184,6 +184,10 @@ public:
 
     bool isStereoSupported() const noexcept { return getDriver().isStereoSupported(); }
 
+    static size_t getMaxStereoscopicEyes() noexcept {
+        return CONFIG_MAX_STEREOSCOPIC_EYES;
+    }
+
     PostProcessManager const& getPostProcessManager() const noexcept {
         return mPostProcessManager;
     }

--- a/filament/src/details/View.cpp
+++ b/filament/src/details/View.cpp
@@ -1126,9 +1126,7 @@ View::PickingQuery& FView::pick(uint32_t x, uint32_t y, backend::CallbackHandler
     return *pQuery;
 }
 
-void FView::setStereoscopicOptions(const StereoscopicOptions& options) {
-    ASSERT_PRECONDITION(!options.enabled || mIsStereoSupported,
-            "Stereo rendering is not supported.");
+void FView::setStereoscopicOptions(const StereoscopicOptions& options) noexcept {
     mStereoscopicOptions = options;
 }
 

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -164,7 +164,9 @@ public:
     bool hasDPCF() const noexcept { return mShadowType == ShadowType::DPCF; }
     bool hasPCSS() const noexcept { return mShadowType == ShadowType::PCSS; }
     bool hasPicking() const noexcept { return mActivePickingQueriesList != nullptr; }
-    bool hasInstancedStereo() const noexcept { return mStereoscopicOptions.enabled; }
+    bool hasInstancedStereo() const noexcept {
+        return mIsStereoSupported && mStereoscopicOptions.enabled;
+    }
 
     FrameGraphId<FrameGraphTexture> renderShadowMaps(FEngine& engine, FrameGraph& fg,
             CameraInfo const& cameraInfo, math::float4 const& userTime,
@@ -188,7 +190,7 @@ public:
 
     bool isStencilBufferEnabled() const noexcept { return mStencilBufferEnabled; }
 
-    void setStereoscopicOptions(StereoscopicOptions const& options);
+    void setStereoscopicOptions(StereoscopicOptions const& options) noexcept;
 
     FCamera const* getDirectionalLightCamera() const noexcept {
         return mShadowMapManager.getDirectionalLightCamera();

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -77,6 +77,7 @@ using TemporalAntiAliasingOptions = filament::View::TemporalAntiAliasingOptions;
 using VignetteOptions = filament::View::VignetteOptions;
 using VsmShadowOptions = filament::View::VsmShadowOptions;
 using GuardBandOptions = filament::View::GuardBandOptions;
+using StereoscopicOptions = filament::View::StereoscopicOptions;
 using LightManager = filament::LightManager;
 
 // These functions push all editable property values to their respective Filament objects.
@@ -192,6 +193,7 @@ struct ViewSettings {
     VignetteOptions vignette;
     VsmShadowOptions vsmShadowOptions;
     GuardBandOptions guardBand;
+    StereoscopicOptions stereoscopicOptions;
 
     // Custom View Options
     ColorGradingSettings colorGrading;
@@ -231,6 +233,7 @@ struct ViewerOptions {
     float cameraISO = 100.0f;
     float cameraNear = 0.1f;
     float cameraFar = 100.0f;
+    float cameraEyeOcularDistance = 0.0f;
     float groundShadowStrength = 0.75f;
     bool groundPlaneEnabled = false;
     bool skyboxEnabled = true;

--- a/libs/viewer/include/viewer/ViewerGui.h
+++ b/libs/viewer/include/viewer/ViewerGui.h
@@ -231,8 +231,6 @@ public:
 
     int getCurrentCamera() const { return mCurrentCamera; }
 
-    float getOcularDistance() const { return mOcularDistance; }
-
 private:
     using SceneMask = gltfio::NodeManager::SceneMask;
 
@@ -267,9 +265,6 @@ private:
     std::vector<float> mMorphWeights;
     SceneMask mVisibleScenes;
     bool mShowingRestPose = false;
-
-    // Stereoscopic debugging
-    float mOcularDistance = 0.0f;
 
     // 0 is the default "free camera". Additional cameras come from the gltf file (1-based index).
     int mCurrentCamera = 0;

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -302,6 +302,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ViewSett
             i = parse(tokens, i + 1, jsonChunk, &out->vsmShadowOptions);
         } else if (compare(tok, jsonChunk, "postProcessingEnabled") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->postProcessingEnabled);
+        } else if (compare(tok, jsonChunk, "stereoscopicOptions") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->stereoscopicOptions);
         } else {
             slog.w << "Invalid view setting key: '" << STR(tok, jsonChunk) << "'" << io::endl;
             i = parse(tokens, i + 1);
@@ -500,6 +502,8 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, ViewerOp
              i = parse(tokens, i + 1, jsonChunk, &out->cameraNear);
         } else if (compare(tok, jsonChunk, "cameraFar") == 0) {
              i = parse(tokens, i + 1, jsonChunk, &out->cameraFar);
+        } else if (compare(tok, jsonChunk, "cameraEyeOcularDistance") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->cameraEyeOcularDistance);
         } else if (compare(tok, jsonChunk, "groundShadowStrength") == 0) {
              i = parse(tokens, i + 1, jsonChunk, &out->groundShadowStrength);
         } else if (compare(tok, jsonChunk, "groundPlaneEnabled") == 0) {
@@ -572,6 +576,7 @@ void applySettings(Engine* engine, const ViewSettings& settings, View* dest) {
     dest->setShadowType(settings.shadowType);
     dest->setVsmShadowOptions(settings.vsmShadowOptions);
     dest->setGuardBandOptions(settings.guardBand);
+    dest->setStereoscopicOptions(settings.stereoscopicOptions);
     dest->setPostProcessingEnabled(settings.postProcessingEnabled);
 }
 
@@ -646,6 +651,20 @@ void applySettings(Engine* engine, const ViewerOptions& settings, Camera* camera
         camera->setFocusDistance(settings.cameraFocusDistance);
     }
     engine->setAutomaticInstancingEnabled(settings.autoInstancingEnabled);
+
+    // Eyes are rendered from left-to-right, i.e., eye 0 is rendered to the left side of the
+    // window.
+    // For testing, we want to render a side-by-side layout so users can view with
+    // "cross-eyed" stereo.
+    // For cross-eyed stereo, Eye 0 is really the RIGHT eye, while Eye 1 is the LEFT eye.
+    const auto od = settings.cameraEyeOcularDistance;
+    const auto eyeCount = engine->getConfig().stereoscopicEyeCount;
+    const mat4 rightEye = mat4::translation(double3{ od, 0.0, 0.0});    // right eye
+    const mat4 leftEye  = mat4::translation(double3{-od, 0.0, 0.0});    // left eye
+    const mat4 modelMatrices[2] = { rightEye, leftEye };
+    for (int i = 0; i < eyeCount; i++) {
+        camera->setEyeModelMatrix(i, modelMatrices[i % 2]);
+    }
 }
 
 constexpr ToneMapper* createToneMapper(const ColorGradingSettings& settings) noexcept {
@@ -857,6 +876,7 @@ static std::ostream& operator<<(std::ostream& out, const ViewerOptions& in) {
         << "\"cameraISO\": " << (in.cameraISO) << ",\n"
         << "\"cameraNear\": " << (in.cameraNear) << ",\n"
         << "\"cameraFar\": " << (in.cameraFar) << ",\n"
+        << "\"cameraEyeOcularDistance\": " << (in.cameraEyeOcularDistance) << ",\n"
         << "\"groundShadowStrength\": " << (in.groundShadowStrength) << ",\n"
         << "\"groundPlaneEnabled\": " << to_string(in.groundPlaneEnabled) << ",\n"
         << "\"skyboxEnabled\": " << to_string(in.skyboxEnabled) << ",\n"
@@ -894,6 +914,7 @@ static std::ostream& operator<<(std::ostream& out, const ViewSettings& in) {
         << "\"shadowType\": " << (in.shadowType) << ",\n"
         << "\"vsmShadowOptions\": " << (in.vsmShadowOptions) << ",\n"
         << "\"guardBand\": " << (in.guardBand) << ",\n"
+        << "\"stereoscopicOptions\": " << (in.stereoscopicOptions) << ",\n"
         << "\"postProcessingEnabled\": " << to_string(in.postProcessingEnabled) << "\n"
         << "}";
 }

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1067,13 +1067,9 @@ void ViewerGui::updateUserInterface() {
             ImGui::ListBox("Cameras", &mCurrentCamera, cstrings.data(), cstrings.size());
         }
 
-        StereoscopicOptions stereoOptions = mView->getStereoscopicOptions();
-        ImGui::Checkbox("Instanced stereo", &stereoOptions.enabled);
-        if (stereoOptions.enabled) {
-            ImGui::SliderFloat("Ocular distance", &mOcularDistance, 0.0f, 10.0f);
-
-        }
-        mView->setStereoscopicOptions(stereoOptions);
+        ImGui::Checkbox("Instanced stereo", &mSettings.view.stereoscopicOptions.enabled);
+        ImGui::SliderFloat(
+                "Ocular distance", &mSettings.viewer.cameraEyeOcularDistance, 0.0f, 1.0f);
 
         ImGui::Unindent();
     }

--- a/samples/gltf_viewer.cpp
+++ b/samples/gltf_viewer.cpp
@@ -1003,25 +1003,6 @@ int main(int argc, char** argv) {
             camera->setScaling({1.0 / aspectRatio, 1.0});
         }
 
-        if (view->getStereoscopicOptions().enabled) {
-            Camera& c = view->getCamera();
-            auto od = app.viewer->getOcularDistance();
-            // Eyes are rendered from left-to-right, i.e., eye 0 is rendered to the left side of the
-            // window.
-            // For testing, we want to render a side-by-side layout so users can view with
-            // "cross-eyed" stereo.
-            // For cross-eyed stereo, Eye 0 is really the RIGHT eye, while Eye 1 is the LEFT eye.
-            const mat4 rightEye = mat4::translation(double3{ od, 0.0, 0.0});    // right eye
-            const mat4 leftEye  = mat4::translation(double3{-od, 0.0, 0.0});    // left eye
-            const mat4 modelMatrices[4] = { rightEye, leftEye, rightEye, leftEye };
-            for (int i = 0; i < std::min(app.config.stereoscopicEyeCount, 4); i++) {
-                c.setEyeModelMatrix(i, modelMatrices[i]);
-            }
-        } else {
-            for (int i = 0; i < app.config.stereoscopicEyeCount; i++) {
-                view->getCamera().setEyeModelMatrix(i, {});
-            }
-        }
         static bool stereoscopicEnabled = false;
         if (stereoscopicEnabled != view->getStereoscopicOptions().enabled) {
             // Stereo was turned on/off.

--- a/web/filament-js/extensions.js
+++ b/web/filament-js/extensions.js
@@ -339,6 +339,12 @@ Filament.loadClassExtensions = function() {
         this._setGuardBandOptions(options);
     };
 
+    /// setStereoscopicOptions ::method::
+    Filament.View.prototype.setStereoscopicOptions = function(overrides) {
+        const options = this.setStereoscopicOptionsDefaults(overrides);
+        this._setStereoscopicOptions(options);
+    }
+
     /// BufferObject ::core class::
 
     /// setBuffer ::method::

--- a/web/filament-js/filament.d.ts
+++ b/web/filament-js/filament.d.ts
@@ -505,6 +505,7 @@ export class View {
     public setFogOptions(options: View$FogOptions): void;
     public setVignetteOptions(options: View$VignetteOptions): void;
     public setGuardBandOptions(options: View$GuardBandOptions): void;
+    public setStereoscopicOptions(options: View$StereoscopicOptions): void;
     public setAmbientOcclusion(ambientOcclusion: View$AmbientOcclusion): void;
     public getAmbientOcclusion(): View$AmbientOcclusion;
     public setBlendMode(mode: View$BlendMode): void;
@@ -545,6 +546,8 @@ export class Engine {
     public createSwapChain(): SwapChain;
     public createTextureFromJpeg(urlOrBuffer: BufferReference, options?: object): Texture;
     public createTextureFromPng(urlOrBuffer: BufferReference, options?: object): Texture;
+
+    public static getMaxStereoscopicEyes(): number;
 
     public createIblFromKtx1(urlOrBuffer: BufferReference): IndirectLight;
     public createSkyFromKtx1(urlOrBuffer: BufferReference): Skybox;

--- a/web/filament-js/jsbindings.cpp
+++ b/web/filament-js/jsbindings.cpp
@@ -400,6 +400,8 @@ class_<Engine>("Engine")
 
     .function("getActiveFeatureLevel", &Engine::getActiveFeatureLevel)
 
+    .class_function("getMaxStereoscopicEyes", &Engine::getMaxStereoscopicEyes)
+
     .function("_execute", EMBIND_LAMBDA(void, (Engine* engine), {
         EM_ASM_INT({
             const handle = window.filament_contextHandle;
@@ -654,6 +656,7 @@ class_<View>("View")
     .function("_setFogOptions", &View::setFogOptions)
     .function("_setVignetteOptions", &View::setVignetteOptions)
     .function("_setGuardBandOptions", &View::setGuardBandOptions)
+    .function("_setStereoscopicOptions", &View::setStereoscopicOptions)
     .function("setAmbientOcclusion", &View::setAmbientOcclusion)
     .function("getAmbientOcclusion", &View::getAmbientOcclusion)
     .function("setAntiAliasing", &View::setAntiAliasing)


### PR DESCRIPTION
This also adds a public `Engine::getConfig` API, which helps simplify things.

Fixes #7330