### PR TITLE
Add missing include for latest glslang

### DIFF
--- a/tools/matc/src/matc/MaterialCompiler.cpp
+++ b/tools/matc/src/matc/MaterialCompiler.cpp
@@ -34,6 +34,7 @@
 #include "ParametersProcessor.h"
 
 #include <GlslangToSpv.h>
+#include "glslang/Include/intermediate.h"
 
 #include "sca/builtinResource.h"
 


### PR DESCRIPTION
This change in glslang removes the include of "intermediate.h" from GlslangToSpv.h:
https://github.com/KhronosGroup/glslang/commit/62de186c3383feef067feb6ea578f79977910722

As a result, the definition of "class TIntermediate" is removed, and will fail compilation of MaterialCompiler.cpp when glslang is updated to a version including the aforementioned change. We fix this by adding an explicit include to this header in MaterialCompiler.cpp.

[internal]
