### PR TITLE
Small compilation fixes

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -176,6 +176,11 @@ if (WEBGL_PTHREADS)
     target_compile_definitions(gltfio_core PUBLIC -DFILAMENT_WASM_THREADS)
 endif()
 
+set(GLTFIO_WARNINGS -Wall -Werror)
+if (NOT MSVC)
+    target_compile_options(gltfio_core PRIVATE ${GLTFIO_WARNINGS})
+endif()
+
 if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
 
     # ==================================================================================================
@@ -185,10 +190,6 @@ if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
     target_link_libraries(${TARGET} PUBLIC filamat gltfio_core)
     target_include_directories(${TARGET} PUBLIC ${PUBLIC_HDR_DIR})
     set_target_properties(${TARGET} PROPERTIES FOLDER Libs)
-
-    # ==================================================================================================
-    # Compiler flags
-    # ==================================================================================================
     if (NOT MSVC)
         target_compile_options(${TARGET} PRIVATE -Wno-deprecated-register)
     endif()
@@ -229,7 +230,7 @@ if (TNT_DEV AND NOT WEBGL AND NOT ANDROID AND NOT IOS)
 
     target_link_libraries(${TEST_TARGET} PRIVATE ${TARGET} gtest uberarchive)
     if (NOT MSVC)
-        target_compile_options(${TEST_TARGET} PRIVATE -Wno-deprecated-register)
+        target_compile_options(${TEST_TARGET} PRIVATE ${GLTFIO_WARNINGS})
     endif()
     set_target_properties(${TEST_TARGET} PROPERTIES FOLDER Tests)
 endif()

--- a/libs/gltfio/include/gltfio/ResourceLoader.h
+++ b/libs/gltfio/include/gltfio/ResourceLoader.h
@@ -157,7 +157,6 @@ public:
 private:
     bool loadResources(FFilamentAsset* asset, bool async);
     void normalizeSkinningWeights(FFilamentAsset* asset) const;
-    AssetPool* mPool;
     struct Impl;
     Impl* pImpl;
 };

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -42,6 +42,7 @@
 #include <math/vec3.h>
 #include <math/vec4.h>
 
+#include <utils/compiler.h>
 #include <utils/EntityManager.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Log.h>
@@ -768,7 +769,6 @@ void FAssetLoader::createRenderable(const cgltf_node* node, Entity entity, const
 
 void FAssetLoader::createMaterialVariants(const cgltf_mesh* mesh, Entity entity,
         FFilamentAsset* fAsset, FFilamentInstance* instance) {
-    const cgltf_data* srcAsset = fAsset->mSourceAsset->hierarchy;
     UvMap uvmap {};
     for (cgltf_size prim = 0, n = mesh->primitives_count; prim < n; ++prim) {
         const cgltf_primitive& srcPrim = mesh->primitives[prim];
@@ -1076,7 +1076,7 @@ bool FAssetLoader::createPrimitive(const cgltf_primitive& inPrim, const char* na
                 .build(mEngine);
         outPrim->targets = targets;
         fAsset->mMorphTargetBuffers.push_back(targets);
-        const cgltf_accessor* previous = nullptr;
+        UTILS_UNUSED_IN_RELEASE cgltf_accessor const* previous = nullptr;
         for (int tindex = 0; tindex < targetsCount; ++tindex) {
             const cgltf_morph_target& inTarget = inPrim.targets[tindex];
             for (cgltf_size aindex = 0; aindex < inTarget.attributes_count; ++aindex) {

--- a/libs/gltfio/src/DracoCache.cpp
+++ b/libs/gltfio/src/DracoCache.cpp
@@ -20,6 +20,7 @@
 #include <draco/compression/decode.h>
 #endif
 
+#include <utils/compiler.h>
 #include <utils/Log.h>
 
 #if GLTFIO_DRACO_SUPPORTED
@@ -65,7 +66,7 @@ DracoMesh::~DracoMesh() {
 }
 
 // Gets the number of components in the given cgltf vector type, or -1 for matrices.
-static int getNumComponents(cgltf_type ctype) {
+UTILS_UNUSED_IN_RELEASE static int getNumComponents(cgltf_type ctype) {
     return ((int) ctype) <= 4 ? ((int) ctype) : -1;
 }
 

--- a/libs/gltfio/src/FFilamentAsset.h
+++ b/libs/gltfio/src/FFilamentAsset.h
@@ -71,7 +71,7 @@ namespace utils {
 
 namespace filament::gltfio {
 
-class Wireframe;
+struct Wireframe;
 
 // Encapsulates VertexBuffer::setBufferAt() or IndexBuffer::setBuffer().
 struct BufferSlot {

--- a/libs/gltfio/src/Ktx2Provider.cpp
+++ b/libs/gltfio/src/Ktx2Provider.cpp
@@ -116,7 +116,7 @@ Texture* Ktx2Provider::pushTexture(const uint8_t* data, size_t byteCount,
     }
 
     JobSystem* js = &mEngine->getJobSystem();
-    item->job = jobs::createJob(*js, mDecoderRootJob, [this, item] {
+    item->job = jobs::createJob(*js, mDecoderRootJob, [item] {
         using Result = ktxreader::Ktx2Reader::Result;
         const bool success = Result::SUCCESS == item->async->doTranscoding();
         item->transcoderState.store(success ? TranscoderState::SUCCESS : TranscoderState::ERROR);

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -32,6 +32,7 @@
 
 #include <geometry/Transcoder.h>
 
+#include <utils/compiler.h>
 #include <utils/JobSystem.h>
 #include <utils/Log.h>
 #include <utils/Systrace.h>
@@ -243,7 +244,7 @@ static void decodeMeshoptCompression(cgltf_data* data) {
         void* destination = malloc(compression->count * compression->stride);
         assert_invariant(destination);
 
-        int error = 0;
+        UTILS_UNUSED_IN_RELEASE int error = 0;
         switch (compression->mode) {
             case cgltf_meshopt_compression_mode_invalid:
                 break;

--- a/libs/gltfio/src/StbProvider.cpp
+++ b/libs/gltfio/src/StbProvider.cpp
@@ -126,7 +126,7 @@ Texture* StbProvider::pushTexture(const uint8_t* data, size_t byteCount,
     }
 
     JobSystem* js = &mEngine->getJobSystem();
-    info->decoderJob = jobs::createJob(*js, mDecoderRootJob, [this, info] {
+    info->decoderJob = jobs::createJob(*js, mDecoderRootJob, [info] {
         auto& source = info->sourceBuffer;
         int width, height, comp;
 

--- a/libs/gltfio/test/gltfio_test.cpp
+++ b/libs/gltfio/test/gltfio_test.cpp
@@ -43,9 +43,6 @@ using namespace backend;
 using namespace gltfio;
 using namespace utils;
 
-constexpr uint32_t WIDTH = 64;
-constexpr uint32_t HEIGHT = 64;
-
 char const* ANIMATED_MORPH_CUBE_GLB = "AnimatedMorphCube.glb";
 
 static std::ifstream::pos_type getFileSize(const char* filename) {
@@ -178,7 +175,6 @@ do {                                                            \
 TEST_F(glTFIOTest, AnimatedMorphCubeTransforms) {
     FilamentAsset const& morphCubeAsset = *mData[ANIMATED_MORPH_CUBE_GLB]->getAsset();
     auto const& transformManager = mEngine->getTransformManager();
-    auto const& renderableManager = mEngine->getRenderableManager();
     Entity const* renderables = morphCubeAsset.getRenderableEntities();
 
     EXPECT_EQ(morphCubeAsset.getRenderableEntityCount(), 1u);

--- a/libs/matdbg/src/ApiHandler.h
+++ b/libs/matdbg/src/ApiHandler.h
@@ -60,7 +60,7 @@ private:
     // This variable is to implement a *hanging* effect for /api/status. The call to /api/status
     // will always block until statusMaterialId is updated again. The client is expected to keep
     // calling /api/status (a constant "pull" to simulate a push).
-    std::atomic_uint64_t mCurrentStatus = 0;
+    std::atomic<uint64_t> mCurrentStatus = 0;
 };
 
 } // filament::matdbg


### PR DESCRIPTION
 - gltfio: Enable -Wall -Werror for gltfio_core
 - gltfio: Fix various errors that were missed warnings
 - matdbg: switch from std::atomic_uint64_t to std::atomic<uint64_t> for older clang