### PR TITLE
Enable optimizations for ESSL 1.0 code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ set(FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB "8" CACHE STRING
     "Size of the Metal handle arena, default 8."
 )
 
+# Enable exceptions by default in spirv-cross.
+set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS OFF)
+
 # ==================================================================================================
 # CMake policies
 # ==================================================================================================
@@ -339,6 +342,7 @@ endif()
 
 if (CYGWIN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
+    set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ON)
 endif()
 
 if (MSVC)
@@ -375,6 +379,7 @@ endif()
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
 if (ANDROID OR IOS OR WEBGL)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
+    set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ON)
 
     if (ANDROID OR WEBGL)
         # Omitting unwind info prevents the generation of readable stack traces in crash reports on iOS
@@ -386,6 +391,7 @@ endif()
 # std::visit, which is not supported on iOS 11.0 when exceptions are enabled.
 if (IOS)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-exceptions")
+    set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ON)
 endif()
 
 # With WebGL, we disable RTTI even for debug builds because we pass emscripten::val back and forth

--- a/NEW_RELEASE_NOTES.md
+++ b/NEW_RELEASE_NOTES.md
@@ -9,4 +9,4 @@ appropriate header in [RELEASE_NOTES.md](./RELEASE_NOTES.md).
 ## Release notes for next branch cut
 
 - matc: New option `-1` to disable generation of ESSL 1.0 code in Feature Level 0 materials
-- matc: Enable preprocessor optimization of ESSL 1.0 shader code [⚠️ **Recompile materials**]
+- matc: Support optimizations for ESSL 1.0 code [⚠️ **Recompile materials**]

--- a/libs/filamat/src/GLSLPostProcessor.h
+++ b/libs/filamat/src/GLSLPostProcessor.h
@@ -93,7 +93,7 @@ private:
         ShaderMinifier minifier;
     };
 
-    void fullOptimization(const glslang::TShader& tShader,
+    bool fullOptimization(const glslang::TShader& tShader,
             GLSLPostProcessor::Config const& config, InternalConfig& internalConfig) const;
 
     void preprocessOptimization(glslang::TShader& tShader,

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -142,11 +142,10 @@ void MaterialBuilderBase::prepare(bool vulkanSemantics,
             if (mIncludeEssl1
                     && featureLevel == filament::backend::FeatureLevel::FEATURE_LEVEL_0
                     && shaderModel == ShaderModel::MOBILE) {
-                // ESSL1 code may never be compiled to SPIR-V.
                 mCodeGenPermutations.push_back({
                     shaderModel,
                     TargetApi::OPENGL,
-                    TargetLanguage::GLSL,
+                    glTargetLanguage,
                     filament::backend::FeatureLevel::FEATURE_LEVEL_0
                 });
             }
@@ -1422,15 +1421,15 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
         uniforms.push_back({
                 "objectUniforms.data[0].morphTargetCount",
                 offsetof(PerRenderableUib, data[0].morphTargetCount), 1,
-                UniformType::UINT });
+                UniformType::INT });
         uniforms.push_back({
                 "objectUniforms.data[0].flagsChannels",
                 offsetof(PerRenderableUib, data[0].flagsChannels), 1,
-                UniformType::UINT });
+                UniformType::INT });
         uniforms.push_back({
                 "objectUniforms.data[0].objectId",
                 offsetof(PerRenderableUib, data[0].objectId), 1,
-                UniformType::UINT });
+                UniformType::INT });
         uniforms.push_back({
                 "objectUniforms.data[0].userData",
                 offsetof(PerRenderableUib, data[0].userData), 1,


### PR DESCRIPTION
The CL introducing the ESSL 1.0 chunk in materials inadvertently disabled optimizations for said code. This commit reintroduces those optimizations and fixes associated bugs which manifested. In particular, spirv-cross was generating uints for bools; this has been fixed with a hack. Additionally, spirv-cross is now compiled with exceptions enabled so that matc can gracefully fail and show the code which failed to compile rather than abruptly aborting.

[Upstream issue for spirv-cross.](https://github.com/KhronosGroup/SPIRV-Cross/issues/2223)

[Upstream PR for spirv-cross.](https://github.com/KhronosGroup/SPIRV-Cross/pull/2227)