### PR TITLE
fix a lot of issues with the backend tests

### DIFF
--- a/filament/backend/test/BackendTest.cpp
+++ b/filament/backend/test/BackendTest.cpp
@@ -86,9 +86,9 @@ void BackendTest::executeCommands() {
 }
 
 void BackendTest::flushAndWait() {
-    auto& api = getDriverApi();
-    api.finish();
+    getDriverApi().finish();
     executeCommands();
+    getDriver().purge();
 }
 
 Handle<HwSwapChain> BackendTest::createSwapChain() {

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -50,7 +50,7 @@ layout(location = 0) out vec4 fragColor;
 
 // Filament's Vulkan backend requires a descriptor set index of 1 for all samplers.
 // This parameter is ignored for other backends.
-layout(location = 0, set = 1) uniform sampler2D tex;
+layout(location = 0, set = 1) uniform sampler2D test_tex;
 
 uniform Params {
     highp float fbWidth;
@@ -61,7 +61,7 @@ uniform Params {
 void main() {
     vec2 fbsize = vec2(params.fbWidth, params.fbHeight);
     vec2 uv = (gl_FragCoord.xy + 0.5) / fbsize;
-    fragColor = textureLod(tex, uv, params.sourceLevel);
+    fragColor = textureLod(test_tex, uv, params.sourceLevel);
 })";
 
 static uint32_t sPixelHashResult = 0;
@@ -133,24 +133,24 @@ TEST_F(BackendTest, FeedbackLoops) {
         // Create a program.
         ProgramHandle program;
         {
-            SamplerInterfaceBlock sib = filament::SamplerInterfaceBlock::Builder()
-                    .name("backend_test_sib")
+            SamplerInterfaceBlock const sib = filament::SamplerInterfaceBlock::Builder()
+                    .name("Test")
                     .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
                     .add( {{"tex", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH }} )
                     .build();
             ShaderGenerator shaderGen(fullscreenVs, fullscreenFs, sBackend, sIsMobilePlatform, &sib);
             Program prog = shaderGen.getProgram(api);
-            Program::Sampler psamplers[] = { utils::CString("tex"), 0 };
+            Program::Sampler psamplers[] = { utils::CString("test_tex"), 0 };
             prog.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
             prog.uniformBlockBindings({{"params", 1}});
             program = api.createProgram(std::move(prog));
         }
 
-        TrianglePrimitive triangle(getDriverApi());
+        TrianglePrimitive const triangle(getDriverApi());
 
         // Create a texture.
         auto usage = TextureUsage::COLOR_ATTACHMENT | TextureUsage::SAMPLEABLE;
-        Handle<HwTexture> texture = api.createTexture(
+        Handle<HwTexture> const texture = api.createTexture(
             SamplerType::SAMPLER_2D, kNumLevels, kTexFormat, 1, kTexWidth, kTexHeight, 1, usage);
 
         // Create a RenderTarget for each miplevel.

--- a/filament/backend/test/test_LoadImage.cpp
+++ b/filament/backend/test/test_LoadImage.cpp
@@ -174,6 +174,41 @@ static const char* getSamplerTypeName(TextureFormat textureFormat) {
         default:
             return "sampler2D";
     }
+
+}
+static SamplerFormat getSamplerFormat(TextureFormat textureFormat) {
+    switch (textureFormat) {
+        case TextureFormat::R8UI:
+        case TextureFormat::R16UI:
+        case TextureFormat::RG8UI:
+        case TextureFormat::RGB8UI:
+        case TextureFormat::R32UI:
+        case TextureFormat::RG16UI:
+        case TextureFormat::RGBA8UI:
+        case TextureFormat::RGB16UI:
+        case TextureFormat::RG32UI:
+        case TextureFormat::RGBA16UI:
+        case TextureFormat::RGB32UI:
+        case TextureFormat::RGBA32UI:
+            return SamplerFormat::UINT;
+
+        case TextureFormat::R8I:
+        case TextureFormat::R16I:
+        case TextureFormat::RG8I:
+        case TextureFormat::RGB8I:
+        case TextureFormat::R32I:
+        case TextureFormat::RG16I:
+        case TextureFormat::RGBA8I:
+        case TextureFormat::RGB16I:
+        case TextureFormat::RG32I:
+        case TextureFormat::RGBA16I:
+        case TextureFormat::RGB32I:
+        case TextureFormat::RGBA32I:
+            return SamplerFormat::INT;
+
+        default:
+            return SamplerFormat::FLOAT;
+    }
 }
 
 TEST_F(BackendTest, UpdateImage2D) {
@@ -232,9 +267,9 @@ TEST_F(BackendTest, UpdateImage2D) {
     // Test integer format uploads.
     // TODO: These cases fail on OpenGL and Vulkan.
     // TODO: These cases now also fail on Metal, but at some point previously worked.
-    // testCases.emplace_back("RGB_INTEGER, UBYTE -> RGB8UI", PixelDataFormat::RGB_INTEGER, PixelDataType::UBYTE, TextureFormat::RGB8UI);
-    // testCases.emplace_back("RGB_INTEGER, USHORT -> RGB16UI", PixelDataFormat::RGB_INTEGER, PixelDataType::USHORT, TextureFormat::RGB16UI);
-    // testCases.emplace_back("RGB_INTEGER, INT -> RGB32I", PixelDataFormat::RGB_INTEGER, PixelDataType::INT, TextureFormat::RGB32I);
+     testCases.emplace_back("RGB_INTEGER, UBYTE -> RGB8UI", PixelDataFormat::RGB_INTEGER, PixelDataType::UBYTE, TextureFormat::RGB8UI);
+     testCases.emplace_back("RGB_INTEGER, USHORT -> RGB16UI", PixelDataFormat::RGB_INTEGER, PixelDataType::USHORT, TextureFormat::RGB16UI);
+     testCases.emplace_back("RGB_INTEGER, INT -> RGB32I", PixelDataFormat::RGB_INTEGER, PixelDataType::INT, TextureFormat::RGB32I);
 
     // Test uploads with buffer padding.
     // TODO: Vulkan crashes with "Assertion failed: (offset + size <= allocationSize)"
@@ -262,48 +297,45 @@ TEST_F(BackendTest, UpdateImage2D) {
         auto defaultRenderTarget = api.createDefaultRenderTarget(0);
 
         // Create a program.
-        SamplerInterfaceBlock sib = filament::SamplerInterfaceBlock::Builder()
+        SamplerInterfaceBlock const sib = filament::SamplerInterfaceBlock::Builder()
                 .name("Test")
                 .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
-                .add( {{"tex", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH }} )
+                .add( {{"tex", SamplerType::SAMPLER_2D, getSamplerFormat(t.textureFormat), Precision::HIGH }} )
                 .build();
-        ProgramHandle program;
-        std::string fragment = stringReplace("{samplerType}",
+
+        std::string const fragment = stringReplace("{samplerType}",
                 getSamplerTypeName(t.textureFormat), fragmentTemplate);
         ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform, &sib);
         Program prog = shaderGen.getProgram(api);
-        Program::Sampler psamplers[] = { utils::CString("tex"), 0 };
+        Program::Sampler psamplers[] = { utils::CString("test_tex"), 0 };
         prog.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-        program = api.createProgram(std::move(prog));
+        ProgramHandle const program = api.createProgram(std::move(prog));
 
         // Create a Texture.
-        auto usage = TextureUsage::SAMPLEABLE;
-        Handle<HwTexture> texture = api.createTexture(SamplerType::SAMPLER_2D, 1,
+        auto usage = TextureUsage::SAMPLEABLE | TextureUsage::UPLOADABLE;
+        Handle<HwTexture> const texture = api.createTexture(SamplerType::SAMPLER_2D, 1,
                 t.textureFormat, 1, 512, 512, 1u, usage);
 
         // Upload some pixel data.
         if (t.uploadSubregions) {
-            const auto& pf = t.pixelFormat;
-            const auto& pt = t.pixelType;
-            PixelBufferDescriptor subregion1 = checkerboardPixelBuffer(pf, pt, 256, t.bufferPadding);
-            PixelBufferDescriptor subregion2 = checkerboardPixelBuffer(pf, pt, 256, t.bufferPadding);
-            PixelBufferDescriptor subregion3 = checkerboardPixelBuffer(pf, pt, 256, t.bufferPadding);
-            PixelBufferDescriptor subregion4 = checkerboardPixelBuffer(pf, pt, 256, t.bufferPadding);
-            api.update3DImage(texture, 0,   0,   0, 0, 256, 256, 1, std::move(subregion1));
-            api.update3DImage(texture, 0, 256,   0, 0, 256, 256, 1, std::move(subregion2));
-            api.update3DImage(texture, 0,   0, 256, 0, 256, 256, 1, std::move(subregion3));
-            api.update3DImage(texture, 0, 256, 256, 0, 256, 256, 1, std::move(subregion4));
+            api.update3DImage(texture, 0,   0,   0, 0, 256, 256, 1,
+                    checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 256, t.bufferPadding));
+            api.update3DImage(texture, 0, 256,   0, 0, 256, 256, 1,
+                    checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 256, t.bufferPadding));
+            api.update3DImage(texture, 0,   0, 256, 0, 256, 256, 1,
+                    checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 256, t.bufferPadding));
+            api.update3DImage(texture, 0, 256, 256, 0, 256, 256, 1,
+                    checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 256, t.bufferPadding));
         } else {
-            PixelBufferDescriptor descriptor
-                = checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 512, t.bufferPadding);
-            api.update3DImage(texture, 0, 0, 0, 0, 512, 512, 1, std::move(descriptor));
+            api.update3DImage(texture, 0, 0, 0, 0, 512, 512, 1,
+                    checkerboardPixelBuffer(t.pixelFormat, t.pixelType, 512, t.bufferPadding));
         }
 
         SamplerGroup samplers(1);
-        SamplerParams sparams = {};
-        sparams.filterMag = SamplerMagFilter::LINEAR;
-        sparams.filterMin = SamplerMinFilter::LINEAR_MIPMAP_NEAREST;
-        samplers.setSampler(0, { texture, sparams });
+        samplers.setSampler(0, { texture, {
+                .filterMag = SamplerMagFilter::NEAREST,
+                .filterMin = SamplerMinFilter::NEAREST_MIPMAP_NEAREST } });
+
         auto sgroup = api.createSamplerGroup(samplers.getSize(), utils::FixedSizeString<32>("Test"));
         api.updateSamplerGroup(sgroup, samplers.toBufferDescriptor(api));
 
@@ -313,7 +345,6 @@ TEST_F(BackendTest, UpdateImage2D) {
 
         readPixelsAndAssertHash(t.name, 512, 512, defaultRenderTarget, expectedHash);
 
-        api.flush();
         api.commit(swapChain);
         api.endFrame(0);
 
@@ -321,25 +352,21 @@ TEST_F(BackendTest, UpdateImage2D) {
         api.destroySwapChain(swapChain);
         api.destroyRenderTarget(defaultRenderTarget);
         api.destroyTexture(texture);
-
-        // This ensures all driver commands have finished before exiting the test.
-        api.finish();
     }
 
+    api.finish();
     api.stopCapture();
 
-    executeCommands();
-
-    getDriver().purge();
+    flushAndWait();
 }
 
 TEST_F(BackendTest, UpdateImageSRGB) {
     auto& api = getDriverApi();
     api.startCapture();
 
-    PixelDataFormat pixelFormat = PixelDataFormat::RGB;
-    PixelDataType pixelType = PixelDataType::UBYTE;
-    TextureFormat textureFormat = TextureFormat::SRGB8_A8;
+    PixelDataFormat const pixelFormat = PixelDataFormat::RGBA;
+    PixelDataType const pixelType = PixelDataType::UBYTE;
+    TextureFormat const textureFormat = TextureFormat::SRGB8_A8;
 
     // Create a platform-specific SwapChain and make it current.
     auto swapChain = createSwapChain();
@@ -347,22 +374,22 @@ TEST_F(BackendTest, UpdateImageSRGB) {
     auto defaultRenderTarget = api.createDefaultRenderTarget(0);
 
     // Create a program.
-    SamplerInterfaceBlock sib = filament::SamplerInterfaceBlock::Builder()
+    SamplerInterfaceBlock const sib = filament::SamplerInterfaceBlock::Builder()
             .name("Test")
             .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
             .add( {{"tex", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH }} )
             .build();
-    std::string fragment = stringReplace("{samplerType}",
+    std::string const fragment = stringReplace("{samplerType}",
             getSamplerTypeName(textureFormat), fragmentTemplate);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform, &sib);
     Program prog = shaderGen.getProgram(api);
-    Program::Sampler psamplers[] = { utils::CString("tex"), 0 };
+    Program::Sampler psamplers[] = { utils::CString("test_tex"), 0 };
     prog.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-    ProgramHandle program = api.createProgram(std::move(prog));
+    ProgramHandle const program = api.createProgram(std::move(prog));
 
     // Create a texture.
-    Handle<HwTexture> texture = api.createTexture(SamplerType::SAMPLER_2D, 1,
-            textureFormat, 1, 512, 512, 1, TextureUsage::SAMPLEABLE);
+    Handle<HwTexture> const texture = api.createTexture(SamplerType::SAMPLER_2D, 1,
+            textureFormat, 1, 512, 512, 1, TextureUsage::SAMPLEABLE | TextureUsage::UPLOADABLE);
 
     // Create image data.
     size_t components; int bpp;
@@ -402,7 +429,7 @@ TEST_F(BackendTest, UpdateImageSRGB) {
 
     renderTriangle(defaultRenderTarget, swapChain, program);
 
-    static const uint32_t expectedHash = 519370995;
+    static const uint32_t expectedHash = 359858623;
     readPixelsAndAssertHash("UpdateImageSRGB", 512, 512, defaultRenderTarget, expectedHash);
 
     api.flush();
@@ -416,12 +443,9 @@ TEST_F(BackendTest, UpdateImageSRGB) {
 
     // This ensures all driver commands have finished before exiting the test.
     api.finish();
-
     api.stopCapture();
 
-    executeCommands();
-
-    getDriver().purge();
+    flushAndWait();
 }
 
 TEST_F(BackendTest, UpdateImageMipLevel) {
@@ -443,20 +467,20 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
             .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
             .add( {{"tex", SamplerType::SAMPLER_2D, SamplerFormat::FLOAT, Precision::HIGH }} )
             .build();
-    std::string fragment = stringReplace("{samplerType}",
+    std::string const fragment = stringReplace("{samplerType}",
             getSamplerTypeName(textureFormat), fragmentUpdateImageMip);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform, &sib);
     Program prog = shaderGen.getProgram(api);
-    Program::Sampler psamplers[] = { utils::CString("tex"), 0 };
+    Program::Sampler psamplers[] = { utils::CString("test_tex"), 0 };
     prog.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-    ProgramHandle program = api.createProgram(std::move(prog));
+    ProgramHandle const program = api.createProgram(std::move(prog));
 
     // Create a texture with 3 mip levels.
     // Base level: 1024
     // Level 1:     512     <-- upload data and sample from this level
     // Level 2:     256
     Handle<HwTexture> texture = api.createTexture(SamplerType::SAMPLER_2D, 3,
-            textureFormat, 1, 1024, 1024, 1, TextureUsage::SAMPLEABLE);
+            textureFormat, 1, 1024, 1024, 1, TextureUsage::SAMPLEABLE | TextureUsage::UPLOADABLE);
 
     // Create image data.
     PixelBufferDescriptor descriptor = checkerboardPixelBuffer(pixelFormat, pixelType, 512);
@@ -491,12 +515,9 @@ TEST_F(BackendTest, UpdateImageMipLevel) {
 
     // This ensures all driver commands have finished before exiting the test.
     api.finish();
-
     api.stopCapture();
 
-    executeCommands();
-
-    getDriver().purge();
+    flushAndWait();
 }
 
 TEST_F(BackendTest, UpdateImage3D) {
@@ -507,7 +528,7 @@ TEST_F(BackendTest, UpdateImage3D) {
     PixelDataType pixelType = PixelDataType::FLOAT;
     TextureFormat textureFormat = TextureFormat::RGBA16F;
     SamplerType samplerType = SamplerType::SAMPLER_2D_ARRAY;
-    TextureUsage usage = TextureUsage::SAMPLEABLE;
+    TextureUsage usage = TextureUsage::SAMPLEABLE | TextureUsage::UPLOADABLE;
 
     // Create a platform-specific SwapChain and make it current.
     auto swapChain = createSwapChain();
@@ -524,9 +545,9 @@ TEST_F(BackendTest, UpdateImage3D) {
             getSamplerTypeName(samplerType), fragmentUpdateImage3DTemplate);
     ShaderGenerator shaderGen(vertex, fragment, sBackend, sIsMobilePlatform, &sib);
     Program prog = shaderGen.getProgram(api);
-    Program::Sampler psamplers[] = { utils::CString("tex"), 0 };
+    Program::Sampler psamplers[] = { utils::CString("test_tex"), 0 };
     prog.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, psamplers, sizeof(psamplers) / sizeof(psamplers[0]));
-    ProgramHandle program = api.createProgram(std::move(prog));
+    ProgramHandle const program = api.createProgram(std::move(prog));
 
     // Create a texture.
     Handle<HwTexture> texture = api.createTexture(samplerType, 1,
@@ -578,12 +599,9 @@ TEST_F(BackendTest, UpdateImage3D) {
 
     // This ensures all driver commands have finished before exiting the test.
     api.finish();
-
     api.stopCapture();
 
-    executeCommands();
-
-    getDriver().purge();
+    flushAndWait();
 }
 
 } // namespace test

--- a/filament/backend/test/test_RenderExternalImage.cpp
+++ b/filament/backend/test/test_RenderExternalImage.cpp
@@ -45,10 +45,10 @@ std::string fragment (R"(#version 450 core
 layout(location = 0) out vec4 fragColor;
 layout(location = 0) in vec2 uv;
 
-layout(location = 0, set = 1) uniform sampler2D tex;
+layout(location = 0, set = 1) uniform sampler2D test_tex;
 
 void main() {
-    fragColor = texture(tex, uv);
+    fragColor = texture(test_tex, uv);
 }
 )");
 
@@ -66,7 +66,7 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
     auto swapChain = createSwapChain();
 
     SamplerInterfaceBlock sib = filament::SamplerInterfaceBlock::Builder()
-            .name("backend_test_sib")
+            .name("Test")
             .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
             .add( {{"tex", SamplerType::SAMPLER_EXTERNAL, SamplerFormat::FLOAT, Precision::HIGH }} )
             .build();
@@ -74,7 +74,7 @@ TEST_F(BackendTest, RenderExternalImageWithoutSet) {
 
     // Create a program that samples a texture.
     Program p = shaderGen.getProgram(getDriverApi());
-    Program::Sampler sampler { utils::CString("tex"), 0 };
+    Program::Sampler sampler { utils::CString("test_tex"), 0 };
     p.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, &sampler, 1);
     backend::Handle<HwProgram> program = getDriverApi().createProgram(std::move(p));
 
@@ -146,7 +146,7 @@ TEST_F(BackendTest, RenderExternalImage) {
     auto swapChain = createSwapChain();
 
     SamplerInterfaceBlock sib = filament::SamplerInterfaceBlock::Builder()
-            .name("backend_test_sib")
+            .name("Test")
             .stageFlags(backend::ShaderStageFlags::ALL_SHADER_STAGE_FLAGS)
             .add( {{"tex", SamplerType::SAMPLER_EXTERNAL, SamplerFormat::FLOAT, Precision::HIGH }} )
             .build();
@@ -154,7 +154,7 @@ TEST_F(BackendTest, RenderExternalImage) {
 
     // Create a program that samples a texture.
     Program p = shaderGen.getProgram(getDriverApi());
-    Program::Sampler sampler { utils::CString("tex"), 0 };
+    Program::Sampler sampler { utils::CString("test_tex"), 0 };
     p.setSamplerGroup(0, ShaderStageFlags::ALL_SHADER_STAGE_FLAGS, &sampler, 1);
     auto program = getDriverApi().createProgram(std::move(p));
 


### PR DESCRIPTION
With these fixes failing tests are:

OpenGL:
BackendTest.FeedbackLoops

Metal:
BackendTest.FeedbackLoops
BackendTest.ColorResolve
BackendTest.BufferObjectUpdateWithOffset
BasicStencilBufferTest.StencilBufferMSAA

Vulkan:
Many failures still